### PR TITLE
refactor(frontend): expand Tabs primitive — EntityTabs + CategoryTabs (#225)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -25,6 +25,11 @@ paths:
 - Utilities: camelCase (`formatDate.ts`)
 - Types/Interfaces: PascalCase with descriptive names
 
+## Tabs
+- In-page tabs MUST use the Tabs primitive from `@/components/ui/tabs`. Do not build ad-hoc tab UIs.
+- Use `Tabs` (pill style) for facets of one entity (e.g., Overview / Settings of a context).
+- Use `CategoryTabs` (underline style) for independent feature categories grouped under one route (e.g., API Keys / OAuth Apps / Resource Tokens). `CategoryTabsContent` requires a `helpText` string explaining when to use the category.
+
 ## Forbidden
 - No `any` type (use `unknown` or proper types)
 - No `console.log` in committed code (use proper logging)

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,11 +1,31 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from "@/lib/utils/cn"
+import { cn } from "@/lib/utils/cn";
 
-const Tabs = TabsPrimitive.Root
+// ---------------------------------------------------------------------------
+// Entity Tabs (pill style) — facets of one entity
+// ---------------------------------------------------------------------------
+
+/**
+ * Entity-style tabs for switching between facets of a single entity.
+ * Uses a pill/segmented style with a muted background.
+ *
+ * @example
+ * ```tsx
+ * <Tabs defaultValue="overview">
+ *   <TabsList>
+ *     <TabsTrigger value="overview">Overview</TabsTrigger>
+ *     <TabsTrigger value="settings">Settings</TabsTrigger>
+ *   </TabsList>
+ *   <TabsContent value="overview">...</TabsContent>
+ *   <TabsContent value="settings">...</TabsContent>
+ * </Tabs>
+ * ```
+ */
+const Tabs = TabsPrimitive.Root;
 
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
@@ -15,12 +35,12 @@ const TabsList = React.forwardRef<
     ref={ref}
     className={cn(
       "inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground",
-      className
+      className,
     )}
     {...props}
   />
-))
-TabsList.displayName = TabsPrimitive.List.displayName
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
 
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
@@ -30,12 +50,12 @@ const TabsTrigger = React.forwardRef<
     ref={ref}
     className={cn(
       "inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
-      className
+      className,
     )}
     {...props}
   />
-))
-TabsTrigger.displayName = TabsPrimitive.Trigger.displayName
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
@@ -45,11 +65,111 @@ const TabsContent = React.forwardRef<
     ref={ref}
     className={cn(
       "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-      className
+      className,
     )}
     {...props}
   />
-))
-TabsContent.displayName = TabsPrimitive.Content.displayName
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
 
-export { Tabs, TabsList, TabsTrigger, TabsContent }
+// ---------------------------------------------------------------------------
+// Category Tabs (underline style) — independent feature categories
+// ---------------------------------------------------------------------------
+
+/**
+ * Category-style tabs for switching between independent feature surfaces
+ * grouped under one route. Uses an underline style with no background.
+ * `CategoryTabsContent` requires a `helpText` prop explaining when to use
+ * the selected category.
+ *
+ * @example
+ * ```tsx
+ * <CategoryTabs defaultValue="api-keys">
+ *   <CategoryTabsList>
+ *     <CategoryTabsTrigger value="api-keys">API Keys</CategoryTabsTrigger>
+ *     <CategoryTabsTrigger value="oauth">OAuth Apps</CategoryTabsTrigger>
+ *   </CategoryTabsList>
+ *   <CategoryTabsContent value="api-keys" helpText="Use API keys for server-to-server authentication.">
+ *     ...
+ *   </CategoryTabsContent>
+ *   <CategoryTabsContent value="oauth" helpText="Use OAuth apps for user-facing integrations.">
+ *     ...
+ *   </CategoryTabsContent>
+ * </CategoryTabs>
+ * ```
+ */
+const CategoryTabs = TabsPrimitive.Root;
+CategoryTabs.displayName = "CategoryTabs";
+
+const CategoryTabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-10 items-center gap-4 border-b border-border text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+CategoryTabsList.displayName = "CategoryTabsList";
+
+const CategoryTabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap px-1 py-2 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 border-b-2 border-transparent -mb-px data-[state=active]:border-primary data-[state=active]:text-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+CategoryTabsTrigger.displayName = "CategoryTabsTrigger";
+
+interface CategoryTabsContentProps extends React.ComponentPropsWithoutRef<
+  typeof TabsPrimitive.Content
+> {
+  helpText: string;
+}
+
+const CategoryTabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  CategoryTabsContentProps
+>(({ className, helpText, children, ...props }, ref) => {
+  const descId = `category-tab-desc-${props.value}`;
+  return (
+    <TabsPrimitive.Content
+      ref={ref}
+      aria-describedby={helpText ? descId : undefined}
+      className={cn(
+        "mt-4 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+        className,
+      )}
+      {...props}
+    >
+      {helpText && (
+        <p id={descId} className="text-sm text-muted-foreground mb-4">
+          {helpText}
+        </p>
+      )}
+      {children}
+    </TabsPrimitive.Content>
+  );
+});
+CategoryTabsContent.displayName = "CategoryTabsContent";
+
+export {
+  Tabs,
+  TabsList,
+  TabsTrigger,
+  TabsContent,
+  CategoryTabs,
+  CategoryTabsList,
+  CategoryTabsTrigger,
+  CategoryTabsContent,
+};


### PR DESCRIPTION
## Summary
- Add `CategoryTabs` / `CategoryTabsList` / `CategoryTabsTrigger` / `CategoryTabsContent` (underline style) to `frontend/src/components/ui/tabs.tsx`
- `CategoryTabsContent` enforces `helpText: string` at type level — omitting it is a compile error
- `TabsContent` does NOT accept `helpText` — passing it is a compile error
- Accessibility: `aria-describedby` links helpText to its panel
- Visual: `-mb-px` on triggers for clean border overlap
- Rules addendum in `.claude/rules/frontend.md` for EntityTabs vs CategoryTabs usage

Closes #225

## Test plan
- [x] `<TabsContent helpText="x" />` fails `tsc`
- [x] `<CategoryTabsContent value="x">` without `helpText` fails `tsc`
- [x] Existing usages (`admin/plans/page.tsx`, `SessionDetailDialog.tsx`) compile without changes
- [x] JSDoc hover shows examples for both variants
- [ ] Visual check: underline style renders correctly on localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)