### PR TITLE
fix(api): use fixed-length mask for API key display (#132)

### DIFF
--- a/backend/src/utils/masking.py
+++ b/backend/src/utils/masking.py
@@ -28,11 +28,11 @@ def mask_secret(
         min_mask_length: Minimum number of mask characters
 
     Returns:
-        Masked value (e.g., "sk-p***f456")
+        Masked value (e.g., "sk-p****f456")
 
     Example:
         >>> mask_secret("sk-proj-abc123def456")
-        'sk-p***f456'
+        'sk-p****f456'
 
         >>> mask_secret("short")
         '*****'
@@ -49,8 +49,9 @@ def mask_secret(
     if len(value) <= total_shown:
         return mask_char * len(value)
 
-    # Fixed-length mask (don't reveal original length)
-    mask_length = min_mask_length
+    # Fixed-length mask, but never exceed original length
+    available = len(value) - total_shown
+    mask_length = min(min_mask_length, available)
 
     return f"{value[:show_start]}{mask_char * mask_length}{value[-show_end:]}"
 

--- a/backend/tests/utils/test_masking.py
+++ b/backend/tests/utils/test_masking.py
@@ -43,6 +43,18 @@ class TestMaskSecret:
         short_stars = short_result.count("*")
         long_stars = long_result.count("*")
         assert short_stars == long_stars == 4
+        # Output should never exceed input length
+        assert len(short_result) <= len("sk-proj-abc123")
+        assert len(long_result) <= len("sk-proj-abc123def456ghi789jkl012mno345pqr678stu901vwx")
+
+    def test_boundary_near_total_shown(self):
+        """Test value just barely longer than show_start + show_end (#132)."""
+        # 9 chars, show 4+4=8, only 1 char available for mask
+        result = mask_secret("abcdefghi")
+        assert result.startswith("abcd")
+        assert result.endswith("fghi")
+        assert len(result) <= len("abcdefghi")
+        assert result.count("*") == 1
 
 
 class TestMaskPrefixOnly:


### PR DESCRIPTION
## Summary
- `mask_secret()` now uses fixed-length mask instead of proportional to original value length
- Prevents `sk-p************************************************eFfe` (48 asterisks) in External Keys page
- Result: `sk-p****eFfe`

Closes #132

## Test plan
- [x] Unit test: `test_fixed_length_mask` verifies same mask count for short/long values
- [ ] Manual: External Keys page shows short masked values

🤖 Generated with [Claude Code](https://claude.com/claude-code)