### PR TITLE
fix(frontend): hide admin-only context settings sections from non-admin workspace members (#365)

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -207,17 +207,20 @@ export default function ContextDetailPage() {
             context={context}
             onContextUpdated={handleContextUpdated}
           />
-          <Separator className="my-8" />
-          <SearchSettingsSection contextId={contextId} />
-          {!context.is_private &&
-            hasWorkspaceRole(currentWorkspace?.current_user_role, "admin") && (
-              <>
-                <Separator className="my-8" />
-                <MembersSection contextId={contextId} context={context} />
-              </>
-            )}
-          <Separator className="my-8" />
-          <ProtectionSection context={context} />
+          {hasWorkspaceRole(currentWorkspace?.current_user_role, "admin") && (
+            <>
+              <Separator className="my-8" />
+              <SearchSettingsSection contextId={contextId} />
+              {!context.is_private && (
+                <>
+                  <Separator className="my-8" />
+                  <MembersSection contextId={contextId} context={context} />
+                </>
+              )}
+              <Separator className="my-8" />
+              <ProtectionSection context={context} />
+            </>
+          )}
         </TabsContent>
       </Tabs>
     </PageContainer>


### PR DESCRIPTION
Closes #365

## Summary
- Wrap `SearchSettingsSection`, `MembersSection`, `ProtectionSection` under a single `hasWorkspaceRole(admin)` check on the context detail Settings tab
- Move all `Separator`s inside the admin conditional so non-admins see no stray dividers below `SettingsTabPanel`
- Keep `!is_private` gate only on `MembersSection`, preserving #362 behavior for private contexts

## Implementation notes
- Single file change: `frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx` (+14 / -11)
- Directly extends the #362 caller-side gating pattern (`!is_private && hasWorkspaceRole(admin)`) to cover `SearchSettingsSection` and `ProtectionSection`
- No new abstraction, no new dependencies, no new components
- Backend RBAC unchanged — the 403 is the API's proper response; fix is purely presentational
- Conditional rendering prevents admin-only components from mounting for non-admins, so their mount-time `useEffect` fetches (`getContextSearchConfig`, `listExternalAPIKeys`, `/api/v1/system/telemetry`) no longer fire for members

## Acceptance criteria
- [x] Workspace admin/owner still sees all 3 sections as before
- [x] Workspace member / viewer sees only `SettingsTabPanel` in the Settings tab — no 403 banner
- [x] Private context still hides `MembersSection` even for admins (preserves #362 behavior)
- [x] No API calls from `SearchSettingsSection` / `ProtectionSection` fire for members (lazy-mount via conditional rendering)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/365-fix-fix-frontend-hide-admin-only-context-set.gate1.md`
- `~/.claude/cache/gh-issue-driven/365-fix-fix-frontend-hide-admin-only-context-set.gate2.md`

🤖 Generated via /gh-issue-driven:ship
