### PR TITLE
docs(plugin): update kagura-memory skills for v0.11.1 API features (#307)

### DIFF
--- a/claude-skills/guide.md
+++ b/claude-skills/guide.md
@@ -68,6 +68,9 @@ Tell the user to restart Claude Code to pick up the config.
 2. Team members connect via their own API keys (same workspace)
 3. Onboarding: new members `recall` to learn project history
 
+**External integration — file and vault sync:**
+Use `source_uri` and `source_type` with `remember` to track where knowledge originated (e.g. Obsidian vaults, local files, web pages). Then use `source_uri_prefix` and `source_type` filters with `recall` to query memories from a specific source. Example: `remember(..., source_uri="vault://my-vault/note.md", source_type="vault")` → `recall(..., filters={"source_uri_prefix": "vault://my-vault/"})`.
+
 **Session workflow:**
 1. Start session: `/kagura-memory:session-start` to restore context
 2. During work: `/kagura-memory:remember` and `/kagura-memory:recall` as needed

--- a/claude-skills/recall.md
+++ b/claude-skills/recall.md
@@ -39,19 +39,33 @@ recall(context_id=..., query="$ARGUMENTS", k=10, search_mode="keyword")
 recall(context_id=..., query="$ARGUMENTS", k=10, use_rerank=true)
 ```
 
-**Filters** — narrow results by type, tags, importance, or date:
+**Explore hints** — get suggestions for follow-up `explore()` calls to discover related memories via the knowledge graph:
+
+```
+recall(context_id=..., query="auth token handling", k=10, include_explore_hints=true)
+```
+
+When enabled, the response includes up to 3 `explore_hints` — each with a `memory_id` and a `reason` (`top_result`, `high_centrality`, or `unexplored_neighbor`). Use the suggested memory_id as a seed for `explore()` to discover related knowledge beyond keyword/semantic matching.
+
+**Filters** — narrow results by type, tags, importance, date, or source:
 
 ```
 recall(context_id=..., query="...", k=10, filters={"type": "decision"})
 recall(context_id=..., query="...", k=10, filters={"tags": ["python", "fastapi"]})
 recall(context_id=..., query="...", k=10, filters={"importance": {"gte": 0.8}})
 recall(context_id=..., query="...", k=10, filters={"created_after": "2026-01-01T00:00:00Z"})
+recall(context_id=..., query="...", k=10, filters={"source_uri_prefix": "vault://my-vault/"})
+recall(context_id=..., query="...", k=10, filters={"source_type": "file"})
 ```
+
+- `source_uri_prefix`: Filter by origin URI prefix (e.g. `"file://"`, `"vault://my-vault/"`). Useful for querying memories from a specific vault or directory.
+- `source_type`: Filter by origin type — `"file"` | `"url"` | `"vault"` | `"api"` | `"manual"`.
 
 Filters can be combined:
 
 ```
 recall(context_id=..., query="...", k=10, filters={"type": "bug-fix", "tags": ["auth"], "created_after": "2026-03-01T00:00:00Z"})
+recall(context_id=..., query="...", k=10, filters={"source_uri_prefix": "vault://", "source_type": "vault", "importance": {"gte": 0.7}})
 ```
 
 ### 3. Display results

--- a/claude-skills/remember.md
+++ b/claude-skills/remember.md
@@ -46,6 +46,44 @@ remember(
 )
 ```
 
+**External source tracking** — when saving knowledge from a specific file, URL, or vault, set `source_uri` and `source_type` for traceability:
+
+```
+remember(
+  context_id=...,
+  summary="...",
+  content="...",
+  type="pattern",
+  importance=0.8,
+  tags=["obsidian", "architecture"],
+  context_summary="...",
+  source_uri="vault://my-vault/architecture/decisions.md",
+  source_type="vault"
+)
+```
+
+- `source_uri`: Origin URI (e.g. `file:///path/to/note.md`, `vault://my-vault/note`, `https://example.com/page`). Max 2048 chars.
+- `source_type`: `"file"` | `"url"` | `"vault"` | `"api"` | `"manual"`
+
+**Explicit linking** — connect related memories at creation time using `linked_memory_ids` or `linked_source_uris`:
+
+```
+remember(
+  context_id=...,
+  summary="...",
+  content="...",
+  type="decision",
+  importance=0.9,
+  tags=["auth"],
+  context_summary="...",
+  linked_memory_ids=["<existing-memory-uuid>"],
+  linked_source_uris=["vault://my-vault/related-note.md"]
+)
+```
+
+- `linked_memory_ids`: Creates `declared_link` edges (weight 1.0) to existing memories by ID. Use for known relationships like resolved `[[wikilinks]]`.
+- `linked_source_uris`: Links by source_uri — resolved to memory_id at remember time. Unresolved URIs are silently skipped (the plugin can retry later when the target memory exists).
+
 ### 4. Confirm
 
 Show what was saved: summary, type, importance, tags.

--- a/claude-skills/session-start.md
+++ b/claude-skills/session-start.md
@@ -40,7 +40,7 @@ Then recall recent memories (last 7 days). The 7-day window balances recency wit
 Calculate the date 7 days ago from today and use it as `created_after` filter. Run these recalls in parallel:
 
 ```
-recall(context_id=..., query="session summary progress decision", k=5, filters={"created_after": "{7_days_ago_ISO8601}"})
+recall(context_id=..., query="session summary progress decision", k=5, filters={"created_after": "{7_days_ago_ISO8601}"}, include_explore_hints=true)
 ```
 
 ```

--- a/claude-skills/session-start.md
+++ b/claude-skills/session-start.md
@@ -37,7 +37,7 @@ If multiple contexts exist, pick the one most relevant to the current project. I
 
 Then recall recent memories (last 7 days). The 7-day window balances recency with coverage — long enough to span a typical work week including weekends, short enough to avoid stale context drowning out current work.
 
-Calculate the date 7 days ago from today and use it as `created_after` filter. Run these recalls in parallel:
+Calculate the date 7 days ago from today and use it as `created_after` filter. Run these recalls in parallel. Only the first query enables `include_explore_hints` — it covers broad session context where graph discovery adds value; the other two are narrow, targeted queries where explore hints would add overhead without benefit.
 
 ```
 recall(context_id=..., query="session summary progress decision", k=5, filters={"created_after": "{7_days_ago_ISO8601}"}, include_explore_hints=true)

--- a/claude-skills/session-summary.md
+++ b/claude-skills/session-summary.md
@@ -44,8 +44,8 @@ For each item, use `remember` with:
 - **type**: From the table above
 - **importance**: Based on reusability across future sessions
 - **tags**: `category:{domain}` + entity tags + writing variations for Japanese + `issue:#N` for each related issue
-- **context_summary**: Why this matters, when to recall it
-- **content**: Include a `Related issues: #N, #M` line at the end linking to relevant GitHub issues
+- **context_summary**: Why this matters, when to recall it. Include a `Related issues: #N, #M` line at the end of **content** linking to relevant GitHub issues.
+- **linked_source_uris** (optional): If the knowledge relates to a specific file or document already in memory, link it by source_uri (e.g. `["vault://my-vault/related-note.md"]`). Unresolved URIs are silently skipped.
 
 ### 5. Guidelines
 

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -50,7 +50,7 @@ remember(
   source_uri="file:///smoke-test/test-memory.md",
   source_type="file"
 )
--> Verify: returns memory with id (UUID format)
+-> Verify: returns a success response containing memory_id (UUID format)
 -> Save returned memory_id
 -> Note: source_uri/source_type are persisted but not in the remember response; validated via recall filters in step 4
 ```
@@ -68,10 +68,10 @@ recall(context_id=..., query="smoke test memory", k=5, include_explore_hints=tru
 -> Verify: empty explore_hints is acceptable (best-effort generation) and should not fail the smoke test
 
 recall(context_id=..., query="smoke test memory", k=5, filters={"source_uri_prefix": "file:///smoke-test/"})
--> Verify: returns results filtered to memories with matching source_uri
+-> Verify: results contain the memory_id from step 3 (confirms source_uri filter works)
 
 recall(context_id=..., query="smoke test memory", k=5, filters={"source_type": "file"})
--> Verify: returns results filtered to memories with source_type="file"
+-> Verify: results contain the memory_id from step 3 (confirms source_type filter works)
 
 reference(memory_id=..., context_id=...)
 -> Verify: returns full memory with summary, content, tags matching step 3

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -3,7 +3,7 @@ description: Run comprehensive smoke test of all MCP tools via live MCP connecti
 ---
 
 Verify MCP tools work correctly by executing them in sequence against temporary test contexts.
-Tests 21 of 24 tools (excludes 3 sleep tools that require a prior Sleep Maintenance run).
+Tests 18 of 21 tools (excludes 3 sleep tools that require a prior Sleep Maintenance run).
 Use this after deployments, tool description changes, or MCP server updates.
 
 **Prerequisite:** MCP server must be running and connected.
@@ -46,9 +46,12 @@ remember(
   type="note",
   importance=0.5,
   tags=["smoke-test", "automated"],
-  context_summary="Created during automated MCP smoke test for verification purposes."
+  context_summary="Created during automated MCP smoke test for verification purposes.",
+  source_uri="file:///smoke-test/test-memory.md",
+  source_type="file"
 )
 -> Verify: returns memory with id (UUID format)
+-> Verify: response includes source_uri and source_type fields
 -> Save returned memory_id
 ```
 
@@ -59,8 +62,19 @@ recall(context_id=..., query="smoke test memory", k=5)
 -> Verify: returns results array with length >= 1
 -> Verify: at least one result matches the memory created in step 3
 
+recall(context_id=..., query="smoke test memory", k=5, include_explore_hints=true)
+-> Verify: response contains explore_hints array
+-> Verify: at least one hint has reason "top_result"
+
+recall(context_id=..., query="smoke test memory", k=5, filters={"source_uri_prefix": "file:///smoke-test/"})
+-> Verify: returns results filtered to memories with matching source_uri
+
+recall(context_id=..., query="smoke test memory", k=5, filters={"source_type": "file"})
+-> Verify: returns results filtered to memories with source_type="file"
+
 reference(memory_id=..., context_id=...)
 -> Verify: returns full memory with summary, content, tags matching step 3
+-> Verify: response includes source_uri="file:///smoke-test/test-memory.md" and source_type="file"
 
 explore(memory_id=..., context_id=..., depth=2, min_weight=0.0)
 -> Verify: returns response (total_activated >= 0, no error)
@@ -78,7 +92,7 @@ recall(context_id=..., query="smoke test UPDATED", k=5)
 
 ### 6. Edge CRUD tools
 
-First, create a second test memory for edge testing (self-loops are not allowed):
+First, create a second test memory for edge testing (self-loops are not allowed). Use `linked_memory_ids` to create a `declared_link` edge at creation time:
 
 ```
 remember(
@@ -87,9 +101,12 @@ remember(
   content="Second test memory for edge CRUD testing.",
   type="note",
   importance=0.5,
-  tags=["smoke-test", "automated"]
+  tags=["smoke-test", "automated"],
+  linked_memory_ids=[<memory_id>],
+  linked_source_uris=["file:///smoke-test/test-memory.md"]
 )
 -> Save returned memory_id as memory_id_2
+-> Verify: list_edges(context_id=..., memory_id=<memory_id_2>) returns at least one edge with edge_type="declared_link"
 ```
 
 ```
@@ -126,11 +143,8 @@ Note: Sleep tools (`get_sleep_history`, `get_sleep_report`, `rollback_sleep_run`
 ### Cleanup
 
 ```
-forget(memory_id=..., context_id=<merge_target_id>)
--> Verify: success response (merged memory deleted from target)
-
 delete_context(context_id=<merge_target_id>)
--> Verify: success response (merge target deleted)
+-> Verify: success response (merge target deleted — cascade-deletes merged memories)
 
 forget(memory_id=<memory_id_2>, context_id=...)
 -> Verify: success response (memory 2 deleted from source)
@@ -153,26 +167,29 @@ Print a summary table:
 | 3 | get_context_info | Get context details | PASS/FAIL |
 | 4 | update_context | Update display name | PASS/FAIL |
 | 5 | update_search_config | Update search weights | PASS/FAIL |
-| 6 | remember | Create test memory | PASS/FAIL |
+| 6 | remember | Create test memory (with source_uri, source_type) | PASS/FAIL |
 | 7 | recall | Search for memory | PASS/FAIL |
-| 8 | reference | Get full memory | PASS/FAIL |
-| 9 | explore | Graph traversal | PASS/FAIL |
-| 10 | update_memory | Update memory | PASS/FAIL |
-| 11 | recall (verify) | Verify update | PASS/FAIL |
-| 12 | remember | Create 2nd test memory (edge target) | PASS/FAIL |
-| 13 | create_edge | Create test edge | PASS/FAIL |
-| 14 | list_edges | List edges | PASS/FAIL |
-| 15 | update_edge | Update edge weight | PASS/FAIL |
-| 16 | delete_edge | Delete edge | PASS/FAIL |
-| 17 | create_context | Create merge target context | PASS/FAIL |
-| 18 | merge_contexts | Merge source into target | PASS/FAIL |
-| 19 | get_usage | Get workspace usage | PASS/FAIL |
-| 20 | forget | Delete merged memory | PASS/FAIL |
-| 21 | delete_context | Delete merge target | PASS/FAIL |
-| 22 | forget | Delete memory 2 | PASS/FAIL |
-| 23 | delete_context | Delete source context | PASS/FAIL |
+| 8 | recall | Search with include_explore_hints=true | PASS/FAIL |
+| 9 | recall | Search with source_uri_prefix filter | PASS/FAIL |
+| 10 | recall | Search with source_type filter | PASS/FAIL |
+| 11 | reference | Get full memory (verify source_uri, source_type) | PASS/FAIL |
+| 12 | explore | Graph traversal | PASS/FAIL |
+| 13 | update_memory | Update memory | PASS/FAIL |
+| 14 | recall (verify) | Verify update | PASS/FAIL |
+| 15 | remember | Create 2nd memory (with linked_memory_ids, linked_source_uris) | PASS/FAIL |
+| 16 | list_edges (verify) | Verify declared_link edge created | PASS/FAIL |
+| 17 | create_edge | Create test edge | PASS/FAIL |
+| 18 | list_edges | List edges | PASS/FAIL |
+| 19 | update_edge | Update edge weight | PASS/FAIL |
+| 20 | delete_edge | Delete edge | PASS/FAIL |
+| 21 | create_context | Create merge target context | PASS/FAIL |
+| 22 | merge_contexts | Merge source into target | PASS/FAIL |
+| 23 | get_usage | Get workspace usage | PASS/FAIL |
+| 24 | delete_context | Delete merge target (cascade-deletes merged memories) | PASS/FAIL |
+| 25 | forget | Delete memory 2 | PASS/FAIL |
+| 26 | delete_context | Delete source context | PASS/FAIL |
 
-**Result: N/23 passed**
+**Result: N/26 passed**
 
 Test context: smoke-test-{timestamp} (cleaned up)
 

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -172,7 +172,7 @@ Print a summary table:
 | 8 | recall | Search with include_explore_hints=true | PASS/FAIL |
 | 9 | recall | Search with source_uri_prefix filter | PASS/FAIL |
 | 10 | recall | Search with source_type filter | PASS/FAIL |
-| 11 | reference | Get full memory (verify source_uri, source_type) | PASS/FAIL |
+| 11 | reference | Get full memory | PASS/FAIL |
 | 12 | explore | Graph traversal | PASS/FAIL |
 | 13 | update_memory | Update memory | PASS/FAIL |
 | 14 | recall (verify) | Verify update | PASS/FAIL |

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -63,8 +63,9 @@ recall(context_id=..., query="smoke test memory", k=5)
 -> Verify: at least one result matches the memory created in step 3
 
 recall(context_id=..., query="smoke test memory", k=5, include_explore_hints=true)
--> Verify: response contains explore_hints array
--> Verify: at least one hint has reason "top_result"
+-> Verify: response contains explore_hints field (array)
+-> Verify: if explore_hints is non-empty, at least one hint has reason "top_result"
+-> Verify: empty explore_hints is acceptable (best-effort generation) and should not fail the smoke test
 
 recall(context_id=..., query="smoke test memory", k=5, filters={"source_uri_prefix": "file:///smoke-test/"})
 -> Verify: returns results filtered to memories with matching source_uri
@@ -144,7 +145,7 @@ Note: Sleep tools (`get_sleep_history`, `get_sleep_report`, `rollback_sleep_run`
 
 ```
 delete_context(context_id=<merge_target_id>)
--> Verify: success response (merge target deleted — cascade-deletes merged memories)
+-> Verify: success response (merge target soft-deleted, along with its memories)
 
 forget(memory_id=<memory_id_2>, context_id=...)
 -> Verify: success response (memory 2 deleted from source)
@@ -185,7 +186,7 @@ Print a summary table:
 | 21 | create_context | Create merge target context | PASS/FAIL |
 | 22 | merge_contexts | Merge source into target | PASS/FAIL |
 | 23 | get_usage | Get workspace usage | PASS/FAIL |
-| 24 | delete_context | Delete merge target (cascade-deletes merged memories) | PASS/FAIL |
+| 24 | delete_context | Soft-delete merge target and its memories | PASS/FAIL |
 | 25 | forget | Delete memory 2 | PASS/FAIL |
 | 26 | delete_context | Delete source context | PASS/FAIL |
 

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -51,8 +51,8 @@ remember(
   source_type="file"
 )
 -> Verify: returns memory with id (UUID format)
--> Verify: response includes source_uri and source_type fields
 -> Save returned memory_id
+-> Note: source_uri/source_type are persisted but not in the remember response; validated via recall filters in step 4
 ```
 
 ### 4. Memory read tools
@@ -75,7 +75,6 @@ recall(context_id=..., query="smoke test memory", k=5, filters={"source_type": "
 
 reference(memory_id=..., context_id=...)
 -> Verify: returns full memory with summary, content, tags matching step 3
--> Verify: response includes source_uri="file:///smoke-test/test-memory.md" and source_type="file"
 
 explore(memory_id=..., context_id=..., depth=2, min_weight=0.0)
 -> Verify: returns response (total_activated >= 0, no error)


### PR DESCRIPTION
Closes #307

## Summary
- Update all 6 kagura-memory plugin skills (`claude-skills/*.md`) to document v0.11.1 MCP API features shipped in #213, #214, #215, #216
- Add `source_uri`, `source_type`, `linked_memory_ids`, `linked_source_uris` documentation with examples to `remember.md`
- Add `include_explore_hints`, `source_uri_prefix` and `source_type` filter documentation to `recall.md`
- Add 5 smoke test cases for v0.11.1 params, fix tool count (21/24 → 18/21), and fix pre-existing merge cleanup bug in `smoke-test.md`

## Implementation notes
- Documentation-only change — no backend/frontend code modified
- All parameter names, types, and enum values verified against `_definitions.py` schema
- Fixed pre-existing bug in `smoke-test.md`: cleanup step used original `memory_id` to `forget` on merge target, but merged memories get new UUIDs — replaced with `delete_context` cascade
- Fixed pre-existing duplicate `content` bullet in `session-summary.md`

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: (ship-only mode — no gate1 data)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/307-docs-docs-plugin-update-kagura-memory-skills.gate2.md

🤖 Generated via /gh-issue-driven:ship
