### PR TITLE
fix(infra): add /redoc reverse_proxy to Caddyfile.tpl (#384)

### DIFF
--- a/terraform/single-server/Caddyfile.tpl
+++ b/terraform/single-server/Caddyfile.tpl
@@ -55,6 +55,10 @@ memory.kagura-ai.com {
 		reverse_proxy ${API_UPSTREAM}:8080
 	}
 
+	handle /redoc* {
+		reverse_proxy ${API_UPSTREAM}:8080
+	}
+
 	handle /openapi.json {
 		reverse_proxy ${API_UPSTREAM}:8080
 	}


### PR DESCRIPTION
Closes #384

## Summary
- Add `handle /redoc*` reverse_proxy block to `terraform/single-server/Caddyfile.tpl`, routed to `${API_UPSTREAM}:8080`.
- Restores public access to `/redoc` (broken since PR #363 switched canonical API docs to backend `/redoc` without updating the Caddy template).
- Wildcard matcher (`/redoc*`) ensures both `/redoc` and `/redoc/` (trailing-slash variants) reach the API instead of falling through to the Next.js catch-all.

## Implementation notes
- Inserted right after the existing `/docs*` block, matching the wildcard style of `/api/*`, `/mcp*`, etc.
- Uses the same `${API_UPSTREAM}` placeholder that `deploy.sh` substitutes with `api-blue` / `api-green` at deploy time.
- No code, no dependencies, no migration. Caddy restart is part of the standard blue-green deploy flow — no extra downtime.

## Pre-PR review summary
- gate2 mode: advisor-only (default)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/384-fix-fix-infra-add-redoc-reverse-proxy-to-cad.gate1.md
- ~/.claude/cache/gh-issue-driven/384-fix-fix-infra-add-redoc-reverse-proxy-to-cad.gate2.md

## Test plan
- [ ] After merge, deploy to production via `sudo bash terraform/single-server/scripts/deploy.sh`
- [ ] Verify `curl https://memory.kagura-ai.com/redoc` returns HTTP 200
- [ ] Open `https://memory.kagura-ai.com/redoc` in a browser and confirm ReDoc UI renders
- [ ] Confirm `curl https://memory.kagura-ai.com/openapi.json` still returns HTTP 200 (no regression)

🤖 Generated via /gh-issue-driven:ship
