### PR TITLE
fix(frontend): dashboard timeline date-only strings skip timezone conversion (#168)

### DIFF
--- a/frontend/src/lib/utils/datetime.ts
+++ b/frontend/src/lib/utils/datetime.ts
@@ -62,9 +62,21 @@ export function formatDate(
   timezone: string = "UTC",
   locale: string = "ja",
 ): string {
-  const date = new Date(utcTime);
   const bcp47 = locale === "ja" ? "ja-JP" : "en-US";
 
+  // Date-only strings (YYYY-MM-DD): display as-is without timezone conversion
+  // Backend timeline API returns date-only strings already computed in UTC
+  if (/^\d{4}-\d{2}-\d{2}$/.test(utcTime)) {
+    const [year, month, day] = utcTime.split("-").map(Number);
+    const date = new Date(year, month - 1, day);
+    return new Intl.DateTimeFormat(bcp47, {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    }).format(date);
+  }
+
+  const date = new Date(utcTime);
   return new Intl.DateTimeFormat(bcp47, {
     timeZone: timezone,
     year: "numeric",


### PR DESCRIPTION
## Summary
- `formatDate()` now detects date-only inputs (`YYYY-MM-DD`) and formats without timezone conversion
- Backend timeline API returns UTC dates that don't need TZ adjustment
- PR #169 introduced a regression: applying timezone conversion to date-only strings shifted dates backward for western timezones (e.g. `2026-04-05` → `04/04` in EDT)

## Root Cause
`new Date("2026-04-05")` is interpreted as UTC midnight. `Intl.DateTimeFormat` with `America/New_York` then displays it as April 4th. Header totals were correct (backend-computed), only chart bars were affected.

## Test plan
- [x] `make test-frontend` passes (5/5)
- [ ] Dashboard with `America/New_York` timezone: dates align correctly
- [ ] Dashboard with `Asia/Tokyo` timezone: dates align correctly

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)