### PR TITLE
feat(mcp): add secrets guardrail to remember/update_memory descriptions (#210)

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -21,7 +21,7 @@ def get_tool_definitions() -> list[dict]:
 SECURITY: DO NOT store secrets, credentials, or sensitive data in memories, including:
 - API keys, tokens, passwords, client secrets
 - Private keys, certificates
-- Personal Identifiable Information (PII)
+- Personally Identifiable Information (PII)
 - OAuth refresh tokens, session cookies
 - Contents of .env files or environment variables with credentials
 If the user's input contains such data, refuse to store it and ask them to redact the sensitive values first.
@@ -144,7 +144,7 @@ Provide exactly one of memory_id or external_id.
 SECURITY: DO NOT store secrets, credentials, or sensitive data in memories, including:
 - API keys, tokens, passwords, client secrets
 - Private keys, certificates
-- Personal Identifiable Information (PII)
+- Personally Identifiable Information (PII)
 - OAuth refresh tokens, session cookies
 - Contents of .env files or environment variables with credentials
 If the user's input contains such data, refuse to store it and ask them to redact the sensitive values first.

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -18,6 +18,14 @@ def get_tool_definitions() -> list[dict]:
             "name": "remember",
             "description": """Store important information, decisions, code snippets, or context into long-term memory. Use this when you want to preserve information for future recall across conversations.
 
+SECURITY: DO NOT store secrets, credentials, or sensitive data in memories, including:
+- API keys, tokens, passwords, client secrets
+- Private keys, certificates
+- Personal Identifiable Information (PII)
+- OAuth refresh tokens, session cookies
+- Contents of .env files or environment variables with credentials
+If the user's input contains such data, refuse to store it and ask them to redact the sensitive values first.
+
 Supports 3-layer architecture:
 - summary: Concise overview for search (10-500 chars) - write the reusable conclusion/decision, not the process
   Include synonyms and related terms that users might search for.
@@ -132,6 +140,14 @@ Two modes:
 2. **Upsert (external_id)**: Finds existing memory by external resource ID within the context. If found, replaces it (new memory_id). If not found, creates new. Requires summary, content, and type. Use for sync workflows with stable external identifiers.
 
 Provide exactly one of memory_id or external_id.
+
+SECURITY: DO NOT store secrets, credentials, or sensitive data in memories, including:
+- API keys, tokens, passwords, client secrets
+- Private keys, certificates
+- Personal Identifiable Information (PII)
+- OAuth refresh tokens, session cookies
+- Contents of .env files or environment variables with credentials
+If the user's input contains such data, refuse to store it and ask them to redact the sensitive values first.
 
 IMPORTANT: Always specify context_id.""",
             "inputSchema": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1140,7 +1140,7 @@
     "search": "Search",
     "settings": "Settings",
     "members": "Members",
-    "graph": "Knowledge Graph",
+    "graph": "Graph",
     "connections": "Connections",
     "searchSettings": "Search Settings",
     "viewStats": "View Usage Stats",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1140,7 +1140,7 @@
     "search": "検索",
     "settings": "設定",
     "members": "メンバー",
-    "graph": "知識グラフ",
+    "graph": "グラフ",
     "connections": "接続",
     "searchSettings": "検索設定",
     "viewStats": "使用状況を表示",


### PR DESCRIPTION
Closes #210

## Summary
- Add `SECURITY:` guardrail text to `remember` and `update_memory` MCP tool descriptions, instructing LLMs to refuse storing secrets, credentials, PII, API keys, tokens, or `.env` file contents
- Place guardrail early in `remember` description (after overview, before chunking tips) to maximize instruction following in long descriptions, per CAIO recommendation
- Unify graph tab label: "Knowledge Graph"/"知識グラフ" → "Graph"/"グラフ" to match context detail tab naming

## Implementation notes
- `backend/src/mcp_server/tools/_definitions.py`: 8-line `SECURITY:` block added to both `remember` (L21-27) and `update_memory` (L144-150) tool descriptions. Same text in both — consistent with existing DRY pattern (UUID fabrication warnings are also duplicated per-tool)
- `frontend/src/messages/en.json` + `ja.json`: context list dropdown label changed to match context detail tab label
- Scope limited to `remember` + `update_memory` only (operator confirmed; `create_context`, `reference` etc. excluded)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO routed)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/210-feat-feat-mcp-add-secrets-guardrail-to-rememb-20260412.gate1.md
- ~/.claude/cache/gh-issue-driven/210-feat-feat-mcp-add-secrets-guardrail-to-rememb-20260412.gate2.md

🤖 Generated via /gh-issue-driven:ship
