### PR TITLE
feat: replace err instanceof Error catch pattern with ApiError class (#299)

### DIFF
--- a/frontend/src/app/(authenticated)/admin/neural-config/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/neural-config/page.tsx
@@ -13,7 +13,7 @@ import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { Section } from "@/components/common/Section";
 import { LoadingState } from "@/components/common/LoadingState";
-import { apiClient } from "@/lib/api";
+import { apiClient, ApiError } from "@/lib/api";
 import {
   Table,
   TableBody,
@@ -103,10 +103,13 @@ export default function AdminNeuralConfigPage() {
       });
       setEditing(null);
       loadConfigs();
-    } catch (error: any) {
+    } catch (error: unknown) {
+      const apiErr = error instanceof ApiError ? error : null;
       toast({
         title: tCommon("error"),
-        description: error?.details?.detail || t("messages.updateError"),
+        description:
+          apiErr?.details?.detail ||
+          (error instanceof Error ? error.message : t("messages.updateError")),
         variant: "destructive",
       });
     } finally {

--- a/frontend/src/app/(authenticated)/admin/sleep-reports/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/page.test.tsx
@@ -21,6 +21,7 @@ import {
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 import AdminSleepReportsPage from "./page";
+import { ApiError } from "@/lib/api/base";
 
 // ---------- Mocks ------------------------------------------------------------
 
@@ -28,12 +29,16 @@ const mockGet = vi.fn();
 const mockPost = vi.fn();
 const mockToast = vi.fn();
 
-vi.mock("@/lib/api", () => ({
-  apiClient: {
-    get: (...args: unknown[]) => mockGet(...args),
-    post: (...args: unknown[]) => mockPost(...args),
-  },
-}));
+vi.mock("@/lib/api", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...original,
+    apiClient: {
+      get: (...args: unknown[]) => mockGet(...args),
+      post: (...args: unknown[]) => mockPost(...args),
+    },
+  };
+});
 
 // Stable references so useCallback/useEffect deps do not invalidate on
 // every render and spin up an infinite loadReports loop.
@@ -183,15 +188,17 @@ describe("AdminSleepReportsPage — Run Now button", () => {
     await renderReady();
 
     const runningReportId = "22222222-2222-2222-2222-222222222222";
-    mockPost.mockRejectedValueOnce({
-      status: 409,
-      error: "sleep_run_in_progress",
-      message: "A sleep run is already in progress for this user.",
-      details: {
-        running_report_id: runningReportId,
-        started_at: "2026-04-09T11:30:00Z",
-      },
-    });
+    mockPost.mockRejectedValueOnce(
+      new ApiError({
+        status: 409,
+        error: "sleep_run_in_progress",
+        message: "A sleep run is already in progress for this user.",
+        details: {
+          running_report_id: runningReportId,
+          started_at: "2026-04-09T11:30:00Z",
+        },
+      }),
+    );
 
     const button = screen.getByRole("button", { name: "actions.runNow" });
     fireEvent.click(button);

--- a/frontend/src/app/(authenticated)/admin/sleep-reports/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/page.tsx
@@ -27,7 +27,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { RefreshCw, Eye, ChevronLeft, ChevronRight, Play } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import type { ApiError } from "@/lib/api";
+import { ApiError } from "@/lib/api";
 import { formatRelativeTime } from "@/lib/utils/datetime";
 import {
   getSleepStatusColor,
@@ -123,12 +123,11 @@ export default function AdminSleepReportsPage() {
       });
       await loadReports();
     } catch (err) {
-      const apiErr = err as ApiError;
+      const apiErr = err instanceof ApiError ? err : null;
       if (apiErr?.status === 409) {
-        const details = apiErr.details as
-          | { running_report_id?: string }
+        const runningReportId = apiErr.details?.running_report_id as
+          | string
           | undefined;
-        const runningReportId = details?.running_report_id;
         toast({
           title: t("messages.runConflict"),
           description: runningReportId ? (
@@ -144,7 +143,8 @@ export default function AdminSleepReportsPage() {
       } else {
         toast({
           title: tCommon("error"),
-          description: apiErr?.message || t("messages.runError"),
+          description:
+            err instanceof Error ? err.message : t("messages.runError"),
           variant: "destructive",
         });
       }

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -87,6 +87,7 @@ import {
   type EmbeddingModel,
 } from "@/lib/api/contexts";
 import { checkOpenAIKeyStatus } from "@/lib/api/workspaces";
+import { ApiError } from "@/lib/api/base";
 import type { Context, ContextStats } from "@/lib/types/context";
 import { CONTEXT_TEMPLATES, getTemplate } from "@/lib/templates/usage-guide";
 import { createExternalAPIKey } from "@/lib/api/external-keys";
@@ -250,17 +251,11 @@ export default function ContextsPage() {
       await refetchUser();
       fetchContexts();
     } catch (err: unknown) {
-      const apiError = err as {
-        message?: string;
-        details?: { detail?: string };
-        response?: { data?: { detail?: string } };
-      };
+      const apiError = err instanceof ApiError ? err : null;
 
       let errorMessage =
-        apiError?.response?.data?.detail ||
         apiError?.details?.detail ||
-        apiError?.message ||
-        t("failedToCreate");
+        (err instanceof Error ? err.message : t("failedToCreate"));
 
       // Translate common error messages
       if (errorMessage.includes("Context limit reached")) {
@@ -323,10 +318,8 @@ export default function ContextsPage() {
       await refetchUser();
       fetchContexts();
     } catch (err: unknown) {
-      const apiErr = err as { message?: string };
       let errorMessage =
-        apiErr?.message ||
-        (typeof err === "string" ? err : t("failedToCreate"));
+        err instanceof Error ? err.message : t("failedToCreate");
 
       // Translate common error messages (but keep resource_id duplicates as-is)
       if (errorMessage.includes("already used")) {
@@ -410,10 +403,7 @@ export default function ContextsPage() {
       setApiKeyValue("");
       setApiKeyError(null);
     } catch (err: unknown) {
-      const apiErr = err as {
-        status?: number;
-        details?: { detail?: string };
-      };
+      const apiErr = err instanceof ApiError ? err : null;
       let errorMessage = t("failedToSaveApiKey");
       if (
         apiErr?.status === 409 ||

--- a/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
@@ -68,9 +68,7 @@ export default function WorkspaceStatsPage() {
       setContextStats(contextStatsResponse);
     } catch (err: unknown) {
       console.error("Failed to fetch workspace stats:", err);
-      const message =
-        (err as { message?: string })?.message || t("failedToLoadStats");
-      setError(message);
+      setError(err instanceof Error ? err.message : t("failedToLoadStats"));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/external-keys/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * External API Keys Management Page
@@ -10,18 +10,24 @@
  * Fix: Added permission check and redirect on workspace change
  */
 
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useTranslations } from 'next-intl';
-import { PageHeader } from '@/components/common/PageHeader';
-import { PageContainer } from '@/components/common/PageContainer';
-import { FeatureGuide } from '@/components/common/FeatureGuide';
-import { LoadingState } from '@/components/common/LoadingState';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { PageHeader } from "@/components/common/PageHeader";
+import { PageContainer } from "@/components/common/PageContainer";
+import { FeatureGuide } from "@/components/common/FeatureGuide";
+import { LoadingState } from "@/components/common/LoadingState";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Table,
   TableBody,
@@ -29,7 +35,7 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table';
+} from "@/components/ui/table";
 import {
   Dialog,
   DialogContent,
@@ -37,22 +43,32 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
+} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
-import { Key, Plus, Trash2, Edit, RefreshCw, AlertCircle, CheckCircle, AlertTriangle, ChevronDown } from 'lucide-react';
+} from "@/components/ui/select";
+import {
+  Key,
+  Plus,
+  Trash2,
+  Edit,
+  RefreshCw,
+  AlertCircle,
+  CheckCircle,
+  AlertTriangle,
+  ChevronDown,
+} from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { Switch } from '@/components/ui/switch';
+} from "@/components/ui/dropdown-menu";
+import { Switch } from "@/components/ui/switch";
 import {
   listExternalAPIKeys,
   createExternalAPIKey,
@@ -60,26 +76,45 @@ import {
   deleteExternalAPIKey,
   toggleExternalAPIKey,
   type ExternalAPIKey,
-} from '@/lib/api/external-keys';
-import { useToast } from '@/hooks/use-toast';
-import { InlineSpinner } from '@/components/common/LoadingState';
-import { useMemoryContext } from '@/contexts/MemoryContextContext';
-import { useWorkspace } from '@/contexts/WorkspaceContext';
+} from "@/lib/api/external-keys";
+import { ApiError } from "@/lib/api/base";
+import { useToast } from "@/hooks/use-toast";
+import { InlineSpinner } from "@/components/common/LoadingState";
+import { useMemoryContext } from "@/contexts/MemoryContextContext";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
 
 export default function ExternalKeysPage() {
-  const t = useTranslations('externalKeys');
-  const tCommon = useTranslations('common');
+  const t = useTranslations("externalKeys");
+  const tCommon = useTranslations("common");
   const router = useRouter();
 
   // Provider definitions with auto-generated key names
   const PROVIDERS = [
-    { value: 'openai', label: t('providers.openai'), keyName: 'OPENAI_API_KEY', icon: '🔑', description: t('providers.openaiDesc') },
-    { value: 'voyage', label: t('providers.voyage'), keyName: 'VOYAGE_API_KEY', icon: '🚀', description: t('providers.voyageDesc') },
-    { value: 'cohere', label: t('providers.cohere'), keyName: 'COHERE_API_KEY', icon: '🧬', description: t('providers.cohereDesc') },
+    {
+      value: "openai",
+      label: t("providers.openai"),
+      keyName: "OPENAI_API_KEY",
+      icon: "🔑",
+      description: t("providers.openaiDesc"),
+    },
+    {
+      value: "voyage",
+      label: t("providers.voyage"),
+      keyName: "VOYAGE_API_KEY",
+      icon: "🚀",
+      description: t("providers.voyageDesc"),
+    },
+    {
+      value: "cohere",
+      label: t("providers.cohere"),
+      keyName: "COHERE_API_KEY",
+      icon: "🧬",
+      description: t("providers.cohereDesc"),
+    },
   ];
 
-  const { contextId } = useMemoryContext();  // For context-scoped keys
-  const { currentWorkspaceId, currentWorkspace } = useWorkspace();  // For workspace-scoped keys
+  const { contextId } = useMemoryContext(); // For context-scoped keys
+  const { currentWorkspaceId, currentWorkspace } = useWorkspace(); // For workspace-scoped keys
   const [keys, setKeys] = useState<ExternalAPIKey[]>([]);
   const [loading, setLoading] = useState(true);
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -89,40 +124,44 @@ export default function ExternalKeysPage() {
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [selectedKey, setSelectedKey] = useState<ExternalAPIKey | null>(null);
-  const [formData, setFormData] = useState({ key_name: '', provider: '', value: '' });
+  const [formData, setFormData] = useState({
+    key_name: "",
+    provider: "",
+    value: "",
+  });
   const { toast } = useToast();
 
   // Filter providers - only show ones not already configured
   const availableProviders = PROVIDERS.filter(
-    (p) => !keys.some((k) => k.provider === p.value)
+    (p) => !keys.some((k) => k.provider === p.value),
   );
 
   // Issue #169: Quick add handler for dropdown
-  const handleQuickAdd = (provider: typeof PROVIDERS[0]) => {
+  const handleQuickAdd = (provider: (typeof PROVIDERS)[0]) => {
     setFormData({
       key_name: provider.keyName,
       provider: provider.value,
-      value: '',
+      value: "",
     });
     setCreateDialogOpen(true);
   };
 
   // Issue #115: Check if OpenAI key is configured (required for memory operations)
-  const hasOpenAIKey = keys.some((k) => k.provider === 'openai' && k.enabled);
+  const hasOpenAIKey = keys.some((k) => k.provider === "openai" && k.enabled);
 
   const handleProviderChange = (provider: string) => {
     const selectedProvider = PROVIDERS.find((p) => p.value === provider);
     setFormData({
       ...formData,
       provider,
-      key_name: selectedProvider?.keyName || '',
+      key_name: selectedProvider?.keyName || "",
     });
   };
 
   // Permission check: Redirect if not owner when workspace changes
   useEffect(() => {
-    if (currentWorkspace && currentWorkspace.current_user_role !== 'owner') {
-      router.push('/workspace/dashboard');
+    if (currentWorkspace && currentWorkspace.current_user_role !== "owner") {
+      router.push("/workspace/dashboard");
     }
   }, [currentWorkspace, router]);
 
@@ -141,12 +180,14 @@ export default function ExternalKeysPage() {
       setLoading(true);
       const response = await listExternalAPIKeys();
       // API returns { keys: [], total: 0 } structure
-      setKeys(Array.isArray(response) ? response : (response as any).keys || []);
+      setKeys(
+        Array.isArray(response) ? response : (response as any).keys || [],
+      );
     } catch (error) {
       toast({
-        title: tCommon('error'),
-        description: t('errorLoadKeys'),
-        variant: 'destructive',
+        title: tCommon("error"),
+        description: t("errorLoadKeys"),
+        variant: "destructive",
       });
     } finally {
       setLoading(false);
@@ -157,18 +198,21 @@ export default function ExternalKeysPage() {
     try {
       await createExternalAPIKey(formData);
       toast({
-        title: tCommon('success'),
-        description: t('successCreate'),
+        title: tCommon("success"),
+        description: t("successCreate"),
       });
       setCreateDialogOpen(false);
-      setFormData({ key_name: '', provider: '', value: '' });
+      setFormData({ key_name: "", provider: "", value: "" });
       loadKeys();
-    } catch (error: any) {
-      const errorMessage = error?.details?.detail || error?.message || t('errorCreateKey');
+    } catch (error: unknown) {
+      const apiErr = error instanceof ApiError ? error : null;
+      const errorMessage =
+        apiErr?.details?.detail ||
+        (error instanceof Error ? error.message : t("errorCreateKey"));
       toast({
-        title: tCommon('error'),
+        title: tCommon("error"),
         description: errorMessage,
-        variant: 'destructive',
+        variant: "destructive",
       });
     }
   };
@@ -179,19 +223,22 @@ export default function ExternalKeysPage() {
     try {
       await updateExternalAPIKey(selectedKey.key_name, formData.value);
       toast({
-        title: tCommon('success'),
-        description: t('successUpdate'),
+        title: tCommon("success"),
+        description: t("successUpdate"),
       });
       setEditDialogOpen(false);
       setSelectedKey(null);
-      setFormData({ key_name: '', provider: '', value: '' });
+      setFormData({ key_name: "", provider: "", value: "" });
       loadKeys();
-    } catch (error: any) {
-      const errorMessage = error?.details?.detail || error?.message || t('errorUpdateKey');
+    } catch (error: unknown) {
+      const apiErr = error instanceof ApiError ? error : null;
+      const errorMessage =
+        apiErr?.details?.detail ||
+        (error instanceof Error ? error.message : t("errorUpdateKey"));
       toast({
-        title: tCommon('error'),
+        title: tCommon("error"),
         description: errorMessage,
-        variant: 'destructive',
+        variant: "destructive",
       });
     }
   };
@@ -210,14 +257,17 @@ export default function ExternalKeysPage() {
       setDeleteError(null);
       await deleteExternalAPIKey(deleteKeyName);
       toast({
-        title: tCommon('success'),
-        description: t('successDelete'),
+        title: tCommon("success"),
+        description: t("successDelete"),
       });
       setDeleteDialogOpen(false);
       setDeleteKeyName(null);
       loadKeys();
-    } catch (error: any) {
-      const errorMessage = error?.details?.detail || error?.message || t('errorDeleteKey');
+    } catch (error: unknown) {
+      const apiErr = error instanceof ApiError ? error : null;
+      const errorMessage =
+        apiErr?.details?.detail ||
+        (error instanceof Error ? error.message : t("errorDeleteKey"));
       setDeleteError(errorMessage);
       setDeleteLoading(false);
     }
@@ -226,31 +276,41 @@ export default function ExternalKeysPage() {
   const handleToggle = async (key: ExternalAPIKey) => {
     try {
       await toggleExternalAPIKey(key.key_name, !key.enabled);
-      const action = key.enabled ? t('disabled') : t('enabled');
+      const action = key.enabled ? t("disabled") : t("enabled");
       toast({
-        title: tCommon('success'),
-        description: t('successToggle', { action }),
+        title: tCommon("success"),
+        description: t("successToggle", { action }),
       });
       loadKeys();
-    } catch (error: any) {
-      const detail = error?.details?.detail;
-      if (detail?.error === 'reranker_provider_conflict') {
+    } catch (error: unknown) {
+      const apiErr = error instanceof ApiError ? error : null;
+      const detail = apiErr?.details?.detail as
+        | { error?: string; message?: string }
+        | string
+        | undefined;
+      if (
+        typeof detail === "object" &&
+        detail?.error === "reranker_provider_conflict"
+      ) {
         toast({
-          title: t('conflict'),
+          title: t("conflict"),
           description: detail.message,
-          variant: 'destructive',
+          variant: "destructive",
         });
-      } else if (detail?.error === 'cannot_disable_embeddings') {
+      } else if (
+        typeof detail === "object" &&
+        detail?.error === "cannot_disable_embeddings"
+      ) {
         toast({
-          title: t('cannotDisable'),
+          title: t("cannotDisable"),
           description: detail.message,
-          variant: 'destructive',
+          variant: "destructive",
         });
       } else {
         toast({
-          title: tCommon('error'),
-          description: t('errorToggleKey'),
-          variant: 'destructive',
+          title: tCommon("error"),
+          description: t("errorToggleKey"),
+          variant: "destructive",
         });
       }
     }
@@ -258,17 +318,14 @@ export default function ExternalKeysPage() {
 
   const openEditDialog = (key: ExternalAPIKey) => {
     setSelectedKey(key);
-    setFormData({ key_name: key.key_name, provider: key.provider, value: '' });
+    setFormData({ key_name: key.key_name, provider: key.provider, value: "" });
     setEditDialogOpen(true);
   };
 
   if (loading && keys.length === 0) {
     return (
       <PageContainer>
-        <PageHeader
-          title={t('title')}
-          description={t('description')}
-        />
+        <PageHeader title={t("title")} description={t("description")} />
         <LoadingState lines={3} />
       </PageContainer>
     );
@@ -277,13 +334,17 @@ export default function ExternalKeysPage() {
   return (
     <PageContainer>
       <PageHeader
-        title={t('title')}
-        description={t('description')}
+        title={t("title")}
+        description={t("description")}
         actions={
           <div className="flex gap-2">
             <Button onClick={loadKeys} variant="outline" disabled={loading}>
-              {loading ? <InlineSpinner size="sm" className="mr-2" /> : <RefreshCw className="h-4 w-4 mr-2" />}
-              {t('refresh')}
+              {loading ? (
+                <InlineSpinner size="sm" className="mr-2" />
+              ) : (
+                <RefreshCw className="h-4 w-4 mr-2" />
+              )}
+              {t("refresh")}
             </Button>
             {/* Issue #169: Dropdown for API Key creation */}
             <DropdownMenu>
@@ -293,14 +354,14 @@ export default function ExternalKeysPage() {
                   className="bg-gradient-to-r from-brand-green-600 to-emerald-600 text-white shadow-lg hover:from-brand-green-700 hover:to-emerald-700"
                 >
                   <Plus className="mr-2 h-5 w-5" />
-                  {t('addApiKey')}
+                  {t("addApiKey")}
                   <ChevronDown className="ml-2 h-4 w-4" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-64">
                 {availableProviders.length === 0 ? (
                   <div className="px-2 py-3 text-sm text-muted-foreground text-center">
-                    {t('allProvidersConfigured')}
+                    {t("allProvidersConfigured")}
                   </div>
                 ) : (
                   availableProviders.map((provider) => (
@@ -311,7 +372,9 @@ export default function ExternalKeysPage() {
                       <span className="mr-3 text-lg">{provider.icon}</span>
                       <div>
                         <div className="font-medium">{provider.label}</div>
-                        <div className="text-xs text-muted-foreground">{provider.description}</div>
+                        <div className="text-xs text-muted-foreground">
+                          {provider.description}
+                        </div>
                       </div>
                     </DropdownMenuItem>
                   ))
@@ -322,21 +385,22 @@ export default function ExternalKeysPage() {
         }
       />
 
-      <FeatureGuide storageKey="external-keys" title={t('featureGuide.title')}>
-        <p>{t('featureGuide.overview')}</p>
-        <p>{t('featureGuide.useCases')}</p>
-        <p className="font-medium">{t('featureGuide.howItWorks')}</p>
+      <FeatureGuide storageKey="external-keys" title={t("featureGuide.title")}>
+        <p>{t("featureGuide.overview")}</p>
+        <p>{t("featureGuide.useCases")}</p>
+        <p className="font-medium">{t("featureGuide.howItWorks")}</p>
       </FeatureGuide>
 
       {/* Issue #115: OpenAI Required Alert */}
       {!loading && !hasOpenAIKey && (
-        <Alert variant="destructive" className="mb-6 border-red-300 bg-red-50 dark:bg-red-950/50">
+        <Alert
+          variant="destructive"
+          className="mb-6 border-red-300 bg-red-50 dark:bg-red-950/50"
+        >
           <AlertTriangle className="h-5 w-5" />
           <AlertDescription className="ml-2">
-            <strong className="font-semibold">{t('openAIRequired')}</strong>
-            <p className="mt-1 text-sm">
-              {t('openAIRequiredDesc')}
-            </p>
+            <strong className="font-semibold">{t("openAIRequired")}</strong>
+            <p className="mt-1 text-sm">{t("openAIRequiredDesc")}</p>
           </AlertDescription>
         </Alert>
       )}
@@ -346,62 +410,73 @@ export default function ExternalKeysPage() {
         <Alert className="mb-6 border-green-300 bg-green-50 dark:bg-green-950/50">
           <CheckCircle className="h-5 w-5 text-green-600" />
           <AlertDescription className="ml-2 text-green-800 dark:text-green-200">
-            <strong className="font-semibold">{t('openAIConfigured')}</strong> - {t('openAIConfiguredDesc')}
+            <strong className="font-semibold">{t("openAIConfigured")}</strong> -{" "}
+            {t("openAIConfiguredDesc")}
           </AlertDescription>
         </Alert>
       )}
 
       <Alert className="mb-6">
         <AlertCircle className="h-4 w-4" />
-        <AlertDescription>
-          {t('securityNotice')}
-        </AlertDescription>
+        <AlertDescription>{t("securityNotice")}</AlertDescription>
       </Alert>
 
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
             <Key className="h-5 w-5" />
-            {t('yourApiKeys')}
+            {t("yourApiKeys")}
           </CardTitle>
           <CardDescription>
-            {keys.length === 1 ? t('keysConfigured', { count: keys.length }) : t('keysConfiguredPlural', { count: keys.length })}
+            {keys.length === 1
+              ? t("keysConfigured", { count: keys.length })
+              : t("keysConfiguredPlural", { count: keys.length })}
           </CardDescription>
         </CardHeader>
         <CardContent>
           {loading ? (
-            <p className="text-center py-8 text-gray-500">{t('loading')}</p>
+            <p className="text-center py-8 text-gray-500">{t("loading")}</p>
           ) : keys.length === 0 ? (
             <div className="text-center py-12">
               <Key className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-              <p className="text-gray-600 mb-4">{t('noKeysYet')}</p>
+              <p className="text-gray-600 mb-4">{t("noKeysYet")}</p>
               <Button onClick={() => setCreateDialogOpen(true)}>
                 <Plus className="h-4 w-4 mr-2" />
-                {t('addFirstKey')}
+                {t("addFirstKey")}
               </Button>
             </div>
           ) : (
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>{t('provider')}</TableHead>
-                  <TableHead>{t('keyName')}</TableHead>
-                  <TableHead>{t('value')}</TableHead>
-                  <TableHead>{t('updated')}</TableHead>
-                  <TableHead className="text-right">{t('actions')}</TableHead>
+                  <TableHead>{t("provider")}</TableHead>
+                  <TableHead>{t("keyName")}</TableHead>
+                  <TableHead>{t("value")}</TableHead>
+                  <TableHead>{t("updated")}</TableHead>
+                  <TableHead className="text-right">{t("actions")}</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {keys.map((key) => (
-                  <TableRow key={key.id} className={!key.enabled ? 'opacity-50' : ''}>
+                  <TableRow
+                    key={key.id}
+                    className={!key.enabled ? "opacity-50" : ""}
+                  >
                     <TableCell className="font-medium">
                       {key.provider}
-                      {key.enabled && ['cohere', 'voyage'].includes(key.provider) && (
-                        <span className="ml-2 text-xs text-orange-600">{t('activeReranker')}</span>
-                      )}
+                      {key.enabled &&
+                        ["cohere", "voyage"].includes(key.provider) && (
+                          <span className="ml-2 text-xs text-orange-600">
+                            {t("activeReranker")}
+                          </span>
+                        )}
                     </TableCell>
-                    <TableCell className="font-mono text-sm">{key.key_name}</TableCell>
-                    <TableCell className="font-mono text-xs text-gray-500">{key.masked_value}</TableCell>
+                    <TableCell className="font-mono text-sm">
+                      {key.key_name}
+                    </TableCell>
+                    <TableCell className="font-mono text-xs text-gray-500">
+                      {key.masked_value}
+                    </TableCell>
                     <TableCell className="text-sm text-gray-500">
                       {new Date(key.updated_at).toLocaleDateString()}
                     </TableCell>
@@ -410,17 +485,21 @@ export default function ExternalKeysPage() {
                         <Switch
                           checked={key.enabled}
                           onCheckedChange={() => handleToggle(key)}
-                          disabled={key.provider === 'openai'}
+                          disabled={key.provider === "openai"}
                           title={
-                            key.provider === 'openai'
-                              ? t('openAICannotDisable')
-                              : t('toggleEnabled')
+                            key.provider === "openai"
+                              ? t("openAICannotDisable")
+                              : t("toggleEnabled")
                           }
                         />
-                        <Button variant="ghost" size="sm" onClick={() => openEditDialog(key)}>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => openEditDialog(key)}
+                        >
                           <Edit className="h-4 w-4" />
                         </Button>
-                        {key.key_name !== 'OPENAI_API_KEY' ? (
+                        {key.key_name !== "OPENAI_API_KEY" ? (
                           <Button
                             variant="ghost"
                             size="sm"
@@ -430,7 +509,7 @@ export default function ExternalKeysPage() {
                           </Button>
                         ) : (
                           <div className="text-xs text-muted-foreground px-2">
-                            {t('required')}
+                            {t("required")}
                           </div>
                         )}
                       </div>
@@ -447,22 +526,23 @@ export default function ExternalKeysPage() {
       <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t('addExternalKey')}</DialogTitle>
-            <DialogDescription>
-              {t('addNewKey')}
-            </DialogDescription>
+            <DialogTitle>{t("addExternalKey")}</DialogTitle>
+            <DialogDescription>{t("addNewKey")}</DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>
-              <Label htmlFor="provider">{t('provider')}</Label>
-              <Select value={formData.provider} onValueChange={handleProviderChange}>
+              <Label htmlFor="provider">{t("provider")}</Label>
+              <Select
+                value={formData.provider}
+                onValueChange={handleProviderChange}
+              >
                 <SelectTrigger>
-                  <SelectValue placeholder={t('selectProvider')} />
+                  <SelectValue placeholder={t("selectProvider")} />
                 </SelectTrigger>
                 <SelectContent>
                   {availableProviders.length === 0 ? (
                     <div className="px-2 py-1.5 text-sm text-gray-500">
-                      {t('allProvidersConfigured')}
+                      {t("allProvidersConfigured")}
                     </div>
                   ) : (
                     availableProviders.map((provider) => (
@@ -475,7 +555,7 @@ export default function ExternalKeysPage() {
               </Select>
             </div>
             <div>
-              <Label htmlFor="key_name">{t('keyNameAutoGenerated')}</Label>
+              <Label htmlFor="key_name">{t("keyNameAutoGenerated")}</Label>
               <Input
                 id="key_name"
                 value={formData.key_name}
@@ -484,21 +564,26 @@ export default function ExternalKeysPage() {
               />
             </div>
             <div>
-              <Label htmlFor="value">{t('apiKeyValue')}</Label>
+              <Label htmlFor="value">{t("apiKeyValue")}</Label>
               <Input
                 id="value"
                 type="password"
                 placeholder="sk-..."
                 value={formData.value}
-                onChange={(e) => setFormData({ ...formData, value: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, value: e.target.value })
+                }
               />
             </div>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setCreateDialogOpen(false)}>
-              {tCommon('cancel')}
+            <Button
+              variant="outline"
+              onClick={() => setCreateDialogOpen(false)}
+            >
+              {tCommon("cancel")}
             </Button>
-            <Button onClick={handleCreate}>{tCommon('create')}</Button>
+            <Button onClick={handleCreate}>{tCommon("create")}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -507,55 +592,56 @@ export default function ExternalKeysPage() {
       <Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t('updateApiKey')}</DialogTitle>
+            <DialogTitle>{t("updateApiKey")}</DialogTitle>
             <DialogDescription>
-              {t('updateKeyValue', { keyName: selectedKey?.key_name || '' })}
+              {t("updateKeyValue", { keyName: selectedKey?.key_name || "" })}
             </DialogDescription>
           </DialogHeader>
           <div className="space-y-4">
             <div>
-              <Label htmlFor="edit_value">{t('newApiKeyValue')}</Label>
+              <Label htmlFor="edit_value">{t("newApiKeyValue")}</Label>
               <Input
                 id="edit_value"
                 type="password"
-                placeholder={t('enterNewValue')}
+                placeholder={t("enterNewValue")}
                 value={formData.value}
-                onChange={(e) => setFormData({ ...formData, value: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, value: e.target.value })
+                }
               />
             </div>
           </div>
           <DialogFooter>
             <Button variant="outline" onClick={() => setEditDialogOpen(false)}>
-              {tCommon('cancel')}
+              {tCommon("cancel")}
             </Button>
-            <Button onClick={handleUpdate}>{tCommon('update')}</Button>
+            <Button onClick={handleUpdate}>{tCommon("update")}</Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
       {/* Delete Dialog */}
-      <Dialog open={deleteDialogOpen} onOpenChange={(open) => {
-        if (!deleteLoading) {
-          setDeleteDialogOpen(open);
-          if (!open) {
-            setDeleteKeyName(null);
-            setDeleteError(null);
+      <Dialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          if (!deleteLoading) {
+            setDeleteDialogOpen(open);
+            if (!open) {
+              setDeleteKeyName(null);
+              setDeleteError(null);
+            }
           }
-        }
-      }}>
+        }}
+      >
         <DialogContent className="sm:max-w-[500px]">
           <DialogHeader>
-            <DialogTitle>{t('deleteApiKey')}</DialogTitle>
-            <DialogDescription>
-              {t('deleteKeyPermanent')}
-            </DialogDescription>
+            <DialogTitle>{t("deleteApiKey")}</DialogTitle>
+            <DialogDescription>{t("deleteKeyPermanent")}</DialogDescription>
           </DialogHeader>
           <div className="space-y-4 py-4">
             <Alert variant="destructive">
               <AlertCircle className="h-4 w-4" />
-              <AlertDescription>
-                {t('deleteWarning')}
-              </AlertDescription>
+              <AlertDescription>{t("deleteWarning")}</AlertDescription>
             </Alert>
             {deleteError && (
               <Alert variant="destructive">
@@ -564,15 +650,23 @@ export default function ExternalKeysPage() {
               </Alert>
             )}
             <p className="text-sm">
-              {t('deleteConfirm', { keyName: deleteKeyName || '' })}
+              {t("deleteConfirm", { keyName: deleteKeyName || "" })}
             </p>
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setDeleteDialogOpen(false)} disabled={deleteLoading}>
-              {tCommon('cancel')}
+            <Button
+              variant="outline"
+              onClick={() => setDeleteDialogOpen(false)}
+              disabled={deleteLoading}
+            >
+              {tCommon("cancel")}
             </Button>
-            <Button variant="destructive" onClick={handleDelete} disabled={deleteLoading}>
-              {deleteLoading ? t('deleting') : tCommon('delete')}
+            <Button
+              variant="destructive"
+              onClick={handleDelete}
+              disabled={deleteLoading}
+            >
+              {deleteLoading ? t("deleting") : tCommon("delete")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.test.tsx
@@ -13,6 +13,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
 import { EditOAuthClientDialog } from "./EditOAuthClientDialog";
+import { ApiError } from "@/lib/api/base";
 import type { OAuth2Client } from "@/lib/api/oauth";
 
 // ---------- Mocks ------------------------------------------------------------
@@ -142,12 +143,17 @@ describe("EditOAuthClientDialog", () => {
   });
 
   it("displays API error and keeps the dialog open on failure", async () => {
-    mockUpdateOAuth2Client.mockRejectedValueOnce({
-      message: "Validation failed",
-      details: {
-        detail: [{ loc: ["body", "redirect_uris"], msg: "Invalid URI format" }],
-      },
-    });
+    mockUpdateOAuth2Client.mockRejectedValueOnce(
+      new ApiError({
+        status: 422,
+        message: "Validation failed",
+        details: {
+          detail: [
+            { loc: ["body", "redirect_uris"], msg: "Invalid URI format" },
+          ],
+        },
+      }),
+    );
 
     const { props } = renderDialog();
 

--- a/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/oauth-apps/EditOAuthClientDialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { updateOAuth2Client } from "@/lib/api/oauth";
+import { ApiError } from "@/lib/api/base";
 import type { OAuth2Client } from "@/lib/api/oauth";
 import { useToast } from "@/hooks/use-toast";
 import { X, Pencil } from "lucide-react";
@@ -84,15 +85,15 @@ export function EditOAuthClientDialog({
       onOpenChange(false);
       onSuccess();
     } catch (err: unknown) {
-      const apiError = err as {
-        message?: string;
-        details?: { detail?: string | Array<{ loc?: string[]; msg?: string }> };
-      };
+      const apiError = err instanceof ApiError ? err : null;
       // Handle Pydantic 422 field-level errors
-      const detail = apiError?.details?.detail;
-      if (Array.isArray(detail)) {
+      const rawDetail = apiError?.details?.["detail"] as unknown;
+      if (Array.isArray(rawDetail)) {
         const newFieldErrors: Record<string, string> = {};
-        for (const item of detail) {
+        for (const item of rawDetail as Array<{
+          loc?: string[];
+          msg?: string;
+        }>) {
           const field = item.loc?.slice(-1)[0];
           if (field) {
             newFieldErrors[field] = item.msg || "Invalid value";
@@ -104,13 +105,10 @@ export function EditOAuthClientDialog({
           return;
         }
       }
-      const fallbackMessage =
-        typeof apiError?.message === "string"
-          ? apiError.message
-          : typeof apiError?.details?.detail === "string"
-            ? apiError.details.detail
-            : t("editFieldError");
-      setError(fallbackMessage);
+      setError(
+        apiError?.details?.detail ||
+          (err instanceof Error ? err.message : t("editFieldError")),
+      );
     } finally {
       setSaving(false);
     }

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -30,6 +30,7 @@ import {
   WorkspaceMember,
 } from "@/lib/api/workspaces";
 import { getContexts, Context } from "@/lib/api/contexts";
+import { ApiError } from "@/lib/api/base";
 import {
   listInvitations,
   createInvitation,
@@ -169,10 +170,10 @@ export default function WorkspaceMembersPage() {
     try {
       const data = await listInvitations(currentWorkspaceId, false); // Only pending invitations
       setInvitations(data);
-    } catch (error: any) {
+    } catch (error: unknown) {
       // 403 = Not admin/owner, silently skip invitations feature
-      if (error?.status === 403) {
-        setInvitations([]); // No invitations to show
+      if (error instanceof ApiError && error.status === 403) {
+        setInvitations([]);
         return;
       }
       console.error("Failed to load invitations:", error);
@@ -187,9 +188,9 @@ export default function WorkspaceMembersPage() {
       setQuotaLoading(true);
       const quota = await getMemberQuota(currentWorkspaceId);
       setMemberQuota(quota);
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Silently fail if user doesn't have access
-      if (error?.status === 403) {
+      if (error instanceof ApiError && error.status === 403) {
         setMemberQuota(null);
         return;
       }
@@ -253,10 +254,10 @@ export default function WorkspaceMembersPage() {
       });
 
       setShowContextAccessDialog(false);
-    } catch (error: any) {
+    } catch (error: unknown) {
       toast({
         title: t("contextAccessUpdateFailed"),
-        description: error?.message || "Unknown error",
+        description: error instanceof Error ? error.message : "Unknown error",
         variant: "destructive",
       });
     } finally {
@@ -312,13 +313,14 @@ export default function WorkspaceMembersPage() {
         title: t("invitationCreated"),
         description: t("invitationSentTo", { email: inviteEmail }),
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to create invitation:", error);
-      // Issue #217: Extract error message for display in dialog
+      const apiErr = error instanceof ApiError ? error : null;
       const errorMsg =
-        error?.details?.detail ||
-        error?.message ||
-        (typeof error === "string" ? error : "Failed to create invitation");
+        apiErr?.details?.detail ||
+        (error instanceof Error
+          ? error.message
+          : "Failed to create invitation");
       setInviteError(errorMsg);
     } finally {
       setInviteLoading(false);
@@ -372,12 +374,14 @@ export default function WorkspaceMembersPage() {
           email: invitationToDelete.email || "user",
         }),
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to delete invitation:", error);
+      const apiErr = error instanceof ApiError ? error : null;
       const errorMsg =
-        error?.details?.detail ||
-        error?.message ||
-        t("failedToRevokeInvitation");
+        apiErr?.details?.detail ||
+        (error instanceof Error
+          ? error.message
+          : t("failedToRevokeInvitation"));
       toast({
         title: t("failedToRevokeInvitation"),
         description: errorMsg,
@@ -411,10 +415,12 @@ export default function WorkspaceMembersPage() {
             memberToDelete.user_name || memberToDelete.user_email || "Member",
         }),
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to remove member:", error);
+      const apiErr = error instanceof ApiError ? error : null;
       const errorMsg =
-        error?.details?.detail || error?.message || t("failedToRemoveMember");
+        apiErr?.details?.detail ||
+        (error instanceof Error ? error.message : t("failedToRemoveMember"));
       toast({
         title: t("failedToRemoveMember"),
         description: errorMsg,
@@ -457,16 +463,16 @@ export default function WorkspaceMembersPage() {
       await loadMembers();
       setShowRoleChangeDialog(false);
       setPendingRoleChange(null);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error("Failed to update role:", error);
 
-      // Issue #254: Show specific message for role change errors
-      let errorMessage = error?.message || "Failed to update role";
+      let errorMessage =
+        error instanceof Error ? error.message : "Failed to update role";
 
-      if (error?.status === 403) {
-        if (error?.message?.includes("own role")) {
+      if (error instanceof ApiError && error.status === 403) {
+        if (error.message.includes("own role")) {
           errorMessage = t("cannotModifyOwnRoleDesc");
-        } else if (error?.message?.includes("owner can change")) {
+        } else if (error.message.includes("owner can change")) {
           errorMessage = t("onlyOwnerCanChangeOwner");
         }
       }

--- a/frontend/src/app/(authenticated)/workspace/settings/general/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/settings/general/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * Workspace Settings Page
@@ -11,24 +11,24 @@
  * Edit workspace details (name, description) or create new workspace.
  */
 
-import { useEffect, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useTranslations } from 'next-intl';
-import { PageHeader } from '@/components/common/PageHeader';
-import { PageContainer } from '@/components/common/PageContainer';
-import { Section } from '@/components/common/Section';
-import { ActionButton } from '@/components/common/ActionButton';
-import { SpinnerLoading } from '@/components/common/LoadingState';
-import { useWorkspace } from '@/contexts/WorkspaceContext';
-import { useAuth } from '@/contexts/AuthContext';
+import { useEffect, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { PageHeader } from "@/components/common/PageHeader";
+import { PageContainer } from "@/components/common/PageContainer";
+import { Section } from "@/components/common/Section";
+import { ActionButton } from "@/components/common/ActionButton";
+import { SpinnerLoading } from "@/components/common/LoadingState";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { useAuth } from "@/contexts/AuthContext";
 import {
   getWorkspace,
   updateWorkspace,
   deleteWorkspace,
   Workspace,
-} from '@/lib/api/workspaces';
-import { Save, Trash2 } from 'lucide-react';
-import { useToast } from '@/hooks/use-toast';
+} from "@/lib/api/workspaces";
+import { Save, Trash2 } from "lucide-react";
+import { useToast } from "@/hooks/use-toast";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,20 +38,27 @@ import {
   AlertDialogFooter,
   AlertDialogHeader,
   AlertDialogTitle,
-} from '@/components/ui/alert-dialog';
-import { WorkspaceCreateForm } from '@/components/workspaces/WorkspaceCreateForm';
+} from "@/components/ui/alert-dialog";
+import { WorkspaceCreateForm } from "@/components/workspaces/WorkspaceCreateForm";
+import { ApiError } from "@/lib/api/base";
 
 export default function WorkspaceSettingsPage() {
-  const t = useTranslations('workspace');
-  const tCommon = useTranslations('common');
+  const t = useTranslations("workspace");
+  const tCommon = useTranslations("common");
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { currentWorkspaceId, currentWorkspace, refreshWorkspaces, workspaces, loading: workspaceLoading } = useWorkspace();
+  const {
+    currentWorkspaceId,
+    currentWorkspace,
+    refreshWorkspaces,
+    workspaces,
+    loading: workspaceLoading,
+  } = useWorkspace();
   const { toast } = useToast();
   const { logout } = useAuth();
 
   // Issue #276: Check if in create mode
-  const isCreateMode = searchParams.get('create') === 'true';
+  const isCreateMode = searchParams.get("create") === "true";
 
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [loading, setLoading] = useState(true);
@@ -60,8 +67,8 @@ export default function WorkspaceSettingsPage() {
   const [error, setError] = useState<string | null>(null);
 
   // Form state
-  const [name, setName] = useState('');
-  const [description, setDescription] = useState('');
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
 
   // Delete dialog state
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
@@ -77,8 +84,8 @@ export default function WorkspaceSettingsPage() {
     if (workspaceLoading) return;
 
     // Owner-only access check
-    if (currentWorkspace && currentWorkspace.current_user_role !== 'owner') {
-      router.push('/workspace/dashboard');
+    if (currentWorkspace && currentWorkspace.current_user_role !== "owner") {
+      router.push("/workspace/dashboard");
       return;
     }
 
@@ -95,10 +102,10 @@ export default function WorkspaceSettingsPage() {
       const workspace = await getWorkspace(currentWorkspaceId);
       setWorkspace(workspace);
       setName(workspace.name);
-      setDescription(workspace.description || '');
+      setDescription(workspace.description || "");
     } catch (error) {
-      console.error('Failed to load workspace:', error);
-      setError(t('failedToLoadWorkspace'));
+      console.error("Failed to load workspace:", error);
+      setError(t("failedToLoadWorkspace"));
     } finally {
       setLoading(false);
     }
@@ -113,7 +120,7 @@ export default function WorkspaceSettingsPage() {
 
       // Validation
       if (!name) {
-        setError(t('workspaceNameRequired'));
+        setError(t("workspaceNameRequired"));
         return;
       }
 
@@ -124,27 +131,33 @@ export default function WorkspaceSettingsPage() {
       });
 
       toast({
-        title: tCommon('success'),
-        description: t('settingsSaved'),
+        title: tCommon("success"),
+        description: t("settingsSaved"),
       });
       await loadWorkspace();
       await refreshWorkspaces();
-    } catch (err: any) {
-      console.error('Failed to save workspace:', err);
+    } catch (err: unknown) {
+      console.error("Failed to save workspace:", err);
 
       // Extract validation error details
-      if (err.status === 422 && err.details?.detail) {
-        const validationErrors = err.details.detail;
-        if (Array.isArray(validationErrors)) {
-          const messages = validationErrors.map((e: any) =>
-            `${e.loc?.join('.') || 'Field'}: ${e.msg}`
-          ).join('\n');
+      const apiError = err instanceof ApiError ? err : null;
+      // FastAPI 422 detail can be a string or validation error array at runtime
+      if (apiError?.status === 422 && apiError.details?.detail !== undefined) {
+        const rawDetail = apiError.details["detail"] as unknown;
+        if (Array.isArray(rawDetail)) {
+          const messages = (
+            rawDetail as Array<{ loc?: string[]; msg?: string }>
+          )
+            .map((e) => `${e.loc?.join(".") || "Field"}: ${e.msg}`)
+            .join("\n");
           setError(messages);
         } else {
-          setError(err.message || t('validationFailed'));
+          setError(apiError.message || t("validationFailed"));
         }
       } else {
-        setError(err.message || t('failedToUpdateWorkspace'));
+        setError(
+          err instanceof Error ? err.message : t("failedToUpdateWorkspace"),
+        );
       }
     } finally {
       setSaving(false);
@@ -171,8 +184,8 @@ export default function WorkspaceSettingsPage() {
       if (isLastWorkspace) {
         // Last workspace deleted - logout user
         toast({
-          title: t('workspaceDeleted'),
-          description: t('lastWorkspaceDeleteDesc'),
+          title: t("workspaceDeleted"),
+          description: t("lastWorkspaceDeleteDesc"),
         });
 
         // Small delay to allow toast to show, then logout
@@ -182,23 +195,24 @@ export default function WorkspaceSettingsPage() {
       } else {
         // Still have workspaces - refresh and redirect to home
         toast({
-          title: t('workspaceDeleted'),
-          description: t('workspaceDeletedDesc'),
+          title: t("workspaceDeleted"),
+          description: t("workspaceDeletedDesc"),
         });
 
         await refreshWorkspaces();
 
         setTimeout(() => {
-          router.push('/');
+          router.push("/");
           router.refresh();
         }, 500);
       }
-    } catch (error: any) {
-      console.error('Failed to delete workspace:', error);
+    } catch (error: unknown) {
+      console.error("Failed to delete workspace:", error);
       toast({
-        title: tCommon('error'),
-        description: error?.message || t('failedToDeleteWorkspace'),
-        variant: 'destructive',
+        title: tCommon("error"),
+        description:
+          error instanceof Error ? error.message : t("failedToDeleteWorkspace"),
+        variant: "destructive",
       });
       setDeleting(false);
     }
@@ -210,7 +224,7 @@ export default function WorkspaceSettingsPage() {
       <PageContainer>
         <WorkspaceCreateForm
           onSuccess={(workspace) => {
-            router.push('/workspace/dashboard');
+            router.push("/workspace/dashboard");
           }}
           onCancel={() => router.back()}
         />
@@ -221,9 +235,9 @@ export default function WorkspaceSettingsPage() {
   if (loading) {
     return (
       <PageContainer>
-        <PageHeader title={t('workspaceSettings')} />
+        <PageHeader title={t("workspaceSettings")} />
         <div className="flex items-center justify-center py-12">
-          <SpinnerLoading message={tCommon('loading')} />
+          <SpinnerLoading message={tCommon("loading")} />
         </div>
       </PageContainer>
     );
@@ -232,8 +246,8 @@ export default function WorkspaceSettingsPage() {
   return (
     <PageContainer>
       <PageHeader
-        title={t('workspaceSettings')}
-        description={t('settingsDesc')}
+        title={t("workspaceSettings")}
+        description={t("settingsDesc")}
       />
 
       <Section>
@@ -250,35 +264,35 @@ export default function WorkspaceSettingsPage() {
           {/* Workspace Name */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              {t('workspaceName')} *
+              {t("workspaceName")} *
             </label>
             <input
               type="text"
               value={name}
               onChange={(e) => setName(e.target.value)}
-              placeholder={t('workspaceNamePlaceholder')}
+              placeholder={t("workspaceNamePlaceholder")}
               required
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
             />
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              {t('workspaceNameHelp')}
+              {t("workspaceNameHelp")}
             </p>
           </div>
 
           {/* Description */}
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              {t('workspaceDesc')} {t('optional')}
+              {t("workspaceDesc")} {t("optional")}
             </label>
             <textarea
               value={description}
               onChange={(e) => setDescription(e.target.value)}
-              placeholder={t('descPlaceholder')}
+              placeholder={t("descPlaceholder")}
               rows={3}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100"
             />
             <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              {t('descHelp')}
+              {t("descHelp")}
             </p>
           </div>
 
@@ -289,14 +303,14 @@ export default function WorkspaceSettingsPage() {
               icon={<Save className="w-4 h-4" />}
               disabled={!name || saving}
             >
-              {saving ? t('saving') : tCommon('saveChanges')}
+              {saving ? t("saving") : tCommon("saveChanges")}
             </ActionButton>
 
             <button
               onClick={() => router.back()}
               className="px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100"
             >
-              {tCommon('cancel')}
+              {tCommon("cancel")}
             </button>
           </div>
         </div>
@@ -304,21 +318,24 @@ export default function WorkspaceSettingsPage() {
 
       {/* Danger Zone */}
       {workspace && (
-        <Section title={t('dangerZone')} className="border-red-200 dark:border-red-900">
+        <Section
+          title={t("dangerZone")}
+          className="border-red-200 dark:border-red-900"
+        >
           <div className="space-y-4 max-w-2xl">
             <div className="p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-900 rounded">
               <h3 className="font-semibold text-red-900 dark:text-red-400 mb-2">
-                {t('deleteWorkspace')}
+                {t("deleteWorkspace")}
               </h3>
               <p className="text-sm text-red-700 dark:text-red-300 mb-4">
-                {t('deleteWorkspaceWarning')}
+                {t("deleteWorkspaceWarning")}
               </p>
               <ActionButton
                 onClick={handleDeleteClick}
                 icon={<Trash2 className="w-4 h-4" />}
                 variant="danger"
               >
-                {t('deleteWorkspace')}
+                {t("deleteWorkspace")}
               </ActionButton>
             </div>
           </div>
@@ -330,32 +347,36 @@ export default function WorkspaceSettingsPage() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle className="text-red-600 dark:text-red-400">
-              {t('deleteConfirmTitle')}
+              {t("deleteConfirmTitle")}
             </AlertDialogTitle>
             <AlertDialogDescription asChild>
               <div className="space-y-2">
                 <p>
-                  {t('deleteWorkspaceDialogDesc', { workspaceName: workspace?.name || '' })}
+                  {t("deleteWorkspaceDialogDesc", {
+                    workspaceName: workspace?.name || "",
+                  })}
                 </p>
                 <ul className="list-disc list-inside space-y-1 text-sm">
-                  <li>{t('allContexts')}</li>
-                  <li>{t('allMemories')}</li>
-                  <li>{t('allMembers')}</li>
+                  <li>{t("allContexts")}</li>
+                  <li>{t("allMemories")}</li>
+                  <li>{t("allMembers")}</li>
                 </ul>
                 <p className="font-semibold text-red-600 dark:text-red-400">
-                  {tCommon('thisActionCannotBeUndone')}
+                  {tCommon("thisActionCannotBeUndone")}
                 </p>
               </div>
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel disabled={deleting}>{tCommon('cancel')}</AlertDialogCancel>
+            <AlertDialogCancel disabled={deleting}>
+              {tCommon("cancel")}
+            </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleConfirmDelete}
               disabled={deleting}
               className="bg-red-600 hover:bg-red-700 text-white"
             >
-              {deleting ? t('deleting') : t('deleteWorkspace')}
+              {deleting ? t("deleting") : t("deleteWorkspace")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/app/invite/[token]/page.tsx
+++ b/frontend/src/app/invite/[token]/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * Accept Invitation Page
@@ -17,27 +17,27 @@
  * Next.js 15: params is now a Promise and must be unwrapped with React.use()
  */
 
-import { use, useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { useTranslations } from 'next-intl';
+import { use, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import {
   acceptInvitation,
   getInvitationInfo,
   AcceptInvitationResponse,
   InvitationInfo,
-} from '@/lib/api/invitations';
-import { apiClient } from '@/lib/api/base';
-import { SpinnerLoading } from '@/components/common/LoadingState';
-import { LanguageSelector } from '@/components/LanguageSelector';
-import { Check, AlertCircle, LogIn, Mail } from 'lucide-react';
+} from "@/lib/api/invitations";
+import { apiClient, ApiError } from "@/lib/api/base";
+import { SpinnerLoading } from "@/components/common/LoadingState";
+import { LanguageSelector } from "@/components/LanguageSelector";
+import { Check, AlertCircle, LogIn, Mail } from "lucide-react";
 
 type PageState =
-  | 'loading'
-  | 'login_required'
-  | 'email_mismatch'
-  | 'accepting'
-  | 'success'
-  | 'error';
+  | "loading"
+  | "login_required"
+  | "email_mismatch"
+  | "accepting"
+  | "success"
+  | "error";
 
 interface CurrentUser {
   user_id: string;
@@ -52,10 +52,12 @@ export default function AcceptInvitationPage({
 }) {
   const router = useRouter();
   const { token } = use(params);
-  const t = useTranslations('invitation');
+  const t = useTranslations("invitation");
 
-  const [state, setState] = useState<PageState>('loading');
-  const [invitationInfo, setInvitationInfo] = useState<InvitationInfo | null>(null);
+  const [state, setState] = useState<PageState>("loading");
+  const [invitationInfo, setInvitationInfo] = useState<InvitationInfo | null>(
+    null,
+  );
   const [currentUser, setCurrentUser] = useState<CurrentUser | null>(null);
   const [result, setResult] = useState<AcceptInvitationResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -66,7 +68,7 @@ export default function AcceptInvitationPage({
 
   const initializeAcceptanceFlow = async () => {
     try {
-      setState('loading');
+      setState("loading");
 
       // Step 1: Load invitation info (public endpoint)
       const info = await getInvitationInfo(token);
@@ -77,7 +79,7 @@ export default function AcceptInvitationPage({
 
       if (!user) {
         // Not authenticated → Show login prompt
-        setState('login_required');
+        setState("login_required");
         return;
       }
 
@@ -92,64 +94,72 @@ export default function AcceptInvitationPage({
 
       // Step 4: Attempt to accept invitation
       await attemptAcceptInvitation(user);
-    } catch (err: any) {
-      console.error('Initialization error:', err);
-      console.error('Error details:', JSON.stringify(err, null, 2));
+    } catch (err: unknown) {
+      console.error("Initialization error:", err);
 
-      // Extract error message with multiple fallbacks
-      let errorMessage = 'Failed to load invitation';
-
-      if (err.status === 404) {
-        errorMessage = 'Invitation not found or invalid';
-      } else if (err.status === 410) {
-        errorMessage = err.details?.detail || err.message || 'This invitation has expired or been accepted';
-      } else if (err.details?.detail) {
-        errorMessage = err.details.detail;
-      } else if (err.message) {
+      let errorMessage = "Failed to load invitation";
+      if (err instanceof ApiError) {
+        if (err.status === 404) {
+          errorMessage = "Invitation not found or invalid";
+        } else if (err.status === 410) {
+          errorMessage =
+            err.details?.detail ||
+            err.message ||
+            "This invitation has expired or been accepted";
+        } else if (err.details?.detail) {
+          errorMessage = err.details.detail;
+        } else {
+          errorMessage = err.message;
+        }
+      } else if (err instanceof Error) {
         errorMessage = err.message;
       }
 
       setError(errorMessage);
-      setState('error');
+      setState("error");
     }
   };
 
   const checkAuthentication = async (): Promise<CurrentUser | null> => {
     try {
-      const user = await apiClient.get<CurrentUser>('/api/v1/auth/me');
+      const user = await apiClient.get<CurrentUser>("/api/v1/auth/me");
       return user;
-    } catch (err: any) {
+    } catch {
       return null; // Not authenticated
     }
   };
 
   const attemptAcceptInvitation = async (user: CurrentUser) => {
     try {
-      setState('accepting');
+      setState("accepting");
       const response = await acceptInvitation(token);
       setResult(response);
-      setState('success');
+      setState("success");
 
       // Redirect after 3 seconds
       setTimeout(() => {
-        router.push('/workspace/members');
+        router.push("/workspace/members");
       }, 3000);
-    } catch (err: any) {
-      console.error('[INVITE] ❌ Acceptance failed');
-      console.error('[INVITE] Error object:', err);
-      console.error('[INVITE] Error stringified:', JSON.stringify(err, null, 2));
+    } catch (err: unknown) {
+      console.error("[INVITE] ❌ Acceptance failed:", err);
 
-      const errorMessage = err.details?.detail || err.message || 'Failed to accept invitation';
+      const apiError = err instanceof ApiError ? err : null;
+      const errorMessage =
+        apiError?.details?.detail ||
+        (err instanceof Error ? err.message : "Failed to accept invitation");
 
       // Check if it's an email mismatch error
-      if (errorMessage.includes('restricted to') && errorMessage.includes('logged in as')) {
-        setState('email_mismatch');
+      if (
+        errorMessage.includes("restricted to") &&
+        errorMessage.includes("logged in as")
+      ) {
+        setState("email_mismatch");
         setError(errorMessage);
-      } else if (errorMessage.includes('already a member')) {
+      } else if (errorMessage.includes("already a member")) {
         // Already a member - treat as success
-        router.push('/workspace/members');
+        router.push("/workspace/members");
       } else {
-        setState('error');
+        setState("error");
         setError(errorMessage);
       }
     }
@@ -158,7 +168,8 @@ export default function AcceptInvitationPage({
   const handleLogin = () => {
     const currentUrl = window.location.href;
     // Get backend API URL (defaults to localhost:8080 in dev)
-    const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+    const apiBaseUrl =
+      process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
     // Redirect to backend OAuth endpoint with full URL
     window.location.href = `${apiBaseUrl}/api/v1/auth/google/login?return_to=${encodeURIComponent(currentUrl)}`;
   };
@@ -166,35 +177,38 @@ export default function AcceptInvitationPage({
   const handleLogout = async () => {
     try {
       // Call logout API (POST)
-      await apiClient.post('/api/v1/auth/logout', {});
+      await apiClient.post("/api/v1/auth/logout", {});
       // Reload page to re-check auth status
       window.location.reload();
     } catch (err) {
-      console.error('Logout failed:', err);
+      console.error("Logout failed:", err);
       // Force reload anyway
       window.location.reload();
     }
   };
 
   const maskEmail = (email: string): string => {
-    if (!email || !email.includes('@')) return email;
+    if (!email || !email.includes("@")) return email;
 
-    const [localPart, domain] = email.split('@');
+    const [localPart, domain] = email.split("@");
 
     // Mask local part: show first 2 chars + *** + last char
     let maskedLocal = localPart;
     if (localPart.length > 3) {
-      maskedLocal = localPart.substring(0, 2) + '***' + localPart.substring(localPart.length - 1);
+      maskedLocal =
+        localPart.substring(0, 2) +
+        "***" +
+        localPart.substring(localPart.length - 1);
     } else if (localPart.length > 1) {
-      maskedLocal = localPart[0] + '***';
+      maskedLocal = localPart[0] + "***";
     }
 
     // Mask domain: show first char + *** + TLD
-    const domainParts = domain.split('.');
+    const domainParts = domain.split(".");
     if (domainParts.length > 1) {
       const baseDomain = domainParts[0];
-      const tld = domainParts.slice(1).join('.');
-      const maskedDomain = baseDomain[0] + '***.' + tld;
+      const tld = domainParts.slice(1).join(".");
+      const maskedDomain = baseDomain[0] + "***." + tld;
       return `${maskedLocal}@${maskedDomain}`;
     }
 
@@ -202,7 +216,7 @@ export default function AcceptInvitationPage({
   };
 
   // Loading State
-  if (state === 'loading' || state === 'accepting') {
+  if (state === "loading" || state === "accepting") {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900">
         <div className="absolute top-4 right-4">
@@ -210,7 +224,9 @@ export default function AcceptInvitationPage({
         </div>
         <div className="text-center">
           <SpinnerLoading
-            message={state === 'loading' ? t('status.loading') : t('status.accepting')}
+            message={
+              state === "loading" ? t("status.loading") : t("status.accepting")
+            }
           />
         </div>
       </div>
@@ -218,7 +234,7 @@ export default function AcceptInvitationPage({
   }
 
   // Login Required State
-  if (state === 'login_required') {
+  if (state === "login_required") {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
         <div className="absolute top-4 right-4">
@@ -231,14 +247,15 @@ export default function AcceptInvitationPage({
             </div>
 
             <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">
-              {t('loginRequired.title')}
+              {t("loginRequired.title")}
             </h2>
 
             <p className="text-center text-gray-600 dark:text-gray-400 mb-6">
-              {t('loginRequired.message')}
+              {t("loginRequired.message")}
               {invitationInfo && (
                 <>
-                  {' '}{t('loginRequired.messageTo')}{' '}
+                  {" "}
+                  {t("loginRequired.messageTo")}{" "}
                   <strong className="text-gray-900 dark:text-gray-100">
                     {invitationInfo.workspace_name}
                   </strong>
@@ -251,11 +268,11 @@ export default function AcceptInvitationPage({
               className="w-full px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors flex items-center justify-center gap-2 text-lg font-medium mb-4"
             >
               <LogIn className="w-5 h-5" />
-              {t('loginRequired.loginButton')}
+              {t("loginRequired.loginButton")}
             </button>
 
             <p className="text-xs text-center text-gray-500 dark:text-gray-400">
-              {t('loginRequired.noAccount')}
+              {t("loginRequired.noAccount")}
             </p>
           </div>
         </div>
@@ -264,12 +281,14 @@ export default function AcceptInvitationPage({
   }
 
   // Email Mismatch State
-  if (state === 'email_mismatch') {
+  if (state === "email_mismatch") {
     // Extract emails from error message (capture full email with @domain)
-    const restrictedMatch = error?.match(/restricted to ([^\s]+@[^\s.]+\.[^\s]+)/);
+    const restrictedMatch = error?.match(
+      /restricted to ([^\s]+@[^\s.]+\.[^\s]+)/,
+    );
     const loggedInMatch = error?.match(/logged in as ([^\s]+@[^\s.]+\.[^\s]+)/);
-    const requiredEmail = restrictedMatch?.[1] || 'the invited email';
-    const userEmail = loggedInMatch?.[1] || currentUser?.email || 'unknown';
+    const requiredEmail = restrictedMatch?.[1] || "the invited email";
+    const userEmail = loggedInMatch?.[1] || currentUser?.email || "unknown";
 
     // Mask emails for privacy
     const maskedRequired = maskEmail(requiredEmail);
@@ -287,23 +306,25 @@ export default function AcceptInvitationPage({
             </div>
 
             <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">
-              {t('emailMismatch.title')}
+              {t("emailMismatch.title")}
             </h2>
 
             <div className="space-y-4 mb-6">
               <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4">
                 <p className="text-sm text-blue-900 dark:text-blue-100 mb-2 font-medium">
-                  {t('emailMismatch.required')}
+                  {t("emailMismatch.required")}
                 </p>
                 <div className="flex items-center gap-2 text-blue-700 dark:text-blue-300">
                   <Mail className="w-4 h-4" />
-                  <span className="font-mono font-semibold">{maskedRequired}</span>
+                  <span className="font-mono font-semibold">
+                    {maskedRequired}
+                  </span>
                 </div>
               </div>
 
               <div className="bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
                 <p className="text-sm text-gray-700 dark:text-gray-300 mb-2">
-                  {t('emailMismatch.currentlyLoggedIn')}
+                  {t("emailMismatch.currentlyLoggedIn")}
                 </p>
                 <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">
                   <Mail className="w-4 h-4" />
@@ -317,11 +338,11 @@ export default function AcceptInvitationPage({
               className="w-full px-6 py-3 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors flex items-center justify-center gap-2 text-lg font-medium mb-4"
             >
               <LogIn className="w-5 h-5" />
-              {t('emailMismatch.logoutButton')}
+              {t("emailMismatch.logoutButton")}
             </button>
 
             <p className="text-xs text-center text-gray-500 dark:text-gray-400">
-              {t('emailMismatch.returnNote')}
+              {t("emailMismatch.returnNote")}
             </p>
           </div>
         </div>
@@ -330,7 +351,7 @@ export default function AcceptInvitationPage({
   }
 
   // Success State
-  if (state === 'success' && result) {
+  if (state === "success" && result) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
         <div className="absolute top-4 right-4">
@@ -343,11 +364,11 @@ export default function AcceptInvitationPage({
             </div>
 
             <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">
-              {t('success.title', { workspaceName: result.workspace.name })}
+              {t("success.title", { workspaceName: result.workspace.name })}
             </h2>
 
             <p className="text-center text-gray-600 dark:text-gray-400 mb-6">
-              {t('success.message')}{' '}
+              {t("success.message")}{" "}
               <strong className="text-blue-600 dark:text-blue-400">
                 {t(`roles.${result.member.role.toLowerCase()}`)}
               </strong>
@@ -355,20 +376,20 @@ export default function AcceptInvitationPage({
 
             <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-4 mb-6">
               <p className="text-sm text-blue-800 dark:text-blue-200">
-                {t('success.accessNote')}
+                {t("success.accessNote")}
               </p>
             </div>
 
             <div className="text-center">
               <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">
-                {t('success.redirecting')}
+                {t("success.redirecting")}
               </p>
 
               <button
-                onClick={() => router.push('/workspace/members')}
+                onClick={() => router.push("/workspace/members")}
                 className="w-full px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
               >
-                {t('success.goToWorkspace')}
+                {t("success.goToWorkspace")}
               </button>
             </div>
           </div>
@@ -378,7 +399,7 @@ export default function AcceptInvitationPage({
   }
 
   // Error State
-  if (state === 'error') {
+  if (state === "error") {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 p-4">
         <div className="absolute top-4 right-4">
@@ -391,26 +412,28 @@ export default function AcceptInvitationPage({
             </div>
 
             <h2 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 mb-2">
-              {t('error.title')}
+              {t("error.title")}
             </h2>
 
-            <p className="text-center text-red-600 dark:text-red-400 mb-6">{error}</p>
+            <p className="text-center text-red-600 dark:text-red-400 mb-6">
+              {error}
+            </p>
 
             <div className="space-y-2 text-sm text-gray-600 dark:text-gray-400 mb-6">
-              <p>{t('error.mayHave')}</p>
+              <p>{t("error.mayHave")}</p>
               <ul className="list-disc list-inside space-y-1 ml-4">
-                <li>{t('error.alreadyAccepted')}</li>
-                <li>{t('error.expired')}</li>
-                <li>{t('error.revoked')}</li>
-                <li>{t('error.invalidToken')}</li>
+                <li>{t("error.alreadyAccepted")}</li>
+                <li>{t("error.expired")}</li>
+                <li>{t("error.revoked")}</li>
+                <li>{t("error.invalidToken")}</li>
               </ul>
             </div>
 
             <button
-              onClick={() => router.push('/workspace/dashboard')}
+              onClick={() => router.push("/workspace/dashboard")}
               className="w-full px-4 py-2 bg-gray-600 text-white rounded-md hover:bg-gray-700 transition-colors"
             >
-              {t('error.goToDashboard')}
+              {t("error.goToDashboard")}
             </button>
           </div>
         </div>

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -21,7 +21,6 @@ import {
   FolderOpen,
   Database,
   TrendingUp,
-  Calendar,
 } from "lucide-react";
 import { getUserDetails, UserDetail } from "@/lib/api/admin";
 import { SpinnerLoading } from "@/components/common/LoadingState";

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * User Detail Modal
@@ -12,13 +12,22 @@
  * - Usage statistics
  */
 
-import { useEffect, useState } from 'react';
-import { X, Shield, Lock, Building2, FolderOpen, Database, TrendingUp, Calendar } from 'lucide-react';
-import { getUserDetails, UserDetail } from '@/lib/api/admin';
-import { SpinnerLoading } from '@/components/common/LoadingState';
-import { Badge } from '@/components/ui/badge';
-import { useAuth } from '@/contexts/AuthContext';
-import { formatRelativeTime, formatDate } from '@/lib/utils/datetime';
+import { useEffect, useState } from "react";
+import {
+  X,
+  Shield,
+  Lock,
+  Building2,
+  FolderOpen,
+  Database,
+  TrendingUp,
+  Calendar,
+} from "lucide-react";
+import { getUserDetails, UserDetail } from "@/lib/api/admin";
+import { SpinnerLoading } from "@/components/common/LoadingState";
+import { Badge } from "@/components/ui/badge";
+import { useAuth } from "@/contexts/AuthContext";
+import { formatRelativeTime, formatDate } from "@/lib/utils/datetime";
 
 interface UserDetailModalProps {
   userId: string;
@@ -41,9 +50,11 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
       setError(null);
       const data = await getUserDetails(userId);
       setDetails(data);
-    } catch (err: any) {
-      console.error('Failed to load user details:', err);
-      setError(err.message || 'Failed to load user details');
+    } catch (err: unknown) {
+      console.error("Failed to load user details:", err);
+      setError(
+        err instanceof Error ? err.message : "Failed to load user details",
+      );
     } finally {
       setLoading(false);
     }
@@ -51,20 +62,20 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
 
   const getRoleBadgeClass = (role: string) => {
     switch (role) {
-      case 'admin':
-        return 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200';
-      case 'user':
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
-      case 'owner':
-        return 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200';
-      case 'member':
-        return 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200';
-      case 'viewer':
-        return 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200';
-      case 'editor':
-        return 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200';
+      case "admin":
+        return "bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200";
+      case "user":
+        return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
+      case "owner":
+        return "bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200";
+      case "member":
+        return "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200";
+      case "viewer":
+        return "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200";
+      case "editor":
+        return "bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-200";
       default:
-        return 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200';
+        return "bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200";
     }
   };
 
@@ -83,7 +94,7 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
       <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
         <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-2xl w-full mx-4">
           <div className="text-center text-red-600 dark:text-red-400">
-            {error || 'Failed to load user details'}
+            {error || "Failed to load user details"}
           </div>
           <button
             onClick={onClose}
@@ -105,7 +116,9 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
             <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
               {details.user.name}
             </h2>
-            <p className="text-gray-600 dark:text-gray-400">{details.user.email}</p>
+            <p className="text-gray-600 dark:text-gray-400">
+              {details.user.email}
+            </p>
           </div>
           <button
             onClick={onClose}
@@ -123,17 +136,23 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
             </h3>
             <dl className="grid grid-cols-2 gap-4">
               <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">User ID</dt>
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  User ID
+                </dt>
                 <dd className="text-sm text-gray-900 dark:text-gray-100 mt-1 font-mono">
                   {details.user.id || details.user.user_id}
                 </dd>
               </div>
               <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">System Role</dt>
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  System Role
+                </dt>
                 <dd className="mt-1">
                   <div className="flex items-center gap-2">
                     <Badge className={getRoleBadgeClass(details.user.role)}>
-                      {details.user.role === 'admin' && <Shield className="h-3 w-3 mr-1" />}
+                      {details.user.role === "admin" && (
+                        <Shield className="h-3 w-3 mr-1" />
+                      )}
                       {details.user.role}
                     </Badge>
                     {details.user.is_initial_admin && (
@@ -146,17 +165,24 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                 </dd>
               </div>
               <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Created</dt>
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Created
+                </dt>
                 <dd className="text-sm text-gray-900 dark:text-gray-100 mt-1">
                   {formatDate(details.user.created_at, user?.timezone)}
                 </dd>
               </div>
               <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
-                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">Last Login</dt>
+                <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">
+                  Last Login
+                </dt>
                 <dd className="text-sm text-gray-900 dark:text-gray-100 mt-1">
                   {details.user.last_login_at
-                    ? formatRelativeTime(details.user.last_login_at, user?.timezone)
-                    : 'Never'}
+                    ? formatRelativeTime(
+                        details.user.last_login_at,
+                        user?.timezone,
+                      )
+                    : "Never"}
                 </dd>
               </div>
             </dl>
@@ -244,7 +270,8 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                     </div>
                     {ctx.last_used_at && (
                       <p className="text-xs text-gray-500 dark:text-gray-400">
-                        Last used {formatRelativeTime(ctx.last_used_at, user?.timezone)}
+                        Last used{" "}
+                        {formatRelativeTime(ctx.last_used_at, user?.timezone)}
                       </p>
                     )}
                   </div>
@@ -271,7 +298,8 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                   {details.stats.total_memories}
                 </dd>
                 <div className="text-xs text-blue-600 dark:text-blue-400 mt-1">
-                  Working: {details.stats.working_memories} | Persistent: {details.stats.persistent_memories}
+                  Working: {details.stats.working_memories} | Persistent:{" "}
+                  {details.stats.persistent_memories}
                 </div>
               </div>
 

--- a/frontend/src/components/api-keys/CreateAPIKeyDialog.tsx
+++ b/frontend/src/components/api-keys/CreateAPIKeyDialog.tsx
@@ -5,8 +5,8 @@
  * Shows plaintext key ONLY once (one-time display)
  */
 
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -14,20 +14,21 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
-import { AlertCircle, Check, CheckCircle, Copy } from 'lucide-react';
-import { createAPIKey } from '@/lib/api/api-keys';
-import type { APIKeyCreateResponse } from '@/lib/types/api-key';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+} from "@/components/ui/select";
+import { AlertCircle, Check, CheckCircle, Copy } from "lucide-react";
+import { createAPIKey } from "@/lib/api/api-keys";
+import { ApiError } from "@/lib/api/base";
+import type { APIKeyCreateResponse } from "@/lib/types/api-key";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 
 interface CreateAPIKeyDialogProps {
   isOpen: boolean;
@@ -40,20 +41,22 @@ export function CreateAPIKeyDialog({
   onClose,
   onSuccess,
 }: CreateAPIKeyDialogProps) {
-  const [name, setName] = useState('');
-  const [expiryDays, setExpiryDays] = useState<string>('null');
+  const [name, setName] = useState("");
+  const [expiryDays, setExpiryDays] = useState<string>("null");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   // One-time display state
-  const [createdKey, setCreatedKey] = useState<APIKeyCreateResponse | null>(null);
+  const [createdKey, setCreatedKey] = useState<APIKeyCreateResponse | null>(
+    null,
+  );
   const [copied, setCopied] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!name.trim()) {
-      setError('Please enter a name for the API key');
+      setError("Please enter a name for the API key");
       return;
     }
 
@@ -63,17 +66,18 @@ export function CreateAPIKeyDialog({
 
       const response = await createAPIKey({
         name: name.trim(),
-        expires_days: expiryDays === 'null' ? null : parseInt(expiryDays, 10),
+        expires_days: expiryDays === "null" ? null : parseInt(expiryDays, 10),
       });
 
       // Show one-time display
       setCreatedKey(response);
     } catch (err) {
-      console.error('Failed to create API key:', err);
-      // Extract error message from ApiError or Error
-      const apiError = err as { message?: string; details?: { detail?: string } };
-      const errorMessage = apiError.details?.detail || apiError.message || 'Failed to create API key';
-      setError(errorMessage);
+      console.error("Failed to create API key:", err);
+      const apiError = err instanceof ApiError ? err : null;
+      setError(
+        apiError?.details?.detail ||
+          (err instanceof Error ? err.message : "Failed to create API key"),
+      );
     } finally {
       setLoading(false);
     }
@@ -88,8 +92,8 @@ export function CreateAPIKeyDialog({
   };
 
   const handleClose = () => {
-    setName('');
-    setExpiryDays('null');
+    setName("");
+    setExpiryDays("null");
     setError(null);
     setCreatedKey(null);
     setCopied(false);
@@ -118,7 +122,8 @@ export function CreateAPIKeyDialog({
               <CheckCircle className="h-4 w-4 text-green-500" />
               <AlertTitle className="text-green-800">Success!</AlertTitle>
               <AlertDescription className="text-green-700">
-                Copy this API key immediately. It will only be shown once for security reasons.
+                Copy this API key immediately. It will only be shown once for
+                security reasons.
               </AlertDescription>
             </Alert>
 
@@ -141,7 +146,7 @@ export function CreateAPIKeyDialog({
                   <Button
                     onClick={handleCopy}
                     variant="outline"
-                    className={copied ? 'bg-green-50 border-green-300' : ''}
+                    className={copied ? "bg-green-50 border-green-300" : ""}
                   >
                     {copied ? (
                       <>
@@ -179,14 +184,15 @@ export function CreateAPIKeyDialog({
               )}
 
               <p className="text-xs text-slate-500">
-                Store this key securely. You'll need it to authenticate API requests.
+                Store this key securely. You'll need it to authenticate API
+                requests.
               </p>
             </div>
           </div>
 
           <DialogFooter>
             <Button onClick={handleDone} className="w-full" disabled={!copied}>
-              {copied ? 'Done' : 'Copy the key first'}
+              {copied ? "Done" : "Copy the key first"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -231,7 +237,11 @@ export function CreateAPIKeyDialog({
 
             <div className="space-y-2">
               <Label htmlFor="expiry">Expiration</Label>
-              <Select value={expiryDays} onValueChange={setExpiryDays} disabled={loading}>
+              <Select
+                value={expiryDays}
+                onValueChange={setExpiryDays}
+                disabled={loading}
+              >
                 <SelectTrigger id="expiry">
                   <SelectValue placeholder="Select expiration" />
                 </SelectTrigger>
@@ -249,11 +259,16 @@ export function CreateAPIKeyDialog({
           </div>
 
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={handleClose} disabled={loading}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={loading}
+            >
               Cancel
             </Button>
             <Button type="submit" disabled={loading}>
-              {loading ? 'Creating...' : 'Create API Key'}
+              {loading ? "Creating..." : "Create API Key"}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/api-keys/DeleteAPIKeyDialog.tsx
+++ b/frontend/src/components/api-keys/DeleteAPIKeyDialog.tsx
@@ -4,8 +4,8 @@
  * Issue #655 - Confirmation dialog for deleting API keys
  */
 
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -13,10 +13,10 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertCircle } from 'lucide-react';
-import { deleteSystemAPIKey } from '@/lib/api/api-keys';
+} from "@/components/ui/dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertCircle } from "lucide-react";
+import { deleteSystemAPIKey } from "@/lib/api/api-keys";
 
 interface DeleteAPIKeyDialogProps {
   isOpen: boolean;
@@ -48,9 +48,8 @@ export function DeleteAPIKeyDialog({
       // Don't set loading to false here since component will unmount
       onSuccess();
     } catch (err) {
-      console.error('Failed to delete API key:', err);
-      const errorMessage = (err as { message?: string })?.message || 'Failed to delete API key';
-      setError(errorMessage);
+      console.error("Failed to delete API key:", err);
+      setError(err instanceof Error ? err.message : "Failed to delete API key");
       setLoading(false);
     }
   };
@@ -69,7 +68,9 @@ export function DeleteAPIKeyDialog({
           <Alert variant="destructive">
             <AlertCircle className="h-4 w-4" />
             <AlertDescription>
-              <strong>Warning:</strong> This action cannot be undone. The API key will be permanently deleted from the database, including all audit history.
+              <strong>Warning:</strong> This action cannot be undone. The API
+              key will be permanently deleted from the database, including all
+              audit history.
             </AlertDescription>
           </Alert>
 
@@ -82,7 +83,8 @@ export function DeleteAPIKeyDialog({
 
           <div className="space-y-2">
             <p className="text-sm">
-              Are you sure you want to permanently delete the API key <strong>"{keyName}"</strong>?
+              Are you sure you want to permanently delete the API key{" "}
+              <strong>"{keyName}"</strong>?
             </p>
             <p className="text-xs text-slate-500">
               Consider revoking instead if you want to keep audit history.
@@ -91,7 +93,12 @@ export function DeleteAPIKeyDialog({
         </div>
 
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={onClose} disabled={loading}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={onClose}
+            disabled={loading}
+          >
             Cancel
           </Button>
           <Button
@@ -100,7 +107,7 @@ export function DeleteAPIKeyDialog({
             onClick={handleDelete}
             disabled={loading}
           >
-            {loading ? 'Deleting...' : 'Delete Permanently'}
+            {loading ? "Deleting..." : "Delete Permanently"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/api-keys/RegenerateAPIKeyDialog.tsx
+++ b/frontend/src/components/api-keys/RegenerateAPIKeyDialog.tsx
@@ -5,8 +5,8 @@
  * Shows new plaintext key ONLY once after regeneration
  */
 
-import { useState } from 'react';
-import { Button } from '@/components/ui/button';
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -14,13 +14,20 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { AlertCircle, AlertTriangle, Check, Copy, RefreshCw } from 'lucide-react';
-import { regenerateAPIKey } from '@/lib/api/api-keys';
-import type { APIKeyCreateResponse } from '@/lib/types/api-key';
-import { Alert, AlertDescription } from '@/components/ui/alert';
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  AlertCircle,
+  AlertTriangle,
+  Check,
+  Copy,
+  RefreshCw,
+} from "lucide-react";
+import { regenerateAPIKey } from "@/lib/api/api-keys";
+import { ApiError } from "@/lib/api/base";
+import type { APIKeyCreateResponse } from "@/lib/types/api-key";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 
 interface RegenerateAPIKeyDialogProps {
   isOpen: boolean;
@@ -41,7 +48,8 @@ export function RegenerateAPIKeyDialog({
   const [error, setError] = useState<string | null>(null);
 
   // New key display state
-  const [regeneratedKey, setRegeneratedKey] = useState<APIKeyCreateResponse | null>(null);
+  const [regeneratedKey, setRegeneratedKey] =
+    useState<APIKeyCreateResponse | null>(null);
   const [copied, setCopied] = useState(false);
 
   const handleRegenerate = async () => {
@@ -54,9 +62,11 @@ export function RegenerateAPIKeyDialog({
       // Show new key
       setRegeneratedKey(response);
     } catch (err) {
-      console.error('Failed to regenerate API key:', err);
-      const apiError = err as { message?: string; details?: { detail?: string } };
-      const errorMessage = apiError.details?.detail || apiError.message || 'Failed to regenerate API key';
+      console.error("Failed to regenerate API key:", err);
+      const apiError = err instanceof ApiError ? err : null;
+      const errorMessage =
+        apiError?.details?.detail ||
+        (err instanceof Error ? err.message : "Failed to regenerate API key");
       setError(errorMessage);
     } finally {
       setLoading(false);
@@ -102,7 +112,8 @@ export function RegenerateAPIKeyDialog({
             <Alert>
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
-                <strong>Important:</strong> Copy this API key immediately. The old key has been invalidated.
+                <strong>Important:</strong> Copy this API key immediately. The
+                old key has been invalidated.
               </AlertDescription>
             </Alert>
 
@@ -155,7 +166,7 @@ export function RegenerateAPIKeyDialog({
 
           <DialogFooter>
             <Button onClick={handleDone} className="w-full">
-              {copied ? 'Done' : 'I have saved the new key'}
+              {copied ? "Done" : "I have saved the new key"}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -185,11 +196,15 @@ export function RegenerateAPIKeyDialog({
             </Alert>
           )}
 
-          <Alert variant="default" className="border-amber-200 bg-amber-50 dark:bg-amber-900/20">
+          <Alert
+            variant="default"
+            className="border-amber-200 bg-amber-50 dark:bg-amber-900/20"
+          >
             <AlertTriangle className="h-4 w-4 text-amber-600" />
             <AlertDescription className="text-amber-800 dark:text-amber-200">
-              <strong>Warning:</strong> Regenerating this key will immediately invalidate the existing key.
-              Any applications using it will stop working until updated with the new key.
+              <strong>Warning:</strong> Regenerating this key will immediately
+              invalidate the existing key. Any applications using it will stop
+              working until updated with the new key.
             </AlertDescription>
           </Alert>
 
@@ -200,7 +215,12 @@ export function RegenerateAPIKeyDialog({
         </div>
 
         <DialogFooter>
-          <Button type="button" variant="outline" onClick={handleClose} disabled={loading}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleClose}
+            disabled={loading}
+          >
             Cancel
           </Button>
           <Button
@@ -210,7 +230,7 @@ export function RegenerateAPIKeyDialog({
             disabled={loading}
             className="bg-amber-600 hover:bg-amber-700 text-white"
           >
-            {loading ? 'Regenerating...' : 'Regenerate Key'}
+            {loading ? "Regenerating..." : "Regenerate Key"}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/contexts/ConnectionsTabPanel.tsx
+++ b/frontend/src/components/contexts/ConnectionsTabPanel.tsx
@@ -52,18 +52,9 @@ export function ConnectionsTabPanel({ contextId }: ConnectionsTabPanelProps) {
       setGraphData(dataResult);
       setStats(statsResult);
     } catch (err) {
-      // apiClient throws plain-object ApiError (see frontend/src/lib/api/base.ts),
-      // so `err instanceof Error` is false. Runtime shape check for a string
-      // `.message` — this also handles real Error instances transparently
-      // (Error.prototype.message is a string field).
-      let message = "Failed to load graph data";
-      if (err !== null && typeof err === "object" && "message" in err) {
-        const m = (err as { message: unknown }).message;
-        if (typeof m === "string") {
-          message = m;
-        }
-      }
-      setError(message);
+      setError(
+        err instanceof Error ? err.message : "Failed to load graph data",
+      );
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/contexts/GraphTabPanel.tsx
+++ b/frontend/src/components/contexts/GraphTabPanel.tsx
@@ -92,12 +92,7 @@ export function GraphTabPanel({ contextId }: GraphTabPanelProps) {
       });
       setGraphData(result);
     } catch (err) {
-      let message = t("graphVizLoadError");
-      if (err !== null && typeof err === "object" && "message" in err) {
-        const m = (err as { message: unknown }).message;
-        if (typeof m === "string") message = m;
-      }
-      setError(message);
+      setError(err instanceof Error ? err.message : t("graphVizLoadError"));
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/contexts/ProtectionSection.tsx
+++ b/frontend/src/components/contexts/ProtectionSection.tsx
@@ -26,6 +26,7 @@ import {
 import { Trash2, Loader2, ShieldCheck, ShieldOff } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
 import { updateContext, deleteContext } from "@/lib/api/contexts";
+import { ApiError } from "@/lib/api/base";
 import type { Context } from "@/lib/types/context";
 import { useAuth } from "@/contexts/AuthContext";
 
@@ -72,7 +73,7 @@ export function ProtectionSection({ context }: ProtectionSectionProps) {
       await refetchUser();
       router.push("/workspace/contexts");
     } catch (err: unknown) {
-      const apiError = err as { details?: { detail?: string } };
+      const apiError = err instanceof ApiError ? err : null;
       toast({
         title: apiError?.details?.detail || t("deleteFailed"),
         variant: "destructive",

--- a/frontend/src/components/contexts/SearchSettingsSection.tsx
+++ b/frontend/src/components/contexts/SearchSettingsSection.tsx
@@ -92,10 +92,6 @@ const DEFAULT_RERANKER_MODELS: Record<string, string> = {
   ollama: "dengcao/Qwen3-Reranker-8B:Q5_K_M",
 };
 
-function getErrorMessage(err: unknown, fallback: string): string {
-  return (err as { message?: string })?.message ?? fallback;
-}
-
 interface SearchSettingsSectionProps {
   contextId: string;
 }
@@ -151,7 +147,7 @@ export function SearchSettingsSection({
       setConfig(data);
       setEditedConfig({});
     } catch (err: unknown) {
-      const errorMsg = getErrorMessage(err, t("errorLoad"));
+      const errorMsg = err instanceof Error ? err.message : t("errorLoad");
       setError(errorMsg);
       toast({
         title: tCommon("error"),
@@ -201,7 +197,7 @@ export function SearchSettingsSection({
       toast({ title: tCommon("success"), description: t("configSaved") });
       await refreshConfig();
     } catch (err: unknown) {
-      const errorMsg = getErrorMessage(err, t("errorSave"));
+      const errorMsg = err instanceof Error ? err.message : t("errorSave");
       setError(errorMsg);
       toast({
         title: tCommon("error"),

--- a/frontend/src/components/contexts/SettingsTabPanel.tsx
+++ b/frontend/src/components/contexts/SettingsTabPanel.tsx
@@ -150,10 +150,9 @@ export function SettingsTabPanel({
       });
       await refreshContext();
     } catch (err: unknown) {
-      const apiError = err as { message?: string };
       toast({
         title: t("saveFailedTitle"),
-        description: apiError?.message || t("saveFailedDesc"),
+        description: err instanceof Error ? err.message : t("saveFailedDesc"),
         variant: "destructive",
         duration: 6000,
       });

--- a/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
+++ b/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
@@ -32,6 +32,7 @@ import {
   type ResourceToken,
 } from "@/lib/api/resource-tokens";
 import { getContexts } from "@/lib/api/contexts";
+import { ApiError } from "@/lib/api/base";
 import { getMaxQuotaCapacity } from "@/config/resource-tokens";
 import { Plus, AlertTriangle, ChevronDown } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
@@ -114,11 +115,7 @@ export function ResourceTokensTabPanel() {
 
       // Use structured error codes instead of string matching
       // Normal empty state: RES-001 (Resource not found) with 404 status
-      const apiErr = err as {
-        error?: string;
-        status?: number;
-        message?: string;
-      };
+      const apiErr = err instanceof ApiError ? err : null;
       const isNormalEmptyState =
         apiErr?.error === "RES-001" && apiErr?.status === 404;
 

--- a/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
+++ b/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
@@ -5,9 +5,9 @@
  * Shows plaintext token ONLY once (one-time display)
  */
 
-import { useState, useEffect } from 'react';
-import { useTranslations } from 'next-intl';
-import { Button } from '@/components/ui/button';
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -15,24 +15,32 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
-} from '@/components/ui/select';
-import { AlertCircle, Check, CheckCircle, Copy, Info } from 'lucide-react';
-import { createResourceToken, type ResourceToken, type ResourceTokenCreateResponse } from '@/lib/api/resource-tokens';
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { useWorkspace } from '@/contexts/WorkspaceContext';
-import { getContexts, type Context } from '@/lib/api/contexts';
-import type { ApiError } from '@/lib/api/base';
-import { MAX_QUOTA_PER_TOKEN, getMaxTokens, getMaxQuotaCapacity } from '@/config/resource-tokens';
+} from "@/components/ui/select";
+import { AlertCircle, Check, CheckCircle, Copy, Info } from "lucide-react";
+import {
+  createResourceToken,
+  type ResourceToken,
+  type ResourceTokenCreateResponse,
+} from "@/lib/api/resource-tokens";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { getContexts, type Context } from "@/lib/api/contexts";
+import { ApiError } from "@/lib/api/base";
+import {
+  MAX_QUOTA_PER_TOKEN,
+  getMaxTokens,
+  getMaxQuotaCapacity,
+} from "@/config/resource-tokens";
 
 interface CreateResourceTokenDialogProps {
   isOpen: boolean;
@@ -54,9 +62,10 @@ export function CreateResourceTokenDialog({
   onSuccess,
   currentTokens,
 }: CreateResourceTokenDialogProps) {
-  const t = useTranslations('resourceTokens');
+  const t = useTranslations("resourceTokens");
   const { currentWorkspace } = useWorkspace();
-  const planName = (currentWorkspace?.plan_name || 'free') as keyof typeof QUOTA_CONFIG;
+  const planName = (currentWorkspace?.plan_name ||
+    "free") as keyof typeof QUOTA_CONFIG;
   const quotaConfig = QUOTA_CONFIG[planName] || QUOTA_CONFIG.basic;
 
   // Calculate remaining quota (use centralized constants)
@@ -64,15 +73,15 @@ export function CreateResourceTokenDialog({
   const maxTokens = getMaxTokens(planName);
   const maxTotalQuota = getMaxQuotaCapacity(planName);
   const usedQuota = currentTokens
-    .filter(t => t.status === 'active')
+    .filter((t) => t.status === "active")
     .reduce((sum, t) => sum + t.quota_events_per_hour, 0);
   const remainingQuota = Math.max(0, maxTotalQuota - usedQuota);
-  const quotaMax = Math.min(remainingQuota, maxPerToken);  // Max for this token: min(remaining, 10000)
-  const quotaDefault = Math.min(remainingQuota, maxPerToken);  // Default: same as max
+  const quotaMax = Math.min(remainingQuota, maxPerToken); // Max for this token: min(remaining, 10000)
+  const quotaDefault = Math.min(remainingQuota, maxPerToken); // Default: same as max
 
-  const [resourceId, setResourceId] = useState('');
-  const [description, setDescription] = useState('');
-  const [quotaInput, setQuotaInput] = useState(quotaDefault.toString());  // Fixed: use quotaMax, not remainingQuota
+  const [resourceId, setResourceId] = useState("");
+  const [description, setDescription] = useState("");
+  const [quotaInput, setQuotaInput] = useState(quotaDefault.toString()); // Fixed: use quotaMax, not remainingQuota
   const [loading, setLoading] = useState(false);
   const [loadingContexts, setLoadingContexts] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -81,7 +90,8 @@ export function CreateResourceTokenDialog({
   const [resourceContexts, setResourceContexts] = useState<Context[]>([]);
 
   // One-time display state
-  const [createdToken, setCreatedToken] = useState<ResourceTokenCreateResponse | null>(null);
+  const [createdToken, setCreatedToken] =
+    useState<ResourceTokenCreateResponse | null>(null);
   const [copied, setCopied] = useState(false);
 
   // Load contexts with resource_id when dialog opens
@@ -95,13 +105,11 @@ export function CreateResourceTokenDialog({
     try {
       setLoadingContexts(true);
       const data = await getContexts();
-      const ctxs = data.contexts.filter(
-        ctx => ctx.resource_id
-      );
+      const ctxs = data.contexts.filter((ctx) => ctx.resource_id);
       setResourceContexts(ctxs);
     } catch (err) {
-      if (process.env.NODE_ENV === 'development') {
-        console.error('Failed to load contexts:', err);
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to load contexts:", err);
       }
       // TODO: Send to logging service in production
     } finally {
@@ -113,13 +121,15 @@ export function CreateResourceTokenDialog({
     e.preventDefault();
 
     if (!resourceId.trim()) {
-      setError(t('createDialog.resourceIdRequired'));
+      setError(t("createDialog.resourceIdRequired"));
       return;
     }
 
     const quotaNum = parseInt(quotaInput, 10);
     if (isNaN(quotaNum) || quotaNum < 1 || quotaNum > quotaMax) {
-      setError(`Quota must be between 1 and ${quotaMax.toLocaleString()} (${remainingQuota.toLocaleString()} remaining)`);
+      setError(
+        `Quota must be between 1 and ${quotaMax.toLocaleString()} (${remainingQuota.toLocaleString()} remaining)`,
+      );
       return;
     }
 
@@ -136,12 +146,12 @@ export function CreateResourceTokenDialog({
       // Show one-time display
       setCreatedToken(response);
     } catch (err) {
-      if (process.env.NODE_ENV === 'development') {
-        console.error('Failed to create resource token:', err);
+      if (process.env.NODE_ENV === "development") {
+        console.error("Failed to create resource token:", err);
       }
-      const apiError = err as ApiError;
-      const errorMessage = apiError.message || 'Failed to create resource token';
-      setError(errorMessage);
+      setError(
+        err instanceof Error ? err.message : "Failed to create resource token",
+      );
     } finally {
       setLoading(false);
     }
@@ -156,9 +166,9 @@ export function CreateResourceTokenDialog({
   };
 
   const handleClose = () => {
-    setResourceId('');
-    setDescription('');
-    setQuotaInput(quotaDefault.toString());  // Reset to default (not remainingQuota)
+    setResourceId("");
+    setDescription("");
+    setQuotaInput(quotaDefault.toString()); // Reset to default (not remainingQuota)
     setError(null);
     setCreatedToken(null);
     setCopied(false);
@@ -176,25 +186,27 @@ export function CreateResourceTokenDialog({
       <Dialog open={isOpen} onOpenChange={handleClose}>
         <DialogContent className="sm:max-w-[600px]">
           <DialogHeader>
-            <DialogTitle>{t('successDialog.title')}</DialogTitle>
+            <DialogTitle>{t("successDialog.title")}</DialogTitle>
             <DialogDescription>
-              {t('successDialog.description')}
+              {t("successDialog.description")}
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-4 py-4">
             <Alert className="border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20">
               <CheckCircle className="h-4 w-4 text-green-500" />
-              <AlertTitle className="text-green-800 dark:text-green-200">{t('successDialog.alertTitle')}</AlertTitle>
+              <AlertTitle className="text-green-800 dark:text-green-200">
+                {t("successDialog.alertTitle")}
+              </AlertTitle>
               <AlertDescription className="text-green-700">
-                {t('successDialog.alertDescription')}
+                {t("successDialog.alertDescription")}
               </AlertDescription>
             </Alert>
 
             <div className="space-y-4">
               {/* Resource ID */}
               <div className="space-y-2">
-                <Label>{t('successDialog.resourceId')}</Label>
+                <Label>{t("successDialog.resourceId")}</Label>
                 <code className="text-xs bg-slate-100 dark:bg-slate-800 px-3 py-2 rounded block">
                   {createdToken.resource_id}
                 </code>
@@ -202,7 +214,7 @@ export function CreateResourceTokenDialog({
 
               {/* Token */}
               <div className="space-y-2">
-                <Label>{t('successDialog.token')}</Label>
+                <Label>{t("successDialog.token")}</Label>
                 <div className="flex gap-2">
                   <Input
                     value={createdToken.token}
@@ -212,17 +224,25 @@ export function CreateResourceTokenDialog({
                   <Button
                     onClick={handleCopy}
                     variant="outline"
-                    className={copied ? 'bg-green-50 dark:bg-green-900/30 border-green-300 dark:border-green-700' : ''}
+                    className={
+                      copied
+                        ? "bg-green-50 dark:bg-green-900/30 border-green-300 dark:border-green-700"
+                        : ""
+                    }
                   >
                     {copied ? (
                       <>
                         <Check className="h-4 w-4 text-green-600 mr-1" />
-                        <span className="text-green-600 text-sm">{t('successDialog.copied')}</span>
+                        <span className="text-green-600 text-sm">
+                          {t("successDialog.copied")}
+                        </span>
                       </>
                     ) : (
                       <>
                         <Copy className="h-4 w-4 mr-1" />
-                        <span className="text-sm">{t('successDialog.copy')}</span>
+                        <span className="text-sm">
+                          {t("successDialog.copy")}
+                        </span>
                       </>
                     )}
                   </Button>
@@ -231,7 +251,7 @@ export function CreateResourceTokenDialog({
 
               {/* Quota */}
               <div className="space-y-2">
-                <Label>{t('successDialog.quota')}</Label>
+                <Label>{t("successDialog.quota")}</Label>
                 <Input
                   value={createdToken.quota_events_per_hour.toLocaleString()}
                   readOnly
@@ -240,17 +260,25 @@ export function CreateResourceTokenDialog({
               </div>
 
               <p className="text-xs text-slate-500">
-                {t('successDialog.helpText')}{' '}
-                <code className="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded">{t('successDialog.headerName')}</code>{' '}
-                {t('successDialog.header')}
+                {t("successDialog.helpText")}{" "}
+                <code className="bg-slate-100 dark:bg-slate-800 px-1 py-0.5 rounded">
+                  {t("successDialog.headerName")}
+                </code>{" "}
+                {t("successDialog.header")}
               </p>
             </div>
           </div>
 
           <DialogFooter>
             <div className="w-full space-y-2">
-              <Button onClick={handleDone} className="w-full" disabled={!copied}>
-                {copied ? t('successDialog.done') : t('successDialog.copyFirst')}
+              <Button
+                onClick={handleDone}
+                className="w-full"
+                disabled={!copied}
+              >
+                {copied
+                  ? t("successDialog.done")
+                  : t("successDialog.copyFirst")}
               </Button>
               {!copied && (
                 <Button
@@ -258,7 +286,7 @@ export function CreateResourceTokenDialog({
                   onClick={handleClose}
                   className="w-full text-xs text-slate-500"
                 >
-                  {t('successDialog.cancelWarning')}
+                  {t("successDialog.cancelWarning")}
                 </Button>
               )}
             </div>
@@ -273,7 +301,7 @@ export function CreateResourceTokenDialog({
     <Dialog open={isOpen} onOpenChange={handleClose}>
       <DialogContent className="sm:max-w-[500px]">
         <DialogHeader>
-          <DialogTitle>{t('createDialog.title')}</DialogTitle>
+          <DialogTitle>{t("createDialog.title")}</DialogTitle>
         </DialogHeader>
 
         <form onSubmit={handleSubmit}>
@@ -286,32 +314,44 @@ export function CreateResourceTokenDialog({
             )}
 
             <div className="space-y-2">
-              <Label htmlFor="resource_id">{t('createDialog.resourceId')} *</Label>
+              <Label htmlFor="resource_id">
+                {t("createDialog.resourceId")} *
+              </Label>
               {resourceContexts.length > 0 ? (
-                <Select value={resourceId} onValueChange={setResourceId} disabled={loading || loadingContexts}>
+                <Select
+                  value={resourceId}
+                  onValueChange={setResourceId}
+                  disabled={loading || loadingContexts}
+                >
                   <SelectTrigger id="resource_id">
-                    <SelectValue placeholder={t('createDialog.resourceIdPlaceholder')} />
+                    <SelectValue
+                      placeholder={t("createDialog.resourceIdPlaceholder")}
+                    />
                   </SelectTrigger>
                   <SelectContent>
                     {resourceContexts.map((ctx) => (
-                      <SelectItem value={ctx.resource_id ?? ''} key={ctx.id}>
+                      <SelectItem value={ctx.resource_id ?? ""} key={ctx.id}>
                         {ctx.display_name || ctx.name}
                         {ctx.resource_id && (
-                          <span className="text-slate-500 text-xs ml-2">({ctx.resource_id})</span>
+                          <span className="text-slate-500 text-xs ml-2">
+                            ({ctx.resource_id})
+                          </span>
                         )}
                       </SelectItem>
                     ))}
                   </SelectContent>
                 </Select>
               ) : loadingContexts ? (
-                <div className="text-sm text-slate-500 py-2">{t('loading')}</div>
+                <div className="text-sm text-slate-500 py-2">
+                  {t("loading")}
+                </div>
               ) : (
                 <div className="rounded-lg border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3">
                   <p className="text-sm text-amber-800 dark:text-amber-200">
-                    {t('noPublicContexts')}
+                    {t("noPublicContexts")}
                   </p>
                   <p className="text-xs text-amber-700 mt-1">
-                    {t('noPublicContextsDesc')}
+                    {t("noPublicContextsDesc")}
                   </p>
                 </div>
               )}
@@ -319,10 +359,12 @@ export function CreateResourceTokenDialog({
                 <div className="flex gap-2">
                   <Info className="h-4 w-4 text-blue-600 flex-shrink-0 mt-0.5" />
                   <div className="text-xs text-blue-800 dark:text-blue-200 space-y-1">
-                    <p><strong>{t('createDialog.n1DesignNote')}</strong></p>
-                    <p>{t('createDialog.n1DesignDetail')}</p>
+                    <p>
+                      <strong>{t("createDialog.n1DesignNote")}</strong>
+                    </p>
+                    <p>{t("createDialog.n1DesignDetail")}</p>
                     <p className="text-blue-600 dark:text-blue-300 italic">
-                      {t('createDialog.n1DesignExample')}
+                      {t("createDialog.n1DesignExample")}
                     </p>
                   </div>
                 </div>
@@ -330,10 +372,12 @@ export function CreateResourceTokenDialog({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="description">{t('createDialog.description')}</Label>
+              <Label htmlFor="description">
+                {t("createDialog.description")}
+              </Label>
               <Textarea
                 id="description"
-                placeholder={t('createDialog.descriptionPlaceholder')}
+                placeholder={t("createDialog.descriptionPlaceholder")}
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 disabled={loading}
@@ -342,7 +386,7 @@ export function CreateResourceTokenDialog({
             </div>
 
             <div className="space-y-2">
-              <Label htmlFor="quota">{t('createDialog.quota')}</Label>
+              <Label htmlFor="quota">{t("createDialog.quota")}</Label>
               <Input
                 id="quota"
                 type="number"
@@ -355,27 +399,37 @@ export function CreateResourceTokenDialog({
               />
               <p className="text-xs text-slate-500">
                 {remainingQuota > 0 ? (
-                  t('createDialog.quotaRemaining', {
+                  t("createDialog.quotaRemaining", {
                     remaining: remainingQuota.toLocaleString(),
-                    unit: t('eventsPerHour'),
-                    maxPerToken: maxPerToken.toLocaleString()
+                    unit: t("eventsPerHour"),
+                    maxPerToken: maxPerToken.toLocaleString(),
                   })
                 ) : (
-                  <span className="text-red-600">{t('createDialog.quotaLimitReached')}</span>
+                  <span className="text-red-600">
+                    {t("createDialog.quotaLimitReached")}
+                  </span>
                 )}
               </p>
               <p className="text-xs text-slate-400 italic">
-                {t('createDialog.quotaNote')}
+                {t("createDialog.quotaNote")}
               </p>
             </div>
           </div>
 
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={handleClose} disabled={loading}>
-              {t('createDialog.cancel')}
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleClose}
+              disabled={loading}
+            >
+              {t("createDialog.cancel")}
             </Button>
-            <Button type="submit" disabled={loading || resourceContexts.length === 0}>
-              {loading ? t('createDialog.creating') : t('createDialog.create')}
+            <Button
+              type="submit"
+              disabled={loading || resourceContexts.length === 0}
+            >
+              {loading ? t("createDialog.creating") : t("createDialog.create")}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
+++ b/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
@@ -35,7 +35,7 @@ import {
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
 import { getContexts, type Context } from "@/lib/api/contexts";
-import { ApiError } from "@/lib/api/base";
+
 import {
   MAX_QUOTA_PER_TOKEN,
   getMaxTokens,

--- a/frontend/src/contexts/MemoryContextContext.tsx
+++ b/frontend/src/contexts/MemoryContextContext.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * Context Context
@@ -9,10 +9,19 @@
  * Issue #82: Context-based Multi-Collection Support
  */
 
-import { createContext, useContext, useEffect, useState, useCallback, useMemo, ReactNode } from 'react';
-import { getContext } from '@/lib/api/contexts';
-import type { Context } from '@/lib/types/context';
-import { useSearchParams } from 'next/navigation';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  ReactNode,
+} from "react";
+import { getContext } from "@/lib/api/contexts";
+import { ApiError } from "@/lib/api/base";
+import type { Context } from "@/lib/types/context";
+import { useSearchParams } from "next/navigation";
 
 interface MemoryContextContextValue {
   currentContext: Context | null;
@@ -23,11 +32,13 @@ interface MemoryContextContextValue {
   refresh: () => Promise<void>;
 }
 
-const MemoryContextContext = createContext<MemoryContextContextValue | undefined>(undefined);
+const MemoryContextContext = createContext<
+  MemoryContextContextValue | undefined
+>(undefined);
 
 export function MemoryContextProvider({ children }: { children: ReactNode }) {
   const searchParams = useSearchParams();
-  const contextIdFromUrl = searchParams?.get('context');
+  const contextIdFromUrl = searchParams?.get("context");
 
   const [currentContext, setCurrentContext] = useState<Context | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -46,14 +57,15 @@ export function MemoryContextProvider({ children }: { children: ReactNode }) {
         // No context selected - set to null
         setCurrentContext(null);
       }
-    } catch (err: any) {
+    } catch (err: unknown) {
       // Silent fail if no context or not found
-      if (err?.status === 404 || err?.status === 400) {
+      const apiErr = err instanceof ApiError ? err : null;
+      if (apiErr?.status === 404 || apiErr?.status === 400) {
         setCurrentContext(null);
         setError(null);
       } else {
-        console.error('Failed to fetch context:', err);
-        setError('Failed to load context');
+        console.error("Failed to fetch context:", err);
+        setError("Failed to load context");
         setCurrentContext(null);
       }
     } finally {
@@ -75,16 +87,22 @@ export function MemoryContextProvider({ children }: { children: ReactNode }) {
       error,
       refresh,
     }),
-    [currentContext, isLoading, error, refresh]
+    [currentContext, isLoading, error, refresh],
   );
 
-  return <MemoryContextContext.Provider value={value}>{children}</MemoryContextContext.Provider>;
+  return (
+    <MemoryContextContext.Provider value={value}>
+      {children}
+    </MemoryContextContext.Provider>
+  );
 }
 
 export function useMemoryContext(): MemoryContextContextValue {
   const context = useContext(MemoryContextContext);
   if (context === undefined) {
-    throw new Error('useMemoryContext must be used within MemoryContextProvider');
+    throw new Error(
+      "useMemoryContext must be used within MemoryContextProvider",
+    );
   }
   return context;
 }

--- a/frontend/src/lib/api/base.test.ts
+++ b/frontend/src/lib/api/base.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { ApiError } from "./base";
+
+describe("ApiError", () => {
+  it("is an instance of Error", () => {
+    const err = new ApiError({ message: "Not found", status: 404 });
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(ApiError);
+  });
+
+  it("sets .message from constructor", () => {
+    const err = new ApiError({ message: "Something went wrong", status: 500 });
+    expect(err.message).toBe("Something went wrong");
+  });
+
+  it("sets .name to ApiError", () => {
+    const err = new ApiError({ message: "test", status: 400 });
+    expect(err.name).toBe("ApiError");
+  });
+
+  it("exposes .status, .error, and .details", () => {
+    const err = new ApiError({
+      error: "RES-001",
+      message: "Resource limit exceeded",
+      status: 429,
+      details: { limit: 100 },
+    });
+    expect(err.status).toBe(429);
+    expect(err.error).toBe("RES-001");
+    expect(err.details).toEqual({ limit: 100 });
+  });
+
+  it("has a .stack trace", () => {
+    const err = new ApiError({ message: "test", status: 500 });
+    expect(err.stack).toBeDefined();
+    expect(err.stack).toContain("ApiError");
+  });
+
+  it("works with instanceof Error in catch blocks", () => {
+    let caught: unknown;
+    try {
+      throw new ApiError({ message: "backend error", status: 422 });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toBe("backend error");
+  });
+
+  it("defaults .error and .details to undefined when omitted", () => {
+    const err = new ApiError({ message: "minimal", status: 0 });
+    expect(err.error).toBeUndefined();
+    expect(err.details).toBeUndefined();
+  });
+});

--- a/frontend/src/lib/api/base.ts
+++ b/frontend/src/lib/api/base.ts
@@ -5,13 +5,30 @@
  * Handles authentication, error handling, and response parsing.
  */
 
-const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
-export interface ApiError {
-  error?: string;  // Error code from backend (e.g., "RES-001", "AUTH-001")
-  message: string;
-  status: number;
-  details?: unknown;
+export interface ApiErrorDetails {
+  detail?: string;
+  [key: string]: unknown;
+}
+
+export class ApiError extends Error {
+  readonly error?: string; // Error code from backend (e.g., "RES-001", "AUTH-001")
+  readonly status: number;
+  readonly details?: ApiErrorDetails;
+
+  constructor(init: {
+    error?: string;
+    message: string;
+    status: number;
+    details?: unknown;
+  }) {
+    super(init.message);
+    this.name = "ApiError";
+    this.error = init.error;
+    this.status = init.status;
+    this.details = init.details as ApiErrorDetails | undefined;
+  }
 }
 
 export class ApiClient {
@@ -26,12 +43,12 @@ export class ApiClient {
    */
   private async fetch<T>(
     endpoint: string,
-    options: RequestInit = {}
+    options: RequestInit = {},
   ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     const defaultHeaders: HeadersInit = {
-      'Content-Type': 'application/json',
+      "Content-Type": "application/json",
     };
 
     // Merge headers
@@ -44,7 +61,7 @@ export class ApiClient {
       const response = await fetch(url, {
         ...options,
         headers,
-        credentials: 'include', // Include cookies for session management
+        credentials: "include", // Include cookies for session management
       });
 
       // Handle non-OK responses
@@ -59,44 +76,47 @@ export class ApiClient {
 
         // Backend returns { error: "RES-001", message: "...", details: {...} }
         // FastAPI may also return { detail: "..." }
-        const errorMessage = errorDetails.message || errorDetails.detail || `HTTP ${response.status}: ${response.statusText}`;
+        const errorMessage =
+          errorDetails.message ||
+          errorDetails.detail ||
+          `HTTP ${response.status}: ${response.statusText}`;
         const errorCode = errorDetails.error;
 
-        throw {
+        throw new ApiError({
           error: errorCode,
           message: errorMessage,
           status: response.status,
           details: errorDetails.details || errorDetails,
-        } as ApiError;
+        });
       }
 
       // Handle empty responses (e.g., 204 No Content)
-      const contentLength = response.headers.get('content-length');
-      const contentType = response.headers.get('content-type');
+      const contentLength = response.headers.get("content-length");
+      const contentType = response.headers.get("content-type");
 
       // No content or empty body
-      if (response.status === 204 || contentLength === '0' || !contentType) {
+      if (response.status === 204 || contentLength === "0" || !contentType) {
         return {} as T;
       }
 
       // Non-JSON response
-      if (!contentType.includes('application/json')) {
+      if (!contentType.includes("application/json")) {
         return {} as T;
       }
 
       return (await response.json()) as T;
     } catch (error) {
       // Re-throw ApiError
-      if ((error as ApiError).status) {
+      if (error instanceof ApiError) {
         throw error;
       }
 
       // Wrap network errors
-      throw {
-        message: error instanceof Error ? error.message : 'Network error',
+      throw new ApiError({
+        message: error instanceof Error ? error.message : "Network error",
         status: 0,
         details: error,
-      } as ApiError;
+      });
     }
   }
 
@@ -106,7 +126,7 @@ export class ApiClient {
   async get<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     return this.fetch<T>(endpoint, {
       ...options,
-      method: 'GET',
+      method: "GET",
     });
   }
 
@@ -116,11 +136,11 @@ export class ApiClient {
   async post<T>(
     endpoint: string,
     body?: unknown,
-    options: RequestInit = {}
+    options: RequestInit = {},
   ): Promise<T> {
     return this.fetch<T>(endpoint, {
       ...options,
-      method: 'POST',
+      method: "POST",
       body: body ? JSON.stringify(body) : undefined,
     });
   }
@@ -131,11 +151,11 @@ export class ApiClient {
   async put<T>(
     endpoint: string,
     body?: unknown,
-    options: RequestInit = {}
+    options: RequestInit = {},
   ): Promise<T> {
     return this.fetch<T>(endpoint, {
       ...options,
-      method: 'PUT',
+      method: "PUT",
       body: body ? JSON.stringify(body) : undefined,
     });
   }
@@ -146,11 +166,11 @@ export class ApiClient {
   async patch<T>(
     endpoint: string,
     body?: unknown,
-    options: RequestInit = {}
+    options: RequestInit = {},
   ): Promise<T> {
     return this.fetch<T>(endpoint, {
       ...options,
-      method: 'PATCH',
+      method: "PATCH",
       body: body ? JSON.stringify(body) : undefined,
     });
   }
@@ -161,7 +181,7 @@ export class ApiClient {
   async delete<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     return this.fetch<T>(endpoint, {
       ...options,
-      method: 'DELETE',
+      method: "DELETE",
     });
   }
 }
@@ -190,14 +210,14 @@ export interface UpdateUserProfileRequest {
  * Get current user profile
  */
 export async function getUserProfile(): Promise<UserProfile> {
-  return apiClient.get<UserProfile>('/api/v1/users/profile');
+  return apiClient.get<UserProfile>("/api/v1/users/profile");
 }
 
 /**
  * Update current user profile
  */
 export async function updateUserProfile(
-  data: UpdateUserProfileRequest
+  data: UpdateUserProfileRequest,
 ): Promise<UserProfile> {
-  return apiClient.put<UserProfile>('/api/v1/users/profile', data);
+  return apiClient.put<UserProfile>("/api/v1/users/profile", data);
 }

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -4,14 +4,14 @@
  */
 
 // Base API client
-export { apiClient, type ApiError } from './base';
+export { apiClient, ApiError } from "./base";
 
 // Domain-specific APIs
-export * from './memory';
-export * from './api-keys';
-export * from './coding-sessions';
-export * from './doctor';
-export * from './oauth';
-export * from './external-keys';
-export * from './graph';
-export * from './system';
+export * from "./memory";
+export * from "./api-keys";
+export * from "./coding-sessions";
+export * from "./doctor";
+export * from "./oauth";
+export * from "./external-keys";
+export * from "./graph";
+export * from "./system";


### PR DESCRIPTION
Closes #299

## Summary
- Convert `ApiError` from a plain-object interface to a class extending `Error`, making `err instanceof Error` work correctly for all API errors
- Unify all catch-block patterns across 26 frontend files: replace `as` type casts, `err: any`, ad-hoc shape checks, and `String(err)` with `instanceof Error` / `instanceof ApiError`
- Add `ApiErrorDetails` interface for typed access to FastAPI's `.details.detail` field
- Add 7 unit tests for `ApiError` class behavior; update 2 test mocks to throw `ApiError` instances

## Implementation notes
- **Core change**: `frontend/src/lib/api/base.ts` — `interface ApiError` → `class ApiError extends Error` with `ApiErrorDetails` for typed `.details` access
- **Re-export fix**: `frontend/src/lib/api/index.ts` — changed from `type ApiError` to value export to enable `instanceof`
- **Call sites (Pattern A)**: 18 occurrences of `err instanceof Error ? err.message` — no code changes needed (they become correct automatically)
- **Other patterns unified**: Pattern C (loose cast), Pattern D (runtime shape check in ConnectionsTabPanel/GraphTabPanel), Pattern E (FastAPI detail chain), Pattern F (String(err)) — all converted to `instanceof` narrowing
- **Removed**: local `getErrorMessage` helper in `SearchSettingsSection.tsx` (now redundant)
- **`err: any` eliminated**: all API error catch blocks now use `err: unknown`

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/299-feat-refactor-frontend-replace-err-instanceof.gate1.md
- ~/.claude/cache/gh-issue-driven/299-feat-refactor-frontend-replace-err-instanceof.gate2.md

🤖 Generated via /gh-issue-driven:ship
