### PR TITLE
docs(plugin+claude): add plugin install guide and dev-environment rule (#208) (#209)

### DIFF
--- a/.claude/rules/dev-environment.md
+++ b/.claude/rules/dev-environment.md
@@ -1,0 +1,58 @@
+---
+paths:
+  - "docker-compose*"
+  - "Makefile"
+  - "backend/tests/**"
+  - ".env*"
+---
+
+# Development Environment
+
+## Docker Compose
+
+- **Only `docker-compose.yml` exists** — there is no `docker-compose.dev.yml` or `docker-compose.override.yml`
+- All environments (dev, test, prod) use the same compose file with environment variables for differentiation
+- Container names: `kagura-api`, `kagura-web`, `kagura-db`, `kagura-redis`
+
+## Test Execution
+
+| Command | What it runs | Requires Docker? |
+|---------|-------------|-----------------|
+| `make test-local` | Unit tests (excludes e2e/integration) | No |
+| `make test-frontend` | Vitest frontend tests | No |
+| `make test-integration` | DB + migration tests | Yes (DB container) |
+| `make test-e2e` | End-to-end tests | Yes |
+| `make test-smoke` | Health, auth, well-known endpoints | Yes |
+| `make test` | All tests via Docker exec | Yes |
+| `make test-unit` | Unit tests (api/neural/utils/auth) | No |
+
+For local backend tests: `cd backend && pytest tests/api/ -v`
+
+## Python Environment
+
+- Backend source: `backend/src/`
+- `PYTHONPATH=src` is required when running scripts outside pytest (pytest configures this via `pyproject.toml`)
+- Virtual env: `backend/.venv/` (not committed)
+- Dependencies: `backend/requirements.txt`
+
+## Key Makefile Targets
+
+| Target | Purpose |
+|--------|---------|
+| `make up` / `make down` | Start/stop all Docker services |
+| `make restart` | Restart API container only |
+| `make rebuild` | No-cache rebuild + restart |
+| `make logs` | Follow API logs |
+| `make lint` | ruff check (backend) |
+| `make format` | ruff format (backend) |
+| `make type-check` | pyright (backend) |
+| `make migrate` | Run pending Alembic migrations |
+| `make migrate-create name='...'` | Create new migration |
+| `make health` | Curl API health endpoint |
+
+## Things That Do NOT Exist
+
+- `docker-compose.dev.yml` — does not exist, never existed
+- `memory-dev` VM — no separate dev VM
+- `backend/manage.py` — this is not Django
+- `npm start` in frontend — Next.js dev server runs inside Docker via `kagura-web` container

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Comment `/review` on the PR to run AI review + quality checks via GitHub Actions
 - [CONTRIBUTING.md](CONTRIBUTING.md) — Contribution guide, code style, testing
 - [SECURITY.md](SECURITY.md) — Vulnerability reporting, security design
 - `.claude/rules/` — Coding standards (auto-loaded by file path)
+- `.claude/rules/dev-environment.md` — Docker, test commands, Python env, Makefile targets (auto-loaded)
 - `.claude/rules/development-workflow.md` — Development flow, commit discipline, PR rules (auto-loaded)
 - `.claude/commands/` — Project-specific slash commands (`/test-unit`, `/test-e2e`, `/quality`, `/self-review`, `/issue-start`, `/self-maint`, `/api-docs-audit`, `/workflow`, `/release`, `/docker`, `/admin`)
 - `.claude-plugin/` + `claude-skills/` — Kagura Memory Cloud plugin (marketplace-compatible)

--- a/claude-skills/guide.md
+++ b/claude-skills/guide.md
@@ -107,3 +107,32 @@ Merge this into your existing `hooks` object if you already have other hooks def
 | `remember` | Save new knowledge |
 | `guide` | This guide |
 | `smoke-test` | Verify all MCP tools work |
+
+### 6. Install in another project / machine
+
+If you're setting up Kagura Memory Cloud plugin in a new project or on another machine:
+
+**Option A: Marketplace install (recommended)**
+
+Run `/install-plugin` in Claude Code and search for `kagura-memory`, or install directly:
+
+```bash
+claude /install-plugin kagura-memory-cloud
+```
+
+After install, the plugin skills (`/kagura-memory:*`) become available. Proceed to Step 2 above to configure the MCP server connection.
+
+**Option B: Local install (from this repository)**
+
+If you have the `memory-cloud` repo cloned locally:
+
+```bash
+claude /install-plugin /path/to/memory-cloud
+```
+
+This installs the plugin from `.claude-plugin/plugin.json` and `claude-skills/` in the repo.
+
+**After either install:**
+- Plugin skills are available immediately after restart
+- MCP server connection still needs to be configured (Step 2) — the plugin provides skills, not the server connection
+- Each project needs its own `.mcp.json` with workspace-specific credentials

--- a/claude-skills/session-start.md
+++ b/claude-skills/session-start.md
@@ -43,6 +43,10 @@ recall(context_id=..., query="session summary progress decision", k=5, filters={
 recall(context_id=..., query="blocker issue TODO pending", k=5, filters={"created_after": "{7_days_ago_ISO8601}"})
 ```
 
+```
+recall(context_id=..., query="dev environment troubleshooting workaround", k=3, filters={"type": "troubleshooting", "tags": ["dev-environment"]})
+```
+
 ### 5. Check related GitHub issues
 
 If issue numbers appear in the branch name, recent commits, or recalled memories:

--- a/claude-skills/session-summary.md
+++ b/claude-skills/session-summary.md
@@ -55,6 +55,7 @@ For each item, use `remember` with:
 - **Separate concerns** — one memory per decision/pattern, not one giant dump
 - **Skip ephemeral details** — don't save "ran make lint", do save "lint requires ruff check from project root"
 - **Include rejected approaches** — knowing what NOT to do is as valuable as what to do
+- **Save dev-env traps** — if you hit a dev environment gotcha (wrong file path, missing env var, non-existent compose file, etc.), save it as `type="troubleshooting"` with `tags=["dev-environment"]` so future sessions can avoid the same mistake
 
 ### 6. Report
 


### PR DESCRIPTION
## Summary
- Add "Install in another project / machine" section to `/kagura-memory:guide` skill (marketplace + local install paths) — Closes #208
- Create `.claude/rules/dev-environment.md` as single source of truth for Docker compose, test commands, Python env, Makefile targets, and things that don't exist — Closes #209
- Wire `session-start` to recall dev-env troubleshooting memories and `session-summary` to save dev-env traps

## Test plan
- [ ] `/kagura-memory:guide` renders correctly with new Step 6
- [ ] `.claude/rules/dev-environment.md` auto-loads on relevant paths
- [ ] `/kagura-memory:session-start` includes troubleshooting recall query
- [ ] `/kagura-memory:session-summary` guidelines include dev-env trap saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)