### PR TITLE
refactor(frontend): URL-sync Tabs active state via ?tab= search param (#230)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -29,6 +29,7 @@ paths:
 - In-page tabs MUST use the Tabs primitive from `@/components/ui/tabs`. Do not build ad-hoc tab UIs.
 - Use `Tabs` (pill style) for facets of one entity (e.g., Overview / Settings of a context).
 - Use `CategoryTabs` (underline style) for independent feature categories grouped under one route (e.g., API Keys / OAuth Apps / Resource Tokens). `CategoryTabsContent` requires a `helpText` string explaining when to use the category.
+- In-page Tabs that cross information boundaries MUST sync active tab to a URL search param via `useTabParam` from `@/hooks/useTabParam`. Exception: tabs inside a Dialog/Sheet (use local state, not URL-addressable).
 
 ## Forbidden
 - No `any` type (use `unknown` or proper types)

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useTabParam } from "@/hooks/useTabParam";
 import {
   Table,
   TableBody,
@@ -96,6 +97,7 @@ export default function AdminPlansPage() {
   const [addonMember, setAddonMember] = useState(0);
   const [addonContext, setAddonContext] = useState(0);
   const { toast } = useToast();
+  const [tab, setTab] = useTabParam("workspaces");
 
   useEffect(() => {
     loadData();
@@ -231,7 +233,7 @@ export default function AdminPlansPage() {
         }
       />
 
-      <Tabs defaultValue="workspaces" className="mt-6">
+      <Tabs value={tab} onValueChange={setTab} className="mt-6">
         <TabsList>
           <TabsTrigger value="workspaces">{t("tabs.workspaces")}</TabsTrigger>
           <TabsTrigger value="tiers">{t("tabs.tiers")}</TabsTrigger>

--- a/frontend/src/hooks/useTabParam.ts
+++ b/frontend/src/hooks/useTabParam.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+/**
+ * Sync the active tab with a URL search parameter.
+ *
+ * Returns `[value, setValue]` compatible with
+ * `<Tabs value={value} onValueChange={setValue}>`.
+ *
+ * Uses `router.replace` so tab switches don't pollute browser history.
+ *
+ * @param defaultValue - Fallback when the search param is absent
+ * @param paramName - URL search param key (default `"tab"`)
+ *
+ * @example
+ * ```tsx
+ * const [tab, setTab] = useTabParam("overview");
+ * // URL: /page          → tab = "overview"
+ * // URL: /page?tab=settings → tab = "settings"
+ *
+ * <Tabs value={tab} onValueChange={setTab}>
+ *   ...
+ * </Tabs>
+ * ```
+ */
+export function useTabParam(
+  defaultValue: string,
+  paramName: string = "tab",
+): [string, (value: string) => void] {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+  const router = useRouter();
+
+  const value = searchParams.get(paramName) ?? defaultValue;
+
+  const setValue = useCallback(
+    (newValue: string) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (newValue === defaultValue) {
+        params.delete(paramName);
+      } else {
+        params.set(paramName, newValue);
+      }
+      const qs = params.toString();
+      router.replace(qs ? `${pathname}?${qs}` : pathname);
+    },
+    [searchParams, pathname, router, defaultValue, paramName],
+  );
+
+  return [value, setValue];
+}


### PR DESCRIPTION
## Summary
- New `useTabParam(defaultValue, paramName?)` hook in `frontend/src/hooks/useTabParam.ts`
  - Reads from `useSearchParams`, writes via `router.replace` (no history pollution)
  - Cleans URL param when returning to default value
  - Supports custom `paramName` for multi-tab-group pages
- Migrated `admin/plans/page.tsx` from `defaultValue` to URL-synced `value` + `onValueChange`
- Added URL-sync rule to `.claude/rules/frontend.md` (Dialog/Sheet tabs exempt)

Closes #230

## Test plan
- [ ] Navigate to `/admin/plans?tab=tiers` → lands on Tiers tab
- [ ] Switch tabs → URL updates via replace (back button doesn't cycle tabs)
- [ ] Refresh page → stays on active tab
- [ ] Navigate to `/admin/plans` (no param) → defaults to Workspaces tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)