### PR TITLE
fix(sleep): preserve directed edge_type pair order (#373)

### DIFF
--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -711,8 +711,20 @@ class EdgeDiscoveryPhase:
             # the `related` check so the directional dispatch can run before
             # we accept or reject — a flipped directed pair is malformed
             # regardless of `related=true|false`.
+            #
+            # `isinstance(raw_type, str)` guard: LLM JSON could return a
+            # list/dict for `edge_type` (malformed schema). A non-string in
+            # `set.__contains__` raises `TypeError`, which would abort
+            # parsing of the entire successful LLM response — a single bad
+            # row would silently lose every other valid edge in the batch.
+            # Treat non-strings as invalid and coerce to `related_to`,
+            # matching the existing fallback for unknown string values.
             raw_type = edge.get("edge_type", "related_to")
-            edge_type = raw_type if raw_type in valid_edge_types else "related_to"
+            edge_type = (
+                raw_type
+                if isinstance(raw_type, str) and raw_type in valid_edge_types
+                else "related_to"
+            )
 
             # #373: directed edge_types must preserve input pair order. The
             # frozenset hallucination guard above is orientation-agnostic, so

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -96,6 +96,15 @@ def _is_synthetic_seed_edge(edge: NeuralMemoryEdge) -> bool:
 # `dict.fromkeys(KEYS, 0)` widens to `dict[str, int]` for downstream consumers.
 CONFIDENCE_HISTOGRAM_KEYS: tuple[str, ...] = ("0.0-0.5", "0.5-0.7", "0.7-0.85", "0.85-1.0")
 
+# Issue #373: edge_type directionality semantics.
+# `related_to` is undirected (A related_to B ⇔ B related_to A); the parser
+# accepts the LLM's pair order as-is. `depends_on` and `learned_from` are
+# directed (A depends_on B ≠ B depends_on A); the parser MUST reject pairs
+# where the LLM flipped the input order, otherwise edges are silently stored
+# in the wrong direction (PR #371 PhD-pl review finding). Module-level so
+# tests can import the same source of truth.
+DIRECTED_EDGE_TYPES: frozenset[str] = frozenset({"depends_on", "learned_from"})
+
 
 @dataclass
 class BatchStats:
@@ -191,6 +200,16 @@ def _metrics_from_agg(
     would alias the caller's mutable structures and any post-emit mutation
     would silently corrupt `result.details`. The copy cost is negligible
     (O(3) for edge_type, O(4) for histogram).
+
+    Directional semantics (#373): `edge_type_dist` only counts edges that
+    survived the parser's directional canonicalization in `_llm_judge_batch`.
+    Undirected `related_to` matches the LLM response orientation-agnostically
+    (frozenset). Directed `depends_on` / `learned_from` require the LLM to
+    preserve the input pair order (`requested_ordered_pairs` ordered-tuple
+    match); flipped directed pairs are silently dropped — they do NOT
+    contribute to `llm_accepted`, `llm_rejected`, or `llm_call_failures`.
+    `prompt_revision` distinguishes pre/post-#373 prompts so historical
+    counts can be interpreted under the correct semantics.
     """
     return {
         "llm_accepted": agg.accepted,
@@ -621,22 +640,22 @@ class EdgeDiscoveryPhase:
         # `edges_created` and skewing observability metrics. Addresses
         # Copilot review #371 finding (loop 4).
         #
-        # KNOWN LIMITATION (#373): the `frozenset` match is orientation-agnostic,
-        # so the LLM may return (B, A) for our requested (A, B) pair and we
-        # accept it — then we use the LLM's order to populate src_id/dst_id.
-        # For `related_to` (undirected) this is correct. For `depends_on` /
-        # `learned_from` (directed) this can silently create the edge in the
-        # WRONG direction if the LLM flipped. The prompt does not currently
-        # forbid the flip, and we have no measurement of the flip rate. See
-        # #373 for the proposed fix (prompt clarification + directional
-        # canonicalization for directed edge_types).
+        # `requested_ordered_pairs` (#373): same pairs as `requested_pairs` but
+        # preserves the (src_label, dst_label) input order. The parser uses
+        # this for directed edge_types (`depends_on`, `learned_from`) so that
+        # an LLM-flipped pair is detected and silently dropped, preventing the
+        # edge from being stored in the wrong direction. Undirected
+        # `related_to` continues to use `requested_pairs` (orientation-agnostic).
         pair_lines = []
         requested_pairs: set[frozenset[str]] = set()
+        requested_ordered_pairs: set[tuple[str, str]] = set()
         for src, dst, score in batch:
             if src not in id_to_label or dst not in id_to_label:
                 continue
-            pair_lines.append(f"  ({id_to_label[src]}, {id_to_label[dst]}): similarity={score:.3f}")
-            requested_pairs.add(frozenset({id_to_label[src], id_to_label[dst]}))
+            src_label, dst_label = id_to_label[src], id_to_label[dst]
+            pair_lines.append(f"  ({src_label}, {dst_label}): similarity={score:.3f}")
+            requested_pairs.add(frozenset({src_label, dst_label}))
+            requested_ordered_pairs.add((src_label, dst_label))
 
         if not pair_lines:
             # All pairs in this batch had at least one end outside memory_map.
@@ -683,18 +702,36 @@ class EdgeDiscoveryPhase:
 
             # Reject hallucinated/unrequested pairs: the LLM may invent pair
             # combinations that were never in `pair_lines`. Match
-            # orientation-agnostic via frozenset to allow the model to flip
-            # the pair order (the relationship is undirected at this stage).
+            # orientation-agnostic via frozenset; directional canonicalization
+            # is applied below per `edge_type`.
             if frozenset(pair) not in requested_pairs:
+                continue
+
+            # Validate edge_type against DB CHECK constraint. Hoisted above
+            # the `related` check so the directional dispatch can run before
+            # we accept or reject — a flipped directed pair is malformed
+            # regardless of `related=true|false`.
+            raw_type = edge.get("edge_type", "related_to")
+            edge_type = raw_type if raw_type in valid_edge_types else "related_to"
+
+            # #373: directed edge_types must preserve input pair order. The
+            # frozenset hallucination guard above is orientation-agnostic, so
+            # an LLM that flipped (A, B) → (B, A) for `depends_on` / `learned_from`
+            # would otherwise be accepted and the edge stored as B→A. Silently
+            # skip flipped directed pairs — same treatment as hallucinated /
+            # malformed pairs (no contribution to accepted/rejected/failures).
+            # Undirected `related_to` is unaffected; coerced edge_types fall
+            # through to the undirected path because `related_to` is the
+            # coercion target.
+            if (
+                edge_type in DIRECTED_EDGE_TYPES
+                and (pair[0], pair[1]) not in requested_ordered_pairs
+            ):
                 continue
 
             if not edge.get("related", False):
                 stats.rejected += 1
                 continue
-
-            # Validate edge_type against DB CHECK constraint
-            raw_type = edge.get("edge_type", "related_to")
-            edge_type = raw_type if raw_type in valid_edge_types else "related_to"
 
             raw_conf = edge.get("confidence", 0.5)
             # Guard against non-finite values (NaN/Inf): a NaN here would

--- a/backend/src/services/sleep/prompts.py
+++ b/backend/src/services/sleep/prompts.py
@@ -75,7 +75,9 @@ Example:
 # Bump on every edit to EDGE_DISCOVERY_SYSTEM or EDGE_DISCOVERY_USER so
 # sleep_reports.edge_discovery_result.details can distinguish runs that used
 # different prompts.
-EDGE_DISCOVERY_PROMPT_REVISION = "v1"
+# v2 (#373): added IMPORTANT directive forbidding pair-order flip for directed
+# edge_types and a depends_on example so the LLM can learn the directed pattern.
+EDGE_DISCOVERY_PROMPT_REVISION = "v2"
 
 EDGE_DISCOVERY_SYSTEM = """\
 You are a knowledge graph edge discovery agent. You analyze pairs of memory \
@@ -101,6 +103,11 @@ Memories:
 Pairs to evaluate (with cosine similarity scores):
 {pairs}
 
+IMPORTANT: For directed edge types ("depends_on", "learned_from"), preserve
+the input pair order. The first element of "pair" must remain the first
+element you received. Direction is encoded by input order; do not flip.
+For "related_to" (undirected), order does not matter.
+
 Respond with this exact JSON schema:
 {{
   "edges": [
@@ -123,6 +130,13 @@ Example:
       "edge_type": "related_to",
       "confidence": 0.85,
       "reason": "B describes the implementation of the pattern introduced in A"
+    }},
+    {{
+      "pair": ["C", "D"],
+      "related": true,
+      "edge_type": "depends_on",
+      "confidence": 0.78,
+      "reason": "C builds on the abstraction defined in D (C depends_on D)"
     }}
   ]
 }}\

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -11,6 +11,7 @@ import pytest
 from services.sleep.edge_discovery import (
     BATCH_SIZE,
     CONFIDENCE_HISTOGRAM_KEYS,
+    DIRECTED_EDGE_TYPES,
     DISCOVERY_EDGE_WEIGHT,
     SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD,
     SIMILARITY_MAX,
@@ -710,6 +711,144 @@ class TestLLMJudgeBatch:
         assert stats.failures == 0
         # complete_json was not invoked: skipped before the LLM call.
         llm_judge_phase.llm_service.complete_json.assert_not_called()
+
+
+class TestDirectedEdgeOrientation:
+    """Issue #373: directional canonicalization in `_llm_judge_batch`.
+
+    `related_to` is undirected — the LLM may return the pair in either order
+    and the parser still accepts. `depends_on` and `learned_from` are directed
+    — if the LLM flips the input pair order, the parser MUST silently drop
+    that pair (same treatment as hallucinated/malformed pairs: no contribution
+    to accepted/rejected/failures). Without this, edges would be silently
+    stored in the wrong direction (PR #371 PhD-pl review finding).
+    """
+
+    def test_directed_edge_types_constant_matches_design(self):
+        """Sanity check: the constant covers exactly the two directed types
+        called out in the issue, so future additions to the schema must pass
+        through this list deliberately."""
+        assert DIRECTED_EDGE_TYPES == frozenset({"depends_on", "learned_from"})
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("directed_edge_type", ["depends_on", "learned_from"])
+    async def test_directed_pair_flipped_silently_skipped(
+        self, llm_judge_phase, directed_edge_type
+    ):
+        """Directed edge_type with LLM-flipped pair order must be silently
+        dropped — not accepted (would store wrong direction), not rejected
+        (the LLM did not say "not related"), and not counted as a failure
+        (the LLM call itself succeeded). Same accounting as hallucinated /
+        malformed pairs."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=2)
+        labels = _labels_for(memory_map)
+        # Request (A, B); LLM returns the flipped (B, A) for a directed type.
+        src_label = labels[batch[0][0]]
+        dst_label = labels[batch[0][1]]
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [(dst_label, src_label, True, directed_edge_type, 0.9)]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert confirmed == []
+        assert stats.accepted == 0
+        assert stats.rejected == 0
+        assert stats.failures == 0
+        assert stats.edge_type_counts == {}
+        assert stats.confidences == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("directed_edge_type", ["depends_on", "learned_from"])
+    async def test_directed_pair_correct_order_accepted(self, llm_judge_phase, directed_edge_type):
+        """Sanity: directed edge_type with the input pair order preserved is
+        accepted normally. Guards against an over-eager direction filter that
+        rejects every directed pair."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=2)
+        labels = _labels_for(memory_map)
+        src_label = labels[batch[0][0]]
+        dst_label = labels[batch[0][1]]
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [(src_label, dst_label, True, directed_edge_type, 0.9)]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert len(confirmed) == 1
+        assert stats.accepted == 1
+        assert stats.rejected == 0
+        assert stats.edge_type_counts == {directed_edge_type: 1}
+        # src/dst preserved in the order the LLM returned (which equals the
+        # input order, by construction of this test).
+        assert confirmed[0][0] == batch[0][0]
+        assert confirmed[0][1] == batch[0][1]
+        assert confirmed[0][2] == directed_edge_type
+
+    @pytest.mark.asyncio
+    async def test_undirected_pair_flipped_still_accepted(self, llm_judge_phase):
+        """Undirected `related_to` is unaffected by #373 — the LLM may flip
+        the pair order and the parser still accepts. The orientation-agnostic
+        frozenset match (existing hallucination guard) is preserved for this
+        edge_type."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=2)
+        labels = _labels_for(memory_map)
+        src_label = labels[batch[0][0]]
+        dst_label = labels[batch[0][1]]
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [(dst_label, src_label, True, "related_to", 0.9)]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert len(confirmed) == 1
+        assert stats.accepted == 1
+        assert stats.edge_type_counts == {"related_to": 1}
+        # The parser uses the LLM's pair order verbatim for undirected edges,
+        # so src/dst here reflect the flipped order. Semantically equivalent
+        # to (src=A, dst=B) for the consumer because `related_to` is symmetric.
+        assert confirmed[0][0] == batch[0][1]
+        assert confirmed[0][1] == batch[0][0]
+
+    @pytest.mark.asyncio
+    async def test_invalid_edge_type_flipped_treated_as_undirected(self, llm_judge_phase):
+        """An unknown edge_type is coerced to `related_to` (existing #306
+        behavior). Coercion happens BEFORE the directional check, so a
+        flipped pair with `garbage_type` lands in the undirected branch and
+        is accepted. This makes coercion direction-safe by construction —
+        operators don't get a silent-drop surprise from unknown types."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=2)
+        labels = _labels_for(memory_map)
+        src_label = labels[batch[0][0]]
+        dst_label = labels[batch[0][1]]
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [(dst_label, src_label, True, "garbage_type", 0.8)]
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert len(confirmed) == 1
+        assert confirmed[0][2] == "related_to"
+        assert stats.edge_type_counts == {"related_to": 1}
 
 
 class TestExecuteAggregation:

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -825,6 +825,62 @@ class TestDirectedEdgeOrientation:
         assert confirmed[0][1] == batch[0][0]
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "raw_edge_type",
+        [
+            ["depends_on"],  # list — common LLM "I returned an array" mistake
+            {"type": "depends_on"},  # dict — schema confusion
+            42,  # int — wrong type entirely
+            None,  # explicit null
+        ],
+    )
+    async def test_non_string_edge_type_does_not_crash(self, llm_judge_phase, raw_edge_type):
+        """LLM may return a non-string `edge_type` (list, dict, int, null) due
+        to schema confusion. Pre-fix, `raw_type in valid_edge_types` raised
+        `TypeError` on unhashables, aborting parsing of EVERY edge in the
+        batch (including valid ones). The `isinstance(raw_type, str)` guard
+        coerces the bad row to `related_to` and lets the rest of the response
+        parse normally. Addresses Copilot review on PR #380."""
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=3)
+        labels = _labels_for(memory_map)
+
+        # Build the response by hand — _make_llm_response only takes str.
+        llm_judge_phase.llm_service.complete_json.return_value = (
+            {
+                "edges": [
+                    {
+                        "pair": [labels[batch[0][0]], labels[batch[0][1]]],
+                        "related": True,
+                        "edge_type": raw_edge_type,
+                        "confidence": 0.8,
+                    },
+                    # Valid follow-up row — must still be parsed even though
+                    # the first row had a non-string edge_type.
+                    {
+                        "pair": [labels[batch[1][0]], labels[batch[1][1]]],
+                        "related": True,
+                        "edge_type": "related_to",
+                        "confidence": 0.9,
+                    },
+                ]
+            },
+            100,
+        )
+
+        confirmed, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        # Both rows accepted: bad-row coerced to related_to, valid row passes
+        # through. Pre-fix, the TypeError would have aborted parsing → 0 edges.
+        assert len(confirmed) == 2
+        assert stats.accepted == 2
+        # Both end up as related_to (one coerced, one explicit).
+        assert stats.edge_type_counts == {"related_to": 2}
+
+    @pytest.mark.asyncio
     async def test_invalid_edge_type_flipped_treated_as_undirected(self, llm_judge_phase):
         """An unknown edge_type is coerced to `related_to` (existing #306
         behavior). Coercion happens BEFORE the directional check, so a


### PR DESCRIPTION
Closes #373

## Summary
- Fix silent direction-flip bug in `_llm_judge_batch` parser for directed edge_types (`depends_on`, `learned_from`) — the orientation-agnostic frozenset hallucination guard from PR #371 silently accepted LLM-flipped pair order, storing edges in the wrong direction
- Add `requested_ordered_pairs` validation alongside the existing `requested_pairs` so directed types require ordered match while undirected `related_to` keeps orientation-agnostic semantics
- Bump `EDGE_DISCOVERY_PROMPT_REVISION` v1→v2 with an IMPORTANT directive forbidding pair flip plus a new `depends_on` example so the LLM can learn the directed pattern

## Implementation notes
- New module-level constant `DIRECTED_EDGE_TYPES: frozenset[str] = frozenset({"depends_on", "learned_from"})` co-located with `CONFIDENCE_HISTOGRAM_KEYS` in `backend/src/services/sleep/edge_discovery.py` — importable from tests as the single source of truth
- `requested_ordered_pairs: set[tuple[str, str]]` built in the same loop as `requested_pairs` (negligible cost, parallel structure)
- `edge_type` validation hoisted above the `related` check so directional dispatch runs before accept/reject — a flipped directed pair is malformed regardless of `related=true|false`
- Flipped directed pairs are silently dropped: same accounting as hallucinated/malformed pairs (no contribution to `llm_accepted`, `llm_rejected`, or `llm_call_failures`)
- Coerced (unknown) edge_types fall through to the undirected path because `related_to` is the coercion target — locked down by `test_invalid_edge_type_flipped_treated_as_undirected`
- `_metrics_from_agg` docstring documents the new directional semantics so metric readers can interpret `edge_type_dist` correctly
- Removed obsolete `KNOWN LIMITATION (#373)` comment block (8 lines) replaced with a 6-line explanation of the new `requested_ordered_pairs` role
- 7 new tests in the `TestDirectedEdgeOrientation` class — parametrized over `depends_on`/`learned_from` for both flipped (silently skipped) and correct-order (accepted) cases, plus undirected flipped (accepted), unknown edge_type fall-through, and a constant trip-wire

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CAIO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/373-fix-fix-sleep-preserve-pair-direction-for-di.gate1.md`
- `~/.claude/cache/gh-issue-driven/373-fix-fix-sleep-preserve-pair-direction-for-di.gate2.md`

## Test results
- 51/51 pass in `tests/services/sleep/test_edge_discovery.py` (44 existing + 7 new)
- 125/125 pass across `tests/services/sleep/` + `tests/mcp_server/test_sleep_tools.py`
- ruff check: clean
- pyright: 5 pre-existing errors (#370 SQLAlchemy `Column[T]` migration scope, unrelated to this change)

🤖 Generated via /gh-issue-driven:ship
