### PR TITLE
fix(mcp): graph read tools honor Context.is_private (#395)

### DIFF
--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -178,6 +178,45 @@ async def _resolve_context(
         raise _ContextNotFoundError(context_id, error_msg) from e
 
 
+async def _resolve_context_for_read(
+    db: "AsyncSession",
+    user_id: str,
+    context_id: UUID,
+    *,
+    required_role: str = "viewer",
+) -> Any:
+    """Resolve a context_id to a Context the caller can read, MCP-flavored.
+
+    Thin wrapper around ``PermissionService.resolve_context_for_workspace_read``
+    that translates the HTTP-flavored ``HTTPException(404)`` into the MCP-native
+    ``_ContextNotFoundError`` so every MCP read tool surfaces the same uniform
+    context_not_found shape (CWE-639 / OWASP A01 uniform disclosure) regardless
+    of the underlying deny reason (not found, private non-creator, not a
+    workspace member, member-suspended, whitelist miss).
+
+    The ``required_role="viewer"`` default matches the HTTP ``/graph/*`` and
+    ``/memory/stats`` reference implementations — writers should pass ``admin``
+    or ``owner``.
+    """
+    # Local fastapi import keeps the HTTP layer leak contained to this helper;
+    # callers only need to catch _ContextNotFoundError. See the parent docstring.
+    from fastapi import HTTPException
+
+    from services.permission_service import PermissionService
+
+    try:
+        return await PermissionService(db).resolve_context_for_workspace_read(
+            user_id=user_id, context_id=context_id, required_role=required_role
+        )
+    except HTTPException as exc:
+        if exc.status_code == 404:
+            raise _ContextNotFoundError(
+                context_id,
+                "Context not found or you don't have access to it.",
+            ) from exc
+        raise
+
+
 def _resolve_context_id(arg_context_id: str) -> UUID:
     """Parse and return context_id from tool argument.
 

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -10,6 +10,7 @@ import time
 from typing import Any
 from uuid import UUID
 
+from fastapi import HTTPException
 from mcp.types import TextContent
 
 from mcp_server.tools._constants import KAGURA_MEMORY_INSTRUCTIONS
@@ -29,7 +30,19 @@ logger = logging.getLogger(__name__)
 async def handle_get_context_info(
     args: dict[str, Any], user_id: str, workspace_id: UUID | None
 ) -> list[TextContent]:
-    """Retrieve context information and memory statistics."""
+    """Retrieve context information and memory statistics.
+
+    Issue #395: Context resolution honors
+    ``PermissionService.resolve_context_for_workspace_read`` (same contract
+    as the HTTP ``/graph/*`` endpoints fixed in #383/#394). Shared-context
+    stats aggregate across all workspace members; private-context stats
+    are creator-scoped; private non-creators (including workspace admins)
+    get a uniform ``context_not_found`` denial. The pre-#395 stale
+    fallback that re-read the context without any access check is removed
+    — it silently authorized cross-workspace and private-non-creator
+    reads. The workspace returned by the resolver is authoritative; the
+    MCP-session ``workspace_id`` is informational-only when they diverge.
+    """
     include_details = args.get("include_details", True)
 
     from db.base import get_db
@@ -37,63 +50,57 @@ async def handle_get_context_info(
     start_time = time.time()
     async for db in get_db():
         try:
-            from services.context_service import ContextService
             from services.memory_service import MemoryService
+            from services.permission_service import PermissionService
 
             current_context_id = _resolve_context_id(args["context_id"])
 
-            # Get context details (with fallback for stats if access check fails)
-            context_service = ContextService(db)
             current_context = None
-            context_for_stats = None
+            is_shared = False
+            effective_workspace_id = workspace_id
 
             if current_context_id:
                 try:
-                    current_context = await context_service.get_context(user_id, current_context_id)
-                    context_for_stats = current_context
-                except Exception as e:
-                    logger.warning(
-                        f"Failed to fetch context with access check {current_context_id}: {e}"
+                    current_context = await PermissionService(
+                        db
+                    ).resolve_context_for_workspace_read(
+                        user_id=user_id, context_id=current_context_id
                     )
-                    from sqlalchemy import select
+                except HTTPException as exc:
+                    if exc.status_code == 404:
+                        raise _ContextNotFoundError(
+                            current_context_id,
+                            "Context not found or you don't have access to it.",
+                        ) from exc
+                    raise
 
-                    from models.auth import Context
+                # Private context + creator: creator-only stats (user_id filter).
+                # Shared context + any workspace member: aggregate across all
+                # creators (no user_id filter). Past this gate the caller is
+                # always either the private-context creator or an authorized
+                # shared-context reader, so the is_private flag alone picks
+                # the correct scope — the pre-#395 ``is_workspace_owner``
+                # special case was a pre-workspace-era workaround and is
+                # removed to align with ``can_access_memory`` / #383.
+                is_shared = not current_context.is_private
+                effective_workspace_id = current_context.workspace_id
 
-                    result = await db.execute(
-                        select(Context).where(
-                            Context.id == current_context_id,
-                            Context.deleted_at.is_(None),
-                        )
-                    )
-                    context_for_stats = result.scalar_one_or_none()
-
-            # Issue #204: Check if context is shared or if user is workspace owner
-            is_shared = False
             workspace = None
-            logger.info(
-                f"MCP get_context_info: workspace_id={workspace_id}, current_context={current_context is not None}, context_for_stats={context_for_stats is not None}"
-            )
-
-            if context_for_stats and workspace_id:
+            if effective_workspace_id:
                 from sqlalchemy import select
 
                 from models.auth import Workspace
 
                 workspace_result = await db.execute(
-                    select(Workspace).where(Workspace.id == workspace_id)
+                    select(Workspace).where(Workspace.id == effective_workspace_id)
                 )
                 workspace = workspace_result.scalar_one_or_none()
-                logger.info(
-                    f"MCP workspace lookup: workspace_id={workspace_id}, workspace_found={workspace is not None}"
-                )
-                is_workspace_owner = workspace and workspace.owner_user_id == user_id
-                is_shared = is_workspace_owner or not context_for_stats.is_private
 
             service = MemoryService(db)
             result = await execute_with_timeout(
                 service.get_stats(
                     user_id=user_id,
-                    workspace_id=str(workspace_id) if workspace_id else None,
+                    workspace_id=str(effective_workspace_id) if effective_workspace_id else None,
                     context_id=str(current_context_id) if current_context_id else None,
                     include_details=include_details,
                     time_window_hours=168,
@@ -196,6 +203,18 @@ async def handle_get_context_info(
                     ),
                 )
             ]
+        except _ContextNotFoundError as e:
+            await db.rollback()
+            await _log_tool_usage(
+                db,
+                user_id,
+                "get_context_info",
+                start_time,
+                404,
+                args.get("context_id"),
+                workspace_id,
+            )
+            return e.to_response()
         except Exception as e:
             await db.rollback()
             await _log_tool_usage(

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -10,7 +10,6 @@ import time
 from typing import Any
 from uuid import UUID
 
-from fastapi import HTTPException
 from mcp.types import TextContent
 
 from mcp_server.tools._constants import KAGURA_MEMORY_INSTRUCTIONS
@@ -20,6 +19,7 @@ from mcp_server.tools._helpers import (
     _error_response,
     _get_workspace_member_role,
     _log_tool_usage,
+    _resolve_context_for_read,
     _resolve_context_id,
     execute_with_timeout,
 )
@@ -32,16 +32,10 @@ async def handle_get_context_info(
 ) -> list[TextContent]:
     """Retrieve context information and memory statistics.
 
-    Issue #395: Context resolution honors
-    ``PermissionService.resolve_context_for_workspace_read`` (same contract
-    as the HTTP ``/graph/*`` endpoints fixed in #383/#394). Shared-context
-    stats aggregate across all workspace members; private-context stats
-    are creator-scoped; private non-creators (including workspace admins)
-    get a uniform ``context_not_found`` denial. The pre-#395 stale
-    fallback that re-read the context without any access check is removed
-    — it silently authorized cross-workspace and private-non-creator
-    reads. The workspace returned by the resolver is authoritative; the
-    MCP-session ``workspace_id`` is informational-only when they diverge.
+    Visibility: shared context → stats aggregate across all workspace members;
+    private context → creator-only. Non-creators get uniform ``context_not_found``.
+    The workspace returned by the resolver is authoritative; the MCP-session
+    ``workspace_id`` is informational only.
     """
     include_details = args.get("include_details", True)
 
@@ -51,7 +45,6 @@ async def handle_get_context_info(
     async for db in get_db():
         try:
             from services.memory_service import MemoryService
-            from services.permission_service import PermissionService
 
             current_context_id = _resolve_context_id(args["context_id"])
 
@@ -60,28 +53,10 @@ async def handle_get_context_info(
             effective_workspace_id = workspace_id
 
             if current_context_id:
-                try:
-                    current_context = await PermissionService(
-                        db
-                    ).resolve_context_for_workspace_read(
-                        user_id=user_id, context_id=current_context_id
-                    )
-                except HTTPException as exc:
-                    if exc.status_code == 404:
-                        raise _ContextNotFoundError(
-                            current_context_id,
-                            "Context not found or you don't have access to it.",
-                        ) from exc
-                    raise
-
-                # Private context + creator: creator-only stats (user_id filter).
-                # Shared context + any workspace member: aggregate across all
-                # creators (no user_id filter). Past this gate the caller is
-                # always either the private-context creator or an authorized
-                # shared-context reader, so the is_private flag alone picks
-                # the correct scope — the pre-#395 ``is_workspace_owner``
-                # special case was a pre-workspace-era workaround and is
-                # removed to align with ``can_access_memory`` / #383.
+                current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+                # Past this gate the caller is either the private-context creator
+                # or an authorized shared-context reader, so is_private alone
+                # picks the correct scope for MemoryService.get_stats.
                 is_shared = not current_context.is_private
                 effective_workspace_id = current_context.workspace_id
 

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -8,7 +8,6 @@ from itertools import chain
 from typing import Any
 from uuid import UUID
 
-from fastapi import HTTPException
 from mcp.types import TextContent
 
 from mcp_server.tools._helpers import (
@@ -17,6 +16,7 @@ from mcp_server.tools._helpers import (
     _error_response,
     _log_tool_usage,
     _resolve_context,
+    _resolve_context_for_read,
     _resolve_context_id,
     _success_response,
     _validate_memory_id,
@@ -98,16 +98,10 @@ async def handle_list_edges(
 ) -> list[TextContent]:
     """List edges connected to a specific memory.
 
-    Issue #395: Visibility honors ``Context.is_private`` via
-    ``PermissionService.resolve_context_for_workspace_read`` (same contract
-    as the HTTP ``/graph/*`` endpoints fixed in #383/#394). Shared-context
-    workspace members see edges authored by ALL creators; private-context
-    non-creators (including workspace admins) see a uniform
-    ``context_not_found`` denial indistinguishable from "context does not
-    exist at all" (CWE-639 / OWASP A01). The ``context.workspace_id``
-    returned by the resolver is authoritative — the pre-#395 fallback to
-    the MCP-session ``workspace_id`` could diverge from the context's
-    actual workspace and is intentionally removed.
+    Visibility: shared context → workspace members see all creators' edges;
+    private context → only the creator sees edges, non-creators get a uniform
+    ``context_not_found`` denial. ``context.workspace_id`` (from the resolver)
+    is authoritative — the MCP-session ``workspace_id`` is informational only.
     """
     memory_uuid, error = _validate_memory_id(args, "list_edges")
     if error or memory_uuid is None:
@@ -115,7 +109,6 @@ async def handle_list_edges(
 
     from db.base import get_db
     from repositories.neural_edge import NeuralEdgeRepository
-    from services.permission_service import PermissionService
 
     min_weight, error = _parse_float(args.get("min_weight"), "min_weight", 0.0, 3.0, 0.0)
     if error:
@@ -128,23 +121,7 @@ async def handle_list_edges(
     async for db in get_db():
         try:
             current_context_id = _resolve_context_id(args["context_id"])
-
-            try:
-                context = await PermissionService(db).resolve_context_for_workspace_read(
-                    user_id=user_id, context_id=current_context_id
-                )
-            except HTTPException as exc:
-                # Uniform denial — same shape whether the context does not
-                # exist, is private and the caller is not its creator, or
-                # the caller is not a workspace member. Mirrors HTTP 404
-                # uniform disclosure (CWE-639 / OWASP A01) by routing
-                # through the existing _ContextNotFoundError path.
-                if exc.status_code == 404:
-                    raise _ContextNotFoundError(
-                        current_context_id,
-                        "Context not found or you don't have access to it.",
-                    ) from exc
-                raise
+            context = await _resolve_context_for_read(db, user_id, current_context_id)
 
             ws_id = str(context.workspace_id)
             ctx_id = str(context.id)
@@ -196,6 +173,9 @@ async def handle_list_edges(
             )
         except _ContextNotFoundError as e:
             await db.rollback()
+            await _log_tool_usage(
+                db, user_id, "list_edges", start_time, 404, args.get("context_id"), workspace_id
+            )
             return e.to_response()
         except Exception:
             await db.rollback()

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -8,6 +8,7 @@ from itertools import chain
 from typing import Any
 from uuid import UUID
 
+from fastapi import HTTPException
 from mcp.types import TextContent
 
 from mcp_server.tools._helpers import (
@@ -95,13 +96,26 @@ def _parse_float(
 async def handle_list_edges(
     args: dict[str, Any], user_id: str, workspace_id: UUID | None
 ) -> list[TextContent]:
-    """List edges connected to a specific memory."""
+    """List edges connected to a specific memory.
+
+    Issue #395: Visibility honors ``Context.is_private`` via
+    ``PermissionService.resolve_context_for_workspace_read`` (same contract
+    as the HTTP ``/graph/*`` endpoints fixed in #383/#394). Shared-context
+    workspace members see edges authored by ALL creators; private-context
+    non-creators (including workspace admins) see a uniform
+    ``context_not_found`` denial indistinguishable from "context does not
+    exist at all" (CWE-639 / OWASP A01). The ``context.workspace_id``
+    returned by the resolver is authoritative — the pre-#395 fallback to
+    the MCP-session ``workspace_id`` could diverge from the context's
+    actual workspace and is intentionally removed.
+    """
     memory_uuid, error = _validate_memory_id(args, "list_edges")
     if error or memory_uuid is None:
         return error or _error_response("invalid_memory_id_format", "Invalid memory_id")
 
     from db.base import get_db
     from repositories.neural_edge import NeuralEdgeRepository
+    from services.permission_service import PermissionService
 
     min_weight, error = _parse_float(args.get("min_weight"), "min_weight", 0.0, 3.0, 0.0)
     if error:
@@ -114,17 +128,33 @@ async def handle_list_edges(
     async for db in get_db():
         try:
             current_context_id = _resolve_context_id(args["context_id"])
-            context = await _resolve_context(db, user_id, current_context_id)
 
-            # Use context's workspace_id for isolation (fallback from MCP session)
-            ws_id = str(workspace_id) if workspace_id else str(context.workspace_id)
-            ctx_id = str(current_context_id)
+            try:
+                context = await PermissionService(db).resolve_context_for_workspace_read(
+                    user_id=user_id, context_id=current_context_id
+                )
+            except HTTPException as exc:
+                # Uniform denial — same shape whether the context does not
+                # exist, is private and the caller is not its creator, or
+                # the caller is not a workspace member. Mirrors HTTP 404
+                # uniform disclosure (CWE-639 / OWASP A01) by routing
+                # through the existing _ContextNotFoundError path.
+                if exc.status_code == 404:
+                    raise _ContextNotFoundError(
+                        current_context_id,
+                        "Context not found or you don't have access to it.",
+                    ) from exc
+                raise
+
+            ws_id = str(context.workspace_id)
+            ctx_id = str(context.id)
+            owner_filter = user_id if context.is_private else None
 
             repo = NeuralEdgeRepository(db)
 
             outgoing = await execute_with_timeout(
                 repo.get_outgoing_edges(
-                    user_id=user_id,
+                    user_id=owner_filter,
                     src_id=memory_uuid,
                     min_weight=min_weight,
                     edge_types=edge_types,
@@ -136,7 +166,7 @@ async def handle_list_edges(
             )
             incoming = await execute_with_timeout(
                 repo.get_incoming_edges(
-                    user_id=user_id,
+                    user_id=owner_filter,
                     dst_id=memory_uuid,
                     min_weight=min_weight,
                     edge_types=edge_types,

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -328,12 +328,13 @@ class NeuralEdgeRepository:
         """Get outgoing edges from a node with 3-level isolation.
 
         Single Collection Migration: Added workspace_id and context_id filtering.
-        Issue #395: ``user_id`` is now optional — mirrors ``get_all_edges`` /
-        ``get_stats`` / ``get_top_connected_nodes`` (extended for #383).
-        ``None`` returns all creators' outgoing edges from ``src_id`` in the
-        workspace+context (shared-context reads where authorization is
-        enforced upstream by ``PermissionService``); a concrete value keeps
-        the prior private-context / owner-scoped behavior.
+
+        ``user_id`` is optional and mirrors the signature of ``get_all_edges`` /
+        ``get_stats`` / ``get_top_connected_nodes``: ``None`` returns all
+        creators' outgoing edges within the resolved (workspace_id, context_id)
+        scope (shared-context reads where authorization is enforced upstream
+        by ``PermissionService``); a concrete value keeps the prior
+        creator-scoped behavior (private-context or owner-only reads).
 
         Args:
             user_id: Optional creator filter. ``None`` returns all creators'
@@ -395,12 +396,13 @@ class NeuralEdgeRepository:
         """Get incoming edges to a node with 3-level isolation.
 
         Single Collection Migration: Added workspace_id and context_id filtering.
-        Issue #395: ``user_id`` is now optional — mirrors ``get_all_edges`` /
-        ``get_stats`` / ``get_top_connected_nodes`` (extended for #383).
-        ``None`` returns all creators' incoming edges to ``dst_id`` in the
-        workspace+context (shared-context reads where authorization is
-        enforced upstream by ``PermissionService``); a concrete value keeps
-        the prior private-context / owner-scoped behavior.
+
+        ``user_id`` is optional and mirrors the signature of ``get_all_edges`` /
+        ``get_stats`` / ``get_top_connected_nodes``: ``None`` returns all
+        creators' incoming edges within the resolved (workspace_id, context_id)
+        scope (shared-context reads where authorization is enforced upstream
+        by ``PermissionService``); a concrete value keeps the prior
+        creator-scoped behavior (private-context or owner-only reads).
 
         Args:
             user_id: Optional creator filter. ``None`` returns all creators'

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -317,7 +317,7 @@ class NeuralEdgeRepository:
 
     async def get_outgoing_edges(
         self,
-        user_id: str,
+        user_id: str | None,
         src_id: UUID,
         min_weight: float = 0.0,
         edge_types: list[str] | None = None,
@@ -328,9 +328,16 @@ class NeuralEdgeRepository:
         """Get outgoing edges from a node with 3-level isolation.
 
         Single Collection Migration: Added workspace_id and context_id filtering.
+        Issue #395: ``user_id`` is now optional — mirrors ``get_all_edges`` /
+        ``get_stats`` / ``get_top_connected_nodes`` (extended for #383).
+        ``None`` returns all creators' outgoing edges from ``src_id`` in the
+        workspace+context (shared-context reads where authorization is
+        enforced upstream by ``PermissionService``); a concrete value keeps
+        the prior private-context / owner-scoped behavior.
 
         Args:
-            user_id: User identifier
+            user_id: Optional creator filter. ``None`` returns all creators'
+                edges in the workspace+context.
             src_id: Source node ID
             min_weight: Minimum edge weight threshold
             edge_types: Filter by edge types
@@ -348,10 +355,11 @@ class NeuralEdgeRepository:
         self._validate_isolation_params(workspace_id, context_id)
 
         conditions = [
-            NeuralMemoryEdge.user_id == user_id,
             NeuralMemoryEdge.src_id == src_id,
             NeuralMemoryEdge.weight >= min_weight,
         ]
+        if user_id is not None:
+            conditions.append(NeuralMemoryEdge.user_id == user_id)
 
         # Single Collection Migration: Add workspace and context filters
         if workspace_id:
@@ -376,7 +384,7 @@ class NeuralEdgeRepository:
 
     async def get_incoming_edges(
         self,
-        user_id: str,
+        user_id: str | None,
         dst_id: UUID,
         min_weight: float = 0.0,
         edge_types: list[str] | None = None,
@@ -387,9 +395,16 @@ class NeuralEdgeRepository:
         """Get incoming edges to a node with 3-level isolation.
 
         Single Collection Migration: Added workspace_id and context_id filtering.
+        Issue #395: ``user_id`` is now optional — mirrors ``get_all_edges`` /
+        ``get_stats`` / ``get_top_connected_nodes`` (extended for #383).
+        ``None`` returns all creators' incoming edges to ``dst_id`` in the
+        workspace+context (shared-context reads where authorization is
+        enforced upstream by ``PermissionService``); a concrete value keeps
+        the prior private-context / owner-scoped behavior.
 
         Args:
-            user_id: User identifier
+            user_id: Optional creator filter. ``None`` returns all creators'
+                edges in the workspace+context.
             dst_id: Destination node ID
             min_weight: Minimum edge weight threshold
             edge_types: Filter by edge types
@@ -407,10 +422,11 @@ class NeuralEdgeRepository:
         self._validate_isolation_params(workspace_id, context_id)
 
         conditions = [
-            NeuralMemoryEdge.user_id == user_id,
             NeuralMemoryEdge.dst_id == dst_id,
             NeuralMemoryEdge.weight >= min_weight,
         ]
+        if user_id is not None:
+            conditions.append(NeuralMemoryEdge.user_id == user_id)
 
         # Single Collection Migration: Add workspace and context filters
         if workspace_id:

--- a/backend/tests/integration/test_graph_visibility.py
+++ b/backend/tests/integration/test_graph_visibility.py
@@ -17,6 +17,7 @@ class) rather than a parametric sweep so a failure clearly identifies
 which visibility contract regressed.
 """
 
+import json
 from uuid import uuid4
 
 import pytest
@@ -464,9 +465,6 @@ async def test_soft_deleted_context_returns_404(visibility_scenario, db_session)
 # from ``async_engine`` so MCP handlers read from the same test database the
 # ``visibility_scenario`` fixture seeds into.
 # ============================================================================
-
-
-import json  # noqa: E402  — lazy import kept local to the MCP parity block
 
 
 def _json_of(result):

--- a/backend/tests/integration/test_graph_visibility.py
+++ b/backend/tests/integration/test_graph_visibility.py
@@ -160,7 +160,21 @@ async def visibility_scenario(async_engine, db_session):
     db_session.add_all(
         [
             WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
-            WorkspaceMember(workspace_id=ws_a.id, user_id=member_a_id, role="member"),
+            # member_a needs an explicit allowed_context_ids whitelist — post-#398
+            # (commit bd5b7a4) a member with ``allowed_context_ids=NULL`` is
+            # treated as suspended and uniformly 404s on every UUID-addressed
+            # read. The whitelist must include ctx_shared so the shared-context
+            # visibility matrix can be exercised. ctx_private is intentionally
+            # omitted: the private-creator-only rule blocks non-creators before
+            # the whitelist check runs anyway, so both "in whitelist" and "out
+            # of whitelist" yield the same 404 for a private non-creator — the
+            # minimal whitelist keeps the fixture intent obvious.
+            WorkspaceMember(
+                workspace_id=ws_a.id,
+                user_id=member_a_id,
+                role="member",
+                allowed_context_ids=[ctx_shared.id],
+            ),
             WorkspaceMember(workspace_id=ws_b.id, user_id=outsider_b_id, role="owner"),
         ]
     )
@@ -435,3 +449,274 @@ async def test_soft_deleted_context_returns_404(visibility_scenario, db_session)
         )
 
     assert response.status_code == 404, response.text
+
+
+# ============================================================================
+# MCP parity — Issue #395
+# ----------------------------------------------------------------------------
+# These tests directly invoke the MCP tool handlers (``handle_list_edges`` and
+# ``handle_get_context_info``) and assert that the same 6-way visibility
+# matrix enforced for the HTTP ``/graph/*`` endpoints above also holds on the
+# MCP surface. The handlers are plain ``async def`` functions that take
+# ``(args, user_id, workspace_id)``; they internally call ``db.base.get_db()``
+# which reads the module-level ``async_session_factory`` global. The
+# ``_mcp_db_factory`` fixture below rebinds that global to a factory built
+# from ``async_engine`` so MCP handlers read from the same test database the
+# ``visibility_scenario`` fixture seeds into.
+# ============================================================================
+
+
+import json  # noqa: E402  — lazy import kept local to the MCP parity block
+
+
+def _json_of(result):
+    """Parse the JSON payload from an MCP TextContent response."""
+    return json.loads(result[0].text)
+
+
+@pytest_asyncio.fixture
+async def _mcp_db_factory(async_engine, monkeypatch):
+    """Rebind ``db.base.async_session_factory`` to the test engine's factory.
+
+    MCP handlers use ``async for db in get_db()`` rather than FastAPI's
+    dependency injection, so the TestClient-oriented
+    ``app.dependency_overrides[get_db]`` override used by the HTTP tests
+    above does not reach them. This fixture monkeypatches the module-level
+    session factory that ``_get_session_factory`` returns so the handlers
+    operate against the same engine the ``visibility_scenario`` fixture
+    seeds, without requiring ``DATABASE_URL == TEST_DATABASE_URL``.
+    """
+    import db.base as _db_base
+
+    test_factory = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+    monkeypatch.setattr(_db_base, "async_session_factory", test_factory)
+    yield
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_edges_shared_context_member_sees_other_creator_edges(
+    visibility_scenario, _mcp_db_factory
+):
+    """Pre-#395 regression target — member must see owner-authored edges via MCP.
+
+    ``edge_owner_shared`` is authored by ``owner_a_id`` and connects
+    ``mem_owner_shared_src`` → ``mem_owner_shared_dst``. Before #395 the MCP
+    ``list_edges`` handler hardcoded the ``user_id`` filter to the MCP
+    caller, so ``member_a`` querying edges on ``mem_owner_shared_dst`` saw
+    0 edges. Post-fix they see ``edge_owner_shared`` because the shared
+    context's visibility model delegates to ``PermissionService`` rather
+    than a per-caller creator filter.
+    """
+    from mcp_server.tools.edge import handle_list_edges
+
+    result = await handle_list_edges(
+        {
+            "memory_id": str(visibility_scenario["memory_ids"][1]),  # mem_owner_shared_dst
+            "context_id": str(visibility_scenario["ctx_shared_id"]),
+        },
+        visibility_scenario["member_a_id"],
+        visibility_scenario["ws_a_id"],
+    )
+    data = _json_of(result)
+    assert data["status"] == "success", data
+    assert data["count"] >= 1, (
+        "Member must see owner-authored edges in a shared context via MCP "
+        "(#395: MCP parity with HTTP /graph/* visibility fix from #383)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_edges_shared_context_owner_sees_other_creator_edges(
+    visibility_scenario, _mcp_db_factory
+):
+    """Mirror of the above — owner must see member-authored edges via MCP."""
+    from mcp_server.tools.edge import handle_list_edges
+
+    result = await handle_list_edges(
+        {
+            "memory_id": str(visibility_scenario["memory_ids"][3]),  # mem_member_shared_dst
+            "context_id": str(visibility_scenario["ctx_shared_id"]),
+        },
+        visibility_scenario["owner_a_id"],
+        visibility_scenario["ws_a_id"],
+    )
+    data = _json_of(result)
+    assert data["status"] == "success", data
+    assert data["count"] >= 1, "Owner must see member-authored edges in a shared context via MCP"
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_edges_shared_context_cross_workspace_returns_not_found(
+    visibility_scenario, _mcp_db_factory
+):
+    """Cross-workspace probe via MCP surfaces as uniform ``context_not_found``.
+
+    CWE-639 / OWASP A01 uniform-disclosure contract — MCP caller from a
+    different workspace must not distinguish "context exists but forbidden"
+    from "context does not exist at all".
+    """
+    from mcp_server.tools.edge import handle_list_edges
+
+    result = await handle_list_edges(
+        {
+            "memory_id": str(visibility_scenario["memory_ids"][0]),
+            "context_id": str(visibility_scenario["ctx_shared_id"]),
+        },
+        visibility_scenario["outsider_b_id"],
+        visibility_scenario["ws_b_id"],
+    )
+    data = _json_of(result)
+    assert data["status"] == "error"
+    assert data["error"] == "context_not_found", data
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_edges_private_context_creator_sees_own_edges(
+    visibility_scenario, _mcp_db_factory
+):
+    """Creator of a private context retains full visibility of own edges via MCP."""
+    from mcp_server.tools.edge import handle_list_edges
+
+    result = await handle_list_edges(
+        {
+            "memory_id": str(visibility_scenario["memory_ids"][4]),  # mem_owner_private_src
+            "context_id": str(visibility_scenario["ctx_private_id"]),
+        },
+        visibility_scenario["owner_a_id"],
+        visibility_scenario["ws_a_id"],
+    )
+    data = _json_of(result)
+    assert data["status"] == "success", data
+    assert data["count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_edges_private_context_non_creator_returns_not_found(
+    visibility_scenario, _mcp_db_factory
+):
+    """Workspace member who is NOT the private-context creator gets uniform denial.
+
+    Matches ``can_access_memory`` ("private → only creator can access") and
+    the HTTP contract established in #383 — avoids leaking "a private
+    context with this UUID exists in this workspace, and you aren't its
+    creator".
+    """
+    from mcp_server.tools.edge import handle_list_edges
+
+    result = await handle_list_edges(
+        {
+            "memory_id": str(visibility_scenario["memory_ids"][4]),
+            "context_id": str(visibility_scenario["ctx_private_id"]),
+        },
+        visibility_scenario["member_a_id"],
+        visibility_scenario["ws_a_id"],
+    )
+    data = _json_of(result)
+    assert data["status"] == "error"
+    assert data["error"] == "context_not_found", data
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_context_info_shared_context_member_sees_full_stats(
+    visibility_scenario, _mcp_db_factory
+):
+    """Shared-context stats via MCP aggregate across all workspace members.
+
+    Pre-#395 the MCP ``get_context_info`` computed
+    ``is_shared = is_workspace_owner or not is_private`` — a member
+    (non-owner) hitting a shared context saw only their own memories. The
+    fix aligns with HTTP ``/memory/stats`` so workspace members see the
+    same per-context totals regardless of transport.
+    """
+    from mcp_server.tools.context import handle_get_context_info
+
+    result = await handle_get_context_info(
+        {"context_id": str(visibility_scenario["ctx_shared_id"])},
+        visibility_scenario["member_a_id"],
+        visibility_scenario["ws_a_id"],
+    )
+    data = _json_of(result)
+    assert data["status"] == "success", data
+    # The shared context has 4 memories (2 by owner_a, 2 by member_a). Both
+    # creators must be counted regardless of which of them is the caller.
+    assert data["stats"]["total_memories"] >= 4, (
+        "Shared-context stats must aggregate across all workspace members' "
+        "memories (not just the caller's)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_context_info_private_context_non_creator_returns_not_found(
+    visibility_scenario, _mcp_db_factory
+):
+    """Private-context non-creator (even a workspace admin) gets uniform denial.
+
+    The pre-#395 ``is_workspace_owner`` fast path let workspace owners peek
+    at another member's private context stats. Post-fix that fast path is
+    removed — the contract now matches ``resolve_context_for_workspace_read``
+    (private → creator-only, regardless of workspace role).
+    """
+    from mcp_server.tools.context import handle_get_context_info
+
+    result = await handle_get_context_info(
+        {"context_id": str(visibility_scenario["ctx_private_id"])},
+        visibility_scenario["member_a_id"],
+        visibility_scenario["ws_a_id"],
+    )
+    data = _json_of(result)
+    assert data["status"] == "error"
+    assert data["error"] == "context_not_found", data
+
+
+@pytest.mark.asyncio
+async def test_mcp_get_context_info_cross_workspace_returns_not_found(
+    visibility_scenario, _mcp_db_factory
+):
+    """Cross-workspace probe of MCP ``get_context_info`` surfaces as uniform denial."""
+    from mcp_server.tools.context import handle_get_context_info
+
+    result = await handle_get_context_info(
+        {"context_id": str(visibility_scenario["ctx_shared_id"])},
+        visibility_scenario["outsider_b_id"],
+        visibility_scenario["ws_b_id"],
+    )
+    data = _json_of(result)
+    assert data["status"] == "error"
+    assert data["error"] == "context_not_found", data
+
+
+@pytest.mark.asyncio
+async def test_mcp_list_edges_soft_deleted_context_returns_not_found(
+    visibility_scenario, _mcp_db_factory, db_session
+):
+    """Soft-deleted context — MCP honors ``Context.deleted_at IS NULL`` via the resolver."""
+    from mcp_server.tools.edge import handle_list_edges
+    from models.auth import Context
+    from utils.datetime import utcnow
+
+    ctx_id = visibility_scenario["ctx_shared_id"]
+    await db_session.execute(
+        Context.__table__.update()
+        .where(Context.id == ctx_id)
+        .values(deleted_at=utcnow().replace(tzinfo=None))
+    )
+    await db_session.commit()
+
+    try:
+        result = await handle_list_edges(
+            {
+                "memory_id": str(visibility_scenario["memory_ids"][0]),
+                "context_id": str(ctx_id),
+            },
+            visibility_scenario["owner_a_id"],
+            visibility_scenario["ws_a_id"],
+        )
+        data = _json_of(result)
+        assert data["status"] == "error"
+        assert data["error"] == "context_not_found", data
+    finally:
+        # Restore so ``visibility_scenario`` teardown sees a live row.
+        await db_session.execute(
+            Context.__table__.update().where(Context.id == ctx_id).values(deleted_at=None)
+        )
+        await db_session.commit()


### PR DESCRIPTION
Closes #395

## Summary
- Align MCP `handle_list_edges` and `handle_get_context_info` read paths with the workspace-aware visibility model shipped for HTTP `/graph/*` in #383 / PR #394. Shared-context workspace members now see edges and stats from ALL creators via MCP (previously saw only their own — HTTP/MCP divergence for the same `context_id`).
- **Also closes a data-leak path** in `handle_get_context_info`: a pre-#395 fallback re-read the Context via a raw SELECT bypassing all access checks when `context_service.get_context` raised. For cross-workspace probes and private-context non-creators this leaked `stats.total_memories` / `working_memories` / `persistent_memories` plus `workspace.name` / `description`. Post-fix these surface as uniform `context_not_found`, matching the HTTP `/graph/*` contract and the CWE-639 / OWASP A01 uniform-disclosure principle encoded in `resolve_context_for_workspace_read`.
- Extract `_resolve_context_for_read` helper in `mcp_server/tools/_helpers.py` to confine the `fastapi.HTTPException` layer leak to one module and avoid duplicating the translation block across handlers.

## Implementation notes

**`_resolve_context_for_read` helper** (`backend/src/mcp_server/tools/_helpers.py`)
- Thin wrapper around `PermissionService.resolve_context_for_workspace_read`
- Translates `HTTPException(404)` → `_ContextNotFoundError` so every MCP read tool returns the same uniform-denial shape regardless of deny reason (not found / private non-creator / not a workspace member / member-suspended / whitelist miss)

**`handle_list_edges`** (`backend/src/mcp_server/tools/edge.py`)
- `owner_filter = user_id if context.is_private else None` passed to `get_outgoing_edges` / `get_incoming_edges`
- Drops the pre-#395 `ws_id = workspace_id or context.workspace_id` fallback (could bypass the MCP session's workspace boundary when caller supplied a cross-workspace `context_id`) — resolver's `context.workspace_id` is now authoritative
- Adds matching `_log_tool_usage(..., 404, ...)` on the `_ContextNotFoundError` branch for observability parity with `handle_get_context_info`

**`handle_get_context_info`** (`backend/src/mcp_server/tools/context.py`)
- Drops the raw-SELECT fallback (the data-leak path)
- Collapses `is_shared = is_workspace_owner or not context.is_private` to `is_shared = not context.is_private` — workspace owners can no longer peek at another member's private-context stats (aligns with `can_access_memory` / #383 contract)
- Uses `context.workspace_id` as authoritative

**Repo layer** (`backend/src/repositories/neural_edge.py`)
- `get_outgoing_edges` / `get_incoming_edges` signature widened from `user_id: str` to `user_id: str | None`
- Mirrors the already-optional `get_all_edges` / `get_stats` / `get_top_connected_nodes` (extended for #383)
- Backward-compatible: all 9 existing call sites pass concrete user_id

**Write paths unchanged** per gate1 guidance. `handle_create_edge` / `handle_update_edge` / `handle_delete_edge` still pass `user_id=user_id` (caller) — shared-context members cannot overwrite each other's edges.

## Test coverage
- 8 new MCP parity integration tests in `backend/tests/integration/test_graph_visibility.py` mirror the 6-way visibility matrix (shared/private × owner/member/outsider) that #383 pinned for HTTP `/graph/*`, plus soft-delete coverage
- `_mcp_db_factory` fixture monkeypatches `db.base.async_session_factory` so MCP handlers (which use `async for db in get_db()`, not FastAPI `Depends`) hit the test engine
- **Fixture repair included**: `member_a` WorkspaceMember now gets explicit `allowed_context_ids=[ctx_shared.id]`. Commit `bd5b7a4` (merged as part of #398) added a member-suspended gate (member + NULL `allowed_context_ids` → 404) that silently broke `test_shared_context_member_sees_all_edges` on main. The new MCP tests hit the same latent bug and surfaced it; repaired here because splitting the fix out would have blocked #395 behind a chained PR.

**Verified locally**:
- 18 `test_graph_visibility.py` tests pass (10 existing HTTP + 8 new MCP)
- 390 broader tests pass (MCP unit / API / permission_service) — no regressions
- 235 neural + sleep + knn_seeding tests pass — repo signature widening is backward-compatible
- `ruff check` clean on all touched files

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CSO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/395-fix-fix-mcp-align-graph-read-tools-with-383.gate1.md
- ~/.claude/cache/gh-issue-driven/395-fix-fix-mcp-align-graph-read-tools-with-383.gate2.md

## Follow-ups suggested by gate2 (not blocking)
- refactor(services): replace `HTTPException` with domain exceptions in `PermissionService` (CTO) — currently the helper contains the leak to one MCP module; a future refactor would remove the layer violation at the root
- docs(rules): document the MCP read-tool visibility pattern in `.claude/rules/backend.md` so subsequent MCP read tools adopt it by convention (CTO)
- test(integration): tighten `count >= 1` assertions to exact counts, add the missing `private × outsider` cell for `handle_list_edges` (QA Lead)

🤖 Generated via /gh-issue-driven:ship
