### PR TITLE
feat(api): admin context recovery from Qdrant data (#86)

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -791,12 +791,13 @@ async def recover_context(
 
     Default is dry_run=True — shows what would be recovered without making changes.
     """
+    import re
     from uuid import UUID as PyUUID
 
     from qdrant_client.models import FieldCondition, Filter, MatchValue
 
     from config.settings import get_settings
-    from db.qdrant import get_qdrant_client
+    from db.qdrant import KAGURA_MEMORIES_COLLECTION, get_qdrant_client
     from models.config import ContextSearchConfig
 
     context_id = request_body.context_id
@@ -809,7 +810,7 @@ async def recover_context(
 
     settings = get_settings()
     client = get_qdrant_client()
-    collection_name = settings.qdrant_collection_name
+    collection_name = KAGURA_MEMORIES_COLLECTION
     errors: list[str] = []
 
     # Scroll Qdrant for all points with this context_id (capped at 10k)
@@ -829,7 +830,8 @@ async def recover_context(
         )
         all_points.extend(points)
         if next_offset is None or len(all_points) >= max_points:
-            if len(all_points) >= max_points:
+            if len(all_points) > max_points:
+                all_points = all_points[:max_points]
                 errors.append(f"Capped at {max_points} points. Context may have more.")
             break
         offset = next_offset
@@ -863,6 +865,12 @@ async def recover_context(
             errors=["Cannot determine workspace_id from Qdrant data. Please provide it."],
         )
 
+    # Validate workspace_id UUID format
+    try:
+        workspace_id = str(PyUUID(workspace_id))
+    except (TypeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail="Invalid workspace_id format") from e
+
     if request_body.dry_run:
         # Just report what we found
         # Check if context record exists
@@ -874,6 +882,12 @@ async def recover_context(
         existing_result = await db.execute(select(Memory.id).where(Memory.id.in_(point_ids)))
         existing_mem_ids = {row[0] for row in existing_result.all()}
 
+        # Check if search config exists independently of context
+        existing_cfg = await db.execute(
+            select(ContextSearchConfig).where(ContextSearchConfig.context_id == PyUUID(context_id))
+        )
+        config_exists = existing_cfg.scalar_one_or_none() is not None
+
         return ContextRecoveryResponse(
             context_id=context_id,
             workspace_id=workspace_id,
@@ -881,7 +895,7 @@ async def recover_context(
             memories_recovered=len(all_points) - len(existing_mem_ids),
             memories_already_existed=len(existing_mem_ids),
             context_record_created=not context_exists,
-            search_config_restored=not context_exists,
+            search_config_restored=not config_exists,
             dry_run=True,
             errors=errors,
         )
@@ -890,12 +904,16 @@ async def recover_context(
     context_record_created = False
     existing_context = await db.execute(select(Context).where(Context.id == PyUUID(context_id)))
     if existing_context.scalar_one_or_none() is None:
-        context_name = request_body.context_name or f"recovered-{context_id[:8]}"
+        raw_name = request_body.context_name or f"recovered-{context_id[:8]}"
+        # Sanitize name to match DB constraint ^[a-z0-9_-]+$
+        context_name = re.sub(r"[^a-z0-9_-]", "-", raw_name.lower()).strip("-")
+        if not context_name:
+            context_name = f"recovered-{context_id[:8]}"
         new_context = Context(
             id=PyUUID(context_id),
             workspace_id=PyUUID(workspace_id),
             name=context_name,
-            display_name=context_name,
+            display_name=raw_name,
             created_by=get_user_id(user),
         )
         db.add(new_context)
@@ -937,6 +955,7 @@ async def recover_context(
         try:
             new_memory = Memory(
                 id=mem_id,
+                summary_embedding_id=mem_id,  # Qdrant point ID
                 user_id=payload.get("user_id", get_user_id(user)),
                 workspace_id=PyUUID(workspace_id),
                 context_id=PyUUID(context_id),

--- a/backend/tests/api/test_context_recovery.py
+++ b/backend/tests/api/test_context_recovery.py
@@ -93,14 +93,17 @@ class TestRecoverContext:
         mock_existing_mems = MagicMock()
         mock_existing_mems.all.return_value = []
 
-        mock_db.execute.side_effect = [mock_context_result, mock_existing_mems]
+        # Mock: 3 queries — context check, memory ID check, search config check
+        mock_config_result = MagicMock()
+        mock_config_result.scalar_one_or_none.return_value = None
+
+        mock_db.execute.side_effect = [mock_context_result, mock_existing_mems, mock_config_result]
 
         with (
             patch("db.qdrant.get_qdrant_client", return_value=mock_client),
             patch("config.settings.get_settings") as mock_settings,
         ):
             mock_settings.return_value = MagicMock(
-                qdrant_collection_name="kagura_memories",
                 embedding_model="text-embedding-3-small",
                 embedding_dimensions=512,
             )
@@ -111,6 +114,7 @@ class TestRecoverContext:
         assert response.memories_recovered == 2
         assert response.memories_already_existed == 0
         assert response.context_record_created is True
+        assert response.search_config_restored is True
         # No db.add calls in dry_run
         mock_db.add.assert_not_called()
         mock_db.commit.assert_not_called()


### PR DESCRIPTION
## Summary
- `POST /admin/contexts/recover`: reconstruct deleted context + memories from Qdrant points
- dry_run=True (default): preview without changes
- UUID validation, 10k point cap, narrowed exception handling, batch ID check

Closes #86

## Test plan
- [x] Unit tests: 3 tests pass (invalid UUID 400, no points error, dry_run report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)