### PR TITLE
fix(frontend): scope workspace role UI surface (#398)

### DIFF
--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -431,6 +431,59 @@ async def require_workspace_owner(
     return user_id, workspace_id
 
 
+async def require_workspace_admin(
+    user: dict = Depends(get_user_from_api_key_or_session),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Verify user is workspace admin or owner.
+
+    Issue #398: billing checkout/portal and similar admin-level operations.
+    Mirrors require_workspace_owner but also accepts the 'admin' role.
+    Accepts both session auth and API key auth.
+
+    Args:
+        user: Current authenticated user (session or API key)
+        db: Database session
+
+    Returns:
+        User info dict (full dict, like require_workspace_member)
+
+    Raises:
+        HTTPException: 400 if no workspace selected
+        HTTPException: 403 if viewer/member (not admin or owner)
+    """
+    user_id = user.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    workspace_id = user.get("current_workspace_id")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=400, detail="No workspace selected. Please select a workspace first."
+        )
+
+    from services.permission_service import PermissionService
+
+    perm_service = PermissionService(db)
+    try:
+        await perm_service.check_workspace_admin(user_id, workspace_id)
+    except HTTPException as exc:
+        # WARN on deny so audit pipelines can surface workspace-admin violations
+        # (same audit-log pattern as require_workspace_owner — Issue #389 gate1).
+        logger.warning(
+            "workspace_admin_denied",
+            user_id=user_id,
+            workspace_id=str(workspace_id),
+            status_code=exc.status_code,
+            detail=exc.detail if isinstance(exc.detail, str) else None,
+        )
+        raise
+
+    logger.info("workspace_admin_verified", user_id=user_id, workspace_id=str(workspace_id))
+
+    return user
+
+
 async def require_workspace_member(
     user: dict = Depends(get_user_from_api_key_or_session),
     db: AsyncSession = Depends(get_db),
@@ -481,4 +534,5 @@ APIKeyUser = Annotated[dict, Depends(verify_api_key_user)]
 APIKeyOrSessionUser = Annotated[dict, Depends(get_user_from_api_key_or_session)]
 SessionUser = Annotated[dict, Depends(require_session_auth)]  # Issue #252
 WorkspaceOwner = Annotated[tuple[str, UUID], Depends(require_workspace_owner)]  # Issue #276
+WorkspaceAdmin = Annotated[dict, Depends(require_workspace_admin)]  # Issue #398
 WorkspaceMember = Annotated[dict, Depends(require_workspace_member)]  # Issue #59

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -431,13 +431,67 @@ async def require_workspace_owner(
     return user_id, workspace_id
 
 
+async def require_workspace_admin_session(
+    user: dict = Depends(require_session_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Verify user is workspace admin or owner — session auth only.
+
+    Issue #398: billing checkout/portal use this variant so a leaked API key
+    cannot initiate Stripe checkout sessions on behalf of an admin/owner.
+    Mirrors require_workspace_admin but rejects API-key auth at the door
+    (require_session_auth raises 403 for any Bearer token).
+
+    Args:
+        user: Current authenticated user (session only)
+        db: Database session
+
+    Returns:
+        User info dict (full dict, like require_workspace_member)
+
+    Raises:
+        HTTPException: 400 if no workspace selected
+        HTTPException: 403 if API key was provided OR if viewer/member
+    """
+    user_id = user.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    workspace_id = user.get("current_workspace_id")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=400, detail="No workspace selected. Please select a workspace first."
+        )
+
+    from services.permission_service import PermissionService
+
+    perm_service = PermissionService(db)
+    try:
+        await perm_service.check_workspace_admin(user_id, workspace_id)
+    except HTTPException as exc:
+        logger.warning(
+            "workspace_admin_session_denied",
+            user_id=user_id,
+            workspace_id=str(workspace_id),
+            status_code=exc.status_code,
+            detail=exc.detail if isinstance(exc.detail, str) else None,
+        )
+        raise
+
+    logger.info("workspace_admin_session_verified", user_id=user_id, workspace_id=str(workspace_id))
+
+    return user
+
+
 async def require_workspace_admin(
     user: dict = Depends(get_user_from_api_key_or_session),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Verify user is workspace admin or owner.
 
-    Issue #398: billing checkout/portal and similar admin-level operations.
+    Issue #398: admin-level operations that can be invoked via session OR API
+    key. For UI-only actions where API-key auth would be inappropriate (e.g.
+    billing checkout), use require_workspace_admin_session instead.
     Mirrors require_workspace_owner but also accepts the 'admin' role.
     Accepts both session auth and API key auth.
 
@@ -535,4 +589,5 @@ APIKeyOrSessionUser = Annotated[dict, Depends(get_user_from_api_key_or_session)]
 SessionUser = Annotated[dict, Depends(require_session_auth)]  # Issue #252
 WorkspaceOwner = Annotated[tuple[str, UUID], Depends(require_workspace_owner)]  # Issue #276
 WorkspaceAdmin = Annotated[dict, Depends(require_workspace_admin)]  # Issue #398
+WorkspaceAdminSession = Annotated[dict, Depends(require_workspace_admin_session)]  # Issue #398
 WorkspaceMember = Annotated[dict, Depends(require_workspace_member)]  # Issue #59

--- a/backend/src/plugins/billing/routes.py
+++ b/backend/src/plugins/billing/routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import require_workspace_admin
+from auth.dependencies import WorkspaceAdmin
 from db.base import get_db
 from services import stripe_service
 from utils.logger import get_logger
@@ -41,7 +41,7 @@ class PortalResponse(BaseModel):
 @router.post("/checkout", response_model=CheckoutResponse)
 async def create_checkout(
     request: CheckoutRequest,
-    user: dict = Depends(require_workspace_admin),
+    user: WorkspaceAdmin,
     db: AsyncSession = Depends(get_db),
 ):
     """Create a Stripe Checkout Session for plan upgrade.
@@ -97,7 +97,7 @@ async def handle_webhook(
 @router.get("/portal", response_model=PortalResponse)
 async def get_portal(
     return_url: str,
-    user: dict = Depends(require_workspace_admin),
+    user: WorkspaceAdmin,
     db: AsyncSession = Depends(get_db),
 ):
     """Get Stripe Customer Portal URL.

--- a/backend/src/plugins/billing/routes.py
+++ b/backend/src/plugins/billing/routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import get_current_user
+from auth.dependencies import require_workspace_admin
 from db.base import get_db
 from services import stripe_service
 from utils.logger import get_logger
@@ -41,16 +41,14 @@ class PortalResponse(BaseModel):
 @router.post("/checkout", response_model=CheckoutResponse)
 async def create_checkout(
     request: CheckoutRequest,
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_workspace_admin),
     db: AsyncSession = Depends(get_db),
 ):
     """Create a Stripe Checkout Session for plan upgrade.
 
-    Owner-only. Redirects user to Stripe-hosted payment page.
+    Admin/owner-only (Issue #398). Redirects user to Stripe-hosted payment page.
     """
-    workspace_id = user.get("current_workspace_id")
-    if not workspace_id:
-        raise HTTPException(status_code=400, detail="No workspace selected")
+    workspace_id = user["current_workspace_id"]
 
     if request.plan_name not in ("basic", "pro"):
         raise HTTPException(status_code=400, detail="Invalid plan. Must be 'basic' or 'pro'")
@@ -99,16 +97,14 @@ async def handle_webhook(
 @router.get("/portal", response_model=PortalResponse)
 async def get_portal(
     return_url: str,
-    user: dict = Depends(get_current_user),
+    user: dict = Depends(require_workspace_admin),
     db: AsyncSession = Depends(get_db),
 ):
     """Get Stripe Customer Portal URL.
 
-    Owner-only. Allows managing payment methods and subscriptions.
+    Admin/owner-only (Issue #398). Allows managing payment methods and subscriptions.
     """
-    workspace_id = user.get("current_workspace_id")
-    if not workspace_id:
-        raise HTTPException(status_code=400, detail="No workspace selected")
+    workspace_id = user["current_workspace_id"]
 
     try:
         portal_url = await stripe_service.create_portal_session(

--- a/backend/src/plugins/billing/routes.py
+++ b/backend/src/plugins/billing/routes.py
@@ -8,7 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import WorkspaceAdmin
+from auth.dependencies import WorkspaceAdminSession
 from db.base import get_db
 from services import stripe_service
 from utils.logger import get_logger
@@ -41,7 +41,7 @@ class PortalResponse(BaseModel):
 @router.post("/checkout", response_model=CheckoutResponse)
 async def create_checkout(
     request: CheckoutRequest,
-    user: WorkspaceAdmin,
+    user: WorkspaceAdminSession,
     db: AsyncSession = Depends(get_db),
 ):
     """Create a Stripe Checkout Session for plan upgrade.
@@ -97,7 +97,7 @@ async def handle_webhook(
 @router.get("/portal", response_model=PortalResponse)
 async def get_portal(
     return_url: str,
-    user: WorkspaceAdmin,
+    user: WorkspaceAdminSession,
     db: AsyncSession = Depends(get_db),
 ):
     """Get Stripe Customer Portal URL.

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -221,7 +221,7 @@ class PermissionService:
         user_id: str,
         context_id: UUID,
         *,
-        required_role: str = "member",
+        required_role: str = "viewer",
     ) -> Context:
         """Resolve a ``context_id`` to a Context the caller can read, with uniform 404.
 
@@ -232,12 +232,20 @@ class PermissionService:
         (CWE-639 / OWASP A01 uniform disclosure — same principle as
         ``resolve_resource_by_slug`` for slug-addressed paths).
 
+        Issue #398: default lowered from ``member`` to ``viewer`` — this is
+        a *read* helper and viewers must be able to read shared-context
+        graphs/stats. Previously a viewer hitting ``/graph/stats`` for a
+        shared context they could otherwise see surfaced as
+        ``404 Context not found`` because the membership gate rejected
+        viewer before any per-role logic ran.
+
         Args:
             user_id: Authenticated principal.
             context_id: UUID of the context to resolve.
             required_role: Minimum workspace role to accept. Defaults to
-                ``member`` — suitable for read endpoints like ``/graph/*``.
-                Writers should pass ``admin`` or ``owner``.
+                ``viewer`` — suitable for read endpoints like ``/graph/*``
+                and ``/memory/stats``. Writers should pass ``admin`` or
+                ``owner``.
 
         Returns:
             The ``Context`` row for ``context_id`` if the caller has the
@@ -556,6 +564,10 @@ class PermissionService:
         """Get all contexts user can access in workspace.
 
         Issue #234: Respects allowed_context_ids whitelist for member/viewer.
+        Issue #398: viewer must reach the viewer branch below — gating at
+        ``required_role="member"`` made that branch unreachable and silently
+        hid every shared context from viewers (UX-visible: contexts list
+        was empty for viewer even when shared contexts existed).
 
         Args:
             user_id: User ID
@@ -566,9 +578,10 @@ class PermissionService:
         """
         from sqlalchemy import select
 
-        # Check workspace membership
+        # Check workspace membership (viewer is the floor — the per-role
+        # branches below decide what each role can actually see).
         workspace_member = await self.check_workspace_access(
-            user_id, workspace_id, required_role="member"
+            user_id, workspace_id, required_role="viewer"
         )
 
         # Workspace owner/admin → all contexts (ignore allowed_context_ids)

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -287,7 +287,7 @@ class PermissionService:
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
 
         try:
-            await self.check_workspace_access(
+            workspace_member = await self.check_workspace_access(
                 user_id=user_id,
                 workspace_id=context.workspace_id,
                 required_role=required_role,
@@ -314,6 +314,25 @@ class PermissionService:
                 user_id=user_id,
             )
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
+
+        # PR #399 review (Copilot): apply the same allowed_context_ids whitelist
+        # that check_context_access enforces for member/viewer (line 432-437).
+        # Without this, a restricted member/viewer could read /graph/stats for
+        # contexts outside their whitelist via this UUID-addressed read path.
+        # Workspace owner/admin bypass the whitelist by design (line 427-429).
+        if (
+            workspace_member.role in ("member", "viewer")
+            and workspace_member.allowed_context_ids is not None
+            and context_id not in workspace_member.allowed_context_ids
+        ):
+            logger.warning(
+                "context_read_denied",
+                reason="not_in_whitelist",
+                context_id=str(context_id),
+                context_workspace_id=str(context.workspace_id),
+                user_id=user_id,
+            )
+            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
 
         return context
 
@@ -597,6 +616,15 @@ class PermissionService:
             result = await self.db.execute(stmt)
             return list(result.scalars().all())
 
+        # PR #399 review (Copilot): viewer/member must NOT receive other users'
+        # private contexts in the listing — those are creator-only per
+        # check_context_access:401-410. Without this filter, the listing leaks
+        # the existence of private contexts that the caller cannot then open
+        # (resulting in 403 when clicking through, plus existence disclosure).
+        # Owner/admin branch above intentionally returns everything; this
+        # filter is for the lower-privilege roles only.
+        privacy_filter = (Context.is_private.is_(False)) | (Context.created_by == user_id)
+
         # Issue #234: Workspace viewer with allowed_context_ids restriction
         if workspace_member.role == "viewer":
             if workspace_member.allowed_context_ids is not None:
@@ -609,16 +637,18 @@ class PermissionService:
                         Context.workspace_id == workspace_id,
                         Context.deleted_at.is_(None),
                         Context.id.in_(workspace_member.allowed_context_ids),
+                        privacy_filter,
                     )
                     .order_by(Context.created_at.desc())
                 )
             else:
-                # No restriction → all contexts
+                # No restriction → all shared contexts (+ caller's own private)
                 stmt = (
                     select(Context)
                     .where(
                         Context.workspace_id == workspace_id,
                         Context.deleted_at.is_(None),
+                        privacy_filter,
                     )
                     .order_by(Context.created_at.desc())
                 )
@@ -636,13 +666,14 @@ class PermissionService:
         if not workspace_member.allowed_context_ids:
             return []
 
-        # Show only whitelisted contexts
+        # Show only whitelisted contexts (filtered to non-private + own private)
         stmt = (
             select(Context)
             .where(
                 Context.workspace_id == workspace_id,
                 Context.deleted_at.is_(None),
                 Context.id.in_(workspace_member.allowed_context_ids),
+                privacy_filter,
             )
             .order_by(Context.created_at.desc())
         )

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -315,11 +315,11 @@ class PermissionService:
             )
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
 
-        # PR #399 review (Copilot): apply the same allowed_context_ids whitelist
-        # that check_context_access enforces for member/viewer (line 432-437).
-        # Without this, a restricted member/viewer could read /graph/stats for
-        # contexts outside their whitelist via this UUID-addressed read path.
-        # Workspace owner/admin bypass the whitelist by design (line 427-429).
+        # Apply the same allowed_context_ids whitelist that check_context_access
+        # enforces for member/viewer (line 432-437). Without this check, a
+        # restricted member/viewer could read /graph/stats and other UUID-
+        # addressed endpoints for contexts outside their whitelist. Workspace
+        # owner/admin bypass the whitelist by design (line 427-429).
         if (
             workspace_member.role in ("member", "viewer")
             and workspace_member.allowed_context_ids is not None
@@ -603,27 +603,29 @@ class PermissionService:
             user_id, workspace_id, required_role="viewer"
         )
 
-        # Workspace owner/admin → all contexts (ignore allowed_context_ids)
+        # Private contexts are creator-only across every workspace role
+        # (matches check_context_access:401-410 — even an owner/admin gets 403
+        # when trying to open another user's private context). Filter the
+        # listing to non-private contexts plus the caller's own private ones
+        # so the list shape matches the per-context access check; otherwise
+        # the listing leaks the existence of private contexts that 403 on
+        # click-through.
+        privacy_filter = (Context.is_private.is_(False)) | (Context.created_by == user_id)
+
+        # Workspace owner/admin → all accessible contexts (ignore
+        # allowed_context_ids; privacy still applies).
         if workspace_member.role in ("owner", "admin"):
             stmt = (
                 select(Context)
                 .where(
                     Context.workspace_id == workspace_id,
                     Context.deleted_at.is_(None),
+                    privacy_filter,
                 )
                 .order_by(Context.created_at.desc())
             )
             result = await self.db.execute(stmt)
             return list(result.scalars().all())
-
-        # PR #399 review (Copilot): viewer/member must NOT receive other users'
-        # private contexts in the listing — those are creator-only per
-        # check_context_access:401-410. Without this filter, the listing leaks
-        # the existence of private contexts that the caller cannot then open
-        # (resulting in 403 when clicking through, plus existence disclosure).
-        # Owner/admin branch above intentionally returns everything; this
-        # filter is for the lower-privilege roles only.
-        privacy_filter = (Context.is_private.is_(False)) | (Context.created_by == user_id)
 
         # Issue #234: Workspace viewer with allowed_context_ids restriction
         if workspace_member.role == "viewer":

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -315,11 +315,27 @@ class PermissionService:
             )
             raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
 
-        # Apply the same allowed_context_ids whitelist that check_context_access
-        # enforces for member/viewer (line 432-437). Without this check, a
-        # restricted member/viewer could read /graph/stats and other UUID-
-        # addressed endpoints for contexts outside their whitelist. Workspace
-        # owner/admin bypass the whitelist by design (line 427-429).
+        # Apply the same allowed_context_ids semantics that get_accessible_contexts
+        # and check_context_access enforce for the lower-privilege roles. Without
+        # this, a restricted member/viewer could read /graph/stats and other
+        # UUID-addressed endpoints for contexts they cannot list. Workspace
+        # owner/admin bypass these restrictions by design (line 427-429).
+        #
+        # Per Migration 042 the NULL/[] semantics differ by role:
+        #   - member, allowed_context_ids IS NULL → suspended (no access)
+        #   - viewer, allowed_context_ids IS NULL → no restriction (all)
+        #   - either, allowed_context_ids = [<ids>] → whitelist enforced
+        #   - either, allowed_context_ids = []     → explicit no access
+        if workspace_member.role == "member" and workspace_member.allowed_context_ids is None:
+            logger.warning(
+                "context_read_denied",
+                reason="member_suspended",
+                context_id=str(context_id),
+                context_workspace_id=str(context.workspace_id),
+                user_id=user_id,
+            )
+            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+
         if (
             workspace_member.role in ("member", "viewer")
             and workspace_member.allowed_context_ids is not None

--- a/backend/tests/api/test_billing_rbac.py
+++ b/backend/tests/api/test_billing_rbac.py
@@ -1,0 +1,151 @@
+"""RBAC tests for billing routes (Issue #398).
+
+Workspace admin/owner-only access on the two self-service Stripe endpoints:
+
+- ``POST /api/v1/billing/checkout``
+- ``GET  /api/v1/billing/portal``
+
+The ``POST /api/v1/billing/webhook`` route remains open (Stripe signature
+verification) and is intentionally not covered here.
+
+The billing router is registered in ``api.main`` only when ``BILLING_ENABLED=true``.
+This test mounts the router directly on a fresh FastAPI app so the suite runs
+without environment toggles. The role gate is exercised in isolation by
+overriding ``require_workspace_admin``.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from auth.dependencies import require_workspace_admin
+from db.base import get_db
+from plugins.billing.routes import router as billing_router
+
+WORKSPACE_ID = uuid4()
+
+
+def _mock_user(workspace_role: str) -> dict:
+    return {
+        "user_id": f"test_{workspace_role}",
+        "email": f"{workspace_role}@test.com",
+        "role": "user",
+        "current_workspace_id": WORKSPACE_ID,
+        "workspace_role": workspace_role,
+    }
+
+
+def _build_app() -> FastAPI:
+    """Mount the billing router on a fresh app so tests are independent of BILLING_ENABLED."""
+    app = FastAPI()
+    app.include_router(billing_router)
+    return app
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def non_admin_client():
+    """Client where ``require_workspace_admin`` rejects with 403 (member or viewer)."""
+    app = _build_app()
+
+    async def mock_reject_admin():
+        raise HTTPException(status_code=403, detail="Requires 'admin' role or higher")
+
+    async def mock_db():
+        yield MagicMock()
+
+    app.dependency_overrides[require_workspace_admin] = mock_reject_admin
+    app.dependency_overrides[get_db] = mock_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+@pytest.fixture
+def admin_client():
+    """Client where ``require_workspace_admin`` accepts (admin or owner)."""
+    app = _build_app()
+    user = _mock_user("admin")
+
+    async def mock_admin():
+        return user
+
+    async def mock_db():
+        yield MagicMock()
+
+    app.dependency_overrides[require_workspace_admin] = mock_admin
+    app.dependency_overrides[get_db] = mock_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+# ============================================================================
+# Tests — denial path
+# ============================================================================
+
+
+class TestBillingNonAdminDenied:
+    """Issue #398: billing checkout + portal must reject member/viewer roles."""
+
+    def test_checkout_non_admin_gets_403(self, non_admin_client):
+        response = non_admin_client.post(
+            "/api/v1/billing/checkout",
+            json={
+                "plan_name": "pro",
+                "success_url": "https://example.com/ok",
+                "cancel_url": "https://example.com/cancel",
+            },
+        )
+        assert response.status_code == 403, (
+            f"checkout returned {response.status_code}, expected 403"
+        )
+
+    def test_portal_non_admin_gets_403(self, non_admin_client):
+        response = non_admin_client.get(
+            "/api/v1/billing/portal",
+            params={"return_url": "https://example.com/back"},
+        )
+        assert response.status_code == 403, f"portal returned {response.status_code}, expected 403"
+
+
+# ============================================================================
+# Tests — admin/owner happy path
+# ============================================================================
+
+
+class TestBillingAdminHappyPath:
+    """Smoke: an admin reaches the handler body. Proves the dep is wired, not bypassed."""
+
+    def test_checkout_admin_reaches_handler(self, admin_client):
+        with patch(
+            "plugins.billing.routes.stripe_service.create_checkout_session",
+            new=AsyncMock(return_value="https://stripe.test/session/abc"),
+        ):
+            response = admin_client.post(
+                "/api/v1/billing/checkout",
+                json={
+                    "plan_name": "pro",
+                    "success_url": "https://example.com/ok",
+                    "cancel_url": "https://example.com/cancel",
+                },
+            )
+        assert response.status_code == 200
+        assert response.json() == {"checkout_url": "https://stripe.test/session/abc"}
+
+    def test_portal_admin_reaches_handler(self, admin_client):
+        with patch(
+            "plugins.billing.routes.stripe_service.create_portal_session",
+            new=AsyncMock(return_value="https://stripe.test/portal/xyz"),
+        ):
+            response = admin_client.get(
+                "/api/v1/billing/portal",
+                params={"return_url": "https://example.com/back"},
+            )
+        assert response.status_code == 200
+        assert response.json() == {"portal_url": "https://stripe.test/portal/xyz"}

--- a/backend/tests/api/test_billing_rbac.py
+++ b/backend/tests/api/test_billing_rbac.py
@@ -1,17 +1,20 @@
 """RBAC tests for billing routes (Issue #398).
 
-Workspace admin/owner-only access on the two self-service Stripe endpoints:
+Workspace admin/owner-only, session-only access on the two self-service
+Stripe endpoints:
 
 - ``POST /api/v1/billing/checkout``
 - ``GET  /api/v1/billing/portal``
 
-The ``POST /api/v1/billing/webhook`` route remains open (Stripe signature
+Session-only enforcement (require_workspace_admin_session) prevents a leaked
+long-lived API key from initiating a Stripe checkout. The
+``POST /api/v1/billing/webhook`` route remains open (Stripe signature
 verification) and is intentionally not covered here.
 
 The billing router is registered in ``api.main`` only when ``BILLING_ENABLED=true``.
 This test mounts the router directly on a fresh FastAPI app so the suite runs
 without environment toggles. The role gate is exercised in isolation by
-overriding ``require_workspace_admin``.
+overriding ``require_workspace_admin_session``.
 """
 
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -21,7 +24,7 @@ import pytest
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
 
-from auth.dependencies import require_workspace_admin
+from auth.dependencies import require_workspace_admin_session
 from db.base import get_db
 from plugins.billing.routes import router as billing_router
 
@@ -61,7 +64,7 @@ def non_admin_client():
     async def mock_db():
         yield MagicMock()
 
-    app.dependency_overrides[require_workspace_admin] = mock_reject_admin
+    app.dependency_overrides[require_workspace_admin_session] = mock_reject_admin
     app.dependency_overrides[get_db] = mock_db
     with TestClient(app, raise_server_exceptions=False) as client:
         yield client
@@ -79,7 +82,7 @@ def admin_client():
     async def mock_db():
         yield MagicMock()
 
-    app.dependency_overrides[require_workspace_admin] = mock_admin
+    app.dependency_overrides[require_workspace_admin_session] = mock_admin
     app.dependency_overrides[get_db] = mock_db
     with TestClient(app, raise_server_exceptions=False) as client:
         yield client

--- a/backend/tests/services/test_permission_service.py
+++ b/backend/tests/services/test_permission_service.py
@@ -347,11 +347,10 @@ class TestGetAccessibleContextsForViewer:
 
 
 class TestResolveContextWhitelistEnforcement:
-    """PR #399 regression: ``resolve_context_for_workspace_read`` must apply
-    the same ``allowed_context_ids`` whitelist that ``check_context_access``
-    enforces. Without this, a restricted member/viewer could read
-    UUID-addressed read endpoints (``/graph/*``) for shared contexts outside
-    their whitelist.
+    """``resolve_context_for_workspace_read`` must apply the same
+    ``allowed_context_ids`` whitelist that ``check_context_access`` enforces.
+    Without this, a restricted member/viewer could read UUID-addressed
+    endpoints (``/graph/*``) for contexts outside their whitelist.
     """
 
     def _service_with_member(self, member, context):

--- a/backend/tests/services/test_permission_service.py
+++ b/backend/tests/services/test_permission_service.py
@@ -282,3 +282,65 @@ class TestCountContextOwners:
         db.execute = AsyncMock(return_value=mock_result)
         service = PermissionService(db)
         assert await service.count_context_owners(uuid4()) == 0
+
+
+class TestGetAccessibleContextsForViewer:
+    """Issue #398 regression: get_accessible_contexts must reach the viewer
+    branch.
+
+    Previously gated at ``required_role="member"``, which raised 403 for
+    viewer (weight=1 < member weight=2) — making the explicit viewer branch
+    at lines ~588-613 unreachable. UX symptom: viewer's contexts list was
+    empty even when shared contexts existed in the workspace.
+    """
+
+    @pytest.fixture
+    def viewer_member(self):
+        member = MagicMock()
+        member.role = "viewer"
+        member.allowed_context_ids = None  # No restriction → all shared contexts
+        return member
+
+    @pytest.fixture
+    def service_with_viewer(self, viewer_member):
+        db = MagicMock()
+        # Workspace lookup (not deleted)
+        ws_lookup_result = MagicMock()
+        ws_lookup_result.scalar_one_or_none.return_value = MagicMock(id=uuid4(), deleted_at=None)
+        # Context list query result
+        ctx_list_result = MagicMock()
+        ctx_list_result.scalars.return_value.all.return_value = ["ctx-a", "ctx-b"]
+        db.execute = AsyncMock(side_effect=[ws_lookup_result, ctx_list_result])
+        service = PermissionService(db)
+        service.workspace_service.get_member = AsyncMock(return_value=viewer_member)
+        return service
+
+    @pytest.mark.asyncio
+    async def test_viewer_reaches_viewer_branch(self, service_with_viewer):
+        """Viewer must NOT be 403'd by the membership gate before the
+        per-role branches run."""
+        result = await service_with_viewer.get_accessible_contexts("viewer-user", uuid4())
+        assert result == ["ctx-a", "ctx-b"], (
+            "viewer should reach the per-role branch and receive shared "
+            "contexts; receiving an empty list (or HTTPException) means "
+            "the membership gate rejected viewer before the branch ran"
+        )
+
+    @pytest.mark.asyncio
+    async def test_viewer_with_empty_whitelist_returns_empty(self):
+        """Viewer with allowed_context_ids=[] → no access (explicit empty)."""
+        viewer = MagicMock()
+        viewer.role = "viewer"
+        viewer.allowed_context_ids = []
+
+        db = MagicMock()
+        ws_lookup_result = MagicMock()
+        ws_lookup_result.scalar_one_or_none.return_value = MagicMock(id=uuid4(), deleted_at=None)
+        ctx_list_result = MagicMock()
+        ctx_list_result.scalars.return_value.all.return_value = []
+        db.execute = AsyncMock(side_effect=[ws_lookup_result, ctx_list_result])
+        service = PermissionService(db)
+        service.workspace_service.get_member = AsyncMock(return_value=viewer)
+
+        result = await service.get_accessible_contexts("viewer-user", uuid4())
+        assert result == []

--- a/backend/tests/services/test_permission_service.py
+++ b/backend/tests/services/test_permission_service.py
@@ -419,3 +419,34 @@ class TestResolveContextWhitelistEnforcement:
 
         result = await service.resolve_context_for_workspace_read("user1", ctx_id)
         assert result is ctx
+
+    @pytest.mark.asyncio
+    async def test_suspended_member_with_null_whitelist_gets_404(self):
+        """Migration 042: a member with allowed_context_ids=NULL is in the
+        suspended state and must not reach any UUID-addressed read endpoint.
+        get_accessible_contexts returns [] for the same shape; this helper
+        must align so /graph/* doesn't become a back door."""
+        ctx_id = uuid4()
+        ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
+        suspended_member = MagicMock()
+        suspended_member.role = "member"
+        suspended_member.allowed_context_ids = None  # suspended
+        service = self._service_with_member(suspended_member, ctx)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.resolve_context_for_workspace_read("user1", ctx_id)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_viewer_with_null_whitelist_succeeds(self):
+        """Viewer NULL whitelist means "no restriction" per Migration 042 —
+        unlike the member NULL case (suspended). Viewer should pass."""
+        ctx_id = uuid4()
+        ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
+        viewer = MagicMock()
+        viewer.role = "viewer"
+        viewer.allowed_context_ids = None  # no restriction (all contexts)
+        service = self._service_with_member(viewer, ctx)
+
+        result = await service.resolve_context_for_workspace_read("user1", ctx_id)
+        assert result is ctx

--- a/backend/tests/services/test_permission_service.py
+++ b/backend/tests/services/test_permission_service.py
@@ -344,3 +344,79 @@ class TestGetAccessibleContextsForViewer:
 
         result = await service.get_accessible_contexts("viewer-user", uuid4())
         assert result == []
+
+
+class TestResolveContextWhitelistEnforcement:
+    """PR #399 regression: ``resolve_context_for_workspace_read`` must apply
+    the same ``allowed_context_ids`` whitelist that ``check_context_access``
+    enforces. Without this, a restricted member/viewer could read
+    UUID-addressed read endpoints (``/graph/*``) for shared contexts outside
+    their whitelist.
+    """
+
+    def _service_with_member(self, member, context):
+        db = MagicMock()
+        # First db.execute → context lookup
+        ctx_result = MagicMock()
+        ctx_result.scalar_one_or_none.return_value = context
+        # Second db.execute (inside check_workspace_access) → workspace lookup
+        ws_result = MagicMock()
+        ws_result.scalar_one_or_none.return_value = MagicMock(
+            id=context.workspace_id, deleted_at=None
+        )
+        db.execute = AsyncMock(side_effect=[ctx_result, ws_result])
+        service = PermissionService(db)
+        service.workspace_service.get_member = AsyncMock(return_value=member)
+        return service
+
+    @pytest.mark.asyncio
+    async def test_member_outside_whitelist_gets_404(self):
+        ctx_id = uuid4()
+        ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
+        member = MagicMock()
+        member.role = "member"
+        member.allowed_context_ids = [uuid4()]  # whitelist excludes ctx_id
+        service = self._service_with_member(member, ctx)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.resolve_context_for_workspace_read("user1", ctx_id)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_viewer_outside_whitelist_gets_404(self):
+        ctx_id = uuid4()
+        ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
+        viewer = MagicMock()
+        viewer.role = "viewer"
+        viewer.allowed_context_ids = []  # explicit empty whitelist
+        service = self._service_with_member(viewer, ctx)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await service.resolve_context_for_workspace_read("user1", ctx_id)
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_member_inside_whitelist_succeeds(self):
+        ctx_id = uuid4()
+        ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
+        member = MagicMock()
+        member.role = "member"
+        member.allowed_context_ids = [ctx_id]  # whitelist includes ctx_id
+        service = self._service_with_member(member, ctx)
+
+        result = await service.resolve_context_for_workspace_read("user1", ctx_id)
+        assert result is ctx
+
+    @pytest.mark.asyncio
+    async def test_admin_bypasses_whitelist(self):
+        """Workspace admin/owner should never be filtered by allowed_context_ids
+        (matches check_context_access bypass semantics)."""
+        ctx_id = uuid4()
+        ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
+        admin = MagicMock()
+        admin.role = "admin"
+        admin.allowed_context_ids = [uuid4()]  # would exclude ctx_id if checked
+        service = self._service_with_member(admin, ctx)
+
+        result = await service.resolve_context_for_workspace_read("user1", ctx_id)
+        assert result is ctx

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.test.tsx
@@ -209,10 +209,10 @@ describe("ContextDetailPage deep-link tab guard (#398)", () => {
     },
   );
 
-  // PR #399 review (Copilot): on a hard reload `currentWorkspace` is null
-  // while WorkspaceContext hydrates. Without the workspace-loaded guard,
-  // canSeeAdminTabs collapses to false and the snap effect would clobber
-  // an admin's deep-link target before their role resolves.
+  // On a hard reload `currentWorkspace` is null while WorkspaceContext
+  // hydrates. Without the workspace-loaded guard, canSeeAdminTabs collapses
+  // to false and the snap effect would clobber an admin's deep-link target
+  // before their role resolves.
   it("does NOT snap URL while WorkspaceContext is still loading (currentWorkspace=null)", async () => {
     mockUseParams.mockReturnValue({ id: "ctx-1" });
     mockUseSearchParams.mockReturnValue(new URLSearchParams("tab=settings"));
@@ -222,12 +222,15 @@ describe("ContextDetailPage deep-link tab guard (#398)", () => {
     mockGetContext.mockResolvedValue(makeContext());
 
     render(<ContextDetailPage />);
-    // Give effects time to flush.
-    await new Promise((r) => setTimeout(r, 50));
-    const overviewSnaps = mockReplace.mock.calls.filter(
-      (c) =>
-        typeof c[0] === "string" && (c[0] as string).includes("tab=overview"),
-    );
-    expect(overviewSnaps.length).toBe(0);
+    // Tie the assertion to React's effect processing rather than a fixed
+    // wall-clock delay (which is CI-flaky). The snap effect must NOT push
+    // a tab=overview replace while currentWorkspace is null.
+    await waitFor(() => {
+      const overviewSnaps = mockReplace.mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" && (c[0] as string).includes("tab=overview"),
+      );
+      expect(overviewSnaps.length).toBe(0);
+    });
   });
 });

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * Tests for the consolidated context detail page tab visibility (Issue #398).
+ *
+ * Workspace member/viewer roles must see only the Overview tab. Admin and
+ * owner see all four tabs. Deep-link probes to `?tab=settings` (or graph /
+ * connections) for member/viewer must clamp the rendered tab back to overview
+ * AND update the URL via setTab — otherwise the address bar drifts from the
+ * rendered content.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+import ContextDetailPage from "./page";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockGetContext = vi.fn();
+vi.mock("@/lib/api/contexts", () => ({
+  getContext: (...a: unknown[]) => mockGetContext(...a),
+}));
+
+const mockUseParams = vi.fn();
+const mockUseSearchParams = vi.fn();
+const mockReplace = vi.fn();
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useParams: () => mockUseParams(),
+  useSearchParams: () => mockUseSearchParams(),
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+  usePathname: () => "/workspace/contexts/ctx-1",
+}));
+
+// useTranslations must return a stable identity — fetchContext's useCallback
+// depends on `t`, and the page's data-load useEffect depends on fetchContext.
+// A new t on every render would trigger an infinite re-fetch loop in the test.
+const stableT = (k: string) => k;
+vi.mock("next-intl", () => ({
+  useTranslations: () => stableT,
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock("@/contexts/AuthContext", () => ({ useAuth: () => mockUseAuth() }));
+
+const mockUseWorkspace = vi.fn();
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+const mockUseMemoryContext = vi.fn();
+vi.mock("@/contexts/MemoryContextContext", () => ({
+  useMemoryContext: () => mockUseMemoryContext(),
+}));
+
+// Stub the lazy-loaded admin tab panels so happy-dom doesn't have to render
+// d3 (graph) or fetch lists. We only care about which tab triggers / panels
+// are present in the DOM, not what they contain.
+vi.mock("@/components/contexts/OverviewTabPanel", () => ({
+  OverviewTabPanel: () => <div data-testid="overview-panel" />,
+}));
+vi.mock("@/components/contexts/ConnectionsTabPanel", () => ({
+  ConnectionsTabPanel: () => <div data-testid="connections-panel" />,
+}));
+vi.mock("@/components/contexts/SettingsTabPanel", () => ({
+  SettingsTabPanel: () => <div data-testid="settings-panel" />,
+}));
+vi.mock("@/components/contexts/SearchSettingsSection", () => ({
+  SearchSettingsSection: () => <div />,
+}));
+vi.mock("@/components/contexts/MembersSection", () => ({
+  MembersSection: () => <div />,
+}));
+vi.mock("@/components/contexts/ProtectionSection", () => ({
+  ProtectionSection: () => <div />,
+}));
+vi.mock("@/components/contexts/GraphTabPanel", () => ({
+  GraphTabPanel: () => <div data-testid="graph-panel" />,
+}));
+
+// next/dynamic is used only to lazy-load GraphTabPanel. Stub the dynamic
+// loader to a no-op so happy-dom doesn't have to chase the import graph
+// (and the page renders synchronously in the test).
+vi.mock("next/dynamic", () => ({
+  default: () => () => null,
+}));
+
+// ---------- Helpers ----------------------------------------------------------
+
+type Role = "owner" | "admin" | "member" | "viewer";
+
+function makeContext() {
+  return {
+    id: "ctx-1",
+    name: "test-ctx",
+    display_name: "Test Context",
+    description: "",
+    summary: "",
+    usage_guide: "",
+    is_private: true,
+    is_public: false,
+    is_default: false,
+    is_locked: false,
+    embedding_model: "small",
+    resource_id: null,
+    workspace_id: "ws-1",
+    created_by: "user-1",
+  };
+}
+
+function setupWithRole(role: Role, urlTab: string | null = null) {
+  mockUseParams.mockReturnValue({ id: "ctx-1" });
+  mockUseSearchParams.mockReturnValue(
+    new URLSearchParams(urlTab ? `tab=${urlTab}` : ""),
+  );
+  mockUseAuth.mockReturnValue({ user: { id: "user-1" } });
+  mockUseWorkspace.mockReturnValue({
+    currentWorkspace: {
+      id: "ws-1",
+      plan_name: "pro",
+      current_user_role: role,
+    },
+  });
+  mockUseMemoryContext.mockReturnValue({ currentContext: null });
+  mockGetContext.mockResolvedValue(makeContext());
+}
+
+beforeEach(() => {
+  mockGetContext.mockReset();
+  mockUseParams.mockReset();
+  mockUseSearchParams.mockReset();
+  mockUseAuth.mockReset();
+  mockUseWorkspace.mockReset();
+  mockUseMemoryContext.mockReset();
+  mockReplace.mockReset();
+  mockPush.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("ContextDetailPage tab visibility (#398)", () => {
+  it.each(["owner", "admin"] as const)(
+    "shows all four tabs for %s",
+    async (role) => {
+      setupWithRole(role);
+      render(<ContextDetailPage />);
+      await waitFor(() =>
+        expect(screen.getByText("tabs.overview")).toBeInTheDocument(),
+      );
+      expect(screen.getByText("tabs.connections")).toBeInTheDocument();
+      expect(screen.getByText("tabs.graph")).toBeInTheDocument();
+      expect(screen.getByText("tabs.settings")).toBeInTheDocument();
+    },
+  );
+
+  it.each(["member", "viewer"] as const)(
+    "shows only the Overview tab for %s",
+    async (role) => {
+      setupWithRole(role);
+      render(<ContextDetailPage />);
+      await waitFor(() =>
+        expect(screen.getByText("tabs.overview")).toBeInTheDocument(),
+      );
+      expect(screen.queryByText("tabs.connections")).toBeNull();
+      expect(screen.queryByText("tabs.graph")).toBeNull();
+      expect(screen.queryByText("tabs.settings")).toBeNull();
+    },
+  );
+});
+
+describe("ContextDetailPage deep-link tab guard (#398)", () => {
+  it.each(["member", "viewer"] as const)(
+    "snaps URL back to ?tab=overview when %s lands on ?tab=settings",
+    async (role) => {
+      setupWithRole(role, "settings");
+      render(<ContextDetailPage />);
+      // The snap useEffect calls setTab("overview") which routes through
+      // router.replace. Wait for the call rather than asserting synchronously
+      // — useEffect fires after the first paint.
+      await waitFor(() => {
+        expect(mockReplace).toHaveBeenCalled();
+      });
+      // The URL written into history must include tab=overview, not settings.
+      const lastCall = mockReplace.mock.calls.at(-1)?.[0] as string | undefined;
+      expect(lastCall).toBeDefined();
+      expect(lastCall).toContain("tab=overview");
+    },
+  );
+
+  it.each(["owner", "admin"] as const)(
+    "does NOT snap URL away from ?tab=settings when %s lands on it",
+    async (role) => {
+      setupWithRole(role, "settings");
+      render(<ContextDetailPage />);
+      await waitFor(() =>
+        expect(screen.getByText("tabs.overview")).toBeInTheDocument(),
+      );
+      // Admin/owner can stay on settings — no snap should fire. We only assert
+      // that no replace call carries tab=overview (a tab=settings replace can
+      // still occur if useTabParam promotes the URL — that's fine).
+      const overviewSnaps = mockReplace.mock.calls.filter(
+        (c) =>
+          typeof c[0] === "string" && (c[0] as string).includes("tab=overview"),
+      );
+      expect(overviewSnaps.length).toBe(0);
+    },
+  );
+});

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.test.tsx
@@ -222,15 +222,17 @@ describe("ContextDetailPage deep-link tab guard (#398)", () => {
     mockGetContext.mockResolvedValue(makeContext());
 
     render(<ContextDetailPage />);
-    // Tie the assertion to React's effect processing rather than a fixed
-    // wall-clock delay (which is CI-flaky). The snap effect must NOT push
-    // a tab=overview replace while currentWorkspace is null.
+    // Anchor on a positive signal (initial getContext fetch) so we know the
+    // page's first effect cycle has run. The negative assertion that follows
+    // would be vacuously true right after render() — without an anchor a
+    // regression that fires the snap on the next tick could still pass.
     await waitFor(() => {
-      const overviewSnaps = mockReplace.mock.calls.filter(
-        (c) =>
-          typeof c[0] === "string" && (c[0] as string).includes("tab=overview"),
-      );
-      expect(overviewSnaps.length).toBe(0);
+      expect(mockGetContext).toHaveBeenCalled();
     });
+    const overviewSnaps = mockReplace.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" && (c[0] as string).includes("tab=overview"),
+    );
+    expect(overviewSnaps.length).toBe(0);
   });
 });

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.test.tsx
@@ -208,4 +208,26 @@ describe("ContextDetailPage deep-link tab guard (#398)", () => {
       expect(overviewSnaps.length).toBe(0);
     },
   );
+
+  // PR #399 review (Copilot): on a hard reload `currentWorkspace` is null
+  // while WorkspaceContext hydrates. Without the workspace-loaded guard,
+  // canSeeAdminTabs collapses to false and the snap effect would clobber
+  // an admin's deep-link target before their role resolves.
+  it("does NOT snap URL while WorkspaceContext is still loading (currentWorkspace=null)", async () => {
+    mockUseParams.mockReturnValue({ id: "ctx-1" });
+    mockUseSearchParams.mockReturnValue(new URLSearchParams("tab=settings"));
+    mockUseAuth.mockReturnValue({ user: { id: "user-1" } });
+    mockUseWorkspace.mockReturnValue({ currentWorkspace: null });
+    mockUseMemoryContext.mockReturnValue({ currentContext: null });
+    mockGetContext.mockResolvedValue(makeContext());
+
+    render(<ContextDetailPage />);
+    // Give effects time to flush.
+    await new Promise((r) => setTimeout(r, 50));
+    const overviewSnaps = mockReplace.mock.calls.filter(
+      (c) =>
+        typeof c[0] === "string" && (c[0] as string).includes("tab=overview"),
+    );
+    expect(overviewSnaps.length).toBe(0);
+  });
 });

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -50,7 +50,13 @@ const GraphTabPanel = dynamic(
   { ssr: false },
 );
 
-const CONTEXT_TABS = ["overview", "connections", "graph", "settings"] as const;
+const ADMIN_CONTEXT_TABS = [
+  "overview",
+  "connections",
+  "graph",
+  "settings",
+] as const;
+const NON_ADMIN_CONTEXT_TABS = ["overview"] as const;
 
 export default function ContextDetailPage() {
   const params = useParams();
@@ -60,7 +66,23 @@ export default function ContextDetailPage() {
   const { currentContext } = useMemoryContext();
   const { currentWorkspace } = useWorkspace();
 
-  const [tab, setTab] = useTabParam("overview", "tab", CONTEXT_TABS);
+  // Issue #398: member/viewer only see Overview. Admin+ see all four tabs.
+  // hasWorkspaceRole returns false while currentWorkspace hydrates — the
+  // admin tabs stay hidden until role is known, preventing a flash where
+  // a member briefly sees admin-only triggers.
+  const canSeeAdminTabs = hasWorkspaceRole(
+    currentWorkspace?.current_user_role,
+    "admin",
+  );
+  const visibleTabs = canSeeAdminTabs
+    ? ADMIN_CONTEXT_TABS
+    : NON_ADMIN_CONTEXT_TABS;
+
+  // Passing visibleTabs as allowedValues makes useTabParam clamp unknown
+  // URL values (e.g. member lands on ?tab=settings via deep-link) back to
+  // "overview" — no separate redirect effect needed for the display. We
+  // still snap the URL below so the address bar matches what's rendered.
+  const [tab, setTab] = useTabParam("overview", "tab", visibleTabs);
   const [context, setContext] = useState<Context | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -81,6 +103,16 @@ export default function ContextDetailPage() {
   useEffect(() => {
     fetchContext();
   }, [fetchContext]);
+
+  // Issue #398: snap the URL to ?tab=overview when a member/viewer arrives
+  // on an admin-only tab via deep-link. useTabParam's allowedValues already
+  // clamps the rendered value, but the raw URL is not auto-corrected — this
+  // keeps the address bar honest.
+  useEffect(() => {
+    if (!canSeeAdminTabs && tab !== "overview") {
+      setTab("overview");
+    }
+  }, [canSeeAdminTabs, tab, setTab]);
 
   useEffect(() => {
     const title = context?.display_name || context?.name || t("title");
@@ -184,31 +216,42 @@ export default function ContextDetailPage() {
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList>
           <TabsTrigger value="overview">{t("tabs.overview")}</TabsTrigger>
-          <TabsTrigger value="connections">{t("tabs.connections")}</TabsTrigger>
-          <TabsTrigger value="graph">{t("tabs.graph")}</TabsTrigger>
-          <TabsTrigger value="settings">{t("tabs.settings")}</TabsTrigger>
+          {/* Issue #398: connections/graph/settings tabs are admin-only. */}
+          {canSeeAdminTabs && (
+            <>
+              <TabsTrigger value="connections">
+                {t("tabs.connections")}
+              </TabsTrigger>
+              <TabsTrigger value="graph">{t("tabs.graph")}</TabsTrigger>
+              <TabsTrigger value="settings">{t("tabs.settings")}</TabsTrigger>
+            </>
+          )}
         </TabsList>
 
         <TabsContent value="overview">
           <OverviewTabPanel contextId={contextId} context={context} />
         </TabsContent>
 
-        <TabsContent value="connections">
-          <ConnectionsTabPanel contextId={contextId} />
-        </TabsContent>
+        {/* TabsContent for admin-only tabs is also gated so the panels never
+            render for member/viewer (eliminates one-frame flash on direct
+            ?tab=settings deep-link before the URL snap effect fires, and
+            keeps GraphTabPanel's d3 bundle out of non-admin sessions). */}
+        {canSeeAdminTabs && (
+          <>
+            <TabsContent value="connections">
+              <ConnectionsTabPanel contextId={contextId} />
+            </TabsContent>
 
-        <TabsContent value="graph">
-          <GraphTabPanel contextId={contextId} />
-        </TabsContent>
+            <TabsContent value="graph">
+              <GraphTabPanel contextId={contextId} />
+            </TabsContent>
 
-        <TabsContent value="settings">
-          <SettingsTabPanel
-            contextId={contextId}
-            context={context}
-            onContextUpdated={handleContextUpdated}
-          />
-          {hasWorkspaceRole(currentWorkspace?.current_user_role, "admin") && (
-            <>
+            <TabsContent value="settings">
+              <SettingsTabPanel
+                contextId={contextId}
+                context={context}
+                onContextUpdated={handleContextUpdated}
+              />
               <Separator className="my-8" />
               <SearchSettingsSection contextId={contextId} />
               {!context.is_private && (
@@ -219,9 +262,9 @@ export default function ContextDetailPage() {
               )}
               <Separator className="my-8" />
               <ProtectionSection context={context} />
-            </>
-          )}
-        </TabsContent>
+            </TabsContent>
+          </>
+        )}
       </Tabs>
     </PageContainer>
   );

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -108,8 +108,8 @@ export default function ContextDetailPage() {
   // on an admin-only tab via deep-link. useTabParam's allowedValues already
   // clamps the *rendered* value to overview, but useTabParam only auto-promotes
   // the URL when the param is absent (not when it is present-but-invalid),
-  // so we have to compare the raw URL value here — `tab` is already clamped
-  // and would always equal "overview" for non-admins, making this a no-op.
+  // so we compare the raw URL value here — checking `tab` would always see
+  // "overview" for non-admins and the snap would never fire.
   const searchParams = useSearchParams();
   const rawTab = searchParams.get("tab");
   useEffect(() => {

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -8,7 +8,7 @@
 "use client";
 
 import { useEffect, useState, useCallback } from "react";
-import { useParams } from "next/navigation";
+import { useParams, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import Link from "next/link";
 import dynamic from "next/dynamic";
@@ -106,13 +106,17 @@ export default function ContextDetailPage() {
 
   // Issue #398: snap the URL to ?tab=overview when a member/viewer arrives
   // on an admin-only tab via deep-link. useTabParam's allowedValues already
-  // clamps the rendered value, but the raw URL is not auto-corrected — this
-  // keeps the address bar honest.
+  // clamps the *rendered* value to overview, but useTabParam only auto-promotes
+  // the URL when the param is absent (not when it is present-but-invalid),
+  // so we have to compare the raw URL value here — `tab` is already clamped
+  // and would always equal "overview" for non-admins, making this a no-op.
+  const searchParams = useSearchParams();
+  const rawTab = searchParams.get("tab");
   useEffect(() => {
-    if (!canSeeAdminTabs && tab !== "overview") {
+    if (!canSeeAdminTabs && rawTab && rawTab !== "overview") {
       setTab("overview");
     }
-  }, [canSeeAdminTabs, tab, setTab]);
+  }, [canSeeAdminTabs, rawTab, setTab]);
 
   useEffect(() => {
     const title = context?.display_name || context?.name || t("title");

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -110,13 +110,20 @@ export default function ContextDetailPage() {
   // the URL when the param is absent (not when it is present-but-invalid),
   // so we compare the raw URL value here — checking `tab` would always see
   // "overview" for non-admins and the snap would never fire.
+  //
+  // PR #399 review (Copilot): the `currentWorkspace` guard is load-bearing.
+  // During WorkspaceContext hydration `currentWorkspace` is null, which makes
+  // `canSeeAdminTabs` false — without this guard, an admin hard-reloading
+  // ?tab=settings would have their URL snapped back to overview before the
+  // role resolved, losing the deep-link target.
   const searchParams = useSearchParams();
   const rawTab = searchParams.get("tab");
   useEffect(() => {
+    if (!currentWorkspace) return;
     if (!canSeeAdminTabs && rawTab && rawTab !== "overview") {
       setTab("overview");
     }
-  }, [canSeeAdminTabs, rawTab, setTab]);
+  }, [currentWorkspace, canSeeAdminTabs, rawTab, setTab]);
 
   useEffect(() => {
     const title = context?.display_name || context?.name || t("title");

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -104,18 +104,17 @@ export default function ContextDetailPage() {
     fetchContext();
   }, [fetchContext]);
 
-  // Issue #398: snap the URL to ?tab=overview when a member/viewer arrives
-  // on an admin-only tab via deep-link. useTabParam's allowedValues already
-  // clamps the *rendered* value to overview, but useTabParam only auto-promotes
-  // the URL when the param is absent (not when it is present-but-invalid),
-  // so we compare the raw URL value here — checking `tab` would always see
-  // "overview" for non-admins and the snap would never fire.
+  // Snap the URL to ?tab=overview when a member/viewer arrives on an
+  // admin-only tab via deep-link. useTabParam's allowedValues already clamps
+  // the *rendered* value to overview, but only auto-promotes the URL when the
+  // param is absent — not when it's present-but-invalid. Compare the raw URL
+  // value here; reading `tab` would always see "overview" for non-admins so
+  // the snap would never fire.
   //
-  // PR #399 review (Copilot): the `currentWorkspace` guard is load-bearing.
-  // During WorkspaceContext hydration `currentWorkspace` is null, which makes
-  // `canSeeAdminTabs` false — without this guard, an admin hard-reloading
-  // ?tab=settings would have their URL snapped back to overview before the
-  // role resolved, losing the deep-link target.
+  // The `!currentWorkspace` guard is load-bearing: during WorkspaceContext
+  // hydration `currentWorkspace` is null, which collapses canSeeAdminTabs to
+  // false. Without the guard, an admin hard-reloading ?tab=settings would
+  // have their URL snapped back to overview before the role resolved.
   const searchParams = useSearchParams();
   const rawTab = searchParams.get("tab");
   useEffect(() => {

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.test.tsx
@@ -228,3 +228,117 @@ describe("ContextsPage empty-state CTA role gating (#382)", () => {
     expect(screen.queryByText("createFirstContext")).toBeNull();
   });
 });
+
+// ---------- Issue #398: New Context button + kebab role gating ---------------
+
+function setupWithRoleAndOneContext(role: Role) {
+  // Set up the auth + workspace mocks the same way setupWithRole does, but
+  // skip its mockGetContexts call so we don't queue an empty-contexts response
+  // that beats the populated one when the page calls getContexts() twice
+  // (initial fetch + any post-action re-fetch).
+  mockUseAuth.mockReturnValue({
+    user: { current_workspace_id: WORKSPACE_ID },
+    refetchUser: vi.fn(),
+  });
+  mockUseWorkspace.mockReturnValue({
+    currentWorkspace: {
+      id: WORKSPACE_ID,
+      plan_name: "pro",
+      current_user_role: role,
+    },
+  });
+  mockCheckOpenAIKeyStatus.mockResolvedValue({ has_key: true });
+  mockGetEmbeddingModels.mockResolvedValue({
+    models: [],
+    default_model: "small",
+  });
+  mockGetContexts.mockResolvedValue({
+    contexts: [
+      {
+        id: "ctx-1",
+        name: "test-ctx",
+        display_name: "Test Context",
+        description: "",
+        memory_count: 0,
+        last_activity_at: null,
+        is_default: false,
+        is_locked: false,
+        is_private: true,
+        is_public: false,
+        embedding_model: "small",
+        resource_id: null,
+      },
+    ],
+  });
+}
+
+describe("ContextsPage New Context header button (#398)", () => {
+  // it.each spreads each row into the test-fn args. Pass scalars (not nested
+  // arrays) so the role string isn't iterated character-by-character.
+  it.each(["owner", "admin"] as const)(
+    "renders the New Context button for %s",
+    async (role) => {
+      setupWithRole(role);
+      render(<ContextsPage />);
+      await waitFor(() =>
+        expect(screen.getByText("noContextsYet")).toBeInTheDocument(),
+      );
+      // The dropdown trigger button contains a Plus icon + "newContext" text.
+      expect(
+        screen.getByText("newContext", { exact: false }),
+      ).toBeInTheDocument();
+    },
+  );
+
+  it.each(["member", "viewer"] as const)(
+    "hides the New Context button for %s",
+    async (role) => {
+      setupWithRole(role);
+      render(<ContextsPage />);
+      await waitFor(() =>
+        expect(screen.getByText("noContextsYet")).toBeInTheDocument(),
+      );
+      expect(screen.queryByText("newContext", { exact: false })).toBeNull();
+    },
+  );
+});
+
+describe("ContextsPage per-row kebab menu (#398)", () => {
+  it.each(["owner", "admin"] as const)(
+    "renders the kebab menu trigger for %s",
+    async (role) => {
+      setupWithRoleAndOneContext(role);
+      const { container } = render(<ContextsPage />);
+      await waitFor(() =>
+        expect(screen.getByText("Test Context")).toBeInTheDocument(),
+      );
+      // Two dropdown triggers when admin/owner: New Context (header) + kebab (row).
+      // Querying via aria-haspopup is independent of lucide icon class churn.
+      const triggers = container.querySelectorAll(
+        'button[aria-haspopup="menu"]',
+      );
+      expect(triggers.length).toBe(2);
+    },
+  );
+
+  it.each(["member", "viewer"] as const)(
+    "hides the kebab menu trigger for %s",
+    async (role) => {
+      setupWithRoleAndOneContext(role);
+      const { container } = render(<ContextsPage />);
+      await waitFor(() =>
+        expect(screen.getByText("Test Context")).toBeInTheDocument(),
+      );
+      // No dropdown triggers anywhere — both the header New Context button
+      // and the per-row kebab are gated behind the same admin check.
+      expect(
+        container.querySelectorAll('button[aria-haspopup="menu"]').length,
+      ).toBe(0);
+      // The BarChart "view usage" button stays visible — overview is reachable
+      // by every role, so the navigation affordance must remain.
+      expect(
+        container.querySelector('button[title="viewUsage"]'),
+      ).not.toBeNull();
+    },
+  );
+});

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -162,6 +162,14 @@ export default function ContextsPage() {
   >({});
   const [loadingStats, setLoadingStats] = useState<Record<string, boolean>>({});
 
+  // Issue #398: admin/owner-only controls (create button, per-row kebab,
+  // settings/connections/graph navigation). hasWorkspaceRole returns false
+  // while currentWorkspace hydrates — controls stay hidden until role is known.
+  const canManageContexts = hasWorkspaceRole(
+    currentWorkspace?.current_user_role,
+    "admin",
+  );
+
   const fetchContexts = useCallback(async () => {
     try {
       setLoading(true);
@@ -431,61 +439,59 @@ export default function ContextsPage() {
         actions={
           <div className="flex items-center gap-2">
             {/* Issue #169: Dropdown for Quick Create vs Advanced Create */}
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  size="sm"
-                  className={colors.button.primary}
-                  disabled={
-                    hasOpenAIKey === false ||
-                    currentWorkspace?.current_user_role === "member" ||
-                    currentWorkspace?.current_user_role === "viewer" ||
-                    isQuotaReached
-                  }
-                >
-                  <Plus className="h-4 w-4 mr-2" />
-                  {t("newContext")}
-                  <ChevronDown className="h-4 w-4 ml-1" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-56">
-                <DropdownMenuItem
-                  onClick={() => {
-                    if (isQuotaReached) {
-                      setQuotaDialogOpen(true);
-                    } else {
-                      setQuickCreateDialogOpen(true);
-                    }
-                  }}
-                >
-                  <Zap className="h-4 w-4 mr-2 text-amber-500" />
-                  <div>
-                    <div className="font-medium">{t("quickCreate")}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {t("quickCreateDesc")}
+            {/* Issue #398: admin/owner-only — hidden for member/viewer. */}
+            {canManageContexts && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    size="sm"
+                    className={colors.button.primary}
+                    disabled={hasOpenAIKey === false || isQuotaReached}
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    {t("newContext")}
+                    <ChevronDown className="h-4 w-4 ml-1" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuItem
+                    onClick={() => {
+                      if (isQuotaReached) {
+                        setQuotaDialogOpen(true);
+                      } else {
+                        setQuickCreateDialogOpen(true);
+                      }
+                    }}
+                  >
+                    <Zap className="h-4 w-4 mr-2 text-amber-500" />
+                    <div>
+                      <div className="font-medium">{t("quickCreate")}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {t("quickCreateDesc")}
+                      </div>
                     </div>
-                  </div>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem
-                  onClick={() => {
-                    if (isQuotaReached) {
-                      setQuotaDialogOpen(true);
-                    } else {
-                      setCreateDialogOpen(true);
-                    }
-                  }}
-                >
-                  <Settings2 className="h-4 w-4 mr-2 text-blue-500" />
-                  <div>
-                    <div className="font-medium">{t("advancedCreate")}</div>
-                    <div className="text-xs text-muted-foreground">
-                      {t("advancedCreateDesc")}
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem
+                    onClick={() => {
+                      if (isQuotaReached) {
+                        setQuotaDialogOpen(true);
+                      } else {
+                        setCreateDialogOpen(true);
+                      }
+                    }}
+                  >
+                    <Settings2 className="h-4 w-4 mr-2 text-blue-500" />
+                    <div>
+                      <div className="font-medium">{t("advancedCreate")}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {t("advancedCreateDesc")}
+                      </div>
                     </div>
-                  </div>
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
           </div>
         }
       />
@@ -1012,49 +1018,54 @@ export default function ContextsPage() {
                       >
                         <BarChart className="h-3.5 w-3.5" />
                       </Button>
-                      <DropdownMenu>
-                        <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-7 w-7 p-0"
-                          >
-                            <MoreVertical className="h-3.5 w-3.5" />
-                          </Button>
-                        </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end">
-                          <DropdownMenuItem
-                            onClick={() =>
-                              router.push(
-                                `/workspace/contexts/${context.id}?tab=connections`,
-                              )
-                            }
-                          >
-                            <Settings2 className="h-4 w-4 mr-2" />
-                            {t("connections")}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() =>
-                              router.push(
-                                `/workspace/contexts/${context.id}?tab=graph`,
-                              )
-                            }
-                          >
-                            <Settings2 className="h-4 w-4 mr-2" />
-                            {t("graph")}
-                          </DropdownMenuItem>
-                          <DropdownMenuItem
-                            onClick={() =>
-                              router.push(
-                                `/workspace/contexts/${context.id}?tab=settings`,
-                              )
-                            }
-                          >
-                            <Settings2 className="h-4 w-4 mr-2" />
-                            {tCommon("settings")}
-                          </DropdownMenuItem>
-                        </DropdownMenuContent>
-                      </DropdownMenu>
+                      {/* Issue #398: kebab navigates to admin-only tabs;
+                          hide entirely for member/viewer (overview reachable
+                          via the BarChart button above). */}
+                      {canManageContexts && (
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              className="h-7 w-7 p-0"
+                            >
+                              <MoreVertical className="h-3.5 w-3.5" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() =>
+                                router.push(
+                                  `/workspace/contexts/${context.id}?tab=connections`,
+                                )
+                              }
+                            >
+                              <Settings2 className="h-4 w-4 mr-2" />
+                              {t("connections")}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() =>
+                                router.push(
+                                  `/workspace/contexts/${context.id}?tab=graph`,
+                                )
+                              }
+                            >
+                              <Settings2 className="h-4 w-4 mr-2" />
+                              {t("graph")}
+                            </DropdownMenuItem>
+                            <DropdownMenuItem
+                              onClick={() =>
+                                router.push(
+                                  `/workspace/contexts/${context.id}?tab=settings`,
+                                )
+                              }
+                            >
+                              <Settings2 className="h-4 w-4 mr-2" />
+                              {tCommon("settings")}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
+                      )}
                     </div>
                   </td>
                 </tr>

--- a/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
@@ -8,7 +8,9 @@
  */
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { hasWorkspaceRole } from "@/lib/auth/rbac";
 import { PageContainer } from "@/components/common/PageContainer";
 import { Button } from "@/components/ui/button";
 import {
@@ -40,7 +42,20 @@ import {
 export default function WorkspaceStatsPage() {
   const t = useTranslations("workspace");
   const tCommon = useTranslations("common");
+  const router = useRouter();
   const { currentWorkspace, currentWorkspaceId } = useWorkspace();
+
+  // Issue #398: viewer cannot read workspace stats (backend 403's on
+  // /workspaces/{id}/contexts/stats with required_role="member"). Send
+  // viewers to the contexts list — their only data-bearing surface.
+  useEffect(() => {
+    if (
+      currentWorkspace &&
+      !hasWorkspaceRole(currentWorkspace.current_user_role, "member")
+    ) {
+      router.push("/workspace/contexts");
+    }
+  }, [currentWorkspace, router]);
   const [stats, setStats] = useState<WorkspaceStats | null>(null);
   const [contextStats, setContextStats] = useState<ContextStatsResponse | null>(
     null,

--- a/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
@@ -94,17 +94,16 @@ export default function WorkspaceStatsPage() {
   };
 
   useEffect(() => {
-    // Issue #398: skip the protected fetches for viewer — the redirect
-    // useEffect above is sending them to /workspace/contexts, and the
-    // backend (workspace stats + contexts/stats) returns 403 for viewer.
-    // Without this guard a viewer flashes a "Requires 'member' role or
-    // higher" error toast in the gap between login and the redirect.
+    // Skip the protected fetches for viewer — the redirect useEffect above
+    // is sending them to /workspace/contexts, and the backend (workspace
+    // stats + contexts/stats) returns 403 for viewer. Without this guard a
+    // viewer flashes a "Requires 'member' role or higher" error toast in
+    // the gap between login and the redirect.
     //
-    // PR #399 review (Copilot): also wait for WorkspaceContext to finish
-    // loading. During hydration `currentWorkspace` is null while
-    // `currentWorkspaceId` may already be cached — without the loading
-    // guard the viewer-skip is bypassed and fetchStats fires once with
-    // unknown role, recreating the very flash this code is preventing.
+    // The workspaceLoading guard is load-bearing: during hydration
+    // currentWorkspace is null while currentWorkspaceId may already be
+    // cached. Without it the viewer-skip is bypassed and fetchStats fires
+    // once with unknown role, recreating the flash this code prevents.
     if (workspaceLoading) return;
     if (
       currentWorkspace &&

--- a/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
@@ -90,11 +90,29 @@ export default function WorkspaceStatsPage() {
   };
 
   useEffect(() => {
+    // Issue #398: skip the protected fetches for viewer — the redirect
+    // useEffect above is sending them to /workspace/contexts, and the
+    // backend (workspace stats + contexts/stats) returns 403 for viewer.
+    // Without this guard a viewer flashes a "Requires 'member' role or
+    // higher" error toast in the gap between login and the redirect.
+    if (
+      currentWorkspace &&
+      !hasWorkspaceRole(currentWorkspace.current_user_role, "member")
+    ) {
+      return;
+    }
     fetchStats();
-  }, [currentWorkspaceId]);
+  }, [currentWorkspaceId, currentWorkspace?.current_user_role]);
 
   useEffect(() => {
     if (!currentWorkspaceId) return;
+    // Same viewer-skip as above — memory-timeline is a member+ surface.
+    if (
+      currentWorkspace &&
+      !hasWorkspaceRole(currentWorkspace.current_user_role, "member")
+    ) {
+      return;
+    }
 
     const controller = new AbortController();
     getWorkspaceMemoryTimeline(
@@ -113,7 +131,12 @@ export default function WorkspaceStatsPage() {
       });
 
     return () => controller.abort();
-  }, [timelineDays, currentWorkspaceId, selectedContextId]);
+  }, [
+    timelineDays,
+    currentWorkspaceId,
+    selectedContextId,
+    currentWorkspace?.current_user_role,
+  ]);
 
   return (
     <PageContainer>

--- a/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
@@ -43,7 +43,11 @@ export default function WorkspaceStatsPage() {
   const t = useTranslations("workspace");
   const tCommon = useTranslations("common");
   const router = useRouter();
-  const { currentWorkspace, currentWorkspaceId } = useWorkspace();
+  const {
+    currentWorkspace,
+    currentWorkspaceId,
+    loading: workspaceLoading,
+  } = useWorkspace();
 
   // Issue #398: viewer cannot read workspace stats (backend 403's on
   // /workspaces/{id}/contexts/stats with required_role="member"). Send
@@ -95,6 +99,13 @@ export default function WorkspaceStatsPage() {
     // backend (workspace stats + contexts/stats) returns 403 for viewer.
     // Without this guard a viewer flashes a "Requires 'member' role or
     // higher" error toast in the gap between login and the redirect.
+    //
+    // PR #399 review (Copilot): also wait for WorkspaceContext to finish
+    // loading. During hydration `currentWorkspace` is null while
+    // `currentWorkspaceId` may already be cached — without the loading
+    // guard the viewer-skip is bypassed and fetchStats fires once with
+    // unknown role, recreating the very flash this code is preventing.
+    if (workspaceLoading) return;
     if (
       currentWorkspace &&
       !hasWorkspaceRole(currentWorkspace.current_user_role, "member")
@@ -102,10 +113,15 @@ export default function WorkspaceStatsPage() {
       return;
     }
     fetchStats();
-  }, [currentWorkspaceId, currentWorkspace?.current_user_role]);
+  }, [
+    currentWorkspaceId,
+    currentWorkspace?.current_user_role,
+    workspaceLoading,
+  ]);
 
   useEffect(() => {
     if (!currentWorkspaceId) return;
+    if (workspaceLoading) return;
     // Same viewer-skip as above — memory-timeline is a member+ surface.
     if (
       currentWorkspace &&
@@ -136,6 +152,7 @@ export default function WorkspaceStatsPage() {
     currentWorkspaceId,
     selectedContextId,
     currentWorkspace?.current_user_role,
+    workspaceLoading,
   ]);
 
   return (

--- a/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
@@ -145,9 +145,9 @@ describe("WorkspaceMembersPage redirect guard (#398)", () => {
     mockGetContexts.mockResolvedValue({ contexts: [] });
 
     render(<WorkspaceMembersPage />);
-    // Give React a chance to flush effects. No redirect should fire because
+    // Tie the assertion to React's effect processing rather than a fixed
+    // wall-clock delay (which is CI-flaky). No redirect should fire because
     // workspaceLoading is true.
-    await new Promise((r) => setTimeout(r, 50));
-    expect(mockPush).not.toHaveBeenCalled();
+    await waitFor(() => expect(mockPush).not.toHaveBeenCalled());
   });
 });

--- a/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { render, waitFor, cleanup } from "@testing-library/react";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
 
 import WorkspaceMembersPage from "./page";
 
@@ -145,9 +145,15 @@ describe("WorkspaceMembersPage redirect guard (#398)", () => {
     mockGetContexts.mockResolvedValue({ contexts: [] });
 
     render(<WorkspaceMembersPage />);
-    // Tie the assertion to React's effect processing rather than a fixed
-    // wall-clock delay (which is CI-flaky). No redirect should fire because
-    // workspaceLoading is true.
-    await waitFor(() => expect(mockPush).not.toHaveBeenCalled());
+    // Anchor on a positive signal (PageHeader renders) so the page's first
+    // effect cycle is known to have run. The negative assertion that
+    // follows would be vacuously true right after render() — without an
+    // anchor a regression that fires the redirect on the next tick could
+    // still pass. Both API fetches are also gated on workspaceLoading so
+    // there's no API call to anchor on during the loading state.
+    await waitFor(() => {
+      expect(screen.getByText("membersTitle")).toBeInTheDocument();
+    });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
@@ -134,10 +134,13 @@ describe("WorkspaceMembersPage redirect guard (#398)", () => {
     mockListMembers.mockResolvedValue([]);
     mockListInvitations.mockResolvedValue([]);
     mockGetMemberQuota.mockResolvedValue({
-      plan_name: "pro",
-      members_used: 0,
-      members_limit: 100,
-      upgrade_required: false,
+      current_members: 0,
+      pending_invitations: 0,
+      total_used: 0,
+      limit: 100,
+      available: 100,
+      percentage: 0,
+      can_invite: true,
     });
     mockGetContexts.mockResolvedValue({ contexts: [] });
 

--- a/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
-import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { render, waitFor, cleanup } from "@testing-library/react";
 
 import WorkspaceMembersPage from "./page";
 

--- a/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for the workspace members page redirect guard (Issue #398).
+ *
+ * Workspace member/viewer roles must NOT see the members roster — the page
+ * pushes them back to /workspace/dashboard. Admin/owner stay. The redirect
+ * is suppressed while WorkspaceContext is still loading so admins don't
+ * flash through the dashboard during hydration.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+import WorkspaceMembersPage from "./page";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockListMembers = vi.fn();
+const mockListInvitations = vi.fn();
+const mockGetMemberQuota = vi.fn();
+const mockGetContexts = vi.fn();
+
+vi.mock("@/lib/api/workspaces", () => ({
+  listMembers: (...a: unknown[]) => mockListMembers(...a),
+  addMember: vi.fn(),
+  updateMemberRole: vi.fn(),
+  removeMember: vi.fn(),
+  updateMemberContextAccess: vi.fn(),
+}));
+vi.mock("@/lib/api/invitations", () => ({
+  listInvitations: (...a: unknown[]) => mockListInvitations(...a),
+  createInvitation: vi.fn(),
+  deleteInvitation: vi.fn(),
+  getMemberQuota: (...a: unknown[]) => mockGetMemberQuota(...a),
+}));
+vi.mock("@/lib/api/contexts", () => ({
+  getContexts: (...a: unknown[]) => mockGetContexts(...a),
+}));
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn() }),
+}));
+
+const stableT = (k: string) => k;
+vi.mock("next-intl", () => ({
+  useTranslations: () => stableT,
+}));
+
+const mockUseAuth = vi.fn();
+vi.mock("@/contexts/AuthContext", () => ({ useAuth: () => mockUseAuth() }));
+
+const mockUseWorkspace = vi.fn();
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// ---------- Helpers ----------------------------------------------------------
+
+type Role = "owner" | "admin" | "member" | "viewer";
+
+const WORKSPACE_ID = "ws-1";
+
+function setupWithRole(role: Role) {
+  mockUseAuth.mockReturnValue({ user: { id: "user-1" } });
+  mockUseWorkspace.mockReturnValue({
+    currentWorkspaceId: WORKSPACE_ID,
+    currentWorkspace: {
+      id: WORKSPACE_ID,
+      plan_name: "pro",
+      current_user_role: role,
+    },
+    loading: false,
+  });
+  mockListMembers.mockResolvedValue([]);
+  mockListInvitations.mockResolvedValue([]);
+  mockGetMemberQuota.mockResolvedValue({
+    plan_name: "pro",
+    members_used: 0,
+    members_limit: 100,
+    upgrade_required: false,
+  });
+  mockGetContexts.mockResolvedValue({ contexts: [] });
+}
+
+beforeEach(() => {
+  mockUseAuth.mockReset();
+  mockUseWorkspace.mockReset();
+  mockListMembers.mockReset();
+  mockListInvitations.mockReset();
+  mockGetMemberQuota.mockReset();
+  mockGetContexts.mockReset();
+  mockPush.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("WorkspaceMembersPage redirect guard (#398)", () => {
+  it.each(["member", "viewer"] as const)(
+    "redirects %s to /workspace/dashboard",
+    async (role) => {
+      setupWithRole(role);
+      render(<WorkspaceMembersPage />);
+      await waitFor(() =>
+        expect(mockPush).toHaveBeenCalledWith("/workspace/dashboard"),
+      );
+    },
+  );
+
+  it.each(["admin", "owner"] as const)("does NOT redirect %s", async (role) => {
+    setupWithRole(role);
+    render(<WorkspaceMembersPage />);
+    // Wait for the data-load useEffect to fire so we know the redirect
+    // useEffect has had a chance too. listMembers being called is a
+    // good proxy for "page mounted past the role check".
+    await waitFor(() => expect(mockListMembers).toHaveBeenCalled());
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("does NOT redirect while WorkspaceContext is still loading", async () => {
+    mockUseAuth.mockReturnValue({ user: { id: "user-1" } });
+    mockUseWorkspace.mockReturnValue({
+      currentWorkspaceId: null,
+      currentWorkspace: null,
+      loading: true,
+    });
+    mockListMembers.mockResolvedValue([]);
+    mockListInvitations.mockResolvedValue([]);
+    mockGetMemberQuota.mockResolvedValue({
+      plan_name: "pro",
+      members_used: 0,
+      members_limit: 100,
+      upgrade_required: false,
+    });
+    mockGetContexts.mockResolvedValue({ contexts: [] });
+
+    render(<WorkspaceMembersPage />);
+    // Give React a chance to flush effects. No redirect should fire because
+    // workspaceLoading is true.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -150,13 +150,20 @@ export default function WorkspaceMembersPage() {
   const isProPlan = currentWorkspace?.plan_name === "pro";
 
   useEffect(() => {
+    // Issue #398: skip the four protected fetches for member/viewer — the
+    // redirect useEffect above is sending them to /dashboard, and the backend
+    // would 403 each call. Without this guard a non-admin briefly hits four
+    // protected endpoints in parallel with the redirect, surfacing spurious
+    // error toasts before the route change lands.
+    if (workspaceLoading) return;
+    if (!hasWorkspaceRole(currentWorkspace?.current_user_role, "admin")) return;
     if (currentWorkspaceId) {
       loadMembers();
       loadInvitations();
       loadMemberQuota(); // Issue #229
       loadContexts(); // Issue #234
     }
-  }, [currentWorkspaceId]);
+  }, [currentWorkspaceId, currentWorkspace, workspaceLoading]);
 
   const loadMembers = async () => {
     if (!currentWorkspaceId) return;

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -9,7 +9,9 @@
  */
 
 import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
+import { hasWorkspaceRole } from "@/lib/auth/rbac";
 import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { Section } from "@/components/common/Section";
@@ -68,6 +70,7 @@ import { useToast } from "@/hooks/use-toast";
 export default function WorkspaceMembersPage() {
   const t = useTranslations("workspace");
   const tCommon = useTranslations("common");
+  const router = useRouter();
   const {
     currentWorkspaceId,
     currentWorkspace,
@@ -75,6 +78,19 @@ export default function WorkspaceMembersPage() {
   } = useWorkspace();
   const { user } = useAuth();
   const { toast } = useToast();
+
+  // Issue #398: admin/owner only — redirect member/viewer to dashboard.
+  // Mirrors settings/general/page.tsx:83-90 pattern. The workspaceLoading
+  // guard prevents a flash-redirect while WorkspaceContext hydrates.
+  useEffect(() => {
+    if (workspaceLoading) return;
+    if (
+      currentWorkspace &&
+      !hasWorkspaceRole(currentWorkspace.current_user_role, "admin")
+    ) {
+      router.push("/workspace/dashboard");
+    }
+  }, [currentWorkspace, workspaceLoading, router]);
   const [members, setMembers] = useState<WorkspaceMember[]>([]);
   const [invitations, setInvitations] = useState<WorkspaceInvitation[]>([]);
   const [loading, setLoading] = useState(true);

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -163,7 +163,14 @@ export default function WorkspaceMembersPage() {
       loadMemberQuota(); // Issue #229
       loadContexts(); // Issue #234
     }
-  }, [currentWorkspaceId, currentWorkspace, workspaceLoading]);
+    // Depend on the role string (a primitive) rather than the whole
+    // currentWorkspace object — a context provider re-render with the same
+    // workspace would otherwise re-trigger four protected fetches.
+  }, [
+    currentWorkspaceId,
+    currentWorkspace?.current_user_role,
+    workspaceLoading,
+  ]);
 
   const loadMembers = async () => {
     if (!currentWorkspaceId) return;

--- a/frontend/src/components/contexts/OverviewTabPanel.tsx
+++ b/frontend/src/components/contexts/OverviewTabPanel.tsx
@@ -327,11 +327,13 @@ export function OverviewTabPanel({
               </Table>
             ) : (
               <div className="text-center py-8 text-gray-500">
+                {/* PR #399 review (Copilot): the card is now gated to admin/
+                    owner via canSeeUserActivity above. Reaching the null
+                    branch means a real fetch failure (network/5xx), not an
+                    authorization denial — drop the misleading "requires
+                    admin role" sub-copy. */}
                 {userActivity === null ? (
-                  <div>
-                    <p>{t("userActivityNotAvailable")}</p>
-                    <p className="text-sm mt-2">{t("requiresAdminRole")}</p>
-                  </div>
+                  <p>{t("userActivityNotAvailable")}</p>
                 ) : (
                   <p>{t("noActivityData")}</p>
                 )}

--- a/frontend/src/components/contexts/OverviewTabPanel.tsx
+++ b/frontend/src/components/contexts/OverviewTabPanel.tsx
@@ -327,11 +327,11 @@ export function OverviewTabPanel({
               </Table>
             ) : (
               <div className="text-center py-8 text-gray-500">
-                {/* PR #399 review (Copilot): the card is now gated to admin/
-                    owner via canSeeUserActivity above. Reaching the null
-                    branch means a real fetch failure (network/5xx), not an
-                    authorization denial — drop the misleading "requires
-                    admin role" sub-copy. */}
+                {/* The card is gated to admin/owner via canSeeUserActivity
+                    above, so reaching the null branch means a real fetch
+                    failure (network/5xx) rather than an authorization
+                    denial. The pre-gating "requires admin role" sub-copy
+                    would be misleading here. */}
                 {userActivity === null ? (
                   <p>{t("userActivityNotAvailable")}</p>
                 ) : (

--- a/frontend/src/components/contexts/OverviewTabPanel.tsx
+++ b/frontend/src/components/contexts/OverviewTabPanel.tsx
@@ -319,7 +319,7 @@ export function OverviewTabPanel({
                               authUser?.timezone,
                               locale,
                             )
-                          : "Never"}
+                          : t("never")}
                       </TableCell>
                     </TableRow>
                   ))}

--- a/frontend/src/components/contexts/OverviewTabPanel.tsx
+++ b/frontend/src/components/contexts/OverviewTabPanel.tsx
@@ -54,6 +54,7 @@ import { PublicAPIStats } from "@/components/dashboard/PublicAPIStats";
 import { formatRelativeTime, formatDate } from "@/lib/utils/datetime";
 import type { Context } from "@/lib/types/context";
 import { useAuth } from "@/contexts/AuthContext";
+import { hasWorkspaceRole } from "@/lib/auth/rbac";
 
 interface OverviewTabPanelProps {
   contextId: string;
@@ -78,7 +79,14 @@ export function OverviewTabPanel({
   const [publicAPIStats, setPublicAPIStats] =
     useState<PublicAPIStatsResponse | null>(null);
   const [timelineDays, setTimelineDays] = useState<7 | 30>(7);
-  const { currentWorkspaceId } = useWorkspace();
+  const { currentWorkspace, currentWorkspaceId } = useWorkspace();
+  // Issue #398: User Activity is admin/owner only. Backend 403's the
+  // /user-activity endpoint for non-admins; gating here both hides the
+  // card and skips the doomed API call.
+  const canSeeUserActivity = hasWorkspaceRole(
+    currentWorkspace?.current_user_role,
+    "admin",
+  );
 
   const fetchUsageStats = useCallback(async () => {
     if (!contextId || !currentWorkspaceId) return;
@@ -91,15 +99,17 @@ export function OverviewTabPanel({
       );
       setTimeline(timelineData);
 
-      try {
-        const activityData = await getContextUserActivity(
-          currentWorkspaceId,
-          contextId,
-          timelineDays,
-        );
-        setUserActivity(activityData);
-      } catch {
-        setUserActivity(null);
+      if (canSeeUserActivity) {
+        try {
+          const activityData = await getContextUserActivity(
+            currentWorkspaceId,
+            contextId,
+            timelineDays,
+          );
+          setUserActivity(activityData);
+        } catch {
+          setUserActivity(null);
+        }
       }
 
       if (context?.is_public) {
@@ -117,7 +127,13 @@ export function OverviewTabPanel({
     } catch {
       // Timeline fetch failed — graceful degradation
     }
-  }, [contextId, currentWorkspaceId, timelineDays, context]);
+  }, [
+    contextId,
+    currentWorkspaceId,
+    timelineDays,
+    context,
+    canSeeUserActivity,
+  ]);
 
   useEffect(() => {
     if (context && currentWorkspaceId) {
@@ -248,78 +264,82 @@ export function OverviewTabPanel({
       {/* Memory Health & Neural Activity */}
       <RichMemoryOverview ref={overviewRef} contextId={contextId} />
 
-      {/* User Activity Table */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <UserCircle className="h-5 w-5" />
-            {t("userActivity")}
-          </CardTitle>
-          <CardDescription>
-            {timelineDays === 7
-              ? t("topUsersLast7Days")
-              : t("topUsersLast30Days")}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          {userActivity && userActivity.users.length > 0 ? (
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>{t("user")}</TableHead>
-                  <TableHead className="text-right">{t("apiCalls")}</TableHead>
-                  <TableHead className="text-right">
-                    {t("lastActivity")}
-                  </TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {userActivity.users.map((user) => (
-                  <TableRow key={user.user_id}>
-                    <TableCell>
-                      <div>
-                        <div className="font-medium">
-                          {user.user_name || user.user_email}
-                        </div>
-                        {user.user_name && user.user_email && (
-                          <div className="text-sm text-gray-500">
-                            {user.user_email}
-                          </div>
-                        )}
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      <span className="font-semibold text-green-600">
-                        {user.api_calls.toLocaleString()}
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-right text-sm text-gray-500">
-                      {user.last_activity
-                        ? formatRelativeTime(
-                            user.last_activity,
-                            authUser?.timezone,
-                            locale,
-                          )
-                        : "Never"}
-                    </TableCell>
+      {/* User Activity Table — Issue #398: admin/owner only. */}
+      {canSeeUserActivity && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <UserCircle className="h-5 w-5" />
+              {t("userActivity")}
+            </CardTitle>
+            <CardDescription>
+              {timelineDays === 7
+                ? t("topUsersLast7Days")
+                : t("topUsersLast30Days")}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            {userActivity && userActivity.users.length > 0 ? (
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>{t("user")}</TableHead>
+                    <TableHead className="text-right">
+                      {t("apiCalls")}
+                    </TableHead>
+                    <TableHead className="text-right">
+                      {t("lastActivity")}
+                    </TableHead>
                   </TableRow>
-                ))}
-              </TableBody>
-            </Table>
-          ) : (
-            <div className="text-center py-8 text-gray-500">
-              {userActivity === null ? (
-                <div>
-                  <p>{t("userActivityNotAvailable")}</p>
-                  <p className="text-sm mt-2">{t("requiresAdminRole")}</p>
-                </div>
-              ) : (
-                <p>{t("noActivityData")}</p>
-              )}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                </TableHeader>
+                <TableBody>
+                  {userActivity.users.map((user) => (
+                    <TableRow key={user.user_id}>
+                      <TableCell>
+                        <div>
+                          <div className="font-medium">
+                            {user.user_name || user.user_email}
+                          </div>
+                          {user.user_name && user.user_email && (
+                            <div className="text-sm text-gray-500">
+                              {user.user_email}
+                            </div>
+                          )}
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <span className="font-semibold text-green-600">
+                          {user.api_calls.toLocaleString()}
+                        </span>
+                      </TableCell>
+                      <TableCell className="text-right text-sm text-gray-500">
+                        {user.last_activity
+                          ? formatRelativeTime(
+                              user.last_activity,
+                              authUser?.timezone,
+                              locale,
+                            )
+                          : "Never"}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            ) : (
+              <div className="text-center py-8 text-gray-500">
+                {userActivity === null ? (
+                  <div>
+                    <p>{t("userActivityNotAvailable")}</p>
+                    <p className="text-sm mt-2">{t("requiresAdminRole")}</p>
+                  </div>
+                ) : (
+                  <p>{t("noActivityData")}</p>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -87,6 +87,7 @@ const navigationGroups: NavGroup[] = [
         nameKey: "dashboard",
         href: "/workspace/dashboard",
         icon: BarChart,
+        requiredWorkspaceRole: "member", // Issue #398: hide from viewer (read-only role)
       },
       {
         nameKey: "contexts",

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -105,6 +105,7 @@ const navigationGroups: NavGroup[] = [
         href: "/workspace/members",
         icon: Users,
         showMemberCount: true,
+        requiredWorkspaceRole: "admin", // Issue #398: hide from member/viewer
       },
     ],
   },

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1742,6 +1742,7 @@
     "userActivityNotAvailable": "User activity data not available",
     "requiresAdminRole": "This feature requires Admin role",
     "noActivityData": "No activity data available",
+    "never": "Never",
     "publicAPIUsage": "Public API Usage",
     "publicAPI": {
       "resourceIngestAPI": "Resource Ingest API",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1742,6 +1742,7 @@
     "userActivityNotAvailable": "ユーザーアクティビティデータを取得できません",
     "requiresAdminRole": "この機能にはAdmin権限が必要です",
     "noActivityData": "アクティビティデータがありません",
+    "never": "なし",
     "publicAPIUsage": "公開API使用状況",
     "publicAPI": {
       "resourceIngestAPI": "リソース取り込みAPI",


### PR DESCRIPTION
## Summary

Closes #398.

UI-side companion to the backend RBAC model. Previously the frontend exposed admin-only controls to every workspace role, which either 403'd on submit or silently no-op'd — confusing for users and contradicting the `PermissionService` contract. This PR scopes the UI surface per role and patches three real backend bugs uncovered while implementing the frontend gates.

## Changes

### Frontend gating (admin/owner only)
- **Sidebar**: Members nav item gated to `admin+`; Dashboard nav item gated to `member+` (viewer doesn't see either)
- **Members page**: redirect non-admin to `/workspace/dashboard`; data-load fetches skipped for non-admin
- **Dashboard page**: redirect viewer to `/workspace/contexts`; stats / contexts-stats / memory-timeline fetches skipped for viewer (avoids login-flash 403 toast)
- **Contexts list**: New Context dropdown hidden for member/viewer; per-row kebab hidden for member/viewer (BarChart "view usage" stays visible to all)
- **Context detail**: only Overview tab visible to member/viewer; URL deep-link to `?tab=settings|connections|graph` snaps back to overview
- **Overview tab**: User Activity card hidden for member/viewer (admin-only endpoint)

### Backend bug fixes (same PR, surfaced by manual viewer testing)
- **`get_accessible_contexts`**: was gated at `required_role="member"` — viewer never reached the per-role branch, so viewer's contexts list silently returned empty even when shared contexts existed. Fixed to `"viewer"`.
- **`resolve_context_for_workspace_read`**: same shape — default `"member"` made viewer hit `404 Context not found` on `/api/v1/graph/stats`. This is a *read* helper; default lowered to `"viewer"`.
- **Billing routes** (`POST /checkout`, `GET /portal`): added new `require_workspace_admin` dependency (admin+owner). Previously accepted any authenticated workspace user; webhook stays open (Stripe signature auth).

## Test plan

- [x] `make lint` — clean
- [x] `make type-check` — 0 errors, 0 warnings
- [x] `tsc --noEmit` (frontend) — clean
- [x] Backend tests: `tests/services/test_permission_service.py` (27/27) + `tests/api/test_billing_rbac.py` (4/4) — including 2 new viewer-branch regression tests
- [x] Frontend tests: matrix coverage for the 3 new gated surfaces (27/27)
- [x] Manual localhost verification across all four roles (owner / admin / member / viewer)

### Manual checks completed
- Owner / admin: New Context, kebab, all four context tabs, Members page, Dashboard all visible and functional
- Member: New Context hidden, kebab hidden, only Overview tab, Members page → dashboard redirect, Dashboard accessible
- Viewer: Same as member + Dashboard hidden from sidebar + Dashboard direct URL → contexts redirect (no flash error)
- Deep-link: `?tab=settings` as member → URL snaps to `?tab=overview`
- Backend: billing checkout/portal verified 403 for member/viewer

## Out of scope (follow-up)

- **Playwright E2E**: issue acceptance criteria says "Playwright / component tests" — this PR satisfies the spirit with comprehensive Vitest matrix coverage. Bringing up Playwright requires test-user seeding + CI fixture infrastructure that's a separate PR.
- **Existing `members/page.tsx` raw `=== "member"` comparisons**: pre-existing inline checks not in scope per the architecture decision (don't refactor untouched call sites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)