### PR TITLE
fix(frontend): stop row-click bubbling through dropdown trigger (#297)

### DIFF
--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -382,6 +382,8 @@ export default function AdminUsersPage() {
                         <Button
                           variant="ghost"
                           size="sm"
+                          aria-label="Row actions"
+                          title="Row actions"
                           onClick={(e) => e.stopPropagation()}
                         >
                           <MoreVertical className="h-4 w-4" />

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -379,7 +379,11 @@ export default function AdminUsersPage() {
                   <TableCell className="text-right">
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="sm">
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={(e) => e.stopPropagation()}
+                        >
                           <MoreVertical className="h-4 w-4" />
                         </Button>
                       </DropdownMenuTrigger>


### PR DESCRIPTION
Closes #297

## Summary
- Add `e.stopPropagation()` to the `DropdownMenuTrigger` button in admin/users table to prevent row onClick from firing when the kebab menu is clicked
- Follows existing codebase pattern used in `admin/plans/page.tsx:342` and the same file's "View Details" menu item at line 406
- No other table pages have the same row-click + dropdown combination, so no horizontal spread needed

## Implementation notes
- Single file changed: `frontend/src/app/(authenticated)/admin/users/page.tsx`
- The existing `closest('[role="menu"]')` guard on the row handler is retained as defense-in-depth
- The fix is a standard React event propagation control — no new dependencies or architectural changes

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/297-fix-fix-frontend-admin-users-row-click-bubbl.gate1.md
- ~/.claude/cache/gh-issue-driven/297-fix-fix-frontend-admin-users-row-click-bubbl.gate2.md

🤖 Generated via /gh-issue-driven:ship
