### PR TITLE
fix: use plan tier memory_limit in effective_memory_limit (fixes #198)

### DIFF
--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1101,7 +1101,7 @@ class Workspace(Base):
     @property
     def effective_memory_limit(self) -> int:
         """Memory limit including addon bonus."""
-        return (self.memory_limit or 0) + (self.addon_memory_bonus or 0)
+        return self._plan_tier.memory_limit + (self.addon_memory_bonus or 0)
 
     @property
     def effective_mcp_calls_per_day(self) -> int:


### PR DESCRIPTION
## Summary

The effective_memory_limit property in Workspace model was reading from the stale memory_limit DB column instead of the _plan_tier.memory_limit.

## Root Cause

In ackend/src/models/auth.py:

`python
@property
def effective_memory_limit(self) -> int:
    return (self.memory_limit or 0) + (self.addon_memory_bonus or 0)  # WRONG
`

The memory_limit column is a static DB column that is not updated when plan tiers change. The _plan_tier (loaded from config/plan_tiers.py) is the authoritative source.

## Fix

`python
@property
def effective_memory_limit(self) -> int:
    return self._plan_tier.memory_limit + (self.addon_memory_bonus or 0)  # CORRECT
`

This is consistent with how effective_mcp_calls_per_day, effective_max_contexts, and effective_max_members already work (they all read from _plan_tier).

## References

- Fixes #198