### PR TITLE
fix(frontend): prevent sidebar context warning icon flash on reload

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -229,22 +229,32 @@ export function Sidebar() {
   const router = useRouter();
   const { user, logout } = useAuth();
 
-  // Load context count on mount
+  // Load context count on mount / workspace switch.
+  // Reset to null on each run so the warning icon does not show a stale
+  // "0 contexts" value from the previous workspace while the new fetch is
+  // in flight. Cancellation guard prevents a late fetch from clobbering a
+  // newer workspace's state (same pattern as hasExternalKeys below).
   useEffect(() => {
-    if (currentWorkspaceId) {
-      getContexts()
-        .then((data) => {
-          setContextCount(data.contexts.length);
-        })
-        .catch((error) => {
-          if (process.env.NODE_ENV === "development") {
-            console.error("Failed to load context count for sidebar:", error);
-          }
-          setContextCount(null);
-          // Note: Error not shown in UI to keep sidebar clean
-          // Users can see detailed error on /workspace/contexts page
-        });
-    }
+    setContextCount(null);
+    if (!currentWorkspaceId) return;
+
+    let cancelled = false;
+    getContexts()
+      .then((data) => {
+        if (!cancelled) setContextCount(data.contexts.length);
+      })
+      .catch((error) => {
+        if (process.env.NODE_ENV === "development") {
+          console.error("Failed to load context count for sidebar:", error);
+        }
+        if (!cancelled) setContextCount(null);
+        // Note: Error not shown in UI to keep sidebar clean
+        // Users can see detailed error on /workspace/contexts page
+      });
+
+    return () => {
+      cancelled = true;
+    };
   }, [currentWorkspaceId]);
 
   // Load external key status (with race condition guard).

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -605,7 +605,6 @@ export function Sidebar() {
                       >
                         <Icon className="h-5 w-5 flex-shrink-0" />
                         <span className="flex-1">{itemName}</span>
-                        {/* Show warning if contexts menu and no contexts or load error */}
                         {item.nameKey === "externalKeys" &&
                           hasExternalKeys === false && (
                             <span
@@ -621,25 +620,15 @@ export function Sidebar() {
                               />
                             </span>
                           )}
-                        {item.nameKey === "contexts" &&
-                          (contextCount === 0 || contextCount === null) && (
-                            <span
-                              title={
-                                contextCount === null
-                                  ? "Failed to load contexts"
-                                  : "No contexts found"
-                              }
-                            >
-                              <AlertTriangle
-                                className="h-4 w-4 text-yellow-500 flex-shrink-0"
-                                aria-label={
-                                  contextCount === null
-                                    ? "Failed to load contexts"
-                                    : "No contexts found"
-                                }
-                              />
-                            </span>
-                          )}
+                        {/* null = loading-or-error (stay quiet; errors surface on /workspace/contexts) */}
+                        {item.nameKey === "contexts" && contextCount === 0 && (
+                          <span title={t("noContexts")}>
+                            <AlertTriangle
+                              className="h-4 w-4 text-yellow-500 flex-shrink-0"
+                              aria-label={t("noContexts")}
+                            />
+                          </span>
+                        )}
                       </Link>
                     );
                   })}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -55,6 +55,7 @@
     "resourceTokens": "Resource Tokens",
     "externalKeys": "External Keys",
     "noExternalKeys": "No API keys configured — add OpenAI key to enable memory features",
+    "noContexts": "No contexts found",
     "settings": "Settings",
     "workspaceSettings": "Workspace",
     "admin": "Admin",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -55,6 +55,7 @@
     "resourceTokens": "リソーストークン",
     "externalKeys": "外部APIキー",
     "noExternalKeys": "APIキー未設定 — OpenAIキーを追加してメモリ機能を有効化",
+    "noContexts": "コンテキストがありません",
     "settings": "設定",
     "workspaceSettings": "ワークスペース",
     "admin": "管理",


### PR DESCRIPTION
## Summary
- Sidebar の contexts 警告アイコン (AlertTriangle) がページリロード時に一瞬表示されるフラッシュを修正
- 原因: `contextCount` 初期値 `null` が「ロード中」と「エラー」の両用で、条件 `contextCount === 0 || contextCount === null` が初回レンダリングで必ず一致していた
- 修正: `contextCount === 0`(確定 empty)のみで表示。null (loading/error) は静かに出さない — `Sidebar.tsx:244-245` の既存コメント「errors surface on /workspace/contexts」方針と整合
- i18n: `sidebar.noContexts` を en/ja に追加してハードコード文字列を解消

## Behavior change
- **Before**: リロード毎に警告アイコンが一瞬ちらっと見える。context 取得失敗時にも警告アイコン(title=Failed to load contexts)が出ていた
- **After**: 取得完了後 contexts=0 のときだけ警告表示。取得失敗はサイドバーには出ず `/workspace/contexts` ページで確認する運用

## Test plan
- [ ] `/workspace/dashboard` をリロードしてサイドバー contexts 行にアイコンフラッシュが出ないこと(contexts >0 のワークスペースで)
- [ ] contexts=0 のワークスペースではリロード後に AlertTriangle が表示されること
- [ ] ja ロケールで tooltip が「コンテキストがありません」に、en ロケールで「No contexts found」になること

🤖 Generated with [Claude Code](https://claude.com/claude-code)