### PR TITLE
refactor(plugin): skills quality pass (#281)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI",

--- a/claude-skills/recall.md
+++ b/claude-skills/recall.md
@@ -18,7 +18,41 @@ If only one context exists, use it. If multiple, pick the one most relevant to t
 
 ### 2. Search
 
-Use `recall` with the resolved context_id, query="$ARGUMENTS", k=10.
+Use `recall` with the resolved context_id:
+
+```
+recall(context_id=..., query="$ARGUMENTS", k=10)
+```
+
+**Search modes** — choose based on the query type:
+- `hybrid` (default): Best for most queries — combines semantic understanding with keyword matching
+- `semantic`: Use when you know the concept but not the exact words (e.g., "how we handled auth token expiry")
+- `keyword`: Use for exact term matching, hiragana queries, or when semantic returns noise
+
+```
+recall(context_id=..., query="$ARGUMENTS", k=10, search_mode="keyword")
+```
+
+**Reranking** — enable for higher-quality results when the user has a reranker configured:
+
+```
+recall(context_id=..., query="$ARGUMENTS", k=10, use_rerank=true)
+```
+
+**Filters** — narrow results by type, tags, importance, or date:
+
+```
+recall(context_id=..., query="...", k=10, filters={"type": "decision"})
+recall(context_id=..., query="...", k=10, filters={"tags": ["python", "fastapi"]})
+recall(context_id=..., query="...", k=10, filters={"importance": {"gte": 0.8}})
+recall(context_id=..., query="...", k=10, filters={"created_after": "2026-01-01T00:00:00Z"})
+```
+
+Filters can be combined:
+
+```
+recall(context_id=..., query="...", k=10, filters={"type": "bug-fix", "tags": ["auth"], "created_after": "2026-03-01T00:00:00Z"})
+```
 
 ### 3. Display results
 
@@ -26,5 +60,13 @@ Show results in a table: memory_id, summary, type, importance, tags.
 
 ### 4. Follow up
 
-- If relevant results found, suggest using `reference` for detailed content on the most relevant match
-- If no results found, suggest broader search terms or different search_mode (keyword, semantic)
+- **Results found** — suggest using `reference` for detailed content on the most relevant match:
+  ```
+  reference(memory_id=<id_from_results>, context_id=...)
+  ```
+- **Zero results** — try these adjustments:
+  1. Shorten or broaden the query (remove specific terms)
+  2. Switch search_mode: try `keyword` if `hybrid` missed, or vice versa
+  3. Remove filters to widen the search
+  4. Try related terms or synonyms
+  5. Check `list_contexts()` — the memory may be in a different context

--- a/claude-skills/remember.md
+++ b/claude-skills/remember.md
@@ -32,6 +32,20 @@ If only one context exists, use it. If multiple, pick the one most relevant to t
 
 Use `remember` with the resolved context_id, parsed summary, content with details, and appropriate type/importance/tags.
 
+Include `context_summary` to explain why this memory matters and how to use it (max 2000 chars). This field helps future recall understand the memory's purpose without reading the full content.
+
+```
+remember(
+  context_id=...,
+  summary="...",
+  content="...",
+  type="decision",
+  importance=0.9,
+  tags=["auth", "architecture"],
+  context_summary="Why this matters and when to reference it."
+)
+```
+
 ### 4. Confirm
 
 Show what was saved: summary, type, importance, tags.

--- a/claude-skills/session-start.md
+++ b/claude-skills/session-start.md
@@ -19,8 +19,10 @@ Use the branch name, recent commits, modified files, and uncommitted changes to 
 
 ### 2. Check open GitHub issues
 
+First verify `gh` is available. If not, skip this step and steps that use `gh` — git state alone is sufficient.
+
 ```bash
-gh issue list --state open --limit 10 --json number,title,milestone --jq '.[] | "#\(.number) [\(.milestone.title // "no milestone")] \(.title)"'
+command -v gh >/dev/null 2>&1 && gh issue list --state open --limit 10 --json number,title,milestone --jq '.[] | "#\(.number) [\(.milestone.title // "no milestone")] \(.title)"' || echo "(gh CLI not available — skipping GitHub issues)"
 ```
 
 ### 3. Identify the working context
@@ -33,7 +35,10 @@ If multiple contexts exist, pick the one most relevant to the current project. I
 
 ### 4. Recall recent memories (last 7 days)
 
-Calculate the date 7 days ago from today and use it as `created_after` filter. Run these in parallel:
+Calculate the date 7 days ago from today and use it as `created_after` filter.
+The 7-day window balances recency with coverage — long enough to span a typical work week including weekends, short enough to avoid stale context drowning out current work.
+
+Run these in parallel:
 
 ```
 recall(context_id=..., query="session summary progress decision", k=5, filters={"created_after": "{7_days_ago_ISO8601}"})
@@ -49,7 +54,7 @@ recall(context_id=..., query="dev environment troubleshooting workaround", k=3, 
 
 ### 5. Check related GitHub issues
 
-If issue numbers appear in the branch name, recent commits, or recalled memories:
+If issue numbers appear in the branch name, recent commits, or recalled memories (and `gh` is available):
 
 ```bash
 gh issue view <number> --json title,state,body,labels

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -2,7 +2,8 @@
 description: Run comprehensive smoke test of all MCP tools via live MCP connection
 ---
 
-Verify every MCP tool works correctly by executing them in sequence against a temporary test context.
+Verify MCP tools work correctly by executing them in sequence against temporary test contexts.
+Tests 21 of 24 tools (excludes 3 sleep tools that require a prior Sleep Maintenance run).
 Use this after deployments, tool description changes, or MCP server updates.
 
 **Prerequisite:** MCP server must be running and connected.
@@ -105,20 +106,40 @@ delete_edge(context_id=..., source_id=<memory_id>, target_id=<memory_id_2>)
 -> Verify: success response (edge deleted)
 ```
 
-### 7. Cleanup
+### 7. Merge & usage tools
+
+Create a second temporary context, then test merge and usage:
 
 ```
-forget(memory_id=..., context_id=...)
--> Verify: success response (memory 1 deleted)
+create_context(name="smoke-test-merge-{unix_timestamp}", description="Merge target for smoke test.")
+-> Save returned context_id as merge_target_id
+
+merge_contexts(source_id=<context_id>, target_id=<merge_target_id>)
+-> Verify: success response with merged memory count
+
+get_usage()
+-> Verify: returns plan, memories.used, contexts.used (no error)
+```
+
+Note: Sleep tools (`get_sleep_history`, `get_sleep_report`, `rollback_sleep_run`) are not tested here because they require a completed Sleep Maintenance run. Verify these manually after a sleep cycle.
+
+### Cleanup
+
+```
+forget(memory_id=..., context_id=<merge_target_id>)
+-> Verify: success response (merged memory deleted from target)
+
+delete_context(context_id=<merge_target_id>)
+-> Verify: success response (merge target deleted)
 
 forget(memory_id=<memory_id_2>, context_id=...)
--> Verify: success response (memory 2 deleted)
+-> Verify: success response (memory 2 deleted from source)
 
 delete_context(context_id=...)
--> Verify: success response (context deleted)
+-> Verify: success response (source context deleted)
 ```
 
-### 7. Report
+### 8. Report
 
 Print a summary table:
 
@@ -143,17 +164,24 @@ Print a summary table:
 | 14 | list_edges | List edges | PASS/FAIL |
 | 15 | update_edge | Update edge weight | PASS/FAIL |
 | 16 | delete_edge | Delete edge | PASS/FAIL |
-| 17 | forget | Delete memory 1 | PASS/FAIL |
-| 18 | forget | Delete memory 2 | PASS/FAIL |
-| 19 | delete_context | Delete test context | PASS/FAIL |
+| 17 | create_context | Create merge target context | PASS/FAIL |
+| 18 | merge_contexts | Merge source into target | PASS/FAIL |
+| 19 | get_usage | Get workspace usage | PASS/FAIL |
+| 20 | forget | Delete merged memory | PASS/FAIL |
+| 21 | delete_context | Delete merge target | PASS/FAIL |
+| 22 | forget | Delete memory 2 | PASS/FAIL |
+| 23 | delete_context | Delete source context | PASS/FAIL |
 
-**Result: N/19 passed**
+**Result: N/23 passed**
 
 Test context: smoke-test-{timestamp} (cleaned up)
+
+Not tested (require prior Sleep Maintenance run):
+- get_sleep_history, get_sleep_report, rollback_sleep_run
 ```
 
 If any step fails:
 - Mark it as FAIL with error message
 - **Continue** with remaining steps where possible (skip dependent steps)
-- Still attempt cleanup (step 6) even if earlier steps failed
+- Still attempt cleanup even if earlier steps failed
 - Show total pass/fail count in summary


### PR DESCRIPTION
## Summary
- **recall.md**: expanded from 31→63 lines — filter examples, search_mode/use_rerank docs, `reference()` call syntax, zero-result guidance
- **remember.md**: documented `context_summary` parameter with usage example
- **smoke-test.md**: fixed duplicate step numbering, added `merge_contexts` + `get_usage` tests (19→23), noted 3 untestable sleep tools
- **session-start.md**: `gh` CLI availability guard, 7-day lookback rationale
- **plugin.json**: version bump `0.1.0` → `0.2.0`

Closes #281

## Test plan
- [ ] `/kagura-memory:smoke-test` passes with updated step numbering
- [ ] `/kagura-memory:recall` shows filter/search_mode guidance
- [ ] `/kagura-memory:session-start` works without `gh` CLI installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)