### PR TITLE
feat(frontend): add edit dialog for existing OAuth clients (#219)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,9 @@ marimo/_static/
 marimo/_lsp/
 __marimo__/
 
+# Local scratch data (eval pilots, experiments)
+_local/
+
 # Kagura Memory Cloud v5.0 specific
 kagura-ai-v4/
 .env.local

--- a/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.test.tsx
@@ -1,0 +1,214 @@
+/**
+ * Tests for EditOAuthClientDialog (Issue #219).
+ *
+ * Covers:
+ *   - Pre-fill from existing client on open
+ *   - Successful save: calls API, shows toast, triggers onSuccess
+ *   - Client-side validation: empty name, empty URIs
+ *   - API error (422): field-level errors displayed, dialog stays open
+ *   - Add / remove redirect URI interactions
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+import { EditOAuthClientDialog } from "./EditOAuthClientDialog";
+import type { OAuth2Client } from "@/lib/api/oauth";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockUpdateOAuth2Client = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/lib/api/oauth", () => ({
+  updateOAuth2Client: (...args: unknown[]) => mockUpdateOAuth2Client(...args),
+}));
+
+const stableToastCtx = { toast: mockToast };
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => stableToastCtx,
+}));
+
+const stableTranslator = (key: string) => key;
+vi.mock("next-intl", () => ({
+  useTranslations: (_namespace: string) => stableTranslator,
+}));
+
+// ---------- Helpers ----------------------------------------------------------
+
+const MOCK_CLIENT: OAuth2Client = {
+  id: 1,
+  client_id: "test-client-id",
+  client_name: "Test Client",
+  redirect_uris: ["https://example.com/callback"],
+  grant_types: ["authorization_code"],
+  response_types: ["code"],
+  scope: "openid",
+  token_endpoint_auth_method: "client_secret_post",
+  provider: "custom",
+  created_at: "2026-04-01T00:00:00Z",
+  plaintext_secret: null,
+  is_visible: false,
+  visibility_expires_at: null,
+};
+
+function renderDialog(
+  overrides: Partial<{
+    client: OAuth2Client | null;
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    onSuccess: () => void;
+  }> = {},
+) {
+  const props = {
+    client: MOCK_CLIENT,
+    open: true,
+    onOpenChange: vi.fn(),
+    onSuccess: vi.fn(),
+    ...overrides,
+  };
+  const utils = render(<EditOAuthClientDialog {...props} />);
+  return { ...utils, props };
+}
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("EditOAuthClientDialog", () => {
+  beforeEach(() => {
+    mockUpdateOAuth2Client.mockReset();
+    mockToast.mockReset();
+  });
+
+  it("pre-fills client name and redirect URIs from the client prop", () => {
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText("appNamePlaceholder");
+    expect(nameInput).toHaveValue("Test Client");
+
+    const uriInput = screen.getByPlaceholderText("redirectUriPlaceholder");
+    expect(uriInput).toHaveValue("https://example.com/callback");
+  });
+
+  it("calls updateOAuth2Client with trimmed values on save", async () => {
+    mockUpdateOAuth2Client.mockResolvedValueOnce({});
+    const { props } = renderDialog();
+
+    const saveButton = screen.getByRole("button", { name: "saveChanges" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateOAuth2Client).toHaveBeenCalledWith("test-client-id", {
+        client_name: "Test Client",
+        redirect_uris: ["https://example.com/callback"],
+      });
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "success" }),
+    );
+    expect(props.onSuccess).toHaveBeenCalled();
+  });
+
+  it("shows validation error when client name is empty", async () => {
+    renderDialog();
+
+    const nameInput = screen.getByPlaceholderText("appNamePlaceholder");
+    fireEvent.change(nameInput, { target: { value: "   " } });
+
+    const saveButton = screen.getByRole("button", { name: "saveChanges" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("appNameRequired")).toBeInTheDocument();
+    });
+
+    expect(mockUpdateOAuth2Client).not.toHaveBeenCalled();
+  });
+
+  it("shows validation error when all redirect URIs are empty", async () => {
+    renderDialog();
+
+    const uriInput = screen.getByPlaceholderText("redirectUriPlaceholder");
+    fireEvent.change(uriInput, { target: { value: "" } });
+
+    const saveButton = screen.getByRole("button", { name: "saveChanges" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("redirectUriRequired")).toBeInTheDocument();
+    });
+
+    expect(mockUpdateOAuth2Client).not.toHaveBeenCalled();
+  });
+
+  it("displays API error and keeps the dialog open on failure", async () => {
+    mockUpdateOAuth2Client.mockRejectedValueOnce({
+      message: "Validation failed",
+      details: {
+        detail: [{ loc: ["body", "redirect_uris"], msg: "Invalid URI format" }],
+      },
+    });
+
+    const { props } = renderDialog();
+
+    const saveButton = screen.getByRole("button", { name: "saveChanges" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid URI format")).toBeInTheDocument();
+    });
+
+    // Dialog stays open — onOpenChange(false) not called on error
+    expect(props.onOpenChange).not.toHaveBeenCalledWith(false);
+  });
+
+  it("adds and removes redirect URI fields", () => {
+    renderDialog();
+
+    // Initially one URI field
+    expect(
+      screen.getAllByPlaceholderText("redirectUriPlaceholder"),
+    ).toHaveLength(1);
+
+    // Add a URI
+    fireEvent.click(screen.getByText("+ addRedirectUri"));
+    expect(
+      screen.getAllByPlaceholderText("redirectUriPlaceholder"),
+    ).toHaveLength(2);
+
+    // Remove button appears when > 1 URI
+    const removeButtons = screen.getAllByTitle("removeUri");
+    expect(removeButtons).toHaveLength(2);
+
+    // Remove one URI
+    fireEvent.click(removeButtons[0]);
+    expect(
+      screen.getAllByPlaceholderText("redirectUriPlaceholder"),
+    ).toHaveLength(1);
+  });
+
+  it("disables buttons while saving", async () => {
+    let resolveUpdate: () => void = () => {};
+    mockUpdateOAuth2Client.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        resolveUpdate = resolve;
+      }),
+    );
+
+    renderDialog();
+
+    const saveButton = screen.getByRole("button", { name: "saveChanges" });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "saving" })).toBeDisabled();
+    });
+
+    // Resolve the save
+    resolveUpdate();
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useTranslations } from "next-intl";
-import { updateOAuth2Client, OAuth2Client } from "@/lib/api/oauth";
+import { updateOAuth2Client } from "@/lib/api/oauth";
+import type { OAuth2Client } from "@/lib/api/oauth";
 import { useToast } from "@/hooks/use-toast";
 import { X, Pencil } from "lucide-react";
 import {
@@ -103,11 +104,13 @@ export function EditOAuthClientDialog({
           return;
         }
       }
-      setError(
-        apiError?.message ||
-          (apiError?.details?.detail as string) ||
-          "Failed to update OAuth client",
-      );
+      const fallbackMessage =
+        typeof apiError?.message === "string"
+          ? apiError.message
+          : typeof apiError?.details?.detail === "string"
+            ? apiError.details.detail
+            : t("editFieldError");
+      setError(fallbackMessage);
     } finally {
       setSaving(false);
     }
@@ -197,6 +200,7 @@ export function EditOAuthClientDialog({
                     />
                     {redirectUris.length > 1 && (
                       <button
+                        type="button"
                         onClick={() => {
                           setRedirectUris(
                             redirectUris.filter((_, i) => i !== index),
@@ -204,6 +208,7 @@ export function EditOAuthClientDialog({
                         }}
                         className="p-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
                         title={t("removeUri")}
+                        aria-label={t("removeUri")}
                       >
                         <X className="w-4 h-4" />
                       </button>

--- a/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.tsx
@@ -1,0 +1,254 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { updateOAuth2Client, OAuth2Client } from "@/lib/api/oauth";
+import { useToast } from "@/hooks/use-toast";
+import { X, Pencil } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface EditOAuthClientDialogProps {
+  client: OAuth2Client | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+export function EditOAuthClientDialog({
+  client,
+  open,
+  onOpenChange,
+  onSuccess,
+}: EditOAuthClientDialogProps) {
+  const t = useTranslations("customApps");
+  const tCommon = useTranslations("common");
+  const { toast } = useToast();
+
+  const [clientName, setClientName] = useState("");
+  const [redirectUris, setRedirectUris] = useState<string[]>([""]);
+  const [error, setError] = useState<string | null>(null);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  const [saving, setSaving] = useState(false);
+
+  // Pre-fill when client changes or dialog opens
+  useEffect(() => {
+    if (client && open) {
+      setClientName(client.client_name);
+      setRedirectUris(
+        client.redirect_uris.length > 0 ? [...client.redirect_uris] : [""],
+      );
+      setError(null);
+      setFieldErrors({});
+    }
+  }, [client, open]);
+
+  const handleSave = useCallback(async () => {
+    if (!client) return;
+
+    setError(null);
+    setFieldErrors({});
+
+    // Client-side validation
+    if (!clientName.trim()) {
+      setFieldErrors({ clientName: t("appNameRequired") });
+      return;
+    }
+
+    const validUris = redirectUris.filter((uri) => uri.trim());
+    if (validUris.length === 0) {
+      setFieldErrors({ redirectUris: t("redirectUriRequired") });
+      return;
+    }
+
+    try {
+      setSaving(true);
+      await updateOAuth2Client(client.client_id, {
+        client_name: clientName.trim(),
+        redirect_uris: validUris.map((u) => u.trim()),
+      });
+
+      toast({
+        title: tCommon("success"),
+        description: t("editSuccess"),
+      });
+      onOpenChange(false);
+      onSuccess();
+    } catch (err: unknown) {
+      const apiError = err as {
+        message?: string;
+        details?: { detail?: string | Array<{ loc?: string[]; msg?: string }> };
+      };
+      // Handle Pydantic 422 field-level errors
+      const detail = apiError?.details?.detail;
+      if (Array.isArray(detail)) {
+        const newFieldErrors: Record<string, string> = {};
+        for (const item of detail) {
+          const field = item.loc?.slice(-1)[0];
+          if (field) {
+            newFieldErrors[field] = item.msg || "Invalid value";
+          }
+        }
+        if (Object.keys(newFieldErrors).length > 0) {
+          setFieldErrors(newFieldErrors);
+          setError(t("editFieldError"));
+          return;
+        }
+      }
+      setError(
+        apiError?.message ||
+          (apiError?.details?.detail as string) ||
+          "Failed to update OAuth client",
+      );
+    } finally {
+      setSaving(false);
+    }
+  }, [
+    client,
+    clientName,
+    redirectUris,
+    t,
+    tCommon,
+    toast,
+    onOpenChange,
+    onSuccess,
+  ]);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent className="max-w-2xl">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <Pencil className="w-4 h-4" />
+            {t("editOAuthTitle")}
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-4">
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t("editOAuthDesc")}
+              </p>
+
+              {/* Client Name */}
+              <div>
+                <label className="block text-sm font-medium mb-1">
+                  {t("clientNameLabel")}
+                </label>
+                <input
+                  type="text"
+                  value={clientName}
+                  onChange={(e) => {
+                    setClientName(e.target.value);
+                    setFieldErrors((prev) => {
+                      const next = { ...prev };
+                      delete next.clientName;
+                      delete next.client_name;
+                      return next;
+                    });
+                  }}
+                  placeholder={t("appNamePlaceholder")}
+                  className={`w-full px-3 py-2 border rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 ${
+                    fieldErrors.clientName || fieldErrors.client_name
+                      ? "border-red-500"
+                      : "border-gray-300 dark:border-gray-600"
+                  }`}
+                />
+                {(fieldErrors.clientName || fieldErrors.client_name) && (
+                  <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+                    {fieldErrors.clientName || fieldErrors.client_name}
+                  </p>
+                )}
+              </div>
+
+              {/* Redirect URIs */}
+              <div>
+                <label className="block text-sm font-medium mb-1">
+                  {t("redirectUris")}
+                </label>
+                {redirectUris.map((uri, index) => (
+                  <div key={index} className="flex items-center gap-2 mb-2">
+                    <input
+                      type="text"
+                      value={uri}
+                      onChange={(e) => {
+                        const newUris = [...redirectUris];
+                        newUris[index] = e.target.value;
+                        setRedirectUris(newUris);
+                        setFieldErrors((prev) => {
+                          const next = { ...prev };
+                          delete next.redirectUris;
+                          delete next.redirect_uris;
+                          return next;
+                        });
+                      }}
+                      placeholder={t("redirectUriPlaceholder")}
+                      className={`flex-1 px-3 py-2 border rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 text-sm ${
+                        fieldErrors.redirectUris || fieldErrors.redirect_uris
+                          ? "border-red-500"
+                          : "border-gray-300 dark:border-gray-600"
+                      }`}
+                    />
+                    {redirectUris.length > 1 && (
+                      <button
+                        onClick={() => {
+                          setRedirectUris(
+                            redirectUris.filter((_, i) => i !== index),
+                          );
+                        }}
+                        className="p-2 text-red-600 hover:bg-red-50 dark:hover:bg-red-900/20 rounded"
+                        title={t("removeUri")}
+                      >
+                        <X className="w-4 h-4" />
+                      </button>
+                    )}
+                  </div>
+                ))}
+                {(fieldErrors.redirectUris || fieldErrors.redirect_uris) && (
+                  <p className="text-xs text-red-600 dark:text-red-400 mb-1">
+                    {fieldErrors.redirectUris || fieldErrors.redirect_uris}
+                  </p>
+                )}
+                <button
+                  onClick={() => setRedirectUris([...redirectUris, ""])}
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:underline"
+                >
+                  + {t("addRedirectUri")}
+                </button>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
+                  {t("redirectUriHint")}
+                </p>
+              </div>
+
+              {error && (
+                <p className="text-sm text-red-600 dark:text-red-400">
+                  {error}
+                </p>
+              )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={saving}>
+            {tCommon("cancel")}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={(e) => {
+              e.preventDefault();
+              handleSave();
+            }}
+            disabled={saving}
+          >
+            {saving ? t("saving") : t("saveChanges")}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/page.tsx
@@ -31,11 +31,13 @@ import {
   regenerateOAuth2ClientSecret,
   OAuth2Client,
 } from "@/lib/api/oauth";
+import { EditOAuthClientDialog } from "./EditOAuthClientDialog";
 import { hideOAuthClientSecret } from "@/lib/api/member-credentials";
 import {
   Copy,
   Check,
   EyeOff,
+  Pencil,
   RefreshCw,
   Trash2,
   AlertTriangle,
@@ -102,6 +104,10 @@ export default function CustomAppsPage() {
   } | null>(null);
   const [showDeleteOAuthDialog, setShowDeleteOAuthDialog] = useState(false);
   const [oauthToDelete, setOauthToDelete] = useState<string | null>(null);
+
+  // Edit dialog state
+  const [showEditDialog, setShowEditDialog] = useState(false);
+  const [oauthToEdit, setOauthToEdit] = useState<OAuth2Client | null>(null);
 
   // Track if component is mounted
   const isMountedRef = useRef(true);
@@ -539,6 +545,15 @@ export default function CustomAppsPage() {
                   {/* Actions */}
                   <div className="flex gap-2">
                     <ActionButton
+                      onClick={() => {
+                        setOauthToEdit(app);
+                        setShowEditDialog(true);
+                      }}
+                      icon={<Pencil className="w-4 h-4" />}
+                    >
+                      {tCommon("edit")}
+                    </ActionButton>
+                    <ActionButton
                       onClick={() =>
                         handleRegenerateOAuthClick(app.client_id, title)
                       }
@@ -749,6 +764,15 @@ export default function CustomAppsPage() {
                     {/* Actions */}
                     <div className="flex gap-2">
                       <ActionButton
+                        onClick={() => {
+                          setOauthToEdit(app);
+                          setShowEditDialog(true);
+                        }}
+                        icon={<Pencil className="w-4 h-4" />}
+                      >
+                        {tCommon("edit")}
+                      </ActionButton>
+                      <ActionButton
                         onClick={() =>
                           handleRegenerateOAuthClick(
                             app.client_id,
@@ -947,6 +971,14 @@ export default function CustomAppsPage() {
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      {/* Edit OAuth Client Dialog */}
+      <EditOAuthClientDialog
+        client={oauthToEdit}
+        open={showEditDialog}
+        onOpenChange={setShowEditDialog}
+        onSuccess={loadOAuthClients}
+      />
     </PageContainer>
   );
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1527,7 +1527,14 @@
     "hideSecretNow": "Hide secret now (cannot be shown again)",
     "createSuccess": "{provider} app created successfully",
     "deleteSuccess": "OAuth app deleted successfully",
-    "regenerateSuccess": "OAuth secret regenerated successfully"
+    "regenerateSuccess": "OAuth secret regenerated successfully",
+    "editOAuthTitle": "Edit OAuth Client",
+    "editOAuthDesc": "Update client name and redirect URIs for this OAuth application.",
+    "clientNameLabel": "Client Name",
+    "saveChanges": "Save Changes",
+    "saving": "Saving...",
+    "editSuccess": "OAuth client updated successfully",
+    "editFieldError": "Please fix the errors above before saving."
   },
   "systemSettings": {
     "title": "System Settings",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1527,7 +1527,14 @@
     "hideSecretNow": "今すぐシークレットを非表示（再表示不可）",
     "createSuccess": "{provider}アプリが正常に作成されました",
     "deleteSuccess": "OAuthアプリが正常に削除されました",
-    "regenerateSuccess": "OAuthシークレットが正常に再生成されました"
+    "regenerateSuccess": "OAuthシークレットが正常に再生成されました",
+    "editOAuthTitle": "OAuthクライアントを編集",
+    "editOAuthDesc": "このOAuthアプリケーションのクライアント名とリダイレクトURIを更新します。",
+    "clientNameLabel": "クライアント名",
+    "saveChanges": "変更を保存",
+    "saving": "保存中...",
+    "editSuccess": "OAuthクライアントが正常に更新されました",
+    "editFieldError": "保存する前にエラーを修正してください。"
   },
   "systemSettings": {
     "title": "システム設定",


### PR DESCRIPTION
## Summary
- Add `EditOAuthClientDialog` component for editing existing OAuth client `redirect_uris` and `client_name` via the admin UI
- Wire up the previously unused `updateOAuth2Client` API client function
- Resolves the production incident from #207 where admins had to run direct SQL `UPDATE` on the DB to fix stale redirect URIs

## Changes
- **New**: `EditOAuthClientDialog.tsx` — standalone dialog with pre-fill, redirect URI array editing, Pydantic 422 field-level error display
- **New**: `EditOAuthClientDialog.test.tsx` — 7 unit tests (save, validation, 422 errors, URI add/remove, saving state)
- **Modified**: `page.tsx` — Edit button (pencil icon) added before Regenerate/Delete on Claude, ChatGPT, and Custom OAuth client cards
- **Modified**: `en.json` / `ja.json` — 7 new i18n keys each

## Design decisions
- `e.preventDefault()` on `AlertDialogAction` to prevent Radix auto-close on save — keeps dialog open so users can see field-level errors on 422
- Follows existing dialog patterns in the same file (AlertDialog, separate boolean+data state)
- `token_endpoint_auth_method` dropped from scope per gate1 CDO review (not in `OAuth2ClientUpdateRequest` type)
- No backend changes needed — `PUT /api/v1/oauth/clients/{id}` already exists with Pydantic validation

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `vitest run` — 17/17 tests pass (10 existing + 7 new)
- [x] `ruff check` + `pyright` — backend unchanged, all pass
- [x] Manual: open admin UI → OAuth Apps → click Edit on a client → verify pre-fill, save, error handling

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)