### PR TITLE
feat(frontend): show SDK and MCP setup links on API Keys page (#9)

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/integrations/api-keys/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/api-keys/page.tsx
@@ -344,6 +344,46 @@ export default function APIKeysPage() {
             </div>
           </details>
 
+          {/* SDK & Integration Links */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <a
+              href="https://github.com/kagura-ai/kagura-memory-python-sdk"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              <span className="text-lg">🐍</span>
+              <div>
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{t('sdkLinks.pythonSdk')}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">pip install kagura-memory</p>
+              </div>
+            </a>
+            <a
+              href={`${process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'}/redoc`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              <span className="text-lg">📘</span>
+              <div>
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{t('sdkLinks.restApi')}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">ReDoc / OpenAPI</p>
+              </div>
+            </a>
+            <a
+              href="https://github.com/kagura-ai/memory-cloud#claude-code-recommended"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 p-3 border border-gray-200 dark:border-gray-700 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+            >
+              <span className="text-lg">🤖</span>
+              <div>
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{t('sdkLinks.claudeCode')}</p>
+                <p className="text-xs text-gray-500 dark:text-gray-400">.mcp.json</p>
+              </div>
+            </a>
+          </div>
+
           {/* Create API Key Button */}
           <div>
             <ActionButton

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1362,6 +1362,11 @@
       "useCases": "Use cases: connect Claude Code to your memory workspace, integrate with CI/CD pipelines, build custom MCP clients.",
       "howItWorks": "Create an API key → Add it to your .mcp.json config → Your MCP client can now remember, recall, and explore memories in this workspace."
     },
+    "sdkLinks": {
+      "pythonSdk": "Python SDK",
+      "restApi": "REST API Docs",
+      "claudeCode": "Claude Code / MCP"
+    },
     "mcpConnection": "MCP Connection",
     "mcpConnectionDesc": "MCP endpoint URL for all clients",
     "copyMcpUrl": "Copy MCP URL",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1362,6 +1362,11 @@
       "useCases": "ユースケース: Claude Codeをメモリワークスペースに接続、CI/CDパイプラインとの統合、カスタムMCPクライアントの構築。",
       "howItWorks": "APIキーを作成 → .mcp.json設定に追加 → MCPクライアントがこのワークスペースのメモリをremember、recall、exploreできるようになります。"
     },
+    "sdkLinks": {
+      "pythonSdk": "Python SDK",
+      "restApi": "REST APIドキュメント",
+      "claudeCode": "Claude Code / MCP"
+    },
     "mcpConnection": "MCP接続",
     "mcpConnectionDesc": "全クライアント用のMCPエンドポイントURL",
     "copyMcpUrl": "MCP URLをコピー",


### PR DESCRIPTION
## Summary

Add integration links on the API Keys page to guide users from "I have an API key" to "I'm using it":

- 🐍 **Python SDK** → kagura-memory-python-sdk GitHub
- 📘 **REST API Docs** → ReDoc
- 🤖 **Claude Code / MCP** → README setup guide

3-column responsive grid, dark mode supported, en/ja i18n.

Closes #9

## Test plan
- [ ] CI (lint + frontend build)
- [ ] Visual check on API Keys page

🤖 Generated with [Claude Code](https://claude.com/claude-code)