### PR TITLE
feat(infra): blue-green deploy for zero-downtime API container restart (#239)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -541,46 +541,53 @@ async def readiness():
     Note: Uses _get_session_factory() directly (not Depends(get_db)) because
     this is a standalone probe, not a typical route handler.
     """
-    checks: dict[str, str] = {}
 
-    # PostgreSQL — timeout wraps entire session lifecycle
-    try:
-        from sqlalchemy import text
+    async def _check_postgres() -> str:
+        try:
+            from sqlalchemy import text
 
-        from db.base import _get_session_factory
+            from db.base import _get_session_factory
 
-        async def _check_pg() -> None:
             async with _get_session_factory()() as session:
                 await session.execute(text("SELECT 1"))
+            return "ok"
+        except Exception as exc:
+            logger.warning("readiness_check_failed", backend="postgres", error=str(exc))
+            return "error"
 
-        await asyncio.wait_for(_check_pg(), timeout=3.0)
-        checks["postgres"] = "ok"
-    except Exception as exc:
-        logger.warning("readiness_check_failed", backend="postgres", error=str(exc))
-        checks["postgres"] = "error"
+    async def _check_qdrant() -> str:
+        try:
+            from db.qdrant import get_qdrant_client
 
-    # Qdrant — reuse singleton client from db.qdrant
+            qdrant = get_qdrant_client()
+            await qdrant.get_collections()
+            return "ok"
+        except Exception as exc:
+            logger.warning("readiness_check_failed", backend="qdrant", error=str(exc))
+            return "error"
+
+    async def _check_redis() -> str:
+        try:
+            from db.redis import get_redis_client
+
+            redis = get_redis_client()
+            await redis.ping()
+            return "ok"
+        except Exception as exc:
+            logger.warning("readiness_check_failed", backend="redis", error=str(exc))
+            return "error"
+
+    # Run all checks concurrently with a single 3s budget
     try:
-        from db.qdrant import get_qdrant_client
+        pg, qd, rd = await asyncio.wait_for(
+            asyncio.gather(_check_postgres(), _check_qdrant(), _check_redis()),
+            timeout=3.0,
+        )
+    except TimeoutError:
+        logger.warning("readiness_check_timeout", timeout=3.0)
+        pg, qd, rd = "error", "error", "error"
 
-        qdrant = get_qdrant_client()
-        await asyncio.wait_for(qdrant.get_collections(), timeout=3.0)
-        checks["qdrant"] = "ok"
-    except Exception as exc:
-        logger.warning("readiness_check_failed", backend="qdrant", error=str(exc))
-        checks["qdrant"] = "error"
-
-    # Redis
-    try:
-        from db.redis import get_redis_client
-
-        redis = get_redis_client()
-        await asyncio.wait_for(redis.ping(), timeout=3.0)
-        checks["redis"] = "ok"
-    except Exception as exc:
-        logger.warning("readiness_check_failed", backend="redis", error=str(exc))
-        checks["redis"] = "error"
-
+    checks = {"postgres": pg, "qdrant": qd, "redis": rd}
     all_ok = all(v == "ok" for v in checks.values())
     status_code = 200 if all_ok else 503
     return JSONResponse(

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -3,6 +3,7 @@
 Based on: kagura-ai/src/kagura/api/server.py
 """
 
+import asyncio
 import sys
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -540,8 +541,6 @@ async def readiness():
     Note: Uses _get_session_factory() directly (not Depends(get_db)) because
     this is a standalone probe, not a typical route handler.
     """
-    import asyncio
-
     checks: dict[str, str] = {}
 
     # PostgreSQL — timeout wraps entire session lifecycle
@@ -556,7 +555,8 @@ async def readiness():
 
         await asyncio.wait_for(_check_pg(), timeout=3.0)
         checks["postgres"] = "ok"
-    except Exception:
+    except Exception as exc:
+        logger.warning("readiness_check_failed", backend="postgres", error=str(exc))
         checks["postgres"] = "error"
 
     # Qdrant — reuse singleton client from db.qdrant
@@ -566,7 +566,8 @@ async def readiness():
         qdrant = get_qdrant_client()
         await asyncio.wait_for(qdrant.get_collections(), timeout=3.0)
         checks["qdrant"] = "ok"
-    except Exception:
+    except Exception as exc:
+        logger.warning("readiness_check_failed", backend="qdrant", error=str(exc))
         checks["qdrant"] = "error"
 
     # Redis
@@ -576,7 +577,8 @@ async def readiness():
         redis = get_redis_client()
         await asyncio.wait_for(redis.ping(), timeout=3.0)
         checks["redis"] = "ok"
-    except Exception:
+    except Exception as exc:
+        logger.warning("readiness_check_failed", backend="redis", error=str(exc))
         checks["redis"] = "error"
 
     all_ok = all(v == "ok" for v in checks.values())

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -525,8 +525,66 @@ async def root():
 
 @app.get("/health")
 async def health():
-    """Health check endpoint."""
+    """Health check endpoint (liveness probe — always fast)."""
     return {"status": "ok"}
+
+
+@app.get("/readiness")
+async def readiness():
+    """Readiness probe for blue-green deploy.
+
+    Checks PostgreSQL, Qdrant, and Redis connectivity with tight timeouts.
+    Returns 200 only when all backends are reachable.
+    Returns 503 if any backend is unavailable.
+
+    Note: Uses _get_session_factory() directly (not Depends(get_db)) because
+    this is a standalone probe, not a typical route handler.
+    """
+    import asyncio
+
+    checks: dict[str, str] = {}
+
+    # PostgreSQL — timeout wraps entire session lifecycle
+    try:
+        from sqlalchemy import text
+
+        from db.base import _get_session_factory
+
+        async def _check_pg() -> None:
+            async with _get_session_factory()() as session:
+                await session.execute(text("SELECT 1"))
+
+        await asyncio.wait_for(_check_pg(), timeout=3.0)
+        checks["postgres"] = "ok"
+    except Exception:
+        checks["postgres"] = "error"
+
+    # Qdrant — reuse singleton client from db.qdrant
+    try:
+        from db.qdrant import get_qdrant_client
+
+        qdrant = get_qdrant_client()
+        await asyncio.wait_for(qdrant.get_collections(), timeout=3.0)
+        checks["qdrant"] = "ok"
+    except Exception:
+        checks["qdrant"] = "error"
+
+    # Redis
+    try:
+        from db.redis import get_redis_client
+
+        redis = get_redis_client()
+        await asyncio.wait_for(redis.ping(), timeout=3.0)
+        checks["redis"] = "ok"
+    except Exception:
+        checks["redis"] = "error"
+
+    all_ok = all(v == "ok" for v in checks.values())
+    status_code = 200 if all_ok else 503
+    return JSONResponse(
+        content={"status": "ready" if all_ok else "not_ready", "checks": checks},
+        status_code=status_code,
+    )
 
 
 if __name__ == "__main__":

--- a/backend/tests/smoke/test_health.py
+++ b/backend/tests/smoke/test_health.py
@@ -4,6 +4,8 @@ Verifies that basic endpoints respond correctly after deployment.
 No authentication required.
 """
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -68,20 +70,66 @@ class TestHealthEndpoints:
 
 
 class TestReadinessEndpoint:
-    """Test /readiness probe for blue-green deploy (Issue #239)."""
+    """Test /readiness probe for blue-green deploy (Issue #239).
 
-    def test_readiness_returns_503_when_backends_unavailable(self, client):
-        """GET /readiness returns 503 when backends are not reachable.
+    Uses mocks to make tests deterministic regardless of whether
+    backends are actually running in the test environment.
+    """
 
-        In the test environment DB/Qdrant/Redis are not running,
-        so all checks should fail and return 503.
-        """
-        response = client.get("/readiness")
+    def _mock_all_ok(self):
+        """Patch all backends to succeed."""
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=False)
+        mock_session.execute = AsyncMock()
+
+        mock_factory = MagicMock(return_value=MagicMock(return_value=mock_session))
+        mock_qdrant = MagicMock()
+        mock_qdrant.get_collections = AsyncMock()
+        mock_redis = MagicMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+
+        return (
+            patch("db.base._get_session_factory", mock_factory),
+            patch("db.qdrant.get_qdrant_client", return_value=mock_qdrant),
+            patch("db.redis.get_redis_client", return_value=mock_redis),
+        )
+
+    def _mock_partial_failure(self):
+        """Patch postgres to fail, others succeed."""
+        mock_factory = MagicMock(side_effect=ConnectionError("pg down"))
+        mock_qdrant = MagicMock()
+        mock_qdrant.get_collections = AsyncMock()
+        mock_redis = MagicMock()
+        mock_redis.ping = AsyncMock(return_value=True)
+
+        return (
+            patch("db.base._get_session_factory", mock_factory),
+            patch("db.qdrant.get_qdrant_client", return_value=mock_qdrant),
+            patch("db.redis.get_redis_client", return_value=mock_redis),
+        )
+
+    def test_readiness_all_ok(self, client):
+        """GET /readiness returns 200 when all backends are reachable."""
+        p1, p2, p3 = self._mock_all_ok()
+        with p1, p2, p3:
+            response = client.get("/readiness")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ready"
+        assert data["checks"] == {"postgres": "ok", "qdrant": "ok", "redis": "ok"}
+
+    def test_readiness_partial_failure(self, client):
+        """GET /readiness returns 503 when any backend is down."""
+        p1, p2, p3 = self._mock_partial_failure()
+        with p1, p2, p3:
+            response = client.get("/readiness")
         assert response.status_code == 503
         data = response.json()
         assert data["status"] == "not_ready"
-        assert "checks" in data
-        assert set(data["checks"].keys()) == {"postgres", "qdrant", "redis"}
+        assert data["checks"]["postgres"] == "error"
+        assert data["checks"]["qdrant"] == "ok"
+        assert data["checks"]["redis"] == "ok"
 
     def test_readiness_response_shape(self, client):
         """GET /readiness always returns the expected JSON structure."""

--- a/backend/tests/smoke/test_health.py
+++ b/backend/tests/smoke/test_health.py
@@ -65,3 +65,31 @@ class TestHealthEndpoints:
         """GET /api/v1/system/info returns 200."""
         response = client.get("/api/v1/system/info")
         assert response.status_code in (200, 401, 403)
+
+
+class TestReadinessEndpoint:
+    """Test /readiness probe for blue-green deploy (Issue #239)."""
+
+    def test_readiness_returns_503_when_backends_unavailable(self, client):
+        """GET /readiness returns 503 when backends are not reachable.
+
+        In the test environment DB/Qdrant/Redis are not running,
+        so all checks should fail and return 503.
+        """
+        response = client.get("/readiness")
+        assert response.status_code == 503
+        data = response.json()
+        assert data["status"] == "not_ready"
+        assert "checks" in data
+        assert set(data["checks"].keys()) == {"postgres", "qdrant", "redis"}
+
+    def test_readiness_response_shape(self, client):
+        """GET /readiness always returns the expected JSON structure."""
+        response = client.get("/readiness")
+        data = response.json()
+        assert "status" in data
+        assert data["status"] in ("ready", "not_ready")
+        assert "checks" in data
+        for backend in ("postgres", "qdrant", "redis"):
+            assert backend in data["checks"]
+            assert data["checks"][backend] in ("ok", "error")

--- a/terraform/single-server/Caddyfile
+++ b/terraform/single-server/Caddyfile
@@ -37,9 +37,8 @@ memory.kagura-ai.com {
 		reverse_proxy api-blue:8080
 	}
 
-	handle /readiness {
-		reverse_proxy api-blue:8080
-	}
+	# /readiness is intentionally NOT exposed through Caddy.
+	# deploy.sh probes it from inside the container via `docker compose exec`.
 
 	handle /docs* {
 		reverse_proxy api-blue:8080

--- a/terraform/single-server/Caddyfile.tpl
+++ b/terraform/single-server/Caddyfile.tpl
@@ -1,11 +1,22 @@
 # =============================================================================
-# Kagura Memory Cloud — Caddy reverse proxy (production)
+# Kagura Memory Cloud — Caddy reverse proxy (production, blue-green template)
 # =============================================================================
-# GENERATED from Caddyfile.tpl by scripts/deploy.sh — do not edit directly.
-# To make permanent changes, edit Caddyfile.tpl instead.
+# This is a TEMPLATE. Do not edit directly.
+# scripts/deploy.sh generates Caddyfile from this template via envsubst.
 #
-# This default targets api-blue. scripts/deploy.sh regenerates this file
-# on each deploy to point at the active color.
+# Placeholder:
+#   ${API_UPSTREAM} — replaced with "api-blue" or "api-green" at deploy time
+#
+# TLS is terminated here using a Cloudflare Origin CA certificate. Cloudflare
+# sits in front in "Full (strict)" mode, so client → Cloudflare and
+# Cloudflare → Caddy are both TLS, but the origin cert doesn't need to be
+# publicly trusted — only trusted by Cloudflare, which Cloudflare Origin CA
+# certs are by construction.
+#
+# Place the cert and key at:
+#   /etc/caddy/origin-ca/cert.pem
+#   /etc/caddy/origin-ca/key.pem
+# (These are mounted into the caddy container from the host.)
 # =============================================================================
 
 {
@@ -19,8 +30,8 @@
 	}
 }
 
-# Replace memory.kagura-ai.com with your domain. This file is deployed as-is
-# to the VM, so the operator edits it in place or templates it before scp.
+# Replace memory.kagura-ai.com with your domain in this template file.
+# scripts/deploy.sh generates Caddyfile from this via envsubst.
 memory.kagura-ai.com {
 	tls /etc/caddy/origin-ca/cert.pem /etc/caddy/origin-ca/key.pem
 
@@ -30,31 +41,31 @@ memory.kagura-ai.com {
 	# Backend API (FastAPI on :8080) — blue-green upstream
 	# -------------------------------------------------------------------------
 	handle /api/* {
-		reverse_proxy api-blue:8080
+		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
 	handle /health {
-		reverse_proxy api-blue:8080
+		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
 	handle /readiness {
-		reverse_proxy api-blue:8080
+		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
 	handle /docs* {
-		reverse_proxy api-blue:8080
+		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
 	handle /openapi.json {
-		reverse_proxy api-blue:8080
+		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
 	handle /.well-known/* {
-		reverse_proxy api-blue:8080
+		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
 	handle /oauth/* {
-		reverse_proxy api-blue:8080
+		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
 	# -------------------------------------------------------------------------
@@ -63,7 +74,7 @@ memory.kagura-ai.com {
 	#   and the client never sees events until the stream closes.
 	# -------------------------------------------------------------------------
 	handle /mcp* {
-		reverse_proxy api-blue:8080 {
+		reverse_proxy ${API_UPSTREAM}:8080 {
 			flush_interval -1
 			transport http {
 				read_timeout  24h

--- a/terraform/single-server/Caddyfile.tpl
+++ b/terraform/single-server/Caddyfile.tpl
@@ -48,9 +48,8 @@ memory.kagura-ai.com {
 		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
-	handle /readiness {
-		reverse_proxy ${API_UPSTREAM}:8080
-	}
+	# /readiness is intentionally NOT exposed through Caddy.
+	# deploy.sh probes it from inside the container via `docker compose exec`.
 
 	handle /docs* {
 		reverse_proxy ${API_UPSTREAM}:8080

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -208,10 +208,12 @@ vim .env.prod      # set KAGURA_DOMAIN, DB_PASSWORD, QDRANT_API_KEY,
                    # API_KEY_SECRET, JWT_SECRET, Google OAuth client, etc.
 ```
 
-Start everything:
+Start everything (initial setup starts both API colors; Caddy defaults to
+`api-blue`):
 
 ```bash
-docker compose -f docker-compose.prod.yml up -d --build
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d --build
+echo "blue" > /opt/kagura-memory/active-color
 ```
 
 The first build takes several minutes (backend + frontend images).
@@ -226,10 +228,11 @@ sudo systemctl enable kagura-memory
 ## Step 6 — Initialize the database and create the first admin
 
 ```bash
-docker compose -f docker-compose.prod.yml exec api alembic upgrade head
+docker compose -f docker-compose.prod.yml --env-file .env.prod \
+  exec api-blue alembic upgrade head
 
-docker compose -f docker-compose.prod.yml exec api \
-  python -m src.cli.create_admin
+docker compose -f docker-compose.prod.yml --env-file .env.prod \
+  exec api-blue python -m src.cli.create_admin
 ```
 
 ## Step 7 — Verify
@@ -295,17 +298,56 @@ gcloud compute disks snapshot kagura-memory-vm \
   --snapshot-names "kagura-memory-$(date +%Y%m%d-%H%M)"
 ```
 
-### Update to a new release
+### Update to a new release (zero-downtime)
+
+The stack uses **blue-green deploy** for the API container. Caddy always
+routes to one color; the deploy script builds the other, waits for it to
+be ready, switches Caddy, then drains and stops the old color.
 
 ```bash
 # On the VM
 cd /opt/kagura-memory/src
-git pull
+git fetch && git reset --hard origin/main
+
 cd terraform/single-server
-docker compose -f docker-compose.prod.yml build
-docker compose -f docker-compose.prod.yml up -d
-docker compose -f docker-compose.prod.yml exec api alembic upgrade head
+./scripts/deploy.sh           # zero-downtime blue-green deploy
 ```
+
+The script handles building, migrations, readiness checks, Caddy reload,
+and draining automatically. Use `./scripts/deploy.sh --status` to see
+which color is active, or `./scripts/deploy.sh --rollback` to switch back.
+
+Tunable environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `READINESS_TIMEOUT` | 60 | Seconds to wait for `/readiness` |
+| `DRAIN_TIMEOUT` | 30 | Seconds to drain old container |
+
+### Migration discipline
+
+Database migrations run **before** the Caddy switch so both old and new
+containers can coexist on the same schema:
+
+- **Forward-compatible** (additive columns, new tables): always safe.
+  `deploy.sh` runs `alembic upgrade head` on the active container before
+  starting the new color.
+- **Backward-incompatible** (drop columns, type changes): require a
+  **two-phase deploy**:
+  1. First deploy: add new columns/tables, update code to use both old and new
+  2. Second deploy: remove old columns after the previous deploy is verified
+
+### Rollback
+
+If the new color misbehaves after switching:
+
+```bash
+./scripts/deploy.sh --rollback
+```
+
+This flips Caddy back to the previous color and reloads. The old container
+must still be running (it stays up for `DRAIN_TIMEOUT` seconds after
+deploy, but `restart: always` brings it back if needed).
 
 ## Teardown
 

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -330,8 +330,8 @@ Database migrations run **before** the Caddy switch so both old and new
 containers can coexist on the same schema:
 
 - **Forward-compatible** (additive columns, new tables): always safe.
-  `deploy.sh` runs `alembic upgrade head` on the active container before
-  starting the new color.
+  `deploy.sh` starts the new container, waits for readiness, then runs
+  `alembic upgrade head` on the new container before switching Caddy.
 - **Backward-incompatible** (drop columns, type changes): require a
   **two-phase deploy**:
   1. First deploy: add new columns/tables, update code to use both old and new

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -345,9 +345,8 @@ If the new color misbehaves after switching:
 ./scripts/deploy.sh --rollback
 ```
 
-This flips Caddy back to the previous color and reloads. The old container
-must still be running (it stays up for `DRAIN_TIMEOUT` seconds after
-deploy, but `restart: always` brings it back if needed).
+This starts the previous color if it's not running, waits for readiness,
+then flips Caddy back and reloads. Safe to run at any time after a deploy.
 
 ## Teardown
 

--- a/terraform/single-server/docker-compose.ollama.yml
+++ b/terraform/single-server/docker-compose.ollama.yml
@@ -31,7 +31,21 @@ services:
       retries: 3
       start_period: 60s
 
-  api:
+  api-blue:
+    environment:
+      EMBEDDING_PROVIDER: ollama
+      OLLAMA_BASE_URL: http://ollama:11434
+    depends_on:
+      postgres:
+        condition: service_healthy
+      qdrant:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      ollama:
+        condition: service_healthy
+
+  api-green:
     environment:
       EMBEDDING_PROVIDER: ollama
       OLLAMA_BASE_URL: http://ollama:11434

--- a/terraform/single-server/docker-compose.prod.yml
+++ b/terraform/single-server/docker-compose.prod.yml
@@ -1,12 +1,15 @@
 # =============================================================================
-# Kagura Memory Cloud — production docker-compose
+# Kagura Memory Cloud — production docker-compose (blue-green)
 # =============================================================================
-# Single-host production stack. All services share a default docker network;
+# Single-host production stack with blue-green API deploy.
 # Caddy is the only container exposed to the outside world.
 #
 # Usage (on the VM):
 #   cp .env.prod.example .env.prod      # then edit secrets
-#   docker compose -f docker-compose.prod.yml up -d
+#   docker compose -f docker-compose.prod.yml --env-file .env.prod up -d
+#
+# Deploy (zero-downtime):
+#   ./scripts/deploy.sh
 #
 # Add Ollama (local embeddings) as an override:
 #   docker compose -f docker-compose.prod.yml -f docker-compose.ollama.yml up -d
@@ -15,6 +18,38 @@
 # the same repo. On the VM, `git clone` the repo next to this file, or
 # `scp -r` the source, and point build.context at the right path.
 # =============================================================================
+
+# Shared API config — referenced by api-blue and api-green via YAML anchor.
+x-api-common: &api-common
+  build:
+    context: ../../backend
+    dockerfile: Dockerfile
+  restart: always
+  env_file:
+    - .env.prod
+  environment:
+    DATABASE_URL: postgresql+asyncpg://kagura:${DB_PASSWORD}@postgres:5432/kagura
+    QDRANT_URL: http://qdrant:6333
+    QDRANT_API_KEY: ${QDRANT_API_KEY}
+    REDIS_URL: redis://redis:6379
+    API_HOST: 0.0.0.0
+    API_PORT: 8080
+    ENVIRONMENT: production
+    PYTHONUNBUFFERED: "1"
+  depends_on:
+    postgres:
+      condition: service_healthy
+    qdrant:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "curl", "-sf", "http://localhost:8080/readiness"]
+    interval: 10s
+    timeout: 5s
+    retries: 3
+    start_period: 15s
+  command: uvicorn src.api.main:app --host 0.0.0.0 --port 8080 --log-level info
 
 services:
   # ==========================================================================
@@ -67,34 +102,20 @@ services:
       retries: 5
 
   # ==========================================================================
-  # Application
+  # Application — blue-green API (Issue #239)
+  # ==========================================================================
+  # Two identical API services share the same image, env, and dependencies.
+  # Only one receives traffic at a time (controlled by Caddy upstream).
+  # scripts/deploy.sh automates the switchover.
   # ==========================================================================
 
-  api:
-    build:
-      context: ../../backend
-      dockerfile: Dockerfile
-    container_name: kagura-api
-    restart: always
-    env_file:
-      - .env.prod
-    environment:
-      DATABASE_URL: postgresql+asyncpg://kagura:${DB_PASSWORD}@postgres:5432/kagura
-      QDRANT_URL: http://qdrant:6333
-      QDRANT_API_KEY: ${QDRANT_API_KEY}
-      REDIS_URL: redis://redis:6379
-      API_HOST: 0.0.0.0
-      API_PORT: 8080
-      ENVIRONMENT: production
-      PYTHONUNBUFFERED: "1"
-    depends_on:
-      postgres:
-        condition: service_healthy
-      qdrant:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    command: uvicorn src.api.main:app --host 0.0.0.0 --port 8080 --log-level info
+  api-blue:
+    <<: *api-common
+    container_name: kagura-api-blue
+
+  api-green:
+    <<: *api-common
+    container_name: kagura-api-green
 
   web:
     build:
@@ -110,8 +131,6 @@ services:
       NEXT_TELEMETRY_DISABLED: "1"
       PORT: "3000"
       HOSTNAME: "0.0.0.0"
-    depends_on:
-      - api
 
   # ==========================================================================
   # Reverse proxy — only service bound to host ports
@@ -129,8 +148,9 @@ services:
       - /var/lib/kagura/origin-ca:/etc/caddy/origin-ca:ro
       - caddy_data:/data
       - caddy_config:/config
+    # No hard dependency on api-blue/api-green: during normal operation only
+    # one color is active. Caddy handles upstream unavailability gracefully.
     depends_on:
-      - api
       - web
 
 volumes:

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -186,12 +186,17 @@ generate_caddyfile() {
         error "Caddyfile.tpl not found at $CADDYFILE_TPL"
     fi
 
-    # envsubst with explicit var list — only ${API_UPSTREAM} is replaced
+    # envsubst with explicit var list — only ${API_UPSTREAM} is replaced.
+    # Use tmp + cp (not mv) because Caddyfile is bind-mounted as a single
+    # file into the caddy container. mv changes the inode, so the container
+    # would keep seeing the old file. cp overwrites in-place, preserving
+    # the inode that Docker tracks.
     if ! API_UPSTREAM="$upstream" envsubst '${API_UPSTREAM}' < "$CADDYFILE_TPL" > "$CADDYFILE.tmp"; then
         rm -f "$CADDYFILE.tmp"
         error "envsubst failed — Caddyfile not updated"
     fi
-    mv "$CADDYFILE.tmp" "$CADDYFILE"
+    cp "$CADDYFILE.tmp" "$CADDYFILE"
+    rm -f "$CADDYFILE.tmp"
     log "  Caddyfile generated: upstream=$upstream"
 }
 

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -107,8 +107,10 @@ cmd_deploy() {
     dc build "api-${inactive}"
 
     # Step 2: Start the inactive color (uses new image)
+    # Re-enable restart policy in case it was disabled by a previous deploy.
     log "Step 2/7: Starting api-${inactive}..."
     dc up -d "api-${inactive}"
+    docker update --restart=always "kagura-api-${inactive}" 2>/dev/null || true
 
     # Step 3: Wait for readiness (DB + Qdrant + Redis all reachable)
     log "Step 3/7: Waiting for api-${inactive} readiness (timeout: ${READINESS_TIMEOUT}s)..."
@@ -130,10 +132,13 @@ cmd_deploy() {
     reload_caddy
 
     # Step 7: Drain and stop old container
+    # Disable restart policy first — otherwise `restart: always` revives
+    # the container immediately after stop.
     log "Step 7/7: Draining api-${active} for ${DRAIN_TIMEOUT}s..."
     sleep "$DRAIN_TIMEOUT"
+    docker update --restart=no "kagura-api-${active}" 2>/dev/null || true
     dc stop "api-${active}" || true
-    log "api-${active} stopped."
+    log "api-${active} stopped (restart policy disabled)."
 
     log "=== DEPLOY COMPLETE ==="
     log "Active: $inactive"
@@ -205,6 +210,9 @@ command -v envsubst > /dev/null 2>&1 || error "envsubst not found. Install: apt-
 # Validate timeout values are integers
 [[ "$READINESS_TIMEOUT" =~ ^[0-9]+$ ]] || error "READINESS_TIMEOUT must be an integer (got: $READINESS_TIMEOUT)"
 [[ "$DRAIN_TIMEOUT" =~ ^[0-9]+$ ]] || error "DRAIN_TIMEOUT must be an integer (got: $DRAIN_TIMEOUT)"
+
+# Ensure marker directory exists
+mkdir -p "$(dirname "$MARKER_FILE")"
 
 case "${1:-}" in
     --rollback)

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -79,10 +79,13 @@ cmd_rollback() {
     active="$(get_active_color)"
     inactive="$(get_inactive_color)"
 
-    # Check that the previous color's container is still running
+    # Ensure the previous color's container is running
     if ! is_container_running "$inactive"; then
-        error "api-${inactive} is not running — cannot rollback. Start it first:
-  docker compose -f $COMPOSE_FILE --env-file $ENV_FILE up -d api-${inactive}"
+        log "api-${inactive} is not running — starting it for rollback..."
+        docker update --restart=always "kagura-api-${inactive}" 2>/dev/null || true
+        dc up -d "api-${inactive}"
+        log "Waiting for api-${inactive} readiness..."
+        wait_for_readiness "$inactive"
     fi
 
     # Write marker BEFORE switching Caddy (atomic: same filesystem mv)

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Kagura Memory Cloud — Blue-Green Deploy Script (Issue #239)
+# =============================================================================
+# Zero-downtime deployment for the API container. Switches between api-blue
+# and api-green while keeping Caddy routing live.
+#
+# Usage:
+#   ./scripts/deploy.sh              # normal deploy
+#   ./scripts/deploy.sh --rollback   # switch back to previous color
+#   ./scripts/deploy.sh --status     # show current active color
+#
+# Requires: docker compose, curl, envsubst (gettext-base)
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$PROJECT_DIR/docker-compose.prod.yml"
+CADDYFILE_TPL="$PROJECT_DIR/Caddyfile.tpl"
+CADDYFILE="$PROJECT_DIR/Caddyfile"
+MARKER_FILE="/opt/kagura-memory/active-color"
+ENV_FILE="$PROJECT_DIR/.env.prod"
+
+READINESS_TIMEOUT="${READINESS_TIMEOUT:-60}"   # seconds to wait for /readiness
+READINESS_INTERVAL=2                            # seconds between checks
+DRAIN_TIMEOUT="${DRAIN_TIMEOUT:-30}"            # seconds to drain old container
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+log()   { echo "[deploy] $(date -u +%H:%M:%S) $*"; }
+error() { echo "[deploy] ERROR: $*" >&2; exit 1; }
+
+dc() { docker compose -f "$COMPOSE_FILE" --env-file "$ENV_FILE" "$@"; }
+
+get_active_color() {
+    local color
+    color="$(cat "$MARKER_FILE" 2>/dev/null || echo "blue")"
+    # Validate — must be exactly "blue" or "green"
+    if [ "$color" != "blue" ] && [ "$color" != "green" ]; then
+        error "Marker file $MARKER_FILE contains invalid value: '$color'. Expected 'blue' or 'green'."
+    fi
+    echo "$color"
+}
+
+get_inactive_color() {
+    local active
+    active="$(get_active_color)"
+    if [ "$active" = "blue" ]; then echo "green"; else echo "blue"; fi
+}
+
+is_container_running() {
+    local container="kagura-api-$1"
+    docker inspect --format '{{.State.Running}}' "$container" 2>/dev/null | grep -q "true"
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+cmd_status() {
+    local active
+    active="$(get_active_color)"
+    log "Active color: $active"
+    log "Marker file:  $MARKER_FILE"
+
+    # Show container states
+    dc ps --format "table {{.Name}}\t{{.Status}}" 2>/dev/null \
+        | grep -E "kagura-api|NAME" || true
+}
+
+cmd_rollback() {
+    log "=== ROLLBACK ==="
+    local active inactive
+    active="$(get_active_color)"
+    inactive="$(get_inactive_color)"
+
+    # Check that the previous color's container is still running
+    if ! is_container_running "$inactive"; then
+        error "api-${inactive} is not running — cannot rollback. Start it first:
+  docker compose -f $COMPOSE_FILE --env-file $ENV_FILE up -d api-${inactive}"
+    fi
+
+    # Write marker BEFORE switching Caddy (atomic: same filesystem mv)
+    log "Switching Caddy: api-${active} -> api-${inactive}"
+    echo "$inactive" > "${MARKER_FILE}.tmp"
+    mv "${MARKER_FILE}.tmp" "$MARKER_FILE"
+    generate_caddyfile "api-${inactive}"
+    reload_caddy
+
+    log "Rollback complete. Active: $inactive"
+}
+
+cmd_deploy() {
+    log "=== BLUE-GREEN DEPLOY ==="
+    local active inactive
+    active="$(get_active_color)"
+    inactive="$(get_inactive_color)"
+    log "Current active: $active — deploying to: $inactive"
+
+    # Step 1: Build new image
+    log "Step 1/7: Building api-${inactive} image..."
+    dc build "api-${inactive}"
+
+    # Step 2: Start the inactive color (uses new image)
+    log "Step 2/7: Starting api-${inactive}..."
+    dc up -d "api-${inactive}"
+
+    # Step 3: Wait for readiness (DB + Qdrant + Redis all reachable)
+    log "Step 3/7: Waiting for api-${inactive} readiness (timeout: ${READINESS_TIMEOUT}s)..."
+    wait_for_readiness "$inactive"
+
+    # Step 4: Run Alembic migrations on the NEW container
+    # Forward-compatible by convention: both old and new code work with new schema.
+    log "Step 4/7: Running database migrations on api-${inactive}..."
+    dc exec -T "api-${inactive}" alembic upgrade head
+
+    # Step 5: Write marker BEFORE switching Caddy (crash-safe ordering)
+    log "Step 5/7: Updating marker -> ${inactive}"
+    echo "$inactive" > "${MARKER_FILE}.tmp"
+    mv "${MARKER_FILE}.tmp" "$MARKER_FILE"
+
+    # Step 6: Switch Caddy upstream
+    log "Step 6/7: Switching Caddy upstream -> api-${inactive}..."
+    generate_caddyfile "api-${inactive}"
+    reload_caddy
+
+    # Step 7: Drain and stop old container
+    log "Step 7/7: Draining api-${active} for ${DRAIN_TIMEOUT}s..."
+    sleep "$DRAIN_TIMEOUT"
+    dc stop "api-${active}" || true
+    log "api-${active} stopped."
+
+    log "=== DEPLOY COMPLETE ==="
+    log "Active: $inactive"
+    log "To rollback: $0 --rollback"
+}
+
+# ---------------------------------------------------------------------------
+# Readiness check
+# ---------------------------------------------------------------------------
+wait_for_readiness() {
+    local color="$1"
+    local start_time=$SECONDS
+
+    while (( SECONDS - start_time < READINESS_TIMEOUT )); do
+        # Fail fast if container has exited
+        if ! is_container_running "$color"; then
+            error "api-${color} has stopped unexpectedly. Check logs:
+  docker compose -f $COMPOSE_FILE --env-file $ENV_FILE logs api-${color}"
+        fi
+
+        # Check readiness endpoint from inside the container
+        if dc exec -T "api-${color}" \
+                curl -sf --max-time 3 http://localhost:8080/readiness > /dev/null 2>&1; then
+            log "  api-${color} is ready ($((SECONDS - start_time))s)"
+            return 0
+        fi
+        sleep "$READINESS_INTERVAL"
+    done
+
+    error "api-${color} did not become ready within ${READINESS_TIMEOUT}s. Aborting.
+  The new container is running but Caddy has NOT been switched.
+  Investigate: docker compose -f $COMPOSE_FILE --env-file $ENV_FILE logs api-${color}"
+}
+
+# ---------------------------------------------------------------------------
+# Caddy config generation
+# ---------------------------------------------------------------------------
+generate_caddyfile() {
+    local upstream="$1"
+
+    if [ ! -f "$CADDYFILE_TPL" ]; then
+        error "Caddyfile.tpl not found at $CADDYFILE_TPL"
+    fi
+
+    # envsubst with explicit var list — only ${API_UPSTREAM} is replaced
+    if ! API_UPSTREAM="$upstream" envsubst '${API_UPSTREAM}' < "$CADDYFILE_TPL" > "$CADDYFILE.tmp"; then
+        rm -f "$CADDYFILE.tmp"
+        error "envsubst failed — Caddyfile not updated"
+    fi
+    mv "$CADDYFILE.tmp" "$CADDYFILE"
+    log "  Caddyfile generated: upstream=$upstream"
+}
+
+reload_caddy() {
+    dc exec -T caddy caddy reload --config /etc/caddy/Caddyfile --force
+    log "  Caddy reloaded"
+}
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+cd "$PROJECT_DIR"
+
+# Validate prerequisites
+command -v envsubst > /dev/null 2>&1 || error "envsubst not found. Install: apt-get install gettext-base"
+[ -f "$COMPOSE_FILE" ] || error "docker-compose.prod.yml not found at $COMPOSE_FILE"
+[ -f "$ENV_FILE" ] || error ".env.prod not found at $ENV_FILE"
+
+# Validate timeout values are integers
+[[ "$READINESS_TIMEOUT" =~ ^[0-9]+$ ]] || error "READINESS_TIMEOUT must be an integer (got: $READINESS_TIMEOUT)"
+[[ "$DRAIN_TIMEOUT" =~ ^[0-9]+$ ]] || error "DRAIN_TIMEOUT must be an integer (got: $DRAIN_TIMEOUT)"
+
+case "${1:-}" in
+    --rollback)
+        cmd_rollback
+        ;;
+    --status)
+        cmd_status
+        ;;
+    --help|-h)
+        echo "Usage: $0 [--rollback|--status|--help]"
+        echo ""
+        echo "  (no args)    Deploy to the inactive color (zero-downtime)"
+        echo "  --rollback   Switch back to the previous color"
+        echo "  --status     Show current active color and container states"
+        echo ""
+        echo "Environment variables:"
+        echo "  READINESS_TIMEOUT  Seconds to wait for /readiness (default: 60)"
+        echo "  DRAIN_TIMEOUT      Seconds to drain old container (default: 30)"
+        ;;
+    "")
+        cmd_deploy
+        ;;
+    *)
+        error "Unknown argument: $1 (try --help)"
+        ;;
+esac


### PR DESCRIPTION
Closes #239

## Summary
- Add `/readiness` endpoint checking DB+Qdrant+Redis with 3s timeouts (liveness/readiness separation)
- Split `api` service into `api-blue`/`api-green` via YAML anchor in `docker-compose.prod.yml`
- Add `Caddyfile.tpl` template with `${API_UPSTREAM}` placeholder, generated by `envsubst` at deploy time
- Add `scripts/deploy.sh` automating the full blue-green sequence: build → start → readiness → migrate → marker → Caddy reload → drain → stop
- Document deploy procedure, migration discipline, and rollback in README

## Implementation notes
- `/readiness` is internal-only (not exposed through Caddy) — deploy script probes via `docker compose exec`
- Marker file (`/opt/kagura-memory/active-color`) written atomically (tmp + mv) before Caddy reload for crash safety
- Old container's `restart: always` policy is disabled before stop to prevent Docker from reviving it
- YAML anchor `x-api-common` eliminates config drift between blue/green services
- Readiness check failures are logged at WARNING level for incident triage

## Pre-PR review summary
- audit: unknown (plugin audit script N/A)
- cso: yellow → fixed (removed public /readiness exposure)
- qa-lead: yellow → fixed (added tests, logging)
- cto: yellow → fixed (restart policy, mkdir guard, README correction)
- gate1: green via /ask (COO)

## Test plan
- [x] `make lint` — all checks passed
- [x] `make test-local` — 1075 passed, 0 new failures
- [x] `bash -n deploy.sh` — syntax OK
- [ ] Manual: deploy on staging VM, verify `curl /health` never 502 during switch
- [ ] Manual: deploy mid-conversation with Claude Code MCP, verify no disconnect

🤖 Generated via /gh-issue-driven:ship