### PR TITLE
fix(frontend): i18n toast messages in OAuth apps page

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/page.tsx
@@ -238,7 +238,7 @@ export default function CustomAppsPage() {
 
       toast({
         title: tCommon("success"),
-        description: "Custom OAuth app created successfully",
+        description: t("createCustomSuccess"),
       });
     } catch (err: any) {
       setCustomDialogError(err.message || "Failed to create OAuth app");
@@ -277,7 +277,7 @@ export default function CustomAppsPage() {
 
       toast({
         title: tCommon("success"),
-        description: `OAuth secret regenerated successfully`,
+        description: t("regenerateSecretSuccess"),
       });
     } catch (err: any) {
       setError(`Failed to regenerate OAuth secret: ${err.message}`);

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1510,6 +1510,8 @@
     "regenerateOAuthDesc": "Regenerate {provider} OAuth secret? This will invalidate the old secret.",
     "deleteOAuthTitle": "Delete OAuth App?",
     "deleteOAuthDesc": "This will revoke all tokens and permanently delete the OAuth application. This action cannot be undone.",
+    "createCustomSuccess": "Custom OAuth app created successfully",
+    "regenerateSecretSuccess": "OAuth secret regenerated successfully",
     "copyAuthUrl": "Copy Authorization URL",
     "copyTokenUrl": "Copy Token URL",
     "copyClientId": "Copy Client ID",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1516,6 +1516,8 @@
     "regenerateOAuthDesc": "{provider}のOAuthシークレットを再生成しますか？古いシークレットは無効になります。",
     "deleteOAuthTitle": "OAuthアプリを削除しますか？",
     "deleteOAuthDesc": "すべてのトークンが取り消され、OAuthアプリケーションが完全に削除されます。この操作は元に戻せません。",
+    "createCustomSuccess": "カスタムOAuthアプリが正常に作成されました",
+    "regenerateSecretSuccess": "OAuthシークレットが正常に再生成されました",
     "copyAuthUrl": "認可URLをコピー",
     "copyTokenUrl": "トークンURLをコピー",
     "copyClientId": "クライアントIDをコピー",


### PR DESCRIPTION
## Summary
- Replace hardcoded English toast messages with i18n keys
- `"Custom OAuth app created successfully"` → `t("createCustomSuccess")`
- `"OAuth secret regenerated successfully"` → `t("regenerateSecretSuccess")`
- Added en + ja translations

## Test plan
- [ ] Manual: Create custom OAuth app → toast shows localized message
- [ ] Manual: Regenerate secret → toast shows localized message

🤖 Generated with [Claude Code](https://claude.com/claude-code)