### PR TITLE
fix(db): close CWE-639 on resource_* satellite reads (Phase 2) (#390)

### DIFF
--- a/backend/alembic/versions/b01_resource_pk_writer_phase2.py
+++ b/backend/alembic/versions/b01_resource_pk_writer_phase2.py
@@ -268,23 +268,65 @@ def _backfill_resource_tokens_workspace_id(conn: sa.Connection) -> None:
     )
 
 
+def _seed_missing_resources_from_active_contexts(conn: sa.Connection) -> None:
+    """Ensure every active Context has a workspace-scoped ``resources`` row.
+
+    a97 (Phase 1) seeded ``resources`` from the then-active contexts at
+    migration time. Contexts created between a97 ship and the Phase 2
+    writer update (``handle_setup_resource`` didn't start upserting
+    ``Resource`` rows until this PR) can exist without a backing
+    ``resources`` row. The ambiguity audit + slug-only backfill assume
+    that invariant holds; if it doesn't, a workspace with an active
+    Context but no ``resources`` row leaves its orphan satellite rows
+    unmatched — and the slug-only backfill JOIN can silently re-home
+    them to a different workspace's Resource that happens to share the
+    slug. Reintroducing the CWE-639 leak this migration is supposed to
+    close.
+
+    Re-seed from the same shape a97 used, but with a ``NOT EXISTS``
+    guard so existing rows are preserved. Copilot catch on PR #392
+    loop 6 (re-entry).
+    """
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO resources (workspace_id, resource_id)
+            SELECT DISTINCT c.workspace_id, c.resource_id
+            FROM contexts c
+            WHERE c.deleted_at IS NULL
+              AND c.resource_id IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1 FROM resources r
+                WHERE r.workspace_id = c.workspace_id
+                  AND r.resource_id = c.resource_id
+              )
+            """
+        )
+    )
+
+
 def upgrade() -> None:
     conn = op.get_bind()
 
-    # Step 1: abort if any slug-only orphan is ambiguous across workspaces.
+    # Step 1: seed missing ``resources`` rows from active contexts. Ensures
+    # every live (workspace_id, resource_id) has a Resource row BEFORE the
+    # audit runs, so audit COUNT(resources) reflects the complete set.
+    _seed_missing_resources_from_active_contexts(conn)
+
+    # Step 2: abort if any slug-only orphan is ambiguous across workspaces.
     _audit_cross_workspace_ambiguity(conn)
 
-    # Step 2: backfill the context-scoped table (safest JOIN shape).
+    # Step 3: backfill the context-scoped table (safest JOIN shape).
     _backfill_indexer_state(conn)
 
-    # Step 3: backfill resource_tokens (workspace-safe pass + slug-only fallback).
+    # Step 4: backfill resource_tokens (workspace-safe pass + slug-only fallback).
     _backfill_resource_tokens(conn)
 
-    # Step 4: backfill the pure slug-only satellite tables (events, schemas).
+    # Step 5: backfill the pure slug-only satellite tables (events, schemas).
     for table_name in _SATELLITE_TABLES_SLUG_ONLY:
         _backfill_slug_only_table(conn, table_name)
 
-    # Step 5: finish a97 Phase 1's ``workspace_id`` backfill for any
+    # Step 6: finish a97 Phase 1's ``workspace_id`` backfill for any
     # newly-populated ``resource_pk`` values on resource_tokens.
     _backfill_resource_tokens_workspace_id(conn)
 

--- a/backend/alembic/versions/b01_resource_pk_writer_phase2.py
+++ b/backend/alembic/versions/b01_resource_pk_writer_phase2.py
@@ -1,0 +1,210 @@
+"""Issue #390: orphan backfill + ambiguity audit for resource_pk (Phase 2 of 3).
+
+Phase 1 (``a97_resources_entity``) backfilled ``resource_pk`` on rows that
+existed at migration time and introduced the column as nullable. Phase 2
+(this migration + application writer updates) populates ``resource_pk`` on
+every new insert via SQLAlchemy ``before_insert`` event listeners; this
+migration catches any orphan rows that were written between the a97 ship
+date and the application writer ship date — rows where application code
+set only ``resource_id`` (slug) while ``resource_pk`` silently defaulted
+to NULL.
+
+This migration is forward-only by intent: NULL → populated backfill is
+trivially reversible (the column is still nullable), so a ``downgrade()``
+to the pre-backfill state is a no-op. Phase C (``#325``) will tighten the
+column to NOT NULL and drop the ``postgresql_where`` partial clause,
+converting the partial UNIQUE indexes to full UNIQUE.
+
+Revision ID: b01_resource_pk_ph2
+Revises: a99_ext_keys_ws_not_null
+
+BINDING CROSS-WORKSPACE AMBIGUITY AUDIT
+---------------------------------------
+Before attempting backfill, the migration scans for orphan rows whose
+slug maps to more than one live ``resources`` row across workspaces. That
+shape — which requires a soft-deleted workspace A resource sharing a slug
+with a live workspace B resource — would cause an unqualified JOIN to
+silently re-home workspace A's orphan satellite rows to workspace B,
+reintroducing the same CWE-639 leak vector the writer migration is closing.
+When detected, the migration aborts with an operator-actionable error
+listing the offending slugs per table. In a solo-user deployment this is
+expected to detect zero rows, but the audit itself is a shipped regression
+guard (#390 design feedback, gate1 yellow → green after scope addendum).
+
+TABLE-BY-TABLE BACKFILL STRATEGY
+---------------------------------
+- ``indexer_state`` has a ``context_id`` FK that is workspace-scoped via
+  Context, so the backfill JOIN can safely use the Context →
+  Resource correspondence to recover the correct ``resource_pk`` even
+  under slug reuse. Safe to backfill row-by-row via a direct JOIN.
+- ``resource_events``, ``resource_schemas``, ``resource_tokens`` have no
+  ``context_id`` column. Without the ambiguity audit having passed,
+  a slug-only JOIN could misattribute orphan rows. After the audit
+  confirms the slug resolves to exactly one live workspace-scoped
+  ``resources`` row, the JOIN is safe.
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b01_resource_pk_ph2"
+down_revision = "a99_ext_keys_ws_not_null"
+branch_labels = None
+depends_on = None
+
+
+# Tables that need orphan backfill. ``has_context_id`` controls whether the
+# backfill JOIN can use ``context_id`` for workspace disambiguation.
+_SATELLITE_TABLES = [
+    ("resource_events", False),
+    ("resource_schemas", False),
+    ("indexer_state", True),
+    ("resource_tokens", False),
+]
+
+
+def _audit_cross_workspace_ambiguity(conn: sa.Connection) -> None:
+    """Abort the migration if any satellite slug maps to >1 live workspace.
+
+    This is the canonical "0635c675 pattern" applied to Phase 2 orphan
+    backfill. See the module docstring for the exploit shape being
+    prevented.
+    """
+    ambiguities: list[str] = []
+    # The audit runs on all 4 satellite tables regardless of context_id
+    # presence, so unpack just the name.
+    for table_name, _ in _SATELLITE_TABLES:
+        # Table name is a module-constant from ``_SATELLITE_TABLES``; slug
+        # values never appear in the f-string (only the whole-table scan
+        # does). Matches the a97 precedent (``# noqa: S608 -- table names
+        # are module-constant``) for the same shape.
+        result = conn.execute(
+            sa.text(
+                f"""
+                SELECT DISTINCT s.resource_id
+                FROM {table_name} s
+                WHERE s.resource_pk IS NULL
+                  AND (
+                    SELECT COUNT(*)
+                    FROM resources r
+                    WHERE r.resource_id = s.resource_id
+                  ) > 1
+                """  # noqa: S608 -- table names are module-constant
+            )
+        ).fetchall()
+        if result:
+            slugs = ", ".join(repr(row[0]) for row in result)
+            ambiguities.append(f"{table_name}: {slugs}")
+
+    if ambiguities:
+        lines = "\n  ".join(ambiguities)
+        raise RuntimeError(
+            "Phase 2 orphan backfill aborted: cross-workspace slug ambiguity "
+            "detected. Manual resolution required before this migration can "
+            "run.\n"
+            f"  {lines}\n\n"
+            "Each listed slug maps to >1 row in the ``resources`` table, which "
+            "means a soft-deleted workspace's orphan satellite rows would be "
+            "silently re-homed to another workspace by an unqualified JOIN. "
+            "Inspect the ``resources`` and satellite tables for the offending "
+            "slugs and either delete the orphan satellite rows or hard-delete "
+            "the soft-deleted workspace before retrying."
+        )
+
+
+def _backfill_indexer_state(conn: sa.Connection) -> None:
+    """Backfill ``indexer_state.resource_pk`` via (Context → Resource) JOIN.
+
+    ``indexer_state.context_id`` FK gives us workspace scope even when the
+    slug collides across workspaces — resolve via Context, then Resource.
+    """
+    conn.execute(
+        sa.text(
+            """
+            UPDATE indexer_state s
+            SET resource_pk = r.id
+            FROM contexts c
+            JOIN resources r
+              ON r.workspace_id = c.workspace_id
+             AND r.resource_id = c.resource_id
+            WHERE s.resource_pk IS NULL
+              AND s.context_id = c.id
+            """
+        )
+    )
+
+
+def _backfill_slug_only_table(conn: sa.Connection, table_name: str) -> None:
+    """Backfill ``<satellite>.resource_pk`` via direct ``resources`` JOIN.
+
+    Precondition: the cross-workspace ambiguity audit has confirmed every
+    orphan slug maps to at most one ``resources`` row, so the JOIN is
+    deterministic. ``resource_events``, ``resource_schemas``, and
+    ``resource_tokens`` all take this path.
+    """
+    conn.execute(
+        sa.text(
+            f"""
+            UPDATE {table_name} s
+            SET resource_pk = r.id
+            FROM resources r
+            WHERE s.resource_pk IS NULL
+              AND r.resource_id = s.resource_id
+            """  # noqa: S608 -- table_name is module-constant
+        )
+    )
+
+
+def _backfill_resource_tokens_workspace_id(conn: sa.Connection) -> None:
+    """Complete the a97 Phase 1 intent by backfilling ``workspace_id``.
+
+    a97 backfilled ``resource_tokens.workspace_id`` from the at-rest
+    ``resources.workspace_id`` JOIN once. Any token written between a97
+    ship and this migration may still have ``workspace_id IS NULL``
+    because the application writer for the token manager did not set it.
+    This catches those — after this migration + the corresponding writer
+    update, no new NULL rows should appear, which is what the Phase C
+    NOT NULL tightening observation window verifies.
+    """
+    conn.execute(
+        sa.text(
+            """
+            UPDATE resource_tokens t
+            SET workspace_id = r.workspace_id
+            FROM resources r
+            WHERE t.workspace_id IS NULL
+              AND t.resource_pk = r.id
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Step 1: abort if any orphan slug is ambiguous across workspaces.
+    _audit_cross_workspace_ambiguity(conn)
+
+    # Step 2: backfill the context-scoped table first (safest JOIN shape).
+    _backfill_indexer_state(conn)
+
+    # Step 3: backfill the three slug-only satellite tables.
+    for table_name, has_context_id in _SATELLITE_TABLES:
+        if has_context_id:
+            continue  # indexer_state handled above
+        _backfill_slug_only_table(conn, table_name)
+
+    # Step 4: finish a97 Phase 1's ``workspace_id`` backfill for any
+    # newly-populated ``resource_pk`` values on resource_tokens.
+    _backfill_resource_tokens_workspace_id(conn)
+
+
+def downgrade() -> None:
+    # Forward-only migration. NULL → populated is not reversible without
+    # data loss (the NULL state cannot be reconstructed after the JOIN
+    # has resolved ``resource_pk``), and Phase 1's schema still permits
+    # NULL rows to coexist, so downgrade is a no-op.
+    pass

--- a/backend/alembic/versions/b01_resource_pk_writer_phase2.py
+++ b/backend/alembic/versions/b01_resource_pk_writer_phase2.py
@@ -278,24 +278,32 @@ def _backfill_resource_tokens_workspace_id(conn: sa.Connection) -> None:
     )
 
 
-def _seed_missing_resources_from_active_contexts(conn: sa.Connection) -> None:
-    """Ensure every active Context has a workspace-scoped ``resources`` row.
+def _seed_missing_resources_from_all_contexts(conn: sa.Connection) -> None:
+    """Ensure every Context (active OR soft-deleted) has a workspace-scoped
+    ``resources`` row so the ambiguity audit sees the full picture.
 
     a97 (Phase 1) seeded ``resources`` from the then-active contexts at
     migration time. Contexts created between a97 ship and the Phase 2
     writer update (``handle_setup_resource`` didn't start upserting
     ``Resource`` rows until this PR) can exist without a backing
     ``resources`` row. The ambiguity audit + slug-only backfill assume
-    that invariant holds; if it doesn't, a workspace with an active
-    Context but no ``resources`` row leaves its orphan satellite rows
-    unmatched — and the slug-only backfill JOIN can silently re-home
-    them to a different workspace's Resource that happens to share the
-    slug. Reintroducing the CWE-639 leak this migration is supposed to
-    close.
+    that invariant holds.
 
-    Re-seed from the same shape a97 used, but with a ``NOT EXISTS``
-    guard so existing rows are preserved. Copilot catch on PR #392
-    loop 6 (re-entry).
+    **Include soft-deleted contexts** (Copilot catch on PR #392 loop
+    10): if a post-a97 Context was soft-deleted before the Phase 2
+    writer shipped, its orphan satellite rows live on — but restricting
+    the seed to active contexts leaves the slug mapping to zero
+    ``resources`` rows in that workspace. When another workspace later
+    reuses the slug and DOES have an active Resource, the audit sees
+    COUNT(resources) = 1 (only the live workspace) and does not abort,
+    then the slug-only backfill silently re-homes the soft-deleted
+    workspace's orphan satellites to the live workspace's Resource.
+    Seeding from all contexts (soft-deleted included) ensures
+    COUNT(resources) reflects every workspace that has ever owned the
+    slug, so ambiguity is correctly detected.
+
+    ``NOT EXISTS`` guard preserves existing rows — re-running is a
+    no-op.
     """
     conn.execute(
         sa.text(
@@ -303,8 +311,7 @@ def _seed_missing_resources_from_active_contexts(conn: sa.Connection) -> None:
             INSERT INTO resources (workspace_id, resource_id)
             SELECT DISTINCT c.workspace_id, c.resource_id
             FROM contexts c
-            WHERE c.deleted_at IS NULL
-              AND c.resource_id IS NOT NULL
+            WHERE c.resource_id IS NOT NULL
               AND NOT EXISTS (
                 SELECT 1 FROM resources r
                 WHERE r.workspace_id = c.workspace_id
@@ -318,10 +325,12 @@ def _seed_missing_resources_from_active_contexts(conn: sa.Connection) -> None:
 def upgrade() -> None:
     conn = op.get_bind()
 
-    # Step 1: seed missing ``resources`` rows from active contexts. Ensures
-    # every live (workspace_id, resource_id) has a Resource row BEFORE the
-    # audit runs, so audit COUNT(resources) reflects the complete set.
-    _seed_missing_resources_from_active_contexts(conn)
+    # Step 1: seed missing ``resources`` rows from ALL contexts
+    # (including soft-deleted). Ensures every (workspace_id, resource_id)
+    # that has ever been bound to a Context has a Resource row BEFORE the
+    # audit runs, so audit COUNT(resources) reflects every workspace that
+    # ever owned the slug — not just the workspaces currently live.
+    _seed_missing_resources_from_all_contexts(conn)
 
     # Step 2: abort if any slug-only orphan is ambiguous across workspaces.
     _audit_cross_workspace_ambiguity(conn)

--- a/backend/alembic/versions/b01_resource_pk_writer_phase2.py
+++ b/backend/alembic/versions/b01_resource_pk_writer_phase2.py
@@ -56,40 +56,50 @@ branch_labels = None
 depends_on = None
 
 
-# Tables that need orphan backfill. ``has_context_id`` controls whether the
-# backfill JOIN can use ``context_id`` for workspace disambiguation.
-_SATELLITE_TABLES = [
-    ("resource_events", False),
-    ("resource_schemas", False),
-    ("indexer_state", True),
-    ("resource_tokens", False),
-]
+# Tables that need orphan backfill, classified by which column (if any) gives
+# them a workspace-safe disambiguation path. The audit only runs on
+# slug-only tables (the leftmost category). Tables with a usable
+# disambiguation column skip the audit and use a workspace-scoped JOIN.
+#
+# - ``slug_only``: no workspace-scoped FK. Backfill via direct ``resources``
+#   JOIN with ambiguity audit prerequisite. Used for ``resource_events``
+#   and ``resource_schemas``.
+# - ``has_context_id``: FK to ``contexts`` gives workspace via
+#   ``contexts.workspace_id``. Backfill JOIN through contexts. Used for
+#   ``indexer_state``.
+# - ``has_workspace_id``: nullable shadow ``workspace_id`` FK (a97 Phase 1
+#   backfilled existing rows; new writers populate it). When populated,
+#   backfill via (workspace_id, resource_id) is safe even under slug reuse.
+#   Rows with ``workspace_id IS NULL`` fall back to the slug-only path
+#   with its ambiguity audit. Used for ``resource_tokens``.
+_SATELLITE_TABLES_SLUG_ONLY = ("resource_events", "resource_schemas")
+_SATELLITE_TABLES_HAS_WORKSPACE_ID = ("resource_tokens",)
+# ``indexer_state`` (has_context_id) is handled inline by ``_backfill_indexer_state``;
+# no constant tuple needed since it's a single-table special case.
 
 
 def _audit_cross_workspace_ambiguity(conn: sa.Connection) -> None:
-    """Abort the migration if any satellite slug maps to >1 live workspace.
+    """Abort the migration if any slug-only orphan maps to >1 live workspace.
 
     This is the canonical "0635c675 pattern" applied to Phase 2 orphan
     backfill. See the module docstring for the exploit shape being
-    prevented.
+    prevented. The audit runs ONLY on tables that have no workspace-safe
+    disambiguation path — ``has_context_id`` and ``has_workspace_id``
+    tables are workspace-safe by JOIN construction and auditing them
+    would falsely abort whenever two workspaces legitimately share a slug
+    (common case — slugs are per-workspace unique, not globally unique).
+    ``resource_tokens`` additionally scopes the audit to
+    ``workspace_id IS NULL`` rows, since rows with a populated
+    ``workspace_id`` are workspace-safe via that column.
     """
     ambiguities: list[str] = []
-    # Only audit tables that CANNOT disambiguate via ``context_id`` —
-    # those whose backfill JOIN key is slug-only. ``indexer_state`` has a
-    # ``context_id`` FK that pins the workspace via ``contexts.workspace_id``,
-    # so ``_backfill_indexer_state`` already resolves the correct Resource
-    # row per (workspace_id, resource_id) tuple even when the slug maps to
-    # >1 live Resource globally. Auditing indexer_state would falsely abort
-    # whenever two workspaces legitimately share a slug (a common case —
-    # slugs are per-workspace unique, not globally unique). Skip those tables
-    # here and let the workspace-aware JOIN handle them safely in step 2.
-    for table_name, has_context_id in _SATELLITE_TABLES:
-        if has_context_id:
-            continue
-        # Table name is a module-constant from ``_SATELLITE_TABLES``; slug
-        # values never appear in the f-string (only the whole-table scan
-        # does). Matches the a97 precedent (``# noqa: S608 -- table names
-        # are module-constant``) for the same shape.
+
+    # Straight slug-only tables: resource_events, resource_schemas.
+    # Any orphan row whose slug maps to >1 live Resource is ambiguous.
+    for table_name in _SATELLITE_TABLES_SLUG_ONLY:
+        # Table name is a module-constant; slug values never appear in the
+        # f-string (only the whole-table scan does). Matches the a97
+        # precedent (``# noqa: S608 -- table names are module-constant``).
         result = conn.execute(
             sa.text(
                 f"""
@@ -107,6 +117,29 @@ def _audit_cross_workspace_ambiguity(conn: sa.Connection) -> None:
         if result:
             slugs = ", ".join(repr(row[0]) for row in result)
             ambiguities.append(f"{table_name}: {slugs}")
+
+    # resource_tokens special case: only audit rows that lack workspace_id.
+    # Rows with workspace_id populated can backfill via
+    # (workspace_id, resource_id) JOIN without ambiguity risk.
+    for table_name in _SATELLITE_TABLES_HAS_WORKSPACE_ID:
+        result = conn.execute(
+            sa.text(
+                f"""
+                SELECT DISTINCT s.resource_id
+                FROM {table_name} s
+                WHERE s.resource_pk IS NULL
+                  AND s.workspace_id IS NULL
+                  AND (
+                    SELECT COUNT(*)
+                    FROM resources r
+                    WHERE r.resource_id = s.resource_id
+                  ) > 1
+                """  # noqa: S608 -- table names are module-constant
+            )
+        ).fetchall()
+        if result:
+            slugs = ", ".join(repr(row[0]) for row in result)
+            ambiguities.append(f"{table_name} (workspace_id IS NULL): {slugs}")
 
     if ambiguities:
         lines = "\n  ".join(ambiguities)
@@ -151,8 +184,9 @@ def _backfill_slug_only_table(conn: sa.Connection, table_name: str) -> None:
 
     Precondition: the cross-workspace ambiguity audit has confirmed every
     orphan slug maps to at most one ``resources`` row, so the JOIN is
-    deterministic. ``resource_events``, ``resource_schemas``, and
-    ``resource_tokens`` all take this path.
+    deterministic. Used for ``resource_events`` and ``resource_schemas``;
+    ``resource_tokens`` has its own workspace-scoped path via
+    ``_backfill_resource_tokens``.
     """
     conn.execute(
         sa.text(
@@ -163,6 +197,49 @@ def _backfill_slug_only_table(conn: sa.Connection, table_name: str) -> None:
             WHERE s.resource_pk IS NULL
               AND r.resource_id = s.resource_id
             """  # noqa: S608 -- table_name is module-constant
+        )
+    )
+
+
+def _backfill_resource_tokens(conn: sa.Connection) -> None:
+    """Backfill ``resource_tokens.resource_pk`` in two passes.
+
+    Pass 1 (workspace-safe): rows where ``workspace_id`` is populated
+    JOIN on ``(workspace_id, resource_id)`` — this pins the correct
+    Resource row even when the slug is globally reused across workspaces,
+    so no audit prerequisite.
+
+    Pass 2 (slug-only fallback): rows where ``workspace_id IS NULL``
+    (pre-a97 legacy writes that predate the shadow column) can only JOIN
+    on slug. These depend on the cross-workspace ambiguity audit having
+    already passed.
+    """
+    # Pass 1: workspace-scoped JOIN — safe under slug reuse.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE resource_tokens t
+            SET resource_pk = r.id
+            FROM resources r
+            WHERE t.resource_pk IS NULL
+              AND t.workspace_id IS NOT NULL
+              AND r.workspace_id = t.workspace_id
+              AND r.resource_id = t.resource_id
+            """
+        )
+    )
+    # Pass 2: slug-only for legacy rows; audit has already ruled out
+    # ambiguity for workspace_id IS NULL + resource_pk IS NULL shape.
+    conn.execute(
+        sa.text(
+            """
+            UPDATE resource_tokens t
+            SET resource_pk = r.id
+            FROM resources r
+            WHERE t.resource_pk IS NULL
+              AND t.workspace_id IS NULL
+              AND r.resource_id = t.resource_id
+            """
         )
     )
 
@@ -194,19 +271,20 @@ def _backfill_resource_tokens_workspace_id(conn: sa.Connection) -> None:
 def upgrade() -> None:
     conn = op.get_bind()
 
-    # Step 1: abort if any orphan slug is ambiguous across workspaces.
+    # Step 1: abort if any slug-only orphan is ambiguous across workspaces.
     _audit_cross_workspace_ambiguity(conn)
 
-    # Step 2: backfill the context-scoped table first (safest JOIN shape).
+    # Step 2: backfill the context-scoped table (safest JOIN shape).
     _backfill_indexer_state(conn)
 
-    # Step 3: backfill the three slug-only satellite tables.
-    for table_name, has_context_id in _SATELLITE_TABLES:
-        if has_context_id:
-            continue  # indexer_state handled above
+    # Step 3: backfill resource_tokens (workspace-safe pass + slug-only fallback).
+    _backfill_resource_tokens(conn)
+
+    # Step 4: backfill the pure slug-only satellite tables (events, schemas).
+    for table_name in _SATELLITE_TABLES_SLUG_ONLY:
         _backfill_slug_only_table(conn, table_name)
 
-    # Step 4: finish a97 Phase 1's ``workspace_id`` backfill for any
+    # Step 5: finish a97 Phase 1's ``workspace_id`` backfill for any
     # newly-populated ``resource_pk`` values on resource_tokens.
     _backfill_resource_tokens_workspace_id(conn)
 

--- a/backend/alembic/versions/b01_resource_pk_writer_phase2.py
+++ b/backend/alembic/versions/b01_resource_pk_writer_phase2.py
@@ -74,9 +74,18 @@ def _audit_cross_workspace_ambiguity(conn: sa.Connection) -> None:
     prevented.
     """
     ambiguities: list[str] = []
-    # The audit runs on all 4 satellite tables regardless of context_id
-    # presence, so unpack just the name.
-    for table_name, _ in _SATELLITE_TABLES:
+    # Only audit tables that CANNOT disambiguate via ``context_id`` —
+    # those whose backfill JOIN key is slug-only. ``indexer_state`` has a
+    # ``context_id`` FK that pins the workspace via ``contexts.workspace_id``,
+    # so ``_backfill_indexer_state`` already resolves the correct Resource
+    # row per (workspace_id, resource_id) tuple even when the slug maps to
+    # >1 live Resource globally. Auditing indexer_state would falsely abort
+    # whenever two workspaces legitimately share a slug (a common case —
+    # slugs are per-workspace unique, not globally unique). Skip those tables
+    # here and let the workspace-aware JOIN handle them safely in step 2.
+    for table_name, has_context_id in _SATELLITE_TABLES:
+        if has_context_id:
+            continue
         # Table name is a module-constant from ``_SATELLITE_TABLES``; slug
         # values never appear in the f-string (only the whole-table scan
         # does). Matches the a97 precedent (``# noqa: S608 -- table names

--- a/backend/alembic/versions/b01_resource_pk_writer_phase2.py
+++ b/backend/alembic/versions/b01_resource_pk_writer_phase2.py
@@ -94,8 +94,24 @@ def _audit_cross_workspace_ambiguity(conn: sa.Connection) -> None:
     """
     ambiguities: list[str] = []
 
+    # Pre-aggregate the "slug → workspace count" map once for the whole
+    # audit pass. This avoids the correlated per-orphan-row subquery
+    # shape (O(N*M)) the earlier revision used — on large
+    # ``resource_events`` tables the correlated form could make the
+    # migration unexpectedly slow. JOIN against the pre-aggregated CTE
+    # is O(N + M) with the planner's choice of hash or merge join.
+    # Copilot catch on PR #392 loop 8.
+    ambiguous_cte = """
+        WITH ambiguous_slugs AS (
+            SELECT resource_id
+            FROM resources
+            GROUP BY resource_id
+            HAVING COUNT(*) > 1
+        )
+    """
+
     # Straight slug-only tables: resource_events, resource_schemas.
-    # Any orphan row whose slug maps to >1 live Resource is ambiguous.
+    # Any orphan row whose slug appears in ``ambiguous_slugs`` is unsafe.
     for table_name in _SATELLITE_TABLES_SLUG_ONLY:
         # Table name is a module-constant; slug values never appear in the
         # f-string (only the whole-table scan does). Matches the a97
@@ -103,14 +119,11 @@ def _audit_cross_workspace_ambiguity(conn: sa.Connection) -> None:
         result = conn.execute(
             sa.text(
                 f"""
+                {ambiguous_cte}
                 SELECT DISTINCT s.resource_id
                 FROM {table_name} s
+                JOIN ambiguous_slugs a ON a.resource_id = s.resource_id
                 WHERE s.resource_pk IS NULL
-                  AND (
-                    SELECT COUNT(*)
-                    FROM resources r
-                    WHERE r.resource_id = s.resource_id
-                  ) > 1
                 """  # noqa: S608 -- table names are module-constant
             )
         ).fetchall()
@@ -125,15 +138,12 @@ def _audit_cross_workspace_ambiguity(conn: sa.Connection) -> None:
         result = conn.execute(
             sa.text(
                 f"""
+                {ambiguous_cte}
                 SELECT DISTINCT s.resource_id
                 FROM {table_name} s
+                JOIN ambiguous_slugs a ON a.resource_id = s.resource_id
                 WHERE s.resource_pk IS NULL
                   AND s.workspace_id IS NULL
-                  AND (
-                    SELECT COUNT(*)
-                    FROM resources r
-                    WHERE r.resource_id = s.resource_id
-                  ) > 1
                 """  # noqa: S608 -- table names are module-constant
             )
         ).fetchall()

--- a/backend/src/api/routes/public_search.py
+++ b/backend/src/api/routes/public_search.py
@@ -11,14 +11,13 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import get_current_user_optional
 from db.base import get_db
 from db.redis import increment_counter
 from models.auth import Context
-from models.resource import ResourceSchema
+from services.resource_lookup import get_latest_schema
 from services.search_service import SearchService
 from utils.datetime import utcnow
 from utils.exceptions import AuthorizationError, NotFoundException, RateLimitError
@@ -264,16 +263,12 @@ async def public_search(
             search_mode=request.search_mode,
         )
 
-        # 4. Load schema for response formatting (if resource-backed)
-        schema = None
-        if context.resource_id is not None:
-            schema_result = await db.execute(
-                select(ResourceSchema)
-                .where(ResourceSchema.resource_id == context.resource_id)
-                .order_by(ResourceSchema.schema_version.desc())
-                .limit(1)
-            )
-            schema = schema_result.scalar_one_or_none()
+        # 4. Load schema for response formatting (if resource-backed).
+        schema = (
+            await get_latest_schema(db, context.workspace_id, context.resource_id)
+            if context.resource_id is not None
+            else None
+        )
 
         # 5. Format results with schema-aware metadata
         formatted_results = []
@@ -387,16 +382,12 @@ async def get_public_context_info(
     if context.is_public is not True:
         raise AuthorizationError("This context is not public")
 
-    # Load schema if resource-backed
-    schema = None
-    if context.resource_id is not None:
-        schema_result = await db.execute(
-            select(ResourceSchema)
-            .where(ResourceSchema.resource_id == context.resource_id)
-            .order_by(ResourceSchema.schema_version.desc())
-            .limit(1)
-        )
-        schema = schema_result.scalar_one_or_none()
+    # Load schema if resource-backed.
+    schema = (
+        await get_latest_schema(db, context.workspace_id, context.resource_id)
+        if context.resource_id is not None
+        else None
+    )
 
     return {
         "context_id": str(context_id),

--- a/backend/src/api/routes/resource_indexer.py
+++ b/backend/src/api/routes/resource_indexer.py
@@ -40,6 +40,7 @@ IndexerSkippedReason = Literal[
     "schema_not_found",
     "context_not_found",
     "empty_valid_points",
+    "resource_entity_missing",
 ]
 """Reasons the indexer may record under ``metrics.reason`` when a run was
 skipped. Enum is derived from in-tree uses in ``services.resource_indexer``;

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -7,6 +7,8 @@ Provides endpoints for external systems (EC inventory, etc.) to push events.
 
 from __future__ import annotations
 
+from uuid import UUID
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
@@ -20,7 +22,7 @@ from db.constraint_names import (
     integrity_error_constraint_name,
 )
 from models.auth import Context
-from models.resource import ResourceEvent, ResourceToken
+from models.resource import Resource, ResourceEvent, ResourceToken
 from models.schemas import (
     ResourceEventBatchRequest,
     ResourceEventBatchResponse,
@@ -205,7 +207,7 @@ async def _enforce_workspace_membership(
         ) from auth_error
 
     # Issue #390 Phase 2 — close the CWE-639 auth-boundary variant
-    # (Copilot catch on PR #392 loops 7 + 9). Even after verify_token
+    # (Copilot catches on PR #392 loops 7, 9, 10). Even after verify_token
     # pins the token to a single Resource via the resource_pk JOIN, the
     # slug-reused case can let the ingest pipeline:
     #   1) verify T pinned to workspace A's Resource (via resource_pk)
@@ -216,16 +218,31 @@ async def _enforce_workspace_membership(
     #   4) handler write the event with T.resource_pk = A's Resource ID,
     #      despite the request looking like a workspace-B operation
     #
-    # The fix: reject when the token's bound workspace (via its Resource)
-    # does not match the Context's workspace. Both must agree for ingest
-    # to proceed. This is the same contract the read-path hardening
-    # enforces — resource_pk FK pins workspace by construction.
-    if token_record.workspace_id is not None and token_record.workspace_id != context.workspace_id:
+    # The fix: resolve the authoritative workspace via ``Resource.workspace_id``
+    # (via token's ``resource_pk`` FK) and reject if it does not match the
+    # Context's workspace. The token's own ``workspace_id`` column is still
+    # a Phase 1 nullable shadow — relying on it alone would let legacy
+    # NULL-workspace_id tokens bypass the check (loop 10 catch). The FK
+    # ``resource_pk → Resource`` is the authoritative binding.
+    resource_workspace_id: UUID | None = None
+    if token_record.resource_pk is not None:
+        resource_workspace_id = (
+            await db.execute(
+                select(Resource.workspace_id).where(Resource.id == token_record.resource_pk)
+            )
+        ).scalar_one_or_none()
+    elif token_record.workspace_id is not None:
+        # Fallback: legacy token with resource_pk IS NULL but workspace_id
+        # populated (transient state between a97 workspace_id backfill and
+        # b01 resource_pk backfill). Use the shadow column directly.
+        resource_workspace_id = token_record.workspace_id
+
+    if resource_workspace_id is not None and resource_workspace_id != context.workspace_id:
         logger.warning(
             "cross_tenant_ingest_token_workspace_mismatch",
             resource_id=context.resource_id,
             token_id=token_record.id,
-            token_workspace_id=str(token_record.workspace_id),
+            token_workspace_id=str(resource_workspace_id),
             context_workspace_id=str(context.workspace_id),
             token_creator=token_record.created_by,
             client_ip=request.client.host if request.client else None,

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -204,6 +204,40 @@ async def _enforce_workspace_membership(
             ),
         ) from auth_error
 
+    # Issue #390 Phase 2 — close the CWE-639 auth-boundary variant
+    # (Copilot catch on PR #392 loops 7 + 9). Even after verify_token
+    # pins the token to a single Resource via the resource_pk JOIN, the
+    # slug-reused case can let the ingest pipeline:
+    #   1) verify T pinned to workspace A's Resource (via resource_pk)
+    #   2) resolve_authoritative_context return workspace B's Context
+    #      (A's Context soft-deleted, B's Context active, same slug)
+    #   3) enforce_workspace_membership pass because the token creator is
+    #      ALSO a member of workspace B
+    #   4) handler write the event with T.resource_pk = A's Resource ID,
+    #      despite the request looking like a workspace-B operation
+    #
+    # The fix: reject when the token's bound workspace (via its Resource)
+    # does not match the Context's workspace. Both must agree for ingest
+    # to proceed. This is the same contract the read-path hardening
+    # enforces — resource_pk FK pins workspace by construction.
+    if token_record.workspace_id is not None and token_record.workspace_id != context.workspace_id:
+        logger.warning(
+            "cross_tenant_ingest_token_workspace_mismatch",
+            resource_id=context.resource_id,
+            token_id=token_record.id,
+            token_workspace_id=str(token_record.workspace_id),
+            context_workspace_id=str(context.workspace_id),
+            token_creator=token_record.created_by,
+            client_ip=request.client.host if request.client else None,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=(
+                "Resource ingest denied: the token's workspace does not match "
+                "the context's workspace for this resource."
+            ),
+        )
+
 
 # ============================================================================
 # Resource Ingest Endpoints

--- a/backend/src/api/routes/resource_schema.py
+++ b/backend/src/api/routes/resource_schema.py
@@ -319,17 +319,22 @@ async def get_resource_impact(
     )
 
     # Issue #390 Phase 2: resolve ``resource_pk`` so impact subqueries
-    # scope by authoritative FK instead of by slug. Fail-safe to "no
-    # impact" if the Resource row is absent — matches the uniform
-    # disclosure contract of get_schema.
+    # scope by authoritative FK instead of by slug. At this point
+    # ``resolve_resource_by_slug`` has already confirmed the Context
+    # exists and the caller has owner access, so ``resource_pk is None``
+    # means a data-integrity gap (Context persists without a backing
+    # Resource entity row — setup_resource never ran or the row was
+    # deleted). Returning 200 with zeroed counts would silently hide
+    # this; raise 404 with an actionable hint instead.
     resource_pk = await resolve_resource_pk(db, context.workspace_id, resource_id)
     if resource_pk is None:
-        return ResourceImpactResponse(
+        logger.warning(
+            "resource_entity_missing_on_impact",
             resource_id=resource_id,
-            token_count=0,
-            memory_count=0,
-            current_schema_version=None,
+            workspace_id=str(context.workspace_id),
+            user_id=user_id,
         )
+        raise NotFoundException("Resource", resource_id)
 
     # Performance: Get all stats in a single query using subqueries.
     # ResourceToken + ResourceSchema use strict ``resource_pk`` filter.

--- a/backend/src/api/routes/resource_schema.py
+++ b/backend/src/api/routes/resource_schema.py
@@ -17,6 +17,7 @@ from db.base import get_db
 from models.memory import Memory
 from models.resource import ResourceSchema, ResourceToken
 from services.permission_service import PermissionService
+from services.resource_lookup import resolve_resource_pk
 from utils.exceptions import NotFoundException, ValidationError
 from utils.logger import get_logger
 
@@ -126,14 +127,23 @@ async def get_schema(
     # admin) of workspace B could otherwise probe B's slug with this helper
     # at default required_role="member" and receive B's schema data. See
     # Copilot catch on PR #391.
-    await PermissionService(db).resolve_resource_by_slug(
+    context = await PermissionService(db).resolve_resource_by_slug(
         user_id=user_id,
         resource_id=resource_id,
         required_role="owner",
     )
 
-    # Build query
-    query = select(ResourceSchema).where(ResourceSchema.resource_id == resource_id)
+    # Issue #390 Phase 2: strict ``resource_pk`` filter on the satellite
+    # table. ``ResourceSchema`` has no ``context_id`` column, so a slug-only
+    # filter is not workspace-safe — soft-delete + slug reuse would surface
+    # the prior workspace's schemas. Fail-safe to 404 when the Resource row
+    # is absent (pre-a97 orphan or migration gap) rather than fall back to
+    # slug filtering.
+    resource_pk = await resolve_resource_pk(db, context.workspace_id, resource_id)
+    if resource_pk is None:
+        raise NotFoundException("Resource schema", resource_id)
+
+    query = select(ResourceSchema).where(ResourceSchema.resource_pk == resource_pk)
 
     if schema_version:
         query = query.where(ResourceSchema.schema_version == schema_version)
@@ -224,18 +234,36 @@ async def create_schema(
     if request.resource_id != resource_id:
         raise ValidationError("resource_id in body must match URL parameter")
 
-    # Get next schema version
+    # Issue #390 Phase 2: resolve ``resource_pk`` so the writer populates
+    # both columns atomically. The before_insert event listener on
+    # ResourceSchema rejects inserts that set resource_id without
+    # resource_pk — surfacing this Phase 2 contract at the model layer
+    # rather than relying on every future writer to remember.
+    resource_pk = await resolve_resource_pk(db, workspace_id, resource_id)
+    if resource_pk is None:
+        # Schema creation is owner-only and goes through WorkspaceOwner +
+        # resolve_resource_by_slug upstream (added in the read-path hardening
+        # for #390), but the POST endpoint here does not currently resolve
+        # the slug — the route pre-dates #326. A missing Resource row at
+        # this point means the caller supplied a slug that is not bound to
+        # any live Context in their workspace; reject with 404 for uniform
+        # disclosure (matches the GET side's cross-workspace probe contract).
+        raise NotFoundException("Resource", resource_id)
+
+    # Get next schema version (strict resource_pk filter — see get_schema).
     result = await db.execute(
         select(ResourceSchema.schema_version)
-        .where(ResourceSchema.resource_id == resource_id)
+        .where(ResourceSchema.resource_pk == resource_pk)
         .order_by(ResourceSchema.schema_version.desc())
         .limit(1)
     )
     max_version = result.scalar()
     new_version = (max_version or 0) + 1
 
-    # Create schema
+    # Create schema with both resource_pk (authoritative FK) and resource_id
+    # (legacy mirror, kept for API read contracts until Phase C drops it).
     schema = ResourceSchema(
+        resource_pk=resource_pk,
         resource_id=resource_id,
         schema_version=new_version,
         field_definitions=[f.model_dump() for f in request.field_definitions],
@@ -284,28 +312,49 @@ async def get_resource_impact(
 
     # Workspace boundary + cross-workspace 404 disclosure. See get_schema
     # for the required_role="owner" rationale (multi-workspace member case).
-    await PermissionService(db).resolve_resource_by_slug(
+    context = await PermissionService(db).resolve_resource_by_slug(
         user_id=user_id,
         resource_id=resource_id,
         required_role="owner",
     )
 
-    # Performance: Get all stats in a single query using subqueries
+    # Issue #390 Phase 2: resolve ``resource_pk`` so impact subqueries
+    # scope by authoritative FK instead of by slug. Fail-safe to "no
+    # impact" if the Resource row is absent — matches the uniform
+    # disclosure contract of get_schema.
+    resource_pk = await resolve_resource_pk(db, context.workspace_id, resource_id)
+    if resource_pk is None:
+        return ResourceImpactResponse(
+            resource_id=resource_id,
+            token_count=0,
+            memory_count=0,
+            current_schema_version=None,
+        )
+
+    # Performance: Get all stats in a single query using subqueries.
+    # ResourceToken + ResourceSchema use strict ``resource_pk`` filter.
+    # Memory still uses resource_id (slug) because its workspace_id column
+    # scopes the query defensively — this is the pre-existing behavior and
+    # not part of the #390 Phase A scope.
     token_count_subq = (
         select(func.count(ResourceToken.id))
-        .where(ResourceToken.resource_id == resource_id, ResourceToken.is_active == True)  # noqa: E712
+        .where(ResourceToken.resource_pk == resource_pk, ResourceToken.is_active == True)  # noqa: E712
         .scalar_subquery()
     )
 
     memory_count_subq = (
         select(func.count(Memory.id))
-        .where(Memory.resource_id == resource_id, Memory.deleted_at.is_(None))
+        .where(
+            Memory.resource_id == resource_id,
+            Memory.workspace_id == context.workspace_id,
+            Memory.deleted_at.is_(None),
+        )
         .scalar_subquery()
     )
 
     schema_version_subq = (
         select(func.max(ResourceSchema.schema_version))
-        .where(ResourceSchema.resource_id == resource_id)
+        .where(ResourceSchema.resource_pk == resource_pk)
         .scalar_subquery()
     )
 

--- a/backend/src/api/routes/resource_tokens.py
+++ b/backend/src/api/routes/resource_tokens.py
@@ -20,6 +20,7 @@ from auth.dependencies import WorkspaceOwner
 from auth.resource_tokens import ResourceTokenManager
 from db.base import get_db
 from models.resource import ResourceToken
+from services.resource_lookup import resolve_resource_pk
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -340,9 +341,25 @@ async def create_resource_token(
                         detail=f"Token limit reached. Your {plan_name.upper()} plan allows {plan.max_resource_tokens} active tokens. Please revoke unused tokens or upgrade your plan.",
                     )
 
+        # Issue #390 Phase 2: resolve authoritative ``resource_pk`` + pass
+        # ``workspace_id`` so the ResourceToken insert satisfies the
+        # before_insert event listener invariant (models/resource.py).
+        # The context-existence check above already confirmed the Resource
+        # is bound to this workspace, so resolve_resource_pk should always
+        # return a non-None UUID; guard defensively for the race where the
+        # resource is deleted between the two queries.
+        resource_pk = await resolve_resource_pk(db, workspace_id, data.resource_id)
+        if resource_pk is None:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=f"Resource ID '{data.resource_id}' not found in your workspace or you don't have access to it.",
+            )
+
         # Create token (returns plaintext + token object)
         plaintext_token, new_token = await manager.create_token(
             resource_id=data.resource_id,
+            resource_pk=resource_pk,
+            workspace_id=workspace_id,
             description=data.description,
             quota_events_per_hour=data.quota_events_per_hour,
             created_by=user_id,

--- a/backend/src/api/routes/resource_tokens.py
+++ b/backend/src/api/routes/resource_tokens.py
@@ -345,14 +345,22 @@ async def create_resource_token(
         # ``workspace_id`` so the ResourceToken insert satisfies the
         # before_insert event listener invariant (models/resource.py).
         # The context-existence check above already confirmed the Resource
-        # is bound to this workspace, so resolve_resource_pk should always
-        # return a non-None UUID; guard defensively for the race where the
-        # resource is deleted between the two queries.
+        # is bound to this workspace; if resolve_resource_pk still returns
+        # None it indicates either a delete race between the two queries or
+        # a data-integrity gap (Context exists without a backing Resource
+        # row), NOT an authorization failure. Surface 409 CONFLICT with an
+        # actionable hint so operators can distinguish "not authorized" from
+        # "resource binding is inconsistent" in logs and error reports.
         resource_pk = await resolve_resource_pk(db, workspace_id, data.resource_id)
         if resource_pk is None:
             raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=f"Resource ID '{data.resource_id}' not found in your workspace or you don't have access to it.",
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Resource ID '{data.resource_id}' exists as a Context but has no "
+                    "backing Resource entity row. This is either a delete race or a "
+                    "data-integrity gap. Retry in a moment, or run setup_resource() "
+                    "to rebind."
+                ),
             )
 
         # Create token (returns plaintext + token object)

--- a/backend/src/api/routes/resources.py
+++ b/backend/src/api/routes/resources.py
@@ -21,7 +21,7 @@ from auth.dependencies import WorkspaceOwner
 from db.base import get_db
 from models.auth import Context
 from models.memory import Memory
-from models.resource import ResourceEvent, ResourceSchema, ResourceToken
+from models.resource import Resource, ResourceEvent, ResourceSchema, ResourceToken
 from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso
 from utils.logger import get_logger
@@ -105,25 +105,25 @@ async def list_resources(
         )
         return ResourceListResponse(resources=[], total=0)
 
-    # Correlated subqueries — one stats bundle per matching context row.
-    # resource_* tables are keyed by resource_id only (see Migration 055 note on
-    # per-workspace uniqueness). We scope to this workspace via the Context join
-    # on the outer query; collisions across workspaces are a pre-existing
-    # architectural invariant tracked separately.
+    # Issue #390 Phase 2: satellite stats are scoped by ``resource_pk``
+    # (authoritative FK to ``resources.id``) instead of by slug. The outer
+    # query joins ``Context`` to ``Resource`` via
+    # ``(workspace_id, resource_id)`` so each row carries the UUID that the
+    # correlated subqueries filter against — this closes the cross-workspace
+    # slug-reuse leak that could otherwise surface counts from a different
+    # workspace's soft-deleted resource.
     token_count_subq = (
         select(func.count(ResourceToken.id))
         .where(
-            ResourceToken.resource_id == Context.resource_id,
+            ResourceToken.resource_pk == Resource.id,
             ResourceToken.is_active == True,  # noqa: E712
         )
-        .correlate(Context)
+        .correlate(Resource)
         .scalar_subquery()
     )
 
-    # Memory has a workspace_id column, so we can scope defensively here even
-    # though the other resource_* tables cannot (per the architectural invariant
-    # comment above). For Memory specifically this tightens the count against
-    # the unlikely case of a resource_id collision across workspaces.
+    # Memory has a workspace_id column and is not part of the resource_pk
+    # migration — keep the slug + workspace_id filter. Context carries both.
     memory_count_subq = (
         select(func.count(Memory.id))
         .where(
@@ -137,20 +137,25 @@ async def list_resources(
 
     schema_version_subq = (
         select(func.max(ResourceSchema.schema_version))
-        .where(ResourceSchema.resource_id == Context.resource_id)
-        .correlate(Context)
+        .where(ResourceSchema.resource_pk == Resource.id)
+        .correlate(Resource)
         .scalar_subquery()
     )
 
     last_event_subq = (
         select(func.max(ResourceEvent.created_at))
-        .where(ResourceEvent.resource_id == Context.resource_id)
-        .correlate(Context)
+        .where(ResourceEvent.resource_pk == Resource.id)
+        .correlate(Resource)
         .scalar_subquery()
     )
 
     # Main query: workspace-scoped, resource-bound contexts with aggregated stats.
     # ORDER BY coalesces the most recent signal (last event vs context update).
+    # Resource is joined via (workspace_id, resource_id) and the subqueries
+    # above correlate against ``Resource.id`` (the authoritative resource_pk).
+    # LEFT OUTER JOIN: Contexts with a resource_id but no Resource row yet
+    # (pre-a97 migration gap) still appear in the list with zero stats,
+    # preserving backward visibility during the Phase 1 → Phase 2 transition.
     result = await db.execute(
         select(
             Context.id.label("context_id"),
@@ -163,6 +168,14 @@ async def list_resources(
             memory_count_subq.label("memory_count"),
             schema_version_subq.label("schema_version"),
             last_event_subq.label("last_event_at"),
+        )
+        .select_from(Context)
+        .outerjoin(
+            Resource,
+            and_(
+                Resource.workspace_id == Context.workspace_id,
+                Resource.resource_id == Context.resource_id,
+            ),
         )
         .where(
             and_(

--- a/backend/src/auth/resource_tokens.py
+++ b/backend/src/auth/resource_tokens.py
@@ -14,7 +14,7 @@ from uuid import UUID
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.resource import ResourceToken
+from models.resource import Resource, ResourceToken
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -131,6 +131,16 @@ class ResourceTokenManager:
     async def verify_token(self, token: str, resource_id: str) -> ResourceToken | None:
         """Verify resource token and return token record.
 
+        Issue #390 Phase 2: JOIN on ``Resource`` via ``resource_pk`` so
+        the auth query is workspace-scoped by construction. Without this
+        join, a still-valid token from a soft-deleted workspace whose
+        slug has been reused in a different live workspace could
+        authenticate for the new workspace's resource — the same
+        CWE-639 leak that the read-path hardening closes, but on the
+        auth boundary. Legacy tokens with ``resource_pk IS NULL`` are
+        rejected here (backfilled by migration b01 before this code
+        ships; no legacy NULL tokens are expected in production).
+
         Args:
             token: Plaintext token to verify
             resource_id: Expected resource_id (must match token's scope)
@@ -140,12 +150,17 @@ class ResourceTokenManager:
         """
         token_hash = self._hash_token(token)
 
-        # Query token with resource_id validation
+        # Query token with resource_id validation via Resource JOIN — the
+        # JOIN pins workspace even when the slug is reused across
+        # workspaces, because each token's resource_pk FK identifies
+        # exactly one Resource (and therefore one workspace).
         result = await self.db.execute(
-            select(ResourceToken).where(
+            select(ResourceToken)
+            .join(Resource, Resource.id == ResourceToken.resource_pk)
+            .where(
                 and_(
                     ResourceToken.token_hash == token_hash,
-                    ResourceToken.resource_id == resource_id,
+                    Resource.resource_id == resource_id,
                     ResourceToken.is_active == True,  # noqa: E712
                 )
             )

--- a/backend/src/auth/resource_tokens.py
+++ b/backend/src/auth/resource_tokens.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 import secrets
+from uuid import UUID
 
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -63,6 +64,9 @@ class ResourceTokenManager:
     async def create_token(
         self,
         resource_id: str,
+        *,
+        resource_pk: UUID,
+        workspace_id: UUID,
         description: str | None = None,
         quota_events_per_hour: int = 1000,
         created_by: str | None = None,
@@ -71,6 +75,14 @@ class ResourceTokenManager:
 
         Args:
             resource_id: Resource identifier this token is scoped to
+            resource_pk: Authoritative ``resources.id`` UUID (Issue #390
+                Phase 2). Keyword-only so every caller is forced to resolve
+                it — the ``before_insert`` event listener on ResourceToken
+                rejects inserts with resource_id but no resource_pk, so a
+                forgotten value surfaces as a hard error at test time.
+            workspace_id: Owning workspace UUID (Issue #390 Phase 2).
+                Keyword-only for the same reason; populates the Phase 1
+                shadow column that Phase C (#325) will tighten to NOT NULL.
             description: Human-readable description
             quota_events_per_hour: Event ingestion quota (default: 1000/hour)
             created_by: User ID who created this token
@@ -89,9 +101,13 @@ class ResourceTokenManager:
         token = self._generate_token()
         token_hash = self._hash_token(token)
 
-        # Create database record
+        # Create database record. ``resource_pk`` + ``workspace_id`` are
+        # populated from the caller's resolved values so the event listener
+        # invariant (models/resource.py) passes.
         new_token = ResourceToken(
+            resource_pk=resource_pk,
             resource_id=resource_id,
+            workspace_id=workspace_id,
             token_hash=token_hash,
             description=description,
             quota_events_per_hour=quota_events_per_hour,
@@ -104,6 +120,8 @@ class ResourceTokenManager:
         logger.info(
             "resource_token_created",
             resource_id=resource_id,
+            resource_pk=str(resource_pk),
+            workspace_id=str(workspace_id),
             quota=quota_events_per_hour,
             created_by=created_by,
         )

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -134,23 +134,42 @@ async def handle_get_resource_impact(
             if boundary_err:
                 return boundary_err
 
-            # Combined stats query — all subqueries workspace-scoped to prevent
-            # cross-workspace leakage when resource_id collides across workspaces
-            # (resource_id is unique per workspace, not globally).
+            # Issue #390 Phase 2: resolve ``resource_pk`` and filter the
+            # satellite queries by authoritative FK instead of slug. This
+            # closes the cross-workspace slug-reuse leak vector on
+            # ResourceToken and ResourceSchema (neither has a context_id
+            # column to enforce the workspace boundary at query time).
             from sqlalchemy import func, select
 
-            from models.auth import Context
             from models.memory import Memory
             from models.resource import ResourceSchema, ResourceToken
+            from services.resource_lookup import resolve_resource_pk
+
+            resource_pk = await resolve_resource_pk(db, workspace_id, resource_id)
+            if resource_pk is None:
+                # Boundary check passed but no Resource row — pre-a97
+                # orphan or post-a97 gap. Return zero impact rather than
+                # surface slug-only counts.
+                await _log_tool_usage(
+                    db,
+                    user_id,
+                    "get_resource_impact",
+                    start_time,
+                    200,
+                    workspace_id=workspace_id,
+                )
+                return _success_response(
+                    resource_id=resource_id,
+                    token_count=0,
+                    memory_count=0,
+                    current_schema_version=None,
+                )
 
             token_count_subq = (
                 select(func.count(ResourceToken.id))
-                .join(Context, Context.resource_id == ResourceToken.resource_id)
                 .where(
-                    ResourceToken.resource_id == resource_id,
+                    ResourceToken.resource_pk == resource_pk,
                     ResourceToken.is_active == True,  # noqa: E712
-                    Context.workspace_id == workspace_id,
-                    Context.deleted_at.is_(None),
                 )
                 .scalar_subquery()
             )
@@ -165,12 +184,7 @@ async def handle_get_resource_impact(
             )
             schema_version_subq = (
                 select(func.max(ResourceSchema.schema_version))
-                .join(Context, Context.resource_id == ResourceSchema.resource_id)
-                .where(
-                    ResourceSchema.resource_id == resource_id,
-                    Context.workspace_id == workspace_id,
-                    Context.deleted_at.is_(None),
-                )
+                .where(ResourceSchema.resource_pk == resource_pk)
                 .scalar_subquery()
             )
 
@@ -242,20 +256,24 @@ async def handle_get_resource_schema(
 
             from sqlalchemy import select
 
-            from models.auth import Context
             from models.resource import ResourceSchema
+            from services.resource_lookup import resolve_resource_pk
 
-            # Workspace-scope the schema lookup (resource_id is unique per workspace,
-            # not globally — join via Context to avoid cross-workspace leakage).
-            query = (
-                select(ResourceSchema)
-                .join(Context, Context.resource_id == ResourceSchema.resource_id)
-                .where(
-                    ResourceSchema.resource_id == resource_id,
-                    Context.workspace_id == workspace_id,
-                    Context.deleted_at.is_(None),
+            # Issue #390 Phase 2: resolve ``resource_pk`` once and filter the
+            # schema lookup by authoritative FK. ResourceSchema has no
+            # context_id, so the prior Context-JOIN pattern was defensive
+            # but not definitive — soft-deleted context slug reuse could
+            # still have surfaced another workspace's schema under the
+            # Phase 1 writer gap.
+            resource_pk = await resolve_resource_pk(db, workspace_id, resource_id)
+            if resource_pk is None:
+                return _error_response(
+                    "schema_not_found",
+                    f"No schema found for resource '{resource_id}'.",
+                    help="Use the REST API to create a schema first.",
                 )
-            )
+
+            query = select(ResourceSchema).where(ResourceSchema.resource_pk == resource_pk)
 
             schema_version = args.get("schema_version")
             if schema_version is not None:
@@ -344,11 +362,10 @@ async def handle_list_resource_tokens(
                 if boundary_err:
                     return boundary_err
 
-            from sqlalchemy import and_, exists, func
+            from sqlalchemy import and_, func
             from sqlalchemy import select as sa_select
 
-            from models.auth import Context
-            from models.resource import ResourceToken
+            from models.resource import Resource, ResourceToken
 
             include_revoked = args.get("include_revoked", True)
             try:
@@ -357,26 +374,30 @@ async def handle_list_resource_tokens(
             except (ValueError, TypeError):
                 return _error_response("validation_error", "limit and offset must be integers.")
 
-            # Workspace-scoped token query using EXISTS subquery
-            workspace_filter = exists().where(
-                Context.resource_id == ResourceToken.resource_id,
-                Context.workspace_id == workspace_id,
-                Context.deleted_at.is_(None),
-            )
-
-            conditions = [workspace_filter]
+            # Issue #390 Phase 2: filter tokens by ``resource_pk`` instead of
+            # the Context-JOIN / slug pattern. Workspace scope is enforced by
+            # joining against ``resources`` (workspace-scoped by table
+            # invariant ``uq_resources_workspace_resource_id``) — a token's
+            # resource_pk FK guarantees it belongs to exactly one workspace.
+            # Legacy resource_pk IS NULL rows are excluded from the list view;
+            # they are draining in production within the observation window
+            # before Phase C tightens the column to NOT NULL.
+            conditions = [Resource.workspace_id == workspace_id]
             if resource_id:
-                conditions.append(ResourceToken.resource_id == resource_id)
+                conditions.append(Resource.resource_id == resource_id)
             if not include_revoked:
                 conditions.append(ResourceToken.is_active == True)  # noqa: E712
 
             total_result = await db.execute(
-                sa_select(func.count(ResourceToken.id)).where(and_(*conditions))
+                sa_select(func.count(ResourceToken.id))
+                .join(Resource, Resource.id == ResourceToken.resource_pk)
+                .where(and_(*conditions))
             )
             total = total_result.scalar() or 0
 
             tokens_result = await db.execute(
                 sa_select(ResourceToken)
+                .join(Resource, Resource.id == ResourceToken.resource_pk)
                 .where(and_(*conditions))
                 .order_by(ResourceToken.created_at.desc())
                 .offset(offset)
@@ -492,7 +513,6 @@ async def handle_ingest_events(
                 )
 
             # Process events
-            from sqlalchemy import select
             from sqlalchemy.exc import IntegrityError
 
             from db.constraint_names import (
@@ -500,20 +520,24 @@ async def handle_ingest_events(
                 RESOURCE_EVENTS_UPSERT_UNIQUE,
                 integrity_error_constraint_name,
             )
-            from models.resource import Resource, ResourceEvent
+            from models.resource import ResourceEvent
+            from services.resource_lookup import resolve_resource_pk
 
-            # Resolve resources.id once per batch so the partial UNIQUE on
-            # (resource_pk, doc_id, version) actually applies. Returns None
-            # when the resources row has not been created yet (Phase 1
-            # legacy state) — see the HTTP path for the full rationale.
-            resource_pk = (
-                await db.execute(
-                    select(Resource.id).where(
-                        Resource.workspace_id == workspace_id,
-                        Resource.resource_id == resource_id,
-                    )
+            # Resolve resources.id once per batch via the shared chokepoint
+            # (Issue #390 Phase 2). If the Resource entity row does not
+            # exist, ingest cannot safely proceed — the before_insert
+            # invariant listener on ResourceEvent would raise IntegrityError
+            # for every event in the batch and the errors would be masked
+            # as generic "constraint violation" strings. Reject the batch
+            # up front with an actionable error so the caller knows to run
+            # ``setup_resource`` first.
+            resource_pk = await resolve_resource_pk(db, workspace_id, resource_id)
+            if resource_pk is None:
+                return _error_response(
+                    "resource_not_found",
+                    f"Resource '{resource_id}' has no backing entity row in your workspace.",
+                    help="Run setup_resource() first to bind the resource to a Context + Resource entity.",
                 )
-            ).scalar_one_or_none()
 
             created_ids: list[int] = []
             errors: list[dict] = []
@@ -790,7 +814,25 @@ async def handle_setup_resource(
             else:
                 actual_dimensions = settings.embedding_dimensions
 
-            # 7. Create context (direct ORM — ContextService.create_context commits internally)
+            # 7a. Upsert Resource entity (Issue #390 Phase 2). Every satellite
+            # table write (IndexerState, ResourceEvent, ResourceSchema,
+            # ResourceToken) references ``resources.id`` as ``resource_pk``;
+            # the entity row must exist before any satellite write fires its
+            # ``before_insert`` invariant listener. Pre-a97 deployments
+            # backfilled Resource rows from existing Contexts; post-a97
+            # setup_resource calls create the Resource row themselves to
+            # close that gap.
+            from services.resource_lookup import upsert_resource
+
+            resource_pk = await upsert_resource(
+                db,
+                workspace_id=workspace_id,
+                resource_id=resource_id,
+                name=args.get("display_name") or name,
+                created_by=user_id,
+            )
+
+            # 7b. Create context (direct ORM — ContextService.create_context commits internally)
             context = Context(
                 workspace_id=workspace_id,
                 name=name,
@@ -872,6 +914,8 @@ async def handle_setup_resource(
             manager = ResourceTokenManager(db)
             plaintext_token, token_record = await manager.create_token(
                 resource_id=resource_id,
+                resource_pk=resource_pk,
+                workspace_id=workspace_id,
                 description=args.get("description"),
                 quota_events_per_hour=quota_events_per_hour,
                 created_by=user_id,

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -362,9 +362,10 @@ async def handle_list_resource_tokens(
                 if boundary_err:
                     return boundary_err
 
-            from sqlalchemy import and_, func
+            from sqlalchemy import and_, exists, func
             from sqlalchemy import select as sa_select
 
+            from models.auth import Context
             from models.resource import Resource, ResourceToken
 
             include_revoked = args.get("include_revoked", True)
@@ -382,7 +383,20 @@ async def handle_list_resource_tokens(
             # Legacy resource_pk IS NULL rows are excluded from the list view;
             # they are draining in production within the observation window
             # before Phase C tightens the column to NOT NULL.
-            conditions = [Resource.workspace_id == workspace_id]
+            #
+            # Preserve the pre-#390 behavior of hiding tokens whose backing
+            # Context was soft-deleted — the existence filter runs as an
+            # EXISTS subquery against ``contexts`` so the CWE-639 fix
+            # (resource_pk-scoped reads) is not compromised.
+            active_context_exists = exists().where(
+                Context.workspace_id == Resource.workspace_id,
+                Context.resource_id == Resource.resource_id,
+                Context.deleted_at.is_(None),
+            )
+            conditions = [
+                Resource.workspace_id == workspace_id,
+                active_context_exists,
+            ]
             if resource_id:
                 conditions.append(Resource.resource_id == resource_id)
             if not include_revoked:

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -267,10 +267,17 @@ async def handle_get_resource_schema(
             # Phase 1 writer gap.
             resource_pk = await resolve_resource_pk(db, workspace_id, resource_id)
             if resource_pk is None:
+                # The workspace boundary check passed but no Resource entity
+                # row exists — this is a data-integrity gap (setup_resource
+                # never ran, or the Resource row was dropped while the
+                # Context persists). Returning ``schema_not_found`` would
+                # mislead callers into creating a schema for a resource
+                # that cannot accept it. Surface a distinct error so the
+                # next step is "bind the resource", not "create a schema".
                 return _error_response(
-                    "schema_not_found",
-                    f"No schema found for resource '{resource_id}'.",
-                    help="Use the REST API to create a schema first.",
+                    "resource_not_found",
+                    f"Resource '{resource_id}' is not initialized or is no longer bound in this workspace.",
+                    help="Run setup_resource for this resource or rebind it before requesting its schema.",
                 )
 
             query = select(ResourceSchema).where(ResourceSchema.resource_pk == resource_pk)

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -19,11 +19,11 @@ Phase 2 (Issue #390, v0.12.3): all application writers now populate
 ``resource_pk`` on insert, and the ``before_insert`` event listener at
 the bottom of this module enforces the invariant at the ORM layer —
 inserts with ``resource_id`` set but ``resource_pk`` NULL raise
-``IntegrityError``. Orphan backfill migration
-``b01_resource_pk_writer_phase2`` closes any rows written between a97
-and the writer migration, and includes a cross-workspace slug
-ambiguity audit that aborts on the rare soft-delete-plus-reuse shape
-the CWE-639 fix is meant to close.
+``IntegrityError``. Orphan backfill migration ``b01_resource_pk_ph2``
+(file: ``b01_resource_pk_writer_phase2.py``) closes any rows written
+between a97 and the writer migration, and includes a cross-workspace
+slug ambiguity audit that aborts on the rare soft-delete-plus-reuse
+shape the CWE-639 fix is meant to close.
 
 Phase C (Issue #325, v0.13.0 follow-up): after a prod observation
 window confirms no new NULL rows, ``resource_pk`` (and

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -11,15 +11,32 @@ Provides ORM models for:
     - ``resource_tokens`` — Resource API authentication
     - ``workspace_addons`` — Addon purchase system
 
-Phase 1 rollout (Issue #323): ``resource_pk`` and
-``resource_tokens.workspace_id`` are nullable shadow columns populated
-by migration ``a97_resources_entity`` on existing rows. Writers that
-have not yet been updated (tracked under #324) still work because the
-columns are nullable during Phase 1; once all writers populate them,
-migration #325 tightens them to NOT NULL. Application code MUST NOT
-write ``resource_id`` independently of ``resource_pk`` once the
-writer migration begins — see the migration docstring for the full
-rationale.
+Phase 1 (Issue #323, shipped v0.12.0): ``resource_pk`` and
+``resource_tokens.workspace_id`` introduced as nullable shadow columns
+populated by migration ``a97_resources_entity`` on existing rows.
+
+Phase 2 (Issue #390, v0.12.3): all application writers now populate
+``resource_pk`` on insert, and the ``before_insert`` event listener at
+the bottom of this module enforces the invariant at the ORM layer —
+inserts with ``resource_id`` set but ``resource_pk`` NULL raise
+``IntegrityError``. Orphan backfill migration
+``b01_resource_pk_writer_phase2`` closes any rows written between a97
+and the writer migration, and includes a cross-workspace slug
+ambiguity audit that aborts on the rare soft-delete-plus-reuse shape
+the CWE-639 fix is meant to close.
+
+Phase C (Issue #325, v0.13.0 follow-up): after a prod observation
+window confirms no new NULL rows, ``resource_pk`` (and
+``resource_tokens.workspace_id``) are tightened to NOT NULL, the
+partial UNIQUE indexes are promoted to full UNIQUE, and a matching
+PostgreSQL CHECK constraint is added. The app-layer listener becomes
+redundant at that point but stays in place as defense-in-depth.
+
+Dual-write prohibition: application code MUST NOT write
+``resource_id`` independently of ``resource_pk``. The legacy
+``resource_id`` column is a read-only mirror and will be dropped in a
+Phase C+ cleanup once all external API contracts have migrated to
+UUID-based identifiers.
 """
 
 from sqlalchemy import (
@@ -35,10 +52,12 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    event,
     func,
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.exc import IntegrityError
 
 from db.base import Base
 from db.constraint_names import RESOURCE_EVENTS_UPSERT_UNIQUE
@@ -359,3 +378,43 @@ class WorkspaceAddon(Base):
         ),
         CheckConstraint("quantity > 0", name="check_quantity_positive"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Writer invariant (Issue #390 — Phase 2)
+# ---------------------------------------------------------------------------
+# Application-layer enforcement of the dual-write prohibition spelled out in
+# this module's top docstring: once Phase 2 writers are migrated, any INSERT
+# that sets ``resource_id`` without also setting ``resource_pk`` is a bug.
+# Catching it here prevents future writer paths from silently producing
+# orphan rows that reintroduce the CWE-639 slug-reuse leak. The DB-level
+# CHECK constraint equivalent is intentionally deferred to Phase C (#325) so
+# the prod observation window (``resource_pk IS NULL`` row count should
+# drain to zero over one week) is not invalidated by a hard schema gate.
+
+
+def _enforce_resource_pk_invariant(mapper, connection, target) -> None:
+    """Raise if ``resource_id`` is populated without a matching ``resource_pk``.
+
+    Hooked into ``before_insert`` for every satellite model. UPDATE paths
+    are NOT hooked — a single-column ``resource_pk`` clearing is unreachable
+    through normal ORM use (FK column, not user-settable in any route), and
+    adding ``before_update`` would fire on every unrelated column write with
+    no load-bearing invariant to check.
+    """
+    del mapper, connection  # SQLAlchemy event contract — we only inspect target.
+    if target.resource_id is not None and target.resource_pk is None:
+        raise IntegrityError(
+            statement=None,
+            params=None,
+            orig=ValueError(
+                f"{type(target).__name__}: resource_pk must be populated "
+                f"when resource_id is set (resource_id={target.resource_id!r}). "
+                "See models/resource.py top docstring for the Phase 2 writer "
+                "contract."
+            ),
+        )
+
+
+for _model in (ResourceEvent, ResourceSchema, IndexerState, ResourceToken):
+    event.listen(_model, "before_insert", _enforce_resource_pk_invariant)

--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -79,6 +79,7 @@ _KNOWN_SKIPPED_REASONS: frozenset[str] = frozenset(
         "schema_not_found",
         "context_not_found",
         "empty_valid_points",
+        "resource_entity_missing",
     }
 )
 

--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -317,12 +317,33 @@ class ResourceIndexer:
         metrics = IndexerMetrics()
 
         try:
-            # 1. Get or create indexer state
-            state = await self._get_or_create_state(resource_id, context_id)
+            # 1. Resolve context first so workspace_id is available for
+            # ``resource_pk`` lookup (Issue #390 Phase 2). All satellite
+            # queries below filter by resource_pk to avoid the CWE-639
+            # slug-reuse leak when a soft-deleted context releases its slug.
+            context = await self._get_context(context_id)
+
+            from services.resource_lookup import resolve_resource_pk
+
+            resource_pk = await resolve_resource_pk(self.db, context.workspace_id, resource_id)
+            if resource_pk is None:
+                # Pre-a97 orphan or writer gap: refuse to index rather than
+                # surface potentially cross-tenant rows via slug fallback.
+                metrics.skipped = True
+                metrics.reason = "resource_entity_missing"
+                logger.warning(
+                    "indexer_resource_entity_missing",
+                    resource_id=resource_id,
+                    context_id=context_id,
+                )
+                return metrics
+
+            # 2. Get or create indexer state
+            state = await self._get_or_create_state(resource_id, context_id, resource_pk)
             last_offset = state.last_offset
 
-            # 2. Fetch pending events
-            events = await self._fetch_events(resource_id, after_id=last_offset, limit=batch_size)
+            # 3. Fetch pending events
+            events = await self._fetch_events(resource_pk, after_id=last_offset, limit=batch_size)
 
             if not events:
                 metrics.skipped = True
@@ -335,8 +356,8 @@ class ResourceIndexer:
                 )
                 return metrics
 
-            # 3. Load schema for JSONB projection
-            schema = await self._get_latest_schema(resource_id)
+            # 4. Load schema for JSONB projection
+            schema = await self._get_latest_schema(resource_pk)
             if not schema:
                 logger.warning(
                     "indexer_schema_not_found",
@@ -345,9 +366,6 @@ class ResourceIndexer:
                 metrics.skipped = True
                 metrics.reason = "schema_not_found"
                 return metrics
-
-            # 4. Get context for workspace_id/context_id
-            context = await self._get_context(context_id)
 
             # Resolve Qdrant collection + per-context EmbeddingService from the
             # same ContextSearchConfig (#334 Layer B + #338 Layer C). Single
@@ -904,26 +922,54 @@ class ResourceIndexer:
     # Helper Methods
     # ========================================================================
 
-    async def _get_or_create_state(self, resource_id: str, context_id: UUID) -> IndexerState:
+    async def _get_or_create_state(
+        self,
+        resource_id: str,
+        context_id: UUID,
+        resource_pk: UUID,
+    ) -> IndexerState:
         """Get or create indexer state.
 
+        Issue #390 Phase 2: lookup uses the dual-row OR fallback pattern
+        (resource_indexer.get_indexer_status_for_context:156-162) so
+        legacy ``resource_pk IS NULL`` rows still resolve correctly during
+        the writer transition. Newly created rows populate both columns,
+        satisfying the before_insert invariant listener.
+
         Args:
-            resource_id: Resource ID
-            context_id: Context ID
+            resource_id: Resource ID (slug, legacy mirror)
+            context_id: Context ID (workspace-scoped FK)
+            resource_pk: Authoritative ``resources.id`` UUID
 
         Returns:
             IndexerState record
         """
+        # Prefer rows with resource_pk populated; fall back to legacy
+        # ``resource_pk IS NULL`` rows scoped by slug + context_id during
+        # the Phase 1 → Phase 2 transition window.
         result = await self.db.execute(
-            select(IndexerState).where(
-                IndexerState.resource_id == resource_id,
+            select(IndexerState)
+            .where(
                 IndexerState.context_id == context_id,
+                or_(
+                    IndexerState.resource_pk == resource_pk,
+                    (IndexerState.resource_pk.is_(None))
+                    & (IndexerState.resource_id == resource_id),
+                ),
             )
+            .order_by(
+                # Populated rows sort before legacy NULLs; id DESC is the
+                # tiebreaker if an in-flight writer leaves both shapes.
+                IndexerState.resource_pk.is_(None).asc(),
+                IndexerState.id.desc(),
+            )
+            .limit(1)
         )
         state = result.scalar_one_or_none()
 
         if not state:
             state = IndexerState(
+                resource_pk=resource_pk,
                 resource_id=resource_id,
                 context_id=context_id,
                 last_offset=0,
@@ -936,24 +982,19 @@ class ResourceIndexer:
 
     async def _fetch_events(
         self,
-        resource_id: str,
+        resource_pk: UUID,
         after_id: int,
         limit: int,
     ) -> list[ResourceEvent]:
         """Fetch pending events since last_offset.
 
-        Args:
-            resource_id: Resource ID
-            after_id: Last processed event ID
-            limit: Max events to fetch
-
-        Returns:
-            List of ResourceEvent records (ordered by ID)
+        ResourceEvent has no ``context_id`` column, so slug is not a
+        workspace boundary — filter strictly by ``resource_pk``.
         """
         result = await self.db.execute(
             select(ResourceEvent)
             .where(
-                ResourceEvent.resource_id == resource_id,
+                ResourceEvent.resource_pk == resource_pk,
                 ResourceEvent.id > after_id,
             )
             .order_by(ResourceEvent.id)
@@ -961,18 +1002,14 @@ class ResourceIndexer:
         )
         return list(result.scalars().all())
 
-    async def _get_latest_schema(self, resource_id: str) -> ResourceSchema | None:
-        """Get latest schema version for resource.
-
-        Args:
-            resource_id: Resource ID
-
-        Returns:
-            ResourceSchema or None if not found
-        """
+    async def _get_latest_schema(
+        self,
+        resource_pk: UUID,
+    ) -> ResourceSchema | None:
+        """Get latest schema version for resource (strict resource_pk filter)."""
         result = await self.db.execute(
             select(ResourceSchema)
-            .where(ResourceSchema.resource_id == resource_id)
+            .where(ResourceSchema.resource_pk == resource_pk)
             .order_by(ResourceSchema.schema_version.desc())
             .limit(1)
         )

--- a/backend/src/services/resource_lookup.py
+++ b/backend/src/services/resource_lookup.py
@@ -1,0 +1,152 @@
+"""Resource entity lookup helpers (Issue #390 Phase A).
+
+Shared chokepoint for resolving ``resources.id`` (UUID primary key) from
+a workspace-scoped ``(workspace_id, resource_id)`` tuple. Every writer
+and reader of the satellite tables (``resource_events``,
+``resource_schemas``, ``indexer_state``, ``resource_tokens``) that needs
+to populate or filter by ``resource_pk`` routes through this helper, so
+the "slug + workspace → UUID" resolution lives in exactly one place.
+
+The reference read-path implementation in
+``services/resource_indexer.py:get_indexer_status_for_context`` already
+follows this pattern; this module extracts the step into a reusable
+helper and exposes the ``workspace_id + resource_id`` tuple form that
+callers without a pre-resolved ``Context`` need.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.resource import Resource, ResourceSchema
+
+
+async def resolve_resource_pk(
+    db: AsyncSession,
+    workspace_id: UUID,
+    resource_id: str,
+) -> UUID | None:
+    """Resolve ``resources.id`` for a workspace-scoped slug.
+
+    Args:
+        db: Async DB session.
+        workspace_id: Owning workspace UUID.
+        resource_id: External-facing slug.
+
+    Returns:
+        The ``resources.id`` UUID, or ``None`` if no matching Resource
+        row exists in this workspace. Callers on read paths should
+        fail-safe to empty results on ``None`` rather than fall back to
+        a slug-only filter — a missing Resource row indicates either a
+        pre-a97 orphan or a cross-workspace probe; both cases must not
+        surface satellite rows (CWE-639 / OWASP A01).
+    """
+    result = await db.execute(
+        select(Resource.id).where(
+            Resource.workspace_id == workspace_id,
+            Resource.resource_id == resource_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_resource(
+    db: AsyncSession,
+    workspace_id: UUID,
+    resource_id: str,
+    *,
+    name: str | None = None,
+    created_by: str | None = None,
+) -> UUID:
+    """Return the ``resources.id`` for ``(workspace_id, resource_id)``,
+    creating the row if missing.
+
+    Used by ``setup_resource`` and any other path that needs to bind a
+    new Context to a Resource entity. Safe under concurrent calls —
+    relies on ``uq_resources_workspace_resource_id`` and retries the
+    SELECT once if the INSERT races.
+
+    Args:
+        db: Async DB session.
+        workspace_id: Owning workspace UUID.
+        resource_id: External-facing slug.
+        name: Human-readable label (populated by ``setup_resource``;
+            preserved on pre-existing rows — only applied on insert).
+        created_by: Creator user ID (same semantics as ``name``).
+
+    Returns:
+        The ``resources.id`` UUID.
+    """
+    existing = await resolve_resource_pk(db, workspace_id, resource_id)
+    if existing is not None:
+        return existing
+
+    resource = Resource(
+        workspace_id=workspace_id,
+        resource_id=resource_id,
+        name=name,
+        created_by=created_by,
+    )
+    # Nested savepoint (SAVEPOINT) so a concurrent insert that violates the
+    # ``uq_resources_workspace_resource_id`` UNIQUE constraint only rolls
+    # back THIS insert — the caller's outer transaction (and any prior
+    # ``db.add()`` state staged on the session, e.g. ``handle_setup_resource``'s
+    # role/plan/quota checks) is preserved. Using ``db.rollback()`` here
+    # would silently wipe the caller's session identity map and cause
+    # cryptic DetachedInstanceError failures downstream.
+    try:
+        async with db.begin_nested():
+            db.add(resource)
+            await db.flush()
+    except IntegrityError:
+        # Concurrent insert raced on ``uq_resources_workspace_resource_id``;
+        # savepoint rolled back, outer tx intact. Narrow exception class so
+        # ``CancelledError`` / ``OSError`` / other real failures are not
+        # silently reinterpreted as "another writer got here first".
+        existing = await resolve_resource_pk(db, workspace_id, resource_id)
+        if existing is None:
+            raise
+        return existing
+    # ``resource.id`` is populated by ``server_default=gen_random_uuid()`` on
+    # flush. SQLAlchemy types it as ``Column[UUID]`` at the class level, so
+    # cast the instance attribute to silence pyright — at instance level it
+    # is the actual UUID value.
+    assert isinstance(resource.id, UUID)
+    return resource.id
+
+
+async def get_latest_schema(
+    db: AsyncSession,
+    workspace_id: UUID,
+    resource_id: str,
+) -> ResourceSchema | None:
+    """Return the highest-version ResourceSchema for a workspace-scoped slug.
+
+    Shared chokepoint for reads that need the latest schema: extracts the
+    resolve_resource_pk → filter-by-pk → order-by-version-desc → limit-1
+    shape so each call site doesn't re-implement it. Fails safe to ``None``
+    when the Resource row is missing (pre-a97 orphan, cross-workspace probe).
+
+    Args:
+        db: Async DB session.
+        workspace_id: Owning workspace UUID.
+        resource_id: External-facing slug.
+
+    Returns:
+        ResourceSchema with the highest schema_version, or ``None`` if the
+        Resource or any schema for it is missing.
+    """
+    resource_pk = await resolve_resource_pk(db, workspace_id, resource_id)
+    if resource_pk is None:
+        return None
+    result = await db.execute(
+        select(ResourceSchema)
+        .where(ResourceSchema.resource_pk == resource_pk)
+        .order_by(ResourceSchema.schema_version.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()

--- a/backend/tests/api/test_resource_ingest.py
+++ b/backend/tests/api/test_resource_ingest.py
@@ -336,10 +336,12 @@ class TestResourceIngestWorkspaceBoundary:
         token.resource_id = "acme"
         token.created_by = "user_owner"
         token.is_active = True
-        # Issue #390 Phase 2: token carries its workspace binding so the
-        # ingest-side cross-check (token.workspace_id == context.workspace_id)
-        # passes for the happy-path "matching workspace" fixture. Tests that
-        # exercise the mismatch path (CWE-639 auth vector) override this.
+        # Issue #390 Phase 2 happy-path fixture: legacy token shape
+        # (resource_pk IS NULL, workspace_id populated by a97 backfill).
+        # The ingest-side cross-check falls through to the workspace_id
+        # shadow column fallback. Tests exercising the CWE-639 mismatch
+        # path override both fields.
+        token.resource_pk = None
         token.workspace_id = workspace_id
         return token
 
@@ -519,7 +521,12 @@ class TestResourceIngestWorkspaceBoundary:
         """
         db = MagicMock()
         # Force mismatch: token pinned to a different workspace than context.
-        mock_token.workspace_id = uuid4()  # NOT mock_context.workspace_id
+        # Uses the workspace_id shadow column fallback (resource_pk IS NULL)
+        # to keep the mock lightweight; the resource_pk-primary path is
+        # exercised in integration tests where a real Resource row exists.
+        mismatched_workspace_id = uuid4()
+        mock_token.resource_pk = None
+        mock_token.workspace_id = mismatched_workspace_id
 
         with (
             patch(
@@ -535,5 +542,5 @@ class TestResourceIngestWorkspaceBoundary:
             # Verify the forensics log captures the mismatch for post-mortem.
             mock_logger.warning.assert_called_once()
             call_kwargs = mock_logger.warning.call_args.kwargs
-            assert call_kwargs.get("token_workspace_id") == str(mock_token.workspace_id)
+            assert call_kwargs.get("token_workspace_id") == str(mismatched_workspace_id)
             assert call_kwargs.get("context_workspace_id") == str(mock_context.workspace_id)

--- a/backend/tests/api/test_resource_ingest.py
+++ b/backend/tests/api/test_resource_ingest.py
@@ -330,12 +330,17 @@ class TestResourceIngestWorkspaceBoundary:
         return ctx
 
     @pytest.fixture
-    def mock_token(self):
+    def mock_token(self, workspace_id):
         token = MagicMock(spec=ResourceToken)
         token.id = 42
         token.resource_id = "acme"
         token.created_by = "user_owner"
         token.is_active = True
+        # Issue #390 Phase 2: token carries its workspace binding so the
+        # ingest-side cross-check (token.workspace_id == context.workspace_id)
+        # passes for the happy-path "matching workspace" fixture. Tests that
+        # exercise the mismatch path (CWE-639 auth vector) override this.
+        token.workspace_id = workspace_id
         return token
 
     @pytest.fixture
@@ -495,3 +500,40 @@ class TestResourceIngestWorkspaceBoundary:
             )
         # No permission check (and therefore no DB query) for unattributed tokens.
         db.execute.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_membership_denied_on_token_workspace_mismatch(
+        self, mock_request, mock_token, mock_context
+    ):
+        """CWE-639 auth-boundary fix: reject when token.workspace_id does NOT
+        match context.workspace_id.
+
+        Copilot catch on PR #392 loop 7 + 9. The slug-reuse attack path:
+          1) verify_token pins T to workspace A via resource_pk JOIN
+          2) resolve_authoritative_context returns workspace B's Context
+             (A's Context soft-deleted, B's Context live with same slug)
+          3) enforce_workspace_membership's check_workspace_access passes
+             because T.created_by is a member of workspace B
+          4) Without the cross-check, the handler writes events to A's
+             resource (via T.resource_pk) from what looks like a B API call
+        """
+        db = MagicMock()
+        # Force mismatch: token pinned to a different workspace than context.
+        mock_token.workspace_id = uuid4()  # NOT mock_context.workspace_id
+
+        with (
+            patch(
+                "services.permission_service.PermissionService.check_workspace_access",
+                new=AsyncMock(return_value=MagicMock()),
+            ),
+            patch("api.routes.resource_ingest.logger") as mock_logger,
+        ):
+            with pytest.raises(HTTPException) as exc:
+                await _enforce_workspace_membership(db, mock_request, mock_token, mock_context)
+
+            assert exc.value.status_code == 403
+            # Verify the forensics log captures the mismatch for post-mortem.
+            mock_logger.warning.assert_called_once()
+            call_kwargs = mock_logger.warning.call_args.kwargs
+            assert call_kwargs.get("token_workspace_id") == str(mock_token.workspace_id)
+            assert call_kwargs.get("context_workspace_id") == str(mock_context.workspace_id)

--- a/backend/tests/api/test_resource_ingest.py
+++ b/backend/tests/api/test_resource_ingest.py
@@ -79,9 +79,15 @@ class TestResourceTokenManager:
     @pytest.mark.asyncio
     async def test_create_token_success(self, manager, mock_db):
         """Test successful token creation."""
-        # Execute
+        import uuid
+
+        # Issue #390 Phase 2: create_token now requires keyword-only
+        # resource_pk + workspace_id so the before_insert event listener
+        # invariant on ResourceToken passes.
         token, token_obj = await manager.create_token(
             resource_id="ec_products",
+            resource_pk=uuid.uuid4(),
+            workspace_id=uuid.uuid4(),
             description="Test EC integration",
             quota_events_per_hour=500,
             created_by="admin_user",

--- a/backend/tests/db/test_resource_pk_invariant.py
+++ b/backend/tests/db/test_resource_pk_invariant.py
@@ -1,0 +1,125 @@
+"""Writer invariant tests for Issue #390 Phase 2.
+
+The ``models/resource.py`` module registers ``before_insert`` event
+listeners on all four satellite models to raise ``IntegrityError`` when
+an insert would create a row with ``resource_id`` set but
+``resource_pk`` left NULL. These tests pin the invariant so a future
+writer that forgets to populate ``resource_pk`` is caught at test time
+rather than silently producing orphan rows that reintroduce the CWE-639
+slug-reuse leak vector.
+
+The listeners live at the ORM layer, not at the DB layer — a PostgreSQL
+CHECK constraint is intentionally deferred to Phase C (#325) so the
+writer observation window between Phase 2 and Phase C can detect the
+"zero new NULL rows" signal without a hard schema gate causing
+hypothetical production errors during the rollout.
+
+Tests call the listener function directly (via module import) rather
+than going through SQLAlchemy's ``dispatch`` — the dispatch path expects
+an internal ``InstanceState`` wrapper and cannot be invoked from outside
+a live session. Direct function invocation is still a faithful pin: the
+listener is what runs during INSERT in production, and this is the same
+callable.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from models.resource import (
+    IndexerState,
+    ResourceEvent,
+    ResourceSchema,
+    ResourceToken,
+    _enforce_resource_pk_invariant,
+)
+
+
+class TestResourcePkInvariantRejectsMissingPk:
+    """Each satellite model with resource_id but no resource_pk must raise."""
+
+    def test_resource_event_requires_resource_pk(self):
+        event = ResourceEvent(
+            resource_id="test_slug",
+            op="upsert",
+            doc_id="d1",
+            version=1,
+            payload={"k": "v"},
+        )
+        with pytest.raises(IntegrityError, match="resource_pk must be populated"):
+            _enforce_resource_pk_invariant(None, None, event)
+
+    def test_resource_schema_requires_resource_pk(self):
+        schema = ResourceSchema(
+            resource_id="test_slug",
+            schema_version=1,
+            field_definitions=[],
+        )
+        with pytest.raises(IntegrityError, match="resource_pk must be populated"):
+            _enforce_resource_pk_invariant(None, None, schema)
+
+    def test_indexer_state_requires_resource_pk(self):
+        state = IndexerState(
+            resource_id="test_slug",
+            context_id=uuid.uuid4(),
+            last_offset=0,
+            job_status="idle",
+        )
+        with pytest.raises(IntegrityError, match="resource_pk must be populated"):
+            _enforce_resource_pk_invariant(None, None, state)
+
+    def test_resource_token_requires_resource_pk(self):
+        token = ResourceToken(
+            resource_id="test_slug",
+            token_hash="x" * 64,
+            quota_events_per_hour=1000,
+        )
+        with pytest.raises(IntegrityError, match="resource_pk must be populated"):
+            _enforce_resource_pk_invariant(None, None, token)
+
+
+class TestResourcePkInvariantAcceptsValidInsert:
+    """Happy path: resource_pk populated means the listener is a no-op."""
+
+    def test_resource_event_with_resource_pk_passes(self):
+        event = ResourceEvent(
+            resource_pk=uuid.uuid4(),
+            resource_id="test_slug",
+            op="upsert",
+            doc_id="d1",
+            version=1,
+            payload={"k": "v"},
+        )
+        _enforce_resource_pk_invariant(None, None, event)
+
+    def test_resource_schema_with_resource_pk_passes(self):
+        schema = ResourceSchema(
+            resource_pk=uuid.uuid4(),
+            resource_id="test_slug",
+            schema_version=1,
+            field_definitions=[],
+        )
+        _enforce_resource_pk_invariant(None, None, schema)
+
+    def test_indexer_state_with_resource_pk_passes(self):
+        state = IndexerState(
+            resource_pk=uuid.uuid4(),
+            resource_id="test_slug",
+            context_id=uuid.uuid4(),
+            last_offset=0,
+            job_status="idle",
+        )
+        _enforce_resource_pk_invariant(None, None, state)
+
+    def test_resource_token_with_resource_pk_passes(self):
+        token = ResourceToken(
+            resource_pk=uuid.uuid4(),
+            resource_id="test_slug",
+            workspace_id=uuid.uuid4(),
+            token_hash="y" * 64,
+            quota_events_per_hour=1000,
+        )
+        _enforce_resource_pk_invariant(None, None, token)

--- a/backend/tests/db/test_resource_pk_invariant.py
+++ b/backend/tests/db/test_resource_pk_invariant.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import uuid
 
 import pytest
+from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
 
 from models.resource import (
@@ -123,3 +124,27 @@ class TestResourcePkInvariantAcceptsValidInsert:
             quota_events_per_hour=1000,
         )
         _enforce_resource_pk_invariant(None, None, token)
+
+
+class TestResourcePkInvariantEventListenerRegistration:
+    """Pin the event wiring itself, not just the listener function body.
+
+    Copilot catch on PR #392 loop 2: calling ``_enforce_resource_pk_invariant``
+    directly verifies the function's behavior but would still pass if the
+    ``event.listen(...)`` wiring at the bottom of ``models/resource.py`` were
+    accidentally removed — producing the silent orphan-row regression this
+    module is supposed to prevent. Asserting ``event.contains(...)`` locks the
+    wiring at test time.
+    """
+
+    @pytest.mark.parametrize(
+        "model",
+        [ResourceEvent, ResourceSchema, IndexerState, ResourceToken],
+    )
+    def test_before_insert_listener_is_registered(self, model):
+        """Every satellite model must carry the _enforce_resource_pk_invariant hook."""
+        assert event.contains(model, "before_insert", _enforce_resource_pk_invariant), (
+            f"{model.__name__} is missing the 'before_insert' invariant listener. "
+            "The event.listen(...) loop at the bottom of models/resource.py must "
+            "register _enforce_resource_pk_invariant on every satellite model."
+        )

--- a/backend/tests/integration/test_resource_cross_workspace.py
+++ b/backend/tests/integration/test_resource_cross_workspace.py
@@ -32,7 +32,8 @@ from auth.dependencies import (
 )
 from db.base import get_db
 from models.auth import Context, Workspace, WorkspaceMember
-from models.resource import ResourceSchema
+from models.resource import Resource, ResourceSchema, ResourceToken
+from utils.datetime import utcnow
 
 SLUG_IN_WORKSPACE_B = "ws_b_only_slug"
 
@@ -96,6 +97,17 @@ async def cross_workspace_scenario(async_engine, db_session):
         resource_id=SLUG_IN_WORKSPACE_B,
         created_by=owner_b_id,
     )
+    # Issue #390 Phase 2: Resource entity row for workspace B so the
+    # canary ResourceSchema below can carry a valid ``resource_pk`` — the
+    # before_insert event listener on ResourceSchema rejects rows with
+    # only ``resource_id`` set.
+    resource_b = Resource(
+        id=uuid4(),
+        workspace_id=ws_b.id,
+        resource_id=SLUG_IN_WORKSPACE_B,
+        name="ws-b-canary",
+        created_by=owner_b_id,
+    )
     # A ResourceSchema row for the slug is load-bearing for the regression
     # contract: without it, /schema would return 404 simply because no
     # schema exists, and the test would pass for the wrong reason if the
@@ -104,6 +116,7 @@ async def cross_workspace_scenario(async_engine, db_session):
     # entirely) would return 200 + this schema's data, correctly failing
     # the 404 assertion. Copilot catch on PR #391 loop 4.
     schema_b = ResourceSchema(
+        resource_pk=resource_b.id,
         resource_id=SLUG_IN_WORKSPACE_B,
         schema_version=1,
         field_definitions=[{"name": "canary_field", "type": "text"}],
@@ -114,6 +127,7 @@ async def cross_workspace_scenario(async_engine, db_session):
             ws_b,
             WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
             WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
+            resource_b,
             ctx_b,
             schema_b,
         ]
@@ -158,6 +172,9 @@ async def cross_workspace_scenario(async_engine, db_session):
             )
         )
         await db_session.delete(ctx_b)
+        # Delete Resource after its satellite rows — CASCADE would also work
+        # but being explicit keeps the teardown deterministic.
+        await db_session.execute(Resource.__table__.delete().where(Resource.id == resource_b.id))
         await db_session.execute(
             WorkspaceMember.__table__.delete().where(
                 WorkspaceMember.workspace_id.in_([ws_a.id, ws_b.id])
@@ -247,10 +264,19 @@ async def cross_workspace_multi_member_scenario(async_engine, db_session):
         resource_id=SLUG_IN_WORKSPACE_B,
         created_by=owner_b_id,
     )
+    # Issue #390 Phase 2: Resource entity row to back the schema canary.
+    resource_b = Resource(
+        id=uuid4(),
+        workspace_id=ws_b.id,
+        resource_id=SLUG_IN_WORKSPACE_B,
+        name="ws-b-canary",
+        created_by=owner_b_id,
+    )
     # Same ResourceSchema canary as the base fixture — makes the 404
     # assertion on /schema a true boundary check rather than a
     # "no-schema-exists" coincidence. See the base fixture docstring.
     schema_b = ResourceSchema(
+        resource_pk=resource_b.id,
         resource_id=SLUG_IN_WORKSPACE_B,
         schema_version=1,
         field_definitions=[{"name": "canary_field", "type": "text"}],
@@ -263,6 +289,7 @@ async def cross_workspace_multi_member_scenario(async_engine, db_session):
             WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
             WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
             WorkspaceMember(workspace_id=ws_b.id, user_id=owner_a_id, role="member"),
+            resource_b,
             ctx_b,
             schema_b,
         ]
@@ -302,6 +329,7 @@ async def cross_workspace_multi_member_scenario(async_engine, db_session):
             )
         )
         await db_session.delete(ctx_b)
+        await db_session.execute(Resource.__table__.delete().where(Resource.id == resource_b.id))
         await db_session.execute(
             WorkspaceMember.__table__.delete().where(
                 WorkspaceMember.workspace_id.in_([ws_a.id, ws_b.id])
@@ -336,4 +364,338 @@ async def test_multi_workspace_member_probe_returns_404(
         f"GET {path} returned {response.status_code}, expected 404 "
         f"(multi-workspace member must not leak via resolve_resource_by_slug "
         f"default required_role=member)"
+    )
+
+
+# ============================================================================
+# Issue #390 Phase 2: list endpoint body-inspection + slug-reuse scenarios
+# ============================================================================
+#
+# The parametrized slug-path tests above verify 404 uniform disclosure on
+# per-resource endpoints. The list endpoints (``/api/v1/resources`` and
+# ``/api/v1/resource-tokens``) return 200 with a possibly-empty body, so
+# status code alone cannot distinguish "properly isolated" from "leaked".
+# These tests inspect the response body directly.
+#
+# The slug-reuse test exercises the core exploit vector #390 closes:
+# workspace A soft-deletes a Context with slug ``x``; workspace B then
+# creates a Resource with slug ``x``. Without the Phase 2 writer +
+# read-path migration, any orphan satellite rows from workspace A (still
+# keyed by slug) would surface under workspace B's reads.
+
+
+@pytest_asyncio.fixture
+async def cross_workspace_list_scenario(async_engine, db_session):
+    """Owner-of-A probes list endpoints while workspace B has a live resource.
+
+    Yields auth overrides that make the caller owner of workspace A. The
+    list endpoints called under these overrides must NOT return any row
+    whose data came from workspace B (identifiable by the canary resource
+    ``ws_b_list_canary``).
+    """
+    owner_a_id = f"owner_a_{uuid4().hex[:8]}"
+    owner_b_id = f"owner_b_{uuid4().hex[:8]}"
+    canary_slug = f"ws_b_list_canary_{uuid4().hex[:8]}"
+
+    ws_a = Workspace(
+        id=uuid4(),
+        name=f"ws-a-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_a_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+    ws_b = Workspace(
+        id=uuid4(),
+        name=f"ws-b-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_b_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+    resource_b = Resource(
+        id=uuid4(),
+        workspace_id=ws_b.id,
+        resource_id=canary_slug,
+        name="ws-b-list-canary",
+        created_by=owner_b_id,
+    )
+    ctx_b = Context(
+        id=uuid4(),
+        workspace_id=ws_b.id,
+        name=f"ctx-b-{uuid4().hex[:8]}",
+        resource_id=canary_slug,
+        created_by=owner_b_id,
+    )
+    token_b = ResourceToken(
+        resource_pk=resource_b.id,
+        resource_id=canary_slug,
+        workspace_id=ws_b.id,
+        token_hash="canary_hash_" + uuid4().hex,
+        description="ws-b list canary token",
+        quota_events_per_hour=100,
+        created_by=owner_b_id,
+    )
+
+    db_session.add_all(
+        [
+            ws_a,
+            ws_b,
+            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
+            resource_b,
+            ctx_b,
+            token_b,
+        ]
+    )
+    await db_session.commit()
+
+    async def override_auth():
+        return {
+            "user_id": owner_a_id,
+            "email": f"{owner_a_id}@test.com",
+            "role": "user",
+            "current_workspace_id": ws_a.id,
+            "workspace_role": "owner",
+        }
+
+    async def override_require_workspace_owner():
+        return (owner_a_id, ws_a.id)
+
+    app.dependency_overrides[get_db] = _make_fresh_session_override(async_engine)
+    app.dependency_overrides[get_user_from_api_key_or_session] = override_auth
+    app.dependency_overrides[require_workspace_owner] = override_require_workspace_owner
+
+    yield {
+        "owner_a_id": owner_a_id,
+        "ws_a_id": ws_a.id,
+        "canary_slug": canary_slug,
+    }
+
+    app.dependency_overrides.clear()
+
+    try:
+        await db_session.execute(
+            ResourceToken.__table__.delete().where(ResourceToken.id == token_b.id)
+        )
+        await db_session.delete(ctx_b)
+        await db_session.execute(Resource.__table__.delete().where(Resource.id == resource_b.id))
+        await db_session.execute(
+            WorkspaceMember.__table__.delete().where(
+                WorkspaceMember.workspace_id.in_([ws_a.id, ws_b.id])
+            )
+        )
+        await db_session.delete(ws_a)
+        await db_session.delete(ws_b)
+        await db_session.commit()
+    except Exception:
+        await db_session.rollback()
+        raise
+
+
+@pytest.mark.asyncio
+async def test_resources_list_excludes_other_workspace_rows(cross_workspace_list_scenario):
+    """GET /api/v1/resources from owner-of-A must not include workspace B's canary.
+
+    Status code alone (200) does not distinguish isolated from leaky on a
+    list endpoint — we must inspect the body. The canary slug lives only
+    in workspace B; workspace A's response body must not contain it.
+    """
+    canary = cross_workspace_list_scenario["canary_slug"]
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/resources")
+
+    assert response.status_code == 200, f"Unexpected status: {response.status_code}"
+    data = response.json()
+    resource_ids = [r["resource_id"] for r in data.get("resources", [])]
+    assert canary not in resource_ids, (
+        f"Cross-workspace leak: GET /api/v1/resources from owner-of-A "
+        f"returned workspace B's canary slug '{canary}'. "
+        f"Full response: {resource_ids}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_slug_reuse_after_soft_delete_isolates_orphans(async_engine, db_session):
+    """Workspace A soft-deletes slug ``x``; workspace B creates slug ``x``.
+
+    Owner-of-B reading ``/resources/x/schema`` must see only B's schema —
+    workspace A's orphan ResourceSchema (still keyed by slug + stale
+    resource_pk) must not surface. This is the core CWE-639 exploit
+    vector that #390 Phase 2 closes via strict ``resource_pk`` read
+    filtering.
+    """
+    shared_slug = f"reused_slug_{uuid4().hex[:8]}"
+
+    owner_a_id = f"owner_a_{uuid4().hex[:8]}"
+    owner_b_id = f"owner_b_{uuid4().hex[:8]}"
+
+    ws_a = Workspace(
+        id=uuid4(),
+        name=f"ws-a-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_a_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+    ws_b = Workspace(
+        id=uuid4(),
+        name=f"ws-b-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_b_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+
+    # Workspace A: resource + soft-deleted context + orphan ResourceSchema.
+    resource_a = Resource(
+        id=uuid4(),
+        workspace_id=ws_a.id,
+        resource_id=shared_slug,
+        name="ws-a-original",
+        created_by=owner_a_id,
+    )
+    ctx_a_soft_deleted = Context(
+        id=uuid4(),
+        workspace_id=ws_a.id,
+        name=f"ctx-a-{uuid4().hex[:8]}",
+        resource_id=shared_slug,
+        created_by=owner_a_id,
+    )
+    # Mark as soft-deleted — releases the slug under the partial UNIQUE
+    # index ``deleted_at IS NULL``.
+    ctx_a_soft_deleted.deleted_at = utcnow()
+    schema_a_orphan = ResourceSchema(
+        resource_pk=resource_a.id,
+        resource_id=shared_slug,
+        schema_version=1,
+        field_definitions=[{"name": "ws_a_orphan_canary", "type": "text"}],
+    )
+
+    # Workspace B: new resource with same slug + its own schema.
+    resource_b = Resource(
+        id=uuid4(),
+        workspace_id=ws_b.id,
+        resource_id=shared_slug,
+        name="ws-b-reused",
+        created_by=owner_b_id,
+    )
+    ctx_b = Context(
+        id=uuid4(),
+        workspace_id=ws_b.id,
+        name=f"ctx-b-{uuid4().hex[:8]}",
+        resource_id=shared_slug,
+        created_by=owner_b_id,
+    )
+    schema_b = ResourceSchema(
+        resource_pk=resource_b.id,
+        resource_id=shared_slug,
+        schema_version=1,
+        field_definitions=[{"name": "ws_b_correct_field", "type": "text"}],
+    )
+
+    db_session.add_all(
+        [
+            ws_a,
+            ws_b,
+            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
+            resource_a,
+            resource_b,
+            ctx_a_soft_deleted,
+            ctx_b,
+            schema_a_orphan,
+            schema_b,
+        ]
+    )
+    await db_session.commit()
+
+    async def override_auth():
+        return {
+            "user_id": owner_b_id,
+            "email": f"{owner_b_id}@test.com",
+            "role": "user",
+            "current_workspace_id": ws_b.id,
+            "workspace_role": "owner",
+        }
+
+    async def override_require_workspace_owner():
+        return (owner_b_id, ws_b.id)
+
+    app.dependency_overrides[get_db] = _make_fresh_session_override(async_engine)
+    app.dependency_overrides[get_user_from_api_key_or_session] = override_auth
+    app.dependency_overrides[require_workspace_owner] = override_require_workspace_owner
+
+    try:
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get(f"/api/v1/resources/{shared_slug}/schema")
+
+        assert response.status_code == 200, (
+            f"Owner-of-B probing shared slug should see their own schema; "
+            f"got {response.status_code}"
+        )
+        data = response.json()
+        fields = [f.get("name") for f in data.get("field_definitions", [])]
+        assert "ws_b_correct_field" in fields, (
+            f"Expected workspace B's schema, got fields: {fields}"
+        )
+        assert "ws_a_orphan_canary" not in fields, (
+            f"Cross-workspace leak: workspace A's orphan schema surfaced in "
+            f"workspace B's response. Fields returned: {fields}"
+        )
+    finally:
+        app.dependency_overrides.clear()
+        try:
+            await db_session.execute(
+                ResourceSchema.__table__.delete().where(ResourceSchema.resource_id == shared_slug)
+            )
+            await db_session.delete(ctx_a_soft_deleted)
+            await db_session.delete(ctx_b)
+            await db_session.execute(
+                Resource.__table__.delete().where(Resource.id.in_([resource_a.id, resource_b.id]))
+            )
+            await db_session.execute(
+                WorkspaceMember.__table__.delete().where(
+                    WorkspaceMember.workspace_id.in_([ws_a.id, ws_b.id])
+                )
+            )
+            await db_session.delete(ws_a)
+            await db_session.delete(ws_b)
+            await db_session.commit()
+        except Exception:
+            await db_session.rollback()
+            raise
+
+
+@pytest.mark.asyncio
+async def test_resource_tokens_list_excludes_other_workspace_rows(
+    cross_workspace_list_scenario,
+):
+    """GET /api/v1/resource-tokens from owner-of-A with workspace-B canary.
+
+    The REST list endpoint filters by ``created_by=user_id`` at the manager
+    layer. Because owner_b (not owner_a) created the canary token in
+    workspace B, owner_a's list should be empty regardless of workspace
+    scoping. The assertion also defends against a future refactor that
+    switches to a slug-based filter without a workspace boundary: any
+    rows surfacing here with the canary ``resource_id`` would prove a
+    cross-workspace leak.
+    """
+    canary = cross_workspace_list_scenario["canary_slug"]
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/api/v1/resource-tokens")
+
+    assert response.status_code == 200, f"Unexpected status: {response.status_code}"
+    data = response.json()
+    token_resource_ids = [t["resource_id"] for t in data.get("tokens", [])]
+    assert canary not in token_resource_ids, (
+        f"Cross-workspace leak: GET /api/v1/resource-tokens from owner-of-A "
+        f"returned workspace B's canary token ({canary!r}). "
+        f"Full response resource_ids: {token_resource_ids}"
     )

--- a/backend/tests/integration/test_resource_cross_workspace.py
+++ b/backend/tests/integration/test_resource_cross_workspace.py
@@ -386,16 +386,30 @@ async def test_multi_workspace_member_probe_returns_404(
 
 @pytest_asyncio.fixture
 async def cross_workspace_list_scenario(async_engine, db_session):
-    """Owner-of-A probes list endpoints while workspace B has a live resource.
+    """Exercise the real CWE-639 list-endpoint leak path (Copilot catch loop 10).
 
-    Yields auth overrides that make the caller owner of workspace A. The
-    list endpoints called under these overrides must NOT return any row
-    whose data came from workspace B (identifiable by the canary resource
-    ``ws_b_list_canary``).
+    Earlier revision only put data in workspace B and asserted A's list was
+    empty — but ``list_resources`` filters ``Context.workspace_id ==
+    current_workspace_id`` so an empty response was trivially guaranteed
+    regardless of satellite-subquery scoping. To catch a real leak, we need:
+
+    - Workspace A: **also** owns the reused slug with its own Context +
+      Resource + ResourceSchema (v1). A's list row should reflect A's
+      schema version and zero tokens.
+    - Workspace B: had the slug first, then soft-deleted its Context.
+      The orphan ResourceSchema (v9 — distinct number so a mis-scoped
+      subquery surfaces) and ResourceToken rows linger in the DB, still
+      bound to B's Resource via resource_pk.
+
+    If the ``list_resources`` correlated subqueries were still keyed by
+    slug-only, A's list row would pick up B's schema_version=9 and
+    token_count=1 — that's the CWE-639 leak. The resource_pk-scoped
+    subqueries this PR introduces must isolate A's stats from B's
+    orphans.
     """
     owner_a_id = f"owner_a_{uuid4().hex[:8]}"
     owner_b_id = f"owner_b_{uuid4().hex[:8]}"
-    canary_slug = f"ws_b_list_canary_{uuid4().hex[:8]}"
+    reused_slug = f"reused_list_{uuid4().hex[:8]}"
 
     ws_a = Workspace(
         id=uuid4(),
@@ -415,26 +429,61 @@ async def cross_workspace_list_scenario(async_engine, db_session):
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
+
+    # Workspace A owns the reused slug NOW: Context + Resource + schema v1
+    # + zero tokens.
+    resource_a = Resource(
+        id=uuid4(),
+        workspace_id=ws_a.id,
+        resource_id=reused_slug,
+        name="ws-a-current",
+        created_by=owner_a_id,
+    )
+    ctx_a = Context(
+        id=uuid4(),
+        workspace_id=ws_a.id,
+        name=f"ctx-a-{uuid4().hex[:8]}",
+        resource_id=reused_slug,
+        created_by=owner_a_id,
+    )
+    schema_a = ResourceSchema(
+        resource_pk=resource_a.id,
+        resource_id=reused_slug,
+        schema_version=1,
+        field_definitions=[{"name": "a_field", "type": "text"}],
+    )
+
+    # Workspace B had the slug first; Context is soft-deleted. Its
+    # Resource + orphan ResourceSchema (v9) + ResourceToken linger.
     resource_b = Resource(
         id=uuid4(),
         workspace_id=ws_b.id,
-        resource_id=canary_slug,
-        name="ws-b-list-canary",
+        resource_id=reused_slug,
+        name="ws-b-orphan",
         created_by=owner_b_id,
     )
     ctx_b = Context(
         id=uuid4(),
         workspace_id=ws_b.id,
         name=f"ctx-b-{uuid4().hex[:8]}",
-        resource_id=canary_slug,
+        resource_id=reused_slug,
         created_by=owner_b_id,
     )
-    token_b = ResourceToken(
+    ctx_b.deleted_at = utcnow()
+    schema_b_orphan = ResourceSchema(
         resource_pk=resource_b.id,
-        resource_id=canary_slug,
+        resource_id=reused_slug,
+        schema_version=9,  # deliberately higher than A's v1 so a leak
+        # via slug-only subquery would surface as
+        # current_schema_version=9 on A's row.
+        field_definitions=[{"name": "b_orphan_field", "type": "text"}],
+    )
+    token_b_orphan = ResourceToken(
+        resource_pk=resource_b.id,
+        resource_id=reused_slug,
         workspace_id=ws_b.id,
         token_hash="canary_hash_" + uuid4().hex,
-        description="ws-b list canary token",
+        description="ws-b orphan token (should not surface in A's count)",
         quota_events_per_hour=100,
         created_by=owner_b_id,
     )
@@ -445,9 +494,13 @@ async def cross_workspace_list_scenario(async_engine, db_session):
             ws_b,
             WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
             WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
+            resource_a,
             resource_b,
+            ctx_a,
             ctx_b,
-            token_b,
+            schema_a,
+            schema_b_orphan,
+            token_b_orphan,
         ]
     )
     await db_session.commit()
@@ -471,17 +524,25 @@ async def cross_workspace_list_scenario(async_engine, db_session):
     yield {
         "owner_a_id": owner_a_id,
         "ws_a_id": ws_a.id,
-        "canary_slug": canary_slug,
+        "reused_slug": reused_slug,
+        "expected_schema_version": 1,  # A's own version
+        "expected_token_count": 0,  # A has zero tokens
     }
 
     app.dependency_overrides.clear()
 
     try:
         await db_session.execute(
-            ResourceToken.__table__.delete().where(ResourceToken.id == token_b.id)
+            ResourceToken.__table__.delete().where(ResourceToken.id == token_b_orphan.id)
         )
+        await db_session.execute(
+            ResourceSchema.__table__.delete().where(ResourceSchema.resource_id == reused_slug)
+        )
+        await db_session.delete(ctx_a)
         await db_session.delete(ctx_b)
-        await db_session.execute(Resource.__table__.delete().where(Resource.id == resource_b.id))
+        await db_session.execute(
+            Resource.__table__.delete().where(Resource.id.in_([resource_a.id, resource_b.id]))
+        )
         await db_session.execute(
             WorkspaceMember.__table__.delete().where(
                 WorkspaceMember.workspace_id.in_([ws_a.id, ws_b.id])
@@ -497,24 +558,51 @@ async def cross_workspace_list_scenario(async_engine, db_session):
 
 @pytest.mark.asyncio
 async def test_resources_list_excludes_other_workspace_rows(cross_workspace_list_scenario):
-    """GET /api/v1/resources from owner-of-A must not include workspace B's canary.
+    """GET /api/v1/resources from owner-of-A must isolate reused-slug stats.
 
-    Status code alone (200) does not distinguish isolated from leaky on a
-    list endpoint — we must inspect the body. The canary slug lives only
-    in workspace B; workspace A's response body must not contain it.
+    This regression exercises the real CWE-639 risk on the list endpoint:
+    workspace B previously owned the slug (now soft-deleted with orphan
+    ResourceSchema v9 and orphan ResourceToken still keyed to B's
+    Resource), workspace A now owns the same slug with its own schema
+    v1 and zero tokens. If the correlated subqueries in
+    ``list_resources`` were still keyed by slug, A's row would show B's
+    orphan schema_version=9 and token_count=1. After the resource_pk
+    hardening, A's row must show A's v1 and zero tokens.
+
+    Copilot catch on PR #392 loop 10: the prior "empty response"
+    assertion was too weak — list_resources filters on
+    ``Context.workspace_id`` so an empty body was trivially guaranteed
+    even if satellite subqueries leaked.
     """
-    canary = cross_workspace_list_scenario["canary_slug"]
+    reused_slug = cross_workspace_list_scenario["reused_slug"]
+    expected_schema_version = cross_workspace_list_scenario["expected_schema_version"]
+    expected_token_count = cross_workspace_list_scenario["expected_token_count"]
 
     with TestClient(app, raise_server_exceptions=False) as client:
         response = client.get("/api/v1/resources")
 
     assert response.status_code == 200, f"Unexpected status: {response.status_code}"
     data = response.json()
-    resource_ids = [r["resource_id"] for r in data.get("resources", [])]
-    assert canary not in resource_ids, (
-        f"Cross-workspace leak: GET /api/v1/resources from owner-of-A "
-        f"returned workspace B's canary slug '{canary}'. "
-        f"Full response: {resource_ids}"
+    rows = data.get("resources", [])
+    # Workspace A should see its own row for the reused slug, with its
+    # own stats — not workspace B's orphan stats.
+    a_rows = [r for r in rows if r["resource_id"] == reused_slug]
+    assert len(a_rows) == 1, (
+        f"Expected workspace A's row for reused slug {reused_slug!r}; "
+        f"got {len(a_rows)} rows. Full response: {rows}"
+    )
+    a_row = a_rows[0]
+    assert a_row["current_schema_version"] == expected_schema_version, (
+        f"Cross-workspace leak via slug-only subquery: workspace A's list row "
+        f"shows schema_version={a_row['current_schema_version']} "
+        f"(expected A's v{expected_schema_version}). If v9 surfaces, the "
+        f"subquery is still keyed by slug and picks up B's orphan schema."
+    )
+    assert a_row["token_count"] == expected_token_count, (
+        f"Cross-workspace leak via slug-only subquery: workspace A's list row "
+        f"shows token_count={a_row['token_count']} "
+        f"(expected A's {expected_token_count}). Non-zero means B's orphan "
+        f"token is surfacing in A's stats."
     )
 
 
@@ -686,7 +774,7 @@ async def test_resource_tokens_list_excludes_other_workspace_rows(
     rows surfacing here with the canary ``resource_id`` would prove a
     cross-workspace leak.
     """
-    canary = cross_workspace_list_scenario["canary_slug"]
+    reused_slug = cross_workspace_list_scenario["reused_slug"]
 
     with TestClient(app, raise_server_exceptions=False) as client:
         response = client.get("/api/v1/resource-tokens")
@@ -694,8 +782,15 @@ async def test_resource_tokens_list_excludes_other_workspace_rows(
     assert response.status_code == 200, f"Unexpected status: {response.status_code}"
     data = response.json()
     token_resource_ids = [t["resource_id"] for t in data.get("tokens", [])]
-    assert canary not in token_resource_ids, (
+    # Workspace B's orphan token (created_by=owner_b_id, resource_pk=B's
+    # Resource) must not surface in owner-of-A's list. The REST manager
+    # filters by created_by=user_id at the query level, so an orphan
+    # created by owner_b already falls out — but the assertion still
+    # guards against a future refactor that loosens that filter without
+    # restoring workspace scoping. A non-empty match for the reused
+    # slug here would prove the leak.
+    assert reused_slug not in token_resource_ids, (
         f"Cross-workspace leak: GET /api/v1/resource-tokens from owner-of-A "
-        f"returned workspace B's canary token ({canary!r}). "
+        f"returned workspace B's orphan token for slug {reused_slug!r}. "
         f"Full response resource_ids: {token_resource_ids}"
     )

--- a/backend/tests/mcp_server/test_resource_tools.py
+++ b/backend/tests/mcp_server/test_resource_tools.py
@@ -325,9 +325,13 @@ class TestIngestEventsValidation:
         # 2) boundary check → found
         boundary_result = MagicMock()
         boundary_result.scalar_one_or_none.return_value = uuid4()
-        # 3) resource_pk lookup (PR #346): legacy state returns None
+        # 3) resource_pk lookup (Issue #390 Phase 2): returns a valid UUID
+        # so the batch is not rejected up front. Legacy None-returning
+        # state is now an error path — the prior test that asserted "works
+        # with resource_pk=None" was structurally wrong after the writer
+        # invariant landed and has been updated accordingly.
         pk_result = MagicMock()
-        pk_result.scalar_one_or_none.return_value = None
+        pk_result.scalar_one_or_none.return_value = uuid4()
         mock_db.execute.side_effect = [role_result, boundary_result, pk_result]
         mock_db.commit = AsyncMock()
         return mock_db
@@ -519,7 +523,11 @@ class TestGetResourceImpactHappyPath:
         boundary_result = MagicMock()
         boundary_result.scalar_one_or_none.return_value = uuid4()
 
-        # 2) combined stats query: row with 3 counts
+        # 2) resolve_resource_pk (Issue #390 Phase 2)
+        pk_result = MagicMock()
+        pk_result.scalar_one_or_none.return_value = uuid4()
+
+        # 3) combined stats query: row with 3 counts
         stats_row = MagicMock()
         stats_row.token_count = 2
         stats_row.memory_count = 47
@@ -527,7 +535,7 @@ class TestGetResourceImpactHappyPath:
         stats_result = MagicMock()
         stats_result.one.return_value = stats_row
 
-        mock_db.execute.side_effect = [boundary_result, stats_result]
+        mock_db.execute.side_effect = [boundary_result, pk_result, stats_result]
         mock_db.commit = AsyncMock()
 
         async def mock_get_db():
@@ -556,7 +564,11 @@ class TestGetResourceSchemaHappyPath:
         boundary_result = MagicMock()
         boundary_result.scalar_one_or_none.return_value = uuid4()
 
-        # 2) schema query: schema row
+        # 2) resolve_resource_pk (Issue #390 Phase 2)
+        pk_result = MagicMock()
+        pk_result.scalar_one_or_none.return_value = uuid4()
+
+        # 3) schema query: schema row
         schema_row = MagicMock()
         schema_row.resource_id = "res1"
         schema_row.schema_version = 4
@@ -565,7 +577,7 @@ class TestGetResourceSchemaHappyPath:
         schema_result = MagicMock()
         schema_result.scalar_one_or_none.return_value = schema_row
 
-        mock_db.execute.side_effect = [boundary_result, schema_result]
+        mock_db.execute.side_effect = [boundary_result, pk_result, schema_result]
         mock_db.commit = AsyncMock()
 
         async def mock_get_db():
@@ -672,9 +684,13 @@ class TestIngestEventsHappyPath:
         # 2) boundary check → found
         boundary_result = MagicMock()
         boundary_result.scalar_one_or_none.return_value = uuid4()
-        # 3) resource_pk lookup (PR #346): legacy state returns None
+        # 3) resource_pk lookup (Issue #390 Phase 2): returns a valid UUID
+        # so the batch is not rejected up front. Legacy None-returning
+        # state is now an error path — the prior test that asserted "works
+        # with resource_pk=None" was structurally wrong after the writer
+        # invariant landed and has been updated accordingly.
         pk_result = MagicMock()
-        pk_result.scalar_one_or_none.return_value = None
+        pk_result.scalar_one_or_none.return_value = uuid4()
         mock_db.execute.side_effect = [role_result, boundary_result, pk_result]
 
         # Capture the added event so we can assign an id before flush returns
@@ -748,7 +764,8 @@ class TestSetupResourceHappyPath:
         # 1) role check → owner
         # 2) resource_id duplicate check → none
         # 3) workspace plan_name lookup → "pro"
-        # 4) active token count → 0
+        # 4) upsert_resource: resolve_resource_pk → existing uuid (Issue #390 Phase 2)
+        # 5) active token count → 0
         role_result = MagicMock()
         owner = MagicMock()
         owner.role = "owner"
@@ -760,6 +777,9 @@ class TestSetupResourceHappyPath:
         plan_result = MagicMock()
         plan_result.scalar_one_or_none.return_value = "pro"
 
+        resource_pk_result = MagicMock()
+        resource_pk_result.scalar_one_or_none.return_value = uuid4()
+
         token_count_result = MagicMock()
         token_count_result.scalar.return_value = 0
 
@@ -767,6 +787,7 @@ class TestSetupResourceHappyPath:
             role_result,
             resource_dup_result,
             plan_result,
+            resource_pk_result,
             token_count_result,
         ]
 

--- a/backend/tests/services/test_workspace_service_member_removal.py
+++ b/backend/tests/services/test_workspace_service_member_removal.py
@@ -131,9 +131,26 @@ async def test_remove_member_comprehensive_cleanup(db_session):
         db_session.add(memory)
 
     # 3d. Resource token created by member (resource_id matches context_by_member.resource_id
-    # so cleanup_member_resource_tokens can find and transfer it via Context.resource_id)
-    resource_token = ResourceToken(
+    # so cleanup_member_resource_tokens can find and transfer it via Context.resource_id).
+    # Issue #390 Phase 2: ResourceToken requires resource_pk — create a
+    # backing Resource entity row first so the before_insert invariant
+    # listener passes.
+    from models.resource import Resource
+
+    member_resource = Resource(
+        id=uuid4(),
+        workspace_id=workspace.id,
         resource_id=member_resource_id,
+        name="member-test-resource",
+        created_by=member_id,
+    )
+    db_session.add(member_resource)
+    await db_session.flush()
+
+    resource_token = ResourceToken(
+        resource_pk=member_resource.id,
+        resource_id=member_resource_id,
+        workspace_id=workspace.id,
         token_hash="test_hash_123",
         created_by=member_id,
         description="Test token",


### PR DESCRIPTION
Closes #390

## Summary

- v0.12.3 Phase A — Writer migration + read-path hardening for the CWE-639 cross-workspace slug-reuse leak on `resource_*` satellite tables.
- Complements #389 (owner-only hotfix, closed 90% of blast radius) by making `resource_pk` (UUID FK) load-bearing on every write + read path.
- Adds SQLAlchemy `before_insert` event listener enforcing the writer invariant at the ORM layer.
- Alembic migration `b01_resource_pk_writer_phase2` runs a cross-workspace ambiguity audit before backfilling orphan rows.

## Implementation notes

- **New chokepoint**: `backend/src/services/resource_lookup.py` — `resolve_resource_pk`, `upsert_resource` (savepoint-safe), `get_latest_schema`. Every writer + reader routes through this helper.
- **Writer invariant**: event listener on `ResourceEvent`, `ResourceSchema`, `IndexerState`, `ResourceToken` raises `IntegrityError` when `resource_id` is set without `resource_pk`. PostgreSQL `CHECK` deferred to Phase C (#325) to preserve the 1-week prod observation window.
- **Writers migrated**: `create_schema`, `ResourceTokenManager.create_token` (kw-only `resource_pk` + `workspace_id`), `handle_setup_resource` (now upserts Resource entity), `_get_or_create_state`, `handle_ingest_events`.
- **Read paths hardened across 16 sites**: `resource_schema.py` (3), `resources.py` list (correlated subqueries rewritten as JOIN on Resource), `public_search.py` (2, via shared `get_latest_schema` helper), `resource_indexer.py` helpers (3), `mcp_server/tools/resource.py` (4 handlers).
- **b01 migration**: ambiguity audit aborts on the soft-delete+slug-reuse shape; backfill uses Context→Resource JOIN for `indexer_state` (workspace-safe) and direct `resources` JOIN for the 3 non-context satellites (safe post-audit).
- **Regression tests**: 8 writer invariant tests (`test_resource_pk_invariant.py`), 3 new integration tests (`test_slug_reuse_after_soft_delete_isolates_orphans`, list body-inspection for `/resources` and `/resource-tokens`). 745 unit tests + 8 invariant pass.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green (after scope addendum) via /ask routed to CSO + /qa-lead enrichment
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/390-fix-fix-security-close-cwe-639-on-resource-s.gate1.md`
- `~/.claude/cache/gh-issue-driven/390-fix-fix-security-close-cwe-639-on-resource-s.gate2.md`

## Non-goals (explicit — Phase C / #325)

- NOT NULL tightening on `resource_pk` (4 tables)
- Partial UNIQUE → full UNIQUE promotion
- PostgreSQL CHECK constraint on `resource_pk IS NOT NULL`
- `resource_tokens.workspace_id` NOT NULL
- Forensics logging on cross-tenant denial attempts

## Test plan

- [x] `make test-local` — 745 unit tests pass
- [x] `tests/db/test_resource_pk_invariant.py` — 8 tests pin event listener
- [x] `tests/integration/test_resource_cross_workspace.py` — existing + slug-reuse + list body-inspection
- [ ] Manual: run `make migrate` against staging DB to verify b01 audit no-ops on production data (solo-user, expected zero orphans)
- [ ] Manual: post-deploy observe `SELECT COUNT(*) FROM resource_events WHERE resource_pk IS NULL` for 1 week before Phase C tightening

🤖 Generated via /gh-issue-driven:ship
