### PR TITLE
fix(api): pass request as first arg to OAuth TemplateResponse (#205)

### DIFF
--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -1196,11 +1196,16 @@ async def oauth_authorize_get(
 
         query_string = urlencode(query_params)
 
-        # Use Jinja2 template (Issue #52, #221 i18n)
+        # Use Jinja2 template (Issue #52, #221 i18n).
+        # Modern Starlette TemplateResponse takes ``request`` as the first
+        # positional argument; the legacy form
+        # ``TemplateResponse(name, context_with_request)`` causes
+        # ``TypeError: unhashable type: 'dict'`` deep inside Jinja2's cache
+        # because Starlette interprets the dict as the template name.
         return templates.TemplateResponse(
+            request,
             "oauth_authorize.html",
             {
-                "request": request,
                 "client_name": client.client_name,
                 "user_email": user.email,
                 "query_string": query_string,

--- a/backend/tests/api/test_oauth_authorize_template.py
+++ b/backend/tests/api/test_oauth_authorize_template.py
@@ -1,0 +1,88 @@
+"""Regression test for the OAuth /authorize TemplateResponse bug.
+
+The route was calling Starlette's ``templates.TemplateResponse`` with the
+legacy positional shape — ``TemplateResponse(name, context_with_request)``
+— which newer Starlette versions interpret with ``request`` as the first
+positional argument. With the legacy form, Starlette treats the dict as
+the template name and Jinja2's cache lookup raises
+``TypeError: unhashable type: 'dict'`` deep in the call stack, surfacing
+to the client as a bare 500 "Internal Server Error".
+
+This test mocks the session, sync DB, and Redis dependencies so the
+authorize handler reaches the ``TemplateResponse`` call and verifies it
+returns a 200 HTML response instead of crashing.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Match the sys.path layout the rest of the backend tests use.
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api.main import app  # noqa: E402
+
+
+class TestOAuthAuthorizeTemplate:
+    def test_authorize_renders_template_for_logged_in_user(self):
+        """Regression for #205: TemplateResponse must accept request as
+        the first positional arg, otherwise Jinja2 raises
+        TypeError: unhashable type: 'dict' and the client sees 500."""
+        fake_user = MagicMock(email="test@example.com")
+        fake_client = MagicMock(client_name="Test Client")
+        fake_db_user = MagicMock(locale="en")
+
+        with (
+            patch("api.routes.oauth.get_current_user_from_session", return_value=fake_user),
+            patch("api.routes.oauth.get_sync_session") as mock_sess,
+            patch("redis.Redis") as mock_redis,
+        ):
+            db = MagicMock()
+            db.query.return_value.filter_by.return_value.first.side_effect = [
+                fake_client,
+                fake_db_user,
+            ]
+            mock_sess.return_value = db
+            mock_redis.from_url.return_value.setex = MagicMock()
+
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.get(
+                    "/api/v1/oauth/authorize",
+                    params={
+                        "response_type": "code",
+                        "client_id": "test",
+                        "redirect_uri": "http://x",
+                        "state": "s",
+                        "code_challenge": "abc",
+                        "code_challenge_method": "S256",
+                    },
+                    follow_redirects=False,
+                )
+
+        assert response.status_code == 200, (
+            f"Expected 200 HTML, got {response.status_code}: {response.text[:300]}"
+        )
+        assert response.headers.get("content-type", "").startswith("text/html")
+        # Body should mention the client name from our mock.
+        assert "Test Client" in response.text
+
+    def test_authorize_redirects_to_login_when_no_session(self):
+        """Sanity guard: the no-session redirect path still works."""
+        with patch("api.routes.oauth.get_current_user_from_session", return_value=None):
+            with TestClient(app, raise_server_exceptions=False) as client:
+                response = client.get(
+                    "/api/v1/oauth/authorize",
+                    params={
+                        "response_type": "code",
+                        "client_id": "test",
+                        "redirect_uri": "http://x",
+                        "state": "s",
+                    },
+                    follow_redirects=False,
+                )
+        assert response.status_code in (302, 307)
+        assert "/login" in response.headers.get("location", "")


### PR DESCRIPTION
## Summary

\`GET /api/v1/oauth/authorize\` returned a bare \`500 Internal Server Error\` for any logged-in user. The user thought it was admin-account specific but it actually fires for **every** logged-in user — only the no-session redirect path worked because it returns BEFORE the \`TemplateResponse\` call.

## Root cause

\`oauth.py:1200\` used the legacy Starlette positional form:

\`\`\`python
templates.TemplateResponse(
    "oauth_authorize.html",
    {"request": request, "client_name": ..., ...},
)
\`\`\`

Newer Starlette takes \`request\` as the **first** positional argument. The legacy form gets interpreted as \`(name=<dict>, context=...)\`, so Jinja2's cache lookup receives a dict as the cache key and crashes:

\`\`\`
File "/app/src/api/routes/oauth.py", line 1200, in oauth_authorize_get
    return templates.TemplateResponse(...)
File ".../jinja2/utils.py", line 515, in __getitem__
    rv = self._mapping[key]
TypeError: unhashable type: 'dict'
\`\`\`

## Why the #193 exception handlers didn't catch it

#193 (PR #202) added handlers for \`SQLAlchemyError\` and the specific \`OSError\` subclasses (\`ConnectionRefusedError\` etc). \`TypeError\` is correctly NOT caught — that's a real code bug, not infrastructure failure. Starlette's default error middleware returns a bare 500.

## Fix

\`backend/src/api/routes/oauth.py:1200\` — pass \`request\` as the first positional arg, drop it from the context dict.

## Tests

\`backend/tests/api/test_oauth_authorize_template.py\` (new, 2 tests):

- **\`test_authorize_renders_template_for_logged_in_user\`** — mocks session / sync DB / Redis to drive the handler all the way to \`TemplateResponse\` and asserts a 200 HTML body containing the client name. **Canonical regression guard for #205.** Without the fix this raises \`TypeError: unhashable type: 'dict'\` deep in Jinja2.
- **\`test_authorize_redirects_to_login_when_no_session\`** — sanity guard for the existing 307 redirect path so we don't accidentally break it.

## Verification

| Suite | Result |
|---|---|
| \`pytest tests/api/test_oauth_authorize_template.py\` | 2/2 ✅ |
| \`make lint\` | clean ✅ |
| \`grep -rn TemplateResponse backend/src/\` | only one call site (no other handlers affected) |

Manually verified by running the production-shaped request locally with mocked auth → returns 200 HTML, client name embedded.

## Impact

- **Severity**: high — OAuth authorization flow was completely broken in production. Any client (Claude.ai, ChatGPT, custom MCP integrations) needing the consent screen could not complete OAuth.
- **Blast radius**: every workspace that wants OAuth-based MCP authentication.
- **Discovered**: trying to connect claude.ai to memory.kagura-ai.com via the public MCP endpoint during v0.9.0 Soft Launch dogfood.
- **Hotfix candidate**: yes — should deploy to memory.kagura-ai.com immediately after merge.

## Quality

- Surgical fix: 1-line code change + comprehensive regression test
- No \`/simplify\` needed (single line, single function)
- Self-reviewed in commit message

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)