### PR TITLE
feat(indexer): send sparse bm25 vector alongside dense in resource_indexer (#335)

### DIFF
--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -51,6 +51,7 @@ KAGURA_MEMORIES_COLLECTION = "kagura_memories"
 # `{"dense": VectorParams(...), "bm25": SparseVectorParams(...)}` — anonymous
 # vectors will fail with "Not existing vector name error".
 KAGURA_MEMORIES_VECTOR_NAME = "dense"
+KAGURA_MEMORIES_BM25_VECTOR_NAME = "bm25"
 
 
 def get_collection_name(model: str, dimensions: int) -> str:
@@ -368,7 +369,9 @@ async def add_memory_to_qdrant(
         # Issue #16: Named vectors (dense + sparse BM25)
         point_vector: dict[str, Any] = {KAGURA_MEMORIES_VECTOR_NAME: vector}
         if sparse_indices and sparse_values:
-            point_vector["bm25"] = SparseVector(indices=sparse_indices, values=sparse_values)
+            point_vector[KAGURA_MEMORIES_BM25_VECTOR_NAME] = SparseVector(
+                indices=sparse_indices, values=sparse_values
+            )
 
         await client.upsert(
             collection_name=collection_name,
@@ -625,7 +628,7 @@ async def search_memories_fulltext(
         results = await client.query_points(
             collection_name=collection_name,
             query=SparseVector(indices=query_indices, values=query_values),
-            using="bm25",
+            using=KAGURA_MEMORIES_BM25_VECTOR_NAME,
             limit=limit,
             query_filter=qdrant_filter,
         )
@@ -692,7 +695,7 @@ async def ensure_kagura_memories_collection(
             info = await client.get_collection(collection_name)
             params = getattr(info.config, "params", None) if info.config else None
             sparse_cfg = getattr(params, "sparse_vectors", None) if params else None
-            has_sparse = sparse_cfg is not None and "bm25" in sparse_cfg
+            has_sparse = sparse_cfg is not None and KAGURA_MEMORIES_BM25_VECTOR_NAME in sparse_cfg
 
             if has_sparse:
                 # Collection is up-to-date, ensure keyword indexes
@@ -732,7 +735,7 @@ async def ensure_kagura_memories_collection(
                 ),
             },
             sparse_vectors_config={
-                "bm25": SparseVectorParams(
+                KAGURA_MEMORIES_BM25_VECTOR_NAME: SparseVectorParams(
                     modifier=Modifier.IDF,
                 ),
             },

--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -14,15 +14,21 @@ from __future__ import annotations
 # Standard library imports (PEP8)
 import json  # Issue #262: JSON serialization for Memory content
 from dataclasses import dataclass
+from typing import Any
 from uuid import NAMESPACE_DNS, UUID, uuid4, uuid5  # Issue #262: uuid5 for deterministic point_id
 
 # Third-party imports (PEP8)
-from qdrant_client.models import PointStruct
+from qdrant_client.models import PointStruct, SparseVector
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 # Local application imports (PEP8)
-from db.qdrant import KAGURA_MEMORIES_VECTOR_NAME, get_collection_name, get_qdrant_client
+from db.qdrant import (
+    KAGURA_MEMORIES_BM25_VECTOR_NAME,
+    KAGURA_MEMORIES_VECTOR_NAME,
+    get_collection_name,
+    get_qdrant_client,
+)
 from models.auth import Context
 from models.memory import Memory  # Issue #262: Memory model for resource data storage
 from models.resource import IndexerState, ResourceEvent, ResourceSchema
@@ -30,6 +36,7 @@ from services.embedding_service import EmbeddingService
 from utils.datetime import utcnow
 from utils.exceptions import QdrantError
 from utils.logger import get_logger
+from utils.sparse_vector import build_resource_sparse_vector
 
 logger = get_logger(__name__)
 
@@ -315,11 +322,22 @@ class ResourceIndexer:
         # Generate Memory ID for new memories (may be overwritten if memory exists)
         memory_id = uuid4()
 
+        # Issue #335: Build sparse BM25 vector from the same fulltext_content
+        # used for the dense embedding, so resource points participate in
+        # hybrid search instead of scoring zero on BM25.
+        sparse_indices, sparse_values = build_resource_sparse_vector(content)
+
         # kagura_memories collections are configured with named vectors
         # (dense + sparse bm25); anonymous vectors are rejected at upsert.
+        point_vector: dict[str, Any] = {KAGURA_MEMORIES_VECTOR_NAME: embedding}
+        if sparse_indices and sparse_values:
+            point_vector[KAGURA_MEMORIES_BM25_VECTOR_NAME] = SparseVector(
+                indices=sparse_indices, values=sparse_values
+            )
+
         point = PointStruct(
             id=str(point_id_uuid),
-            vector={KAGURA_MEMORIES_VECTOR_NAME: embedding},
+            vector=point_vector,
             payload={
                 "workspace_id": str(context.workspace_id),  # 3-level isolation
                 "context_id": str(context.id),  # 3-level isolation

--- a/backend/src/utils/sparse_vector.py
+++ b/backend/src/utils/sparse_vector.py
@@ -3,14 +3,18 @@
 Issue #16: Converts Sudachi-tokenized text into sparse vectors
 using MurmurHash3 for deterministic token-to-index mapping.
 
-Used with Qdrant's SparseVectorParams(modifier=Modifier.IDF)
-which applies IDF weighting and document length normalization
-at query time (true BM25).
+Used with Qdrant's SparseVectorParams(modifier=Modifier.IDF),
+which applies IDF weighting at query time (dot-product with IDF).
+Length normalization and the k1/b saturation of textbook Okapi BM25
+are NOT performed by Modifier.IDF — pre-weight tf values in the
+document-side builders to shape ranking.
 """
 
 from collections import Counter
 
 import mmh3
+
+from utils.tokenizer import tokenize_for_search
 
 
 def tokens_to_sparse_vector(
@@ -73,6 +77,36 @@ def build_document_sparse_vector(
     indices = list(merged.keys())
     values = list(merged.values())
     return indices, values
+
+
+def build_resource_sparse_vector(fulltext_content: str) -> tuple[list[int], list[float]]:
+    """Build sparse BM25 vector for a resource_indexer document (Issue #335).
+
+    Resource payloads are flat — the indexer joins projected fields into a
+    single `fulltext_content` string and has no summary/body/reading
+    structure to weight separately (unlike Memory, see
+    build_document_sparse_vector). We tokenize with Sudachi and emit the
+    raw term frequencies at weight=1.0, intentionally matching the
+    memory-side `content` field weight so corpus-wide IDF stays consistent
+    across both write paths. The helper lives in utils/sparse_vector (not
+    the indexer) to keep memory_service and resource_indexer sharing a
+    single source of truth for doc-side sparse encoding.
+
+    Args:
+        fulltext_content: Projected fulltext string from ResourceIndexer
+
+    Returns:
+        (indices, values) tuple for SparseVector constructor.
+        Returns ([], []) for empty or tokenization-free input — callers
+        should skip attaching a bm25 vector in that case.
+    """
+    tokens = tokenize_for_search(fulltext_content)
+    if not tokens:
+        return [], []
+    merged = tokens_to_sparse_vector(tokens, weight=1.0)
+    if not merged:
+        return [], []
+    return list(merged.keys()), list(merged.values())
 
 
 def build_query_sparse_vector(query_tokens: str) -> tuple[list[int], list[float]]:

--- a/backend/tests/integration/test_resource_indexer_qdrant.py
+++ b/backend/tests/integration/test_resource_indexer_qdrant.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import uuid
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 from qdrant_client import QdrantClient
@@ -26,12 +27,16 @@ from qdrant_client.http.exceptions import UnexpectedResponse
 from qdrant_client.models import (
     Distance,
     Modifier,
+    NamedSparseVector,
+    NamedVector,
     PointStruct,
+    SparseVector,
     SparseVectorParams,
     VectorParams,
 )
 
-from db.qdrant import KAGURA_MEMORIES_VECTOR_NAME
+from db.qdrant import KAGURA_MEMORIES_BM25_VECTOR_NAME, KAGURA_MEMORIES_VECTOR_NAME
+from utils.sparse_vector import build_resource_sparse_vector
 
 _EMBEDDING_DIM = 512
 
@@ -74,7 +79,7 @@ def named_vector_collection(qdrant_client: QdrantClient) -> Iterator[str]:
             ),
         },
         sparse_vectors_config={
-            "bm25": SparseVectorParams(modifier=Modifier.IDF),
+            KAGURA_MEMORIES_BM25_VECTOR_NAME: SparseVectorParams(modifier=Modifier.IDF),
         },
     )
     try:
@@ -147,3 +152,134 @@ class TestNamedVectorUpsertContract:
         qdrant_client.upsert(collection_name=named_vector_collection, points=[point], wait=True)
         count = qdrant_client.count(collection_name=named_vector_collection, exact=True)
         assert count.count == 1
+
+
+class TestResourceIndexerSparseBM25:
+    """Issue #335: resource_indexer must send `bm25` alongside `dense`.
+
+    These are contract tests against a real Qdrant — they verify the on-wire
+    shape and hybrid-search behavior, not the indexer's internal assembly
+    (covered by tests/services/test_resource_indexer.py).
+    """
+
+    def _upsert_resource_point(
+        self,
+        qdrant_client: QdrantClient,
+        collection: str,
+        point_id: str,
+        content: str,
+        with_bm25: bool = True,
+    ) -> None:
+        """Mirror what resource_indexer._apply_upsert produces on the wire."""
+        vector: dict[str, Any] = {KAGURA_MEMORIES_VECTOR_NAME: [0.1] * _EMBEDDING_DIM}
+        if with_bm25:
+            indices, values = build_resource_sparse_vector(content)
+            if indices and values:
+                vector[KAGURA_MEMORIES_BM25_VECTOR_NAME] = SparseVector(
+                    indices=indices, values=values
+                )
+        qdrant_client.upsert(
+            collection_name=collection,
+            points=[PointStruct(id=point_id, vector=vector, payload={"content": content})],
+            wait=True,
+        )
+
+    def test_upsert_carries_both_dense_and_bm25(
+        self, qdrant_client: QdrantClient, named_vector_collection: str
+    ) -> None:
+        """AC1: a resource-shaped point persists both `dense` and `bm25` vectors."""
+        point_id = str(uuid.uuid4())
+        self._upsert_resource_point(
+            qdrant_client, named_vector_collection, point_id, "PostgreSQL の migration 戦略"
+        )
+
+        retrieved = qdrant_client.retrieve(
+            collection_name=named_vector_collection,
+            ids=[point_id],
+            with_vectors=True,
+        )
+        assert len(retrieved) == 1
+        vectors = retrieved[0].vector
+        assert isinstance(vectors, dict)
+        assert KAGURA_MEMORIES_VECTOR_NAME in vectors
+        assert KAGURA_MEMORIES_BM25_VECTOR_NAME in vectors, (
+            "AC1: resource points must carry the bm25 sparse vector"
+        )
+
+    def test_bm25_only_query_hits_resource_point(
+        self, qdrant_client: QdrantClient, named_vector_collection: str
+    ) -> None:
+        """AC2: a sparse-only query against the bm25 vector finds resource points.
+
+        Pre-#335, resource points carried no bm25 vector → BM25 score was
+        always zero → `using="bm25"` queries returned nothing from resource
+        data. We assert presence in the hit list, not score value (DB PhD:
+        Modifier.IDF scoring drifts with collection size, so absolute scores
+        are flaky).
+        """
+        point_id = str(uuid.uuid4())
+        content = "Sudachi tokenizer による日本語の BM25 検索"
+        self._upsert_resource_point(qdrant_client, named_vector_collection, point_id, content)
+
+        # Query with the same content as the doc → guaranteed token overlap.
+        # Use the doc-side encoder for the query to keep the test
+        # self-contained; production uses build_query_sparse_vector but the
+        # token space is the same.
+        q_indices, q_values = build_resource_sparse_vector(content)
+        hits = qdrant_client.search(
+            collection_name=named_vector_collection,
+            query_vector=NamedSparseVector(
+                name=KAGURA_MEMORIES_BM25_VECTOR_NAME,
+                vector=SparseVector(indices=q_indices, values=q_values),
+            ),
+            limit=10,
+        )
+        assert any(h.id == point_id for h in hits), (
+            "AC2: bm25-only search must surface resource points"
+        )
+
+    def test_dense_only_backward_compat(
+        self, qdrant_client: QdrantClient, named_vector_collection: str
+    ) -> None:
+        """AC3: legacy points (dense-only, no bm25) still work for dense search.
+
+        Pre-#335 data — already on disk — must continue to be discoverable
+        via dense search even though they will never match a bm25-only query.
+        This guards the migration window where new and old shapes coexist.
+        """
+        point_id = str(uuid.uuid4())
+        self._upsert_resource_point(
+            qdrant_client,
+            named_vector_collection,
+            point_id,
+            "legacy point without bm25",
+            with_bm25=False,
+        )
+
+        dense_hits = qdrant_client.search(
+            collection_name=named_vector_collection,
+            query_vector=NamedVector(
+                name=KAGURA_MEMORIES_VECTOR_NAME,
+                vector=[0.1] * _EMBEDDING_DIM,
+            ),
+            limit=10,
+        )
+        assert any(h.id == point_id for h in dense_hits), (
+            "AC3: legacy dense-only points must remain searchable via dense vector"
+        )
+
+        # And bm25-only search must NOT return the legacy point — points
+        # without a sparse vector contribute zero to sparse retrieval, which
+        # is the contract that makes the migration window safe.
+        q_indices, q_values = build_resource_sparse_vector("legacy point without bm25")
+        sparse_hits = qdrant_client.search(
+            collection_name=named_vector_collection,
+            query_vector=NamedSparseVector(
+                name=KAGURA_MEMORIES_BM25_VECTOR_NAME,
+                vector=SparseVector(indices=q_indices, values=q_values),
+            ),
+            limit=10,
+        )
+        assert all(h.id != point_id for h in sparse_hits), (
+            "Sparse-vectorless points must not appear in bm25-only search results"
+        )

--- a/backend/tests/services/test_resource_indexer.py
+++ b/backend/tests/services/test_resource_indexer.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 import pytest
 
-from db.qdrant import KAGURA_MEMORIES_VECTOR_NAME
+from db.qdrant import KAGURA_MEMORIES_BM25_VECTOR_NAME, KAGURA_MEMORIES_VECTOR_NAME
 from services.resource_indexer import ResourceIndexer
 
 
@@ -115,6 +115,30 @@ class TestResourceIndexerNamedVectorUpsert:
         )
         assert KAGURA_MEMORIES_VECTOR_NAME in point.vector
         assert point.vector[KAGURA_MEMORIES_VECTOR_NAME] == [0.1] * 512
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_attaches_bm25_sparse_vector(self, indexer):
+        """Issue #335: PointStruct.vector must include `bm25` SparseVector
+        derived from the same fulltext_content as the dense embedding, so
+        resource points participate in hybrid search."""
+        from qdrant_client.models import SparseVector
+
+        event = _make_event()
+        schema = _make_schema()
+        context = _make_context()
+
+        await indexer._apply_upsert(
+            event, schema, context, "kagura_memories", indexer.embedding_service
+        )
+
+        point = indexer.qdrant_client.upsert.await_args.kwargs["points"][0]
+        assert KAGURA_MEMORIES_BM25_VECTOR_NAME in point.vector, (
+            "PointStruct.vector must carry both 'dense' and 'bm25' (#335)"
+        )
+        bm25 = point.vector[KAGURA_MEMORIES_BM25_VECTOR_NAME]
+        assert isinstance(bm25, SparseVector)
+        assert len(bm25.indices) == len(bm25.values) > 0
+        assert all(v > 0 for v in bm25.values)
 
     @pytest.mark.asyncio
     async def test_apply_upsert_uses_passed_embedding_service_not_self(self, indexer):

--- a/backend/tests/utils/test_sparse_vector.py
+++ b/backend/tests/utils/test_sparse_vector.py
@@ -8,6 +8,7 @@ import mmh3
 from utils.sparse_vector import (
     build_document_sparse_vector,
     build_query_sparse_vector,
+    build_resource_sparse_vector,
     tokens_to_sparse_vector,
 )
 
@@ -90,6 +91,41 @@ class TestBuildDocumentSparseVector:
         indices, values = build_document_sparse_vector("", "", "")
         assert indices == []
         assert values == []
+
+
+class TestBuildResourceSparseVector:
+    """Test build_resource_sparse_vector (Issue #335)."""
+
+    def test_basic(self):
+        """Non-empty content yields equal-length indices/values."""
+        indices, values = build_resource_sparse_vector("hello world")
+        assert len(indices) > 0
+        assert len(values) == len(indices)
+
+    def test_weight_1x(self):
+        """Resource tokens are weighted at 1.0 to match memory-side `content`."""
+        indices, values = build_resource_sparse_vector("test")
+        idx = mmh3.hash("test", signed=False)
+        pos = indices.index(idx)
+        assert values[pos] == 1.0
+
+    def test_empty(self):
+        """Empty string returns empty lists (caller skips bm25 attach)."""
+        indices, values = build_resource_sparse_vector("")
+        assert indices == []
+        assert values == []
+
+    def test_japanese_content(self):
+        """Japanese fulltext is tokenized via Sudachi before hashing."""
+        indices, values = build_resource_sparse_vector("認証エラーの解決方法")
+        assert len(indices) > 0
+        assert all(v > 0 for v in values)
+
+    def test_deterministic(self):
+        """Same input produces identical output (idempotency for re-index)."""
+        a = build_resource_sparse_vector("PostgreSQL migration 戦略")
+        b = build_resource_sparse_vector("PostgreSQL migration 戦略")
+        assert a == b
 
 
 class TestBuildQuerySparseVector:


### PR DESCRIPTION
Closes #335

## Summary
- Resource-ingested points now carry both `dense` and `bm25` named vectors so they participate in hybrid search instead of scoring zero on BM25.
- New shared doc-side encoder `build_resource_sparse_vector` in `utils/sparse_vector` keeps `memory_service` and `resource_indexer` on a single source of truth (consistent corpus-wide IDF distribution).
- Promoted hardcoded `"bm25"` literal to `KAGURA_MEMORIES_BM25_VECTOR_NAME` constant in `db/qdrant.py`; replaced 4 usages.
- Corrected `sparse_vector` module docstring: Qdrant `Modifier.IDF` applies IDF only — NOT full Okapi BM25 length normalization.

## Implementation notes
- `build_resource_sparse_vector` uses `weight=1.0` to intentionally match the memory-side `content` field weight (vs `summary=2.0`, `reading=0.5`); deviating would skew shared corpus IDF.
- `_apply_upsert` skips attaching `bm25` when content yields no tokens (empty / stopword-only), preserving the dense-only upsert path on edge cases.
- Tests are contract-only (presence / membership / positivity) — no scalar score asserts. Qdrant `Modifier.IDF` scoring is corpus-size-dependent and would be flaky.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/335-feat-indexer-sparse-bm25.gate1.md
- ~/.claude/cache/gh-issue-driven/335-feat-indexer-sparse-bm25.gate2.md

🤖 Generated via /gh-issue-driven:ship
