### PR TITLE
docs: sync architecture/deployment/dev rules with v0.13.0 reality (#410)

### DIFF
--- a/.claude/rules/dev-environment.md
+++ b/.claude/rules/dev-environment.md
@@ -12,7 +12,7 @@ paths:
 
 - **Only `docker-compose.yml` exists** — there is no `docker-compose.dev.yml` or `docker-compose.override.yml`
 - All environments (dev, test, prod) use the same compose file with environment variables for differentiation
-- Container names: `kagura-api`, `kagura-web`, `kagura-db`, `kagura-redis`
+- Container names: `kagura-api`, `kagura-web-dev`, `kagura-postgres`, `kagura-qdrant`, `kagura-redis`
 
 ## Test Execution
 

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -1,12 +1,12 @@
 """Qdrant vector database client.
 
-Issue #1 specification:
-- 1ユーザー1コレクション設計 (kagura_user_{user_id})
-- Multilingual tokenizer (Qdrant 1.15+ built-in, 日本語自動対応)
-- Full-text index (summary + context_summary)
-- Keyword index (scope, type, context.context_id)
-
-Based on: kagura-ai/src/kagura/core/memory/backends/qdrant_rag.py
+Collection design (post Single Collection Migration, Issue #334):
+- Default model (text-embedding-3-small, 512 dims) → `kagura_memories`
+- Non-default models → `kagura_memories_{model_slug}_{dim}` via `get_collection_name()`
+- Isolation is payload-based: every point carries `workspace_id` + `context_id`
+- Named vectors: `dense` (VectorParams) + `bm25` (SparseVectorParams)
+- Multilingual tokenizer (Qdrant 1.15+ built-in; Japanese auto-supported)
+- Full-text index on summary + context_summary; keyword index on scope, type, context_id
 """
 
 from typing import Any

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,10 +17,11 @@ Kagura Memory Cloud is built with a modern, scalable architecture designed for p
                               ↓
 ┌──────────────────────┬──────────────────────────────────────┐
 │   MCP Server (SSE)   │          REST API (FastAPI)          │
-│  - 21 MCP Tools      │  - Memory CRUD                       │
+│  - 26 MCP Tools      │  - Memory CRUD                       │
 │    (memory / ctx /   │  - OAuth2 endpoints                  │
 │     edge / search /  │  - API Key management                │
-│     usage / sleep)   │  - Admin: sleep-reports, neural cfg  │
+│     usage / sleep /  │  - Resource Ingest API               │
+│     resource)        │  - Admin: sleep-reports, neural cfg  │
 │  - Session Mgmt      │                                      │
 │  - JSON-RPC          │                                      │
 └──────────────────────┴──────────────────────────────────────┘
@@ -28,20 +29,23 @@ Kagura Memory Cloud is built with a modern, scalable architecture designed for p
 ┌─────────────────────────────────────────────────────────────┐
 │                      Service Layer                           │
 │  MemoryService │ SearchService │ EmbeddingService           │
-│  GraphService │ NeuralMemoryEngine │ AuthService            │
-│  SleepService │ LLMService                                  │
+│  GraphService │ NeuralMemoryEngine │ WorkspaceService       │
+│  PermissionService │ SleepService │ LLMService              │
+│  ResourceIndexer │ ContextService │ QuotaService            │
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌─────────────────────────────────────────────────────────────┐
-│                    Repository Layer                          │
-│  MemoryRepository │ GraphRepository │ UserRepository        │
+│                     Data Access Layer                        │
+│  SQLAlchemy async models (backend/src/models/)              │
+│  + service-owned queries (no dedicated repository layer)    │
 └─────────────────────────────────────────────────────────────┘
                               ↓
 ┌──────────────┬──────────────┬──────────────┬───────────────┐
 │  PostgreSQL  │   Qdrant     │    Redis     │  External API │
 │  - Memories  │  - Vectors   │  - Sessions  │  - OpenAI     │
-│  - Users     │  - Full-text │  - Cache     │  - Cohere     │
-│  - Graph     │  (1u=1coll)  │  - Rate Lmt  │               │
+│  - Workspace │  - BM25      │  - Cache     │  - Cohere     │
+│  - Resources │  (single     │  - Rate Lmt  │  - Stripe     │
+│  - Graph     │   collection)│              │               │
 └──────────────┴──────────────┴──────────────┴───────────────┘
 ```
 
@@ -155,28 +159,66 @@ score = (
 
 ### PostgreSQL Tables
 
-1. **users** - User accounts
-2. **api_keys** - API key management (SHA256 hashed)
-3. **external_api_keys** - OpenAI/Cohere keys (Fernet encrypted)
-4. **memories** - 3-layer memory storage
-5. **graph_memory** - Neural memory relationships (NetworkX JSON)
-6. **oauth_clients** - OAuth2 client applications
-7. **oauth_authorization_codes** - OAuth2 auth codes
-8. **oauth_tokens** - OAuth2 access/refresh tokens
+Tables are grouped by domain. The authoritative list lives in `backend/src/models/`.
+
+**Identity & access**
+- **users** — User accounts
+- **api_keys** — API key management (SHA256 hashed)
+- **external_api_keys** — OpenAI/Cohere keys (Fernet encrypted)
+- **oauth_clients** / **oauth_authorization_codes** / **oauth_tokens** — OAuth2 server
+- **audit_logs** — Security-relevant audit trail
+
+**Workspaces & contexts** (top-level tenancy)
+- **workspaces** — Top-level organizational unit (team / project owner)
+- **workspace_members** — Role assignments (Owner / Admin / Member / Viewer)
+- **workspace_invitations** — Pending invitations
+- **workspace_addons** — Per-workspace addon entitlements
+- **contexts** — Memory namespaces scoped to a workspace
+- **context_members** — Per-context access (private / shared)
+- **context_search_configs** — Per-context hybrid search weights and reranker tuning
+
+**Memories & graph**
+- **memories** — 3-layer memory storage
+- **attachments** — File attachments linked to memories
+- **neural_memory_edges** — Primary Hebbian edge storage (workspace + context scoped)
+- **graph_memory** — Legacy NetworkX JSON (read paths still reference it; new writes go to `neural_memory_edges`)
+
+**Resource ingest** (v0.12.0 Resource Foundation)
+- **resources** — Normalized Resource entity (UUID PK); satellite tables FK via `resource_pk`
+- **resource_events** — Append-only event log (upsert / delete events)
+- **resource_schemas** — Versioned schemas declared per Resource
+- **indexer_state** — Per-(resource, context) indexer cursor + error metrics
+- **resource_tokens** — Per-Resource ingest tokens (workspace-scoped)
+
+**Plans, quotas & sleep**
+- **user_plans** / **plan_changes** — Plan state and history
+- **usage_stats** — Rate-limit and quota counters
+- **sleep_reports** — Per-run Sleep Maintenance summaries
+- **sleep_actions** — Reversible action audit log (used by `rollback_sleep_run`)
+
+**Configuration**
+- **neural_config** — Neural engine per-workspace config
+- **config_overrides** — System-level config overrides
+- **mcp_tool_descriptions** — Admin-editable MCP tool description overrides
 
 ### Qdrant Collections
 
-**Design**: 1 user = 1 collection
+**Design**: single shared collection per embedding model, scoped via payload filters.
 
-- Collection name: `kagura_user_{user_id}`
-- Vector size: 512 (OpenAI text-embedding-3-small)
+- Default collection: `kagura_memories` (OpenAI `text-embedding-3-small`, 512 dims)
+- Non-default models: `kagura_memories_{model_slug}_{dim}` (e.g. `kagura_memories_qwen3_embedding_8b_4096`)
+- Name resolution: `get_collection_name(model, dimensions)` in `backend/src/db/qdrant.py`
+- Isolation: every point carries `workspace_id` + `context_id` in its payload; searches add these as Qdrant filters
+- Named vectors: `dense` (VectorParams) + `bm25` (SparseVectorParams) — anonymous vectors are rejected
 - Distance metric: Cosine
 - Tokenizer: Multilingual (auto Japanese support)
 
 **Features**:
 - Semantic vector search
-- Full-text BM25 search (MatchText)
-- Metadata filtering
+- Full-text BM25 search (MatchText + sparse vector)
+- Metadata filtering (workspace / context / tags / importance)
+
+Prior "1 user = 1 collection" design (`kagura_user_{user_id}`) was replaced by the single-collection migration; no per-user collections remain in new deployments.
 
 ### Redis Storage
 
@@ -196,11 +238,25 @@ User → OAuth2 Login → Session Cookie → Access Token
                         External API Access
 ```
 
-### Authorization Levels
+### Authorization Model
 
-1. **Admin**: Full access (user management, system config)
-2. **User**: Standard access (own memories, API keys)
-3. **Read-only**: View-only access
+Authorization is **workspace-scoped RBAC**. Every authenticated request is resolved to a `(user, workspace, context)` triple before any data access.
+
+**System roles** (flag on `users`):
+- **System admin**: Operator-level access (user management, system config, admin API endpoints)
+- **Standard user**: Default — scoped by workspace membership
+
+**Workspace roles** (per `workspace_members` row):
+- **Owner**: Billing, members, contexts, memories, settings
+- **Admin**: Manage members and shared contexts, read/write memories
+- **Member**: Read/write memories in assigned contexts
+- **Viewer**: Read-only access to assigned contexts
+
+**Context-level privacy**:
+- **Private** (`is_private=true`): Only the creator can access
+- **Shared** (`is_private=false`): All workspace members with the appropriate role
+
+All checks funnel through `PermissionService` in `backend/src/services/permission_service.py`; clients never supply a raw `workspace_id` without server-side verification.
 
 ### Encryption
 

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -142,7 +142,7 @@ See [Sleep Maintenance](sleep-maintenance.md) for the complete reference.
 
 ## MCP Tools
 
-Kagura Memory Cloud exposes 21 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/):
+Kagura Memory Cloud exposes 26 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/):
 
 | Tool | Description | Read-only |
 |------|------------|-----------|
@@ -167,6 +167,11 @@ Kagura Memory Cloud exposes 21 tools via the [Model Context Protocol (MCP)](http
 | `get_sleep_history` | List recent Sleep Maintenance runs for a context | Yes |
 | `get_sleep_report` | Fetch a Sleep run's full report and action audit log | Yes |
 | `rollback_sleep_run` | Reverse every recorded action of a Sleep run | No |
+| `setup_resource` | Register or update a Resource (schema + indexer config) | No |
+| `ingest_events` | Append versioned events to a Resource | No |
+| `get_resource_schema` | Fetch the schema for a Resource | Yes |
+| `get_resource_impact` | Preview how a Resource re-index would affect memories | Yes |
+| `list_resource_tokens` | List Resource Tokens scoped to the caller | Yes |
 
 **Typical workflow:**
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -40,7 +40,7 @@ your-domain.example.com {
     reverse_proxy /health kagura-api:8080
 
     # Frontend (catch-all)
-    reverse_proxy kagura-frontend:3000
+    reverse_proxy kagura-web-dev:3000
 }
 ```
 
@@ -69,7 +69,7 @@ services:
       - caddy_config:/config
     depends_on:
       - kagura-api
-      - kagura-frontend
+      - kagura-web-dev
 
 volumes:
   caddy_data:


### PR DESCRIPTION
## Summary

Closes #410. Aligns developer-facing docs with the code after v0.12.0 (Resource Foundation) and v0.13.0 (Phase A neural) shipped.

- `docs/architecture.md`: MCP tool count `21 -> 26`, Resource Ingest row added to the REST/MCP box; DB tables section regrouped by domain to cover **29** actual tables (previously listed only 8); Qdrant Collections rewritten for the Single Collection Migration (`kagura_memories` + per-model suffixed variants, payload-scoped workspace/context isolation); `graph_memory` now marked as legacy with `neural_memory_edges` as primary; Authorization section replaced 3-tier Admin/User/Read-only with actual workspace-scoped RBAC (Owner/Admin/Member/Viewer + System admin) with pointer to `PermissionService`.
- `docs/concepts.md`: MCP tool count `21 -> 26`, added the 5 Resource tools (`setup_resource`, `ingest_events`, `get_resource_schema`, `get_resource_impact`, `list_resource_tokens`).
- `docs/deployment.md`: frontend container name `kagura-frontend -> kagura-web-dev` (matches `docker-compose.yml`).
- `.claude/rules/dev-environment.md`: container list `kagura-web -> kagura-web-dev`, `kagura-db -> kagura-postgres`, added missing `kagura-qdrant`.
- `backend/src/db/qdrant.py`: module docstring claimed "1 user = 1 collection (`kagura_user_{user_id}`)" which directly contradicted the actual `get_collection_name()` logic defined ~20 lines below — rewritten to match the current Single Collection design (Issue #334).

## Out of scope (follow-ups)

- Production deployment runbook for GCP / Terraform (separate issue)
- Legacy `graph_memory` table removal (separate refactor)
- Memory-cloud user-memory housekeeping (outside the repo)

## Test plan

- [x] `make lint` — ruff clean
- [x] `import db.qdrant` smoke test — module loads and docstring renders
- [x] No code path changed — docs + 1 docstring only