### PR TITLE
feat(api,frontend): add context name to sleep reports list (#354)

### DIFF
--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -37,6 +37,7 @@ class SleepReportSummary(BaseModel):
     user_id: str
     workspace_id: UUID | None
     context_id: UUID | None
+    context_name: str | None = None
     status: str
     started_at: datetime
     completed_at: datetime | None
@@ -56,7 +57,6 @@ class SleepReportSummary(BaseModel):
 class SleepReportDetail(SleepReportSummary):
     """Sleep report full detail."""
 
-    context_name: str | None = None
     context_deleted: bool = False
     embedding_calls_made: int
     error_message: str | None
@@ -150,6 +150,22 @@ async def list_sleep_reports(
         stmt.order_by(SleepReport.started_at.desc()).limit(limit).offset(offset)
     )
     reports = list(result.scalars().all())
+
+    # Batch-load referenced contexts in one query to avoid N+1.
+    # Same resolution rule as get_sleep_report_detail: display_name or name,
+    # None when deleted or missing.
+    context_ids = {r.context_id for r in reports if r.context_id}
+    ctx_map: dict[UUID, str | None] = {}
+    if context_ids:
+        ctx_result = await db.execute(select(Context).where(Context.id.in_(context_ids)))
+        for ctx in ctx_result.scalars().all():
+            if ctx.deleted_at is not None:
+                ctx_map[ctx.id] = None
+            else:
+                ctx_map[ctx.id] = ctx.display_name or ctx.name
+
+    for r in reports:
+        r.context_name = ctx_map.get(r.context_id) if r.context_id else None
 
     return SleepReportListResponse(
         reports=[SleepReportSummary.model_validate(r, from_attributes=True) for r in reports],

--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -157,12 +157,16 @@ async def list_sleep_reports(
     context_ids = {r.context_id for r in reports if r.context_id}
     ctx_map: dict[UUID, str | None] = {}
     if context_ids:
-        ctx_result = await db.execute(select(Context).where(Context.id.in_(context_ids)))
-        for ctx in ctx_result.scalars().all():
-            if ctx.deleted_at is not None:
-                ctx_map[ctx.id] = None
+        ctx_result = await db.execute(
+            select(Context.id, Context.name, Context.display_name, Context.deleted_at).where(
+                Context.id.in_(context_ids)
+            )
+        )
+        for ctx_id, ctx_name, ctx_display_name, ctx_deleted_at in ctx_result.all():
+            if ctx_deleted_at is not None:
+                ctx_map[ctx_id] = None
             else:
-                ctx_map[ctx.id] = ctx.display_name or ctx.name
+                ctx_map[ctx_id] = ctx_display_name or ctx_name
 
     for r in reports:
         r.context_name = ctx_map.get(r.context_id) if r.context_id else None

--- a/backend/tests/api/test_sleep_reports_admin.py
+++ b/backend/tests/api/test_sleep_reports_admin.py
@@ -113,7 +113,8 @@ class TestListSleepReports:
     """GET /api/v1/admin/sleep-reports"""
 
     def test_returns_paginated_list(self, client):
-        reports = [_make_mock_report() for _ in range(3)]
+        ctx = _make_mock_context()
+        reports = [_make_mock_report(context_id=ctx.id) for _ in range(3)]
 
         mock_db = AsyncMock()
         # Call 1: count query → scalar=3
@@ -122,7 +123,10 @@ class TestListSleepReports:
         # Call 2: list query → scalars().all()=reports
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = reports
-        mock_db.execute.side_effect = [count_result, list_result]
+        # Call 3: batch context query → scalars().all()=[ctx]
+        ctx_result = MagicMock()
+        ctx_result.scalars.return_value.all.return_value = [ctx]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
 
         _install_overrides(mock_db)
 
@@ -135,14 +139,21 @@ class TestListSleepReports:
         assert len(data["reports"]) == 3
         # Verify timestamp has Z suffix (timezone fix)
         assert data["reports"][0]["started_at"].endswith("Z")
+        # Verify context_name is resolved via batch lookup
+        assert data["reports"][0]["context_name"] == "Kagura Dev"
 
     def test_filters_by_status(self, client):
+        ctx = _make_mock_context()
         mock_db = AsyncMock()
         count_result = MagicMock()
         count_result.scalar.return_value = 1
         list_result = MagicMock()
-        list_result.scalars.return_value.all.return_value = [_make_mock_report(status="failed")]
-        mock_db.execute.side_effect = [count_result, list_result]
+        list_result.scalars.return_value.all.return_value = [
+            _make_mock_report(status="failed", context_id=ctx.id)
+        ]
+        ctx_result = MagicMock()
+        ctx_result.scalars.return_value.all.return_value = [ctx]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
 
         _install_overrides(mock_db)
 
@@ -166,6 +177,7 @@ class TestListSleepReports:
         count_result.scalar.return_value = 100
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = []
+        # No context query because reports list is empty
         mock_db.execute.side_effect = [count_result, list_result]
 
         _install_overrides(mock_db)
@@ -192,6 +204,88 @@ class TestListSleepReports:
         data = response.json()
         assert data["total"] == 0
         assert data["reports"] == []
+
+    def test_list_context_name_null_when_no_context(self, client):
+        """Reports with context_id=None should have context_name=None."""
+        reports = [_make_mock_report(context_id=None)]
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = reports
+        # No context query because all context_ids are None
+        mock_db.execute.side_effect = [count_result, list_result]
+
+        _install_overrides(mock_db)
+
+        response = client.get("/api/v1/admin/sleep-reports")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["reports"][0]["context_name"] is None
+        # Only 2 DB calls: count + list (no context batch query)
+        assert mock_db.execute.call_count == 2
+
+    def test_list_context_name_falls_back_to_name(self, client):
+        """When display_name is None, context_name should fall back to name."""
+        ctx = _make_mock_context(name="my-context", display_name=None)
+        reports = [_make_mock_report(context_id=ctx.id)]
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = reports
+        ctx_result = MagicMock()
+        ctx_result.scalars.return_value.all.return_value = [ctx]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
+
+        _install_overrides(mock_db)
+
+        response = client.get("/api/v1/admin/sleep-reports")
+        assert response.status_code == 200
+        assert response.json()["reports"][0]["context_name"] == "my-context"
+
+    def test_list_context_name_none_when_deleted(self, client):
+        """Deleted contexts should resolve to context_name=None."""
+        ctx = _make_mock_context(deleted=True)
+        reports = [_make_mock_report(context_id=ctx.id)]
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = reports
+        ctx_result = MagicMock()
+        ctx_result.scalars.return_value.all.return_value = [ctx]
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
+
+        _install_overrides(mock_db)
+
+        response = client.get("/api/v1/admin/sleep-reports")
+        assert response.status_code == 200
+        assert response.json()["reports"][0]["context_name"] is None
+        # 3 DB calls: count + list + context batch query (deleted path exercised)
+        assert mock_db.execute.call_count == 3
+
+    def test_list_context_name_none_when_context_row_missing(self, client):
+        """Reports referencing a non-existent context should have context_name=None."""
+        reports = [_make_mock_report()]  # context_id is a random UUID
+
+        mock_db = AsyncMock()
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        list_result = MagicMock()
+        list_result.scalars.return_value.all.return_value = reports
+        ctx_result = MagicMock()
+        ctx_result.scalars.return_value.all.return_value = []  # No matching context
+        mock_db.execute.side_effect = [count_result, list_result, ctx_result]
+
+        _install_overrides(mock_db)
+
+        response = client.get("/api/v1/admin/sleep-reports")
+        assert response.status_code == 200
+        assert response.json()["reports"][0]["context_name"] is None
 
 
 class TestGetSleepReportDetail:

--- a/backend/tests/api/test_sleep_reports_admin.py
+++ b/backend/tests/api/test_sleep_reports_admin.py
@@ -123,9 +123,9 @@ class TestListSleepReports:
         # Call 2: list query → scalars().all()=reports
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = reports
-        # Call 3: batch context query → scalars().all()=[ctx]
+        # Call 3: batch context query → .all()=[(id, name, display_name, deleted_at)]
         ctx_result = MagicMock()
-        ctx_result.scalars.return_value.all.return_value = [ctx]
+        ctx_result.all.return_value = [(ctx.id, ctx.name, ctx.display_name, ctx.deleted_at)]
         mock_db.execute.side_effect = [count_result, list_result, ctx_result]
 
         _install_overrides(mock_db)
@@ -152,7 +152,7 @@ class TestListSleepReports:
             _make_mock_report(status="failed", context_id=ctx.id)
         ]
         ctx_result = MagicMock()
-        ctx_result.scalars.return_value.all.return_value = [ctx]
+        ctx_result.all.return_value = [(ctx.id, ctx.name, ctx.display_name, ctx.deleted_at)]
         mock_db.execute.side_effect = [count_result, list_result, ctx_result]
 
         _install_overrides(mock_db)
@@ -237,7 +237,7 @@ class TestListSleepReports:
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = reports
         ctx_result = MagicMock()
-        ctx_result.scalars.return_value.all.return_value = [ctx]
+        ctx_result.all.return_value = [(ctx.id, ctx.name, ctx.display_name, ctx.deleted_at)]
         mock_db.execute.side_effect = [count_result, list_result, ctx_result]
 
         _install_overrides(mock_db)
@@ -257,7 +257,7 @@ class TestListSleepReports:
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = reports
         ctx_result = MagicMock()
-        ctx_result.scalars.return_value.all.return_value = [ctx]
+        ctx_result.all.return_value = [(ctx.id, ctx.name, ctx.display_name, ctx.deleted_at)]
         mock_db.execute.side_effect = [count_result, list_result, ctx_result]
 
         _install_overrides(mock_db)
@@ -278,7 +278,7 @@ class TestListSleepReports:
         list_result = MagicMock()
         list_result.scalars.return_value.all.return_value = reports
         ctx_result = MagicMock()
-        ctx_result.scalars.return_value.all.return_value = []  # No matching context
+        ctx_result.all.return_value = []  # No matching context
         mock_db.execute.side_effect = [count_result, list_result, ctx_result]
 
         _install_overrides(mock_db)

--- a/frontend/src/app/(authenticated)/admin/sleep-reports/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/page.tsx
@@ -40,6 +40,7 @@ interface SleepReportSummary {
   user_id: string;
   workspace_id: string | null;
   context_id: string | null;
+  context_name: string | null;
   status: SleepStatus;
   started_at: string;
   completed_at: string | null;
@@ -244,6 +245,7 @@ export default function AdminSleepReportsPage() {
               <TableHeader>
                 <TableRow>
                   <TableHead>{t("table.startedAt")}</TableHead>
+                  <TableHead>{t("table.context")}</TableHead>
                   <TableHead>{t("table.status")}</TableHead>
                   <TableHead className="text-right">
                     {t("table.memoriesProcessed")}
@@ -270,6 +272,9 @@ export default function AdminSleepReportsPage() {
                   <TableRow key={report.id}>
                     <TableCell className="text-sm whitespace-nowrap">
                       {formatRelativeTime(report.started_at, timezone, locale)}
+                    </TableCell>
+                    <TableCell className="text-sm">
+                      {report.context_name ?? "—"}
                     </TableCell>
                     <TableCell>
                       <span

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2167,6 +2167,7 @@
       },
       "table": {
         "startedAt": "Started",
+        "context": "Context",
         "status": "Status",
         "memoriesProcessed": "Memories",
         "edgesCreated": "Edges",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2167,6 +2167,7 @@
       },
       "table": {
         "startedAt": "開始時刻",
+        "context": "コンテキスト",
         "status": "ステータス",
         "memoriesProcessed": "処理メモリ数",
         "edgesCreated": "作成エッジ数",


### PR DESCRIPTION
Closes #354

## Summary
- Add `context_name` field to `SleepReportSummary` and batch-load contexts in `list_sleep_reports` using a single `IN` query to avoid N+1
- Add Context column to the frontend sleep reports list table between Started and Status columns
- Add i18n translation keys for both `en.json` and `ja.json`
- Remove redundant `context_name` declaration from `SleepReportDetail` (now inherited from parent)

## Implementation notes
- Backend batch context loading follows the same pattern as `admin_plans.py` and `workspace.py` (collect IDs → single IN query → dict lookup)
- Context name resolution uses the same rule as the detail endpoint: `display_name or name`, `None` for deleted/missing contexts
- The monkey-patch pattern (`r.context_name = ...`) matches the existing `get_sleep_report_detail` implementation
- 4 new backend tests cover all edge cases: null context_id, name fallback, deleted context, missing context row
- `call_count` assertions ensure the correct DB call pattern (2 calls without context, 3 with)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/354-feat-feat-frontend-show-context-name-in-sleep.gate1.md
- ~/.claude/cache/gh-issue-driven/354-feat-feat-frontend-show-context-name-in-sleep.gate2.md

🤖 Generated via /gh-issue-driven:ship
