### PR TITLE
feat(api): add source_uri, recall filters, and declared_link edges (#213, #214, #215)

### DIFF
--- a/backend/alembic/versions/a95_add_source_uri_and_declared_link.py
+++ b/backend/alembic/versions/a95_add_source_uri_and_declared_link.py
@@ -1,0 +1,66 @@
+"""Add source_uri/source_type columns and declared_link edge type.
+
+Issues #213, #215:
+- Add source_uri (VARCHAR 2048) and source_type (VARCHAR 20) to memories table
+- Add partial B-tree index on source_uri WHERE source_uri IS NOT NULL
+- Add 'declared_link' to valid_edge_type check constraint
+
+Revision ID: a95_source_uri_declared_link
+Revises: a94_semantic_similarity_edge
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "a95_source_uri_declared_link"
+down_revision = "a94_semantic_similarity_edge"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add source_uri, source_type columns and declared_link edge type."""
+    # #213: Add source_uri and source_type columns to memories
+    op.add_column("memories", sa.Column("source_uri", sa.String(2048), nullable=True))
+    op.add_column("memories", sa.Column("source_type", sa.String(20), nullable=True))
+
+    # #213: Partial B-tree index for efficient source_uri lookups
+    op.create_index(
+        "idx_memories_source_uri",
+        "memories",
+        ["source_uri"],
+        postgresql_where=sa.text("source_uri IS NOT NULL"),
+    )
+
+    # #215: Add 'declared_link' to valid_edge_type check constraint
+    op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+        "'learned_from', 'semantic_similarity', 'declared_link')",
+    )
+
+
+def downgrade() -> None:
+    """Remove source_uri, source_type columns and declared_link edge type.
+
+    Note: declared_link downgrade will fail if edges with that type exist.
+    Delete them first:
+        DELETE FROM neural_memory_edges WHERE edge_type = 'declared_link';
+    """
+    # Revert edge type constraint
+    op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+        "'learned_from', 'semantic_similarity')",
+    )
+
+    # Remove source_uri index and columns
+    op.drop_index("idx_memories_source_uri", "memories")
+    op.drop_column("memories", "source_type")
+    op.drop_column("memories", "source_uri")

--- a/backend/alembic/versions/a95_add_source_uri_and_declared_link.py
+++ b/backend/alembic/versions/a95_add_source_uri_and_declared_link.py
@@ -45,12 +45,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Remove source_uri, source_type columns and declared_link edge type.
+    """Remove source_uri, source_type columns and declared_link edge type."""
+    # Delete declared_link edges before narrowing the constraint
+    op.execute("DELETE FROM neural_memory_edges WHERE edge_type = 'declared_link'")
 
-    Note: declared_link downgrade will fail if edges with that type exist.
-    Delete them first:
-        DELETE FROM neural_memory_edges WHERE edge_type = 'declared_link';
-    """
     # Revert edge type constraint
     op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
     op.create_check_constraint(

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -101,6 +101,25 @@ IMPORTANT: Always specify context_id to ensure you're using the intended context
                         "format": "uuid",
                         "description": "Target context UUID (e.g. '550e8400-e29b-41d4-a716-446655440000'). MUST be a valid UUID from list_contexts(). Do NOT guess or fabricate IDs.",
                     },
+                    "source_uri": {
+                        "type": "string",
+                        "description": "Origin URI for external integration (e.g. 'file:///path/to/note.md', 'vault://my-vault/note', 'https://example.com/page'). Max 2048 chars.",
+                    },
+                    "source_type": {
+                        "type": "string",
+                        "enum": ["file", "url", "vault", "api", "manual"],
+                        "description": "Origin type. Use 'file' for local files, 'url' for web pages, 'vault' for Obsidian vaults, 'api' for API-ingested content, 'manual' for user-entered.",
+                    },
+                    "linked_memory_ids": {
+                        "type": "array",
+                        "items": {"type": "string", "format": "uuid"},
+                        "description": "Explicit links to existing memories by ID. Creates declared_link edges (weight 1.0). Use for known relationships like Obsidian [[wikilinks]] resolved to memory IDs.",
+                    },
+                    "linked_source_uris": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Explicit links by source_uri (resolved to memory_id at remember time). Unresolved URIs are silently skipped — the plugin can retry later when the target memory exists.",
+                    },
                 },
             },
         },

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -235,7 +235,7 @@ Search modes: Use search_mode to control the search strategy.
                     },
                     "filters": {
                         "type": "object",
-                        "description": "Optional filters as JSON. Tag filter matches ANY of the specified tags by default (exact match). Set tags_match='all' to require ALL tags (AND logic). Date filters: created_after, created_before, updated_after, updated_before (ISO 8601). Examples: {'type': 'code'}, {'tags': ['python', 'fastapi'], 'tags_match': 'all'}, {'importance': {'gte': 0.7}}, {'created_after': '2026-03-01T00:00:00Z'}",
+                        "description": "Optional filters as JSON. Tag filter matches ANY of the specified tags by default (exact match). Set tags_match='all' to require ALL tags (AND logic). Date filters: created_after, created_before, updated_after, updated_before (ISO 8601). Source filters: 'source_uri_prefix' for origin prefix match (e.g. 'file://', 'vault://my-vault/'), 'source_type' for exact type match ('file'|'url'|'vault'|'api'|'manual'). Examples: {'type': 'code'}, {'tags': ['python', 'fastapi'], 'tags_match': 'all'}, {'importance': {'gte': 0.7}}, {'created_after': '2026-03-01T00:00:00Z'}, {'source_uri_prefix': 'vault://', 'source_type': 'vault'}",
                     },
                     "context_id": {
                         "type": "string",

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -30,6 +30,8 @@ VALID_EDGE_TYPES = frozenset(
         "learned_from",
         # Cold-start seeding (Issue #221): synthetic edges from k-NN at remember() time
         "semantic_similarity",
+        # Issue #215: Explicit links from clients (Obsidian wikilinks, code imports, etc.)
+        "declared_link",
     }
 )
 

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -49,6 +49,10 @@ async def handle_remember(
         importance=args.get("importance", 0.5),
         tags=args.get("tags", []),
         context=args.get("context"),
+        source_uri=args.get("source_uri"),  # Issue #213
+        source_type=args.get("source_type"),  # Issue #213
+        linked_memory_ids=args.get("linked_memory_ids"),  # Issue #215
+        linked_source_uris=args.get("linked_source_uris"),  # Issue #215
     )
 
     start_time = time.time()

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -49,10 +49,10 @@ async def handle_remember(
         importance=args.get("importance", 0.5),
         tags=args.get("tags", []),
         context=args.get("context"),
-        source_uri=args.get("source_uri"),  # Issue #213
-        source_type=args.get("source_type"),  # Issue #213
-        linked_memory_ids=args.get("linked_memory_ids"),  # Issue #215
-        linked_source_uris=args.get("linked_source_uris"),  # Issue #215
+        source_uri=args.get("source_uri"),
+        source_type=args.get("source_type"),
+        linked_memory_ids=args.get("linked_memory_ids"),
+        linked_source_uris=args.get("linked_source_uris"),
     )
 
     start_time = time.time()

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -136,6 +136,11 @@ class Memory(Base):
     # P2-7: Remove index=True (index created in migration 057)
     source = Column(String(50), nullable=False, default="mcp_remember")
 
+    # Issue #213: Origin URI for external integration (Obsidian, code ingestion, web clipping)
+    # Partial index idx_memories_source_uri created in migration a95
+    source_uri = Column(String(2048), nullable=True)
+    source_type = Column(String(20), nullable=True)  # file, url, vault, api, manual
+
     # Migration 061: Generated columns for efficient resource memory lookups
     # These columns are automatically computed from details JSONB field
     resource_id = Column(
@@ -310,7 +315,7 @@ class NeuralMemoryEdge(Base):
         CheckConstraint("confidence >= 0.0 AND confidence <= 1.0", name="valid_confidence"),
         CheckConstraint(
             "edge_type IN ('neural_association', 'related_to', 'depends_on', "
-            "'learned_from', 'semantic_similarity')",
+            "'learned_from', 'semantic_similarity', 'declared_link')",
             name="valid_edge_type",
         ),
         Index("idx_edges_user_src", "user_id", "src_id"),

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -172,9 +172,8 @@ class MemoryResponse(BaseModel):
     tags: list[str]
     context: dict | None
     score: float | None = Field(None, description="検索スコア（recall時のみ）")
-    # Issue #213: Origin tracking
     source_uri: str | None = None
-    source_type: str | None = None
+    source_type: Literal["file", "url", "vault", "api", "manual"] | None = None
 
     class Config:
         from_attributes = True

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -5,6 +5,7 @@ Based on Issue #1 - API specifications.
 
 import logging
 from datetime import datetime
+from typing import Literal
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator, model_validator
@@ -76,6 +77,25 @@ class RememberRequest(BaseModel):
     importance: float = Field(0.5, ge=0.0, le=1.0, description="重要度 (0.0-1.0)")
     tags: list[str] = Field(default_factory=list, description="タグ")
     context: dict | None = Field(None, description="コンテキスト情報")
+
+    # Issue #213: Origin tracking for external integration
+    source_uri: str | None = Field(
+        None,
+        max_length=2048,
+        description="Origin URI: file://, http(s)://, vault://, obsidian://",
+    )
+    source_type: Literal["file", "url", "vault", "api", "manual"] | None = Field(
+        None, description="Origin type"
+    )
+
+    # Issue #215: Explicit links (declared_link edges)
+    linked_memory_ids: list[UUID] | None = Field(
+        None, description="Explicit links to existing memories (creates declared_link edges)"
+    )
+    linked_source_uris: list[str] | None = Field(
+        None,
+        description="Explicit links by source_uri (resolved at remember time, unresolved silently skipped)",
+    )
 
     @field_validator("summary")
     @classmethod
@@ -152,6 +172,9 @@ class MemoryResponse(BaseModel):
     tags: list[str]
     context: dict | None
     score: float | None = Field(None, description="検索スコア（recall時のみ）")
+    # Issue #213: Origin tracking
+    source_uri: str | None = None
+    source_type: str | None = None
 
     class Config:
         from_attributes = True

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -53,6 +53,8 @@ class GraphService:
         "related_to",
         "depends_on",
         "learned_from",
+        "semantic_similarity",
+        "declared_link",
     ]
 
     def __init__(

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -667,6 +667,7 @@ class MemoryService:
                     count=created,
                 )
         except Exception as e:
+            await self.db.rollback()
             logger.warning(
                 "declared_links_failed",
                 memory_id=str(memory_id),
@@ -755,7 +756,8 @@ class MemoryService:
         # Issue #214: source_uri_prefix and source_type post-filters
         if request.filters:
             if prefix := request.filters.get("source_uri_prefix"):
-                pg_conditions.append(Memory.source_uri.like(f"{prefix}%"))
+                escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+                pg_conditions.append(Memory.source_uri.like(f"{escaped}%", escape="\\"))
             if stype := request.filters.get("source_type"):
                 pg_conditions.append(Memory.source_type == stype)
         result = await self.db.execute(select(Memory).where(*pg_conditions))

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -635,6 +635,7 @@ class MemoryService:
                 result = await self.db.execute(
                     select(Memory.source_uri, Memory.id).where(
                         Memory.user_id == user_id,
+                        Memory.workspace_id == UUID(workspace_id),
                         Memory.context_id == UUID(context_id),
                         Memory.source_uri.in_(uris),
                         Memory.deleted_at.is_(None),

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -243,6 +243,8 @@ class MemoryService:
             client=client,
             summary_embedding_id=memory_id,  # Same as memory_id
             embedding_status="pending",  # Issue #122: Track embedding state
+            source_uri=request.source_uri,  # Issue #213
+            source_type=request.source_type,  # Issue #213
         )
 
         try:
@@ -255,6 +257,15 @@ class MemoryService:
                 memory_id=str(memory_id),
                 user_id=user_id,
                 type=request.type,
+            )
+
+            # Issue #215: Create declared_link edges (best-effort, after commit)
+            await self._create_declared_links(
+                memory_id=memory_id,
+                request=request,
+                user_id=user_id,
+                workspace_id=workspace_id_str,
+                context_id=context_id_str,
             )
 
             import asyncio
@@ -575,6 +586,94 @@ class MemoryService:
             client=memory.client,
         )
 
+    async def _create_declared_links(
+        self,
+        memory_id: UUID,
+        request: RememberRequest,
+        user_id: str,
+        workspace_id: str | None,
+        context_id: str | None,
+    ) -> None:
+        """Create declared_link edges from linked_memory_ids and linked_source_uris.
+
+        Issue #215: Best-effort — failures are logged but never roll back
+        the memory creation. Forward references (source_uri not yet in DB)
+        are silently skipped.
+        """
+        if not request.linked_memory_ids and not request.linked_source_uris:
+            return
+
+        if not workspace_id or not context_id:
+            logger.warning("declared_links_skipped_no_isolation", memory_id=str(memory_id))
+            return
+
+        from repositories.neural_edge import NeuralEdgeRepository
+
+        edge_repo = NeuralEdgeRepository(self.db)
+        created = 0
+
+        try:
+            # Direct links by memory ID
+            for target_id in request.linked_memory_ids or []:
+                if target_id == memory_id:
+                    continue  # skip self-link
+                await edge_repo.create_edge_if_absent(
+                    user_id=user_id,
+                    src_id=memory_id,
+                    dst_id=target_id,
+                    edge_type="declared_link",
+                    weight=1.0,
+                    confidence=1.0,
+                    workspace_id=workspace_id,
+                    context_id=context_id,
+                )
+                created += 1
+
+            # Links by source_uri (resolve to memory_id)
+            for uri in request.linked_source_uris or []:
+                result = await self.db.execute(
+                    select(Memory.id)
+                    .where(
+                        Memory.user_id == user_id,
+                        Memory.context_id == UUID(context_id),
+                        Memory.source_uri == uri,
+                        Memory.deleted_at.is_(None),
+                    )
+                    .limit(1)
+                )
+                target_id = result.scalar_one_or_none()
+                if target_id is None:
+                    logger.debug("declared_link_forward_ref_skipped", uri=uri)
+                    continue
+                if target_id == memory_id:
+                    continue
+                await edge_repo.create_edge_if_absent(
+                    user_id=user_id,
+                    src_id=memory_id,
+                    dst_id=target_id,
+                    edge_type="declared_link",
+                    weight=1.0,
+                    confidence=1.0,
+                    workspace_id=workspace_id,
+                    context_id=context_id,
+                )
+                created += 1
+
+            if created > 0:
+                await self.db.commit()
+                logger.info(
+                    "declared_links_created",
+                    memory_id=str(memory_id),
+                    count=created,
+                )
+        except Exception as e:
+            logger.warning(
+                "declared_links_failed",
+                memory_id=str(memory_id),
+                error=str(e),
+            )
+            # Best-effort: do not raise — memory creation already succeeded
+
     async def recall(
         self,
         request: RecallRequest,
@@ -649,12 +748,17 @@ class MemoryService:
             return RecallResponse(results=[])
 
         # Fetch memories from PostgreSQL (exclude soft-deleted)
-        result = await self.db.execute(
-            select(Memory).where(
-                Memory.id.in_(memory_ids),
-                Memory.deleted_at.is_(None),  # Exclude deleted memories
-            )
-        )
+        pg_conditions = [
+            Memory.id.in_(memory_ids),
+            Memory.deleted_at.is_(None),
+        ]
+        # Issue #214: source_uri_prefix and source_type post-filters
+        if request.filters:
+            if prefix := request.filters.get("source_uri_prefix"):
+                pg_conditions.append(Memory.source_uri.like(f"{prefix}%"))
+            if stype := request.filters.get("source_type"):
+                pg_conditions.append(Memory.source_type == stype)
+        result = await self.db.execute(select(Memory).where(*pg_conditions))
         memories_list = list(result.scalars().all())
         memories = {str(m.id): m for m in memories_list}
 
@@ -692,6 +796,8 @@ class MemoryService:
                     tags=memory.tags or [],
                     context=memory.context,
                     score=search_result.get("hybrid_score", search_result["score"]),
+                    source_uri=memory.source_uri,  # Issue #213
+                    source_type=memory.source_type,  # Issue #213
                 )
             )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -243,8 +243,8 @@ class MemoryService:
             client=client,
             summary_embedding_id=memory_id,  # Same as memory_id
             embedding_status="pending",  # Issue #122: Track embedding state
-            source_uri=request.source_uri,  # Issue #213
-            source_type=request.source_type,  # Issue #213
+            source_uri=request.source_uri,
+            source_type=request.source_type,
         )
 
         try:
@@ -629,35 +629,36 @@ class MemoryService:
                 )
                 created += 1
 
-            # Links by source_uri (resolve to memory_id)
-            for uri in request.linked_source_uris or []:
+            # Links by source_uri (batch resolve to memory_id)
+            uris = request.linked_source_uris or []
+            if uris:
                 result = await self.db.execute(
-                    select(Memory.id)
-                    .where(
+                    select(Memory.source_uri, Memory.id).where(
                         Memory.user_id == user_id,
                         Memory.context_id == UUID(context_id),
-                        Memory.source_uri == uri,
+                        Memory.source_uri.in_(uris),
                         Memory.deleted_at.is_(None),
                     )
-                    .limit(1)
                 )
-                target_id = result.scalar_one_or_none()
-                if target_id is None:
-                    logger.debug("declared_link_forward_ref_skipped", uri=uri)
-                    continue
-                if target_id == memory_id:
-                    continue
-                await edge_repo.create_edge_if_absent(
-                    user_id=user_id,
-                    src_id=memory_id,
-                    dst_id=target_id,
-                    edge_type="declared_link",
-                    weight=1.0,
-                    confidence=1.0,
-                    workspace_id=workspace_id,
-                    context_id=context_id,
-                )
-                created += 1
+                uri_to_id = {row.source_uri: row.id for row in result}
+                for uri in uris:
+                    target_id = uri_to_id.get(uri)
+                    if target_id is None:
+                        logger.debug("declared_link_forward_ref_skipped", uri=uri)
+                        continue
+                    if target_id == memory_id:
+                        continue
+                    await edge_repo.create_edge_if_absent(
+                        user_id=user_id,
+                        src_id=memory_id,
+                        dst_id=target_id,
+                        edge_type="declared_link",
+                        weight=1.0,
+                        confidence=1.0,
+                        workspace_id=workspace_id,
+                        context_id=context_id,
+                    )
+                    created += 1
 
             if created > 0:
                 await self.db.commit()
@@ -798,8 +799,8 @@ class MemoryService:
                     tags=memory.tags or [],
                     context=memory.context,
                     score=search_result.get("hybrid_score", search_result["score"]),
-                    source_uri=memory.source_uri,  # Issue #213
-                    source_type=memory.source_type,  # Issue #213
+                    source_uri=memory.source_uri,
+                    source_type=memory.source_type,
                 )
             )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -613,21 +613,34 @@ class MemoryService:
         created = 0
 
         try:
-            # Direct links by memory ID
-            for target_id in request.linked_memory_ids or []:
-                if target_id == memory_id:
-                    continue  # skip self-link
-                await edge_repo.create_edge_if_absent(
-                    user_id=user_id,
-                    src_id=memory_id,
-                    dst_id=target_id,
-                    edge_type="declared_link",
-                    weight=1.0,
-                    confidence=1.0,
-                    workspace_id=workspace_id,
-                    context_id=context_id,
+            # Direct links by memory ID (batch-validate targets exist in same scope)
+            requested_ids = [t for t in (request.linked_memory_ids or []) if t != memory_id]
+            if requested_ids:
+                result = await self.db.execute(
+                    select(Memory.id).where(
+                        Memory.id.in_(requested_ids),
+                        Memory.user_id == user_id,
+                        Memory.workspace_id == UUID(workspace_id),
+                        Memory.context_id == UUID(context_id),
+                        Memory.deleted_at.is_(None),
+                    )
                 )
-                created += 1
+                valid_ids = {row.id for row in result}
+                for target_id in requested_ids:
+                    if target_id not in valid_ids:
+                        logger.debug("declared_link_target_not_found", target_id=str(target_id))
+                        continue
+                    await edge_repo.create_edge_if_absent(
+                        user_id=user_id,
+                        src_id=memory_id,
+                        dst_id=target_id,
+                        edge_type="declared_link",
+                        weight=1.0,
+                        confidence=1.0,
+                        workspace_id=workspace_id,
+                        context_id=context_id,
+                    )
+                    created += 1
 
             # Links by source_uri (batch resolve to memory_id)
             uris = request.linked_source_uris or []

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -209,6 +209,124 @@ class TestReference:
         assert response.summary == "Test"
 
 
+class TestRememberRequest:
+    """Test RememberRequest schema validation for #213/#215 fields."""
+
+    def test_source_uri_accepted(self):
+        """source_uri and source_type are accepted as optional fields."""
+        req = RememberRequest(
+            summary="Test memory for search quality",
+            content="Test content",
+            type="note",
+            source_uri="vault://my-vault/note.md",
+            source_type="vault",
+        )
+        assert req.source_uri == "vault://my-vault/note.md"
+        assert req.source_type == "vault"
+
+    def test_source_fields_optional(self):
+        """source_uri/source_type default to None."""
+        req = RememberRequest(
+            summary="Test memory for search quality",
+            content="Test content",
+            type="note",
+        )
+        assert req.source_uri is None
+        assert req.source_type is None
+
+    def test_invalid_source_type_rejected(self):
+        """Invalid source_type is rejected by Literal validation."""
+        with pytest.raises(ValueError):
+            RememberRequest(
+                summary="Test memory for search quality",
+                content="Test content",
+                type="note",
+                source_type="invalid_type",
+            )
+
+    def test_linked_fields_accepted(self):
+        """linked_memory_ids and linked_source_uris are accepted."""
+        target_id = uuid4()
+        req = RememberRequest(
+            summary="Test memory for search quality",
+            content="Test content",
+            type="note",
+            linked_memory_ids=[target_id],
+            linked_source_uris=["vault://my-vault/other.md"],
+        )
+        assert req.linked_memory_ids == [target_id]
+        assert req.linked_source_uris == ["vault://my-vault/other.md"]
+
+
+class TestDeclaredLinks:
+    """Test _create_declared_links logic (#215)."""
+
+    @pytest.fixture
+    def service(self):
+        return MemoryService(MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_skips_when_no_links(self, service):
+        """No-op when neither linked_memory_ids nor linked_source_uris provided."""
+        request = RememberRequest(
+            summary="Test memory for search quality",
+            content="Test content",
+            type="note",
+        )
+        # Should return immediately without touching DB
+        await service._create_declared_links(
+            memory_id=uuid4(),
+            request=request,
+            user_id="test_user",
+            workspace_id=str(uuid4()),
+            context_id=str(uuid4()),
+        )
+        service.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_without_isolation(self, service):
+        """Skips when workspace_id or context_id is None."""
+        request = RememberRequest(
+            summary="Test memory for search quality",
+            content="Test content",
+            type="note",
+            linked_memory_ids=[uuid4()],
+        )
+        await service._create_declared_links(
+            memory_id=uuid4(),
+            request=request,
+            user_id="test_user",
+            workspace_id=None,
+            context_id=None,
+        )
+        service.db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_self_link_filtered(self, service):
+        """Self-links are filtered out before DB query."""
+        memory_id = uuid4()
+        request = RememberRequest(
+            summary="Test memory for search quality",
+            content="Test content",
+            type="note",
+            linked_memory_ids=[memory_id],  # self-link
+        )
+        # Mock the validation query to return empty (self-link filtered before query)
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        service.db.execute = AsyncMock(return_value=mock_result)
+
+        await service._create_declared_links(
+            memory_id=memory_id,
+            request=request,
+            user_id="test_user",
+            workspace_id=str(uuid4()),
+            context_id=str(uuid4()),
+        )
+        # The empty requested_ids list means no DB query at all
+        service.db.execute.assert_not_called()
+
+
 class TestForget:
     """Test forget (delete) operations."""
 

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -84,6 +84,8 @@ class TestRecall:
         mock_memory.client = "test"
         mock_memory.tags = []
         mock_memory.context = None
+        mock_memory.source_uri = None
+        mock_memory.source_type = None
 
         mock_scalars = MagicMock()
         mock_scalars.all.return_value = [mock_memory]


### PR DESCRIPTION
Closes #213
Closes #214
Closes #215

## Summary
- Add `source_uri` (VARCHAR 2048) and `source_type` (enum) fields to Memory model for tracking memory origin (Obsidian vaults, files, URLs, API)
- Add `source_uri_prefix` and `source_type` post-filters to `recall()` with LIKE metacharacter escaping
- Add `linked_memory_ids` and `linked_source_uris` parameters to `remember()` that create `declared_link` edges for explicit client-declared relationships
- Add `declared_link` to all edge type registries (DB constraint, VALID_EDGE_TYPES, EDGE_TYPES)

## Implementation notes
- Single Alembic migration (a95) covers all 3 issues: nullable columns + partial B-tree index + constraint update
- `_create_declared_links()` is best-effort (failures logged, never roll back memory creation)
- Forward references (linked_source_uri not yet in DB) are silently skipped — clients can retry later
- URI resolution uses batch `IN` query (not N+1) for efficiency
- LIKE metacharacters (%, _) escaped in `source_uri_prefix` filter to prevent unintended wildcard matching
- `source_type` validated by Pydantic `Literal` (no DB CheckConstraint — extensibility over strictness)
- MCP tool definitions updated for both `remember` and `recall`

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (batch coherence review)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/213-batch-213-214-215.gate1.md
- ~/.claude/cache/gh-issue-driven/213-batch-213-214-215.gate2.md

🤖 Generated via /gh-issue-driven:ship
