### PR TITLE
fix(security): MCP ingest_events workspace-scoped quota enforcement (#332)

### DIFF
--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -23,8 +23,9 @@ from models.schemas import (
     ResourceEventResponse,
 )
 from services.permission_service import PermissionService
+from services.resource_quota_service import check_event_quota
 from utils.datetime import utcnow
-from utils.exceptions import ConflictError, RateLimitError, RedisError, ValidationError
+from utils.exceptions import ConflictError, ValidationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -264,8 +265,9 @@ async def ingest_event(
         has_payload=request.payload is not None,
     )
 
-    # 1. Check quota (events per hour)
-    await _check_event_quota(resource_id, token_record.id, quota_per_hour)
+    # 1. Check quota (events per hour) — counter is workspace-scoped and shared
+    # with the MCP ingest path so combined traffic counts against one ceiling.
+    await check_event_quota(resource_id, context.workspace_id, quota_per_hour)
 
     # 2. Validate payload size
     if request.payload:
@@ -429,9 +431,9 @@ async def ingest_batch(
     if len(request.events) > 100:
         raise ValidationError("Batch size exceeds maximum (100 events)")
 
-    # 2. Check quota for entire batch
-    await _check_event_quota(
-        resource_id, token_record.id, quota_per_hour, count=len(request.events)
+    # 2. Check quota for entire batch (workspace-scoped counter shared with MCP)
+    await check_event_quota(
+        resource_id, context.workspace_id, quota_per_hour, count=len(request.events)
     )
 
     # 3. Process events
@@ -565,71 +567,6 @@ async def ingest_batch(
 # ============================================================================
 # Helper Functions
 # ============================================================================
-
-
-async def _check_event_quota(
-    resource_id: str,
-    token_id: int,
-    quota_per_hour: int,
-    count: int = 1,
-) -> None:
-    """Check event ingestion quota (per token per hour).
-
-    Uses Redis counter with 1-hour TTL. Reserves `count` units after a passing
-    check so concurrent callers observe the updated total.
-
-    Fail-open: if Redis is unavailable (RedisError), the function logs and returns
-    without raising. This matches SECURITY.md "Rate Limiting" policy — Redis
-    outages must not block ingest. Non-Redis exceptions (programming bugs) are
-    NOT swallowed and will propagate to the caller.
-
-    Args:
-        resource_id: Resource identifier
-        token_id: Token ID
-        quota_per_hour: Maximum events allowed per hour
-        count: Number of events to check (default: 1)
-
-    Raises:
-        RateLimitError: If quota exceeded (429).
-    """
-    from db.redis import get_cache, incrby_counter
-
-    redis_key = f"resource:events:{resource_id}:{token_id}:hour"
-
-    try:
-        current_count_str = await get_cache(redis_key)
-        current_count = int(current_count_str) if current_count_str else 0
-
-        if current_count + count > quota_per_hour:
-            logger.warning(
-                "resource_event_quota_exceeded",
-                resource_id=resource_id,
-                token_id=token_id,
-                current=current_count,
-                quota=quota_per_hour,
-            )
-            raise RateLimitError(
-                message=f"Event quota exceeded: {current_count}/{quota_per_hour} events per hour",
-                retry_after=3600,  # Retry after 1 hour
-            )
-
-        new_count = await incrby_counter(redis_key, count, ttl=3600)
-
-        logger.debug(
-            "resource_event_quota_checked",
-            resource_id=resource_id,
-            previous=current_count,
-            reserved=new_count,
-            quota=quota_per_hour,
-        )
-
-    except RateLimitError:
-        raise
-    except RedisError as e:
-        # Fail-open per SECURITY.md "Rate Limiting": Redis outage must not block ingest.
-        # Narrow to RedisError so programming bugs (ValueError from parse, etc.) surface.
-        logger.error("redis_quota_check_failed", error=str(e))
-        return
 
 
 async def _schedule_indexer_for_resource(db: AsyncSession, resource_id: str) -> None:

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -294,6 +294,17 @@ async def _check_viewer_permission(
         return None
 
     user_role = await _get_workspace_member_role(db, user_id, workspace_id)
+    if user_role is None:
+        # Caller is not a member of this workspace, OR the workspace is
+        # soft-deleted (`_get_workspace_member_role` filters Workspace.deleted_at
+        # IS NULL). Either way: deny writes (fail-closed).
+        return _error_response(
+            "permission_denied",
+            f"Cannot {operation}: workspace not accessible.",
+            your_role="not_a_member",
+            required_role="member",
+            help="Verify the workspace is active and you are a member with at least 'member' role.",
+        )
     if user_role == "viewer":
         return _error_response(
             "permission_denied",

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -243,21 +243,30 @@ async def _get_workspace_member_role(
 ) -> str | None:
     """Get user's role in workspace.
 
+    Returns ``None`` when the workspace itself is soft-deleted
+    (``Workspace.deleted_at IS NOT NULL``) so MCP write tools do not
+    silently authorize ingest into a deleted workspace.
+
     Args:
         db: Database session
         user_id: User ID
         workspace_id: Workspace ID
 
     Returns:
-        Role string ('owner', 'admin', 'member', 'viewer') or None if not a member
+        Role string ('owner', 'admin', 'member', 'viewer') or ``None`` if
+        not a member or the workspace is soft-deleted.
     """
     from sqlalchemy import select
 
-    from models.auth import WorkspaceMember
+    from models.auth import Workspace, WorkspaceMember
 
     result = await db.execute(
-        select(WorkspaceMember).where(
-            WorkspaceMember.user_id == user_id, WorkspaceMember.workspace_id == workspace_id
+        select(WorkspaceMember)
+        .join(Workspace, Workspace.id == WorkspaceMember.workspace_id)
+        .where(
+            WorkspaceMember.user_id == user_id,
+            WorkspaceMember.workspace_id == workspace_id,
+            Workspace.deleted_at.is_(None),
         )
     )
     member = result.scalar_one_or_none()

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -474,10 +474,12 @@ async def handle_ingest_events(
                 return boundary_err
 
             # MCP shares the per-hour ceiling with the HTTP ingest path via a
-            # workspace-scoped Redis counter. The cap is derived from the
-            # workspace's most permissive ResourceToken, with a default
-            # fallback when no token exists.
-            quota_per_hour = await resolve_workspace_event_quota_per_hour(db, workspace_id)
+            # workspace-scoped Redis counter. The cap is derived from the most
+            # permissive ResourceToken for this (workspace, resource) pair, with
+            # a default fallback when no token exists.
+            quota_per_hour = await resolve_workspace_event_quota_per_hour(
+                db, workspace_id, resource_id
+            )
             try:
                 await check_event_quota(
                     resource_id, workspace_id, quota_per_hour, count=len(events)

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -26,6 +26,11 @@ from mcp_server.tools._helpers import (
     _log_tool_usage,
     _success_response,
 )
+from services.resource_quota_service import (
+    check_event_quota,
+    resolve_workspace_event_quota_per_hour,
+)
+from utils.exceptions import RateLimitError
 
 logger = logging.getLogger(__name__)
 
@@ -467,6 +472,22 @@ async def handle_ingest_events(
             boundary_err = await _check_resource_workspace_boundary(db, resource_id, workspace_id)
             if boundary_err:
                 return boundary_err
+
+            # MCP shares the per-hour ceiling with the HTTP ingest path via a
+            # workspace-scoped Redis counter. The cap is derived from the
+            # workspace's most permissive ResourceToken, with a default
+            # fallback when no token exists.
+            quota_per_hour = await resolve_workspace_event_quota_per_hour(db, workspace_id)
+            try:
+                await check_event_quota(
+                    resource_id, workspace_id, quota_per_hour, count=len(events)
+                )
+            except RateLimitError as quota_err:
+                return _error_response(
+                    "quota_exceeded",
+                    quota_err.message,
+                    retry_after_seconds=quota_err.retry_after,
+                )
 
             # Process events
             from sqlalchemy.exc import IntegrityError

--- a/backend/src/services/resource_quota_service.py
+++ b/backend/src/services/resource_quota_service.py
@@ -1,0 +1,130 @@
+"""Resource event quota — Redis-backed per-hour rate limiting.
+
+Issue #332: Shared between HTTP (``api/routes/resource_ingest``) and MCP
+(``mcp_server/tools/resource``) ingest paths so the per-hour ceiling is
+enforced regardless of entry point. Both paths INCR the same Redis key so
+their counts are combined against the same ceiling.
+
+Key format: ``resource:events:{resource_id}:{workspace_id}:hour``
+
+- Workspace-scoped (not token-scoped) so HTTP and MCP requests against the
+  same resource share one counter (Issue #332 design decision).
+- 1-hour TTL, set only on first INCR (matches ``db.redis.incrby_counter``).
+- Fail-open on Redis backend errors — Redis outage MUST NOT block ingest
+  (see SECURITY.md "Rate Limiting").
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.redis import get_cache, incrby_counter
+from utils.exceptions import RateLimitError, RedisError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Fallback ceiling for MCP ingest when the workspace has no ResourceToken to
+# derive a quota from (e.g. resource was created without tokens). Matches
+# ``ResourceToken.quota_events_per_hour`` default so behaviour is consistent.
+MCP_INGEST_DEFAULT_QUOTA_PER_HOUR = 1000
+
+_TTL_SECONDS = 3600
+
+
+def _build_key(resource_id: str, workspace_id: UUID) -> str:
+    return f"resource:events:{resource_id}:{workspace_id}:hour"
+
+
+async def check_event_quota(
+    resource_id: str,
+    workspace_id: UUID,
+    quota_per_hour: int,
+    count: int = 1,
+) -> None:
+    """Reserve ``count`` units against the per-hour event ceiling.
+
+    Args:
+        resource_id: Resource slug being ingested into.
+        workspace_id: Owning workspace; combined with ``resource_id`` forms
+            the Redis counter key. Both HTTP and MCP paths share this key.
+        quota_per_hour: Maximum events allowed per hour. Values <= 0 disable
+            the check (skip Redis round-trip).
+        count: Number of events to reserve in one shot. Batch ingest passes
+            ``len(events)`` so batching cannot bypass the ceiling.
+
+    Raises:
+        RateLimitError: If reserving ``count`` would exceed ``quota_per_hour``.
+            Status 429, ``retry_after=3600``.
+
+    Fail-open: ``RedisError`` (backend outage) is logged and swallowed so
+    ingest is not blocked. Other exceptions propagate.
+    """
+    if quota_per_hour <= 0:
+        return
+
+    key = _build_key(resource_id, workspace_id)
+
+    try:
+        current_str = await get_cache(key)
+        current = int(current_str) if current_str else 0
+
+        if current + count > quota_per_hour:
+            logger.warning(
+                "resource_event_quota_exceeded",
+                resource_id=resource_id,
+                workspace_id=str(workspace_id),
+                current=current,
+                quota=quota_per_hour,
+                requested=count,
+            )
+            raise RateLimitError(
+                message=(f"Event quota exceeded: {current}/{quota_per_hour} events per hour"),
+                retry_after=_TTL_SECONDS,
+            )
+
+        new_count = await incrby_counter(key, count, ttl=_TTL_SECONDS)
+        logger.debug(
+            "resource_event_quota_checked",
+            resource_id=resource_id,
+            workspace_id=str(workspace_id),
+            previous=current,
+            reserved=new_count,
+            quota=quota_per_hour,
+        )
+    except RateLimitError:
+        raise
+    except RedisError as e:
+        logger.error("redis_quota_check_failed", error=str(e), key=key)
+        return
+
+
+async def resolve_workspace_event_quota_per_hour(
+    db: AsyncSession,
+    workspace_id: UUID,
+) -> int:
+    """Derive the effective per-hour event quota for an MCP ingest call.
+
+    MCP authenticates via session user + workspace, not via ResourceToken,
+    so it has no per-token ``quota_events_per_hour`` to read. We use the
+    maximum across the workspace's active resource tokens — ensuring an
+    MCP caller cannot exceed the most permissive token configured for the
+    workspace. Falls back to ``MCP_INGEST_DEFAULT_QUOTA_PER_HOUR`` when the
+    workspace has no token (e.g. resource created without tokens, or pre-#324
+    legacy tokens with ``workspace_id`` not yet backfilled).
+    """
+    from models.resource import ResourceToken
+
+    result = await db.execute(
+        select(func.max(ResourceToken.quota_events_per_hour)).where(
+            ResourceToken.workspace_id == workspace_id,
+            ResourceToken.is_active.is_(True),
+        )
+    )
+    max_quota = result.scalar_one_or_none()
+    # ``is None`` (not truthy) so an explicit 0 from an operator stays as 0
+    # — check_event_quota treats <= 0 as "disabled".
+    return int(max_quota) if max_quota is not None else MCP_INGEST_DEFAULT_QUOTA_PER_HOUR

--- a/backend/src/services/resource_quota_service.py
+++ b/backend/src/services/resource_quota_service.py
@@ -105,22 +105,29 @@ async def check_event_quota(
 async def resolve_workspace_event_quota_per_hour(
     db: AsyncSession,
     workspace_id: UUID,
+    resource_id: str,
 ) -> int:
     """Derive the effective per-hour event quota for an MCP ingest call.
 
     MCP authenticates via session user + workspace, not via ResourceToken,
     so it has no per-token ``quota_events_per_hour`` to read. We use the
-    maximum across the workspace's active resource tokens — ensuring an
-    MCP caller cannot exceed the most permissive token configured for the
-    workspace. Falls back to ``MCP_INGEST_DEFAULT_QUOTA_PER_HOUR`` when the
-    workspace has no token (e.g. resource created without tokens, or pre-#324
-    legacy tokens with ``workspace_id`` not yet backfilled).
+    maximum across the workspace's active tokens **for this resource_id** —
+    ensuring an MCP caller cannot exceed the most permissive token configured
+    for the resource being ingested into. Filtering by ``resource_id`` matches
+    the Redis key scope (`resource:events:{resource_id}:{workspace_id}:hour`),
+    so a high-quota token on resource B cannot relax the cap on resource A
+    in the same workspace.
+
+    Falls back to ``MCP_INGEST_DEFAULT_QUOTA_PER_HOUR`` when the resource has
+    no token in this workspace (e.g. resource created without tokens, or
+    pre-#324 legacy tokens with ``workspace_id`` not yet backfilled).
     """
     from models.resource import ResourceToken
 
     result = await db.execute(
         select(func.max(ResourceToken.quota_events_per_hour)).where(
             ResourceToken.workspace_id == workspace_id,
+            ResourceToken.resource_id == resource_id,
             ResourceToken.is_active.is_(True),
         )
     )

--- a/backend/src/services/resource_quota_service.py
+++ b/backend/src/services/resource_quota_service.py
@@ -92,7 +92,8 @@ async def check_event_quota(
             resource_id=resource_id,
             workspace_id=str(workspace_id),
             previous=current,
-            reserved=new_count,
+            reserved=count,
+            new_total=new_count,
             quota=quota_per_hour,
         )
     except RateLimitError:

--- a/backend/src/services/resource_quota_service.py
+++ b/backend/src/services/resource_quota_service.py
@@ -66,6 +66,12 @@ async def check_event_quota(
     if quota_per_hour <= 0:
         return
 
+    if count <= 0:
+        # Defensive: a non-positive count would decrement the Redis counter via
+        # INCRBY and could silently bypass the per-hour ceiling. This is never
+        # valid input from callers (HTTP + MCP both pass len(events) >= 1).
+        raise ValueError(f"count must be >= 1, got {count}")
+
     key = _build_key(resource_id, workspace_id)
 
     try:

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -146,6 +146,12 @@ class RateLimitError(MemoryCloudException):
     ):
         super().__init__(message, status_code=429, error_code="RATE-001", retry_after=retry_after)
 
+    @property
+    def retry_after(self) -> int | None:
+        """Seconds the client should wait before retrying, if known."""
+        retry = self.details.get("retry_after")
+        return int(retry) if retry is not None else None
+
 
 class QuotaExceededError(MemoryCloudException):
     """Quota exceeded (429)."""

--- a/backend/tests/api/test_resource_ingest.py
+++ b/backend/tests/api/test_resource_ingest.py
@@ -11,7 +11,6 @@ import pytest
 from fastapi import HTTPException
 
 from api.routes.resource_ingest import (
-    _check_event_quota,
     _enforce_workspace_membership,
     _resolve_authoritative_context,
 )
@@ -19,7 +18,6 @@ from auth.resource_tokens import ResourceTokenManager
 from models.auth import Context
 from models.resource import ResourceToken
 from models.schemas import ResourceEventRequest
-from utils.exceptions import RateLimitError, RedisError
 
 
 class TestResourceTokenManager:
@@ -95,107 +93,9 @@ class TestResourceTokenManager:
         mock_db.flush.assert_not_awaited()
 
 
-class TestResourceEventQuotaCheck:
-    """Test event quota checking."""
-
-    @pytest.mark.asyncio
-    async def test_quota_within_limit(self):
-        """Test quota check when within limit — counter is reserved after pass."""
-        with (
-            patch("db.redis.get_cache", new_callable=AsyncMock) as mock_cache,
-            patch("db.redis.incrby_counter", new_callable=AsyncMock) as mock_incr,
-        ):
-            mock_cache.return_value = "50"
-            mock_incr.return_value = 51
-
-            await _check_event_quota("ec_products", token_id=1, quota_per_hour=1000)
-
-            mock_cache.assert_awaited_once()
-            mock_incr.assert_awaited_once_with("resource:events:ec_products:1:hour", 1, ttl=3600)
-
-    @pytest.mark.asyncio
-    async def test_quota_exceeded(self):
-        """Test quota check when exceeded — no increment on reject."""
-        with (
-            patch("db.redis.get_cache", new_callable=AsyncMock) as mock_cache,
-            patch("db.redis.incrby_counter", new_callable=AsyncMock) as mock_incr,
-        ):
-            mock_cache.return_value = "1001"
-
-            with pytest.raises(RateLimitError) as exc_info:
-                await _check_event_quota("ec_products", token_id=1, quota_per_hour=1000)
-
-            assert "Event quota exceeded" in str(exc_info.value.message)
-            assert exc_info.value.status_code == 429
-            mock_incr.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_quota_batch_check(self):
-        """Test quota check for batch (multiple events at once)."""
-        with (
-            patch("db.redis.get_cache", new_callable=AsyncMock) as mock_cache,
-            patch("db.redis.incrby_counter", new_callable=AsyncMock) as mock_incr,
-        ):
-            mock_cache.return_value = "990"  # 990 + 20 > 1000
-
-            with pytest.raises(RateLimitError):
-                await _check_event_quota("ec_products", token_id=1, quota_per_hour=1000, count=20)
-
-            mock_incr.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_quota_batch_reserves_amount(self):
-        """Batch ingest reserves `count` units, not 1 — prevents bypass via batching."""
-        with (
-            patch("db.redis.get_cache", new_callable=AsyncMock) as mock_cache,
-            patch("db.redis.incrby_counter", new_callable=AsyncMock) as mock_incr,
-        ):
-            mock_cache.return_value = "100"
-            mock_incr.return_value = 150
-
-            await _check_event_quota("ec_products", token_id=1, quota_per_hour=1000, count=50)
-
-            mock_incr.assert_awaited_once_with("resource:events:ec_products:1:hour", 50, ttl=3600)
-
-    @pytest.mark.asyncio
-    async def test_quota_fresh_key_proceeds(self):
-        """Fresh Redis key (GET returns None, which is also how get_cache signals a
-        swallowed read failure) → treated as count=0 and ingest proceeds."""
-        with (
-            patch("db.redis.get_cache", new_callable=AsyncMock) as mock_cache,
-            patch("db.redis.incrby_counter", new_callable=AsyncMock) as mock_incr,
-        ):
-            mock_cache.return_value = None
-            mock_incr.return_value = 1
-
-            await _check_event_quota("ec_products", token_id=1, quota_per_hour=1000)
-
-            mock_incr.assert_awaited_once_with("resource:events:ec_products:1:hour", 1, ttl=3600)
-
-    @pytest.mark.asyncio
-    async def test_quota_incr_failure_fails_open(self):
-        """If INCR fails after a passing check, fail-open rather than block ingest."""
-        with (
-            patch("db.redis.get_cache", new_callable=AsyncMock) as mock_cache,
-            patch("db.redis.incrby_counter", new_callable=AsyncMock) as mock_incr,
-        ):
-            mock_cache.return_value = "50"
-            mock_incr.side_effect = RedisError("redis write failed")
-
-            await _check_event_quota("ec_products", token_id=1, quota_per_hour=1000)
-
-    @pytest.mark.asyncio
-    async def test_quota_non_redis_error_surfaces(self):
-        """Non-Redis exceptions (programming bugs) must NOT be swallowed by fail-open."""
-        with (
-            patch("db.redis.get_cache", new_callable=AsyncMock) as mock_cache,
-            patch("db.redis.incrby_counter", new_callable=AsyncMock) as mock_incr,
-        ):
-            mock_cache.return_value = "50"
-            mock_incr.side_effect = ValueError("programming bug, not a Redis error")
-
-            with pytest.raises(ValueError):
-                await _check_event_quota("ec_products", token_id=1, quota_per_hour=1000)
+# Issue #332: ``_check_event_quota`` moved to
+# ``services/resource_quota_service.check_event_quota`` (workspace-scoped key
+# shared with the MCP ingest path). See ``tests/services/test_resource_quota_service.py``.
 
 
 class TestResourceEventIdempotency:

--- a/backend/tests/mcp_server/test_resource_ingest_quota.py
+++ b/backend/tests/mcp_server/test_resource_ingest_quota.py
@@ -44,6 +44,12 @@ def _build_db_mock(*, role: str | None, boundary_ok: bool):
 
     mock_db = AsyncMock()
     mock_db.execute = AsyncMock(side_effect=[role_result, boundary_result])
+    # `db.add(event)` is a *sync* method on SQLAlchemy sessions — keep it as
+    # a plain MagicMock so AsyncMock doesn't hand back an un-awaited coroutine
+    # when the handler proceeds past the quota check into the ingest loop.
+    mock_db.add = MagicMock(side_effect=_assign_event_id)
+    mock_db.flush = AsyncMock()
+    mock_db.commit = AsyncMock()
 
     @asynccontextmanager
     async def _begin_nested():
@@ -51,6 +57,15 @@ def _build_db_mock(*, role: str | None, boundary_ok: bool):
 
     mock_db.begin_nested = _begin_nested
     return mock_db
+
+
+_EVENT_ID_COUNTER = {"next": 1}
+
+
+def _assign_event_id(event):
+    """Simulate SQLAlchemy assigning a primary key on flush by setting `.id`."""
+    event.id = _EVENT_ID_COUNTER["next"]
+    _EVENT_ID_COUNTER["next"] += 1
 
 
 @pytest.fixture
@@ -81,6 +96,10 @@ async def test_quota_check_invoked_after_permission_with_workspace_key(workspace
     with (
         _patch_get_db(mock_db),
         _patch_log_tool_usage(),
+        patch(
+            "api.routes.resource_ingest._schedule_indexer_for_resource",
+            new=AsyncMock(return_value=None),
+        ),
         patch(
             "mcp_server.tools.resource.resolve_workspace_event_quota_per_hour",
             new=AsyncMock(return_value=1000),

--- a/backend/tests/mcp_server/test_resource_ingest_quota.py
+++ b/backend/tests/mcp_server/test_resource_ingest_quota.py
@@ -1,0 +1,234 @@
+"""Integration tests for MCP ingest_events quota enforcement.
+
+Issue #332: handle_ingest_events must call services.resource_quota_service.check_event_quota
+after the viewer + workspace boundary checks, and the call MUST be workspace-scoped so
+HTTP and MCP traffic share one Redis counter.
+"""
+
+import json
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.resource import handle_ingest_events
+from utils.exceptions import RateLimitError
+
+
+def _json_of(result):
+    """Decode the JSON body of an MCP TextContent response list."""
+    return json.loads(result[0].text)
+
+
+def _build_db_mock(*, role: str | None, boundary_ok: bool):
+    """Build a mock DB whose db.execute returns role then boundary lookup.
+
+    The MCP handler queries:
+      1. _get_workspace_member_role → SELECT WorkspaceMember.role JOIN Workspace
+         (the JOIN form added in #332 returns the role string directly via .scalar_one_or_none)
+      2. _check_resource_workspace_boundary → SELECT Context.id, .scalar_one_or_none
+    """
+    role_result = MagicMock()
+    if role is None:
+        role_result.scalar_one_or_none.return_value = None
+    else:
+        member = MagicMock()
+        member.role = role
+        role_result.scalar_one_or_none.return_value = member
+
+    boundary_result = MagicMock()
+    boundary_result.scalar_one_or_none.return_value = uuid4() if boundary_ok else None
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[role_result, boundary_result])
+
+    @asynccontextmanager
+    async def _begin_nested():
+        yield None
+
+    mock_db.begin_nested = _begin_nested
+    return mock_db
+
+
+@pytest.fixture
+def workspace_id():
+    return uuid4()
+
+
+def _patch_get_db(mock_db):
+    async def _get_db():
+        yield mock_db
+
+    return patch("db.base.get_db", new=_get_db)
+
+
+def _patch_log_tool_usage():
+    """Skip the usage-log DB write — out of scope for these tests."""
+    return patch(
+        "mcp_server.tools.resource._log_tool_usage",
+        new=AsyncMock(return_value=None),
+    )
+
+
+@pytest.mark.asyncio
+async def test_quota_check_invoked_after_permission_with_workspace_key(workspace_id):
+    """Happy-path wiring: quota helper is called with (resource_id, workspace_id, count)."""
+    mock_db = _build_db_mock(role="member", boundary_ok=True)
+
+    with (
+        _patch_get_db(mock_db),
+        _patch_log_tool_usage(),
+        patch(
+            "mcp_server.tools.resource.resolve_workspace_event_quota_per_hour",
+            new=AsyncMock(return_value=1000),
+        ) as mock_resolve,
+        patch(
+            "mcp_server.tools.resource.check_event_quota",
+            new=AsyncMock(return_value=None),
+        ) as mock_quota,
+    ):
+        events = [
+            {"op": "upsert", "doc_id": f"D-{i}", "version": 1, "payload": {"x": i}}
+            for i in range(3)
+        ]
+        await handle_ingest_events(
+            {"resource_id": "ec_products", "events": events},
+            "user-1",
+            workspace_id,
+        )
+
+        mock_resolve.assert_awaited_once()
+        mock_quota.assert_awaited_once_with("ec_products", workspace_id, 1000, count=3)
+
+
+@pytest.mark.asyncio
+async def test_quota_exceeded_returns_error_and_does_not_ingest(workspace_id):
+    """When check_event_quota raises RateLimitError, handler returns quota_exceeded
+    and never reaches the ingest loop."""
+    mock_db = _build_db_mock(role="member", boundary_ok=True)
+    mock_db.add = MagicMock()  # would be called inside the ingest loop if reached
+
+    with (
+        _patch_get_db(mock_db),
+        _patch_log_tool_usage(),
+        patch(
+            "mcp_server.tools.resource.resolve_workspace_event_quota_per_hour",
+            new=AsyncMock(return_value=10),
+        ),
+        patch(
+            "mcp_server.tools.resource.check_event_quota",
+            new=AsyncMock(
+                side_effect=RateLimitError(
+                    message="Event quota exceeded: 9/10 events per hour",
+                    retry_after=3600,
+                )
+            ),
+        ),
+    ):
+        result = await handle_ingest_events(
+            {
+                "resource_id": "ec_products",
+                "events": [{"op": "upsert", "doc_id": "D-1", "version": 1, "payload": {}}],
+            },
+            "user-1",
+            workspace_id,
+        )
+
+        data = _json_of(result)
+        assert data["error"] == "quota_exceeded"
+        assert "Event quota exceeded" in data["message"]
+        assert data["retry_after_seconds"] == 3600
+        mock_db.add.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_quota_skipped_when_viewer_rejected(workspace_id):
+    """Viewer permission denial happens BEFORE quota check — no quota call, no resolve."""
+    mock_db = _build_db_mock(role="viewer", boundary_ok=True)
+
+    with (
+        _patch_get_db(mock_db),
+        _patch_log_tool_usage(),
+        patch(
+            "mcp_server.tools.resource.resolve_workspace_event_quota_per_hour",
+            new=AsyncMock(return_value=1000),
+        ) as mock_resolve,
+        patch(
+            "mcp_server.tools.resource.check_event_quota",
+            new=AsyncMock(return_value=None),
+        ) as mock_quota,
+    ):
+        result = await handle_ingest_events(
+            {
+                "resource_id": "ec_products",
+                "events": [{"op": "upsert", "doc_id": "D-1", "version": 1, "payload": {}}],
+            },
+            "user-1",
+            workspace_id,
+        )
+
+        data = _json_of(result)
+        assert data["error"] == "permission_denied"
+        mock_resolve.assert_not_awaited()
+        mock_quota.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_quota_skipped_when_workspace_boundary_fails(workspace_id):
+    """Workspace boundary fails BEFORE quota check — no quota call."""
+    mock_db = _build_db_mock(role="member", boundary_ok=False)
+
+    with (
+        _patch_get_db(mock_db),
+        _patch_log_tool_usage(),
+        patch(
+            "mcp_server.tools.resource.resolve_workspace_event_quota_per_hour",
+            new=AsyncMock(return_value=1000),
+        ) as mock_resolve,
+        patch(
+            "mcp_server.tools.resource.check_event_quota",
+            new=AsyncMock(return_value=None),
+        ) as mock_quota,
+    ):
+        result = await handle_ingest_events(
+            {
+                "resource_id": "ec_products",
+                "events": [{"op": "upsert", "doc_id": "D-1", "version": 1, "payload": {}}],
+            },
+            "user-1",
+            workspace_id,
+        )
+
+        data = _json_of(result)
+        assert data["error"] == "resource_not_found"
+        mock_resolve.assert_not_awaited()
+        mock_quota.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_active_workspace_returns_early_without_quota(workspace_id):
+    """workspace_id=None should return ``workspace_required`` before any DB / quota work."""
+    with (
+        patch(
+            "mcp_server.tools.resource.resolve_workspace_event_quota_per_hour",
+            new=AsyncMock(return_value=1000),
+        ) as mock_resolve,
+        patch(
+            "mcp_server.tools.resource.check_event_quota",
+            new=AsyncMock(return_value=None),
+        ) as mock_quota,
+    ):
+        result = await handle_ingest_events(
+            {
+                "resource_id": "ec_products",
+                "events": [{"op": "upsert", "doc_id": "D-1", "version": 1, "payload": {}}],
+            },
+            "user-1",
+            None,
+        )
+
+        data = _json_of(result)
+        assert data["error"] == "workspace_required"
+        mock_resolve.assert_not_awaited()
+        mock_quota.assert_not_awaited()

--- a/backend/tests/mcp_server/test_resource_ingest_quota.py
+++ b/backend/tests/mcp_server/test_resource_ingest_quota.py
@@ -25,8 +25,10 @@ def _build_db_mock(*, role: str | None, boundary_ok: bool):
     """Build a mock DB whose db.execute returns role then boundary lookup.
 
     The MCP handler queries:
-      1. _get_workspace_member_role → SELECT WorkspaceMember.role JOIN Workspace
-         (the JOIN form added in #332 returns the role string directly via .scalar_one_or_none)
+      1. _get_workspace_member_role → SELECT WorkspaceMember JOIN Workspace.
+         .scalar_one_or_none returns a WorkspaceMember-like object whose
+         .role attribute is the role string, or None when no member row
+         matches (includes soft-deleted workspaces).
       2. _check_resource_workspace_boundary → SELECT Context.id, .scalar_one_or_none
     """
     role_result = MagicMock()

--- a/backend/tests/mcp_server/test_resource_tools.py
+++ b/backend/tests/mcp_server/test_resource_tools.py
@@ -299,6 +299,22 @@ class TestIngestEventsValidation:
     need enough DB mock to pass viewer + boundary checks.
     """
 
+    @pytest.fixture(autouse=True)
+    def _stub_quota(self):
+        """Issue #332: ingest_events now consults a workspace-scoped quota helper.
+        These tests cover validation paths only, so stub the quota layer to a no-op."""
+        with (
+            patch(
+                "mcp_server.tools.resource.resolve_workspace_event_quota_per_hour",
+                new=AsyncMock(return_value=1000),
+            ),
+            patch(
+                "mcp_server.tools.resource.check_event_quota",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            yield
+
     def _make_db(self):
         mock_db = AsyncMock()
         # 1) viewer role check → member (write allowed)
@@ -622,9 +638,25 @@ class TestListResourceTokensHappyPath:
         assert data["tokens"][1]["is_active"] is False
 
 
+@pytest.fixture
+def _stub_quota_for_ingest():
+    """Issue #332: stub the workspace-scoped quota helper for ingest happy-paths."""
+    with (
+        patch(
+            "mcp_server.tools.resource.resolve_workspace_event_quota_per_hour",
+            new=AsyncMock(return_value=1000),
+        ),
+        patch(
+            "mcp_server.tools.resource.check_event_quota",
+            new=AsyncMock(return_value=None),
+        ),
+    ):
+        yield
+
+
 class TestIngestEventsHappyPath:
     @pytest.mark.asyncio
-    async def test_creates_upsert_event(self):
+    async def test_creates_upsert_event(self, _stub_quota_for_ingest):
         """ingest_events persists valid upsert event and schedules indexer."""
         workspace_id = uuid4()
         mock_db = AsyncMock()

--- a/backend/tests/services/test_resource_quota_service.py
+++ b/backend/tests/services/test_resource_quota_service.py
@@ -194,23 +194,47 @@ class TestResolveWorkspaceEventQuotaPerHour:
     """Resolution of the per-hour ceiling for MCP ingest calls."""
 
     @pytest.mark.asyncio
-    async def test_returns_max_token_quota(self):
+    async def test_returns_max_token_quota_for_resource(self):
         mock_db = MagicMock()
         result_mock = MagicMock()
         result_mock.scalar_one_or_none.return_value = 5000
         mock_db.execute = AsyncMock(return_value=result_mock)
 
-        quota = await resolve_workspace_event_quota_per_hour(mock_db, WORKSPACE_ID)
+        quota = await resolve_workspace_event_quota_per_hour(mock_db, WORKSPACE_ID, "ec_products")
 
         assert quota == 5000
 
     @pytest.mark.asyncio
-    async def test_falls_back_to_default_when_no_tokens(self):
+    async def test_falls_back_to_default_when_no_token_for_resource(self):
         mock_db = MagicMock()
         result_mock = MagicMock()
         result_mock.scalar_one_or_none.return_value = None
         mock_db.execute = AsyncMock(return_value=result_mock)
 
-        quota = await resolve_workspace_event_quota_per_hour(mock_db, WORKSPACE_ID)
+        quota = await resolve_workspace_event_quota_per_hour(mock_db, WORKSPACE_ID, "ec_products")
 
         assert quota == MCP_INGEST_DEFAULT_QUOTA_PER_HOUR
+
+    @pytest.mark.asyncio
+    async def test_query_filters_on_resource_id(self):
+        """Regression for Copilot review: workspace-wide MAX would over-allow
+        ingest into a low-quota resource if a higher-quota token exists for a
+        sibling resource. The query MUST filter on resource_id."""
+        from models.resource import ResourceToken
+
+        mock_db = MagicMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = 100
+        mock_db.execute = AsyncMock(return_value=result_mock)
+
+        await resolve_workspace_event_quota_per_hour(mock_db, WORKSPACE_ID, "ec_products")
+
+        # Inspect the compiled WHERE clause includes a resource_id predicate.
+        called_stmt = mock_db.execute.await_args.args[0]
+        compiled = str(called_stmt.compile(compile_kwargs={"literal_binds": False}))
+        assert "resource_id" in compiled
+        assert "workspace_id" in compiled
+        assert "is_active" in compiled
+        # ResourceToken is referenced for the import side-effect; static
+        # analyzers should not flag it as unused.
+        assert ResourceToken is not None

--- a/backend/tests/services/test_resource_quota_service.py
+++ b/backend/tests/services/test_resource_quota_service.py
@@ -1,0 +1,216 @@
+"""Unit tests for services/resource_quota_service.
+
+The helper is shared between HTTP and MCP ingest paths and must key the Redis
+counter on ``workspace_id`` (not token_id) so combined traffic is enforced
+against one ceiling.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from services.resource_quota_service import (
+    MCP_INGEST_DEFAULT_QUOTA_PER_HOUR,
+    check_event_quota,
+    resolve_workspace_event_quota_per_hour,
+)
+from utils.exceptions import RateLimitError, RedisError
+
+WORKSPACE_ID = uuid4()
+EXPECTED_KEY = f"resource:events:ec_products:{WORKSPACE_ID}:hour"
+
+
+@pytest.fixture
+def redis_mocks():
+    """Yield (mock_get_cache, mock_incrby_counter) patched at the service module."""
+    with (
+        patch("services.resource_quota_service.get_cache", new_callable=AsyncMock) as mock_get,
+        patch(
+            "services.resource_quota_service.incrby_counter", new_callable=AsyncMock
+        ) as mock_incr,
+    ):
+        yield mock_get, mock_incr
+
+
+class TestCheckEventQuota:
+    """Behaviour of the workspace-scoped quota helper."""
+
+    @pytest.mark.asyncio
+    async def test_within_limit_reserves_count(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = "50"
+        mock_incr.return_value = 51
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000)
+
+        mock_get.assert_awaited_once_with(EXPECTED_KEY)
+        mock_incr.assert_awaited_once_with(EXPECTED_KEY, 1, ttl=3600)
+
+    @pytest.mark.asyncio
+    async def test_exceeded_raises_and_does_not_increment(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = "1001"
+
+        with pytest.raises(RateLimitError) as exc_info:
+            await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000)
+
+        assert "Event quota exceeded" in exc_info.value.message
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.retry_after == 3600
+        mock_incr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_batch_count_must_fit_or_reject(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = "990"  # 990 + 20 > 1000
+
+        with pytest.raises(RateLimitError):
+            await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000, count=20)
+
+        mock_incr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_batch_reserves_full_amount(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = "100"
+        mock_incr.return_value = 150
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000, count=50)
+
+        mock_incr.assert_awaited_once_with(EXPECTED_KEY, 50, ttl=3600)
+
+    @pytest.mark.asyncio
+    async def test_fresh_key_treated_as_zero(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = None
+        mock_incr.return_value = 1
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000)
+
+        mock_incr.assert_awaited_once_with(EXPECTED_KEY, 1, ttl=3600)
+
+    @pytest.mark.asyncio
+    async def test_get_cache_redis_error_fails_open(self, redis_mocks):
+        # NOTE: db.redis.get_cache itself catches and swallows backend errors,
+        # returning None — so the RedisError branch in check_event_quota
+        # primarily covers incrby_counter failures. This test verifies the
+        # contract holds even if get_cache leaks a RedisError.
+        mock_get, mock_incr = redis_mocks
+        mock_get.side_effect = RedisError("redis read failed")
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000)
+
+        mock_incr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_incr_redis_error_fails_open_after_passing_check(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = "50"
+        mock_incr.side_effect = RedisError("redis write failed")
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000)
+
+    @pytest.mark.asyncio
+    async def test_non_redis_error_surfaces(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = "50"
+        mock_incr.side_effect = ValueError("programming bug, not a Redis error")
+
+        with pytest.raises(ValueError):
+            await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000)
+
+    @pytest.mark.asyncio
+    async def test_zero_quota_disables_check(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=0)
+
+        mock_get.assert_not_awaited()
+        mock_incr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_negative_quota_disables_check(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=-1)
+
+        mock_get.assert_not_awaited()
+        mock_incr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_boundary_exact_limit_passes(self, redis_mocks):
+        """current + count == quota_per_hour is allowed (strict > test)."""
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = "999"
+        mock_incr.return_value = 1000
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000, count=1)
+
+        mock_incr.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_boundary_one_over_rejects(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = "1000"
+
+        with pytest.raises(RateLimitError):
+            await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000, count=1)
+
+        mock_incr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_key_format_uses_workspace_id_not_token(self, redis_mocks):
+        """Regression: the key MUST be workspace-scoped so HTTP and MCP share
+        the same counter."""
+        mock_get, mock_incr = redis_mocks
+        mock_get.return_value = None
+        mock_incr.return_value = 1
+
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=10)
+
+        called_key = mock_get.await_args.args[0]
+        assert called_key == f"resource:events:ec_products:{WORKSPACE_ID}:hour"
+
+    @pytest.mark.asyncio
+    async def test_combined_http_mcp_share_counter(self, redis_mocks):
+        """Two callers (one HTTP, one MCP) targeting the same workspace+resource
+        hit the same Redis key and increment one counter."""
+        mock_get, mock_incr = redis_mocks
+        # Simulated counter progression: 0 -> 5 (HTTP) -> 8 (MCP)
+        mock_get.side_effect = [None, "5"]
+        mock_incr.side_effect = [5, 8]
+
+        # HTTP-style call (5 events)
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=10, count=5)
+        # MCP-style call (3 events) — same key
+        await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=10, count=3)
+
+        assert mock_incr.await_args_list[0].args[0] == EXPECTED_KEY
+        assert mock_incr.await_args_list[1].args[0] == EXPECTED_KEY
+
+
+class TestResolveWorkspaceEventQuotaPerHour:
+    """Resolution of the per-hour ceiling for MCP ingest calls."""
+
+    @pytest.mark.asyncio
+    async def test_returns_max_token_quota(self):
+        mock_db = MagicMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = 5000
+        mock_db.execute = AsyncMock(return_value=result_mock)
+
+        quota = await resolve_workspace_event_quota_per_hour(mock_db, WORKSPACE_ID)
+
+        assert quota == 5000
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_default_when_no_tokens(self):
+        mock_db = MagicMock()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none.return_value = None
+        mock_db.execute = AsyncMock(return_value=result_mock)
+
+        quota = await resolve_workspace_event_quota_per_hour(mock_db, WORKSPACE_ID)
+
+        assert quota == MCP_INGEST_DEFAULT_QUOTA_PER_HOUR

--- a/backend/tests/services/test_resource_quota_service.py
+++ b/backend/tests/services/test_resource_quota_service.py
@@ -139,6 +139,29 @@ class TestCheckEventQuota:
         mock_incr.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_negative_count_raises(self, redis_mocks):
+        """Defensive guard: a negative count would DECR the Redis counter and
+        silently relax the quota. All internal callers pass len(events) >= 1,
+        so negative count is never a valid input."""
+        mock_get, mock_incr = redis_mocks
+
+        with pytest.raises(ValueError, match="count must be >= 1"):
+            await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000, count=-5)
+
+        mock_get.assert_not_awaited()
+        mock_incr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_zero_count_raises(self, redis_mocks):
+        mock_get, mock_incr = redis_mocks
+
+        with pytest.raises(ValueError, match="count must be >= 1"):
+            await check_event_quota("ec_products", WORKSPACE_ID, quota_per_hour=1000, count=0)
+
+        mock_get.assert_not_awaited()
+        mock_incr.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_boundary_exact_limit_passes(self, redis_mocks):
         """current + count == quota_per_hour is allowed (strict > test)."""
         mock_get, mock_incr = redis_mocks


### PR DESCRIPTION
Closes #332

## Summary
- `handle_ingest_events` previously skipped quota enforcement entirely; an authenticated MCP caller could ingest unbounded events per hour, bypassing `quota_events_per_hour` configured on resource tokens.
- Extracts the helper to `services/resource_quota_service.py` and switches the Redis counter key to a workspace-scoped form (`resource:events:{resource_id}:{workspace_id}:hour`) so HTTP and MCP traffic combine against one ceiling.
- Tightens `_get_workspace_member_role` to JOIN `Workspace` and reject soft-deleted workspaces — closes the same `is_workspace_member`-style auth gap PR #329 fixed for the HTTP path, and the change propagates to all MCP write tools (memory/edge/sleep/resource).
- Adds `RateLimitError.retry_after` property so callers don't reach into `details` dict directly.

## Implementation notes
- New module: `backend/src/services/resource_quota_service.py`
  - `check_event_quota(resource_id, workspace_id, quota_per_hour, count=1)` — workspace-keyed, fail-open on Redis backend errors (matches SECURITY.md "Rate Limiting" advisory model).
  - `resolve_workspace_event_quota_per_hour(db, workspace_id, resource_id)` — derives MCP cap from `MAX(quota_events_per_hour)` across the workspace's active `ResourceToken` rows **for this `resource_id`**, so a high-quota token on one resource cannot relax the cap on a sibling resource in the same workspace. Falls back to `MCP_INGEST_DEFAULT_QUOTA_PER_HOUR=1000` when this resource has no token in this workspace.
- HTTP `_check_event_quota` (79 lines) removed from `api/routes/resource_ingest.py`; both call sites now import from the service.
- MCP `handle_ingest_events` adds the quota check after viewer permission + workspace boundary, before the ingest loop. `RateLimitError` is converted to `_error_response("quota_exceeded", retry_after_seconds=...)` so the MCP client sees a typed quota error, not a leaked exception.
- Tests:
  - `backend/tests/services/test_resource_quota_service.py` — 14 unit cases (boundary, TTL, fail-open, key format, HTTP+MCP combined counter, batch reserve, zero/negative quota disables check)
  - `backend/tests/mcp_server/test_resource_ingest_quota.py` — 5 integration cases (happy path wiring, quota_exceeded short-circuit, viewer-rejected-before-quota, boundary-fail-before-quota, no-workspace-early-exit)
  - Pre-existing `tests/mcp_server/test_resource_tools.py` ingest tests adapted via autouse `_stub_quota` fixture
- 1218 unit/integration tests pass locally; 7 unrelated pre-existing failures unchanged on `main`.

## Breaking change (operations note)
HTTP Redis counter key changes from `resource:events:{resource_id}:{token_id}:hour` to `resource:events:{resource_id}:{workspace_id}:hour`. Old counters expire in 1 h after deploy — quota is briefly slightly looser during that window. No migration required.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped (binary_gate=null, default config)
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO lens, with /cto + /qa-lead cross-lens)
- review provider: copilot

## Follow-up issues to file (out of scope for #332)
- Cache `resolve_workspace_event_quota_per_hour` for ~60 s — quota config rarely changes; current pattern is one DB MAX query per MCP ingest.
- Tighten quota INCR atomicity via Lua script — closes the GET+INCRBY TOCTOU race that exists in the original advisory pattern.
- Replace `_check_viewer_permission` with `PermissionService.check_workspace_access(required_role="member")` across all MCP write tools — broader auth refactor (this PR fixed the soft-delete bug only).
- HTTP/MCP parity check test — import-time assertion that both ingest paths run the same precondition list (would have caught #332 at write time).

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/332-fix-bug-mcp-ingest-events-bypasses-per-token.gate1.md
- ~/.claude/cache/gh-issue-driven/332-fix-bug-mcp-ingest-events-bypasses-per-token.gate2.md

🤖 Generated via /gh-issue-driven:ship

