### PR TITLE
docs: add frontend environment variables to deployment guide (#11)

### DIFF
--- a/.claude/commands/guide.md
+++ b/.claude/commands/guide.md
@@ -146,6 +146,15 @@ For running Kagura Memory Cloud as a hosted service:
    GITHUB_OAUTH_ENABLED=true      # Enable/disable GitHub login
    ```
 
+4. Frontend environment variables (`frontend/.env.local`):
+   ```
+   NEXT_PUBLIC_API_URL=https://api.your-domain.com
+   NEXT_PUBLIC_APP_URL=https://your-domain.com
+   NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME=S    # optional: customize plan names
+   NEXT_PUBLIC_PLAN_BASIC_DISPLAY_NAME=M
+   NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME=L
+   ```
+
 Users sign up via OAuth, get a Free (S) workspace, and can upgrade to M/L via Stripe checkout. Admins manage users and plans via the Admin panel (`/admin`).
 
 #### Recommended Workflows

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ cd frontend && npm install && npm run dev
 - **macOS**: Install Docker Desktop for Mac. `brew install python@3.11 node`
 - **Linux (Ubuntu/Debian)**: `sudo apt install docker.io docker-compose-v2 python3.11 nodejs npm`
 - **GCP (Production)**: Set production values in `.env.local` (`DATABASE_URL`, `QDRANT_URL`, `ENVIRONMENT=production`, `CORS_ORIGINS`)
+- **Frontend env vars**: Copy `frontend/.env.example` to `frontend/.env.local` and set:
+  - `NEXT_PUBLIC_API_URL` — backend URL (default: `http://localhost:8080`)
+  - `NEXT_PUBLIC_APP_URL` — frontend URL for metadata
+  - `NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME` / `BASIC` / `PRO` — plan display name customization (default: S/M/L)
 
 </details>
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -75,3 +75,20 @@ volumes:
   caddy_data:
   caddy_config:
 ```
+
+## Frontend Environment Variables
+
+Copy `frontend/.env.example` to `frontend/.env.local` and configure:
+
+```bash
+# Required: Backend API URL (must be accessible from the browser)
+NEXT_PUBLIC_API_URL=https://api.your-domain.com
+
+# Required: Frontend URL (for OpenGraph metadata)
+NEXT_PUBLIC_APP_URL=https://your-domain.com
+
+# Optional: Custom plan display names (default: S/M/L)
+# NEXT_PUBLIC_PLAN_FREE_DISPLAY_NAME=Free
+# NEXT_PUBLIC_PLAN_BASIC_DISPLAY_NAME=Standard
+# NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME=Premium
+```


### PR DESCRIPTION
## Summary

Add frontend env var documentation (`NEXT_PUBLIC_API_URL`, `NEXT_PUBLIC_APP_URL`, plan display names) to:
- README platform-specific notes
- `/guide` SaaS deployment section
- `docs/deployment.md`

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)