### PR TITLE
fix(api): exclude soft-deleted memories from admin total count

### DIFF
--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -819,7 +819,10 @@ class WorkspaceService:
 
         # Aggregate memories across all workspace members
         if member_ids:
-            memory_count_stmt = select(func.count(Memory.id)).where(Memory.user_id.in_(member_ids))
+            memory_count_stmt = select(func.count(Memory.id)).where(
+                Memory.user_id.in_(member_ids),
+                Memory.deleted_at.is_(None),
+            )
 
             memory_count_result = await self.db.execute(memory_count_stmt)
             total_memories = memory_count_result.scalar() or 0


### PR DESCRIPTION
## Summary

- Fix admin dashboard Total Memories count including soft-deleted memories
- `get_workspace_stats()` was missing `deleted_at IS NULL` filter
- Before: 6007 (included 5363 soft-deleted bench test memories)
- After: 644 (active memories only)

One-line fix: add `Memory.deleted_at.is_(None)` to the count query.
The per-context breakdown (`get_context_stats`) already had the correct filter.

## Test plan

- [x] Verified via direct SQL query in Docker
- [ ] Check admin dashboard shows corrected count after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)