### PR TITLE
docs: refresh concepts / api-reference / getting-started (#189)

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -599,21 +599,41 @@ System information.
 
 ```json
 {
-  "version": "0.5.1",
+  "version": "0.7.0",
   "environment": "production",
   "features": {
     "neural_memory": true,
     "hybrid_search": true,
-    "oauth2": true
+    "oauth2": true,
+    "sleep_maintenance": true
   }
 }
 ```
 
 ---
 
+## Admin APIs
+
+Admin endpoints require `system_admin` or `workspace_admin` role.
+
+### Sleep Maintenance
+
+| Endpoint                                         | Purpose                                                       |
+|--------------------------------------------------|---------------------------------------------------------------|
+| `GET /api/v1/admin/sleep-reports`                | List Sleep runs with filters (`status`, `context_id`, `user_id`) and pagination. |
+| `GET /api/v1/admin/sleep-reports/{report_id}`    | Fetch a single report with per-phase results and the full action audit log. |
+
+See [Sleep Maintenance](sleep-maintenance.md) for the full Sleep cycle design, `sleep_mode`, and rollback semantics.
+
+### Neural Config
+
+Sleep and Neural Memory tuning knobs (LLM provider, budgets, per-phase toggles, reranker weights) are persisted in `neural_config` and exposed under `/api/v1/admin/neural-config`. The fields are editable from the admin UI's Neural Config page.
+
+---
+
 ## MCP Tools
 
-Kagura Memory Cloud provides 5 MCP tools for AI assistants:
+Kagura Memory Cloud provides 21 MCP tools for AI assistants. See [Core Concepts › MCP Tools](concepts.md#mcp-tools) for the full table. The examples below are the most commonly used tools; the remaining tools (context CRUD, edge CRUD, `update_search_config`, `get_usage`, and the Sleep observability tools `get_sleep_history` / `get_sleep_report` / `rollback_sleep_run`) share the same JSON-RPC call shape.
 
 ### 1. remember
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -125,9 +125,24 @@ The `explore()` tool uses graph traversal to discover related memories:
 
 Starting from a seed memory, activation spreads outward through the graph, returning memories ranked by connection strength.
 
+## Sleep Maintenance
+
+**Sleep Maintenance** is a nightly background cycle that pays down memory debt asynchronously. Write paths optimize for ingest speed; over time this leaves near-duplicates, stale importance values, and graph gaps. Sleep runs per context and executes six phases in order:
+
+1. **Edge Discovery** — find missing edges between related memories via medium-similarity search + optional LLM judgment
+2. **Dedup / Merge** — cluster high-similarity memories and merge duplicates
+3. **Importance Re-eval** — adjust importance via LLM scoring with EMA smoothing
+4. **Consolidation** — promote / keep / archive working memories (replaces the legacy rule-only consolidation)
+5. **Reindex** — re-embed memories modified by earlier phases so Qdrant stays in sync with PostgreSQL
+6. **Report** — aggregate per-phase results and the action audit log
+
+Each context has a `sleep_mode` setting (`full`, `edges_only`, or `skip`) that controls which phases run. Every action is recorded in `sleep_actions` and can be reversed via `rollback_sleep_run`.
+
+See [Sleep Maintenance](sleep-maintenance.md) for the complete reference.
+
 ## MCP Tools
 
-Kagura Memory Cloud exposes 17 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/):
+Kagura Memory Cloud exposes 21 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/):
 
 | Tool | Description | Read-only |
 |------|------------|-----------|
@@ -148,6 +163,10 @@ Kagura Memory Cloud exposes 17 tools via the [Model Context Protocol (MCP)](http
 | `delete_context` | Delete a context and all its memories | No |
 | `merge_contexts` | Merge memories from source into target context | No |
 | `update_search_config` | Tune hybrid search weights and reranker per context | No |
+| `get_usage` | Quota and usage queries for the current workspace | Yes |
+| `get_sleep_history` | List recent Sleep Maintenance runs for a context | Yes |
+| `get_sleep_report` | Fetch a Sleep run's full report and action audit log | Yes |
+| `rollback_sleep_run` | Reverse every recorded action of a Sleep run | No |
 
 **Typical workflow:**
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -142,6 +142,7 @@ curl -X POST http://localhost:8080/api/v1/memory/recall \
 - [API Reference](api-reference.md) — Detailed API documentation
 - [Architecture](architecture.md) — System design overview
 - [Concepts](concepts.md) — Core concepts (contexts, workspaces, neural memory)
+- [Sleep Maintenance](sleep-maintenance.md) — Background cleanup cycle, `sleep_mode`, observability, and rollback
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- `docs/concepts.md`: MCP tools count 17 → 21, add missing tools (`get_usage`, `get_sleep_history`, `get_sleep_report`, `rollback_sleep_run`), add a new Sleep Maintenance concept section linking to the full reference
- `docs/api-reference.md`: refresh example version (0.5.1 → 0.7.0, adds `sleep_maintenance` feature flag), add an Admin APIs section for `/admin/sleep-reports` and Neural Config, bump MCP tools count 5 → 21 with a pointer to the concepts.md table
- `docs/getting-started.md`: add Sleep Maintenance link to Next Steps

## Scope
Docs-only freshness audit — no conceptual rewrites. Wraps up the (B) slice of #135 that was deferred after #188 landed.

The Neural Memory section is intentionally **not** touched here; its rewrite is tracked in #190 for v0.9.0.

Closes #189
Refs #135, #188

## Test plan
- [x] Tool count (21) matches `backend/src/mcp_server/tools/_definitions.py`
- [x] All four previously missing tools now appear in the concepts.md table
- [x] `docs/sleep-maintenance.md` link target exists (added in #191)
- [x] No edits to Neural Memory sections (scoped to #190)
- [ ] GitHub preview renders tables and new sections correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)