### PR TITLE
fix(api): include addon bonus in admin plans memory_limit (#136)

### DIFF
--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -205,7 +205,7 @@ async def list_workspaces_with_plans(
                     owner_name=owner.name if owner else None,
                     owner_email=owner.email if owner else None,
                     total_memories=total_memories,
-                    memory_limit=workspace.memory_limit,
+                    memory_limit=workspace.memory_limit + workspace.addon_memory_bonus,
                     daily_api_limit=workspace.daily_api_limit,
                     weekly_api_limit=workspace.weekly_api_limit,
                 )


### PR DESCRIPTION
## Summary
- Admin plans workspace list showed base `memory_limit` without addon bonus
- Fix: `workspace.memory_limit + workspace.addon_memory_bonus`
- Workaround for #136 (full refactor in v0.6.2)

## Test plan
- [ ] Manual: admin plans page shows "652 / 11,000" instead of "652 / 1,000"

🤖 Generated with [Claude Code](https://claude.com/claude-code)