### PR TITLE
fix(api): repair broken exception subclass constructors (#203)

### DIFF
--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -46,8 +46,15 @@ class MemoryCloudException(Exception):
 class AuthenticationError(MemoryCloudException):
     """Authentication failed (401)."""
 
-    def __init__(self, message: str = "Authentication failed", **details: Any):
-        super().__init__(message, status_code=401, error_code="AUTH-001", **details)
+    def __init__(
+        self,
+        message: str = "Authentication failed",
+        *,
+        status_code: int = 401,
+        error_code: str = "AUTH-001",
+        **details: Any,
+    ) -> None:
+        super().__init__(message, status_code=status_code, error_code=error_code, **details)
 
 
 class InvalidCredentialsError(AuthenticationError):
@@ -74,21 +81,28 @@ class AuthorizationError(MemoryCloudException):
 class APIKeyError(MemoryCloudException):
     """API key related error (401)."""
 
-    def __init__(self, message: str = "Invalid or missing API key"):
-        super().__init__(message, status_code=401, error_code="AUTH-201")
+    def __init__(
+        self,
+        message: str = "Invalid or missing API key",
+        *,
+        status_code: int = 401,
+        error_code: str = "AUTH-201",
+        **details: Any,
+    ) -> None:
+        super().__init__(message, status_code=status_code, error_code=error_code, **details)
 
 
 class APIKeyRevokedError(APIKeyError):
     """API key has been revoked (401)."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("API key has been revoked", error_code="AUTH-202")
 
 
 class APIKeyExpiredError(APIKeyError):
     """API key has expired (401)."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__("API key has expired", error_code="AUTH-203")
 
 

--- a/backend/tests/utils/test_exceptions.py
+++ b/backend/tests/utils/test_exceptions.py
@@ -1,7 +1,5 @@
 """Tests for custom exceptions."""
 
-import pytest
-
 from utils.exceptions import (
     APIKeyError,
     APIKeyExpiredError,
@@ -62,15 +60,17 @@ class TestAuthErrors:
         assert exc.status_code == 401
         assert exc.error_code == "AUTH-001"
 
-    @pytest.mark.skip(reason="Bug: error_code double-passed in subclass constructors")
     def test_invalid_credentials(self):
         exc = InvalidCredentialsError()
         assert exc.status_code == 401
+        assert exc.error_code == "AUTH-002"
+        assert exc.message == "Invalid credentials"
 
-    @pytest.mark.skip(reason="Bug: error_code double-passed in subclass constructors")
     def test_token_expired(self):
         exc = TokenExpiredError()
         assert exc.status_code == 401
+        assert exc.error_code == "AUTH-003"
+        assert exc.message == "Token has expired"
 
     def test_authorization_error(self):
         exc = AuthorizationError("Access denied")
@@ -80,15 +80,17 @@ class TestAuthErrors:
         exc = APIKeyError()
         assert exc.status_code == 401
 
-    @pytest.mark.skip(reason="Bug: error_code double-passed in subclass constructors")
     def test_api_key_revoked(self):
         exc = APIKeyRevokedError()
         assert exc.status_code == 401
+        assert exc.error_code == "AUTH-202"
+        assert exc.message == "API key has been revoked"
 
-    @pytest.mark.skip(reason="Bug: error_code double-passed in subclass constructors")
     def test_api_key_expired(self):
         exc = APIKeyExpiredError()
         assert exc.status_code == 401
+        assert exc.error_code == "AUTH-203"
+        assert exc.message == "API key has expired"
 
     def test_token_revoked(self):
         exc = TokenRevokedError()


### PR DESCRIPTION
## Summary

Closes #203.

Four exception subclasses in `backend/src/utils/exceptions.py` could not be instantiated — calling them raised `TypeError: ... got an unexpected keyword argument 'error_code'`. The corresponding tests were marked `@pytest.mark.skip` as a known bug. This made `AUTH-002` / `AUTH-003` / `AUTH-202` / `AUTH-203` error codes documented but unreachable.

| Class | Parent | Error code |
|---|---|---|
| `InvalidCredentialsError` | `AuthenticationError` | `AUTH-002` |
| `TokenExpiredError` | `AuthenticationError` | `AUTH-003` |
| `APIKeyRevokedError` | `APIKeyError` | `AUTH-202` |
| `APIKeyExpiredError` | `APIKeyError` | `AUTH-203` |

### Root cause

`AuthenticationError` / `APIKeyError` parent constructors did not declare `error_code` as a parameter, so subclasses passing `super().__init__(..., error_code="AUTH-xxx")` had nowhere to land it.

### Fix

Apply the same keyword-only override pattern that `DatabaseError` got in #202 — parents accept `status_code` and `error_code` as keyword-only params with sensible defaults. Subclasses then forward `error_code` cleanly.

### Impact

`src/auth/jwt.py:74` and `src/mcp_server/auth.py:175` already raise `TokenExpiredError` in production code paths — both were silently crashing with `TypeError` on the error path. This PR makes those paths produce the intended structured 401 response.

No breaking changes: verified all callers of the affected classes use either `Error()` or `Error("msg")` form (no positional `status_code`/`error_code` callers). `oauth2.py`'s `InvalidCredentialsError` is a separate class from `auth.exceptions` and is unaffected.

## Test plan

- [x] `make test-local` — `tests/utils/test_exceptions.py` 31 passed / 0 skipped (was 27 passed / 4 skipped)
- [x] `exceptions.py` coverage 100%
- [x] `make lint` clean
- [x] All four classes instantiate without args and produce documented `status_code` / `error_code` / `message`
- [x] Grep for callers — no broken or positional usages

🤖 Generated with [Claude Code](https://claude.com/claude-code)