### PR TITLE
fix(security): ingest-time workspace boundary + partial UNIQUE (#322)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,12 @@
 
 Release notes are published on [GitHub Releases](https://github.com/kagura-ai/memory-cloud/releases).
 
+## [Unreleased] v0.12.0 — Resource Foundation (security-driven)
+
+### Security
+- **Critical (OWASP A01 / CWE-639)**: Fixed cross-tenant memory injection via Resource Ingest API (#322, parent epic #321). All self-hosted deployments with Resource Ingest enabled must upgrade. See `SECURITY.md` for the advisory and upgrade steps.
+
+### Database
+- Added migration `a96`: global partial UNIQUE index `ux_contexts_resource_id_active` on `contexts(resource_id)` for active rows. Zero-downtime (`CREATE INDEX CONCURRENTLY`). Aborts if pre-existing cross-workspace `resource_id` collisions are detected — operators must resolve duplicates before upgrading.
+
 ## [v0.11.1](https://github.com/kagura-ai/memory-cloud/releases/tag/v0.11.1) — 2026-04-12

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,3 +66,40 @@ All Qdrant vector searches and PostgreSQL queries include isolation filters.
 - Context names validated against `^[a-z0-9_-]+$`
 - Request body validation via Pydantic models
 - UUID format validation on all ID parameters
+
+## Security Advisories
+
+### 2026-04-14 — Cross-tenant Resource ingest (fixed in v0.12.0)
+
+**Severity**: Critical (OWASP A01: Broken Access Control / CWE-639: Authorization Bypass Through User-Controlled Key)
+**Affected versions**: all pre-v0.12.0 deployments with Resource Ingest enabled (Issue #238 onward).
+**Discovered during**: internal design audit (#322 parent epic #321).
+
+#### Description
+
+The Resource Ingest API (`POST /api/v1/resources/{resource_id}/events`) authenticated tokens by `(token_hash, resource_id)` only and never verified that the token's creator was a member of the workspace whose Context owned that `resource_id`. Because `contexts.resource_id` had no global uniqueness constraint, two workspaces could legitimately create Contexts with the same `resource_id` string. An authenticated attacker (self-signup + PRO plan) could then:
+
+1. Create a Context in their own workspace with the same `resource_id` as a victim's Context
+2. Obtain a Resource Token for that `resource_id` (the existing per-workspace CRUD check allowed this)
+3. Send ingest events that the victim's indexer would consume and write into the victim's memory store
+
+#### Remediation (v0.12.0)
+
+1. **Ingest-path workspace boundary**: `verify_resource_token` now enforces `WorkspaceMember.user_id == ResourceToken.created_by AND WorkspaceMember.workspace_id == Context.workspace_id`. Mismatches return 403 and emit a `cross_tenant_ingest_attempt` structured warning log.
+2. **Schema-level tenant isolation**: Alembic migration `a96` adds a global partial UNIQUE index `ux_contexts_resource_id_active ON contexts (resource_id) WHERE resource_id IS NOT NULL AND deleted_at IS NULL`. Cross-workspace `resource_id` collisions are now impossible at the database level.
+3. **Audit logging**: Structured warnings are emitted for unbound resources, missing token attribution, and membership violations. No raw token material is ever logged — only the integer `token_id` (DB PK), the workspace UUIDs, and the request's client IP.
+
+#### Upgrade steps for self-hosted operators
+
+1. Before upgrading, run the collision audit query to detect pre-existing cross-workspace duplicates:
+   ```sql
+   SELECT resource_id, COUNT(DISTINCT workspace_id) AS ws_count
+   FROM contexts
+   WHERE resource_id IS NOT NULL AND deleted_at IS NULL
+   GROUP BY resource_id
+   HAVING COUNT(DISTINCT workspace_id) > 1;
+   ```
+2. If rows are returned, rename one side of each collision (`UPDATE contexts SET resource_id = ... WHERE id = ...`) before upgrading. The `a96` migration will abort if any active collisions remain.
+3. Run `make migrate` (or your standard Alembic upgrade step). `a96` uses `CREATE UNIQUE INDEX CONCURRENTLY` and does not hold a table lock.
+4. Restart API containers to pick up the updated `verify_resource_token` dependency.
+5. Monitor logs for `cross_tenant_ingest_attempt` warnings — ongoing hits indicate either active exploit attempts or legitimate callers whose token attribution needs review.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,15 +91,17 @@ The Resource Ingest API (`POST /api/v1/resources/{resource_id}/events`) authenti
 
 #### Upgrade steps for self-hosted operators
 
-1. Before upgrading, run the collision audit query to detect pre-existing cross-workspace duplicates:
+1. Before upgrading, run the collision audit query to detect any pre-existing active duplicates that would block the new UNIQUE index. Because the index is global on `resource_id` for active rows, **both same-workspace and cross-workspace duplicates** would abort the migration, so the query must match the index predicate with `COUNT(*) > 1`:
    ```sql
-   SELECT resource_id, COUNT(DISTINCT workspace_id) AS ws_count
+   SELECT resource_id,
+          COUNT(*) AS active_count,
+          COUNT(DISTINCT workspace_id) AS ws_count
    FROM contexts
    WHERE resource_id IS NOT NULL AND deleted_at IS NULL
    GROUP BY resource_id
-   HAVING COUNT(DISTINCT workspace_id) > 1;
+   HAVING COUNT(*) > 1;
    ```
-2. If rows are returned, rename one side of each collision (`UPDATE contexts SET resource_id = ... WHERE id = ...`) before upgrading. The `a96` migration will abort if any active collisions remain.
+2. If rows are returned, resolve each active duplicate (`UPDATE contexts SET resource_id = ... WHERE id = ...`) before upgrading. The `a96` migration will abort if any active duplicates remain.
 3. Run `make migrate` (or your standard Alembic upgrade step). `a96` uses `CREATE UNIQUE INDEX CONCURRENTLY` and does not hold a table lock.
 4. Restart API containers to pick up the updated `verify_resource_token` dependency.
 5. Monitor logs for `cross_tenant_ingest_attempt` warnings — ongoing hits indicate either active exploit attempts or legitimate callers whose token attribution needs review.

--- a/backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py
+++ b/backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py
@@ -42,50 +42,57 @@ def upgrade() -> None:
     would otherwise skip the CREATE and leave the database without the
     security boundary this migration is meant to establish.
     """
-    # Step 1: Abort if active cross-workspace collisions exist.
+    # Step 1: Abort if any active duplicate resource_id values exist.
+    # The partial UNIQUE index is global on resource_id, so duplicates
+    # within the same workspace would also fail the CREATE INDEX step.
+    # Using COUNT(*) > 1 keeps the audit aligned with the index predicate.
     # Operators must rename or remove duplicates before this migration
     # (see SECURITY.md for remediation steps).
     bind = op.get_bind()
     result = bind.execute(
         sa.text(
-            "SELECT resource_id, COUNT(DISTINCT workspace_id) AS ws_count "
+            "SELECT resource_id, COUNT(*) AS duplicate_count "
             "FROM contexts "
             "WHERE resource_id IS NOT NULL AND deleted_at IS NULL "
             "GROUP BY resource_id "
-            "HAVING COUNT(DISTINCT workspace_id) > 1 "
+            "HAVING COUNT(*) > 1 "
             "LIMIT :limit"
         ),
         {"limit": _MAX_COLLISION_EXAMPLES},
     )
     collisions = result.fetchall()
     if collisions:
-        examples = ", ".join(f"'{row[0]}' ({row[1]} workspaces)" for row in collisions)
+        examples = ", ".join(f"'{row[0]}' ({row[1]} active rows)" for row in collisions)
         raise RuntimeError(
-            "Migration aborted: resource_id collisions found across "
-            f"workspaces (examples: {examples}). Rename or remove "
-            "duplicates before running this migration. See SECURITY.md "
-            "for remediation steps."
+            "Migration aborted: duplicate active resource_id values found "
+            f"that would violate the global unique index (examples: {examples}). "
+            "Rename or remove duplicates before running this migration. "
+            "See SECURITY.md for remediation steps."
         )
+
+    # Check for a prior INVALID index from Python side — PostgreSQL forbids
+    # DROP INDEX CONCURRENTLY inside DO / function bodies, so the INVALID
+    # detection must live out here where it can issue a plain DDL next.
+    invalid_index_result = bind.execute(
+        sa.text(
+            "SELECT 1 "
+            "FROM pg_class c "
+            "JOIN pg_index i ON i.indexrelid = c.oid "
+            "WHERE c.relname = :index_name "
+            "AND NOT i.indisvalid "
+            "LIMIT 1"
+        ),
+        {"index_name": INDEX_NAME},
+    )
+    has_invalid_index = invalid_index_result.fetchone() is not None
 
     # autocommit_block lets us issue DDL outside Alembic's transaction so
     # CONCURRENTLY is accepted.
     with op.get_context().autocommit_block():
         # INVALID indexes from a prior failed CONCURRENTLY run would bypass
         # the IF NOT EXISTS check on CREATE and leave us unprotected.
-        op.execute(
-            sa.text(
-                "DO $$ BEGIN "
-                "IF EXISTS ("
-                "  SELECT 1 FROM pg_class c "
-                "  JOIN pg_index i ON i.indexrelid = c.oid "
-                "  WHERE c.relname = 'ux_contexts_resource_id_active' "
-                "  AND NOT i.indisvalid"
-                ") THEN "
-                "  EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS ux_contexts_resource_id_active'; "
-                "END IF; "
-                "END $$;"
-            )
-        )
+        if has_invalid_index:
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}"))
         op.execute(
             sa.text(
                 "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "

--- a/backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py
+++ b/backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py
@@ -1,0 +1,97 @@
+"""Add global partial UNIQUE index on contexts.resource_id for active rows.
+
+Issue #322: Zero-downtime hotfix — enforce resource_id uniqueness across
+all workspaces for active (non-soft-deleted) contexts. Closes the routing
+ambiguity that enabled cross-tenant Resource ingest (OWASP A01 / CWE-639).
+
+Revision ID: a96_unique_contexts_resource_id_active
+Revises: a95_source_uri_declared_link
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a96_unique_contexts_resource_id_active"
+down_revision = "a95_source_uri_declared_link"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "ux_contexts_resource_id_active"
+# Cap collision examples in the abort message: enough to give the operator
+# actionable context without spamming the logs on a wide collision.
+_MAX_COLLISION_EXAMPLES = 5
+
+
+def upgrade() -> None:
+    """Add a global partial UNIQUE index on contexts.resource_id.
+
+    Guarantees every active (non-deleted) context row with a non-null
+    resource_id is globally unique, so Resource ingest can resolve a
+    resource_id to exactly one workspace.
+
+    CREATE INDEX CONCURRENTLY cannot run inside a transaction, so we wrap
+    the DDL in Alembic's autocommit_block. A prior INVALID index (from a
+    partial failure) is explicitly dropped first, because IF NOT EXISTS
+    would otherwise skip the CREATE and leave the database without the
+    security boundary this migration is meant to establish.
+    """
+    # Step 1: Abort if active cross-workspace collisions exist.
+    # Operators must rename or remove duplicates before this migration
+    # (see SECURITY.md for remediation steps).
+    bind = op.get_bind()
+    result = bind.execute(
+        sa.text(
+            "SELECT resource_id, COUNT(DISTINCT workspace_id) AS ws_count "
+            "FROM contexts "
+            "WHERE resource_id IS NOT NULL AND deleted_at IS NULL "
+            "GROUP BY resource_id "
+            "HAVING COUNT(DISTINCT workspace_id) > 1 "
+            "LIMIT :limit"
+        ),
+        {"limit": _MAX_COLLISION_EXAMPLES},
+    )
+    collisions = result.fetchall()
+    if collisions:
+        examples = ", ".join(f"'{row[0]}' ({row[1]} workspaces)" for row in collisions)
+        raise RuntimeError(
+            "Migration aborted: resource_id collisions found across "
+            f"workspaces (examples: {examples}). Rename or remove "
+            "duplicates before running this migration. See SECURITY.md "
+            "for remediation steps."
+        )
+
+    # autocommit_block lets us issue DDL outside Alembic's transaction so
+    # CONCURRENTLY is accepted.
+    with op.get_context().autocommit_block():
+        # INVALID indexes from a prior failed CONCURRENTLY run would bypass
+        # the IF NOT EXISTS check on CREATE and leave us unprotected.
+        op.execute(
+            sa.text(
+                "DO $$ BEGIN "
+                "IF EXISTS ("
+                "  SELECT 1 FROM pg_class c "
+                "  JOIN pg_index i ON i.indexrelid = c.oid "
+                "  WHERE c.relname = 'ux_contexts_resource_id_active' "
+                "  AND NOT i.indisvalid"
+                ") THEN "
+                "  EXECUTE 'DROP INDEX CONCURRENTLY IF EXISTS ux_contexts_resource_id_active'; "
+                "END IF; "
+                "END $$;"
+            )
+        )
+        op.execute(
+            sa.text(
+                "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ux_contexts_resource_id_active "
+                "ON contexts (resource_id) "
+                "WHERE resource_id IS NOT NULL AND deleted_at IS NULL"
+            )
+        )
+
+
+def downgrade() -> None:
+    """Drop the partial unique index (tolerant of missing/invalid state)."""
+    op.execute(sa.text("DROP INDEX IF EXISTS ux_contexts_resource_id_active"))

--- a/backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py
+++ b/backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py
@@ -95,8 +95,7 @@ def upgrade() -> None:
             op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}"))
         op.execute(
             sa.text(
-                "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "
-                "ux_contexts_resource_id_active "
+                f"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {INDEX_NAME} "
                 "ON contexts (resource_id) "
                 "WHERE resource_id IS NOT NULL AND deleted_at IS NULL"
             )
@@ -104,5 +103,10 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Drop the partial unique index (tolerant of missing/invalid state)."""
-    op.execute(sa.text("DROP INDEX IF EXISTS ux_contexts_resource_id_active"))
+    """Drop the partial unique index concurrently (zero-downtime parity)."""
+    # Mirror the upgrade path: DROP INDEX CONCURRENTLY is also forbidden
+    # inside a transaction, so we use autocommit_block here too. IF EXISTS
+    # keeps the downgrade tolerant of partially-applied or already-rolled-
+    # back state.
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}"))

--- a/backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py
+++ b/backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py
@@ -4,8 +4,12 @@ Issue #322: Zero-downtime hotfix — enforce resource_id uniqueness across
 all workspaces for active (non-soft-deleted) contexts. Closes the routing
 ambiguity that enabled cross-tenant Resource ingest (OWASP A01 / CWE-639).
 
-Revision ID: a96_unique_contexts_resource_id_active
+Revision ID: a96_ctx_resource_id_unique
 Revises: a95_source_uri_declared_link
+
+NOTE: The revision ID is kept under 32 characters because
+`alembic_version.version_num` is `VARCHAR(32)` in this database
+(asyncpg raises `StringDataRightTruncationError` otherwise).
 """
 
 import sqlalchemy as sa
@@ -13,7 +17,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "a96_unique_contexts_resource_id_active"
+revision = "a96_ctx_resource_id_unique"
 down_revision = "a95_source_uri_declared_link"
 branch_labels = None
 depends_on = None

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -7,13 +7,14 @@ Provides endpoints for external systems (EC inventory, etc.) to push events.
 
 from __future__ import annotations
 
-from fastapi import APIRouter, Depends, Header, HTTPException, status
+from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.resource_tokens import ResourceTokenManager
 from db.base import get_db
+from models.auth import Context
 from models.resource import ResourceEvent, ResourceToken
 from models.schemas import (
     ResourceEventBatchRequest,
@@ -21,6 +22,7 @@ from models.schemas import (
     ResourceEventRequest,
     ResourceEventResponse,
 )
+from services.permission_service import PermissionService
 from utils.datetime import utcnow
 from utils.exceptions import ConflictError, RateLimitError, ValidationError
 from utils.logger import get_logger
@@ -40,21 +42,21 @@ MAX_PAYLOAD_SIZE_BYTES = 100_000
 
 async def verify_resource_token(
     resource_id: str,
+    request: Request,
     x_resource_api_key: str | None = Header(None, alias="X-Resource-API-Key"),
     db: AsyncSession = Depends(get_db),
-) -> tuple[ResourceToken, int]:
-    """Verify resource token and return (token_record, quota).
+) -> tuple[ResourceToken, int, Context]:
+    """Verify resource token and enforce workspace boundary.
 
-    Args:
-        resource_id: Resource ID from path parameter
-        x_resource_api_key: Resource API token from header
-        db: Database session
+    See SECURITY.md (2026-04-14 advisory) for the threat model.
 
     Returns:
-        Tuple of (token_record, quota_events_per_hour)
+        (token_record, quota_events_per_hour, context)
 
     Raises:
-        HTTPException: 401 if token is invalid/revoked
+        HTTPException 401: missing/invalid/revoked token
+        HTTPException 403: token creator is not a member of the Context's workspace
+        HTTPException 404: resource_id is not bound to any active Context
     """
     if not x_resource_api_key:
         raise HTTPException(
@@ -62,7 +64,6 @@ async def verify_resource_token(
             detail="X-Resource-API-Key header required",
         )
 
-    # Verify token
     manager = ResourceTokenManager(db)
     token_record = await manager.verify_token(x_resource_api_key, resource_id)
 
@@ -72,7 +73,114 @@ async def verify_resource_token(
             detail="Invalid or revoked resource token",
         )
 
-    return token_record, token_record.quota_events_per_hour
+    context = await _resolve_authoritative_context(db, resource_id)
+    if context is None:
+        logger.warning(
+            "resource_id_unbound_on_ingest",
+            resource_id=resource_id,
+            token_id=token_record.id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Resource is not bound to an active context",
+        )
+
+    await _enforce_workspace_membership(db, request, token_record, context)
+
+    return token_record, token_record.quota_events_per_hour, context
+
+
+async def _resolve_authoritative_context(
+    db: AsyncSession,
+    resource_id: str,
+) -> Context | None:
+    """Return the single active Context for resource_id, if any.
+
+    After migration a96, the partial UNIQUE index
+    ``ux_contexts_resource_id_active`` guarantees at most one active row
+    per resource_id. This helper defends against the window before that
+    migration runs: if pre-existing cross-workspace collisions are still
+    in the table, we fail closed (409) rather than silently picking one
+    row or bubbling an opaque 500.
+
+    Returns:
+        Single active Context, or None if no match.
+
+    Raises:
+        HTTPException 409: multiple active contexts share the resource_id
+            (only reachable pre-migration; run a96 to eliminate).
+    """
+    result = await db.execute(
+        select(Context).where(
+            Context.resource_id == resource_id,
+            Context.deleted_at.is_(None),
+        )
+    )
+    rows = result.scalars().all()
+    if not rows:
+        return None
+    if len(rows) > 1:
+        logger.warning(
+            "resource_id_ambiguous_on_ingest",
+            resource_id=resource_id,
+            match_count=len(rows),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "resource_id is ambiguous across workspaces — contact an "
+                "administrator to resolve the collision."
+            ),
+        )
+    return rows[0]
+
+
+async def _enforce_workspace_membership(
+    db: AsyncSession,
+    request: Request,
+    token_record: ResourceToken,
+    context: Context,
+) -> None:
+    """Reject ingest unless token creator is a member of context's workspace.
+
+    Uses ``PermissionService.is_workspace_member`` — the canonical
+    durable membership check (``WorkspaceMember`` row lookup). Does NOT
+    use ``User.current_workspace_id``, which is a mutable UI preference
+    and cannot be trusted for authorization.
+    """
+    if not token_record.created_by:
+        logger.warning(
+            "resource_ingest_missing_token_creator",
+            resource_id=context.resource_id,
+            token_id=token_record.id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Token is missing creator attribution and cannot be authorized.",
+        )
+
+    permissions = PermissionService(db)
+    is_member = await permissions.is_workspace_member(
+        user_id=token_record.created_by,
+        workspace_id=context.workspace_id,
+    )
+
+    if not is_member:
+        logger.warning(
+            "cross_tenant_ingest_attempt",
+            resource_id=context.resource_id,
+            token_id=token_record.id,
+            target_workspace_id=str(context.workspace_id),
+            token_creator=token_record.created_by,
+            client_ip=request.client.host if request.client else None,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Resource ingest denied: the token's creator is not a member "
+                "of the workspace that owns this resource."
+            ),
+        )
 
 
 # ============================================================================
@@ -88,7 +196,7 @@ async def verify_resource_token(
 async def ingest_event(
     resource_id: str,
     request: ResourceEventRequest,
-    auth: tuple = Depends(verify_resource_token),
+    auth: tuple[ResourceToken, int, Context] = Depends(verify_resource_token),
     db: AsyncSession = Depends(get_db),
 ):
     """Ingest a single resource event (upsert or delete).
@@ -128,7 +236,8 @@ async def ingest_event(
         - 422: Validation error (e.g., missing payload for upsert)
         - 429: Quota exceeded
     """
-    token_record, quota_per_hour = auth
+    # Context is resolved and workspace-verified in the dependency — always non-None here.
+    token_record, quota_per_hour, context = auth
 
     logger.info(
         "resource_event_ingest_started",
@@ -153,36 +262,7 @@ async def ingest_event(
                 detail=f"Payload too large: {payload_size} bytes (max {MAX_PAYLOAD_SIZE_BYTES})",
             )
 
-    # 3. SECURITY: Verify Context-Resource binding BEFORE creating event
-    # Issue #271 Code Review C-3: Validate before insert (avoid rollback)
-    from models.auth import Context, User
-
-    context_result = await db.execute(
-        select(Context).where(Context.resource_id == resource_id, Context.deleted_at.is_(None))
-    )
-    context = context_result.scalar_one_or_none()
-
-    if context and token_record.created_by:
-        # Get token creator's workspace
-        user_result = await db.execute(
-            select(User.current_workspace_id).where(User.user_id == token_record.created_by)
-        )
-        user_workspace_id = user_result.scalar_one_or_none()
-
-        # Verify context belongs to same workspace as token creator
-        if user_workspace_id and context.workspace_id != user_workspace_id:
-            logger.warning(
-                "resource_ingest_workspace_boundary_violation_prevented",
-                resource_id=resource_id,
-                context_workspace_id=str(context.workspace_id),
-                token_creator_org_id=str(user_workspace_id),
-            )
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Context-Resource binding validation failed. This resource is bound to a context in a different workspace.",
-            )
-
-    # 4. Create event record
+    # 3. Create event record
     try:
         event = ResourceEvent(
             resource_id=resource_id,
@@ -207,11 +287,10 @@ async def ingest_event(
             doc_id=request.doc_id,
         )
 
-        # 5. Schedule indexer run (find all contexts using this resource)
+        # 4. Schedule indexer run (find all contexts using this resource)
         await _schedule_indexer_for_resource(db, resource_id)
 
-        # 6. Log usage statistics (Issue #242)
-        # Context was already fetched in step 3 for validation
+        # 5. Log usage statistics (Issue #242)
         from utils.usage_logger import log_usage
 
         await log_usage(
@@ -221,8 +300,8 @@ async def ingest_event(
             method="POST",
             status_code=201,
             response_time_ms=None,
-            context_id=str(context.id) if context else None,  # Bugfix: Add context_id
-            workspace_id=str(context.workspace_id) if context else None,  # Bugfix: Add workspace_id
+            context_id=str(context.id),
+            workspace_id=str(context.workspace_id),
         )
 
         return ResourceEventResponse(
@@ -282,7 +361,7 @@ async def ingest_event(
 async def ingest_batch(
     resource_id: str,
     request: ResourceEventBatchRequest,
-    auth: tuple = Depends(verify_resource_token),
+    auth: tuple[ResourceToken, int, Context] = Depends(verify_resource_token),
     db: AsyncSession = Depends(get_db),
 ):
     """Ingest multiple resource events in a single request.
@@ -316,10 +395,13 @@ async def ingest_batch(
 
     Errors:
         - 401: Invalid/revoked token
+        - 403: Cross-tenant ingest blocked (Issue #322)
+        - 404: Resource not bound to an active Context
         - 422: Validation error (max 100 events)
         - 429: Quota exceeded
     """
-    token_record, quota_per_hour = auth
+    # Context is resolved and workspace-verified in the dependency — always non-None here.
+    token_record, quota_per_hour, context = auth
 
     logger.info(
         "resource_batch_ingest_started",
@@ -444,6 +526,8 @@ async def ingest_batch(
             method="POST",
             status_code=201,
             response_time_ms=None,
+            context_id=str(context.id),
+            workspace_id=str(context.workspace_id),
         )
 
     logger.info(

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -57,6 +57,8 @@ async def verify_resource_token(
         HTTPException 401: missing/invalid/revoked token
         HTTPException 403: token creator is not a member of the Context's workspace
         HTTPException 404: resource_id is not bound to any active Context
+        HTTPException 409: resource_id is ambiguous across active Context bindings
+            (only reachable pre-migration; see `_resolve_authoritative_context`)
     """
     if not x_resource_api_key:
         raise HTTPException(
@@ -128,8 +130,9 @@ async def _resolve_authoritative_context(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail=(
-                "resource_id is ambiguous across workspaces — contact an "
-                "administrator to resolve the collision."
+                "resource_id is ambiguous — multiple active contexts share "
+                "this identifier. Contact an administrator to resolve the "
+                "collision."
             ),
         )
     return rows[0]

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -112,11 +112,15 @@ async def _resolve_authoritative_context(
         HTTPException 409: multiple active contexts share the resource_id
             (only reachable pre-migration; run a96 to eliminate).
     """
+    # LIMIT 2 is enough to distinguish 0 / 1 / ambiguous — we do not need to
+    # know how many total duplicates exist, just that there are at least two.
     result = await db.execute(
-        select(Context).where(
+        select(Context)
+        .where(
             Context.resource_id == resource_id,
             Context.deleted_at.is_(None),
         )
+        .limit(2)
     )
     rows = result.scalars().all()
     if not rows:
@@ -144,12 +148,16 @@ async def _enforce_workspace_membership(
     token_record: ResourceToken,
     context: Context,
 ) -> None:
-    """Reject ingest unless token creator is a member of context's workspace.
+    """Reject ingest unless token creator has active workspace access.
 
-    Uses ``PermissionService.is_workspace_member`` — the canonical
-    durable membership check (``WorkspaceMember`` row lookup). Does NOT
-    use ``User.current_workspace_id``, which is a mutable UI preference
-    and cannot be trusted for authorization.
+    Uses ``PermissionService.check_workspace_access`` which enforces:
+    (a) the workspace exists and is not soft-deleted, and
+    (b) the token creator is still a ``WorkspaceMember``.
+    ``is_workspace_member`` was insufficient because it skipped (a) —
+    a deleted workspace would have left ingest open on lingering tokens.
+
+    Does NOT use ``User.current_workspace_id``, which is a mutable UI
+    preference and cannot be trusted for authorization.
     """
     if not token_record.created_by:
         logger.warning(
@@ -163,12 +171,16 @@ async def _enforce_workspace_membership(
         )
 
     permissions = PermissionService(db)
-    is_member = await permissions.is_workspace_member(
-        user_id=token_record.created_by,
-        workspace_id=context.workspace_id,
-    )
-
-    if not is_member:
+    try:
+        await permissions.check_workspace_access(
+            user_id=token_record.created_by,
+            workspace_id=context.workspace_id,
+            required_role="member",
+        )
+    except HTTPException as auth_error:
+        # `reason` captures the underlying cause (workspace deleted /
+        # non-member / role-too-low) for forensics without re-leaking the
+        # detail to the caller.
         logger.warning(
             "cross_tenant_ingest_attempt",
             resource_id=context.resource_id,
@@ -176,14 +188,15 @@ async def _enforce_workspace_membership(
             target_workspace_id=str(context.workspace_id),
             token_creator=token_record.created_by,
             client_ip=request.client.host if request.client else None,
+            reason=auth_error.detail,
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=(
-                "Resource ingest denied: the token's creator is not a member "
-                "of the workspace that owns this resource."
+                "Resource ingest denied: the token's creator does not have "
+                "active access to the workspace that owns this resource."
             ),
-        )
+        ) from auth_error
 
 
 # ============================================================================

--- a/backend/tests/api/test_resource_ingest.py
+++ b/backend/tests/api/test_resource_ingest.py
@@ -251,8 +251,8 @@ class TestResourceIngestWorkspaceBoundary:
     ):
         db = MagicMock()
         with patch(
-            "services.permission_service.PermissionService.is_workspace_member",
-            new=AsyncMock(return_value=True),
+            "services.permission_service.PermissionService.check_workspace_access",
+            new=AsyncMock(return_value=MagicMock()),
         ):
             # Should not raise.
             await _enforce_workspace_membership(db, mock_request, mock_token, mock_context)
@@ -261,12 +261,18 @@ class TestResourceIngestWorkspaceBoundary:
     async def test_membership_denied_logs_cross_tenant_attempt(
         self, mock_request, mock_token, mock_context
     ):
-        """Attacker token (non-member) must be rejected with audit warning."""
+        """Attacker token (non-member) must be rejected with audit warning.
+        The log's `reason` kwarg carries the underlying auth failure detail
+        for forensics."""
         db = MagicMock()
+        auth_error = HTTPException(
+            status_code=403,
+            detail="Not a member of workspace " + str(mock_context.workspace_id),
+        )
         with (
             patch(
-                "services.permission_service.PermissionService.is_workspace_member",
-                new=AsyncMock(return_value=False),
+                "services.permission_service.PermissionService.check_workspace_access",
+                new=AsyncMock(side_effect=auth_error),
             ),
             patch("api.routes.resource_ingest.logger") as mock_logger,
         ):
@@ -281,7 +287,33 @@ class TestResourceIngestWorkspaceBoundary:
                 target_workspace_id=str(mock_context.workspace_id),
                 token_creator=mock_token.created_by,
                 client_ip="203.0.113.7",
+                reason=auth_error.detail,
             )
+
+    @pytest.mark.asyncio
+    async def test_membership_denied_when_workspace_soft_deleted(
+        self, mock_request, mock_token, mock_context
+    ):
+        """Soft-deleted workspace must deny ingest — the prior is_workspace_member
+        check silently allowed this. `check_workspace_access` now catches it."""
+        db = MagicMock()
+        soft_deleted_error = HTTPException(
+            status_code=403,
+            detail=f"Workspace {mock_context.workspace_id} not found or has been deleted",
+        )
+        with (
+            patch(
+                "services.permission_service.PermissionService.check_workspace_access",
+                new=AsyncMock(side_effect=soft_deleted_error),
+            ),
+            patch("api.routes.resource_ingest.logger") as mock_logger,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await _enforce_workspace_membership(db, mock_request, mock_token, mock_context)
+
+            assert exc.value.status_code == 403
+            call_kwargs = mock_logger.warning.call_args.kwargs
+            assert "deleted" in call_kwargs["reason"]
 
     @pytest.mark.asyncio
     async def test_membership_denied_without_request_client(self, mock_token, mock_context):
@@ -289,10 +321,11 @@ class TestResourceIngestWorkspaceBoundary:
         req = MagicMock()
         req.client = None
         db = MagicMock()
+        auth_error = HTTPException(status_code=403, detail="Not a member")
         with (
             patch(
-                "services.permission_service.PermissionService.is_workspace_member",
-                new=AsyncMock(return_value=False),
+                "services.permission_service.PermissionService.check_workspace_access",
+                new=AsyncMock(side_effect=auth_error),
             ),
             patch("api.routes.resource_ingest.logger") as mock_logger,
         ):

--- a/backend/tests/api/test_resource_ingest.py
+++ b/backend/tests/api/test_resource_ingest.py
@@ -1,14 +1,22 @@
 """Tests for Resource Ingest API.
 
 Issue #238: Resource-driven incremental indexing.
+Issue #322: Workspace boundary enforcement on ingest (security hotfix).
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 
-from api.routes.resource_ingest import _check_event_quota
+from api.routes.resource_ingest import (
+    _check_event_quota,
+    _enforce_workspace_membership,
+    _resolve_authoritative_context,
+)
 from auth.resource_tokens import ResourceTokenManager
+from models.auth import Context
 from models.resource import ResourceToken
 from models.schemas import ResourceEventRequest
 from utils.exceptions import RateLimitError
@@ -151,3 +159,167 @@ class TestResourceEventIdempotency:
         """Test that duplicate idempotency_key returns existing event (idempotent)."""
         # This would be an integration test
         pass  # TODO: Implement after integration test setup
+
+
+def _mock_db_scalars(values):
+    """Build a mock async DB session whose single execute() returns `values`
+    from `.scalars().all()`. Accepts an empty list, one item, or many.
+    """
+    scalars_obj = MagicMock()
+    scalars_obj.all = MagicMock(return_value=list(values))
+    result = MagicMock()
+    result.scalars = MagicMock(return_value=scalars_obj)
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+class TestResourceIngestWorkspaceBoundary:
+    """Workspace boundary enforcement in verify_resource_token (security hotfix)."""
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def mock_context(self, workspace_id):
+        ctx = MagicMock(spec=Context)
+        ctx.id = uuid4()
+        ctx.resource_id = "acme"
+        ctx.workspace_id = workspace_id
+        ctx.deleted_at = None
+        return ctx
+
+    @pytest.fixture
+    def mock_token(self):
+        token = MagicMock(spec=ResourceToken)
+        token.id = 42
+        token.resource_id = "acme"
+        token.created_by = "user_owner"
+        token.is_active = True
+        return token
+
+    @pytest.fixture
+    def mock_request(self):
+        request = MagicMock()
+        request.client.host = "203.0.113.7"
+        return request
+
+    # --- _resolve_authoritative_context ----------------------------------
+
+    @pytest.mark.asyncio
+    async def test_resolve_context_returns_single_active_match(self, mock_context):
+        db = _mock_db_scalars([mock_context])
+        got = await _resolve_authoritative_context(db, "acme")
+        assert got is mock_context
+
+    @pytest.mark.asyncio
+    async def test_resolve_context_returns_none_when_unbound(self):
+        """Helper returns None for unbound resource_id; caller (verify_resource_token)
+        owns the 404 + warning policy."""
+        db = _mock_db_scalars([])
+        got = await _resolve_authoritative_context(db, "orphan_id")
+        assert got is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_context_raises_409_on_cross_workspace_collision(self, mock_context):
+        """Defensive: pre-migration cross-workspace collisions must fail closed
+        (409) rather than bubble MultipleResultsFound as a 500."""
+        other_ctx = MagicMock(spec=Context)
+        other_ctx.id = uuid4()
+        other_ctx.resource_id = "acme"
+        other_ctx.workspace_id = uuid4()
+        other_ctx.deleted_at = None
+        db = _mock_db_scalars([mock_context, other_ctx])
+
+        with patch("api.routes.resource_ingest.logger") as mock_logger:
+            with pytest.raises(HTTPException) as exc:
+                await _resolve_authoritative_context(db, "acme")
+
+            assert exc.value.status_code == 409
+            mock_logger.warning.assert_called_once_with(
+                "resource_id_ambiguous_on_ingest",
+                resource_id="acme",
+                match_count=2,
+            )
+
+    # --- _enforce_workspace_membership -----------------------------------
+
+    @pytest.mark.asyncio
+    async def test_membership_allowed_for_workspace_member(
+        self, mock_request, mock_token, mock_context
+    ):
+        db = MagicMock()
+        with patch(
+            "services.permission_service.PermissionService.is_workspace_member",
+            new=AsyncMock(return_value=True),
+        ):
+            # Should not raise.
+            await _enforce_workspace_membership(db, mock_request, mock_token, mock_context)
+
+    @pytest.mark.asyncio
+    async def test_membership_denied_logs_cross_tenant_attempt(
+        self, mock_request, mock_token, mock_context
+    ):
+        """Attacker token (non-member) must be rejected with audit warning."""
+        db = MagicMock()
+        with (
+            patch(
+                "services.permission_service.PermissionService.is_workspace_member",
+                new=AsyncMock(return_value=False),
+            ),
+            patch("api.routes.resource_ingest.logger") as mock_logger,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await _enforce_workspace_membership(db, mock_request, mock_token, mock_context)
+
+            assert exc.value.status_code == 403
+            mock_logger.warning.assert_called_once_with(
+                "cross_tenant_ingest_attempt",
+                resource_id=mock_context.resource_id,
+                token_id=mock_token.id,
+                target_workspace_id=str(mock_context.workspace_id),
+                token_creator=mock_token.created_by,
+                client_ip="203.0.113.7",
+            )
+
+    @pytest.mark.asyncio
+    async def test_membership_denied_without_request_client(self, mock_token, mock_context):
+        """client_ip is None when request.client is None (FastAPI edge case)."""
+        req = MagicMock()
+        req.client = None
+        db = MagicMock()
+        with (
+            patch(
+                "services.permission_service.PermissionService.is_workspace_member",
+                new=AsyncMock(return_value=False),
+            ),
+            patch("api.routes.resource_ingest.logger") as mock_logger,
+        ):
+            with pytest.raises(HTTPException):
+                await _enforce_workspace_membership(db, req, mock_token, mock_context)
+
+            call_kwargs = mock_logger.warning.call_args.kwargs
+            assert call_kwargs["client_ip"] is None
+
+    @pytest.mark.asyncio
+    async def test_membership_denied_when_token_has_no_creator(self, mock_request, mock_context):
+        """Legacy tokens without created_by cannot be authorized, without hitting the DB."""
+        token = MagicMock(spec=ResourceToken)
+        token.id = 99
+        token.created_by = None
+        db = MagicMock()
+        db.execute = AsyncMock()
+
+        with patch("api.routes.resource_ingest.logger") as mock_logger:
+            with pytest.raises(HTTPException) as exc:
+                await _enforce_workspace_membership(db, mock_request, token, mock_context)
+
+            assert exc.value.status_code == 403
+            mock_logger.warning.assert_called_once_with(
+                "resource_ingest_missing_token_creator",
+                resource_id=mock_context.resource_id,
+                token_id=99,
+            )
+        # No permission check (and therefore no DB query) for unattributed tokens.
+        db.execute.assert_not_awaited()


### PR DESCRIPTION
Closes #322

## Summary

- Close a critical cross-tenant Resource ingest vulnerability (OWASP A01 / CWE-639) at both the application layer (durable workspace membership check) and the schema layer (global partial UNIQUE on `contexts.resource_id`).
- Replace the mutable `User.current_workspace_id` proxy — which was the authorization bug's root cause — with `PermissionService.is_workspace_member`.
- Add a defensive 409 path for the pre-migration ambiguity window so that any residual cross-workspace collision fails closed rather than bubbling as a 500.
- Emit a structured `cross_tenant_ingest_attempt` warning on denied ingest for post-incident forensics; no raw token material is logged.

## Implementation notes

- `backend/alembic/versions/a96_add_unique_contexts_resource_id_active.py` — new migration adding a global partial UNIQUE index `ux_contexts_resource_id_active` on `contexts(resource_id)` filtered by `resource_id IS NOT NULL AND deleted_at IS NULL`. Zero-downtime via `autocommit_block()` + `CREATE INDEX CONCURRENTLY`. Aborts with actionable diagnostics if pre-existing cross-workspace collisions exist, and pre-drops INVALID indexes from a prior partial run so `IF NOT EXISTS` cannot silently bypass the security boundary.
- `backend/src/api/routes/resource_ingest.py` — `verify_resource_token` is now a composite dependency: hash check → authoritative Context lookup → workspace membership check via `PermissionService`. Returns `(token, quota, context)` 3-tuple so `ingest_event` and `ingest_batch` can use the authoritative Context directly for `log_usage` without re-querying.
- `backend/tests/api/test_resource_ingest.py` — 7 new unit tests in `TestResourceIngestWorkspaceBoundary`: single-active-match / unbound / 409-on-collision for the Context resolver, plus allowed / denied-with-log / denied-without-request-client / no-creator-early-exit for the membership enforcer. A `_mock_db_scalars` helper replaces setup duplication.
- `SECURITY.md` — CVE-style advisory with threat model, remediation, and self-hosted operator upgrade steps (including the SQL audit query).
- `CHANGELOG.md` — v0.12.0 security-driven release entry.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (scope expansion bundled into this PR per operator approval)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/322-fix-critical-security-ingest-time-workspace.gate1.md
- ~/.claude/cache/gh-issue-driven/322-fix-critical-security-ingest-time-workspace.gate2.md

Part of Epic #321 (Resource Foundation refactor).

🤖 Generated via /gh-issue-driven:ship
