### PR TITLE
feat(frontend): add narrative layer to sleep report detail page (#352)

### DIFF
--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import require_admin
 from db.base import get_db
+from models.auth import Context
 from models.sleep import SleepAction, SleepReport
 from utils.datetime import to_utc_iso
 from utils.logger import get_logger
@@ -55,6 +56,7 @@ class SleepReportSummary(BaseModel):
 class SleepReportDetail(SleepReportSummary):
     """Sleep report full detail."""
 
+    context_name: str | None = None
     embedding_calls_made: int
     error_message: str | None
     edge_discovery_result: dict[str, Any] | None
@@ -174,13 +176,27 @@ async def get_sleep_report_detail(
             detail=f"Sleep report {report_id} not found.",
         )
 
+    context_name: str | None = None
+    if report.context_id is not None:
+        ctx_result = await db.execute(select(Context).where(Context.id == report.context_id))
+        ctx = ctx_result.scalar_one_or_none()
+        if ctx is None or ctx.deleted_at is not None:
+            context_name = "(deleted)"
+        else:
+            context_name = ctx.display_name or ctx.name
+
     actions_result = await db.execute(
         select(SleepAction).where(SleepAction.report_id == report_id).order_by(SleepAction.id)
     )
     actions = list(actions_result.scalars().all())
 
+    # Inject the resolved context_name onto the ORM instance before validation;
+    # the SleepReport model itself has no such column.
+    report.context_name = context_name
+    report_detail = SleepReportDetail.model_validate(report, from_attributes=True)
+
     return SleepReportDetailResponse(
-        report=SleepReportDetail.model_validate(report, from_attributes=True),
+        report=report_detail,
         actions=[SleepActionItem.model_validate(a, from_attributes=True) for a in actions],
         action_count=len(actions),
     )

--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -57,6 +57,7 @@ class SleepReportDetail(SleepReportSummary):
     """Sleep report full detail."""
 
     context_name: str | None = None
+    context_deleted: bool = False
     embedding_calls_made: int
     error_message: str | None
     edge_discovery_result: dict[str, Any] | None
@@ -177,11 +178,12 @@ async def get_sleep_report_detail(
         )
 
     context_name: str | None = None
+    context_deleted = False
     if report.context_id is not None:
         ctx_result = await db.execute(select(Context).where(Context.id == report.context_id))
         ctx = ctx_result.scalar_one_or_none()
         if ctx is None or ctx.deleted_at is not None:
-            context_name = "(deleted)"
+            context_deleted = True
         else:
             context_name = ctx.display_name or ctx.name
 
@@ -190,9 +192,11 @@ async def get_sleep_report_detail(
     )
     actions = list(actions_result.scalars().all())
 
-    # Inject the resolved context_name onto the ORM instance before validation;
-    # the SleepReport model itself has no such column.
+    # Inject resolved context fields onto the ORM instance before validation;
+    # the SleepReport model itself has no such columns. Localization of the
+    # deleted marker happens on the frontend via the context_deleted flag.
     report.context_name = context_name
+    report.context_deleted = context_deleted
     report_detail = SleepReportDetail.model_validate(report, from_attributes=True)
 
     return SleepReportDetailResponse(

--- a/backend/tests/api/test_sleep_reports_admin.py
+++ b/backend/tests/api/test_sleep_reports_admin.py
@@ -219,6 +219,7 @@ class TestGetSleepReportDetail:
         assert data["action_count"] == 2
         assert data["report"]["memories_processed"] == 7
         assert data["report"]["context_name"] == "Kagura Dev"
+        assert data["report"]["context_deleted"] is False
         # Verify Z suffix on both report and action timestamps
         assert data["report"]["started_at"].endswith("Z")
         assert data["actions"][0]["created_at"].endswith("Z")
@@ -242,9 +243,11 @@ class TestGetSleepReportDetail:
 
         response = client.get(f"/api/v1/admin/sleep-reports/{report.id}")
         assert response.status_code == 200
-        assert response.json()["report"]["context_name"] == "kagura-dev"
+        body = response.json()["report"]
+        assert body["context_name"] == "kagura-dev"
+        assert body["context_deleted"] is False
 
-    def test_deleted_context_returns_deleted_marker(self, client):
+    def test_deleted_context_returns_deleted_flag(self, client):
         report = _make_mock_report()
         ctx = _make_mock_context(deleted=True)
 
@@ -261,9 +264,11 @@ class TestGetSleepReportDetail:
 
         response = client.get(f"/api/v1/admin/sleep-reports/{report.id}")
         assert response.status_code == 200
-        assert response.json()["report"]["context_name"] == "(deleted)"
+        body = response.json()["report"]
+        assert body["context_name"] is None
+        assert body["context_deleted"] is True
 
-    def test_missing_context_row_returns_deleted_marker(self, client):
+    def test_missing_context_row_returns_deleted_flag(self, client):
         report = _make_mock_report()
 
         mock_db = AsyncMock()
@@ -279,9 +284,11 @@ class TestGetSleepReportDetail:
 
         response = client.get(f"/api/v1/admin/sleep-reports/{report.id}")
         assert response.status_code == 200
-        assert response.json()["report"]["context_name"] == "(deleted)"
+        body = response.json()["report"]
+        assert body["context_name"] is None
+        assert body["context_deleted"] is True
 
-    def test_null_context_id_omits_context_name(self, client):
+    def test_null_context_id_omits_context_fields(self, client):
         report = _make_mock_report(context_id=False)
         report.context_id = None
 
@@ -297,7 +304,9 @@ class TestGetSleepReportDetail:
 
         response = client.get(f"/api/v1/admin/sleep-reports/{report.id}")
         assert response.status_code == 200
-        assert response.json()["report"]["context_name"] is None
+        body = response.json()["report"]
+        assert body["context_name"] is None
+        assert body["context_deleted"] is False
 
     def test_not_found_returns_404(self, client):
         mock_db = AsyncMock()

--- a/backend/tests/api/test_sleep_reports_admin.py
+++ b/backend/tests/api/test_sleep_reports_admin.py
@@ -59,6 +59,20 @@ def _make_mock_report(
     return r
 
 
+def _make_mock_context(
+    *,
+    name: str = "kagura-dev",
+    display_name: str | None = "Kagura Dev",
+    deleted: bool = False,
+):
+    ctx = MagicMock()
+    ctx.id = uuid4()
+    ctx.name = name
+    ctx.display_name = display_name
+    ctx.deleted_at = datetime(2026, 1, 1) if deleted else None
+    return ctx
+
+
 def _make_mock_action(phase: str = "edge_discovery", action_type: str = "create_edge"):
     a = MagicMock()
     a.id = 1
@@ -182,6 +196,7 @@ class TestGetSleepReportDetail:
 
     def test_returns_report_with_actions(self, client):
         report = _make_mock_report()
+        ctx = _make_mock_context()
         actions = [
             _make_mock_action(),
             _make_mock_action(phase="dedup_merge", action_type="merge"),
@@ -190,9 +205,11 @@ class TestGetSleepReportDetail:
         mock_db = AsyncMock()
         report_result = MagicMock()
         report_result.scalar_one_or_none.return_value = report
+        ctx_result = MagicMock()
+        ctx_result.scalar_one_or_none.return_value = ctx
         actions_result = MagicMock()
         actions_result.scalars.return_value.all.return_value = actions
-        mock_db.execute.side_effect = [report_result, actions_result]
+        mock_db.execute.side_effect = [report_result, ctx_result, actions_result]
 
         _install_overrides(mock_db)
 
@@ -201,11 +218,86 @@ class TestGetSleepReportDetail:
         data = response.json()
         assert data["action_count"] == 2
         assert data["report"]["memories_processed"] == 7
+        assert data["report"]["context_name"] == "Kagura Dev"
         # Verify Z suffix on both report and action timestamps
         assert data["report"]["started_at"].endswith("Z")
         assert data["actions"][0]["created_at"].endswith("Z")
         assert data["actions"][0]["action_type"] == "create_edge"
         assert data["actions"][1]["action_type"] == "merge"
+
+    def test_falls_back_to_name_when_display_name_missing(self, client):
+        report = _make_mock_report()
+        ctx = _make_mock_context(name="kagura-dev", display_name=None)
+
+        mock_db = AsyncMock()
+        report_result = MagicMock()
+        report_result.scalar_one_or_none.return_value = report
+        ctx_result = MagicMock()
+        ctx_result.scalar_one_or_none.return_value = ctx
+        actions_result = MagicMock()
+        actions_result.scalars.return_value.all.return_value = []
+        mock_db.execute.side_effect = [report_result, ctx_result, actions_result]
+
+        _install_overrides(mock_db)
+
+        response = client.get(f"/api/v1/admin/sleep-reports/{report.id}")
+        assert response.status_code == 200
+        assert response.json()["report"]["context_name"] == "kagura-dev"
+
+    def test_deleted_context_returns_deleted_marker(self, client):
+        report = _make_mock_report()
+        ctx = _make_mock_context(deleted=True)
+
+        mock_db = AsyncMock()
+        report_result = MagicMock()
+        report_result.scalar_one_or_none.return_value = report
+        ctx_result = MagicMock()
+        ctx_result.scalar_one_or_none.return_value = ctx
+        actions_result = MagicMock()
+        actions_result.scalars.return_value.all.return_value = []
+        mock_db.execute.side_effect = [report_result, ctx_result, actions_result]
+
+        _install_overrides(mock_db)
+
+        response = client.get(f"/api/v1/admin/sleep-reports/{report.id}")
+        assert response.status_code == 200
+        assert response.json()["report"]["context_name"] == "(deleted)"
+
+    def test_missing_context_row_returns_deleted_marker(self, client):
+        report = _make_mock_report()
+
+        mock_db = AsyncMock()
+        report_result = MagicMock()
+        report_result.scalar_one_or_none.return_value = report
+        ctx_result = MagicMock()
+        ctx_result.scalar_one_or_none.return_value = None
+        actions_result = MagicMock()
+        actions_result.scalars.return_value.all.return_value = []
+        mock_db.execute.side_effect = [report_result, ctx_result, actions_result]
+
+        _install_overrides(mock_db)
+
+        response = client.get(f"/api/v1/admin/sleep-reports/{report.id}")
+        assert response.status_code == 200
+        assert response.json()["report"]["context_name"] == "(deleted)"
+
+    def test_null_context_id_omits_context_name(self, client):
+        report = _make_mock_report(context_id=False)
+        report.context_id = None
+
+        mock_db = AsyncMock()
+        report_result = MagicMock()
+        report_result.scalar_one_or_none.return_value = report
+        actions_result = MagicMock()
+        actions_result.scalars.return_value.all.return_value = []
+        # No Context query because context_id is None
+        mock_db.execute.side_effect = [report_result, actions_result]
+
+        _install_overrides(mock_db)
+
+        response = client.get(f"/api/v1/admin/sleep-reports/{report.id}")
+        assert response.status_code == 200
+        assert response.json()["report"]["context_name"] is None
 
     def test_not_found_returns_404(self, client):
         mock_db = AsyncMock()
@@ -228,13 +320,16 @@ class TestGetSleepReportDetail:
 
     def test_empty_actions_returns_zero_count(self, client):
         report = _make_mock_report()
+        ctx = _make_mock_context()
 
         mock_db = AsyncMock()
         report_result = MagicMock()
         report_result.scalar_one_or_none.return_value = report
+        ctx_result = MagicMock()
+        ctx_result.scalar_one_or_none.return_value = ctx
         actions_result = MagicMock()
         actions_result.scalars.return_value.all.return_value = []
-        mock_db.execute.side_effect = [report_result, actions_result]
+        mock_db.execute.side_effect = [report_result, ctx_result, actions_result]
 
         _install_overrides(mock_db)
 

--- a/backend/tests/api/test_sleep_reports_admin.py
+++ b/backend/tests/api/test_sleep_reports_admin.py
@@ -27,18 +27,21 @@ def _mock_admin_user() -> dict:
     }
 
 
+_SENTINEL = object()
+
+
 def _make_mock_report(
     *,
     status: str = "completed",
     memories_processed: int = 7,
-    context_id=None,
+    context_id=_SENTINEL,
     user_id: str = "local:admin",
 ):
     r = MagicMock()
     r.id = uuid4()
     r.user_id = user_id
     r.workspace_id = uuid4()
-    r.context_id = context_id or uuid4()
+    r.context_id = uuid4() if context_id is _SENTINEL else context_id
     r.status = status
     r.started_at = datetime(2026, 4, 6, 3, 0, 0)
     r.completed_at = datetime(2026, 4, 6, 3, 3, 0)
@@ -289,8 +292,7 @@ class TestGetSleepReportDetail:
         assert body["context_deleted"] is True
 
     def test_null_context_id_omits_context_fields(self, client):
-        report = _make_mock_report(context_id=False)
-        report.context_id = None
+        report = _make_mock_report(context_id=None)
 
         mock_db = AsyncMock()
         report_result = MagicMock()

--- a/frontend/src/app/(authenticated)/admin/sleep-reports/[reportId]/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/[reportId]/page.tsx
@@ -14,6 +14,7 @@ import { useTranslations, useLocale } from "next-intl";
 import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { LoadingState } from "@/components/common/LoadingState";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { apiClient } from "@/lib/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
@@ -37,9 +38,13 @@ import {
   TrendingUp,
   Sparkles,
 } from "lucide-react";
-import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { formatDateTime, formatRelativeTime } from "@/lib/utils/datetime";
+import {
+  buildHeadline,
+  buildPhaseNarrative,
+  type PhaseName,
+} from "@/lib/utils/sleep-narrative";
 import { getSleepStatusColor, type SleepStatus } from "@/lib/sleep-report";
 
 interface SleepReportDetail {
@@ -47,6 +52,7 @@ interface SleepReportDetail {
   user_id: string;
   workspace_id: string | null;
   context_id: string | null;
+  context_name: string | null;
   status: SleepStatus;
   started_at: string;
   completed_at: string | null;
@@ -102,74 +108,6 @@ function formatDuration(startedAt: string, completedAt: string | null): string {
   return `${minutes}m ${remainSec}s`;
 }
 
-/**
- * Extract a human-readable summary from a phase result's details dict.
- * Each phase writes different keys; we pick the most meaningful ones.
- */
-function getPhaseSummary(phaseKey: string, result: PhaseResult): string | null {
-  if (result.skipped) {
-    return result.skip_reason || "skipped";
-  }
-  if (result.error) {
-    return result.error;
-  }
-  const d = result.details || {};
-  const num = (k: string): number | null =>
-    typeof d[k] === "number" ? (d[k] as number) : null;
-  const str = (k: string): string | null =>
-    typeof d[k] === "string" ? (d[k] as string) : null;
-
-  switch (phaseKey) {
-    case "edgeDiscovery": {
-      const sampled = num("sampled");
-      const edges = num("edges_created");
-      if (sampled !== null || edges !== null) {
-        return `${sampled ?? 0} sampled → ${edges ?? 0} edges created`;
-      }
-      return null;
-    }
-    case "dedup": {
-      const candidates = num("candidates");
-      const clusters = num("clusters");
-      const merged = num("merged");
-      if (merged !== null || candidates !== null) {
-        return `${candidates ?? 0} candidates → ${clusters ?? 0} clusters → ${merged ?? 0} merged`;
-      }
-      return null;
-    }
-    case "importance": {
-      const updated = num("updated");
-      const candidates = num("candidates");
-      const message = str("message");
-      if (message) return message;
-      if (updated !== null || candidates !== null) {
-        return `${candidates ?? 0} candidates → ${updated ?? 0} updated`;
-      }
-      return null;
-    }
-    case "consolidation": {
-      const working = num("working_count");
-      const promoted = (num("rule_promoted") ?? 0) + (num("llm_promoted") ?? 0);
-      const archived = (num("rule_deleted") ?? 0) + (num("llm_archived") ?? 0);
-      if (working !== null) {
-        return `${working} working → ${promoted} promoted, ${archived} archived`;
-      }
-      return null;
-    }
-    case "reindex": {
-      const reindexed = num("reindexed");
-      const failed = num("failed");
-      if (reindexed !== null) {
-        return failed && failed > 0
-          ? `${reindexed} reindexed, ${failed} failed`
-          : `${reindexed} reindexed`;
-      }
-      return null;
-    }
-  }
-  return null;
-}
-
 function PhaseIcon({
   result,
 }: {
@@ -219,7 +157,6 @@ export default function AdminSleepReportDetailPage() {
     ? params.reportId[0]
     : (params.reportId ?? "");
   const t = useTranslations("admin.sleepReports");
-  const tCommon = useTranslations("admin.common");
   const locale = useLocale();
   const { user } = useAuth();
   const timezone = user?.timezone || "UTC";
@@ -227,13 +164,14 @@ export default function AdminSleepReportDetailPage() {
   const [detail, setDetail] = useState<SleepReportDetailResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
   const [showMetadata, setShowMetadata] = useState(false);
-  const { toast } = useToast();
 
   useEffect(() => {
     const loadDetail = async () => {
       try {
         setLoading(true);
+        setLoadError(null);
         const data = await apiClient.get<SleepReportDetailResponse>(
           `/api/v1/admin/sleep-reports/${reportId}`,
         );
@@ -243,18 +181,14 @@ export default function AdminSleepReportDetailPage() {
         if (err?.status === 404) {
           setNotFound(true);
         } else {
-          toast({
-            title: tCommon("error"),
-            description: t("messages.loadError"),
-            variant: "destructive",
-          });
+          setLoadError(t("messages.loadError"));
         }
       } finally {
         setLoading(false);
       }
     };
     loadDetail();
-    // t/tCommon/toast are stable across renders; only reportId should trigger refetch
+    // t is stable across renders; only reportId should trigger refetch
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reportId]);
 
@@ -263,6 +197,21 @@ export default function AdminSleepReportDetailPage() {
       <PageContainer>
         <PageHeader title={t("title")} />
         <LoadingState lines={5} />
+      </PageContainer>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} />
+        <ErrorBanner error={loadError} />
+        <Link href="/admin/sleep-reports">
+          <Button variant="outline">
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            {t("actions.back")}
+          </Button>
+        </Link>
       </PageContainer>
     );
   }
@@ -286,13 +235,15 @@ export default function AdminSleepReportDetailPage() {
 
   const { report, actions, action_count } = detail;
 
-  const phaseResults = [
+  const phaseResults: { key: PhaseName; result: PhaseResult | null }[] = [
     { key: "edgeDiscovery", result: report.edge_discovery_result },
     { key: "dedup", result: report.dedup_result },
     { key: "importance", result: report.importance_result },
     { key: "consolidation", result: report.consolidation_result },
     { key: "reindex", result: report.reindex_result },
   ];
+
+  const headline = buildHeadline(report.context_name, report);
 
   const relativeStarted = formatRelativeTime(
     report.started_at,
@@ -316,6 +267,16 @@ export default function AdminSleepReportDetailPage() {
       />
 
       <div className="space-y-6">
+        {(report.status === "failed" || report.error_message) && (
+          <ErrorBanner
+            error={
+              report.error_message
+                ? `${t("detail.errorMessage")}: ${report.error_message}`
+                : t(`status.${report.status}`)
+            }
+          />
+        )}
+
         <div className="p-6 bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700">
           <div className="flex items-start justify-between gap-4 flex-wrap">
             <div className="flex items-center gap-3">
@@ -334,16 +295,9 @@ export default function AdminSleepReportDetailPage() {
               </div>
             </div>
           </div>
-          {report.error_message && (
-            <div className="mt-4 p-3 rounded bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800">
-              <div className="text-xs font-medium text-red-700 dark:text-red-300 mb-1">
-                {t("detail.errorMessage")}
-              </div>
-              <div className="text-sm text-red-600 dark:text-red-400 font-mono break-all">
-                {report.error_message}
-              </div>
-            </div>
-          )}
+          <div className="mt-4 text-sm text-gray-800 dark:text-gray-100">
+            {t(headline.key, headline.values)}
+          </div>
         </div>
 
         <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
@@ -380,7 +334,7 @@ export default function AdminSleepReportDetailPage() {
           </CardHeader>
           <CardContent className="space-y-2">
             {phaseResults.map(({ key, result }) => {
-              const summary = result ? getPhaseSummary(key, result) : null;
+              const narrative = buildPhaseNarrative(key, result);
               return (
                 <details
                   key={key}
@@ -392,9 +346,9 @@ export default function AdminSleepReportDetailPage() {
                       <div className="text-sm font-medium text-gray-900 dark:text-gray-100">
                         {t(`detail.${key}`)}
                       </div>
-                      {summary && (
+                      {narrative && (
                         <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
-                          {summary}
+                          {t(narrative.key, narrative.values)}
                         </div>
                       )}
                     </div>

--- a/frontend/src/app/(authenticated)/admin/sleep-reports/[reportId]/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/[reportId]/page.tsx
@@ -53,6 +53,7 @@ interface SleepReportDetail {
   workspace_id: string | null;
   context_id: string | null;
   context_name: string | null;
+  context_deleted: boolean;
   status: SleepStatus;
   started_at: string;
   completed_at: string | null;
@@ -243,7 +244,13 @@ export default function AdminSleepReportDetailPage() {
     { key: "reindex", result: report.reindex_result },
   ];
 
-  const headline = buildHeadline(report.context_name, report);
+  const headline = buildHeadline(
+    {
+      context_name: report.context_name,
+      context_deleted: report.context_deleted,
+    },
+    report,
+  );
 
   const relativeStarted = formatRelativeTime(
     report.started_at,
@@ -271,7 +278,9 @@ export default function AdminSleepReportDetailPage() {
           <ErrorBanner
             error={
               report.error_message
-                ? `${t("detail.errorMessage")}: ${report.error_message}`
+                ? t("detail.narrative.runFailed", {
+                    error: report.error_message,
+                  })
                 : t(`status.${report.status}`)
             }
           />

--- a/frontend/src/app/(authenticated)/admin/sleep-reports/[reportId]/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/[reportId]/page.tsx
@@ -173,6 +173,7 @@ export default function AdminSleepReportDetailPage() {
       try {
         setLoading(true);
         setLoadError(null);
+        setNotFound(false);
         const data = await apiClient.get<SleepReportDetailResponse>(
           `/api/v1/admin/sleep-reports/${reportId}`,
         );

--- a/frontend/src/lib/utils/sleep-narrative.test.ts
+++ b/frontend/src/lib/utils/sleep-narrative.test.ts
@@ -118,7 +118,7 @@ describe("buildPhaseNarrative", () => {
   });
 
   describe("dedup", () => {
-    it("builds success and derives held count", () => {
+    it("builds success with candidates and merged", () => {
       const n = buildPhaseNarrative(
         "dedup",
         phase({
@@ -133,15 +133,7 @@ describe("buildPhaseNarrative", () => {
       expect(n?.key).toBe("detail.narrative.phases.dedup.success");
       expect(n?.values.count).toBe(12);
       expect(n?.values.merged).toBe(3);
-      expect(n?.values.held).toBe(9);
-    });
-
-    it("clamps held to 0 when merged exceeds candidates", () => {
-      const n = buildPhaseNarrative(
-        "dedup",
-        phase({ details: { candidates: 2, merged: 5 } }),
-      );
-      expect(n?.values.held).toBe(0);
+      expect(n?.values.clusters).toBe(5);
     });
 
     it("empty when neither candidates nor merged present", () => {

--- a/frontend/src/lib/utils/sleep-narrative.test.ts
+++ b/frontend/src/lib/utils/sleep-narrative.test.ts
@@ -115,6 +115,14 @@ describe("buildPhaseNarrative", () => {
       const n = buildPhaseNarrative("edgeDiscovery", phase({ details: null }));
       expect(n?.key).toBe("detail.narrative.phases.edgeDiscovery.empty");
     });
+
+    it("empty when edges_created is 0 even if sampled > 0", () => {
+      const n = buildPhaseNarrative(
+        "edgeDiscovery",
+        phase({ details: { edges_created: 0, sampled: 20 } }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.edgeDiscovery.empty");
+    });
   });
 
   describe("dedup", () => {

--- a/frontend/src/lib/utils/sleep-narrative.test.ts
+++ b/frontend/src/lib/utils/sleep-narrative.test.ts
@@ -28,23 +28,41 @@ function phase(
 
 describe("buildHeadline", () => {
   it("uses headline key when context name is present", () => {
-    const n = buildHeadline("kagura-dev", HEADLINE_SRC);
+    const n = buildHeadline(
+      { context_name: "kagura-dev", context_deleted: false },
+      HEADLINE_SRC,
+    );
     expect(n.key).toBe("detail.narrative.headline");
     expect(n.values.contextName).toBe("kagura-dev");
     expect(n.values.processed).toBe(42);
     expect(n.values.merged).toBe(3);
   });
 
-  it("uses headlineNoContext when context name is null", () => {
-    const n = buildHeadline(null, HEADLINE_SRC);
+  it("uses headlineNoContext when context is absent", () => {
+    const n = buildHeadline(
+      { context_name: null, context_deleted: false },
+      HEADLINE_SRC,
+    );
     expect(n.key).toBe("detail.narrative.headlineNoContext");
-    expect(n.values.contextName).toBe("");
+    expect(n.values.contextName).toBeUndefined();
   });
 
-  it("passes through (deleted) marker as-is", () => {
-    const n = buildHeadline("(deleted)", HEADLINE_SRC);
+  it("uses headlineDeletedContext when context_deleted is true", () => {
+    const n = buildHeadline(
+      { context_name: null, context_deleted: true },
+      HEADLINE_SRC,
+    );
+    expect(n.key).toBe("detail.narrative.headlineDeletedContext");
+    expect(n.values.contextName).toBeUndefined();
+  });
+
+  it("prefers context_name when both set (race: not expected but defined)", () => {
+    const n = buildHeadline(
+      { context_name: "kagura-dev", context_deleted: true },
+      HEADLINE_SRC,
+    );
     expect(n.key).toBe("detail.narrative.headline");
-    expect(n.values.contextName).toBe("(deleted)");
+    expect(n.values.contextName).toBe("kagura-dev");
   });
 });
 
@@ -71,9 +89,10 @@ describe("buildPhaseNarrative", () => {
     expect(n?.values.reason).toBe("LLM budget exhausted");
   });
 
-  it("falls back to generic reason when skip_reason is null", () => {
+  it("uses skippedNoReason key when skip_reason is null", () => {
     const n = buildPhaseNarrative("consolidation", phase({ skipped: true }));
-    expect(n?.values.reason).toBe("skipped");
+    expect(n?.key).toBe("detail.narrative.skippedNoReason");
+    expect(n?.values).toEqual({});
   });
 
   describe("edgeDiscovery", () => {

--- a/frontend/src/lib/utils/sleep-narrative.test.ts
+++ b/frontend/src/lib/utils/sleep-narrative.test.ts
@@ -80,13 +80,38 @@ describe("buildPhaseNarrative", () => {
     expect(n?.values.error).toBe("boom");
   });
 
-  it("renders skipped with skip_reason", () => {
+  it("maps budget_exhausted to localized key", () => {
     const n = buildPhaseNarrative(
       "consolidation",
-      phase({ skipped: true, skip_reason: "LLM budget exhausted" }),
+      phase({ skipped: true, skip_reason: "budget_exhausted" }),
     );
-    expect(n?.key).toBe("detail.narrative.skipped");
-    expect(n?.values.reason).toBe("LLM budget exhausted");
+    expect(n?.key).toBe("detail.narrative.skipReasons.budgetExhausted");
+  });
+
+  it("maps disabled phase reasons to phaseDisabled key", () => {
+    const n = buildPhaseNarrative(
+      "dedup",
+      phase({ skipped: true, skip_reason: "dedup_disabled" }),
+    );
+    expect(n?.key).toBe("detail.narrative.skipReasons.phaseDisabled");
+  });
+
+  it("maps sleep_mode_* reasons to sleepMode key with mode value", () => {
+    const n = buildPhaseNarrative(
+      "edgeDiscovery",
+      phase({ skipped: true, skip_reason: "sleep_mode_edges_only" }),
+    );
+    expect(n?.key).toBe("detail.narrative.skipReasons.sleepMode");
+    expect(n?.values.mode).toBe("edges_only");
+  });
+
+  it("falls back to skippedUnknown for unrecognized reasons", () => {
+    const n = buildPhaseNarrative(
+      "reindex",
+      phase({ skipped: true, skip_reason: "some_future_reason" }),
+    );
+    expect(n?.key).toBe("detail.narrative.skippedUnknown");
+    expect(n?.values.reason).toBe("some_future_reason");
   });
 
   it("uses skippedNoReason key when skip_reason is null", () => {

--- a/frontend/src/lib/utils/sleep-narrative.test.ts
+++ b/frontend/src/lib/utils/sleep-narrative.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildHeadline,
+  buildPhaseNarrative,
+  type NarrativePhaseResult,
+} from "./sleep-narrative";
+
+const HEADLINE_SRC = {
+  memories_processed: 42,
+  edges_created: 7,
+  memories_merged: 3,
+  memories_promoted: 1,
+  memories_flagged: 1,
+};
+
+function phase(
+  overrides: Partial<NarrativePhaseResult> = {},
+): NarrativePhaseResult {
+  return {
+    success: true,
+    skipped: false,
+    skip_reason: null,
+    error: null,
+    details: null,
+    ...overrides,
+  };
+}
+
+describe("buildHeadline", () => {
+  it("uses headline key when context name is present", () => {
+    const n = buildHeadline("kagura-dev", HEADLINE_SRC);
+    expect(n.key).toBe("detail.narrative.headline");
+    expect(n.values.contextName).toBe("kagura-dev");
+    expect(n.values.processed).toBe(42);
+    expect(n.values.merged).toBe(3);
+  });
+
+  it("uses headlineNoContext when context name is null", () => {
+    const n = buildHeadline(null, HEADLINE_SRC);
+    expect(n.key).toBe("detail.narrative.headlineNoContext");
+    expect(n.values.contextName).toBe("");
+  });
+
+  it("passes through (deleted) marker as-is", () => {
+    const n = buildHeadline("(deleted)", HEADLINE_SRC);
+    expect(n.key).toBe("detail.narrative.headline");
+    expect(n.values.contextName).toBe("(deleted)");
+  });
+});
+
+describe("buildPhaseNarrative", () => {
+  it("returns null when result is null", () => {
+    expect(buildPhaseNarrative("edgeDiscovery", null)).toBeNull();
+  });
+
+  it("prefers error over skipped", () => {
+    const n = buildPhaseNarrative(
+      "dedup",
+      phase({ error: "boom", skipped: true, skip_reason: "budget" }),
+    );
+    expect(n?.key).toBe("detail.narrative.failed");
+    expect(n?.values.error).toBe("boom");
+  });
+
+  it("renders skipped with skip_reason", () => {
+    const n = buildPhaseNarrative(
+      "consolidation",
+      phase({ skipped: true, skip_reason: "LLM budget exhausted" }),
+    );
+    expect(n?.key).toBe("detail.narrative.skipped");
+    expect(n?.values.reason).toBe("LLM budget exhausted");
+  });
+
+  it("falls back to generic reason when skip_reason is null", () => {
+    const n = buildPhaseNarrative("consolidation", phase({ skipped: true }));
+    expect(n?.values.reason).toBe("skipped");
+  });
+
+  describe("edgeDiscovery", () => {
+    it("builds success from edges_created and sampled", () => {
+      const n = buildPhaseNarrative(
+        "edgeDiscovery",
+        phase({ details: { edges_created: 7, sampled: 20 } }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.edgeDiscovery.success");
+      expect(n?.values.count).toBe(7);
+      expect(n?.values.sampled).toBe(20);
+    });
+
+    it("empty when details lack both keys", () => {
+      const n = buildPhaseNarrative("edgeDiscovery", phase({ details: {} }));
+      expect(n?.key).toBe("detail.narrative.phases.edgeDiscovery.empty");
+    });
+
+    it("null-safe on missing details dict", () => {
+      const n = buildPhaseNarrative("edgeDiscovery", phase({ details: null }));
+      expect(n?.key).toBe("detail.narrative.phases.edgeDiscovery.empty");
+    });
+  });
+
+  describe("dedup", () => {
+    it("builds success and derives held count", () => {
+      const n = buildPhaseNarrative(
+        "dedup",
+        phase({
+          details: {
+            candidates: 12,
+            merged: 3,
+            clusters: 5,
+            deferred_clusters: 1,
+          },
+        }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.dedup.success");
+      expect(n?.values.count).toBe(12);
+      expect(n?.values.merged).toBe(3);
+      expect(n?.values.held).toBe(9);
+    });
+
+    it("clamps held to 0 when merged exceeds candidates", () => {
+      const n = buildPhaseNarrative(
+        "dedup",
+        phase({ details: { candidates: 2, merged: 5 } }),
+      );
+      expect(n?.values.held).toBe(0);
+    });
+
+    it("empty when neither candidates nor merged present", () => {
+      const n = buildPhaseNarrative("dedup", phase({ details: {} }));
+      expect(n?.key).toBe("detail.narrative.phases.dedup.empty");
+    });
+  });
+
+  describe("importance", () => {
+    it("recognizes the no_stale_memories sentinel", () => {
+      const n = buildPhaseNarrative(
+        "importance",
+        phase({ details: { message: "no_stale_memories" } }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.importance.empty");
+    });
+
+    it("builds success with alpha formatted to 2 decimals", () => {
+      const n = buildPhaseNarrative(
+        "importance",
+        phase({ details: { candidates: 10, updated: 4, alpha: 0.333 } }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.importance.success");
+      expect(n?.values.alpha).toBe("0.33");
+    });
+
+    it("emits '-' for missing alpha", () => {
+      const n = buildPhaseNarrative(
+        "importance",
+        phase({ details: { candidates: 1, updated: 0 } }),
+      );
+      expect(n?.values.alpha).toBe("-");
+    });
+  });
+
+  describe("consolidation", () => {
+    it("builds success from working_count + promoted + borderline", () => {
+      const n = buildPhaseNarrative(
+        "consolidation",
+        phase({
+          details: {
+            working_count: 8,
+            rule_promoted: 2,
+            llm_promoted: 1,
+            borderline: 5,
+          },
+        }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.consolidation.success");
+      expect(n?.values.candidates).toBe(8);
+      expect(n?.values.rulePromoted).toBe(2);
+      expect(n?.values.llmPromoted).toBe(1);
+      expect(n?.values.borderline).toBe(5);
+    });
+
+    it("empty when everything is zero/absent", () => {
+      const n = buildPhaseNarrative("consolidation", phase({ details: {} }));
+      expect(n?.key).toBe("detail.narrative.phases.consolidation.empty");
+    });
+  });
+
+  describe("reindex", () => {
+    it("recognizes the no_memories_to_reindex sentinel", () => {
+      const n = buildPhaseNarrative(
+        "reindex",
+        phase({ details: { message: "no_memories_to_reindex" } }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.reindex.empty");
+    });
+
+    it("builds success with count and failed", () => {
+      const n = buildPhaseNarrative(
+        "reindex",
+        phase({ details: { reindexed: 42, failed: 1 } }),
+      );
+      expect(n?.key).toBe("detail.narrative.phases.reindex.success");
+      expect(n?.values.count).toBe(42);
+      expect(n?.values.failed).toBe(1);
+    });
+
+    it("defaults failed to 0 when absent", () => {
+      const n = buildPhaseNarrative(
+        "reindex",
+        phase({ details: { reindexed: 10 } }),
+      );
+      expect(n?.values.failed).toBe(0);
+    });
+  });
+});

--- a/frontend/src/lib/utils/sleep-narrative.ts
+++ b/frontend/src/lib/utils/sleep-narrative.ts
@@ -159,16 +159,9 @@ export function buildPhaseNarrative(
       if (candidates === 0 && merged === 0) {
         return { key: "detail.narrative.phases.dedup.empty", values: {} };
       }
-      const heldCount = Math.max(candidates - merged, 0);
       return {
         key: "detail.narrative.phases.dedup.success",
-        values: {
-          count: candidates,
-          merged,
-          held: heldCount,
-          clusters,
-          deferred,
-        },
+        values: { count: candidates, merged, clusters, deferred },
       };
     }
     case "importance": {

--- a/frontend/src/lib/utils/sleep-narrative.ts
+++ b/frontend/src/lib/utils/sleep-narrative.ts
@@ -125,13 +125,29 @@ export function buildPhaseNarrative(
   }
 
   if (result.skipped) {
-    if (result.skip_reason) {
+    if (!result.skip_reason) {
+      return { key: "detail.narrative.skippedNoReason", values: {} };
+    }
+    const knownReasons: Record<string, string> = {
+      budget_exhausted: "detail.narrative.skipReasons.budgetExhausted",
+      edge_discovery_disabled: "detail.narrative.skipReasons.phaseDisabled",
+      importance_reeval_disabled: "detail.narrative.skipReasons.phaseDisabled",
+      dedup_disabled: "detail.narrative.skipReasons.phaseDisabled",
+    };
+    const key = knownReasons[result.skip_reason];
+    if (key) {
+      return { key, values: {} };
+    }
+    if (result.skip_reason.startsWith("sleep_mode_")) {
       return {
-        key: "detail.narrative.skipped",
-        values: { reason: result.skip_reason },
+        key: "detail.narrative.skipReasons.sleepMode",
+        values: { mode: result.skip_reason.replace("sleep_mode_", "") },
       };
     }
-    return { key: "detail.narrative.skippedNoReason", values: {} };
+    return {
+      key: "detail.narrative.skippedUnknown",
+      values: { reason: result.skip_reason },
+    };
   }
 
   const d = result.details;

--- a/frontend/src/lib/utils/sleep-narrative.ts
+++ b/frontend/src/lib/utils/sleep-narrative.ts
@@ -1,0 +1,215 @@
+/**
+ * Pure helpers that turn Sleep Maintenance phase results into i18n-ready
+ * narrative descriptors. Each descriptor is `{ key, values }` and is meant to
+ * be consumed via `t(key, values)` on a `useTranslations("admin.sleepReports")`
+ * scope.
+ *
+ * Keeping this layer pure keeps the detail page simple and lets future
+ * enhancements (action samples, pipeline timelines, new phases) extend the
+ * narrative without touching the page structure.
+ */
+
+export type PhaseName =
+  | "edgeDiscovery"
+  | "dedup"
+  | "importance"
+  | "consolidation"
+  | "reindex";
+
+export interface NarrativePhaseResult {
+  success: boolean;
+  skipped: boolean;
+  skip_reason: string | null;
+  error: string | null;
+  details: Record<string, unknown> | null;
+}
+
+export interface NarrativeHeadlineSource {
+  memories_processed: number;
+  edges_created: number;
+  memories_merged: number;
+  memories_promoted: number;
+  memories_flagged: number;
+}
+
+export interface Narrative {
+  key: string;
+  values: Record<string, string | number>;
+}
+
+function num(
+  details: Record<string, unknown> | null,
+  key: string,
+): number | null {
+  if (!details) return null;
+  const v = details[key];
+  return typeof v === "number" ? v : null;
+}
+
+function str(
+  details: Record<string, unknown> | null,
+  key: string,
+): string | null {
+  if (!details) return null;
+  const v = details[key];
+  return typeof v === "string" ? v : null;
+}
+
+/**
+ * Build the top-of-page headline narrative.
+ *
+ * - contextName = null → "Processed N memories: ..." (workspace-wide run, no context)
+ * - contextName set    → "<contextName> — processed N memories: ..."
+ *
+ * The "(deleted)" marker is already encoded in contextName by the backend when
+ * the referenced context row is soft-deleted or missing.
+ */
+export function buildHeadline(
+  contextName: string | null,
+  report: NarrativeHeadlineSource,
+): Narrative {
+  const values = {
+    contextName: contextName ?? "",
+    processed: report.memories_processed,
+    merged: report.memories_merged,
+    edges: report.edges_created,
+    promoted: report.memories_promoted,
+    flagged: report.memories_flagged,
+  };
+  return {
+    key: contextName
+      ? "detail.narrative.headline"
+      : "detail.narrative.headlineNoContext",
+    values,
+  };
+}
+
+/**
+ * Build a single-line narrative for a phase card.
+ *
+ * Returns null when the phase was not run (result === null). Callers should
+ * treat null as "render nothing" rather than emitting an empty bullet.
+ *
+ * Precedence:
+ *   1. `error`       → "Failed: {error}"
+ *   2. `skipped`     → "Skipped: {reason}" (reason falls back to a generic string)
+ *   3. phase-specific `success` (or `empty` if nothing to report)
+ */
+export function buildPhaseNarrative(
+  phase: PhaseName,
+  result: NarrativePhaseResult | null,
+): Narrative | null {
+  if (result === null) return null;
+
+  if (result.error) {
+    return {
+      key: "detail.narrative.failed",
+      values: { error: result.error },
+    };
+  }
+
+  if (result.skipped) {
+    return {
+      key: "detail.narrative.skipped",
+      values: { reason: result.skip_reason ?? "skipped" },
+    };
+  }
+
+  const d = result.details;
+
+  switch (phase) {
+    case "edgeDiscovery": {
+      const edges = num(d, "edges_created");
+      const sampled = num(d, "sampled");
+      if (edges === null && sampled === null) {
+        return {
+          key: "detail.narrative.phases.edgeDiscovery.empty",
+          values: {},
+        };
+      }
+      return {
+        key: "detail.narrative.phases.edgeDiscovery.success",
+        values: { count: edges ?? 0, sampled: sampled ?? 0 },
+      };
+    }
+    case "dedup": {
+      const candidates = num(d, "candidates");
+      const merged = num(d, "merged");
+      const clusters = num(d, "clusters");
+      const deferred = num(d, "deferred_clusters") ?? 0;
+      if (candidates === null && merged === null) {
+        return { key: "detail.narrative.phases.dedup.empty", values: {} };
+      }
+      const heldCount =
+        candidates !== null && merged !== null
+          ? Math.max(candidates - merged, 0)
+          : 0;
+      return {
+        key: "detail.narrative.phases.dedup.success",
+        values: {
+          count: candidates ?? 0,
+          merged: merged ?? 0,
+          held: heldCount,
+          clusters: clusters ?? 0,
+          deferred,
+        },
+      };
+    }
+    case "importance": {
+      const message = str(d, "message");
+      if (message === "no_stale_memories") {
+        return { key: "detail.narrative.phases.importance.empty", values: {} };
+      }
+      const candidates = num(d, "candidates");
+      const updated = num(d, "updated");
+      if (candidates === null && updated === null) {
+        return { key: "detail.narrative.phases.importance.empty", values: {} };
+      }
+      const alpha = num(d, "alpha");
+      return {
+        key: "detail.narrative.phases.importance.success",
+        values: {
+          candidates: candidates ?? 0,
+          updated: updated ?? 0,
+          alpha: alpha === null ? "-" : alpha.toFixed(2),
+        },
+      };
+    }
+    case "consolidation": {
+      const working = num(d, "working_count");
+      const rulePromoted = num(d, "rule_promoted") ?? 0;
+      const llmPromoted = num(d, "llm_promoted") ?? 0;
+      const borderline = num(d, "borderline") ?? 0;
+      if (working === null && rulePromoted === 0 && llmPromoted === 0) {
+        return {
+          key: "detail.narrative.phases.consolidation.empty",
+          values: {},
+        };
+      }
+      return {
+        key: "detail.narrative.phases.consolidation.success",
+        values: {
+          candidates: working ?? 0,
+          rulePromoted,
+          llmPromoted,
+          borderline,
+        },
+      };
+    }
+    case "reindex": {
+      const message = str(d, "message");
+      if (message === "no_memories_to_reindex") {
+        return { key: "detail.narrative.phases.reindex.empty", values: {} };
+      }
+      const reindexed = num(d, "reindexed");
+      const failed = num(d, "failed") ?? 0;
+      if (reindexed === null) {
+        return { key: "detail.narrative.phases.reindex.empty", values: {} };
+      }
+      return {
+        key: "detail.narrative.phases.reindex.success",
+        values: { count: reindexed, failed },
+      };
+    }
+  }
+}

--- a/frontend/src/lib/utils/sleep-narrative.ts
+++ b/frontend/src/lib/utils/sleep-narrative.ts
@@ -140,7 +140,7 @@ export function buildPhaseNarrative(
     case "edgeDiscovery": {
       const edges = num(d, "edges_created") ?? 0;
       const sampled = num(d, "sampled") ?? 0;
-      if (edges === 0 && sampled === 0) {
+      if (edges === 0) {
         return {
           key: "detail.narrative.phases.edgeDiscovery.empty",
           values: {},

--- a/frontend/src/lib/utils/sleep-narrative.ts
+++ b/frontend/src/lib/utils/sleep-narrative.ts
@@ -32,6 +32,11 @@ export interface NarrativeHeadlineSource {
   memories_flagged: number;
 }
 
+export interface NarrativeHeadlineContext {
+  context_name: string | null;
+  context_deleted: boolean;
+}
+
 export interface Narrative {
   key: string;
   values: Record<string, string | number>;
@@ -58,29 +63,40 @@ function str(
 /**
  * Build the top-of-page headline narrative.
  *
- * - contextName = null → "Processed N memories: ..." (workspace-wide run, no context)
- * - contextName set    → "<contextName> — processed N memories: ..."
+ * Routing by context state:
+ *   - context.context_name set            → "headline" with the name
+ *   - context.context_deleted true        → "headlineDeletedContext" (localized marker)
+ *   - neither (workspace-wide run)        → "headlineNoContext"
  *
- * The "(deleted)" marker is already encoded in contextName by the backend when
- * the referenced context row is soft-deleted or missing.
+ * Localization of the "(deleted)" marker is the frontend's responsibility;
+ * the backend only reports the boolean flag.
  */
 export function buildHeadline(
-  contextName: string | null,
+  context: NarrativeHeadlineContext,
   report: NarrativeHeadlineSource,
 ): Narrative {
-  const values = {
-    contextName: contextName ?? "",
+  const baseValues = {
     processed: report.memories_processed,
     merged: report.memories_merged,
     edges: report.edges_created,
     promoted: report.memories_promoted,
     flagged: report.memories_flagged,
   };
+  if (context.context_name) {
+    return {
+      key: "detail.narrative.headline",
+      values: { contextName: context.context_name, ...baseValues },
+    };
+  }
+  if (context.context_deleted) {
+    return {
+      key: "detail.narrative.headlineDeletedContext",
+      values: baseValues,
+    };
+  }
   return {
-    key: contextName
-      ? "detail.narrative.headline"
-      : "detail.narrative.headlineNoContext",
-    values,
+    key: "detail.narrative.headlineNoContext",
+    values: baseValues,
   };
 }
 
@@ -109,19 +125,22 @@ export function buildPhaseNarrative(
   }
 
   if (result.skipped) {
-    return {
-      key: "detail.narrative.skipped",
-      values: { reason: result.skip_reason ?? "skipped" },
-    };
+    if (result.skip_reason) {
+      return {
+        key: "detail.narrative.skipped",
+        values: { reason: result.skip_reason },
+      };
+    }
+    return { key: "detail.narrative.skippedNoReason", values: {} };
   }
 
   const d = result.details;
 
   switch (phase) {
     case "edgeDiscovery": {
-      const edges = num(d, "edges_created");
-      const sampled = num(d, "sampled");
-      if (edges === null && sampled === null) {
+      const edges = num(d, "edges_created") ?? 0;
+      const sampled = num(d, "sampled") ?? 0;
+      if (edges === 0 && sampled === 0) {
         return {
           key: "detail.narrative.phases.edgeDiscovery.empty",
           values: {},
@@ -129,28 +148,25 @@ export function buildPhaseNarrative(
       }
       return {
         key: "detail.narrative.phases.edgeDiscovery.success",
-        values: { count: edges ?? 0, sampled: sampled ?? 0 },
+        values: { count: edges, sampled },
       };
     }
     case "dedup": {
-      const candidates = num(d, "candidates");
-      const merged = num(d, "merged");
-      const clusters = num(d, "clusters");
+      const candidates = num(d, "candidates") ?? 0;
+      const merged = num(d, "merged") ?? 0;
+      const clusters = num(d, "clusters") ?? 0;
       const deferred = num(d, "deferred_clusters") ?? 0;
-      if (candidates === null && merged === null) {
+      if (candidates === 0 && merged === 0) {
         return { key: "detail.narrative.phases.dedup.empty", values: {} };
       }
-      const heldCount =
-        candidates !== null && merged !== null
-          ? Math.max(candidates - merged, 0)
-          : 0;
+      const heldCount = Math.max(candidates - merged, 0);
       return {
         key: "detail.narrative.phases.dedup.success",
         values: {
-          count: candidates ?? 0,
-          merged: merged ?? 0,
+          count: candidates,
+          merged,
           held: heldCount,
-          clusters: clusters ?? 0,
+          clusters,
           deferred,
         },
       };
@@ -176,11 +192,16 @@ export function buildPhaseNarrative(
       };
     }
     case "consolidation": {
-      const working = num(d, "working_count");
+      const working = num(d, "working_count") ?? 0;
       const rulePromoted = num(d, "rule_promoted") ?? 0;
       const llmPromoted = num(d, "llm_promoted") ?? 0;
       const borderline = num(d, "borderline") ?? 0;
-      if (working === null && rulePromoted === 0 && llmPromoted === 0) {
+      if (
+        working === 0 &&
+        rulePromoted === 0 &&
+        llmPromoted === 0 &&
+        borderline === 0
+      ) {
         return {
           key: "detail.narrative.phases.consolidation.empty",
           values: {},
@@ -189,7 +210,7 @@ export function buildPhaseNarrative(
       return {
         key: "detail.narrative.phases.consolidation.success",
         values: {
-          candidates: working ?? 0,
+          candidates: working,
           rulePromoted,
           llmPromoted,
           borderline,
@@ -201,9 +222,9 @@ export function buildPhaseNarrative(
       if (message === "no_memories_to_reindex") {
         return { key: "detail.narrative.phases.reindex.empty", values: {} };
       }
-      const reindexed = num(d, "reindexed");
+      const reindexed = num(d, "reindexed") ?? 0;
       const failed = num(d, "failed") ?? 0;
-      if (reindexed === null) {
+      if (reindexed === 0 && failed === 0) {
         return { key: "detail.narrative.phases.reindex.empty", values: {} };
       }
       return {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2214,7 +2214,35 @@
         "dedup": "Deduplication",
         "importance": "Importance Re-evaluation",
         "consolidation": "Consolidation",
-        "reindex": "Reindex"
+        "reindex": "Reindex",
+        "narrative": {
+          "headline": "{contextName} — processed {processed} memories: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
+          "headlineNoContext": "Processed {processed} memories: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
+          "skipped": "Skipped: {reason}",
+          "failed": "Failed: {error}",
+          "phases": {
+            "edgeDiscovery": {
+              "success": "Added {count, plural, one {# edge} other {# edges}} across {sampled} sampled",
+              "empty": "No new edges created"
+            },
+            "dedup": {
+              "success": "Detected {count, plural, one {# duplicate pair} other {# duplicate pairs}} → {merged} merged, {held} held below threshold",
+              "empty": "No duplicate candidates found"
+            },
+            "importance": {
+              "success": "Re-evaluated {candidates} memories → {updated} updated (α={alpha})",
+              "empty": "No importance changes this run"
+            },
+            "consolidation": {
+              "success": "Evaluated {candidates, plural, one {# promotion candidate} other {# promotion candidates}} → {rulePromoted} rule-promoted, {llmPromoted} LLM-promoted, {borderline} deferred",
+              "empty": "No promotions this run"
+            },
+            "reindex": {
+              "success": "Reindexed {count, plural, one {# memory} other {# memories}}{failed, plural, =0 {} other {, {failed} failed}}",
+              "empty": "Nothing to reindex"
+            }
+          }
+        }
       },
       "pagination": {
         "showing": "Showing {from}-{to} of {total}",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2220,8 +2220,13 @@
           "headlineNoContext": "Processed {processed, plural, one {# memory} other {# memories}}: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
           "headlineDeletedContext": "(deleted context) — processed {processed, plural, one {# memory} other {# memories}}: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
           "runFailed": "Run failed: {error}",
-          "skipped": "Skipped: {reason}",
           "skippedNoReason": "Skipped",
+          "skippedUnknown": "Skipped: {reason}",
+          "skipReasons": {
+            "budgetExhausted": "Skipped: LLM budget exhausted",
+            "phaseDisabled": "Skipped: phase disabled in configuration",
+            "sleepMode": "Skipped: sleep mode is {mode}"
+          },
           "failed": "Failed: {error}",
           "phases": {
             "edgeDiscovery": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2216,9 +2216,9 @@
         "consolidation": "Consolidation",
         "reindex": "Reindex",
         "narrative": {
-          "headline": "{contextName} — processed {processed} memories: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
-          "headlineNoContext": "Processed {processed} memories: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
-          "headlineDeletedContext": "(deleted context) — processed {processed} memories: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
+          "headline": "{contextName} — processed {processed, plural, one {# memory} other {# memories}}: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
+          "headlineNoContext": "Processed {processed, plural, one {# memory} other {# memories}}: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
+          "headlineDeletedContext": "(deleted context) — processed {processed, plural, one {# memory} other {# memories}}: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
           "runFailed": "Run failed: {error}",
           "skipped": "Skipped: {reason}",
           "skippedNoReason": "Skipped",
@@ -2229,7 +2229,7 @@
               "empty": "No new edges created"
             },
             "dedup": {
-              "success": "Detected {count, plural, one {# duplicate pair} other {# duplicate pairs}} → {merged} merged, {held} held below threshold",
+              "success": "Detected {count, plural, one {# duplicate pair} other {# duplicate pairs}} → {merged} merged",
               "empty": "No duplicate candidates found"
             },
             "importance": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2218,7 +2218,10 @@
         "narrative": {
           "headline": "{contextName} — processed {processed} memories: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
           "headlineNoContext": "Processed {processed} memories: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
+          "headlineDeletedContext": "(deleted context) — processed {processed} memories: {merged} merged, {edges} edges, {promoted} promoted, {flagged} flagged",
+          "runFailed": "Run failed: {error}",
           "skipped": "Skipped: {reason}",
+          "skippedNoReason": "Skipped",
           "failed": "Failed: {error}",
           "phases": {
             "edgeDiscovery": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2225,7 +2225,7 @@
           "failed": "Failed: {error}",
           "phases": {
             "edgeDiscovery": {
-              "success": "Added {count, plural, one {# edge} other {# edges}} across {sampled} sampled",
+              "success": "Added {count, plural, one {# edge} other {# edges}} across {sampled, plural, one {# sampled memory} other {# sampled memories}}",
               "empty": "No new edges created"
             },
             "dedup": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2238,7 +2238,7 @@
               "empty": "No duplicate candidates found"
             },
             "importance": {
-              "success": "Re-evaluated {candidates} memories → {updated} updated (α={alpha})",
+              "success": "Re-evaluated {candidates, plural, one {# memory} other {# memories}} → {updated} updated (α={alpha})",
               "empty": "No importance changes this run"
             },
             "consolidation": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2218,7 +2218,10 @@
         "narrative": {
           "headline": "{contextName} — {processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
           "headlineNoContext": "{processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
+          "headlineDeletedContext": "(削除済みコンテキスト) — {processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
+          "runFailed": "実行に失敗しました: {error}",
           "skipped": "スキップ: {reason}",
+          "skippedNoReason": "スキップされました",
           "failed": "失敗: {error}",
           "phases": {
             "edgeDiscovery": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2214,7 +2214,35 @@
         "dedup": "重複排除",
         "importance": "重要度再評価",
         "consolidation": "統合",
-        "reindex": "再インデックス"
+        "reindex": "再インデックス",
+        "narrative": {
+          "headline": "{contextName} — {processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
+          "headlineNoContext": "{processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
+          "skipped": "スキップ: {reason}",
+          "failed": "失敗: {error}",
+          "phases": {
+            "edgeDiscovery": {
+              "success": "サンプル {sampled} 件から {count} 件のエッジを追加",
+              "empty": "新しいエッジは作成されませんでした"
+            },
+            "dedup": {
+              "success": "重複候補 {count} ペアを検出 → {merged} 件マージ、{held} 件は類似度不足で保留",
+              "empty": "重複候補は見つかりませんでした"
+            },
+            "importance": {
+              "success": "{candidates} 件のメモリを再評価 → {updated} 件を更新 (α={alpha})",
+              "empty": "今回のランでは重要度の変更はありませんでした"
+            },
+            "consolidation": {
+              "success": "昇格候補 {candidates} 件を評価 → ルール昇格 {rulePromoted} / LLM 昇格 {llmPromoted} / 保留 {borderline}",
+              "empty": "今回のランでは昇格は発生しませんでした"
+            },
+            "reindex": {
+              "success": "{count} 件のメモリを再インデックス{failed, plural, =0 {} other {（{failed} 件失敗）}}",
+              "empty": "再インデックス対象はありませんでした"
+            }
+          }
+        }
       },
       "pagination": {
         "showing": "{total} 件中 {from}〜{to} 件目",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2220,8 +2220,13 @@
           "headlineNoContext": "{processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
           "headlineDeletedContext": "(削除済みコンテキスト) — {processed} 件のメモリを処理: マージ {merged} / エッジ {edges} / 昇格 {promoted} / 要確認 {flagged}",
           "runFailed": "実行に失敗しました: {error}",
-          "skipped": "スキップ: {reason}",
           "skippedNoReason": "スキップされました",
+          "skippedUnknown": "スキップ: {reason}",
+          "skipReasons": {
+            "budgetExhausted": "スキップ: LLM バジェット上限に到達",
+            "phaseDisabled": "スキップ: 設定でフェーズが無効",
+            "sleepMode": "スキップ: sleep モードが {mode}"
+          },
           "failed": "失敗: {error}",
           "phases": {
             "edgeDiscovery": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2229,7 +2229,7 @@
               "empty": "新しいエッジは作成されませんでした"
             },
             "dedup": {
-              "success": "重複候補 {count} ペアを検出 → {merged} 件マージ、{held} 件は類似度不足で保留",
+              "success": "重複候補 {count} ペアを検出 → {merged} 件マージ",
               "empty": "重複候補は見つかりませんでした"
             },
             "importance": {


### PR DESCRIPTION
Closes #352

## Summary
- Expose `context_name` and `context_deleted` on `SleepReportDetail` — `display_name → name` fallback for live contexts; `context_name: null, context_deleted: true` for soft-deleted or missing rows (the deleted marker is localized on the frontend via an i18n key, not hardcoded in the API)
- New pure helper `frontend/src/lib/utils/sleep-narrative.ts` with `buildHeadline` + `buildPhaseNarrative`, each returning `{key, values}` for `useTranslations` consumption
- Replace ad-hoc `getPhaseSummary` with i18n-driven narrative per phase card; add headline at top of the detail page
- Fix pre-existing Error Surface rule violation: page-load failure now uses `ErrorBanner` instead of `toast`; failed runs surface a top-of-page banner via a dedicated `runFailed` i18n key
- Add `admin.sleepReports.detail.narrative.*` keys to both `en.json` and `ja.json` using ICU `{count, plural, ...}`

## Implementation notes
- Backend: one additional query for `Context` (no `relationship()` added on `SleepReport` — deferred to avoid cascade coupling on soft-delete). `context_name` and `context_deleted` are set via transient attribute injection before `model_validate`; commented inline.
- Frontend: detail page changes limited to three touch points (headline, per-phase narrative, banner). Narrative helper is null-safe across all 5 phases. Skip/fail/deleted states are all localized via dedicated i18n keys — no English literals leak to non-English locales.
- i18n: ICU plural form on phases and headlines; Japanese side omits plural branches (language-appropriate).
- Out of scope (tracked as follow-ups): representative action samples, horizontal pipeline timeline, dedicated warning Alert variant for skipped phases, context column in list table (#354).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CDO lens)
- review provider: copilot (4 loops, 10 findings addressed)

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/352-feat-add-narrative-layer-to-sleep-report-deta.gate1.md`
- `~/.claude/cache/gh-issue-driven/352-feat-add-narrative-layer-to-sleep-report-deta.gate2.md`

🤖 Generated via /gh-issue-driven:ship
