### PR TITLE
feat(ui): add resource data viewer, schema inspector, and stats dashboard (#47)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -330,6 +330,7 @@ from api.routes import (  # noqa: E402
     resource_ingest,  # Issue #238: Resource Ingest API
     resource_schema,  # Issue #238: Schema Management API
     resource_tokens,  # Issue #242: Resource Token Management API
+    resources,  # Issue #47: Workspace resource list
     sleep_reports,  # Issue #179: Sleep Report admin UI
     system,
     system_admins,
@@ -412,6 +413,9 @@ app.include_router(resource_ingest.router, prefix="/api/v1")
 
 # Resource Schema routes (Issue #238 - Schema Registry)
 app.include_router(resource_schema.router, prefix="/api/v1")
+
+# Resource list route (Issue #47 - Web UI resource list)
+app.include_router(resources.router, prefix="/api/v1")
 
 # Resource Token routes (Issue #242 - Resource Token Management)
 app.include_router(resource_tokens.router, prefix="/api/v1")

--- a/backend/src/api/routes/resources.py
+++ b/backend/src/api/routes/resources.py
@@ -12,8 +12,6 @@ Complements the existing per-resource endpoints in ``resource_schema.py``
 
 from __future__ import annotations
 
-from datetime import datetime
-
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, select, text
@@ -24,25 +22,13 @@ from db.base import get_db
 from models.auth import Context
 from models.memory import Memory
 from models.resource import ResourceEvent, ResourceSchema, ResourceToken
+from utils.datetime import to_utc_iso
 from utils.exceptions import AuthorizationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/resources", tags=["resources"])
-
-
-def _iso_utc(dt: datetime) -> str:
-    """Render a DB timestamp as ISO 8601 UTC with explicit Z suffix.
-
-    The project's DateTime columns are naive (TIMESTAMP WITHOUT TIME ZONE) and
-    stored by convention in UTC. ``datetime.isoformat()`` on a naive value omits
-    any offset, which browsers then parse as local time. Appending ``Z`` makes
-    the UTC contract explicit on the wire.
-    """
-    if dt.tzinfo is not None:
-        return dt.isoformat()
-    return dt.isoformat() + "Z"
 
 
 # ============================================================================
@@ -64,7 +50,11 @@ class ResourceListItem(BaseModel):
     )
     created_at: str = Field(..., description="Context creation time (ISO 8601 UTC)")
     updated_at: str = Field(
-        ..., description="Latest activity time — max(context.updated_at, last_event_at)"
+        ...,
+        description=(
+            "Most recent activity — GREATEST(last_event_at, context.updated_at, "
+            "context.created_at) as ISO 8601 UTC"
+        ),
     )
 
 
@@ -196,13 +186,14 @@ async def list_resources(
                 Context.deleted_at.is_(None),
             )
         )
+        # "Most recent activity" = max across the three signals. GREATEST
+        # ignores NULLs on PostgreSQL so a missing last_event_at still picks
+        # up context.updated_at (or created_at as the final fallback).
         # ORDER BY references the SELECT alias so the correlated subquery is
-        # evaluated once per row, not twice. SQLAlchemy re-emits scalar_subquery
-        # objects at each use site; referencing the alias via text() avoids that.
-        # The 3-level coalesce mirrors the response `updated_at` fallback so the
-        # server-side sort order agrees with the timestamp each row exposes.
+        # evaluated once per row, not twice — SQLAlchemy re-emits scalar_subquery
+        # objects at each use site, so text(alias) avoids that duplication.
         .order_by(
-            func.coalesce(
+            func.greatest(
                 text("last_event_at"),
                 Context.updated_at,
                 Context.created_at,
@@ -220,11 +211,19 @@ async def list_resources(
             token_count=row.token_count or 0,
             memory_count=row.memory_count or 0,
             current_schema_version=row.schema_version,
-            created_at=_iso_utc(row.created_at),
-            # Fall back through last_event → context.updated_at → context.created_at
-            # so we never call .isoformat() on None. _iso_utc() appends the Z
-            # suffix that naive UTC timestamps need for JS clients to parse.
-            updated_at=_iso_utc(row.last_event_at or row.context_updated_at or row.created_at),
+            created_at=to_utc_iso(row.created_at),
+            # Pick the most recent signal across the three timestamps, ignoring
+            # None — matches the ORDER BY greatest() above so the sort order
+            # agrees with the rendered value. to_utc_iso() handles None + adds
+            # the explicit Z suffix that JS clients need.
+            updated_at=to_utc_iso(
+                max(
+                    filter(
+                        None,
+                        (row.last_event_at, row.context_updated_at, row.created_at),
+                    )
+                )
+            ),
         )
         for row in rows
     ]

--- a/backend/src/api/routes/resources.py
+++ b/backend/src/api/routes/resources.py
@@ -12,6 +12,8 @@ Complements the existing per-resource endpoints in ``resource_schema.py``
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
 from sqlalchemy import and_, func, select, text
@@ -28,6 +30,19 @@ from utils.logger import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter(prefix="/resources", tags=["resources"])
+
+
+def _iso_utc(dt: datetime) -> str:
+    """Render a DB timestamp as ISO 8601 UTC with explicit Z suffix.
+
+    The project's DateTime columns are naive (TIMESTAMP WITHOUT TIME ZONE) and
+    stored by convention in UTC. ``datetime.isoformat()`` on a naive value omits
+    any offset, which browsers then parse as local time. Appending ``Z`` makes
+    the UTC contract explicit on the wire.
+    """
+    if dt.tzinfo is not None:
+        return dt.isoformat()
+    return dt.isoformat() + "Z"
 
 
 # ============================================================================
@@ -130,10 +145,15 @@ async def list_resources(
         .scalar_subquery()
     )
 
+    # Memory has a workspace_id column, so we can scope defensively here even
+    # though the other resource_* tables cannot (per the architectural invariant
+    # comment above). For Memory specifically this tightens the count against
+    # the unlikely case of a resource_id collision across workspaces.
     memory_count_subq = (
         select(func.count(Memory.id))
         .where(
             Memory.resource_id == Context.resource_id,
+            Memory.workspace_id == Context.workspace_id,
             Memory.deleted_at.is_(None),
         )
         .correlate(Context)
@@ -179,8 +199,14 @@ async def list_resources(
         # ORDER BY references the SELECT alias so the correlated subquery is
         # evaluated once per row, not twice. SQLAlchemy re-emits scalar_subquery
         # objects at each use site; referencing the alias via text() avoids that.
+        # The 3-level coalesce mirrors the response `updated_at` fallback so the
+        # server-side sort order agrees with the timestamp each row exposes.
         .order_by(
-            func.coalesce(text("last_event_at"), Context.updated_at).desc(),
+            func.coalesce(
+                text("last_event_at"),
+                Context.updated_at,
+                Context.created_at,
+            ).desc(),
         )
     )
     rows = result.all()
@@ -194,10 +220,11 @@ async def list_resources(
             token_count=row.token_count or 0,
             memory_count=row.memory_count or 0,
             current_schema_version=row.schema_version,
-            created_at=row.created_at.isoformat(),
+            created_at=_iso_utc(row.created_at),
             # Fall back through last_event → context.updated_at → context.created_at
-            # so we never call .isoformat() on None.
-            updated_at=(row.last_event_at or row.context_updated_at or row.created_at).isoformat(),
+            # so we never call .isoformat() on None. _iso_utc() appends the Z
+            # suffix that naive UTC timestamps need for JS clients to parse.
+            updated_at=_iso_utc(row.last_event_at or row.context_updated_at or row.created_at),
         )
         for row in rows
     ]

--- a/backend/src/api/routes/resources.py
+++ b/backend/src/api/routes/resources.py
@@ -22,6 +22,7 @@ from db.base import get_db
 from models.auth import Context
 from models.memory import Memory
 from models.resource import ResourceEvent, ResourceSchema, ResourceToken
+from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso
 from utils.exceptions import AuthorizationError
 from utils.logger import get_logger
@@ -120,6 +121,25 @@ async def list_resources(
     if not current_workspace_id:
         raise AuthorizationError("User must belong to a workspace")
 
+    # Access-filter contexts BEFORE running the aggregate query so private
+    # contexts (and contexts excluded by WorkspaceMember.allowed_context_ids)
+    # don't leak resource_ids/stats to members/viewers. Owners/admins see all
+    # contexts in the workspace — this matches the contexts list behavior.
+    # Suspended members (allowed_context_ids IS NULL) and users with an empty
+    # whitelist get an empty list here and short-circuit out below.
+    accessible = await PermissionService(db).get_accessible_contexts(
+        user["user_id"], current_workspace_id
+    )
+    accessible_ids = [c.id for c in accessible]
+    if not accessible_ids:
+        logger.info(
+            "list_resources_success",
+            user_id=user["user_id"],
+            workspace_id=str(current_workspace_id),
+            count=0,
+        )
+        return ResourceListResponse(resources=[], total=0)
+
     # Correlated subqueries — one stats bundle per matching context row.
     # resource_* tables are keyed by resource_id only (see Migration 055 note on
     # per-workspace uniqueness). We scope to this workspace via the Context join
@@ -184,6 +204,8 @@ async def list_resources(
                 Context.workspace_id == current_workspace_id,
                 Context.resource_id.is_not(None),
                 Context.deleted_at.is_(None),
+                # Scope to the subset the caller can actually see, per RBAC.
+                Context.id.in_(accessible_ids),
             )
         )
         # "Most recent activity" = max across the three signals. PostgreSQL's

--- a/backend/src/api/routes/resources.py
+++ b/backend/src/api/routes/resources.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
-from sqlalchemy import and_, func, select, text
+from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser
@@ -186,15 +186,17 @@ async def list_resources(
                 Context.deleted_at.is_(None),
             )
         )
-        # "Most recent activity" = max across the three signals. GREATEST
-        # ignores NULLs on PostgreSQL so a missing last_event_at still picks
-        # up context.updated_at (or created_at as the final fallback).
-        # ORDER BY references the SELECT alias so the correlated subquery is
-        # evaluated once per row, not twice — SQLAlchemy re-emits scalar_subquery
-        # objects at each use site, so text(alias) avoids that duplication.
+        # "Most recent activity" = max across the three signals. PostgreSQL's
+        # GREATEST ignores NULLs, so a missing last_event_at still picks up
+        # context.updated_at (or created_at as the final fallback).
+        # Note: SELECT aliases are not visible inside function calls in ORDER BY
+        # per PG's scoping rules, so we reference the scalar_subquery object
+        # directly here. This does cause the subquery to be emitted twice, but
+        # with < 50 resources/workspace the duplication is negligible, and PG's
+        # query planner can often hoist the correlated subquery to a join.
         .order_by(
             func.greatest(
-                text("last_event_at"),
+                last_event_subq,
                 Context.updated_at,
                 Context.created_at,
             ).desc(),

--- a/backend/src/api/routes/resources.py
+++ b/backend/src/api/routes/resources.py
@@ -1,0 +1,212 @@
+"""Resource list API route.
+
+Issue #47: Web UI for resource management.
+
+Provides a workspace-scoped list of resources with aggregated stats
+(token count, memory count, current schema version, last event time)
+for the Resource list page at /workspace/resources.
+
+Complements the existing per-resource endpoints in ``resource_schema.py``
+(``/resources/{resource_id}/impact``, ``/resources/{resource_id}/schema``).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy import and_, func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import APIKeyOrSessionUser
+from db.base import get_db
+from models.auth import Context
+from models.memory import Memory
+from models.resource import ResourceEvent, ResourceSchema, ResourceToken
+from utils.exceptions import AuthorizationError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/resources", tags=["resources"])
+
+
+# ============================================================================
+# Pydantic Models
+# ============================================================================
+
+
+class ResourceListItem(BaseModel):
+    """Single resource entry in the workspace resource list."""
+
+    resource_id: str = Field(..., description="Resource identifier")
+    context_id: str = Field(..., description="UUID of the context bound to this resource")
+    context_name: str = Field(..., description="Context name (URL-safe identifier)")
+    context_display_name: str | None = Field(None, description="Human-readable context name")
+    token_count: int = Field(..., description="Number of active resource tokens")
+    memory_count: int = Field(..., description="Number of non-deleted memories")
+    current_schema_version: int | None = Field(
+        None, description="Latest schema version, or null if no schema registered"
+    )
+    created_at: str = Field(..., description="Context creation time (ISO 8601 UTC)")
+    updated_at: str = Field(
+        ..., description="Latest activity time — max(context.updated_at, last_event_at)"
+    )
+
+
+class ResourceListResponse(BaseModel):
+    """Workspace resource list response."""
+
+    resources: list[ResourceListItem]
+    total: int
+
+
+# ============================================================================
+# Route
+# ============================================================================
+
+
+@router.get("", response_model=ResourceListResponse)
+async def list_resources(
+    user: APIKeyOrSessionUser,
+    db: AsyncSession = Depends(get_db),
+):
+    """List all resources in the caller's current workspace.
+
+    Returns an ordered list (latest activity first) of contexts that have a
+    non-null ``resource_id``, with aggregated counts joined from the
+    resource_tokens, memories, resource_schemas, and resource_events tables.
+
+    Args:
+        user: Current user (session or API key).
+        db: Database session.
+
+    Returns:
+        ResourceListResponse with resources[] and total count.
+
+    Raises:
+        AuthorizationError: User has no current workspace.
+
+    Example:
+        GET /api/v1/resources
+
+        Response:
+        {
+            "resources": [
+                {
+                    "resource_id": "ec_products",
+                    "context_id": "550e8400-...",
+                    "context_name": "ec-products",
+                    "context_display_name": "EC Products",
+                    "token_count": 2,
+                    "memory_count": 1234,
+                    "current_schema_version": 3,
+                    "created_at": "2026-03-01T12:00:00Z",
+                    "updated_at": "2026-04-14T09:15:30Z"
+                }
+            ],
+            "total": 1
+        }
+    """
+    logger.info("list_resources_request", user_id=user["user_id"])
+
+    # auth.dependencies injects current_workspace_id into the user dict already —
+    # no extra SELECT needed.
+    current_workspace_id = user.get("current_workspace_id")
+    if not current_workspace_id:
+        raise AuthorizationError("User must belong to a workspace")
+
+    # Correlated subqueries — one stats bundle per matching context row.
+    # resource_* tables are keyed by resource_id only (see Migration 055 note on
+    # per-workspace uniqueness). We scope to this workspace via the Context join
+    # on the outer query; collisions across workspaces are a pre-existing
+    # architectural invariant tracked separately.
+    token_count_subq = (
+        select(func.count(ResourceToken.id))
+        .where(
+            ResourceToken.resource_id == Context.resource_id,
+            ResourceToken.is_active == True,  # noqa: E712
+        )
+        .correlate(Context)
+        .scalar_subquery()
+    )
+
+    memory_count_subq = (
+        select(func.count(Memory.id))
+        .where(
+            Memory.resource_id == Context.resource_id,
+            Memory.deleted_at.is_(None),
+        )
+        .correlate(Context)
+        .scalar_subquery()
+    )
+
+    schema_version_subq = (
+        select(func.max(ResourceSchema.schema_version))
+        .where(ResourceSchema.resource_id == Context.resource_id)
+        .correlate(Context)
+        .scalar_subquery()
+    )
+
+    last_event_subq = (
+        select(func.max(ResourceEvent.created_at))
+        .where(ResourceEvent.resource_id == Context.resource_id)
+        .correlate(Context)
+        .scalar_subquery()
+    )
+
+    # Main query: workspace-scoped, resource-bound contexts with aggregated stats.
+    # ORDER BY coalesces the most recent signal (last event vs context update).
+    result = await db.execute(
+        select(
+            Context.id.label("context_id"),
+            Context.name.label("context_name"),
+            Context.display_name.label("context_display_name"),
+            Context.resource_id.label("resource_id"),
+            Context.created_at.label("created_at"),
+            Context.updated_at.label("context_updated_at"),
+            token_count_subq.label("token_count"),
+            memory_count_subq.label("memory_count"),
+            schema_version_subq.label("schema_version"),
+            last_event_subq.label("last_event_at"),
+        )
+        .where(
+            and_(
+                Context.workspace_id == current_workspace_id,
+                Context.resource_id.is_not(None),
+                Context.deleted_at.is_(None),
+            )
+        )
+        # ORDER BY references the SELECT alias so the correlated subquery is
+        # evaluated once per row, not twice. SQLAlchemy re-emits scalar_subquery
+        # objects at each use site; referencing the alias via text() avoids that.
+        .order_by(
+            func.coalesce(text("last_event_at"), Context.updated_at).desc(),
+        )
+    )
+    rows = result.all()
+
+    resources = [
+        ResourceListItem(
+            resource_id=row.resource_id,
+            context_id=str(row.context_id),
+            context_name=row.context_name,
+            context_display_name=row.context_display_name,
+            token_count=row.token_count or 0,
+            memory_count=row.memory_count or 0,
+            current_schema_version=row.schema_version,
+            created_at=row.created_at.isoformat(),
+            # Fall back through last_event → context.updated_at → context.created_at
+            # so we never call .isoformat() on None.
+            updated_at=(row.last_event_at or row.context_updated_at or row.created_at).isoformat(),
+        )
+        for row in rows
+    ]
+
+    logger.info(
+        "list_resources_success",
+        user_id=user["user_id"],
+        workspace_id=str(current_workspace_id),
+        count=len(resources),
+    )
+
+    return ResourceListResponse(resources=resources, total=len(resources))

--- a/backend/tests/api/test_resources.py
+++ b/backend/tests/api/test_resources.py
@@ -3,7 +3,10 @@
 Issue #47: Web UI for resource management — backend list endpoint tests.
 
 Requires: async_client, authenticated_user fixtures (integration test infrastructure).
-These are skipped when fixtures are not available (no test DB connection).
+These are marked ``xfail(strict=True)`` until those fixtures land — the tests
+still run as expected failures today, and once fixtures exist they will XPASS,
+which strict=True converts into a CI failure that forces removal of the xfail
+marker (matching the pattern in ``test_resource_tokens.py``).
 """
 
 import pytest

--- a/backend/tests/api/test_resources.py
+++ b/backend/tests/api/test_resources.py
@@ -109,7 +109,7 @@ async def test_list_resources_requires_current_workspace(
     """Users without a current_workspace_id get AuthorizationError (403)."""
     response = await async_client.get("/api/v1/resources")
 
-    assert response.status_code in (200, 403)
+    assert response.status_code == 403
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_resources.py
+++ b/backend/tests/api/test_resources.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 # Mark as expected failure — requires integration test fixtures
 # (async_client, authenticated_user) that are not yet implemented.
 pytestmark = pytest.mark.xfail(
-    strict=False,
+    strict=True,
     reason="Integration test fixtures not available (async_client, authenticated_user)",
 )
 

--- a/backend/tests/api/test_resources.py
+++ b/backend/tests/api/test_resources.py
@@ -127,3 +127,28 @@ async def test_list_resources_order_by_recent_activity(
         rows = data["resources"]
         for i in range(len(rows) - 1):
             assert rows[i]["updated_at"] >= rows[i + 1]["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_list_resources_respects_context_access(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    authenticated_user: dict,
+):
+    """Members/viewers must not see resources for contexts outside
+    ``PermissionService.get_accessible_contexts`` — private contexts and
+    contexts excluded by ``WorkspaceMember.allowed_context_ids`` are hidden.
+    Suspended members (allowed_context_ids IS NULL) get an empty list.
+    """
+    # Arrange: caller is a workspace member with allowed_context_ids = [A]
+    # Workspace also has resource-bound contexts B (private) and C (public,
+    # not whitelisted). Only A should appear in the response.
+    response = await async_client.get("/api/v1/resources")
+
+    assert response.status_code == 200
+    data = response.json()
+    visible_ids = {r["context_id"] for r in data["resources"]}
+    # Must exclude contexts outside the caller's access scope.
+    # (Real IDs filled in once integration fixtures land.)
+    assert all(cid in visible_ids for cid in [])  # placeholder: allowed contexts
+    assert not any(cid in visible_ids for cid in [])  # placeholder: forbidden

--- a/backend/tests/api/test_resources.py
+++ b/backend/tests/api/test_resources.py
@@ -1,0 +1,126 @@
+"""Tests for Resource list API.
+
+Issue #47: Web UI for resource management — backend list endpoint tests.
+
+Requires: async_client, authenticated_user fixtures (integration test infrastructure).
+These are skipped when fixtures are not available (no test DB connection).
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Mark as expected failure — requires integration test fixtures
+# (async_client, authenticated_user) that are not yet implemented.
+pytestmark = pytest.mark.xfail(
+    strict=False,
+    reason="Integration test fixtures not available (async_client, authenticated_user)",
+)
+
+
+@pytest.mark.asyncio
+async def test_list_resources_empty_workspace(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    authenticated_user: dict,
+):
+    """A workspace with no resource-bound contexts returns an empty list."""
+    response = await async_client.get("/api/v1/resources")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["resources"] == []
+    assert data["total"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_resources_returns_workspace_scoped(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    authenticated_user: dict,
+):
+    """Only resources in the caller's current workspace are returned."""
+    # Arrange: seed a context with resource_id in the caller's workspace
+    # (fixture helpers not yet available — placeholder).
+    response = await async_client.get("/api/v1/resources")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data["resources"], list)
+    assert "total" in data
+    # Each row includes the documented shape
+    for row in data["resources"]:
+        assert "resource_id" in row
+        assert "context_id" in row
+        assert "token_count" in row
+        assert "memory_count" in row
+        assert "current_schema_version" in row
+
+
+@pytest.mark.asyncio
+async def test_list_resources_aggregates_counts(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    authenticated_user: dict,
+):
+    """token_count / memory_count / schema_version reflect real table state."""
+    # Arrange: seed a resource with 2 active tokens, 47 memories, schema v3.
+    response = await async_client.get("/api/v1/resources")
+
+    assert response.status_code == 200
+    data = response.json()
+    if data["total"] > 0:
+        row = data["resources"][0]
+        assert isinstance(row["token_count"], int)
+        assert isinstance(row["memory_count"], int)
+
+
+@pytest.mark.asyncio
+async def test_list_resources_excludes_deleted_contexts(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    authenticated_user: dict,
+):
+    """Soft-deleted contexts must not appear in the list."""
+    response = await async_client.get("/api/v1/resources")
+
+    assert response.status_code == 200
+    # Seed a soft-deleted resource context, confirm it's filtered out.
+
+
+@pytest.mark.asyncio
+async def test_list_resources_requires_auth(async_client: AsyncClient):
+    """Unauthenticated requests are rejected."""
+    response = await async_client.get("/api/v1/resources")
+
+    # Actual status depends on dependency — typically 401/403
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_list_resources_requires_current_workspace(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    authenticated_user: dict,
+):
+    """Users without a current_workspace_id get AuthorizationError (403)."""
+    response = await async_client.get("/api/v1/resources")
+
+    assert response.status_code in (200, 403)
+
+
+@pytest.mark.asyncio
+async def test_list_resources_order_by_recent_activity(
+    async_client: AsyncClient,
+    db_session: AsyncSession,
+    authenticated_user: dict,
+):
+    """Resources are ordered by max(last_event_at, context.updated_at) DESC."""
+    response = await async_client.get("/api/v1/resources")
+
+    assert response.status_code == 200
+    data = response.json()
+    if data["total"] >= 2:
+        rows = data["resources"]
+        for i in range(len(rows) - 1):
+            assert rows[i]["updated_at"] >= rows[i + 1]["updated_at"]

--- a/backend/tests/e2e/test_resources_page.py
+++ b/backend/tests/e2e/test_resources_page.py
@@ -1,0 +1,86 @@
+"""E2E tests for the Resources list + detail pages (#47).
+
+Verifies the new workspace-scoped resource management UI:
+- Resource list page loads without ErrorBanner (regression for the
+  "column last_event_at does not exist" bug caught in the round-10 review)
+- Resource list page renders either the table or the empty-state
+- Detail page does not throw when given a non-existent resource_id
+- i18n: the Japanese locale surfaces translated column headers / copy
+
+Requires running Docker services:
+    docker compose up -d
+
+Run:
+    pytest tests/e2e/test_resources_page.py -m e2e -v
+"""
+
+import os
+import time
+
+import pytest
+from playwright.sync_api import Page
+
+BASE_URL = os.environ.get("E2E_BASE_URL", "http://localhost:3000")
+
+
+@pytest.mark.e2e
+def test_resources_list_page_loads_without_error_banner(page: Page):
+    """The /workspace/resources page must render cleanly against the real DB.
+
+    Regression: an earlier revision of GET /api/v1/resources used a
+    text("last_event_at") alias reference inside a GREATEST() call in
+    ORDER BY, which PostgreSQL resolved as a column reference and failed
+    with UndefinedColumnError. Unit tests mocked the DB and missed this.
+    """
+    page.goto(f"{BASE_URL}/workspace/resources")
+    page.wait_for_load_state("networkidle")
+    time.sleep(1)
+
+    # The ErrorBanner uses role="alert" (see frontend/src/components/common/ErrorBanner.tsx)
+    error_banner = page.locator('[role="alert"]')
+    assert error_banner.count() == 0, (
+        "Resources list page rendered an ErrorBanner — likely a backend "
+        "failure. Check kagura-api logs for the /api/v1/resources request."
+    )
+
+    # Page should show either the table header or the empty-state title
+    # (both are acceptable — depends on whether the workspace has resources).
+    has_table_header = page.locator("th", has_text="Resource ID").count() > 0
+    has_empty_state = page.locator("text=No resources yet").count() > 0
+    assert has_table_header or has_empty_state, (
+        "Neither resource table nor empty-state rendered on /workspace/resources"
+    )
+
+
+@pytest.mark.e2e
+def test_resources_list_page_has_sidebar_entry(page: Page):
+    """Sidebar must expose the Resources nav entry in the workspace group."""
+    page.goto(f"{BASE_URL}/workspace/dashboard")
+    page.wait_for_load_state("networkidle")
+    time.sleep(1)
+
+    # Sidebar.tsx registers href="/workspace/resources"
+    resources_link = page.locator('a[href="/workspace/resources"]')
+    assert resources_link.count() > 0, "Sidebar does not expose a link to /workspace/resources"
+
+
+@pytest.mark.e2e
+def test_resources_detail_page_404_shows_not_found_title(page: Page):
+    """Unknown resource_id renders the notFoundTitle + back link (not a crash).
+
+    Regression: round-6 fix introduced `setError(detail.notFound)` which
+    incorrectly flipped `isFetchError` true and showed the generic title
+    instead of the dedicated notFoundTitle.
+    """
+    page.goto(f"{BASE_URL}/workspace/resources/this_resource_does_not_exist")
+    page.wait_for_load_state("networkidle")
+    time.sleep(1)
+
+    # ErrorBanner should be visible (role="alert")
+    assert page.locator('[role="alert"]').count() > 0, (
+        "Expected ErrorBanner on a resource_id that doesn't exist"
+    )
+
+    # Back-to-list button/link must be present
+    back_link = page.locator('a[href="/workspace/resources"]')
+    assert back_link.count() > 0, "Back-to-resources link missing on the not-found page"

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
@@ -225,7 +225,9 @@ describe("ResourceDetailPage", () => {
       resources: [makeResource()],
       total: 1,
     });
-    mockGetSchema.mockRejectedValue(new ApiError({ message: "Not found", status: 404 }));
+    mockGetSchema.mockRejectedValue(
+      new ApiError({ message: "Not found", status: 404 }),
+    );
 
     render(<ResourceDetailPage />);
 
@@ -255,18 +257,41 @@ describe("ResourceDetailPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("url-decodes the resource_id from the URL param", async () => {
-    mockParamsId = "has%20spaces";
+  it("passes useParams() id through unchanged (App Router already decodes)", async () => {
+    // Simulate useParams()'s actual behavior: it returns the already-decoded
+    // route segment. So the fixture uses the decoded form directly.
+    mockParamsId = "has spaces";
     mockListResources.mockResolvedValue({
       resources: [makeResource({ resource_id: "has spaces" })],
       total: 1,
     });
-    mockGetSchema.mockRejectedValue(new ApiError({ message: "Not found", status: 404 }));
+    mockGetSchema.mockRejectedValue(
+      new ApiError({ message: "Not found", status: 404 }),
+    );
 
     render(<ResourceDetailPage />);
 
     await waitFor(() => {
       expect(mockGetSchema).toHaveBeenCalledWith("has spaces");
+    });
+  });
+
+  it("does not throw URIError on resource_ids containing a literal %", async () => {
+    // Regression: decodeURIComponent("%") throws URIError. Since useParams
+    // already decodes, the page must not re-decode — only apply decode() once.
+    mockParamsId = "50%-complete";
+    mockListResources.mockResolvedValue({
+      resources: [makeResource({ resource_id: "50%-complete" })],
+      total: 1,
+    });
+    mockGetSchema.mockRejectedValue(
+      new ApiError({ message: "Not found", status: 404 }),
+    );
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(mockGetSchema).toHaveBeenCalledWith("50%-complete");
     });
   });
 

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
 
 import ResourceDetailPage from "./page";
+import { ApiError } from "@/lib/api/base";
 
 // ---------- Mocks ------------------------------------------------------------
 
@@ -146,12 +147,14 @@ describe("ResourceDetailPage", () => {
     expect(screen.getByText(/versionLabel.*"version":3/)).toBeInTheDocument();
   });
 
-  it("renders 'no schema' empty state when getSchema rejects", async () => {
+  it("renders 'no schema' empty state when getSchema returns ApiError(404)", async () => {
     mockListResources.mockResolvedValue({
       resources: [makeResource()],
       total: 1,
     });
-    mockGetSchema.mockRejectedValue(new Error("not found"));
+    mockGetSchema.mockRejectedValue(
+      new ApiError({ message: "Not found", status: 404 }),
+    );
 
     render(<ResourceDetailPage />);
 
@@ -159,6 +162,24 @@ describe("ResourceDetailPage", () => {
       expect(
         screen.getByText("resources.schema.emptyTitle"),
       ).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces non-404 getSchema errors via ErrorBanner (not silenced as 'no schema')", async () => {
+    mockListResources.mockResolvedValue({
+      resources: [makeResource()],
+      total: 1,
+    });
+    mockGetSchema.mockRejectedValue(
+      new ApiError({ message: "Internal server error", status: 500 }),
+    );
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(
+        "Internal server error",
+      );
     });
   });
 
@@ -204,7 +225,7 @@ describe("ResourceDetailPage", () => {
       resources: [makeResource()],
       total: 1,
     });
-    mockGetSchema.mockRejectedValue(new Error("not found"));
+    mockGetSchema.mockRejectedValue(new ApiError({ message: "Not found", status: 404 }));
 
     render(<ResourceDetailPage />);
 
@@ -240,7 +261,7 @@ describe("ResourceDetailPage", () => {
       resources: [makeResource({ resource_id: "has spaces" })],
       total: 1,
     });
-    mockGetSchema.mockRejectedValue(new Error("not found"));
+    mockGetSchema.mockRejectedValue(new ApiError({ message: "Not found", status: 404 }));
 
     render(<ResourceDetailPage />);
 

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Tests for the Resource detail page.
+ *
+ * Verifies:
+ * - stats strip + schema table render on success
+ * - schema absence (404) renders the "no schema" EmptyState
+ * - listResources() and getSchema() run in parallel (both start before either resolves)
+ * - unknown resource_id renders ErrorBanner + back link
+ * - data tab renders the #316 placeholder
+ * - url-encoded resource_id is decoded before use
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+import ResourceDetailPage from "./page";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockListResources = vi.fn();
+const mockGetSchema = vi.fn();
+const mockRouterReplace = vi.fn();
+
+let mockParamsId = "ec_products";
+let mockSearchParams = new URLSearchParams();
+
+vi.mock("@/lib/api/resources", () => ({
+  listResources: (...args: unknown[]) => mockListResources(...args),
+}));
+
+vi.mock("@/lib/api/schemas", () => ({
+  getSchema: (...args: unknown[]) => mockGetSchema(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: mockParamsId }),
+  useSearchParams: () => mockSearchParams,
+  usePathname: () => "/workspace/resources/ec_products",
+  useRouter: () => ({ replace: mockRouterReplace }),
+}));
+
+// Stable translator — a new function reference each render would invalidate
+// useCallback([t]) and re-fire the fetch effect every render (infinite loop).
+const makeTranslator = (namespace: string) => {
+  const prefix = namespace ? `${namespace}.` : "";
+  return (key: string, values?: Record<string, unknown>) => {
+    if (values && Object.keys(values).length > 0) {
+      return `${prefix}${key}:${JSON.stringify(values)}`;
+    }
+    return `${prefix}${key}`;
+  };
+};
+const translatorCache = new Map<string, ReturnType<typeof makeTranslator>>();
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace?: string) => {
+    const ns = namespace ?? "";
+    if (!translatorCache.has(ns)) {
+      translatorCache.set(ns, makeTranslator(ns));
+    }
+    return translatorCache.get(ns)!;
+  },
+}));
+
+vi.mock("@/lib/utils/datetime", () => ({
+  formatRelativeTime: (iso: string) => `rel(${iso})`,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) => <a href={href}>{children}</a>,
+}));
+
+// ---------- Fixtures ---------------------------------------------------------
+
+const makeResource = (overrides = {}) => ({
+  resource_id: "ec_products",
+  context_id: "550e8400-e29b-41d4-a716-446655440000",
+  context_name: "ec-products",
+  context_display_name: "EC Products",
+  token_count: 2,
+  memory_count: 47,
+  current_schema_version: 3,
+  created_at: "2026-03-01T00:00:00Z",
+  updated_at: "2026-04-14T09:15:30Z",
+  ...overrides,
+});
+
+const makeSchema = (overrides = {}) => ({
+  resource_id: "ec_products",
+  schema_version: 3,
+  field_definitions: [
+    {
+      name: "title",
+      type: "text" as const,
+      description: "Product title",
+      classification: "public" as const,
+      index_hint: "fulltext",
+      required: true,
+    },
+  ],
+  created_at: "2026-03-01T00:00:00Z",
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockListResources.mockReset();
+  mockGetSchema.mockReset();
+  mockRouterReplace.mockReset();
+  mockParamsId = "ec_products";
+  mockSearchParams = new URLSearchParams();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("ResourceDetailPage", () => {
+  it("renders stats strip and schema table on success", async () => {
+    mockListResources.mockResolvedValue({
+      resources: [makeResource()],
+      total: 1,
+    });
+    mockGetSchema.mockResolvedValue(makeSchema());
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("EC Products")).toBeInTheDocument();
+    });
+    expect(screen.getByText("title")).toBeInTheDocument();
+    expect(screen.getByText(/versionLabel.*"version":3/)).toBeInTheDocument();
+  });
+
+  it("renders 'no schema' empty state when getSchema rejects", async () => {
+    mockListResources.mockResolvedValue({
+      resources: [makeResource()],
+      total: 1,
+    });
+    mockGetSchema.mockRejectedValue(new Error("not found"));
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("resources.schema.emptyTitle"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("fetches list and schema in parallel", async () => {
+    let listStarted = false;
+    let schemaStarted = false;
+    let resolveList: (value: unknown) => void = () => {};
+    let resolveSchema: (value: unknown) => void = () => {};
+
+    mockListResources.mockImplementation(() => {
+      listStarted = true;
+      return new Promise((resolve) => {
+        resolveList = resolve;
+      });
+    });
+    mockGetSchema.mockImplementation(() => {
+      schemaStarted = true;
+      return new Promise((resolve) => {
+        resolveSchema = resolve;
+      });
+    });
+
+    render(<ResourceDetailPage />);
+
+    // Let the effect run its microtasks
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Both must have started before either resolves — proves parallelism
+    expect(listStarted).toBe(true);
+    expect(schemaStarted).toBe(true);
+
+    resolveList({ resources: [makeResource()], total: 1 });
+    resolveSchema(makeSchema());
+    await waitFor(() => {
+      expect(screen.getByText("EC Products")).toBeInTheDocument();
+    });
+  });
+
+  it("renders ErrorBanner when resource_id is not found in list", async () => {
+    mockParamsId = "missing_resource";
+    mockListResources.mockResolvedValue({
+      resources: [makeResource()],
+      total: 1,
+    });
+    mockGetSchema.mockRejectedValue(new Error("not found"));
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(screen.getByText("resources.detail.backToList")).toBeInTheDocument();
+  });
+
+  it("exposes both tabs (overview + data) in the tablist", async () => {
+    mockListResources.mockResolvedValue({
+      resources: [makeResource()],
+      total: 1,
+    });
+    mockGetSchema.mockResolvedValue(makeSchema());
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("EC Products")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByRole("tab", { name: "resources.tabs.overview" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("tab", { name: "resources.tabs.data" }),
+    ).toBeInTheDocument();
+  });
+
+  it("url-decodes the resource_id from the URL param", async () => {
+    mockParamsId = "has%20spaces";
+    mockListResources.mockResolvedValue({
+      resources: [makeResource({ resource_id: "has spaces" })],
+      total: 1,
+    });
+    mockGetSchema.mockRejectedValue(new Error("not found"));
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(mockGetSchema).toHaveBeenCalledWith("has spaces");
+    });
+  });
+});

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
@@ -66,6 +66,11 @@ vi.mock("next-intl", () => ({
     }
     return translatorCache.get(ns)!;
   },
+  useLocale: () => "en",
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { timezone: "UTC" } }),
 }));
 
 vi.mock("@/lib/utils/datetime", () => ({

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
@@ -3,11 +3,14 @@
  *
  * Verifies:
  * - stats strip + schema table render on success
- * - schema absence (404) renders the "no schema" EmptyState
+ * - schema absence (ApiError 404) renders the "no schema" EmptyState
+ * - non-404 getSchema errors surface via ErrorBanner (not silenced)
  * - listResources() and getSchema() run in parallel (both start before either resolves)
  * - unknown resource_id renders ErrorBanner + back link
- * - data tab renders the #316 placeholder
- * - url-encoded resource_id is decoded before use
+ * - both tabs (overview + data) are exposed in the tablist
+ * - the route `id` from useParams() is used directly (App Router already decodes)
+ * - resource_ids containing a literal `%` do not throw URIError
+ * - Pro-plan gate + workspaceReady hydration guard
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
@@ -227,7 +227,7 @@ describe("ResourceDetailPage", () => {
     });
   });
 
-  it("renders ErrorBanner when resource_id is not found in list", async () => {
+  it("renders notFoundTitle when resource_id is not in the workspace list", async () => {
     mockParamsId = "missing_resource";
     mockListResources.mockResolvedValue({
       resources: [makeResource()],
@@ -242,7 +242,34 @@ describe("ResourceDetailPage", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
+    // Not-found uses the dedicated title, not the generic "Resource" title
+    expect(
+      screen.getByText("resources.detail.notFoundTitle"),
+    ).toBeInTheDocument();
     expect(screen.getByText("resources.detail.backToList")).toBeInTheDocument();
+  });
+
+  it("renders generic title (not notFoundTitle) when a real fetch fails", async () => {
+    // Regression: a server error used to set error=notFound, making
+    // isFetchError true AND rendering the generic title — masking the
+    // real "backend error" intent as "resource doesn't exist".
+    mockListResources.mockRejectedValue(
+      new ApiError({ message: "backend offline", status: 500 }),
+    );
+    mockGetSchema.mockRejectedValue(
+      new ApiError({ message: "backend offline", status: 500 }),
+    );
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("backend offline");
+    });
+    // Fetch error renders the generic title, NOT the not-found title
+    expect(screen.getByText("resources.detail.title")).toBeInTheDocument();
+    expect(
+      screen.queryByText("resources.detail.notFoundTitle"),
+    ).not.toBeInTheDocument();
   });
 
   it("exposes both tabs (overview + data) in the tablist", async () => {

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.test.tsx
@@ -20,9 +20,11 @@ import ResourceDetailPage from "./page";
 const mockListResources = vi.fn();
 const mockGetSchema = vi.fn();
 const mockRouterReplace = vi.fn();
+const mockRouterPush = vi.fn();
 
 let mockParamsId = "ec_products";
 let mockSearchParams = new URLSearchParams();
+let mockCurrentWorkspace: { plan_name?: string } | null = null;
 
 vi.mock("@/lib/api/resources", () => ({
   listResources: (...args: unknown[]) => mockListResources(...args),
@@ -36,7 +38,11 @@ vi.mock("next/navigation", () => ({
   useParams: () => ({ id: mockParamsId }),
   useSearchParams: () => mockSearchParams,
   usePathname: () => "/workspace/resources/ec_products",
-  useRouter: () => ({ replace: mockRouterReplace }),
+  useRouter: () => ({ replace: mockRouterReplace, push: mockRouterPush }),
+}));
+
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => ({ currentWorkspace: mockCurrentWorkspace }),
 }));
 
 // Stable translator — a new function reference each render would invalidate
@@ -111,8 +117,10 @@ beforeEach(() => {
   mockListResources.mockReset();
   mockGetSchema.mockReset();
   mockRouterReplace.mockReset();
+  mockRouterPush.mockReset();
   mockParamsId = "ec_products";
   mockSearchParams = new URLSearchParams();
+  mockCurrentWorkspace = { plan_name: "pro" };
 });
 
 afterEach(() => {
@@ -239,5 +247,31 @@ describe("ResourceDetailPage", () => {
     await waitFor(() => {
       expect(mockGetSchema).toHaveBeenCalledWith("has spaces");
     });
+  });
+
+  it("renders upgrade CTA and skips fetch on basic plan", async () => {
+    mockCurrentWorkspace = { plan_name: "basic" };
+
+    render(<ResourceDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("resources.planGate.title")).toBeInTheDocument();
+    });
+    expect(mockListResources).not.toHaveBeenCalled();
+    expect(mockGetSchema).not.toHaveBeenCalled();
+  });
+
+  it("holds the fetch until WorkspaceContext hydrates", async () => {
+    mockCurrentWorkspace = null;
+    mockListResources.mockResolvedValue({
+      resources: [makeResource()],
+      total: 1,
+    });
+    mockGetSchema.mockResolvedValue(makeSchema());
+
+    render(<ResourceDetailPage />);
+
+    await Promise.resolve();
+    expect(mockListResources).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
@@ -10,10 +10,10 @@
  */
 
 import { useCallback, useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { ArrowLeft, ChevronRight, FileJson } from "lucide-react";
+import { ArrowLeft, ChevronRight, Database, FileJson } from "lucide-react";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
 import { SpinnerLoading } from "@/components/common/LoadingState";
@@ -27,13 +27,24 @@ import { SchemaFieldTable } from "@/components/resources/SchemaFieldTable";
 import { ResourceDataTabPlaceholder } from "@/components/resources/ResourceDataTabPlaceholder";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
 
 const RESOURCE_TABS = ["overview", "data"] as const;
 
 export default function ResourceDetailPage() {
   const params = useParams();
+  const router = useRouter();
   const resourceId = decodeURIComponent(params.id as string);
   const t = useTranslations("resources");
+  const { currentWorkspace } = useWorkspace();
+
+  // Match the list page's plan-gate posture — a deep-link direct to this URL
+  // on a Free/Basic workspace must see the upgrade CTA, not a generic
+  // not-found/error after a wasted API round-trip.
+  const planName = currentWorkspace?.plan_name;
+  const workspaceReady = currentWorkspace !== null && planName !== undefined;
+  const isPlanGated =
+    workspaceReady && (planName === "free" || planName === "basic");
 
   const [tab, setTab] = useTabParam("overview", "tab", RESOURCE_TABS);
 
@@ -78,8 +89,16 @@ export default function ResourceDetailPage() {
   }, [resourceId, t]);
 
   useEffect(() => {
+    // Hold the fetch until WorkspaceContext hydrates, then skip entirely for
+    // plan-gated workspaces — same rule as the list page so a direct deep-link
+    // on Free/Basic never fires an API call.
+    if (!workspaceReady) return;
+    if (isPlanGated) {
+      setLoading(false);
+      return;
+    }
     fetchResource();
-  }, [fetchResource]);
+  }, [fetchResource, isPlanGated, workspaceReady]);
 
   useEffect(() => {
     const title = resource
@@ -89,6 +108,21 @@ export default function ResourceDetailPage() {
       : t("detail.title");
     document.title = `${title} - Kagura Memory Cloud`;
   }, [resource, t]);
+
+  if (isPlanGated) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("list.title")} />
+        <EmptyState
+          icon={Database}
+          title={t("planGate.title")}
+          description={t("planGate.description")}
+          actionLabel={t("planGate.action")}
+          onAction={() => router.push("/workspace/settings/billing")}
+        />
+      </PageContainer>
+    );
+  }
 
   if (loading) {
     return (

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
@@ -22,6 +22,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useTabParam } from "@/hooks/useTabParam";
 import { listResources, type ResourceListItem } from "@/lib/api/resources";
 import { getSchema, type ResourceSchema } from "@/lib/api/schemas";
+import { ApiError } from "@/lib/api/base";
 import { ResourceStatsStrip } from "@/components/resources/ResourceStatsStrip";
 import { SchemaFieldTable } from "@/components/resources/SchemaFieldTable";
 import { ResourceDataTabPlaceholder } from "@/components/resources/ResourceDataTabPlaceholder";
@@ -77,10 +78,19 @@ export default function ResourceDetailPage() {
       }
       setResource(found);
 
-      // 404 from getSchema is expected when no schema has been registered yet.
-      setSchema(
-        schemaResult.status === "fulfilled" ? schemaResult.value : null,
-      );
+      // Schema is optional but only a 404 counts as "no schema yet"; other
+      // errors (auth, network, 5xx) should surface so we don't misleadingly
+      // show the "No schema registered" EmptyState while the server is broken.
+      if (schemaResult.status === "fulfilled") {
+        setSchema(schemaResult.value);
+      } else {
+        const err = schemaResult.reason;
+        if (err instanceof ApiError && err.status === 404) {
+          setSchema(null);
+        } else {
+          throw err;
+        }
+      }
     } catch (e) {
       setError(e instanceof Error ? e.message : t("detail.fetchError"));
     } finally {

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
@@ -35,7 +35,10 @@ const RESOURCE_TABS = ["overview", "data"] as const;
 export default function ResourceDetailPage() {
   const params = useParams();
   const router = useRouter();
-  const resourceId = decodeURIComponent(params.id as string);
+  // Next.js App Router's useParams() returns route segments already decoded —
+  // calling decodeURIComponent here is redundant and throws URIError on any
+  // legitimate literal `%` (e.g., an encoded `%25` becomes `%` after useParams).
+  const resourceId = params.id as string;
   const t = useTranslations("resources");
   const { currentWorkspace } = useWorkspace();
 

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
@@ -76,7 +76,10 @@ export default function ResourceDetailPage() {
         (r) => r.resource_id === resourceId,
       );
       if (!found) {
-        setError(t("detail.notFound"));
+        // Not-found is signalled by `resource === null` (leave `error` unset)
+        // so the render path renders `notFoundTitle` + the "not found" copy
+        // via the `error || t("detail.notFound")` ErrorBanner fallback, and
+        // `isFetchError` stays false for the PageHeader title branch.
         return;
       }
       setResource(found);

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
@@ -146,16 +146,22 @@ export default function ResourceDetailPage() {
   }
 
   if (error || !resource) {
+    // Separate "fetch failure" (server/network error) from "resource not found"
+    // (the workspace simply doesn't have this resource_id) so users don't see
+    // a misleading "Resource not found" banner on a 500.
+    const isFetchError = !!error;
     return (
       <PageContainer>
-        <PageHeader title={t("detail.notFoundTitle")} />
+        <PageHeader
+          title={isFetchError ? t("detail.title") : t("detail.notFoundTitle")}
+        />
         <ErrorBanner error={error || t("detail.notFound")} />
-        <Link href="/workspace/resources">
-          <Button variant="outline" className="mt-4">
+        <Button variant="outline" className="mt-4" asChild>
+          <Link href="/workspace/resources">
             <ArrowLeft className="h-4 w-4 mr-2" />
             {t("detail.backToList")}
-          </Button>
-        </Link>
+          </Link>
+        </Button>
       </PageContainer>
     );
   }

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+/**
+ * Resource Detail Page
+ *
+ * Two-tab layout (Overview = schema viewer, Data = #316 placeholder) plus a
+ * stats strip header. Follows the IA of workspace/contexts/[id]/page.tsx.
+ *
+ * Issue #47
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { ArrowLeft, ChevronRight, FileJson } from "lucide-react";
+import { PageContainer } from "@/components/common/PageContainer";
+import { PageHeader } from "@/components/common/PageHeader";
+import { SpinnerLoading } from "@/components/common/LoadingState";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useTabParam } from "@/hooks/useTabParam";
+import { listResources, type ResourceListItem } from "@/lib/api/resources";
+import { getSchema, type ResourceSchema } from "@/lib/api/schemas";
+import { ResourceStatsStrip } from "@/components/resources/ResourceStatsStrip";
+import { SchemaFieldTable } from "@/components/resources/SchemaFieldTable";
+import { ResourceDataTabPlaceholder } from "@/components/resources/ResourceDataTabPlaceholder";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+
+const RESOURCE_TABS = ["overview", "data"] as const;
+
+export default function ResourceDetailPage() {
+  const params = useParams();
+  const resourceId = decodeURIComponent(params.id as string);
+  const t = useTranslations("resources");
+
+  const [tab, setTab] = useTabParam("overview", "tab", RESOURCE_TABS);
+
+  const [resource, setResource] = useState<ResourceListItem | null>(null);
+  const [schema, setSchema] = useState<ResourceSchema | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchResource = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      // Parallel fetch: list (for the stats row) and schema (for the Overview tab)
+      // are independent. List-then-find is acceptable at < 50 rows/workspace; if
+      // that invariant breaks, replace with a dedicated /resources/{id} endpoint.
+      const [listResult, schemaResult] = await Promise.allSettled([
+        listResources(),
+        getSchema(resourceId),
+      ]);
+
+      if (listResult.status !== "fulfilled") {
+        throw listResult.reason;
+      }
+      const found = listResult.value.resources.find(
+        (r) => r.resource_id === resourceId,
+      );
+      if (!found) {
+        setError(t("detail.notFound"));
+        return;
+      }
+      setResource(found);
+
+      // 404 from getSchema is expected when no schema has been registered yet.
+      setSchema(
+        schemaResult.status === "fulfilled" ? schemaResult.value : null,
+      );
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("detail.fetchError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [resourceId, t]);
+
+  useEffect(() => {
+    fetchResource();
+  }, [fetchResource]);
+
+  useEffect(() => {
+    const title = resource
+      ? resource.context_display_name ||
+        resource.context_name ||
+        resource.resource_id
+      : t("detail.title");
+    document.title = `${title} - Kagura Memory Cloud`;
+  }, [resource, t]);
+
+  if (loading) {
+    return (
+      <PageContainer>
+        <SpinnerLoading size="lg" message={t("detail.loading")} />
+      </PageContainer>
+    );
+  }
+
+  if (error || !resource) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("detail.notFoundTitle")} />
+        <ErrorBanner error={error || t("detail.notFound")} />
+        <Link href="/workspace/resources">
+          <Button variant="outline" className="mt-4">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            {t("detail.backToList")}
+          </Button>
+        </Link>
+      </PageContainer>
+    );
+  }
+
+  const displayName =
+    resource.context_display_name ||
+    resource.context_name ||
+    resource.resource_id;
+
+  return (
+    <PageContainer>
+      {/* Breadcrumb */}
+      <nav className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 mb-4">
+        <Link
+          href="/workspace/resources"
+          className="hover:text-gray-900 dark:hover:text-gray-200 hover:underline"
+        >
+          {t("list.title")}
+        </Link>
+        <ChevronRight className="h-4 w-4" />
+        <span className="text-gray-900 dark:text-gray-100 font-mono">
+          {resource.resource_id}
+        </span>
+      </nav>
+
+      <PageHeader title={displayName} description={resource.resource_id} />
+
+      <div className="mb-6">
+        <ResourceStatsStrip resource={resource} />
+      </div>
+
+      <Tabs value={tab} onValueChange={setTab}>
+        <TabsList>
+          <TabsTrigger value="overview">{t("tabs.overview")}</TabsTrigger>
+          <TabsTrigger value="data">{t("tabs.data")}</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="overview" className="mt-6">
+          {schema ? (
+            <div className="space-y-4">
+              <div className="text-sm text-muted-foreground">
+                {t("schema.versionLabel", { version: schema.schema_version })}
+              </div>
+              <SchemaFieldTable fields={schema.field_definitions} />
+            </div>
+          ) : (
+            <EmptyState
+              icon={FileJson}
+              title={t("schema.emptyTitle")}
+              description={t("schema.emptyDescription")}
+            />
+          )}
+        </TabsContent>
+
+        <TabsContent value="data" className="mt-6">
+          <ResourceDataTabPlaceholder />
+        </TabsContent>
+      </Tabs>
+    </PageContainer>
+  );
+}

--- a/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
@@ -173,6 +173,21 @@ describe("ResourcesListPage", () => {
     });
   });
 
+  it("does not render the EmptyState 'No resources yet' copy on fetch error", async () => {
+    // Regression: resources=[] + error set used to render the ErrorBanner
+    // alongside the "No resources yet / Set one up" EmptyState, which
+    // misleadingly implied the workspace was empty rather than that the
+    // fetch had failed.
+    mockListResources.mockRejectedValue(new Error("backend offline"));
+
+    render(<ResourcesListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("list.emptyTitle")).not.toBeInTheDocument();
+  });
+
   it("renders an accessible Link per row for navigation (not a row click handler)", async () => {
     mockListResources.mockResolvedValue({
       resources: [item({ resource_id: "foo_bar" })],

--- a/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * Tests for the Resources list page.
+ *
+ * Verifies:
+ * - table rows render from listResources() response
+ * - empty-state renders when the response is empty
+ * - plan-gated workspaces see the upgrade CTA and never fire the fetch
+ * - the fetch is held until WorkspaceContext hydrates (no flash for free/basic)
+ * - errors render via ErrorBanner, not toast
+ * - row click navigates to detail page
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  cleanup,
+} from "@testing-library/react";
+
+import ResourcesListPage from "./page";
+import type { ResourceListItem } from "@/lib/api/resources";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockListResources = vi.fn();
+const mockPush = vi.fn();
+
+let mockCurrentWorkspace: { plan_name?: string } | null = null;
+
+vi.mock("@/lib/api/resources", () => ({
+  listResources: (...args: unknown[]) => mockListResources(...args),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => ({ currentWorkspace: mockCurrentWorkspace }),
+}));
+
+vi.mock("@/lib/utils/datetime", () => ({
+  formatRelativeTime: (iso: string) => `rel(${iso})`,
+}));
+
+// ---------- Fixtures ---------------------------------------------------------
+
+const item = (overrides: Partial<ResourceListItem> = {}): ResourceListItem => ({
+  resource_id: "ec_products",
+  context_id: "550e8400-e29b-41d4-a716-446655440000",
+  context_name: "ec-products",
+  context_display_name: "EC Products",
+  token_count: 2,
+  memory_count: 47,
+  current_schema_version: 3,
+  created_at: "2026-03-01T00:00:00Z",
+  updated_at: "2026-04-14T09:15:30Z",
+  ...overrides,
+});
+
+beforeEach(() => {
+  mockListResources.mockReset();
+  mockPush.mockReset();
+  mockCurrentWorkspace = { plan_name: "pro" };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("ResourcesListPage", () => {
+  it("renders table rows from listResources()", async () => {
+    mockListResources.mockResolvedValue({
+      resources: [
+        item(),
+        item({
+          resource_id: "other",
+          context_display_name: "Other",
+          current_schema_version: 5,
+        }),
+      ],
+      total: 2,
+    });
+
+    render(<ResourcesListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("ec_products")).toBeInTheDocument();
+    });
+    expect(screen.getByText("EC Products")).toBeInTheDocument();
+    expect(screen.getByText("other")).toBeInTheDocument();
+    expect(screen.getByText("v3")).toBeInTheDocument();
+    expect(screen.getByText("v5")).toBeInTheDocument();
+  });
+
+  it("renders empty state when the list is empty", async () => {
+    mockListResources.mockResolvedValue({ resources: [], total: 0 });
+
+    render(<ResourcesListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("list.emptyTitle")).toBeInTheDocument();
+    });
+    const link = screen.getByRole("link", { name: /list\.setupGuide/ });
+    expect(link.getAttribute("href")).toContain("kagura-ai/memory-cloud");
+  });
+
+  it("renders upgrade CTA and skips fetch on basic plan", async () => {
+    mockCurrentWorkspace = { plan_name: "basic" };
+
+    render(<ResourcesListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("planGate.title")).toBeInTheDocument();
+    });
+    expect(mockListResources).not.toHaveBeenCalled();
+  });
+
+  it("upgrade CTA button navigates to billing", async () => {
+    mockCurrentWorkspace = { plan_name: "free" };
+
+    render(<ResourcesListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("planGate.title")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: "planGate.action" }));
+    expect(mockPush).toHaveBeenCalledWith("/workspace/settings/billing");
+  });
+
+  it("holds the fetch until WorkspaceContext hydrates", async () => {
+    mockCurrentWorkspace = null;
+    mockListResources.mockResolvedValue({ resources: [], total: 0 });
+
+    render(<ResourcesListPage />);
+
+    // Yield microtasks — should still be pending because workspace is null
+    await Promise.resolve();
+    expect(mockListResources).not.toHaveBeenCalled();
+  });
+
+  it("renders ErrorBanner when fetch rejects", async () => {
+    mockListResources.mockRejectedValue(new Error("backend offline"));
+
+    render(<ResourcesListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent("backend offline");
+    });
+  });
+
+  it("navigates to detail page on row click", async () => {
+    mockListResources.mockResolvedValue({
+      resources: [item({ resource_id: "foo_bar" })],
+      total: 1,
+    });
+
+    render(<ResourcesListPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("foo_bar")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("foo_bar"));
+    expect(mockPush).toHaveBeenCalledWith("/workspace/resources/foo_bar");
+  });
+});

--- a/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
@@ -157,7 +157,7 @@ describe("ResourcesListPage", () => {
     });
   });
 
-  it("navigates to detail page on row click", async () => {
+  it("renders an accessible Link per row for navigation (not a row click handler)", async () => {
     mockListResources.mockResolvedValue({
       resources: [item({ resource_id: "foo_bar" })],
       total: 1,
@@ -168,7 +168,9 @@ describe("ResourcesListPage", () => {
     await waitFor(() => {
       expect(screen.getByText("foo_bar")).toBeInTheDocument();
     });
-    fireEvent.click(screen.getByText("foo_bar"));
-    expect(mockPush).toHaveBeenCalledWith("/workspace/resources/foo_bar");
+    // Anchor preserves browser affordances (open-in-new-tab, copy-link, etc.)
+    // that a row-level onClick cannot. role=link is the expected a11y semantic.
+    const link = screen.getByRole("link", { name: "foo_bar" });
+    expect(link).toHaveAttribute("href", "/workspace/resources/foo_bar");
   });
 });

--- a/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
@@ -39,10 +39,15 @@ vi.mock("next/navigation", () => ({
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
 }));
 
 vi.mock("@/contexts/WorkspaceContext", () => ({
   useWorkspace: () => ({ currentWorkspace: mockCurrentWorkspace }),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { timezone: "UTC" } }),
 }));
 
 vi.mock("@/lib/utils/datetime", () => ({

--- a/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
@@ -125,8 +125,8 @@ describe("ResourcesListPage", () => {
     await waitFor(() => {
       expect(screen.getByText("list.emptyTitle")).toBeInTheDocument();
     });
-    const link = screen.getByRole("link", { name: /list\.setupGuide/ });
-    expect(link.getAttribute("href")).toContain("kagura-ai/memory-cloud");
+    expect(screen.getByText("list.emptyDescription")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /setupGuide/i })).toBeNull();
   });
 
   it("renders upgrade CTA and skips fetch on basic plan", async () => {

--- a/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
@@ -37,8 +37,19 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
 }));
 
+// Stable translator — a fresh function on every render invalidates
+// useCallback([t]) in the component and turns an effect that depends on
+// that callback into a tight re-fetch loop (masquerades as flaky tests).
+// Cache per-namespace in module scope, same idea as the detail page test.
+const translatorCache = new Map<string, (k: string) => string>();
 vi.mock("next-intl", () => ({
-  useTranslations: () => (key: string) => key,
+  useTranslations: (ns?: string) => {
+    const key = ns ?? "";
+    if (!translatorCache.has(key)) {
+      translatorCache.set(key, (k: string) => k);
+    }
+    return translatorCache.get(key)!;
+  },
   useLocale: () => "en",
 }));
 

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -111,7 +111,10 @@ export default function ResourcesListPage() {
 
       {loading ? (
         <TableLoadingState rows={5} />
-      ) : resources.length === 0 ? (
+      ) : error ? null : resources.length === 0 ? (
+        // Empty state is reserved for "request succeeded, zero results" —
+        // suppress it when the fetch errored so the ErrorBanner above isn't
+        // paired with a misleading "Set one up" CTA.
         <EmptyState
           icon={Database}
           title={t("list.emptyTitle")}

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -11,6 +11,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
+import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { Database, ExternalLink } from "lucide-react";
 import { PageContainer } from "@/components/common/PageContainer";
@@ -76,12 +77,6 @@ export default function ResourcesListPage() {
     document.title = `${t("list.title")} - Kagura Memory Cloud`;
   }, [t]);
 
-  const handleRowClick = (resource: ResourceListItem) => {
-    router.push(
-      `/workspace/resources/${encodeURIComponent(resource.resource_id)}`,
-    );
-  };
-
   if (isPlanGated) {
     return (
       <PageContainer>
@@ -141,44 +136,48 @@ export default function ResourcesListPage() {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {resources.map((r) => (
-                <TableRow
-                  key={r.resource_id}
-                  className="cursor-pointer hover:bg-muted/50"
-                  onClick={() => handleRowClick(r)}
-                  role="button"
-                  tabIndex={0}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" || e.key === " ") {
-                      e.preventDefault();
-                      handleRowClick(r);
-                    }
-                  }}
-                >
-                  <TableCell className="font-mono text-sm">
-                    {r.resource_id}
-                  </TableCell>
-                  <TableCell>
-                    {r.context_display_name || r.context_name}
-                  </TableCell>
-                  <TableCell className="text-right">{r.token_count}</TableCell>
-                  <TableCell className="text-right">
-                    {r.memory_count.toLocaleString()}
-                  </TableCell>
-                  <TableCell>
-                    {r.current_schema_version !== null ? (
-                      <Badge variant="secondary">
-                        v{r.current_schema_version}
-                      </Badge>
-                    ) : (
-                      <span className="text-muted-foreground">—</span>
-                    )}
-                  </TableCell>
-                  <TableCell className="text-muted-foreground text-sm">
-                    {formatRelativeTime(r.updated_at)}
-                  </TableCell>
-                </TableRow>
-              ))}
+              {resources.map((r) => {
+                // Navigation is a <Link> inside the first cell rather than a
+                // click handler on the row itself — preserves <tr> table
+                // semantics for assistive tech, and enables browser affordances
+                // like middle-click / open-in-new-tab / copy-link-address.
+                const href = `/workspace/resources/${encodeURIComponent(
+                  r.resource_id,
+                )}`;
+                return (
+                  <TableRow key={r.resource_id} className="hover:bg-muted/50">
+                    <TableCell className="font-mono text-sm">
+                      <Link
+                        href={href}
+                        className="hover:underline focus:outline-none focus:ring-2 focus:ring-ring rounded"
+                      >
+                        {r.resource_id}
+                      </Link>
+                    </TableCell>
+                    <TableCell>
+                      {r.context_display_name || r.context_name}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {r.token_count}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {r.memory_count.toLocaleString()}
+                    </TableCell>
+                    <TableCell>
+                      {r.current_schema_version !== null ? (
+                        <Badge variant="secondary">
+                          v{r.current_schema_version}
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm">
+                      {formatRelativeTime(r.updated_at)}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
             </TableBody>
           </Table>
         </div>

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -40,6 +40,10 @@ export default function ResourcesListPage() {
   const { user } = useAuth();
   const locale = useLocale();
   const timezone = user?.timezone || "UTC";
+  // Route number formatting through next-intl locale so grouping rules match
+  // the selected UI language (e.g., 1,234 in en, 1,234 in ja for Latin digits
+  // but proper grouping semantics per locale).
+  const numberFormatter = new Intl.NumberFormat(locale);
 
   const [resources, setResources] = useState<ResourceListItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -162,10 +166,10 @@ export default function ResourcesListPage() {
                       {r.context_display_name || r.context_name}
                     </TableCell>
                     <TableCell className="text-right">
-                      {r.token_count}
+                      {numberFormatter.format(r.token_count)}
                     </TableCell>
                     <TableCell className="text-right">
-                      {r.memory_count.toLocaleString()}
+                      {numberFormatter.format(r.memory_count)}
                     </TableCell>
                     <TableCell>
                       {r.current_schema_version !== null ? (

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -14,7 +14,7 @@ import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useTranslations, useLocale } from "next-intl";
 import { useAuth } from "@/contexts/AuthContext";
-import { Database, ExternalLink } from "lucide-react";
+import { Database } from "lucide-react";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
 import { TableLoadingState } from "@/components/common/LoadingState";
@@ -119,16 +119,7 @@ export default function ResourcesListPage() {
           icon={Database}
           title={t("list.emptyTitle")}
           description={t("list.emptyDescription")}
-        >
-          <a
-            href="https://github.com/kagura-ai/memory-cloud/blob/main/docs/resources.md"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-4 inline-flex items-center gap-1.5 text-sm text-brand-green-600 hover:text-brand-green-700 dark:text-brand-green-400"
-          >
-            {t("list.setupGuide")} <ExternalLink className="h-3.5 w-3.5" />
-          </a>
-        </EmptyState>
+        />
       ) : (
         <div className="rounded-lg border bg-card">
           <Table>

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -12,7 +12,8 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
+import { useAuth } from "@/contexts/AuthContext";
 import { Database, ExternalLink } from "lucide-react";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
@@ -36,6 +37,9 @@ export default function ResourcesListPage() {
   const router = useRouter();
   const t = useTranslations("resources");
   const { currentWorkspace } = useWorkspace();
+  const { user } = useAuth();
+  const locale = useLocale();
+  const timezone = user?.timezone || "UTC";
 
   const [resources, setResources] = useState<ResourceListItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -173,7 +177,7 @@ export default function ResourcesListPage() {
                       )}
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm">
-                      {formatRelativeTime(r.updated_at)}
+                      {formatRelativeTime(r.updated_at, timezone, locale)}
                     </TableCell>
                   </TableRow>
                 );

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+/**
+ * Resources List Page
+ *
+ * Lists all resources in the current workspace with aggregated stats
+ * (token count, memory count, schema version, last activity).
+ *
+ * Issue #47
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
+import { Database, ExternalLink } from "lucide-react";
+import { PageContainer } from "@/components/common/PageContainer";
+import { PageHeader } from "@/components/common/PageHeader";
+import { TableLoadingState } from "@/components/common/LoadingState";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { formatRelativeTime } from "@/lib/utils/datetime";
+import { listResources, type ResourceListItem } from "@/lib/api/resources";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
+
+export default function ResourcesListPage() {
+  const router = useRouter();
+  const t = useTranslations("resources");
+  const { currentWorkspace } = useWorkspace();
+
+  const [resources, setResources] = useState<ResourceListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const planName = currentWorkspace?.plan_name;
+  // Wait for currentWorkspace to resolve before deciding on plan gating —
+  // otherwise we flash the loading skeleton and fire a spurious API call on
+  // the first render (before WorkspaceContext hydrates).
+  const workspaceReady = currentWorkspace !== null && planName !== undefined;
+  const isPlanGated =
+    workspaceReady && (planName === "free" || planName === "basic");
+
+  const fetchResources = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const res = await listResources();
+      setResources(res.resources);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : t("list.fetchError"));
+    } finally {
+      setLoading(false);
+    }
+  }, [t]);
+
+  useEffect(() => {
+    // Hold until the workspace context has hydrated; avoids a free/basic user
+    // issuing an authenticated round-trip before the CTA renders.
+    if (!workspaceReady) return;
+    if (isPlanGated) {
+      setLoading(false);
+      return;
+    }
+    fetchResources();
+  }, [fetchResources, isPlanGated, workspaceReady]);
+
+  useEffect(() => {
+    document.title = `${t("list.title")} - Kagura Memory Cloud`;
+  }, [t]);
+
+  const handleRowClick = (resource: ResourceListItem) => {
+    router.push(
+      `/workspace/resources/${encodeURIComponent(resource.resource_id)}`,
+    );
+  };
+
+  if (isPlanGated) {
+    return (
+      <PageContainer>
+        <PageHeader
+          title={t("list.title")}
+          description={t("list.description")}
+        />
+        <EmptyState
+          icon={Database}
+          title={t("planGate.title")}
+          description={t("planGate.description")}
+          actionLabel={t("planGate.action")}
+          onAction={() => router.push("/workspace/settings/billing")}
+        />
+      </PageContainer>
+    );
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader title={t("list.title")} description={t("list.description")} />
+
+      {error && <ErrorBanner error={error} />}
+
+      {loading ? (
+        <TableLoadingState rows={5} />
+      ) : resources.length === 0 ? (
+        <EmptyState
+          icon={Database}
+          title={t("list.emptyTitle")}
+          description={t("list.emptyDescription")}
+        >
+          <a
+            href="https://github.com/kagura-ai/memory-cloud/blob/main/docs/resources.md"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-4 inline-flex items-center gap-1.5 text-sm text-brand-green-600 hover:text-brand-green-700 dark:text-brand-green-400"
+          >
+            {t("list.setupGuide")} <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </EmptyState>
+      ) : (
+        <div className="rounded-lg border bg-card">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>{t("list.column.resourceId")}</TableHead>
+                <TableHead>{t("list.column.context")}</TableHead>
+                <TableHead className="text-right">
+                  {t("list.column.tokens")}
+                </TableHead>
+                <TableHead className="text-right">
+                  {t("list.column.memories")}
+                </TableHead>
+                <TableHead>{t("list.column.schema")}</TableHead>
+                <TableHead>{t("list.column.lastActivity")}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {resources.map((r) => (
+                <TableRow
+                  key={r.resource_id}
+                  className="cursor-pointer hover:bg-muted/50"
+                  onClick={() => handleRowClick(r)}
+                  role="button"
+                  tabIndex={0}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      handleRowClick(r);
+                    }
+                  }}
+                >
+                  <TableCell className="font-mono text-sm">
+                    {r.resource_id}
+                  </TableCell>
+                  <TableCell>
+                    {r.context_display_name || r.context_name}
+                  </TableCell>
+                  <TableCell className="text-right">{r.token_count}</TableCell>
+                  <TableCell className="text-right">
+                    {r.memory_count.toLocaleString()}
+                  </TableCell>
+                  <TableCell>
+                    {r.current_schema_version !== null ? (
+                      <Badge variant="secondary">
+                        v{r.current_schema_version}
+                      </Badge>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-muted-foreground text-sm">
+                    {formatRelativeTime(r.updated_at)}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </div>
+      )}
+    </PageContainer>
+  );
+}

--- a/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
+++ b/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
@@ -95,6 +95,12 @@ export function ResourceTokensTabPanel() {
   const searchParams = useSearchParams();
   const resourceIdFilter = searchParams.get("resource_id") || undefined;
 
+  // Reset pagination when the filter changes so a deep-link landing on page 2
+  // doesn't request an out-of-range offset on a smaller filtered result set.
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [resourceIdFilter]);
+
   // Load tokens on mount and page change
   useEffect(() => {
     if (!currentWorkspaceId) return;

--- a/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
+++ b/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useState } from "react";
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { Section } from "@/components/common/Section";
 import {
@@ -88,12 +89,19 @@ export function ResourceTokensTabPanel() {
   // Check if user is owner
   const isOwner = currentWorkspace?.current_user_role === "owner";
 
+  // Issue #47: Deep-link support — `?resource_id=<id>` pre-filters the token list.
+  // Passed through to the backend list endpoint; also gates the create dialog's
+  // initial resource selection.
+  const searchParams = useSearchParams();
+  const resourceIdFilter = searchParams.get("resource_id") || undefined;
+
   // Load tokens on mount and page change
   useEffect(() => {
     if (!currentWorkspaceId) return;
     if (!isOwner) return; // Skip loading if not owner
     loadTokens();
-  }, [currentWorkspaceId, currentPage, isOwner]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentWorkspaceId, currentPage, isOwner, resourceIdFilter]);
 
   const loadTokens = async () => {
     try {
@@ -101,7 +109,7 @@ export function ResourceTokensTabPanel() {
       setError(null);
       const offset = (currentPage - 1) * limit;
       const [tokensResponse, contextsData] = await Promise.all([
-        listResourceTokens(undefined, limit, offset),
+        listResourceTokens(resourceIdFilter, limit, offset),
         getContexts(),
       ]);
       // Handle paginated response
@@ -647,6 +655,7 @@ export function ResourceTokensTabPanel() {
             onClose={() => setShowCreateDialog(false)}
             onSuccess={handleCreateSuccess}
             currentTokens={tokens}
+            initialResourceId={resourceIdFilter}
           />
         )}
 

--- a/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
+++ b/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
@@ -8,7 +8,7 @@
 
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -95,16 +95,26 @@ export function ResourceTokensTabPanel() {
   const searchParams = useSearchParams();
   const resourceIdFilter = searchParams.get("resource_id") || undefined;
 
-  // Reset pagination when the filter changes so a deep-link landing on page 2
-  // doesn't request an out-of-range offset on a smaller filtered result set.
-  useEffect(() => {
-    setCurrentPage(1);
-  }, [resourceIdFilter]);
+  // Track the previous filter so we can detect an actual change and reset
+  // pagination within the same effect as the load. A separate reset effect
+  // would race with the load effect in the same commit and cause a duplicate
+  // fetch with the old offset before the reset takes effect.
+  const prevFilterRef = useRef(resourceIdFilter);
 
   // Load tokens on mount and page change
   useEffect(() => {
     if (!currentWorkspaceId) return;
     if (!isOwner) return; // Skip loading if not owner
+
+    // Filter change: reset pagination and skip this cycle's fetch —
+    // the setCurrentPage(1) will re-trigger this effect with the right offset.
+    if (prevFilterRef.current !== resourceIdFilter) {
+      prevFilterRef.current = resourceIdFilter;
+      if (currentPage !== 1) {
+        setCurrentPage(1);
+        return;
+      }
+    }
     loadTokens();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentWorkspaceId, currentPage, isOwner, resourceIdFilter]);

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -95,6 +95,11 @@ const navigationGroups: NavGroup[] = [
         showContextCount: true,
       },
       {
+        nameKey: "resources",
+        href: "/workspace/resources",
+        icon: Database,
+      },
+      {
         nameKey: "members",
         href: "/workspace/members",
         icon: Users,

--- a/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
+++ b/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
@@ -47,6 +47,8 @@ interface CreateResourceTokenDialogProps {
   onClose: () => void;
   onSuccess: () => void;
   currentTokens: ResourceToken[];
+  /** Issue #47: Pre-select this resource_id when opened via deep-link. */
+  initialResourceId?: string;
 }
 
 // Plan-based quota defaults and limits
@@ -61,6 +63,7 @@ export function CreateResourceTokenDialog({
   onClose,
   onSuccess,
   currentTokens,
+  initialResourceId,
 }: CreateResourceTokenDialogProps) {
   const t = useTranslations("resourceTokens");
   const { currentWorkspace } = useWorkspace();
@@ -79,7 +82,7 @@ export function CreateResourceTokenDialog({
   const quotaMax = Math.min(remainingQuota, maxPerToken); // Max for this token: min(remaining, 10000)
   const quotaDefault = Math.min(remainingQuota, maxPerToken); // Default: same as max
 
-  const [resourceId, setResourceId] = useState("");
+  const [resourceId, setResourceId] = useState(initialResourceId ?? "");
   const [description, setDescription] = useState("");
   const [quotaInput, setQuotaInput] = useState(quotaDefault.toString()); // Fixed: use quotaMax, not remainingQuota
   const [loading, setLoading] = useState(false);
@@ -98,8 +101,13 @@ export function CreateResourceTokenDialog({
   useEffect(() => {
     if (isOpen) {
       loadResourceContexts();
+      // Re-sync pre-selected resource_id each time the dialog opens so a
+      // deep-linked operator can open, close, and re-open without losing scope.
+      if (initialResourceId) {
+        setResourceId(initialResourceId);
+      }
     }
-  }, [isOpen]);
+  }, [isOpen, initialResourceId]);
 
   const loadResourceContexts = async () => {
     try {

--- a/frontend/src/components/resources/ResourceDataTabPlaceholder.test.tsx
+++ b/frontend/src/components/resources/ResourceDataTabPlaceholder.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * Tests for ResourceDataTabPlaceholder.
+ *
+ * Verifies:
+ * - EmptyState renders with placeholder copy
+ * - #316 follow-up link is present with correct URL
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ResourceDataTabPlaceholder } from "./ResourceDataTabPlaceholder";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("ResourceDataTabPlaceholder", () => {
+  it("renders placeholder title and description", () => {
+    render(<ResourceDataTabPlaceholder />);
+    expect(screen.getByText("comingSoonTitle")).toBeInTheDocument();
+    expect(screen.getByText("comingSoonDescription")).toBeInTheDocument();
+  });
+
+  it("links to follow-up issue #316", () => {
+    render(<ResourceDataTabPlaceholder />);
+    const link = screen.getByRole("link", { name: /trackProgress/ });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://github.com/kagura-ai/memory-cloud/issues/316",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/frontend/src/components/resources/ResourceDataTabPlaceholder.tsx
+++ b/frontend/src/components/resources/ResourceDataTabPlaceholder.tsx
@@ -1,0 +1,36 @@
+/**
+ * Resource Data tab placeholder.
+ *
+ * The Data browser (paginated ingested records + JSONB viewer) is tracked
+ * in the follow-up issue #316 for v0.13.0. This placeholder keeps the tab
+ * URL shape stable while the feature is pending.
+ *
+ * Issue #47 (placeholder) · Issue #316 (implementation)
+ */
+
+"use client";
+
+import { Database, ExternalLink } from "lucide-react";
+import { useTranslations } from "next-intl";
+import { EmptyState } from "@/components/ui/empty-state";
+
+export function ResourceDataTabPlaceholder() {
+  const t = useTranslations("resources.data");
+
+  return (
+    <EmptyState
+      icon={Database}
+      title={t("comingSoonTitle")}
+      description={t("comingSoonDescription")}
+    >
+      <a
+        href="https://github.com/kagura-ai/memory-cloud/issues/316"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="mt-4 inline-flex items-center gap-1.5 text-sm text-brand-green-600 hover:text-brand-green-700 dark:text-brand-green-400"
+      >
+        {t("trackProgress")} <ExternalLink className="h-3.5 w-3.5" />
+      </a>
+    </EmptyState>
+  );
+}

--- a/frontend/src/components/resources/ResourceStatsStrip.test.tsx
+++ b/frontend/src/components/resources/ResourceStatsStrip.test.tsx
@@ -15,6 +15,11 @@ import type { ResourceListItem } from "@/lib/api/resources";
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { timezone: "UTC" } }),
 }));
 
 vi.mock("@/lib/utils/datetime", () => ({

--- a/frontend/src/components/resources/ResourceStatsStrip.test.tsx
+++ b/frontend/src/components/resources/ResourceStatsStrip.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for ResourceStatsStrip.
+ *
+ * Verifies:
+ * - all four KpiCards render with expected values
+ * - "Manage" deep-link URL contains encoded resource_id
+ * - schema_version === null renders em-dash + "not registered" subtext
+ * - schema_version > 0 renders "v<version>"
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ResourceStatsStrip } from "./ResourceStatsStrip";
+import type { ResourceListItem } from "@/lib/api/resources";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/lib/utils/datetime", () => ({
+  formatRelativeTime: (iso: string) => `relative(${iso})`,
+}));
+
+const make = (overrides: Partial<ResourceListItem> = {}): ResourceListItem => ({
+  resource_id: "ec_products",
+  context_id: "550e8400-e29b-41d4-a716-446655440000",
+  context_name: "ec-products",
+  context_display_name: "EC Products",
+  token_count: 2,
+  memory_count: 47,
+  current_schema_version: 3,
+  created_at: "2026-03-01T00:00:00Z",
+  updated_at: "2026-04-14T09:15:30Z",
+  ...overrides,
+});
+
+describe("ResourceStatsStrip", () => {
+  it("renders token/memory counts and schema version", () => {
+    render(<ResourceStatsStrip resource={make()} />);
+    expect(screen.getByText("2")).toBeInTheDocument(); // token_count
+    expect(screen.getByText("47")).toBeInTheDocument(); // memory_count
+    expect(screen.getByText("v3")).toBeInTheDocument(); // schema version
+  });
+
+  it("links 'Manage' to credentials page with encoded resource_id", () => {
+    render(
+      <ResourceStatsStrip
+        resource={make({ resource_id: "has spaces/weird" })}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /stats\.manage/ });
+    expect(link).toHaveAttribute(
+      "href",
+      "/workspace/integrations/credentials?tab=resource-tokens&resource_id=has%20spaces%2Fweird",
+    );
+  });
+
+  it("renders em-dash and 'not registered' when no schema version exists", () => {
+    render(
+      <ResourceStatsStrip resource={make({ current_schema_version: null })} />,
+    );
+    expect(screen.getByText("—")).toBeInTheDocument();
+    expect(screen.getByText("stats.noSchemaYet")).toBeInTheDocument();
+  });
+
+  it("renders last-activity via formatRelativeTime", () => {
+    render(<ResourceStatsStrip resource={make()} />);
+    expect(
+      screen.getByText("relative(2026-04-14T09:15:30Z)"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/resources/ResourceStatsStrip.tsx
+++ b/frontend/src/components/resources/ResourceStatsStrip.tsx
@@ -31,13 +31,18 @@ export function ResourceStatsStrip({ resource }: ResourceStatsStripProps) {
     resource.resource_id,
   )}`;
 
+  // Route number formatting through the app's next-intl locale so grouping /
+  // decimal rules match the UI (KpiCard's default toLocaleString() picks the
+  // runtime default locale, which can diverge from the operator's selection).
+  const numberFormatter = new Intl.NumberFormat(locale);
+
   return (
     <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
       <div className="relative">
         <KpiCard
           icon={Key}
           label={t("stats.activeTokens")}
-          value={resource.token_count}
+          value={numberFormatter.format(resource.token_count)}
         />
         <Link
           href={tokensHref}
@@ -50,7 +55,7 @@ export function ResourceStatsStrip({ resource }: ResourceStatsStripProps) {
       <KpiCard
         icon={Database}
         label={t("stats.memories")}
-        value={resource.memory_count}
+        value={numberFormatter.format(resource.memory_count)}
       />
 
       <KpiCard

--- a/frontend/src/components/resources/ResourceStatsStrip.tsx
+++ b/frontend/src/components/resources/ResourceStatsStrip.tsx
@@ -1,0 +1,74 @@
+/**
+ * Resource Stats Strip
+ *
+ * Always-visible header metrics for the Resource Detail page.
+ * Sits between PageHeader and the Tabs block.
+ *
+ * Issue #47
+ */
+
+"use client";
+
+import { Key, Database, FileJson, Clock } from "lucide-react";
+import { useTranslations } from "next-intl";
+import Link from "next/link";
+import { KpiCard } from "@/components/ui/kpi-card";
+import { formatRelativeTime } from "@/lib/utils/datetime";
+import type { ResourceListItem } from "@/lib/api/resources";
+
+interface ResourceStatsStripProps {
+  resource: ResourceListItem;
+}
+
+export function ResourceStatsStrip({ resource }: ResourceStatsStripProps) {
+  const t = useTranslations("resources");
+
+  const tokensHref = `/workspace/integrations/credentials?tab=resource-tokens&resource_id=${encodeURIComponent(
+    resource.resource_id,
+  )}`;
+
+  return (
+    <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+      <div className="relative">
+        <KpiCard
+          icon={Key}
+          label={t("stats.activeTokens")}
+          value={resource.token_count}
+        />
+        <Link
+          href={tokensHref}
+          className="absolute right-3 top-3 text-xs text-muted-foreground hover:text-foreground focus:outline-none focus:ring-2 focus:ring-ring rounded"
+        >
+          {t("stats.manage")}
+        </Link>
+      </div>
+
+      <KpiCard
+        icon={Database}
+        label={t("stats.memories")}
+        value={resource.memory_count}
+      />
+
+      <KpiCard
+        icon={FileJson}
+        label={t("stats.schemaVersion")}
+        value={
+          resource.current_schema_version !== null
+            ? `v${resource.current_schema_version}`
+            : "—"
+        }
+        subtext={
+          resource.current_schema_version === null
+            ? t("stats.noSchemaYet")
+            : undefined
+        }
+      />
+
+      <KpiCard
+        icon={Clock}
+        label={t("stats.lastActivity")}
+        value={formatRelativeTime(resource.updated_at)}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/resources/ResourceStatsStrip.tsx
+++ b/frontend/src/components/resources/ResourceStatsStrip.tsx
@@ -10,10 +10,11 @@
 "use client";
 
 import { Key, Database, FileJson, Clock } from "lucide-react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import Link from "next/link";
 import { KpiCard } from "@/components/ui/kpi-card";
 import { formatRelativeTime } from "@/lib/utils/datetime";
+import { useAuth } from "@/contexts/AuthContext";
 import type { ResourceListItem } from "@/lib/api/resources";
 
 interface ResourceStatsStripProps {
@@ -22,6 +23,9 @@ interface ResourceStatsStripProps {
 
 export function ResourceStatsStrip({ resource }: ResourceStatsStripProps) {
   const t = useTranslations("resources");
+  const locale = useLocale();
+  const { user } = useAuth();
+  const timezone = user?.timezone || "UTC";
 
   const tokensHref = `/workspace/integrations/credentials?tab=resource-tokens&resource_id=${encodeURIComponent(
     resource.resource_id,
@@ -67,7 +71,7 @@ export function ResourceStatsStrip({ resource }: ResourceStatsStripProps) {
       <KpiCard
         icon={Clock}
         label={t("stats.lastActivity")}
-        value={formatRelativeTime(resource.updated_at)}
+        value={formatRelativeTime(resource.updated_at, timezone, locale)}
       />
     </div>
   );

--- a/frontend/src/components/resources/SchemaFieldTable.test.tsx
+++ b/frontend/src/components/resources/SchemaFieldTable.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * Tests for SchemaFieldTable.
+ *
+ * Verifies:
+ * - renders a row per field definition
+ * - classification badge variant reflects classification value (pii/confidential → destructive)
+ * - required field shows the "required" badge
+ * - unit annotation renders below the field name
+ * - empty index_hint renders em-dash
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { SchemaFieldTable } from "./SchemaFieldTable";
+import type { FieldDefinition } from "@/lib/api/schemas";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const f = (overrides: Partial<FieldDefinition> = {}): FieldDefinition => ({
+  name: "product_name",
+  type: "text",
+  description: "商品名",
+  classification: "public",
+  index_hint: "fulltext",
+  required: false,
+  ...overrides,
+});
+
+describe("SchemaFieldTable", () => {
+  it("renders one row per field", () => {
+    render(
+      <SchemaFieldTable
+        fields={[
+          f({ name: "title" }),
+          f({ name: "price", type: "number" }),
+          f({ name: "active", type: "boolean" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("title")).toBeInTheDocument();
+    expect(screen.getByText("price")).toBeInTheDocument();
+    expect(screen.getByText("active")).toBeInTheDocument();
+  });
+
+  it("shows required badge only for required fields", () => {
+    render(
+      <SchemaFieldTable
+        fields={[
+          f({ name: "mandatory", required: true }),
+          f({ name: "optional", required: false }),
+        ]}
+      />,
+    );
+    const badges = screen.getAllByText("required");
+    expect(badges).toHaveLength(1);
+    const mandatoryRow = screen.getByText("mandatory").closest("tr");
+    expect(mandatoryRow).not.toBeNull();
+    expect(
+      within(mandatoryRow as HTMLElement).getByText("required"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders classification as visible text", () => {
+    render(
+      <SchemaFieldTable
+        fields={[
+          f({ name: "open", classification: "public" }),
+          f({ name: "private_id", classification: "pii" }),
+          f({ name: "secret", classification: "confidential" }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("public")).toBeInTheDocument();
+    expect(screen.getByText("pii")).toBeInTheDocument();
+    expect(screen.getByText("confidential")).toBeInTheDocument();
+  });
+
+  it("renders em-dash when index_hint is empty", () => {
+    render(
+      <SchemaFieldTable fields={[f({ name: "no_hint", index_hint: "" })]} />,
+    );
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("renders unit annotation when unit is provided", () => {
+    render(
+      <SchemaFieldTable
+        fields={[f({ name: "price", type: "number", unit: "JPY" })]}
+      />,
+    );
+    expect(screen.getByText("JPY")).toBeInTheDocument();
+  });
+
+  it("handles empty fields list without errors", () => {
+    render(<SchemaFieldTable fields={[]} />);
+    expect(screen.getByText("field")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/resources/SchemaFieldTable.tsx
+++ b/frontend/src/components/resources/SchemaFieldTable.tsx
@@ -1,0 +1,98 @@
+/**
+ * Schema Field Table
+ *
+ * Renders a resource's field_definitions as a table.
+ * Used inside the Overview tab of the Resource Detail page.
+ *
+ * Issue #47
+ */
+
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import type { FieldDefinition } from "@/lib/api/schemas";
+
+interface SchemaFieldTableProps {
+  fields: FieldDefinition[];
+}
+
+function classificationVariant(
+  classification: FieldDefinition["classification"],
+): "default" | "secondary" | "destructive" | "outline" {
+  switch (classification) {
+    case "pii":
+    case "confidential":
+      return "destructive";
+    case "internal":
+      return "secondary";
+    case "public":
+    default:
+      return "outline";
+  }
+}
+
+export function SchemaFieldTable({ fields }: SchemaFieldTableProps) {
+  const t = useTranslations("resources.schema");
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{t("field")}</TableHead>
+            <TableHead>{t("type")}</TableHead>
+            <TableHead>{t("classification")}</TableHead>
+            <TableHead>{t("indexHint")}</TableHead>
+            <TableHead>{t("description")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {fields.map((field) => (
+            <TableRow key={field.name}>
+              <TableCell className="font-mono text-sm">
+                <div className="flex items-center gap-2">
+                  <span>{field.name}</span>
+                  {field.required && (
+                    <Badge variant="outline" className="text-xs">
+                      {t("required")}
+                    </Badge>
+                  )}
+                </div>
+                {field.unit && (
+                  <div className="text-xs text-muted-foreground mt-0.5">
+                    {field.unit}
+                  </div>
+                )}
+              </TableCell>
+              <TableCell>
+                <Badge variant="secondary" className="font-mono">
+                  {field.type}
+                </Badge>
+              </TableCell>
+              <TableCell>
+                <Badge variant={classificationVariant(field.classification)}>
+                  {field.classification}
+                </Badge>
+              </TableCell>
+              <TableCell className="font-mono text-xs text-muted-foreground">
+                {field.index_hint || "—"}
+              </TableCell>
+              <TableCell className="text-sm text-muted-foreground">
+                {field.description}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/resources.ts
+++ b/frontend/src/lib/api/resources.ts
@@ -1,0 +1,40 @@
+/**
+ * Workspace Resource List Client
+ *
+ * Issue #47 — Web UI for resource management.
+ *
+ * Companion to schemas.ts (per-resource impact + schema) and
+ * resource-tokens.ts (token CRUD). This module owns only the
+ * workspace-scoped list endpoint.
+ */
+
+import { apiClient } from "./base";
+
+/** Single row in the workspace resource list. */
+export interface ResourceListItem {
+  resource_id: string;
+  context_id: string;
+  context_name: string;
+  context_display_name: string | null;
+  token_count: number;
+  memory_count: number;
+  current_schema_version: number | null;
+  /** ISO 8601 UTC — context creation time. */
+  created_at: string;
+  /** ISO 8601 UTC — max(context.updated_at, last_event_at). */
+  updated_at: string;
+}
+
+/** Response from GET /api/v1/resources. */
+export interface ResourceListResponse {
+  resources: ResourceListItem[];
+  total: number;
+}
+
+/**
+ * List all resources in the caller's current workspace.
+ * Ordered by most recent activity first.
+ */
+export async function listResources(): Promise<ResourceListResponse> {
+  return apiClient.get<ResourceListResponse>("/api/v1/resources");
+}

--- a/frontend/src/lib/api/resources.ts
+++ b/frontend/src/lib/api/resources.ts
@@ -21,7 +21,7 @@ export interface ResourceListItem {
   current_schema_version: number | null;
   /** ISO 8601 UTC — context creation time. */
   created_at: string;
-  /** ISO 8601 UTC — max(context.updated_at, last_event_at). */
+  /** ISO 8601 UTC — max(last_event_at, context.updated_at, context.created_at). */
   updated_at: string;
 }
 

--- a/frontend/src/lib/api/schemas.ts
+++ b/frontend/src/lib/api/schemas.ts
@@ -5,17 +5,17 @@
  * Issue #243 - Schema Management UI (Web-based)
  */
 
-import { apiClient } from './base';
+import { apiClient } from "./base";
 
 /**
  * Validation error keys for type safety
  * High Priority Fix: Added type-safe validation error keys
  */
 export type ValidationErrorKey =
-  | 'fieldNameRequired'
-  | 'fieldNamePattern'
-  | 'fieldNameTooLong'
-  | 'descriptionRequired';
+  | "fieldNameRequired"
+  | "fieldNamePattern"
+  | "fieldNameTooLong"
+  | "descriptionRequired";
 
 /**
  * Field Definition interface
@@ -23,9 +23,9 @@ export type ValidationErrorKey =
  */
 export interface FieldDefinition {
   name: string;
-  type: 'text' | 'number' | 'boolean' | 'date' | 'array' | 'object';
+  type: "text" | "number" | "boolean" | "date" | "array" | "object";
   description: string;
-  classification: 'public' | 'internal' | 'pii' | 'confidential';
+  classification: "public" | "internal" | "pii" | "confidential";
   index_hint: string;
   unit?: string | null;
   enum_values?: string[] | null;
@@ -70,16 +70,19 @@ export interface SchemaCreateRequest {
  */
 export async function getSchema(
   resourceId: string,
-  schemaVersion?: number
+  schemaVersion?: number,
 ): Promise<ResourceSchema> {
   const searchParams = new URLSearchParams();
   if (schemaVersion) {
-    searchParams.set('schema_version', schemaVersion.toString());
+    searchParams.set("schema_version", schemaVersion.toString());
   }
 
+  // encodeURIComponent protects against reserved chars in resource_id
+  // (e.g., a literal `%` or `/`) that would otherwise break the path.
+  const encodedId = encodeURIComponent(resourceId);
   const url = searchParams.toString()
-    ? `/api/v1/resources/${resourceId}/schema?${searchParams.toString()}`
-    : `/api/v1/resources/${resourceId}/schema`;
+    ? `/api/v1/resources/${encodedId}/schema?${searchParams.toString()}`
+    : `/api/v1/resources/${encodedId}/schema`;
 
   return apiClient.get<ResourceSchema>(url);
 }
@@ -90,8 +93,12 @@ export async function getSchema(
  *
  * @param resourceId - Resource identifier
  */
-export async function getResourceImpact(resourceId: string): Promise<ResourceImpact> {
-  return apiClient.get<ResourceImpact>(`/api/v1/resources/${resourceId}/impact`);
+export async function getResourceImpact(
+  resourceId: string,
+): Promise<ResourceImpact> {
+  return apiClient.get<ResourceImpact>(
+    `/api/v1/resources/${encodeURIComponent(resourceId)}/impact`,
+  );
 }
 
 /**
@@ -102,12 +109,15 @@ export async function getResourceImpact(resourceId: string): Promise<ResourceImp
  */
 export async function createSchema(
   resourceId: string,
-  fieldDefinitions: FieldDefinition[]
+  fieldDefinitions: FieldDefinition[],
 ): Promise<ResourceSchema> {
-  return apiClient.post<ResourceSchema>(`/api/v1/resources/${resourceId}/schema`, {
-    resource_id: resourceId,
-    field_definitions: fieldDefinitions,
-  });
+  return apiClient.post<ResourceSchema>(
+    `/api/v1/resources/${encodeURIComponent(resourceId)}/schema`,
+    {
+      resource_id: resourceId,
+      field_definitions: fieldDefinitions,
+    },
+  );
 }
 
 /**
@@ -115,11 +125,11 @@ export async function createSchema(
  */
 export function getEmptyField(): FieldDefinition {
   return {
-    name: '',
-    type: 'text',
-    description: '',
-    classification: 'public',
-    index_hint: '',
+    name: "",
+    type: "text",
+    description: "",
+    classification: "public",
+    index_hint: "",
     unit: null,
     enum_values: null,
     example: null,
@@ -133,16 +143,16 @@ export function getEmptyField(): FieldDefinition {
  */
 export function validateFieldName(name: string): ValidationErrorKey | null {
   if (!name.trim()) {
-    return 'fieldNameRequired';
+    return "fieldNameRequired";
   }
 
   const pattern = /^[a-z0-9_]+$/;
   if (!pattern.test(name)) {
-    return 'fieldNamePattern';
+    return "fieldNamePattern";
   }
 
   if (name.length > 100) {
-    return 'fieldNameTooLong';
+    return "fieldNameTooLong";
   }
 
   return null;
@@ -153,7 +163,9 @@ export function validateFieldName(name: string): ValidationErrorKey | null {
  */
 export function findDuplicateFieldNames(fields: FieldDefinition[]): string[] {
   const names = fields.map((f) => f.name.trim()).filter((n) => n.length > 0);
-  const duplicates = names.filter((name, index) => names.indexOf(name) !== index);
+  const duplicates = names.filter(
+    (name, index) => names.indexOf(name) !== index,
+  );
   return [...new Set(duplicates)];
 }
 
@@ -161,8 +173,13 @@ export function findDuplicateFieldNames(fields: FieldDefinition[]): string[] {
  * Helper: Validate all fields
  * Returns translation keys for error messages (type-safe where possible)
  */
-export function validateFields(fields: FieldDefinition[]): Record<number, Record<string, ValidationErrorKey | string>> {
-  const errors: Record<number, Record<string, ValidationErrorKey | string>> = {};
+export function validateFields(
+  fields: FieldDefinition[],
+): Record<number, Record<string, ValidationErrorKey | string>> {
+  const errors: Record<
+    number,
+    Record<string, ValidationErrorKey | string>
+  > = {};
 
   fields.forEach((field, index) => {
     const fieldErrors: Record<string, ValidationErrorKey | string> = {};
@@ -173,7 +190,7 @@ export function validateFields(fields: FieldDefinition[]): Record<number, Record
     }
 
     if (!field.description.trim()) {
-      fieldErrors.description = 'descriptionRequired' as ValidationErrorKey;
+      fieldErrors.description = "descriptionRequired" as ValidationErrorKey;
     }
 
     if (Object.keys(fieldErrors).length > 0) {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2687,7 +2687,6 @@
       "description": "Resources ingested into this workspace via external systems.",
       "emptyTitle": "No resources yet",
       "emptyDescription": "This workspace has no resources. Set one up via the MCP tool setup_resource() or the Python SDK, then refresh this page.",
-      "setupGuide": "Setup guide",
       "fetchError": "Failed to load resources.",
       "column": {
         "resourceId": "Resource ID",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2724,7 +2724,7 @@
       "classification": "Classification",
       "indexHint": "Index hint",
       "description": "Description",
-      "required": "required",
+      "required": "Required",
       "versionLabel": "Current schema version: v{version}",
       "emptyTitle": "No schema registered",
       "emptyDescription": "This resource does not have a schema yet. Use the REST API or MCP tools to register field definitions."

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -46,6 +46,7 @@
     "dashboard": "Dashboard",
     "contexts": "Contexts",
     "contextsWithCount": "Contexts ({count})",
+    "resources": "Resources",
     "members": "Members",
     "membersWithCount": "Members ({count})",
     "integrations": "Integrations",
@@ -2679,5 +2680,64 @@
     "copied": "Copied!",
     "copyFailed": "Failed to copy",
     "deleteFailed": "Failed to delete context"
+  },
+  "resources": {
+    "list": {
+      "title": "Resources",
+      "description": "Resources ingested into this workspace via external systems.",
+      "emptyTitle": "No resources yet",
+      "emptyDescription": "This workspace has no resources. Set one up via the MCP tool setup_resource() or the Python SDK, then refresh this page.",
+      "setupGuide": "Setup guide",
+      "fetchError": "Failed to load resources.",
+      "column": {
+        "resourceId": "Resource ID",
+        "context": "Context",
+        "tokens": "Tokens",
+        "memories": "Memories",
+        "schema": "Schema",
+        "lastActivity": "Last activity"
+      }
+    },
+    "detail": {
+      "title": "Resource",
+      "loading": "Loading resource…",
+      "notFoundTitle": "Resource not found",
+      "notFound": "This resource does not exist in your workspace, or has been removed.",
+      "fetchError": "Failed to load resource details.",
+      "backToList": "Back to resources"
+    },
+    "tabs": {
+      "overview": "Overview",
+      "data": "Data"
+    },
+    "stats": {
+      "activeTokens": "Active tokens",
+      "memories": "Memories",
+      "schemaVersion": "Schema",
+      "noSchemaYet": "Not registered",
+      "lastActivity": "Last activity",
+      "manage": "Manage"
+    },
+    "schema": {
+      "field": "Field",
+      "type": "Type",
+      "classification": "Classification",
+      "indexHint": "Index hint",
+      "description": "Description",
+      "required": "required",
+      "versionLabel": "Current schema version: v{version}",
+      "emptyTitle": "No schema registered",
+      "emptyDescription": "This resource does not have a schema yet. Use the REST API or MCP tools to register field definitions."
+    },
+    "data": {
+      "comingSoonTitle": "Data browser coming soon",
+      "comingSoonDescription": "Paginated record viewer with schema-driven key-value display and raw JSON pane. Planned for v0.13.0.",
+      "trackProgress": "Track progress on #316"
+    },
+    "planGate": {
+      "title": "Resources require Pro plan",
+      "description": "Resource setup and ingestion are available on Pro and higher plans. Upgrade to unlock Web UI visibility, MCP resource tools, and ingestion quotas.",
+      "action": "Upgrade to Pro"
+    }
   }
 }

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -46,6 +46,7 @@
     "dashboard": "ダッシュボード",
     "contexts": "コンテキスト",
     "contextsWithCount": "コンテキスト ({count})",
+    "resources": "リソース",
     "members": "メンバー",
     "membersWithCount": "メンバー ({count})",
     "integrations": "インテグレーション",
@@ -2679,5 +2680,64 @@
     "copied": "コピーしました！",
     "copyFailed": "コピーに失敗しました",
     "deleteFailed": "コンテキストの削除に失敗しました"
+  },
+  "resources": {
+    "list": {
+      "title": "リソース",
+      "description": "外部システムからこのワークスペースへ ingest されたリソース。",
+      "emptyTitle": "リソースがまだありません",
+      "emptyDescription": "このワークスペースにはリソースが設定されていません。MCPツール setup_resource() または Python SDK から作成後、このページを更新してください。",
+      "setupGuide": "セットアップガイド",
+      "fetchError": "リソース一覧の取得に失敗しました。",
+      "column": {
+        "resourceId": "Resource ID",
+        "context": "コンテキスト",
+        "tokens": "トークン",
+        "memories": "メモリ",
+        "schema": "スキーマ",
+        "lastActivity": "最終アクティビティ"
+      }
+    },
+    "detail": {
+      "title": "リソース",
+      "loading": "リソースを読み込み中…",
+      "notFoundTitle": "リソースが見つかりません",
+      "notFound": "このリソースはワークスペースに存在しないか、削除されています。",
+      "fetchError": "リソース詳細の取得に失敗しました。",
+      "backToList": "リソース一覧へ戻る"
+    },
+    "tabs": {
+      "overview": "概要",
+      "data": "データ"
+    },
+    "stats": {
+      "activeTokens": "有効トークン",
+      "memories": "メモリ数",
+      "schemaVersion": "スキーマ",
+      "noSchemaYet": "未登録",
+      "lastActivity": "最終アクティビティ",
+      "manage": "管理"
+    },
+    "schema": {
+      "field": "フィールド",
+      "type": "型",
+      "classification": "分類",
+      "indexHint": "インデックスヒント",
+      "description": "説明",
+      "required": "必須",
+      "versionLabel": "現在のスキーマバージョン: v{version}",
+      "emptyTitle": "スキーマ未登録",
+      "emptyDescription": "このリソースにはまだスキーマが登録されていません。REST API または MCP ツールからフィールド定義を登録してください。"
+    },
+    "data": {
+      "comingSoonTitle": "データブラウザは近日公開",
+      "comingSoonDescription": "スキーマ連動の key-value 表示 + raw JSON ペインによるページネーション付き記録ビューア。v0.13.0 で提供予定です。",
+      "trackProgress": "#316 で進捗を確認"
+    },
+    "planGate": {
+      "title": "リソース機能は Pro プラン必須",
+      "description": "リソースのセットアップと ingest は Pro 以上のプランで利用可能です。アップグレードして Web UI 可視化、MCP リソースツール、ingest クォータを解放しましょう。",
+      "action": "Pro にアップグレード"
+    }
   }
 }

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2687,7 +2687,6 @@
       "description": "外部システムからこのワークスペースへ ingest されたリソース。",
       "emptyTitle": "リソースがまだありません",
       "emptyDescription": "このワークスペースにはリソースが設定されていません。MCPツール setup_resource() または Python SDK から作成後、このページを更新してください。",
-      "setupGuide": "セットアップガイド",
       "fetchError": "リソース一覧の取得に失敗しました。",
       "column": {
         "resourceId": "リソースID",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2690,7 +2690,7 @@
       "setupGuide": "セットアップガイド",
       "fetchError": "リソース一覧の取得に失敗しました。",
       "column": {
-        "resourceId": "Resource ID",
+        "resourceId": "リソースID",
         "context": "コンテキスト",
         "tokens": "トークン",
         "memories": "メモリ",


### PR DESCRIPTION
Closes #47

## Summary
- Add Web UI for resource management: list page `/workspace/resources` + detail page `/workspace/resources/[id]` with stats strip + schema viewer
- New backend endpoint `GET /api/v1/resources` (workspace-scoped list with aggregated token/memory/schema/last-event stats via correlated subqueries)
- Deep-link from Resource Detail → credentials page for token CRUD (single source of truth, not duplicated)
- Scope per gate1 design review: P3 data browser moved to follow-up #316 for v0.13.0

## Implementation notes
- **Backend** (`backend/src/api/routes/resources.py`): single SQL with 4 correlated subqueries; `ORDER BY` references `text("last_event_at")` alias to avoid re-emitting scalar_subquery. `user.get("current_workspace_id")` reuses auth-injected value. Returns `{resources: [...], total: N}` with 3-tier `updated_at` fallback (`last_event_at → context.updated_at → created_at`).
- **Frontend detail page**: Pill Tabs `["overview", "data"]` with `useTabParam` (matches `workspace/contexts/[id]` IA). `Promise.allSettled` for parallel `listResources()` + `getSchema()`. `workspaceReady` guard prevents spurious fetch before `WorkspaceContext` hydrates.
- **Plan gate**: Pro plan only. Basic/Free see `EmptyState` upgrade CTA → `/workspace/settings/billing`.
- **Deep-link**: `ResourceTokensTabPanel` honors `?resource_id=` (pre-filters list + pre-selects `CreateResourceTokenDialog` via new `initialResourceId` prop).
- **Testing**: 25 new vitest tests (125 → 150). 7 xfail backend placeholders using `strict=True` (matches `test_resource_tokens.py` pattern; XPASS will force marker removal when fixtures land).

## Pre-PR review summary
- gate2 mode: advisor-only (binary_gate null)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (resolved by in-PR issue body revision + filing #316)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/47-feat-feat-ui-add-resource-data-viewer-schema.gate1.md
- ~/.claude/cache/gh-issue-driven/47-feat-feat-ui-add-resource-data-viewer-schema.gate2.md

🤖 Generated via /gh-issue-driven:ship

