### PR TITLE
chore(api): centralize version from __init__.__version__ (#151)

### DIFF
--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.1.0"
+__version__ = "0.6.1"

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -12,6 +12,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from __init__ import __version__
+
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from config.settings import get_settings
@@ -147,7 +149,7 @@ openapi_tags = [
 app = FastAPI(
     title="Kagura Memory Cloud",
     description="Universal AI Memory Platform - Remote MCP Server + Web Management",
-    version="0.6.1",
+    version=__version__,
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_tags=openapi_tags,

--- a/backend/src/api/routes/system.py
+++ b/backend/src/api/routes/system.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from __init__ import __version__
 from auth.dependencies import APIKeyOrSessionUser
 from db.base import get_db
 
@@ -71,7 +72,7 @@ async def system_info():
 
     return {
         "name": "Kagura Memory Cloud",
-        "version": "0.6.0",
+        "version": __version__,
         "description": "Remote MCP Server + Web Management",
         "environment": settings.environment,
         "features": {
@@ -251,7 +252,7 @@ async def get_system_telemetry(
             },
             neural_memory=neural_stats,
             uptime_seconds=uptime_seconds,
-            version="0.6.0",
+            version=__version__,
         )
 
     except Exception as e:

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -13,6 +13,7 @@ from uuid import UUID
 from starlette.responses import Response
 from starlette.types import Receive, Scope, Send
 
+from __init__ import __version__
 from mcp_server.auth import authenticate_mcp_request
 from mcp_server.session import get_session_manager
 
@@ -125,7 +126,7 @@ async def handle_streamable_http_post(
                 "capabilities": {"tools": {}},
                 "serverInfo": {
                     "name": "kagura-memory-cloud",
-                    "version": "0.6.1",
+                    "version": __version__,
                 },
             },
         }


### PR DESCRIPTION
## Summary

- Replace hardcoded version strings (`"0.6.0"`, `"0.6.1"`) with `from __init__ import __version__`
- Update `__init__.__version__` from `0.1.0` to `0.6.1` (matching `pyproject.toml`)
- Affected: `/api/v1/system/info`, `/api/v1/system/telemetry`, OpenAPI docs, MCP `serverInfo`

## Test plan

- [x] `python -c "from __init__ import __version__"` returns `0.6.1`
- [x] `make lint` clean
- [x] No new dependencies

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)