### PR TITLE
fix(backend): graph reads honor Context.is_private (#383)

### DIFF
--- a/backend/alembic/versions/b02_383_graph_edges_composite_indexes.py
+++ b/backend/alembic/versions/b02_383_graph_edges_composite_indexes.py
@@ -16,6 +16,18 @@ admin paths (decay, consolidation) that filter by ``user_id``. A follow-up
 migration may remove them once production query plans confirm they are
 unused.
 
+ZERO-DOWNTIME INDEX BUILDS
+--------------------------
+``neural_memory_edges`` is a high-write table (every new memory + sleep
+consolidation cycle inserts rows). A plain transactional ``op.create_index``
+would take ``ACCESS EXCLUSIVE`` on the table for the duration of the build,
+blocking writes. This migration follows the same zero-downtime pattern
+a96/a97 established: ``autocommit_block`` + ``CREATE INDEX CONCURRENTLY
+IF NOT EXISTS`` so writes continue through the build, plus invalid-index
+guards on retry after a mid-build failure.
+
+Downgrade mirrors the pattern with ``DROP INDEX CONCURRENTLY IF EXISTS``.
+
 Revision ID: b02_383_edges_ws_ctx_idx
 Revises: b01_resource_pk_ph2
 Create Date: 2026-04-20
@@ -23,6 +35,7 @@ Create Date: 2026-04-20
 
 from collections.abc import Sequence
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -32,23 +45,53 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+_CONCURRENT_INDEXES: tuple[tuple[str, str], ...] = (
+    ("idx_edges_ws_ctx_src", "neural_memory_edges (workspace_id, context_id, src_id)"),
+    ("idx_edges_ws_ctx_dst", "neural_memory_edges (workspace_id, context_id, dst_id)"),
+)
+
+
+def _invalid_concurrent_indexes(name_iter: Sequence[str]) -> set[str]:
+    """Return concurrent indexes from ``name_iter`` that exist in an INVALID state.
+
+    A mid-build failure of ``CREATE INDEX CONCURRENTLY`` leaves the index row
+    in ``pg_index`` with ``indisvalid = false``. Re-running ``CREATE INDEX
+    CONCURRENTLY IF NOT EXISTS`` would skip (the name exists) without retrying,
+    leaving the cluster permanently without a usable index. This helper
+    enumerates names that need to be dropped first so the retry rebuilds cleanly.
+    """
+    bind = op.get_bind()
+    rows = bind.execute(
+        sa.text(
+            "SELECT c.relname "
+            "FROM pg_class c JOIN pg_index i ON c.oid = i.indexrelid "
+            "WHERE c.relname = ANY(:names) AND i.indisvalid IS FALSE"
+        ),
+        {"names": list(name_iter)},
+    ).fetchall()
+    return {row[0] for row in rows}
+
+
 def upgrade() -> None:
-    """Create composite indexes for the new shared-context graph read path."""
-    op.create_index(
-        "idx_edges_ws_ctx_src",
-        "neural_memory_edges",
-        ["workspace_id", "context_id", "src_id"],
-        unique=False,
-    )
-    op.create_index(
-        "idx_edges_ws_ctx_dst",
-        "neural_memory_edges",
-        ["workspace_id", "context_id", "dst_id"],
-        unique=False,
-    )
+    """Create composite indexes concurrently for the new shared-context graph read path."""
+    names = [name for name, _ in _CONCURRENT_INDEXES]
+    invalid = _invalid_concurrent_indexes(names)
+
+    with op.get_context().autocommit_block():
+        # Drop any INVALID leftovers from a prior failed attempt before the
+        # IF NOT EXISTS rebuild (IF NOT EXISTS alone would skip the rebuild).
+        for name in names:
+            if name in invalid:
+                op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {name}"))
+
+        for name, table_and_cols in _CONCURRENT_INDEXES:
+            op.execute(
+                sa.text(f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {name} ON {table_and_cols}")
+            )
 
 
 def downgrade() -> None:
-    """Drop the composite indexes added in ``upgrade``."""
-    op.drop_index("idx_edges_ws_ctx_dst", table_name="neural_memory_edges")
-    op.drop_index("idx_edges_ws_ctx_src", table_name="neural_memory_edges")
+    """Drop the composite indexes concurrently, mirroring the upgrade pattern."""
+    with op.get_context().autocommit_block():
+        for name, _ in _CONCURRENT_INDEXES:
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {name}"))

--- a/backend/alembic/versions/b02_383_graph_edges_composite_indexes.py
+++ b/backend/alembic/versions/b02_383_graph_edges_composite_indexes.py
@@ -1,0 +1,54 @@
+"""Add (workspace_id, context_id) composite indexes on neural_memory_edges (#383).
+
+Issue #383: graph reads move from ``user_id == caller`` hardcoded filter to
+``PermissionService``-driven visibility. The new primary access pattern is
+``WHERE workspace_id = :ws AND context_id = :ctx (AND src_id|dst_id = :node)``
+— the existing ``idx_edges_user_src`` / ``idx_edges_user_dst`` composite
+indexes are ``user_id``-leading and therefore inert for shared-context reads
+under PostgreSQL's leftmost-prefix rule.
+
+This migration adds two composite indexes matching the new access pattern:
+``(workspace_id, context_id, src_id)`` and ``(workspace_id, context_id, dst_id)``.
+
+Old indexes are intentionally **retained** in this revision — they still
+serve the private-context read path (caller-scoped edges) and internal
+admin paths (decay, consolidation) that filter by ``user_id``. A follow-up
+migration may remove them once production query plans confirm they are
+unused.
+
+Revision ID: b02_383_edges_ws_ctx_idx
+Revises: b01_resource_pk_ph2
+Create Date: 2026-04-20
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b02_383_edges_ws_ctx_idx"
+down_revision: str | Sequence[str] | None = "b01_resource_pk_ph2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create composite indexes for the new shared-context graph read path."""
+    op.create_index(
+        "idx_edges_ws_ctx_src",
+        "neural_memory_edges",
+        ["workspace_id", "context_id", "src_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_edges_ws_ctx_dst",
+        "neural_memory_edges",
+        ["workspace_id", "context_id", "dst_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop the composite indexes added in ``upgrade``."""
+    op.drop_index("idx_edges_ws_ctx_dst", table_name="neural_memory_edges")
+    op.drop_index("idx_edges_ws_ctx_src", table_name="neural_memory_edges")

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -93,47 +93,85 @@ async def get_graph_stats(
     db: AsyncSession = Depends(get_db),
     context_service: ContextService = Depends(lambda db=Depends(get_db): ContextService(db)),
 ):
-    """Get Neural Memory graph statistics for specified or current context.
+    """Get Neural Memory graph statistics for specified context.
 
-    Issue #82: Now context-scoped - returns graph stats for specified or current context.
+    Issue #82: Context-scoped stats.
+    Issue #383: Authorization is delegated to ``PermissionService``. Previously
+    this endpoint hard-filtered by ``user_id == caller``, hiding shared-context
+    memories authored by other workspace members. Now:
+
+        - Shared context (``is_private = false``): any workspace member sees
+          the full graph for the context.
+        - Private context (``is_private = true``): only the creator of each
+          edge/memory sees their own subgraph.
+        - Cross-workspace probes surface as 404 (CWE-639 / OWASP A01 uniform
+          disclosure) rather than 403 to avoid existence leakage.
 
     Args:
-        context_id: Optional context ID (defaults to current context)
+        context_id: Optional context ID. When absent, returns an empty graph
+            (no scope = no visible edges).
 
     Returns:
         Graph statistics including node/edge counts, top connections, etc.
-
-    Raises:
-        HTTPException: 404 if graph not found
     """
     try:
         user_id = user["user_id"]
-        # Issue #246: current_context_id removed - use provided context_id or None
-        target_context_id = context_id if context_id else None
 
-        # Single Collection Migration: Graph uses workspace_id/context_id for filtering
-        # Get context for workspace_id resolution if context_id provided
-        workspace_id = None
-        str_context_id = None
-        if target_context_id:
-            context_result = await db.execute(
-                select(Context).where(Context.id == target_context_id)
+        # Without context scope there is no visible graph (Issue #383).
+        if not context_id:
+            return GraphStatsResponse(
+                user_id=user_id,
+                stats=GraphStats(
+                    total_nodes=0,
+                    total_edges=0,
+                    avg_edge_weight=0.0,
+                    max_edge_weight=0.0,
+                    min_edge_weight=0.0,
+                    density=0.0,
+                    top_connections=[],
+                    recent_edges=[],
+                ),
+                last_updated=utcnow().isoformat(),
             )
-            context = context_result.scalar_one_or_none()
-            if context:
-                workspace_id = str(context.workspace_id)
-                str_context_id = str(context.id)
+
+        # Resolve context → workspace + privacy. Unified 404 on miss/forbidden.
+        context_result = await db.execute(select(Context).where(Context.id == context_id))
+        context = context_result.scalar_one_or_none()
+        if not context:
+            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+
+        from services.permission_service import PermissionService
+
+        perm_service = PermissionService(db)
+        try:
+            await perm_service.check_workspace_access(
+                user_id=user_id,
+                workspace_id=context.workspace_id,
+                required_role="member",
+            )
+        except HTTPException:
+            # CWE-639 uniform disclosure: cross-workspace probes look identical
+            # to non-existent contexts. Do NOT reveal workspace membership state.
+            raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
+
+        workspace_id = str(context.workspace_id)
+        str_context_id = str(context.id)
+
+        # Issue #383: visibility-aware creator filter.
+        # - private context: only the caller's own edges are visible
+        # - shared context: all workspace members' edges are visible (no filter)
+        owner_filter = user_id if context.is_private else None
 
         # SQL backend: edges are in neural_memory_edges table (Issue #84)
         graph_service = GraphService(
             user_id, db, workspace_id=workspace_id, context_id=str_context_id
         )
-        # Get basic stats with 3-level isolation
-        stats = await graph_service.stats()
+        # Get basic stats with 3-level isolation (Issue #383 visibility filter)
+        stats = await graph_service.stats(owner_filter=owner_filter)
 
-        # Get top connected nodes (by degree) - SQL backend with isolation
+        # Get top connected nodes (by degree) - SQL backend with isolation (#383)
         top_nodes_data = await graph_service.edge_repo.get_top_connected_nodes(
-            user_id,
+            user_id=owner_filter,
             limit=10,
             workspace_id=workspace_id,
             context_id=str_context_id,
@@ -213,22 +251,40 @@ async def get_graph_data(
     try:
         user_id = user["user_id"]
 
-        # Resolve workspace_id from context (required)
+        # Resolve context → workspace + privacy. Unified 404 on miss/forbidden.
         context_result = await db.execute(select(Context).where(Context.id == context_id))
         context = context_result.scalar_one_or_none()
         if not context:
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+
+        from services.permission_service import PermissionService
+
+        perm_service = PermissionService(db)
+        try:
+            await perm_service.check_workspace_access(
+                user_id=user_id,
+                workspace_id=context.workspace_id,
+                required_role="member",
+            )
+        except HTTPException:
+            # CWE-639 uniform disclosure (Issue #383): cross-workspace probes
+            # surface as 404, not 403, to avoid leaking workspace membership.
+            raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
+
         workspace_id = str(context.workspace_id)
         str_context_id = str(context.id)
+
+        # Issue #383: visibility-aware creator filter.
+        owner_filter = user_id if context.is_private else None
 
         # SQL backend: Load graph (Issue #84)
         graph_service = GraphService(
             user_id, db, workspace_id=workspace_id, context_id=str_context_id
         )
 
-        # Get all edges with 3-level isolation
+        # Get all edges with 3-level isolation (Issue #383 visibility filter)
         all_edges = await graph_service.edge_repo.get_all_edges(
-            user_id,
+            user_id=owner_filter,
             min_weight=min_weight,
             workspace_id=workspace_id,
             context_id=str_context_id,
@@ -263,7 +319,7 @@ async def get_graph_data(
             node_scores.append((node_id_str, score, degree, memory))
 
         if not node_scores:
-            stats = await graph_service.stats()
+            stats = await graph_service.stats(owner_filter=owner_filter)
             return GraphDataResponse(
                 nodes=[],
                 edges=[],
@@ -313,8 +369,8 @@ async def get_graph_data(
                     )
                 )
 
-        # Get statistics
-        graph_stats = await graph_service.stats()
+        # Get statistics (Issue #383 visibility filter)
+        graph_stats = await graph_service.stats(owner_filter=owner_filter)
         stats = {
             "total_nodes": graph_stats["total_nodes"],
             "total_edges": graph_stats["total_edges"],

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -13,10 +13,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import SessionUser
 from db.base import get_db
-from models.auth import Context
 from models.memory import Memory
 from services.context_service import ContextService
 from services.graph_service import GraphService
+from services.permission_service import PermissionService
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -134,42 +134,18 @@ async def get_graph_stats(
                 last_updated=utcnow().isoformat(),
             )
 
-        # Resolve context → workspace + privacy. Unified 404 on miss/forbidden.
-        context_result = await db.execute(select(Context).where(Context.id == context_id))
-        context = context_result.scalar_one_or_none()
-        if not context:
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
-
-        from services.permission_service import PermissionService
-
-        perm_service = PermissionService(db)
-        try:
-            await perm_service.check_workspace_access(
-                user_id=user_id,
-                workspace_id=context.workspace_id,
-                required_role="member",
-            )
-        except HTTPException:
-            # CWE-639 uniform disclosure: cross-workspace probes look identical
-            # to non-existent contexts. Do NOT reveal workspace membership state.
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
-
+        context = await PermissionService(db).resolve_context_for_workspace_read(
+            user_id=user_id, context_id=context_id
+        )
         workspace_id = str(context.workspace_id)
         str_context_id = str(context.id)
-
-        # Issue #383: visibility-aware creator filter.
-        # - private context: only the caller's own edges are visible
-        # - shared context: all workspace members' edges are visible (no filter)
         owner_filter = user_id if context.is_private else None
 
-        # SQL backend: edges are in neural_memory_edges table (Issue #84)
         graph_service = GraphService(
             user_id, db, workspace_id=workspace_id, context_id=str_context_id
         )
-        # Get basic stats with 3-level isolation (Issue #383 visibility filter)
         stats = await graph_service.stats(owner_filter=owner_filter)
 
-        # Get top connected nodes (by degree) - SQL backend with isolation (#383)
         top_nodes_data = await graph_service.edge_repo.get_top_connected_nodes(
             user_id=owner_filter,
             limit=10,
@@ -178,9 +154,6 @@ async def get_graph_stats(
         )
 
         # Fetch memory summaries for top nodes
-
-        from models.memory import Memory
-
         top_node_ids = [node_id for node_id, _ in top_nodes_data]
         memories_result = await db.execute(select(Memory).where(Memory.id.in_(top_node_ids)))
         memories_map = {str(m.id): m for m in memories_result.scalars().all()}
@@ -251,38 +224,17 @@ async def get_graph_data(
     try:
         user_id = user["user_id"]
 
-        # Resolve context → workspace + privacy. Unified 404 on miss/forbidden.
-        context_result = await db.execute(select(Context).where(Context.id == context_id))
-        context = context_result.scalar_one_or_none()
-        if not context:
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
-
-        from services.permission_service import PermissionService
-
-        perm_service = PermissionService(db)
-        try:
-            await perm_service.check_workspace_access(
-                user_id=user_id,
-                workspace_id=context.workspace_id,
-                required_role="member",
-            )
-        except HTTPException:
-            # CWE-639 uniform disclosure (Issue #383): cross-workspace probes
-            # surface as 404, not 403, to avoid leaking workspace membership.
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
-
+        context = await PermissionService(db).resolve_context_for_workspace_read(
+            user_id=user_id, context_id=context_id
+        )
         workspace_id = str(context.workspace_id)
         str_context_id = str(context.id)
-
-        # Issue #383: visibility-aware creator filter.
         owner_filter = user_id if context.is_private else None
 
-        # SQL backend: Load graph (Issue #84)
         graph_service = GraphService(
             user_id, db, workspace_id=workspace_id, context_id=str_context_id
         )
 
-        # Get all edges with 3-level isolation (Issue #383 visibility filter)
         all_edges = await graph_service.edge_repo.get_all_edges(
             user_id=owner_filter,
             min_weight=min_weight,
@@ -319,13 +271,12 @@ async def get_graph_data(
             node_scores.append((node_id_str, score, degree, memory))
 
         if not node_scores:
-            stats = await graph_service.stats(owner_filter=owner_filter)
             return GraphDataResponse(
                 nodes=[],
                 edges=[],
                 stats={
-                    "total_nodes": stats["total_nodes"],
-                    "total_edges": stats["total_edges"],
+                    "total_nodes": len(all_node_ids),
+                    "total_edges": len(all_edges),
                     "filtered_nodes": 0,
                     "filtered_edges": 0,
                 },
@@ -369,11 +320,12 @@ async def get_graph_data(
                     )
                 )
 
-        # Get statistics (Issue #383 visibility filter)
-        graph_stats = await graph_service.stats(owner_filter=owner_filter)
+        # total_nodes/total_edges are derived from ``all_edges`` already loaded
+        # above — a second ``stats()`` call would re-run 3 queries for data we
+        # already have. filtered_* reflect the post-limit/post-memory_types cut.
         stats = {
-            "total_nodes": graph_stats["total_nodes"],
-            "total_edges": graph_stats["total_edges"],
+            "total_nodes": len(all_node_ids),
+            "total_edges": len(all_edges),
             "filtered_nodes": len(nodes),
             "filtered_edges": len(edges),
         }

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -102,10 +102,15 @@ async def get_graph_stats(
 
         - Shared context (``is_private = false``): any workspace member sees
           the full graph for the context.
-        - Private context (``is_private = true``): only the creator of each
-          edge/memory sees their own subgraph.
-        - Cross-workspace probes surface as 404 (CWE-639 / OWASP A01 uniform
-          disclosure) rather than 403 to avoid existence leakage.
+        - Private context (``is_private = true``): only the private-context
+          creator can access the graph for that context. Non-creators are
+          denied at the context level by ``resolve_context_for_workspace_read``
+          and surface as 404 (same uniform disclosure as cross-workspace
+          probes), matching ``can_access_memory`` / ``check_context_access``
+          semantics across the rest of the API.
+        - Cross-workspace probes and private-context access by non-creators
+          both surface as 404 (CWE-639 / OWASP A01 uniform disclosure)
+          rather than 403 to avoid existence leakage.
 
     Args:
         context_id: Optional context ID. When absent, returns an empty graph

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -301,12 +301,21 @@ async def get_graph_data(
             node_scores.append((node_id_str, score, degree, memory))
 
         if not node_scores:
+            # Same post-Memory-scope stats as the main path below — counting
+            # edges that reference out-of-scope/deleted memories would report
+            # "edges exist" when nothing is actually renderable.
+            visible_node_ids = set(memories_map.keys())
+            visible_edges = [
+                edge
+                for edge in all_edges
+                if str(edge.src_id) in visible_node_ids and str(edge.dst_id) in visible_node_ids
+            ]
             return GraphDataResponse(
                 nodes=[],
                 edges=[],
                 stats={
-                    "total_nodes": len(all_node_ids),
-                    "total_edges": len(all_edges),
+                    "total_nodes": len(visible_node_ids),
+                    "total_edges": len(visible_edges),
                     "filtered_nodes": 0,
                     "filtered_edges": 0,
                 },

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -103,14 +103,17 @@ async def get_graph_stats(
         - Shared context (``is_private = false``): any workspace member sees
           the full graph for the context.
         - Private context (``is_private = true``): only the private-context
-          creator can access the graph for that context. Non-creators are
-          denied at the context level by ``resolve_context_for_workspace_read``
-          and surface as 404 (same uniform disclosure as cross-workspace
-          probes), matching ``can_access_memory`` / ``check_context_access``
-          semantics across the rest of the API.
+          creator can access the graph for that context. The creator-only
+          rule matches ``can_access_memory`` (returns ``False`` for
+          non-creators) and ``check_context_access`` (raises 403 for
+          non-creators). This endpoint deliberately **remaps that denial
+          to 404**, unifying with the cross-workspace-probe shape so
+          neither path leaks existence — an intentional divergence from
+          ``check_context_access``'s 403 status code, not from its
+          authorization semantics.
         - Cross-workspace probes and private-context access by non-creators
           both surface as 404 (CWE-639 / OWASP A01 uniform disclosure)
-          rather than 403 to avoid existence leakage.
+          to avoid existence leakage.
 
     Args:
         context_id: Optional context ID. When absent, returns an empty graph
@@ -347,12 +350,22 @@ async def get_graph_data(
                     )
                 )
 
-        # total_nodes/total_edges are derived from ``all_edges`` already loaded
-        # above — a second ``stats()`` call would re-run 3 queries for data we
-        # already have. filtered_* reflect the post-limit/post-memory_types cut.
+        # Base totals on the post-Memory-scope set so they stay consistent
+        # with what the UI can actually render. A stale edge whose src/dst
+        # Memory has been soft-deleted or has drifted out of the resolved
+        # (workspace_id, context_id) scope is counted in ``all_edges`` but
+        # cannot be rendered — including it in ``total_edges`` would produce
+        # a "10 edges, 0 rendered" mismatch that confuses the viewer.
+        visible_node_ids = set(memories_map.keys())
+        visible_edges = [
+            edge
+            for edge in all_edges
+            if str(edge.src_id) in visible_node_ids and str(edge.dst_id) in visible_node_ids
+        ]
+        # total_* = post-Memory-scope; filtered_* = post-limit/post-memory_types cut.
         stats = {
-            "total_nodes": len(all_node_ids),
-            "total_edges": len(all_edges),
+            "total_nodes": len(visible_node_ids),
+            "total_edges": len(visible_edges),
             "filtered_nodes": len(nodes),
             "filtered_edges": len(edges),
         }

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -14,7 +14,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import SessionUser
 from db.base import get_db
 from models.memory import Memory
-from services.context_service import ContextService
 from services.graph_service import GraphService
 from services.permission_service import PermissionService
 from utils.datetime import utcnow
@@ -88,10 +87,11 @@ class GraphDataResponse(BaseModel):
 async def get_graph_stats(
     user: SessionUser,
     context_id: UUID | None = Query(
-        None, description="Optional context ID (defaults to current context)"
+        None,
+        description="Optional context ID. When absent, returns an empty graph "
+        "(no scope = no visible edges) per Issue #383.",
     ),
     db: AsyncSession = Depends(get_db),
-    context_service: ContextService = Depends(lambda db=Depends(get_db): ContextService(db)),
 ):
     """Get Neural Memory graph statistics for specified context.
 
@@ -153,9 +153,21 @@ async def get_graph_stats(
             context_id=str_context_id,
         )
 
-        # Fetch memory summaries for top nodes
+        # Fetch memory summaries for top nodes.
+        # Defense in depth against a stale/corrupt edge row that references a
+        # Memory outside the resolved (workspace_id, context_id): re-scope the
+        # Memory lookup itself so cross-context metadata cannot leak via summaries
+        # even if the edge invariant is violated. Follow-up AC 6 enforces the
+        # invariant at write time; this keeps the read path safe in the meantime.
         top_node_ids = [node_id for node_id, _ in top_nodes_data]
-        memories_result = await db.execute(select(Memory).where(Memory.id.in_(top_node_ids)))
+        memories_result = await db.execute(
+            select(Memory).where(
+                Memory.id.in_(top_node_ids),
+                Memory.workspace_id == context.workspace_id,
+                Memory.context_id == context.id,
+                Memory.deleted_at.is_(None),
+            )
+        )
         memories_map = {str(m.id): m for m in memories_result.scalars().all()}
 
         top_connections = []
@@ -248,8 +260,18 @@ async def get_graph_data(
             all_node_ids.add(edge.src_id)
             all_node_ids.add(edge.dst_id)
 
-        # Fetch memories for all nodes
-        memories_result = await db.execute(select(Memory).where(Memory.id.in_(list(all_node_ids))))
+        # Fetch memories for all nodes — scoped to (workspace_id, context_id)
+        # for the same defense-in-depth reason as /graph/stats: prevents stale
+        # or invariant-violating edge rows from leaking cross-context memory
+        # metadata even before AC 6 (edge invariant) enforcement lands.
+        memories_result = await db.execute(
+            select(Memory).where(
+                Memory.id.in_(list(all_node_ids)),
+                Memory.workspace_id == context.workspace_id,
+                Memory.context_id == context.id,
+                Memory.deleted_at.is_(None),
+            )
+        )
         memories_map = {str(m.id): m for m in memories_result.scalars().all()}
 
         # Calculate node degrees from edges

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -320,6 +320,12 @@ class NeuralMemoryEdge(Base):
         ),
         Index("idx_edges_user_src", "user_id", "src_id"),
         Index("idx_edges_user_dst", "user_id", "dst_id"),
+        # Issue #383: composite indexes matching the new PermissionService-driven
+        # graph read path. ``(workspace_id, context_id)``-leading, so leftmost-
+        # prefix matches ``WHERE workspace_id = :ws AND context_id = :ctx`` for
+        # shared-context visualization without relying on ``user_id``.
+        Index("idx_edges_ws_ctx_src", "workspace_id", "context_id", "src_id"),
+        Index("idx_edges_ws_ctx_dst", "workspace_id", "context_id", "dst_id"),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -770,7 +770,18 @@ class NeuralEdgeRepository:
 
         Returns:
             List of (node_id, total_degree) tuples sorted by degree descending
+
+        Raises:
+            ValueError: If workspace_id or context_id is None (Issue #273 H-2).
+                Mirrors the guard on sibling read methods so ``user_id=None``
+                cannot devolve into an unscoped full-table aggregation
+                (Copilot catch on PR #394 loop 2).
         """
+        # Issue #273 H-2 / Issue #383: Enforce workspace_id/context_id even when
+        # user_id is None (shared-context mode) — without both, the shared mode
+        # would aggregate across tenants.
+        self._validate_isolation_params(workspace_id, context_id)
+
         # Build filter conditions
         conditions: list = []
         if user_id is not None:

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -435,23 +435,29 @@ class NeuralEdgeRepository:
 
     async def get_all_edges(
         self,
-        user_id: str,
+        user_id: str | None = None,
         min_weight: float = 0.0,
         workspace_id: str | None = None,
         context_id: str | None = None,
     ) -> list[NeuralMemoryEdge]:
-        """Get all edges for a user with 3-level isolation.
+        """Get all edges in a context with 3-level isolation.
 
         Single Collection Migration: Added workspace_id and context_id filtering.
+        Issue #383: ``user_id`` is now optional — when ``None``, all edges in the
+        workspace+context are returned regardless of creator (shared context
+        mode). When set, results are restricted to that creator (private context
+        mode or creator-scoped admin paths).
 
         Args:
-            user_id: User identifier
+            user_id: Optional creator filter. ``None`` returns all edges in
+                the workspace+context (use for shared-context reads where
+                authorization is enforced upstream).
             min_weight: Minimum edge weight threshold
             workspace_id: Workspace ID (for isolation)
             context_id: Context ID (for isolation)
 
         Returns:
-            List of all edges (context-filtered)
+            List of edges in the context that pass the creator filter.
 
         Raises:
             ValueError: If workspace_id or context_id is None (Issue #273 H-2)
@@ -459,10 +465,9 @@ class NeuralEdgeRepository:
         # Issue #273 H-2: Enforce workspace_id/context_id for 3-level isolation
         self._validate_isolation_params(workspace_id, context_id)
 
-        conditions = [
-            NeuralMemoryEdge.user_id == user_id,
-            NeuralMemoryEdge.weight >= min_weight,
-        ]
+        conditions = [NeuralMemoryEdge.weight >= min_weight]
+        if user_id is not None:
+            conditions.append(NeuralMemoryEdge.user_id == user_id)
 
         # Single Collection Migration: Use workspace_id/context_id for filtering
         if workspace_id:
@@ -632,16 +637,20 @@ class NeuralEdgeRepository:
 
     async def get_stats(
         self,
-        user_id: str,
+        user_id: str | None = None,
         workspace_id: str | None = None,
         context_id: str | None = None,
     ) -> dict[str, int | float]:
-        """Get graph statistics for a user with 3-level isolation.
+        """Get graph statistics for a context with 3-level isolation.
 
         Single Collection Migration: Added workspace_id and context_id filtering.
+        Issue #383: ``user_id`` is now optional — ``None`` aggregates over all
+        creators in the workspace+context (shared context), otherwise restricts
+        to that single creator (private context).
 
         Args:
-            user_id: User identifier
+            user_id: Optional creator filter. ``None`` aggregates over all
+                creators in the workspace+context.
             workspace_id: Workspace ID (for isolation)
             context_id: Context ID (for isolation)
 
@@ -659,7 +668,9 @@ class NeuralEdgeRepository:
         self._validate_isolation_params(workspace_id, context_id)
 
         # Build conditions
-        conditions = [NeuralMemoryEdge.user_id == user_id]
+        conditions: list = []
+        if user_id is not None:
+            conditions.append(NeuralMemoryEdge.user_id == user_id)
 
         # Single Collection Migration: Use workspace_id/context_id for filtering
         if workspace_id:
@@ -731,7 +742,7 @@ class NeuralEdgeRepository:
 
     async def get_top_connected_nodes(
         self,
-        user_id: str,
+        user_id: str | None = None,
         limit: int = 10,
         workspace_id: str | None = None,
         context_id: str | None = None,
@@ -739,9 +750,11 @@ class NeuralEdgeRepository:
         """Get most connected nodes (highest total degree).
 
         Single Collection Migration: Added workspace_id/context_id for filtering.
+        Issue #383: ``user_id`` is now optional — ``None`` aggregates across all
+        creators in the workspace+context (shared context mode).
 
         Args:
-            user_id: User identifier
+            user_id: Optional creator filter. ``None`` = all creators.
             limit: Number of top nodes to return
             workspace_id: Workspace ID (for isolation)
             context_id: Context ID (for isolation)
@@ -750,7 +763,9 @@ class NeuralEdgeRepository:
             List of (node_id, total_degree) tuples sorted by degree descending
         """
         # Build filter conditions
-        conditions = [NeuralMemoryEdge.user_id == user_id]
+        conditions: list = []
+        if user_id is not None:
+            conditions.append(NeuralMemoryEdge.user_id == user_id)
         if workspace_id:
             conditions.append(NeuralMemoryEdge.workspace_id == UUID(workspace_id))
         if context_id:

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -648,11 +648,20 @@ class NeuralEdgeRepository:
         creators in the workspace+context (shared context), otherwise restricts
         to that single creator (private context).
 
+        **Caller contract**: ``workspace_id`` and ``context_id`` are **always**
+        required (enforced by ``_validate_isolation_params`` below). The
+        ``user_id`` axis is the only optional one. "All edges authored by this
+        user across all contexts" is NOT a supported use case for this method —
+        that access pattern would bypass the 3-level isolation and is rejected
+        by the validator. The pre-existing ``neural/decay.py:get_decay_statistics``
+        caller is currently on a latent error path and is uncalled (dead code);
+        see Issue #383 PR body for the tracked follow-up.
+
         Args:
             user_id: Optional creator filter. ``None`` aggregates over all
                 creators in the workspace+context.
-            workspace_id: Workspace ID (for isolation)
-            context_id: Context ID (for isolation)
+            workspace_id: Workspace ID (required for isolation)
+            context_id: Context ID (required for isolation)
 
         Returns:
             Dictionary with graph metrics:

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -47,6 +47,14 @@ class GraphService:
         db: AsyncSession for database access
     """
 
+    # Sentinel for ``stats(owner_filter=...)`` to distinguish "caller did not
+    # pass the argument, use the legacy self.user_id default" from "caller
+    # explicitly requested the no-filter (shared-context) mode by passing None".
+    # Without this sentinel, the shared-mode default would silently regress
+    # existing per-user callers (sleep/consolidation, neural_tasks) that invoke
+    # ``stats()`` with no arguments and rely on implicit creator scoping.
+    _STATS_OWNER_DEFAULT: Any = object()
+
     NODE_TYPES = ["memory", "user", "topic"]
     EDGE_TYPES = [
         "neural_association",
@@ -298,26 +306,33 @@ class GraphService:
     # Statistics
     # ========================================================================
 
-    async def stats(self, *, owner_filter: str | None = None) -> dict[str, Any]:
+    async def stats(self, *, owner_filter: Any = _STATS_OWNER_DEFAULT) -> dict[str, Any]:
         """Get graph statistics with 3-level isolation.
 
         Issue #383: visibility-aware. ``owner_filter`` controls creator scoping:
 
-        - ``None`` (default): aggregate over all creators in workspace+context
-          (shared-context mode). Use this for HTTP graph endpoints after the
-          caller's workspace membership has been verified upstream.
+        - **Omitted** (default, backward-compatible): filter by ``self.user_id``
+          — the pre-#383 "per-user metrics" semantics that sleep/consolidation,
+          neural_tasks, and internal callers rely on. Does NOT aggregate across
+          the whole workspace, which would distort consolidation heuristics.
+        - ``None`` (explicit): no creator filter — aggregate across all creators
+          in workspace+context (shared-context HTTP reads). Only pass this when
+          the caller's workspace membership has been verified upstream.
         - ``str`` (creator user_id): restrict to edges created by that user.
-          Use this for private-context reads where only the creator's own
-          subgraph should be visible.
+          Private-context reads or admin paths pass this explicitly.
 
         Args:
-            owner_filter: Optional creator filter — see above.
+            owner_filter: Optional creator filter — see above. The sentinel
+                default distinguishes "omitted" from "explicit None".
 
         Returns:
             Stats dict with edge counts and weights
         """
+        effective_filter: str | None = (
+            self.user_id if owner_filter is self._STATS_OWNER_DEFAULT else owner_filter
+        )
         edge_stats = await self.edge_repo.get_stats(
-            owner_filter,
+            effective_filter,
             workspace_id=self.workspace_id,
             context_id=self.context_id,
         )
@@ -328,8 +343,8 @@ class GraphService:
         from models.memory import NeuralMemoryEdge
 
         conditions: list = []
-        if owner_filter is not None:
-            conditions.append(NeuralMemoryEdge.user_id == owner_filter)
+        if effective_filter is not None:
+            conditions.append(NeuralMemoryEdge.user_id == effective_filter)
         if self.workspace_id:
             conditions.append(NeuralMemoryEdge.workspace_id == UUID(self.workspace_id))
         if self.context_id:

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -327,7 +327,6 @@ class GraphService:
 
         from models.memory import NeuralMemoryEdge
 
-        # Build conditions for node queries with 3-level isolation (#383)
         conditions: list = []
         if owner_filter is not None:
             conditions.append(NeuralMemoryEdge.user_id == owner_filter)

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -298,14 +298,26 @@ class GraphService:
     # Statistics
     # ========================================================================
 
-    async def stats(self) -> dict[str, Any]:
+    async def stats(self, *, owner_filter: str | None = None) -> dict[str, Any]:
         """Get graph statistics with 3-level isolation.
+
+        Issue #383: visibility-aware. ``owner_filter`` controls creator scoping:
+
+        - ``None`` (default): aggregate over all creators in workspace+context
+          (shared-context mode). Use this for HTTP graph endpoints after the
+          caller's workspace membership has been verified upstream.
+        - ``str`` (creator user_id): restrict to edges created by that user.
+          Use this for private-context reads where only the creator's own
+          subgraph should be visible.
+
+        Args:
+            owner_filter: Optional creator filter — see above.
 
         Returns:
             Stats dict with edge counts and weights
         """
         edge_stats = await self.edge_repo.get_stats(
-            self.user_id,
+            owner_filter,
             workspace_id=self.workspace_id,
             context_id=self.context_id,
         )
@@ -315,8 +327,10 @@ class GraphService:
 
         from models.memory import NeuralMemoryEdge
 
-        # Build conditions for node queries with 3-level isolation
-        conditions = [NeuralMemoryEdge.user_id == self.user_id]
+        # Build conditions for node queries with 3-level isolation (#383)
+        conditions: list = []
+        if owner_filter is not None:
+            conditions.append(NeuralMemoryEdge.user_id == owner_filter)
         if self.workspace_id:
             conditions.append(NeuralMemoryEdge.workspace_id == UUID(self.workspace_id))
         if self.context_id:

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -332,10 +332,12 @@ class MemoryService:
             raise NotFoundException("Memory", str(request.memory_id))
 
         # Permission check
+        from services.permission_service import CallerId, MemoryAuthorId
+
         perm_service = PermissionService(self.db)
         can_access = await perm_service.can_access_memory(
-            user_id=user_id,
-            memory_user_id=memory.user_id,
+            user_id=CallerId(user_id),
+            memory_user_id=MemoryAuthorId(memory.user_id),
             workspace_id=memory.workspace_id,
             context_id=memory.context_id,
         )
@@ -530,12 +532,12 @@ class MemoryService:
             raise NotFoundException("Memory", str(memory_id))
 
         # Issue #XXX: Team collaboration - verify access permission
-        from services.permission_service import PermissionService
+        from services.permission_service import CallerId, MemoryAuthorId, PermissionService
 
         perm_service = PermissionService(self.db)
         can_access = await perm_service.can_access_memory(
-            user_id=user_id,
-            memory_user_id=memory.user_id,
+            user_id=CallerId(user_id),
+            memory_user_id=MemoryAuthorId(memory.user_id),
             workspace_id=memory.workspace_id,
             context_id=memory.context_id,
         )
@@ -956,12 +958,12 @@ class MemoryService:
 
             if memory:
                 # Issue #XXX: Team collaboration - verify delete permission
-                from services.permission_service import PermissionService
+                from services.permission_service import CallerId, MemoryAuthorId, PermissionService
 
                 perm_service = PermissionService(self.db)
                 can_access = await perm_service.can_access_memory(
-                    user_id=user_id,
-                    memory_user_id=memory.user_id,
+                    user_id=CallerId(user_id),
+                    memory_user_id=MemoryAuthorId(memory.user_id),
                     workspace_id=memory.workspace_id,
                     context_id=memory.context_id,
                 )
@@ -1194,12 +1196,12 @@ class MemoryService:
             raise NotFoundException(f"Memory {request.memory_id} not found")
 
         # Issue #XXX: Team collaboration - verify access permission
-        from services.permission_service import PermissionService
+        from services.permission_service import CallerId, MemoryAuthorId, PermissionService
 
         perm_service = PermissionService(self.db)
         can_access = await perm_service.can_access_memory(
-            user_id=user_id,
-            memory_user_id=seed_memory.user_id,
+            user_id=CallerId(user_id),
+            memory_user_id=MemoryAuthorId(seed_memory.user_id),
             workspace_id=seed_memory.workspace_id,
             context_id=seed_memory.context_id,
         )

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -216,6 +216,53 @@ class PermissionService:
 
         raise HTTPException(status_code=404, detail="Resource not found")
 
+    async def resolve_context_for_workspace_read(
+        self,
+        user_id: str,
+        context_id: UUID,
+        *,
+        required_role: str = "member",
+    ) -> Context:
+        """Resolve a ``context_id`` to a Context the caller can read, with uniform 404.
+
+        Issue #383: centralizes the "look up a Context + verify workspace
+        membership" chokepoint for UUID-addressed context reads. Returns a
+        unified 404 on either "context does not exist" or "caller is not a
+        workspace member" so cross-workspace existence does not leak
+        (CWE-639 / OWASP A01 uniform disclosure — same principle as
+        ``resolve_resource_by_slug`` for slug-addressed paths).
+
+        Args:
+            user_id: Authenticated principal.
+            context_id: UUID of the context to resolve.
+            required_role: Minimum workspace role to accept. Defaults to
+                ``member`` — suitable for read endpoints like ``/graph/*``.
+                Writers should pass ``admin`` or ``owner``.
+
+        Returns:
+            The ``Context`` row for ``context_id`` if the caller has the
+            required workspace role.
+
+        Raises:
+            HTTPException(404): context does not exist, or the caller is not
+                a member of its owning workspace with the required role.
+        """
+        context_result = await self.db.execute(select(Context).where(Context.id == context_id))
+        context = context_result.scalar_one_or_none()
+        if context is None:
+            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+
+        try:
+            await self.check_workspace_access(
+                user_id=user_id,
+                workspace_id=context.workspace_id,
+                required_role=required_role,
+            )
+        except HTTPException:
+            raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
+
+        return context
+
     async def check_workspace_owner(self, user_id: str, workspace_id: UUID) -> WorkspaceMember:
         """Check if user is workspace owner.
 

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -255,6 +255,15 @@ class PermissionService:
         )
         context = context_result.scalar_one_or_none()
         if context is None:
+            # Indistinguishable from "cross-workspace probe" to the caller (both
+            # surface as 404) — but logged distinctly so forensics can tell a
+            # stale-UUID / deleted-context miss from an active enumeration probe.
+            logger.info(
+                "context_read_denied",
+                reason="not_found",
+                context_id=str(context_id),
+                user_id=user_id,
+            )
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
 
         try:
@@ -264,6 +273,16 @@ class PermissionService:
                 required_role=required_role,
             )
         except HTTPException:
+            # A valid-looking UUID for a workspace the caller does not belong to:
+            # the signal worth alerting on. Surfaced as the same uniform 404 as
+            # the "not_found" branch (CWE-639 / OWASP A01 uniform disclosure).
+            logger.warning(
+                "context_read_denied",
+                reason="cross_workspace",
+                context_id=str(context_id),
+                context_workspace_id=str(context.workspace_id),
+                user_id=user_id,
+            )
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
 
         return context

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -255,13 +255,25 @@ class PermissionService:
         )
         context = context_result.scalar_one_or_none()
         if context is None:
-            # Indistinguishable from "cross-workspace probe" to the caller (both
-            # surface as 404) — but logged distinctly so forensics can tell a
-            # stale-UUID / deleted-context miss from an active enumeration probe.
             logger.info(
                 "context_read_denied",
                 reason="not_found",
                 context_id=str(context_id),
+                user_id=user_id,
+            )
+            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+
+        # Private context: creator-only. Enforce here so graph / other
+        # UUID-addressed read endpoints match ``can_access_memory`` semantics
+        # (private → only the creator sees anything) instead of returning an
+        # empty 200 that leaks "a private context with this ID exists in
+        # this workspace, and you're not its owner".
+        if context.is_private and context.created_by != user_id:
+            logger.warning(
+                "context_read_denied",
+                reason="private_non_creator",
+                context_id=str(context_id),
+                context_workspace_id=str(context.workspace_id),
                 user_id=user_id,
             )
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
@@ -272,13 +284,23 @@ class PermissionService:
                 workspace_id=context.workspace_id,
                 required_role=required_role,
             )
-        except HTTPException:
-            # A valid-looking UUID for a workspace the caller does not belong to:
-            # the signal worth alerting on. Surfaced as the same uniform 404 as
-            # the "not_found" branch (CWE-639 / OWASP A01 uniform disclosure).
+        except HTTPException as exc:
+            # Classify the deny reason by the detail string so observability
+            # distinguishes cross-tenant probes (enumeration signal worth
+            # alerting on) from routine role-too-low / workspace-deleted paths.
+            # External 404 stays uniform regardless (CWE-639 / OWASP A01).
+            detail = str(exc.detail or "")
+            if "deleted" in detail:
+                reason = "workspace_deleted"
+            elif detail.startswith("Not a member"):
+                reason = "not_a_member"
+            elif "role" in detail.lower():
+                reason = "role_too_low"
+            else:
+                reason = "workspace_access_denied"
             logger.warning(
                 "context_read_denied",
-                reason="cross_workspace",
+                reason=reason,
                 context_id=str(context_id),
                 context_workspace_id=str(context.workspace_id),
                 user_id=user_id,

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -247,7 +247,12 @@ class PermissionService:
             HTTPException(404): context does not exist, or the caller is not
                 a member of its owning workspace with the required role.
         """
-        context_result = await self.db.execute(select(Context).where(Context.id == context_id))
+        context_result = await self.db.execute(
+            select(Context).where(
+                Context.id == context_id,
+                Context.deleted_at.is_(None),
+            )
+        )
         context = context_result.scalar_one_or_none()
         if context is None:
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found")

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -5,6 +5,7 @@ Issue #115 Phase B-2: Workspace-level Multi-tenancy
 Manages access control at workspace and context levels.
 """
 
+from typing import NewType
 from uuid import UUID
 
 from fastapi import HTTPException
@@ -16,6 +17,12 @@ from services.workspace_service import WorkspaceService
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Brand types for authz identities (Issue #383).
+# NewType is zero-cost at runtime but prevents str/str argument swaps at pyright.
+# Mint at authz function boundaries; do not leak these into repository layers.
+CallerId = NewType("CallerId", str)
+MemoryAuthorId = NewType("MemoryAuthorId", str)
 
 # Role hierarchy weights (higher = more privilege)
 ORG_ROLE_WEIGHTS = {
@@ -574,8 +581,9 @@ class PermissionService:
 
     async def can_access_memory(
         self,
-        user_id: str,
-        memory_user_id: str,
+        *,
+        user_id: CallerId,
+        memory_user_id: MemoryAuthorId,
         workspace_id: UUID,
         context_id: UUID,
     ) -> bool:

--- a/backend/tests/integration/test_graph_visibility.py
+++ b/backend/tests/integration/test_graph_visibility.py
@@ -406,3 +406,33 @@ async def test_graph_data_cross_workspace_returns_404(visibility_scenario):
         )
 
     assert response.status_code == 404, response.text
+
+
+@pytest.mark.asyncio
+async def test_soft_deleted_context_returns_404(visibility_scenario, db_session):
+    """Soft-deleted context surfaces as 404 even for a legitimate workspace member.
+
+    ``resolve_context_for_workspace_read`` mirrors ``resolve_resource_by_slug``'s
+    ``Context.deleted_at.is_(None)`` filter — stale graph data from a deleted
+    context must not be reachable.
+    """
+    from models.auth import Context
+    from utils.datetime import utcnow
+
+    ctx_id = visibility_scenario["ctx_shared_id"]
+    await db_session.execute(
+        Context.__table__.update()
+        .where(Context.id == ctx_id)
+        .values(deleted_at=utcnow().replace(tzinfo=None))
+    )
+    await db_session.commit()
+
+    _as(visibility_scenario["owner_a_id"], visibility_scenario["ws_a_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/stats",
+            params={"context_id": str(ctx_id)},
+        )
+
+    assert response.status_code == 404, response.text

--- a/backend/tests/integration/test_graph_visibility.py
+++ b/backend/tests/integration/test_graph_visibility.py
@@ -336,12 +336,14 @@ async def test_private_context_creator_sees_own_edges(visibility_scenario):
 
 
 @pytest.mark.asyncio
-async def test_private_context_non_creator_member_sees_empty(visibility_scenario):
-    """Workspace member who is NOT the private-context creator sees empty.
+async def test_private_context_non_creator_member_returns_404(visibility_scenario):
+    """Workspace member who is NOT the private-context creator gets uniform 404.
 
-    member_a passes ``check_workspace_access`` (200, not 404) but the
-    visibility filter restricts results to member_a's own edges in the context
-    — of which there are none because private contexts are single-owner.
+    Matches the ``can_access_memory`` rule ("private → only creator can
+    access") and the rest-of-API convention established by
+    ``PermissionService.check_context_access``. Copilot catch on PR #394
+    loop 2: returning an empty 200 leaked "a private context with this ID
+    exists, and you are not its creator" — the 404 hides that differential.
     """
     _as(visibility_scenario["member_a_id"], visibility_scenario["ws_a_id"])
 
@@ -351,10 +353,7 @@ async def test_private_context_non_creator_member_sees_empty(visibility_scenario
             params={"context_id": str(visibility_scenario["ctx_private_id"])},
         )
 
-    assert response.status_code == 200, response.text
-    assert response.json()["stats"]["total_edges"] == 0, (
-        "Non-creator workspace member must NOT see private-context edges"
-    )
+    assert response.status_code == 404, response.text
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_graph_visibility.py
+++ b/backend/tests/integration/test_graph_visibility.py
@@ -1,0 +1,408 @@
+"""Graph read visibility tests (Issue #383).
+
+Exercises ``/graph/stats`` and ``/graph/data`` against a real database to
+verify that visibility is driven by ``Context.is_private`` +
+``PermissionService.check_workspace_access`` rather than the pre-#383
+hardcoded ``user_id == caller`` filter.
+
+6-way matrix (the axis that gate1 review pinned as load-bearing):
+
+    {shared | private context} × {owner | same-workspace member | different-workspace user}
+
+Plus the cross-workspace-probe regression from PR #391 (multi-workspace
+member must not leak edges across tenant boundaries).
+
+These cases are expressed as separate test functions (one per outcome
+class) rather than a parametric sweep so a failure clearly identifies
+which visibility contract regressed.
+"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from api.main import app
+from auth.dependencies import require_session_auth
+from db.base import get_db
+from models.auth import Context, Workspace, WorkspaceMember
+from models.memory import Memory, NeuralMemoryEdge
+
+
+def _make_fresh_session_override(engine):
+    """Yield a fresh AsyncSession per request (pattern from test_resource_cross_workspace)."""
+    session_maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async def override_get_db():
+        async with session_maker() as session:
+            try:
+                yield session
+            finally:
+                await session.rollback()
+
+    return override_get_db
+
+
+def _session_user(user_id: str, workspace_id) -> dict:
+    return {
+        "user_id": user_id,
+        "email": f"{user_id}@test.com",
+        "role": "user",
+        "current_workspace_id": workspace_id,
+        "workspace_role": "member",
+    }
+
+
+@pytest_asyncio.fixture
+async def visibility_scenario(async_engine, db_session):
+    """Set up the 6-way matrix fixture.
+
+    Workspace A:
+        - owner_a (role=owner), member_a (role=member)
+        - ctx_shared (is_private=False): edges created by both owner_a and member_a
+        - ctx_private (is_private=True, created_by=owner_a): edges created by owner_a
+
+    Workspace B:
+        - outsider_b (role=owner) — not a member of workspace A
+
+    Two edges per creator per context so ``total_edges`` distinguishes
+    "all" vs "owner's only" vs "empty" outcomes unambiguously.
+    """
+    owner_a_id = f"owner_a_{uuid4().hex[:8]}"
+    member_a_id = f"member_a_{uuid4().hex[:8]}"
+    outsider_b_id = f"outsider_b_{uuid4().hex[:8]}"
+
+    ws_a = Workspace(
+        id=uuid4(),
+        name=f"ws-a-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_a_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+    ws_b = Workspace(
+        id=uuid4(),
+        name=f"ws-b-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=outsider_b_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+
+    ctx_shared = Context(
+        id=uuid4(),
+        workspace_id=ws_a.id,
+        name=f"ctx-shared-{uuid4().hex[:8]}",
+        created_by=owner_a_id,
+        is_private=False,
+    )
+    ctx_private = Context(
+        id=uuid4(),
+        workspace_id=ws_a.id,
+        name=f"ctx-private-{uuid4().hex[:8]}",
+        created_by=owner_a_id,
+        is_private=True,
+    )
+
+    # Helper to mint a memory + return its id
+    def _mk_memory(user_id: str, ctx: Context) -> Memory:
+        return Memory(
+            id=uuid4(),
+            user_id=user_id,
+            workspace_id=ws_a.id,
+            context_id=ctx.id,
+            summary=f"mem-{uuid4().hex[:6]}",
+            content="x",
+            type="note",
+            client="test",
+        )
+
+    # 2 memories per (creator, context) pair → 1 edge between them
+    mem_owner_shared_src = _mk_memory(owner_a_id, ctx_shared)
+    mem_owner_shared_dst = _mk_memory(owner_a_id, ctx_shared)
+    mem_member_shared_src = _mk_memory(member_a_id, ctx_shared)
+    mem_member_shared_dst = _mk_memory(member_a_id, ctx_shared)
+    mem_owner_private_src = _mk_memory(owner_a_id, ctx_private)
+    mem_owner_private_dst = _mk_memory(owner_a_id, ctx_private)
+
+    def _mk_edge(user_id: str, ctx: Context, src: Memory, dst: Memory) -> NeuralMemoryEdge:
+        return NeuralMemoryEdge(
+            user_id=user_id,
+            src_id=src.id,
+            dst_id=dst.id,
+            workspace_id=ws_a.id,
+            context_id=ctx.id,
+            edge_type="neural_association",
+            weight=1.0,
+            confidence=1.0,
+        )
+
+    edge_owner_shared = _mk_edge(owner_a_id, ctx_shared, mem_owner_shared_src, mem_owner_shared_dst)
+    edge_member_shared = _mk_edge(
+        member_a_id, ctx_shared, mem_member_shared_src, mem_member_shared_dst
+    )
+    edge_owner_private = _mk_edge(
+        owner_a_id, ctx_private, mem_owner_private_src, mem_owner_private_dst
+    )
+
+    # Flush in dependency order (workspaces → members → contexts → memories → edges).
+    # SQLAlchemy's UoW heuristic doesn't reliably topo-sort inserts when the
+    # ORM-side ``relationship()`` is absent (Context has only a raw FK column,
+    # no back-populating relationship), so the DB can see contexts before their
+    # workspace rows unless we flush the parents first.
+    db_session.add_all([ws_a, ws_b])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=member_a_id, role="member"),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=outsider_b_id, role="owner"),
+        ]
+    )
+    await db_session.flush()
+
+    db_session.add_all([ctx_shared, ctx_private])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            mem_owner_shared_src,
+            mem_owner_shared_dst,
+            mem_member_shared_src,
+            mem_member_shared_dst,
+            mem_owner_private_src,
+            mem_owner_private_dst,
+        ]
+    )
+    await db_session.flush()
+
+    db_session.add_all([edge_owner_shared, edge_member_shared, edge_owner_private])
+    await db_session.commit()
+
+    app.dependency_overrides[get_db] = _make_fresh_session_override(async_engine)
+
+    scenario = {
+        "owner_a_id": owner_a_id,
+        "member_a_id": member_a_id,
+        "outsider_b_id": outsider_b_id,
+        "ws_a_id": ws_a.id,
+        "ws_b_id": ws_b.id,
+        "ctx_shared_id": ctx_shared.id,
+        "ctx_private_id": ctx_private.id,
+        "edge_ids": [
+            edge_owner_shared.id,
+            edge_member_shared.id,
+            edge_owner_private.id,
+        ],
+        "memory_ids": [
+            mem_owner_shared_src.id,
+            mem_owner_shared_dst.id,
+            mem_member_shared_src.id,
+            mem_member_shared_dst.id,
+            mem_owner_private_src.id,
+            mem_owner_private_dst.id,
+        ],
+    }
+
+    yield scenario
+
+    app.dependency_overrides.clear()
+
+    # Teardown — order matters due to FKs (edges → memories → contexts → workspaces).
+    try:
+        await db_session.execute(
+            NeuralMemoryEdge.__table__.delete().where(NeuralMemoryEdge.id.in_(scenario["edge_ids"]))
+        )
+        await db_session.execute(
+            Memory.__table__.delete().where(Memory.id.in_(scenario["memory_ids"]))
+        )
+        await db_session.execute(
+            Context.__table__.delete().where(Context.id.in_([ctx_shared.id, ctx_private.id]))
+        )
+        await db_session.execute(
+            WorkspaceMember.__table__.delete().where(
+                WorkspaceMember.workspace_id.in_([ws_a.id, ws_b.id])
+            )
+        )
+        await db_session.delete(ws_a)
+        await db_session.delete(ws_b)
+        await db_session.commit()
+    except Exception:
+        await db_session.rollback()
+        raise
+
+
+def _as(user_id: str, workspace_id):
+    """Install a require_session_auth override returning the given user."""
+
+    async def override():
+        return _session_user(user_id, workspace_id)
+
+    app.dependency_overrides[require_session_auth] = override
+
+
+# ============================================================================
+# Shared context × 3 caller roles
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_shared_context_owner_sees_all_edges(visibility_scenario):
+    """Owner of a shared context sees edges authored by OTHER workspace members.
+
+    Pre-#383 this returned only owner-authored edges (count 1). Post-#383 the
+    count must include member_a's edge as well (count 2).
+    """
+    _as(visibility_scenario["owner_a_id"], visibility_scenario["ws_a_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/stats",
+            params={"context_id": str(visibility_scenario["ctx_shared_id"])},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["stats"]["total_edges"] == 2, (
+        "Owner of shared context must see all workspace members' edges, not only their own"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_context_member_sees_all_edges(visibility_scenario):
+    """Non-owner workspace member sees the same edges as the owner for a shared context.
+
+    This is the regression target the bug report pinpointed — members were
+    previously seeing an empty/near-empty graph even though they had legitimate
+    read access through ``PermissionService.can_access_memory``.
+    """
+    _as(visibility_scenario["member_a_id"], visibility_scenario["ws_a_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/stats",
+            params={"context_id": str(visibility_scenario["ctx_shared_id"])},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["stats"]["total_edges"] == 2, (
+        "Workspace member must see the same edges as the owner for a shared context"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_context_cross_workspace_probe_returns_404(visibility_scenario):
+    """Cross-workspace probe must be CWE-639 uniform-disclosure 404, not 403/empty.
+
+    outsider_b knows the UUID of ctx_shared in workspace A (hypothetical leak)
+    but is not a member of workspace A. They must get 404, indistinguishable
+    from "context does not exist at all".
+    """
+    _as(visibility_scenario["outsider_b_id"], visibility_scenario["ws_b_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/stats",
+            params={"context_id": str(visibility_scenario["ctx_shared_id"])},
+        )
+
+    assert response.status_code == 404, response.text
+
+
+# ============================================================================
+# Private context × 3 caller roles
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_private_context_creator_sees_own_edges(visibility_scenario):
+    """Creator of a private context sees their own edges (full subgraph)."""
+    _as(visibility_scenario["owner_a_id"], visibility_scenario["ws_a_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/stats",
+            params={"context_id": str(visibility_scenario["ctx_private_id"])},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["stats"]["total_edges"] == 1, (
+        "Creator of private context must see their own edges"
+    )
+
+
+@pytest.mark.asyncio
+async def test_private_context_non_creator_member_sees_empty(visibility_scenario):
+    """Workspace member who is NOT the private-context creator sees empty.
+
+    member_a passes ``check_workspace_access`` (200, not 404) but the
+    visibility filter restricts results to member_a's own edges in the context
+    — of which there are none because private contexts are single-owner.
+    """
+    _as(visibility_scenario["member_a_id"], visibility_scenario["ws_a_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/stats",
+            params={"context_id": str(visibility_scenario["ctx_private_id"])},
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["stats"]["total_edges"] == 0, (
+        "Non-creator workspace member must NOT see private-context edges"
+    )
+
+
+@pytest.mark.asyncio
+async def test_private_context_cross_workspace_probe_returns_404(visibility_scenario):
+    """Outsider probing a private context UUID gets CWE-639 uniform 404."""
+    _as(visibility_scenario["outsider_b_id"], visibility_scenario["ws_b_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/stats",
+            params={"context_id": str(visibility_scenario["ctx_private_id"])},
+        )
+
+    assert response.status_code == 404, response.text
+
+
+# ============================================================================
+# /graph/data parity — the behavior must match /graph/stats
+# ============================================================================
+
+
+@pytest.mark.asyncio
+async def test_graph_data_shared_member_sees_all_edges(visibility_scenario):
+    """``/graph/data`` honors the same visibility rule as ``/graph/stats``."""
+    _as(visibility_scenario["member_a_id"], visibility_scenario["ws_a_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/data",
+            params={"context_id": str(visibility_scenario["ctx_shared_id"])},
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["stats"]["total_edges"] == 2, (
+        "/graph/data must surface the same shared-context edges as /graph/stats"
+    )
+
+
+@pytest.mark.asyncio
+async def test_graph_data_cross_workspace_returns_404(visibility_scenario):
+    """``/graph/data`` uniform 404 on cross-workspace probes."""
+    _as(visibility_scenario["outsider_b_id"], visibility_scenario["ws_b_id"])
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get(
+            "/api/v1/graph/data",
+            params={"context_id": str(visibility_scenario["ctx_shared_id"])},
+        )
+
+    assert response.status_code == 404, response.text

--- a/backend/tests/services/test_permission_service.py
+++ b/backend/tests/services/test_permission_service.py
@@ -9,6 +9,8 @@ from fastapi import HTTPException
 from services.permission_service import (
     CONTEXT_ROLE_WEIGHTS,
     ORG_ROLE_WEIGHTS,
+    CallerId,
+    MemoryAuthorId,
     PermissionService,
 )
 
@@ -207,7 +209,12 @@ class TestMemoryAccessControl:
     @pytest.mark.asyncio
     async def test_owner_can_access_own_memory(self, service):
         """Memory owner always has access."""
-        result = await service.can_access_memory("user1", "user1", uuid4(), uuid4())
+        result = await service.can_access_memory(
+            user_id=CallerId("user1"),
+            memory_user_id=MemoryAuthorId("user1"),
+            workspace_id=uuid4(),
+            context_id=uuid4(),
+        )
         assert result is True
 
     @pytest.mark.asyncio
@@ -219,7 +226,12 @@ class TestMemoryAccessControl:
         mock_ctx_svc.is_context_shared = AsyncMock(return_value=False)
 
         with patch("services.context_service.ContextService", return_value=mock_ctx_svc):
-            result = await service.can_access_memory("user2", "user1", uuid4(), uuid4())
+            result = await service.can_access_memory(
+                user_id=CallerId("user2"),
+                memory_user_id=MemoryAuthorId("user1"),
+                workspace_id=uuid4(),
+                context_id=uuid4(),
+            )
         assert result is False
 
     @pytest.mark.asyncio
@@ -232,7 +244,12 @@ class TestMemoryAccessControl:
         service.workspace_service.get_member = AsyncMock(return_value=MagicMock(role="member"))
 
         with patch("services.context_service.ContextService", return_value=mock_ctx_svc):
-            result = await service.can_access_memory("user2", "user1", uuid4(), uuid4())
+            result = await service.can_access_memory(
+                user_id=CallerId("user2"),
+                memory_user_id=MemoryAuthorId("user1"),
+                workspace_id=uuid4(),
+                context_id=uuid4(),
+            )
         assert result is True
 
 


### PR DESCRIPTION
Closes #383

## Summary

- `GraphService` / `NeuralEdgeRepository` / `/graph/*` routes moved off the hardcoded `user_id == caller` filter. Visibility is now driven by `PermissionService.check_workspace_access` + `Context.is_private`, aligning graph reads with the `can_access_memory` model that the rest of the backend already uses.
- Shared context in a workspace → every member sees the full graph. Private context → only the creator sees their subgraph. Cross-workspace UUID probes and soft-deleted contexts surface as uniform 404 (CWE-639 / OWASP A01).
- New helper `PermissionService.resolve_context_for_workspace_read` centralizes "SELECT Context → check_workspace_access → 403→404 remap" — mirrors the established `resolve_resource_by_slug` chokepoint pattern.
- Brand types (`CallerId`, `MemoryAuthorId`) added to `can_access_memory` to prevent the same-shape-str argument swap class that was behind the PR #391 gate-review escape.

## Implementation notes

- `NeuralEdgeRepository.{get_all_edges, get_stats, get_top_connected_nodes}`: `user_id: str` → `user_id: str | None = None`. `None` = aggregate across all creators (shared context); `str` = creator-scoped (private / admin paths). Existing internal callers (`decay.py`) unchanged.
- `GraphService.stats()`: new keyword-only `owner_filter` kwarg replaces the inline `self.user_id` reference in the total-nodes subquery.
- Migration `b02_383_graph_edges_composite_indexes.py`: adds `(workspace_id, context_id, src_id)` + `(workspace_id, context_id, dst_id)` composite indexes matching the new primary access pattern. Old `(user_id, src_id/dst_id)` indexes retained for private-context/admin fallback. Reversible downgrade.
- `/graph/data` no longer re-queries `graph_service.stats()` for total counts — derived from already-loaded `all_edges` and `all_node_ids`, saving 3 queries per visualization render.
- Deny-path observability: `resolve_context_for_workspace_read` emits `context_read_denied` structlog events (`info` for `not_found`, `warning` for `cross_workspace`) so forensics can distinguish stale-UUID navigation from enumeration probes, while the external 404 stays uniform.

## Test coverage

`backend/tests/integration/test_graph_visibility.py` — 9 integration tests against real Postgres:

- 6-way matrix: `{shared | private} × {creator | same-workspace other member | different-workspace user}`
- `/graph/data` visibility parity with `/graph/stats`
- Cross-workspace probe → 404 (CWE-639 pin, regression target from PR #391)
- Soft-deleted context → 404

`backend/tests/services/test_permission_service.py` — updated 3 `can_access_memory` tests to keyword-only + branded types.

60 tests pass (9 integration + 50 unit + 1 repository). pyright + ruff clean.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/383-fix-fix-backend-graph-reads-honor-context-is.gate1.md
- ~/.claude/cache/gh-issue-driven/383-fix-fix-backend-graph-reads-honor-context-is.gate2.md

## Scope deferred to follow-up issues

Tracked during gate1 / gate2, explicitly out of scope for this PR to keep the authz fix focused and independently deployable:

- **AC 5**: NULL backfill migration for `neural_memory_edges.workspace_id` / `context_id` (legacy rows from migration 062). Adds 2-step zero-downtime `NOT VALID` → `VALIDATE` pattern + `NOT NULL` enforcement. GDPR CASCADE hygiene — the authz fix itself works correctly around NULL rows (filtered out by the workspace/context predicate).
- **AC 6**: Write-path assertion + one-time audit script for the `edge.context_id == src_memory.context_id == dst_memory.context_id` invariant. The fix trusts this invariant; making it explicit prevents subtle cross-context regressions.
- **AC 3 (MCP parity)**: `backend/src/mcp_server/tools/edge.py` and `context.py` still hit `NeuralEdgeRepository` through the legacy creator-scoped path. HTTP routes are fixed but MCP readers see pre-fix behavior until a follow-up PR aligns them. Flagged by CSO + CTO gate2 as the most visible user-facing inconsistency post-merge.
- **`AuthzChecked[T]` phantom wrapper + Visibility ADT** (CS/PL PhD recommendation): refactors `owner_filter: str | None` tri-state into a type-level sum. Target milestone: v0.16 Hardening, under the `#237` type-annotation audit umbrella.

## Test plan

- [x] `make test-local` — 472 unit tests pass, 60 touch this PR's scope
- [x] `tests/integration/test_graph_visibility.py` — 9 integration tests covering the 6-way matrix + soft-delete + cross-workspace
- [x] `tests/services/test_permission_service.py` — brand-type migration, 50 tests pass
- [x] Alembic migration `b02` reversible (upgrade/downgrade pair)
- [ ] Manual: post-deploy observe `/graph/stats` 404 rate on memory.kagura-ai.com for 1 week — visibility fix changes user-facing behavior (members in shared contexts will suddenly see workspace graph data)
- [ ] Manual: verify `b02` migration applies cleanly to production DB (index creation is online; no lock issues expected)

🤖 Generated via /gh-issue-driven:ship
