### PR TITLE
feat(api): add opt-in explore_hints to recall response (#216)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -177,7 +177,7 @@ async def reference(
     return result
 
 
-@router.post("/recall", response_model=RecallResponse)
+@router.post("/recall", response_model=RecallResponse, response_model_exclude_none=True)
 async def recall(
     request: RecallRequest,
     user: APIKeyOrSessionUser,

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -270,6 +270,10 @@ Search modes: Use search_mode to control the search strategy.
                         "enum": ["hybrid", "semantic", "keyword"],
                         "description": "Search strategy. If omitted, hybrid is used by default: 60% semantic + 40% BM25 with Neural Memory boosting. semantic: vector similarity only (no BM25, Neural Memory skipped). keyword: BM25 only (no embeddings; best for hiragana queries where embedding models struggle).",
                     },
+                    "include_explore_hints": {
+                        "type": "boolean",
+                        "description": "Include up to 3 explore_hints in the response suggesting good seed memories for a follow-up explore() call (default: false). Set to true when the user is exploring a topic broadly or asks 'what else is related?' — the hints bridge recall (precision search) and explore (graph discovery) without mixing their scoring. Each hint includes a memory_id and a reason (top_result, high_centrality, or unexplored_neighbor).",
+                    },
                 },
             },
         },

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -323,7 +323,7 @@ async def handle_recall(
                 **_context_response_fields(current_context),
             }
 
-            if result.explore_hints:
+            if result.explore_hints is not None:
                 response_data["explore_hints"] = [
                     {"memory_id": str(h.memory_id), "reason": h.reason}
                     for h in result.explore_hints

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -236,6 +236,7 @@ async def handle_recall(
         use_rerank=args.get("use_rerank", False),
         filters=args.get("filters"),
         search_mode=args.get("search_mode", "hybrid"),
+        include_explore_hints=args.get("include_explore_hints", False),
     )
 
     start_time = time.time()
@@ -314,18 +315,24 @@ async def handle_recall(
             )
             await db.commit()
 
+            response_data: dict[str, Any] = {
+                "status": "success",
+                "results": results_data,
+                "count": len(results_data),
+                "related_tags": related_tags_data,
+                **_context_response_fields(current_context),
+            }
+
+            if result.explore_hints:
+                response_data["explore_hints"] = [
+                    {"memory_id": str(h.memory_id), "reason": h.reason}
+                    for h in result.explore_hints
+                ]
+
             return [
                 TextContent(
                     type="text",
-                    text=json.dumps(
-                        {
-                            "status": "success",
-                            "results": results_data,
-                            "count": len(results_data),
-                            "related_tags": related_tags_data,
-                            **_context_response_fields(current_context),
-                        }
-                    ),
+                    text=json.dumps(response_data),
                 )
             ]
         except _ContextNotFoundError as e:

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -156,6 +156,10 @@ class RecallRequest(BaseModel):
         pattern="^(hybrid|semantic|keyword)$",
         description="Search mode: hybrid (default), semantic (vector only), keyword (BM25 only)",
     )
+    include_explore_hints: bool = Field(
+        False,
+        description="Include up to 3 explore_hints in response suggesting good seeds for explore()",
+    )
 
 
 class MemoryResponse(BaseModel):
@@ -187,14 +191,26 @@ class RelatedTagItem(BaseModel):
     sample_summary: str | None = None
 
 
+class ExploreHint(BaseModel):
+    """Hint suggesting a memory as a good seed for explore().
+
+    Issue #216: Opt-in field to bridge recall → explore discovery.
+    """
+
+    memory_id: UUID
+    reason: Literal["top_result", "high_centrality", "unexplored_neighbor"]
+
+
 class RecallResponse(BaseModel):
     """Response schema for recall() API.
 
     Issue #104: Added related_tags to help LLMs understand tag context.
+    Issue #216: Added explore_hints for graph discovery bridging.
     """
 
     results: list[MemoryResponse]
     related_tags: list[RelatedTagItem] = []
+    explore_hints: list[ExploreHint] | None = None
 
 
 class ReferenceRequest(BaseModel):

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -928,7 +928,11 @@ class MemoryService:
         if request.include_explore_hints and responses:
             try:
                 explore_hints = await self._generate_explore_hints(
-                    responses, user_id, current_context_id, current_workspace_id
+                    responses,
+                    user_id,
+                    current_context_id,
+                    current_workspace_id,
+                    neural_enabled=neural_enabled,
                 )
             except Exception as exc:
                 logger.warning("explore_hints_generation_failed", error=str(exc))
@@ -1569,6 +1573,7 @@ class MemoryService:
         user_id: str,
         context_id: UUID | None,
         workspace_id: UUID | None,
+        neural_enabled: bool = False,
     ) -> list[ExploreHint]:
         """Generate up to 3 explore hints from recall results.
 
@@ -1578,20 +1583,14 @@ class MemoryService:
         Hint selection:
           1. top_result: highest-scored result
           2. high_centrality: top-3 result with most edges
-          3. unexplored_neighbor: top-3 result with edges + recent update (7d)
+          3. unexplored_neighbor: top-3 result with edges + created in last 7d
         """
-        import os
         from datetime import timedelta
 
         from repositories.neural_edge import NeuralEdgeRepository
-        from utils.datetime import utcnow
 
         hints: list[ExploreHint] = []
-        if not responses:
-            return hints
-
-        neural_enabled = os.getenv("ENABLE_NEURAL_MEMORY", "false").lower() == "true"
-        if not neural_enabled:
+        if not responses or not neural_enabled:
             return hints
 
         # hint #1: top result (always available)
@@ -1619,13 +1618,19 @@ class MemoryService:
             hints.append(ExploreHint(memory_id=best[0], reason="high_centrality"))
             used_ids.add(best[0])
 
-        # hint #3: unexplored_neighbor — has edges + updated in last 7 days
+        # hint #3: unexplored_neighbor — has edges + created in last 7 days
         cutoff = utcnow() - timedelta(days=7)
         for resp in top_n:
             if resp.memory_id in used_ids:
                 continue
             deg = degree_map.get(resp.memory_id, 0)
-            if deg > 0 and resp.created_at and resp.created_at >= cutoff:
+            # Normalize to naive datetime for comparison (DB stores naive UTC)
+            created = (
+                resp.created_at.replace(tzinfo=None)
+                if resp.created_at and resp.created_at.tzinfo
+                else resp.created_at
+            )
+            if deg > 0 and created and created >= cutoff:
                 hints.append(ExploreHint(memory_id=resp.memory_id, reason="unexplored_neighbor"))
                 break
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -924,7 +924,7 @@ class MemoryService:
         await self.db.commit()
 
         # Issue #216: Generate explore hints (best-effort, opt-in)
-        explore_hints = None
+        explore_hints = [] if request.include_explore_hints else None
         if request.include_explore_hints and responses:
             try:
                 explore_hints = await self._generate_explore_hints(
@@ -1590,11 +1590,15 @@ class MemoryService:
         from repositories.neural_edge import NeuralEdgeRepository
 
         hints: list[ExploreHint] = []
-        if not responses or not neural_enabled:
+        if not responses:
             return hints
 
-        # hint #1: top result (always available)
+        # hint #1: top result (always available, no graph query needed)
         hints.append(ExploreHint(memory_id=responses[0].memory_id, reason="top_result"))
+
+        # Graph-derived hints require neural memory to be enabled
+        if not neural_enabled:
+            return hints
 
         # For hints #2 and #3, query edge counts for top-3 results
         top_n = responses[:3]
@@ -1603,7 +1607,7 @@ class MemoryService:
         degree_map: dict[UUID, int] = {}
         for resp in top_n:
             try:
-                in_deg, out_deg = await edge_repo.get_node_degree(user_id, str(resp.memory_id))
+                in_deg, out_deg = await edge_repo.get_node_degree(user_id, resp.memory_id)
                 degree_map[resp.memory_id] = in_deg + out_deg
             except Exception:
                 degree_map[resp.memory_id] = 0

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -762,7 +762,10 @@ class MemoryService:
         memory_ids = [r["id"] for r in search_results]
 
         if not memory_ids:
-            return RecallResponse(results=[])
+            return RecallResponse(
+                results=[],
+                explore_hints=[] if request.include_explore_hints else None,
+            )
 
         # Fetch memories from PostgreSQL (exclude soft-deleted)
         pg_conditions = [

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -22,6 +22,7 @@ from db.qdrant import (
 from models.auth import Context
 from models.memory import Memory
 from models.schemas import (
+    ExploreHint,
     ExploreRequest,
     ExploreResponse,
     ForgetRequest,
@@ -922,12 +923,24 @@ class MemoryService:
 
         await self.db.commit()
 
+        # Issue #216: Generate explore hints (best-effort, opt-in)
+        explore_hints = None
+        if request.include_explore_hints and responses:
+            try:
+                explore_hints = await self._generate_explore_hints(
+                    responses, user_id, current_context_id, current_workspace_id
+                )
+            except Exception as exc:
+                logger.warning("explore_hints_generation_failed", error=str(exc))
+
         # Issue #104: Aggregate related tags from results
         related_tags = self._aggregate_related_tags(responses, limit=10)
 
         logger.info("recall_completed", user_id=user_id, results=len(responses))
 
-        return RecallResponse(results=responses, related_tags=related_tags)
+        return RecallResponse(
+            results=responses, related_tags=related_tags, explore_hints=explore_hints
+        )
 
     async def forget(
         self,
@@ -1549,6 +1562,74 @@ class MemoryService:
         ]
 
         return related_tags
+
+    async def _generate_explore_hints(
+        self,
+        responses: list[MemoryResponse],
+        user_id: str,
+        context_id: UUID | None,
+        workspace_id: UUID | None,
+    ) -> list[ExploreHint]:
+        """Generate up to 3 explore hints from recall results.
+
+        Issue #216: Best-effort hints for graph discovery bridging.
+        Failures never propagate — caller wraps in try/except.
+
+        Hint selection:
+          1. top_result: highest-scored result
+          2. high_centrality: top-3 result with most edges
+          3. unexplored_neighbor: top-3 result with edges + recent update (7d)
+        """
+        import os
+        from datetime import timedelta
+
+        from repositories.neural_edge import NeuralEdgeRepository
+        from utils.datetime import utcnow
+
+        hints: list[ExploreHint] = []
+        if not responses:
+            return hints
+
+        neural_enabled = os.getenv("ENABLE_NEURAL_MEMORY", "false").lower() == "true"
+        if not neural_enabled:
+            return hints
+
+        # hint #1: top result (always available)
+        hints.append(ExploreHint(memory_id=responses[0].memory_id, reason="top_result"))
+
+        # For hints #2 and #3, query edge counts for top-3 results
+        top_n = responses[:3]
+        edge_repo = NeuralEdgeRepository(self.db)
+
+        degree_map: dict[UUID, int] = {}
+        for resp in top_n:
+            try:
+                in_deg, out_deg = await edge_repo.get_node_degree(user_id, str(resp.memory_id))
+                degree_map[resp.memory_id] = in_deg + out_deg
+            except Exception:
+                degree_map[resp.memory_id] = 0
+
+        # hint #2: high_centrality — top-3 result with highest edge count
+        used_ids = {hints[0].memory_id}
+        candidates = [
+            (mid, deg) for mid, deg in degree_map.items() if deg > 0 and mid not in used_ids
+        ]
+        if candidates:
+            best = max(candidates, key=lambda x: x[1])
+            hints.append(ExploreHint(memory_id=best[0], reason="high_centrality"))
+            used_ids.add(best[0])
+
+        # hint #3: unexplored_neighbor — has edges + updated in last 7 days
+        cutoff = utcnow() - timedelta(days=7)
+        for resp in top_n:
+            if resp.memory_id in used_ids:
+                continue
+            deg = degree_map.get(resp.memory_id, 0)
+            if deg > 0 and resp.created_at and resp.created_at >= cutoff:
+                hints.append(ExploreHint(memory_id=resp.memory_id, reason="unexplored_neighbor"))
+                break
+
+        return hints
 
 
 async def _create_knn_seed_edges(

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -347,3 +347,162 @@ class TestForget:
         response = await service.forget(request=request, user_id="test_user")
         assert response.deleted_count == 0
         assert response.memory_ids == []
+
+
+class TestExploreHints:
+    """Test explore_hints generation in recall (Issue #216)."""
+
+    @pytest.fixture
+    def service(self):
+        return MemoryService(MagicMock())
+
+    @pytest.fixture
+    def context_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    def _make_mock_memory(self, memory_id=None, summary="Test", tags=None):
+        m = MagicMock()
+        m.id = memory_id or str(uuid4())
+        m.summary = summary
+        m.context_summary = None
+        m.type = "note"
+        m.importance = 0.7
+        m.scope = "persistent"
+        m.created_at = datetime.utcnow()
+        m.last_used_at = datetime.utcnow()
+        m.access_count = 1
+        m.confidence = 0.8
+        m.client = "test"
+        m.tags = tags or []
+        m.context = None
+        m.source_uri = None
+        m.source_type = None
+        return m
+
+    @pytest.mark.asyncio
+    async def test_recall_no_hints_when_opt_out(self, service, context_id, workspace_id):
+        """When include_explore_hints=False (default), explore_hints is None."""
+        request = RecallRequest(query="test", k=5)
+        mid = str(uuid4())
+
+        service.search_service.hybrid_search = AsyncMock(
+            return_value=[{"id": mid, "score": 0.9, "hybrid_score": 0.9}]
+        )
+        mock_mem = self._make_mock_memory(memory_id=mid)
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [mock_mem]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        service.db.execute = AsyncMock(return_value=mock_result)
+        service.db.commit = AsyncMock()
+        service.memory_repo.update_access_stats = AsyncMock()
+        service._check_and_promote = AsyncMock()
+
+        response = await service.recall(
+            request=request,
+            user_id="test_user",
+            current_context_id=context_id,
+            current_workspace_id=workspace_id,
+        )
+
+        assert response.explore_hints is None
+
+    @pytest.mark.asyncio
+    async def test_recall_hints_with_opt_in(self, service, context_id, workspace_id):
+        """When include_explore_hints=True, at least top_result hint is returned."""
+        request = RecallRequest(query="test", k=5, include_explore_hints=True)
+        mid = str(uuid4())
+
+        service.search_service.hybrid_search = AsyncMock(
+            return_value=[{"id": mid, "score": 0.9, "hybrid_score": 0.9}]
+        )
+        mock_mem = self._make_mock_memory(memory_id=mid)
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [mock_mem]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        service.db.execute = AsyncMock(return_value=mock_result)
+        service.db.commit = AsyncMock()
+        service.memory_repo.update_access_stats = AsyncMock()
+        service._check_and_promote = AsyncMock()
+
+        with patch.dict("os.environ", {"ENABLE_NEURAL_MEMORY": "true"}):
+            with patch("repositories.neural_edge.NeuralEdgeRepository") as MockEdgeRepo:
+                mock_repo = MockEdgeRepo.return_value
+                mock_repo.get_node_degree = AsyncMock(return_value=(2, 3))
+
+                response = await service.recall(
+                    request=request,
+                    user_id="test_user",
+                    current_context_id=context_id,
+                    current_workspace_id=workspace_id,
+                )
+
+        assert response.explore_hints is not None
+        assert len(response.explore_hints) >= 1
+        assert response.explore_hints[0].reason == "top_result"
+
+    @pytest.mark.asyncio
+    async def test_recall_hints_empty_when_no_results(self, service, context_id, workspace_id):
+        """When include_explore_hints=True but no results, hints are empty."""
+        request = RecallRequest(query="nothing", k=5, include_explore_hints=True)
+
+        mock_context = MagicMock(
+            id=context_id,
+            workspace_id=workspace_id,
+            is_private=True,
+            created_by="test_user",
+        )
+        service.context_service.get_context = AsyncMock(return_value=mock_context)
+        service._get_context_search_config = AsyncMock(return_value=None)
+        service.search_service.hybrid_search = AsyncMock(return_value=[])
+
+        response = await service.recall(
+            request=request,
+            user_id="test_user",
+            current_context_id=context_id,
+            current_workspace_id=workspace_id,
+        )
+
+        assert response.explore_hints is None or response.explore_hints == []
+
+    @pytest.mark.asyncio
+    async def test_recall_hints_failure_does_not_fail_recall(
+        self, service, context_id, workspace_id
+    ):
+        """Hint generation failures are swallowed — recall still succeeds."""
+        request = RecallRequest(query="test", k=5, include_explore_hints=True)
+        mid = str(uuid4())
+
+        service.search_service.hybrid_search = AsyncMock(
+            return_value=[{"id": mid, "score": 0.9, "hybrid_score": 0.9}]
+        )
+        mock_mem = self._make_mock_memory(memory_id=mid)
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = [mock_mem]
+        mock_result = MagicMock()
+        mock_result.scalars.return_value = mock_scalars
+        service.db.execute = AsyncMock(return_value=mock_result)
+        service.db.commit = AsyncMock()
+        service.memory_repo.update_access_stats = AsyncMock()
+        service._check_and_promote = AsyncMock()
+
+        with patch.dict("os.environ", {"ENABLE_NEURAL_MEMORY": "true"}):
+            with patch("repositories.neural_edge.NeuralEdgeRepository") as MockEdgeRepo:
+                mock_repo = MockEdgeRepo.return_value
+                mock_repo.get_node_degree = AsyncMock(side_effect=Exception("DB error"))
+
+                response = await service.recall(
+                    request=request,
+                    user_id="test_user",
+                    current_context_id=context_id,
+                    current_workspace_id=workspace_id,
+                )
+
+        # Recall succeeded despite hint failure
+        assert response.results is not None
+        assert len(response.results) == 1


### PR DESCRIPTION
Closes #216

## Summary
- Add opt-in `include_explore_hints` parameter to `RecallRequest` (default `false`)
- When enabled, recall response includes up to 3 `ExploreHint` items suggesting good seed memories for follow-up `explore()` calls
- Three hint types: `top_result` (highest score), `high_centrality` (most graph edges), `unexplored_neighbor` (edges + recent creation)
- Best-effort: hint generation failures never propagate to recall

## Implementation notes
- `ExploreHint` Pydantic model with `Literal["top_result", "high_centrality", "unexplored_neighbor"]` reason type
- Hint generation runs after `db.commit()` in the recall path, using `NeuralEdgeRepository.get_node_degree()` for top-3 results (max 6 additional indexed queries)
- `neural_enabled` passed as parameter to avoid redundant `os.getenv` reads
- Timezone comparison normalized with `replace(tzinfo=None)` for future-proofing against tz-aware DB migrations
- 4 unit tests: opt-out, opt-in, no-results, failure-resilience

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO routed)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/216-feat-feat-api-add-opt-in-explore-hints-to-re.gate1.md
- ~/.claude/cache/gh-issue-driven/216-feat-feat-api-add-opt-in-explore-hints-to-re.gate2.md

🤖 Generated via /gh-issue-driven:ship
