### PR TITLE
chore(frontend): respect OS prefers-color-scheme for default theme

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -6,13 +6,26 @@ import { Toaster as ShadcnToaster } from "@/components/ui/toaster";
 import { I18nProvider } from "@/i18n";
 
 export const metadata: Metadata = {
-  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'),
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
+  ),
   title: {
     default: "Kagura Memory Cloud - Universal AI Memory Platform",
     template: "%s | Kagura Memory Cloud",
   },
-  description: "Self-hosted, open source AI memory platform. 9 MCP tools, Neural Memory, Hybrid Search, team collaboration. Works with Claude, ChatGPT, and any MCP client.",
-  keywords: ["AI memory", "MCP", "Claude", "ChatGPT", "context management", "Neural Memory", "team collaboration", "Qdrant", "vector database"],
+  description:
+    "Self-hosted, open source AI memory platform. 9 MCP tools, Neural Memory, Hybrid Search, team collaboration. Works with Claude, ChatGPT, and any MCP client.",
+  keywords: [
+    "AI memory",
+    "MCP",
+    "Claude",
+    "ChatGPT",
+    "context management",
+    "Neural Memory",
+    "team collaboration",
+    "Qdrant",
+    "vector database",
+  ],
   authors: [{ name: "Kagura AI" }],
   creator: "Kagura AI",
   publisher: "Kagura AI",
@@ -21,7 +34,8 @@ export const metadata: Metadata = {
     locale: "en_US",
     url: process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000",
     title: "Kagura Memory Cloud - Universal AI Memory Platform",
-    description: "Never lose your AI context again. Production-ready memory platform with 8 MCP tools, Neural Memory, and team collaboration.",
+    description:
+      "Never lose your AI context again. Production-ready memory platform with 8 MCP tools, Neural Memory, and team collaboration.",
     siteName: "Kagura Memory Cloud",
     images: [
       {
@@ -35,7 +49,8 @@ export const metadata: Metadata = {
   twitter: {
     card: "summary_large_image",
     title: "Kagura Memory Cloud - Universal AI Memory Platform",
-    description: "Never lose your AI context again. Production-ready memory platform with 8 MCP tools, Neural Memory, and team collaboration.",
+    description:
+      "Never lose your AI context again. Production-ready memory platform with 8 MCP tools, Neural Memory, and team collaboration.",
     images: ["/og-image.png"],
     creator: "@kagura_ai",
   },
@@ -45,9 +60,9 @@ export const metadata: Metadata = {
     googleBot: {
       index: true,
       follow: true,
-      'max-video-preview': -1,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
+      "max-video-preview": -1,
+      "max-image-preview": "large",
+      "max-snippet": -1,
     },
   },
   ...(process.env.NEXT_PUBLIC_GOOGLE_VERIFICATION && {
@@ -65,13 +80,19 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: `
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `
           try {
-            if (localStorage.getItem('theme') === 'dark') {
+            var stored = localStorage.getItem('theme');
+            var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (stored === 'dark' || (!stored && prefersDark)) {
               document.documentElement.classList.add('dark');
             }
           } catch (e) {}
-        ` }} />
+        `,
+          }}
+        />
       </head>
       <body>
         <I18nProvider>


### PR DESCRIPTION
## Summary
- When no theme is stored in localStorage, fall back to the user's OS preference (prefers-color-scheme)
- Users who explicitly chose a theme are unaffected
- Matches industry standard (GitHub, Linear, Vercel)

## Test plan
- [x] \`npx tsc --noEmit\` — no type errors
- [x] \`npm test\` — 5/5 passed
- [ ] Manual: open in a browser with OS dark mode, verify dark theme loads by default
- [ ] Manual: switch to light via the UI, reload, verify light persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)