### PR TITLE
refactor(frontend): unify workspace Add/Refresh buttons, polish Members + resource list (#350)

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -18,7 +18,6 @@ import { useWorkspace } from "@/contexts/WorkspaceContext";
 import { formatRelativeTime } from "@/lib/utils/datetime";
 import {
   Plus,
-  RefreshCw,
   FolderOpen,
   Brain,
   AlertCircle,
@@ -221,10 +220,6 @@ export default function ContextsPage() {
     quickCreateDialogOpen,
     currentWorkspace?.current_user_role,
   ]);
-
-  const handleRefresh = () => {
-    fetchContexts();
-  };
 
   // Issue #169: Quick Create - minimal form, just name
   const handleQuickCreate = async () => {
@@ -434,22 +429,12 @@ export default function ContextsPage() {
         description={t("subtitle")}
         actions={
           <div className="flex items-center gap-2">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handleRefresh}
-              disabled={loading}
-            >
-              <RefreshCw
-                className={cn("h-4 w-4 mr-2", loading && "animate-spin")}
-              />
-              {tCommon("refresh")}
-            </Button>
             {/* Issue #169: Dropdown for Quick Create vs Advanced Create */}
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button
                   size="sm"
+                  className={colors.button.primary}
                   disabled={
                     hasOpenAIKey === false ||
                     currentWorkspace?.current_user_role === "member" ||

--- a/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
@@ -142,7 +142,12 @@ export default function WorkspaceStatsPage() {
               </SelectContent>
             </Select>
           )}
-          <Button onClick={fetchStats} variant="outline" disabled={loading}>
+          <Button
+            onClick={fetchStats}
+            variant="outline"
+            size="sm"
+            disabled={loading}
+          >
             {loading ? (
               <InlineSpinner size="sm" className="mr-2" />
             ) : (

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -687,27 +687,30 @@ export default function WorkspaceMembersPage() {
                       </button>
                     )}
                   </td>
-                  <td className="px-6 py-4 whitespace-nowrap text-right text-sm">
-                    <div className="flex items-center justify-end gap-2">
-                      {/* Remove button - only for owner, not for owner members */}
-                      {member.role !== "owner" &&
-                        currentWorkspace?.current_user_role === "owner" && (
-                          <button
-                            onClick={() => handleRemoveMemberClick(member)}
-                            className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
-                            title={t("removeTitle")}
-                          >
-                            <Trash2 className="w-4 h-4" />
-                          </button>
-                        )}
-
-                      {/* Empty state for consistent spacing */}
-                      {member.user_id !== user?.id &&
-                        (member.role === "owner" ||
-                          currentWorkspace?.current_user_role !== "owner") && (
-                          <span className="text-gray-400 text-xs">—</span>
-                        )}
-                    </div>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm">
+                    {/* Issue #350: Remove button only renders for non-owner
+                        rows when the viewer is an owner. Every other case
+                        (owner rows, admin-viewing-admin rows, self rows)
+                        falls through to a centered muted em-dash so the
+                        actions column never reads as "still loading" to
+                        users. Remove button stays right-aligned; em-dash
+                        centers in the cell. */}
+                    {member.role !== "owner" &&
+                    currentWorkspace?.current_user_role === "owner" ? (
+                      <div className="flex items-center justify-end gap-2">
+                        <button
+                          onClick={() => handleRemoveMemberClick(member)}
+                          className="text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+                          title={t("removeTitle")}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      </div>
+                    ) : (
+                      <span className="block text-center text-gray-400 text-xs">
+                        —
+                      </span>
+                    )}
                   </td>
                 </tr>
               ))}

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -193,7 +193,7 @@ export default function ResourcesListPage() {
                     <TableCell className="font-mono text-sm">
                       <Link
                         href={href}
-                        className="text-primary underline-offset-4 hover:underline focus:outline-none focus:ring-2 focus:ring-ring rounded"
+                        className="text-primary focus:outline-none focus:ring-2 focus:ring-ring rounded"
                       >
                         {r.resource_id}
                       </Link>

--- a/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
+++ b/frontend/src/components/credentials/ResourceTokensTabPanel.tsx
@@ -52,6 +52,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { ResourceTokensTable } from "@/components/resource-tokens/ResourceTokensTable";
 import { CreateResourceTokenDialog } from "@/components/resource-tokens/CreateResourceTokenDialog";
+import { colors } from "@/styles/design-tokens";
 
 interface ResourceTokensTabPanelProps {
   /**
@@ -616,6 +617,8 @@ export function ResourceTokensTabPanel({
             {isOwner && (
               <Button
                 onClick={() => setShowCreateDialog(true)}
+                size="sm"
+                className={colors.button.primary}
                 disabled={
                   !contexts.some((c) => c.resource_id) ||
                   currentWorkspace?.plan_name === "free"


### PR DESCRIPTION
Closes #350

## Summary

- Unify Add button styling across Workspace headers: `size="sm"` + `colors.button.primary` (brand-green) on Contexts list and Resource detail Tokens tab
- Trim redundant Refresh buttons: keep on Dashboard (`size="sm"` applied for visual consistency), remove from Contexts list where auto-refetch handles it
- Drop `hover:underline` visual noise from Resources list `resource_id` Link while keeping the Link element and its a11y affordances (keyboard tab, middle-click, copy-link) intact
- Fill the previously-blank Members actions cell with a centered muted em-dash for every row where the Remove button is not rendered — including owner self rows and admin self rows

## Implementation notes

- Brand-green is sourced from the existing `colors.button.primary` token in `frontend/src/styles/design-tokens.ts:87-90` — no new design tokens introduced
- Contexts list cleanup also removed the now-dead `handleRefresh` handler and the `RefreshCw` lucide import
- Members actions cell: replaced the partial em-dash gate (`member.user_id !== user?.id && …`) with a simple ternary — Remove button branch (right-aligned in inner flex) or centered em-dash branch
- Resources list `<Link>` is preserved per the pre-existing design intent at `page.tsx:147-160` (a11y primary affordance for keyboard / screen reader / middle-click navigation); only the `underline-offset-4 hover:underline` classes were stripped from the className
- Net diff: +35 / -39 lines. Frontend tests: 170/170 pass, `tsc --noEmit` clean

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (after HITL clarification of AC#1/#2/#3 ambiguities)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/350-feat-workspace-ui-polish-add-refresh-members.gate1.md
- ~/.claude/cache/gh-issue-driven/350-feat-workspace-ui-polish-add-refresh-members.gate2.md

🤖 Generated via /gh-issue-driven:ship
