### PR TITLE
fix(indexer): Qdrant named-vector upsert (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Release notes are published on [GitHub Releases](https://github.com/kagura-ai/me
 - **Critical (OWASP A01 / CWE-639)**: Fixed cross-tenant memory injection via Resource Ingest API (#322, parent epic #321). All self-hosted deployments with Resource Ingest enabled must upgrade. See `SECURITY.md` for the advisory and upgrade steps.
 
 ### Fixed
-- **Resource indexer Qdrant upsert** (#324): Resource ingest events were silently failing at the Qdrant write path with `"Not existing vector name error"` because the indexer upserted anonymous vectors into a named-vector collection (`dense` + sparse `bm25`). Fixed by switching to `PointStruct(vector={"dense": embedding})` and unmasked a latent `Memory(collection_name=...)` kwarg error left over from the Single Collection Migration. See `docs/ops/resource-indexer-backfill.md` for re-queue procedure for stuck `resource_indexer_state` rows.
+- **Resource indexer Qdrant upsert** (#324): Resource ingest events were silently failing at the Qdrant write path with `"Not existing vector name error"` because the indexer upserted anonymous vectors into a named-vector collection (`dense` + sparse `bm25`). Fixed by switching to `PointStruct(vector={"dense": embedding})` and unmasked a latent `Memory(collection_name=...)` kwarg error left over from the Single Collection Migration. See `docs/ops/resource-indexer-backfill.md` for re-queue procedure for stuck `indexer_state` rows.
 
 ### Database
 - Added migration `a96`: global partial UNIQUE index `ux_contexts_resource_id_active` on `contexts(resource_id)` for active rows. Zero-downtime (`CREATE INDEX CONCURRENTLY`). Aborts if pre-existing cross-workspace `resource_id` collisions are detected — operators must resolve duplicates before upgrading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Release notes are published on [GitHub Releases](https://github.com/kagura-ai/me
 ### Security
 - **Critical (OWASP A01 / CWE-639)**: Fixed cross-tenant memory injection via Resource Ingest API (#322, parent epic #321). All self-hosted deployments with Resource Ingest enabled must upgrade. See `SECURITY.md` for the advisory and upgrade steps.
 
+### Fixed
+- **Resource indexer Qdrant upsert** (#324): Resource ingest events were silently failing at the Qdrant write path with `"Not existing vector name error"` because the indexer upserted anonymous vectors into a named-vector collection (`dense` + sparse `bm25`). Fixed by switching to `PointStruct(vector={"dense": embedding})` and unmasked a latent `Memory(collection_name=...)` kwarg error left over from the Single Collection Migration. See `docs/ops/resource-indexer-backfill.md` for re-queue procedure for stuck `resource_indexer_state` rows.
+
 ### Database
 - Added migration `a96`: global partial UNIQUE index `ux_contexts_resource_id_active` on `contexts(resource_id)` for active rows. Zero-downtime (`CREATE INDEX CONCURRENTLY`). Aborts if pre-existing cross-workspace `resource_id` collisions are detected — operators must resolve duplicates before upgrading.
 

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -366,7 +366,7 @@ async def add_memory_to_qdrant(
 
     try:
         # Issue #16: Named vectors (dense + sparse BM25)
-        point_vector: dict[str, Any] = {"dense": vector}
+        point_vector: dict[str, Any] = {KAGURA_MEMORIES_VECTOR_NAME: vector}
         if sparse_indices and sparse_values:
             point_vector["bm25"] = SparseVector(indices=sparse_indices, values=sparse_values)
 
@@ -448,14 +448,14 @@ async def search_memories_qdrant(
     )
 
     try:
-        # Issue #16: Named vector "dense" for semantic search
+        # Issue #16: Named vector for semantic search
         results = await client.query_points(
             collection_name=collection_name,
             query=query_vector,
-            using="dense",
+            using=KAGURA_MEMORIES_VECTOR_NAME,
             limit=limit,
             query_filter=qdrant_filter,
-            with_vectors=["dense"] if include_vectors else False,
+            with_vectors=[KAGURA_MEMORIES_VECTOR_NAME] if include_vectors else False,
         )
 
         return [
@@ -464,7 +464,7 @@ async def search_memories_qdrant(
                 "score": point.score,
                 "payload": point.payload,
                 "embedding": (
-                    point.vector.get("dense", [])
+                    point.vector.get(KAGURA_MEMORIES_VECTOR_NAME, [])
                     if include_vectors and isinstance(point.vector, dict)
                     else []
                 ),
@@ -726,7 +726,7 @@ async def ensure_kagura_memories_collection(
         await client.create_collection(
             collection_name=collection_name,
             vectors_config={
-                "dense": VectorParams(
+                KAGURA_MEMORIES_VECTOR_NAME: VectorParams(
                     size=embedding_dim,
                     distance=Distance.COSINE,
                 ),

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -47,6 +47,11 @@ _qdrant_client: AsyncQdrantClient | None = None
 # Single Collection Migration: Collection name constant
 KAGURA_MEMORIES_COLLECTION = "kagura_memories"
 
+# Named vector contract (Issue #16, #324): all kagura_memories collections use
+# `{"dense": VectorParams(...), "bm25": SparseVectorParams(...)}` — anonymous
+# vectors will fail with "Not existing vector name error".
+KAGURA_MEMORIES_VECTOR_NAME = "dense"
+
 
 def get_collection_name(model: str, dimensions: int) -> str:
     """Get Qdrant collection name for a given embedding model.

--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -22,7 +22,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # Local application imports (PEP8)
-from db.qdrant import get_qdrant_client
+from db.qdrant import KAGURA_MEMORIES_VECTOR_NAME, get_qdrant_client
 from models.auth import Context
 from models.memory import Memory  # Issue #262: Memory model for resource data storage
 from models.resource import IndexerState, ResourceEvent, ResourceSchema
@@ -304,10 +304,11 @@ class ResourceIndexer:
         # Generate Memory ID for new memories (may be overwritten if memory exists)
         memory_id = uuid4()
 
-        # Single Collection Migration: Add 3-level isolation to payload
+        # kagura_memories collections are configured with named vectors
+        # (dense + sparse bm25); anonymous vectors are rejected at upsert.
         point = PointStruct(
             id=str(point_id_uuid),
-            vector=embedding,
+            vector={KAGURA_MEMORIES_VECTOR_NAME: embedding},
             payload={
                 "workspace_id": str(context.workspace_id),  # 3-level isolation
                 "context_id": str(context.id),  # 3-level isolation
@@ -425,11 +426,9 @@ class ResourceIndexer:
                 summary = f"[{event.resource_id}] {event.doc_id} v{event.version}"
                 # P2-10: Safe truncation with ellipsis for context_summary
                 context_summary = content[:1997] + "..." if len(content) > 2000 else content
-                # Single Collection Migration: Set workspace_id/context_id
                 memory = Memory(
                     id=memory_id,
                     user_id=str(context.created_by),
-                    collection_name=KAGURA_MEMORIES_COLLECTION,  # Deprecated but kept for compatibility
                     workspace_id=context.workspace_id,
                     context_id=context.id,
                     summary=summary[:500],

--- a/backend/tests/integration/test_resource_indexer_qdrant.py
+++ b/backend/tests/integration/test_resource_indexer_qdrant.py
@@ -1,0 +1,149 @@
+"""Integration test for Issue #324: Qdrant named-vector upsert contract.
+
+Verifies the on-wire contract between the resource indexer and a real Qdrant
+instance configured with named vectors (`dense` + sparse `bm25`). The unit
+test in `tests/services/test_resource_indexer.py` asserts that the indexer
+*produces* `PointStruct(vector={"dense": ...})`; this test asserts that a
+real Qdrant accepts that shape and rejects the pre-fix anonymous shape.
+
+Local-only: this test is not wired into CI yet. Run with:
+
+    make test-integration
+
+It skips automatically when `QDRANT_URL` is unreachable so it never becomes
+a mystery failure for contributors without docker compose running.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Iterator
+
+import pytest
+from qdrant_client import QdrantClient
+from qdrant_client.http.exceptions import UnexpectedResponse
+from qdrant_client.models import (
+    Distance,
+    Modifier,
+    PointStruct,
+    SparseVectorParams,
+    VectorParams,
+)
+
+from db.qdrant import KAGURA_MEMORIES_VECTOR_NAME
+
+_EMBEDDING_DIM = 512
+
+
+def _qdrant_url() -> str:
+    return os.getenv("QDRANT_URL", "http://localhost:6333")
+
+
+@pytest.fixture(scope="module")
+def qdrant_client() -> Iterator[QdrantClient]:
+    """Sync Qdrant client for fast integration assertions.
+
+    Skips the whole module when Qdrant is unreachable so contributors without
+    `docker compose up qdrant` get a clear skip message instead of an opaque
+    connection error.
+    """
+    client = QdrantClient(url=_qdrant_url(), timeout=5)
+    try:
+        client.get_collections()
+    except Exception as exc:  # noqa: BLE001 — intentional broad skip guard
+        pytest.skip(f"Qdrant unreachable at {_qdrant_url()}: {exc}")
+    yield client
+    client.close()
+
+
+@pytest.fixture
+def named_vector_collection(qdrant_client: QdrantClient) -> Iterator[str]:
+    """Create a throwaway kagura_memories-shaped collection and delete it after.
+
+    Shape mirrors `ensure_kagura_memories_collection` in `backend/src/db/qdrant.py`:
+    one named dense vector + sparse bm25. This is the exact schema the resource
+    indexer is writing against in production.
+    """
+    name = f"test_resource_indexer_{uuid.uuid4().hex[:12]}"
+    qdrant_client.create_collection(
+        collection_name=name,
+        vectors_config={
+            KAGURA_MEMORIES_VECTOR_NAME: VectorParams(
+                size=_EMBEDDING_DIM, distance=Distance.COSINE
+            ),
+        },
+        sparse_vectors_config={
+            "bm25": SparseVectorParams(modifier=Modifier.IDF),
+        },
+    )
+    try:
+        yield name
+    finally:
+        qdrant_client.delete_collection(name)
+
+
+class TestNamedVectorUpsertContract:
+    """Regression tests for Issue #324."""
+
+    def test_named_vector_upsert_succeeds(
+        self, qdrant_client: QdrantClient, named_vector_collection: str
+    ) -> None:
+        """Upsert with `vector={"dense": [...]}` must land a point."""
+        point_id = str(uuid.uuid4())
+        qdrant_client.upsert(
+            collection_name=named_vector_collection,
+            points=[
+                PointStruct(
+                    id=point_id,
+                    vector={KAGURA_MEMORIES_VECTOR_NAME: [0.1] * _EMBEDDING_DIM},
+                    payload={"doc_id": "d1", "version": 1},
+                )
+            ],
+            wait=True,
+        )
+        count = qdrant_client.count(collection_name=named_vector_collection, exact=True)
+        assert count.count == 1
+
+    def test_anonymous_vector_upsert_fails(
+        self, qdrant_client: QdrantClient, named_vector_collection: str
+    ) -> None:
+        """Regression guard: the pre-fix shape (bare list) must be rejected.
+
+        If Qdrant ever relaxes this and starts accepting anonymous vectors on
+        named-vector collections, we want to know — the shape contract would
+        have softened and our named-vector assumption would need revisiting.
+        """
+        with pytest.raises((UnexpectedResponse, ValueError)):
+            qdrant_client.upsert(
+                collection_name=named_vector_collection,
+                points=[
+                    PointStruct(
+                        id=str(uuid.uuid4()),
+                        vector=[0.1] * _EMBEDDING_DIM,  # anonymous — pre-#324 bug shape
+                        payload={},
+                    )
+                ],
+                wait=True,
+            )
+
+    def test_named_vector_upsert_is_idempotent(
+        self, qdrant_client: QdrantClient, named_vector_collection: str
+    ) -> None:
+        """Re-queueing the same event (same point_id) must not create duplicates.
+
+        The indexer builds point_id = uuid5(NAMESPACE_DNS, "resource_id:doc_id:v{version}"),
+        which is stable across runs. This is the invariant that makes the
+        Issue #324 backfill runbook safe — ops can re-queue failed
+        indexer_state rows without worrying about duplicate points.
+        """
+        point_id = str(uuid.uuid4())
+        point = PointStruct(
+            id=point_id,
+            vector={KAGURA_MEMORIES_VECTOR_NAME: [0.2] * _EMBEDDING_DIM},
+            payload={"doc_id": "d1", "version": 1},
+        )
+        qdrant_client.upsert(collection_name=named_vector_collection, points=[point], wait=True)
+        qdrant_client.upsert(collection_name=named_vector_collection, points=[point], wait=True)
+        count = qdrant_client.count(collection_name=named_vector_collection, exact=True)
+        assert count.count == 1

--- a/backend/tests/services/test_resource_indexer.py
+++ b/backend/tests/services/test_resource_indexer.py
@@ -1,0 +1,116 @@
+"""Unit tests for ResourceIndexer Qdrant upsert contract.
+
+Issue #324: kagura_memories collection uses named vectors
+({"dense": ..., "bm25": ...}); indexer must upsert with dict-keyed
+vector, not anonymous.
+"""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from db.qdrant import KAGURA_MEMORIES_VECTOR_NAME
+from services.resource_indexer import ResourceIndexer
+
+
+def _make_event() -> MagicMock:
+    event = MagicMock()
+    event.id = 1
+    event.resource_id = "res_test"
+    event.doc_id = "doc_1"
+    event.version = 1
+    event.payload = {"title": "hello", "price": 100}
+    event.created_at = datetime(2026, 4, 15, tzinfo=UTC)
+    event.op = "upsert"
+    return event
+
+
+def _make_schema() -> MagicMock:
+    schema = MagicMock()
+    schema.field_definitions = [
+        {
+            "name": "title",
+            "classification": "public",
+            "index_hint": "fulltext",
+            "description": "Title",
+        },
+        {
+            "name": "price",
+            "classification": "public",
+            "index_hint": "sort",
+            "description": "Price",
+        },
+    ]
+    return schema
+
+
+def _make_context() -> MagicMock:
+    ctx = MagicMock()
+    ctx.id = uuid4()
+    ctx.workspace_id = uuid4()
+    ctx.created_by = uuid4()
+    return ctx
+
+
+class TestResourceIndexerNamedVectorUpsert:
+    """Verify the Qdrant write path uses named vectors (Issue #324)."""
+
+    @pytest.fixture
+    def mock_db(self):
+        db = AsyncMock()
+        # Memory existence check — no row → INSERT branch
+        existing = MagicMock()
+        existing.scalar_one_or_none.return_value = None
+        db.execute.return_value = existing
+        return db
+
+    @pytest.fixture
+    def indexer(self, mock_db):
+        with patch("services.resource_indexer.get_qdrant_client", return_value=AsyncMock()):
+            idx = ResourceIndexer(mock_db)
+        # Replace embedding_service with a predictable stub.
+        idx.embedding_service = MagicMock()
+        idx.embedding_service.embed = AsyncMock(return_value=[0.1] * 512)
+        return idx
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_sends_named_vector(self, indexer):
+        """PointStruct.vector must be {"dense": <embedding>} (named), not a bare list."""
+        event = _make_event()
+        schema = _make_schema()
+        context = _make_context()
+
+        await indexer._apply_upsert(event, schema, context)
+
+        # Qdrant upsert was called exactly once with a named-vector point.
+        assert indexer.qdrant_client.upsert.await_count == 1
+        call = indexer.qdrant_client.upsert.await_args
+        points = call.kwargs["points"]
+        assert len(points) == 1
+
+        point = points[0]
+        assert isinstance(point.vector, dict), (
+            f"PointStruct.vector must be a dict for named-vector collections, got {type(point.vector)}"
+        )
+        assert KAGURA_MEMORIES_VECTOR_NAME in point.vector
+        assert point.vector[KAGURA_MEMORIES_VECTOR_NAME] == [0.1] * 512
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_point_id_is_deterministic_uuid(self, indexer):
+        """uuid5 of resource_id:doc_id:v{version} must produce a stable point_id
+        (idempotency for re-queue after Issue #324 backfill)."""
+        event = _make_event()
+        schema = _make_schema()
+        context = _make_context()
+
+        await indexer._apply_upsert(event, schema, context)
+        first_id = indexer.qdrant_client.upsert.await_args.kwargs["points"][0].id
+
+        indexer.qdrant_client.upsert.reset_mock()
+
+        await indexer._apply_upsert(event, schema, context)
+        second_id = indexer.qdrant_client.upsert.await_args.kwargs["points"][0].id
+
+        assert first_id == second_id

--- a/backend/tests/services/test_resource_indexer.py
+++ b/backend/tests/services/test_resource_indexer.py
@@ -24,6 +24,7 @@ def _make_event() -> MagicMock:
     event.payload = {"title": "hello", "price": 100}
     event.created_at = datetime(2026, 4, 15, tzinfo=UTC)
     event.op = "upsert"
+    event.importance = None
     return event
 
 
@@ -60,10 +61,26 @@ class TestResourceIndexerNamedVectorUpsert:
     @pytest.fixture
     def mock_db(self):
         db = AsyncMock()
-        # Memory existence check — no row → INSERT branch
+        # _apply_upsert issues two queries per call: (1) existing-memory lookup,
+        # (2) old-version cleanup scan. The first expects scalar_one_or_none,
+        # the second iterates result.scalars().all(). Without distinct return
+        # values, the second call sees a MagicMock from result 1 and the
+        # `if old_memories:` branch becomes non-deterministic.
         existing = MagicMock()
         existing.scalar_one_or_none.return_value = None
-        db.execute.return_value = existing
+        old_versions = MagicMock()
+        old_versions.scalars.return_value.all.return_value = []
+
+        call_count = 0
+
+        def _execute_side_effect(*_args, **_kwargs):
+            # Alternate per call: odd → existing-lookup, even → old-version scan.
+            nonlocal call_count
+            call_count += 1
+            return existing if call_count % 2 == 1 else old_versions
+
+        db.execute.side_effect = _execute_side_effect
+        db.add = MagicMock()
         return db
 
     @pytest.fixture

--- a/docs/ops/resource-indexer-backfill.md
+++ b/docs/ops/resource-indexer-backfill.md
@@ -1,9 +1,8 @@
 # Resource Indexer Backfill Runbook
 
-When to use: you have `indexer_state` rows stuck with
-`last_metrics.errors > 0` because of a bug (e.g., Issue #324's
-named-vector upsert failure before the fix), and you need to re-queue
-them once the upstream bug is fixed.
+When to use: you have `indexer_state` rows stuck with `metrics.errors > 0`
+because of a bug (e.g., Issue #324's named-vector upsert failure before the
+fix), and you need to re-queue them once the upstream bug is fixed.
 
 ## Safety
 
@@ -13,22 +12,24 @@ Re-queueing is **idempotent**. The indexer computes each Qdrant point id as:
 uuid5(NAMESPACE_DNS, "{resource_id}:{doc_id}:v{version}")
 ```
 
-Same event → same point id → upsert overwrites in place, `points_count`
-does not drift. You will not create duplicate points by re-queueing the
-same `last_offset`.
+Same event → same point id → upsert overwrites in place. `points_count` does
+**not** grow when re-processing events whose points already exist. You will
+not create duplicate points by re-queueing the same `last_offset`.
 
 ## Identify affected rows
+
+The metrics JSONB column is named `metrics` (not `last_metrics`).
 
 ```sql
 SELECT
   resource_id,
   context_id,
   last_offset,
-  last_metrics->>'errors'   AS errors,
-  last_metrics->>'reason'   AS reason,
+  metrics->>'errors'   AS errors,
+  metrics->>'reason'   AS reason,
   updated_at
 FROM indexer_state
-WHERE (last_metrics->>'errors')::int > 0
+WHERE (metrics->>'errors')::int > 0
 ORDER BY updated_at DESC;
 ```
 
@@ -41,44 +42,77 @@ first.
 
 Rewind `last_offset` to the earliest failing event so the indexer reprocesses
 the backlog. The simplest way is to reset it to the last known-good offset, or
-to `0` if you want a full re-index.
+to `0` if you want a full re-index. Use `coalesce(metrics, '{}'::jsonb)` in
+case the column is NULL (server_default is `{}`, but be defensive).
 
 ```sql
 -- Option A: rewind to just before the first error
 UPDATE indexer_state
 SET last_offset = <known_good_offset>,
-    last_metrics = jsonb_set(last_metrics, '{errors}', '0')
+    metrics = jsonb_set(coalesce(metrics, '{}'::jsonb), '{errors}', '0'::jsonb)
 WHERE resource_id = '<resource_id>' AND context_id = '<context_id>';
 
 -- Option B: full re-index from zero (safe because uuid5 keeps point ids stable)
 UPDATE indexer_state
 SET last_offset = 0,
-    last_metrics = jsonb_set(last_metrics, '{errors}', '0')
+    metrics = jsonb_set(coalesce(metrics, '{}'::jsonb), '{errors}', '0'::jsonb)
 WHERE resource_id = '<resource_id>' AND context_id = '<context_id>';
 ```
 
 The next scheduled indexer run (or manual trigger) will process the pending
-events. Watch the logs for `qdrant_upsert_success` and verify
-`last_metrics.applied_upserts > 0`:
+events. Watch the logs for `qdrant_upsert_success` and verify the metrics:
 
 ```sql
 SELECT
   resource_id,
   last_offset,
-  last_metrics->>'applied_upserts' AS applied_upserts,
-  last_metrics->>'errors'          AS errors
+  metrics->>'applied_upserts' AS applied_upserts,
+  metrics->>'errors'          AS errors
 FROM indexer_state
 WHERE resource_id = '<resource_id>';
 ```
 
+`errors` should drop to `0`. `applied_upserts` should be non-zero on the
+first run that reprocesses the backlog. On subsequent runs with no new
+events, it will be `0` and `skipped=true, reason=no_pending_events` —
+that's the steady state, not a failure.
+
 ## Post-check
 
-In Qdrant, confirm point count increased:
+Because upserts are idempotent, `points_count` **is not a reliable
+success signal** — re-processing an existing event overwrites the same
+point id without changing the count. Verify success by one of:
 
-```bash
-curl -s "$QDRANT_URL/collections/kagura_memories" | jq '.result.points_count'
-```
+1. **Sample a known point.** Compute the point id for a specific
+   `(resource_id, doc_id, version)` that was in the failing batch:
 
-If `applied_upserts > 0` but `points_count` did not change, the indexer
-succeeded at the Postgres layer but the upsert did not land — re-check the
-collection shape and indexer logs.
+   ```python
+   from uuid import uuid5, NAMESPACE_DNS
+   print(uuid5(NAMESPACE_DNS, f"{resource_id}:{doc_id}:v{version}"))
+   ```
+
+   Then retrieve it from Qdrant:
+
+   ```bash
+   curl -s "$QDRANT_URL/collections/kagura_memories/points/<point-id>" \
+     | jq '.result | {id, has_vector: (.vector != null), payload_keys: (.payload | keys)}'
+   ```
+
+   A successful backfill returns the point with `has_vector=true` and the
+   expected payload keys (`resource_id`, `doc_id`, `version`, `content`).
+
+2. **Compare `points_count` against a pre-backfill baseline.** If this is
+   the first time any events for a `(resource_id, context_id)` pair have
+   successfully indexed, `points_count` WILL grow. Capture the baseline
+   before re-queueing:
+
+   ```bash
+   curl -s "$QDRANT_URL/collections/kagura_memories" | jq '.result.points_count'
+   ```
+
+   Compare to the count after the indexer run.
+
+If `applied_upserts > 0` but neither check above succeeds, the indexer
+reported success at the Postgres layer but the upsert did not land in
+Qdrant — re-check the collection shape (`GET /collections/kagura_memories`
+should report `dense` as a named vector) and the indexer logs.

--- a/docs/ops/resource-indexer-backfill.md
+++ b/docs/ops/resource-indexer-backfill.md
@@ -1,0 +1,84 @@
+# Resource Indexer Backfill Runbook
+
+When to use: you have `indexer_state` rows stuck with
+`last_metrics.errors > 0` because of a bug (e.g., Issue #324's
+named-vector upsert failure before the fix), and you need to re-queue
+them once the upstream bug is fixed.
+
+## Safety
+
+Re-queueing is **idempotent**. The indexer computes each Qdrant point id as:
+
+```
+uuid5(NAMESPACE_DNS, "{resource_id}:{doc_id}:v{version}")
+```
+
+Same event → same point id → upsert overwrites in place, `points_count`
+does not drift. You will not create duplicate points by re-queueing the
+same `last_offset`.
+
+## Identify affected rows
+
+```sql
+SELECT
+  resource_id,
+  context_id,
+  last_offset,
+  last_metrics->>'errors'   AS errors,
+  last_metrics->>'reason'   AS reason,
+  updated_at
+FROM indexer_state
+WHERE (last_metrics->>'errors')::int > 0
+ORDER BY updated_at DESC;
+```
+
+Confirm each row's error matches the bug you just fixed (e.g.,
+`"Not existing vector name error"` for #324). **Do not blindly re-queue
+rows whose error is a different root cause** — they need their own fix
+first.
+
+## Re-queue procedure
+
+Rewind `last_offset` to the earliest failing event so the indexer reprocesses
+the backlog. The simplest way is to reset it to the last known-good offset, or
+to `0` if you want a full re-index.
+
+```sql
+-- Option A: rewind to just before the first error
+UPDATE indexer_state
+SET last_offset = <known_good_offset>,
+    last_metrics = jsonb_set(last_metrics, '{errors}', '0')
+WHERE resource_id = '<resource_id>' AND context_id = '<context_id>';
+
+-- Option B: full re-index from zero (safe because uuid5 keeps point ids stable)
+UPDATE indexer_state
+SET last_offset = 0,
+    last_metrics = jsonb_set(last_metrics, '{errors}', '0')
+WHERE resource_id = '<resource_id>' AND context_id = '<context_id>';
+```
+
+The next scheduled indexer run (or manual trigger) will process the pending
+events. Watch the logs for `qdrant_upsert_success` and verify
+`last_metrics.applied_upserts > 0`:
+
+```sql
+SELECT
+  resource_id,
+  last_offset,
+  last_metrics->>'applied_upserts' AS applied_upserts,
+  last_metrics->>'errors'          AS errors
+FROM indexer_state
+WHERE resource_id = '<resource_id>';
+```
+
+## Post-check
+
+In Qdrant, confirm point count increased:
+
+```bash
+curl -s "$QDRANT_URL/collections/kagura_memories" | jq '.result.points_count'
+```
+
+If `applied_upserts > 0` but `points_count` did not change, the indexer
+succeeded at the Postgres layer but the upsert did not land — re-check the
+collection shape and indexer logs.


### PR DESCRIPTION
Closes #324

## Summary
- Fix `resource_indexer` upsert to send `vector={"dense": embedding}` so it matches the named-vector shape of the `kagura_memories` collection (dense + sparse bm25). Anonymous vectors were rejected with `"Not existing vector name error"`, failing every resource ingest event at the Qdrant write path.
- Drop the dead `collection_name=KAGURA_MEMORIES_COLLECTION` kwarg from `Memory(...)` — the column was removed in the Single Collection Migration. The prior Qdrant failure had masked this latent `TypeError` on every new resource Memory insert; fixing the upsert unblocked it.
- Add `KAGURA_MEMORIES_VECTOR_NAME = "dense"` in `backend/src/db/qdrant.py` as the single source of truth for the named-vector contract.
- Add local-only regression tests (unit 2 + integration 3) and an ops runbook for re-queueing stuck `indexer_state` rows.

## Implementation notes
- `backend/src/services/resource_indexer.py` (~L310): `vector=embedding` → `vector={KAGURA_MEMORIES_VECTOR_NAME: embedding}`.
- `backend/src/services/resource_indexer.py` (~L434): removed `collection_name=KAGURA_MEMORIES_COLLECTION` kwarg from `Memory(...)`. No other `Memory(...)` call sites use this kwarg (verified via grep).
- `backend/tests/services/test_resource_indexer.py` (new): mocks `qdrant_client.upsert`, asserts `PointStruct.vector` is a `dict` with the `"dense"` key, and verifies uuid5-based point_id idempotency across two calls.
- `backend/tests/integration/test_resource_indexer_qdrant.py` (new): creates a throwaway named-vector collection against a real Qdrant, asserts dict-keyed upsert succeeds, anonymous vector is rejected, and same point_id does not create duplicates. Skips when `QDRANT_URL` is unreachable. **Not wired into CI yet** — run with `make test-integration` locally. CI integration will be a separate issue.
- `docs/ops/resource-indexer-backfill.md` (new): SQL runbook for re-queueing `indexer_state` rows stuck with `errors > 0`. Re-queueing is safe because point_ids are `uuid5(NAMESPACE_DNS, "{resource_id}:{doc_id}:v{version}")` and therefore stable.
- No DB migration. No API surface change. Internal service layer only.

## Out-of-scope (deferred to follow-up issues)
- **Collection routing for per-context embedding_model (Layer B, v0.12.1)**: `resource_indexer` still hardcodes `KAGURA_MEMORIES_COLLECTION` (legacy 512-dim). Contexts using qwen3-embedding models (1024/2560/4096 dim) would still fail on a dim mismatch after this PR lands. Qwen3 contexts do not exist in production yet, so this is not a release blocker — tracked separately for v0.12.1.
- **Sparse `bm25` vector send**: requires BM25 encoder injection; separate issue.
- **Wire `tests/integration/` into CI**: CI currently runs lint + frontend only; separate issue.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (cascaded through /qa-lead and /coo, converged after scope negotiation)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/324-fix-qdrant-named-vector-upsert.gate1.md
- ~/.claude/cache/gh-issue-driven/324-fix-qdrant-named-vector-upsert.gate2.md

🤖 Generated via /gh-issue-driven:ship
