### PR TITLE
feat(mcp): add resource management tools (setup, ingest, stats, schema) (#46)

### DIFF
--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -34,6 +34,11 @@ _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
         "get_usage",
         "get_sleep_report",  # Uses report_id, not context_id
         "rollback_sleep_run",  # Uses report_id, not context_id
+        "setup_resource",  # Uses resource_id, not context_id
+        "ingest_events",  # Uses resource_id, not context_id
+        "get_resource_impact",  # Uses resource_id, not context_id
+        "get_resource_schema",  # Uses resource_id, not context_id
+        "list_resource_tokens",  # Uses resource_id, not context_id
     }
 )
 
@@ -46,6 +51,9 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "list_edges",  # Read-only edge listing
         "get_sleep_history",  # Read-only sleep report listing
         "get_sleep_report",  # Read-only sleep report detail
+        "get_resource_impact",  # Read-only resource stats
+        "get_resource_schema",  # Read-only schema fetch
+        "list_resource_tokens",  # Read-only token listing
     }
 )
 
@@ -73,6 +81,13 @@ def _build_registry() -> dict[str, Any]:
         handle_delete_edge,
         handle_list_edges,
         handle_update_edge,
+    )
+    from mcp_server.tools.resource import (
+        handle_get_resource_impact,
+        handle_get_resource_schema,
+        handle_ingest_events,
+        handle_list_resource_tokens,
+        handle_setup_resource,
     )
     from mcp_server.tools.search_config import handle_update_search_config
     from mcp_server.tools.sleep import (
@@ -104,6 +119,11 @@ def _build_registry() -> dict[str, Any]:
         "get_sleep_history": handle_get_sleep_history,
         "get_sleep_report": handle_get_sleep_report,
         "rollback_sleep_run": handle_rollback_sleep_run,
+        "setup_resource": handle_setup_resource,
+        "ingest_events": handle_ingest_events,
+        "get_resource_impact": handle_get_resource_impact,
+        "get_resource_schema": handle_get_resource_schema,
+        "list_resource_tokens": handle_list_resource_tokens,
     }
 
 

--- a/backend/src/mcp_server/tools/_constants.py
+++ b/backend/src/mcp_server/tools/_constants.py
@@ -401,7 +401,7 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 
 ---
 
-## Available Tools (25 tools)
+## Available Tools (26 tools)
 
 | Tool | Purpose |
 |------|---------|
@@ -419,6 +419,7 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 | `list_contexts` | List all contexts with quota info |
 | `create_context` | Create a new context namespace |
 | `update_context` | Update context settings (summary, usage_guide, etc.) |
+| `merge_contexts` | Merge memories from one context into another |
 | `update_search_config` | Tune hybrid search weights and reranker |
 | `delete_context` | Delete a context and all its memories |
 | `get_usage` | Get workspace quota and usage information |
@@ -431,7 +432,7 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 | `get_resource_schema` | Get field definitions for a resource |
 | `list_resource_tokens` | List resource tokens for your workspace |
 
-Most tools require `context_id`. Exceptions: `list_contexts`, `create_context`, `get_usage` (no context needed), `get_sleep_report` and `rollback_sleep_run` (use `report_id` instead), and all resource tools (`setup_resource`, `ingest_events`, `get_resource_impact`, `get_resource_schema`, `list_resource_tokens`) which use `resource_id` instead.
+Most tools require `context_id`. Exceptions: `list_contexts`, `create_context`, `update_context`, `merge_contexts`, `get_usage` (no single context needed), `get_sleep_report` and `rollback_sleep_run` (use `report_id` instead), and all resource tools (`setup_resource`, `ingest_events`, `get_resource_impact`, `get_resource_schema`, `list_resource_tokens`) which use `resource_id` instead.
 
 ---
 

--- a/backend/src/mcp_server/tools/_constants.py
+++ b/backend/src/mcp_server/tools/_constants.py
@@ -32,9 +32,17 @@ TOOL_TIMEOUTS: dict[str, float] = {
     "create_edge": _get_timeout("create_edge", 10.0),
     "update_edge": _get_timeout("update_edge", 10.0),
     "delete_edge": _get_timeout("delete_edge", 10.0),
+    "delete_context": _get_timeout("delete_context", 30.0),
+    "merge_contexts": _get_timeout("merge_contexts", 60.0),
+    "get_usage": _get_timeout("get_usage", 10.0),
     "get_sleep_history": _get_timeout("get_sleep_history", 10.0),
     "get_sleep_report": _get_timeout("get_sleep_report", 15.0),
     "rollback_sleep_run": _get_timeout("rollback_sleep_run", 120.0),
+    "setup_resource": _get_timeout("setup_resource", 20.0),
+    "ingest_events": _get_timeout("ingest_events", 30.0),
+    "get_resource_impact": _get_timeout("get_resource_impact", 10.0),
+    "get_resource_schema": _get_timeout("get_resource_schema", 10.0),
+    "list_resource_tokens": _get_timeout("list_resource_tokens", 10.0),
 }
 DEFAULT_TOOL_TIMEOUT = float(os.getenv("MCP_TIMEOUT_DEFAULT", 60.0))
 
@@ -393,7 +401,7 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 
 ---
 
-## Available Tools (20 tools)
+## Available Tools (25 tools)
 
 | Tool | Purpose |
 |------|---------|
@@ -417,8 +425,13 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 | `get_sleep_history` | List recent Sleep Maintenance runs for a context |
 | `get_sleep_report` | Get detailed sleep report with all actions |
 | `rollback_sleep_run` | Rollback all actions from a completed sleep run |
+| `setup_resource` | Set up a resource: create public context + issue token |
+| `ingest_events` | Batch ingest resource events (upsert/delete, max 100) |
+| `get_resource_impact` | Get resource stats (tokens, memories, schema version) |
+| `get_resource_schema` | Get field definitions for a resource |
+| `list_resource_tokens` | List resource tokens for your workspace |
 
-Most tools require `context_id`. Exceptions: `list_contexts`, `create_context`, `get_usage` (no context needed), `get_sleep_report` and `rollback_sleep_run` (use `report_id` instead).
+Most tools require `context_id`. Exceptions: `list_contexts`, `create_context`, `get_usage` (no context needed), `get_sleep_report` and `rollback_sleep_run` (use `report_id` instead), and all resource tools (`setup_resource`, `ingest_events`, `get_resource_impact`, `get_resource_schema`, `list_resource_tokens`) which use `resource_id` instead.
 
 ---
 

--- a/backend/src/mcp_server/tools/_constants.py
+++ b/backend/src/mcp_server/tools/_constants.py
@@ -432,7 +432,13 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 | `get_resource_schema` | Get field definitions for a resource |
 | `list_resource_tokens` | List resource tokens for your workspace |
 
-Most tools require `context_id`. Exceptions: `list_contexts`, `create_context`, `update_context`, `merge_contexts`, `get_usage` (no single context needed), `get_sleep_report` and `rollback_sleep_run` (use `report_id` instead), and all resource tools (`setup_resource`, `ingest_events`, `get_resource_impact`, `get_resource_schema`, `list_resource_tokens`) which use `resource_id` instead.
+Most context-scoped tools take a single `context_id`. Exceptions:
+
+- `list_contexts`, `create_context`, `get_usage` — no context identifier needed.
+- `update_context` — requires `context_id` (despite being a context-management tool).
+- `merge_contexts` — requires both `source_context_id` and `target_context_id`.
+- `get_sleep_report`, `rollback_sleep_run` — use `report_id` instead.
+- Resource tools (`setup_resource`, `ingest_events`, `get_resource_impact`, `get_resource_schema`, `list_resource_tokens`) — use `resource_id` instead.
 
 ---
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -994,6 +994,220 @@ Requires action recording (reports created before this feature have no actions t
                 },
             },
         },
+        # ====================================================================
+        # Resource Management Tools (Issue #46)
+        # ====================================================================
+        {
+            "name": "setup_resource",
+            "description": (
+                "Create a new public context with an associated resource token in a single "
+                "atomic operation. Use this to set up a resource ingestion pipeline.\n\n"
+                "Returns context_id, resource_id, and a plaintext token. "
+                "Save the token immediately — it is shown only once.\n\n"
+                "Requires owner or admin role. Requires PRO plan.\n\n"
+                "Example:\n"
+                '  setup_resource(name="ec-products", resource_id="ec_products")\n'
+                "  → context created, token issued, ready for ingest_events()"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["name", "resource_id"],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": (
+                            "Context name (lowercase alphanumeric, hyphens, underscores; "
+                            "max 100 chars). Example: 'ec-products'."
+                        ),
+                    },
+                    "resource_id": {
+                        "type": "string",
+                        "description": (
+                            "Resource identifier (lowercase alphanumeric, underscores; "
+                            "max 255 chars). Must be unique in the workspace. "
+                            "Example: 'ec_products'."
+                        ),
+                    },
+                    "display_name": {
+                        "type": "string",
+                        "description": "Human-readable display name for the context.",
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Token description to identify its purpose.",
+                    },
+                    "quota_events_per_hour": {
+                        "type": "integer",
+                        "description": (
+                            "Event ingestion quota per hour for the token (1-10000, default: 1000)."
+                        ),
+                    },
+                },
+            },
+        },
+        {
+            "name": "ingest_events",
+            "description": (
+                "Batch ingest resource events (upsert/delete) into a resource. "
+                "Maximum 100 events per call, 100KB max per event payload.\n\n"
+                "Triggers incremental indexing for all contexts bound to this resource. "
+                "Uses session authentication (not resource tokens).\n\n"
+                "For bulk imports (10k+ records), use the CLI or SDK instead.\n\n"
+                "Example:\n"
+                '  ingest_events(resource_id="ec_products", events=[\n'
+                '    {"op": "upsert", "doc_id": "PROD-1", "version": 1, '
+                '"payload": {"name": "...", "price": 5980}},\n'
+                '    {"op": "delete", "doc_id": "PROD-999"}\n'
+                "  ])"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["resource_id", "events"],
+                "properties": {
+                    "resource_id": {
+                        "type": "string",
+                        "description": ("Resource identifier. Must belong to your workspace."),
+                    },
+                    "events": {
+                        "type": "array",
+                        "description": "List of events to ingest (max 100).",
+                        "items": {
+                            "type": "object",
+                            "required": ["op", "doc_id"],
+                            "properties": {
+                                "op": {
+                                    "type": "string",
+                                    "enum": ["upsert", "delete"],
+                                    "description": "Operation type.",
+                                },
+                                "doc_id": {
+                                    "type": "string",
+                                    "description": (
+                                        "Document identifier (stable across versions)."
+                                    ),
+                                },
+                                "version": {
+                                    "type": "integer",
+                                    "description": (
+                                        "Document version (required for upsert, "
+                                        "null for delete-all-versions)."
+                                    ),
+                                },
+                                "payload": {
+                                    "type": "object",
+                                    "description": (
+                                        "Document payload (required for upsert, "
+                                        "null for delete). Max 100KB."
+                                    ),
+                                },
+                                "idempotency_key": {
+                                    "type": "string",
+                                    "description": "Optional deduplication key.",
+                                },
+                                "importance": {
+                                    "type": "number",
+                                    "description": (
+                                        "Memory importance score (0.0-1.0, default 0.6)."
+                                    ),
+                                },
+                                "event_metadata": {
+                                    "type": "object",
+                                    "description": (
+                                        "Optional metadata key-value pairs "
+                                        "(source, tenant, correlation_id, etc.)."
+                                    ),
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        },
+        {
+            "name": "get_resource_impact",
+            "readOnly": True,
+            "description": (
+                "Get resource stats: active token count, memory count, and current "
+                "schema version. Use before creating/modifying a schema to understand "
+                "the impact.\n\n"
+                "Example:\n"
+                '  get_resource_impact(resource_id="ec_products")\n'
+                "  → {token_count: 2, memory_count: 500, current_schema_version: 3}"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["resource_id"],
+                "properties": {
+                    "resource_id": {
+                        "type": "string",
+                        "description": ("Resource identifier. Must belong to your workspace."),
+                    },
+                },
+            },
+        },
+        {
+            "name": "get_resource_schema",
+            "readOnly": True,
+            "description": (
+                "Get the field schema definition for a resource. Returns field names, "
+                "types, descriptions, and classification.\n\n"
+                "Specify schema_version for a historical version, or omit for the latest.\n\n"
+                "Example:\n"
+                '  get_resource_schema(resource_id="ec_products")\n'
+                '  → {schema_version: 3, field_definitions: [{name: "product_name", ...}]}'
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["resource_id"],
+                "properties": {
+                    "resource_id": {
+                        "type": "string",
+                        "description": ("Resource identifier. Must belong to your workspace."),
+                    },
+                    "schema_version": {
+                        "type": "integer",
+                        "description": ("Schema version to retrieve (default: latest)."),
+                    },
+                },
+            },
+        },
+        {
+            "name": "list_resource_tokens",
+            "readOnly": True,
+            "description": (
+                "List resource tokens for your workspace. Optionally filter by resource_id. "
+                "Returns token metadata (no plaintext tokens). "
+                "Requires owner or admin role.\n\n"
+                "Example:\n"
+                '  list_resource_tokens(resource_id="ec_products")\n'
+                "  → {tokens: [{id: 1, resource_id: ..., is_active: true, ...}], total: 3}"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": [],
+                "properties": {
+                    "resource_id": {
+                        "type": "string",
+                        "description": (
+                            "Filter by resource_id (optional). "
+                            "If provided, must belong to your workspace."
+                        ),
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": ("Number of tokens per page (1-100, default: 50)."),
+                    },
+                    "offset": {
+                        "type": "integer",
+                        "description": ("Starting offset for pagination (default: 0)."),
+                    },
+                    "include_revoked": {
+                        "type": "boolean",
+                        "description": ("Include revoked tokens in results (default: true)."),
+                    },
+                },
+            },
+        },
     ]
 
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1023,7 +1023,7 @@ Requires action recording (reports created before this feature have no actions t
                     "resource_id": {
                         "type": "string",
                         "description": (
-                            "Resource identifier (lowercase alphanumeric, underscores; "
+                            "Resource identifier (lowercase alphanumeric, hyphens, underscores; "
                             "max 255 chars). Must be unique in the workspace. "
                             "Example: 'ec_products'."
                         ),

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -232,6 +232,8 @@ async def handle_get_resource_schema(
                     schema_version = int(schema_version)
                 except (ValueError, TypeError):
                     return _error_response("validation_error", "schema_version must be an integer.")
+                if schema_version < 1:
+                    return _error_response("validation_error", "schema_version must be >= 1.")
                 query = query.where(ResourceSchema.schema_version == schema_version)
             else:
                 query = query.order_by(ResourceSchema.schema_version.desc())
@@ -245,7 +247,7 @@ async def handle_get_resource_schema(
                 return _error_response(
                     "schema_not_found",
                     f"No schema found for resource '{resource_id}'."
-                    + (f" (version {schema_version})" if schema_version else ""),
+                    + (f" (version {schema_version})" if schema_version is not None else ""),
                     help="Use the REST API to create a schema first.",
                 )
 
@@ -498,11 +500,21 @@ async def handle_ingest_events(
                     errors.append({"index": i, "error": "importance must be between 0.0 and 1.0"})
                     continue
 
+                # Coerce version for delete (optional, may be None)
+                if op == "delete":
+                    version = event_data.get("version")
+                    if version is not None:
+                        try:
+                            version = int(version)
+                        except (ValueError, TypeError):
+                            errors.append({"index": i, "error": "version must be an integer"})
+                            continue
+
                 event = ResourceEvent(
                     resource_id=resource_id,
                     op=op,
                     doc_id=doc_id,
-                    version=event_data.get("version"),
+                    version=version,
                     payload=payload if op == "upsert" else None,
                     idempotency_key=event_data.get("idempotency_key"),
                     event_metadata=event_data.get("event_metadata", {}),

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -25,7 +25,6 @@ from mcp_server.tools._helpers import (
     _get_workspace_member_role,
     _log_tool_usage,
     _success_response,
-    execute_with_timeout,
 )
 
 logger = logging.getLogger(__name__)
@@ -669,21 +668,8 @@ async def handle_setup_resource(
             db.add(search_config)
             await db.flush()
 
-            # 9. Create Qdrant collection
-            from db.qdrant import get_collection_name
-
-            collection = get_collection_name(actual_embedding_model, actual_dimensions)
-
-            from db.qdrant import qdrant_manager
-
-            try:
-                await execute_with_timeout(
-                    qdrant_manager.get_or_create_collection(collection, actual_dimensions),
-                    operation_name="setup_resource",
-                )
-            except Exception as qe:
-                logger.warning(f"qdrant_collection_creation_warning: {qe}")
-                # Continue — collection may already exist or Qdrant may be offline
+            # 9. Qdrant collection is created lazily on first remember() call
+            # via MemoryService — no need to create it here.
 
             # 10. Check active token count against plan limit (workspace-scoped)
             from models.resource import ResourceToken

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -682,11 +682,28 @@ async def handle_setup_resource(
                     f"Context '{name}' already exists in this workspace.",
                 )
 
-            # 4. Check plan supports resource tokens
+            # 4. Check resource_id not already bound to an existing context in this workspace.
+            # DB constraint `unique_context_resource_id_per_workspace` also enforces this,
+            # but an explicit pre-insert lookup returns a clean `resource_id_conflict`
+            # instead of relying on exception-based control flow.
             from sqlalchemy import func, select
 
             from config.plan_tiers import get_plan_tier
-            from models.auth import Workspace
+            from models.auth import Context, Workspace
+
+            resource_dup_result = await db.execute(
+                select(Context.id).where(
+                    Context.workspace_id == workspace_id,
+                    Context.resource_id == resource_id,
+                    Context.deleted_at.is_(None),
+                )
+            )
+            if resource_dup_result.scalar_one_or_none():
+                return _error_response(
+                    "resource_id_conflict",
+                    f"resource_id '{resource_id}' is already in use in this workspace.",
+                    help="Choose a different resource_id, or update the existing context.",
+                )
 
             ws_result = await db.execute(
                 select(Workspace.plan_name).where(Workspace.id == workspace_id)
@@ -729,8 +746,6 @@ async def handle_setup_resource(
                 actual_dimensions = settings.embedding_dimensions
 
             # 7. Create context (direct ORM — ContextService.create_context commits internally)
-            from models.auth import Context
-
             context = Context(
                 workspace_id=workspace_id,
                 name=name,

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -463,6 +463,7 @@ async def handle_ingest_events(
                     continue
 
                 payload = event_data.get("payload")
+                version = None
 
                 # Upsert requires payload and version >= 1
                 if op == "upsert":
@@ -653,11 +654,12 @@ async def handle_setup_resource(
                 return _error_response("workspace_not_found", "Workspace not found.")
 
             plan = get_plan_tier(plan_name)
-            if plan.max_resource_tokens == 0:
+            # setup_resource creates a shared + public context; both require Pro.
+            # Basic has max_resource_tokens>0 but does NOT allow shared/public contexts.
+            if not plan.allows_shared_contexts or plan.max_resource_tokens == 0:
                 return _error_response(
                     "plan_required",
-                    "Resource Tokens require PRO plan. "
-                    "Public contexts are not available on Free or Basic plans.",
+                    "setup_resource requires PRO plan (public/shared contexts + resource tokens).",
                 )
 
             # 5. Check context creation quota

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -311,8 +311,11 @@ async def handle_list_resource_tokens(
             from models.resource import ResourceToken
 
             include_revoked = args.get("include_revoked", True)
-            limit = min(int(args.get("limit", 50)), 100)
-            offset = max(int(args.get("offset", 0)), 0)
+            try:
+                limit = min(max(int(args.get("limit", 50)), 1), 100)
+                offset = max(int(args.get("offset", 0)), 0)
+            except (ValueError, TypeError):
+                return _error_response("validation_error", "limit and offset must be integers.")
 
             # Workspace-scoped token query using EXISTS subquery
             workspace_filter = exists().where(
@@ -452,14 +455,19 @@ async def handle_ingest_events(
 
                 payload = event_data.get("payload")
 
-                # Upsert requires payload
-                if op == "upsert" and not payload:
-                    errors.append({"index": i, "error": "payload required for upsert"})
-                    continue
+                # Upsert requires payload and version >= 1
+                if op == "upsert":
+                    if not payload:
+                        errors.append({"index": i, "error": "payload required for upsert"})
+                        continue
+                    version = event_data.get("version")
+                    if version is None or (isinstance(version, int) and version < 1):
+                        errors.append({"index": i, "error": "version >= 1 required for upsert"})
+                        continue
 
                 # Payload size check
                 if payload:
-                    payload_size = len(json.dumps(payload))
+                    payload_size = len(json.dumps(payload).encode("utf-8"))
                     if payload_size > _MAX_PAYLOAD_SIZE_BYTES:
                         errors.append(
                             {
@@ -701,14 +709,26 @@ async def handle_setup_resource(
                     help="Revoke unused tokens or upgrade your plan.",
                 )
 
-            # 11. Create resource token
+            # 11. Validate and create resource token
+            try:
+                quota_events_per_hour = int(args.get("quota_events_per_hour", 1000))
+            except (ValueError, TypeError):
+                return _error_response(
+                    "validation_error", "quota_events_per_hour must be an integer."
+                )
+            if quota_events_per_hour < 1 or quota_events_per_hour > 10000:
+                return _error_response(
+                    "validation_error",
+                    "quota_events_per_hour must be between 1 and 10000.",
+                )
+
             from auth.resource_tokens import ResourceTokenManager
 
             manager = ResourceTokenManager(db)
             plaintext_token, token_record = await manager.create_token(
                 resource_id=resource_id,
                 description=args.get("description"),
-                quota_events_per_hour=args.get("quota_events_per_hour", 1000),
+                quota_events_per_hour=quota_events_per_hour,
                 created_by=user_id,
             )
 

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -448,6 +448,9 @@ async def handle_ingest_events(
             errors: list[dict] = []
 
             for i, event_data in enumerate(events):
+                if not isinstance(event_data, dict):
+                    errors.append({"index": i, "error": "event must be an object"})
+                    continue
                 op = event_data.get("op")
                 doc_id = event_data.get("doc_id")
 
@@ -500,14 +503,20 @@ async def handle_ingest_events(
                     errors.append({"index": i, "error": "importance must be between 0.0 and 1.0"})
                     continue
 
-                # Coerce version for delete (optional, may be None)
+                # Delete validation: payload must be null, version (if provided) must be >= 1
                 if op == "delete":
+                    if payload is not None:
+                        errors.append({"index": i, "error": "payload must be null for delete"})
+                        continue
                     version = event_data.get("version")
                     if version is not None:
                         try:
                             version = int(version)
                         except (ValueError, TypeError):
                             errors.append({"index": i, "error": "version must be an integer"})
+                            continue
+                        if version < 1:
+                            errors.append({"index": i, "error": "version must be >= 1"})
                             continue
 
                 event = ResourceEvent(

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -129,28 +129,43 @@ async def handle_get_resource_impact(
             if boundary_err:
                 return boundary_err
 
-            # Combined stats query (same pattern as resource_schema.py)
+            # Combined stats query — all subqueries workspace-scoped to prevent
+            # cross-workspace leakage when resource_id collides across workspaces
+            # (resource_id is unique per workspace, not globally).
             from sqlalchemy import func, select
 
+            from models.auth import Context
             from models.memory import Memory
             from models.resource import ResourceSchema, ResourceToken
 
             token_count_subq = (
                 select(func.count(ResourceToken.id))
+                .join(Context, Context.resource_id == ResourceToken.resource_id)
                 .where(
                     ResourceToken.resource_id == resource_id,
                     ResourceToken.is_active == True,  # noqa: E712
+                    Context.workspace_id == workspace_id,
+                    Context.deleted_at.is_(None),
                 )
                 .scalar_subquery()
             )
             memory_count_subq = (
                 select(func.count(Memory.id))
-                .where(Memory.resource_id == resource_id, Memory.deleted_at.is_(None))
+                .where(
+                    Memory.resource_id == resource_id,
+                    Memory.deleted_at.is_(None),
+                    Memory.workspace_id == workspace_id,
+                )
                 .scalar_subquery()
             )
             schema_version_subq = (
                 select(func.max(ResourceSchema.schema_version))
-                .where(ResourceSchema.resource_id == resource_id)
+                .join(Context, Context.resource_id == ResourceSchema.resource_id)
+                .where(
+                    ResourceSchema.resource_id == resource_id,
+                    Context.workspace_id == workspace_id,
+                    Context.deleted_at.is_(None),
+                )
                 .scalar_subquery()
             )
 
@@ -222,9 +237,20 @@ async def handle_get_resource_schema(
 
             from sqlalchemy import select
 
+            from models.auth import Context
             from models.resource import ResourceSchema
 
-            query = select(ResourceSchema).where(ResourceSchema.resource_id == resource_id)
+            # Workspace-scope the schema lookup (resource_id is unique per workspace,
+            # not globally — join via Context to avoid cross-workspace leakage).
+            query = (
+                select(ResourceSchema)
+                .join(Context, Context.resource_id == ResourceSchema.resource_id)
+                .where(
+                    ResourceSchema.resource_id == resource_id,
+                    Context.workspace_id == workspace_id,
+                    Context.deleted_at.is_(None),
+                )
+            )
 
             schema_version = args.get("schema_version")
             if schema_version is not None:
@@ -302,8 +328,11 @@ async def handle_list_resource_tokens(
 
             resource_id = args.get("resource_id")
 
-            # Workspace boundary check if filtering by resource_id
+            # Validate + workspace boundary check if filtering by resource_id
             if resource_id:
+                format_err = _validate_resource_id(resource_id)
+                if format_err:
+                    return format_err
                 boundary_err = await _check_resource_workspace_boundary(
                     db, resource_id, workspace_id
                 )
@@ -553,7 +582,20 @@ async def handle_ingest_events(
                             }
                         )
                     else:
-                        errors.append({"index": i, "error": error_msg})
+                        # Do not leak raw DB constraint details to clients
+                        logger.warning(
+                            "ingest_events integrity error: resource_id=%s index=%s doc_id=%s",
+                            resource_id,
+                            i,
+                            doc_id,
+                            exc_info=ie,
+                        )
+                        errors.append(
+                            {
+                                "index": i,
+                                "error": "Unable to ingest event due to a constraint violation",
+                            }
+                        )
                     continue
 
             # Schedule indexer if any events were created

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -1,0 +1,781 @@
+"""MCP tool handlers: resource management operations.
+
+Issue #46: Add resource management tools (setup, ingest, stats, schema).
+
+Provides 5 tools for managing resources via MCP:
+- setup_resource: Create public context + resource token in one call
+- ingest_events: Batch ingest resource events
+- get_resource_impact: Get resource stats (tokens, memories, schema version)
+- get_resource_schema: Get field definitions for a resource
+- list_resource_tokens: List tokens for a resource
+"""
+
+import json
+import logging
+import re
+import time
+from typing import Any
+from uuid import UUID
+
+from mcp.types import TextContent
+
+from mcp_server.tools._helpers import (
+    _check_viewer_permission,
+    _error_response,
+    _get_workspace_member_role,
+    _log_tool_usage,
+    _success_response,
+    execute_with_timeout,
+)
+
+logger = logging.getLogger(__name__)
+
+# Resource ID format: lowercase alphanumeric + underscore + hyphen
+_RESOURCE_ID_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+
+# Max payload size per event (100KB)
+_MAX_PAYLOAD_SIZE_BYTES = 100_000
+
+# Max events per batch
+_MAX_BATCH_SIZE = 100
+
+
+# ============================================================================
+# Validation helpers
+# ============================================================================
+
+
+def _validate_resource_id(resource_id: str) -> list[TextContent] | None:
+    """Validate resource_id format. Returns error response or None."""
+    if not resource_id or len(resource_id) > 255:
+        return _error_response(
+            "validation_error",
+            "resource_id must be 1-255 characters.",
+        )
+    if not _RESOURCE_ID_PATTERN.match(resource_id):
+        return _error_response(
+            "validation_error",
+            f"Invalid resource_id format: '{resource_id}'. "
+            "Must be lowercase alphanumeric and underscores only.",
+        )
+    return None
+
+
+async def _check_owner_admin_role(
+    db: Any, user_id: str, workspace_id: UUID
+) -> list[TextContent] | None:
+    """Check user is owner or admin. Returns error response or None."""
+    role = await _get_workspace_member_role(db, user_id, workspace_id)
+    if role not in ("owner", "admin"):
+        return _error_response(
+            "permission_denied",
+            "Only workspace owners and admins can perform this operation.",
+            your_role=role or "not_a_member",
+            required_role="owner or admin",
+        )
+    return None
+
+
+async def _check_resource_workspace_boundary(
+    db: Any, resource_id: str, workspace_id: UUID
+) -> list[TextContent] | None:
+    """Verify resource_id belongs to workspace. Returns error response or None."""
+    from sqlalchemy import select
+
+    from models.auth import Context
+
+    result = await db.execute(
+        select(Context.id).where(
+            Context.resource_id == resource_id,
+            Context.workspace_id == workspace_id,
+            Context.deleted_at.is_(None),
+        )
+    )
+    if not result.scalar_one_or_none():
+        return _error_response(
+            "resource_not_found",
+            f"Resource '{resource_id}' not found in your workspace.",
+            help="Use setup_resource() to create a new resource, or check resource_id spelling.",
+        )
+    return None
+
+
+# ============================================================================
+# Read-only handlers
+# ============================================================================
+
+
+async def handle_get_resource_impact(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Get resource change impact information."""
+    if "resource_id" not in args:
+        return _error_response("missing_fields", "Missing required field: resource_id")
+
+    resource_id = args["resource_id"]
+    err = _validate_resource_id(resource_id)
+    if err:
+        return err
+
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    from db.base import get_db
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            # Workspace boundary check
+            boundary_err = await _check_resource_workspace_boundary(db, resource_id, workspace_id)
+            if boundary_err:
+                return boundary_err
+
+            # Combined stats query (same pattern as resource_schema.py)
+            from sqlalchemy import func, select
+
+            from models.memory import Memory
+            from models.resource import ResourceSchema, ResourceToken
+
+            token_count_subq = (
+                select(func.count(ResourceToken.id))
+                .where(
+                    ResourceToken.resource_id == resource_id,
+                    ResourceToken.is_active == True,  # noqa: E712
+                )
+                .scalar_subquery()
+            )
+            memory_count_subq = (
+                select(func.count(Memory.id))
+                .where(Memory.resource_id == resource_id, Memory.deleted_at.is_(None))
+                .scalar_subquery()
+            )
+            schema_version_subq = (
+                select(func.max(ResourceSchema.schema_version))
+                .where(ResourceSchema.resource_id == resource_id)
+                .scalar_subquery()
+            )
+
+            result = await db.execute(
+                select(
+                    token_count_subq.label("token_count"),
+                    memory_count_subq.label("memory_count"),
+                    schema_version_subq.label("schema_version"),
+                )
+            )
+            row = result.one()
+
+            await _log_tool_usage(
+                db,
+                user_id,
+                "get_resource_impact",
+                start_time,
+                200,
+                workspace_id=workspace_id,
+            )
+
+            return _success_response(
+                resource_id=resource_id,
+                token_count=row.token_count or 0,
+                memory_count=row.memory_count or 0,
+                current_schema_version=row.schema_version,
+            )
+
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"get_resource_impact_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db,
+                user_id,
+                "get_resource_impact",
+                start_time,
+                500,
+                workspace_id=workspace_id,
+            )
+            return _error_response("get_resource_impact_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_get_resource_schema(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Get field schema definition for a resource."""
+    if "resource_id" not in args:
+        return _error_response("missing_fields", "Missing required field: resource_id")
+
+    resource_id = args["resource_id"]
+    err = _validate_resource_id(resource_id)
+    if err:
+        return err
+
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    from db.base import get_db
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            # Workspace boundary check
+            boundary_err = await _check_resource_workspace_boundary(db, resource_id, workspace_id)
+            if boundary_err:
+                return boundary_err
+
+            from sqlalchemy import select
+
+            from models.resource import ResourceSchema
+
+            query = select(ResourceSchema).where(ResourceSchema.resource_id == resource_id)
+
+            schema_version = args.get("schema_version")
+            if schema_version is not None:
+                query = query.where(ResourceSchema.schema_version == int(schema_version))
+            else:
+                query = query.order_by(ResourceSchema.schema_version.desc())
+
+            query = query.limit(1)
+
+            result = await db.execute(query)
+            schema = result.scalar_one_or_none()
+
+            if not schema:
+                return _error_response(
+                    "schema_not_found",
+                    f"No schema found for resource '{resource_id}'."
+                    + (f" (version {schema_version})" if schema_version else ""),
+                    help="Use the REST API to create a schema first.",
+                )
+
+            await _log_tool_usage(
+                db,
+                user_id,
+                "get_resource_schema",
+                start_time,
+                200,
+                workspace_id=workspace_id,
+            )
+
+            return _success_response(
+                resource_id=schema.resource_id,
+                schema_version=schema.schema_version,
+                field_definitions=schema.field_definitions,
+                created_at=schema.created_at.isoformat(),
+            )
+
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"get_resource_schema_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db,
+                user_id,
+                "get_resource_schema",
+                start_time,
+                500,
+                workspace_id=workspace_id,
+            )
+            return _error_response("get_resource_schema_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_list_resource_tokens(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """List resource tokens for a workspace."""
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    from db.base import get_db
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            # Owner/admin only
+            role_err = await _check_owner_admin_role(db, user_id, workspace_id)
+            if role_err:
+                return role_err
+
+            resource_id = args.get("resource_id")
+
+            # Workspace boundary check if filtering by resource_id
+            if resource_id:
+                boundary_err = await _check_resource_workspace_boundary(
+                    db, resource_id, workspace_id
+                )
+                if boundary_err:
+                    return boundary_err
+
+            from sqlalchemy import and_, exists, func
+            from sqlalchemy import select as sa_select
+
+            from models.auth import Context
+            from models.resource import ResourceToken
+
+            include_revoked = args.get("include_revoked", True)
+            limit = min(int(args.get("limit", 50)), 100)
+            offset = max(int(args.get("offset", 0)), 0)
+
+            # Workspace-scoped token query using EXISTS subquery
+            workspace_filter = exists().where(
+                Context.resource_id == ResourceToken.resource_id,
+                Context.workspace_id == workspace_id,
+                Context.deleted_at.is_(None),
+            )
+
+            conditions = [workspace_filter]
+            if resource_id:
+                conditions.append(ResourceToken.resource_id == resource_id)
+            if not include_revoked:
+                conditions.append(ResourceToken.is_active == True)  # noqa: E712
+
+            total_result = await db.execute(
+                sa_select(func.count(ResourceToken.id)).where(and_(*conditions))
+            )
+            total = total_result.scalar() or 0
+
+            tokens_result = await db.execute(
+                sa_select(ResourceToken)
+                .where(and_(*conditions))
+                .order_by(ResourceToken.created_at.desc())
+                .offset(offset)
+                .limit(limit)
+            )
+            tokens = list(tokens_result.scalars().all())
+
+            token_list = [
+                {
+                    "id": t.id,
+                    "resource_id": t.resource_id,
+                    "description": t.description,
+                    "quota_events_per_hour": t.quota_events_per_hour,
+                    "is_active": t.is_active,
+                    "created_at": t.created_at.isoformat() if t.created_at else None,
+                    "last_used_at": t.last_used_at.isoformat() if t.last_used_at else None,
+                }
+                for t in tokens
+            ]
+
+            await _log_tool_usage(
+                db,
+                user_id,
+                "list_resource_tokens",
+                start_time,
+                200,
+                workspace_id=workspace_id,
+            )
+
+            return _success_response(
+                tokens=token_list,
+                total=total,
+                limit=limit,
+                offset=offset,
+            )
+
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"list_resource_tokens_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db,
+                user_id,
+                "list_resource_tokens",
+                start_time,
+                500,
+                workspace_id=workspace_id,
+            )
+            return _error_response("list_resource_tokens_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+# ============================================================================
+# Write handlers
+# ============================================================================
+
+
+async def handle_ingest_events(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Batch ingest resource events."""
+    if "resource_id" not in args or "events" not in args:
+        return _error_response("missing_fields", "Missing required fields: resource_id, events")
+
+    resource_id = args["resource_id"]
+    err = _validate_resource_id(resource_id)
+    if err:
+        return err
+
+    events = args["events"]
+    if not isinstance(events, list) or len(events) == 0:
+        return _error_response("validation_error", "events must be a non-empty list.")
+    if len(events) > _MAX_BATCH_SIZE:
+        return _error_response(
+            "validation_error",
+            f"Batch size {len(events)} exceeds maximum of {_MAX_BATCH_SIZE}.",
+        )
+
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    from db.base import get_db
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            # Viewer permission check
+            viewer_err = await _check_viewer_permission(db, user_id, workspace_id, "ingest events")
+            if viewer_err:
+                return viewer_err
+
+            # Workspace boundary check
+            boundary_err = await _check_resource_workspace_boundary(db, resource_id, workspace_id)
+            if boundary_err:
+                return boundary_err
+
+            # Process events
+            from sqlalchemy.exc import IntegrityError
+
+            from models.resource import ResourceEvent
+
+            created_ids: list[int] = []
+            errors: list[dict] = []
+
+            for i, event_data in enumerate(events):
+                op = event_data.get("op")
+                doc_id = event_data.get("doc_id")
+
+                # Basic validation
+                if op not in ("upsert", "delete"):
+                    errors.append({"index": i, "error": f"Invalid op: {op}"})
+                    continue
+                if not doc_id:
+                    errors.append({"index": i, "error": "Missing doc_id"})
+                    continue
+
+                payload = event_data.get("payload")
+
+                # Upsert requires payload
+                if op == "upsert" and not payload:
+                    errors.append({"index": i, "error": "payload required for upsert"})
+                    continue
+
+                # Payload size check
+                if payload:
+                    payload_size = len(json.dumps(payload))
+                    if payload_size > _MAX_PAYLOAD_SIZE_BYTES:
+                        errors.append(
+                            {
+                                "index": i,
+                                "error": f"Payload too large: {payload_size} bytes "
+                                f"(max {_MAX_PAYLOAD_SIZE_BYTES})",
+                            }
+                        )
+                        continue
+
+                event = ResourceEvent(
+                    resource_id=resource_id,
+                    op=op,
+                    doc_id=doc_id,
+                    version=event_data.get("version"),
+                    payload=payload if op == "upsert" else None,
+                    idempotency_key=event_data.get("idempotency_key"),
+                    event_metadata=event_data.get("event_metadata", {}),
+                    importance=event_data.get("importance", 0.6),
+                )
+
+                try:
+                    async with db.begin_nested():
+                        db.add(event)
+                        await db.flush()
+                    created_ids.append(event.id)
+                except IntegrityError as ie:
+                    error_msg = str(ie)
+                    if "unique_resource_doc_version" in error_msg:
+                        errors.append(
+                            {
+                                "index": i,
+                                "error": f"Duplicate version for doc_id={doc_id}",
+                            }
+                        )
+                    elif "unique_idempotency_key" in error_msg:
+                        errors.append(
+                            {
+                                "index": i,
+                                "error": "Duplicate idempotency_key",
+                            }
+                        )
+                    else:
+                        errors.append({"index": i, "error": error_msg})
+                    continue
+
+            # Schedule indexer if any events were created
+            if created_ids:
+                from api.routes.resource_ingest import _schedule_indexer_for_resource
+
+                await _schedule_indexer_for_resource(db, resource_id)
+                await db.commit()
+
+            await _log_tool_usage(
+                db,
+                user_id,
+                "ingest_events",
+                start_time,
+                200,
+                workspace_id=workspace_id,
+            )
+
+            return _success_response(
+                resource_id=resource_id,
+                created_count=len(created_ids),
+                failed_count=len(errors),
+                event_ids=created_ids,
+                errors=errors,
+            )
+
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"ingest_events_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db,
+                user_id,
+                "ingest_events",
+                start_time,
+                500,
+                workspace_id=workspace_id,
+            )
+            return _error_response("ingest_events_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_setup_resource(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Create public context + resource token in one atomic operation."""
+    if "name" not in args or "resource_id" not in args:
+        return _error_response("missing_fields", "Missing required fields: name, resource_id")
+
+    resource_id = args["resource_id"]
+    err = _validate_resource_id(resource_id)
+    if err:
+        return err
+
+    name = args["name"]
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    from db.base import get_db
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            # 1. Role check: owner/admin only
+            role_err = await _check_owner_admin_role(db, user_id, workspace_id)
+            if role_err:
+                return role_err
+
+            # 2. Validate context name
+            from services.context_service import ContextService
+            from utils.exceptions import ValidationError
+
+            try:
+                ContextService.validate_context_name(name)
+            except ValidationError as ve:
+                return _error_response("validation_error", str(ve))
+
+            # 3. Check context name doesn't already exist
+            context_service = ContextService(db)
+            existing = await context_service.get_context_by_name_for_workspace(workspace_id, name)
+            if existing:
+                return _error_response(
+                    "validation_error",
+                    f"Context '{name}' already exists in this workspace.",
+                )
+
+            # 4. Check plan supports resource tokens
+            from sqlalchemy import func, select
+
+            from config.plan_tiers import get_plan_tier
+            from models.auth import Workspace
+
+            ws_result = await db.execute(
+                select(Workspace.plan_name).where(Workspace.id == workspace_id)
+            )
+            plan_name = ws_result.scalar_one_or_none()
+            if not plan_name:
+                return _error_response("workspace_not_found", "Workspace not found.")
+
+            plan = get_plan_tier(plan_name)
+            if plan.max_resource_tokens == 0:
+                return _error_response(
+                    "plan_required",
+                    "Resource Tokens require PRO plan. "
+                    "Public contexts are not available on Free or Basic plans.",
+                )
+
+            # 5. Check context creation quota
+            from services.quota_service import QuotaService
+
+            can_create, error_msg = await QuotaService(db).check_context_creation_allowed(
+                workspace_id
+            )
+            if not can_create:
+                return _error_response(
+                    "quota_exceeded",
+                    error_msg or "Context creation limit reached.",
+                    help="Delete unused contexts or upgrade your plan.",
+                )
+
+            # 6. Determine embedding model
+            from config.constants import EMBEDDING_MODEL_REGISTRY
+            from config.settings import get_settings
+
+            settings = get_settings()
+            actual_embedding_model = settings.embedding_model
+            if actual_embedding_model in EMBEDDING_MODEL_REGISTRY:
+                actual_dimensions = EMBEDDING_MODEL_REGISTRY[actual_embedding_model][0]
+            else:
+                actual_dimensions = settings.embedding_dimensions
+
+            # 7. Create context (direct ORM — ContextService.create_context commits internally)
+            from models.auth import Context
+
+            context = Context(
+                workspace_id=workspace_id,
+                name=name,
+                display_name=args.get("display_name") or name,
+                description=f"Resource context for {resource_id}",
+                created_by=user_id,
+                is_private=False,
+                is_public=True,
+                resource_id=resource_id,
+            )
+            db.add(context)
+            await db.flush()
+            await db.refresh(context)
+
+            # 8. Create search config
+            from models.config import ContextSearchConfig
+
+            search_config = ContextSearchConfig(
+                context_id=context.id,
+                semantic_weight=0.6,
+                fetch_factor=3,
+                use_rerank=False,
+                reranker_provider="voyage",
+                reranker_model="rerank-2-lite",
+                embedding_model=actual_embedding_model,
+                embedding_dimensions=actual_dimensions,
+            )
+            db.add(search_config)
+            await db.flush()
+
+            # 9. Create Qdrant collection
+            from db.qdrant import get_collection_name
+
+            collection = get_collection_name(actual_embedding_model, actual_dimensions)
+
+            from db.qdrant import qdrant_manager
+
+            try:
+                await execute_with_timeout(
+                    qdrant_manager.get_or_create_collection(collection, actual_dimensions),
+                    operation_name="setup_resource",
+                )
+            except Exception as qe:
+                logger.warning(f"qdrant_collection_creation_warning: {qe}")
+                # Continue — collection may already exist or Qdrant may be offline
+
+            # 10. Check active token count against plan limit (workspace-scoped)
+            from models.resource import ResourceToken
+
+            active_count_result = await db.execute(
+                select(func.count(ResourceToken.id))
+                .join(Context, Context.resource_id == ResourceToken.resource_id)
+                .where(
+                    Context.workspace_id == workspace_id,
+                    Context.deleted_at.is_(None),
+                    ResourceToken.is_active == True,  # noqa: E712
+                )
+            )
+            active_count = active_count_result.scalar() or 0
+            if active_count >= plan.max_resource_tokens:
+                await db.rollback()
+                await _log_tool_usage(
+                    db,
+                    user_id,
+                    "setup_resource",
+                    start_time,
+                    403,
+                    workspace_id=workspace_id,
+                )
+                return _error_response(
+                    "quota_exceeded",
+                    f"Token limit reached. Your {plan_name.upper()} plan allows "
+                    f"{plan.max_resource_tokens} active tokens.",
+                    help="Revoke unused tokens or upgrade your plan.",
+                )
+
+            # 11. Create resource token
+            from auth.resource_tokens import ResourceTokenManager
+
+            manager = ResourceTokenManager(db)
+            plaintext_token, token_record = await manager.create_token(
+                resource_id=resource_id,
+                description=args.get("description"),
+                quota_events_per_hour=args.get("quota_events_per_hour", 1000),
+                created_by=user_id,
+            )
+
+            # 12. Commit everything in one transaction
+            await db.commit()
+            await db.refresh(token_record)
+
+            await _log_tool_usage(
+                db,
+                user_id,
+                "setup_resource",
+                start_time,
+                200,
+                str(context.id),
+                workspace_id,
+            )
+
+            return _success_response(
+                message=f"Resource '{resource_id}' set up successfully.",
+                context_id=str(context.id),
+                context_name=context.name,
+                resource_id=resource_id,
+                token=plaintext_token,
+                token_id=token_record.id,
+                warning="Save this token — it will not be shown again.",
+            )
+
+        except Exception as e:
+            await db.rollback()
+            error_str = str(e)
+            if "already exists" in error_str:
+                await _log_tool_usage(
+                    db,
+                    user_id,
+                    "setup_resource",
+                    start_time,
+                    409,
+                    workspace_id=workspace_id,
+                )
+                return _error_response(
+                    "validation_error",
+                    error_str,
+                    help="Check the context name and resource_id.",
+                )
+            logger.error(f"setup_resource_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db,
+                user_id,
+                "setup_resource",
+                start_time,
+                500,
+                workspace_id=workspace_id,
+            )
+            return _error_response("setup_resource_error", error_str)
+
+    return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -55,7 +55,7 @@ def _validate_resource_id(resource_id: str) -> list[TextContent] | None:
         return _error_response(
             "validation_error",
             f"Invalid resource_id format: '{resource_id}'. "
-            "Must be lowercase alphanumeric and underscores only.",
+            "Must be lowercase alphanumeric, underscores, and hyphens only.",
         )
     return None
 
@@ -228,7 +228,11 @@ async def handle_get_resource_schema(
 
             schema_version = args.get("schema_version")
             if schema_version is not None:
-                query = query.where(ResourceSchema.schema_version == int(schema_version))
+                try:
+                    schema_version = int(schema_version)
+                except (ValueError, TypeError):
+                    return _error_response("validation_error", "schema_version must be an integer.")
+                query = query.where(ResourceSchema.schema_version == schema_version)
             else:
                 query = query.order_by(ResourceSchema.schema_version.desc())
 
@@ -461,7 +465,12 @@ async def handle_ingest_events(
                         errors.append({"index": i, "error": "payload required for upsert"})
                         continue
                     version = event_data.get("version")
-                    if version is None or (isinstance(version, int) and version < 1):
+                    try:
+                        version = int(version) if version is not None else None
+                    except (ValueError, TypeError):
+                        errors.append({"index": i, "error": "version must be an integer"})
+                        continue
+                    if version is None or version < 1:
                         errors.append({"index": i, "error": "version >= 1 required for upsert"})
                         continue
 
@@ -478,6 +487,17 @@ async def handle_ingest_events(
                         )
                         continue
 
+                # Validate importance range
+                importance = event_data.get("importance", 0.6)
+                try:
+                    importance = float(importance)
+                except (ValueError, TypeError):
+                    errors.append({"index": i, "error": "importance must be a number"})
+                    continue
+                if importance < 0.0 or importance > 1.0:
+                    errors.append({"index": i, "error": "importance must be between 0.0 and 1.0"})
+                    continue
+
                 event = ResourceEvent(
                     resource_id=resource_id,
                     op=op,
@@ -486,7 +506,7 @@ async def handle_ingest_events(
                     payload=payload if op == "upsert" else None,
                     idempotency_key=event_data.get("idempotency_key"),
                     event_metadata=event_data.get("event_metadata", {}),
-                    importance=event_data.get("importance", 0.6),
+                    importance=importance,
                 )
 
                 try:
@@ -759,7 +779,20 @@ async def handle_setup_resource(
         except Exception as e:
             await db.rollback()
             error_str = str(e)
-            if "already exists" in error_str:
+
+            # Map known constraint failures to sanitized responses
+            from sqlalchemy.exc import IntegrityError as SQLIntegrityError
+
+            if isinstance(e, SQLIntegrityError) or "already exists" in error_str:
+                if "unique_context_resource_id" in error_str or "resource_id" in error_str:
+                    sanitized_msg = f"resource_id '{resource_id}' is already in use."
+                    error_code = "resource_id_conflict"
+                elif "unique_context_name" in error_str or "already exists" in error_str:
+                    sanitized_msg = f"Context name '{name}' already exists in this workspace."
+                    error_code = "context_name_conflict"
+                else:
+                    sanitized_msg = "A uniqueness constraint was violated."
+                    error_code = "conflict"
                 await _log_tool_usage(
                     db,
                     user_id,
@@ -769,8 +802,8 @@ async def handle_setup_resource(
                     workspace_id=workspace_id,
                 )
                 return _error_response(
-                    "validation_error",
-                    error_str,
+                    error_code,
+                    sanitized_msg,
                     help="Check the context name and resource_id.",
                 )
             logger.error(f"setup_resource_failed: {e}", exc_info=True)

--- a/backend/tests/mcp_server/test_resource_tools.py
+++ b/backend/tests/mcp_server/test_resource_tools.py
@@ -175,17 +175,21 @@ class TestSetupResourcePlanGating:
 
         # db.execute order:
         # 1) role check → owner
-        # 2) workspace plan_name lookup → "basic"
+        # 2) resource_id duplicate check → none
+        # 3) workspace plan_name lookup → "basic"
         # (context name duplicate check is patched below, so it does not touch db.execute)
         role_result = MagicMock()
         owner = MagicMock()
         owner.role = "owner"
         role_result.scalar_one_or_none.return_value = owner
 
+        resource_dup_result = MagicMock()
+        resource_dup_result.scalar_one_or_none.return_value = None
+
         plan_result = MagicMock()
         plan_result.scalar_one_or_none.return_value = "basic"
 
-        mock_db.execute.side_effect = [role_result, plan_result]
+        mock_db.execute.side_effect = [role_result, resource_dup_result, plan_result]
 
         async def mock_get_db():
             yield mock_db
@@ -478,3 +482,373 @@ class TestIngestEventsValidation:
         data = _json_of(result)
         assert data["error"] == "validation_error"
         assert "Batch size" in data["message"]
+
+
+# ============================================================================
+# Happy-path tests (one per handler)
+# ============================================================================
+
+
+class TestGetResourceImpactHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_stats(self):
+        """get_resource_impact returns token/memory/schema stats on success."""
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+
+        # 1) boundary check: resource found
+        boundary_result = MagicMock()
+        boundary_result.scalar_one_or_none.return_value = uuid4()
+
+        # 2) combined stats query: row with 3 counts
+        stats_row = MagicMock()
+        stats_row.token_count = 2
+        stats_row.memory_count = 47
+        stats_row.schema_version = 3
+        stats_result = MagicMock()
+        stats_result.one.return_value = stats_row
+
+        mock_db.execute.side_effect = [boundary_result, stats_result]
+        mock_db.commit = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_get_resource_impact({"resource_id": "res1"}, "user", workspace_id)
+        data = _json_of(result)
+        assert data["status"] == "success"
+        assert data["resource_id"] == "res1"
+        assert data["token_count"] == 2
+        assert data["memory_count"] == 47
+        assert data["current_schema_version"] == 3
+
+
+class TestGetResourceSchemaHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_latest_schema(self):
+        """get_resource_schema returns the highest schema_version when unspecified."""
+        from datetime import UTC, datetime
+
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+
+        # 1) boundary check: resource found
+        boundary_result = MagicMock()
+        boundary_result.scalar_one_or_none.return_value = uuid4()
+
+        # 2) schema query: schema row
+        schema_row = MagicMock()
+        schema_row.resource_id = "res1"
+        schema_row.schema_version = 4
+        schema_row.field_definitions = [{"name": "title", "type": "string"}]
+        schema_row.created_at = datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC)
+        schema_result = MagicMock()
+        schema_result.scalar_one_or_none.return_value = schema_row
+
+        mock_db.execute.side_effect = [boundary_result, schema_result]
+        mock_db.commit = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_get_resource_schema({"resource_id": "res1"}, "user", workspace_id)
+        data = _json_of(result)
+        assert data["status"] == "success"
+        assert data["schema_version"] == 4
+        assert data["field_definitions"] == [{"name": "title", "type": "string"}]
+
+
+class TestListResourceTokensHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_paginated_tokens(self):
+        """list_resource_tokens returns total + paginated token list."""
+        from datetime import UTC, datetime
+
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+
+        # 1) role check → owner
+        role_result = MagicMock()
+        owner = MagicMock()
+        owner.role = "owner"
+        role_result.scalar_one_or_none.return_value = owner
+
+        # 2) total count query
+        total_result = MagicMock()
+        total_result.scalar.return_value = 5
+
+        # 3) paginated tokens query
+        token1 = MagicMock()
+        token1.id = 1
+        token1.resource_id = "res1"
+        token1.description = "t1"
+        token1.quota_events_per_hour = 1000
+        token1.is_active = True
+        token1.created_at = datetime(2026, 1, 1, tzinfo=UTC)
+        token1.last_used_at = None
+
+        token2 = MagicMock()
+        token2.id = 2
+        token2.resource_id = "res2"
+        token2.description = None
+        token2.quota_events_per_hour = 500
+        token2.is_active = False
+        token2.created_at = datetime(2026, 1, 2, tzinfo=UTC)
+        token2.last_used_at = datetime(2026, 1, 3, tzinfo=UTC)
+
+        tokens_result = MagicMock()
+        tokens_result.scalars.return_value.all.return_value = [token1, token2]
+
+        mock_db.execute.side_effect = [role_result, total_result, tokens_result]
+        mock_db.commit = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_list_resource_tokens(
+                {"limit": 2, "offset": 0}, "user", workspace_id
+            )
+        data = _json_of(result)
+        assert data["status"] == "success"
+        assert data["total"] == 5
+        assert data["limit"] == 2
+        assert data["offset"] == 0
+        assert len(data["tokens"]) == 2
+        assert data["tokens"][0]["id"] == 1
+        assert data["tokens"][0]["is_active"] is True
+        assert data["tokens"][1]["is_active"] is False
+
+
+class TestIngestEventsHappyPath:
+    @pytest.mark.asyncio
+    async def test_creates_upsert_event(self):
+        """ingest_events persists valid upsert event and schedules indexer."""
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+
+        # 1) viewer role check → member
+        role_result = MagicMock()
+        m = MagicMock()
+        m.role = "member"
+        role_result.scalar_one_or_none.return_value = m
+        # 2) boundary check → found
+        boundary_result = MagicMock()
+        boundary_result.scalar_one_or_none.return_value = uuid4()
+        mock_db.execute.side_effect = [role_result, boundary_result]
+
+        # Capture the added event so we can assign an id before flush returns
+        added_events: list = []
+
+        def _add(obj):
+            obj.id = 123
+            added_events.append(obj)
+
+        # db.add is sync (AsyncMock defaults attributes to AsyncMock; override to MagicMock)
+        mock_db.add = MagicMock(side_effect=_add)
+        mock_db.flush = AsyncMock()
+        mock_db.commit = AsyncMock()
+
+        # begin_nested must return an async context manager
+        nested_cm = AsyncMock()
+        nested_cm.__aenter__ = AsyncMock(return_value=None)
+        nested_cm.__aexit__ = AsyncMock(return_value=None)
+        mock_db.begin_nested = MagicMock(return_value=nested_cm)
+
+        async def mock_get_db():
+            yield mock_db
+
+        async def mock_schedule(db, resource_id):
+            return None
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "api.routes.resource_ingest._schedule_indexer_for_resource",
+                new=mock_schedule,
+            ),
+        ):
+            result = await handle_ingest_events(
+                {
+                    "resource_id": "res1",
+                    "events": [
+                        {
+                            "op": "upsert",
+                            "doc_id": "d1",
+                            "version": 1,
+                            "payload": {"x": 1},
+                            "importance": 0.7,
+                        }
+                    ],
+                },
+                "user",
+                workspace_id,
+            )
+
+        data = _json_of(result)
+        assert data["status"] == "success"
+        assert data["created_count"] == 1
+        assert data["failed_count"] == 0
+        assert data["event_ids"] == [123]
+        assert len(added_events) == 1
+        assert added_events[0].resource_id == "res1"
+        assert added_events[0].op == "upsert"
+        mock_db.commit.assert_awaited()
+
+
+class TestSetupResourceHappyPath:
+    @pytest.mark.asyncio
+    async def test_creates_context_search_config_and_token(self):
+        """setup_resource creates context + search config + token on Pro plan."""
+        workspace_id = uuid4()
+        context_uuid = uuid4()
+        mock_db = AsyncMock()
+
+        # db.execute sequence:
+        # 1) role check → owner
+        # 2) resource_id duplicate check → none
+        # 3) workspace plan_name lookup → "pro"
+        # 4) active token count → 0
+        role_result = MagicMock()
+        owner = MagicMock()
+        owner.role = "owner"
+        role_result.scalar_one_or_none.return_value = owner
+
+        resource_dup_result = MagicMock()
+        resource_dup_result.scalar_one_or_none.return_value = None
+
+        plan_result = MagicMock()
+        plan_result.scalar_one_or_none.return_value = "pro"
+
+        token_count_result = MagicMock()
+        token_count_result.scalar.return_value = 0
+
+        mock_db.execute.side_effect = [
+            role_result,
+            resource_dup_result,
+            plan_result,
+            token_count_result,
+        ]
+
+        # Capture added objects
+        added: list = []
+
+        def _add(obj):
+            # Assign ids so that db.refresh works
+            cls_name = type(obj).__name__
+            if cls_name == "Context":
+                obj.id = context_uuid
+            added.append(obj)
+
+        # db.add is sync
+        mock_db.add = MagicMock(side_effect=_add)
+        mock_db.flush = AsyncMock()
+        mock_db.refresh = AsyncMock()
+        mock_db.commit = AsyncMock()
+
+        # Mock services/managers
+        mock_token_record = MagicMock()
+        mock_token_record.id = 42
+
+        async def mock_create_token(self, **kwargs):
+            return ("plaintext-token-xyz", mock_token_record)
+
+        async def mock_can_create(self, wsid):
+            return (True, None)
+
+        async def mock_get_ctx_by_name(self, wsid, name):
+            return None
+
+        def mock_validate_name(name):
+            return None
+
+        async def mock_get_db():
+            yield mock_db
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "services.context_service.ContextService.validate_context_name",
+                new=mock_validate_name,
+            ),
+            patch(
+                "services.context_service.ContextService.get_context_by_name_for_workspace",
+                new=mock_get_ctx_by_name,
+            ),
+            patch(
+                "services.quota_service.QuotaService.check_context_creation_allowed",
+                new=mock_can_create,
+            ),
+            patch(
+                "auth.resource_tokens.ResourceTokenManager.create_token",
+                new=mock_create_token,
+            ),
+        ):
+            result = await handle_setup_resource(
+                {
+                    "name": "ctx-res1",
+                    "resource_id": "res1",
+                    "description": "smoke",
+                },
+                "user",
+                workspace_id,
+            )
+
+        data = _json_of(result)
+        assert data["status"] == "success"
+        assert data["resource_id"] == "res1"
+        assert data["token"] == "plaintext-token-xyz"
+        assert data["token_id"] == 42
+        assert data["context_id"] == str(context_uuid)
+        # Verify Context + ContextSearchConfig were added
+        type_names = [type(o).__name__ for o in added]
+        assert "Context" in type_names
+        assert "ContextSearchConfig" in type_names
+        mock_db.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_resource_id_conflict_pre_insert(self):
+        """setup_resource rejects duplicate resource_id with resource_id_conflict."""
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+
+        role_result = MagicMock()
+        owner = MagicMock()
+        owner.role = "owner"
+        role_result.scalar_one_or_none.return_value = owner
+
+        # resource_id duplicate check → existing context found
+        resource_dup_result = MagicMock()
+        resource_dup_result.scalar_one_or_none.return_value = uuid4()
+
+        mock_db.execute.side_effect = [role_result, resource_dup_result]
+
+        async def mock_get_db():
+            yield mock_db
+
+        async def mock_get_ctx_by_name(self, wsid, name):
+            return None
+
+        def mock_validate_name(name):
+            return None
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "services.context_service.ContextService.validate_context_name",
+                new=mock_validate_name,
+            ),
+            patch(
+                "services.context_service.ContextService.get_context_by_name_for_workspace",
+                new=mock_get_ctx_by_name,
+            ),
+        ):
+            result = await handle_setup_resource(
+                {"name": "ctx-res1", "resource_id": "res1"},
+                "user",
+                workspace_id,
+            )
+        data = _json_of(result)
+        assert data["error"] == "resource_id_conflict"

--- a/backend/tests/mcp_server/test_resource_tools.py
+++ b/backend/tests/mcp_server/test_resource_tools.py
@@ -1,0 +1,480 @@
+"""Tests for Resource management MCP tool handlers.
+
+Issue #46: setup_resource, ingest_events, get_resource_impact,
+get_resource_schema, list_resource_tokens.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.resource import (
+    handle_get_resource_impact,
+    handle_get_resource_schema,
+    handle_ingest_events,
+    handle_list_resource_tokens,
+    handle_setup_resource,
+)
+
+
+def _json_of(result):
+    return json.loads(result[0].text)
+
+
+# ============================================================================
+# workspace_required
+# ============================================================================
+
+
+class TestWorkspaceRequired:
+    """All resource handlers must return workspace_required when workspace_id is None."""
+
+    @pytest.mark.asyncio
+    async def test_get_resource_impact(self):
+        result = await handle_get_resource_impact({"resource_id": "res1"}, "user", None)
+        data = _json_of(result)
+        assert data["status"] == "error"
+        assert data["error"] == "workspace_required"
+
+    @pytest.mark.asyncio
+    async def test_get_resource_schema(self):
+        result = await handle_get_resource_schema({"resource_id": "res1"}, "user", None)
+        data = _json_of(result)
+        assert data["error"] == "workspace_required"
+
+    @pytest.mark.asyncio
+    async def test_list_resource_tokens(self):
+        result = await handle_list_resource_tokens({}, "user", None)
+        data = _json_of(result)
+        assert data["error"] == "workspace_required"
+
+    @pytest.mark.asyncio
+    async def test_ingest_events(self):
+        result = await handle_ingest_events(
+            {"resource_id": "res1", "events": [{"op": "upsert", "doc_id": "d1"}]},
+            "user",
+            None,
+        )
+        data = _json_of(result)
+        assert data["error"] == "workspace_required"
+
+    @pytest.mark.asyncio
+    async def test_setup_resource(self):
+        result = await handle_setup_resource({"name": "r", "resource_id": "res1"}, "user", None)
+        data = _json_of(result)
+        assert data["error"] == "workspace_required"
+
+
+# ============================================================================
+# resource_id format validation
+# ============================================================================
+
+
+class TestResourceIdValidation:
+    @pytest.mark.asyncio
+    async def test_get_resource_impact_invalid_format(self):
+        result = await handle_get_resource_impact({"resource_id": "Invalid ID!"}, "user", uuid4())
+        data = _json_of(result)
+        assert data["error"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_list_resource_tokens_invalid_format(self):
+        """list_resource_tokens must also validate optional resource_id format."""
+        # Mock role check as owner so validation gate is reached
+        mock_db = AsyncMock()
+        role_result = MagicMock()
+        owner = MagicMock()
+        owner.role = "owner"
+        role_result.scalar_one_or_none.return_value = owner
+        mock_db.execute.return_value = role_result
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_list_resource_tokens({"resource_id": "Invalid!"}, "user", uuid4())
+        data = _json_of(result)
+        # Should be validation_error, not resource_not_found
+        assert data["error"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_list_resource_tokens_no_filter_skips_validation(self):
+        """When resource_id is not provided, skip format validation path."""
+        # Role check fails first (no member) — confirms we got past resource_id gate
+        mock_db = AsyncMock()
+        mock_role_result = MagicMock()
+        mock_role_result.scalar_one_or_none.return_value = None
+        mock_db.execute.return_value = mock_role_result
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_list_resource_tokens({}, "user", uuid4())
+        data = _json_of(result)
+        # Role check denies: not validation_error
+        assert data["error"] == "permission_denied"
+
+
+# ============================================================================
+# list_resource_tokens: role gating (owner/admin only)
+# ============================================================================
+
+
+class TestListResourceTokensRoleGating:
+    @pytest.mark.asyncio
+    async def test_viewer_denied(self):
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+        mock_role_result = MagicMock()
+        member = MagicMock()
+        member.role = "viewer"
+        mock_role_result.scalar_one_or_none.return_value = member
+        mock_db.execute.return_value = mock_role_result
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_list_resource_tokens({}, "user", workspace_id)
+        data = _json_of(result)
+        assert data["error"] == "permission_denied"
+
+    @pytest.mark.asyncio
+    async def test_member_denied(self):
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+        mock_role_result = MagicMock()
+        member = MagicMock()
+        member.role = "member"
+        mock_role_result.scalar_one_or_none.return_value = member
+        mock_db.execute.return_value = mock_role_result
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_list_resource_tokens({}, "user", workspace_id)
+        data = _json_of(result)
+        assert data["error"] == "permission_denied"
+
+
+# ============================================================================
+# setup_resource: plan + role gating
+# ============================================================================
+
+
+class TestSetupResourcePlanGating:
+    @pytest.mark.asyncio
+    async def test_non_pro_plan_denied(self):
+        """Basic/Free plan should not be able to run setup_resource."""
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+
+        # db.execute order:
+        # 1) role check → owner
+        # 2) workspace plan_name lookup → "basic"
+        # (context name duplicate check is patched below, so it does not touch db.execute)
+        role_result = MagicMock()
+        owner = MagicMock()
+        owner.role = "owner"
+        role_result.scalar_one_or_none.return_value = owner
+
+        plan_result = MagicMock()
+        plan_result.scalar_one_or_none.return_value = "basic"
+
+        mock_db.execute.side_effect = [role_result, plan_result]
+
+        async def mock_get_db():
+            yield mock_db
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "services.context_service.ContextService.validate_context_name",
+                return_value=None,
+            ),
+            patch(
+                "services.context_service.ContextService.get_context_by_name_for_workspace",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+        ):
+            result = await handle_setup_resource(
+                {"name": "ctx", "resource_id": "res1"}, "user", workspace_id
+            )
+
+        data = _json_of(result)
+        assert data["error"] == "plan_required"
+
+    @pytest.mark.asyncio
+    async def test_non_owner_denied(self):
+        """Members cannot run setup_resource."""
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+        role_result = MagicMock()
+        member = MagicMock()
+        member.role = "member"
+        role_result.scalar_one_or_none.return_value = member
+        mock_db.execute.return_value = role_result
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_setup_resource(
+                {"name": "ctx", "resource_id": "res1"}, "user", workspace_id
+            )
+
+        data = _json_of(result)
+        assert data["error"] == "permission_denied"
+
+
+# ============================================================================
+# get_resource_schema: schema_version validation
+# ============================================================================
+
+
+class TestSchemaVersionValidation:
+    @pytest.mark.asyncio
+    async def test_non_int_schema_version(self):
+        """schema_version must be coerceable to int."""
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+        # boundary check: found
+        boundary_result = MagicMock()
+        boundary_result.scalar_one_or_none.return_value = uuid4()
+        mock_db.execute.return_value = boundary_result
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_get_resource_schema(
+                {"resource_id": "res1", "schema_version": "abc"},
+                "user",
+                workspace_id,
+            )
+        data = _json_of(result)
+        assert data["error"] == "validation_error"
+        assert "integer" in data["message"].lower()
+
+    @pytest.mark.asyncio
+    async def test_zero_schema_version_rejected(self):
+        workspace_id = uuid4()
+        mock_db = AsyncMock()
+        boundary_result = MagicMock()
+        boundary_result.scalar_one_or_none.return_value = uuid4()
+        mock_db.execute.return_value = boundary_result
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_get_resource_schema(
+                {"resource_id": "res1", "schema_version": 0},
+                "user",
+                workspace_id,
+            )
+        data = _json_of(result)
+        assert data["error"] == "validation_error"
+
+
+# ============================================================================
+# ingest_events: per-item validation + partial success
+# ============================================================================
+
+
+class TestIngestEventsValidation:
+    """Tests that verify per-item validation without hitting DB.
+
+    Events that fail validation are caught BEFORE the begin_nested savepoint,
+    so no DB session mocking for ResourceEvent insert is required — we only
+    need enough DB mock to pass viewer + boundary checks.
+    """
+
+    def _make_db(self):
+        mock_db = AsyncMock()
+        # 1) viewer role check → member (write allowed)
+        role_result = MagicMock()
+        m = MagicMock()
+        m.role = "member"
+        role_result.scalar_one_or_none.return_value = m
+        # 2) boundary check → found
+        boundary_result = MagicMock()
+        boundary_result.scalar_one_or_none.return_value = uuid4()
+        mock_db.execute.side_effect = [role_result, boundary_result]
+        mock_db.commit = AsyncMock()
+        return mock_db
+
+    @pytest.mark.asyncio
+    async def test_non_dict_event_rejected(self):
+        mock_db = self._make_db()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_ingest_events(
+                {"resource_id": "res1", "events": ["not a dict"]},
+                "user",
+                uuid4(),
+            )
+        data = _json_of(result)
+        assert data["status"] == "success"
+        assert data["created_count"] == 0
+        assert data["failed_count"] == 1
+        assert data["errors"][0]["error"] == "event must be an object"
+
+    @pytest.mark.asyncio
+    async def test_invalid_op_rejected(self):
+        mock_db = self._make_db()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_ingest_events(
+                {"resource_id": "res1", "events": [{"op": "bogus", "doc_id": "d1"}]},
+                "user",
+                uuid4(),
+            )
+        data = _json_of(result)
+        assert data["failed_count"] == 1
+        assert "Invalid op" in data["errors"][0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_upsert_missing_version(self):
+        mock_db = self._make_db()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_ingest_events(
+                {
+                    "resource_id": "res1",
+                    "events": [{"op": "upsert", "doc_id": "d1", "payload": {"x": 1}}],
+                },
+                "user",
+                uuid4(),
+            )
+        data = _json_of(result)
+        assert data["failed_count"] == 1
+        assert "version" in data["errors"][0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_upsert_non_int_version(self):
+        mock_db = self._make_db()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_ingest_events(
+                {
+                    "resource_id": "res1",
+                    "events": [
+                        {
+                            "op": "upsert",
+                            "doc_id": "d1",
+                            "payload": {"x": 1},
+                            "version": "not_an_int",
+                        }
+                    ],
+                },
+                "user",
+                uuid4(),
+            )
+        data = _json_of(result)
+        assert data["failed_count"] == 1
+        assert "integer" in data["errors"][0]["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_upsert_missing_payload(self):
+        mock_db = self._make_db()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_ingest_events(
+                {
+                    "resource_id": "res1",
+                    "events": [{"op": "upsert", "doc_id": "d1", "version": 1}],
+                },
+                "user",
+                uuid4(),
+            )
+        data = _json_of(result)
+        assert data["failed_count"] == 1
+        assert "payload" in data["errors"][0]["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_delete_with_payload_rejected(self):
+        mock_db = self._make_db()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_ingest_events(
+                {
+                    "resource_id": "res1",
+                    "events": [{"op": "delete", "doc_id": "d1", "payload": {"x": 1}}],
+                },
+                "user",
+                uuid4(),
+            )
+        data = _json_of(result)
+        assert data["failed_count"] == 1
+        assert "payload must be null" in data["errors"][0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_importance_out_of_range(self):
+        mock_db = self._make_db()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_ingest_events(
+                {
+                    "resource_id": "res1",
+                    "events": [
+                        {
+                            "op": "upsert",
+                            "doc_id": "d1",
+                            "version": 1,
+                            "payload": {"x": 1},
+                            "importance": 2.5,
+                        }
+                    ],
+                },
+                "user",
+                uuid4(),
+            )
+        data = _json_of(result)
+        assert data["failed_count"] == 1
+        assert "importance" in data["errors"][0]["error"]
+
+    @pytest.mark.asyncio
+    async def test_empty_events_rejected(self):
+        result = await handle_ingest_events({"resource_id": "res1", "events": []}, "user", uuid4())
+        data = _json_of(result)
+        assert data["error"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_batch_size_exceeded(self):
+        events = [
+            {"op": "upsert", "doc_id": f"d{i}", "version": 1, "payload": {"x": i}}
+            for i in range(101)
+        ]
+        result = await handle_ingest_events(
+            {"resource_id": "res1", "events": events}, "user", uuid4()
+        )
+        data = _json_of(result)
+        assert data["error"] == "validation_error"
+        assert "Batch size" in data["message"]

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -3,7 +3,8 @@ description: Run comprehensive smoke test of all MCP tools via live MCP connecti
 ---
 
 Verify MCP tools work correctly by executing them in sequence against temporary test contexts.
-Tests 18 of 21 tools (excludes 3 sleep tools that require a prior Sleep Maintenance run).
+Tests 18 of 21 memory/context tools (excludes 3 sleep tools that require a prior Sleep Maintenance run).
+Optionally tests 5 resource tools if the workspace has a PRO plan.
 Use this after deployments, tool description changes, or MCP server updates.
 
 **Prerequisite:** MCP server must be running and connected.
@@ -140,6 +141,38 @@ get_usage()
 
 Note: Sleep tools (`get_sleep_history`, `get_sleep_report`, `rollback_sleep_run`) are not tested here because they require a completed Sleep Maintenance run. Verify these manually after a sleep cycle.
 
+### 7.5. Resource tools (PRO plan only)
+
+**Pre-check:** Call `get_usage()` and check the plan. If the plan is `free` or `basic`, skip this section entirely and note "Resource tools skipped — PRO plan required" in the report.
+
+```
+setup_resource(name="smoke-test-resource-{unix_timestamp}", resource_id="smoke_test_{unix_timestamp}")
+-> Verify: returns context_id (UUID), resource_id, token (plaintext), token_id
+-> Save context_id as resource_context_id, resource_id, and token
+
+ingest_events(resource_id=<resource_id>, events=[
+  {"op": "upsert", "doc_id": "TEST-001", "version": 1, "payload": {"name": "Test Product", "price": 1000}},
+  {"op": "upsert", "doc_id": "TEST-002", "version": 1, "payload": {"name": "Test Product 2", "price": 2000}}
+])
+-> Verify: created_count=2, failed_count=0, event_ids has 2 entries
+
+get_resource_impact(resource_id=<resource_id>)
+-> Verify: token_count >= 1, current_schema_version is null (no schema created)
+
+get_resource_schema(resource_id=<resource_id>)
+-> Verify: returns schema_not_found error (expected — no schema exists yet)
+
+list_resource_tokens(resource_id=<resource_id>)
+-> Verify: returns tokens array with at least 1 token matching resource_id
+```
+
+**Resource cleanup** (runs even if some steps failed):
+
+```
+delete_context(context_id=<resource_context_id>)
+-> Verify: success response (resource context soft-deleted)
+```
+
 ### Cleanup
 
 ```
@@ -188,13 +221,23 @@ Print a summary table:
 | 24 | delete_context | Soft-delete merge target and its memories | PASS/FAIL |
 | 25 | forget | Delete memory 2 | PASS/FAIL |
 | 26 | delete_context | Delete source context | PASS/FAIL |
+| 27 | setup_resource | Create resource context + token (PRO only) | PASS/FAIL/SKIP |
+| 28 | ingest_events | Batch ingest 2 test events (PRO only) | PASS/FAIL/SKIP |
+| 29 | get_resource_impact | Get resource stats (PRO only) | PASS/FAIL/SKIP |
+| 30 | get_resource_schema | Get schema (expect not_found) (PRO only) | PASS/FAIL/SKIP |
+| 31 | list_resource_tokens | List tokens for resource (PRO only) | PASS/FAIL/SKIP |
+| 32 | delete_context | Delete resource context (PRO only) | PASS/FAIL/SKIP |
 
-**Result: N/26 passed**
+**Result: N/26 passed** (+ N/6 resource tools passed, or skipped if not PRO)
 
 Test context: smoke-test-{timestamp} (cleaned up)
 
 Not tested (require prior Sleep Maintenance run):
 - get_sleep_history, get_sleep_report, rollback_sleep_run
+
+Resource tools (PRO plan only):
+- If plan is free/basic: all 6 resource rows show SKIP
+- setup_resource, ingest_events, get_resource_impact, get_resource_schema, list_resource_tokens
 ```
 
 If any step fails:

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -4,7 +4,7 @@ description: Run comprehensive smoke test of all MCP tools via live MCP connecti
 
 Verify MCP tools work correctly by executing them in sequence against temporary test contexts.
 Tests 18 of 21 memory/context tools (excludes 3 sleep tools that require a prior Sleep Maintenance run).
-Optionally tests 5 resource tools if the workspace has a PRO plan.
+Optionally tests 5 resource tools (6 PRO-only rows including delete_context cleanup) if the workspace has a PRO plan.
 Use this after deployments, tool description changes, or MCP server updates.
 
 **Prerequisite:** MCP server must be running and connected.


### PR DESCRIPTION
Closes #46

## Summary
- Add 5 new MCP resource management tools: `setup_resource`, `ingest_events`, `get_resource_impact`, `get_resource_schema`, `list_resource_tokens`
- Enable Claude Code / Desktop users to interactively set up resources, ingest data, and monitor status without leaving the MCP session
- All tools use MCP session auth (not Resource Tokens) with workspace boundary checks
- Read-only tools exempt from MCP rate limiting

## Implementation notes
- New module `backend/src/mcp_server/tools/resource.py` with 5 handlers following existing MCP tool patterns
- `setup_resource` bypasses `ContextService.create_context()` (which commits internally) to maintain single-transaction atomicity for context + search config + token creation
- `ingest_events` uses `begin_nested()` savepoints for partial-success batch processing
- Token quota and listing scoped to workspace (not individual user) via EXISTS subquery on Context table
- Qdrant collection creation deferred to first `remember()` call (lazy creation)
- Added timeouts for 3 pre-existing tools missing from TOOL_TIMEOUTS
- Updated smoke-test skill with PRO-plan-conditional resource tool section

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/46-feat-feat-mcp-add-resource-management-tools-s.gate1.md
- ~/.claude/cache/gh-issue-driven/46-feat-feat-mcp-add-resource-management-tools-s.gate2.md

🤖 Generated via /gh-issue-driven:ship
