### PR TITLE
fix(db): redact password from engine/client init logs (#272)

### DIFF
--- a/backend/src/db/base.py
+++ b/backend/src/db/base.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.orm import Session, declarative_base, sessionmaker
 
 from utils.logger import get_logger
+from utils.url_redact import redact_db_url
 
 logger = get_logger(__name__)
 
@@ -41,7 +42,7 @@ def _get_engine():
             pool_size=5,
             max_overflow=10,
         )
-        logger.info("database_engine_created", url=DATABASE_URL.split("@")[0] + "@...")
+        logger.info("database_engine_created", url=redact_db_url(DATABASE_URL))
 
     return engine
 

--- a/backend/src/db/redis.py
+++ b/backend/src/db/redis.py
@@ -8,6 +8,7 @@ import redis.asyncio as aioredis
 from config.database import REDIS_URL
 from utils.exceptions import RedisError
 from utils.logger import get_logger
+from utils.url_redact import redact_generic_url
 
 logger = get_logger(__name__)
 
@@ -34,7 +35,7 @@ def get_redis_client() -> aioredis.Redis:
                 decode_responses=True,
                 max_connections=10,
             )
-            logger.info("redis_client_initialized", url=REDIS_URL)
+            logger.info("redis_client_initialized", url=redact_generic_url(REDIS_URL))
         except Exception as e:
             raise RedisError(f"Failed to connect to Redis: {e}") from e
 

--- a/backend/src/utils/url_redact.py
+++ b/backend/src/utils/url_redact.py
@@ -72,8 +72,16 @@ def redact_generic_url(url: str) -> str:
         return _REDACTED
     try:
         parsed = urlparse(url)
-        if not parsed.netloc or "@" not in parsed.netloc:
-            return url  # Nothing to redact
+        if "@" not in parsed.netloc:
+            # Either no credentials present (e.g. "redis://host:6379"), OR
+            # urlparse did not recognize the string as a URL and the `@` was
+            # pushed into path (e.g. scheme-less "user:pw@host" parses as
+            # scheme="user", netloc="", path="pw@host"). If the raw input
+            # contains `@`, we cannot safely extract credentials — return the
+            # placeholder rather than risk logging the password.
+            if "@" in url:
+                return _REDACTED
+            return url
         userinfo, _, host = parsed.netloc.rpartition("@")
         if ":" in userinfo:
             user, _, _ = userinfo.partition(":")

--- a/backend/src/utils/url_redact.py
+++ b/backend/src/utils/url_redact.py
@@ -1,0 +1,87 @@
+"""URL redaction utilities for safe logging.
+
+Provides helpers that strip passwords from database and service URLs before
+they are emitted to logs. Use these for every ``logger.info("...", url=...)``
+call site so credentials never leak via stdout, ``docker logs``, or log
+aggregators.
+
+Issue #272: ``db/base.py`` logger exposed the Postgres password; ``db/redis.py``
+had the same class of bug for the Redis URL.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlparse, urlunparse
+
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
+
+_REDACTED = "<redacted-url>"
+
+
+def redact_db_url(url: str) -> str:
+    """Return a log-safe SQLAlchemy URL with the password removed.
+
+    Uses SQLAlchemy's canonical ``make_url(...).render_as_string(hide_password=True)``
+    which correctly handles dialect schemes like ``postgresql+asyncpg``, URLs
+    with no password, and URLs with percent-encoded characters in the password.
+
+    Args:
+        url: A SQLAlchemy connection URL (e.g. the value of ``DATABASE_URL``).
+
+    Returns:
+        The URL with the password replaced by ``***`` if one was present,
+        or a safe placeholder if the input cannot be parsed.
+
+    Example:
+        >>> redact_db_url("postgresql+asyncpg://kagura:s3cret@db:5432/app")
+        'postgresql+asyncpg://kagura:***@db:5432/app'
+        >>> redact_db_url("postgresql://kagura@db/app")
+        'postgresql://kagura@db/app'
+    """
+    if not url:
+        return _REDACTED
+    try:
+        return make_url(url).render_as_string(hide_password=True)
+    except (ArgumentError, ValueError, TypeError):
+        return _REDACTED
+
+
+def redact_generic_url(url: str) -> str:
+    """Return a log-safe generic URL (Redis, Qdrant, HTTP) with password removed.
+
+    Parses the URL with :func:`urllib.parse.urlparse` and rewrites ``netloc``
+    to drop the password while preserving scheme, user, host, port, path, and
+    query. Use this for non-SQLAlchemy URLs — for SQLAlchemy URLs use
+    :func:`redact_db_url` instead.
+
+    Args:
+        url: A generic URL string (e.g. ``redis://:pass@host:6379/0``).
+
+    Returns:
+        The URL with the password replaced by ``***``, or a safe placeholder
+        if the input cannot be parsed.
+
+    Example:
+        >>> redact_generic_url("redis://:s3cret@redis:6379/0")
+        'redis://:***@redis:6379/0'
+        >>> redact_generic_url("redis://redis:6379/0")
+        'redis://redis:6379/0'
+    """
+    if not url:
+        return _REDACTED
+    try:
+        parsed = urlparse(url)
+        if not parsed.netloc or "@" not in parsed.netloc:
+            return url  # Nothing to redact
+        userinfo, _, host = parsed.netloc.rpartition("@")
+        if ":" in userinfo:
+            user, _, _ = userinfo.partition(":")
+            safe_userinfo = f"{user}:***"
+        else:
+            # User but no password — preserve as-is, do not fabricate a marker
+            safe_userinfo = userinfo
+        safe_netloc = f"{safe_userinfo}@{host}" if safe_userinfo else host
+        return urlunparse(parsed._replace(netloc=safe_netloc))
+    except (ValueError, TypeError):
+        return _REDACTED

--- a/backend/src/utils/url_redact.py
+++ b/backend/src/utils/url_redact.py
@@ -72,24 +72,33 @@ def redact_generic_url(url: str) -> str:
         return _REDACTED
     try:
         parsed = urlparse(url)
-        if "@" not in parsed.netloc:
-            # Either no credentials present (e.g. "redis://host:6379"), OR
-            # urlparse did not recognize the string as a URL and the `@` was
-            # pushed into path (e.g. scheme-less "user:pw@host" parses as
-            # scheme="user", netloc="", path="pw@host"). If the raw input
-            # contains `@`, we cannot safely extract credentials — return the
-            # placeholder rather than risk logging the password.
-            if "@" in url:
-                return _REDACTED
+
+        # Credentials in the netloc (the @-before-host form) — redact them.
+        if "@" in parsed.netloc:
+            userinfo, _, host = parsed.netloc.rpartition("@")
+            if ":" in userinfo:
+                user, _, _ = userinfo.partition(":")
+                safe_userinfo = f"{user}:***"
+            else:
+                # User but no password — preserve as-is, do not fabricate a marker
+                safe_userinfo = userinfo
+            safe_netloc = f"{safe_userinfo}@{host}" if safe_userinfo else host
+            return urlunparse(parsed._replace(netloc=safe_netloc))
+
+        # Well-formed URL (both scheme and netloc present) with no credentials
+        # in netloc — any `@` in the raw string is in path/query/fragment, which
+        # is not a credential (e.g. "https://example.com/path@v1" or a query
+        # with "?email=a@b.com"). Pass through unchanged.
+        if parsed.scheme and parsed.netloc:
             return url
-        userinfo, _, host = parsed.netloc.rpartition("@")
-        if ":" in userinfo:
-            user, _, _ = userinfo.partition(":")
-            safe_userinfo = f"{user}:***"
-        else:
-            # User but no password — preserve as-is, do not fabricate a marker
-            safe_userinfo = userinfo
-        safe_netloc = f"{safe_userinfo}@{host}" if safe_userinfo else host
-        return urlunparse(parsed._replace(netloc=safe_netloc))
+
+        # urlparse did not produce a well-formed URL (scheme or netloc missing).
+        # A scheme-less credential string like "user:pw@host" parses as
+        # scheme="user", netloc="", path="pw@host" — the password ends up in
+        # `path`, so we cannot safely extract it. If the raw input contains `@`,
+        # return the placeholder rather than risk logging the password.
+        if "@" in url:
+            return _REDACTED
+        return url
     except (ValueError, TypeError):
         return _REDACTED

--- a/backend/src/utils/url_redact.py
+++ b/backend/src/utils/url_redact.py
@@ -87,8 +87,13 @@ def redact_generic_url(url: str) -> str:
     try:
         parsed = urlparse(url)
 
-        # Credentials in the netloc (the @-before-host form) — redact them.
-        if "@" in parsed.netloc:
+        # Credentials in the netloc (the @-before-host form) — redact them,
+        # but ONLY if urlparse recognized a scheme. Scheme-less network-path
+        # references like "//user:pw@host" do populate netloc, but they are
+        # not something a log-site caller should be passing to this helper.
+        # Treat them as malformed input and fall through to the fail-closed
+        # branch below, matching the docstring contract.
+        if "@" in parsed.netloc and parsed.scheme:
             userinfo, _, host = parsed.netloc.rpartition("@")
             if ":" in userinfo:
                 user, _, _ = userinfo.partition(":")

--- a/backend/src/utils/url_redact.py
+++ b/backend/src/utils/url_redact.py
@@ -55,18 +55,32 @@ def redact_generic_url(url: str) -> str:
     query. Use this for non-SQLAlchemy URLs — for SQLAlchemy URLs use
     :func:`redact_db_url` instead.
 
+    Behavior on various inputs:
+
+    - Well-formed URL with credentials in netloc → credentials redacted,
+      rest of URL preserved.
+    - Well-formed URL (scheme and netloc both present) with no credentials
+      in netloc → returned unchanged, even if ``@`` appears elsewhere
+      (e.g. in path or query — such ``@`` is not a credential).
+    - Malformed / scheme-less / unrecognizable input → returns the
+      placeholder ``<redacted-url>``. This is fail-closed: if the string
+      is not a URL we can reason about, we refuse to log it verbatim
+      rather than risk a credential (or raw token) leaking through.
+
     Args:
         url: A generic URL string (e.g. ``redis://:pass@host:6379/0``).
 
     Returns:
-        The URL with the password replaced by ``***``, or a safe placeholder
-        if the input cannot be parsed.
+        The URL with the password replaced by ``***``, or the placeholder
+        ``<redacted-url>`` if the input is not a well-formed URL.
 
     Example:
         >>> redact_generic_url("redis://:s3cret@redis:6379/0")
         'redis://:***@redis:6379/0'
         >>> redact_generic_url("redis://redis:6379/0")
         'redis://redis:6379/0'
+        >>> redact_generic_url("not a url")
+        '<redacted-url>'
     """
     if not url:
         return _REDACTED
@@ -93,12 +107,10 @@ def redact_generic_url(url: str) -> str:
             return url
 
         # urlparse did not produce a well-formed URL (scheme or netloc missing).
-        # A scheme-less credential string like "user:pw@host" parses as
-        # scheme="user", netloc="", path="pw@host" — the password ends up in
-        # `path`, so we cannot safely extract it. If the raw input contains `@`,
-        # return the placeholder rather than risk logging the password.
-        if "@" in url:
-            return _REDACTED
-        return url
+        # Fail closed: return the placeholder. This covers scheme-less
+        # credential strings like "user:pw@host" (where the password ends up
+        # in `path`), half-formed inputs like "not a url at all", and any raw
+        # token/secret that a caller accidentally passes instead of a URL.
+        return _REDACTED
     except (ValueError, TypeError):
         return _REDACTED

--- a/backend/tests/utils/test_url_redact.py
+++ b/backend/tests/utils/test_url_redact.py
@@ -115,3 +115,22 @@ class TestRedactGenericUrl:
         assert "/v1/search" in result
         assert "q=foo" in result
         assert "k=5" in result
+
+    def test_scheme_less_credentials_return_placeholder(self):
+        """Scheme-less input like "user:pw@host" puts @ in path, not netloc —
+        urlparse gives scheme='user', netloc='', path='pw@host'. Must not
+        return the raw string (would leak the password).
+        """
+        url = "user:MYSUPERSECRET@host"
+        result = redact_generic_url(url)
+        assert "MYSUPERSECRET" not in result
+        assert result == "<redacted-url>"
+
+    def test_garbage_input_with_at_sign_returns_placeholder(self):
+        """Even malformed strings containing `@` and credential-like text must
+        not be echoed back verbatim.
+        """
+        url = "not a url user:MYSUPERSECRET@host"
+        result = redact_generic_url(url)
+        assert "MYSUPERSECRET" not in result
+        assert result == "<redacted-url>"

--- a/backend/tests/utils/test_url_redact.py
+++ b/backend/tests/utils/test_url_redact.py
@@ -174,3 +174,13 @@ class TestRedactGenericUrl:
         result = redact_generic_url(url)
         assert result == "<redacted-url>"
         assert "sk-abc123" not in result
+
+    def test_scheme_less_network_path_reference_returns_placeholder(self):
+        """Network-path references like `//user:pw@host` populate netloc
+        but have no scheme. Per the fail-closed contract, treat them as
+        malformed and return the placeholder, not a partial redaction.
+        """
+        url = "//user:MYSUPERSECRET@host"
+        result = redact_generic_url(url)
+        assert "MYSUPERSECRET" not in result
+        assert result == "<redacted-url>"

--- a/backend/tests/utils/test_url_redact.py
+++ b/backend/tests/utils/test_url_redact.py
@@ -1,0 +1,117 @@
+"""Tests for URL redaction utilities (issue #272)."""
+
+from __future__ import annotations
+
+from utils.url_redact import redact_db_url, redact_generic_url
+
+
+class TestRedactDbUrl:
+    """Test redact_db_url for SQLAlchemy URLs."""
+
+    def test_postgresql_asyncpg_with_password(self):
+        url = "postgresql+asyncpg://kagura:s3cret@db:5432/app"
+        result = redact_db_url(url)
+        assert "s3cret" not in result
+        assert "kagura" in result
+        assert "db:5432" in result
+        assert "/app" in result
+        assert "postgresql+asyncpg" in result
+        assert "***" in result
+
+    def test_postgresql_plain_with_password(self):
+        url = "postgresql://user:pw@host/db"
+        result = redact_db_url(url)
+        assert "pw" not in result
+        assert "user" in result
+        assert "host" in result
+        assert "***" in result
+
+    def test_no_password_does_not_fabricate_marker(self):
+        """URLs without a password must not gain a fake `***` marker."""
+        url = "postgresql://kagura@db/app"
+        result = redact_db_url(url)
+        assert "***" not in result
+        assert "kagura" in result
+        assert "db" in result
+
+    def test_sqlite_file_url(self):
+        """sqlite URLs have no netloc — should round-trip without change."""
+        url = "sqlite:///./test.db"
+        result = redact_db_url(url)
+        assert "test.db" in result
+
+    def test_empty_string_returns_placeholder(self):
+        assert redact_db_url("") == "<redacted-url>"
+
+    def test_malformed_returns_placeholder(self):
+        """Garbage input must not crash and must not echo back unsafely."""
+        result = redact_db_url("not a url at all")
+        assert result == "<redacted-url>"
+
+    def test_password_with_percent_encoded_chars(self):
+        """Percent-encoded special chars in password must still be redacted."""
+        url = "postgresql://user:p%40ss@host/db"
+        result = redact_db_url(url)
+        assert "p%40ss" not in result
+        assert "p@ss" not in result
+        assert "***" in result
+
+    def test_preserves_query_params(self):
+        url = "postgresql://user:pw@host/db?sslmode=require"
+        result = redact_db_url(url)
+        assert "pw" not in result
+        assert "sslmode=require" in result
+
+
+class TestRedactGenericUrl:
+    """Test redact_generic_url for Redis / Qdrant / HTTP URLs."""
+
+    def test_redis_password_no_user(self):
+        """Redis convention: redis://:password@host."""
+        url = "redis://:s3cret@redis:6379/0"
+        result = redact_generic_url(url)
+        assert "s3cret" not in result
+        assert "redis:6379" in result
+        assert "/0" in result
+        assert "***" in result
+
+    def test_redis_with_user_and_password(self):
+        url = "redis://user:s3cret@redis:6379/0"
+        result = redact_generic_url(url)
+        assert "s3cret" not in result
+        assert "user" in result
+        assert "***" in result
+
+    def test_redis_no_auth(self):
+        """No credentials → pass through unchanged."""
+        url = "redis://redis:6379/0"
+        assert redact_generic_url(url) == url
+
+    def test_qdrant_no_auth(self):
+        url = "http://qdrant:6333"
+        assert redact_generic_url(url) == url
+
+    def test_qdrant_with_basic_auth(self):
+        url = "https://admin:token@qdrant.example.com:6333"
+        result = redact_generic_url(url)
+        assert "token" not in result
+        assert "admin" in result
+        assert "***" in result
+
+    def test_user_only_no_password_no_fake_marker(self):
+        """user@host (no password) must not gain a fake `***` marker."""
+        url = "http://user@host/path"
+        result = redact_generic_url(url)
+        assert "***" not in result
+        assert "user@host" in result
+
+    def test_empty_string_returns_placeholder(self):
+        assert redact_generic_url("") == "<redacted-url>"
+
+    def test_preserves_path_and_query(self):
+        url = "https://user:pw@api.example.com/v1/search?q=foo&k=5"
+        result = redact_generic_url(url)
+        assert "pw" not in result
+        assert "/v1/search" in result
+        assert "q=foo" in result
+        assert "k=5" in result

--- a/backend/tests/utils/test_url_redact.py
+++ b/backend/tests/utils/test_url_redact.py
@@ -134,3 +134,23 @@ class TestRedactGenericUrl:
         result = redact_generic_url(url)
         assert "MYSUPERSECRET" not in result
         assert result == "<redacted-url>"
+
+    def test_at_in_path_is_not_redacted(self):
+        """Well-formed URL with `@` in the path (not credentials) must pass
+        through unchanged — `@` in path/query/fragment is legal per RFC 3986
+        and is not a credential marker.
+        """
+        url = "https://example.com/users/@alice/posts"
+        result = redact_generic_url(url)
+        assert result == url
+        assert "@alice" in result
+
+    def test_at_in_query_is_not_redacted(self):
+        """Well-formed URL with an email address in a query parameter must
+        pass through unchanged — the `@` in `email=a@b.com` is not a
+        credential.
+        """
+        url = "https://example.com/search?email=alice@example.com"
+        result = redact_generic_url(url)
+        assert result == url
+        assert "alice@example.com" in result

--- a/backend/tests/utils/test_url_redact.py
+++ b/backend/tests/utils/test_url_redact.py
@@ -154,3 +154,23 @@ class TestRedactGenericUrl:
         result = redact_generic_url(url)
         assert result == url
         assert "alice@example.com" in result
+
+    def test_malformed_input_without_at_sign_returns_placeholder(self):
+        """Malformed/partial inputs (no scheme, no netloc, no `@`) must not
+        be echoed back verbatim. Fail-closed matches the docstring contract:
+        a caller who misuses the helper (e.g. passes a raw token instead of
+        a URL) should get the placeholder, not a log line containing the
+        secret.
+        """
+        url = "not a url at all"
+        result = redact_generic_url(url)
+        assert result == "<redacted-url>"
+
+    def test_raw_token_returns_placeholder(self):
+        """A caller who accidentally passes a raw API token instead of a URL
+        must get the placeholder, not the token echoed back.
+        """
+        url = "sk-abc123DEFsecret"
+        result = redact_generic_url(url)
+        assert result == "<redacted-url>"
+        assert "sk-abc123" not in result


### PR DESCRIPTION
Closes #272

## Summary
- `backend/src/db/base.py:44` logged `DATABASE_URL.split("@")[0] + "@..."`, which keeps **everything left of the first `@`** — scheme + user + **password** — and only hides the host. Every backend startup emitted the plaintext Postgres password to stdout, docker logs, log aggregators, and any interactive shell that ran the container.
- `backend/src/db/redis.py:37` had the same class of bug — logged `REDIS_URL` with no redaction at all.
- Introduces `backend/src/utils/url_redact.py` with two helpers so all future log sites converge on a single primitive: `redact_db_url()` (SQLAlchemy-native, uses `make_url().render_as_string(hide_password=True)`) and `redact_generic_url()` (urlparse + `netloc.rpartition("@")` for Redis/Qdrant/HTTP URLs).
- Both helpers are **fail-closed**: unparseable input returns `<redacted-url>` rather than echoing raw.

## Implementation notes
- **Two helpers, not one**: SA URLs get the canonical SA primitive; non-SA URLs get stdlib `urlparse`. Unifying would force the wrong tool on one of them.
- **`rpartition("@")`** splits on the *last* `@`, so passwords containing unescaped `@` are still fully hidden.
- **`redact_generic_url` three-branch logic**: (1) `@` in netloc → redact, (2) well-formed URL (scheme+netloc both present) with no credential → pass through (preserves `@` in path/query like `/users/@alice` or `?email=a@b.com`), (3) otherwise → fail-closed placeholder.
- **No-password case** is preserved without fabricating a fake `***` marker (e.g. `postgres://user@host` stays as-is).
- **Host/port/db name are preserved** in the redacted output — ops needs them for debugging, and they are not credentials. Only the password is removed.

## Expected output
After this fix, the startup log line will look like:
```
database_engine_created url=postgresql+asyncpg://kagura:***@db:5432/app
```
(scheme, user, host, port, and database name preserved; password replaced with `***`)

## Test coverage — 22 tests
- Happy path: asyncpg scheme, plain postgres, Redis `:pass@` and `user:pass@`, Qdrant basic-auth
- No-password case: `postgres://kagura@db/app`, `http://user@host/path` (no fake `***` marker)
- Edge cases: sqlite, percent-encoded passwords, query-param preservation, `@` in path (`/users/@alice`), `@` in query (`?email=a@b.com`)
- Fail-closed: empty string, malformed URL (`"not a url at all"`), scheme-less credentials (`"user:pw@host"`), garbage with `@`, raw token misuse
- Property-style adversarial checks: `MYSUPERSECRET` literal never appears in any output

## Scope notes (intentionally deferred)
- `db/qdrant.py:289,292` and `auth/session.py:100,121` were **not** touched — Qdrant passes `api_key` separately from `QDRANT_URL` and `auth/session.py` already uses the correct `.split("@")[-1]` form. Consolidating them onto the new helper is cleanup, not a bug fix.
- **Credential rotation is a separate operational task**. The existing logs on deployed systems still contain the plaintext Postgres password until the `kagura` role is rotated. This PR stops *future* leakage; rotation closes *past* exposure. Tracking rotation as a follow-up so oncall owns it explicitly.

## Pre-PR review summary
- audit: unknown (N/A — `scripts/audit.py` doesn't exist; `/audit` skill is a plugin-conformance tool for the claude-c-suite plugin, not for this repo's code diffs. Force-bypassed.)
- cso: **green** — redaction correct, no other log sites leak URLs, tests prove the invariant, fallback is safe
- qa-lead: **green** — 22 tests with property-style `"<password>" not in result` assertions, strong ratio
- cto: **green** — clean architectural fit beside `utils/masking.py`, zero new deps, scope-disciplined
- gate1: **yellow** via `/claude-c-suite:ask` (CSO lens) → user-confirmed with scope expansion from Postgres-only to Postgres+Redis
- **Copilot review loops: 3** — each surfaced a real bug my reviewers missed. Loop 1 caught scheme-less credential leak (`urlparse("user:pw@host")` puts `@` in path). Loop 2 caught over-redaction regression from loop 1 (`https://example.com/users/@alice` was being redacted). Loop 3 caught docstring/behavior mismatch and hardened fail-closed behavior for raw-token misuse.

## Test plan
- [x] `pytest backend/tests/utils/test_url_redact.py` — 22/22 pass
- [x] `pytest backend/tests/db/ backend/tests/utils/` — 254+ pass (no regressions)
- [x] `ruff check` on all changed files — clean
- [x] `pyright` on `backend/src/` — 0 errors
- [ ] Post-merge: verify `database_engine_created` log line on next backend restart shows `postgresql+asyncpg://kagura:***@db:5432/app` (scheme, user, host, port, db name visible; password hidden)
- [ ] **Rotate `kagura` Postgres role password** (operational follow-up, tracked separately)

🤖 Generated via /gh-issue-driven:ship