### PR TITLE
chore(plugin): update to Claude Code marketplace format

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ Comment `/review` on the PR to run AI review + quality checks via GitHub Actions
 - `.claude/rules/` — Coding standards (auto-loaded by file path)
 - `.claude/rules/development-workflow.md` — Development flow, commit discipline, PR rules (auto-loaded)
 - `.claude/commands/` — Project-specific slash commands (`/test-unit`, `/test-e2e`, `/quality`, `/self-review`, `/issue-start`, `/self-maint`, `/api-docs-audit`, `/workflow`, `/release`, `/docker`, `/admin`)
-- `claude-plugin/` — Kagura Memory Cloud plugin (installable in other projects)
+- `claude-plugin/` — Kagura Memory Cloud plugin (marketplace-compatible, installable in other projects)
   - Skills: `/kagura-memory:session-start`, `/kagura-memory:session-summary`, `/kagura-memory:recall`, `/kagura-memory:remember`, `/kagura-memory:guide`, `/kagura-memory:smoke-test`
 - `/simplify` — Built-in skill (not a local command file)
 - `.claude/agents/` — Specialized agents (`code-reviewer`, `test-runner`)

--- a/README.md
+++ b/README.md
@@ -277,11 +277,12 @@ The **kagura-memory** plugin adds session management and memory workflow skills 
 **Install:**
 
 ```bash
-# From this repository
-claude --plugin-dir ./claude-plugin
+# From marketplace
+/plugin marketplace add kagura-ai/memory-cloud --sparse claude-plugin
+/plugin install kagura-memory@kagura-memory-cloud
 
-# Or install from marketplace (coming soon)
-/plugin install kagura-memory
+# Or load directly for a single session
+claude --plugin-dir ./claude-plugin
 ```
 
 **Available skills:**

--- a/claude-plugin/.claude-plugin/marketplace.json
+++ b/claude-plugin/.claude-plugin/marketplace.json
@@ -1,16 +1,17 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
-  "name": "kagura-memory",
-  "description": "Kagura Memory Cloud plugin — persistent AI memory with session management, recall/save, and setup tools",
+  "name": "kagura-memory-cloud",
   "owner": {
     "name": "Kagura AI",
     "email": "fumikazu.kiyota@gmail.com"
+  },
+  "metadata": {
+    "description": "Kagura Memory Cloud — Universal AI Memory Platform"
   },
   "plugins": [
     {
       "name": "kagura-memory",
       "source": "./",
-      "version": "0.1.0",
+      "description": "Persistent AI memory with session management, recall/save, and setup tools",
       "category": "productivity",
       "homepage": "https://github.com/kagura-ai/memory-cloud"
     }

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,11 +1,12 @@
 {
   "name": "kagura-memory",
-  "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools for AI-assisted development",
   "version": "0.1.0",
+  "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI",
     "url": "https://github.com/kagura-ai"
   },
+  "homepage": "https://github.com/kagura-ai/memory-cloud",
   "repository": "https://github.com/kagura-ai/memory-cloud",
   "license": "MIT",
   "keywords": [
@@ -13,8 +14,6 @@
     "mcp",
     "ai-memory",
     "session-management",
-    "knowledge-base",
-    "claude-code-plugin"
-  ],
-  "skills": ["./skills/"]
+    "knowledge-base"
+  ]
 }


### PR DESCRIPTION
## Summary
- Update `marketplace.json` to official marketplace spec (`source: "./"`, marketplace name, metadata)
- Clean up `plugin.json` (remove `skills` field for auto-discovery, add `homepage`)
- Update README install instructions with marketplace commands

## Install
```bash
/plugin marketplace add kagura-ai/memory-cloud --sparse claude-plugin
/plugin install kagura-memory@kagura-memory-cloud
```

## Test plan
- [ ] `claude plugin validate ./claude-plugin` passes
- [ ] `/plugin marketplace add ./claude-plugin` works locally
- [ ] `/plugin install kagura-memory@kagura-memory-cloud` installs skills
- [ ] `/kagura-memory:guide` runs after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)