### PR TITLE
fix(auth): external API keys owner-only and workspace_id NOT NULL (#381, #385)

### DIFF
--- a/backend/alembic/versions/a99_external_keys_workspace_not_null.py
+++ b/backend/alembic/versions/a99_external_keys_workspace_not_null.py
@@ -1,0 +1,58 @@
+"""Issue #385: enforce workspace_id NOT NULL on external_api_keys + partial unique index.
+
+Phase 2 of the external API keys workspace authorization rework. Phase 1 (#381) removed
+the legacy POST /external-keys/import endpoint (the sole source of workspace_id=NULL rows)
+and confirmed that no legacy pre-#146 data remains. This migration tightens the schema:
+
+1. Drop the historical NULL allowance on workspace_id — every external API key now belongs
+   to exactly one workspace, never to a "global / personal" scope.
+2. Enforce at most one enabled key per (workspace, provider) pair via a partial unique
+   index. Disabled keys are intentionally exempt so an owner can hold a "spare" key for a
+   provider in a disabled state without conflicting with the active one.
+
+Revision ID: a99_ext_keys_ws_not_null
+Revises: a98_bm25_idf_drift_log
+Create Date: 2026-04-19
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "a99_ext_keys_ws_not_null"
+down_revision: str | Sequence[str] | None = "a98_bm25_idf_drift_log"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "external_api_keys",
+        "workspace_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=False,
+    )
+
+    op.create_index(
+        "uq_external_api_keys_workspace_provider_enabled",
+        "external_api_keys",
+        ["workspace_id", "provider"],
+        unique=True,
+        postgresql_where=sa.text("enabled = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_external_api_keys_workspace_provider_enabled",
+        table_name="external_api_keys",
+    )
+    op.alter_column(
+        "external_api_keys",
+        "workspace_id",
+        existing_type=postgresql.UUID(as_uuid=True),
+        nullable=True,
+    )

--- a/backend/alembic/versions/a99_external_keys_workspace_not_null.py
+++ b/backend/alembic/versions/a99_external_keys_workspace_not_null.py
@@ -6,9 +6,17 @@ and confirmed that no legacy pre-#146 data remains. This migration tightens the 
 
 1. Drop the historical NULL allowance on workspace_id — every external API key now belongs
    to exactly one workspace, never to a "global / personal" scope.
-2. Enforce at most one enabled key per (workspace, provider) pair via a partial unique
-   index. Disabled keys are intentionally exempt so an owner can hold a "spare" key for a
-   provider in a disabled state without conflicting with the active one.
+2. Enforce at most one enabled key per (workspace, context, provider) triple via a partial
+   unique index with NULLS NOT DISTINCT (PG 15+). The context_id column is included so the
+   service-layer's context > workspace priority contract (embedding / llm / reranker) can
+   have BOTH a context-scoped enabled key AND a workspace-scoped (context_id IS NULL)
+   fallback for the same provider coexist. NULLS NOT DISTINCT makes NULL context_ids
+   collide, so two workspace-scoped rows for the same provider are still blocked.
+   Disabled keys are intentionally exempt so an owner can hold a "spare" key in a
+   disabled state without conflicting with the active one.
+3. Enforce key_name uniqueness per workspace via a full unique index on
+   (workspace_id, key_name), so the update / toggle / delete handlers'
+   scalar_one_or_none() lookups cannot raise MultipleResultsFound on legacy data.
 
 Revision ID: a99_ext_keys_ws_not_null
 Revises: a98_bm25_idf_drift_log

--- a/backend/alembic/versions/a99_external_keys_workspace_not_null.py
+++ b/backend/alembic/versions/a99_external_keys_workspace_not_null.py
@@ -82,6 +82,39 @@ def upgrade() -> None:
             "delete the duplicates before re-running this migration."
         )
 
+    # Defensive pre-check #3: reranker exclusivity is now enforced per-workspace
+    # (Cohere XOR Voyage). Pre-#385 it was per-user, so a workspace could legitimately
+    # have both providers enabled across different users. The new partial unique index
+    # only covers same-provider duplicates, not cross-provider reranker conflicts, so
+    # those would slip past the schema and leave reranker_service picking a key
+    # nondeterministically. Abort with a clear remediation path.
+    reranker_conflicts = conn.execute(
+        sa.text(
+            "SELECT workspace_id, "
+            "       COUNT(*) AS cnt, "
+            "       STRING_AGG(provider, ', ' ORDER BY provider) AS providers "
+            "FROM external_api_keys "
+            "WHERE enabled = true "
+            "  AND provider IN ('cohere', 'voyage') "
+            "GROUP BY workspace_id "
+            "HAVING COUNT(*) > 1 "
+            "ORDER BY cnt DESC, workspace_id "
+            "LIMIT 5"
+        )
+    ).fetchall()
+    if reranker_conflicts:
+        examples = ", ".join(
+            f"workspace={row[0]} providers=[{row[2]}] ({row[1]} enabled reranker keys)"
+            for row in reranker_conflicts
+        )
+        raise RuntimeError(
+            "Migration aborted: some workspaces have multiple enabled reranker keys "
+            f"across Cohere/Voyage (examples: {examples}). The new per-workspace "
+            "reranker invariant requires choosing exactly one enabled reranker "
+            "provider per workspace. Disable or delete the extra Cohere/Voyage "
+            "keys before re-running this migration."
+        )
+
     op.create_index(
         "uq_external_api_keys_workspace_provider_enabled",
         "external_api_keys",

--- a/backend/alembic/versions/a99_external_keys_workspace_not_null.py
+++ b/backend/alembic/versions/a99_external_keys_workspace_not_null.py
@@ -115,12 +115,48 @@ def upgrade() -> None:
             "keys before re-running this migration."
         )
 
+    # Defensive pre-check #4: the update/toggle/delete handlers look up rows by
+    # (workspace_id, key_name) via scalar_one_or_none(), which would raise
+    # MultipleResultsFound (→ HTTP 500) if any legacy row pair shares the same
+    # (workspace_id, key_name). Pre-#381 multiple users could each create a key
+    # named "openai_primary" in the same workspace — schema allowed it because
+    # uniqueness was per-user. Detect and abort before creating the unique index
+    # below.
+    name_dupes = conn.execute(
+        sa.text(
+            "SELECT workspace_id, key_name, COUNT(*) AS cnt "
+            "FROM external_api_keys "
+            "GROUP BY workspace_id, key_name "
+            "HAVING COUNT(*) > 1 "
+            "ORDER BY cnt DESC, workspace_id, key_name "
+            "LIMIT 5"
+        )
+    ).fetchall()
+    if name_dupes:
+        examples = ", ".join(
+            f"workspace={row[0]} key_name='{row[1]}' ({row[2]} rows)" for row in name_dupes
+        )
+        raise RuntimeError(
+            "Migration aborted: external_api_keys has multiple rows sharing the same "
+            f"(workspace_id, key_name) pair (examples: {examples}). The new "
+            "unique index uq_external_api_keys_workspace_key_name requires names "
+            "to be unique within a workspace. Rename or delete the duplicates "
+            "before re-running this migration."
+        )
+
     op.create_index(
         "uq_external_api_keys_workspace_provider_enabled",
         "external_api_keys",
         ["workspace_id", "provider"],
         unique=True,
         postgresql_where=sa.text("enabled = true"),
+    )
+
+    op.create_index(
+        "uq_external_api_keys_workspace_key_name",
+        "external_api_keys",
+        ["workspace_id", "key_name"],
+        unique=True,
     )
 
 

--- a/backend/alembic/versions/a99_external_keys_workspace_not_null.py
+++ b/backend/alembic/versions/a99_external_keys_workspace_not_null.py
@@ -162,6 +162,10 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     op.drop_index(
+        "uq_external_api_keys_workspace_key_name",
+        table_name="external_api_keys",
+    )
+    op.drop_index(
         "uq_external_api_keys_workspace_provider_enabled",
         table_name="external_api_keys",
     )

--- a/backend/alembic/versions/a99_external_keys_workspace_not_null.py
+++ b/backend/alembic/versions/a99_external_keys_workspace_not_null.py
@@ -55,16 +55,18 @@ def upgrade() -> None:
     )
 
     # Defensive pre-check #2: the partial unique index would fail if any
-    # (workspace_id, provider) pair already has 2+ enabled rows. Pre-#385 the
-    # invariant was per-user (different users in the same workspace could each have
-    # their own enabled provider key), so legacy data could violate. Surface a
-    # clear remediation path instead of a cryptic CREATE INDEX failure.
+    # (workspace_id, context_id, provider) triple already has 2+ enabled rows.
+    # Pre-#385 the invariant was per-user (different users in the same workspace
+    # could each have their own enabled provider key), so legacy data could
+    # violate. Surface a clear remediation path instead of a cryptic CREATE
+    # INDEX failure. Groups include context_id so the service-layer contract
+    # (context-scoped key + workspace-scoped fallback can coexist) stays intact.
     dup_rows = conn.execute(
         sa.text(
-            "SELECT workspace_id, provider, COUNT(*) AS cnt "
+            "SELECT workspace_id, context_id, provider, COUNT(*) AS cnt "
             "FROM external_api_keys "
             "WHERE enabled = true "
-            "GROUP BY workspace_id, provider "
+            "GROUP BY workspace_id, context_id, provider "
             "HAVING COUNT(*) > 1 "
             "ORDER BY cnt DESC "
             "LIMIT 5"
@@ -72,14 +74,16 @@ def upgrade() -> None:
     ).fetchall()
     if dup_rows:
         examples = ", ".join(
-            f"workspace={row[0]} provider={row[1]} ({row[2]} enabled)" for row in dup_rows
+            f"workspace={row[0]} context={row[1]} provider={row[2]} ({row[3]} enabled)"
+            for row in dup_rows
         )
         raise RuntimeError(
             "Migration aborted: external_api_keys has multiple enabled rows for the "
-            f"same (workspace_id, provider) pair (examples: {examples}). The new "
-            "partial unique index uq_external_api_keys_workspace_provider_enabled "
-            "requires at most one enabled key per (workspace, provider). Disable or "
-            "delete the duplicates before re-running this migration."
+            f"same (workspace_id, context_id, provider) triple (examples: {examples}). "
+            "The new partial unique index "
+            "uq_external_api_keys_workspace_provider_enabled requires at most one "
+            "enabled key per (workspace, context, provider). Disable or delete the "
+            "duplicates before re-running this migration."
         )
 
     # Defensive pre-check #3: reranker exclusivity is now enforced per-workspace
@@ -144,12 +148,20 @@ def upgrade() -> None:
             "before re-running this migration."
         )
 
+    # Include context_id in the partial unique so the service-layer
+    # context > workspace priority contract (EmbeddingService / LLMService /
+    # RerankerService) can have BOTH a context-scoped enabled key AND a
+    # workspace-scoped (context_id IS NULL) fallback for the same provider
+    # coexist in the same workspace. NULLS NOT DISTINCT (PG 15+) makes NULL
+    # context_ids collide with each other so two workspace-scoped rows for the
+    # same provider are still caught.
     op.create_index(
         "uq_external_api_keys_workspace_provider_enabled",
         "external_api_keys",
-        ["workspace_id", "provider"],
+        ["workspace_id", "context_id", "provider"],
         unique=True,
         postgresql_where=sa.text("enabled = true"),
+        postgresql_nulls_not_distinct=True,
     )
 
     op.create_index(

--- a/backend/alembic/versions/a99_external_keys_workspace_not_null.py
+++ b/backend/alembic/versions/a99_external_keys_workspace_not_null.py
@@ -29,11 +29,12 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # Defensive pre-check: surface a clear error if any legacy NULL workspace_id rows
-    # remain. Phase 1 (#381) deleted /external-keys/import (the only producer of NULL
-    # workspace_id rows), and the owner confirmed pre-#146 data is gone (2026-04-19),
-    # but we don't want a stale staging DB to fail with a cryptic IntegrityError on
-    # the NOT NULL alter. Pattern mirrors a97_resources_entity's pre-flight audit.
+    # Defensive pre-check #1: surface a clear error if any legacy NULL workspace_id
+    # rows remain. Phase 1 (#381) deleted /external-keys/import (the only producer of
+    # NULL workspace_id rows), and the owner confirmed pre-#146 data is gone
+    # (2026-04-19), but we don't want a stale staging DB to fail with a cryptic
+    # IntegrityError on the NOT NULL alter. Pattern mirrors a97_resources_entity's
+    # pre-flight audit.
     conn = op.get_bind()
     null_count = conn.execute(
         sa.text("SELECT COUNT(*) FROM external_api_keys WHERE workspace_id IS NULL")
@@ -52,6 +53,34 @@ def upgrade() -> None:
         existing_type=postgresql.UUID(as_uuid=True),
         nullable=False,
     )
+
+    # Defensive pre-check #2: the partial unique index would fail if any
+    # (workspace_id, provider) pair already has 2+ enabled rows. Pre-#385 the
+    # invariant was per-user (different users in the same workspace could each have
+    # their own enabled provider key), so legacy data could violate. Surface a
+    # clear remediation path instead of a cryptic CREATE INDEX failure.
+    dup_rows = conn.execute(
+        sa.text(
+            "SELECT workspace_id, provider, COUNT(*) AS cnt "
+            "FROM external_api_keys "
+            "WHERE enabled = true "
+            "GROUP BY workspace_id, provider "
+            "HAVING COUNT(*) > 1 "
+            "ORDER BY cnt DESC "
+            "LIMIT 5"
+        )
+    ).fetchall()
+    if dup_rows:
+        examples = ", ".join(
+            f"workspace={row[0]} provider={row[1]} ({row[2]} enabled)" for row in dup_rows
+        )
+        raise RuntimeError(
+            "Migration aborted: external_api_keys has multiple enabled rows for the "
+            f"same (workspace_id, provider) pair (examples: {examples}). The new "
+            "partial unique index uq_external_api_keys_workspace_provider_enabled "
+            "requires at most one enabled key per (workspace, provider). Disable or "
+            "delete the duplicates before re-running this migration."
+        )
 
     op.create_index(
         "uq_external_api_keys_workspace_provider_enabled",

--- a/backend/alembic/versions/a99_external_keys_workspace_not_null.py
+++ b/backend/alembic/versions/a99_external_keys_workspace_not_null.py
@@ -29,6 +29,23 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
+    # Defensive pre-check: surface a clear error if any legacy NULL workspace_id rows
+    # remain. Phase 1 (#381) deleted /external-keys/import (the only producer of NULL
+    # workspace_id rows), and the owner confirmed pre-#146 data is gone (2026-04-19),
+    # but we don't want a stale staging DB to fail with a cryptic IntegrityError on
+    # the NOT NULL alter. Pattern mirrors a97_resources_entity's pre-flight audit.
+    conn = op.get_bind()
+    null_count = conn.execute(
+        sa.text("SELECT COUNT(*) FROM external_api_keys WHERE workspace_id IS NULL")
+    ).scalar()
+    if null_count and null_count > 0:
+        raise RuntimeError(
+            f"Migration aborted: {null_count} external_api_keys row(s) have NULL "
+            "workspace_id. Phase 1 (#381) was supposed to leave none. Either "
+            "backfill the workspace_id column or delete the legacy rows before "
+            "re-running this migration."
+        )
+
     op.alter_column(
         "external_api_keys",
         "workspace_id",

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -123,10 +123,11 @@ async def validate_reranker_exclusivity(
     Issue #385: scoped per workspace — was per user before, because external keys
         are workspace-shared resources now. The partial unique index
         uq_external_api_keys_workspace_provider_enabled only guarantees at most
-        one enabled key per (workspace, provider) at the DB level — a different
-        invariant. This application-layer check is what enforces the
+        one enabled key per (workspace, context, provider) at the DB level — a
+        different invariant. This application-layer check is what enforces the
         cross-provider reranker exclusivity (no Cohere AND Voyage enabled
-        simultaneously) and produces a friendly 409 with provider details.
+        simultaneously per workspace) and produces a friendly 409 with provider
+        details.
 
     Rules:
     - OpenAI cannot be disabled (embeddings required)
@@ -260,7 +261,7 @@ async def create_external_key(
     Issue #385: workspace-scoped — the new key is stored with the caller's
     current_workspace_id and context_id=None. Per-workspace uniqueness is
     enforced by (a) the app-layer pre-checks in this handler and (b) the
-    partial unique index on (workspace_id, provider) WHERE enabled=true.
+    partial unique index on (workspace_id, context_id, provider) WHERE enabled=true (NULLS NOT DISTINCT).
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
@@ -268,7 +269,7 @@ async def create_external_key(
 
     async with db_transaction(db, "create_external_key", "Failed to create external API key"):
         # Issue #385: workspace-scoped duplicate check — name uniqueness is per-workspace.
-        # The partial unique index (workspace_id, provider) WHERE enabled=true gives DB-level
+        # The partial unique index (workspace_id, context_id, provider) WHERE enabled=true (NULLS NOT DISTINCT) gives DB-level
         # enforcement on top; the application-layer check below produces a friendlier 409.
         result = await db.execute(
             select(ExternalAPIKey).where(
@@ -288,7 +289,7 @@ async def create_external_key(
             )
 
         # Issue #385: enforce the partial unique index invariant
-        # (workspace_id, provider) WHERE enabled=true at the application layer too,
+        # (workspace_id, context_id, provider) WHERE enabled=true at the application layer too,
         # so an arbitrary key_name (different from a duplicate the SELECT above
         # would have caught) doesn't escape with a 500 from the DB IntegrityError.
         if request.enabled:
@@ -340,7 +341,7 @@ async def create_external_key(
             await db.commit()
         except IntegrityError as exc:
             # Issue #385: a concurrent create could win a race against the
-            # partial unique index on (workspace_id, provider) WHERE enabled=true
+            # partial unique index on (workspace_id, context_id, provider) WHERE enabled=true (NULLS NOT DISTINCT)
             # OR the full unique index on (workspace_id, key_name). Narrow to
             # those two specific constraints so unrelated IntegrityErrors
             # (FK violations, unexpected constraints) still surface as 500 via
@@ -488,7 +489,7 @@ async def toggle_external_key(
             )
 
         # Issue #385: enforce the partial unique index invariant
-        # (workspace_id, provider) WHERE enabled=true at the application layer too,
+        # (workspace_id, context_id, provider) WHERE enabled=true at the application layer too,
         # so toggling a disabled key to enabled while another enabled key for the
         # same provider exists doesn't surface as a 500 from the DB IntegrityError.
         if request.enabled and not bool(key.enabled):

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -10,6 +10,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser, require_workspace_owner
@@ -320,7 +321,22 @@ async def create_external_key(
         )
 
         db.add(new_key)
-        await db.commit()
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            # Issue #385: a concurrent create/toggle could win the race between the
+            # app-layer pre-check above and this commit, leaving the partial unique
+            # index on (workspace_id, provider) WHERE enabled=true to reject us.
+            # Translate that to a friendly 409 — matches the pre-check's contract.
+            await db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"An enabled {request.provider} API key already exists in this "
+                    "workspace (concurrent create). Disable it first or update its "
+                    "value instead."
+                ),
+            ) from exc
         await db.refresh(new_key)
 
         logger.info(
@@ -476,7 +492,21 @@ async def toggle_external_key(
         key.enabled = request.enabled
         key.updated_by = user_email
 
-        await db.commit()
+        try:
+            await db.commit()
+        except IntegrityError as exc:
+            # Issue #385: see create_external_key for the same TOCTOU rationale —
+            # a concurrent toggle could race with this one against the partial
+            # unique index. Map the IntegrityError to a friendly 409.
+            await db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Another enabled {key.provider} API key already exists in this "
+                    "workspace (concurrent toggle). Disable it first before enabling "
+                    "this one."
+                ),
+            ) from exc
         await db.refresh(key)
 
         logger.info(

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -21,6 +21,12 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Issue #385: name of the partial unique index defined in migration a99 and
+# mirrored in models.auth.ExternalAPIKey.__table_args__. Used by the create /
+# toggle handlers to narrow IntegrityError → 409 mapping to this specific
+# constraint, so unrelated DB errors (FK / NOT NULL / etc.) still surface as 500.
+_PARTIAL_UNIQUE_INDEX = "uq_external_api_keys_workspace_provider_enabled"
+
 # Issue #381: All external API key routes are owner-only.
 # External API keys are workspace-level secrets (OpenAI/Cohere/Anthropic credentials)
 # that should only be managed by the workspace owner. Viewers, members, and admins
@@ -327,16 +333,20 @@ async def create_external_key(
             # Issue #385: a concurrent create/toggle could win the race between the
             # app-layer pre-check above and this commit, leaving the partial unique
             # index on (workspace_id, provider) WHERE enabled=true to reject us.
-            # Translate that to a friendly 409 — matches the pre-check's contract.
+            # Narrow to the specific constraint so unrelated IntegrityErrors
+            # (FK violations, unexpected constraints) still surface as 500 via
+            # db_transaction — only the known race becomes a friendly 409.
             await db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"An enabled {request.provider} API key already exists in this "
-                    "workspace (concurrent create). Disable it first or update its "
-                    "value instead."
-                ),
-            ) from exc
+            if _PARTIAL_UNIQUE_INDEX in str(getattr(exc, "orig", exc)):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"An enabled {request.provider} API key already exists in "
+                        "this workspace (concurrent create). Disable it first or "
+                        "update its value instead."
+                    ),
+                ) from exc
+            raise
         await db.refresh(new_key)
 
         logger.info(
@@ -495,18 +505,20 @@ async def toggle_external_key(
         try:
             await db.commit()
         except IntegrityError as exc:
-            # Issue #385: see create_external_key for the same TOCTOU rationale —
-            # a concurrent toggle could race with this one against the partial
-            # unique index. Map the IntegrityError to a friendly 409.
+            # Issue #385: see create_external_key for the same TOCTOU + narrow-
+            # constraint rationale. Only the partial unique index becomes a 409;
+            # any other IntegrityError still surfaces as 500 via db_transaction.
             await db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"Another enabled {key.provider} API key already exists in this "
-                    "workspace (concurrent toggle). Disable it first before enabling "
-                    "this one."
-                ),
-            ) from exc
+            if _PARTIAL_UNIQUE_INDEX in str(getattr(exc, "orig", exc)):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"Another enabled {key.provider} API key already exists in "
+                        "this workspace (concurrent toggle). Disable it first "
+                        "before enabling this one."
+                    ),
+                ) from exc
+            raise
         await db.refresh(key)
 
         logger.info(

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -252,9 +252,11 @@ async def create_external_key(
 ):
     """Create a new external API key for the current workspace.
 
-    Issue #82: Auto-assigns external key to current context.
-    Issue #246: current_context_id removed - use context_id=None
-    Issue #381: Owner-only (router-level dependency).
+    Issue #381: owner-only (router-level dependency).
+    Issue #385: workspace-scoped — the new key is stored with the caller's
+    current_workspace_id and context_id=None. Per-workspace uniqueness is
+    enforced by (a) the app-layer pre-checks in this handler and (b) the
+    partial unique index on (workspace_id, provider) WHERE enabled=true.
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
@@ -377,9 +379,10 @@ async def update_external_key(
 ):
     """Update an external API key value in the current workspace.
 
-    Issue #112: Now filters by context_id to handle duplicate key names across contexts.
-    Issue #246: current_context_id removed - use context_id=None
-    Issue #381: Owner-only (router-level dependency).
+    Issue #381: owner-only (router-level dependency).
+    Issue #385: workspace-scoped lookup by (key_name, workspace_id). Any owner
+    of the workspace can update any key registered in it, including keys
+    originally registered by a previous owner.
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
@@ -551,9 +554,10 @@ async def delete_external_key(
 ):
     """Delete an external API key from the current workspace.
 
-    Issue #112: Now filters by context_id to handle duplicate key names across contexts.
-    Issue #246: current_context_id removed - no context filtering
-    Issue #381: Owner-only (router-level dependency).
+    Issue #381: owner-only (router-level dependency).
+    Issue #385: workspace-scoped lookup by (key_name, workspace_id); any owner
+    can delete any key registered in the workspace.
+    Issue #149: protected keys (in PROTECTED_KEYS) are refused with 400.
     """
     user_id = user.get("user_id")
     current_workspace_id = user.get("current_workspace_id")

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -294,12 +294,18 @@ async def create_external_key(
         # would have caught) doesn't escape with a 500 from the DB IntegrityError.
         if request.enabled:
             # Existence check only; .limit(1) makes scalar_one_or_none() resilient
-            # to legacy/dirty data that has multiple matching rows.
+            # to legacy/dirty data that has multiple matching rows. Scope the
+            # check to context_id IS NULL to match the partial unique index's
+            # (workspace_id, context_id, provider) key — create_external_key
+            # always stores context_id=None, so a context-scoped enabled key
+            # for the same provider legitimately coexists at the DB level and
+            # should not block creation of the workspace-scoped fallback.
             dup_result = await db.execute(
                 select(ExternalAPIKey)
                 .where(
                     and_(
                         ExternalAPIKey.workspace_id == current_workspace_id,
+                        ExternalAPIKey.context_id.is_(None),
                         ExternalAPIKey.provider == request.provider,
                         ExternalAPIKey.enabled.is_(True),
                     )
@@ -310,8 +316,9 @@ async def create_external_key(
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=(
-                        f"An enabled {request.provider} API key already exists in this "
-                        "workspace. Disable it first or update its value instead."
+                        f"An enabled workspace-scoped {request.provider} API key "
+                        "already exists in this workspace. Disable it first or "
+                        "update its value instead."
                     ),
                 )
 
@@ -494,17 +501,23 @@ async def toggle_external_key(
         # same provider exists doesn't surface as a 500 from the DB IntegrityError.
         if request.enabled and not bool(key.enabled):
             # Existence check only — same rationale as create_external_key.
+            # Scope to the same context_id as the row being toggled so the
+            # pre-check matches the (workspace_id, context_id, provider)
+            # partial unique index. key.context_id may be NULL (workspace-
+            # scoped) or a context UUID; the comparison handles both via
+            # the same IS-NULL-vs-equal split SQLAlchemy applies normally.
+            dup_conditions = [
+                ExternalAPIKey.workspace_id == current_workspace_id,
+                ExternalAPIKey.provider == key.provider,
+                ExternalAPIKey.enabled.is_(True),
+                ExternalAPIKey.id != key.id,
+            ]
+            if key.context_id is None:
+                dup_conditions.append(ExternalAPIKey.context_id.is_(None))
+            else:
+                dup_conditions.append(ExternalAPIKey.context_id == key.context_id)
             dup_result = await db.execute(
-                select(ExternalAPIKey)
-                .where(
-                    and_(
-                        ExternalAPIKey.workspace_id == current_workspace_id,
-                        ExternalAPIKey.provider == key.provider,
-                        ExternalAPIKey.enabled.is_(True),
-                        ExternalAPIKey.id != key.id,
-                    )
-                )
-                .limit(1)
+                select(ExternalAPIKey).where(and_(*dup_conditions)).limit(1)
             )
             if dup_result.scalar_one_or_none():
                 raise HTTPException(

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -114,11 +114,13 @@ async def validate_reranker_exclusivity(
     """Ensure only ONE reranker (Cohere OR Voyage) is enabled at a time per workspace.
 
     Issue #105: Reranker exclusivity validation.
-    Issue #385: scoped per workspace — was per user before, but external keys are
-        workspace-shared resources now and the partial unique index
-        uq_external_api_keys_workspace_provider_enabled enforces the same invariant
-        at the DB level. This application-layer check produces a friendlier 409
-        with provider details.
+    Issue #385: scoped per workspace — was per user before, because external keys
+        are workspace-shared resources now. The partial unique index
+        uq_external_api_keys_workspace_provider_enabled only guarantees at most
+        one enabled key per (workspace, provider) at the DB level — a different
+        invariant. This application-layer check is what enforces the
+        cross-provider reranker exclusivity (no Cohere AND Voyage enabled
+        simultaneously) and produces a friendly 409 with provider details.
 
     Rules:
     - OpenAI cannot be disabled (embeddings required)

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import APIKeyOrSessionUser, require_workspace_owner
 from db.base import get_db
 from db.constraint_names import (
+    EXTERNAL_API_KEYS_WORKSPACE_KEY_NAME_UNIQUE,
     EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE,
     integrity_error_constraint_name,
 )
@@ -331,23 +332,30 @@ async def create_external_key(
         try:
             await db.commit()
         except IntegrityError as exc:
-            # Issue #385: a concurrent create/toggle could win the race between the
-            # app-layer pre-check above and this commit, leaving the partial unique
-            # index on (workspace_id, provider) WHERE enabled=true to reject us.
-            # Narrow to the specific constraint so unrelated IntegrityErrors
+            # Issue #385: a concurrent create could win a race against the
+            # partial unique index on (workspace_id, provider) WHERE enabled=true
+            # OR the full unique index on (workspace_id, key_name). Narrow to
+            # those two specific constraints so unrelated IntegrityErrors
             # (FK violations, unexpected constraints) still surface as 500 via
-            # db_transaction — only the known race becomes a friendly 409.
+            # db_transaction — only the known races become friendly 409s.
             await db.rollback()
-            if (
-                integrity_error_constraint_name(exc)
-                == EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE
-            ):
+            constraint = integrity_error_constraint_name(exc)
+            if constraint == EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE:
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=(
                         f"An enabled {request.provider} API key already exists in "
                         "this workspace (concurrent create). Disable it first or "
                         "update its value instead."
+                    ),
+                ) from exc
+            if constraint == EXTERNAL_API_KEYS_WORKSPACE_KEY_NAME_UNIQUE:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"An API key named '{request.key_name}' already exists in "
+                        "this workspace (concurrent create). Choose a different "
+                        "key_name or update the existing key's value."
                     ),
                 ) from exc
             raise

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -5,6 +5,8 @@ Issue #45: Web UI Endpoint Implementation
 Issue #106: Refactored to use consolidated utilities
 """
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel
 from sqlalchemy import and_, select
@@ -104,7 +106,7 @@ EMBEDDING_PROVIDERS = {"openai"}
 
 async def validate_reranker_exclusivity(
     db: AsyncSession,
-    workspace_id,
+    workspace_id: UUID,
     provider: str,
     enabled: bool,
     exclude_key_id: int | None = None,

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import WorkspaceMember
+from auth.dependencies import APIKeyOrSessionUser, require_workspace_owner
 from db.base import get_db
 from models.auth import ExternalAPIKey
 from utils import db_transaction, get_user_email, mask_secret
@@ -18,7 +18,15 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-router = APIRouter(prefix="/external-keys", tags=["external-keys"])
+# Issue #381: All external API key routes are owner-only.
+# External API keys are workspace-level secrets (OpenAI/Cohere/Anthropic credentials)
+# that should only be managed by the workspace owner. Viewers, members, and admins
+# cannot list/create/update/toggle/delete keys.
+router = APIRouter(
+    prefix="/external-keys",
+    tags=["external-keys"],
+    dependencies=[Depends(require_workspace_owner)],
+)
 
 
 # ============================================================================
@@ -172,14 +180,15 @@ async def validate_reranker_exclusivity(
 
 @router.get("", response_model=ExternalKeyListResponse)
 async def list_external_keys(
-    user: WorkspaceMember,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
-    """List all external API keys for the authenticated user's current context.
+    """List all external API keys for the current workspace.
 
     Issue #82: Now context-scoped - returns external keys for current context only.
     Issue #246: current_context_id removed - show all user keys
-    Issue #59: Viewers cannot access external keys.
+    Issue #381: Owner-only (router-level dependency); members, admins, and viewers
+    are rejected with 403 before reaching this handler.
 
     Returns masked values for security.
     """
@@ -253,14 +262,14 @@ async def list_external_keys(
 @router.post("", response_model=ExternalKeyResponse)
 async def create_external_key(
     request: ExternalKeyCreate,
-    user: WorkspaceMember,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
-    """Create a new external API key for current context.
+    """Create a new external API key for the current workspace.
 
     Issue #82: Auto-assigns external key to current context.
     Issue #246: current_context_id removed - use context_id=None
-    Issue #59: Viewers cannot access external keys.
+    Issue #381: Owner-only (router-level dependency).
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
@@ -343,14 +352,14 @@ async def create_external_key(
 async def update_external_key(
     key_name: str,
     request: ExternalKeyUpdate,
-    user: WorkspaceMember,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
-    """Update an external API key value in current context.
+    """Update an external API key value in the current workspace.
 
     Issue #112: Now filters by context_id to handle duplicate key names across contexts.
     Issue #246: current_context_id removed - use context_id=None
-    Issue #59: Viewers cannot access external keys.
+    Issue #381: Owner-only (router-level dependency).
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
@@ -421,7 +430,7 @@ async def update_external_key(
 async def toggle_external_key(
     key_name: str,
     request: ExternalKeyToggle,
-    user: WorkspaceMember,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
     """Toggle enabled/disabled state without re-entering API key value.
@@ -433,7 +442,7 @@ async def toggle_external_key(
     - OpenAI keys cannot be disabled
     - Only ONE reranker (Cohere/Voyage) can be enabled at a time
 
-    Issue #59: Viewers cannot access external keys.
+    Issue #381: Owner-only (router-level dependency).
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
@@ -516,14 +525,14 @@ async def toggle_external_key(
 @router.delete("/{key_name}")
 async def delete_external_key(
     key_name: str,
-    user: WorkspaceMember,
+    user: APIKeyOrSessionUser,
     db: AsyncSession = Depends(get_db),
 ):
-    """Delete an external API key from current context.
+    """Delete an external API key from the current workspace.
 
     Issue #112: Now filters by context_id to handle duplicate key names across contexts.
     Issue #246: current_context_id removed - no context filtering
-    Issue #59: Viewers cannot access external keys.
+    Issue #381: Owner-only (router-level dependency).
     """
     user_id = user.get("user_id")
     # Issue #246: current_context_id removed
@@ -583,75 +592,3 @@ async def delete_external_key(
         logger.info(f"external_key_deleted: key_name={key_name}, user={user_id}")
 
         return {"message": f"External key '{key_name}' deleted successfully"}
-
-
-@router.post("/import")
-async def import_external_keys(
-    user: WorkspaceMember,
-    db: AsyncSession = Depends(get_db),
-):
-    """Import external API keys from .env.cloud file.
-
-    Reads .env.cloud and imports OPENAI_API_KEY, COHERE_API_KEY if present.
-    """
-    from pathlib import Path
-
-    user_id = user.get("user_id")
-    user_email = get_user_email(user) or user_id
-
-    env_file = Path("/app/.env.cloud")
-    if not env_file.exists():
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=".env.cloud file not found",
-        )
-
-    imported: list[str] = []
-    errors: list[str] = []
-
-    # Mapping of env var names to (key_name, provider)
-    key_mapping = {
-        "OPENAI_API_KEY": ("openai_api_key", "openai"),
-        "COHERE_API_KEY": ("cohere_api_key", "cohere"),
-    }
-
-    async with db_transaction(db, "import_external_keys", "Failed to import external API keys"):
-        # Parse .env file
-        with open(env_file) as f:
-            for line in f:
-                line = line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-
-                env_key, value = line.split("=", 1)
-                env_key = env_key.strip()
-                value = value.strip().strip('"').strip("'")
-
-                if env_key in key_mapping and value:
-                    key_name, provider = key_mapping[env_key]
-                    try:
-                        encrypted = encrypt_value(value)
-                        new_key = ExternalAPIKey(
-                            key_name=key_name,
-                            provider=provider,
-                            encrypted_value=encrypted,
-                            user_id=user_id,
-                            updated_by=user_email,
-                        )
-                        db.add(new_key)
-                        imported.append(key_name)
-                    except Exception as e:
-                        errors.append(f"{key_name}: {str(e)}")
-
-        await db.commit()
-
-        logger.info(
-            f"external_keys_imported: user={user_id}, "
-            f"imported={len(imported)}, errors={len(errors)}"
-        )
-
-        return {
-            "message": f"Imported {len(imported)} external API keys",
-            "imported": imported,
-            "errors": errors,
-        }

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -275,6 +275,29 @@ async def create_external_key(
                 detail="An API key with this configuration already exists",
             )
 
+        # Issue #385: enforce the partial unique index invariant
+        # (workspace_id, provider) WHERE enabled=true at the application layer too,
+        # so an arbitrary key_name (different from a duplicate the SELECT above
+        # would have caught) doesn't escape with a 500 from the DB IntegrityError.
+        if request.enabled:
+            dup_result = await db.execute(
+                select(ExternalAPIKey).where(
+                    and_(
+                        ExternalAPIKey.workspace_id == current_workspace_id,
+                        ExternalAPIKey.provider == request.provider,
+                        ExternalAPIKey.enabled.is_(True),
+                    )
+                )
+            )
+            if dup_result.scalar_one_or_none():
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"An enabled {request.provider} API key already exists in this "
+                        "workspace. Disable it first or update its value instead."
+                    ),
+                )
+
         # Validate reranker exclusivity per workspace (Issue #105 / #385).
         await validate_reranker_exclusivity(
             db=db,
@@ -415,6 +438,30 @@ async def toggle_external_key(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"External key '{key_name}' not found",
             )
+
+        # Issue #385: enforce the partial unique index invariant
+        # (workspace_id, provider) WHERE enabled=true at the application layer too,
+        # so toggling a disabled key to enabled while another enabled key for the
+        # same provider exists doesn't surface as a 500 from the DB IntegrityError.
+        if request.enabled and not bool(key.enabled):
+            dup_result = await db.execute(
+                select(ExternalAPIKey).where(
+                    and_(
+                        ExternalAPIKey.workspace_id == current_workspace_id,
+                        ExternalAPIKey.provider == key.provider,
+                        ExternalAPIKey.enabled.is_(True),
+                        ExternalAPIKey.id != key.id,
+                    )
+                )
+            )
+            if dup_result.scalar_one_or_none():
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail=(
+                        f"Another enabled {key.provider} API key already exists in "
+                        "this workspace. Disable it first before enabling this one."
+                    ),
+                )
 
         # Validate reranker exclusivity per workspace (Issue #105 / #385).
         await validate_reranker_exclusivity(

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -15,17 +15,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser, require_workspace_owner
 from db.base import get_db
+from db.constraint_names import (
+    EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE,
+    integrity_error_constraint_name,
+)
 from models.auth import ExternalAPIKey
 from utils import db_transaction, get_user_email, mask_secret
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
-
-# Issue #385: name of the partial unique index defined in migration a99 and
-# mirrored in models.auth.ExternalAPIKey.__table_args__. Used by the create /
-# toggle handlers to narrow IntegrityError → 409 mapping to this specific
-# constraint, so unrelated DB errors (FK / NOT NULL / etc.) still surface as 500.
-_PARTIAL_UNIQUE_INDEX = "uq_external_api_keys_workspace_provider_enabled"
 
 # Issue #381: All external API key routes are owner-only.
 # External API keys are workspace-level secrets (OpenAI/Cohere/Anthropic credentials)
@@ -198,10 +196,11 @@ async def list_external_keys(
 ):
     """List all external API keys for the current workspace.
 
-    Issue #82: Now context-scoped - returns external keys for current context only.
-    Issue #246: current_context_id removed - show all user keys
-    Issue #381: Owner-only (router-level dependency); members, admins, and viewers
+    Issue #381: owner-only (router-level dependency); members, admins, and viewers
     are rejected with 403 before reaching this handler.
+    Issue #385: workspace-scoped — returns every key registered in
+    `current_workspace_id` regardless of the original creator's user_id, since
+    the workspace owner is the sole manager of these keys.
 
     Returns masked values for security.
     """
@@ -337,7 +336,10 @@ async def create_external_key(
             # (FK violations, unexpected constraints) still surface as 500 via
             # db_transaction — only the known race becomes a friendly 409.
             await db.rollback()
-            if _PARTIAL_UNIQUE_INDEX in str(getattr(exc, "orig", exc)):
+            if (
+                integrity_error_constraint_name(exc)
+                == EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=(
@@ -509,7 +511,10 @@ async def toggle_external_key(
             # constraint rationale. Only the partial unique index becomes a 409;
             # any other IntegrityError still surfaces as 500 via db_transaction.
             await db.rollback()
-            if _PARTIAL_UNIQUE_INDEX in str(getattr(exc, "orig", exc)):
+            if (
+                integrity_error_constraint_name(exc)
+                == EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE
+            ):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=(

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -104,24 +104,28 @@ EMBEDDING_PROVIDERS = {"openai"}
 
 async def validate_reranker_exclusivity(
     db: AsyncSession,
-    user_id: str,
+    workspace_id,
     provider: str,
     enabled: bool,
     exclude_key_id: int | None = None,
 ) -> None:
-    """Ensure only ONE reranker (Cohere OR Voyage) is enabled at a time.
+    """Ensure only ONE reranker (Cohere OR Voyage) is enabled at a time per workspace.
 
     Issue #105: Reranker exclusivity validation.
-    Issue #246: current_context_id parameter removed (no context filtering).
+    Issue #385: scoped per workspace — was per user before, but external keys are
+        workspace-shared resources now and the partial unique index
+        uq_external_api_keys_workspace_provider_enabled enforces the same invariant
+        at the DB level. This application-layer check produces a friendlier 409
+        with provider details.
 
     Rules:
     - OpenAI cannot be disabled (embeddings required)
-    - Only ONE of Cohere/Voyage enabled
+    - Only ONE of Cohere/Voyage enabled per workspace
     - Disabling rerankers is always allowed
 
     Args:
         db: Database session
-        user_id: User ID
+        workspace_id: Workspace UUID — the conflict check is scoped to this workspace.
         provider: Provider name (openai, cohere, voyage)
         enabled: Desired enabled state
         exclude_key_id: Key ID to exclude from conflict check (for updates)
@@ -143,15 +147,13 @@ async def validate_reranker_exclusivity(
     if not enabled or provider not in RERANKER_PROVIDERS:
         return
 
-    # Check for conflicting enabled reranker
+    # Check for a conflicting enabled reranker in the same workspace.
     conditions = [
-        ExternalAPIKey.user_id == user_id,
+        ExternalAPIKey.workspace_id == workspace_id,
         ExternalAPIKey.enabled.is_(True),
         ExternalAPIKey.provider.in_(RERANKER_PROVIDERS),
         ExternalAPIKey.provider != provider,
     ]
-
-    # Issue #246: current_context_id filtering removed
 
     if exclude_key_id:
         conditions.append(ExternalAPIKey.id != exclude_key_id)
@@ -193,43 +195,16 @@ async def list_external_keys(
     Returns masked values for security.
     """
     user_id = user.get("user_id")
-    # Issue #246: current_context_id removed
-    # current_context_id = user.get("current_context_id")
-    current_workspace_id = user.get("current_workspace_id")  # Issue #146
+    current_workspace_id = user.get("current_workspace_id")
 
     async with db_transaction(db, "list_external_keys", "Failed to list external API keys"):
-        # Build query with workspace filter (Issue #146)
-        # Show workspace-scoped keys to all workspace members (not just creator)
-        from sqlalchemy import or_
-
-        if current_workspace_id:
-            # Workspace-scoped: Show all keys for current workspace (shared across workspace members)
-            # User-scoped: Show only user's own keys (workspace_id = NULL AND user_id = current_user)
-            result = await db.execute(
-                select(ExternalAPIKey)
-                .where(
-                    or_(
-                        ExternalAPIKey.workspace_id
-                        == current_workspace_id,  # Workspace-scoped (all members can see)
-                        and_(
-                            ExternalAPIKey.user_id == user_id,
-                            ExternalAPIKey.workspace_id.is_(None),
-                        ),  # User-scoped (own keys only)
-                    )
-                )
-                .order_by(ExternalAPIKey.created_at.desc())
-            )
-        else:
-            # No workspace context - show only user-scoped keys
-            result = await db.execute(
-                select(ExternalAPIKey)
-                .where(
-                    ExternalAPIKey.user_id == user_id,
-                    ExternalAPIKey.workspace_id.is_(None),
-                )
-                .order_by(ExternalAPIKey.created_at.desc())
-            )
-
+        # Issue #385: workspace_id is NOT NULL — every key belongs to exactly one workspace.
+        # The router-level require_workspace_owner dep guarantees current_workspace_id is set.
+        result = await db.execute(
+            select(ExternalAPIKey)
+            .where(ExternalAPIKey.workspace_id == current_workspace_id)
+            .order_by(ExternalAPIKey.created_at.desc())
+        )
         keys = list(result.scalars().all())
 
         # Decrypt and mask values
@@ -273,29 +248,20 @@ async def create_external_key(
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
-    # Issue #246: current_context_id removed
-    # current_context_id = user.get("current_context_id")
-    current_workspace_id = user.get("current_workspace_id")  # Issue #146: Workspace-scoped keys
+    current_workspace_id = user.get("current_workspace_id")
 
     async with db_transaction(db, "create_external_key", "Failed to create external API key"):
-        # Issue #223: Check if key already exists in current workspace/context
-        # For workspace-scoped keys: unique on (workspace_id, key_name)
-        # For user-scoped keys: unique on (user_id, key_name, context_id)
-        # Issue #246: current_context_id removed - context_id always None
-        conditions = [ExternalAPIKey.key_name == request.key_name]
-
-        if current_workspace_id:
-            # Workspace-scoped key: check within workspace
-            conditions.append(ExternalAPIKey.workspace_id == current_workspace_id)
-        else:
-            # User-scoped key (legacy): check within user + context
-            conditions.append(ExternalAPIKey.workspace_id.is_(None))
-            conditions.append(ExternalAPIKey.user_id == user_id)
-            # Issue #246: current_context_id removed
-            # if current_context_id:
-            #     conditions.append(ExternalAPIKey.context_id == current_context_id)
-
-        result = await db.execute(select(ExternalAPIKey).where(and_(*conditions)))
+        # Issue #385: workspace-scoped duplicate check — name uniqueness is per-workspace.
+        # The partial unique index (workspace_id, provider) WHERE enabled=true gives DB-level
+        # enforcement on top; the application-layer check below produces a friendlier 409.
+        result = await db.execute(
+            select(ExternalAPIKey).where(
+                and_(
+                    ExternalAPIKey.key_name == request.key_name,
+                    ExternalAPIKey.workspace_id == current_workspace_id,
+                )
+            )
+        )
         existing = result.scalar_one_or_none()
 
         if existing:
@@ -305,11 +271,10 @@ async def create_external_key(
                 detail="An API key with this configuration already exists",
             )
 
-        # Validate reranker exclusivity (Issue #105)
-        # Issue #246: current_context_id removed - use None
+        # Validate reranker exclusivity per workspace (Issue #105 / #385).
         await validate_reranker_exclusivity(
             db=db,
-            user_id=user_id,
+            workspace_id=current_workspace_id,
             provider=request.provider,
             enabled=request.enabled,
         )
@@ -363,25 +328,21 @@ async def update_external_key(
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
-    # Issue #246: current_context_id removed
-    # current_context_id = user.get("current_context_id")
-
-    # SECURITY: Get current workspace for boundary check
-    # Issue #269: Workspace boundary violation prevention
     current_workspace_id = user.get("current_workspace_id")
 
     async with db_transaction(db, "update_external_key", "Failed to update external API key"):
-        # Get existing key (Issue #112: filter by context too)
-        # Issue #246: current_context_id removed - no context filtering
-        conditions = [
-            ExternalAPIKey.key_name == key_name,
-            ExternalAPIKey.user_id == user_id,
-        ]
-        # Issue #246: current_context_id removed
-        # if current_context_id:
-        #     conditions.append(ExternalAPIKey.context_id == current_context_id)
-
-        result = await db.execute(select(ExternalAPIKey).where(and_(*conditions)))
+        # Issue #385: workspace-scoped lookup. Any owner of this workspace can update
+        # any key registered in it (including keys originally created by a previous
+        # owner) — the previous user_id == caller filter was a creator-only check that
+        # broke ownership transitions.
+        result = await db.execute(
+            select(ExternalAPIKey).where(
+                and_(
+                    ExternalAPIKey.key_name == key_name,
+                    ExternalAPIKey.workspace_id == current_workspace_id,
+                )
+            )
+        )
         key = result.scalar_one_or_none()
 
         if not key:
@@ -389,21 +350,6 @@ async def update_external_key(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"External key '{key_name}' not found",
             )
-
-        # SECURITY: Verify key belongs to current workspace
-        # Issue #269: Prevent updating keys from other workspaces
-        if key.workspace_id is not None:
-            # Workspace-scoped key: must match current_workspace_id
-            if not current_workspace_id:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="No workspace selected. Please select an workspace first.",
-                )
-            if key.workspace_id != current_workspace_id:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="This API key belongs to a different workspace.",
-                )
 
         # Encrypt and update
         key.encrypted_value = encrypt_value(request.value)
@@ -446,25 +392,18 @@ async def toggle_external_key(
     """
     user_id = user.get("user_id")
     user_email = get_user_email(user) or user_id
-    # Issue #246: current_context_id removed
-    # current_context_id = user.get("current_context_id")
-
-    # SECURITY: Get current workspace for boundary check
-    # Issue #269: Workspace boundary violation prevention
     current_workspace_id = user.get("current_workspace_id")
 
     async with db_transaction(db, "toggle_external_key", "Failed to toggle external API key"):
-        # Get existing key
-        # Issue #246: current_context_id removed - no context filtering
-        conditions = [
-            ExternalAPIKey.key_name == key_name,
-            ExternalAPIKey.user_id == user_id,
-        ]
-        # Issue #246: current_context_id removed
-        # if current_context_id:
-        #     conditions.append(ExternalAPIKey.context_id == current_context_id)
-
-        result = await db.execute(select(ExternalAPIKey).where(and_(*conditions)))
+        # Issue #385: workspace-scoped lookup (see update_external_key for rationale).
+        result = await db.execute(
+            select(ExternalAPIKey).where(
+                and_(
+                    ExternalAPIKey.key_name == key_name,
+                    ExternalAPIKey.workspace_id == current_workspace_id,
+                )
+            )
+        )
         key = result.scalar_one_or_none()
 
         if not key:
@@ -473,26 +412,10 @@ async def toggle_external_key(
                 detail=f"External key '{key_name}' not found",
             )
 
-        # SECURITY: Verify key belongs to current workspace
-        # Issue #269: Prevent toggling keys from other workspaces
-        if key.workspace_id is not None:
-            # Workspace-scoped key: must match current_workspace_id
-            if not current_workspace_id:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="No workspace selected. Please select an workspace first.",
-                )
-            if key.workspace_id != current_workspace_id:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="This API key belongs to a different workspace.",
-                )
-
-        # Validate reranker exclusivity (Issue #105)
-        # Issue #246: current_context_id removed - use None
+        # Validate reranker exclusivity per workspace (Issue #105 / #385).
         await validate_reranker_exclusivity(
             db=db,
-            user_id=user_id,
+            workspace_id=current_workspace_id,
             provider=key.provider,
             enabled=request.enabled,
             exclude_key_id=key.id,
@@ -535,25 +458,18 @@ async def delete_external_key(
     Issue #381: Owner-only (router-level dependency).
     """
     user_id = user.get("user_id")
-    # Issue #246: current_context_id removed
-    # current_context_id = user.get("current_context_id")
-
-    # SECURITY: Get current workspace for boundary check
-    # Issue #269: Workspace boundary violation prevention
     current_workspace_id = user.get("current_workspace_id")
 
     async with db_transaction(db, "delete_external_key", "Failed to delete external API key"):
-        # Get existing key (Issue #112: filter by context too)
-        # Issue #246: current_context_id removed - no context filtering
-        conditions = [
-            ExternalAPIKey.key_name == key_name,
-            ExternalAPIKey.user_id == user_id,
-        ]
-        # Issue #246: current_context_id removed
-        # if current_context_id:
-        #     conditions.append(ExternalAPIKey.context_id == current_context_id)
-
-        result = await db.execute(select(ExternalAPIKey).where(and_(*conditions)))
+        # Issue #385: workspace-scoped lookup (see update_external_key for rationale).
+        result = await db.execute(
+            select(ExternalAPIKey).where(
+                and_(
+                    ExternalAPIKey.key_name == key_name,
+                    ExternalAPIKey.workspace_id == current_workspace_id,
+                )
+            )
+        )
         key = result.scalar_one_or_none()
 
         if not key:
@@ -561,21 +477,6 @@ async def delete_external_key(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail=f"External key '{key_name}' not found",
             )
-
-        # SECURITY: Verify key belongs to current workspace
-        # Issue #269: Prevent deleting keys from other workspaces
-        if key.workspace_id is not None:
-            # Workspace-scoped key: must match current_workspace_id
-            if not current_workspace_id:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="No workspace selected. Please select an workspace first.",
-                )
-            if key.workspace_id != current_workspace_id:
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail="This API key belongs to a different workspace.",
-                )
 
         # Issue #149: Prevent deletion of protected keys (required for system operations)
         from config.plan_tiers import PROTECTED_KEYS

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -168,7 +168,10 @@ async def validate_reranker_exclusivity(
     if exclude_key_id:
         conditions.append(ExternalAPIKey.id != exclude_key_id)
 
-    result = await db.execute(select(ExternalAPIKey).where(and_(*conditions)))
+    # Existence check only — .limit(1) makes scalar_one_or_none() safe even
+    # against legacy/dirty data with multiple matching rows (would otherwise
+    # raise MultipleResultsFound → 500).
+    result = await db.execute(select(ExternalAPIKey).where(and_(*conditions)).limit(1))
     conflicting_key = result.scalar_one_or_none()
 
     if conflicting_key:
@@ -289,14 +292,18 @@ async def create_external_key(
         # so an arbitrary key_name (different from a duplicate the SELECT above
         # would have caught) doesn't escape with a 500 from the DB IntegrityError.
         if request.enabled:
+            # Existence check only; .limit(1) makes scalar_one_or_none() resilient
+            # to legacy/dirty data that has multiple matching rows.
             dup_result = await db.execute(
-                select(ExternalAPIKey).where(
+                select(ExternalAPIKey)
+                .where(
                     and_(
                         ExternalAPIKey.workspace_id == current_workspace_id,
                         ExternalAPIKey.provider == request.provider,
                         ExternalAPIKey.enabled.is_(True),
                     )
                 )
+                .limit(1)
             )
             if dup_result.scalar_one_or_none():
                 raise HTTPException(
@@ -483,8 +490,10 @@ async def toggle_external_key(
         # so toggling a disabled key to enabled while another enabled key for the
         # same provider exists doesn't surface as a 500 from the DB IntegrityError.
         if request.enabled and not bool(key.enabled):
+            # Existence check only — same rationale as create_external_key.
             dup_result = await db.execute(
-                select(ExternalAPIKey).where(
+                select(ExternalAPIKey)
+                .where(
                     and_(
                         ExternalAPIKey.workspace_id == current_workspace_id,
                         ExternalAPIKey.provider == key.provider,
@@ -492,6 +501,7 @@ async def toggle_external_key(
                         ExternalAPIKey.id != key.id,
                     )
                 )
+                .limit(1)
             )
             if dup_result.scalar_one_or_none():
                 raise HTTPException(

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -357,12 +357,14 @@ async def create_external_key(
                     ),
                 ) from exc
             if constraint == EXTERNAL_API_KEYS_WORKSPACE_KEY_NAME_UNIQUE:
+                # Issue #223: don't reveal the submitted key_name — matches the
+                # non-revealing message used by the pre-check on line 281.
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail=(
-                        f"An API key named '{request.key_name}' already exists in "
-                        "this workspace (concurrent create). Choose a different "
-                        "key_name or update the existing key's value."
+                        "An API key with this configuration already exists "
+                        "(concurrent create). Try a different name or update "
+                        "the existing key's value."
                     ),
                 ) from exc
             raise

--- a/backend/src/db/constraint_names.py
+++ b/backend/src/db/constraint_names.py
@@ -31,6 +31,12 @@ EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE = (
     "uq_external_api_keys_workspace_provider_enabled"
 )
 
+# Issue #385: full unique index on (workspace_id, key_name). Guarantees that
+# scalar_one_or_none() lookups in update/toggle/delete handlers cannot raise
+# MultipleResultsFound on legacy data (pre-#381, multiple users could each create
+# keys with the same key_name in one workspace). Created by migration a99.
+EXTERNAL_API_KEYS_WORKSPACE_KEY_NAME_UNIQUE = "uq_external_api_keys_workspace_key_name"
+
 
 def integrity_error_constraint_name(error: IntegrityError) -> str | None:
     """Return the PostgreSQL constraint name for ``error``, or ``None``.

--- a/backend/src/db/constraint_names.py
+++ b/backend/src/db/constraint_names.py
@@ -23,6 +23,14 @@ RESOURCE_EVENTS_UPSERT_UNIQUE = "ux_resource_events_upsert_version"
 # ``sa.UniqueConstraint("idempotency_key")`` in baseline 157247e0df86.
 RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE = "resource_events_idempotency_key_key"
 
+# Issue #385: partial unique index on (workspace_id, provider) WHERE enabled=true.
+# Created by migration a99 + mirrored in models.auth.ExternalAPIKey.__table_args__.
+# Used by external_keys routes (create / toggle) to map IntegrityError → 409 only
+# when this specific constraint fires; other IntegrityErrors stay as 500.
+EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE = (
+    "uq_external_api_keys_workspace_provider_enabled"
+)
+
 
 def integrity_error_constraint_name(error: IntegrityError) -> str | None:
     """Return the PostgreSQL constraint name for ``error``, or ``None``.

--- a/backend/src/db/constraint_names.py
+++ b/backend/src/db/constraint_names.py
@@ -23,10 +23,17 @@ RESOURCE_EVENTS_UPSERT_UNIQUE = "ux_resource_events_upsert_version"
 # ``sa.UniqueConstraint("idempotency_key")`` in baseline 157247e0df86.
 RESOURCE_EVENTS_IDEMPOTENCY_UNIQUE = "resource_events_idempotency_key_key"
 
-# Issue #385: partial unique index on (workspace_id, provider) WHERE enabled=true.
-# Created by migration a99 + mirrored in models.auth.ExternalAPIKey.__table_args__.
-# Used by external_keys routes (create / toggle) to map IntegrityError → 409 only
-# when this specific constraint fires; other IntegrityErrors stay as 500.
+# Issue #385: partial unique index on
+# (workspace_id, context_id, provider) WHERE enabled=true
+# with NULLS NOT DISTINCT (PG 15+). Created by migration a99 + mirrored in
+# models.auth.ExternalAPIKey.__table_args__. The three-column key supports the
+# service-layer's context > workspace priority contract: a context-scoped
+# enabled key and a workspace-scoped (context_id IS NULL) fallback for the same
+# provider coexist, while NULLS NOT DISTINCT blocks two workspace-scoped rows
+# for the same provider.
+#
+# Used by external_keys routes (create / toggle) to map IntegrityError → 409
+# only when this specific constraint fires; other IntegrityErrors stay as 500.
 EXTERNAL_API_KEYS_WORKSPACE_PROVIDER_ENABLED_UNIQUE = (
     "uq_external_api_keys_workspace_provider_enabled"
 )

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -312,6 +312,16 @@ class ExternalAPIKey(Base):
             unique=True,
             postgresql_where=text("enabled = true"),
         ),
+        # Issue #385: unique key_name per workspace. Guarantees the
+        # scalar_one_or_none() lookups in the update/toggle/delete handlers can
+        # never raise MultipleResultsFound (→ 500) on legacy data pre-#381 that
+        # had per-user uniqueness only.
+        Index(
+            "uq_external_api_keys_workspace_key_name",
+            "workspace_id",
+            "key_name",
+            unique=True,
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -303,14 +303,22 @@ class ExternalAPIKey(Base):
         Index("idx_external_user_provider", "user_id", "provider"),
         Index("idx_external_updated", "updated_at"),
         Index("idx_external_enabled", "user_id", "provider", "enabled"),  # Issue #105
-        # Issue #385: at most one enabled key per (workspace, provider). Disabled keys
-        # are intentionally exempt so an owner can hold a spare key in disabled state.
+        # Issue #385: at most one enabled key per (workspace, context, provider).
+        # Includes context_id so the service-layer context > workspace priority
+        # contract (embedding / llm / reranker) permits a context-scoped key and
+        # a workspace-scoped (context_id IS NULL) fallback to coexist for the
+        # same provider. Disabled keys are exempt so an owner can hold a spare
+        # key in disabled state. NULLS NOT DISTINCT (PG 15+) makes NULL
+        # context_ids collide, blocking two workspace-scoped rows for the same
+        # provider.
         Index(
             "uq_external_api_keys_workspace_provider_enabled",
             "workspace_id",
+            "context_id",
             "provider",
             unique=True,
             postgresql_where=text("enabled = true"),
+            postgresql_nulls_not_distinct=True,
         ),
         # Issue #385: unique key_name per workspace. Guarantees the
         # scalar_one_or_none() lookups in the update/toggle/delete handlers can

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -32,6 +32,7 @@ from sqlalchemy import (
     String,
     Text,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import relationship
@@ -281,10 +282,11 @@ class ExternalAPIKey(Base):
     )
 
     # Issue #146: Workspace-scoped external keys
+    # Issue #385: NOT NULL — every external API key belongs to exactly one workspace.
     workspace_id = Column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
-        nullable=True,
+        nullable=False,
         index=True,
     )
 
@@ -301,9 +303,15 @@ class ExternalAPIKey(Base):
         Index("idx_external_user_provider", "user_id", "provider"),
         Index("idx_external_updated", "updated_at"),
         Index("idx_external_enabled", "user_id", "provider", "enabled"),  # Issue #105
-        # Issue #223: Unique constraint includes workspace_id for workspace-scoped keys
-        # Actual constraint in DB is idx_external_unique_with_project_and_org
-        # which uses COALESCE for NULL handling - enforced at DB level
+        # Issue #385: at most one enabled key per (workspace, provider). Disabled keys
+        # are intentionally exempt so an owner can hold a spare key in disabled state.
+        Index(
+            "uq_external_api_keys_workspace_provider_enabled",
+            "workspace_id",
+            "provider",
+            unique=True,
+            postgresql_where=text("enabled = true"),
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -1,9 +1,13 @@
 """Embedding service for vector generation.
 
-Uses user-specific OpenAI API keys stored in database (ExternalAPIKey table).
+Uses workspace-scoped OpenAI API keys stored in the ExternalAPIKey table (#385):
+the current workspace's enabled OpenAI key is shared by every member of that
+workspace. `user_id` on the key is creator metadata only, not a visibility filter.
+
 Issue #1: API keys are DB-managed, not in .env
 Issue #84 Phase 2A: Redis caching with xxHash keys (50-80% API reduction, 4x space savings)
 Issue #105: DB-first API key retrieval with environment variable fallback
+Issue #385: workspace-keyed lookup (was user-keyed pre-#385)
 """
 
 from __future__ import annotations

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -71,74 +71,66 @@ class EmbeddingService:
         self,
         user_id: str,
         context_id: str | None = None,
-        workspace_id: str | None = None,  # NEW: Workspace ID (Issue #146)
+        workspace_id: str | None = None,  # Issue #146
     ) -> str:
-        """Get user's OpenAI API key from database or environment.
+        """Resolve the OpenAI API key for the calling user's workspace context.
 
-        Issue #105: DB-first API key retrieval with environment variable fallback.
-        Issue #146: Added workspace-scoped key support.
+        Issue #105: DB-first lookup with environment variable fallback.
+        Issue #146: workspace-scoped keys.
+        Issue #385: the lookup is workspace-keyed, not user-keyed — any workspace
+            member can use the owner-registered workspace API key. The `user_id`
+            parameter is retained for audit logging only; it is NOT a visibility
+            filter.
 
         Priority:
-        1. Context-scoped key (most specific)
-        2. Workspace-scoped key (workspace-wide)
-        3. User-scoped key (personal)
-        4. Environment variable (OPENAI_API_KEY) - fallback for development
+        1. Context-scoped key (context_id matches AND workspace_id matches)
+        2. Workspace-scoped key (workspace_id matches AND context_id IS NULL)
+        3. Environment variable (OPENAI_API_KEY) — development fallback only
 
         Args:
-            user_id: User ID
-            context_id: Optional project ID (Issue #82: context-scoped keys)
-            workspace_id: Optional workspace ID (Issue #146: workspace-scoped keys)
+            user_id: Caller's user ID — logged for audit, NOT used as a filter (#385).
+            context_id: Optional context UUID (#82: context-scoped keys take priority).
+            workspace_id: Workspace UUID (#146); when omitted the DB lookup is skipped
+                and only the env-var fallback can satisfy the request.
 
         Returns:
-            Decrypted OpenAI API key
+            Decrypted OpenAI API key.
 
         Raises:
-            ConfigurationError: If API key not configured
+            ConfigurationError: If neither a DB key nor an env var is available.
         """
         from uuid import UUID
 
         from sqlalchemy import or_
 
-        # 1. Try DB first (production mode)
-        conditions = [
-            ExternalAPIKey.user_id == user_id,
-            ExternalAPIKey.provider == "openai",
-            ExternalAPIKey.enabled.is_(True),
-        ]
-
-        # Add scope filters with priority (context OR workspace OR user-only)
-        scope_conditions = []
-        if context_id:
-            context_uuid = UUID(context_id) if isinstance(context_id, str) else context_id
-            scope_conditions.append(ExternalAPIKey.context_id == context_uuid)
+        api_key_entry = None
         if workspace_id:
             workspace_uuid = UUID(workspace_id) if isinstance(workspace_id, str) else workspace_id
-            scope_conditions.append(ExternalAPIKey.workspace_id == workspace_uuid)
-
-        if scope_conditions:
-            # Match: (project_id OR workspace_id) OR (no context AND no workspace = user-scoped)
-            conditions.append(
-                or_(
-                    *scope_conditions,
-                    and_(
-                        ExternalAPIKey.context_id.is_(None), ExternalAPIKey.workspace_id.is_(None)
-                    ),
+            conditions = [
+                ExternalAPIKey.workspace_id == workspace_uuid,
+                ExternalAPIKey.provider == "openai",
+                ExternalAPIKey.enabled.is_(True),
+            ]
+            if context_id:
+                context_uuid = UUID(context_id) if isinstance(context_id, str) else context_id
+                # Context-scoped key wins; fall back to workspace-scoped (context_id IS NULL).
+                conditions.append(
+                    or_(
+                        ExternalAPIKey.context_id == context_uuid,
+                        ExternalAPIKey.context_id.is_(None),
+                    )
                 )
-            )
+            else:
+                conditions.append(ExternalAPIKey.context_id.is_(None))
 
-        # Priority ordering: context > workspace > user
-        query = (
-            select(ExternalAPIKey)
-            .where(and_(*conditions))
-            .order_by(
-                ExternalAPIKey.context_id.desc().nulls_last(),
-                ExternalAPIKey.workspace_id.desc().nulls_last(),
+            query = (
+                select(ExternalAPIKey)
+                .where(and_(*conditions))
+                .order_by(ExternalAPIKey.context_id.desc().nulls_last())
+                .limit(1)
             )
-            .limit(1)
-        )
-
-        result = await self.db.execute(query)
-        api_key_entry = result.scalar_one_or_none()
+            result = await self.db.execute(query)
+            api_key_entry = result.scalar_one_or_none()
 
         if api_key_entry:
             encryptor = get_encryptor()
@@ -147,10 +139,11 @@ class EmbeddingService:
                 "openai_api_key_from_db",
                 user_id=user_id,
                 context_id=context_id,
+                workspace_id=workspace_id,
             )
             return api_key
 
-        # 2. Fallback to environment variable (development mode)
+        # Fallback to environment variable (development / env-only deployments).
         env_key = os.getenv("OPENAI_API_KEY")
         if env_key:
             logger.debug(
@@ -159,7 +152,6 @@ class EmbeddingService:
             )
             return env_key
 
-        # 3. No API key found
         raise ConfigurationError(
             f"OpenAI API key not configured for user {user_id}. "
             "Please set OPENAI_API_KEY environment variable or configure in settings."

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -152,9 +152,16 @@ class EmbeddingService:
             )
             return env_key
 
+        if workspace_id:
+            raise ConfigurationError(
+                f"OpenAI API key not configured for workspace {workspace_id}. "
+                "Configure a workspace OpenAI API key in settings, or set the "
+                "OPENAI_API_KEY environment variable."
+            )
         raise ConfigurationError(
-            f"OpenAI API key not configured for user {user_id}. "
-            "Please set OPENAI_API_KEY environment variable or configure in settings."
+            "OpenAI API key not configured: no workspace context was provided. "
+            "Provide a workspace_id, configure a workspace OpenAI API key in "
+            "settings, or set the OPENAI_API_KEY environment variable."
         )
 
     async def _get_client(

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -3,8 +3,10 @@
 Issue #101: Multi-provider async LLM client for structured JSON completions.
 Supports OpenAI and Ollama via OpenAI-compatible API.
 
-API key retrieval follows the same priority pattern as EmbeddingService:
-context-scoped → workspace-scoped → user-scoped → env fallback.
+Issue #385: API key retrieval is workspace-keyed, matching EmbeddingService. The
+current workspace's enabled OpenAI key is shared by every workspace member;
+`user_id` on the key row is creator metadata only. Priority within a workspace:
+context-scoped > workspace-scoped > env var fallback. No user-scoped tier.
 """
 
 from __future__ import annotations

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -275,7 +275,14 @@ class LLMService:
             logger.debug("llm_api_key_from_env", user_id=user_id)
             return env_key
 
+        if workspace_id:
+            raise ConfigurationError(
+                f"OpenAI API key not configured for workspace {workspace_id}. "
+                "Configure a workspace OpenAI API key in settings, or set the "
+                "OPENAI_API_KEY environment variable."
+            )
         raise ConfigurationError(
-            f"OpenAI API key not configured for user {user_id}. "
-            "Please set OPENAI_API_KEY environment variable or configure in settings."
+            "OpenAI API key not configured: no workspace context was provided. "
+            "Provide a workspace_id, configure a workspace OpenAI API key in "
+            "settings, or set the OPENAI_API_KEY environment variable."
         )

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -205,66 +205,59 @@ class LLMService:
         context_id: str | None = None,
         workspace_id: str | None = None,
     ) -> str:
-        """Get user's OpenAI API key from database or environment.
+        """Resolve the LLM (OpenAI) API key for the calling user's workspace context.
 
-        Same priority as EmbeddingService._get_user_api_key():
-        1. Context-scoped key (most specific)
-        2. Workspace-scoped key (workspace-wide)
-        3. User-scoped key (personal)
-        4. Environment variable (OPENAI_API_KEY) fallback
+        Mirrors EmbeddingService._get_user_api_key — same Issue #385 contract:
+        the lookup is workspace-keyed; user_id is for audit logging only, not a
+        visibility filter. Any workspace member uses the owner-registered key.
+
+        Priority:
+        1. Context-scoped key (context_id matches AND workspace_id matches)
+        2. Workspace-scoped key (workspace_id matches AND context_id IS NULL)
+        3. Environment variable (OPENAI_API_KEY) — development fallback only
 
         Args:
-            user_id: User ID
-            context_id: Optional context ID
-            workspace_id: Optional workspace ID
+            user_id: Caller's user ID — logged for audit, NOT used as a filter (#385).
+            context_id: Optional context UUID.
+            workspace_id: Workspace UUID; when omitted the DB lookup is skipped.
 
         Returns:
-            Decrypted API key
+            Decrypted API key.
 
         Raises:
-            ConfigurationError: If no API key found
+            ConfigurationError: If neither a DB key nor an env var is available.
         """
         from uuid import UUID
 
         from sqlalchemy import or_
 
-        conditions = [
-            ExternalAPIKey.user_id == user_id,
-            ExternalAPIKey.provider == "openai",
-            ExternalAPIKey.enabled.is_(True),
-        ]
-
-        scope_conditions = []
-        if context_id:
-            context_uuid = UUID(context_id) if isinstance(context_id, str) else context_id
-            scope_conditions.append(ExternalAPIKey.context_id == context_uuid)
+        api_key_entry = None
         if workspace_id:
             workspace_uuid = UUID(workspace_id) if isinstance(workspace_id, str) else workspace_id
-            scope_conditions.append(ExternalAPIKey.workspace_id == workspace_uuid)
-
-        if scope_conditions:
-            conditions.append(
-                or_(
-                    *scope_conditions,
-                    and_(
+            conditions = [
+                ExternalAPIKey.workspace_id == workspace_uuid,
+                ExternalAPIKey.provider == "openai",
+                ExternalAPIKey.enabled.is_(True),
+            ]
+            if context_id:
+                context_uuid = UUID(context_id) if isinstance(context_id, str) else context_id
+                conditions.append(
+                    or_(
+                        ExternalAPIKey.context_id == context_uuid,
                         ExternalAPIKey.context_id.is_(None),
-                        ExternalAPIKey.workspace_id.is_(None),
-                    ),
+                    )
                 )
-            )
+            else:
+                conditions.append(ExternalAPIKey.context_id.is_(None))
 
-        query = (
-            select(ExternalAPIKey)
-            .where(and_(*conditions))
-            .order_by(
-                ExternalAPIKey.context_id.desc().nulls_last(),
-                ExternalAPIKey.workspace_id.desc().nulls_last(),
+            query = (
+                select(ExternalAPIKey)
+                .where(and_(*conditions))
+                .order_by(ExternalAPIKey.context_id.desc().nulls_last())
+                .limit(1)
             )
-            .limit(1)
-        )
-
-        result = await self.db.execute(query)
-        api_key_entry = result.scalar_one_or_none()
+            result = await self.db.execute(query)
+            api_key_entry = result.scalar_one_or_none()
 
         if api_key_entry:
             encryptor = get_encryptor()
@@ -273,6 +266,7 @@ class LLMService:
                 "llm_api_key_from_db",
                 user_id=user_id,
                 context_id=context_id,
+                workspace_id=workspace_id,
             )
             return api_key
 

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -423,38 +423,37 @@ class RerankerService:
                 logger.debug("using_ollama_reranker", user_id=user_id, model=model)
                 return OllamaReranker(base_url=settings.ollama_base_url, model=model)
 
-        # API-key providers (Voyage, Cohere)
+        # API-key providers (Voyage, Cohere).
+        # Issue #385: workspace-keyed lookup; user_id is for audit, not a filter.
+        # Without a workspace context the reranker is treated as not configured —
+        # API-key reranker rows live in the external_api_keys table which is now
+        # workspace-scoped (NOT NULL), so a no-workspace caller has nothing to find.
+        if not workspace_id:
+            logger.debug("no_reranker_configured", user_id=user_id, reason="no_workspace_context")
+            return None
+
+        workspace_uuid = UUID(workspace_id) if isinstance(workspace_id, str) else workspace_id
         conditions = [
-            ExternalAPIKey.user_id == user_id,
+            ExternalAPIKey.workspace_id == workspace_uuid,
             ExternalAPIKey.provider.in_(RERANKER_PROVIDERS),
             ExternalAPIKey.enabled.is_(True),
         ]
-
-        scope_conditions = []
         if context_id:
             context_uuid = UUID(context_id) if isinstance(context_id, str) else context_id
-            scope_conditions.append(ExternalAPIKey.context_id == context_uuid)
-        if workspace_id:
-            workspace_uuid = UUID(workspace_id) if isinstance(workspace_id, str) else workspace_id
-            scope_conditions.append(ExternalAPIKey.workspace_id == workspace_uuid)
-
-        if scope_conditions:
+            # Context-scoped key wins; fall back to workspace-scoped (context_id IS NULL).
             conditions.append(
                 or_(
-                    *scope_conditions,
-                    and_(
-                        ExternalAPIKey.context_id.is_(None), ExternalAPIKey.workspace_id.is_(None)
-                    ),
+                    ExternalAPIKey.context_id == context_uuid,
+                    ExternalAPIKey.context_id.is_(None),
                 )
             )
+        else:
+            conditions.append(ExternalAPIKey.context_id.is_(None))
 
         query = (
             select(ExternalAPIKey)
             .where(and_(*conditions))
-            .order_by(
-                ExternalAPIKey.context_id.desc().nulls_last(),
-                ExternalAPIKey.workspace_id.desc().nulls_last(),
-            )
+            .order_by(ExternalAPIKey.context_id.desc().nulls_last())
             .limit(1)
         )
 

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -387,8 +387,10 @@ class RerankerService:
 
         Queries ExternalAPIKey for the enabled reranker key. Issue #105's
         cross-provider exclusivity (one of Cohere / Voyage per workspace) is
-        enforced at validate_reranker_exclusivity call sites in external_keys.py
-        plus by the a99 migration's pre-flight check.
+        enforced at runtime by validate_reranker_exclusivity call sites in
+        external_keys.py (create / toggle). The a99 migration has a matching
+        pre-flight check, but that check only runs once during upgrade — it
+        is a legacy-data safeguard, not a runtime enforcement mechanism.
 
         Issue #385: key resolution is workspace-keyed. When workspace_id is
         omitted, the reranker is treated as not configured (returns None) —

--- a/backend/src/services/reranker_service.py
+++ b/backend/src/services/reranker_service.py
@@ -383,20 +383,26 @@ class RerankerService:
         context_id: str | None = None,
         workspace_id: str | None = None,  # NEW: Workspace ID (Issue #146)
     ) -> RerankerProvider | None:
-        """Get the active reranker provider for user/context/workspace.
+        """Get the active reranker provider for the current workspace context.
 
-        Queries ExternalAPIKey table for enabled reranker key.
-        Only ONE reranker can be enabled at a time (validated by external_keys.py).
+        Queries ExternalAPIKey for the enabled reranker key. Issue #105's
+        cross-provider exclusivity (one of Cohere / Voyage per workspace) is
+        enforced at validate_reranker_exclusivity call sites in external_keys.py
+        plus by the a99 migration's pre-flight check.
 
-        Priority: context-scoped > workspace-scoped > user-scoped > env var
+        Issue #385: key resolution is workspace-keyed. When workspace_id is
+        omitted, the reranker is treated as not configured (returns None) —
+        there is no user-scoped or global fallback tier anymore.
+
+        Priority within a workspace: context-scoped > workspace-scoped.
 
         Args:
-            user_id: User ID
-            context_id: Optional context ID (Issue #82: context-scoped keys)
-            workspace_id: Optional workspace ID (Issue #146: workspace-scoped keys)
+            user_id: Caller's user ID — logged for audit, NOT used as a filter (#385).
+            context_id: Optional context UUID (context-scoped keys take priority).
+            workspace_id: Workspace UUID; when omitted returns None.
 
         Returns:
-            RerankerProvider instance or None if no reranker enabled
+            RerankerProvider instance, or None if no reranker key configured.
         """
         from uuid import UUID
 

--- a/backend/tests/api/test_external_keys.py
+++ b/backend/tests/api/test_external_keys.py
@@ -29,17 +29,19 @@ class TestRerankerExclusivity:
         return AsyncMock()
 
     @pytest.fixture
-    def user_id(self):
-        """Test user ID."""
-        return "test_user_123"
+    def workspace_id(self):
+        """Test workspace UUID — Issue #385: reranker exclusivity is workspace-scoped."""
+        from uuid import UUID
+
+        return UUID("00000000-0000-0000-0000-000000000001")
 
     @pytest.mark.asyncio
-    async def test_openai_cannot_be_disabled(self, mock_db, user_id):
+    async def test_openai_cannot_be_disabled(self, mock_db, workspace_id):
         """Test that OpenAI keys cannot be disabled."""
         with pytest.raises(HTTPException) as exc_info:
             await validate_reranker_exclusivity(
                 db=mock_db,
-                user_id=user_id,
+                workspace_id=workspace_id,
                 provider="openai",
                 enabled=False,  # Trying to disable
             )
@@ -48,29 +50,29 @@ class TestRerankerExclusivity:
         assert exc_info.value.detail["error"] == "cannot_disable_embeddings"
 
     @pytest.mark.asyncio
-    async def test_openai_enable_always_allowed(self, mock_db, user_id):
+    async def test_openai_enable_always_allowed(self, mock_db, workspace_id):
         """Test that enabling OpenAI is always allowed."""
         # Should not raise any exception
         await validate_reranker_exclusivity(
             db=mock_db,
-            user_id=user_id,
+            workspace_id=workspace_id,
             provider="openai",
             enabled=True,
         )
 
     @pytest.mark.asyncio
-    async def test_disable_reranker_allowed(self, mock_db, user_id):
+    async def test_disable_reranker_allowed(self, mock_db, workspace_id):
         """Test that disabling a reranker is always allowed."""
         # Should not raise - disabling is fine
         await validate_reranker_exclusivity(
             db=mock_db,
-            user_id=user_id,
+            workspace_id=workspace_id,
             provider="cohere",
             enabled=False,
         )
 
     @pytest.mark.asyncio
-    async def test_enable_reranker_with_no_conflict(self, mock_db, user_id):
+    async def test_enable_reranker_with_no_conflict(self, mock_db, workspace_id):
         """Test enabling reranker when no other reranker is enabled."""
         # Mock DB query returning no conflicting key
         mock_result = MagicMock()
@@ -80,13 +82,13 @@ class TestRerankerExclusivity:
         # Should not raise
         await validate_reranker_exclusivity(
             db=mock_db,
-            user_id=user_id,
+            workspace_id=workspace_id,
             provider="cohere",
             enabled=True,
         )
 
     @pytest.mark.asyncio
-    async def test_enable_cohere_when_voyage_enabled(self, mock_db, user_id):
+    async def test_enable_cohere_when_voyage_enabled(self, mock_db, workspace_id):
         """Test that enabling Cohere fails when Voyage is already enabled."""
         # Mock existing Voyage key
         mock_voyage_key = MagicMock()
@@ -100,7 +102,7 @@ class TestRerankerExclusivity:
         with pytest.raises(HTTPException) as exc_info:
             await validate_reranker_exclusivity(
                 db=mock_db,
-                user_id=user_id,
+                workspace_id=workspace_id,
                 provider="cohere",
                 enabled=True,
             )
@@ -110,7 +112,7 @@ class TestRerankerExclusivity:
         assert exc_info.value.detail["conflicting_provider"] == "voyage"
 
     @pytest.mark.asyncio
-    async def test_enable_voyage_when_cohere_enabled(self, mock_db, user_id):
+    async def test_enable_voyage_when_cohere_enabled(self, mock_db, workspace_id):
         """Test that enabling Voyage fails when Cohere is already enabled."""
         # Mock existing Cohere key
         mock_cohere_key = MagicMock()
@@ -124,7 +126,7 @@ class TestRerankerExclusivity:
         with pytest.raises(HTTPException) as exc_info:
             await validate_reranker_exclusivity(
                 db=mock_db,
-                user_id=user_id,
+                workspace_id=workspace_id,
                 provider="voyage",
                 enabled=True,
             )
@@ -134,7 +136,7 @@ class TestRerankerExclusivity:
         assert exc_info.value.detail["conflicting_provider"] == "cohere"
 
     @pytest.mark.asyncio
-    async def test_no_conflict_check(self, mock_db, user_id):
+    async def test_no_conflict_check(self, mock_db, workspace_id):
         """Test enabling reranker with no existing conflict."""
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = None
@@ -142,7 +144,7 @@ class TestRerankerExclusivity:
 
         await validate_reranker_exclusivity(
             db=mock_db,
-            user_id=user_id,
+            workspace_id=workspace_id,
             provider="cohere",
             enabled=True,
         )
@@ -150,7 +152,7 @@ class TestRerankerExclusivity:
         mock_db.execute.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_exclude_self_when_updating(self, mock_db, user_id):
+    async def test_exclude_self_when_updating(self, mock_db, workspace_id):
         """Test that updating a key excludes itself from conflict check."""
         existing_key_id = 123
 
@@ -160,7 +162,7 @@ class TestRerankerExclusivity:
 
         await validate_reranker_exclusivity(
             db=mock_db,
-            user_id=user_id,
+            workspace_id=workspace_id,
             provider="cohere",
             enabled=True,
             exclude_key_id=existing_key_id,

--- a/backend/tests/api/test_rbac_issue59.py
+++ b/backend/tests/api/test_rbac_issue59.py
@@ -1,10 +1,15 @@
-"""RBAC tests for Issue #59: Viewer restriction and resource token owner-only.
+"""RBAC tests for external keys (#381 owner-only) and resource tokens (#59 owner-only).
 
-Tests:
-- Viewer role is rejected from all external keys endpoints (403)
-- Member/admin/owner roles can access external keys endpoints
-- Non-owner is rejected from resource token list (403)
-- Owner can access resource token list
+External keys (Issue #59 → tightened in #381):
+- Issue #59 originally restricted viewers; Issue #381 tightened the contract to owner-only
+  because external API keys are workspace-level secrets (OpenAI/Cohere/Anthropic credentials).
+- ALL non-owner roles (viewer, member, admin) are now rejected with 403.
+- Only the workspace owner can list/create/update/toggle/delete external keys.
+- The legacy POST /external-keys/import endpoint was deleted in #381 (dead code).
+
+Resource tokens (Issue #59 — unchanged):
+- Non-owner is rejected from resource token list (403).
+- Owner can access resource token list.
 
 Uses dependency_overrides to mock auth — no DB or Docker required.
 """
@@ -18,7 +23,6 @@ from fastapi.testclient import TestClient
 from api.main import app
 from auth.dependencies import (
     get_user_from_api_key_or_session,
-    require_workspace_member,
     require_workspace_owner,
 )
 
@@ -42,35 +46,15 @@ def _mock_user(workspace_role: str = "member") -> dict:
 
 
 @pytest.fixture
-def viewer_client():
-    """Client authenticated as a viewer — WorkspaceMember dependency rejects."""
-
-    async def mock_reject_viewer():
-        raise HTTPException(status_code=403, detail="Requires 'member' role or higher")
-
-    app.dependency_overrides[require_workspace_member] = mock_reject_viewer
-    with TestClient(app, raise_server_exceptions=False) as client:
-        yield client
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
-def member_client():
-    """Client authenticated as a member — WorkspaceMember passes."""
-    user = _mock_user("member")
-
-    async def mock_member():
-        return user
-
-    app.dependency_overrides[require_workspace_member] = mock_member
-    with TestClient(app, raise_server_exceptions=False) as client:
-        yield client
-    app.dependency_overrides.clear()
-
-
-@pytest.fixture
 def non_owner_client():
-    """Client authenticated as a member — WorkspaceOwner rejects."""
+    """Client authenticated as a non-owner — WorkspaceOwner rejects.
+
+    Used for both external keys (#381) and resource tokens (#59) — both require owner.
+    The mocked user role doesn't matter here because the override directly raises 403;
+    the test only verifies that the route's owner gate fires, not which non-owner role
+    triggered it. Parametrize the underlying role at the test layer if that distinction
+    becomes important.
+    """
     user = _mock_user("member")
 
     async def mock_auth():
@@ -105,7 +89,7 @@ def owner_client():
 
 
 # ============================================================================
-# External Keys — Viewer Rejection (Issue #59)
+# External Keys — Owner-Only (Issue #381, tightened from #59)
 # ============================================================================
 
 
@@ -115,16 +99,15 @@ EXTERNAL_KEYS_ENDPOINTS = [
     ("PUT", "/api/v1/external-keys/test_key"),
     ("PATCH", "/api/v1/external-keys/test_key/toggle"),
     ("DELETE", "/api/v1/external-keys/test_key"),
-    ("POST", "/api/v1/external-keys/import"),
 ]
 
 
-class TestExternalKeysViewerRejection:
-    """Viewer role should be rejected from all external keys endpoints."""
+class TestExternalKeysOwnerOnly:
+    """Issue #381: external keys are owner-only — non-owners (viewer/member/admin) get 403."""
 
     @pytest.mark.parametrize("method,path", EXTERNAL_KEYS_ENDPOINTS)
-    def test_viewer_gets_403(self, viewer_client, method, path):
-        """Viewer should get 403 on all external keys endpoints."""
+    def test_non_owner_gets_403(self, non_owner_client, method, path):
+        """Any non-owner role should get 403 on every external keys endpoint."""
         json_body = None
         if method == "POST" and path == "/api/v1/external-keys":
             json_body = {
@@ -137,22 +120,30 @@ class TestExternalKeysViewerRejection:
         elif method == "PATCH":
             json_body = {"enabled": True}
 
-        response = viewer_client.request(method, path, json=json_body)
+        response = non_owner_client.request(method, path, json=json_body)
         assert response.status_code == 403, (
             f"{method} {path} returned {response.status_code}, expected 403"
         )
 
+    def test_import_endpoint_removed(self, owner_client):
+        """Issue #381: POST /external-keys/import is removed; even owner gets 404/405."""
+        response = owner_client.post("/api/v1/external-keys/import")
+        assert response.status_code in (404, 405), (
+            f"POST /external-keys/import returned {response.status_code}; "
+            "endpoint should be removed (expected 404 Not Found or 405 Method Not Allowed)"
+        )
 
-class TestExternalKeysMemberAccess:
-    """Member role should be able to access external keys endpoints."""
 
-    def test_member_can_list_external_keys(self, member_client):
-        """Member should not get 403 on list endpoint.
+class TestExternalKeysOwnerAccess:
+    """Workspace owner should reach the handler body on every external keys endpoint."""
+
+    def test_owner_can_list_external_keys(self, owner_client):
+        """Owner should not get 403 on list endpoint.
 
         May get 500 (no DB) but NOT 403.
         """
-        response = member_client.get("/api/v1/external-keys")
-        assert response.status_code != 403, "Member got 403 on list — RBAC too restrictive"
+        response = owner_client.get("/api/v1/external-keys")
+        assert response.status_code != 403, "Owner got 403 on list — RBAC too restrictive"
 
 
 # ============================================================================

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -121,12 +121,6 @@ const navigationGroups: NavGroup[] = [
         href: "/workspace/integrations/credentials?tab=oauth-apps",
         icon: Puzzle,
       },
-      {
-        nameKey: "externalKeys",
-        href: "/workspace/integrations/external-keys",
-        icon: KeyRound,
-        requiredWorkspaceRole: "member", // Issue #59: Hide from viewers
-      },
     ],
   },
   {
@@ -138,6 +132,12 @@ const navigationGroups: NavGroup[] = [
         href: "/workspace/settings/general",
         icon: Sliders,
         requiredWorkspaceRole: "owner",
+      },
+      {
+        nameKey: "externalKeys",
+        href: "/workspace/integrations/external-keys",
+        icon: KeyRound,
+        requiredWorkspaceRole: "owner", // Issue #381: Owner-only (workspace-level secrets)
       },
     ],
   },

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -246,10 +246,16 @@ export function Sidebar() {
     }
   }, [currentWorkspaceId]);
 
-  // Load external key status (with race condition guard)
+  // Load external key status (with race condition guard).
+  // Issue #381: external keys are owner-only. Non-owners would get 403 — skip the
+  // fetch entirely for them to avoid noisy auth logs / avoidable network traffic.
+  // The AlertTriangle indicator on the nav item is owner-only too, so this also
+  // keeps the `hasExternalKeys=null` path unreachable for non-owners.
+  const currentWorkspaceRole = currentWorkspace?.current_user_role;
   useEffect(() => {
     setHasExternalKeys(null);
     if (!currentWorkspaceId) return;
+    if (currentWorkspaceRole !== "owner") return;
 
     let cancelled = false;
     listExternalAPIKeys()
@@ -263,7 +269,7 @@ export function Sidebar() {
     return () => {
       cancelled = true;
     };
-  }, [currentWorkspaceId]);
+  }, [currentWorkspaceId, currentWorkspaceRole]);
 
   // Sync collapse state across browser tabs
   useEffect(() => {

--- a/frontend/src/lib/api/external-keys.ts
+++ b/frontend/src/lib/api/external-keys.ts
@@ -1,11 +1,11 @@
-import { apiClient } from './base';
+import { apiClient } from "./base";
 
 export interface ExternalAPIKey {
   id: number;
   key_name: string;
   provider: string;
   masked_value: string;
-  enabled: boolean;  // Issue #105
+  enabled: boolean; // Issue #105
   created_at: string;
   updated_at: string;
   updated_by: string | null;
@@ -15,7 +15,7 @@ export interface CreateExternalAPIKeyRequest {
   key_name: string;
   provider: string;
   value: string;
-  enabled?: boolean;  // Issue #105, defaults to true
+  enabled?: boolean; // Issue #105, defaults to true
 }
 
 export interface UpdateExternalAPIKeyRequest {
@@ -26,12 +26,6 @@ export interface ToggleExternalAPIKeyRequest {
   enabled: boolean;
 }
 
-export interface ImportResult {
-  created: string[];
-  skipped: string[];
-  failed: [string, string][];
-}
-
 export interface ExternalKeyListResponse {
   keys: ExternalAPIKey[];
   total: number;
@@ -40,24 +34,35 @@ export interface ExternalKeyListResponse {
 /**
  * List all external API keys, optionally filtered by provider
  */
-export async function listExternalAPIKeys(provider?: string): Promise<ExternalAPIKey[]> {
-  const params = provider ? `?provider=${provider}` : '';
-  const response = await apiClient.get<ExternalKeyListResponse>(`/api/v1/external-keys${params}`);
+export async function listExternalAPIKeys(
+  provider?: string,
+): Promise<ExternalAPIKey[]> {
+  const params = provider ? `?provider=${provider}` : "";
+  const response = await apiClient.get<ExternalKeyListResponse>(
+    `/api/v1/external-keys${params}`,
+  );
   return response.keys;
 }
 
 /**
  * Create a new external API key
  */
-export async function createExternalAPIKey(data: CreateExternalAPIKeyRequest): Promise<ExternalAPIKey> {
-  return apiClient.post<ExternalAPIKey>('/api/v1/external-keys', data);
+export async function createExternalAPIKey(
+  data: CreateExternalAPIKeyRequest,
+): Promise<ExternalAPIKey> {
+  return apiClient.post<ExternalAPIKey>("/api/v1/external-keys", data);
 }
 
 /**
  * Update an existing external API key
  */
-export async function updateExternalAPIKey(keyName: string, value: string): Promise<ExternalAPIKey> {
-  return apiClient.put<ExternalAPIKey>(`/api/v1/external-keys/${keyName}`, { value });
+export async function updateExternalAPIKey(
+  keyName: string,
+  value: string,
+): Promise<ExternalAPIKey> {
+  return apiClient.put<ExternalAPIKey>(`/api/v1/external-keys/${keyName}`, {
+    value,
+  });
 }
 
 /**
@@ -65,11 +70,11 @@ export async function updateExternalAPIKey(keyName: string, value: string): Prom
  */
 export async function toggleExternalAPIKey(
   keyName: string,
-  enabled: boolean
+  enabled: boolean,
 ): Promise<ExternalAPIKey> {
   return apiClient.patch<ExternalAPIKey>(
     `/api/v1/external-keys/${keyName}/toggle`,
-    { enabled }
+    { enabled },
   );
 }
 
@@ -78,11 +83,4 @@ export async function toggleExternalAPIKey(
  */
 export async function deleteExternalAPIKey(keyName: string): Promise<void> {
   await apiClient.delete(`/api/v1/external-keys/${keyName}`);
-}
-
-/**
- * Import API keys from .env.cloud file
- */
-export async function importExternalAPIKeys(): Promise<ImportResult> {
-  return apiClient.post<ImportResult>('/api/v1/external-keys/import', {});
 }


### PR DESCRIPTION
Closes #381
Closes #385

## Summary

External API keys (OpenAI / Cohere / Anthropic credentials) are workspace-level secrets that must be managed only by the workspace owner, and the underlying `external_api_keys` row must always belong to exactly one workspace. This PR ships both halves of that contract:

- **#381 (Phase 1)**: tighten authorization at the router and frontend so non-owners can never list / create / update / toggle / delete external API keys; remove the legacy `POST /external-keys/import` endpoint that was the only producer of `workspace_id=NULL` rows.
- **#385 (Phase 2)**: enforce `workspace_id NOT NULL` at the schema level (with a defensive pre-flight check), add a partial unique index `(workspace_id, provider) WHERE enabled=true` for at-most-one-enabled-key-per-provider, and refactor the embedding / LLM / reranker services to drop their legacy `user_id == caller` visibility filter so an owner-registered workspace key is actually usable by every workspace member.

Net diff: `+342 / -441 = -99 lines` (subtraction PR; tech debt purely net negative).

## Implementation notes

**Router-level owner enforcement (#381)** — `external_keys.py` adopts the FastAPI router-level `dependencies=[Depends(require_workspace_owner)]` pattern (novel in this codebase; existing routers use per-handler `Depends(WorkspaceOwner)`). All 5 routes share one declarative gate. Migrating the rest of the codebase to this pattern is a recommended follow-up.

**Schema migration (`a99_external_keys_workspace_not_null`)** — defensive `SELECT COUNT(*) WHERE workspace_id IS NULL` pre-flight (mirrors `a97_resources_entity`'s pattern); aborts with an actionable error if any legacy row survived. `ALTER COLUMN ... SET NOT NULL` runs inside the standard transaction, then `CREATE UNIQUE INDEX ... WHERE enabled=true`. Forward + downgrade defined.

**Service-layer refactor** — `embedding_service._get_user_api_key`, `llm_service._get_user_api_key`, `reranker_service._get_reranker` all switched to workspace-keyed lookup. The `user_id` parameter is preserved on the function signatures for audit logging only (clearly noted in each docstring). The 3 functions are now nearly identical; extracting a shared `external_key_resolver` is recommended as a separate refactor.

**Route cleanup** — `update / toggle / delete` switched from `user_id == caller` filter to `workspace_id == current_workspace_id`. This fixes ownership-transition correctness: a new owner can now manage keys originally registered by a previous owner. Workspace-boundary check blocks (`if key.workspace_id is not None: ...`) became unconditional and were removed.

**Reranker exclusivity scope shift** — `validate_reranker_exclusivity` is now per-workspace (was per-user). DB partial unique index enforces the same invariant; the application-layer check is retained to produce a friendly 409 with provider details on conflict.

**Frontend** — `Sidebar.tsx` moves the External Keys nav item from Integrations → Settings group and tightens the gate from `member` → `owner`. The page-level redirect (`current_user_role !== "owner"`) was already in place, so this is pure defense in depth. Dead `importExternalAPIKeys` client + `ImportResult` interface removed (orphaned after the backend endpoint was deleted).

**`member_credentials_service.cleanup_member_credentials`** is intentionally LEFT UNCHANGED — the `user_id` filter there scopes the DELETE to a leaving member's contributions, not caller-visibility. Whether workspace-shared keys should survive a member's removal is a separate design question (different axis from #385); proposing as a follow-up.

## Pre-PR review summary

- **gate1**: green via `/ask` (after operator-confirmed milestone correction — #383/#385 had been moved to v0.12.1 since the issue bodies were written)
- **gate2 mode**: advisor-only (binary_gate = none)
- **gate2 advisors**:
  - cso: green
  - qa-lead: yellow (deferred items — see Deferred / Follow-up below)
  - cto: green
- **gate2 aggregate**: yellow → operator confirmed ship intent at the HITL gate
- **review provider**: copilot

Full reviews are saved locally in the plugin cache:
- `~/.claude/cache/gh-issue-driven/381-batch-381-383-385.gate1.md`
- `~/.claude/cache/gh-issue-driven/381-batch-381-383-385.gate2.md`

## Test plan

- [x] `make lint` — backend ruff: clean
- [x] `make type-check` — pyright: 0 errors, 0 warnings
- [x] `pytest tests/api/test_external_keys.py tests/api/test_rbac_issue59.py` — 19 + 10 = 29 passing (parametrized `test_non_owner_gets_403` × 5 endpoints, `test_import_endpoint_removed`, `test_owner_can_list`, full reranker exclusivity coverage)
- [x] `pytest tests/services/` — 325 passing (no regression in service layer)
- [x] Frontend tsc + dashboard Vitest — clean (verified via container with worktree file)
- [ ] **Deferred to follow-up** (require Docker DB):
  - Owner registers workspace OpenAI key → member calls `recall()` → embedding succeeds using owner's key (#385 AC)
  - Cross-workspace isolation for workspace-scoped keys
  - Second enabled `(workspace, provider)` insert returns 409 (DB partial unique index)
  - Owner deletes workspace key → member's subsequent `recall()` falls back to env var

## Deferred / Follow-up

This PR was originally batched with **#383** (graph reads via `PermissionService` instead of hardcoded `user_id` filter), but that issue was split out per operator decision: same legacy-filter pattern as #385 but in the graph layer (`routes/graph.py`, `services/graph_service.py`, `repositories/neural_edge.py`), requiring a 4×4 visibility matrix integration test. Tracking continues on **#383**.

Recommended follow-up issues to file:
1. Integration tests for #385 AC (4 tests, require Docker DB) — see Test plan above
2. Extract shared `external_key_resolver` from the 3 service functions
3. Migrate other routers (resource_tokens / oauth_clients / api_keys) to the router-level `Depends(require_workspace_owner)` pattern
4. Add migration round-trip test infrastructure (no existing pattern)
5. `member_credentials_service.cleanup_member_credentials` design review — should workspace-shared keys survive a member's removal?

🤖 Generated via /gh-issue-driven:ship
