### PR TITLE
refactor(db): introduce resources entity + resource_pk shadow FK (#323)

### DIFF
--- a/backend/alembic/versions/a97_resources_entity.py
+++ b/backend/alembic/versions/a97_resources_entity.py
@@ -447,19 +447,28 @@ def upgrade() -> None:
     # ``resource_pk IS NOT NULL`` (Phase 1 semantics). Mirror a96's
     # INVALID-index guard for resilience against a prior failed
     # CONCURRENTLY run.
-    invalid_index_result = bind.execute(
-        sa.text(
-            "SELECT 1 FROM pg_class c "
-            "JOIN pg_index i ON i.indexrelid = c.oid "
-            "WHERE c.relname = :index_name AND NOT i.indisvalid LIMIT 1"
-        ),
-        {"index_name": _PARTIAL_UNIQUE_INDEX},
-    )
-    has_invalid_index = invalid_index_result.fetchone() is not None
+    # Both concurrently-built indexes need the same INVALID-index guard:
+    # ``IF NOT EXISTS`` alone would skip the rebuild of a partially-built
+    # index left behind by a prior failed CONCURRENTLY run, silently
+    # leaving production without the index. Detect and drop any INVALID
+    # version first, then recreate.
+    concurrent_indexes = (_PARTIAL_UNIQUE_INDEX, "ix_resource_events_resource_pk")
+    invalid_names = {
+        row[0]
+        for row in bind.execute(
+            sa.text(
+                "SELECT c.relname FROM pg_class c "
+                "JOIN pg_index i ON i.indexrelid = c.oid "
+                "WHERE c.relname = ANY(:names) AND NOT i.indisvalid"
+            ),
+            {"names": list(concurrent_indexes)},
+        ).fetchall()
+    }
 
     with op.get_context().autocommit_block():
-        if has_invalid_index:
-            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_PARTIAL_UNIQUE_INDEX}"))
+        for name in concurrent_indexes:
+            if name in invalid_names:
+                op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {name}"))
         op.execute(
             sa.text(
                 f"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {_PARTIAL_UNIQUE_INDEX} "
@@ -470,8 +479,7 @@ def upgrade() -> None:
         # ``ix_resource_events_resource_pk`` is created concurrently for
         # the same reason as the partial UNIQUE: resource_events is the
         # high-write append-only log, so a blocking index build would
-        # stall ingest traffic for the duration. IF NOT EXISTS lets this
-        # path be safely re-run after a partial failure.
+        # stall ingest traffic for the duration.
         op.execute(
             sa.text(
                 "CREATE INDEX CONCURRENTLY IF NOT EXISTS "

--- a/backend/alembic/versions/a97_resources_entity.py
+++ b/backend/alembic/versions/a97_resources_entity.py
@@ -1,0 +1,325 @@
+"""Introduce resources entity + resource_pk FK + 3 UNIQUE constraints.
+
+Issue #323: Normalize the resource subsystem. Add an authoritative
+``resources`` table keyed by UUID with a ``workspace_id`` FK, then
+introduce ``resource_pk UUID`` FK columns on the four existing tables
+that currently key themselves by ``resource_id VARCHAR`` alone
+(``resource_events``, ``resource_schemas``, ``indexer_state``,
+``resource_tokens``). Finally add the three UNIQUE constraints the model
+docstrings have always promised but the baseline migration never
+materialized, and make ``resource_tokens.workspace_id`` a NOT NULL FK so
+tenancy is enforced at the schema layer.
+
+Revision ID: a97_resources_entity
+Revises: a96_ctx_resource_id_unique
+
+NOTE: The revision ID is capped at 32 characters because
+``alembic_version.version_num`` is ``VARCHAR(32)`` in this database
+(asyncpg raises ``StringDataRightTruncationError`` otherwise).
+
+PHASE 1 OF 2 — SHADOW-COLUMN ROLLOUT
+------------------------------------
+This migration is the schema half of the resources normalization
+refactor. It **adds** ``resource_pk`` and ``resource_tokens.workspace_id``
+as *nullable* shadow columns and backfills them from existing data, but
+does **not** tighten them to NOT NULL. Tightening lives in a follow-up
+(#325 in the same epic) so the intervening release can ship application
+code updates (#324) that populate the new columns on every write.
+
+If ``resource_pk`` were tightened to NOT NULL here, every existing write
+path that only supplies ``resource_id VARCHAR`` would start throwing
+``NullViolationError`` on the first request after deploy — the whole
+point of the shadow phase is to let old writers continue working while
+new writers migrate over.
+
+DUAL-WRITE PROHIBITION (forward-looking)
+----------------------------------------
+Once application writers are updated to populate ``resource_pk``, they
+MUST NOT write ``resource_id`` independently. The ``resource_id``
+VARCHAR column, while it still exists, should only be set via a shim
+that looks up the slug through ``resources.id = resource_pk``.
+Independent writes will silently diverge and break the invariant this
+migration is preparing. The legacy ``resource_id`` column will be
+dropped once every writer has switched over (tracked under epic #321).
+
+UNIQUE constraint semantics during Phase 1
+-------------------------------------------
+The three UNIQUE constraints are added as **partial indexes** with
+``WHERE resource_pk IS NOT NULL`` (composed with ``op = 'upsert'`` on
+``resource_events``). During Phase 1 this protects backfilled rows and
+any new writes that correctly populate ``resource_pk``; rows that still
+write only ``resource_id`` with ``resource_pk = NULL`` are unprotected
+— matching the pre-migration status quo, so no regression. After #325
+tightens the columns to NOT NULL, the partial predicate becomes
+universally true and the constraints are effectively full UNIQUEs.
+
+Step order inside ``upgrade()``:
+    1. CREATE TABLE ``resources``
+    2. Seed ``resources`` from active contexts (workspace_id, resource_id)
+    3. Pre-migration audit: abort if any satellite row references a
+       ``resource_id`` with no matching active context, which would
+       leave ``resource_pk`` NULL permanently and defeat the audit.
+    4. ADD COLUMN ``resource_pk`` nullable on four satellite tables
+    5. Backfill ``resource_pk`` via JOIN on ``resources.resource_id``
+       (kept nullable — see "PHASE 1 OF 2" above)
+    6. Add FK + index on ``resource_pk`` per table
+    7. ADD COLUMN ``resource_tokens.workspace_id`` nullable
+    8. Backfill ``workspace_id`` from ``resources.workspace_id`` via
+       the just-populated ``resource_pk``
+    9. Add FK + index on ``resource_tokens.workspace_id``
+    10. Create three partial UNIQUE indexes
+        (``resource_events`` goes through CREATE INDEX CONCURRENTLY
+        because it is the high-write satellite table)
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a97_resources_entity"
+down_revision = "a96_ctx_resource_id_unique"
+branch_labels = None
+depends_on = None
+
+
+_MAX_AUDIT_EXAMPLES = 5
+
+# Satellite tables that key themselves by resource_id today and will gain
+# a resource_pk UUID FK column. Ordered for readable backfill logs.
+_SATELLITE_TABLES = (
+    "resource_events",
+    "resource_schemas",
+    "indexer_state",
+    "resource_tokens",
+)
+
+_PARTIAL_UNIQUE_INDEX = "ux_resource_events_upsert_version"
+
+
+def upgrade() -> None:
+    """Normalize resource schema in a single migration (see module docstring)."""
+    bind = op.get_bind()
+
+    # --- Step 1: create the authoritative resources table -----------------
+    op.create_table(
+        "resources",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("resource_id", sa.String(255), nullable=False),
+        # name / created_by are populated by later setup flows (issue #324+);
+        # the migration cannot infer them from contexts alone.
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "workspace_id",
+            "resource_id",
+            name="uq_resources_workspace_resource_id",
+        ),
+    )
+
+    # --- Step 2: seed resources from ACTIVE contexts only -----------------
+    # Scoping the seed to active, non-deleted contexts keeps
+    # ``resources.resource_id`` globally unique (a96 enforces this
+    # invariant for the active set) and guarantees the Step 5 backfill
+    # JOIN resolves deterministically. Including soft-deleted contexts
+    # would let a historical workspace's slug reappear in ``resources``
+    # and silently cross-assign its satellite rows to a different
+    # workspace that happens to share the slug — a tenancy boundary
+    # break the whole refactor is meant to prevent. Satellite rows
+    # whose owning context has been soft-deleted are handled by the
+    # Step 3 audit (they are orphans that the operator must clean up).
+    bind.execute(
+        sa.text(
+            "INSERT INTO resources (workspace_id, resource_id, created_by, created_at) "
+            "SELECT DISTINCT workspace_id, resource_id, created_by, created_at "
+            "FROM contexts "
+            "WHERE resource_id IS NOT NULL AND deleted_at IS NULL"
+        )
+    )
+
+    # --- Step 3: pre-migration audit (fail fast on orphans) ---------------
+    # Any satellite row whose resource_id has no resources entry would
+    # survive step 5 with resource_pk NULL and break step 6's NOT NULL
+    # tightening. Raise with actionable examples so the operator can
+    # clean up before rerunning.
+    orphans: list[tuple[str, str, int]] = []
+    for table in _SATELLITE_TABLES:
+        result = bind.execute(
+            sa.text(
+                f"SELECT s.resource_id, COUNT(*) AS row_count "  # noqa: S608 -- table names are module-constant
+                f"FROM {table} AS s "
+                "LEFT JOIN resources r ON r.resource_id = s.resource_id "
+                "WHERE r.id IS NULL "
+                "GROUP BY s.resource_id "
+                "LIMIT :limit"
+            ),
+            {"limit": _MAX_AUDIT_EXAMPLES},
+        )
+        for row in result.fetchall():
+            orphans.append((table, row[0], row[1]))
+
+    if orphans:
+        examples = ", ".join(f"{tbl}.resource_id='{rid}' ({cnt} rows)" for tbl, rid, cnt in orphans)
+        raise RuntimeError(
+            "Migration aborted: satellite rows reference resource_id values that "
+            f"have no matching public context (examples: {examples}). Either "
+            "create the corresponding public contexts first or remove the "
+            "orphaned rows before re-running this migration."
+        )
+
+    # --- Step 4-6: add resource_pk (nullable), backfill, add FK + index ---
+    # resource_pk stays nullable so existing writers that only supply
+    # resource_id keep working until application updates land (#324).
+    # The follow-up migration (#325) tightens to NOT NULL.
+    for table in _SATELLITE_TABLES:
+        op.add_column(
+            table,
+            sa.Column("resource_pk", UUID(as_uuid=True), nullable=True),
+        )
+        bind.execute(
+            sa.text(
+                # noqa: S608 -- table names are module-constant
+                f"UPDATE {table} AS s "
+                "SET resource_pk = r.id "
+                "FROM resources AS r "
+                "WHERE r.resource_id = s.resource_id"
+            )
+        )
+        op.create_foreign_key(
+            f"fk_{table}_resource_pk",
+            table,
+            "resources",
+            ["resource_pk"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+        op.create_index(
+            f"ix_{table}_resource_pk",
+            table,
+            ["resource_pk"],
+        )
+
+    # --- Step 7-9: resource_tokens.workspace_id shadow FK ----------------
+    # Added separately from the resource_pk loop because the backfill
+    # source is ``resources.workspace_id`` via the resource_pk populated
+    # just above. Kept nullable for the same Phase 1 reason as
+    # resource_pk — writers that do not yet know about workspace_id
+    # must keep working until #324 updates them.
+    op.add_column(
+        "resource_tokens",
+        sa.Column("workspace_id", UUID(as_uuid=True), nullable=True),
+    )
+    bind.execute(
+        sa.text(
+            "UPDATE resource_tokens AS t "
+            "SET workspace_id = r.workspace_id "
+            "FROM resources AS r "
+            "WHERE r.id = t.resource_pk"
+        )
+    )
+    op.create_foreign_key(
+        "fk_resource_tokens_workspace",
+        "resource_tokens",
+        "workspaces",
+        ["workspace_id"],
+        ["id"],
+        ondelete="CASCADE",
+    )
+    op.create_index(
+        "ix_resource_tokens_workspace_id",
+        "resource_tokens",
+        ["workspace_id"],
+    )
+
+    # --- Step 10: partial UNIQUE indexes (Phase 1 semantics) --------------
+    # All three are partial on ``resource_pk IS NOT NULL`` so rows still
+    # waiting for writer migration (resource_pk = NULL) do not collide
+    # with each other and do not break ongoing traffic. Once #325
+    # tightens resource_pk to NOT NULL, the predicate becomes universally
+    # true and the indexes behave as full UNIQUEs.
+    op.create_index(
+        "uq_resource_schemas_version",
+        "resource_schemas",
+        ["resource_pk", "schema_version"],
+        unique=True,
+        postgresql_where=sa.text("resource_pk IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_indexer_state_resource_context",
+        "indexer_state",
+        ["resource_pk", "context_id"],
+        unique=True,
+        postgresql_where=sa.text("resource_pk IS NOT NULL"),
+    )
+
+    # resource_events is append-only and high-write, so the partial UNIQUE
+    # goes through CREATE INDEX CONCURRENTLY. The predicate combines
+    # ``op = 'upsert'`` (so delete events stay replayable — upsert →
+    # delete → upsert revival is a valid invariant) with
+    # ``resource_pk IS NOT NULL`` (Phase 1 semantics). Mirror a96's
+    # INVALID-index guard for resilience against a prior failed
+    # CONCURRENTLY run.
+    invalid_index_result = bind.execute(
+        sa.text(
+            "SELECT 1 FROM pg_class c "
+            "JOIN pg_index i ON i.indexrelid = c.oid "
+            "WHERE c.relname = :index_name AND NOT i.indisvalid LIMIT 1"
+        ),
+        {"index_name": _PARTIAL_UNIQUE_INDEX},
+    )
+    has_invalid_index = invalid_index_result.fetchone() is not None
+
+    with op.get_context().autocommit_block():
+        if has_invalid_index:
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_PARTIAL_UNIQUE_INDEX}"))
+        op.execute(
+            sa.text(
+                f"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS {_PARTIAL_UNIQUE_INDEX} "
+                "ON resource_events (resource_pk, doc_id, version) "
+                "WHERE op = 'upsert' AND resource_pk IS NOT NULL"
+            )
+        )
+
+
+def downgrade() -> None:
+    """Reverse every upgrade step so the schema returns to a96 state."""
+    # Drop the partial UNIQUE first (same autocommit_block requirement).
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_PARTIAL_UNIQUE_INDEX}"))
+
+    # Drop the two partial UNIQUE indexes (created via op.create_index,
+    # not create_unique_constraint, so drop_index is the right inverse).
+    op.drop_index("uq_indexer_state_resource_context", table_name="indexer_state")
+    op.drop_index("uq_resource_schemas_version", table_name="resource_schemas")
+
+    # resource_tokens.workspace_id teardown (reverse of step 7-9).
+    op.drop_index("ix_resource_tokens_workspace_id", table_name="resource_tokens")
+    op.drop_constraint("fk_resource_tokens_workspace", "resource_tokens", type_="foreignkey")
+    op.drop_column("resource_tokens", "workspace_id")
+
+    # resource_pk teardown on satellite tables (reverse of step 4-6).
+    for table in reversed(_SATELLITE_TABLES):
+        op.drop_index(f"ix_{table}_resource_pk", table_name=table)
+        op.drop_constraint(f"fk_{table}_resource_pk", table, type_="foreignkey")
+        op.drop_column(table, "resource_pk")
+
+    op.drop_table("resources")

--- a/backend/alembic/versions/a97_resources_entity.py
+++ b/backend/alembic/versions/a97_resources_entity.py
@@ -45,6 +45,31 @@ Independent writes will silently diverge and break the invariant this
 migration is preparing. The legacy ``resource_id`` column will be
 dropped once every writer has switched over (tracked under epic #321).
 
+Restart semantics after a mid-migration failure
+-----------------------------------------------
+``autocommit_block`` commits the preceding transactional DDL (table
+creation, column adds, backfills, FKs, plain UNIQUE indexes) before
+entering the ``CREATE INDEX CONCURRENTLY`` section. If the concurrent
+build itself fails (disk, cancellation, duplicate rows inserted after
+Step 10's duplicate audit), the earlier DDL is already persisted:
+
+- the ``CREATE INDEX CONCURRENTLY IF NOT EXISTS`` guard on retry is
+  safe because the INVALID-index detection above it drops the broken
+  index before the re-run, mirroring the a96 pattern that has shipped
+  to production;
+- the preceding DDL is NOT guarded by ``IF NOT EXISTS`` — that would
+  require raw SQL for every ``op.create_table`` / ``op.add_column``.
+  A retry after a committed-then-failed run therefore requires the
+  operator to manually clean up (``DROP TABLE resources CASCADE`` and
+  the per-satellite ``ALTER TABLE ... DROP COLUMN resource_pk``)
+  before re-invoking the migration.
+
+This trade-off matches the a96 precedent. Splitting the concurrent
+index into a follow-up migration would remove the gap but would also
+fragment the Phase 1 schema step across two revisions; given the
+pre-v1 scale of ``resource_events``, the simpler single-migration
+shape is preferred.
+
 UNIQUE constraint semantics during Phase 1
 -------------------------------------------
 The three UNIQUE constraints are added as **partial indexes** with
@@ -168,7 +193,52 @@ def upgrade() -> None:
         )
     )
 
-    # --- Step 3: pre-migration audit (fail fast on orphans) ---------------
+    # --- Step 3a: cross-workspace ambiguity audit -------------------------
+    # a96 enforces uniqueness only among active contexts. If the same
+    # ``resource_id`` slug was once owned by workspace A (context later
+    # soft-deleted, which keeps resource_id populated) and is now owned
+    # by workspace B, the Step 5 backfill UPDATE — which joins satellite
+    # rows to ``resources`` on ``resource_id`` alone — would silently
+    # re-home workspace A's historical satellite rows onto workspace
+    # B's resources row. That is the exact tenancy-boundary violation
+    # this refactor is meant to prevent, so abort fast with operator
+    # guidance. Detection scans contexts (including deleted) plus
+    # satellite rows; the violation fires only when BOTH conditions
+    # hold (otherwise there is nothing to re-home).
+    ambiguity_rows = bind.execute(
+        sa.text(
+            "WITH resource_owners AS ( "
+            "  SELECT resource_id, COUNT(DISTINCT workspace_id) AS ws_count "
+            "  FROM contexts "
+            "  WHERE resource_id IS NOT NULL "
+            "  GROUP BY resource_id "
+            "  HAVING COUNT(DISTINCT workspace_id) > 1 "
+            "), satellite_slugs AS ( "
+            "  SELECT resource_id FROM resource_events "
+            "  UNION SELECT resource_id FROM resource_schemas "
+            "  UNION SELECT resource_id FROM indexer_state "
+            "  UNION SELECT resource_id FROM resource_tokens "
+            ") "
+            "SELECT ro.resource_id, ro.ws_count "
+            "FROM resource_owners ro "
+            "JOIN satellite_slugs ss ON ss.resource_id = ro.resource_id "
+            "LIMIT :limit"
+        ),
+        {"limit": _MAX_AUDIT_EXAMPLES},
+    ).fetchall()
+    if ambiguity_rows:
+        examples = ", ".join(f"'{rid}' owned by {wc} workspaces" for rid, wc in ambiguity_rows)
+        raise RuntimeError(
+            "Migration aborted: resource_id slugs exist across multiple "
+            "workspaces (including soft-deleted contexts) with satellite "
+            f"rows that would be re-homed to the wrong workspace (examples: "
+            f"{examples}). Rename or remove the duplicate slugs, or delete "
+            "the stale satellite rows from the non-current workspace, "
+            "before re-running this migration. This check prevents silent "
+            "cross-tenant data mixing during the shadow-column backfill."
+        )
+
+    # --- Step 3b: orphan audit (fail fast on rows without a matching active context)
     # Any satellite row whose resource_id has no resources entry would
     # survive Step 5 with resource_pk still NULL, leaving the backfill
     # incomplete. Raise with actionable examples so the operator can
@@ -223,15 +293,44 @@ def upgrade() -> None:
                 "WHERE r.resource_id = s.resource_id"
             )
         )
-        op.create_foreign_key(
-            f"fk_{table}_resource_pk",
-            table,
-            "resources",
-            ["resource_pk"],
-            ["id"],
-            ondelete="CASCADE",
-        )
-        if table != "resource_events":
+        if table == "resource_events":
+            # resource_events is the high-write append-only log — add the
+            # FK with NOT VALID so ADD CONSTRAINT skips the synchronous
+            # table scan (avoids an ACCESS EXCLUSIVE lock that would
+            # stall ingest for the scan duration). VALIDATE CONSTRAINT
+            # runs below under SHARE UPDATE EXCLUSIVE, which does not
+            # block reads/writes. Future inserts are checked as they
+            # happen, so the FK is enforced from the moment it is added
+            # — only the one-time validation of pre-existing rows is
+            # deferred.
+            op.execute(
+                sa.text(
+                    f"ALTER TABLE {table} "  # noqa: S608 -- table name is module-constant
+                    f"ADD CONSTRAINT fk_{table}_resource_pk "
+                    "FOREIGN KEY (resource_pk) "
+                    "REFERENCES resources (id) "
+                    "ON DELETE CASCADE "
+                    "NOT VALID"
+                )
+            )
+            op.execute(
+                sa.text(
+                    f"ALTER TABLE {table} "  # noqa: S608
+                    f"VALIDATE CONSTRAINT fk_{table}_resource_pk"
+                )
+            )
+            # The non-unique ix_resource_events_resource_pk index is
+            # built via CREATE INDEX CONCURRENTLY inside Step 10's
+            # autocommit_block, together with the partial UNIQUE.
+        else:
+            op.create_foreign_key(
+                f"fk_{table}_resource_pk",
+                table,
+                "resources",
+                ["resource_pk"],
+                ["id"],
+                ondelete="CASCADE",
+            )
             op.create_index(
                 f"ix_{table}_resource_pk",
                 table,

--- a/backend/alembic/versions/a97_resources_entity.py
+++ b/backend/alembic/versions/a97_resources_entity.py
@@ -121,7 +121,13 @@ def upgrade() -> None:
             nullable=False,
             index=True,
         ),
-        sa.Column("resource_id", sa.String(255), nullable=False),
+        # ``resource_id`` gets a standalone non-unique index so the Step
+        # 3 orphan audit and Step 5 backfill UPDATEs can resolve the
+        # ``resource_id`` slug without a sequential scan. The composite
+        # ``UNIQUE(workspace_id, resource_id)`` below cannot serve those
+        # lookups efficiently because the leading column is
+        # ``workspace_id``.
+        sa.Column("resource_id", sa.String(255), nullable=False, index=True),
         # name / created_by are populated by later setup flows (issue #324+);
         # the migration cannot infer them from contexts alone.
         sa.Column("name", sa.Text(), nullable=True),
@@ -193,6 +199,13 @@ def upgrade() -> None:
     # resource_pk stays nullable so existing writers that only supply
     # resource_id keep working until application updates land (#324).
     # The follow-up migration (#325) tightens to NOT NULL.
+    #
+    # Index creation is split by table: the three low-write satellites
+    # use a regular ``op.create_index`` (brief ACCESS EXCLUSIVE is fine
+    # at their volume), while ``resource_events`` — the append-only
+    # high-write log — gets its index built via
+    # ``CREATE INDEX CONCURRENTLY`` further below to avoid blocking
+    # writes during the build.
     for table in _SATELLITE_TABLES:
         op.add_column(
             table,
@@ -215,11 +228,12 @@ def upgrade() -> None:
             ["id"],
             ondelete="CASCADE",
         )
-        op.create_index(
-            f"ix_{table}_resource_pk",
-            table,
-            ["resource_pk"],
-        )
+        if table != "resource_events":
+            op.create_index(
+                f"ix_{table}_resource_pk",
+                table,
+                ["resource_pk"],
+            )
 
     # --- Step 7-9: resource_tokens.workspace_id shadow FK ----------------
     # Added separately from the resource_pk loop because the backfill
@@ -253,7 +267,57 @@ def upgrade() -> None:
         ["workspace_id"],
     )
 
-    # --- Step 10: partial UNIQUE indexes (Phase 1 semantics) --------------
+    # --- Step 10: pre-UNIQUE duplicate audit ------------------------------
+    # Baseline never enforced these UNIQUEs, so the backfilled rows may
+    # already violate them. Build the partial indexes only after proving
+    # the existing data is clean; otherwise CREATE INDEX raises a
+    # low-level ``duplicate key value violates unique constraint`` that
+    # leaves the operator without an actionable hint. The audit mirrors
+    # Step 3's orphan check pattern.
+    unique_audits: tuple[tuple[str, str, str], ...] = (
+        (
+            "resource_schemas",
+            "resource_pk, schema_version",
+            "resource_pk IS NOT NULL",
+        ),
+        (
+            "indexer_state",
+            "resource_pk, context_id",
+            "resource_pk IS NOT NULL",
+        ),
+        (
+            "resource_events",
+            "resource_pk, doc_id, version",
+            "op = 'upsert' AND resource_pk IS NOT NULL",
+        ),
+    )
+    duplicate_findings: list[tuple[str, str, int]] = []
+    for table, columns, predicate in unique_audits:
+        result = bind.execute(
+            sa.text(
+                # noqa: S608 -- audit query built from module-constant tuples
+                f"SELECT {columns}, COUNT(*) AS dup_count "
+                f"FROM {table} "
+                f"WHERE {predicate} "
+                f"GROUP BY {columns} "
+                "HAVING COUNT(*) > 1 "
+                "LIMIT :limit"
+            ),
+            {"limit": _MAX_AUDIT_EXAMPLES},
+        )
+        for row in result.fetchall():
+            dup_key = ", ".join(str(v) for v in row[:-1])
+            duplicate_findings.append((table, dup_key, row[-1]))
+
+    if duplicate_findings:
+        examples = ", ".join(f"{tbl}({keys})={cnt} rows" for tbl, keys, cnt in duplicate_findings)
+        raise RuntimeError(
+            "Migration aborted: duplicate rows exist that would violate the "
+            f"Phase 1 partial UNIQUE indexes (examples: {examples}). These "
+            "are pre-existing baseline duplicates — de-duplicate them via "
+            "the usual DELETE/merge flow before re-running this migration."
+        )
+
     # All three are partial on ``resource_pk IS NOT NULL`` so rows still
     # waiting for writer migration (resource_pk = NULL) do not collide
     # with each other and do not break ongoing traffic. Once #325
@@ -301,13 +365,26 @@ def upgrade() -> None:
                 "WHERE op = 'upsert' AND resource_pk IS NOT NULL"
             )
         )
+        # ``ix_resource_events_resource_pk`` is created concurrently for
+        # the same reason as the partial UNIQUE: resource_events is the
+        # high-write append-only log, so a blocking index build would
+        # stall ingest traffic for the duration. IF NOT EXISTS lets this
+        # path be safely re-run after a partial failure.
+        op.execute(
+            sa.text(
+                "CREATE INDEX CONCURRENTLY IF NOT EXISTS "
+                "ix_resource_events_resource_pk ON resource_events (resource_pk)"
+            )
+        )
 
 
 def downgrade() -> None:
     """Reverse every upgrade step so the schema returns to a96 state."""
-    # Drop the partial UNIQUE first (same autocommit_block requirement).
+    # Drop the resource_events partial UNIQUE and non-unique resource_pk
+    # index concurrently, mirroring how they were created.
     with op.get_context().autocommit_block():
         op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_PARTIAL_UNIQUE_INDEX}"))
+        op.execute(sa.text("DROP INDEX CONCURRENTLY IF EXISTS ix_resource_events_resource_pk"))
 
     # Drop the two partial UNIQUE indexes (created via op.create_index,
     # not create_unique_constraint, so drop_index is the right inverse).
@@ -320,8 +397,11 @@ def downgrade() -> None:
     op.drop_column("resource_tokens", "workspace_id")
 
     # resource_pk teardown on satellite tables (reverse of step 4-6).
+    # resource_events' index was already dropped concurrently above, so
+    # we skip drop_index for that table here.
     for table in reversed(_SATELLITE_TABLES):
-        op.drop_index(f"ix_{table}_resource_pk", table_name=table)
+        if table != "resource_events":
+            op.drop_index(f"ix_{table}_resource_pk", table_name=table)
         op.drop_constraint(f"fk_{table}_resource_pk", table, type_="foreignkey")
         op.drop_column(table, "resource_pk")
 

--- a/backend/alembic/versions/a97_resources_entity.py
+++ b/backend/alembic/versions/a97_resources_entity.py
@@ -119,15 +119,8 @@ def upgrade() -> None:
             UUID(as_uuid=True),
             sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
             nullable=False,
-            index=True,
         ),
-        # ``resource_id`` gets a standalone non-unique index so the Step
-        # 3 orphan audit and Step 5 backfill UPDATEs can resolve the
-        # ``resource_id`` slug without a sequential scan. The composite
-        # ``UNIQUE(workspace_id, resource_id)`` below cannot serve those
-        # lookups efficiently because the leading column is
-        # ``workspace_id``.
-        sa.Column("resource_id", sa.String(255), nullable=False, index=True),
+        sa.Column("resource_id", sa.String(255), nullable=False),
         # name / created_by are populated by later setup flows (issue #324+);
         # the migration cannot infer them from contexts alone.
         sa.Column("name", sa.Text(), nullable=True),
@@ -144,6 +137,16 @@ def upgrade() -> None:
             name="uq_resources_workspace_resource_id",
         ),
     )
+    # Explicit indexes, emitted via op.create_index so they are visible
+    # to alembic autogenerate and so the migration's index footprint
+    # matches the ORM exactly (Resource.workspace_id + resource_id both
+    # declare ``index=True``). ``resource_id`` needs its own index — the
+    # composite UNIQUE above is keyed on (workspace_id, resource_id), so
+    # Postgres cannot serve ``resource_id``-only lookups via that index,
+    # and both the Step 3 orphan audit and the Step 5 backfill UPDATEs
+    # resolve the slug without the workspace context.
+    op.create_index("ix_resources_workspace_id", "resources", ["workspace_id"])
+    op.create_index("ix_resources_resource_id", "resources", ["resource_id"])
 
     # --- Step 2: seed resources from ACTIVE contexts only -----------------
     # Scoping the seed to active, non-deleted contexts keeps
@@ -167,8 +170,8 @@ def upgrade() -> None:
 
     # --- Step 3: pre-migration audit (fail fast on orphans) ---------------
     # Any satellite row whose resource_id has no resources entry would
-    # survive step 5 with resource_pk NULL and break step 6's NOT NULL
-    # tightening. Raise with actionable examples so the operator can
+    # survive Step 5 with resource_pk still NULL, leaving the backfill
+    # incomplete. Raise with actionable examples so the operator can
     # clean up before rerunning.
     orphans: list[tuple[str, str, int]] = []
     for table in _SATELLITE_TABLES:

--- a/backend/alembic/versions/a97_resources_entity.py
+++ b/backend/alembic/versions/a97_resources_entity.py
@@ -7,8 +7,11 @@ that currently key themselves by ``resource_id VARCHAR`` alone
 (``resource_events``, ``resource_schemas``, ``indexer_state``,
 ``resource_tokens``). Finally add the three UNIQUE constraints the model
 docstrings have always promised but the baseline migration never
-materialized, and make ``resource_tokens.workspace_id`` a NOT NULL FK so
-tenancy is enforced at the schema layer.
+materialized, and add/backfill ``resource_tokens.workspace_id`` as a
+nullable FK shadow column ahead of follow-up NOT NULL enforcement in
+#325 (so tenancy is ultimately enforced at the schema layer, once all
+writers have been migrated to populate it — see the Phase 1 section
+below).
 
 Revision ID: a97_resources_entity
 Revises: a96_ctx_resource_id_unique
@@ -181,8 +184,8 @@ def upgrade() -> None:
         examples = ", ".join(f"{tbl}.resource_id='{rid}' ({cnt} rows)" for tbl, rid, cnt in orphans)
         raise RuntimeError(
             "Migration aborted: satellite rows reference resource_id values that "
-            f"have no matching public context (examples: {examples}). Either "
-            "create the corresponding public contexts first or remove the "
+            f"have no matching active context (examples: {examples}). Either "
+            "create the corresponding active contexts first or remove the "
             "orphaned rows before re-running this migration."
         )
 

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -78,7 +78,7 @@ class Resource(Base):
         nullable=False,
         index=True,
     )
-    resource_id = Column(String(255), nullable=False)
+    resource_id = Column(String(255), nullable=False, index=True)
     name = Column(Text, nullable=True)
     created_by = Column(String(255), nullable=True)
     created_at = Column(DateTime, nullable=False, server_default=func.now())

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -1,13 +1,25 @@
 """SQLAlchemy models for Resource management.
 
-Issue #238 - Public Context: Resource-driven incremental indexing
+Issue #238 — Public Context: Resource-driven incremental indexing.
 
 Provides ORM models for:
-- resource_events table (append-only event log)
-- resource_schemas table (Schema Registry)
-- indexer_state table (job tracking)
-- resource_tokens table (Resource API authentication)
-- workspace_addons table (Addon purchase system)
+
+    - ``resources`` — authoritative resource entity (Issue #323)
+    - ``resource_events`` — append-only event log
+    - ``resource_schemas`` — Schema Registry
+    - ``indexer_state`` — job tracking
+    - ``resource_tokens`` — Resource API authentication
+    - ``workspace_addons`` — Addon purchase system
+
+Phase 1 rollout (Issue #323): ``resource_pk`` and
+``resource_tokens.workspace_id`` are nullable shadow columns populated
+by migration ``a97_resources_entity`` on existing rows. Writers that
+have not yet been updated (tracked under #324) still work because the
+columns are nullable during Phase 1; once all writers populate them,
+migration #325 tightens them to NOT NULL. Application code MUST NOT
+write ``resource_id`` independently of ``resource_pk`` once the
+writer migration begins — see the migration docstring for the full
+rationale.
 """
 
 from sqlalchemy import (
@@ -18,24 +30,80 @@ from sqlalchemy import (
     DateTime,
     Float,  # Issue #262: For importance column
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
+    UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from db.base import Base
 
 
+class Resource(Base):
+    """Authoritative resource entity (Issue #323).
+
+    Serves as the single source of truth for workspace-scoped resource
+    identity. Satellite tables (events, schemas, indexer_state, tokens)
+    reference ``resources.id`` via their ``resource_pk`` FK column. The
+    external-facing ``resource_id`` slug is kept here for API contracts
+    (REST + MCP accept slug on input), but every internal relationship
+    travels through the UUID primary key.
+
+    Attributes:
+        id: Primary key (UUID)
+        workspace_id: Owning workspace (FK, CASCADE on workspace delete)
+        resource_id: External-facing slug (unique within workspace)
+        name: Human-readable label (populated by setup_resource;
+            nullable because migration ``a97`` cannot infer a label from
+            the ``contexts`` backfill source)
+        created_by: User ID who created the resource (nullable for the
+            same reason as ``name``)
+        created_at: Creation timestamp
+    """
+
+    __tablename__ = "resources"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    resource_id = Column(String(255), nullable=False)
+    name = Column(Text, nullable=True)
+    created_by = Column(String(255), nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id",
+            "resource_id",
+            name="uq_resources_workspace_resource_id",
+        ),
+    )
+
+
 class ResourceEvent(Base):
     """Resource event model (append-only event log).
 
-    Issue #238: Stores upsert/delete events from external systems (EC inventory, etc.)
+    Issue #238: Stores upsert/delete events from external systems (EC inventory, etc.).
+    Issue #323: Added ``resource_pk`` FK to ``resources.id``. See module
+    docstring for the dual-write prohibition rule.
 
     Attributes:
         id: Sequential ID for incremental reads (offset-based)
-        resource_id: Resource identifier (e.g., "ec_products")
+        resource_pk: Authoritative FK to ``resources.id`` (Issue #323)
+        resource_id: Resource slug (legacy, read-only mirror of
+            ``resources.resource_id`` — will be dropped in a follow-up)
         op: Operation type ('upsert' or 'delete')
         doc_id: Document identifier (stable across versions)
         version: Document version number (monotonically increasing)
@@ -48,6 +116,12 @@ class ResourceEvent(Base):
     __tablename__ = "resource_events"
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
+    resource_pk = Column(
+        UUID(as_uuid=True),
+        ForeignKey("resources.id", ondelete="CASCADE"),
+        nullable=True,  # Phase 1 shadow column — tightened in #325
+        index=True,
+    )
     resource_id = Column(String(255), nullable=False, index=True)
     op = Column(String(10), nullable=False)  # 'upsert' or 'delete'
     doc_id = Column(String(255), nullable=False)
@@ -62,8 +136,19 @@ class ResourceEvent(Base):
 
     __table_args__ = (
         CheckConstraint("op IN ('upsert', 'delete')", name="check_op_type"),
-        # Unique constraint prevents duplicate document versions
-        # Handled in migration: CONSTRAINT unique_resource_doc_version UNIQUE (resource_id, doc_id, version)
+        # Issue #323: partial UNIQUE index on (resource_pk, doc_id, version)
+        # WHERE op = 'upsert' — delete events stay replayable so
+        # upsert → delete → upsert revival works. Created via CREATE INDEX
+        # CONCURRENTLY in migration a97_resources_entity; the declarative
+        # Index keeps alembic autogenerate from reporting spurious drift.
+        Index(
+            "ux_resource_events_upsert_version",
+            "resource_pk",
+            "doc_id",
+            "version",
+            unique=True,
+            postgresql_where=text("op = 'upsert' AND resource_pk IS NOT NULL"),
+        ),
     )
 
 
@@ -71,10 +156,13 @@ class ResourceSchema(Base):
     """Resource schema model (Schema Registry).
 
     Issue #238: Defines field metadata for JSONB payload interpretation.
+    Issue #323: Added ``resource_pk`` FK to ``resources.id``. See module
+    docstring for the dual-write prohibition rule.
 
     Attributes:
         id: Primary key
-        resource_id: Resource identifier (matches resource_events.resource_id)
+        resource_pk: Authoritative FK to ``resources.id`` (Issue #323)
+        resource_id: Resource slug (legacy mirror — will be dropped)
         schema_version: Schema version number (monotonically increasing)
         field_definitions: JSONB array of field metadata
         created_at: Schema creation timestamp
@@ -84,6 +172,12 @@ class ResourceSchema(Base):
     __tablename__ = "resource_schemas"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    resource_pk = Column(
+        UUID(as_uuid=True),
+        ForeignKey("resources.id", ondelete="CASCADE"),
+        nullable=True,  # Phase 1 shadow column — tightened in #325
+        index=True,
+    )
     resource_id = Column(String(255), nullable=False, index=True)
     schema_version = Column(Integer, nullable=False, default=1)
     field_definitions = Column(JSONB, nullable=False)
@@ -91,8 +185,17 @@ class ResourceSchema(Base):
     updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
 
     __table_args__ = (
-        # Unique constraint ensures one schema per version
-        # Handled in migration: CONSTRAINT unique_resource_schema_version UNIQUE (resource_id, schema_version)
+        # Issue #323: partial UNIQUE(resource_pk, schema_version) created
+        # by migration a97_resources_entity. Partial on
+        # ``resource_pk IS NOT NULL`` during Phase 1 so rows awaiting
+        # writer migration do not collide.
+        Index(
+            "uq_resource_schemas_version",
+            "resource_pk",
+            "schema_version",
+            unique=True,
+            postgresql_where=text("resource_pk IS NOT NULL"),
+        ),
     )
 
 
@@ -100,10 +203,13 @@ class IndexerState(Base):
     """Indexer state model (job tracking).
 
     Issue #238: Tracks incremental indexer progress per (resource_id, context_id).
+    Issue #323: Added ``resource_pk`` FK to ``resources.id``. See module
+    docstring for the dual-write prohibition rule.
 
     Attributes:
         id: Primary key
-        resource_id: Resource identifier
+        resource_pk: Authoritative FK to ``resources.id`` (Issue #323)
+        resource_id: Resource slug (legacy mirror — will be dropped)
         context_id: Public context ID (foreign key to contexts table)
         last_offset: Last processed resource_events.id
         last_run_at: Last indexer execution timestamp
@@ -118,6 +224,12 @@ class IndexerState(Base):
     __tablename__ = "indexer_state"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    resource_pk = Column(
+        UUID(as_uuid=True),
+        ForeignKey("resources.id", ondelete="CASCADE"),
+        nullable=True,  # Phase 1 shadow column — tightened in #325
+        index=True,
+    )
     resource_id = Column(String(255), nullable=False, index=True)
     context_id = Column(
         UUID(as_uuid=True),
@@ -138,8 +250,17 @@ class IndexerState(Base):
         CheckConstraint(
             "job_status IN ('idle', 'queued', 'running', 'failed')", name="check_job_status"
         ),
-        # Unique constraint ensures one indexer per (resource, context) pair
-        # Handled in migration: CONSTRAINT unique_resource_context UNIQUE (resource_id, context_id)
+        # Issue #323: partial UNIQUE(resource_pk, context_id) created by
+        # migration a97_resources_entity. Partial on
+        # ``resource_pk IS NOT NULL`` during Phase 1 so rows awaiting
+        # writer migration do not collide.
+        Index(
+            "uq_indexer_state_resource_context",
+            "resource_pk",
+            "context_id",
+            unique=True,
+            postgresql_where=text("resource_pk IS NOT NULL"),
+        ),
     )
 
 
@@ -147,10 +268,19 @@ class ResourceToken(Base):
     """Resource token model (Resource API authentication).
 
     Issue #238: API tokens scoped to specific resource_id for secure external access.
+    Issue #323: Added ``resource_pk`` FK to ``resources.id`` and
+    ``workspace_id`` FK to ``workspaces.id`` as Phase 1 shadow columns.
+    Once all writers populate them (epic #321, follow-up #324), #325
+    tightens both to NOT NULL, at which point tenancy is enforced at
+    the schema layer. Until then, authorization must continue to go
+    through the legacy ``contexts`` JOIN path. See module docstring
+    for the dual-write rule.
 
     Attributes:
         id: Primary key
-        resource_id: Resource identifier this token is authorized for
+        resource_pk: FK to ``resources.id`` (Issue #323, Phase 1 nullable)
+        resource_id: Resource slug (legacy mirror — will be dropped)
+        workspace_id: Owning workspace FK (Issue #323, Phase 1 nullable)
         token_hash: SHA256 hash of API token (never store plaintext)
         description: Human-readable description
         quota_events_per_hour: Max events allowed per hour
@@ -163,7 +293,19 @@ class ResourceToken(Base):
     __tablename__ = "resource_tokens"
 
     id = Column(Integer, primary_key=True, autoincrement=True)
+    resource_pk = Column(
+        UUID(as_uuid=True),
+        ForeignKey("resources.id", ondelete="CASCADE"),
+        nullable=True,  # Phase 1 shadow column — tightened in #325
+        index=True,
+    )
     resource_id = Column(String(255), nullable=False, index=True)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=True,  # Phase 1 shadow column — tightened in #325
+        index=True,
+    )
     token_hash = Column(String(255), nullable=False, unique=True)
     description = Column(Text, nullable=True)
     quota_events_per_hour = Column(Integer, nullable=False, default=1000)

--- a/backend/tests/integration/test_resources_foundation_migration.py
+++ b/backend/tests/integration/test_resources_foundation_migration.py
@@ -367,11 +367,18 @@ class TestA97ResourcesMigration:
                 # Simulate a pre-#324 writer that only knows about
                 # ``resource_id`` — no resource_pk, no workspace_id on
                 # resource_tokens. Must succeed.
+                # Two identical upserts with resource_pk = NULL: the
+                # partial UNIQUE is ``WHERE resource_pk IS NOT NULL`` so
+                # NULL rows are excluded from the uniqueness check and
+                # the second INSERT must succeed. If this ever raises,
+                # the partial predicate has regressed and Phase 1
+                # writers would start throwing UniqueViolationError.
                 conn.execute(
                     text(
                         "INSERT INTO resource_events "
-                        "(resource_id, op, doc_id, version, importance) "
-                        "VALUES ('legacy-writer', 'upsert', 'doc-legacy', 1, 0.5)"
+                        "(resource_id, op, doc_id, version, importance) VALUES "
+                        "('legacy-writer', 'upsert', 'doc-legacy', 1, 0.5), "
+                        "('legacy-writer', 'upsert', 'doc-legacy', 1, 0.5)"
                     )
                 )
                 conn.execute(
@@ -409,5 +416,18 @@ class TestA97ResourcesMigration:
                         text(f"SELECT COUNT(*) FROM {table} WHERE resource_pk IS NULL")  # noqa: S608
                     ).scalar_one()
                     assert null_rows >= 1, f"{table} should accept NULL resource_pk in Phase 1"
+
+                # Both duplicate NULL upserts survived the partial UNIQUE.
+                dup_null_upserts = conn.execute(
+                    text(
+                        "SELECT COUNT(*) FROM resource_events "
+                        "WHERE resource_pk IS NULL AND doc_id = 'doc-legacy' "
+                        "AND version = 1 AND op = 'upsert'"
+                    )
+                ).scalar_one()
+                assert dup_null_upserts == 2, (
+                    "partial UNIQUE must exclude resource_pk=NULL rows so "
+                    "Phase 1 legacy writers do not collide with themselves"
+                )
         finally:
             engine.dispose()

--- a/backend/tests/integration/test_resources_foundation_migration.py
+++ b/backend/tests/integration/test_resources_foundation_migration.py
@@ -1,0 +1,413 @@
+"""Data-bearing round-trip + audit assertion tests for migration a97.
+
+Issue #323: the schema-only round-trip in ``test_alembic_migrations.py``
+runs against an empty database, so it cannot catch backfill bugs. These
+tests seed a realistic single-workspace dataset before crossing the a97
+boundary and verify:
+
+    - ``resources`` is populated, ``resource_pk`` is fully backfilled on
+      all four satellite tables, ``resource_tokens.workspace_id`` is
+      backfilled, and the partial UNIQUE allows upsert → delete → upsert
+      revival (the business invariant behind the ``op='upsert'``
+      predicate).
+    - ``downgrade`` restores the a96 schema and the original data is
+      still readable through the legacy ``resource_id`` slug.
+    - Re-running ``upgrade`` after a full round-trip is idempotent.
+    - The pre-migration audit aborts when a satellite table references a
+      ``resource_id`` that has no matching active context, with an
+      actionable error message.
+"""
+
+import contextlib
+import os
+import uuid
+from collections.abc import Iterator
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine.url import make_url
+
+from alembic import command
+
+from .test_alembic_migrations import _get_alembic_config, _reset_alembic_state
+
+_A96 = "a96_ctx_resource_id_unique"
+_A97 = "a97_resources_entity"
+
+_DEFAULT_TEST_URL = "postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test"
+
+
+def _test_url() -> str:
+    return os.getenv("TEST_DATABASE_URL", _DEFAULT_TEST_URL)
+
+
+def _sync_engine() -> sa.Engine:
+    """Build a synchronous engine for raw seed/assert SQL (Alembic sync).
+
+    Normalizes whichever async driver the env specifies down to plain
+    ``postgresql`` so psycopg2 handles the test connection regardless of
+    whether TEST_DATABASE_URL names asyncpg, aiopg, or no driver at all.
+    """
+    url = make_url(_test_url()).set(drivername="postgresql")
+    return create_engine(url)
+
+
+@contextlib.contextmanager
+def _point_alembic_at_test_db() -> Iterator[None]:
+    """Force alembic's env.py to target TEST_DATABASE_URL during the block.
+
+    ``env.py`` reads ``DATABASE_URL`` via ``get_database_url()`` and ignores
+    the URL set on the Alembic ``Config`` object. Without this shim,
+    ``command.upgrade`` would run against the dev database while
+    ``_reset_alembic_state`` wipes the isolated test database — exactly
+    the silent pass-through that lets the existing round-trip tests
+    succeed without actually exercising the test DB.
+    """
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = _test_url()
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+def _seed_workspace_and_context(
+    conn: sa.Connection, *, workspace_id: uuid.UUID, resource_id: str, context_id: uuid.UUID
+) -> None:
+    """Minimal workspace + public context needed to back a resource."""
+    owner_id = "user-test"
+    conn.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_user_id, plan_name) "
+            "VALUES (:id, :name, :owner, 'free')"
+        ),
+        {
+            "id": workspace_id,
+            "name": f"test-ws-{workspace_id.hex[:8]}",
+            "owner": owner_id,
+        },
+    )
+    conn.execute(
+        text(
+            "INSERT INTO contexts (id, workspace_id, name, created_by, "
+            "is_private, is_public, resource_id) "
+            "VALUES (:id, :ws, :name, :owner, false, true, :rid)"
+        ),
+        {
+            "id": context_id,
+            "ws": workspace_id,
+            "name": f"ctx-{resource_id}",
+            "owner": owner_id,
+            "rid": resource_id,
+        },
+    )
+
+
+class TestA97ResourcesMigration:
+    """Data-bearing round-trip + audit assertion tests for a97."""
+
+    def test_a97_data_bearing_roundtrip(self) -> None:
+        """Full seed → upgrade → assert backfill → downgrade → upgrade cycle."""
+        with _point_alembic_at_test_db():
+            self._run_data_bearing_roundtrip()
+
+    def _run_data_bearing_roundtrip(self) -> None:
+        _reset_alembic_state()
+        config = _get_alembic_config()
+
+        # Stop at a96 so we can seed with the pre-a97 schema shape.
+        command.upgrade(config, _A96)
+
+        workspace_id = uuid.uuid4()
+        context_id = uuid.uuid4()
+        resource_id = "test-resource"
+
+        engine = _sync_engine()
+        try:
+            with engine.begin() as conn:
+                _seed_workspace_and_context(
+                    conn,
+                    workspace_id=workspace_id,
+                    resource_id=resource_id,
+                    context_id=context_id,
+                )
+                # upsert v1 → delete v1 → upsert v2 (event-sourcing revival).
+                # The partial UNIQUE treats each version as a distinct upsert,
+                # so revival must bump the version; two raw upserts of the same
+                # (resource_pk, doc_id, version) would correctly collide.
+                conn.execute(
+                    text(
+                        "INSERT INTO resource_events "
+                        "(resource_id, op, doc_id, version, importance) VALUES "
+                        "(:r, 'upsert', 'doc1', 1, 0.5), "
+                        "(:r, 'delete', 'doc1', 1, 0.5), "
+                        "(:r, 'upsert', 'doc1', 2, 0.5)"
+                    ),
+                    {"r": resource_id},
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO resource_schemas "
+                        "(resource_id, schema_version, field_definitions) "
+                        "VALUES (:r, 1, '[]'::jsonb)"
+                    ),
+                    {"r": resource_id},
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO indexer_state "
+                        "(resource_id, context_id, last_offset, active_version, job_status) "
+                        "VALUES (:r, :ctx, 0, 1, 'idle')"
+                    ),
+                    {"r": resource_id, "ctx": context_id},
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO resource_tokens "
+                        "(resource_id, token_hash, is_active, quota_events_per_hour) "
+                        "VALUES (:r, 'hash-test', true, 1000)"
+                    ),
+                    {"r": resource_id},
+                )
+
+            # Cross the a97 boundary.
+            command.upgrade(config, _A97)
+
+            with engine.begin() as conn:
+                # resources row was seeded from contexts.
+                resources_row = conn.execute(
+                    text(
+                        "SELECT id, workspace_id, resource_id FROM resources WHERE resource_id = :r"
+                    ),
+                    {"r": resource_id},
+                ).one()
+                assert resources_row.workspace_id == workspace_id
+                resource_pk = resources_row.id
+
+                # resource_pk is fully backfilled on every satellite table.
+                for table in (
+                    "resource_events",
+                    "resource_schemas",
+                    "indexer_state",
+                    "resource_tokens",
+                ):
+                    null_rows = conn.execute(
+                        text(f"SELECT COUNT(*) FROM {table} WHERE resource_pk IS NULL")  # noqa: S608
+                    ).scalar_one()
+                    assert null_rows == 0, f"{table} has NULL resource_pk after a97"
+
+                    nonmatching = conn.execute(
+                        text(  # noqa: S608
+                            f"SELECT COUNT(*) FROM {table} WHERE resource_pk != :pk"
+                        ),
+                        {"pk": resource_pk},
+                    ).scalar_one()
+                    assert nonmatching == 0, (
+                        f"{table} has resource_pk rows pointing outside the seeded resource"
+                    )
+
+                # resource_tokens.workspace_id is NOT NULL and correct.
+                ws_rows = conn.execute(
+                    text("SELECT workspace_id FROM resource_tokens WHERE resource_id = :r"),
+                    {"r": resource_id},
+                ).all()
+                assert ws_rows and all(row.workspace_id == workspace_id for row in ws_rows)
+
+                # The partial UNIQUE index actually exists (guards against
+                # a silent CONCURRENTLY failure that would leave the
+                # revival-allowing invariant unprotected).
+                index_exists = conn.execute(
+                    text(
+                        "SELECT 1 FROM pg_class c "
+                        "JOIN pg_index i ON i.indexrelid = c.oid "
+                        "WHERE c.relname = 'ux_resource_events_upsert_version' "
+                        "AND i.indisunique AND i.indisvalid"
+                    )
+                ).scalar_one_or_none()
+                assert index_exists is not None, (
+                    "partial UNIQUE ux_resource_events_upsert_version must exist "
+                    "and be VALID after a97 upgrade"
+                )
+
+                # The partial UNIQUE permits the revival pattern.
+                event_count = conn.execute(
+                    text(
+                        "SELECT COUNT(*) FROM resource_events "
+                        "WHERE resource_pk = :pk AND doc_id = 'doc1'"
+                    ),
+                    {"pk": resource_pk},
+                ).scalar_one()
+                assert event_count == 3, "upsert → delete → upsert revival rows were lost"
+
+                upsert_count = conn.execute(
+                    text(
+                        "SELECT COUNT(*) FROM resource_events "
+                        "WHERE resource_pk = :pk AND doc_id = 'doc1' AND op = 'upsert'"
+                    ),
+                    {"pk": resource_pk},
+                ).scalar_one()
+                assert upsert_count == 2, (
+                    "both upsert rows must survive; the partial UNIQUE should only "
+                    "reject a second concurrent upsert without an intervening delete"
+                )
+
+            # Snapshot the resources count so the idempotency check
+            # below can compare against something non-trivial.
+            with engine.begin() as conn:
+                resources_count_pre = conn.execute(
+                    text("SELECT COUNT(*) FROM resources")
+                ).scalar_one()
+
+            # Downgrade and confirm legacy reads still work.
+            command.downgrade(config, _A96)
+            with engine.begin() as conn:
+                exists = conn.execute(
+                    text(
+                        "SELECT EXISTS (SELECT 1 FROM information_schema.tables "
+                        "WHERE table_name = 'resources')"
+                    )
+                ).scalar_one()
+                assert not exists, "resources table should be dropped on downgrade"
+
+                legacy_count = conn.execute(
+                    text("SELECT COUNT(*) FROM resource_events WHERE resource_id = :r"),
+                    {"r": resource_id},
+                ).scalar_one()
+                assert legacy_count == 3, "legacy resource_id data must survive downgrade"
+
+            # Re-upgrade to confirm idempotency under a full round-trip:
+            # neither a row was lost across down/up, nor a duplicate
+            # slipped past ``uq_resources_workspace_resource_id``.
+            command.upgrade(config, _A97)
+            with engine.begin() as conn:
+                resources_count_post = conn.execute(
+                    text("SELECT COUNT(*) FROM resources")
+                ).scalar_one()
+                assert resources_count_post == resources_count_pre, (
+                    f"re-upgrade must preserve row count: "
+                    f"pre={resources_count_pre} post={resources_count_post}"
+                )
+        finally:
+            engine.dispose()
+
+    def test_a97_audit_fails_on_orphan(self) -> None:
+        """Satellite rows with no matching context must abort the migration.
+
+        Seeds the orphan into ``resource_events`` as a representative case;
+        the migration's audit loop covers all four satellite tables
+        identically, so extending the fixture to the other three would
+        only exercise the same code path.
+        """
+        with _point_alembic_at_test_db():
+            self._run_audit_fails_on_orphan()
+
+    def _run_audit_fails_on_orphan(self) -> None:
+        _reset_alembic_state()
+        config = _get_alembic_config()
+
+        command.upgrade(config, _A96)
+
+        workspace_id = uuid.uuid4()
+        context_id = uuid.uuid4()
+        engine = _sync_engine()
+        try:
+            with engine.begin() as conn:
+                # Real context for one resource so the table isn't empty,
+                # plus an orphan event referencing a resource_id that
+                # never had a public context.
+                _seed_workspace_and_context(
+                    conn,
+                    workspace_id=workspace_id,
+                    resource_id="real-resource",
+                    context_id=context_id,
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO resource_events "
+                        "(resource_id, op, doc_id, version, importance) "
+                        "VALUES ('orphan-resource', 'upsert', 'doc1', 1, 0.5)"
+                    )
+                )
+
+            with pytest.raises(RuntimeError, match="satellite rows reference"):
+                command.upgrade(config, _A97)
+        finally:
+            engine.dispose()
+
+    def test_a97_legacy_writes_without_resource_pk_still_work(self) -> None:
+        """Phase 1 invariant: pre-a97 writer paths that only set
+        ``resource_id`` must keep working after the migration. If this
+        test ever fails, the migration has tightened a shadow column to
+        NOT NULL prematurely and the next production deploy will
+        throw ``NullViolationError`` on the first ingest request.
+        """
+        with _point_alembic_at_test_db():
+            self._run_legacy_writes_without_resource_pk_still_work()
+
+    def _run_legacy_writes_without_resource_pk_still_work(self) -> None:
+        _reset_alembic_state()
+        config = _get_alembic_config()
+        command.upgrade(config, _A97)
+
+        workspace_id = uuid.uuid4()
+        context_id = uuid.uuid4()
+        engine = _sync_engine()
+        try:
+            with engine.begin() as conn:
+                _seed_workspace_and_context(
+                    conn,
+                    workspace_id=workspace_id,
+                    resource_id="legacy-writer",
+                    context_id=context_id,
+                )
+                # Simulate a pre-#324 writer that only knows about
+                # ``resource_id`` — no resource_pk, no workspace_id on
+                # resource_tokens. Must succeed.
+                conn.execute(
+                    text(
+                        "INSERT INTO resource_events "
+                        "(resource_id, op, doc_id, version, importance) "
+                        "VALUES ('legacy-writer', 'upsert', 'doc-legacy', 1, 0.5)"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO resource_schemas "
+                        "(resource_id, schema_version, field_definitions) "
+                        "VALUES ('legacy-writer', 1, '[]'::jsonb)"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO indexer_state "
+                        "(resource_id, context_id, last_offset, active_version, job_status) "
+                        "VALUES ('legacy-writer', :ctx, 0, 1, 'idle')"
+                    ),
+                    {"ctx": context_id},
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO resource_tokens "
+                        "(resource_id, token_hash, is_active, quota_events_per_hour) "
+                        "VALUES ('legacy-writer', 'hash-legacy', true, 1000)"
+                    )
+                )
+
+            # All four tables accepted the NULL resource_pk.
+            with engine.begin() as conn:
+                for table in (
+                    "resource_events",
+                    "resource_schemas",
+                    "indexer_state",
+                    "resource_tokens",
+                ):
+                    null_rows = conn.execute(
+                        text(f"SELECT COUNT(*) FROM {table} WHERE resource_pk IS NULL")  # noqa: S608
+                    ).scalar_one()
+                    assert null_rows >= 1, f"{table} should accept NULL resource_pk in Phase 1"
+        finally:
+            engine.dispose()


### PR DESCRIPTION
Closes #323

## Summary

- Phase 1 of 2 for epic #321. Adds authoritative `resources` table (UUID PK, `workspace_id` FK, `UNIQUE(workspace_id, resource_id)`) and backfills it from the active rows in `contexts`.
- Introduces `resource_pk UUID` as a **nullable shadow FK** on the four satellite tables (`resource_events`, `resource_schemas`, `indexer_state`, `resource_tokens`) and `resource_tokens.workspace_id` as a nullable shadow FK to `workspaces`.
- Adds the three UNIQUE constraints the model docstrings have always promised but baseline never materialized — as **partial indexes** on `resource_pk IS NOT NULL` so pre-#324 writer paths continue to work unchanged.
- Ships with a pre-migration audit that fails fast on orphan satellite rows (no matching active context), the `resource_events` partial UNIQUE via `CREATE INDEX CONCURRENTLY`, and a documented dual-write prohibition for the transition period.

## Implementation notes

- **Phase strategy**: column nullability stays permissive in this PR so existing writers that only set `resource_id VARCHAR` keep working. Tightening to `NOT NULL` lives in **#325**; application writers get migrated to populate `resource_pk` in **#324**. Deploying this PR alone does not break production — proven by E2E smoke on the live dev DB (`make migrate` applied a97, API container rebooted healthy, MCP `recall`/`remember` continued to work, and a legacy direct INSERT with both shadow columns NULL was accepted).
- **Migration step order** (see `backend/alembic/versions/a97_resources_entity.py` docstring): create `resources` → seed from active contexts → orphan audit → add `resource_pk` + backfill + FK/index on 4 satellites → add `resource_tokens.workspace_id` + backfill (depends on the just-populated `resource_pk`) → create 3 partial UNIQUE indexes (`resource_events` via CONCURRENTLY, mirroring the a96 pattern from #329).
- **Dual-write rule**: once #324 lands, `resource_pk` is the source of truth. `resource_id VARCHAR` columns stay as read-side transitional aids only, populated via shim, and will be dropped once every writer has switched over.
- **Downgrade** is complete — `resource_id VARCHAR` columns are preserved across the round-trip so legacy queries remain readable from a96 state.
- **Tests** (`backend/tests/integration/test_resources_foundation_migration.py`):
  - `test_a97_data_bearing_roundtrip` — seed → up → assert backfill + partial UNIQUE existence + revival pattern → down → assert legacy reads work → re-up → assert idempotency.
  - `test_a97_audit_fails_on_orphan` — seeds an orphan satellite row and asserts the audit raises with an actionable message.
  - `test_a97_legacy_writes_without_resource_pk_still_work` — verifies a pre-#324 writer can INSERT into all four satellites without `resource_pk` AND that the partial UNIQUE correctly skips `resource_pk = NULL` duplicates (Phase 1 compatibility guarantee).

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (quick-win addressed in commit 69d122f; remaining notes deferred to #324)
- cto: green
- gate1: yellow via /ask → CIO (operator also consulted /cto and /qa-lead before branch creation; both returned conditional green)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/323-feat-refactor-db-introduce-resources-entity-w.gate1.md`
- `~/.claude/cache/gh-issue-driven/323-feat-refactor-db-introduce-resources-entity-w.gate2.md`

## Coordination

- **#324** (writer migration) must follow to populate `resource_pk` on every write path.
- **#325** (NOT NULL tightening) closes the Phase 1/2 rollout.
- Keep #324 and #325 scheduled in the same milestone so the dual-column state does not persist.

🤖 Generated via /gh-issue-driven:ship
