### PR TITLE
feat(cli): auto-configure embedding provider in create_admin (#55)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ git clone https://github.com/kagura-ai/memory-cloud.git
 cd memory-cloud
 
 # 2. Configure environment (generates secrets, prompts for API keys)
-(cd backend && python -m src.cli.setup_env)
+(cd backend && python3 -m src.cli.setup_env)
 
 # 3. Start all services
 docker compose up -d
@@ -115,7 +115,7 @@ docker compose up -d
 (cd backend && alembic upgrade head)
 
 # 5. Create admin account (interactive — sets password, MFA, API key, embedding provider)
-(cd backend && python -m src.cli.create_admin)
+(cd backend && python3 -m src.cli.create_admin)
 
 # Backend API:  http://localhost:8080
 # Frontend UI:  http://localhost:3000
@@ -140,10 +140,10 @@ docker compose up -d
 
 | Command | Purpose |
 |---------|---------|
-| `python -m src.cli.setup_env` | Generate secrets + configure `.env.local` (run before Docker) |
-| `python -m src.cli.create_admin` | Create admin + workspace + API key + `.mcp.json` + embedding setup |
-| `python -m src.cli.reset_password` | Reset password and/or MFA |
-| `python -m src.cli.delete_admin` | Delete admin (for re-creation) |
+| `python3 -m src.cli.setup_env` | Generate secrets + configure `.env.local` (run before Docker) |
+| `python3 -m src.cli.create_admin` | Create admin + workspace + API key + `.mcp.json` + embedding setup |
+| `python3 -m src.cli.reset_password` | Reset password and/or MFA |
+| `python3 -m src.cli.delete_admin` | Delete admin (for re-creation) |
 
 > Run from `backend/` directory. Docker API container must be running.
 

--- a/backend/src/cli/create_admin.py
+++ b/backend/src/cli/create_admin.py
@@ -136,8 +136,8 @@ def _configure_embedding_provider(db: Session, user_id: str, workspace_id) -> st
     """
     from utils.encryption import get_encryptor  # noqa: E402
 
-    # 1. Check OPENAI_API_KEY
-    openai_key = os.getenv("OPENAI_API_KEY") or _get_env_from_docker("OPENAI_API_KEY")
+    # 1. Check OPENAI_API_KEY (Docker/env.local first, host env as fallback)
+    openai_key = _get_env_from_docker("OPENAI_API_KEY") or os.getenv("OPENAI_API_KEY")
     if openai_key:
         encryptor = get_encryptor()
         ext_key = ExternalAPIKey(

--- a/backend/src/cli/setup_env.py
+++ b/backend/src/cli/setup_env.py
@@ -75,11 +75,13 @@ def setup_env():
     print("Kagura Memory Cloud - Environment Setup")
     print("=" * 50)
 
-    # 1. Ensure .env.local exists (backup existing)
+    # 1. Ensure .env.local exists (backup existing with timestamp)
     if _env_local.exists():
         import shutil
+        from datetime import datetime
 
-        bak_path = _env_local.with_suffix(".local.bak")
+        timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+        bak_path = _project_root / f".env.local.bak.{timestamp}"
         shutil.copy(_env_local, bak_path)
         print(f"\n✓ Backed up existing {_env_local.name} → {bak_path.name}")
     else:

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -108,8 +108,7 @@
     "totpCode": "Verification Code",
     "verify": "Verify",
     "verifying": "Verifying...",
-    "adminLogin": "Admin Login",
-    "back": "Back"
+    "adminLogin": "Admin Login"
   },
   "landing": {
     "heroTitle": "Never lose your AI context",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -108,8 +108,7 @@
     "totpCode": "認証コード",
     "verify": "認証",
     "verifying": "認証中...",
-    "adminLogin": "管理者ログイン",
-    "back": "戻る"
+    "adminLogin": "管理者ログイン"
   },
   "landing": {
     "heroTitle": "AIコンテキストを二度と失わない",

--- a/setup.sh
+++ b/setup.sh
@@ -35,7 +35,7 @@ echo "✓ Prerequisites OK"
 
 # Step 1: Configure environment
 echo ""
-echo "==> Step 1/4: Configure environment"
+echo "==> Step 1/5: Configure environment"
 cd backend && python3 -m src.cli.setup_env
 cd ..
 
@@ -50,9 +50,11 @@ echo ""
 echo "==> Step 3/5: Start Docker services"
 docker compose up -d
 echo "Waiting for services to be healthy..."
-# Wait for postgres to be healthy (up to 30s)
-for i in $(seq 1 30); do
-  if docker compose ps --format json | grep -q '"healthy"'; then
+# Wait for postgres and qdrant to be healthy (up to 60s)
+for i in $(seq 1 60); do
+  pg_healthy=$(docker compose ps postgres --format json 2>/dev/null | grep -c '"healthy"' || echo 0)
+  qd_healthy=$(docker compose ps qdrant --format json 2>/dev/null | grep -c '"healthy"' || echo 0)
+  if [ "$pg_healthy" -ge 1 ] && [ "$qd_healthy" -ge 1 ]; then
     break
   fi
   sleep 1


### PR DESCRIPTION
## Summary

- Add `setup_env` CLI: auto-generates `API_KEY_SECRET`/`JWT_SECRET`, prompts for `OPENAI_API_KEY`, detects Ollama
- Add `setup.sh`: one-line setup script (env → Docker → migration → admin creation)
- `create_admin` auto-registers `OPENAI_API_KEY` as workspace external key, detects Ollama
- README: reorganized setup with 3 methods (one-line / Claude Code / step-by-step) + config table + Admin CLI reference

## New files

| File | Purpose |
|------|---------|
| `setup.sh` | One-line installer with ASCII art hero |
| `backend/src/cli/setup_env.py` | Generate secrets + configure `.env.local` (no Docker needed) |

## Changes

| File | Change |
|------|--------|
| `backend/src/cli/create_admin.py` | Auto-detect and register embedding provider (OpenAI/Ollama) |
| `README.md` | Setup guide rewrite, admin CLI table, .env.local config table, 11 MCP tools |

## Test plan

- [x] `setup_env` generates `API_KEY_SECRET` and `JWT_SECRET` when missing
- [x] `setup_env` skips if secrets already set (no duplicates)
- [x] `setup_env` handles quoted values in `.env.local`
- [x] `create_admin` auto-registers `OPENAI_API_KEY` as external key
- [x] `create_admin` detects Ollama when running
- [x] `setup.sh` runs full setup flow end-to-end
- [x] `make lint` passes

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)