### PR TITLE
feat(observability): BM25 IDF drift tracking (preview) (#343)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -191,6 +191,18 @@ BILLING_ENABLED=false
 # PLAN_PRO_MCP_CALLS_PER_DAY=50000
 
 # -----------------------------------------------------------------------------
+# BM25 IDF Drift Observability (Issue #343)
+# -----------------------------------------------------------------------------
+# Tracks BM25 IDF distribution drift in the kagura_memories collection.
+# DISABLED BY DEFAULT in v0.12.1; production enablement is scheduled for
+# v0.14.0 (after #359 Privacy Policy and #360 right-to-erasure land).
+# Mirrors the sleep_enabled gating pattern (env-only feature flag).
+#
+# BM25_DRIFT_CRON_ENABLED=false   # set to "true" to register the daily cron
+# BM25_DRIFT_CRON_HOUR=3          # UTC hour, default 3 (offset from sleep at 2)
+# BM25_DRIFT_CRON_MINUTE=0
+
+# -----------------------------------------------------------------------------
 # Production Deployment
 # -----------------------------------------------------------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Release notes are published on [GitHub Releases](https://github.com/kagura-ai/memory-cloud/releases).
 
+## v0.12.1 — Unreleased
+
+### Added (preview, disabled by default)
+- **BM25 IDF drift observability** (#343, infrastructure only): new `bm25_idf_drift_log` table, daily cron computing per-context Population Stability Index (PSI) of memory-only vs collection-global BM25 IDF distributions, and admin API at `/api/v1/admin/bm25-drift/`. Cron is gated by `BM25_DRIFT_CRON_ENABLED=false` and remains off in production until v0.14.0 (blocked on #359 Privacy Policy and #360 right-to-erasure). The OpenAPI tag is `bm25-drift (preview)` and only the manual trigger (`POST /admin/bm25-drift/run`) is intended for use in v0.12.1, scoped to dev/staging verification. PSI is computed per Stats PhD spec (rare-term filter via Cochran's rule, 10 quantile bins on `IDF_memory`, ε-smoothing) with `M >= 100` and `|T| >= 50` min-N gates that emit `psi_status="insufficient_data"` rather than a misleading scalar. Stored term entries are mmh3 hashes (no plaintext token storage).
+
+### Database
+- Added migration `a98_bm25_idf_drift_log`: `bm25_idf_drift_log` table with `psi NUMERIC(10,6)`, JSONB `top_divergent_terms`, `psi_status` CHECK enum, an integrity CHECK that pins `psi IS NULL ⇔ psi_status='insufficient_data'`, and three indexes including a partial alerted-status index. CASCADE deletes on context removal so right-to-erasure (#360) sweeps drift rows without an extra hop.
+
 ## [v0.12.0](https://github.com/kagura-ai/memory-cloud/releases/tag/v0.12.0) — 2026-04-16
 
 ### Highlights

--- a/backend/alembic/versions/a98_bm25_idf_drift_log.py
+++ b/backend/alembic/versions/a98_bm25_idf_drift_log.py
@@ -1,0 +1,103 @@
+"""Add bm25_idf_drift_log table.
+
+Issue #343: BM25 IDF drift observability for the kagura_memories collection.
+
+The cron task (disabled by default; gated by BM25_DRIFT_CRON_ENABLED env var)
+walks each context's per-context Qdrant collection slice, computes
+Population Stability Index (PSI) of the IDF distribution between memory-only
+and collection-global term frequencies, and writes one row here per context
+per cycle. Production enablement is scheduled for v0.14.0 once Privacy Policy
+(#359) and right-to-erasure (#360) land.
+
+Revision ID: a98_bm25_idf_drift_log
+Revises: a97_resources_entity
+
+NOTE: Revision ID capped at 32 chars (alembic_version.version_num is
+VARCHAR(32) — asyncpg raises StringDataRightTruncationError otherwise).
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a98_bm25_idf_drift_log"
+down_revision = "a97_resources_entity"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create the bm25_idf_drift_log table with constraints and indexes."""
+    op.create_table(
+        "bm25_idf_drift_log",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column(
+            "context_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "measured_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        # PSI is NULL when the min-N gates fail (psi_status='insufficient_data').
+        # NUMERIC over Float because alert thresholds are precision-sensitive.
+        sa.Column("psi", sa.Numeric(10, 6), nullable=True),
+        sa.Column("psi_status", sa.String(30), nullable=False),
+        sa.Column("m_memory_points", sa.Integer, nullable=False),
+        sa.Column("r_resource_points", sa.Integer, nullable=False),
+        sa.Column("num_terms", sa.Integer, nullable=False),
+        # Each entry: {"index": int32, "df_memory": int, "df_global": int,
+        #              "idf_memory": float, "idf_global": float, "delta": float}
+        # The "index" is the mmh3.hash of a token; the original token text
+        # is NOT stored here. Reverse lookup (token recovery) is a separate
+        # admin operation scheduled for v0.14.0.
+        sa.Column("top_divergent_terms", JSONB, nullable=True),
+        sa.CheckConstraint(
+            "psi_status IN ('insufficient_data', 'stable', 'minor_drift', 'significant_drift')",
+            name="valid_bm25_idf_drift_status",
+        ),
+        # Pin the invariant in the DB: PSI is NULL iff status is insufficient_data.
+        # Application bugs that desync them get caught at INSERT time.
+        sa.CheckConstraint(
+            "(psi_status = 'insufficient_data') = (psi IS NULL)",
+            name="bm25_idf_drift_psi_null_iff_insufficient",
+        ),
+        sa.CheckConstraint(
+            "m_memory_points >= 0 AND r_resource_points >= 0 AND num_terms >= 0",
+            name="bm25_idf_drift_nonneg_counts",
+        ),
+    )
+
+    # Most common admin query: latest rows for a given context.
+    op.create_index(
+        "idx_bm25_idf_drift_context_time",
+        "bm25_idf_drift_log",
+        ["context_id", sa.text("measured_at DESC")],
+    )
+    # Cross-context recent timeline for the operator dashboard.
+    op.create_index(
+        "idx_bm25_idf_drift_measured_at",
+        "bm25_idf_drift_log",
+        [sa.text("measured_at DESC")],
+    )
+    # Partial index keeps the alerted-state lookup small even as the table grows.
+    op.create_index(
+        "idx_bm25_idf_drift_alerted",
+        "bm25_idf_drift_log",
+        ["psi_status", sa.text("measured_at DESC")],
+        postgresql_where=sa.text("psi_status IN ('minor_drift', 'significant_drift')"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the bm25_idf_drift_log table."""
+    op.drop_index("idx_bm25_idf_drift_alerted", table_name="bm25_idf_drift_log")
+    op.drop_index("idx_bm25_idf_drift_measured_at", table_name="bm25_idf_drift_log")
+    op.drop_index("idx_bm25_idf_drift_context_time", table_name="bm25_idf_drift_log")
+    op.drop_table("bm25_idf_drift_log")

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -63,6 +63,7 @@ async def lifespan(app: FastAPI):
     # Start background task scheduler
     from tasks import (
         get_scheduler,
+        schedule_bm25_drift_tasks,
         schedule_credentials_tasks,
         schedule_embedding_tasks,
         schedule_mcp_tasks,
@@ -79,6 +80,7 @@ async def lifespan(app: FastAPI):
     schedule_embedding_tasks(scheduler)
     schedule_resource_indexer_jobs(scheduler)
     schedule_sleep_tasks(scheduler)
+    schedule_bm25_drift_tasks(scheduler)
     start_scheduler()
     logger.info("background_tasks_scheduled")
 
@@ -143,6 +145,15 @@ openapi_tags = [
     {
         "name": "sleep-reports",
         "description": "Admin: Sleep Maintenance execution reports and audit log",
+    },
+    {
+        "name": "bm25-drift (preview)",
+        "description": (
+            "Admin: BM25 IDF drift observability (Issue #343). "
+            "Cron is disabled by default and scheduled for production "
+            "enablement in v0.14.0 alongside Privacy Policy (#359) and "
+            "right-to-erasure (#360)."
+        ),
     },
     {"name": "system-admins", "description": "Admin: system administrator management"},
     # System
@@ -316,6 +327,7 @@ from api.routes import (  # noqa: E402
     api_keys,
     attachments,  # Issue #330: File attachment support
     auth,
+    bm25_drift,  # Issue #343: BM25 IDF drift admin (preview, cron disabled by default)
     config,
     context_search_config,
     contexts,
@@ -388,6 +400,9 @@ app.include_router(sleep_reports.router, prefix="/api/v1")
 
 # Admin Sleep trigger (Issue #247 - Manual Sleep Maintenance trigger)
 app.include_router(admin_sleep.router, prefix="/api/v1")
+
+# BM25 IDF Drift admin (Issue #343 - cron disabled by default until v0.14.0)
+app.include_router(bm25_drift.router, prefix="/api/v1")
 
 # External API Keys routes (Issue #45 - External keys management)
 app.include_router(external_keys.router, prefix="/api/v1")

--- a/backend/src/api/routes/bm25_drift.py
+++ b/backend/src/api/routes/bm25_drift.py
@@ -1,0 +1,297 @@
+"""BM25 IDF drift admin API.
+
+Issue #343: read-only list/detail of bm25_idf_drift_log rows + manual
+trigger for dev/staging. All endpoints are admin-only and tagged
+`(preview)` because the underlying cron is disabled in production until
+v0.14.0.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, field_serializer
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import require_admin
+from db.base import get_db
+from models.auth import Context
+from models.bm25_drift import Bm25IdfDriftLog
+from services.bm25_drift.orchestrator import Bm25DriftOrchestrator
+from services.bm25_drift.psi_calculator import PsiStatus
+from utils.datetime import to_utc_iso
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(
+    prefix="/admin/bm25-drift",
+    tags=["bm25-drift (preview)"],
+)
+
+
+# ============================================================================
+# Schemas
+# ============================================================================
+
+
+class Bm25DriftSummary(BaseModel):
+    """Drift log row, list-view shape (no top_divergent_terms)."""
+
+    id: int
+    context_id: UUID
+    context_name: str | None = None
+    measured_at: datetime
+    psi: float | None
+    psi_status: str
+    m_memory_points: int
+    r_resource_points: int
+    num_terms: int
+
+    @field_serializer("measured_at")
+    def _serialize_dt(self, dt: datetime) -> str:
+        return to_utc_iso(dt) or ""
+
+
+class Bm25DriftDetail(Bm25DriftSummary):
+    """Drift log row, detail-view shape (includes top_divergent_terms)."""
+
+    context_deleted: bool = False
+    top_divergent_terms: list[dict[str, Any]] | None = None
+
+
+class Bm25DriftListResponse(BaseModel):
+    rows: list[Bm25DriftSummary]
+    total: int
+    limit: int
+    offset: int
+
+
+class Bm25DriftDetailResponse(BaseModel):
+    row: Bm25DriftDetail
+
+
+class Bm25DriftRunRequest(BaseModel):
+    """Body for POST /admin/bm25-drift/run.
+
+    Attributes:
+        context_id: Target context. When null, runs against every active
+            context (matches the cron behaviour). For dev/staging
+            verification — production cron remains disabled until v0.14.0.
+    """
+
+    context_id: UUID | None = None
+
+
+class Bm25DriftRunResponse(BaseModel):
+    scheduled_context_count: int
+
+
+# Single source of truth for the status enum: derive from the Literal in
+# psi_calculator. The DB CHECK constraint and ORM model already pin the
+# same set; if a status is added there, it shows up here automatically.
+_VALID_STATUSES = set(PsiStatus.__args__)
+
+
+# ============================================================================
+# Endpoints
+# ============================================================================
+
+
+@router.get("", response_model=Bm25DriftListResponse)
+async def list_drift_logs(
+    _admin: dict = Depends(require_admin),  # noqa: ARG001 - access guard only
+    db: AsyncSession = Depends(get_db),
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
+    status_filter: str | None = Query(None, alias="status"),
+    context_id: UUID | None = Query(None),
+) -> Bm25DriftListResponse:
+    """List BM25 IDF drift log rows. Admin-only.
+
+    Sorted by measured_at DESC. Filterable by psi_status and context_id.
+    """
+    if status_filter is not None and status_filter not in _VALID_STATUSES:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid status. Must be one of: {sorted(_VALID_STATUSES)}",
+        )
+
+    conditions = []
+    if status_filter is not None:
+        conditions.append(Bm25IdfDriftLog.psi_status == status_filter)
+    if context_id is not None:
+        conditions.append(Bm25IdfDriftLog.context_id == context_id)
+
+    count_stmt = select(func.count()).select_from(Bm25IdfDriftLog)
+    if conditions:
+        count_stmt = count_stmt.where(*conditions)
+    total = (await db.execute(count_stmt)).scalar() or 0
+
+    stmt = select(Bm25IdfDriftLog)
+    if conditions:
+        stmt = stmt.where(*conditions)
+    rows_result = await db.execute(
+        stmt.order_by(Bm25IdfDriftLog.measured_at.desc()).limit(limit).offset(offset)
+    )
+    rows = list(rows_result.scalars().all())
+
+    # Batch-resolve context display names to avoid N+1.
+    ctx_ids = {r.context_id for r in rows}
+    ctx_map: dict[UUID, str | None] = {}
+    if ctx_ids:
+        ctx_result = await db.execute(
+            select(Context.id, Context.name, Context.display_name, Context.deleted_at).where(
+                Context.id.in_(ctx_ids)
+            )
+        )
+        for cid, cname, cdisplay, cdeleted in ctx_result.all():
+            ctx_map[cid] = None if cdeleted is not None else (cdisplay or cname)
+
+    for r in rows:
+        r.context_name = ctx_map.get(r.context_id)
+
+    return Bm25DriftListResponse(
+        rows=[Bm25DriftSummary.model_validate(r, from_attributes=True) for r in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{row_id}", response_model=Bm25DriftDetailResponse)
+async def get_drift_log_detail(
+    row_id: int,
+    _admin: dict = Depends(require_admin),  # noqa: ARG001 - access guard only
+    db: AsyncSession = Depends(get_db),
+) -> Bm25DriftDetailResponse:
+    """Detail view including top_divergent_terms. Admin-only.
+
+    Emits an audit log event on every read so historical access is
+    reconstructable from logs alone.
+    """
+    row_result = await db.execute(select(Bm25IdfDriftLog).where(Bm25IdfDriftLog.id == row_id))
+    row = row_result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Drift log {row_id} not found.",
+        )
+
+    ctx_result = await db.execute(
+        select(Context.id, Context.name, Context.display_name, Context.deleted_at).where(
+            Context.id == row.context_id
+        )
+    )
+    ctx_row = ctx_result.first()
+    context_deleted = False
+    if ctx_row is not None:
+        _cid, cname, cdisplay, cdeleted = ctx_row
+        if cdeleted is not None:
+            row.context_name = None
+            context_deleted = True
+        else:
+            row.context_name = cdisplay or cname
+    else:
+        row.context_name = None
+        context_deleted = True
+
+    row.context_deleted = context_deleted
+
+    # Audit log — terms count only, never term content.
+    logger.info(
+        "drift_detail_accessed",
+        row_id=row_id,
+        context_id=str(row.context_id),
+        psi=float(row.psi) if row.psi is not None else None,
+        status=row.psi_status,
+        num_terms=row.num_terms,
+    )
+
+    return Bm25DriftDetailResponse(
+        row=Bm25DriftDetail.model_validate(row, from_attributes=True),
+    )
+
+
+@router.post(
+    "/run",
+    response_model=Bm25DriftRunResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def run_drift_now(
+    body: Bm25DriftRunRequest,
+    _admin: dict = Depends(require_admin),  # noqa: ARG001 - access guard only
+    db: AsyncSession = Depends(get_db),
+) -> Bm25DriftRunResponse:
+    """Manually trigger a drift measurement. Admin-only.
+
+    For dev/staging verification while the production cron is disabled
+    (v0.12.1 ships infrastructure-only; production enablement = v0.14.0).
+    Each requested context is enqueued as an `asyncio.create_task` and
+    runs against an independent DB session.
+    """
+    if body.context_id is not None:
+        target_context_ids: list[UUID] = [body.context_id]
+    else:
+        from models.memory import Memory
+
+        result = await db.execute(
+            select(Memory.context_id)
+            .distinct()
+            .where(Memory.deleted_at.is_(None))
+            .where(Memory.context_id.isnot(None))
+        )
+        target_context_ids = [r[0] for r in result.all() if r[0] is not None]
+
+    # Keep strong references to the spawned tasks until the response
+    # is built. asyncio.create_task returns a Task that is GC-eligible
+    # if the only reference is dropped before the loop schedules it
+    # (cpython#90887). The list survives until function return, which
+    # gives the event loop time to pick the tasks up.
+    _spawned: list[asyncio.Task] = [
+        asyncio.create_task(_run_drift_job(cid)) for cid in target_context_ids
+    ]
+
+    logger.info(
+        "drift_manual_trigger_scheduled",
+        scheduled=len(_spawned),
+    )
+    return Bm25DriftRunResponse(scheduled_context_count=len(_spawned))
+
+
+async def _run_drift_job(context_id: UUID) -> None:
+    """Background task: open an independent session and run one drift cycle.
+
+    Mirrors admin_sleep._run_sleep_job — own session per job avoids
+    request-session lifetime entanglement. The rollback itself can fail
+    (e.g. connection loss); we guard it so the structured error log still
+    reaches the operator.
+    """
+    from db.base import get_db as _get_db
+
+    async for db in _get_db():
+        try:
+            orchestrator = Bm25DriftOrchestrator(db)
+            await orchestrator.run(context_id)
+            await db.commit()
+        except Exception as e:
+            try:
+                await db.rollback()
+            except Exception as rollback_exc:
+                logger.error(
+                    "drift_manual_trigger_rollback_failed",
+                    context_id=str(context_id),
+                    error=str(rollback_exc),
+                )
+            logger.error(
+                "drift_manual_trigger_failed",
+                context_id=str(context_id),
+                error=str(e),
+                exc_info=True,
+            )
+        return

--- a/backend/src/models/bm25_drift.py
+++ b/backend/src/models/bm25_drift.py
@@ -1,0 +1,97 @@
+"""SQLAlchemy model for BM25 IDF drift observability.
+
+Issue #343: One row per context per cron cycle, capturing the PSI score
+between memory-only and collection-global IDF distributions.
+"""
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from db.base import Base
+
+
+class Bm25IdfDriftLog(Base):
+    """A single PSI measurement for a context's BM25 IDF distribution.
+
+    Attributes:
+        id: Auto-increment primary key (high-frequency append-only)
+        context_id: Target context (FK with CASCADE on context delete)
+        measured_at: Cron cycle timestamp (tz-aware)
+        psi: Population Stability Index. NULL iff status is insufficient_data
+        psi_status: One of insufficient_data / stable / minor_drift / significant_drift
+        m_memory_points: Memory-source point count at measurement time
+        r_resource_points: Resource-source point count at measurement time
+        num_terms: Surviving term count after Cochran's df>=5 filter
+        top_divergent_terms: JSONB list of {index, df_memory, df_global, ...}
+            where index is the mmh3 token hash (not plaintext)
+    """
+
+    __tablename__ = "bm25_idf_drift_log"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    context_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    measured_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    psi = Column(Numeric(10, 6), nullable=True)
+    psi_status = Column(String(30), nullable=False)
+    m_memory_points = Column(Integer, nullable=False)
+    r_resource_points = Column(Integer, nullable=False)
+    num_terms = Column(Integer, nullable=False)
+    top_divergent_terms = Column(JSONB, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "psi_status IN ('insufficient_data', 'stable', 'minor_drift', 'significant_drift')",
+            name="valid_bm25_idf_drift_status",
+        ),
+        CheckConstraint(
+            "(psi_status = 'insufficient_data') = (psi IS NULL)",
+            name="bm25_idf_drift_psi_null_iff_insufficient",
+        ),
+        CheckConstraint(
+            "m_memory_points >= 0 AND r_resource_points >= 0 AND num_terms >= 0",
+            name="bm25_idf_drift_nonneg_counts",
+        ),
+        # DESC ordering on measured_at must match the migration (a98) so
+        # alembic autogenerate does not flag a spurious diff.
+        Index(
+            "idx_bm25_idf_drift_context_time",
+            "context_id",
+            text("measured_at DESC"),
+        ),
+        Index(
+            "idx_bm25_idf_drift_measured_at",
+            text("measured_at DESC"),
+        ),
+        Index(
+            "idx_bm25_idf_drift_alerted",
+            "psi_status",
+            text("measured_at DESC"),
+            postgresql_where=text("psi_status IN ('minor_drift', 'significant_drift')"),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<Bm25IdfDriftLog(id={self.id}, context_id={self.context_id}, "
+            f"psi={self.psi}, status={self.psi_status})>"
+        )

--- a/backend/src/services/bm25_drift/__init__.py
+++ b/backend/src/services/bm25_drift/__init__.py
@@ -1,0 +1,6 @@
+"""BM25 IDF drift observability subsystem.
+
+Issue #343: detects systematic divergence between memory-only IDF and the
+collection-global IDF that Qdrant's Modifier.IDF computes. Writes one
+Bm25IdfDriftLog row per context per cron cycle.
+"""

--- a/backend/src/services/bm25_drift/idf_snapshot.py
+++ b/backend/src/services/bm25_drift/idf_snapshot.py
@@ -1,0 +1,134 @@
+"""Snapshot the BM25 IDF state of a context's slice of a Qdrant collection.
+
+Issue #343: Reads sparse vectors back from Qdrant via scroll, classifying
+each point as memory-source vs resource-source by the presence of the
+`resource_id` payload field, and accumulates per-token document
+frequencies. The output feeds psi_calculator.compute_psi.
+
+Per #334 the kagura_memories collection is shared across contexts and
+isolation is achieved at the payload-filter level — both filters here
+include `context_id` so the snapshot is scoped correctly.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from uuid import UUID
+
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.http.models import FieldCondition, Filter, MatchValue
+
+from db.qdrant import KAGURA_MEMORIES_BM25_VECTOR_NAME
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Scroll batch size. Mirrors the value used by admin context-recovery
+# (backend/src/api/routes/admin.py) and check_orphaned_qdrant_points.
+_SCROLL_LIMIT = 100
+
+
+@dataclass(frozen=True)
+class IdfSnapshot:
+    """Per-token document frequency snapshot for one (collection, context)."""
+
+    df_memory: dict[int, int]
+    df_global: dict[int, int]
+    m_memory: int
+    r_resource: int
+
+    @property
+    def n_global(self) -> int:
+        return self.m_memory + self.r_resource
+
+
+async def build_idf_snapshot(
+    client: AsyncQdrantClient,
+    collection_name: str,
+    context_id: UUID,
+) -> IdfSnapshot:
+    """Scroll the context's slice of `collection_name` and accumulate df.
+
+    Each point's bm25 sparse vector is fetched (with_vectors=["bm25"]) and
+    its indices counted as documents-containing-token. Source classification
+    is by `resource_id` payload presence: memory-side writes never set
+    this field, resource-side writes always set it (see
+    services/resource_indexer._apply_upsert).
+    """
+    df_memory: dict[int, int] = defaultdict(int)
+    df_global: dict[int, int] = defaultdict(int)
+    m_memory = 0
+    r_resource = 0
+
+    scroll_filter = Filter(
+        must=[
+            FieldCondition(
+                key="context_id",
+                match=MatchValue(value=str(context_id)),
+            )
+        ]
+    )
+
+    offset = None
+    while True:
+        points, next_offset = await client.scroll(
+            collection_name=collection_name,
+            scroll_filter=scroll_filter,
+            limit=_SCROLL_LIMIT,
+            offset=offset,
+            with_payload=["resource_id"],
+            with_vectors=[KAGURA_MEMORIES_BM25_VECTOR_NAME],
+        )
+
+        for point in points:
+            # Source classification by payload-field presence.
+            payload = point.payload or {}
+            is_resource = payload.get("resource_id") is not None
+            if is_resource:
+                r_resource += 1
+            else:
+                m_memory += 1
+
+            # Defensive: a point may have no bm25 vector (e.g. legacy rows
+            # written before #335 / #345 wired the dual emit). Skip cleanly
+            # rather than corrupting df counts.
+            vector = point.vector
+            if not isinstance(vector, dict):
+                continue
+            sparse = vector.get(KAGURA_MEMORIES_BM25_VECTOR_NAME)
+            if sparse is None:
+                continue
+
+            indices = getattr(sparse, "indices", None)
+            if not indices:
+                continue
+
+            # Each unique index counts once per document for df. The Qdrant
+            # client returns indices as a list of int (not necessarily
+            # de-duplicated), so we set() before counting.
+            unique = set(indices)
+            for idx in unique:
+                df_global[idx] += 1
+                if not is_resource:
+                    df_memory[idx] += 1
+
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    logger.debug(
+        "bm25_idf_snapshot_built",
+        context_id=str(context_id),
+        collection=collection_name,
+        m_memory=m_memory,
+        r_resource=r_resource,
+        unique_terms=len(df_global),
+    )
+
+    return IdfSnapshot(
+        df_memory=dict(df_memory),
+        df_global=dict(df_global),
+        m_memory=m_memory,
+        r_resource=r_resource,
+    )

--- a/backend/src/services/bm25_drift/orchestrator.py
+++ b/backend/src/services/bm25_drift/orchestrator.py
@@ -1,0 +1,88 @@
+"""Per-context orchestration for BM25 IDF drift measurement.
+
+Issue #343: composes idf_snapshot + psi_calculator + persistence. Mirrors
+the SleepOrchestrator pattern (services/sleep/orchestrator.py): one
+instance per (db, qdrant) pair, .run() exec per context.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from qdrant_client import AsyncQdrantClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.qdrant import get_qdrant_client
+from models.bm25_drift import Bm25IdfDriftLog
+from services.bm25_drift.idf_snapshot import build_idf_snapshot
+from services.bm25_drift.psi_calculator import compute_psi
+from services.context_routing import resolve_collection_name
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class Bm25DriftOrchestrator:
+    """Run a single PSI measurement for one context and persist the result."""
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        qdrant: AsyncQdrantClient | None = None,
+    ) -> None:
+        self.db = db
+        # Reuse the global Qdrant singleton unless the caller injects one
+        # (test seam). Constructor takes an explicit param so tests can
+        # patch without monkey-patching get_qdrant_client.
+        self._qdrant = qdrant
+
+    def _get_qdrant(self) -> AsyncQdrantClient:
+        if self._qdrant is None:
+            self._qdrant = get_qdrant_client()
+        return self._qdrant
+
+    async def run(self, context_id: UUID) -> Bm25IdfDriftLog:
+        """Compute drift for `context_id` and INSERT one row.
+
+        The caller owns transaction lifecycle (commit/rollback). On error
+        the row is not flushed; orchestrator does NOT swallow exceptions.
+        """
+        collection_name = await resolve_collection_name(self.db, context_id)
+        qdrant = self._get_qdrant()
+
+        snapshot = await build_idf_snapshot(qdrant, collection_name, context_id)
+
+        result = compute_psi(
+            df_memory=snapshot.df_memory,
+            df_global=snapshot.df_global,
+            m_memory=snapshot.m_memory,
+            n_global=snapshot.n_global,
+        )
+
+        row = Bm25IdfDriftLog(
+            context_id=context_id,
+            psi=result.psi,
+            psi_status=result.status,
+            m_memory_points=snapshot.m_memory,
+            r_resource_points=snapshot.r_resource,
+            num_terms=result.num_terms,
+            top_divergent_terms=result.top_divergent_terms or None,
+        )
+        self.db.add(row)
+        await self.db.flush()
+
+        # Structured log event — operator-side observability for v0.12.1.
+        # Prometheus gauge wiring is deferred to the v0.14.0 enable issue.
+        # Term content is intentionally NOT in this event (CSO/CLO).
+        logger.info(
+            "bm25_idf_drift_computed",
+            context_id=str(context_id),
+            collection=collection_name,
+            psi=float(result.psi) if result.psi is not None else None,
+            status=result.status,
+            m_memory=snapshot.m_memory,
+            r_resource=snapshot.r_resource,
+            num_terms=result.num_terms,
+        )
+
+        return row

--- a/backend/src/services/bm25_drift/psi_calculator.py
+++ b/backend/src/services/bm25_drift/psi_calculator.py
@@ -1,0 +1,225 @@
+"""PSI (Population Stability Index) computation for BM25 IDF distributions.
+
+Issue #343 — Stats PhD spec:
+
+    IDF_global(t) = ln( (N_global - df_global(t) + 0.5) / (df_global(t) + 0.5) + 1 )
+    IDF_memory(t) = ln( (M       - df_memory(t) + 0.5) / (df_memory(t) + 0.5) + 1 )
+
+Workflow:
+    1. Filter terms by Cochran's rule (df_memory >= 5 AND df_global >= 5).
+    2. Compute IDF_memory(t) and IDF_global(t) per surviving term.
+    3. Bin terms into 10 quantiles by IDF_memory value.
+    4. Compute P_memory(b) and P_global(b) (term-share per bin under each
+       distribution).
+    5. PSI = sum_b (P_global(b) - P_memory(b)) * ln(
+                     (P_global(b)+eps) / (P_memory(b)+eps)
+                  )
+       with eps = 1 / |T| to keep zero-bins from making PSI undefined.
+    6. Status: <0.10 stable, <0.25 minor_drift, >=0.25 significant_drift.
+
+Min-N gates (cold-start false-positive guard):
+    M >= MIN_MEMORY_POINTS  AND  |T| >= MIN_SURVIVING_TERMS  → compute PSI
+    otherwise                                                → insufficient_data
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+# Min-N gates from the Stats PhD review. Surfaced as constants so tests can
+# reference them without re-deriving the rationale.
+MIN_MEMORY_POINTS = 100  # binomial CI ~+/-10% at this sample size
+MIN_SURVIVING_TERMS = 50  # chi^2 approximation needs ~5 terms per bin x 10 bins
+MIN_DF = 5  # Cochran's rule: expected count >= 5
+
+# Industry-standard PSI thresholds (recalibrate after #new-B golden eval lands).
+PSI_MINOR_THRESHOLD = 0.10
+PSI_SIGNIFICANT_THRESHOLD = 0.25
+
+NUM_BINS = 10
+TOP_DIVERGENT_TERMS_LIMIT = 20
+
+PsiStatus = Literal["insufficient_data", "stable", "minor_drift", "significant_drift"]
+
+
+@dataclass(frozen=True)
+class PsiResult:
+    """Output of compute_psi.
+
+    Attributes:
+        psi: PSI scalar, or None when status is insufficient_data.
+        status: One of insufficient_data / stable / minor_drift /
+            significant_drift. Pinned to the status enum stored in
+            bm25_idf_drift_log.psi_status.
+        num_terms: |T| after Cochran's filter (0 when insufficient_data
+            because no points were sampled or no terms passed the filter).
+        top_divergent_terms: Up to TOP_DIVERGENT_TERMS_LIMIT entries sorted
+            by |IDF_memory(t) - IDF_global(t)| descending. Empty list when
+            insufficient_data.
+    """
+
+    psi: float | None
+    status: PsiStatus
+    num_terms: int
+    top_divergent_terms: list[dict]
+
+
+def _bm25_idf(n_total: int, df: int) -> float:
+    """Robertson BM25 IDF: ln((N - df + 0.5)/(df + 0.5) + 1).
+
+    Mirrors Qdrant's Modifier.IDF formula. The +1 inside the log keeps the
+    value non-negative even when df > N/2 (which Robertson's original form
+    can produce — Qdrant's variant guards against negative IDF that would
+    invert ranking).
+    """
+    return math.log((n_total - df + 0.5) / (df + 0.5) + 1.0)
+
+
+def classify_status(psi: float) -> PsiStatus:
+    """Map a numeric PSI to its industry-standard status bucket."""
+    if psi < PSI_MINOR_THRESHOLD:
+        return "stable"
+    if psi < PSI_SIGNIFICANT_THRESHOLD:
+        return "minor_drift"
+    return "significant_drift"
+
+
+def _quantile_bin_edges(values: list[float], n_bins: int) -> list[float]:
+    """Compute n_bins+1 quantile edges over `values`.
+
+    Uses linear interpolation between sorted values. Returns sorted edges
+    starting with min(values) and ending with max(values). Caller is
+    responsible for ensuring len(values) >= n_bins.
+    """
+    sorted_vals = sorted(values)
+    n = len(sorted_vals)
+    edges: list[float] = []
+    for i in range(n_bins + 1):
+        # quantile q = i / n_bins; index = q * (n - 1) with linear interp.
+        if i == 0:
+            edges.append(sorted_vals[0])
+            continue
+        if i == n_bins:
+            edges.append(sorted_vals[-1])
+            continue
+        idx = i * (n - 1) / n_bins
+        lo = math.floor(idx)
+        hi = math.ceil(idx)
+        if lo == hi:
+            edges.append(sorted_vals[lo])
+        else:
+            frac = idx - lo
+            edges.append(sorted_vals[lo] * (1 - frac) + sorted_vals[hi] * frac)
+    return edges
+
+
+def _bin_index(value: float, edges: list[float]) -> int:
+    """Find the bin index in [0, len(edges)-2] for `value`.
+
+    Edges are inclusive on the left, inclusive on the right for the last
+    bin. A value equal to the rightmost edge falls into the last bin.
+    """
+    n_bins = len(edges) - 1
+    # Binary search would be more efficient at scale, but with NUM_BINS=10
+    # a linear scan is fine and keeps the code obvious.
+    for i in range(n_bins):
+        if value <= edges[i + 1]:
+            return i
+    return n_bins - 1
+
+
+def compute_psi(
+    *,
+    df_memory: dict[int, int],
+    df_global: dict[int, int],
+    m_memory: int,
+    n_global: int,
+) -> PsiResult:
+    """Compute PSI between memory-only and collection-global IDF distributions.
+
+    Args:
+        df_memory: Document frequency of each token index, restricted to
+            memory-source documents. Keys are mmh3.hash(token) integers.
+        df_global: Document frequency in the full collection (memory +
+            resource). Same key space as df_memory.
+        m_memory: Total number of memory-source documents.
+        n_global: Total number of documents in the collection.
+
+    Returns:
+        PsiResult with `status`, `psi` scalar (or None), surviving term
+        count, and top-divergent term snapshot.
+    """
+    # Min-N gate 1: not enough memory points to estimate IDF reliably.
+    if m_memory < MIN_MEMORY_POINTS:
+        return PsiResult(
+            psi=None,
+            status="insufficient_data",
+            num_terms=0,
+            top_divergent_terms=[],
+        )
+
+    # Apply Cochran's rule: a term must clear MIN_DF in BOTH distributions.
+    # A term that exists in resource only (df_memory=0) is not a memory-side
+    # ranking concern, so excluding it is correct.
+    surviving = [
+        idx for idx, df_m in df_memory.items() if df_m >= MIN_DF and df_global.get(idx, 0) >= MIN_DF
+    ]
+
+    # Min-N gate 2: too few surviving terms for the chi^2 binning approximation.
+    if len(surviving) < MIN_SURVIVING_TERMS:
+        return PsiResult(
+            psi=None,
+            status="insufficient_data",
+            num_terms=len(surviving),
+            top_divergent_terms=[],
+        )
+
+    # Compute per-term IDF under both distributions.
+    idf_pairs: list[tuple[int, float, float, int, int]] = []
+    for idx in surviving:
+        df_m = df_memory[idx]
+        df_g = df_global[idx]
+        idf_m = _bm25_idf(m_memory, df_m)
+        idf_g = _bm25_idf(n_global, df_g)
+        idf_pairs.append((idx, idf_m, idf_g, df_m, df_g))
+
+    # Bin by IDF_memory quantiles.
+    memory_idfs = [p[1] for p in idf_pairs]
+    edges = _quantile_bin_edges(memory_idfs, NUM_BINS)
+
+    p_memory = [0] * NUM_BINS
+    p_global_counts = [0] * NUM_BINS
+    for pair in idf_pairs:
+        p_memory[_bin_index(pair[1], edges)] += 1
+        p_global_counts[_bin_index(pair[2], edges)] += 1
+
+    n = len(surviving)
+    eps = 1.0 / n  # Stats PhD: epsilon-smoothing, prevents log(0).
+    psi = 0.0
+    for b in range(NUM_BINS):
+        p = p_memory[b] / n
+        q = p_global_counts[b] / n
+        psi += (q - p) * math.log((q + eps) / (p + eps))
+
+    # Top-N divergent terms: sorted by |IDF_memory - IDF_global| desc.
+    idf_pairs.sort(key=lambda row: abs(row[1] - row[2]), reverse=True)
+    top = [
+        {
+            "index": idx,
+            "df_memory": df_m,
+            "df_global": df_g,
+            "idf_memory": round(idf_m, 6),
+            "idf_global": round(idf_g, 6),
+            "delta": round(idf_m - idf_g, 6),
+        }
+        for idx, idf_m, idf_g, df_m, df_g in idf_pairs[:TOP_DIVERGENT_TERMS_LIMIT]
+    ]
+
+    return PsiResult(
+        psi=psi,
+        status=classify_status(psi),
+        num_terms=n,
+        top_divergent_terms=top,
+    )

--- a/backend/src/tasks/__init__.py
+++ b/backend/src/tasks/__init__.py
@@ -9,6 +9,7 @@ Implements scheduled tasks for:
 - Resource indexer (every 5 minutes) - Issue #238
 """
 
+from .bm25_drift_tasks import schedule_bm25_drift_tasks
 from .credentials_tasks import schedule_credentials_tasks
 from .embedding_tasks import schedule_embedding_tasks
 from .mcp_tasks import schedule_mcp_tasks
@@ -27,4 +28,5 @@ __all__ = [
     "schedule_embedding_tasks",
     "schedule_resource_indexer_jobs",
     "schedule_sleep_tasks",
+    "schedule_bm25_drift_tasks",
 ]

--- a/backend/src/tasks/bm25_drift_tasks.py
+++ b/backend/src/tasks/bm25_drift_tasks.py
@@ -1,0 +1,116 @@
+"""BM25 IDF drift cron task.
+
+Issue #343: scheduled job that walks every active context, computes the
+IDF distribution drift via Bm25DriftOrchestrator, and persists one
+bm25_idf_drift_log row per context per cycle.
+
+DISABLED IN PRODUCTION by default (BM25_DRIFT_CRON_ENABLED=false).
+Mirrors the sleep_enabled precedent at neural/config.py:168.
+"""
+
+import os
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+
+from db.base import get_db
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def bm25_drift_maintenance_task() -> None:
+    """Run BM25 IDF drift measurement for every active context.
+
+    Iterates over distinct context_id rows from `memories` and calls
+    Bm25DriftOrchestrator per context with per-context commit/rollback —
+    a failing context does not poison the rest of the cycle.
+
+    Only runs when BM25_DRIFT_CRON_ENABLED=true. The double-check inside
+    the task body (mirroring sleep_tasks.py) catches the case where the
+    scheduler somehow registered the job despite the registration-time
+    gate.
+    """
+    logger.info("bm25_drift_task_started")
+
+    if os.getenv("BM25_DRIFT_CRON_ENABLED", "false").lower() != "true":
+        logger.info("bm25_drift_task_skipped", reason="bm25_drift_disabled")
+        return
+
+    try:
+        async for db in get_db():
+            from sqlalchemy import select
+
+            from models.memory import Memory
+            from services.bm25_drift.orchestrator import Bm25DriftOrchestrator
+
+            stmt = (
+                select(Memory.context_id)
+                .distinct()
+                .where(Memory.deleted_at.is_(None))
+                .where(Memory.context_id.isnot(None))
+            )
+            result = await db.execute(stmt)
+            context_ids = [row[0] for row in result.all() if row[0] is not None]
+
+            total_runs = 0
+            total_errors = 0
+
+            orchestrator = Bm25DriftOrchestrator(db)
+            for context_id in context_ids:
+                try:
+                    await orchestrator.run(context_id)
+                    await db.commit()
+                    total_runs += 1
+                except Exception as e:
+                    await db.rollback()
+                    total_errors += 1
+                    logger.error(
+                        "bm25_drift_context_failed",
+                        context_id=str(context_id),
+                        error=str(e),
+                        exc_info=True,
+                    )
+
+            logger.info(
+                "bm25_drift_task_completed",
+                contexts=len(context_ids),
+                runs=total_runs,
+                errors=total_errors,
+            )
+            return
+
+    except Exception as e:
+        logger.error("bm25_drift_task_failed", error=str(e), exc_info=True)
+
+
+def schedule_bm25_drift_tasks(scheduler: AsyncIOScheduler) -> None:
+    """Schedule the BM25 IDF drift maintenance cron.
+
+    Only registers when BM25_DRIFT_CRON_ENABLED=true. The flag is read at
+    registration time AND inside the task body (defense in depth — a
+    misconfigured environment cannot accidentally start emitting drift
+    rows in production).
+    """
+    # TODO(v0.14.0): enable BM25_DRIFT_CRON_ENABLED in production
+    # Blockers: #359 (Privacy Policy), #360 (right-to-erasure), and the
+    # follow-up "enable BM25_DRIFT_CRON_ENABLED" issue scoped to v0.14.0.
+    if os.getenv("BM25_DRIFT_CRON_ENABLED", "false").lower() != "true":
+        logger.info("bm25_drift_tasks_not_scheduled", reason="bm25_drift_disabled")
+        return
+
+    cron_hour = int(os.getenv("BM25_DRIFT_CRON_HOUR", "3"))
+    cron_minute = int(os.getenv("BM25_DRIFT_CRON_MINUTE", "0"))
+
+    scheduler.add_job(
+        bm25_drift_maintenance_task,
+        trigger=CronTrigger(hour=cron_hour, minute=cron_minute),
+        id="bm25_drift_maintenance",
+        name="BM25 IDF Drift Maintenance",
+        replace_existing=True,
+    )
+    logger.info(
+        "scheduled_bm25_drift_task",
+        hour=cron_hour,
+        minute=cron_minute,
+    )

--- a/backend/tests/api/test_bm25_drift_admin.py
+++ b/backend/tests/api/test_bm25_drift_admin.py
@@ -1,0 +1,188 @@
+"""Tests for the /admin/bm25-drift admin API (issue #343).
+
+Mirrors test_sleep_reports_admin.py: dependency_overrides for require_admin
++ get_db, MagicMock AsyncSession with execute.side_effect chained per
+endpoint.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from auth.dependencies import require_admin
+from db.base import get_db
+
+
+@pytest.fixture
+def admin_user() -> dict:
+    return {"email": "admin@example.com", "role": "admin"}
+
+
+@pytest.fixture
+def mock_db() -> MagicMock:
+    db = MagicMock()
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def client(admin_user, mock_db):
+    """TestClient with require_admin / get_db overrides; clears on teardown."""
+
+    async def _admin():
+        return admin_user
+
+    async def _db():
+        yield mock_db
+
+    app.dependency_overrides[require_admin] = _admin
+    app.dependency_overrides[get_db] = _db
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def _make_drift_row(
+    *,
+    row_id: int = 1,
+    psi: Decimal | None = Decimal("0.05"),
+    psi_status: str = "stable",
+    context_id=None,
+) -> SimpleNamespace:
+    """Build a minimal Bm25IdfDriftLog stand-in for from_attributes parsing."""
+    return SimpleNamespace(
+        id=row_id,
+        context_id=context_id or uuid4(),
+        measured_at=datetime(2026, 4, 19, 3, 0, 0, tzinfo=UTC),
+        psi=psi,
+        psi_status=psi_status,
+        m_memory_points=200,
+        r_resource_points=300,
+        num_terms=80,
+        top_divergent_terms=[
+            {
+                "index": 12345,
+                "df_memory": 10,
+                "df_global": 50,
+                "idf_memory": 1.5,
+                "idf_global": 0.3,
+                "delta": 1.2,
+            }
+        ],
+    )
+
+
+class TestList:
+    def test_returns_paginated_list(self, client: TestClient, mock_db: MagicMock) -> None:
+        ctx_id = uuid4()
+        row = _make_drift_row(context_id=ctx_id)
+        # Three queries: count, rows, context-batch.
+        count_result = MagicMock()
+        count_result.scalar.return_value = 1
+        rows_result = MagicMock()
+        rows_result.scalars.return_value.all.return_value = [row]
+        ctx_result = MagicMock()
+        ctx_result.all.return_value = [(ctx_id, "ctx-name", None, None)]
+        mock_db.execute.side_effect = [count_result, rows_result, ctx_result]
+
+        resp = client.get("/api/v1/admin/bm25-drift/")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["total"] == 1
+        assert len(body["rows"]) == 1
+        assert body["rows"][0]["context_name"] == "ctx-name"
+        assert body["rows"][0]["psi_status"] == "stable"
+
+    def test_invalid_status_returns_400(self, client: TestClient) -> None:
+        resp = client.get("/api/v1/admin/bm25-drift/?status=garbage")
+        assert resp.status_code == 400
+
+    def test_filter_by_context_id_skips_batch_lookup_when_no_rows(
+        self, client: TestClient, mock_db: MagicMock
+    ) -> None:
+        count_result = MagicMock()
+        count_result.scalar.return_value = 0
+        rows_result = MagicMock()
+        rows_result.scalars.return_value.all.return_value = []
+        # Only two execute calls when the result list is empty (no
+        # context-batch query needed).
+        mock_db.execute.side_effect = [count_result, rows_result]
+        ctx = uuid4()
+        resp = client.get(f"/api/v1/admin/bm25-drift/?context_id={ctx}")
+        assert resp.status_code == 200
+        assert resp.json() == {"rows": [], "total": 0, "limit": 50, "offset": 0}
+
+
+class TestDetail:
+    def test_returns_detail_with_top_terms(self, client: TestClient, mock_db: MagicMock) -> None:
+        ctx_id = uuid4()
+        row = _make_drift_row(context_id=ctx_id)
+        row_result = MagicMock()
+        row_result.scalar_one_or_none.return_value = row
+        ctx_result = MagicMock()
+        ctx_result.first.return_value = (ctx_id, "ctx-name", "Ctx Display", None)
+        mock_db.execute.side_effect = [row_result, ctx_result]
+
+        resp = client.get("/api/v1/admin/bm25-drift/1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["row"]["psi_status"] == "stable"
+        assert body["row"]["context_name"] == "Ctx Display"
+        assert body["row"]["top_divergent_terms"][0]["index"] == 12345
+
+    def test_missing_returns_404(self, client: TestClient, mock_db: MagicMock) -> None:
+        row_result = MagicMock()
+        row_result.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [row_result]
+
+        resp = client.get("/api/v1/admin/bm25-drift/9999")
+        assert resp.status_code == 404
+
+    def test_deleted_context_marks_flag(self, client: TestClient, mock_db: MagicMock) -> None:
+        ctx_id = uuid4()
+        row = _make_drift_row(context_id=ctx_id)
+        row_result = MagicMock()
+        row_result.scalar_one_or_none.return_value = row
+        ctx_result = MagicMock()
+        # deleted_at is non-null → context is treated as deleted.
+        deleted_at = datetime(2026, 4, 1, tzinfo=UTC)
+        ctx_result.first.return_value = (ctx_id, "ctx", "Ctx", deleted_at)
+        mock_db.execute.side_effect = [row_result, ctx_result]
+
+        resp = client.get("/api/v1/admin/bm25-drift/1")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["row"]["context_deleted"] is True
+        assert body["row"]["context_name"] is None
+
+
+class TestRunTrigger:
+    def test_run_with_explicit_context_returns_202(
+        self, client: TestClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Patch asyncio.create_task so the test does not actually spawn
+        # background work against the mocked DB.
+        from api.routes import bm25_drift as drift_route
+
+        captured = []
+        monkeypatch.setattr(
+            drift_route.asyncio,
+            "create_task",
+            lambda coro: captured.append(coro) or coro.close() or MagicMock(),
+        )
+
+        ctx = uuid4()
+        resp = client.post(
+            "/api/v1/admin/bm25-drift/run",
+            json={"context_id": str(ctx)},
+        )
+        assert resp.status_code == 202
+        assert resp.json() == {"scheduled_context_count": 1}
+        assert len(captured) == 1

--- a/backend/tests/services/bm25_drift/test_idf_snapshot.py
+++ b/backend/tests/services/bm25_drift/test_idf_snapshot.py
@@ -1,0 +1,101 @@
+"""Unit tests for the Qdrant IDF snapshot accumulator (issue #343)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.bm25_drift.idf_snapshot import build_idf_snapshot
+
+
+def _point(point_id: int, indices: list[int], *, resource: bool) -> SimpleNamespace:
+    """Build a minimal Qdrant point stand-in."""
+    payload = {"resource_id": "r1"} if resource else {}
+    sparse = SimpleNamespace(indices=indices, values=[1.0] * len(indices))
+    return SimpleNamespace(id=point_id, payload=payload, vector={"bm25": sparse})
+
+
+@pytest.mark.asyncio
+async def test_resource_id_payload_classifies_source() -> None:
+    points = [
+        _point(1, [10, 20, 30], resource=False),
+        _point(2, [20, 40], resource=False),
+        _point(3, [10, 50], resource=True),
+        _point(4, [60], resource=True),
+    ]
+    client = MagicMock()
+    client.scroll = AsyncMock(return_value=(points, None))
+
+    snapshot = await build_idf_snapshot(client, "kagura_memories", uuid4())
+
+    assert snapshot.m_memory == 2
+    assert snapshot.r_resource == 2
+    assert snapshot.n_global == 4
+    # df_memory only counts memory-source documents.
+    assert snapshot.df_memory == {10: 1, 20: 2, 30: 1, 40: 1}
+    # df_global counts every document (memory + resource).
+    assert snapshot.df_global == {10: 2, 20: 2, 30: 1, 40: 1, 50: 1, 60: 1}
+
+
+@pytest.mark.asyncio
+async def test_paginates_until_next_offset_is_none() -> None:
+    page1 = [_point(1, [10], resource=False)]
+    page2 = [_point(2, [20], resource=False)]
+    page3 = [_point(3, [30], resource=True)]
+    client = MagicMock()
+    client.scroll = AsyncMock(
+        side_effect=[
+            (page1, "cursor-1"),
+            (page2, "cursor-2"),
+            (page3, None),
+        ]
+    )
+
+    snapshot = await build_idf_snapshot(client, "kagura_memories", uuid4())
+
+    # Three pages consumed, three pages of points accumulated.
+    assert client.scroll.await_count == 3
+    assert snapshot.m_memory == 2
+    assert snapshot.r_resource == 1
+    assert set(snapshot.df_global.keys()) == {10, 20, 30}
+
+
+@pytest.mark.asyncio
+async def test_skips_points_with_missing_or_empty_bm25_vector() -> None:
+    points = [
+        _point(1, [10], resource=False),
+        SimpleNamespace(id=2, payload={}, vector=None),  # no vector at all
+        SimpleNamespace(id=3, payload={}, vector={}),  # vector dict, no bm25 key
+        SimpleNamespace(id=4, payload={}, vector={"bm25": SimpleNamespace(indices=[], values=[])}),
+        _point(5, [20], resource=False),
+    ]
+    client = MagicMock()
+    client.scroll = AsyncMock(return_value=(points, None))
+
+    snapshot = await build_idf_snapshot(client, "kagura_memories", uuid4())
+
+    # All five points still count toward source totals (we only skip the
+    # df increment, not the document count). This matches the intent —
+    # legacy rows that predate #335 are still part of the corpus, they
+    # just contribute zero terms.
+    assert snapshot.m_memory == 5
+    assert snapshot.r_resource == 0
+    assert snapshot.df_memory == {10: 1, 20: 1}
+
+
+@pytest.mark.asyncio
+async def test_duplicate_indices_in_one_point_only_count_once() -> None:
+    # df is a count of DOCUMENTS containing a term, not term occurrences.
+    points = [
+        _point(1, [10, 10, 10, 20], resource=False),
+        _point(2, [20, 20], resource=False),
+    ]
+    client = MagicMock()
+    client.scroll = AsyncMock(return_value=(points, None))
+
+    snapshot = await build_idf_snapshot(client, "kagura_memories", uuid4())
+
+    assert snapshot.df_memory == {10: 1, 20: 2}

--- a/backend/tests/services/bm25_drift/test_psi_calculator.py
+++ b/backend/tests/services/bm25_drift/test_psi_calculator.py
@@ -1,0 +1,190 @@
+"""Unit tests for PSI computation (issue #343)."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from services.bm25_drift.psi_calculator import (
+    MIN_DF,
+    MIN_MEMORY_POINTS,
+    MIN_SURVIVING_TERMS,
+    NUM_BINS,
+    PSI_MINOR_THRESHOLD,
+    PSI_SIGNIFICANT_THRESHOLD,
+    classify_status,
+    compute_psi,
+)
+
+
+class TestClassifyStatus:
+    def test_below_minor_is_stable(self) -> None:
+        assert classify_status(0.0) == "stable"
+        assert classify_status(PSI_MINOR_THRESHOLD - 1e-6) == "stable"
+
+    def test_minor_band(self) -> None:
+        assert classify_status(PSI_MINOR_THRESHOLD) == "minor_drift"
+        assert classify_status(PSI_SIGNIFICANT_THRESHOLD - 1e-6) == "minor_drift"
+
+    def test_significant(self) -> None:
+        assert classify_status(PSI_SIGNIFICANT_THRESHOLD) == "significant_drift"
+        assert classify_status(1.0) == "significant_drift"
+
+
+def _identical_term_universe(num_terms: int, df_value: int) -> dict[int, int]:
+    """Build a {hash: df} dict where every term has the same df."""
+    return dict.fromkeys(range(num_terms), df_value)
+
+
+class TestMinNGates:
+    def test_below_min_memory_returns_insufficient(self) -> None:
+        df = _identical_term_universe(MIN_SURVIVING_TERMS + 10, MIN_DF + 5)
+        result = compute_psi(
+            df_memory=df,
+            df_global=df,
+            m_memory=MIN_MEMORY_POINTS - 1,  # one short
+            n_global=MIN_MEMORY_POINTS - 1,
+        )
+        assert result.status == "insufficient_data"
+        assert result.psi is None
+        assert result.top_divergent_terms == []
+
+    def test_below_min_terms_returns_insufficient(self) -> None:
+        # Only 5 unique terms — well below MIN_SURVIVING_TERMS.
+        df_memory = _identical_term_universe(5, MIN_DF + 5)
+        df_global = dict(df_memory)
+        result = compute_psi(
+            df_memory=df_memory,
+            df_global=df_global,
+            m_memory=MIN_MEMORY_POINTS + 50,
+            n_global=MIN_MEMORY_POINTS + 50,
+        )
+        assert result.status == "insufficient_data"
+        assert result.psi is None
+        # Still report num_terms for diagnostics — confirmed by Stats PhD
+        # spec: status='insufficient_data' must remain distinguishable from
+        # absent measurement, so the surviving-term count helps the
+        # operator reason about why the gate fired.
+        assert result.num_terms == 5
+
+    def test_cochran_rule_drops_low_df(self) -> None:
+        # Terms with df < MIN_DF are dropped from BOTH distributions.
+        big = dict.fromkeys(range(100), MIN_DF + 5)
+        small = dict.fromkeys(range(100, 200), MIN_DF - 1)  # below threshold
+        df_memory = {**big, **small}
+        df_global = {**big, **small}
+        result = compute_psi(
+            df_memory=df_memory,
+            df_global=df_global,
+            m_memory=MIN_MEMORY_POINTS + 100,
+            n_global=MIN_MEMORY_POINTS + 100,
+        )
+        # Only the 100 high-df terms survive Cochran's filter.
+        assert result.num_terms == 100
+
+
+class TestPsiMath:
+    def test_identical_distributions_psi_is_zero(self) -> None:
+        df = _identical_term_universe(NUM_BINS * 10, MIN_DF + 10)
+        result = compute_psi(
+            df_memory=df,
+            df_global=df,
+            m_memory=MIN_MEMORY_POINTS + 100,
+            n_global=MIN_MEMORY_POINTS + 100,
+        )
+        assert result.status == "stable"
+        # PSI should be exactly 0.0 (or float-noise close to 0) when both
+        # distributions are identical: P_memory(b) == P_global(b) for every
+        # bin, so each summand (q-p)*log((q+eps)/(p+eps)) collapses.
+        assert result.psi is not None
+        assert abs(result.psi) < 1e-9
+
+    def test_significant_drift_when_df_global_is_doubled(self) -> None:
+        # A heavily resource-laden corpus: df_global ~= 2 * df_memory for
+        # most terms. This shifts IDF_global down systematically (rare
+        # terms in memory become "common" globally), pushing the
+        # distribution mass into different bins.
+        num_terms = 200
+        df_memory = {i: MIN_DF + (i % 7) for i in range(num_terms)}
+        df_global = {i: df_memory[i] * 4 for i in range(num_terms)}
+        # Add resource-only terms to inflate the global vocabulary.
+        for j in range(num_terms, num_terms + 200):
+            df_global[j] = MIN_DF + 10
+        result = compute_psi(
+            df_memory=df_memory,
+            df_global=df_global,
+            m_memory=500,
+            n_global=2000,
+        )
+        assert result.status == "significant_drift"
+        assert result.psi is not None
+        assert result.psi >= PSI_SIGNIFICANT_THRESHOLD
+
+    def test_top_divergent_terms_sorted_by_abs_delta(self) -> None:
+        df_memory = dict.fromkeys(range(60), MIN_DF + 5)
+        df_global = dict.fromkeys(range(60), MIN_DF + 5)
+        # One term has a wildly different global df → biggest delta.
+        df_global[0] = MIN_DF + 500
+        result = compute_psi(
+            df_memory=df_memory,
+            df_global=df_global,
+            m_memory=400,
+            n_global=2000,
+        )
+        assert result.psi is not None
+        assert result.top_divergent_terms, "should report top terms"
+        # The biggest-delta term should land first.
+        assert result.top_divergent_terms[0]["index"] == 0
+
+    def test_eps_smoothing_handles_empty_bin(self) -> None:
+        # Concentrate every memory term into a single IDF region by
+        # setting df_memory uniform, then make df_global vary widely so
+        # IDF_global terms scatter into bins that have zero memory mass.
+        num_terms = 200
+        df_memory = dict.fromkeys(range(num_terms), MIN_DF + 10)
+        df_global = {i: MIN_DF + (i % 50) for i in range(num_terms)}
+        result = compute_psi(
+            df_memory=df_memory,
+            df_global=df_global,
+            m_memory=500,
+            n_global=2000,
+        )
+        # No NaN/Inf — eps-smoothing should keep PSI finite.
+        assert result.psi is not None
+        assert math.isfinite(result.psi)
+
+
+class TestTopDivergentTermsShape:
+    def test_term_entries_use_int_index_no_plaintext(self) -> None:
+        df_memory = dict.fromkeys(range(60), MIN_DF + 5)
+        df_global = dict.fromkeys(range(60), MIN_DF + 50)
+        result = compute_psi(
+            df_memory=df_memory,
+            df_global=df_global,
+            m_memory=400,
+            n_global=2000,
+        )
+        for entry in result.top_divergent_terms:
+            assert set(entry.keys()) == {
+                "index",
+                "df_memory",
+                "df_global",
+                "idf_memory",
+                "idf_global",
+                "delta",
+            }
+            assert isinstance(entry["index"], int)
+
+
+@pytest.mark.parametrize("count", [0, 5, NUM_BINS - 1])
+def test_zero_or_few_memory_points_short_circuits(count: int) -> None:
+    """The min-N gate fires before any expensive computation runs."""
+    result = compute_psi(
+        df_memory={1: MIN_DF + 5},
+        df_global={1: MIN_DF + 5},
+        m_memory=count,
+        n_global=count,
+    )
+    assert result.status == "insufficient_data"
+    assert result.psi is None

--- a/backend/tests/tasks/test_bm25_drift_tasks.py
+++ b/backend/tests/tasks/test_bm25_drift_tasks.py
@@ -1,0 +1,58 @@
+"""Tests for the BM25 IDF drift cron registration + task body (issue #343)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tasks.bm25_drift_tasks import (
+    bm25_drift_maintenance_task,
+    schedule_bm25_drift_tasks,
+)
+
+
+class TestSchedulerRegistration:
+    """Sleeping-code discipline: cron must NOT register when env flag is unset."""
+
+    def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BM25_DRIFT_CRON_ENABLED", raising=False)
+        scheduler = MagicMock()
+        schedule_bm25_drift_tasks(scheduler)
+        scheduler.add_job.assert_not_called()
+
+    def test_explicit_false_does_not_register(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BM25_DRIFT_CRON_ENABLED", "false")
+        scheduler = MagicMock()
+        schedule_bm25_drift_tasks(scheduler)
+        scheduler.add_job.assert_not_called()
+
+    def test_enabled_registers_cron_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("BM25_DRIFT_CRON_ENABLED", "true")
+        monkeypatch.setenv("BM25_DRIFT_CRON_HOUR", "5")
+        monkeypatch.setenv("BM25_DRIFT_CRON_MINUTE", "30")
+        scheduler = MagicMock()
+        schedule_bm25_drift_tasks(scheduler)
+        assert scheduler.add_job.call_count == 1
+        kwargs = scheduler.add_job.call_args.kwargs
+        assert kwargs["id"] == "bm25_drift_maintenance"
+        assert kwargs["replace_existing"] is True
+
+
+class TestTaskBodyGate:
+    """Defense in depth: even if registered, the task must self-skip when off."""
+
+    @pytest.mark.asyncio
+    async def test_task_skips_when_env_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("BM25_DRIFT_CRON_ENABLED", raising=False)
+        # No DB / orchestrator imports should happen — if they did, the
+        # absence of fixtures would raise. The fact that this returns
+        # without error is the assertion.
+        await bm25_drift_maintenance_task()
+
+    @pytest.mark.asyncio
+    async def test_task_skips_when_env_explicit_false(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("BM25_DRIFT_CRON_ENABLED", "false")
+        await bm25_drift_maintenance_task()


### PR DESCRIPTION
Closes #343

## Summary

- Adds `bm25_idf_drift_log` table, a per-context PSI cron, and an admin API at `/api/v1/admin/bm25-drift/` for tracking BM25 IDF distribution drift in the `kagura_memories` collection.
- **Production cron is disabled by default** (`BM25_DRIFT_CRON_ENABLED=false`, mirrors the `sleep_enabled` precedent at `backend/src/neural/config.py:168`) and scheduled for enablement in v0.14.0 once Privacy Policy (#359) and right-to-erasure (#360) land.
- v0.12.1 ships infrastructure only — the OpenAPI tag is `bm25-drift (preview)` and the manual trigger (`POST /admin/bm25-drift/run`) is intended for dev/staging verification.

## Implementation notes

**PSI math** (`backend/src/services/bm25_drift/psi_calculator.py`) follows the Stats PhD spec captured in the issue body:
- Term filter: Cochran's rule (`df_memory(t) >= 5 AND df_global(t) >= 5`)
- 10 quantile bins on `IDF_memory`
- ε-smoothing with `ε = 1/|T|`
- Min-N gates: `M >= 100` AND `|T| >= 50`. When not met, emit `psi_status="insufficient_data"` rather than a misleading scalar — the DB CHECK constraint pins `psi IS NULL ⇔ psi_status='insufficient_data'` so the invariant survives application bugs.

**Source classification** (`idf_snapshot.py`): Qdrant scroll with `with_vectors=["bm25"]`, classifying each point as memory- vs resource-source via the presence of the `payload.resource_id` field. Stored entries in `top_divergent_terms` are mmh3 integer hashes — no plaintext token storage.

**Schema design** (`migrations/a98_bm25_idf_drift_log.py`):
- BigInt PK (high-frequency append-only, mirrors `sleep_actions`)
- `psi NUMERIC(10,6)` (precision-sensitive; not Float)
- `top_divergent_terms JSONB`
- 3 CHECK constraints (status enum, psi-null-iff-insufficient invariant, non-neg counts)
- 3 indexes including a partial alerted-status index
- CASCADE on `context_id` FK so #360 right-to-erasure sweeps drift rows automatically

**Sleeping code discipline**: env-flag-gated cron (registration + body, defense in depth), single `# TODO(v0.14.0): enable BM25_DRIFT_CRON_ENABLED in production` marker at the cron entry point (grep-able for release readiness), and tests green in both `=false` (production) and `=true` (test) states.

**Architecture decision log**: design refinement followed a rigorous pipeline — gate1 (CAIO yellow) → /phd:stats (PSI formalism) → CxO cascade (CIO schema, CSO PII/RBAC, CLO GDPR pseudonymous classification, CAIO operability, PM sequencing, CTO sleeping-code economics) → implementation. The original "term storage mode" flag was dropped in implementation: mmh3 hashing happens at the Qdrant index layer by construction, so no runtime flag is needed and the CSO/CLO constraints are satisfied automatically.

## Test plan

- [x] `pytest backend/tests/services/bm25_drift/ backend/tests/tasks/test_bm25_drift_tasks.py backend/tests/api/test_bm25_drift_admin.py` — 30 tests passing
- [x] `ruff check` — clean on all new files
- [x] `alembic upgrade --sql` dump verified syntactically clean for `a98_bm25_idf_drift_log`
- [ ] CI integration tests against clean DB (covers `a98` upgrade against fresh schema)
- [ ] Live Qdrant scroll exercised when production cron is enabled in v0.14.0 (intentionally deferred)

## Follow-up issues to file (v0.14.0)

These are sequenced to land alongside the legal scaffolding (#359 Privacy Policy, #360 right-to-erasure):

1. `feat(observability): on-demand plain-term reveal endpoint for bm25_idf_drift_log` — `system_admin` second gate, in-memory TTL, audit logged
2. `chore(observability): enable BM25_DRIFT_CRON_ENABLED in production` — blocked by this PR, #359, and #360
3. Privacy Policy update within #359 to add an "Internal Observability Metrics" section referencing this drift log

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CAIO role) after /phd:stats refinement
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/343-feat-feat-observability-track-bm25-idf-drift.gate1.md`
- `~/.claude/cache/gh-issue-driven/343-feat-feat-observability-track-bm25-idf-drift.gate2.md`

🤖 Generated via `/gh-issue-driven:ship`
