### PR TITLE
improve(plugin): session-start uses git state as primary signal (#122)

### DIFF
--- a/claude-plugin/skills/session-start/SKILL.md
+++ b/claude-plugin/skills/session-start/SKILL.md
@@ -2,54 +2,56 @@
 description: Resume work by recalling recent session context from Kagura Memory Cloud
 ---
 
-Restore previous session context from Kagura Memory Cloud to quickly resume development work.
+Restore previous session context to quickly resume development work. Uses git state as the primary signal and Memory Cloud for supplementary context.
 
 ## Steps
 
-### 1. Identify the working context
+### 1. Check current git state
+
+```bash
+git branch --show-current
+git log --oneline -5
+git status --short
+git diff --stat HEAD~3 2>/dev/null || true
+```
+
+Use the branch name, recent commits, modified files, and uncommitted changes to infer what work is in progress.
+
+### 2. Check open GitHub issues
+
+```bash
+gh issue list --state open --limit 10 --json number,title,milestone --jq '.[] | "#\(.number) [\(.milestone.title // "no milestone")] \(.title)"'
+```
+
+### 3. Identify the working context
 
 ```
 list_contexts()
 ```
 
-If multiple contexts exist, pick the one most relevant to the current project directory. If unclear, ask the user.
+If multiple contexts exist, pick the one most relevant to the current project. If unclear, ask the user.
 
-### 2. Check current branch and recent git activity
+### 4. Recall recent memories (last 7 days)
 
-```bash
-git branch --show-current
-git log --oneline -5
-```
-
-Use the branch name and recent commits to infer what work was in progress.
-
-### 3. Recall recent session summaries
+Calculate the date 7 days ago from today and use it as `created_after` filter. Run these in parallel:
 
 ```
-recall(context_id=..., query="session summary recent work progress status", k=5, filters={"type": "note"})
+recall(context_id=..., query="session summary progress decision", k=5, filters={"created_after": "{7_days_ago_ISO8601}"})
 ```
 
-### 4. Recall decisions and patterns from recent work
-
 ```
-recall(context_id=..., query="decision architecture pattern", k=5, filters={"type": "decision"})
+recall(context_id=..., query="blocker issue TODO pending", k=5, filters={"created_after": "{7_days_ago_ISO8601}"})
 ```
 
-### 5. Recall any open issues or blockers
+### 5. Check related GitHub issues
 
-```
-recall(context_id=..., query="blocker issue TODO pending incomplete", k=5)
-```
-
-### 6. Check related GitHub issues
-
-If issue numbers appear in recalled memories or the branch name:
+If issue numbers appear in the branch name, recent commits, or recalled memories:
 
 ```bash
 gh issue view <number> --json title,state,body,labels
 ```
 
-### 7. Present session context
+### 6. Present session context
 
 Display a concise summary:
 
@@ -57,24 +59,26 @@ Display a concise summary:
 ## Session Context Restored
 
 **Branch**: {current_branch}
+**Uncommitted changes**: {yes/no, summary if yes}
 **Context**: {context_name}
 
-### Last Session
-{summary of most recent session memory — what was done, what was decided}
+### Recent Work (from git)
+{what the recent commits and changes indicate}
 
-### Open Items
-{any pending work, blockers, or TODOs found}
+### From Memory Cloud
+{relevant memories from last 7 days, if any}
 
-### Key Decisions
-{recent decisions that are still relevant}
+### Open Issues
+{open issues, prioritized by milestone}
 
 ### Suggested Next Steps
-{based on the above, suggest what to work on}
+{based on git state + memories + issues, suggest what to work on}
 ```
 
-### 8. Guidelines
+### 7. Guidelines
 
+- **Git state is primary** — recent commits and uncommitted changes are the most reliable signal
+- **Memory Cloud is supplementary** — adds context that git alone doesn't capture (decisions, rationale, blockers)
 - **Be concise** — show only what's actionable, not a full history dump
-- **Prioritize recency** — newer memories are more likely to be relevant
-- **Cross-reference** — if a memory mentions an issue number, check its current state
-- **Don't assume** — if the recalled context seems stale or ambiguous, ask the user what they're working on
+- **If no recent memories** — that's fine, rely on git state and issues
+- **Don't assume** — if context seems ambiguous, ask the user what they're working on


### PR DESCRIPTION
## Summary

- git state (branch, log, status, diff) を主要シグナルに変更
- Memory Cloud は supplementary（直近7日の `created_after` フィルタ）
- recall を3クエリから2クエリに削減（並列実行）
- `gh issue list` で open issues の全体像を取得

## Test plan

- [ ] `/kagura-memory:session-start` で git 状態が正しく表示されること
- [ ] Memory Cloud に直近の記憶がなくても git ベースで動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)