### PR TITLE
feat(api): add edge_discovery LLM Judge observability metrics (#306)

### DIFF
--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import math
 import random
+import statistics
 import string
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -104,39 +105,101 @@ class BatchStats:
     `PhaseResult.details`. Per-batch invariant: `failures in {0, 1}` because
     each batch makes exactly one `complete_json` call.
 
-    `confidences` holds raw confidence values for accepted edges only —
-    rejected-side confidence is not retained by the parser.
+    `confidences` holds raw confidence values for **accepted edges only** —
+    rejected-side confidence is not retained by the parser. This is a known
+    limitation: the resulting metrics represent `P(confidence | decision=accept)`
+    not the marginal `P(confidence)` over all judgments. See #372 for the
+    rejected-side retention follow-up that enables decision-boundary analysis.
+
     `edge_type_counts` covers accepted edges only.
+
+    `confidence_imputed` counts how many parsed edges had their confidence
+    field replaced with the 0.5 default because the LLM returned a non-finite
+    value (NaN, Inf) or a non-numeric type. Surfaces silent imputation so
+    operators can detect prompt/model issues from production observability.
     """
 
     accepted: int = 0
     rejected: int = 0
     failures: int = 0
+    confidence_imputed: int = 0
     edge_type_counts: dict[str, int] = field(default_factory=dict)
     confidences: list[float] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class ConfidenceSummary:
+    """5-number summary for accepted-edge confidences (#306).
+
+    `avg` (mean) is reported but is structurally inadequate for bimodal data
+    (textbook example: bimodal mean = midpoint of valley). `median`, `p25`,
+    `p75` give a robust picture of the distribution shape. Pair with
+    `confidence_histogram` for visual inspection. `n` lets readers gauge
+    sample-size noise (per-run N is typically small ≤ 30 — formal bimodality
+    detection requires cross-run aggregation, see #372).
+    """
+
+    avg: float
+    median: float
+    p25: float
+    p75: float
+    n: int
+
+
+def _summarize_confidences(confidences: list[float]) -> ConfidenceSummary:
+    """Compute mean + median + IQR + n from a list of confidences.
+
+    Handles small-N edge cases: n=0 → all zeros (caller convention),
+    n=1 → quartiles collapse to the single value (no IQR information).
+    """
+    n = len(confidences)
+    if n == 0:
+        return ConfidenceSummary(avg=0.0, median=0.0, p25=0.0, p75=0.0, n=0)
+    avg = sum(confidences) / n
+    median = statistics.median(confidences)
+    if n >= 2:
+        # statistics.quantiles(n=4) returns [Q1, Q2, Q3]
+        quartiles = statistics.quantiles(confidences, n=4)
+        p25, p75 = quartiles[0], quartiles[2]
+    else:
+        # Single sample — IQR is undefined; collapse to the lone value.
+        p25 = p75 = median
+    return ConfidenceSummary(avg=avg, median=median, p25=p25, p75=p75, n=n)
 
 
 def _metrics_from_agg(
     agg: BatchStats,
     auto_accepted: int,
-    avg_confidence: float,
+    confidence_summary: ConfidenceSummary,
     confidence_histogram: dict[str, int],
     config: NeuralMemoryConfig,
 ) -> dict[str, object]:
     """Build the #306 metric dict from aggregated values.
 
-    Single source of truth for the 9 metric key names — `_empty_metrics()` and
+    Single source of truth for the metric key names — `_empty_metrics()` and
     `execute()`'s success-path `result.details` both go through here, so a key
     rename or addition only requires editing this one function.
+
+    Mutable fields (`edge_type_counts`, `confidence_histogram`) are
+    **defensive-copied** so that the returned dict is decoupled from the
+    caller's `agg` and any local working state. Without this, the result dict
+    would alias the caller's mutable structures and any post-emit mutation
+    would silently corrupt `result.details`. The copy cost is negligible
+    (O(3) for edge_type, O(4) for histogram).
     """
     return {
         "llm_accepted": agg.accepted,
         "llm_rejected": agg.rejected,
         "llm_call_failures": agg.failures,
         "auto_accepted": auto_accepted,
-        "edge_type_dist": agg.edge_type_counts,
-        "avg_confidence": avg_confidence,
-        "confidence_histogram": confidence_histogram,
+        "edge_type_dist": dict(agg.edge_type_counts),  # defensive copy
+        "avg_confidence": confidence_summary.avg,
+        "median_confidence": confidence_summary.median,
+        "p25_confidence": confidence_summary.p25,
+        "p75_confidence": confidence_summary.p75,
+        "confidence_n": confidence_summary.n,
+        "confidence_imputed": agg.confidence_imputed,
+        "confidence_histogram": dict(confidence_histogram),  # defensive copy
         "llm_model": config.sleep_llm_model,
         "prompt_revision": EDGE_DISCOVERY_PROMPT_REVISION,
     }
@@ -153,7 +216,7 @@ def _empty_metrics(config: NeuralMemoryConfig) -> dict[str, object]:
     return _metrics_from_agg(
         agg=BatchStats(),
         auto_accepted=0,
-        avg_confidence=0.0,
+        confidence_summary=_summarize_confidences([]),
         confidence_histogram=dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0),
         config=config,
     )
@@ -282,6 +345,7 @@ class EdgeDiscoveryPhase:
                 agg.accepted += batch_stats.accepted
                 agg.rejected += batch_stats.rejected
                 agg.failures += batch_stats.failures
+                agg.confidence_imputed += batch_stats.confidence_imputed
                 for k, v in batch_stats.edge_type_counts.items():
                     agg.edge_type_counts[k] = agg.edge_type_counts.get(k, 0) + v
                 agg.confidences.extend(batch_stats.confidences)
@@ -327,7 +391,7 @@ class EdgeDiscoveryPhase:
                         error=str(e),
                     )
 
-        avg_confidence = sum(agg.confidences) / len(agg.confidences) if agg.confidences else 0.0
+        confidence_summary = _summarize_confidences(agg.confidences)
         confidence_histogram = _build_confidence_histogram(agg.confidences)
 
         result.memories_processed = len(sampled)
@@ -338,7 +402,9 @@ class EdgeDiscoveryPhase:
             "candidates": len(candidates),
             "filtered": len(filtered),
             "edges_created": edges_created,
-            **_metrics_from_agg(agg, auto_accepted, avg_confidence, confidence_histogram, config),
+            **_metrics_from_agg(
+                agg, auto_accepted, confidence_summary, confidence_histogram, config
+            ),
         }
 
         logger.info(
@@ -351,7 +417,10 @@ class EdgeDiscoveryPhase:
             llm_call_failures=agg.failures,
             auto_accepted=auto_accepted,
             edge_type_dist=agg.edge_type_counts,
-            avg_confidence=avg_confidence,
+            avg_confidence=confidence_summary.avg,
+            median_confidence=confidence_summary.median,
+            confidence_n=confidence_summary.n,
+            confidence_imputed=agg.confidence_imputed,
             confidence_histogram=confidence_histogram,
             prompt_revision=EDGE_DISCOVERY_PROMPT_REVISION,
         )
@@ -546,6 +615,16 @@ class EdgeDiscoveryPhase:
         # parser would otherwise create edges for them, inflating
         # `edges_created` and skewing observability metrics. Addresses
         # Copilot review #371 finding (loop 4).
+        #
+        # KNOWN LIMITATION (#373): the `frozenset` match is orientation-agnostic,
+        # so the LLM may return (B, A) for our requested (A, B) pair and we
+        # accept it — then we use the LLM's order to populate src_id/dst_id.
+        # For `related_to` (undirected) this is correct. For `depends_on` /
+        # `learned_from` (directed) this can silently create the edge in the
+        # WRONG direction if the LLM flipped. The prompt does not currently
+        # forbid the flip, and we have no measurement of the flip rate. See
+        # #373 for the proposed fix (prompt clarification + directional
+        # canonicalization for directed edge_types).
         pair_lines = []
         requested_pairs: set[frozenset[str]] = set()
         for src, dst, score in batch:
@@ -617,8 +696,11 @@ class EdgeDiscoveryPhase:
             # propagate to avg_confidence (also NaN, breaking JSON-strict
             # serialization) and silently land in the "0.85-1.0" histogram
             # bucket because all NaN comparisons return False (#306).
+            # Track the imputation count so operators can detect prompt/model
+            # issues from production observability (would otherwise be silent).
             if not isinstance(raw_conf, (int, float)) or not math.isfinite(raw_conf):
                 raw_conf = 0.5
+                stats.confidence_imputed += 1
             confidence = max(0.0, min(1.0, float(raw_conf)))
 
             stats.accepted += 1

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -504,8 +504,14 @@ class EdgeDiscoveryPhase:
         if not all_ids:
             return [], stats
 
-        # Assign short labels
-        id_list = list(all_ids)
+        # Assign short labels deterministically. `all_ids` is a set, so
+        # `list(all_ids)` would have non-reproducible iteration order across
+        # runs — sort by str(uuid) so the same batch always produces the same
+        # label↔UUID mapping. Positional bias for the LLM is then handled by
+        # `random.shuffle(shuffled_items)` below, which acts on the *display*
+        # order independently of label assignment (#306, addresses Copilot
+        # review #371 finding).
+        id_list = sorted(all_ids, key=str)
         labels = list(string.ascii_uppercase[: len(id_list)])
         id_to_label = dict(zip(id_list, labels, strict=True))
         label_to_id = dict(zip(labels, id_list, strict=True))
@@ -523,9 +529,25 @@ class EdgeDiscoveryPhase:
                     f"    summary: {mem.summary[:300]}"
                 )
 
+        # Build pair_lines, skipping pairs where either end is not in
+        # id_to_label. The all_ids collection above silently skips IDs not in
+        # memory_map; mirroring that filter here prevents a KeyError when
+        # `_find_candidates` returns a `dst` outside the sampled batch (the
+        # normal case in production with sample_size=30 and corpus≥100).
+        # Unguarded, this raised KeyError → caught by orchestrator try/except
+        # → entire phase silently failed (closes #369). Skipped pairs are
+        # NOT counted toward accepted/rejected/failures because they were
+        # never judged by the LLM at all.
         pair_lines = []
         for src, dst, score in batch:
+            if src not in id_to_label or dst not in id_to_label:
+                continue
             pair_lines.append(f"  ({id_to_label[src]}, {id_to_label[dst]}): similarity={score:.3f}")
+
+        if not pair_lines:
+            # All pairs in this batch had at least one end outside memory_map.
+            # Skip the LLM call entirely — there is nothing to ask.
+            return [], stats
 
         prompt = EDGE_DISCOVERY_USER.format(
             memories="\n".join(memory_lines),

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -158,8 +158,13 @@ def _summarize_confidences(confidences: list[float]) -> ConfidenceSummary:
     avg = sum(confidences) / n
     median = statistics.median(confidences)
     if n >= 2:
-        # statistics.quantiles(n=4) returns [Q1, Q2, Q3]
-        quartiles = statistics.quantiles(confidences, n=4)
+        # Use inclusive quartiles so small samples (n=2, n=3) do not
+        # extrapolate outside the observed confidence range. The default
+        # `exclusive` (Tukey) method can return values < min(data) or
+        # > max(data), which makes p25/p75 fall outside [0.0, 1.0] even
+        # though the inputs are clamped — uninterpretable for a confidence
+        # metric. statistics.quantiles(n=4) returns [Q1, Q2, Q3].
+        quartiles = statistics.quantiles(confidences, n=4, method="inclusive")
         p25, p75 = quartiles[0], quartiles[2]
     else:
         # Single sample — IQR is undefined; collapse to the lone value.

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -538,11 +538,21 @@ class EdgeDiscoveryPhase:
         # → entire phase silently failed (closes #369). Skipped pairs are
         # NOT counted toward accepted/rejected/failures because they were
         # never judged by the LLM at all.
+        #
+        # Also build `requested_pairs` (orientation-agnostic) so the response
+        # parser can reject hallucinated/unrequested pairs the LLM may invent
+        # — the prompt only asks about specific pairs, but a misbehaving model
+        # could return arbitrary (label_a, label_b) combinations and the
+        # parser would otherwise create edges for them, inflating
+        # `edges_created` and skewing observability metrics. Addresses
+        # Copilot review #371 finding (loop 4).
         pair_lines = []
+        requested_pairs: set[frozenset[str]] = set()
         for src, dst, score in batch:
             if src not in id_to_label or dst not in id_to_label:
                 continue
             pair_lines.append(f"  ({id_to_label[src]}, {id_to_label[dst]}): similarity={score:.3f}")
+            requested_pairs.add(frozenset({id_to_label[src], id_to_label[dst]}))
 
         if not pair_lines:
             # All pairs in this batch had at least one end outside memory_map.
@@ -585,6 +595,13 @@ class EdgeDiscoveryPhase:
             pair = edge.get("pair", [])
             if len(pair) != 2 or pair[0] not in label_to_id or pair[1] not in label_to_id:
                 # Malformed pair → not counted toward accepted/rejected.
+                continue
+
+            # Reject hallucinated/unrequested pairs: the LLM may invent pair
+            # combinations that were never in `pair_lines`. Match
+            # orientation-agnostic via frozenset to allow the model to flip
+            # the pair order (the relationship is undirected at this stage).
+            if frozenset(pair) not in requested_pairs:
                 continue
 
             if not edge.get("related", False):

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -554,6 +554,13 @@ class EdgeDiscoveryPhase:
             pairs="\n".join(pair_lines),
         )
 
+        # Consume the budget BEFORE the call so failed attempts are still
+        # counted. Otherwise a failing LLM provider could trigger many more
+        # batches than `max_llm_calls` permits — `execute()`'s budget check
+        # would never see the consumption from the failure path. Tokens are
+        # still only added on success (no tokens consumed when the call
+        # failed). Addresses Copilot review #371 finding (loop 2).
+        budget.consume(llm_calls=1)
         try:
             response, tokens = await self.llm_service.complete_json(
                 user_id=user_id,
@@ -564,7 +571,6 @@ class EdgeDiscoveryPhase:
                 model=config.sleep_llm_model,
                 provider=config.sleep_llm_provider,
             )
-            budget.consume(llm_calls=1)
             self._tokens_used += tokens
 
         except Exception as e:

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -19,8 +19,10 @@ Academic notes:
 
 from __future__ import annotations
 
+import math
 import random
 import string
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -36,7 +38,11 @@ from models.memory import Memory, NeuralMemoryEdge
 from repositories.neural_edge import NeuralEdgeRepository
 from services.embedding_service import EmbeddingService
 from services.llm_service import LLMService
-from services.sleep.prompts import EDGE_DISCOVERY_SYSTEM, EDGE_DISCOVERY_USER
+from services.sleep.prompts import (
+    EDGE_DISCOVERY_PROMPT_REVISION,
+    EDGE_DISCOVERY_SYSTEM,
+    EDGE_DISCOVERY_USER,
+)
 from services.sleep.reporter import PhaseResult, SleepBudget
 from utils.logger import get_logger
 
@@ -79,6 +85,95 @@ def _is_synthetic_seed_edge(edge: NeuralMemoryEdge) -> bool:
     )
 
 
+# Issue #306: Confidence histogram bucket boundaries.
+# Convention: right-open [a, b) for the first three buckets, last bucket [0.85, 1.0]
+# (inclusive at 1.0). Boundary values 0.5/0.7/0.85 fall into the higher bucket.
+# The 0.0-0.5 bucket exists because LLM returns can clamp accepted-edge confidence
+# anywhere in [0, 1] — pilot #249 demonstrated bimodal distribution detection
+# requires the lower-band bucket.
+# Annotated as `tuple[str, ...]` (not the inferred Literal tuple) so that
+# `dict.fromkeys(KEYS, 0)` widens to `dict[str, int]` for downstream consumers.
+CONFIDENCE_HISTOGRAM_KEYS: tuple[str, ...] = ("0.0-0.5", "0.5-0.7", "0.7-0.85", "0.85-1.0")
+
+
+@dataclass
+class BatchStats:
+    """Per-batch LLM Judge stats from `_llm_judge_batch` (#306).
+
+    Aggregated across batches in `execute()` before being unpacked into
+    `PhaseResult.details`. Per-batch invariant: `failures in (0, 1)` because
+    each batch makes exactly one `complete_json` call.
+
+    `confidences` holds raw confidence values for accepted edges only —
+    rejected-side confidence is not retained by the parser.
+    `edge_type_counts` covers accepted edges only.
+    """
+
+    accepted: int = 0
+    rejected: int = 0
+    failures: int = 0
+    edge_type_counts: dict[str, int] = field(default_factory=dict)
+    confidences: list[float] = field(default_factory=list)
+
+
+def _metrics_from_agg(
+    agg: BatchStats,
+    auto_accepted: int,
+    avg_confidence: float,
+    confidence_histogram: dict[str, int],
+    config: NeuralMemoryConfig,
+) -> dict[str, object]:
+    """Build the #306 metric dict from aggregated values.
+
+    Single source of truth for the 9 metric key names — `_empty_metrics()` and
+    `execute()`'s success-path `result.details` both go through here, so a key
+    rename or addition only requires editing this one function.
+    """
+    return {
+        "llm_accepted": agg.accepted,
+        "llm_rejected": agg.rejected,
+        "llm_call_failures": agg.failures,
+        "auto_accepted": auto_accepted,
+        "edge_type_dist": agg.edge_type_counts,
+        "avg_confidence": avg_confidence,
+        "confidence_histogram": confidence_histogram,
+        "llm_model": config.sleep_llm_model,
+        "prompt_revision": EDGE_DISCOVERY_PROMPT_REVISION,
+    }
+
+
+def _empty_metrics(config: NeuralMemoryConfig) -> dict[str, object]:
+    """Zero-initialized #306 metric keys for early-return paths.
+
+    Reader code (`get_sleep_report` MCP tool, admin UI) can use `.get(key, 0)`
+    safely, but emitting zero values keeps every sleep_report uniform.
+    `llm_model` and `prompt_revision` always reflect the config that *would*
+    be used if the LLM path ran, so historical reports stay comparable.
+    """
+    return _metrics_from_agg(
+        agg=BatchStats(),
+        auto_accepted=0,
+        avg_confidence=0.0,
+        confidence_histogram=dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0),
+        config=config,
+    )
+
+
+def _build_confidence_histogram(confidences: list[float]) -> dict[str, int]:
+    """Bucket accepted-edge confidence values per CONFIDENCE_HISTOGRAM_KEYS."""
+    histogram: dict[str, int] = dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0)
+    for c in confidences:
+        if c < 0.5:
+            histogram["0.0-0.5"] += 1
+        elif c < 0.7:
+            histogram["0.5-0.7"] += 1
+        elif c < 0.85:
+            histogram["0.7-0.85"] += 1
+        else:
+            histogram["0.85-1.0"] += 1
+    return histogram
+
+
 class EdgeDiscoveryPhase:
     """Discover missing edges between semantically related memories."""
 
@@ -94,6 +189,9 @@ class EdgeDiscoveryPhase:
         self.edge_repo = NeuralEdgeRepository(db)
         self.collection_name = collection_name
         self.embedding_service = EmbeddingService(db, model=embedding_model)
+        # Reset on every execute(); init here so _llm_judge_batch can be called
+        # in isolation (e.g. from unit tests) without AttributeError (#306).
+        self._tokens_used = 0
 
     async def execute(
         self,
@@ -122,24 +220,47 @@ class EdgeDiscoveryPhase:
         # Step 1: Sample memories (recency-weighted)
         sampled = await self._sample_memories(user_id, workspace_id, context_id, sample_size)
         if not sampled:
-            result.details = {"message": "no_memories_to_sample"}
+            result.details = {
+                "message": "no_memories_to_sample",
+                "sampled": 0,
+                "candidates": 0,
+                "filtered": 0,
+                "edges_created": 0,
+                **_empty_metrics(config),
+            }
             return result
 
         # Step 2: Find medium-similarity candidates
         candidates = await self._find_candidates(sampled, user_id, workspace_id, context_id)
         if not candidates:
-            result.details = {"message": "no_edge_candidates"}
+            result.details = {
+                "message": "no_edge_candidates",
+                "sampled": len(sampled),
+                "candidates": 0,
+                "filtered": 0,
+                "edges_created": 0,
+                **_empty_metrics(config),
+            }
             return result
 
         # Step 3: Filter out existing edges
         filtered = await self._filter_existing_edges(candidates, user_id, workspace_id, context_id)
         if not filtered:
-            result.details = {"message": "all_candidates_already_connected"}
+            result.details = {
+                "message": "all_candidates_already_connected",
+                "sampled": len(sampled),
+                "candidates": len(candidates),
+                "filtered": 0,
+                "edges_created": 0,
+                **_empty_metrics(config),
+            }
             return result
 
         # Step 4: Judge candidates (LLM or auto-accept)
         edges_created = 0
         memory_map = {m.id: m for m in sampled}
+        agg = BatchStats()
+        auto_accepted = 0
 
         # Process in batches
         for batch_start in range(0, len(filtered), BATCH_SIZE):
@@ -149,7 +270,7 @@ class EdgeDiscoveryPhase:
             batch = filtered[batch_start : batch_start + BATCH_SIZE]
 
             if llm_enabled:
-                confirmed = await self._llm_judge_batch(
+                confirmed, batch_stats = await self._llm_judge_batch(
                     batch,
                     memory_map,
                     user_id,
@@ -158,9 +279,18 @@ class EdgeDiscoveryPhase:
                     budget,
                     config,
                 )
+                agg.accepted += batch_stats.accepted
+                agg.rejected += batch_stats.rejected
+                agg.failures += batch_stats.failures
+                for k, v in batch_stats.edge_type_counts.items():
+                    agg.edge_type_counts[k] = agg.edge_type_counts.get(k, 0) + v
+                agg.confidences.extend(batch_stats.confidences)
             else:
-                # Without LLM, accept all candidates with default confidence
+                # Without LLM, accept all candidates with default confidence.
+                # Tracked separately as `auto_accepted` so it does NOT pollute
+                # avg_confidence / confidence_histogram / edge_type_dist (#306).
                 confirmed = [(src, dst, "related_to", 0.5) for src, dst, _score in batch]
+                auto_accepted += len(confirmed)
 
             for src_id, dst_id, edge_type, confidence in confirmed:
                 try:
@@ -197,6 +327,9 @@ class EdgeDiscoveryPhase:
                         error=str(e),
                     )
 
+        avg_confidence = sum(agg.confidences) / len(agg.confidences) if agg.confidences else 0.0
+        confidence_histogram = _build_confidence_histogram(agg.confidences)
+
         result.memories_processed = len(sampled)
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
@@ -205,6 +338,7 @@ class EdgeDiscoveryPhase:
             "candidates": len(candidates),
             "filtered": len(filtered),
             "edges_created": edges_created,
+            **_metrics_from_agg(agg, auto_accepted, avg_confidence, confidence_histogram, config),
         }
 
         logger.info(
@@ -212,6 +346,14 @@ class EdgeDiscoveryPhase:
             sampled=len(sampled),
             candidates=len(candidates),
             edges_created=edges_created,
+            llm_accepted=agg.accepted,
+            llm_rejected=agg.rejected,
+            llm_call_failures=agg.failures,
+            auto_accepted=auto_accepted,
+            edge_type_dist=agg.edge_type_counts,
+            avg_confidence=avg_confidence,
+            confidence_histogram=confidence_histogram,
+            prompt_revision=EDGE_DISCOVERY_PROMPT_REVISION,
         )
 
         return result
@@ -339,11 +481,18 @@ class EdgeDiscoveryPhase:
         workspace_id: str | None,
         budget: SleepBudget,
         config: NeuralMemoryConfig,
-    ) -> list[tuple[UUID, UUID, str, float]]:
+    ) -> tuple[list[tuple[UUID, UUID, str, float]], BatchStats]:
         """Use LLM to judge edge candidates.
 
-        Returns list of (src_id, dst_id, edge_type, confidence) for confirmed edges.
+        Returns:
+            Tuple of (confirmed_edges, stats):
+              - confirmed_edges: list of (src_id, dst_id, edge_type, confidence)
+                for accepted edges.
+              - stats: BatchStats with per-batch counts. `failures` is 0 or 1
+                (one LLM call per batch).
         """
+        stats = BatchStats()
+
         # Collect all unique memories in batch, skip IDs not in memory_map
         all_ids: set[UUID] = set()
         for src, dst, _ in batch:
@@ -353,7 +502,7 @@ class EdgeDiscoveryPhase:
                 all_ids.add(dst)
 
         if not all_ids:
-            return []
+            return [], stats
 
         # Assign short labels
         id_list = list(all_ids)
@@ -398,24 +547,38 @@ class EdgeDiscoveryPhase:
 
         except Exception as e:
             logger.warning("edge_discovery_llm_failed", error=str(e))
-            return []
+            stats.failures = 1
+            return [], stats
 
         # Parse response with label validation
         confirmed: list[tuple[UUID, UUID, str, float]] = []
+        valid_edge_types = {"related_to", "depends_on", "learned_from"}
         for edge in response.get("edges", []):
-            if not edge.get("related", False):
-                continue
-
             pair = edge.get("pair", [])
             if len(pair) != 2 or pair[0] not in label_to_id or pair[1] not in label_to_id:
+                # Malformed pair → not counted toward accepted/rejected.
+                continue
+
+            if not edge.get("related", False):
+                stats.rejected += 1
                 continue
 
             # Validate edge_type against DB CHECK constraint
-            valid_edge_types = {"related_to", "depends_on", "learned_from"}
             raw_type = edge.get("edge_type", "related_to")
             edge_type = raw_type if raw_type in valid_edge_types else "related_to"
 
-            confidence = max(0.0, min(1.0, edge.get("confidence", 0.5)))
+            raw_conf = edge.get("confidence", 0.5)
+            # Guard against non-finite values (NaN/Inf): a NaN here would
+            # propagate to avg_confidence (also NaN, breaking JSON-strict
+            # serialization) and silently land in the "0.85-1.0" histogram
+            # bucket because all NaN comparisons return False (#306).
+            if not isinstance(raw_conf, (int, float)) or not math.isfinite(raw_conf):
+                raw_conf = 0.5
+            confidence = max(0.0, min(1.0, float(raw_conf)))
+
+            stats.accepted += 1
+            stats.edge_type_counts[edge_type] = stats.edge_type_counts.get(edge_type, 0) + 1
+            stats.confidences.append(confidence)
 
             confirmed.append(
                 (
@@ -426,4 +589,8 @@ class EdgeDiscoveryPhase:
                 )
             )
 
-        return confirmed
+        # Per-batch invariant: one LLM call → failures is 0 here. The except
+        # branch above already returned `BatchStats(failures=1)` for the failure
+        # case, so by construction `stats.failures == 0` at this point. The
+        # invariant is documented on `BatchStats`; no runtime assert needed.
+        return confirmed, stats

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -101,7 +101,7 @@ class BatchStats:
     """Per-batch LLM Judge stats from `_llm_judge_batch` (#306).
 
     Aggregated across batches in `execute()` before being unpacked into
-    `PhaseResult.details`. Per-batch invariant: `failures in (0, 1)` because
+    `PhaseResult.details`. Per-batch invariant: `failures in {0, 1}` because
     each batch makes exactly one `complete_json` call.
 
     `confidences` holds raw confidence values for accepted edges only —

--- a/backend/src/services/sleep/prompts.py
+++ b/backend/src/services/sleep/prompts.py
@@ -72,6 +72,10 @@ Example:
 # Phase 1: Edge Discovery
 # ============================================================================
 
+# Bump on every edit to EDGE_DISCOVERY_SYSTEM or EDGE_DISCOVERY_USER so
+# sleep_reports.details can distinguish runs that used different prompts.
+EDGE_DISCOVERY_PROMPT_REVISION = "v1"
+
 EDGE_DISCOVERY_SYSTEM = """\
 You are a knowledge graph edge discovery agent. You analyze pairs of memory \
 entries and determine if they are semantically related and should be connected \

--- a/backend/src/services/sleep/prompts.py
+++ b/backend/src/services/sleep/prompts.py
@@ -73,7 +73,8 @@ Example:
 # ============================================================================
 
 # Bump on every edit to EDGE_DISCOVERY_SYSTEM or EDGE_DISCOVERY_USER so
-# sleep_reports.details can distinguish runs that used different prompts.
+# sleep_reports.edge_discovery_result.details can distinguish runs that used
+# different prompts.
 EDGE_DISCOVERY_PROMPT_REVISION = "v1"
 
 EDGE_DISCOVERY_SYSTEM = """\

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -228,6 +228,85 @@ class TestGetSleepReport:
         assert data["status"] == "error"
         assert data["error"] == "invalid_report_id"
 
+    @pytest.mark.asyncio
+    async def test_get_sleep_report_includes_edge_discovery_metrics(self, user_id, workspace_id):
+        """Issue #306: edge_discovery_result JSON column passes new metric keys
+        through `_report_to_detail` to the MCP response untouched.
+
+        Verifies that the JSON column contract — sleep_reports.details written
+        by `execute()` → SQLAlchemy JSON serialize → `_report_to_detail` read —
+        round-trips the new keys (`llm_accepted`, `llm_rejected`,
+        `llm_call_failures`, `auto_accepted`, `edge_type_dist`,
+        `avg_confidence`, `confidence_histogram`, `llm_model`,
+        `prompt_revision`) without filtering or reshaping.
+        """
+        report_id = uuid4()
+        report = self._mock_report(report_id, user_id)
+        report.edge_discovery_result = {
+            "success": True,
+            "skipped": False,
+            "skip_reason": None,
+            "error": None,
+            "llm_calls": 2,
+            "memories_processed": 10,
+            "details": {
+                "sampled": 10,
+                "candidates": 6,
+                "filtered": 5,
+                "edges_created": 3,
+                "llm_accepted": 3,
+                "llm_rejected": 2,
+                "llm_call_failures": 0,
+                "auto_accepted": 0,
+                "edge_type_dist": {"related_to": 2, "depends_on": 1},
+                "avg_confidence": 0.78,
+                "confidence_histogram": {
+                    "0.0-0.5": 0,
+                    "0.5-0.7": 1,
+                    "0.7-0.85": 1,
+                    "0.85-1.0": 1,
+                },
+                "llm_model": "gpt-5-nano",
+                "prompt_revision": "v1",
+            },
+        }
+
+        mock_db = AsyncMock()
+        mock_report_result = MagicMock()
+        mock_report_result.scalar_one_or_none.return_value = report
+        mock_actions_result = MagicMock()
+        mock_actions_result.scalars.return_value.all.return_value = []
+        mock_log_result = MagicMock()
+        mock_db.execute.side_effect = [mock_report_result, mock_actions_result, mock_log_result]
+        mock_db.commit = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        with patch("db.base.get_db", new=mock_get_db):
+            result = await handle_get_sleep_report(
+                {"report_id": str(report_id)}, user_id, workspace_id
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        ed = data["report"]["edge_discovery_result"]["details"]
+        # Every #306 metric key must reach the MCP response untouched.
+        assert ed["llm_accepted"] == 3
+        assert ed["llm_rejected"] == 2
+        assert ed["llm_call_failures"] == 0
+        assert ed["auto_accepted"] == 0
+        assert ed["edge_type_dist"] == {"related_to": 2, "depends_on": 1}
+        assert ed["avg_confidence"] == 0.78
+        assert ed["confidence_histogram"] == {
+            "0.0-0.5": 0,
+            "0.5-0.7": 1,
+            "0.7-0.85": 1,
+            "0.85-1.0": 1,
+        }
+        assert ed["llm_model"] == "gpt-5-nano"
+        assert ed["prompt_revision"] == "v1"
+
 
 class TestRollbackSleepRun:
     """Test rollback_sleep_run MCP tool handler."""

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -261,6 +261,13 @@ class TestGetSleepReport:
                 "auto_accepted": 0,
                 "edge_type_dist": {"related_to": 2, "depends_on": 1},
                 "avg_confidence": 0.78,
+                # PhD-review additions (#306 follow-up): 5-number summary +
+                # sample size + imputation counter must also round-trip.
+                "median_confidence": 0.80,
+                "p25_confidence": 0.65,
+                "p75_confidence": 0.92,
+                "confidence_n": 3,
+                "confidence_imputed": 0,
                 "confidence_histogram": {
                     "0.0-0.5": 0,
                     "0.5-0.7": 1,
@@ -310,6 +317,14 @@ class TestGetSleepReport:
         # green when EDGE_DISCOVERY_PROMPT_REVISION is bumped on prompt edits
         # (addresses Copilot review #371 finding, loop 5).
         assert ed["prompt_revision"] == EDGE_DISCOVERY_PROMPT_REVISION
+        # PhD-review additions (#306 follow-up FB loop) — without these
+        # assertions, a future filter/reshape regression in _report_to_detail
+        # could silently drop the new keys.
+        assert ed["median_confidence"] == 0.80
+        assert ed["p25_confidence"] == 0.65
+        assert ed["p75_confidence"] == 0.92
+        assert ed["confidence_n"] == 3
+        assert ed["confidence_imputed"] == 0
 
 
 class TestRollbackSleepRun:

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -15,6 +15,7 @@ from mcp_server.tools.sleep import (
     handle_get_sleep_report,
     handle_rollback_sleep_run,
 )
+from services.sleep.prompts import EDGE_DISCOVERY_PROMPT_REVISION
 
 
 class TestGetSleepHistory:
@@ -267,7 +268,7 @@ class TestGetSleepReport:
                     "0.85-1.0": 1,
                 },
                 "llm_model": "gpt-5-nano",
-                "prompt_revision": "v1",
+                "prompt_revision": EDGE_DISCOVERY_PROMPT_REVISION,
             },
         }
 
@@ -305,7 +306,10 @@ class TestGetSleepReport:
             "0.85-1.0": 1,
         }
         assert ed["llm_model"] == "gpt-5-nano"
-        assert ed["prompt_revision"] == "v1"
+        # Track the constant rather than hardcoding "v1" so this test stays
+        # green when EDGE_DISCOVERY_PROMPT_REVISION is bumped on prompt edits
+        # (addresses Copilot review #371 finding, loop 5).
+        assert ed["prompt_revision"] == EDGE_DISCOVERY_PROMPT_REVISION
 
 
 class TestRollbackSleepRun:

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -115,13 +115,14 @@ def llm_judge_phase(edge_phase, deterministic_shuffle):
 
 
 def _make_batch_pair(n=2):
-    """Return ((memory_map, batch), labels) aligned for deterministic A/B/...
+    """Return ``(mems, batch, memory_map)`` for deterministic A/B/... tests.
 
     `_llm_judge_batch` assigns labels by sorting all memory IDs by ``str(id)``
     before mapping them to A/B/.... The ``deterministic_shuffle`` fixture only
     disables the later `random.shuffle` used for display order; it does not
-    control label assignment itself. Use ``_labels_for(memory_map)`` to derive
-    the actual label assignment when constructing canned LLM responses.
+    control label assignment itself. This helper does not return labels; use
+    ``_labels_for(memory_map)`` to derive the actual label assignment when
+    constructing canned LLM responses.
     """
     mems = [_make_memory() for _ in range(n)]
     batch = [(mems[i].id, mems[i + 1].id, 0.75) for i in range(n - 1)]

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -540,9 +540,15 @@ class TestLLMJudgeBatch:
         config = _make_config()
         budget = SleepBudget()
         _, batch, memory_map = _make_batch_pair(n=2)
+        # Use _labels_for to derive labels from sorted-UUID order (matches
+        # _llm_judge_batch's assignment). For n=2 with frozenset hallucination
+        # guard, hardcoded ("A", "B") happens to work today (orientation-
+        # agnostic), but using _labels_for is consistent with multi-pair tests
+        # and robust to a future tightening of the guard semantics.
+        labels = _labels_for(memory_map)
 
         llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
-            [("A", "B", True, "garbage_type", 0.8)]
+            [(labels[batch[0][0]], labels[batch[0][1]], True, "garbage_type", 0.8)]
         )
 
         confirmed, stats = await llm_judge_phase._llm_judge_batch(
@@ -562,10 +568,11 @@ class TestLLMJudgeBatch:
         config = _make_config()
         budget = SleepBudget()
         _, batch, memory_map = _make_batch_pair(n=2)
+        labels = _labels_for(memory_map)
 
         llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
             [
-                ("A", "B", True, "related_to", 0.9),
+                (labels[batch[0][0]], labels[batch[0][1]], True, "related_to", 0.9),
                 # Out-of-range labels — must be silently skipped.
                 ("X", "Y", True, "related_to", 0.9),
             ]

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -10,13 +10,17 @@ import pytest
 
 from services.sleep.edge_discovery import (
     BATCH_SIZE,
+    CONFIDENCE_HISTOGRAM_KEYS,
     DISCOVERY_EDGE_WEIGHT,
     SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD,
     SIMILARITY_MAX,
     SIMILARITY_MIN,
+    BatchStats,
     EdgeDiscoveryPhase,
+    _build_confidence_histogram,
     _is_synthetic_seed_edge,
 )
+from services.sleep.prompts import EDGE_DISCOVERY_PROMPT_REVISION
 from services.sleep.reporter import SleepBudget
 
 
@@ -70,6 +74,60 @@ def _make_edge(edge_type, weight, dst_id=None):
     return e
 
 
+# ---------------------------------------------------------------------------
+# #306 helpers — _llm_judge_batch direct testing
+# ---------------------------------------------------------------------------
+
+
+def _make_llm_response(edges, tokens=100):
+    """Build a canned `complete_json` return value: (response_dict, tokens).
+
+    Each entry in ``edges`` is a tuple of:
+        (label_a, label_b, related: bool, edge_type: str, confidence: float)
+    """
+    return (
+        {
+            "edges": [
+                {
+                    "pair": [a, b],
+                    "related": related,
+                    "edge_type": edge_type,
+                    "confidence": confidence,
+                }
+                for (a, b, related, edge_type, confidence) in edges
+            ]
+        },
+        tokens,
+    )
+
+
+@pytest.fixture
+def deterministic_shuffle(monkeypatch):
+    """Disable random.shuffle in edge_discovery so label assignment is stable."""
+    monkeypatch.setattr("services.sleep.edge_discovery.random.shuffle", lambda x: None)
+
+
+@pytest.fixture
+def llm_judge_phase(edge_phase, deterministic_shuffle):
+    """edge_phase with `complete_json` ready to be stubbed and shuffle pinned."""
+    edge_phase.llm_service.complete_json = AsyncMock()
+    return edge_phase
+
+
+def _make_batch_pair(n=2):
+    """Return ((memory_map, batch), labels) aligned for deterministic A/B/...
+
+    With ``deterministic_shuffle`` active, `_llm_judge_batch` assigns labels
+    in `id_list` order, which is `set(memory_map).insertion_order` from the
+    pair-collection loop. We construct the memories so that the FIRST memory
+    in each pair gets label 'A', the second 'B', etc.
+    """
+    mems = [_make_memory() for _ in range(n)]
+    batch = [(mems[i].id, mems[i + 1].id, 0.75) for i in range(n - 1)]
+    memory_map = {m.id: m for m in mems}
+    return mems, batch, memory_map
+
+
 class TestEdgeDiscoveryPhase:
     """Test EdgeDiscoveryPhase execution."""
 
@@ -93,6 +151,16 @@ class TestEdgeDiscoveryPhase:
         result = await edge_phase.execute(config, "user-1", "ws-1", "ctx-1", budget)
 
         assert result.details["message"] == "no_memories_to_sample"
+        # #306: early-return paths zero-init metric keys.
+        assert result.details["llm_accepted"] == 0
+        assert result.details["llm_rejected"] == 0
+        assert result.details["llm_call_failures"] == 0
+        assert result.details["auto_accepted"] == 0
+        assert result.details["edge_type_dist"] == {}
+        assert result.details["avg_confidence"] == 0.0
+        assert result.details["confidence_histogram"] == dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0)
+        assert result.details["llm_model"] == "gpt-5-nano"
+        assert result.details["prompt_revision"] == EDGE_DISCOVERY_PROMPT_REVISION
 
     @pytest.mark.asyncio
     async def test_no_candidates(self, edge_phase):
@@ -106,6 +174,13 @@ class TestEdgeDiscoveryPhase:
         result = await edge_phase.execute(config, "user-1", "ws-1", "ctx-1", budget)
 
         assert result.details["message"] == "no_edge_candidates"
+        # #306 zero-init.
+        assert result.details["sampled"] == 3
+        assert result.details["candidates"] == 0
+        assert result.details["llm_accepted"] == 0
+        assert result.details["auto_accepted"] == 0
+        assert result.details["confidence_histogram"] == dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0)
+        assert result.details["prompt_revision"] == EDGE_DISCOVERY_PROMPT_REVISION
 
     @pytest.mark.asyncio
     async def test_all_already_connected(self, edge_phase):
@@ -122,6 +197,14 @@ class TestEdgeDiscoveryPhase:
         result = await edge_phase.execute(config, "user-1", "ws-1", "ctx-1", budget)
 
         assert result.details["message"] == "all_candidates_already_connected"
+        # #306 zero-init.
+        assert result.details["sampled"] == 3
+        assert result.details["candidates"] == 1
+        assert result.details["filtered"] == 0
+        assert result.details["llm_accepted"] == 0
+        assert result.details["auto_accepted"] == 0
+        assert result.details["edge_type_dist"] == {}
+        assert result.details["confidence_histogram"] == dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0)
 
     @pytest.mark.asyncio
     async def test_llm_off_accepts_all(self, edge_phase):
@@ -145,6 +228,15 @@ class TestEdgeDiscoveryPhase:
         call_kwargs = edge_phase.edge_repo.create_or_update_edge.call_args[1]
         assert call_kwargs["weight"] == DISCOVERY_EDGE_WEIGHT
         assert call_kwargs["edge_type"] == "related_to"
+        # #306: auto-accept path increments `auto_accepted`, not `llm_accepted`.
+        # avg_confidence / edge_type_dist / histogram stay zero (no pollution).
+        assert result.details["auto_accepted"] == 1
+        assert result.details["llm_accepted"] == 0
+        assert result.details["llm_rejected"] == 0
+        assert result.details["llm_call_failures"] == 0
+        assert result.details["edge_type_dist"] == {}
+        assert result.details["avg_confidence"] == 0.0
+        assert result.details["confidence_histogram"] == dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0)
 
     @pytest.mark.asyncio
     async def test_budget_limits_processing(self, edge_phase):
@@ -332,3 +424,290 @@ class TestFilterExistingEdges:
         )
 
         assert filtered == [(src, dst, 0.75)]
+
+
+# ===========================================================================
+# Issue #306: _llm_judge_batch direct tests + execute() aggregation tests
+# ===========================================================================
+
+
+class TestLLMJudgeBatch:
+    """Direct unit tests for _llm_judge_batch (#306).
+
+    All tests stub `complete_json` and pin `random.shuffle` so the LLM-side
+    contract — counts, edge_type validation, confidence clamping, exception
+    handling — can be exercised hermetically.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_accept(self, llm_judge_phase):
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=3)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                ("A", "B", True, "related_to", 0.9),
+                ("B", "C", True, "depends_on", 0.85),
+            ]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert len(confirmed) == 2
+        assert stats.accepted == 2
+        assert stats.rejected == 0
+        assert stats.failures == 0
+        assert stats.edge_type_counts == {"related_to": 1, "depends_on": 1}
+        assert stats.confidences == [0.9, 0.85]
+
+    @pytest.mark.asyncio
+    async def test_all_reject(self, llm_judge_phase):
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=3)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                ("A", "B", False, "related_to", 0.2),
+                ("B", "C", False, "related_to", 0.3),
+            ]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert confirmed == []
+        assert stats.accepted == 0
+        assert stats.rejected == 2
+        assert stats.failures == 0
+        assert stats.edge_type_counts == {}
+        assert stats.confidences == []
+
+    @pytest.mark.asyncio
+    async def test_mixed_accept_reject(self, llm_judge_phase):
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=3)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                ("A", "B", True, "learned_from", 0.75),
+                ("B", "C", False, "related_to", 0.4),
+            ]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert len(confirmed) == 1
+        assert stats.accepted == 1
+        assert stats.rejected == 1
+        assert stats.edge_type_counts == {"learned_from": 1}
+        assert stats.confidences == [0.75]
+
+    @pytest.mark.asyncio
+    async def test_invalid_edge_type_coerced_to_related_to(self, llm_judge_phase):
+        """Unknown edge_type must be coerced to "related_to" and counted as such."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=2)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [("A", "B", True, "garbage_type", 0.8)]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert len(confirmed) == 1
+        assert confirmed[0][2] == "related_to"
+        assert stats.edge_type_counts == {"related_to": 1}
+        # "garbage_type" must NOT appear in dist
+        assert "garbage_type" not in stats.edge_type_counts
+
+    @pytest.mark.asyncio
+    async def test_invalid_pair_label_skipped(self, llm_judge_phase):
+        """Labels outside the assigned A/B/... range are skipped silently and
+        do NOT count toward accepted or rejected — they are malformed input."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=2)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                ("A", "B", True, "related_to", 0.9),
+                # Out-of-range labels — must be silently skipped.
+                ("X", "Y", True, "related_to", 0.9),
+            ]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert len(confirmed) == 1
+        assert stats.accepted == 1
+        # Malformed pairs (bad labels) must NOT be counted as rejected — they
+        # were never a valid input to begin with.
+        assert stats.rejected == 0
+
+    @pytest.mark.asyncio
+    async def test_confidence_clamped_to_unit_range(self, llm_judge_phase):
+        """Confidence values outside [0.0, 1.0] are clamped before storage."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=3)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                ("A", "B", True, "related_to", 1.5),  # over
+                ("B", "C", True, "related_to", -0.3),  # under
+            ]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert stats.accepted == 2
+        assert stats.confidences == [1.0, 0.0]
+        assert confirmed[0][3] == 1.0
+        assert confirmed[1][3] == 0.0
+
+    @pytest.mark.asyncio
+    async def test_complete_json_raises_increments_failures(self, llm_judge_phase):
+        """Exception in complete_json yields ([], BatchStats(failures=1))."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=2)
+
+        llm_judge_phase.llm_service.complete_json.side_effect = RuntimeError("LLM down")
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert confirmed == []
+        assert stats.accepted == 0
+        assert stats.rejected == 0
+        assert stats.failures == 1
+        assert stats.edge_type_counts == {}
+        assert stats.confidences == []
+
+
+class TestExecuteAggregation:
+    """`execute()` aggregates BatchStats across multiple batches (#306)."""
+
+    @pytest.mark.asyncio
+    async def test_multi_batch_aggregation(self, llm_judge_phase):
+        """With BATCH_SIZE=5 and 6 candidates, _llm_judge_batch is called twice
+        and execute() aggregates accepted/rejected/edge_type/confidences."""
+        config = _make_config()
+        budget = SleepBudget()
+
+        # Build 7 memories so we get 6 pairs (= 2 batches at BATCH_SIZE=5)
+        mems = [_make_memory() for _ in range(7)]
+        candidates = [(mems[i].id, mems[i + 1].id, 0.75) for i in range(6)]
+
+        llm_judge_phase._sample_memories = AsyncMock(return_value=mems)
+        llm_judge_phase._find_candidates = AsyncMock(return_value=candidates)
+        llm_judge_phase._filter_existing_edges = AsyncMock(return_value=candidates)
+        llm_judge_phase.edge_repo.create_or_update_edge = AsyncMock()
+
+        # Stub _llm_judge_batch directly so we control batch_stats per call.
+        async def fake_judge(batch, *args, **kwargs):
+            if len(batch) == 5:
+                # First batch: 3 accepted, 2 rejected
+                stats = BatchStats(
+                    accepted=3,
+                    rejected=2,
+                    edge_type_counts={"related_to": 2, "depends_on": 1},
+                    confidences=[0.9, 0.7, 0.55],
+                )
+                confirmed = [
+                    (batch[0][0], batch[0][1], "related_to", 0.9),
+                    (batch[1][0], batch[1][1], "related_to", 0.7),
+                    (batch[2][0], batch[2][1], "depends_on", 0.55),
+                ]
+                return confirmed, stats
+            # Second batch: 1 accepted, 0 rejected
+            stats = BatchStats(
+                accepted=1,
+                rejected=0,
+                edge_type_counts={"learned_from": 1},
+                confidences=[0.95],
+            )
+            confirmed = [(batch[0][0], batch[0][1], "learned_from", 0.95)]
+            return confirmed, stats
+
+        llm_judge_phase._llm_judge_batch = fake_judge
+
+        result = await llm_judge_phase.execute(config, "user-1", "ws-1", "ctx-1", budget)
+
+        assert result.details["llm_accepted"] == 4
+        assert result.details["llm_rejected"] == 2
+        assert result.details["llm_call_failures"] == 0
+        assert result.details["auto_accepted"] == 0
+        assert result.details["edge_type_dist"] == {
+            "related_to": 2,
+            "depends_on": 1,
+            "learned_from": 1,
+        }
+        # avg = (0.9 + 0.7 + 0.55 + 0.95) / 4 = 0.775
+        assert result.details["avg_confidence"] == pytest.approx(0.775)
+        # 0.55 → "0.5-0.7", 0.7 → "0.7-0.85", 0.9 → "0.85-1.0", 0.95 → "0.85-1.0"
+        assert result.details["confidence_histogram"] == {
+            "0.0-0.5": 0,
+            "0.5-0.7": 1,
+            "0.7-0.85": 1,
+            "0.85-1.0": 2,
+        }
+        assert result.details["llm_model"] == "gpt-5-nano"
+        assert result.details["prompt_revision"] == EDGE_DISCOVERY_PROMPT_REVISION
+
+
+class TestConfidenceHistogram:
+    """Bucket boundary semantics for `_build_confidence_histogram` (#306).
+
+    Convention: right-open `[a, b)` for the first three buckets, last bucket
+    `[0.85, 1.0]` inclusive at 1.0. Boundary values 0.5 / 0.7 / 0.85 fall into
+    the higher bucket.
+    """
+
+    def test_empty_returns_all_zero(self):
+        h = _build_confidence_histogram([])
+        assert h == dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0)
+
+    def test_boundary_0_5_goes_to_upper_bucket(self):
+        assert _build_confidence_histogram([0.5])["0.5-0.7"] == 1
+        assert _build_confidence_histogram([0.5])["0.0-0.5"] == 0
+
+    def test_boundary_0_7_goes_to_upper_bucket(self):
+        assert _build_confidence_histogram([0.7])["0.7-0.85"] == 1
+        assert _build_confidence_histogram([0.7])["0.5-0.7"] == 0
+
+    def test_boundary_0_85_goes_to_upper_bucket(self):
+        assert _build_confidence_histogram([0.85])["0.85-1.0"] == 1
+        assert _build_confidence_histogram([0.85])["0.7-0.85"] == 0
+
+    def test_one_point_zero_included_in_last_bucket(self):
+        """Last bucket is right-inclusive — 1.0 must not fall off the end."""
+        assert _build_confidence_histogram([1.0])["0.85-1.0"] == 1
+
+    def test_zero_goes_to_first_bucket(self):
+        assert _build_confidence_histogram([0.0])["0.0-0.5"] == 1
+
+    def test_distribution_count(self):
+        h = _build_confidence_histogram([0.1, 0.4, 0.5, 0.6, 0.7, 0.8, 0.85, 0.9, 1.0])
+        assert h == {
+            "0.0-0.5": 2,  # 0.1, 0.4
+            "0.5-0.7": 2,  # 0.5, 0.6
+            "0.7-0.85": 2,  # 0.7, 0.8
+            "0.85-1.0": 3,  # 0.85, 0.9, 1.0
+        }

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -120,13 +120,26 @@ def _make_batch_pair(n=2):
     `_llm_judge_batch` assigns labels by sorting all memory IDs by ``str(id)``
     before mapping them to A/B/.... The ``deterministic_shuffle`` fixture only
     disables the later `random.shuffle` used for display order; it does not
-    control label assignment itself. We construct the memories so the expected
-    labels can be derived from that sorted-ID mapping.
+    control label assignment itself. Use ``_labels_for(memory_map)`` to derive
+    the actual label assignment when constructing canned LLM responses.
     """
     mems = [_make_memory() for _ in range(n)]
     batch = [(mems[i].id, mems[i + 1].id, 0.75) for i in range(n - 1)]
     memory_map = {m.id: m for m in mems}
     return mems, batch, memory_map
+
+
+def _labels_for(memory_map):
+    """Return {memory_id: label} matching `_llm_judge_batch`'s sorted assignment.
+
+    `_llm_judge_batch` does `id_list = sorted(all_ids, key=str)` then assigns
+    labels A, B, C, ... in that order. Tests that construct canned LLM
+    responses must use labels derived from this same mapping — hardcoded
+    ("A", "B") would only work by coincidence on UUIDs that happen to sort
+    in insertion order. Loop 4 hallucination guard rejects pairs not in the
+    requested batch, so wrong labels manifest as silent test failures.
+    """
+    return {mid: chr(ord("A") + i) for i, mid in enumerate(sorted(memory_map.keys(), key=str))}
 
 
 class TestEdgeDiscoveryPhase:
@@ -445,11 +458,12 @@ class TestLLMJudgeBatch:
         config = _make_config()
         budget = SleepBudget()
         _, batch, memory_map = _make_batch_pair(n=3)
+        labels = _labels_for(memory_map)
 
         llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
             [
-                ("A", "B", True, "related_to", 0.9),
-                ("B", "C", True, "depends_on", 0.85),
+                (labels[batch[0][0]], labels[batch[0][1]], True, "related_to", 0.9),
+                (labels[batch[1][0]], labels[batch[1][1]], True, "depends_on", 0.85),
             ]
         )
 
@@ -469,11 +483,12 @@ class TestLLMJudgeBatch:
         config = _make_config()
         budget = SleepBudget()
         _, batch, memory_map = _make_batch_pair(n=3)
+        labels = _labels_for(memory_map)
 
         llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
             [
-                ("A", "B", False, "related_to", 0.2),
-                ("B", "C", False, "related_to", 0.3),
+                (labels[batch[0][0]], labels[batch[0][1]], False, "related_to", 0.2),
+                (labels[batch[1][0]], labels[batch[1][1]], False, "related_to", 0.3),
             ]
         )
 
@@ -493,11 +508,12 @@ class TestLLMJudgeBatch:
         config = _make_config()
         budget = SleepBudget()
         _, batch, memory_map = _make_batch_pair(n=3)
+        labels = _labels_for(memory_map)
 
         llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
             [
-                ("A", "B", True, "learned_from", 0.75),
-                ("B", "C", False, "related_to", 0.4),
+                (labels[batch[0][0]], labels[batch[0][1]], True, "learned_from", 0.75),
+                (labels[batch[1][0]], labels[batch[1][1]], False, "related_to", 0.4),
             ]
         )
 
@@ -564,11 +580,12 @@ class TestLLMJudgeBatch:
         config = _make_config()
         budget = SleepBudget()
         _, batch, memory_map = _make_batch_pair(n=3)
+        labels = _labels_for(memory_map)
 
         llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
             [
-                ("A", "B", True, "related_to", 1.5),  # over
-                ("B", "C", True, "related_to", -0.3),  # under
+                (labels[batch[0][0]], labels[batch[0][1]], True, "related_to", 1.5),  # over
+                (labels[batch[1][0]], labels[batch[1][1]], True, "related_to", -0.3),  # under
             ]
         )
 
@@ -604,6 +621,46 @@ class TestLLMJudgeBatch:
         # retries. Pre-fix, budget.consume(llm_calls=1) ran only on success
         # → max_llm_calls would be ignored when the LLM is failing.
         assert budget.llm_calls_used == 1
+
+    @pytest.mark.asyncio
+    async def test_hallucinated_pair_rejected(self, llm_judge_phase):
+        """Loop 4 fix: LLM may return pairs that were never in the requested
+        batch (hallucination). Such pairs MUST be silently dropped — they do
+        NOT contribute to accepted/rejected, do NOT create edges, and must
+        not inflate observability metrics. Orientation-agnostic match: the
+        LLM may flip the pair order; that is allowed and counted as a real
+        response, but a fully unrequested pair is not.
+        """
+        config = _make_config()
+        budget = SleepBudget()
+        # 3 memories: A, B, C. We request only the (A, B) pair.
+        mems = [_make_memory() for _ in range(3)]
+        memory_map = {m.id: m for m in mems}
+        # Sort to match production label assignment order. Only A and B are
+        # used in the requested batch — C exists in memory_map but is NOT in
+        # the batch, so any LLM-returned pair containing C must be rejected.
+        sorted_ids = sorted(memory_map.keys(), key=str)
+        a_id, b_id = sorted_ids[0], sorted_ids[1]
+        batch = [(a_id, b_id, 0.75)]  # only (A, B) requested
+
+        # LLM hallucinates: returns the requested (A, B) AND an unrequested (A, C).
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                ("A", "B", True, "related_to", 0.9),
+                ("A", "C", True, "related_to", 0.8),  # hallucinated — never asked
+            ]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        # Only the requested (A, B) is accepted; (A, C) is silently dropped.
+        assert len(confirmed) == 1
+        assert stats.accepted == 1
+        assert stats.rejected == 0  # hallucinated pairs are dropped, not rejected
+        assert stats.confidences == [0.9]
+        assert stats.edge_type_counts == {"related_to": 1}
 
     @pytest.mark.asyncio
     async def test_dst_outside_memory_map_skips_pair_no_keyerror(self, llm_judge_phase):

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -175,6 +175,12 @@ class TestEdgeDiscoveryPhase:
         assert result.details["confidence_histogram"] == dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0)
         assert result.details["llm_model"] == "gpt-5-nano"
         assert result.details["prompt_revision"] == EDGE_DISCOVERY_PROMPT_REVISION
+        # PhD review additions (#306 follow-up): all summary stats zero, n=0
+        assert result.details["median_confidence"] == 0.0
+        assert result.details["p25_confidence"] == 0.0
+        assert result.details["p75_confidence"] == 0.0
+        assert result.details["confidence_n"] == 0
+        assert result.details["confidence_imputed"] == 0
 
     @pytest.mark.asyncio
     async def test_no_candidates(self, edge_phase):
@@ -767,6 +773,133 @@ class TestExecuteAggregation:
         }
         assert result.details["llm_model"] == "gpt-5-nano"
         assert result.details["prompt_revision"] == EDGE_DISCOVERY_PROMPT_REVISION
+        # PhD review additions (#306 follow-up): 5-number summary + sample size
+        # confidences = [0.9, 0.7, 0.55, 0.95] → sorted [0.55, 0.7, 0.9, 0.95]
+        # statistics.quantiles default (exclusive Tukey method) on n=4:
+        #   position formula: i * (n+1) / 4 where n = len(data)
+        #   i=1: pos 1.25 → 0.55 + 0.25*(0.7-0.55) = 0.5875
+        #   i=2: pos 2.50 → 0.70 + 0.50*(0.9-0.70) = 0.8000 (median)
+        #   i=3: pos 3.75 → 0.90 + 0.75*(0.95-0.9) = 0.9375
+        assert result.details["median_confidence"] == pytest.approx(0.8)
+        assert result.details["p25_confidence"] == pytest.approx(0.5875)
+        assert result.details["p75_confidence"] == pytest.approx(0.9375)
+        assert result.details["confidence_n"] == 4
+        assert result.details["confidence_imputed"] == 0
+
+
+class TestConfidenceImputed:
+    """Confirm that NaN/Inf confidence values are tracked, not silently lost (#306)."""
+
+    @pytest.mark.asyncio
+    async def test_nan_confidence_imputed_and_counted(self, llm_judge_phase):
+        """LLM returning NaN confidence is replaced with 0.5, and the counter
+        increments. Prevents silent imputation from masking prompt/model issues."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=3)
+        labels = _labels_for(memory_map)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                (labels[batch[0][0]], labels[batch[0][1]], True, "related_to", float("nan")),
+                (labels[batch[1][0]], labels[batch[1][1]], True, "related_to", float("inf")),
+            ]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert stats.accepted == 2
+        assert stats.confidence_imputed == 2
+        # Both confidences imputed to 0.5 → fall in [0.5, 0.7) bucket
+        assert stats.confidences == [0.5, 0.5]
+
+
+class TestMetricsAliasing:
+    """Defensive copy in _metrics_from_agg prevents result.details from
+    aliasing the live BatchStats / histogram (#306 PhD-review fix)."""
+
+    @pytest.mark.asyncio
+    async def test_result_details_does_not_alias_agg(self, llm_judge_phase):
+        """After execute() returns, mutating agg.edge_type_counts must NOT
+        affect result.details["edge_type_dist"]. Pre-fix this would silently
+        corrupt the recorded snapshot if any post-emit code touched agg."""
+        config = _make_config()
+        budget = SleepBudget()
+        mems = [_make_memory() for _ in range(3)]
+        candidates = [(mems[0].id, mems[1].id, 0.75), (mems[1].id, mems[2].id, 0.75)]
+
+        llm_judge_phase._sample_memories = AsyncMock(return_value=mems)
+        llm_judge_phase._find_candidates = AsyncMock(return_value=candidates)
+        llm_judge_phase._filter_existing_edges = AsyncMock(return_value=candidates)
+        llm_judge_phase.edge_repo.create_or_update_edge = AsyncMock()
+
+        # Stub _llm_judge_batch to return a known shape with mutable state.
+        async def fake_judge(batch, *args, **kwargs):
+            stats = BatchStats(
+                accepted=1,
+                edge_type_counts={"related_to": 1},
+                confidences=[0.8],
+            )
+            confirmed = [(batch[0][0], batch[0][1], "related_to", 0.8)]
+            return confirmed, stats
+
+        llm_judge_phase._llm_judge_batch = fake_judge
+
+        result = await llm_judge_phase.execute(config, "user-1", "ws-1", "ctx-1", budget)
+
+        # Snapshot the dict reference, then mutate the source structures
+        # (simulating future code that touches agg or histogram after emit).
+        recorded_dist = result.details["edge_type_dist"]
+        recorded_hist = result.details["confidence_histogram"]
+        assert recorded_dist == {"related_to": 1}
+
+        # Mutate the recorded dict — the source must NOT change because they
+        # are independent objects after defensive copy.
+        recorded_dist["related_to"] = 999
+        recorded_hist["0.85-1.0"] = 999
+
+        # Re-read from result.details — the pre-mutation snapshot is preserved
+        # in NEITHER copy of the dict (because they're the same object), but
+        # the point of the defensive copy is that mutation here does NOT
+        # propagate to internal aggregator state. The assertion below would
+        # fail PRE-fix because result.details["edge_type_dist"] would alias
+        # the live BatchStats dict (now extinct, but the principle holds for
+        # any future post-emit reader).
+        assert result.details["edge_type_dist"] is recorded_dist  # the same object
+        assert result.details["edge_type_dist"]["related_to"] == 999  # mutation persists
+        # The defensive copy guarantees result.details was NOT a reference to
+        # the (now-discarded) `agg` instance — proven by the fact that we can
+        # mutate result.details freely without affecting the source.
+
+    def test_metrics_from_agg_returns_independent_dicts(self):
+        """Direct test: _metrics_from_agg copies edge_type_counts and the
+        histogram so callers can mutate freely."""
+        from services.sleep.edge_discovery import (
+            _build_confidence_histogram,
+            _metrics_from_agg,
+            _summarize_confidences,
+        )
+
+        agg = BatchStats(
+            accepted=2,
+            edge_type_counts={"related_to": 1, "depends_on": 1},
+            confidences=[0.6, 0.9],
+        )
+        hist = _build_confidence_histogram(agg.confidences)
+        summary = _summarize_confidences(agg.confidences)
+        config = _make_config()
+
+        emitted = _metrics_from_agg(agg, 0, summary, hist, config)
+
+        # Mutate the emitted dict's mutable fields.
+        emitted["edge_type_dist"]["NEW_KEY"] = 42
+        emitted["confidence_histogram"]["0.0-0.5"] = 999
+
+        # Source data MUST be unchanged (defensive copy worked).
+        assert "NEW_KEY" not in agg.edge_type_counts
+        assert hist["0.0-0.5"] == 0
 
 
 class TestConfidenceHistogram:

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -117,10 +117,11 @@ def llm_judge_phase(edge_phase, deterministic_shuffle):
 def _make_batch_pair(n=2):
     """Return ((memory_map, batch), labels) aligned for deterministic A/B/...
 
-    With ``deterministic_shuffle`` active, `_llm_judge_batch` assigns labels
-    in `id_list` order, which is `set(memory_map).insertion_order` from the
-    pair-collection loop. We construct the memories so that the FIRST memory
-    in each pair gets label 'A', the second 'B', etc.
+    `_llm_judge_batch` assigns labels by sorting all memory IDs by ``str(id)``
+    before mapping them to A/B/.... The ``deterministic_shuffle`` fixture only
+    disables the later `random.shuffle` used for display order; it does not
+    control label assignment itself. We construct the memories so the expected
+    labels can be derived from that sorted-ID mapping.
     """
     mems = [_make_memory() for _ in range(n)]
     batch = [(mems[i].id, mems[i + 1].id, 0.75) for i in range(n - 1)]
@@ -599,6 +600,10 @@ class TestLLMJudgeBatch:
         assert stats.failures == 1
         assert stats.edge_type_counts == {}
         assert stats.confidences == []
+        # Loop 2 fix: failed attempts must consume budget to prevent runaway
+        # retries. Pre-fix, budget.consume(llm_calls=1) ran only on success
+        # → max_llm_calls would be ignored when the LLM is failing.
+        assert budget.llm_calls_used == 1
 
     @pytest.mark.asyncio
     async def test_dst_outside_memory_map_skips_pair_no_keyerror(self, llm_judge_phase):

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -775,14 +775,15 @@ class TestExecuteAggregation:
         assert result.details["prompt_revision"] == EDGE_DISCOVERY_PROMPT_REVISION
         # PhD review additions (#306 follow-up): 5-number summary + sample size
         # confidences = [0.9, 0.7, 0.55, 0.95] → sorted [0.55, 0.7, 0.9, 0.95]
-        # statistics.quantiles default (exclusive Tukey method) on n=4:
-        #   position formula: i * (n+1) / 4 where n = len(data)
-        #   i=1: pos 1.25 → 0.55 + 0.25*(0.7-0.55) = 0.5875
-        #   i=2: pos 2.50 → 0.70 + 0.50*(0.9-0.70) = 0.8000 (median)
-        #   i=3: pos 3.75 → 0.90 + 0.75*(0.95-0.9) = 0.9375
+        # statistics.quantiles(n=4, method="inclusive") on n=4:
+        #   position formula: (n-1) * i/4 where n = len(data)
+        #   i=1: pos 0.75 → 0.55 + 0.75*(0.7-0.55) = 0.6625
+        #   i=2: pos 1.50 → 0.70 + 0.50*(0.9-0.70) = 0.8000 (median)
+        #   i=3: pos 2.25 → 0.90 + 0.25*(0.95-0.9) = 0.9125
+        # Inclusive method ensures small-N quartiles stay in [min(data), max(data)].
         assert result.details["median_confidence"] == pytest.approx(0.8)
-        assert result.details["p25_confidence"] == pytest.approx(0.5875)
-        assert result.details["p75_confidence"] == pytest.approx(0.9375)
+        assert result.details["p25_confidence"] == pytest.approx(0.6625)
+        assert result.details["p75_confidence"] == pytest.approx(0.9125)
         assert result.details["confidence_n"] == 4
         assert result.details["confidence_imputed"] == 0
 
@@ -818,60 +819,48 @@ class TestConfidenceImputed:
 
 class TestMetricsAliasing:
     """Defensive copy in _metrics_from_agg prevents result.details from
-    aliasing the live BatchStats / histogram (#306 PhD-review fix)."""
+    aliasing the live BatchStats / histogram (#306 PhD-review fix).
 
-    @pytest.mark.asyncio
-    async def test_result_details_does_not_alias_agg(self, llm_judge_phase):
-        """After execute() returns, mutating agg.edge_type_counts must NOT
-        affect result.details["edge_type_dist"]. Pre-fix this would silently
-        corrupt the recorded snapshot if any post-emit code touched agg."""
-        config = _make_config()
-        budget = SleepBudget()
-        mems = [_make_memory() for _ in range(3)]
-        candidates = [(mems[0].id, mems[1].id, 0.75), (mems[1].id, mems[2].id, 0.75)]
+    Note: this contract is verified directly via _metrics_from_agg unit test
+    rather than an end-to-end execute() test — the unit test captures the
+    source data structures and proves mutation isolation, which is the
+    precise invariant the defensive copy provides. An end-to-end test that
+    only mutates the result dict cannot demonstrate aliasing was prevented.
+    """
 
-        llm_judge_phase._sample_memories = AsyncMock(return_value=mems)
-        llm_judge_phase._find_candidates = AsyncMock(return_value=candidates)
-        llm_judge_phase._filter_existing_edges = AsyncMock(return_value=candidates)
-        llm_judge_phase.edge_repo.create_or_update_edge = AsyncMock()
+    def test_summarize_confidences_inclusive_quartiles_bounded(self):
+        """Loop FB fix: small-N quartiles MUST stay within [min(data), max(data)].
 
-        # Stub _llm_judge_batch to return a known shape with mutable state.
-        async def fake_judge(batch, *args, **kwargs):
-            stats = BatchStats(
-                accepted=1,
-                edge_type_counts={"related_to": 1},
-                confidences=[0.8],
-            )
-            confirmed = [(batch[0][0], batch[0][1], "related_to", 0.8)]
-            return confirmed, stats
+        statistics.quantiles default ("exclusive" Tukey method) extrapolates
+        outside the data range for n=2 and n=3 — uninterpretable when the
+        underlying data is clamped to [0, 1]. We use method="inclusive" to
+        guarantee p25/p75 ∈ [min, max] of the observed confidences.
+        """
+        from services.sleep.edge_discovery import _summarize_confidences
 
-        llm_judge_phase._llm_judge_batch = fake_judge
+        # n=2 case
+        s2 = _summarize_confidences([0.5, 0.9])
+        assert 0.5 <= s2.p25 <= 0.9
+        assert 0.5 <= s2.p75 <= 0.9
+        # Inclusive on n=2: positions are (n-1)*i/4 = 1*0.25 = 0.25 and 1*0.75 = 0.75
+        # Q1 = 0.5 + 0.25*(0.9-0.5) = 0.6; Q3 = 0.5 + 0.75*0.4 = 0.8
+        assert s2.p25 == pytest.approx(0.6)
+        assert s2.p75 == pytest.approx(0.8)
 
-        result = await llm_judge_phase.execute(config, "user-1", "ws-1", "ctx-1", budget)
+        # n=3 case
+        s3 = _summarize_confidences([0.5, 0.7, 0.9])
+        assert 0.5 <= s3.p25 <= 0.9
+        assert 0.5 <= s3.p75 <= 0.9
+        # Inclusive on n=3: positions are 2*0.25=0.5 and 2*0.75=1.5
+        # Q1 = 0.5 + 0.5*(0.7-0.5) = 0.6; Q3 = 0.7 + 0.5*(0.9-0.7) = 0.8
+        assert s3.p25 == pytest.approx(0.6)
+        assert s3.p75 == pytest.approx(0.8)
 
-        # Snapshot the dict reference, then mutate the source structures
-        # (simulating future code that touches agg or histogram after emit).
-        recorded_dist = result.details["edge_type_dist"]
-        recorded_hist = result.details["confidence_histogram"]
-        assert recorded_dist == {"related_to": 1}
-
-        # Mutate the recorded dict — the source must NOT change because they
-        # are independent objects after defensive copy.
-        recorded_dist["related_to"] = 999
-        recorded_hist["0.85-1.0"] = 999
-
-        # Re-read from result.details — the pre-mutation snapshot is preserved
-        # in NEITHER copy of the dict (because they're the same object), but
-        # the point of the defensive copy is that mutation here does NOT
-        # propagate to internal aggregator state. The assertion below would
-        # fail PRE-fix because result.details["edge_type_dist"] would alias
-        # the live BatchStats dict (now extinct, but the principle holds for
-        # any future post-emit reader).
-        assert result.details["edge_type_dist"] is recorded_dist  # the same object
-        assert result.details["edge_type_dist"]["related_to"] == 999  # mutation persists
-        # The defensive copy guarantees result.details was NOT a reference to
-        # the (now-discarded) `agg` instance — proven by the fact that we can
-        # mutate result.details freely without affecting the source.
+        # n=1 → quartiles collapse to median
+        s1 = _summarize_confidences([0.7])
+        assert s1.p25 == 0.7
+        assert s1.median == 0.7
+        assert s1.p75 == 0.7
 
     def test_metrics_from_agg_returns_independent_dicts(self):
         """Direct test: _metrics_from_agg copies edge_type_counts and the

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -600,6 +600,41 @@ class TestLLMJudgeBatch:
         assert stats.edge_type_counts == {}
         assert stats.confidences == []
 
+    @pytest.mark.asyncio
+    async def test_dst_outside_memory_map_skips_pair_no_keyerror(self, llm_judge_phase):
+        """Issue #369: when `_find_candidates` returns a pair whose `dst` is
+        outside the sampled batch (the normal case in production with
+        sample_size=30 and corpus≥100), `_llm_judge_batch` MUST NOT raise
+        `KeyError` on `id_to_label[dst]`. Instead, the pair is silently
+        skipped — it was never judged, so it counts toward neither accepted
+        nor rejected nor failures.
+        """
+        config = _make_config()
+        budget = SleepBudget()
+
+        # Build a batch with 1 pair where src IS in memory_map but dst is NOT.
+        mem_a = _make_memory()
+        unknown_dst = uuid4()
+        batch = [(mem_a.id, unknown_dst, 0.75)]
+        memory_map = {mem_a.id: mem_a}
+
+        # complete_json should NOT be called — the batch has no judgable pair
+        # after filtering. We assert this below.
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        # Pre-fix this raised KeyError before complete_json ever ran. Post-fix,
+        # the pair is silently skipped and the batch returns the empty result.
+        assert confirmed == []
+        assert stats.accepted == 0
+        assert stats.rejected == 0
+        # CRITICAL: failures stays 0 — the LLM was never called, this is
+        # a "nothing to judge" path, not a "judging failed" path.
+        assert stats.failures == 0
+        # complete_json was not invoked: skipped before the LLM call.
+        llm_judge_phase.llm_service.complete_json.assert_not_called()
+
 
 class TestExecuteAggregation:
     """`execute()` aggregates BatchStats across multiple batches (#306)."""


### PR DESCRIPTION
Closes #306, Closes #369

## Summary
- Add 14 LLM Judge observability metrics to `services/sleep/edge_discovery.py:execute()` — original 9 (`llm_accepted/rejected/call_failures`, `auto_accepted`, `edge_type_dist`, `avg_confidence`, `confidence_histogram`, `llm_model`, `prompt_revision`) plus PhD-review additions (`median_confidence`, `p25_confidence`, `p75_confidence`, `confidence_n`, `confidence_imputed`)
- `BatchStats` `@dataclass` returned from `_llm_judge_batch` carries per-batch counts; `execute()` aggregates across batches; `ConfidenceSummary` helper handles small-N safe quantile computation
- Add `EDGE_DISCOVERY_PROMPT_REVISION = "v1"` constant in `services/sleep/prompts.py` for sleep_reports drift detection across prompt edits
- Resolves #369 (silent KeyError when Qdrant dst is outside sampled batch) via `pair_lines` skip-filter consistency + new unit test
- 16 new unit tests + 1 MCP round-trip test (replaces the original "manual test" criterion in the issue body); 118 sleep suite tests pass with no regression

## Implementation notes
- **Internal API change**: `_llm_judge_batch` return shape changed from `list[(uuid, uuid, str, float)]` to `tuple[list, BatchStats]`. Private method (`_` prefix), only `execute()` calls it. No external ripple.
- **`reporter.py` change: 0 lines** — issue body explicitly required "no new column needed"; new metrics flow through existing `PhaseResult.details: dict | None` boundary into `sleep_reports.edge_discovery_result` JSON column. Verified end-to-end via `test_get_sleep_report_includes_edge_discovery_metrics`.
- **MCP integration: 0 changes** — `mcp_server/tools/sleep.py:_report_to_detail` already returns `report.edge_discovery_result` verbatim; new metric keys reach MCP response automatically.
- **Auto-accept path separation**: `auto_accepted` counter (LLM-disabled path) is kept distinct from `llm_accepted` so the operational toggle does NOT pollute LLM quality signals (`avg_confidence`, `confidence_histogram`, `edge_type_dist`).
- **NaN/Inf guard via `math.isfinite()`** prevents pathological LLM responses from silently landing in the highest histogram bucket (NaN comparisons all return False) and from breaking JSON-strict serialization of `avg_confidence`. `confidence_imputed` counter surfaces silent imputation count.
- **5-number summary** (`avg`/`median`/`p25`/`p75`/`n`) replaces single-mean reporting per Stats PhD review — `avg` alone is structurally inadequate for bimodal data, the very phenomenon pilot #249 motivated this metric to detect.
- **Defensive copy** of mutable fields in `_metrics_from_agg` prevents `result.details` from aliasing live `BatchStats` / working dicts.
- **Histogram buckets**: 4 right-open `[a, b)` boundaries with last bucket `[0.85, 1.0]` inclusive at 1.0. Boundary semantics chosen to detect bimodal confidence distribution (pilot #249 root finding: prompt ambiguity surfaces as bimodality).
- **`_metrics_from_agg` single source of truth** — `_empty_metrics()` (early-return paths) and the `execute()` success path both go through one helper.
- **Backward compat**: existing `sleep_reports` rows lack new fields; reader-side `.get(key, default)` handles absence — no DB migration.
- **Known limitation (#373)**: `requested_pairs` uses orientation-agnostic `frozenset` match for hallucination guard. For directed edge_types (`depends_on`, `learned_from`), this could silently accept LLM-flipped pair order. Documented in source code comment; fix tracked separately.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CAIO routing)
- review provider: copilot
- post-Copilot: PhD Panel review (stats + ds + pl) ran 3 lenses in parallel; 5 in-PR fixes applied (5-number summary, confidence_n, confidence_imputed, defensive copy, frozenset docstring)

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/306-feat-chore-sleep-add-edge-discovery-productio.gate1.md
- ~/.claude/cache/gh-issue-driven/306-feat-chore-sleep-add-edge-discovery-productio.gate2.md

## Related follow-ups (filed as separate issues)

**Pre-Copilot:**
- #369 — pre-existing `KeyError` in `_llm_judge_batch` when Qdrant `dst` is outside sampled batch — **resolved by this PR (Closes #369)**
- #370 — project-wide SQLAlchemy 1.x → 2.0 `Mapped[T]` migration (Pyright type-noise reduction, v0.13.0 cleanup)

**Post-PhD-review (filed alongside the in-PR additions):**
- #372 — rejected-side confidence + cross-run bimodality detection for edge_discovery (v0.13.0). PhD `/stats` flagged that current `confidence_histogram` is conditional on `decision=accept`; rejected-side retention + cross-run aggregation tooling (Hartigan dip test) gives full decision-boundary visibility.
- #373 — preserve pair direction for directed edge_types in `_llm_judge_batch` (v0.12.1, **bug**). PhD `/pl` flagged that the loop-4 `frozenset` hallucination guard silently allows the LLM to flip pair order; for `depends_on` / `learned_from` this can store edges in the wrong direction. Documented in source as KNOWN LIMITATION; fix tracked here.
- #374 — `ConfirmedEdge` dataclass refactor to replace `_llm_judge_batch` return 4-tuple (v0.13.0). PhD `/pl` flagged the inner `tuple[UUID, UUID, str, float]` is stringly-typed; named-access dataclass + `Literal` edge_type would catch swap/garbage values at type-check time.
- #375 — redesign offline eval labeling protocol with IAA gate, as the proper successor to #274 (v0.13.0). PhD `/ds` flagged that "production observation replaces offline eval" is a **category error** — they measure different things. #274 was closed because labeling was hard, not because evaluation should be abandoned.

## Note on monitoring vs evaluation

This PR adds a **monitoring layer** for the LLM Judge — operational signals (call failures, accept rate, confidence distribution shape, prompt revision tracking). It does NOT provide evaluation in the formal sense (no ground truth, no A/B comparison framework). For correctness assessment of the LLM Judge, see #375.

🤖 Generated via /gh-issue-driven:ship
