### PR TITLE
refactor(frontend): unify menu page loading states — pilot (#295)

### DIFF
--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -39,6 +39,21 @@ paths:
 - Errors raised inside a Dialog body → `<Alert variant="destructive">` inside the dialog. Toasts behind a modal are easy to miss.
 - Hand-rolled red `<div>` blocks with `AlertTriangle` are a violation — replace with `ErrorBanner`. Informational gating notices (warnings, prerequisite hints) are not errors and are out of scope for this rule.
 
+## Loading States
+- Use primitives from `@/components/common/LoadingState`. Never hand-roll spinners or skeletons.
+- Shape-driven selection (not author preference):
+  - Table pages → `TableLoadingState rows={n}`
+  - Card grids → `CardLoadingState count={n}`
+  - Form / detail pages → `LoadingState lines={n}`
+  - Full page gated on a single fetch → `SpinnerLoading size="lg"`
+  - App bootstrap / auth gate → `PageLoading`
+  - Button / row / input → `InlineSpinner`
+- Prefer skeletons over spinners for first paint — skeletons preserve layout (no CLS) and communicate what is loading.
+- Never leave a page blank while loading — the initial paint must render a loader, not `null`.
+- Skeleton widths MUST be deterministic — never `Math.random()` in render (SSR hydration mismatch).
+- Loading messages go on `SpinnerLoading` via `message` prop — skeletons are silent.
+- Loading is resolved before empty — see Empty States.
+
 ## Empty States
 - Distinguish empty (request succeeded, zero results) from error (request failed). They use different channels.
 - New code MUST use the `EmptyState` primitive from `@/components/ui/empty-state` for any zero-item list or panel.

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -14,7 +14,6 @@ import { PageContainer } from "@/components/common/PageContainer";
 import { Section } from "@/components/common/Section";
 import { apiClient } from "@/lib/api";
 import { formatRelativeTime } from "@/lib/utils/datetime";
-import { useAuth } from "@/contexts/AuthContext";
 import {
   Table,
   TableBody,
@@ -82,10 +81,8 @@ export default function AdminUsersPage() {
   const t = useTranslations("admin.users");
   const tCommon = useTranslations("admin.common");
 
-  const { user } = useAuth();
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
-  const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const { toast } = useToast();
 
   // Issue #165 Phase 5: Search and filter state
@@ -181,17 +178,6 @@ export default function AdminUsersPage() {
         description: "Failed to delete user",
         variant: "destructive",
       });
-    }
-  };
-
-  const getRoleBadgeColor = (role: string) => {
-    switch (role) {
-      case "admin":
-        return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300";
-      case "user":
-        return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
-      default:
-        return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300";
     }
   };
 

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * Admin Users Management Page
@@ -7,16 +7,15 @@
  * Admin-only page (Issue #43).
  */
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useTranslations } from 'next-intl';
-import { PageHeader } from '@/components/common/PageHeader';
-import { PageContainer } from '@/components/common/PageContainer';
-import { Section } from '@/components/common/Section';
-import { LoadingState } from '@/components/common/LoadingState';
-import { apiClient } from '@/lib/api';
-import { formatRelativeTime } from '@/lib/utils/datetime';
-import { useAuth } from '@/contexts/AuthContext';
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { PageHeader } from "@/components/common/PageHeader";
+import { PageContainer } from "@/components/common/PageContainer";
+import { Section } from "@/components/common/Section";
+import { apiClient } from "@/lib/api";
+import { formatRelativeTime } from "@/lib/utils/datetime";
+import { useAuth } from "@/contexts/AuthContext";
 import {
   Table,
   TableBody,
@@ -24,20 +23,34 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table';
+} from "@/components/ui/table";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
-import { Input } from '@/components/ui/input';
-import { MoreVertical, Shield, User as UserIcon, Eye, Trash2, RefreshCw, Lock, Building2, CreditCard, Search } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
-import { InlineSpinner } from '@/components/common/LoadingState';
-import { UserDetailModal } from '@/components/admin/UserDetailModal';
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import {
+  MoreVertical,
+  Shield,
+  User as UserIcon,
+  Eye,
+  Trash2,
+  RefreshCw,
+  Lock,
+  Building2,
+  CreditCard,
+  Search,
+} from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
+import {
+  InlineSpinner,
+  TableLoadingState,
+} from "@/components/common/LoadingState";
+import { UserDetailModal } from "@/components/admin/UserDetailModal";
 
 interface WorkspaceMembership {
   workspace_id: string;
@@ -52,14 +65,14 @@ interface User {
   name: string;
   picture?: string;
   role: string;
-  is_initial_admin?: boolean;  // Issue #166: System Admin protection
+  is_initial_admin?: boolean; // Issue #166: System Admin protection
   created_at: string;
   last_login?: string;
   memory_count: number;
   is_active: boolean;
-  timezone?: string;  // Issue #175: User timezone preference
-  auth_provider?: string | null;  // Issue #361: Registration provider
-  workspaces?: WorkspaceMembership[];  // Issue #165: Workspace badges
+  timezone?: string; // Issue #175: User timezone preference
+  auth_provider?: string | null; // Issue #361: Registration provider
+  workspaces?: WorkspaceMembership[]; // Issue #165: Workspace badges
 
   // Current context info
   current_context_id?: string | null;
@@ -68,23 +81,23 @@ interface User {
 }
 
 export default function AdminUsersPage() {
-  const t = useTranslations('admin.users');
-  const tCommon = useTranslations('admin.common');
+  const t = useTranslations("admin.users");
+  const tCommon = useTranslations("admin.common");
 
   const { user } = useAuth();
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
-  const { toast} = useToast();
-  const router = useRouter();  // Issue #164: Navigation to user detail
+  const { toast } = useToast();
+  const router = useRouter(); // Issue #164: Navigation to user detail
 
   // Issue #165 Phase 5: Search and filter state
-  const [searchQuery, setSearchQuery] = useState('');
+  const [searchQuery, setSearchQuery] = useState("");
   const [showDetailModal, setShowDetailModal] = useState(false);
   const [detailUserId, setDetailUserId] = useState<string | null>(null);
 
   // Issue #166: Count admin users for protection logic
-  const adminCount = users.filter((u) => u.role === 'admin').length;
+  const adminCount = users.filter((u) => u.role === "admin").length;
 
   // Filter users based on search query (Issue #165)
   const filteredUsers = users.filter((user) => {
@@ -106,14 +119,14 @@ export default function AdminUsersPage() {
       setLoading(true);
       // Issue #165: Include workspace data
       const data = await apiClient.get<{ users: User[]; total: number }>(
-        '/api/v1/admin/users?include_workspaces=true'
+        "/api/v1/admin/users?include_workspaces=true",
       );
       setUsers(data.users);
     } catch (error) {
       toast({
-        title: 'Error',
-        description: 'Failed to load users',
-        variant: 'destructive',
+        title: "Error",
+        description: "Failed to load users",
+        variant: "destructive",
       });
     } finally {
       setLoading(false);
@@ -132,50 +145,56 @@ export default function AdminUsersPage() {
 
   const handleRoleChange = async (userId: string, newRole: string) => {
     try {
-      await apiClient.put(`/api/v1/admin/users/${userId}/role`, { role: newRole });
+      await apiClient.put(`/api/v1/admin/users/${userId}/role`, {
+        role: newRole,
+      });
       toast({
-        title: 'Success',
+        title: "Success",
         description: `User role updated to ${newRole}`,
       });
       loadUsers();
     } catch (error) {
       toast({
-        title: 'Error',
-        description: 'Failed to update user role',
-        variant: 'destructive',
+        title: "Error",
+        description: "Failed to update user role",
+        variant: "destructive",
       });
     }
   };
 
   const handleDeleteUser = async (userId: string, userName: string) => {
-    if (!confirm(`Delete user ${userName}? This will permanently delete all their memories.`)) {
+    if (
+      !confirm(
+        `Delete user ${userName}? This will permanently delete all their memories.`,
+      )
+    ) {
       return;
     }
 
     try {
       await apiClient.delete(`/api/v1/admin/users/${userId}`);
       toast({
-        title: 'Success',
+        title: "Success",
         description: `User ${userName} deleted successfully`,
       });
       loadUsers();
     } catch (error) {
       toast({
-        title: 'Error',
-        description: 'Failed to delete user',
-        variant: 'destructive',
+        title: "Error",
+        description: "Failed to delete user",
+        variant: "destructive",
       });
     }
   };
 
   const getRoleBadgeColor = (role: string) => {
     switch (role) {
-      case 'admin':
-        return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300';
-      case 'user':
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300';
+      case "admin":
+        return "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300";
+      case "user":
+        return "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300";
       default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300';
+        return "bg-gray-100 text-gray-800 dark:bg-gray-800 dark:text-gray-300";
     }
   };
 
@@ -183,19 +202,20 @@ export default function AdminUsersPage() {
     return (
       <PageContainer>
         <PageHeader
-          title={t('title')}
-          description={t('description')}
+          title={t("title")}
+          description={t("description")}
           actions={
             <Button onClick={loadUsers} variant="outline" disabled={loading}>
-              {loading ? <InlineSpinner size="sm" className="mr-2" /> : <RefreshCw className="h-4 w-4 mr-2" />}
-              {tCommon('refresh')}
+              {loading ? (
+                <InlineSpinner size="sm" className="mr-2" />
+              ) : (
+                <RefreshCw className="h-4 w-4 mr-2" />
+              )}
+              {tCommon("refresh")}
             </Button>
           }
         />
-        <div className="text-center py-8">
-          <p className="text-gray-500">{t('messages.loading')}</p>
-          <LoadingState lines={5} />
-        </div>
+        <TableLoadingState rows={5} />
       </PageContainer>
     );
   }
@@ -203,12 +223,16 @@ export default function AdminUsersPage() {
   return (
     <PageContainer>
       <PageHeader
-        title={t('title')}
-        description={t('description')}
+        title={t("title")}
+        description={t("description")}
         actions={
           <Button onClick={loadUsers} variant="outline" disabled={loading}>
-            {loading ? <InlineSpinner size="sm" className="mr-2" /> : <RefreshCw className="h-4 w-4 mr-2" />}
-            {tCommon('refresh')}
+            {loading ? (
+              <InlineSpinner size="sm" className="mr-2" />
+            ) : (
+              <RefreshCw className="h-4 w-4 mr-2" />
+            )}
+            {tCommon("refresh")}
           </Button>
         }
       />
@@ -219,7 +243,7 @@ export default function AdminUsersPage() {
           <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
           <Input
             type="text"
-            placeholder={t('search.placeholder')}
+            placeholder={t("search.placeholder")}
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
             className="pl-10"
@@ -227,25 +251,36 @@ export default function AdminUsersPage() {
         </div>
         {searchQuery && (
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-2">
-            {t('search.showing', { filtered: filteredUsers.length, total: users.length })}
+            {t("search.showing", {
+              filtered: filteredUsers.length,
+              total: users.length,
+            })}
           </p>
         )}
       </Section>
 
-      <Section title={t('overview.title')}>
+      <Section title={t("overview.title")}>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
           <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-lg">
-            <h3 className="text-sm font-medium text-blue-900 dark:text-blue-100">Total Users</h3>
-            <p className="text-2xl font-bold text-blue-700 dark:text-blue-300">{users.length}</p>
+            <h3 className="text-sm font-medium text-blue-900 dark:text-blue-100">
+              Total Users
+            </h3>
+            <p className="text-2xl font-bold text-blue-700 dark:text-blue-300">
+              {users.length}
+            </p>
           </div>
           <div className="bg-green-50 dark:bg-green-900/20 p-4 rounded-lg">
-            <h3 className="text-sm font-medium text-green-900 dark:text-green-100">Active Users</h3>
+            <h3 className="text-sm font-medium text-green-900 dark:text-green-100">
+              Active Users
+            </h3>
             <p className="text-2xl font-bold text-green-700 dark:text-green-300">
               {users.filter((u) => u.is_active).length}
             </p>
           </div>
           <div className="bg-purple-50 dark:bg-purple-900/20 p-4 rounded-lg">
-            <h3 className="text-sm font-medium text-purple-900 dark:text-purple-100">Total Memories</h3>
+            <h3 className="text-sm font-medium text-purple-900 dark:text-purple-100">
+              Total Memories
+            </h3>
             <p className="text-2xl font-bold text-purple-700 dark:text-purple-300">
               {users.reduce((sum, u) => sum + u.memory_count, 0)}
             </p>
@@ -256,11 +291,11 @@ export default function AdminUsersPage() {
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead>{t('table.user')}</TableHead>
-                <TableHead>{t('table.role')}</TableHead>
-                <TableHead>{t('table.workspaces')}</TableHead>
-                <TableHead>{t('table.memories')}</TableHead>
-                <TableHead>{t('table.lastLogin')}</TableHead>
+                <TableHead>{t("table.user")}</TableHead>
+                <TableHead>{t("table.role")}</TableHead>
+                <TableHead>{t("table.workspaces")}</TableHead>
+                <TableHead>{t("table.memories")}</TableHead>
+                <TableHead>{t("table.lastLogin")}</TableHead>
                 <TableHead className="text-right">Actions</TableHead>
               </TableRow>
             </TableHeader>
@@ -271,7 +306,8 @@ export default function AdminUsersPage() {
                   className="cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800"
                   onClick={(e) => {
                     // Don't trigger if clicking on dropdown
-                    if ((e.target as HTMLElement).closest('[role="menu"]')) return;
+                    if ((e.target as HTMLElement).closest('[role="menu"]'))
+                      return;
                     handleUserClick(user.id);
                   }}
                 >
@@ -291,10 +327,20 @@ export default function AdminUsersPage() {
                       <div>
                         <p className="font-medium text-sm">{user.name}</p>
                         <div className="flex items-center gap-1">
-                          <span className="text-xs text-gray-500">{user.email}</span>
+                          <span className="text-xs text-gray-500">
+                            {user.email}
+                          </span>
                           {user.auth_provider && (
-                            <span className="text-xs text-gray-400 dark:text-gray-500" title={`Registered via ${user.auth_provider}`}>
-                              ({user.auth_provider === 'github' ? 'GitHub' : user.auth_provider.charAt(0).toUpperCase() + user.auth_provider.slice(1)})
+                            <span
+                              className="text-xs text-gray-400 dark:text-gray-500"
+                              title={`Registered via ${user.auth_provider}`}
+                            >
+                              (
+                              {user.auth_provider === "github"
+                                ? "GitHub"
+                                : user.auth_provider.charAt(0).toUpperCase() +
+                                  user.auth_provider.slice(1)}
+                              )
                             </span>
                           )}
                         </div>
@@ -303,7 +349,7 @@ export default function AdminUsersPage() {
                   </TableCell>
                   <TableCell>
                     <div className="flex items-center gap-2">
-                      {user.role === 'admin' ? (
+                      {user.role === "admin" ? (
                         <Badge className="bg-red-100 text-red-800">
                           <Shield className="h-3 w-3 mr-1" />
                           System Admin
@@ -344,14 +390,16 @@ export default function AdminUsersPage() {
                         )}
                       </div>
                     ) : (
-                      <span className="text-xs text-gray-400 dark:text-gray-500">None</span>
+                      <span className="text-xs text-gray-400 dark:text-gray-500">
+                        None
+                      </span>
                     )}
                   </TableCell>
                   <TableCell>{user.memory_count}</TableCell>
                   <TableCell className="text-sm text-gray-500">
                     {user.last_login
                       ? formatRelativeTime(user.last_login, user.timezone)
-                      : 'Never'}
+                      : "Never"}
                   </TableCell>
                   <TableCell className="text-right">
                     <DropdownMenu>
@@ -365,13 +413,18 @@ export default function AdminUsersPage() {
                           onClick={() =>
                             handleRoleChange(
                               user.id,
-                              user.role === 'admin' ? 'user' : 'admin'
+                              user.role === "admin" ? "user" : "admin",
                             )
                           }
-                          disabled={user.is_initial_admin || (user.role === 'admin' && adminCount <= 1)}
+                          disabled={
+                            user.is_initial_admin ||
+                            (user.role === "admin" && adminCount <= 1)
+                          }
                         >
                           <Shield className="mr-2 h-4 w-4" />
-                          {user.role === 'admin' ? 'Demote from System Admin' : 'Promote to System Admin'}
+                          {user.role === "admin"
+                            ? "Demote from System Admin"
+                            : "Promote to System Admin"}
                         </DropdownMenuItem>
                         <DropdownMenuItem
                           onClick={(e) => {
@@ -385,11 +438,14 @@ export default function AdminUsersPage() {
                         <DropdownMenuItem
                           onClick={() => handleDeleteUser(user.id, user.name)}
                           className="text-red-600"
-                          disabled={user.is_initial_admin || (user.role === 'admin' && adminCount <= 1)}
+                          disabled={
+                            user.is_initial_admin ||
+                            (user.role === "admin" && adminCount <= 1)
+                          }
                         >
                           <Trash2 className="mr-2 h-4 w-4" />
                           Delete User
-                          {user.is_initial_admin && ' (Protected)'}
+                          {user.is_initial_admin && " (Protected)"}
                         </DropdownMenuItem>
                       </DropdownMenuContent>
                     </DropdownMenu>

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -8,7 +8,6 @@
  */
 
 import { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
@@ -42,7 +41,6 @@ import {
   RefreshCw,
   Lock,
   Building2,
-  CreditCard,
   Search,
 } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
@@ -89,7 +87,6 @@ export default function AdminUsersPage() {
   const [loading, setLoading] = useState(true);
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const { toast } = useToast();
-  const router = useRouter(); // Issue #164: Navigation to user detail
 
   // Issue #165 Phase 5: Search and filter state
   const [searchQuery, setSearchQuery] = useState("");
@@ -205,12 +202,8 @@ export default function AdminUsersPage() {
           title={t("title")}
           description={t("description")}
           actions={
-            <Button onClick={loadUsers} variant="outline" disabled={loading}>
-              {loading ? (
-                <InlineSpinner size="sm" className="mr-2" />
-              ) : (
-                <RefreshCw className="h-4 w-4 mr-2" />
-              )}
+            <Button onClick={loadUsers} variant="outline" disabled>
+              <InlineSpinner size="sm" className="mr-2" />
               {tCommon("refresh")}
             </Button>
           }
@@ -227,11 +220,7 @@ export default function AdminUsersPage() {
         description={t("description")}
         actions={
           <Button onClick={loadUsers} variant="outline" disabled={loading}>
-            {loading ? (
-              <InlineSpinner size="sm" className="mr-2" />
-            ) : (
-              <RefreshCw className="h-4 w-4 mr-2" />
-            )}
+            <RefreshCw className="h-4 w-4 mr-2" />
             {tCommon("refresh")}
           </Button>
         }

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -15,7 +15,10 @@ import { PageContainer } from "@/components/common/PageContainer";
 import { Section } from "@/components/common/Section";
 import { ActionButton } from "@/components/common/ActionButton";
 import { Button } from "@/components/ui/button";
-import { TableLoadingState } from "@/components/common/LoadingState";
+import {
+  InlineSpinner,
+  TableLoadingState,
+} from "@/components/common/LoadingState";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
 import { useAuth } from "@/contexts/AuthContext";
 import {
@@ -43,9 +46,7 @@ import {
   Copy,
   Check,
   X,
-  Key,
   AlertTriangle,
-  Loader2,
   Settings,
   ChevronDown,
   ChevronUp,
@@ -1267,9 +1268,7 @@ export default function WorkspaceMembersPage() {
                         }
                         className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
                       >
-                        {inviteLoading && (
-                          <Loader2 className="w-4 h-4 animate-spin" />
-                        )}
+                        {inviteLoading && <InlineSpinner size="sm" />}
                         {inviteLoading ? t("creating") : t("createInvitation")}
                       </button>
                     </div>
@@ -1418,7 +1417,7 @@ export default function WorkspaceMembersPage() {
             >
               {deleteLoading ? (
                 <>
-                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  <InlineSpinner size="sm" className="mr-2" />
                   {t("removing")}
                 </>
               ) : (
@@ -1462,7 +1461,7 @@ export default function WorkspaceMembersPage() {
             >
               {deleteInvitationLoading ? (
                 <>
-                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  <InlineSpinner size="sm" className="mr-2" />
                   {t("revoking")}
                 </>
               ) : (
@@ -1520,7 +1519,7 @@ export default function WorkspaceMembersPage() {
             >
               {roleChangeLoading ? (
                 <>
-                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  <InlineSpinner size="sm" className="mr-2" />
                   {tCommon("loading")}
                 </>
               ) : (
@@ -1638,7 +1637,7 @@ export default function WorkspaceMembersPage() {
             >
               {contextAccessLoading ? (
                 <>
-                  <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                  <InlineSpinner size="sm" className="mr-2" />
                   {tCommon("saving")}
                 </>
               ) : (

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * Workspace Members Management Page
@@ -8,16 +8,16 @@
  * Manage workspace members, roles, and invitations.
  */
 
-import { useEffect, useState } from 'react';
-import { useTranslations } from 'next-intl';
-import { PageHeader } from '@/components/common/PageHeader';
-import { PageContainer } from '@/components/common/PageContainer';
-import { Section } from '@/components/common/Section';
-import { ActionButton } from '@/components/common/ActionButton';
-import { Button } from '@/components/ui/button';
-import { LoadingState, SpinnerLoading } from '@/components/common/LoadingState';
-import { useWorkspace } from '@/contexts/WorkspaceContext';
-import { useAuth } from '@/contexts/AuthContext';
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { PageHeader } from "@/components/common/PageHeader";
+import { PageContainer } from "@/components/common/PageContainer";
+import { Section } from "@/components/common/Section";
+import { ActionButton } from "@/components/common/ActionButton";
+import { Button } from "@/components/ui/button";
+import { TableLoadingState } from "@/components/common/LoadingState";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { useAuth } from "@/contexts/AuthContext";
 import {
   listMembers,
   addMember,
@@ -25,8 +25,8 @@ import {
   removeMember,
   updateMemberContextAccess,
   WorkspaceMember,
-} from '@/lib/api/workspaces';
-import { getContexts, Context } from '@/lib/api/contexts';
+} from "@/lib/api/workspaces";
+import { getContexts, Context } from "@/lib/api/contexts";
 import {
   listInvitations,
   createInvitation,
@@ -34,9 +34,23 @@ import {
   WorkspaceInvitation,
   getMemberQuota,
   MemberQuota,
-} from '@/lib/api/invitations';
-import { UserPlus, Trash2, Shield, Users, Copy, Check, X, Key, AlertTriangle, Loader2, Settings, ChevronDown, ChevronUp } from 'lucide-react';
-import Link from 'next/link';
+} from "@/lib/api/invitations";
+import {
+  UserPlus,
+  Trash2,
+  Shield,
+  Users,
+  Copy,
+  Check,
+  X,
+  Key,
+  AlertTriangle,
+  Loader2,
+  Settings,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
+import Link from "next/link";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -46,39 +60,49 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import { useToast } from '@/hooks/use-toast';
+} from "@/components/ui/alert-dialog";
+import { useToast } from "@/hooks/use-toast";
 
 export default function WorkspaceMembersPage() {
-  const t = useTranslations('workspace');
-  const tCommon = useTranslations('common');
-  const { currentWorkspaceId, currentWorkspace, loading: workspaceLoading } = useWorkspace();
+  const t = useTranslations("workspace");
+  const tCommon = useTranslations("common");
+  const {
+    currentWorkspaceId,
+    currentWorkspace,
+    loading: workspaceLoading,
+  } = useWorkspace();
   const { user } = useAuth();
   const { toast } = useToast();
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [invitations, setInvitations] = useState<WorkspaceInvitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [showInviteDialog, setShowInviteDialog] = useState(false);
-  const [showUpgradePrompt, setShowUpgradePrompt] = useState(false);  // Issue #165: Pro plan gate
+  const [showUpgradePrompt, setShowUpgradePrompt] = useState(false); // Issue #165: Pro plan gate
 
   // Invite dialog state
-  const [inviteEmail, setInviteEmail] = useState('');
-  const [inviteRole, setInviteRole] = useState<'member' | 'admin' | 'viewer'>('member');
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [inviteRole, setInviteRole] = useState<"member" | "admin" | "viewer">(
+    "member",
+  );
   const [inviteExpiry, setInviteExpiry] = useState<number | null>(30);
-  const [inviteContextIds, setInviteContextIds] = useState<string[]>([]);  // Migration 042
+  const [inviteContextIds, setInviteContextIds] = useState<string[]>([]); // Migration 042
   const [createdInviteUrl, setCreatedInviteUrl] = useState<string | null>(null);
   const [copiedToken, setCopiedToken] = useState<string | null>(null);
-  const [inviteError, setInviteError] = useState<string | null>(null);  // Issue #217
-  const [inviteLoading, setInviteLoading] = useState(false);  // Issue #217
+  const [inviteError, setInviteError] = useState<string | null>(null); // Issue #217
+  const [inviteLoading, setInviteLoading] = useState(false); // Issue #217
 
   // Issue #217: Delete member confirmation dialog
-  const [memberToDelete, setMemberToDelete] = useState<WorkspaceMember | null>(null);
+  const [memberToDelete, setMemberToDelete] = useState<WorkspaceMember | null>(
+    null,
+  );
   const [showDeleteMemberDialog, setShowDeleteMemberDialog] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
 
   // Issue #217: Delete invitation confirmation dialog
-  const [invitationToDelete, setInvitationToDelete] = useState<WorkspaceInvitation | null>(null);
-  const [showDeleteInvitationDialog, setShowDeleteInvitationDialog] = useState(false);
+  const [invitationToDelete, setInvitationToDelete] =
+    useState<WorkspaceInvitation | null>(null);
+  const [showDeleteInvitationDialog, setShowDeleteInvitationDialog] =
+    useState(false);
   const [deleteInvitationLoading, setDeleteInvitationLoading] = useState(false);
 
   // Issue #229: Member quota state
@@ -87,13 +111,17 @@ export default function WorkspaceMembersPage() {
 
   // Issue #234: Context access restriction
   const [contexts, setContexts] = useState<Context[]>([]);
-  const [contextAccessMember, setContextAccessMember] = useState<WorkspaceMember | null>(null);
+  const [contextAccessMember, setContextAccessMember] =
+    useState<WorkspaceMember | null>(null);
   const [showContextAccessDialog, setShowContextAccessDialog] = useState(false);
   const [selectedContextIds, setSelectedContextIds] = useState<string[]>([]);
   const [contextAccessLoading, setContextAccessLoading] = useState(false);
 
   // Issue #234: Role change confirmation (clears context access)
-  const [pendingRoleChange, setPendingRoleChange] = useState<{ member: WorkspaceMember; newRole: string } | null>(null);
+  const [pendingRoleChange, setPendingRoleChange] = useState<{
+    member: WorkspaceMember;
+    newRole: string;
+  } | null>(null);
   const [showRoleChangeDialog, setShowRoleChangeDialog] = useState(false);
   const [roleChangeLoading, setRoleChangeLoading] = useState(false);
 
@@ -101,14 +129,14 @@ export default function WorkspaceMembersPage() {
   const [showRolePermissions, setShowRolePermissions] = useState(false);
 
   // Check if Pro plan
-  const isProPlan = currentWorkspace?.plan_name === 'pro';
+  const isProPlan = currentWorkspace?.plan_name === "pro";
 
   useEffect(() => {
     if (currentWorkspaceId) {
       loadMembers();
       loadInvitations();
-      loadMemberQuota();  // Issue #229
-      loadContexts();  // Issue #234
+      loadMemberQuota(); // Issue #229
+      loadContexts(); // Issue #234
     }
   }, [currentWorkspaceId]);
 
@@ -128,7 +156,7 @@ export default function WorkspaceMembersPage() {
 
       setMembers(sortedMembers);
     } catch (error) {
-      console.error('Failed to load members:', error);
+      console.error("Failed to load members:", error);
     } finally {
       setLoading(false);
     }
@@ -143,10 +171,10 @@ export default function WorkspaceMembersPage() {
     } catch (error: any) {
       // 403 = Not admin/owner, silently skip invitations feature
       if (error?.status === 403) {
-        setInvitations([]);  // No invitations to show
+        setInvitations([]); // No invitations to show
         return;
       }
-      console.error('Failed to load invitations:', error);
+      console.error("Failed to load invitations:", error);
     }
   };
 
@@ -164,7 +192,7 @@ export default function WorkspaceMembersPage() {
         setMemberQuota(null);
         return;
       }
-      console.error('Failed to load member quota:', error);
+      console.error("Failed to load member quota:", error);
     } finally {
       setQuotaLoading(false);
     }
@@ -175,10 +203,10 @@ export default function WorkspaceMembersPage() {
     try {
       const response = await getContexts();
       // Only show shared contexts - private contexts are owner-only anyway
-      const sharedContexts = response.contexts.filter(c => !c.is_private);
+      const sharedContexts = response.contexts.filter((c) => !c.is_private);
       setContexts(sharedContexts);
     } catch (error) {
-      console.error('Failed to load contexts:', error);
+      console.error("Failed to load contexts:", error);
     }
   };
 
@@ -197,9 +225,9 @@ export default function WorkspaceMembersPage() {
     // Migration 042: Require at least 1 context (same as invitation)
     if (selectedContextIds.length === 0) {
       toast({
-        title: tCommon('error'),
-        description: t('inviteContextRequired'),
-        variant: 'destructive',
+        title: tCommon("error"),
+        description: t("inviteContextRequired"),
+        variant: "destructive",
       });
       return;
     }
@@ -210,23 +238,25 @@ export default function WorkspaceMembersPage() {
       await updateMemberContextAccess(
         currentWorkspaceId,
         contextAccessMember.user_id,
-        selectedContextIds
+        selectedContextIds,
       );
 
       // Reload members to get updated data
       await loadMembers();
 
       toast({
-        title: t('contextAccessUpdated'),
-        description: t('contextsSelected', { count: selectedContextIds.length }),
+        title: t("contextAccessUpdated"),
+        description: t("contextsSelected", {
+          count: selectedContextIds.length,
+        }),
       });
 
       setShowContextAccessDialog(false);
     } catch (error: any) {
       toast({
-        title: t('contextAccessUpdateFailed'),
-        description: error?.message || 'Unknown error',
-        variant: 'destructive',
+        title: t("contextAccessUpdateFailed"),
+        description: error?.message || "Unknown error",
+        variant: "destructive",
       });
     } finally {
       setContextAccessLoading(false);
@@ -235,10 +265,10 @@ export default function WorkspaceMembersPage() {
 
   // Issue #234: Toggle context selection
   const toggleContextSelection = (contextId: string) => {
-    setSelectedContextIds(prev =>
+    setSelectedContextIds((prev) =>
       prev.includes(contextId)
-        ? prev.filter(id => id !== contextId)
-        : [...prev, contextId]
+        ? prev.filter((id) => id !== contextId)
+        : [...prev, contextId],
     );
   };
 
@@ -247,13 +277,16 @@ export default function WorkspaceMembersPage() {
 
     // Validate email is required
     if (!inviteEmail.trim()) {
-      setInviteError(t('emailRequiredError'));
+      setInviteError(t("emailRequiredError"));
       return;
     }
 
     // Migration 042: Validate context selection for member/viewer
-    if ((inviteRole === 'member' || inviteRole === 'viewer') && inviteContextIds.length === 0) {
-      setInviteError(t('inviteContextRequired'));
+    if (
+      (inviteRole === "member" || inviteRole === "viewer") &&
+      inviteContextIds.length === 0
+    ) {
+      setInviteError(t("inviteContextRequired"));
       return;
     }
 
@@ -265,23 +298,26 @@ export default function WorkspaceMembersPage() {
         email: inviteEmail,
         role: inviteRole,
         expires_in_days: inviteExpiry,
-        allowed_context_ids: (inviteRole === 'member' || inviteRole === 'viewer') ? inviteContextIds : null,  // Migration 042
+        allowed_context_ids:
+          inviteRole === "member" || inviteRole === "viewer"
+            ? inviteContextIds
+            : null, // Migration 042
       });
 
       setCreatedInviteUrl(invitation.invitation_url);
       await loadInvitations();
-      await loadMemberQuota();  // Issue #229: Reload quota after invitation
+      await loadMemberQuota(); // Issue #229: Reload quota after invitation
       toast({
-        title: t('invitationCreated'),
-        description: t('invitationSentTo', { email: inviteEmail }),
+        title: t("invitationCreated"),
+        description: t("invitationSentTo", { email: inviteEmail }),
       });
     } catch (error: any) {
-      console.error('Failed to create invitation:', error);
+      console.error("Failed to create invitation:", error);
       // Issue #217: Extract error message for display in dialog
       const errorMsg =
         error?.details?.detail ||
         error?.message ||
-        (typeof error === 'string' ? error : 'Failed to create invitation');
+        (typeof error === "string" ? error : "Failed to create invitation");
       setInviteError(errorMsg);
     } finally {
       setInviteLoading(false);
@@ -294,11 +330,11 @@ export default function WorkspaceMembersPage() {
       setCopiedToken(token);
       setTimeout(() => setCopiedToken(null), 2000);
     } catch (error) {
-      console.error('Failed to copy URL:', error);
+      console.error("Failed to copy URL:", error);
       toast({
-        title: tCommon('error'),
-        description: 'Failed to copy URL to clipboard',
-        variant: 'destructive',
+        title: tCommon("error"),
+        description: "Failed to copy URL to clipboard",
+        variant: "destructive",
       });
     }
   };
@@ -306,10 +342,10 @@ export default function WorkspaceMembersPage() {
   const handleCloseInviteDialog = () => {
     setShowInviteDialog(false);
     setCreatedInviteUrl(null);
-    setInviteEmail('');
-    setInviteRole('member');
+    setInviteEmail("");
+    setInviteRole("member");
     setInviteExpiry(30);
-    setInviteError(null);  // Issue #217: Clear error on close
+    setInviteError(null); // Issue #217: Clear error on close
   };
 
   // Issue #217: Open delete invitation confirmation dialog
@@ -326,23 +362,25 @@ export default function WorkspaceMembersPage() {
     try {
       await deleteInvitation(currentWorkspaceId, invitationToDelete.id);
       await loadInvitations();
-      await loadMemberQuota();  // Issue #229: Reload quota after deletion
+      await loadMemberQuota(); // Issue #229: Reload quota after deletion
       setShowDeleteInvitationDialog(false);
       setInvitationToDelete(null);
       toast({
-        title: t('invitationRevoked'),
-        description: t('invitationRevokedDesc', { email: invitationToDelete.email || 'user' }),
+        title: t("invitationRevoked"),
+        description: t("invitationRevokedDesc", {
+          email: invitationToDelete.email || "user",
+        }),
       });
     } catch (error: any) {
-      console.error('Failed to delete invitation:', error);
+      console.error("Failed to delete invitation:", error);
       const errorMsg =
         error?.details?.detail ||
         error?.message ||
-        t('failedToRevokeInvitation');
+        t("failedToRevokeInvitation");
       toast({
-        title: t('failedToRevokeInvitation'),
+        title: t("failedToRevokeInvitation"),
         description: errorMsg,
-        variant: 'destructive',
+        variant: "destructive",
       });
     } finally {
       setDeleteInvitationLoading(false);
@@ -366,19 +404,20 @@ export default function WorkspaceMembersPage() {
       setShowDeleteMemberDialog(false);
       setMemberToDelete(null);
       toast({
-        title: t('memberRemoved'),
-        description: t('memberRemovedDesc', { name: memberToDelete.user_name || memberToDelete.user_email || 'Member' }),
+        title: t("memberRemoved"),
+        description: t("memberRemovedDesc", {
+          name:
+            memberToDelete.user_name || memberToDelete.user_email || "Member",
+        }),
       });
     } catch (error: any) {
-      console.error('Failed to remove member:', error);
+      console.error("Failed to remove member:", error);
       const errorMsg =
-        error?.details?.detail ||
-        error?.message ||
-        t('failedToRemoveMember');
+        error?.details?.detail || error?.message || t("failedToRemoveMember");
       toast({
-        title: t('failedToRemoveMember'),
+        title: t("failedToRemoveMember"),
         description: errorMsg,
-        variant: 'destructive',
+        variant: "destructive",
       });
     } finally {
       setDeleteLoading(false);
@@ -389,8 +428,12 @@ export default function WorkspaceMembersPage() {
     if (!currentWorkspaceId) return;
 
     // Issue #234: Check if member has context restrictions that will be cleared
-    const member = members.find(m => m.user_id === userId);
-    if (member && member.allowed_context_ids !== null && member.allowed_context_ids !== undefined) {
+    const member = members.find((m) => m.user_id === userId);
+    if (
+      member &&
+      member.allowed_context_ids !== null &&
+      member.allowed_context_ids !== undefined
+    ) {
       // Show confirmation dialog
       setPendingRoleChange({ member, newRole });
       setShowRoleChangeDialog(true);
@@ -408,29 +451,29 @@ export default function WorkspaceMembersPage() {
     setRoleChangeLoading(true);
     try {
       await updateMemberRole(currentWorkspaceId, userId, {
-        role: newRole as 'owner' | 'admin' | 'member' | 'viewer',
+        role: newRole as "owner" | "admin" | "member" | "viewer",
       });
       await loadMembers();
       setShowRoleChangeDialog(false);
       setPendingRoleChange(null);
     } catch (error: any) {
-      console.error('Failed to update role:', error);
+      console.error("Failed to update role:", error);
 
       // Issue #254: Show specific message for role change errors
-      let errorMessage = error?.message || 'Failed to update role';
+      let errorMessage = error?.message || "Failed to update role";
 
       if (error?.status === 403) {
-        if (error?.message?.includes('own role')) {
-          errorMessage = t('cannotModifyOwnRoleDesc');
-        } else if (error?.message?.includes('owner can change')) {
-          errorMessage = t('onlyOwnerCanChangeOwner');
+        if (error?.message?.includes("own role")) {
+          errorMessage = t("cannotModifyOwnRoleDesc");
+        } else if (error?.message?.includes("owner can change")) {
+          errorMessage = t("onlyOwnerCanChangeOwner");
         }
       }
 
       toast({
-        title: tCommon('error'),
+        title: tCommon("error"),
         description: errorMessage,
-        variant: 'destructive',
+        variant: "destructive",
       });
     } finally {
       setRoleChangeLoading(false);
@@ -444,7 +487,9 @@ export default function WorkspaceMembersPage() {
       return;
     }
     // Migration 042: Initialize with all shared contexts selected
-    const sharedContextIds = contexts.filter(c => !c.is_private).map(c => c.id);
+    const sharedContextIds = contexts
+      .filter((c) => !c.is_private)
+      .map((c) => c.id);
     setInviteContextIds(sharedContextIds);
     setShowInviteDialog(true);
   };
@@ -452,35 +497,40 @@ export default function WorkspaceMembersPage() {
   if (workspaceLoading || loading) {
     return (
       <PageContainer>
-        <PageHeader title={t('membersTitle')} />
-        <div className="flex items-center justify-center py-12">
-          <SpinnerLoading message={t('loadingMembers')} />
-        </div>
+        <PageHeader title={t("membersTitle")} />
+        <TableLoadingState rows={5} />
       </PageContainer>
     );
   }
 
   return (
     <PageContainer>
-      <PageHeader
-        title={t('membersTitle')}
-        description={t('membersDesc')}
-      />
+      <PageHeader title={t("membersTitle")} description={t("membersDesc")} />
 
       <Section
-        title={t('membersSection')}
-        description={members.length !== 1 ? t('membersCount', { count: members.length }) : t('memberCount', { count: members.length })}
+        title={t("membersSection")}
+        description={
+          members.length !== 1
+            ? t("membersCount", { count: members.length })
+            : t("memberCount", { count: members.length })
+        }
         headerActions={
           <ActionButton
             onClick={handleInviteClick}
             icon={<UserPlus className="w-4 h-4" />}
             disabled={
               !isProPlan ||
-              currentWorkspace?.current_user_role === 'member' ||
-              currentWorkspace?.current_user_role === 'viewer'
+              currentWorkspace?.current_user_role === "member" ||
+              currentWorkspace?.current_user_role === "viewer"
             }
           >
-            {t('inviteMember')} {!isProPlan ? t('proPlanRequired') : currentWorkspace?.current_user_role === 'member' || currentWorkspace?.current_user_role === 'viewer' ? t('ownerAdminOnly') : ''}
+            {t("inviteMember")}{" "}
+            {!isProPlan
+              ? t("proPlanRequired")
+              : currentWorkspace?.current_user_role === "member" ||
+                  currentWorkspace?.current_user_role === "viewer"
+                ? t("ownerAdminOnly")
+                : ""}
           </ActionButton>
         }
       >
@@ -489,22 +539,22 @@ export default function WorkspaceMembersPage() {
             <thead>
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  {t('user')}
+                  {t("user")}
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  {t('role')}
+                  {t("role")}
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  {t('joinedAt')}
+                  {t("joinedAt")}
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  {t('lastLogin')}
+                  {t("lastLogin")}
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  {t('contextAccess')}
+                  {t("contextAccess")}
                 </th>
                 <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                  {t('authentication')}
+                  {t("authentication")}
                 </th>
               </tr>
             </thead>
@@ -514,18 +564,26 @@ export default function WorkspaceMembersPage() {
                   key={member.user_id}
                   className={`hover:bg-gray-100 dark:hover:bg-gray-700 ${
                     index % 2 === 0
-                      ? 'bg-white dark:bg-gray-900'
-                      : 'bg-gray-50 dark:bg-gray-800/50'
+                      ? "bg-white dark:bg-gray-900"
+                      : "bg-gray-50 dark:bg-gray-800/50"
                   }`}
                 >
                   <td className="px-6 py-4 whitespace-nowrap">
                     <div className="flex items-center gap-3">
                       <div className="w-8 h-8 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white text-sm font-bold">
-                        {(member.user_name || member.user_email || member.user_id).charAt(0).toUpperCase()}
+                        {(
+                          member.user_name ||
+                          member.user_email ||
+                          member.user_id
+                        )
+                          .charAt(0)
+                          .toUpperCase()}
                       </div>
                       <div>
                         <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                          {member.user_name || member.user_email || member.user_id}
+                          {member.user_name ||
+                            member.user_email ||
+                            member.user_id}
                         </div>
                         {member.user_email && !member.user_name && (
                           <div className="text-xs text-gray-500 dark:text-gray-400">
@@ -541,60 +599,83 @@ export default function WorkspaceMembersPage() {
                     </div>
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap">
-                    {member.role === 'owner' ? (
+                    {member.role === "owner" ? (
                       <span className="px-3 py-1 text-sm font-medium bg-purple-100 dark:bg-purple-900 text-purple-800 dark:text-purple-200 rounded">
-                        {t('ownerCannotChange')}
+                        {t("ownerCannotChange")}
                       </span>
                     ) : (
                       <select
                         value={member.role}
-                        onChange={(e) => handleUpdateRole(member.user_id, e.target.value)}
-                        disabled={currentWorkspace?.current_user_role === 'member' || currentWorkspace?.current_user_role === 'viewer' || member.user_id === user?.id}
+                        onChange={(e) =>
+                          handleUpdateRole(member.user_id, e.target.value)
+                        }
+                        disabled={
+                          currentWorkspace?.current_user_role === "member" ||
+                          currentWorkspace?.current_user_role === "viewer" ||
+                          member.user_id === user?.id
+                        }
                         className="text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1 bg-white dark:bg-gray-800 disabled:opacity-50 disabled:cursor-not-allowed"
-                        title={member.user_id === user?.id ? t('cannotModifyOwnRole') : undefined}
+                        title={
+                          member.user_id === user?.id
+                            ? t("cannotModifyOwnRole")
+                            : undefined
+                        }
                       >
-                        <option value="admin">{t('admin')}</option>
-                        <option value="member">{t('member')}</option>
-                        <option value="viewer">{t('viewer')}</option>
+                        <option value="admin">{t("admin")}</option>
+                        <option value="member">{t("member")}</option>
+                        <option value="viewer">{t("viewer")}</option>
                       </select>
                     )}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                     {member.joined_at
                       ? new Date(member.joined_at).toLocaleDateString()
-                      : 'N/A'}
+                      : "N/A"}
                   </td>
                   <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                     {member.last_login_at ? (
-                      <span>{new Date(member.last_login_at).toLocaleString()}</span>
+                      <span>
+                        {new Date(member.last_login_at).toLocaleString()}
+                      </span>
                     ) : (
-                      <span className="text-gray-400">{t('never')}</span>
+                      <span className="text-gray-400">{t("never")}</span>
                     )}
                   </td>
                   {/* Issue #234: Context Access column */}
                   <td className="px-6 py-4 whitespace-nowrap text-sm">
-                    {member.role === 'owner' || member.role === 'admin' ? (
-                      <span className="text-gray-400 text-xs">{t('contextAccessNotApplicable')}</span>
-                    ) : member.allowed_context_ids === null || member.allowed_context_ids === undefined ? (
+                    {member.role === "owner" || member.role === "admin" ? (
+                      <span className="text-gray-400 text-xs">
+                        {t("contextAccessNotApplicable")}
+                      </span>
+                    ) : member.allowed_context_ids === null ||
+                      member.allowed_context_ids === undefined ? (
                       <button
                         onClick={() => handleContextAccessClick(member)}
-                        disabled={currentWorkspace?.current_user_role !== 'owner' && currentWorkspace?.current_user_role !== 'admin'}
+                        disabled={
+                          currentWorkspace?.current_user_role !== "owner" &&
+                          currentWorkspace?.current_user_role !== "admin"
+                        }
                         className="flex items-center gap-1 text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300 disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <AlertTriangle className="w-4 h-4" />
                         <span className="text-xs font-medium">
-                          {t('contextNotConfigured')}
+                          {t("contextNotConfigured")}
                         </span>
                       </button>
                     ) : (
                       <button
                         onClick={() => handleContextAccessClick(member)}
-                        disabled={currentWorkspace?.current_user_role !== 'owner' && currentWorkspace?.current_user_role !== 'admin'}
+                        disabled={
+                          currentWorkspace?.current_user_role !== "owner" &&
+                          currentWorkspace?.current_user_role !== "admin"
+                        }
                         className="flex items-center gap-1 text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 disabled:opacity-50 disabled:cursor-not-allowed"
                       >
                         <Settings className="w-4 h-4" />
                         <span className="text-xs">
-                          {t('contextsSelected', { count: member.allowed_context_ids.length })}
+                          {t("contextsSelected", {
+                            count: member.allowed_context_ids.length,
+                          })}
                         </span>
                       </button>
                     )}
@@ -602,21 +683,23 @@ export default function WorkspaceMembersPage() {
                   <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
                     <div className="flex items-center justify-end gap-2">
                       {/* Remove button - only for owner, not for owner members */}
-                      {member.role !== 'owner' && currentWorkspace?.current_user_role === 'owner' && (
-                        <button
-                          onClick={() => handleRemoveMemberClick(member)}
-                          className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                          title={t('removeTitle')}
-                        >
-                          <Trash2 className="w-4 h-4" />
-                        </button>
-                      )}
+                      {member.role !== "owner" &&
+                        currentWorkspace?.current_user_role === "owner" && (
+                          <button
+                            onClick={() => handleRemoveMemberClick(member)}
+                            className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                            title={t("removeTitle")}
+                          >
+                            <Trash2 className="w-4 h-4" />
+                          </button>
+                        )}
 
                       {/* Empty state for consistent spacing */}
                       {member.user_id !== user?.id &&
-                        (member.role === 'owner' || currentWorkspace?.current_user_role !== 'owner') && (
-                        <span className="text-gray-400 text-xs">—</span>
-                      )}
+                        (member.role === "owner" ||
+                          currentWorkspace?.current_user_role !== "owner") && (
+                          <span className="text-gray-400 text-xs">—</span>
+                        )}
                     </div>
                   </td>
                 </tr>
@@ -628,7 +711,7 @@ export default function WorkspaceMembersPage() {
         {members.length === 0 && (
           <div className="text-center py-12 text-gray-500 dark:text-gray-400">
             <Users className="w-12 h-12 mx-auto mb-4 opacity-50" />
-            <p>{t('noMembersYet')}</p>
+            <p>{t("noMembersYet")}</p>
           </div>
         )}
       </Section>
@@ -636,39 +719,46 @@ export default function WorkspaceMembersPage() {
       {/* Pending Invitations Section */}
       {invitations.length > 0 && (
         <Section
-          title={t('pendingInvitations')}
-          description={invitations.length !== 1 ? t('invitationsCount', { count: invitations.length }) : t('invitationCount', { count: invitations.length })}
+          title={t("pendingInvitations")}
+          description={
+            invitations.length !== 1
+              ? t("invitationsCount", { count: invitations.length })
+              : t("invitationCount", { count: invitations.length })
+          }
         >
           <div className="overflow-x-auto">
             <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
               <thead>
                 <tr>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    {t('emailAnyone')}
+                    {t("emailAnyone")}
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    {t('role')}
+                    {t("role")}
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    {t('contextAccess')}
+                    {t("contextAccess")}
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    {t('expires')}
+                    {t("expires")}
                   </th>
                   <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    {t('invitationLink')}
+                    {t("invitationLink")}
                   </th>
                   <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-                    {tCommon('actions')}
+                    {tCommon("actions")}
                   </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
                 {invitations.map((invitation) => (
-                  <tr key={invitation.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                  <tr
+                    key={invitation.id}
+                    className="hover:bg-gray-50 dark:hover:bg-gray-800"
+                  >
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
                       <span className="text-gray-900 dark:text-gray-100">
-                        {invitation.email || 'N/A'}
+                        {invitation.email || "N/A"}
                       </span>
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap">
@@ -677,18 +767,28 @@ export default function WorkspaceMembersPage() {
                       </span>
                     </td>
                     <td className="px-6 py-4 text-sm">
-                      {invitation.role === 'admin' ? (
-                        <span className="text-gray-400 text-xs">{t('contextAccessNotApplicable')}</span>
-                      ) : invitation.allowed_context_ids && invitation.allowed_context_ids.length > 0 ? (
+                      {invitation.role === "admin" ? (
+                        <span className="text-gray-400 text-xs">
+                          {t("contextAccessNotApplicable")}
+                        </span>
+                      ) : invitation.allowed_context_ids &&
+                        invitation.allowed_context_ids.length > 0 ? (
                         <div className="flex flex-wrap gap-1">
-                          {invitation.allowed_context_ids.slice(0, 3).map(ctxId => {
-                            const ctx = contexts.find(c => c.id === ctxId);
-                            return (
-                              <span key={ctxId} className="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded">
-                                {ctx?.display_name || ctx?.name || ctxId.substring(0, 8)}
-                              </span>
-                            );
-                          })}
+                          {invitation.allowed_context_ids
+                            .slice(0, 3)
+                            .map((ctxId) => {
+                              const ctx = contexts.find((c) => c.id === ctxId);
+                              return (
+                                <span
+                                  key={ctxId}
+                                  className="px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900 text-blue-800 dark:text-blue-200 rounded"
+                                >
+                                  {ctx?.display_name ||
+                                    ctx?.name ||
+                                    ctxId.substring(0, 8)}
+                                </span>
+                              );
+                            })}
                           {invitation.allowed_context_ids.length > 3 && (
                             <span className="text-xs text-gray-500 dark:text-gray-400">
                               +{invitation.allowed_context_ids.length - 3}
@@ -698,33 +798,48 @@ export default function WorkspaceMembersPage() {
                       ) : (
                         <span className="text-amber-600 dark:text-amber-400 text-xs flex items-center gap-1">
                           <AlertTriangle className="w-3 h-3" />
-                          {t('contextNotConfigured')}
+                          {t("contextNotConfigured")}
                         </span>
                       )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
                       {invitation.expires_at ? (
-                        <span className={invitation.is_expired ? 'text-red-600 dark:text-red-400' : 'text-gray-700 dark:text-gray-300'}>
+                        <span
+                          className={
+                            invitation.is_expired
+                              ? "text-red-600 dark:text-red-400"
+                              : "text-gray-700 dark:text-gray-300"
+                          }
+                        >
                           {new Date(invitation.expires_at).toLocaleDateString()}
                         </span>
                       ) : (
-                        <span className="text-gray-500 dark:text-gray-400">{t('neverExpires')}</span>
+                        <span className="text-gray-500 dark:text-gray-400">
+                          {t("neverExpires")}
+                        </span>
                       )}
                     </td>
                     <td className="px-6 py-4 whitespace-nowrap text-sm">
                       <button
-                        onClick={() => handleCopyInviteUrl(invitation.invitation_url, invitation.token)}
+                        onClick={() =>
+                          handleCopyInviteUrl(
+                            invitation.invitation_url,
+                            invitation.token,
+                          )
+                        }
                         className="flex items-center gap-2 text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300"
                       >
                         {copiedToken === invitation.token ? (
                           <>
                             <Check className="w-4 h-4 text-green-600 dark:text-green-400" />
-                            <span className="text-green-600 dark:text-green-400">{t('copied')}</span>
+                            <span className="text-green-600 dark:text-green-400">
+                              {t("copied")}
+                            </span>
                           </>
                         ) : (
                           <>
                             <Copy className="w-4 h-4" />
-                            <span>{t('copyLink')}</span>
+                            <span>{t("copyLink")}</span>
                           </>
                         )}
                       </button>
@@ -733,7 +848,7 @@ export default function WorkspaceMembersPage() {
                       <button
                         onClick={() => handleDeleteInvitationClick(invitation)}
                         className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                        title={t('revokeInvitation')}
+                        title={t("revokeInvitation")}
                       >
                         <Trash2 className="w-4 h-4" />
                       </button>
@@ -758,10 +873,10 @@ export default function WorkspaceMembersPage() {
             </div>
             <div className="text-left">
               <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100">
-                {t('rolePermissions')}
+                {t("rolePermissions")}
               </h3>
               <p className="text-sm text-gray-500 dark:text-gray-400">
-                {t('rolePermissionsDesc')}
+                {t("rolePermissionsDesc")}
               </p>
             </div>
           </div>
@@ -778,24 +893,94 @@ export default function WorkspaceMembersPage() {
               <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
                 <thead>
                   <tr className="bg-gray-50 dark:bg-gray-800/50">
-                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('permission')}</th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('ownerRole')}</th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('adminRole')}</th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('memberRole')}</th>
-                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('viewerRole')}</th>
+                    <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      {t("permission")}
+                    </th>
+                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      {t("ownerRole")}
+                    </th>
+                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      {t("adminRole")}
+                    </th>
+                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      {t("memberRole")}
+                    </th>
+                    <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">
+                      {t("viewerRole")}
+                    </th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
-                  <PermissionRow permission={t('permissionManageWorkspace')} owner={true} admin={false} member={false} viewer={false} />
-                  <PermissionRow permission={t('permissionInviteMembers')} owner={true} admin={true} member={false} viewer={false} />
-                  <PermissionRow permission={t('permissionManageRoles')} owner={true} admin={true} member={false} viewer={false} />
-                  <PermissionRow permission={t('permissionManageContexts')} owner={true} admin={true} member={false} viewer={false} />
-                  <PermissionRow permission={t('permissionManagePublicSettings')} owner={true} admin={false} member={false} viewer={false} />
-                  <PermissionRow permission={t('permissionAccessAllContexts')} owner={true} admin={true} member={false} viewer={false} />
-                  <PermissionRow permission={t('permissionAccessAssignedContexts')} owner={false} admin={false} member={true} viewer={true} />
-                  <PermissionRow permission={t('permissionCreateMemories')} owner={true} admin={true} member={true} viewer={false} />
-                  <PermissionRow permission={t('permissionDeleteOwnMemories')} owner={true} admin={true} member={true} viewer={false} />
-                  <PermissionRow permission={t('permissionReadMemories')} owner={true} admin={true} member={true} viewer={true} />
+                  <PermissionRow
+                    permission={t("permissionManageWorkspace")}
+                    owner={true}
+                    admin={false}
+                    member={false}
+                    viewer={false}
+                  />
+                  <PermissionRow
+                    permission={t("permissionInviteMembers")}
+                    owner={true}
+                    admin={true}
+                    member={false}
+                    viewer={false}
+                  />
+                  <PermissionRow
+                    permission={t("permissionManageRoles")}
+                    owner={true}
+                    admin={true}
+                    member={false}
+                    viewer={false}
+                  />
+                  <PermissionRow
+                    permission={t("permissionManageContexts")}
+                    owner={true}
+                    admin={true}
+                    member={false}
+                    viewer={false}
+                  />
+                  <PermissionRow
+                    permission={t("permissionManagePublicSettings")}
+                    owner={true}
+                    admin={false}
+                    member={false}
+                    viewer={false}
+                  />
+                  <PermissionRow
+                    permission={t("permissionAccessAllContexts")}
+                    owner={true}
+                    admin={true}
+                    member={false}
+                    viewer={false}
+                  />
+                  <PermissionRow
+                    permission={t("permissionAccessAssignedContexts")}
+                    owner={false}
+                    admin={false}
+                    member={true}
+                    viewer={true}
+                  />
+                  <PermissionRow
+                    permission={t("permissionCreateMemories")}
+                    owner={true}
+                    admin={true}
+                    member={true}
+                    viewer={false}
+                  />
+                  <PermissionRow
+                    permission={t("permissionDeleteOwnMemories")}
+                    owner={true}
+                    admin={true}
+                    member={true}
+                    viewer={false}
+                  />
+                  <PermissionRow
+                    permission={t("permissionReadMemories")}
+                    owner={true}
+                    admin={true}
+                    member={true}
+                    viewer={true}
+                  />
                 </tbody>
               </table>
             </div>
@@ -809,7 +994,7 @@ export default function WorkspaceMembersPage() {
           <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                {t('inviteTeamMember')}
+                {t("inviteTeamMember")}
               </h3>
               <button
                 onClick={handleCloseInviteDialog}
@@ -827,35 +1012,37 @@ export default function WorkspaceMembersPage() {
                   <div
                     className={`p-3 rounded-lg border ${
                       memberQuota.percentage >= 100
-                        ? 'bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800'
+                        ? "bg-red-50 dark:bg-red-900/20 border-red-200 dark:border-red-800"
                         : memberQuota.percentage >= 80
-                        ? 'bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800'
-                        : 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800'
+                          ? "bg-yellow-50 dark:bg-yellow-900/20 border-yellow-200 dark:border-yellow-800"
+                          : "bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800"
                     }`}
                   >
                     <div className="flex items-center justify-between">
                       <div>
                         <p className="text-sm font-medium">
                           {memberQuota.percentage >= 100
-                            ? '❌'
+                            ? "❌"
                             : memberQuota.percentage >= 80
-                            ? '⚠️'
-                            : 'ℹ️'}{' '}
-                          {t('seatUsage', {
+                              ? "⚠️"
+                              : "ℹ️"}{" "}
+                          {t("seatUsage", {
                             used: memberQuota.total_used,
                             limit: memberQuota.limit,
                           })}
                         </p>
                         <p className="text-xs mt-1">
                           {memberQuota.available > 0
-                            ? t('seatsAvailable', { available: memberQuota.available })
-                            : t('seatLimitReached')}
+                            ? t("seatsAvailable", {
+                                available: memberQuota.available,
+                              })
+                            : t("seatLimitReached")}
                         </p>
                       </div>
                       {memberQuota.percentage >= 100 && (
                         <Link href="/workspace/plan">
                           <button className="px-3 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700">
-                            {t('upgradeToAddMembers')}
+                            {t("upgradeToAddMembers")}
                           </button>
                         </Link>
                       )}
@@ -868,17 +1055,18 @@ export default function WorkspaceMembersPage() {
                   <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 text-center">
                     <AlertTriangle className="w-12 h-12 text-red-600 mx-auto mb-3" />
                     <h4 className="text-lg font-semibold text-red-900 dark:text-red-100 mb-2">
-                      {t('seatLimitReached')}
+                      {t("seatLimitReached")}
                     </h4>
                     <p className="text-sm text-red-800 dark:text-red-200 mb-4">
-                      {t('seatLimitReachedDesc', {
-                        plan: currentWorkspace?.plan_name?.toUpperCase() || 'PRO',
+                      {t("seatLimitReachedDesc", {
+                        plan:
+                          currentWorkspace?.plan_name?.toUpperCase() || "PRO",
                         limit: memberQuota.limit,
                       })}
                     </p>
                     <Link href="/workspace/plan">
                       <button className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700">
-                        {t('upgradeToAddMembers')}
+                        {t("upgradeToAddMembers")}
                       </button>
                     </Link>
                   </div>
@@ -886,173 +1074,205 @@ export default function WorkspaceMembersPage() {
                   <>
                     <div>
                       <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-                        {t('emailRequired')} <span className="text-red-500">*</span>
+                        {t("emailRequired")}{" "}
+                        <span className="text-red-500">*</span>
                       </label>
                       <input
-                    type="email"
-                    value={inviteEmail}
-                    onChange={(e) => setInviteEmail(e.target.value)}
-                    placeholder={t('emailPlaceholder')}
-                    required
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-                  />
-                  <div className="mt-1 p-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded">
-                    <p className="text-xs text-blue-900 dark:text-blue-100 font-medium">
-                      ℹ️ {t('emailImportant')}
-                    </p>
-                    <p className="text-xs text-blue-800 dark:text-blue-200 mt-1">
-                      {t('emailMustMatch')}
-                    </p>
-                  </div>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-                    {t('role')}
-                  </label>
-                  <select
-                    value={inviteRole}
-                    onChange={(e) => setInviteRole(e.target.value as any)}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-                  >
-                    <option value="member">{t('roleMemberDesc')}</option>
-                    <option value="admin">{t('roleAdminDesc')}</option>
-                    <option value="viewer">{t('roleViewerDesc')}</option>
-                  </select>
-                </div>
-
-                <div>
-                  <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-                    {t('expiresIn')}
-                  </label>
-                  <select
-                    value={inviteExpiry ?? 'never'}
-                    onChange={(e) =>
-                      setInviteExpiry(e.target.value === 'never' ? null : Number(e.target.value))
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-                  >
-                    <option value="7">{t('days7')}</option>
-                    <option value="30">{t('days30')}</option>
-                    <option value="90">{t('days90')}</option>
-                    <option value="365">{t('year1')}</option>
-                    <option value="never">{t('neverExpires')}</option>
-                  </select>
-                </div>
-
-                {/* Migration 042: Context Access Selection (for member/viewer only) */}
-                {(inviteRole === 'member' || inviteRole === 'viewer') && (
-                  <div>
-                    <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
-                      {t('inviteContextSelection')}
-                    </label>
-                    <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">
-                      {t('inviteContextSelectionDesc')}
-                    </p>
-
-                    {/* Shared contexts check */}
-                    {contexts.filter(c => !c.is_private).length === 0 ? (
-                      <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
-                        <p className="text-sm text-amber-800 dark:text-amber-200">
-                          ⚠️ {t('noSharedContexts')}
+                        type="email"
+                        value={inviteEmail}
+                        onChange={(e) => setInviteEmail(e.target.value)}
+                        placeholder={t("emailPlaceholder")}
+                        required
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                      />
+                      <div className="mt-1 p-2 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded">
+                        <p className="text-xs text-blue-900 dark:text-blue-100 font-medium">
+                          ℹ️ {t("emailImportant")}
                         </p>
-                        <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
-                          {t('noSharedContextsDesc')}
+                        <p className="text-xs text-blue-800 dark:text-blue-200 mt-1">
+                          {t("emailMustMatch")}
                         </p>
                       </div>
-                    ) : (
-                      <>
-                        {/* Select All / Deselect All buttons */}
-                        <div className="flex items-center gap-2 mb-2">
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => {
-                              const sharedIds = contexts.filter(c => !c.is_private).map(c => c.id);
-                              setInviteContextIds(sharedIds);
-                            }}
-                          >
-                            {t('selectAll')}
-                          </Button>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            onClick={() => setInviteContextIds([])}
-                            disabled={inviteContextIds.length === 0}
-                          >
-                            {t('deselectAll')}
-                          </Button>
-                        </div>
-
-                        {/* Context checkboxes */}
-                        <div className="border border-gray-200 dark:border-gray-700 rounded-lg max-h-40 overflow-y-auto">
-                          <ul className="divide-y divide-gray-200 dark:divide-gray-700">
-                            {contexts.filter(c => !c.is_private).map((context) => (
-                              <li key={context.id} className="px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-800">
-                                <label className="flex items-center gap-2 cursor-pointer">
-                                  <input
-                                    type="checkbox"
-                                    checked={inviteContextIds.includes(context.id)}
-                                    onChange={() => {
-                                      if (inviteContextIds.includes(context.id)) {
-                                        setInviteContextIds(inviteContextIds.filter(id => id !== context.id));
-                                      } else {
-                                        setInviteContextIds([...inviteContextIds, context.id]);
-                                      }
-                                    }}
-                                    className="w-4 h-4 text-blue-600 rounded"
-                                  />
-                                  <span className="text-sm text-gray-900 dark:text-gray-100">
-                                    {context.display_name || context.name}
-                                  </span>
-                                </label>
-                              </li>
-                            ))}
-                          </ul>
-                        </div>
-
-                        {/* Status message */}
-                        <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
-                          {t('contextsSelected', { count: inviteContextIds.length })}
-                        </p>
-                      </>
-                    )}
-                  </div>
-                )}
-
-                {/* Issue #217: Error display */}
-                {inviteError && (
-                  <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
-                    <div className="flex items-start gap-2">
-                      <AlertTriangle className="w-4 h-4 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
-                      <p className="text-sm text-red-700 dark:text-red-300">{inviteError}</p>
                     </div>
-                  </div>
-                )}
 
-                <div className="flex justify-end gap-2 mt-6">
-                  <button
-                    onClick={handleCloseInviteDialog}
-                    disabled={inviteLoading}
-                    className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md disabled:opacity-50"
-                  >
-                    {tCommon('cancel')}
-                  </button>
-                  <button
-                    onClick={handleCreateInvitation}
-                    disabled={
-                      inviteLoading ||
-                      ((inviteRole === 'member' || inviteRole === 'viewer') &&
-                        contexts.filter(c => !c.is_private).length === 0)
-                    }
-                    className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
-                  >
-                    {inviteLoading && <Loader2 className="w-4 h-4 animate-spin" />}
-                    {inviteLoading ? t('creating') : t('createInvitation')}
-                  </button>
-                </div>
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+                        {t("role")}
+                      </label>
+                      <select
+                        value={inviteRole}
+                        onChange={(e) => setInviteRole(e.target.value as any)}
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                      >
+                        <option value="member">{t("roleMemberDesc")}</option>
+                        <option value="admin">{t("roleAdminDesc")}</option>
+                        <option value="viewer">{t("roleViewerDesc")}</option>
+                      </select>
+                    </div>
+
+                    <div>
+                      <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
+                        {t("expiresIn")}
+                      </label>
+                      <select
+                        value={inviteExpiry ?? "never"}
+                        onChange={(e) =>
+                          setInviteExpiry(
+                            e.target.value === "never"
+                              ? null
+                              : Number(e.target.value),
+                          )
+                        }
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                      >
+                        <option value="7">{t("days7")}</option>
+                        <option value="30">{t("days30")}</option>
+                        <option value="90">{t("days90")}</option>
+                        <option value="365">{t("year1")}</option>
+                        <option value="never">{t("neverExpires")}</option>
+                      </select>
+                    </div>
+
+                    {/* Migration 042: Context Access Selection (for member/viewer only) */}
+                    {(inviteRole === "member" || inviteRole === "viewer") && (
+                      <div>
+                        <label className="block text-sm font-medium mb-2 text-gray-700 dark:text-gray-300">
+                          {t("inviteContextSelection")}
+                        </label>
+                        <p className="text-xs text-gray-600 dark:text-gray-400 mb-2">
+                          {t("inviteContextSelectionDesc")}
+                        </p>
+
+                        {/* Shared contexts check */}
+                        {contexts.filter((c) => !c.is_private).length === 0 ? (
+                          <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg p-3">
+                            <p className="text-sm text-amber-800 dark:text-amber-200">
+                              ⚠️ {t("noSharedContexts")}
+                            </p>
+                            <p className="text-xs text-amber-700 dark:text-amber-300 mt-1">
+                              {t("noSharedContextsDesc")}
+                            </p>
+                          </div>
+                        ) : (
+                          <>
+                            {/* Select All / Deselect All buttons */}
+                            <div className="flex items-center gap-2 mb-2">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                  const sharedIds = contexts
+                                    .filter((c) => !c.is_private)
+                                    .map((c) => c.id);
+                                  setInviteContextIds(sharedIds);
+                                }}
+                              >
+                                {t("selectAll")}
+                              </Button>
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                onClick={() => setInviteContextIds([])}
+                                disabled={inviteContextIds.length === 0}
+                              >
+                                {t("deselectAll")}
+                              </Button>
+                            </div>
+
+                            {/* Context checkboxes */}
+                            <div className="border border-gray-200 dark:border-gray-700 rounded-lg max-h-40 overflow-y-auto">
+                              <ul className="divide-y divide-gray-200 dark:divide-gray-700">
+                                {contexts
+                                  .filter((c) => !c.is_private)
+                                  .map((context) => (
+                                    <li
+                                      key={context.id}
+                                      className="px-3 py-2 hover:bg-gray-50 dark:hover:bg-gray-800"
+                                    >
+                                      <label className="flex items-center gap-2 cursor-pointer">
+                                        <input
+                                          type="checkbox"
+                                          checked={inviteContextIds.includes(
+                                            context.id,
+                                          )}
+                                          onChange={() => {
+                                            if (
+                                              inviteContextIds.includes(
+                                                context.id,
+                                              )
+                                            ) {
+                                              setInviteContextIds(
+                                                inviteContextIds.filter(
+                                                  (id) => id !== context.id,
+                                                ),
+                                              );
+                                            } else {
+                                              setInviteContextIds([
+                                                ...inviteContextIds,
+                                                context.id,
+                                              ]);
+                                            }
+                                          }}
+                                          className="w-4 h-4 text-blue-600 rounded"
+                                        />
+                                        <span className="text-sm text-gray-900 dark:text-gray-100">
+                                          {context.display_name || context.name}
+                                        </span>
+                                      </label>
+                                    </li>
+                                  ))}
+                              </ul>
+                            </div>
+
+                            {/* Status message */}
+                            <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
+                              {t("contextsSelected", {
+                                count: inviteContextIds.length,
+                              })}
+                            </p>
+                          </>
+                        )}
+                      </div>
+                    )}
+
+                    {/* Issue #217: Error display */}
+                    {inviteError && (
+                      <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
+                        <div className="flex items-start gap-2">
+                          <AlertTriangle className="w-4 h-4 text-red-600 dark:text-red-400 mt-0.5 flex-shrink-0" />
+                          <p className="text-sm text-red-700 dark:text-red-300">
+                            {inviteError}
+                          </p>
+                        </div>
+                      </div>
+                    )}
+
+                    <div className="flex justify-end gap-2 mt-6">
+                      <button
+                        onClick={handleCloseInviteDialog}
+                        disabled={inviteLoading}
+                        className="px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md disabled:opacity-50"
+                      >
+                        {tCommon("cancel")}
+                      </button>
+                      <button
+                        onClick={handleCreateInvitation}
+                        disabled={
+                          inviteLoading ||
+                          ((inviteRole === "member" ||
+                            inviteRole === "viewer") &&
+                            contexts.filter((c) => !c.is_private).length === 0)
+                        }
+                        className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50 flex items-center gap-2"
+                      >
+                        {inviteLoading && (
+                          <Loader2 className="w-4 h-4 animate-spin" />
+                        )}
+                        {inviteLoading ? t("creating") : t("createInvitation")}
+                      </button>
+                    </div>
                   </>
                 )}
               </div>
@@ -1061,16 +1281,16 @@ export default function WorkspaceMembersPage() {
               <div className="space-y-4">
                 <div className="bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg p-4">
                   <p className="text-sm text-green-800 dark:text-green-200 mb-2">
-                    ✓ {t('invitationSuccess')}
+                    ✓ {t("invitationSuccess")}
                   </p>
                   <p className="text-xs text-green-700 dark:text-green-300">
-                    {t('shareInviteLink')}
+                    {t("shareInviteLink")}
                   </p>
                 </div>
 
                 <div>
                   <label className="block text-sm font-medium mb-1 text-gray-700 dark:text-gray-300">
-                    {t('invitationLink')}
+                    {t("invitationLink")}
                   </label>
                   <div className="flex gap-2">
                     <input
@@ -1080,18 +1300,20 @@ export default function WorkspaceMembersPage() {
                       className="flex-1 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-gray-50 dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm"
                     />
                     <button
-                      onClick={() => handleCopyInviteUrl(createdInviteUrl, createdInviteUrl)}
+                      onClick={() =>
+                        handleCopyInviteUrl(createdInviteUrl, createdInviteUrl)
+                      }
                       className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 flex items-center gap-2"
                     >
                       {copiedToken === createdInviteUrl ? (
                         <>
                           <Check className="w-4 h-4" />
-                          {t('copied')}
+                          {t("copied")}
                         </>
                       ) : (
                         <>
                           <Copy className="w-4 h-4" />
-                          {tCommon('copy')}
+                          {tCommon("copy")}
                         </>
                       )}
                     </button>
@@ -1099,7 +1321,7 @@ export default function WorkspaceMembersPage() {
                 </div>
 
                 <p className="text-xs text-gray-600 dark:text-gray-400">
-                  {t('inviteLinkAddedNote')}
+                  {t("inviteLinkAddedNote")}
                 </p>
 
                 <div className="flex justify-end mt-6">
@@ -1107,7 +1329,7 @@ export default function WorkspaceMembersPage() {
                     onClick={handleCloseInviteDialog}
                     className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700"
                   >
-                    {tCommon('close')}
+                    {tCommon("close")}
                   </button>
                 </div>
               </div>
@@ -1121,21 +1343,21 @@ export default function WorkspaceMembersPage() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
             <h3 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
-              {t('proPlanRequiredTitle')}
+              {t("proPlanRequiredTitle")}
             </h3>
 
             <p className="text-gray-600 dark:text-gray-400 mb-6">
-              {t('proPlanRequiredDesc')}
+              {t("proPlanRequiredDesc")}
             </p>
 
             <div className="bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg p-4 mb-6">
               <p className="text-sm text-purple-900 dark:text-purple-100 font-medium mb-2">
-                {t('proPlanBenefits')}
+                {t("proPlanBenefits")}
               </p>
               <ul className="text-sm text-purple-800 dark:text-purple-200 space-y-1">
-                <li>✓ {t('benefitTeamInvitations')}</li>
-                <li>✓ {t('benefitSharedContexts')}</li>
-                <li>✓ {t('benefitCollaboration')}</li>
+                <li>✓ {t("benefitTeamInvitations")}</li>
+                <li>✓ {t("benefitSharedContexts")}</li>
+                <li>✓ {t("benefitCollaboration")}</li>
               </ul>
             </div>
 
@@ -1144,16 +1366,16 @@ export default function WorkspaceMembersPage() {
                 onClick={() => setShowUpgradePrompt(false)}
                 className="flex-1 px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md"
               >
-                {tCommon('cancel')}
+                {tCommon("cancel")}
               </button>
               <button
                 onClick={() => {
                   setShowUpgradePrompt(false);
-                  window.location.href = '/workspace/plan';
+                  window.location.href = "/workspace/plan";
                 }}
                 className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700"
               >
-                {t('upgradeToPro')}
+                {t("upgradeToPro")}
               </button>
             </div>
           </div>
@@ -1161,24 +1383,34 @@ export default function WorkspaceMembersPage() {
       )}
 
       {/* Issue #217: Delete Member Confirmation Dialog */}
-      <AlertDialog open={showDeleteMemberDialog} onOpenChange={setShowDeleteMemberDialog}>
+      <AlertDialog
+        open={showDeleteMemberDialog}
+        onOpenChange={setShowDeleteMemberDialog}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-red-500" />
-              {t('removeMemberTitle')}
+              {t("removeMemberTitle")}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {t('removeMemberDesc', { name: memberToDelete?.user_name || memberToDelete?.user_email || 'this member' })}
+              {t("removeMemberDesc", {
+                name:
+                  memberToDelete?.user_name ||
+                  memberToDelete?.user_email ||
+                  "this member",
+              })}
             </AlertDialogDescription>
             <div className="mt-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
               <p className="text-sm text-amber-800 dark:text-amber-200">
-                {t('removeMemberWarning')}
+                {t("removeMemberWarning")}
               </p>
             </div>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteLoading}>{tCommon('cancel')}</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleteLoading}>
+              {tCommon("cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleConfirmRemoveMember}
               disabled={deleteLoading}
@@ -1187,10 +1419,10 @@ export default function WorkspaceMembersPage() {
               {deleteLoading ? (
                 <>
                   <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                  {t('removing')}
+                  {t("removing")}
                 </>
               ) : (
-                t('removeMember')
+                t("removeMember")
               )}
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -1198,24 +1430,31 @@ export default function WorkspaceMembersPage() {
       </AlertDialog>
 
       {/* Issue #217: Delete Invitation Confirmation Dialog */}
-      <AlertDialog open={showDeleteInvitationDialog} onOpenChange={setShowDeleteInvitationDialog}>
+      <AlertDialog
+        open={showDeleteInvitationDialog}
+        onOpenChange={setShowDeleteInvitationDialog}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">
               <AlertTriangle className="h-5 w-5 text-amber-500" />
-              {t('revokeInvitationTitle')}
+              {t("revokeInvitationTitle")}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {t('revokeInvitationDesc', { email: invitationToDelete?.email || 'this user' })}
+              {t("revokeInvitationDesc", {
+                email: invitationToDelete?.email || "this user",
+              })}
             </AlertDialogDescription>
             <div className="mt-4 p-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg">
               <p className="text-sm text-amber-800 dark:text-amber-200">
-                {t('revokeInvitationWarning')}
+                {t("revokeInvitationWarning")}
               </p>
             </div>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleteInvitationLoading}>{tCommon('cancel')}</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleteInvitationLoading}>
+              {tCommon("cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleConfirmDeleteInvitation}
               disabled={deleteInvitationLoading}
@@ -1224,10 +1463,10 @@ export default function WorkspaceMembersPage() {
               {deleteInvitationLoading ? (
                 <>
                   <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                  {t('revoking')}
+                  {t("revoking")}
                 </>
               ) : (
-                t('revokeInvitation')
+                t("revokeInvitation")
               )}
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -1235,17 +1474,26 @@ export default function WorkspaceMembersPage() {
       </AlertDialog>
 
       {/* Issue #234: Role Change Confirmation Dialog */}
-      <AlertDialog open={showRoleChangeDialog} onOpenChange={setShowRoleChangeDialog}>
+      <AlertDialog
+        open={showRoleChangeDialog}
+        onOpenChange={setShowRoleChangeDialog}
+      >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{t('roleChangeConfirmTitle')}</AlertDialogTitle>
+            <AlertDialogTitle>{t("roleChangeConfirmTitle")}</AlertDialogTitle>
             <AlertDialogDescription>
-              {pendingRoleChange && t('roleChangeConfirmDesc', { name: pendingRoleChange.member.user_name || pendingRoleChange.member.user_email || 'User' })}
+              {pendingRoleChange &&
+                t("roleChangeConfirmDesc", {
+                  name:
+                    pendingRoleChange.member.user_name ||
+                    pendingRoleChange.member.user_email ||
+                    "User",
+                })}
             </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="py-4">
             <p className="text-sm text-amber-600 dark:text-amber-400">
-              {t('roleChangeWarning')}
+              {t("roleChangeWarning")}
             </p>
           </div>
           <AlertDialogFooter>
@@ -1256,12 +1504,15 @@ export default function WorkspaceMembersPage() {
                 setPendingRoleChange(null);
               }}
             >
-              {tCommon('cancel')}
+              {tCommon("cancel")}
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
                 if (pendingRoleChange) {
-                  executeRoleChange(pendingRoleChange.member.user_id, pendingRoleChange.newRole);
+                  executeRoleChange(
+                    pendingRoleChange.member.user_id,
+                    pendingRoleChange.newRole,
+                  );
                 }
               }}
               disabled={roleChangeLoading}
@@ -1270,10 +1521,10 @@ export default function WorkspaceMembersPage() {
               {roleChangeLoading ? (
                 <>
                   <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                  {tCommon('loading')}
+                  {tCommon("loading")}
                 </>
               ) : (
-                t('confirmRoleChange')
+                t("confirmRoleChange")
               )}
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -1281,22 +1532,25 @@ export default function WorkspaceMembersPage() {
       </AlertDialog>
 
       {/* Issue #234: Context Access Dialog */}
-      <AlertDialog open={showContextAccessDialog} onOpenChange={setShowContextAccessDialog}>
+      <AlertDialog
+        open={showContextAccessDialog}
+        onOpenChange={setShowContextAccessDialog}
+      >
         <AlertDialogContent className="max-w-lg">
           <AlertDialogHeader>
             <AlertDialogTitle className="flex items-center gap-2">
               <Settings className="h-5 w-5 text-blue-500" />
-              {t('editContextAccess')}
+              {t("editContextAccess")}
             </AlertDialogTitle>
             <AlertDialogDescription>
-              {t('contextAccessDesc')}
+              {t("contextAccessDesc")}
             </AlertDialogDescription>
           </AlertDialogHeader>
 
           <div className="py-4 space-y-4">
             {/* Info message */}
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              {t('contextAccessInfo')}
+              {t("contextAccessInfo")}
             </p>
 
             {/* Select All / Deselect All buttons */}
@@ -1305,12 +1559,12 @@ export default function WorkspaceMembersPage() {
                 variant="outline"
                 size="sm"
                 onClick={() => {
-                  const allIds = contexts.map(c => c.id);
+                  const allIds = contexts.map((c) => c.id);
                   setSelectedContextIds(allIds);
                 }}
                 disabled={contexts.length === 0}
               >
-                {t('selectAll')}
+                {t("selectAll")}
               </Button>
               <Button
                 variant="outline"
@@ -1318,7 +1572,7 @@ export default function WorkspaceMembersPage() {
                 onClick={() => setSelectedContextIds([])}
                 disabled={selectedContextIds.length === 0}
               >
-                {t('deselectAll')}
+                {t("deselectAll")}
               </Button>
             </div>
 
@@ -1326,12 +1580,15 @@ export default function WorkspaceMembersPage() {
             <div className="border border-gray-200 dark:border-gray-700 rounded-lg max-h-60 overflow-y-auto">
               {contexts.length === 0 ? (
                 <div className="p-4 text-center text-gray-500 text-sm">
-                  {t('noContextsAvailable')}
+                  {t("noContextsAvailable")}
                 </div>
               ) : (
                 <ul className="divide-y divide-gray-200 dark:divide-gray-700">
                   {contexts.map((context) => (
-                    <li key={context.id} className="px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-800">
+                    <li
+                      key={context.id}
+                      className="px-4 py-2 hover:bg-gray-50 dark:hover:bg-gray-800"
+                    >
                       <label className="flex items-center gap-3 cursor-pointer">
                         <input
                           type="checkbox"
@@ -1360,18 +1617,20 @@ export default function WorkspaceMembersPage() {
             {selectedContextIds.length === 0 ? (
               <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-3">
                 <p className="text-sm text-red-800 dark:text-red-200 font-medium">
-                  ⚠️ {t('inviteContextRequired')}
+                  ⚠️ {t("inviteContextRequired")}
                 </p>
               </div>
             ) : (
               <p className="text-sm text-gray-600 dark:text-gray-400">
-                {t('contextsSelected', { count: selectedContextIds.length })}
+                {t("contextsSelected", { count: selectedContextIds.length })}
               </p>
             )}
           </div>
 
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={contextAccessLoading}>{tCommon('cancel')}</AlertDialogCancel>
+            <AlertDialogCancel disabled={contextAccessLoading}>
+              {tCommon("cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleSaveContextAccess}
               disabled={contextAccessLoading || selectedContextIds.length === 0}
@@ -1380,10 +1639,10 @@ export default function WorkspaceMembersPage() {
               {contextAccessLoading ? (
                 <>
                   <Loader2 className="w-4 h-4 animate-spin mr-2" />
-                  {tCommon('saving')}
+                  {tCommon("saving")}
                 </>
               ) : (
-                t('saveContextAccess')
+                t("saveContextAccess")
               )}
             </AlertDialogAction>
           </AlertDialogFooter>
@@ -1401,7 +1660,13 @@ interface PermissionRowProps {
   viewer: boolean;
 }
 
-function PermissionRow({ permission, owner, admin, member, viewer }: PermissionRowProps) {
+function PermissionRow({
+  permission,
+  owner,
+  admin,
+  member,
+  viewer,
+}: PermissionRowProps) {
   const CheckIcon = () => (
     <Check className="h-4 w-4 text-green-600 dark:text-green-400 mx-auto" />
   );
@@ -1411,11 +1676,21 @@ function PermissionRow({ permission, owner, admin, member, viewer }: PermissionR
 
   return (
     <tr className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-      <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">{permission}</td>
-      <td className="px-4 py-3 text-center">{owner ? <CheckIcon /> : <EmptyIcon />}</td>
-      <td className="px-4 py-3 text-center">{admin ? <CheckIcon /> : <EmptyIcon />}</td>
-      <td className="px-4 py-3 text-center">{member ? <CheckIcon /> : <EmptyIcon />}</td>
-      <td className="px-4 py-3 text-center">{viewer ? <CheckIcon /> : <EmptyIcon />}</td>
+      <td className="px-4 py-3 text-sm text-gray-900 dark:text-gray-100">
+        {permission}
+      </td>
+      <td className="px-4 py-3 text-center">
+        {owner ? <CheckIcon /> : <EmptyIcon />}
+      </td>
+      <td className="px-4 py-3 text-center">
+        {admin ? <CheckIcon /> : <EmptyIcon />}
+      </td>
+      <td className="px-4 py-3 text-center">
+        {member ? <CheckIcon /> : <EmptyIcon />}
+      </td>
+      <td className="px-4 py-3 text-center">
+        {viewer ? <CheckIcon /> : <EmptyIcon />}
+      </td>
     </tr>
   );
 }

--- a/frontend/src/components/common/LoadingState.tsx
+++ b/frontend/src/components/common/LoadingState.tsx
@@ -119,7 +119,7 @@ export function InlineSpinner({
   className,
 }: InlineSpinnerProps) {
   return (
-    <div
+    <span
       className={cn(
         "rounded-full inline-block",
         loadingTokens.spinner[size],

--- a/frontend/src/components/common/LoadingState.tsx
+++ b/frontend/src/components/common/LoadingState.tsx
@@ -6,21 +6,25 @@
  * Issue #58: Standardized Loading State Design
  */
 
-import { cn, loading as loadingTokens } from '@/styles/design-tokens';
+import { cn, loading as loadingTokens } from "@/styles/design-tokens";
 
 interface LoadingStateProps {
   lines?: number;
   className?: string;
 }
 
+// Deterministic width sequence (prevents SSR hydration mismatch).
+// Values span 73-98% to match the previous Math.random()*30+70 distribution.
+const SKELETON_WIDTHS = [95, 82, 91, 76, 88, 98, 73, 86, 94, 80] as const;
+
 export function LoadingState({ lines = 3, className }: LoadingStateProps) {
   return (
-    <div className={cn('space-y-3', className)}>
+    <div className={cn("space-y-3", className)}>
       {Array.from({ length: lines }).map((_, i) => (
         <div
           key={i}
           className="h-4 bg-slate-200 dark:bg-slate-800 rounded animate-pulse"
-          style={{ width: `${Math.random() * 30 + 70}%` }}
+          style={{ width: `${SKELETON_WIDTHS[i % SKELETON_WIDTHS.length]}%` }}
         />
       ))}
     </div>
@@ -57,8 +61,8 @@ export function TableLoadingState({ rows = 5 }: { rows?: number }) {
 // Issue #58: New Loading Variants
 // ============================================================================
 
-type SpinnerSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
-type SpinnerVariant = 'default' | 'brand';
+type SpinnerSize = "xs" | "sm" | "md" | "lg" | "xl";
+type SpinnerVariant = "default" | "brand";
 
 interface SpinnerLoadingProps {
   size?: SpinnerSize;
@@ -72,22 +76,29 @@ interface SpinnerLoadingProps {
  * Usage: <SpinnerLoading size="lg" message="Loading data..." />
  */
 export function SpinnerLoading({
-  size = 'md',
-  variant = 'brand',
+  size = "md",
+  variant = "brand",
   message,
   className,
 }: SpinnerLoadingProps) {
   return (
-    <div className={cn('flex flex-col items-center justify-center gap-3 py-8', className)}>
+    <div
+      className={cn(
+        "flex flex-col items-center justify-center gap-3 py-8",
+        className,
+      )}
+    >
       <div
         className={cn(
-          'rounded-full',
+          "rounded-full",
           loadingTokens.spinner[size],
           loadingTokens.colors[variant],
-          loadingTokens.animations.spin
+          loadingTokens.animations.spin,
         )}
       />
-      {message && <p className="text-sm text-slate-500 dark:text-slate-400">{message}</p>}
+      {message && (
+        <p className="text-sm text-slate-500 dark:text-slate-400">{message}</p>
+      )}
     </div>
   );
 }
@@ -103,18 +114,18 @@ interface InlineSpinnerProps {
  * Usage: <InlineSpinner size="sm" />
  */
 export function InlineSpinner({
-  size = 'sm',
-  variant = 'default',
+  size = "sm",
+  variant = "default",
   className,
 }: InlineSpinnerProps) {
   return (
     <div
       className={cn(
-        'rounded-full inline-block',
+        "rounded-full inline-block",
         loadingTokens.spinner[size],
         loadingTokens.colors[variant],
         loadingTokens.animations.spin,
-        className
+        className,
       )}
     />
   );
@@ -129,7 +140,10 @@ interface PageLoadingProps {
  * Full page loading overlay
  * Usage: <PageLoading message="Loading application..." />
  */
-export function PageLoading({ message = 'Loading...', showLogo = false }: PageLoadingProps) {
+export function PageLoading({
+  message = "Loading...",
+  showLogo = false,
+}: PageLoadingProps) {
   return (
     <div className="fixed inset-0 bg-slate-900/50 backdrop-blur-sm z-50 flex items-center justify-center">
       <div className="bg-white dark:bg-slate-900 rounded-lg p-8 shadow-xl">
@@ -139,13 +153,15 @@ export function PageLoading({ message = 'Loading...', showLogo = false }: PageLo
           )}
           <div
             className={cn(
-              'rounded-full',
+              "rounded-full",
               loadingTokens.spinner.xl,
               loadingTokens.colors.brand,
-              loadingTokens.animations.spin
+              loadingTokens.animations.spin,
             )}
           />
-          <p className="text-sm text-slate-600 dark:text-slate-400">{message}</p>
+          <p className="text-sm text-slate-600 dark:text-slate-400">
+            {message}
+          </p>
         </div>
       </div>
     </div>

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { Section } from "@/components/common/Section";
 import { ActionButton } from "@/components/common/ActionButton";
-import { LoadingState } from "@/components/common/LoadingState";
+import { TableLoadingState } from "@/components/common/LoadingState";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -299,7 +299,7 @@ export function APIKeysTabPanel() {
   };
 
   if (loading && !credentials) {
-    return <LoadingState lines={3} />;
+    return <TableLoadingState rows={3} />;
   }
 
   const apiKeys = credentials?.api_keys || [];

--- a/frontend/src/components/credentials/OAuthAppsTabPanel.tsx
+++ b/frontend/src/components/credentials/OAuthAppsTabPanel.tsx
@@ -12,7 +12,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { Section } from "@/components/common/Section";
 import { ActionButton } from "@/components/common/ActionButton";
-import { LoadingState } from "@/components/common/LoadingState";
+import { TableLoadingState } from "@/components/common/LoadingState";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -270,7 +270,7 @@ export function OAuthAppsTabPanel() {
   // --- Derived data ---
 
   if (loading && oauthClients.length === 0) {
-    return <LoadingState lines={3} />;
+    return <TableLoadingState rows={3} />;
   }
 
   const claudeApp = oauthClients.find((c) => c.provider === "claude");

--- a/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
+++ b/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
@@ -12,7 +12,10 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Section } from "@/components/common/Section";
-import { LoadingState } from "@/components/common/LoadingState";
+import {
+  InlineSpinner,
+  TableLoadingState,
+} from "@/components/common/LoadingState";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -215,7 +218,7 @@ export function ResourceTokensTabPanel() {
   };
 
   if (loading && tokens.length === 0) {
-    return <LoadingState lines={3} />;
+    return <TableLoadingState rows={3} />;
   }
 
   return (
@@ -728,9 +731,7 @@ export function ResourceTokensTabPanel() {
                   onClick={handleEditConfirm}
                   disabled={editing}
                 >
-                  {editing && (
-                    <span className="inline-block mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent"></span>
-                  )}
+                  {editing && <InlineSpinner size="sm" className="mr-2" />}
                   {editing ? t("editDialog.updating") : t("editDialog.update")}
                 </AlertDialogAction>
               </AlertDialogFooter>

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -882,7 +882,6 @@
     "inviteMember": "Invite Member",
     "proPlanRequired": "(Pro Plan)",
     "ownerAdminOnly": "(Owner/Admin only)",
-    "loadingMembers": "Loading members...",
     "user": "User",
     "role": "Role",
     "lastLogin": "Last Login",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -883,7 +883,6 @@
     "inviteMember": "メンバーを招待",
     "proPlanRequired": "（Proプラン）",
     "ownerAdminOnly": "（オーナー/管理者のみ）",
-    "loadingMembers": "メンバーを読み込み中...",
     "user": "ユーザー",
     "role": "ロール",
     "lastLogin": "最終ログイン",


### PR DESCRIPTION
Closes #295 (pilot slice — see issue comments for remaining batch targets)

## Summary
- Adds a **Loading States** section to `.claude/rules/frontend.md` (between Error Surface and Empty States) that codifies shape-driven selection: Table→`TableLoadingState`, Card→`CardLoadingState`, Form→`LoadingState`, Full-page→`SpinnerLoading`, Button→`InlineSpinner`. "Never hand-roll", "never leave a page blank", "skeleton widths must be deterministic", "messages go on SpinnerLoading only".
- Replaces `Math.random()` in `LoadingState.tsx` with a module-level `SKELETON_WIDTHS` constant (deterministic, prevents SSR hydration mismatch).
- Migrates 5 table surfaces as a Batch A pilot:
  - `admin/users/page.tsx` (double-loader text+skeleton → `TableLoadingState rows={5}`)
  - `workspace/members/page.tsx` (`SpinnerLoading` message → `TableLoadingState rows={5}`)
  - `APIKeysTabPanel.tsx` / `OAuthAppsTabPanel.tsx` / `ResourceTokensTabPanel.tsx` (`LoadingState lines={3}` → `TableLoadingState rows={3}`)
  - `ResourceTokensTabPanel.tsx` button: hand-rolled `<span animate-spin>` → `<InlineSpinner size="sm">`
- Removes orphaned `loadingMembers` i18n key from `en.json` / `ja.json`.

## Implementation notes
- **Pilot scope**: this PR lands the rules contract + 5 representative surfaces covering all 3 current-state patterns (skeleton-with-text, spinner, hand-rolled). Remaining batches B (Cards/Grid) and C (Form/Detail) will follow as separate commits/PRs.
- **Audit correction**: the original issue audit flagged several "no loader" pages that turned out to be ComingSoon stubs or redirects to `workspace/integrations/credentials`. The 3 tab panel migrations in this PR are the **effective owners** of 6+ audit entries (all the `workspace/integrations/*` and `workspace/developer/*` redirects funnel into them). Details in the audit-correction comment on #295.
- **Acceptance criterion #5** (`grep -rn "animate-spin" frontend/src/app` returns only button/inline usages): satisfied inside the authenticated route group for Batch A targets. `login/`, `page.tsx` (root), and `(authenticated)/layout.tsx` still contain full-page hand-rolled spinners — these are out of #295's original scope and should be addressed as a follow-up issue.
- **Prettier noise**: ~85% of the PR line count is Prettier quote-style normalization (single → double quotes on touched files). Logic changes are ~50 lines. Suggest using GitHub's "Hide whitespace" option while reviewing.
- No new dependencies. No backend changes. No API contract changes.

## Pre-PR review summary
- gate2 mode: advisor-only (gate2.binary_gate=null)
- cso: green — pure UI refactor, no auth / injection / secret-handling impact, slight attack-surface reduction (hand-rolled spinner dropped, `Math.random()` SSR mismatch closed)
- qa-lead: green — zero existing tests reference the touched surfaces, regression risk low (all early-return swaps), `animate-spin` acceptance criterion satisfied for pilot scope
- cto: green — architecturally textbook (follows #231 Error Surface precedent), zero new debt, correct migration sequencing (rules-doc first)
- gate1: green (via /claude-c-suite:ask → CDO lens, no escalation)

## Follow-ups (not blocking)
- Remaining Batch A / B / C surfaces (re-audited list in #295 comments)
- Full-page hand-rolled spinners in `login`, root `page.tsx`, `(authenticated)/layout.tsx` (pre-auth surfaces, separate issue)
- One-time repo-wide Prettier normalization to stop quote-churn noise on future PRs (separate issue)
- Unit test for `LoadingState` deterministic widths (add in Batch C completion commit)

Full reviews saved in plugin cache:
- \`~/.claude/cache/gh-issue-driven/295-refactor-loading-states-unify.gate1.md\`
- (gate2 reviews are in this session's chat log)

🤖 Generated via /gh-issue-driven:ship