### PR TITLE
chore(auth): migrate python-jose to authlib.jose + refresh token rotation (#183)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -36,8 +36,7 @@ dependencies = [
     "voyageai>=0.3.0",      # Reranking (Issue #105: Voyage AI alternative)
 
     # Authentication
-    "authlib>=1.3.0",       # OAuth2 client/server
-    "python-jose[cryptography]>=3.3.0",  # JWT
+    "authlib>=1.3.0",       # OAuth2 client/server + JWT (authlib.jose)
     "google-auth>=2.35.0",  # Google OAuth2
     "google-auth-oauthlib>=1.2.0",  # Google OAuth2 helpers
     "bcrypt>=4.0.0",        # Password hashing (Issue #51)

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -1694,7 +1694,7 @@ async def introspect_token(
     from sqlalchemy.exc import SQLAlchemyError
 
     caller_ip = request.client.host if request.client else "unknown"
-    token_prefix = token[:8] if len(token) >= 8 else token
+    token_prefix = token[:8] + "..." if token else "(empty)"
 
     try:
         # Look up token in database

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -1664,6 +1664,7 @@ async def introspect_token(
     Allows Resource Servers to validate access tokens.
 
     Args:
+        request: FastAPI request (for caller IP logging)
         token: Access token to introspect
 
     Returns:

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -1324,7 +1324,14 @@ async def oauth_authorize_get(
     Issue #157: Save resource parameter for POST request.
     PKCE (RFC 7636): Save code_challenge for public clients (ChatGPT/Claude).
     """
-    logger.info(f"GET /authorize: client_id={client_id}, state={state}, resource={resource}")
+    logger.info(
+        "oauth_authorize_get",
+        client_id=client_id,
+        state=state,
+        resource=resource,
+        pkce_present=code_challenge is not None,
+        code_challenge_method=code_challenge_method,
+    )
 
     user = get_current_user_from_session(request)
 
@@ -1646,6 +1653,7 @@ async def oauth_token(request: Request):
 
 @router.post("/introspect", response_model=TokenIntrospectionResponse)
 async def introspect_token(
+    request: Request,
     token: str = Form(..., description="Access token to introspect"),
     db: AsyncSession = Depends(get_db),
 ) -> TokenIntrospectionResponse:
@@ -1685,20 +1693,40 @@ async def introspect_token(
     from sqlalchemy import select
     from sqlalchemy.exc import SQLAlchemyError
 
+    caller_ip = request.client.host if request.client else "unknown"
+    token_prefix = token[:8] if len(token) >= 8 else token
+
     try:
         # Look up token in database
         result = await db.execute(select(OAuth2Token).where(OAuth2Token.access_token == token))
         oauth_token = result.scalar_one_or_none()
 
         if not oauth_token:
+            logger.info(
+                "oauth_introspect",
+                caller_ip=caller_ip,
+                token_prefix=token_prefix,
+                active=False,
+                reason="not_found",
+            )
             return TokenIntrospectionResponse(active=False)
 
-        # Check if token is expired
-        if oauth_token.is_expired():
-            return TokenIntrospectionResponse(active=False)
+        # Determine introspection result
+        is_expired = oauth_token.is_expired()
+        is_revoked = oauth_token.is_revoked()
+        active = not is_expired and not is_revoked
+        reason = "expired" if is_expired else "revoked" if is_revoked else None
 
-        # Check if token is revoked
-        if oauth_token.is_revoked():
+        logger.info(
+            "oauth_introspect",
+            caller_ip=caller_ip,
+            token_prefix=token_prefix,
+            active=active,
+            reason=reason,
+            client_id=oauth_token.client_id,
+        )
+
+        if not active:
             return TokenIntrospectionResponse(active=False)
 
         # Return token metadata (RFC 7662) - type-safe response
@@ -1713,7 +1741,7 @@ async def introspect_token(
         )
 
     except SQLAlchemyError as e:
-        logger.error(f"Database error in token introspection: {e}")
+        logger.error("oauth_introspect_db_error", error=str(e), caller_ip=caller_ip)
         await db.rollback()
         raise HTTPException(
             status_code=500, detail="Internal server error during token introspection"

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -1329,7 +1329,7 @@ async def oauth_authorize_get(
         client_id=client_id,
         state=state,
         resource=resource,
-        pkce_present=code_challenge is not None,
+        pkce_present=bool(code_challenge),
         code_challenge_method=code_challenge_method,
     )
 

--- a/backend/src/api/routes/well_known.py
+++ b/backend/src/api/routes/well_known.py
@@ -124,7 +124,6 @@ async def openid_configuration(request: Request):
         # Additional OpenID Connect fields (optional but recommended)
         "response_modes_supported": ["query"],
         "subject_types_supported": ["public"],
-        "id_token_signing_alg_values_supported": ["RS256", "HS256"],
     }
 
 

--- a/backend/src/auth/jwt.py
+++ b/backend/src/auth/jwt.py
@@ -107,13 +107,18 @@ def decode_token_without_verification(token: str) -> dict | None:
         Do NOT use for authentication! Use verify_access_token() instead.
     """
     try:
+        if not isinstance(token, str) or not token:
+            return None
         # Manually decode the payload segment (no signature verification)
         parts = token.split(".")
-        if len(parts) != 3:
+        if len(parts) != 3 or not parts[1]:
             return None
         # Add only the missing padding required for base64url decoding
         payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
         payload_bytes = base64.urlsafe_b64decode(payload_b64)
-        return json.loads(payload_bytes)
-    except (ValueError, json.JSONDecodeError, UnicodeDecodeError, binascii.Error):
+        decoded = json.loads(payload_bytes)
+        if not isinstance(decoded, dict):
+            return None
+        return decoded
+    except (TypeError, ValueError, json.JSONDecodeError, UnicodeDecodeError, binascii.Error):
         return None

--- a/backend/src/auth/jwt.py
+++ b/backend/src/auth/jwt.py
@@ -1,11 +1,16 @@
 """JWT token generation and validation utilities.
 
 Provides JWT access token creation and verification for API authentication.
+Uses authlib.jose for JWT operations (migrated from python-jose in #183).
 """
 
+import base64
+import binascii
+import json
 from datetime import UTC, datetime, timedelta
 
-from jose import JWTError, jwt
+from authlib.jose import jwt
+from authlib.jose.errors import ExpiredTokenError, JoseError
 
 from config.settings import get_settings
 from utils.exceptions import AuthenticationError, TokenExpiredError
@@ -32,6 +37,7 @@ def create_access_token(user_id: str, email: str, role: str) -> str:
     now = datetime.now(UTC)
     expire = now + timedelta(minutes=settings.jwt_expire_minutes)
 
+    header = {"alg": settings.jwt_algorithm}
     payload = {
         "sub": user_id,
         "email": email,
@@ -40,8 +46,8 @@ def create_access_token(user_id: str, email: str, role: str) -> str:
         "exp": expire,
     }
 
-    token = jwt.encode(payload, settings.jwt_secret, algorithm=settings.jwt_algorithm)
-    return token
+    token_bytes = jwt.encode(header, payload, settings.jwt_secret)
+    return token_bytes.decode("utf-8")
 
 
 def verify_access_token(token: str) -> dict:
@@ -67,13 +73,14 @@ def verify_access_token(token: str) -> dict:
     settings = get_settings()
 
     try:
-        payload = jwt.decode(token, settings.jwt_secret, algorithms=[settings.jwt_algorithm])
-        return payload
+        claims = jwt.decode(token, settings.jwt_secret)
+        claims.validate()
+        return dict(claims)
 
-    except jwt.ExpiredSignatureError as e:
+    except ExpiredTokenError as e:
         raise TokenExpiredError("JWT token has expired") from e
 
-    except JWTError as e:
+    except JoseError as e:
         raise AuthenticationError(f"Invalid JWT token: {e}") from e
 
 
@@ -90,6 +97,13 @@ def decode_token_without_verification(token: str) -> dict | None:
         Do NOT use for authentication! Use verify_access_token() instead.
     """
     try:
-        return jwt.get_unverified_claims(token)
-    except JWTError:
+        # Manually decode the payload segment (no signature verification)
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        # Add padding for base64url decoding
+        payload_b64 = parts[1] + "=" * (4 - len(parts[1]) % 4)
+        payload_bytes = base64.urlsafe_b64decode(payload_b64)
+        return json.loads(payload_bytes)
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError, binascii.Error):
         return None

--- a/backend/src/auth/jwt.py
+++ b/backend/src/auth/jwt.py
@@ -73,7 +73,17 @@ def verify_access_token(token: str) -> dict:
     settings = get_settings()
 
     try:
-        claims = jwt.decode(token, settings.jwt_secret)
+        claims = jwt.decode(
+            token,
+            settings.jwt_secret,
+            claims_options={"iss": {"essential": False}},
+        )
+        # Enforce configured algorithm — reject tokens signed with unexpected alg
+        token_alg = claims.header.get("alg")
+        if token_alg != settings.jwt_algorithm:
+            raise AuthenticationError(
+                f"JWT algorithm mismatch: expected {settings.jwt_algorithm}, got {token_alg}"
+            )
         claims.validate()
         return dict(claims)
 
@@ -101,8 +111,8 @@ def decode_token_without_verification(token: str) -> dict | None:
         parts = token.split(".")
         if len(parts) != 3:
             return None
-        # Add padding for base64url decoding
-        payload_b64 = parts[1] + "=" * (4 - len(parts[1]) % 4)
+        # Add only the missing padding required for base64url decoding
+        payload_b64 = parts[1] + "=" * (-len(parts[1]) % 4)
         payload_bytes = base64.urlsafe_b64decode(payload_b64)
         return json.loads(payload_bytes)
     except (ValueError, json.JSONDecodeError, UnicodeDecodeError, binascii.Error):

--- a/backend/src/auth/oauth2_server.py
+++ b/backend/src/auth/oauth2_server.py
@@ -526,8 +526,9 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
         Args:
             credential: Old OAuth2Token instance
         """
-        credential.access_token_revoked_at = utcnow()
-        credential.refresh_token_revoked_at = utcnow()
+        now = utcnow()
+        credential.access_token_revoked_at = now
+        credential.refresh_token_revoked_at = now
         self.server.db_session.commit()
 
         logger.info(

--- a/backend/src/auth/oauth2_server.py
+++ b/backend/src/auth/oauth2_server.py
@@ -517,20 +517,23 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
         return UserStub(user_id=credential.user_id)
 
     def revoke_old_credential(self, credential: OAuth2Token) -> None:
-        """Revoke old access token.
+        """Revoke old access and refresh tokens.
 
-        Called by Authlib after issuing new token.
-        Optionally revoke old token to enforce single active token per refresh.
+        Called by Authlib after issuing new token pair.
+        Revokes both the old access token and the old refresh token
+        to enforce refresh token rotation (RFC 6819 Section 5.2.2.3).
 
         Args:
             credential: Old OAuth2Token instance
         """
-        # Mark old access token as revoked
         credential.access_token_revoked_at = utcnow()
+        credential.refresh_token_revoked_at = utcnow()
         self.server.db_session.commit()
 
         logger.info(
-            f"Old access token revoked: client={credential.client_id}, user={credential.user_id}"
+            "oauth_refresh_token_rotated: client=%s, user=%s",
+            credential.client_id,
+            credential.user_id,
         )
 
 


### PR DESCRIPTION
Closes #183

## Summary
- Migrate JWT operations from `python-jose` (unmaintained since 2021) to `authlib.jose` (already a project dependency for OAuth2)
- Implement refresh token rotation: old refresh tokens are now invalidated when a new token pair is issued (RFC 6819 §5.2.2.3)
- Add structured OAuth monitoring logs for introspection calls and PKCE presence in authorization requests
- Remove false `id_token_signing_alg_values_supported` from OIDC discovery metadata (ID tokens are not implemented)

## Implementation notes
- `jwt.py` fully rewritten (3 functions) — public interface preserved, callers unaffected
- authlib's `jwt.encode()` returns bytes (added `.decode("utf-8")`), `jwt.decode()` returns `JWTClaims` (requires explicit `.validate()` call)
- `decode_token_without_verification` uses manual base64 decode (authlib has no `get_unverified_claims` equivalent)
- `revoke_old_credential()` now sets both `access_token_revoked_at` and `refresh_token_revoked_at` atomically
- Scope-cut from original #183: OIDC userinfo, ID Token RS256, PKCE enforcement, and introspection auth restriction deferred — current OAuth 2.0 works with all MCP clients

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO routed)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/183-feat-chore-auth-oidc-userinfo-endpoint-pkce-e.gate1.md
- ~/.claude/cache/gh-issue-driven/183-feat-chore-auth-oidc-userinfo-endpoint-pkce-e.gate2.md

🤖 Generated via /gh-issue-driven:ship
