### PR TITLE
feat(neural): tag co-occurrence cold-start seeding (Tier 2) (#223)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -21,6 +21,7 @@ import models.memory  # noqa: F401
 import models.config  # noqa: F401
 import models.resource  # noqa: F401
 import models.neural  # noqa: F401
+import models.hub_tag  # noqa: F401
 
 # Alembic Config object
 config = context.config

--- a/backend/alembic/versions/b05_223_tag_cooccurrence.py
+++ b/backend/alembic/versions/b05_223_tag_cooccurrence.py
@@ -1,0 +1,167 @@
+"""Add tag_cooccurrence edge type, GIN index on memories.tags, hub_tag_cache.
+
+Issue #223 (Tier 2 cold-start seeding): three coupled schema changes that ship
+together because the runtime code that uses them is added in the same PR.
+
+1. Drop + recreate ``valid_edge_type`` CHECK constraint to add the new
+   ``tag_cooccurrence`` value. Postgres does not support adding values to a
+   CHECK constraint in-place; drop + recreate is the canonical pattern.
+
+2. Create ``idx_memories_tags_gin`` — a GIN index on ``memories.tags`` so the
+   ``tags && ARRAY[?]::text[]`` overlap query at remember() time can be pushed
+   down to the index instead of degrading to a sequential scan.
+
+   NOTE on CONCURRENTLY: this repo's ``alembic/env.py`` wraps every migration
+   in ``context.begin_transaction()``, and Postgres rejects
+   ``CREATE INDEX CONCURRENTLY`` inside a transaction block. The async
+   ``async_engine_from_config`` path used here also does not plumb
+   ``op.get_context().autocommit_block()`` through ``do_run_migrations``.
+   We therefore use a plain ``CREATE INDEX``. The ``memories.tags`` column is
+   a low-frequency write target (tags are set at remember() and rarely
+   updated), so the brief ACCESS EXCLUSIVE lock during build is acceptable.
+   If a future deployment needs zero-downtime here, split this into a
+   dedicated migration that escapes the env.py transaction wrapping.
+
+3. Create ``hub_tag_cache`` table — per-(workspace, context) cache of "hub
+   tags" (tags appearing on >X% of memories in the context). Computed nightly
+   by Sleep Maintenance. Mirrors the ``Bm25IdfDriftLog`` shape (FK on
+   contexts.id with ON DELETE CASCADE, JSONB payload, server_default
+   timestamp).
+
+Revision ID: b05_223_tag_cooccurrence
+Revises: b04_358_signup_gate
+
+NOTE: Revision IDs are capped at 32 chars because ``alembic_version.version_num``
+is ``VARCHAR(32)`` in this database (asyncpg raises
+``StringDataRightTruncationError`` otherwise).
+
+DOWNGRADE WARNING: ``downgrade()`` deletes all ``tag_cooccurrence`` edges
+before restoring the original ``valid_edge_type`` CHECK constraint. Without
+the delete, constraint recreation would fail validation against the existing
+rows. This is destructive — re-applying ``upgrade`` will not recover the
+edges; they must be re-seeded by Sleep Maintenance / the backfill script.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b05_223_tag_cooccurrence"
+down_revision = "b04_358_signup_gate"
+branch_labels = None
+depends_on = None
+
+
+_OLD_EDGE_TYPES_SQL = (
+    "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+    "'learned_from', 'semantic_similarity', 'declared_link')"
+)
+_NEW_EDGE_TYPES_SQL = (
+    "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+    "'learned_from', 'semantic_similarity', 'declared_link', 'tag_cooccurrence')"
+)
+
+
+def upgrade() -> None:
+    """Apply tag_cooccurrence schema changes."""
+    # 1. Extend valid_edge_type CHECK constraint to include 'tag_cooccurrence'.
+    #    Drop + recreate is the only way; Postgres has no ALTER CONSTRAINT for
+    #    CHECK clause modification.
+    op.drop_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        _NEW_EDGE_TYPES_SQL,
+    )
+
+    # 2. GIN index on memories.tags. Required for the tag_cooccurrence seeding
+    #    query (`WHERE ... AND tags && ARRAY[?]::text[]`) to scale beyond a
+    #    sequential scan.
+    op.create_index(
+        "idx_memories_tags_gin",
+        "memories",
+        ["tags"],
+        postgresql_using="gin",
+    )
+
+    # 3. hub_tag_cache: per-(workspace, context) snapshot of tags considered
+    #    "hub" (frequency above tag_cooccurrence_hub_threshold). Refreshed
+    #    nightly by Sleep Maintenance; read by remember() to skip hub tags
+    #    when computing cooccurrence candidates.
+    op.create_table(
+        "hub_tag_cache",
+        sa.Column("id", sa.BigInteger(), primary_key=True, autoincrement=True),
+        sa.Column("workspace_id", UUID(as_uuid=True), nullable=False),
+        sa.Column(
+            "context_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        # JSON list of tag strings considered "hub" for this (workspace, context).
+        # Empty list ([]) is a valid "no hub tags found this run" result and
+        # is distinct from missing row ("never computed"). remember() treats
+        # missing as "no exclusion" (graceful first-night behavior).
+        sa.Column("hub_tags", JSONB, nullable=False, server_default=sa.text("'[]'::jsonb")),
+        # Total memory count at compute time + threshold used. Useful for
+        # debugging "why is X considered hub?" without re-querying memories.
+        sa.Column("memory_count", sa.Integer(), nullable=False),
+        sa.Column("threshold_used", sa.Float(), nullable=False),
+        sa.Column(
+            "computed_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        # One row per (workspace, context). Refresh = upsert on this key.
+        sa.UniqueConstraint(
+            "workspace_id",
+            "context_id",
+            name="uq_hub_tag_cache_ws_ctx",
+        ),
+        sa.CheckConstraint(
+            "memory_count >= 0",
+            name="hub_tag_cache_nonneg_memory_count",
+        ),
+        sa.CheckConstraint(
+            "threshold_used >= 0.0 AND threshold_used <= 1.0",
+            name="hub_tag_cache_threshold_in_range",
+        ),
+    )
+    op.create_index(
+        "ix_hub_tag_cache_workspace_id",
+        "hub_tag_cache",
+        ["workspace_id"],
+    )
+
+
+def downgrade() -> None:
+    """Reverse all three changes in opposite order.
+
+    Destructive: any existing ``tag_cooccurrence`` edges are deleted before
+    the CHECK constraint is restored to its pre-#223 form. Without the
+    delete, ``op.create_check_constraint`` would validate the existing rows
+    against the narrower IN clause and raise. See module docstring.
+    """
+    op.drop_index("ix_hub_tag_cache_workspace_id", table_name="hub_tag_cache")
+    op.drop_table("hub_tag_cache")
+    op.drop_index("idx_memories_tags_gin", table_name="memories")
+    op.drop_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        type_="check",
+    )
+    # Drop edges that the about-to-be-restored CHECK would reject. Done after
+    # the constraint drop so the DELETE is not blocked by it.
+    op.execute("DELETE FROM neural_memory_edges WHERE edge_type = 'tag_cooccurrence'")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        _OLD_EDGE_TYPES_SQL,
+    )

--- a/backend/alembic/versions/b05_223_tag_cooccurrence.py
+++ b/backend/alembic/versions/b05_223_tag_cooccurrence.py
@@ -8,8 +8,13 @@ together because the runtime code that uses them is added in the same PR.
    CHECK constraint in-place; drop + recreate is the canonical pattern.
 
 2. Create ``idx_memories_tags_gin`` — a GIN index on ``memories.tags`` so the
-   ``tags && ARRAY[?]::text[]`` overlap query at remember() time can be pushed
-   down to the index instead of degrading to a sequential scan.
+   ``tags && CAST(:query_tags AS varchar[])`` overlap query at remember() time
+   can be pushed down to the index instead of degrading to a sequential scan.
+   The runtime code casts the *parameter* to ``varchar[]`` (matching the
+   column type ``Column(ARRAY(String))`` → ``varchar[]`` in Postgres) so the
+   WHERE-clause expression literally is ``tags && X`` and PG can use this
+   index. Casting the column instead would form a different expression
+   (``tags::text[] && X``) that the GIN index does not match.
 
    NOTE on CONCURRENTLY: this repo's ``alembic/env.py`` wraps every migration
    in ``context.begin_transaction()``, and Postgres rejects

--- a/backend/scripts/backfill_tag_cooccurrence_edges.py
+++ b/backend/scripts/backfill_tag_cooccurrence_edges.py
@@ -1,0 +1,387 @@
+#!/usr/bin/env python3
+"""Backfill tag_cooccurrence edges across existing memories (Issue #223).
+
+The migration ``b05_223_tag_cooccurrence`` adds the schema (GIN index +
+extended CHECK + ``hub_tag_cache`` table). New memories created after the
+deploy automatically get tag_cooccurrence seed edges via
+``_create_tag_cooccurrence_seed_edges`` in ``memory_service.py``. This script
+populates the same edges for memories that existed before the deploy.
+
+Operational order (see ``docs/deployment.md``):
+
+    1. Deploy code containing the new seeding function and config.
+    2. Run ``alembic upgrade head`` to apply migration b05_223.
+    3. Sleep Maintenance runs nightly and populates ``hub_tag_cache``
+       (or run ``python -m scripts.refresh_hub_tag_cache`` ad hoc — TODO).
+    4. Run this script per user / globally to backfill edges.
+
+Idempotent: re-runs are safe. ``create_edge_if_absent`` (ON CONFLICT DO
+NOTHING) prevents duplicates. The script also skips memories that already
+have outgoing tag_cooccurrence edges as a fast-path.
+
+Usage:
+
+    # Dry-run for one user (preview counts only):
+    python scripts/backfill_tag_cooccurrence_edges.py --user-id <uuid>
+
+    # Execute for one user, batched 100 memories per commit:
+    python scripts/backfill_tag_cooccurrence_edges.py \
+        --user-id <uuid> --execute --batch-size 100
+
+    # Execute for all users (use sparingly — long-running on large datasets):
+    python scripts/backfill_tag_cooccurrence_edges.py --all-users --execute
+
+    # Optional: scope further to one (workspace, context):
+    python scripts/backfill_tag_cooccurrence_edges.py \
+        --user-id <uuid> --context-id <uuid> --execute
+
+Default mode is **dry-run**: passing ``--execute`` is required for any write.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+# Add src to path for imports (mirrors audit_edge_context_invariant.py).
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from sqlalchemy import select, text  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+
+from db.base import _get_session_factory  # noqa: E402
+from models.hub_tag import HubTagCache  # noqa: E402
+from models.memory import Memory  # noqa: E402
+from neural.config import NeuralMemoryConfig  # noqa: E402
+from repositories.neural_edge import NeuralEdgeRepository  # noqa: E402
+from utils.logger import get_logger  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+async def _hub_tags_for(session: AsyncSession, workspace_id: str, context_id: str) -> set[str]:
+    """Read cached hub-tag set; empty set if never computed.
+
+    Wraps the string args in ``UUID(...)`` so the comparison against the
+    ``UUID(as_uuid=True)`` columns is unambiguous (matches the precedent
+    in ``memory_service.py`` which compares against ORM-loaded UUID
+    objects rather than string forms).
+    """
+    result = await session.execute(
+        select(HubTagCache.hub_tags).where(
+            HubTagCache.workspace_id == UUID(workspace_id),
+            HubTagCache.context_id == UUID(context_id),
+        )
+    )
+    row = result.scalar_one_or_none()
+    return set(row) if row else set()
+
+
+async def _backfill_one_memory(
+    session: AsyncSession,
+    *,
+    memory: Memory,
+    config: NeuralMemoryConfig,
+    hub_tags: set[str],
+    edge_repo: NeuralEdgeRepository,
+    execute: bool,
+) -> tuple[int, str]:
+    """Compute and (optionally) write tag_cooccurrence edges for one memory.
+
+    Returns ``(edges_count, status)`` where ``status`` is one of:
+
+    - ``"no_tags"`` — memory has no tags (or no workspace/context set);
+      skipped without DB work.
+    - ``"already_seeded"`` — at least one tag_cooccurrence edge already
+      exists for this memory; skipped via fast-path.
+    - ``"no_candidates"`` — query ran but found no qualifying neighbors
+      (all tags hub-excluded, or no cooccurring memories above
+      min_shared).
+    - ``"seeded"`` — at least one edge was created (or, in dry-run, would
+      be). The ``edges_count`` is non-zero only in this case.
+    """
+    if not memory.tags or not memory.workspace_id or not memory.context_id:
+        return 0, "no_tags"
+
+    workspace_id_str = str(memory.workspace_id)
+    context_id_str = str(memory.context_id)
+
+    # Fast-path skip: already seeded.
+    existing = await edge_repo.get_outgoing_edges(
+        user_id=memory.user_id,
+        src_id=memory.id,
+        edge_types=["tag_cooccurrence"],
+        workspace_id=workspace_id_str,
+        context_id=context_id_str,
+        limit=1,
+    )
+    if existing:
+        return 0, "already_seeded"
+
+    query_tags = [t for t in memory.tags if t not in hub_tags]
+    if len(query_tags) < config.tag_cooccurrence_min_shared:
+        return 0, "no_candidates"
+
+    sql = text(
+        """
+        SELECT id, cardinality(ARRAY(
+            SELECT unnest(tags)
+            INTERSECT
+            SELECT unnest(CAST(:query_tags AS text[]))
+        )) AS shared_count
+        FROM memories
+        WHERE user_id = :user_id
+          AND workspace_id = CAST(:workspace_id AS uuid)
+          AND context_id = CAST(:context_id AS uuid)
+          AND deleted_at IS NULL
+          AND id != CAST(:self_id AS uuid)
+          AND tags && CAST(:query_tags AS text[])
+          AND cardinality(ARRAY(
+              SELECT unnest(tags)
+              INTERSECT
+              SELECT unnest(CAST(:query_tags AS text[]))
+          )) >= :min_shared
+        ORDER BY shared_count DESC, id
+        LIMIT :max_matches
+        """
+    )
+    res = await session.execute(
+        sql,
+        {
+            "user_id": memory.user_id,
+            "workspace_id": workspace_id_str,
+            "context_id": context_id_str,
+            "self_id": str(memory.id),
+            "query_tags": query_tags,
+            "min_shared": config.tag_cooccurrence_min_shared,
+            "max_matches": config.tag_cooccurrence_max_per_remember,
+        },
+    )
+    rows = res.all()
+    if not rows:
+        return 0, "no_candidates"
+
+    if not execute:
+        # Dry-run: count candidates that would actually create an edge (i.e.
+        # not already present via knn or other path). Cheap approximation:
+        # count rows; the real count after ON CONFLICT skips may be lower.
+        return len(rows), "seeded"
+
+    degree_cap = config.tag_cooccurrence_max_degree_per_node
+    written = 0
+    for row in rows:
+        if written >= degree_cap:
+            break
+        try:
+            neighbor_id = UUID(str(row.id))
+            shared_count = int(row.shared_count)
+        except (ValueError, TypeError, AttributeError):
+            continue
+        weight = min(0.4, 0.15 + 0.10 * (shared_count - 1))
+        confidence = min(1.0, shared_count / 4.0)
+        try:
+            async with session.begin_nested():
+                edge = await edge_repo.create_edge_if_absent(
+                    user_id=memory.user_id,
+                    src_id=memory.id,
+                    dst_id=neighbor_id,
+                    edge_type="tag_cooccurrence",
+                    weight=weight,
+                    confidence=confidence,
+                    workspace_id=workspace_id_str,
+                    context_id=context_id_str,
+                )
+            if edge is not None:
+                written += 1
+        except Exception as e:
+            logger.warning(
+                "backfill_edge_failed",
+                memory_id=str(memory.id),
+                neighbor_id=str(row.id),
+                error=str(e),
+            )
+    return written, ("seeded" if written > 0 else "no_candidates")
+
+
+async def backfill(
+    *,
+    user_id: str | None,
+    context_id: str | None,
+    all_users: bool,
+    execute: bool,
+    batch_size: int,
+) -> dict[str, Any]:
+    """Iterate memories in scope and backfill tag_cooccurrence edges.
+
+    Memory iteration is keyset-paginated by ``id`` (stable ordering) so the
+    script is resumable across crashes — restart with the same args and any
+    already-seeded memories will be fast-path skipped on the second pass.
+    """
+    session_factory = _get_session_factory()
+
+    counts = {
+        "memories_scanned": 0,
+        "memories_skipped_no_tags": 0,
+        "memories_already_seeded": 0,
+        "memories_no_candidates": 0,
+        "memories_seeded": 0,
+        "edges_created": 0,
+        "users_seen": set(),
+    }
+    last_id = None
+
+    async with session_factory() as session:
+        config = await NeuralMemoryConfig.from_db(session)
+
+        # Hub-tag cache reads are scoped per (workspace, context); the cache
+        # itself is shared across users in the same context.
+        hub_cache: dict[tuple[str, str], set[str]] = {}
+
+        edge_repo = NeuralEdgeRepository(session)
+
+        while True:
+            stmt = (
+                select(Memory)
+                .where(Memory.deleted_at.is_(None))
+                .where(Memory.tags.isnot(None))
+                .where(Memory.workspace_id.isnot(None))
+                .where(Memory.context_id.isnot(None))
+                .order_by(Memory.id)
+                .limit(batch_size)
+            )
+            if user_id and not all_users:
+                stmt = stmt.where(Memory.user_id == user_id)
+            if context_id:
+                stmt = stmt.where(Memory.context_id == UUID(context_id))
+            if last_id is not None:
+                stmt = stmt.where(Memory.id > last_id)
+
+            res = await session.execute(stmt)
+            batch = list(res.scalars().all())
+            if not batch:
+                break
+
+            for memory in batch:
+                counts["memories_scanned"] += 1
+                last_id = memory.id
+                counts["users_seen"].add(memory.user_id)
+
+                if not memory.tags:
+                    counts["memories_skipped_no_tags"] += 1
+                    continue
+
+                ws_str = str(memory.workspace_id)
+                ctx_str = str(memory.context_id)
+                cache_key = (ws_str, ctx_str)
+                if cache_key not in hub_cache:
+                    hub_cache[cache_key] = await _hub_tags_for(session, ws_str, ctx_str)
+
+                created, status = await _backfill_one_memory(
+                    session,
+                    memory=memory,
+                    config=config,
+                    hub_tags=hub_cache[cache_key],
+                    edge_repo=edge_repo,
+                    execute=execute,
+                )
+                counts["edges_created"] += created
+                if status == "already_seeded":
+                    counts["memories_already_seeded"] += 1
+                elif status == "no_candidates":
+                    counts["memories_no_candidates"] += 1
+                elif status == "seeded":
+                    counts["memories_seeded"] += 1
+                elif status == "no_tags":
+                    # Should not happen — caller already filtered, but harmless
+                    counts["memories_skipped_no_tags"] += 1
+
+            if execute:
+                await session.commit()
+
+            logger.info(
+                "backfill_batch_complete",
+                last_id=str(last_id) if last_id else None,
+                memories_scanned=counts["memories_scanned"],
+                edges_created=counts["edges_created"],
+                execute=execute,
+            )
+
+    counts["users_seen"] = len(counts["users_seen"])  # type: ignore[assignment]
+    return counts
+
+
+def print_report(counts: dict[str, Any], *, execute: bool) -> None:
+    """Render the run summary."""
+    mode = "EXECUTE" if execute else "DRY-RUN"
+    print(f"\n=== tag_cooccurrence backfill ({mode}) ===")
+    print(f"  Memories scanned:           {counts['memories_scanned']}")
+    print(f"  Skipped (no tags):          {counts['memories_skipped_no_tags']}")
+    print(f"  Already seeded (skipped):   {counts['memories_already_seeded']}")
+    print(f"  No candidates found:        {counts['memories_no_candidates']}")
+    print(
+        f"  Seeded {'(this run)' if execute else '(would seed)'}:           {counts['memories_seeded']}"
+    )
+    print(f"  Distinct users touched:     {counts['users_seen']}")
+    if execute:
+        print(f"  Edges created:              {counts['edges_created']}")
+    else:
+        print(f"  Edges that WOULD be created (upper bound): {counts['edges_created']}")
+        print("  Re-run with --execute to write.")
+
+
+async def main_async(args: argparse.Namespace) -> int:
+    if not args.user_id and not args.all_users:
+        print(
+            "error: pass either --user-id <uuid> or --all-users",
+            file=sys.stderr,
+        )
+        return 2
+    if args.user_id and args.all_users:
+        print(
+            "error: --user-id and --all-users are mutually exclusive",
+            file=sys.stderr,
+        )
+        return 2
+
+    counts = await backfill(
+        user_id=args.user_id,
+        context_id=args.context_id,
+        all_users=args.all_users,
+        execute=args.execute,
+        batch_size=args.batch_size,
+    )
+    print_report(counts, execute=args.execute)
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill tag_cooccurrence edges (Issue #223)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    scope = parser.add_mutually_exclusive_group(required=False)
+    scope.add_argument("--user-id", help="Restrict to one user UUID")
+    scope.add_argument("--all-users", action="store_true", help="Process every user")
+    parser.add_argument("--context-id", help="Further restrict to one context UUID (optional)")
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Actually write edges. Without this flag, runs in dry-run mode.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=200,
+        help="Memories per commit batch (default: 200)",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(main_async(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/backfill_tag_cooccurrence_edges.py
+++ b/backend/scripts/backfill_tag_cooccurrence_edges.py
@@ -126,14 +126,17 @@ async def _backfill_one_memory(
     if len(query_tags) < config.tag_cooccurrence_min_shared:
         return 0, "no_candidates"
 
-    # Cast `tags` (varchar[]) to text[] to match :query_tags element type —
-    # see memory_service.py companion SQL for the same fix (Copilot loop 1).
+    # Cast :query_tags to varchar[] (matching ``Column(ARRAY(String))`` →
+    # varchar[]) and leave ``tags`` uncast so ``idx_memories_tags_gin`` is
+    # eligible. See memory_service.py companion SQL for the rationale
+    # (Copilot loop 3: prior text[] cast on the column bypassed the index
+    # and turned backfill into a seq scan on large contexts).
     sql = text(
         """
         SELECT id, cardinality(ARRAY(
-            SELECT unnest(tags::text[])
+            SELECT unnest(tags)
             INTERSECT
-            SELECT unnest(CAST(:query_tags AS text[]))
+            SELECT unnest(CAST(:query_tags AS varchar[]))
         )) AS shared_count
         FROM memories
         WHERE user_id = :user_id
@@ -141,11 +144,11 @@ async def _backfill_one_memory(
           AND context_id = CAST(:context_id AS uuid)
           AND deleted_at IS NULL
           AND id != CAST(:self_id AS uuid)
-          AND tags::text[] && CAST(:query_tags AS text[])
+          AND tags && CAST(:query_tags AS varchar[])
           AND cardinality(ARRAY(
-              SELECT unnest(tags::text[])
+              SELECT unnest(tags)
               INTERSECT
-              SELECT unnest(CAST(:query_tags AS text[]))
+              SELECT unnest(CAST(:query_tags AS varchar[]))
           )) >= :min_shared
         ORDER BY shared_count DESC, id
         LIMIT :max_matches

--- a/backend/scripts/backfill_tag_cooccurrence_edges.py
+++ b/backend/scripts/backfill_tag_cooccurrence_edges.py
@@ -128,28 +128,27 @@ async def _backfill_one_memory(
 
     # Cast :query_tags to varchar[] (matching ``Column(ARRAY(String))`` →
     # varchar[]) and leave ``tags`` uncast so ``idx_memories_tags_gin`` is
-    # eligible. See memory_service.py companion SQL for the rationale
-    # (Copilot loop 3: prior text[] cast on the column bypassed the index
-    # and turned backfill into a seq scan on large contexts).
+    # eligible. See memory_service.py companion SQL for full rationale
+    # (Copilot loops 1+3+4 history). Subquery shape computes the
+    # cardinality(... INTERSECT ...) exactly once per row.
     sql = text(
         """
-        SELECT id, cardinality(ARRAY(
-            SELECT unnest(tags)
-            INTERSECT
-            SELECT unnest(CAST(:query_tags AS varchar[]))
-        )) AS shared_count
-        FROM memories
-        WHERE user_id = :user_id
-          AND workspace_id = CAST(:workspace_id AS uuid)
-          AND context_id = CAST(:context_id AS uuid)
-          AND deleted_at IS NULL
-          AND id != CAST(:self_id AS uuid)
-          AND tags && CAST(:query_tags AS varchar[])
-          AND cardinality(ARRAY(
-              SELECT unnest(tags)
-              INTERSECT
-              SELECT unnest(CAST(:query_tags AS varchar[]))
-          )) >= :min_shared
+        SELECT id, shared_count
+        FROM (
+            SELECT id, cardinality(ARRAY(
+                SELECT unnest(tags)
+                INTERSECT
+                SELECT unnest(CAST(:query_tags AS varchar[]))
+            )) AS shared_count
+            FROM memories
+            WHERE user_id = :user_id
+              AND workspace_id = CAST(:workspace_id AS uuid)
+              AND context_id = CAST(:context_id AS uuid)
+              AND deleted_at IS NULL
+              AND id != CAST(:self_id AS uuid)
+              AND tags && CAST(:query_tags AS varchar[])
+        ) m
+        WHERE shared_count >= :min_shared
         ORDER BY shared_count DESC, id
         LIMIT :max_matches
         """

--- a/backend/scripts/backfill_tag_cooccurrence_edges.py
+++ b/backend/scripts/backfill_tag_cooccurrence_edges.py
@@ -126,10 +126,12 @@ async def _backfill_one_memory(
     if len(query_tags) < config.tag_cooccurrence_min_shared:
         return 0, "no_candidates"
 
+    # Cast `tags` (varchar[]) to text[] to match :query_tags element type —
+    # see memory_service.py companion SQL for the same fix (Copilot loop 1).
     sql = text(
         """
         SELECT id, cardinality(ARRAY(
-            SELECT unnest(tags)
+            SELECT unnest(tags::text[])
             INTERSECT
             SELECT unnest(CAST(:query_tags AS text[]))
         )) AS shared_count
@@ -139,9 +141,9 @@ async def _backfill_one_memory(
           AND context_id = CAST(:context_id AS uuid)
           AND deleted_at IS NULL
           AND id != CAST(:self_id AS uuid)
-          AND tags && CAST(:query_tags AS text[])
+          AND tags::text[] && CAST(:query_tags AS text[])
           AND cardinality(ARRAY(
-              SELECT unnest(tags)
+              SELECT unnest(tags::text[])
               INTERSECT
               SELECT unnest(CAST(:query_tags AS text[]))
           )) >= :min_shared

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -33,6 +33,9 @@ VALID_EDGE_TYPES = frozenset(
         "semantic_similarity",
         # Issue #215: Explicit links from clients (Obsidian wikilinks, code imports, etc.)
         "declared_link",
+        # Issue #223 (Tier 2 cold-start seeding): synthetic edges from
+        # tag co-occurrence at remember() time
+        "tag_cooccurrence",
     }
 )
 

--- a/backend/src/models/hub_tag.py
+++ b/backend/src/models/hub_tag.py
@@ -1,0 +1,87 @@
+"""SQLAlchemy model for tag co-occurrence hub-tag cache.
+
+Issue #223: per-(workspace, context) snapshot of tags considered "hub"
+(frequency above ``tag_cooccurrence_hub_threshold``). Refreshed nightly by
+Sleep Maintenance and read by ``_create_tag_cooccurrence_seed_edges`` at
+remember() time to prune candidate matches that share only popular tags.
+
+Design:
+    - One row per (workspace, context); refresh = upsert on
+      ``uq_hub_tag_cache_ws_ctx``.
+    - ``hub_tags`` is a JSONB list of tag strings. Empty list ([]) is a
+      valid "no hub tags this run" result; missing row is treated as
+      "no exclusion" by readers (graceful first-night behavior).
+    - Mirrors the ``Bm25IdfDriftLog`` (#343) precedent for per-context
+      computed state.
+"""
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    UniqueConstraint,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from db.base import Base
+
+
+class HubTagCache(Base):
+    """Per-(workspace, context) cache of hub tags for tag_cooccurrence seeding.
+
+    Attributes:
+        id: Auto-increment primary key
+        workspace_id: Workspace UUID (denormalized; not FK because the
+            workspace registry lives outside this app's owned tables)
+        context_id: Context UUID (FK with CASCADE on context delete)
+        hub_tags: JSONB list of tag strings considered hub for this scope.
+            Empty list = "computed and found nothing", missing row = "never
+            computed"
+        memory_count: Total memory count at compute time. Useful for
+            debugging "why is X considered hub?" without re-querying memories
+        threshold_used: ``tag_cooccurrence_hub_threshold`` value applied at
+            compute time (so historical inspection of a row still makes sense
+            if the configured threshold changes)
+        computed_at: Cron cycle timestamp (tz-aware)
+    """
+
+    __tablename__ = "hub_tag_cache"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    workspace_id = Column(UUID(as_uuid=True), nullable=False)
+    context_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    hub_tags = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
+    memory_count = Column(Integer, nullable=False)
+    threshold_used = Column(Float, nullable=False)
+    computed_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "context_id", name="uq_hub_tag_cache_ws_ctx"),
+        CheckConstraint("memory_count >= 0", name="hub_tag_cache_nonneg_memory_count"),
+        CheckConstraint(
+            "threshold_used >= 0.0 AND threshold_used <= 1.0",
+            name="hub_tag_cache_threshold_in_range",
+        ),
+        Index("ix_hub_tag_cache_workspace_id", "workspace_id"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<HubTagCache(workspace_id={self.workspace_id}, "
+            f"context_id={self.context_id}, hub_tags={self.hub_tags})>"
+        )

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -318,7 +318,8 @@ class NeuralMemoryEdge(Base):
         CheckConstraint("confidence >= 0.0 AND confidence <= 1.0", name="valid_confidence"),
         CheckConstraint(
             "edge_type IN ('neural_association', 'related_to', 'depends_on', "
-            "'learned_from', 'semantic_similarity', 'declared_link')",
+            "'learned_from', 'semantic_similarity', 'declared_link', "
+            "'tag_cooccurrence')",
             name="valid_edge_type",
         ),
         # Mirrors the CHECK the b03_396 migration installs so Base.metadata.

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -89,6 +89,14 @@ class NeuralMemoryConfig:
         sleep_edge_discovery_enabled: Enable edge discovery phase
         sleep_edge_discovery_sample_size: Memories sampled for edge discovery
         sleep_importance_reeval_enabled: Enable importance re-evaluation phase
+
+        # Tag Co-Occurrence Cold-Start Seeding (Issue #223, Tier 2)
+        tag_cooccurrence_enabled: Master switch for tag-cooccurrence seeding
+        tag_cooccurrence_min_shared: Minimum shared tags to create an edge (1-10)
+        tag_cooccurrence_max_per_remember: Top-N matches per remember() (1-100)
+        tag_cooccurrence_hub_threshold: Frequency above which a tag is "hub"
+            and excluded from co-occurrence (0.0-1.0)
+        tag_cooccurrence_max_degree_per_node: Per-source-node degree cap (1-1000)
     """
 
     # Class-level cache for from_db() (not serialized as instance fields)
@@ -163,6 +171,21 @@ class NeuralMemoryConfig:
     knn_seed_weight: float = (
         0.3  # Intentionally low — synthetic signal, Sleep Maintenance prunes if unused
     )
+
+    # Tag Co-Occurrence Cold-Start Seeding (Issue #223, Tier 2)
+    # On remember(), find existing memories sharing 2+ tags within the same
+    # (user, workspace, context) and create weak ``tag_cooccurrence`` edges.
+    # Complementary to k-NN: deterministic, free (no embedding cost), and
+    # surfaces structure that semantic similarity alone misses (e.g., two
+    # memories about different topics that share the same project tags).
+    tag_cooccurrence_enabled: bool = True
+    tag_cooccurrence_min_shared: int = 2  # Minimum shared tags to create edge (1-10)
+    tag_cooccurrence_max_per_remember: int = 10  # Top-N matches per remember() (1-100)
+    # Hub-tag exclusion: tags appearing on > threshold * memory_count in a
+    # (workspace, context) are excluded from co-occurrence. Computed nightly by
+    # Sleep Maintenance and cached in ``hub_tag_cache``.
+    tag_cooccurrence_hub_threshold: float = 0.30  # 0.0-1.0
+    tag_cooccurrence_max_degree_per_node: int = 50  # Per-node degree cap (1-1000)
 
     # Sleep Maintenance (Issue #101)
     sleep_enabled: bool = False  # Feature flag (env-only)
@@ -267,6 +290,28 @@ class NeuralMemoryConfig:
             )
         if not (0.0 <= self.knn_seed_weight <= 1.0):
             raise ValueError(f"knn_seed_weight must be in [0, 1], got {self.knn_seed_weight}")
+
+        # Tag Co-Occurrence Cold-Start Seeding validation (Issue #223)
+        if not (1 <= self.tag_cooccurrence_min_shared <= 10):
+            raise ValueError(
+                f"tag_cooccurrence_min_shared must be in [1, 10], "
+                f"got {self.tag_cooccurrence_min_shared}"
+            )
+        if not (1 <= self.tag_cooccurrence_max_per_remember <= 100):
+            raise ValueError(
+                f"tag_cooccurrence_max_per_remember must be in [1, 100], "
+                f"got {self.tag_cooccurrence_max_per_remember}"
+            )
+        if not (0.0 <= self.tag_cooccurrence_hub_threshold <= 1.0):
+            raise ValueError(
+                f"tag_cooccurrence_hub_threshold must be in [0, 1], "
+                f"got {self.tag_cooccurrence_hub_threshold}"
+            )
+        if not (1 <= self.tag_cooccurrence_max_degree_per_node <= 1000):
+            raise ValueError(
+                f"tag_cooccurrence_max_degree_per_node must be in [1, 1000], "
+                f"got {self.tag_cooccurrence_max_degree_per_node}"
+            )
 
         # Sleep Maintenance validation
         if not (0 <= self.sleep_cron_hour <= 23):
@@ -377,6 +422,14 @@ class NeuralMemoryConfig:
             knn_seed_k=get_int("KNN_SEED_K", 5),
             knn_seed_min_similarity=get_float("KNN_SEED_MIN_SIMILARITY", 0.4),
             knn_seed_weight=get_float("KNN_SEED_WEIGHT", 0.3),
+            # Tag Co-Occurrence Cold-Start Seeding (Issue #223)
+            tag_cooccurrence_enabled=get_bool("TAG_COOCCURRENCE_ENABLED", True),
+            tag_cooccurrence_min_shared=get_int("TAG_COOCCURRENCE_MIN_SHARED", 2),
+            tag_cooccurrence_max_per_remember=get_int("TAG_COOCCURRENCE_MAX_PER_REMEMBER", 10),
+            tag_cooccurrence_hub_threshold=get_float("TAG_COOCCURRENCE_HUB_THRESHOLD", 0.30),
+            tag_cooccurrence_max_degree_per_node=get_int(
+                "TAG_COOCCURRENCE_MAX_DEGREE_PER_NODE", 50
+            ),
             # Sleep Maintenance (env-only flags + DB-configurable params)
             sleep_enabled=get_bool("SLEEP_ENABLED", False),
             sleep_cron_hour=get_int("SLEEP_CRON_HOUR", 2),
@@ -490,6 +543,25 @@ class NeuralMemoryConfig:
                 "knn_seed_min_similarity", base_config.knn_seed_min_similarity
             ),
             knn_seed_weight=configs.get("knn_seed_weight", base_config.knn_seed_weight),
+            # Tag Co-Occurrence Cold-Start Seeding (Issue #223) — DB-overridable
+            tag_cooccurrence_enabled=configs.get(
+                "tag_cooccurrence_enabled", base_config.tag_cooccurrence_enabled
+            ),
+            tag_cooccurrence_min_shared=configs.get(
+                "tag_cooccurrence_min_shared", base_config.tag_cooccurrence_min_shared
+            ),
+            tag_cooccurrence_max_per_remember=configs.get(
+                "tag_cooccurrence_max_per_remember",
+                base_config.tag_cooccurrence_max_per_remember,
+            ),
+            tag_cooccurrence_hub_threshold=configs.get(
+                "tag_cooccurrence_hub_threshold",
+                base_config.tag_cooccurrence_hub_threshold,
+            ),
+            tag_cooccurrence_max_degree_per_node=configs.get(
+                "tag_cooccurrence_max_degree_per_node",
+                base_config.tag_cooccurrence_max_degree_per_node,
+            ),
             # Sleep Maintenance (env-only flags use base_config, DB params use configs)
             sleep_enabled=base_config.sleep_enabled,  # Feature flag (env-only)
             sleep_cron_hour=base_config.sleep_cron_hour,  # Schedule (env-only)

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1914,18 +1914,22 @@ async def _create_tag_cooccurrence_seed_edges(
         # coarse filter; cardinality(... INTERSECT ...) enforces the exact
         # threshold. Ordering by INTERSECT cardinality descending lets us
         # pick the top-N "strongest" candidates without client-side sort.
-        # Cast `tags` (Postgres ``varchar[]`` from ``Column(ARRAY(String))``)
-        # to ``text[]`` everywhere it interacts with ``:query_tags``. Without
-        # the cast Postgres rejects the operator with "operator does not
-        # exist: character varying[] && text[]" because && requires
-        # exactly-matching element types (Copilot loop 1 catch).
+        # Cast :query_tags to ``varchar[]`` (matching the column type
+        # ``Column(ARRAY(String))`` → varchar[] in PG) instead of casting
+        # the column. The previous text[] approach (Copilot loop 1)
+        # technically worked but bypassed ``idx_memories_tags_gin`` because
+        # the index expression is ``tags`` (varchar[]), and Postgres only
+        # uses an index whose indexed expression matches the WHERE clause
+        # expression — ``tags::text[] && ...`` is a different expression.
+        # On large contexts this turned the seeding query back into a seq
+        # scan (Copilot loop 3 catch).
         sql = text(
             """
             SELECT id, tags,
                    cardinality(ARRAY(
-                       SELECT unnest(tags::text[])
+                       SELECT unnest(tags)
                        INTERSECT
-                       SELECT unnest(CAST(:query_tags AS text[]))
+                       SELECT unnest(CAST(:query_tags AS varchar[]))
                    )) AS shared_count
             FROM memories
             WHERE user_id = :user_id
@@ -1933,11 +1937,11 @@ async def _create_tag_cooccurrence_seed_edges(
               AND context_id = CAST(:context_id AS uuid)
               AND deleted_at IS NULL
               AND id != CAST(:self_id AS uuid)
-              AND tags::text[] && CAST(:query_tags AS text[])
+              AND tags && CAST(:query_tags AS varchar[])
               AND cardinality(ARRAY(
-                  SELECT unnest(tags::text[])
+                  SELECT unnest(tags)
                   INTERSECT
-                  SELECT unnest(CAST(:query_tags AS text[]))
+                  SELECT unnest(CAST(:query_tags AS varchar[]))
               )) >= :min_shared
             ORDER BY shared_count DESC, id
             LIMIT :max_matches

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1784,6 +1784,248 @@ async def _create_knn_seed_edges(
         )
 
 
+async def _create_tag_cooccurrence_seed_edges(
+    db: AsyncSession,
+    memory: Memory,
+) -> None:
+    """Create tag-cooccurrence seed edges for a newly-persisted memory.
+
+    Issue #223 (Tier 2 cold-start seeding): after a memory persists, find
+    existing memories within the same (user, workspace, context) that share
+    ``tag_cooccurrence_min_shared`` or more tags and create weak
+    ``tag_cooccurrence`` edges. Complementary to k-NN semantic seeding —
+    catches structural similarity that embedding similarity misses.
+
+    Best-effort: any failure is logged and swallowed (must not affect memory
+    creation). Mirrors the structure of ``_create_knn_seed_edges`` with three
+    deliberate divergences:
+
+    1. **SQL candidates, not Qdrant**: uses ``tags && ARRAY[?]`` (GIN-indexed
+       overlap) with a ``cardinality(... INTERSECT ...)`` filter pushed down
+       to SQL so the "shared >= N" threshold is enforced by Postgres, not
+       materialized in Python. Requires the ``idx_memories_tags_gin`` index
+       added by migration b05_223.
+    2. **Edge-type-scoped idempotency guard**: skips only when
+       ``tag_cooccurrence`` edges already exist for this memory (knn uses an
+       any-type guard). If we used the any-type guard, the knn seed pass that
+       ran just before would prevent us from ever seeding, even though the
+       two seed types are independent.
+    3. **One direction only**: mirrors knn (src=memory, dst=neighbor). Tag
+       co-occurrence is logically symmetric, but the graph BFS treats edges
+       as undirected, and the ``unique_edge`` constraint is ``(user, src,
+       dst)`` — creating both directions doubles edge count without adding
+       information. Kept asymmetric for consistency with the knn path.
+
+    Args:
+        db: AsyncSession bound to the caller's transaction context
+        memory: The freshly-created Memory entity (must have non-empty tags)
+    """
+    from sqlalchemy import select, text
+
+    from neural.config import NeuralMemoryConfig
+    from repositories.neural_edge import NeuralEdgeRepository
+
+    try:
+        config = await NeuralMemoryConfig.from_db(db)
+
+        if not config.tag_cooccurrence_enabled:
+            return
+
+        if not memory.workspace_id or not memory.context_id:
+            # Defensive: 3-level isolation requires both
+            return
+
+        if not memory.tags:
+            # No tags → no candidates by definition
+            return
+
+        workspace_id_str = str(memory.workspace_id)
+        context_id_str = str(memory.context_id)
+        memory_id_str = str(memory.id)
+
+        # Edge-type-scoped idempotency guard. Unlike knn (any-type guard), we
+        # only skip when tag_cooccurrence edges already exist for this memory
+        # — otherwise the knn seeding pass that just ran would prevent us from
+        # ever writing tag_cooccurrence edges. Re-embed on update_memory()
+        # would re-enter this function with the guard protecting us from
+        # duplicate writes (create_edge_if_absent also protects via ON
+        # CONFLICT, but skipping the SQL work is cheaper).
+        edge_repo = NeuralEdgeRepository(db)
+        existing_edges = await edge_repo.get_outgoing_edges(
+            user_id=memory.user_id,
+            src_id=memory.id,
+            edge_types=["tag_cooccurrence"],
+            workspace_id=workspace_id_str,
+            context_id=context_id_str,
+            limit=1,
+        )
+        if existing_edges:
+            logger.debug(
+                "tag_cooccurrence_skip_already_seeded",
+                memory_id=memory_id_str,
+            )
+            return
+
+        # Read hub-tag set for this (workspace, context). Missing row = never
+        # computed = "no exclusion" (first-night fallback). Sleep Maintenance
+        # populates the cache on its nightly run.
+        from models.hub_tag import HubTagCache
+
+        hub_row = await db.execute(
+            select(HubTagCache.hub_tags).where(
+                HubTagCache.workspace_id == memory.workspace_id,
+                HubTagCache.context_id == memory.context_id,
+            )
+        )
+        hub_tags_raw = hub_row.scalar_one_or_none()
+        hub_tags_set: set[str] = set(hub_tags_raw) if hub_tags_raw else set()
+
+        # Exclude hub tags from the incoming memory's tag set when forming the
+        # candidate query. If every tag is hub-like, there's nothing left to
+        # correlate on.
+        query_tags = [t for t in memory.tags if t not in hub_tags_set]
+        if len(query_tags) < config.tag_cooccurrence_min_shared:
+            logger.debug(
+                "tag_cooccurrence_skip_no_nonhub_tags",
+                memory_id=memory_id_str,
+                total_tags=len(memory.tags),
+                nonhub_tags=len(query_tags),
+                min_shared=config.tag_cooccurrence_min_shared,
+            )
+            return
+
+        # Push the "share >= min_shared non-hub tags" predicate into SQL.
+        # The `&&` operator uses the GIN index (idx_memories_tags_gin) as a
+        # coarse filter; cardinality(... INTERSECT ...) enforces the exact
+        # threshold. Ordering by INTERSECT cardinality descending lets us
+        # pick the top-N "strongest" candidates without client-side sort.
+        sql = text(
+            """
+            SELECT id, tags,
+                   cardinality(ARRAY(
+                       SELECT unnest(tags)
+                       INTERSECT
+                       SELECT unnest(CAST(:query_tags AS text[]))
+                   )) AS shared_count
+            FROM memories
+            WHERE user_id = :user_id
+              AND workspace_id = CAST(:workspace_id AS uuid)
+              AND context_id = CAST(:context_id AS uuid)
+              AND deleted_at IS NULL
+              AND id != CAST(:self_id AS uuid)
+              AND tags && CAST(:query_tags AS text[])
+              AND cardinality(ARRAY(
+                  SELECT unnest(tags)
+                  INTERSECT
+                  SELECT unnest(CAST(:query_tags AS text[]))
+              )) >= :min_shared
+            ORDER BY shared_count DESC, id
+            LIMIT :max_matches
+            """
+        )
+        result = await db.execute(
+            sql,
+            {
+                "user_id": memory.user_id,
+                "workspace_id": workspace_id_str,
+                "context_id": context_id_str,
+                "self_id": memory_id_str,
+                "query_tags": query_tags,
+                "min_shared": config.tag_cooccurrence_min_shared,
+                "max_matches": config.tag_cooccurrence_max_per_remember,
+            },
+        )
+        rows = result.all()
+
+        if not rows:
+            logger.debug(
+                "tag_cooccurrence_no_candidates",
+                memory_id=memory_id_str,
+                nonhub_tag_count=len(query_tags),
+            )
+            return
+
+        # Degree cap: if this memory already has N tag_cooccurrence edges
+        # (from a prior incomplete run that created some but not all — should
+        # only happen if the process crashed mid-seed; the idempotency guard
+        # above would normally fire), truncate further writes.
+        degree_cap = config.tag_cooccurrence_max_degree_per_node
+        edges_created = 0
+
+        for row in rows:
+            if edges_created >= degree_cap:
+                break
+
+            try:
+                neighbor_id = UUID(str(row.id))
+                shared_count = int(row.shared_count)
+            except (ValueError, TypeError, AttributeError):
+                continue
+
+            # Weight: 2 shared → 0.25, 3 → 0.35, 4+ → 0.40 (capped).
+            weight = min(0.4, 0.15 + 0.10 * (shared_count - 1))
+            # Confidence: 2 → 0.50, 3 → 0.75, 4+ → 1.00.
+            confidence = min(1.0, shared_count / 4.0)
+
+            # SAVEPOINT per edge so a single IntegrityError / validation
+            # failure cannot poison the session for the remaining inserts.
+            try:
+                async with db.begin_nested():
+                    edge = await edge_repo.create_edge_if_absent(
+                        user_id=memory.user_id,
+                        src_id=memory.id,
+                        dst_id=neighbor_id,
+                        edge_type="tag_cooccurrence",
+                        weight=weight,
+                        confidence=confidence,
+                        workspace_id=workspace_id_str,
+                        context_id=context_id_str,
+                    )
+                # edge is None when ON CONFLICT DO NOTHING fired — e.g. a
+                # semantic_similarity edge from knn seeding already exists
+                # for this pair. unique_edge is (user, src, dst) so only one
+                # edge per ordered pair regardless of edge_type.
+                if edge is not None:
+                    edges_created += 1
+            except Exception as edge_err:
+                logger.warning(
+                    "tag_cooccurrence_edge_failed",
+                    memory_id=memory_id_str,
+                    neighbor_id=str(row.id),
+                    error=str(edge_err),
+                )
+
+        if edges_created > 0:
+            await db.commit()
+            logger.info(
+                "tag_cooccurrence_edges_created",
+                memory_id=memory_id_str,
+                edges_created=edges_created,
+                candidates=len(rows),
+                nonhub_tags=len(query_tags),
+                hub_tags_excluded=len(memory.tags) - len(query_tags),
+            )
+
+    except Exception as e:
+        # Best-effort: never let tag-cooccurrence seeding failures affect
+        # memory creation. Rollback may itself fail if the session is in a
+        # bad state; log at debug so the original error (logged below) isn't
+        # masked.
+        try:
+            await db.rollback()
+        except Exception as rollback_err:
+            logger.debug(
+                "tag_cooccurrence_rollback_failed",
+                memory_id=str(memory.id),
+                error=str(rollback_err),
+            )
+        logger.warning(
+            "tag_cooccurrence_seeding_failed",
+            memory_id=str(memory.id),
+            error=str(e),
+        )
+
+
 async def process_pending_embedding(memory_id: UUID) -> None:
     """Process embedding generation + Qdrant upsert for a pending memory.
 
@@ -1929,6 +2171,19 @@ async def process_pending_embedding(memory_id: UUID) -> None:
                 memory=memory,
                 vector=vector,
                 collection_name=collection,
+            )
+
+            # ================================================================
+            # Issue #223: tag co-occurrence cold-start seeding (Tier 2)
+            # ================================================================
+            # Independent of knn (different signal source: shared tags vs
+            # vector similarity). Both can run; unique_edge constraint and
+            # ON CONFLICT DO NOTHING ensure no double-write per pair. The
+            # idempotency guard inside the function is edge-type-scoped so
+            # this does NOT skip just because knn already wrote edges.
+            await _create_tag_cooccurrence_seed_edges(
+                db=db,
+                memory=memory,
             )
 
         except Exception as e:

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1916,33 +1916,37 @@ async def _create_tag_cooccurrence_seed_edges(
         # pick the top-N "strongest" candidates without client-side sort.
         # Cast :query_tags to ``varchar[]`` (matching the column type
         # ``Column(ARRAY(String))`` → varchar[] in PG) instead of casting
-        # the column. The previous text[] approach (Copilot loop 1)
-        # technically worked but bypassed ``idx_memories_tags_gin`` because
-        # the index expression is ``tags`` (varchar[]), and Postgres only
-        # uses an index whose indexed expression matches the WHERE clause
-        # expression — ``tags::text[] && ...`` is a different expression.
-        # On large contexts this turned the seeding query back into a seq
-        # scan (Copilot loop 3 catch).
+        # the column. Casting the column would form expression
+        # ``tags::text[] && X`` which no longer matches
+        # ``idx_memories_tags_gin`` (indexed on bare ``tags``), turning the
+        # seeding query into a seq scan on large contexts (Copilot loops
+        # 1+3 history).
+        #
+        # Compute the expensive ``cardinality(... INTERSECT ...)`` exactly
+        # once per row by wrapping the inner query and filtering on the
+        # alias from the outer query. The previous shape repeated the
+        # INTERSECT in both SELECT and WHERE; Postgres cannot always
+        # CSE-collapse identical scalar subqueries, so on large candidate
+        # sets the duplicate work was visible (Copilot loop 4 catch).
         sql = text(
             """
-            SELECT id, tags,
-                   cardinality(ARRAY(
-                       SELECT unnest(tags)
-                       INTERSECT
-                       SELECT unnest(CAST(:query_tags AS varchar[]))
-                   )) AS shared_count
-            FROM memories
-            WHERE user_id = :user_id
-              AND workspace_id = CAST(:workspace_id AS uuid)
-              AND context_id = CAST(:context_id AS uuid)
-              AND deleted_at IS NULL
-              AND id != CAST(:self_id AS uuid)
-              AND tags && CAST(:query_tags AS varchar[])
-              AND cardinality(ARRAY(
-                  SELECT unnest(tags)
-                  INTERSECT
-                  SELECT unnest(CAST(:query_tags AS varchar[]))
-              )) >= :min_shared
+            SELECT id, tags, shared_count
+            FROM (
+                SELECT id, tags,
+                       cardinality(ARRAY(
+                           SELECT unnest(tags)
+                           INTERSECT
+                           SELECT unnest(CAST(:query_tags AS varchar[]))
+                       )) AS shared_count
+                FROM memories
+                WHERE user_id = :user_id
+                  AND workspace_id = CAST(:workspace_id AS uuid)
+                  AND context_id = CAST(:context_id AS uuid)
+                  AND deleted_at IS NULL
+                  AND id != CAST(:self_id AS uuid)
+                  AND tags && CAST(:query_tags AS varchar[])
+            ) m
+            WHERE shared_count >= :min_shared
             ORDER BY shared_count DESC, id
             LIMIT :max_matches
             """

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1839,6 +1839,21 @@ async def _create_tag_cooccurrence_seed_edges(
             # No tags → no candidates by definition
             return
 
+        # Pre-migration guard (Copilot loop 1): the documented deploy order
+        # ships code before migration b05_223. In that window
+        # ``hub_tag_cache`` does not exist yet, so the first SELECT against
+        # it would raise UndefinedTable for every new memory until migration
+        # runs. Use ``to_regclass`` (returns NULL on missing) to silently
+        # no-op instead of relying on the outer try/except to swallow noisy
+        # warnings. Cheap (no I/O — Postgres catalog lookup, plan cached).
+        table_check = await db.execute(text("SELECT to_regclass('hub_tag_cache')"))
+        if table_check.scalar() is None:
+            logger.debug(
+                "tag_cooccurrence_skip_pre_migration",
+                memory_id=str(memory.id),
+            )
+            return
+
         workspace_id_str = str(memory.workspace_id)
         context_id_str = str(memory.context_id)
         memory_id_str = str(memory.id)
@@ -1899,11 +1914,16 @@ async def _create_tag_cooccurrence_seed_edges(
         # coarse filter; cardinality(... INTERSECT ...) enforces the exact
         # threshold. Ordering by INTERSECT cardinality descending lets us
         # pick the top-N "strongest" candidates without client-side sort.
+        # Cast `tags` (Postgres ``varchar[]`` from ``Column(ARRAY(String))``)
+        # to ``text[]`` everywhere it interacts with ``:query_tags``. Without
+        # the cast Postgres rejects the operator with "operator does not
+        # exist: character varying[] && text[]" because && requires
+        # exactly-matching element types (Copilot loop 1 catch).
         sql = text(
             """
             SELECT id, tags,
                    cardinality(ARRAY(
-                       SELECT unnest(tags)
+                       SELECT unnest(tags::text[])
                        INTERSECT
                        SELECT unnest(CAST(:query_tags AS text[]))
                    )) AS shared_count
@@ -1913,9 +1933,9 @@ async def _create_tag_cooccurrence_seed_edges(
               AND context_id = CAST(:context_id AS uuid)
               AND deleted_at IS NULL
               AND id != CAST(:self_id AS uuid)
-              AND tags && CAST(:query_tags AS text[])
+              AND tags::text[] && CAST(:query_tags AS text[])
               AND cardinality(ARRAY(
-                  SELECT unnest(tags)
+                  SELECT unnest(tags::text[])
                   INTERSECT
                   SELECT unnest(CAST(:query_tags AS text[]))
               )) >= :min_shared

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -74,16 +74,28 @@ SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD = 0.5
 
 
 def _is_synthetic_seed_edge(edge: NeuralMemoryEdge) -> bool:
-    """Return True if ``edge`` is a low-weight k-NN cold-start seed (#248).
+    """Return True if ``edge`` is a synthetic cold-start seed (#248, #223).
 
-    Cold-start seeds from #224/#238 must NOT block Sleep Edge Discovery from
-    re-judging a pair. All other edge types — and high-weight
-    ``semantic_similarity`` edges — represent real connections.
+    Cold-start seeds must NOT block Sleep Edge Discovery from re-judging a
+    pair. Two seed types qualify:
+
+    - **k-NN ``semantic_similarity`` (#221/#224/#238)**: synthetic only when
+      ``weight < SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD`` (0.5).
+      Operators who set ``knn_seed_weight`` >= 0.5 are implicitly opting
+      those edges back into "real connection" semantics.
+    - **``tag_cooccurrence`` (#223)**: synthetic at *any* weight — the type
+      is purely seeding, weight 0.25–0.40 by spec, and there is no operator
+      knob to "promote" tag-cooccurrence to a real connection. If a pair
+      becomes truly related, Sleep Discovery should overwrite the
+      tag_cooccurrence edge with a confirmed ``related_to`` (or similar).
+
+    All other edge types are treated as real connections regardless of weight.
     """
-    return (
-        edge.edge_type == "semantic_similarity"
-        and edge.weight < SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD
-    )
+    if edge.edge_type == "semantic_similarity":
+        return edge.weight < SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD
+    if edge.edge_type == "tag_cooccurrence":
+        return True
+    return False
 
 
 # Issue #306: Confidence histogram bucket boundaries.

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -50,8 +50,11 @@ async def _refresh_hub_tag_cache(
     from models.hub_tag import HubTagCache
 
     # Single SQL: count distinct memory occurrences per tag, normalize by
-    # total memory count in scope, and return tags above threshold. Uses
-    # the GIN index (idx_memories_tags_gin) implicitly via unnest+group.
+    # total memory count in (workspace, context), and return tags above
+    # threshold. Note: this query does NOT exercise the GIN index on
+    # ``memories.tags`` (no array-overlap / contains operators) — it walks
+    # all in-scope rows. The GIN index is used by the seeding query in
+    # ``memory_service._create_tag_cooccurrence_seed_edges``, not here.
     sql = text(
         """
         WITH scope AS (

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -65,13 +65,22 @@ async def _refresh_hub_tag_cache(
             SELECT COUNT(*)::float AS n FROM scope
         ),
         tag_counts AS (
+            -- Count DISTINCT memories per tag, not raw unnest occurrences
+            -- (Copilot loop 2): if a memory's tags array contains duplicate
+            -- entries (e.g. ["python", "python", "backend"]), counting raw
+            -- unnest rows would over-count "python" as 2 even though it
+            -- appears in only 1 memory. Wrapping in SELECT DISTINCT id, tag
+            -- collapses duplicates per memory before the GROUP BY.
+            --
             -- Cast unnest(tags) to text so ARRAY_AGG produces text[] and the
             -- COALESCE fallback ``ARRAY[]::text[]`` is element-type-compatible
-            -- (Copilot loop 1: ``Column(ARRAY(String))`` → varchar[] in PG;
-            -- without the cast COALESCE would mix varchar[] / text[]).
-            SELECT unnest(tags)::text AS tag, COUNT(*) AS cnt
-            FROM scope
-            GROUP BY 1
+            -- (Copilot loop 1: ``Column(ARRAY(String))`` → varchar[] in PG).
+            SELECT tag, COUNT(*) AS cnt
+            FROM (
+                SELECT DISTINCT id, unnest(tags)::text AS tag
+                FROM scope
+            ) sub
+            GROUP BY tag
         )
         SELECT
             (SELECT n FROM total)::int AS memory_count,
@@ -93,9 +102,20 @@ async def _refresh_hub_tag_cache(
             "threshold": threshold,
         },
     )
-    row = result.one()
-    memory_count = int(row.memory_count)
-    hub_tags: list[str] = list(row.hub_tags or [])
+    # Defensive: aggregate-without-GROUP-BY *should* return exactly 1 row
+    # even on empty input, but use one_or_none() so a future SQL refactor
+    # that accidentally turns it into a "0 rows on empty scope" query does
+    # not raise NoResultFound for every context with zero tagged memories
+    # (which would log the whole nightly hub-tag refresh as failed for that
+    # context). Treat None as "empty scope, write empty hub set" — the same
+    # outcome the cache should reflect anyway. (Copilot loop 2.)
+    row = result.one_or_none()
+    if row is None:
+        memory_count = 0
+        hub_tags: list[str] = []
+    else:
+        memory_count = int(row.memory_count)
+        hub_tags = list(row.hub_tags or [])
 
     # Upsert on (workspace_id, context_id). Bypass ORM for the upsert so we
     # can use the DB-side conflict resolution rather than SELECT-then-INSERT.

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -64,7 +64,19 @@ async def _refresh_hub_tag_cache(
               AND cardinality(tags) > 0
         ),
         total AS (
-            SELECT COUNT(*)::float AS n FROM scope
+            -- Denominator is ALL non-deleted memories in the (workspace,
+            -- context), NOT just the tagged subset. The hub-threshold
+            -- semantic per #223 section 5 is "tags appearing on > X% of
+            -- memories within the (workspace, context) scope" — measured
+            -- against every memory the user has, not only those that
+            -- happen to carry tags. Using ``scope`` here would inflate
+            -- frequencies in contexts with many untagged memories
+            -- (Copilot loop 5 catch).
+            SELECT COUNT(*)::float AS n
+            FROM memories
+            WHERE workspace_id = CAST(:workspace_id AS uuid)
+              AND context_id = CAST(:context_id AS uuid)
+              AND deleted_at IS NULL
         ),
         tag_counts AS (
             -- Count DISTINCT memories per tag, not raw unnest occurrences

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -96,16 +96,25 @@ async def _refresh_hub_tag_cache(
             ) sub
             GROUP BY tag
         )
+        -- Outer SELECT has NO `FROM tag_counts` — that would return 0 rows
+        -- when tag_counts is empty (context has memories but none are
+        -- tagged), making `memory_count` incorrectly absent for that
+        -- context. Instead, build both fields as scalar subqueries from
+        -- the FROM-less SELECT, which always returns exactly 1 row.
+        -- ARRAY_AGG inside the scalar subquery handles the empty-tag case
+        -- naturally (returns NULL → COALESCE → []) (Copilot loop 6 catch).
         SELECT
             (SELECT n FROM total)::int AS memory_count,
             COALESCE(
-                ARRAY_AGG(tag) FILTER (
-                    WHERE (SELECT n FROM total) > 0
-                      AND cnt::float / (SELECT n FROM total) > :threshold
+                (
+                    SELECT ARRAY_AGG(tag) FILTER (
+                        WHERE (SELECT n FROM total) > 0
+                          AND cnt::float / (SELECT n FROM total) > :threshold
+                    )
+                    FROM tag_counts
                 ),
                 ARRAY[]::text[]
             ) AS hub_tags
-        FROM tag_counts
         """
     )
     result = await db.execute(

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -1,17 +1,118 @@
 """Sleep Maintenance background tasks.
 
 Issue #101/#103: Scheduled sleep maintenance for all users/contexts.
+Issue #223: Per-(workspace, context) hub-tag cache refresh runs alongside
+the per-context orchestrator loop.
 """
 
 import os
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_db
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+async def _refresh_hub_tag_cache(
+    db: AsyncSession,
+    workspace_id: str,
+    context_id: str,
+    threshold: float,
+) -> int:
+    """Recompute the hub-tag set for one (workspace, context) and upsert.
+
+    Issue #223: hub tags = tags appearing on more than ``threshold`` fraction
+    of the non-deleted memories within this (workspace, context). Used by
+    ``_create_tag_cooccurrence_seed_edges`` to skip overly-popular tags that
+    would otherwise create hub explosions in the graph.
+
+    Args:
+        db: AsyncSession (caller owns commit/rollback).
+        workspace_id: Workspace UUID as string.
+        context_id: Context UUID as string.
+        threshold: Frequency threshold from
+            ``NeuralMemoryConfig.tag_cooccurrence_hub_threshold``.
+
+    Returns:
+        Number of hub tags found (may be 0 — that's a valid result and is
+        upserted explicitly so readers can distinguish "computed: nothing"
+        from "never computed").
+    """
+    from sqlalchemy import text
+    from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+    from models.hub_tag import HubTagCache
+
+    # Single SQL: count distinct memory occurrences per tag, normalize by
+    # total memory count in scope, and return tags above threshold. Uses
+    # the GIN index (idx_memories_tags_gin) implicitly via unnest+group.
+    sql = text(
+        """
+        WITH scope AS (
+            SELECT id, tags
+            FROM memories
+            WHERE workspace_id = CAST(:workspace_id AS uuid)
+              AND context_id = CAST(:context_id AS uuid)
+              AND deleted_at IS NULL
+              AND tags IS NOT NULL
+              AND cardinality(tags) > 0
+        ),
+        total AS (
+            SELECT COUNT(*)::float AS n FROM scope
+        ),
+        tag_counts AS (
+            SELECT unnest(tags) AS tag, COUNT(*) AS cnt
+            FROM scope
+            GROUP BY 1
+        )
+        SELECT
+            (SELECT n FROM total)::int AS memory_count,
+            COALESCE(
+                ARRAY_AGG(tag) FILTER (
+                    WHERE (SELECT n FROM total) > 0
+                      AND cnt::float / (SELECT n FROM total) > :threshold
+                ),
+                ARRAY[]::text[]
+            ) AS hub_tags
+        FROM tag_counts
+        """
+    )
+    result = await db.execute(
+        sql,
+        {
+            "workspace_id": workspace_id,
+            "context_id": context_id,
+            "threshold": threshold,
+        },
+    )
+    row = result.one()
+    memory_count = int(row.memory_count)
+    hub_tags: list[str] = list(row.hub_tags or [])
+
+    # Upsert on (workspace_id, context_id). Bypass ORM for the upsert so we
+    # can use the DB-side conflict resolution rather than SELECT-then-INSERT.
+    stmt = pg_insert(HubTagCache).values(
+        workspace_id=workspace_id,
+        context_id=context_id,
+        hub_tags=hub_tags,
+        memory_count=memory_count,
+        threshold_used=threshold,
+    )
+    stmt = stmt.on_conflict_do_update(
+        constraint="uq_hub_tag_cache_ws_ctx",
+        set_={
+            "hub_tags": stmt.excluded.hub_tags,
+            "memory_count": stmt.excluded.memory_count,
+            "threshold_used": stmt.excluded.threshold_used,
+            "computed_at": text("NOW()"),
+        },
+    )
+    await db.execute(stmt)
+    return len(hub_tags)
 
 
 async def sleep_maintenance_task():
@@ -62,6 +163,54 @@ async def sleep_maintenance_task():
 
             total_runs = 0
             total_errors = 0
+
+            # Issue #223: refresh hub-tag cache once per (workspace, context),
+            # *not* per (user, workspace, context). Multiple users in a
+            # shared context would otherwise re-compute the same set
+            # redundantly. Done before the orchestrator loop so newly-stored
+            # hub tags are visible to any seeding work in the same run.
+            if config.tag_cooccurrence_enabled:
+                seen_ws_ctx: set[tuple[str, str]] = set()
+                hub_refreshed = 0
+                hub_errors = 0
+                for row in contexts:
+                    workspace_id = str(row[1]) if row[1] else None
+                    context_id = str(row[2]) if row[2] else None
+                    if not workspace_id or not context_id:
+                        continue
+                    key = (workspace_id, context_id)
+                    if key in seen_ws_ctx:
+                        continue
+                    seen_ws_ctx.add(key)
+                    try:
+                        n_hub = await _refresh_hub_tag_cache(
+                            db,
+                            workspace_id=workspace_id,
+                            context_id=context_id,
+                            threshold=config.tag_cooccurrence_hub_threshold,
+                        )
+                        await db.commit()
+                        hub_refreshed += 1
+                        logger.debug(
+                            "hub_tag_cache_refreshed",
+                            workspace_id=workspace_id,
+                            context_id=context_id,
+                            hub_tag_count=n_hub,
+                        )
+                    except Exception as e:
+                        await db.rollback()
+                        hub_errors += 1
+                        logger.warning(
+                            "hub_tag_cache_refresh_failed",
+                            workspace_id=workspace_id,
+                            context_id=context_id,
+                            error=str(e),
+                        )
+                logger.info(
+                    "hub_tag_cache_run_completed",
+                    contexts=hub_refreshed,
+                    errors=hub_errors,
+                )
 
             for row in contexts:
                 user_id = row[0]

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -65,7 +65,11 @@ async def _refresh_hub_tag_cache(
             SELECT COUNT(*)::float AS n FROM scope
         ),
         tag_counts AS (
-            SELECT unnest(tags) AS tag, COUNT(*) AS cnt
+            -- Cast unnest(tags) to text so ARRAY_AGG produces text[] and the
+            -- COALESCE fallback ``ARRAY[]::text[]`` is element-type-compatible
+            -- (Copilot loop 1: ``Column(ARRAY(String))`` → varchar[] in PG;
+            -- without the cast COALESCE would mix varchar[] / text[]).
+            SELECT unnest(tags)::text AS tag, COUNT(*) AS cnt
             FROM scope
             GROUP BY 1
         )

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -42,6 +42,8 @@ async def _refresh_hub_tag_cache(
         upserted explicitly so readers can distinguish "computed: nothing"
         from "never computed").
     """
+    from uuid import UUID
+
     from sqlalchemy import text
     from sqlalchemy.dialects.postgresql import insert as pg_insert
 
@@ -119,9 +121,13 @@ async def _refresh_hub_tag_cache(
 
     # Upsert on (workspace_id, context_id). Bypass ORM for the upsert so we
     # can use the DB-side conflict resolution rather than SELECT-then-INSERT.
+    # Coerce str → UUID explicitly: the columns are ``UUID(as_uuid=True)`` and
+    # the postgresql dialect ``insert()`` does not invoke the column type
+    # processor for raw kwargs the same way ORM ``add()`` would, so a plain
+    # str can fail bind on asyncpg (Copilot loop 3).
     stmt = pg_insert(HubTagCache).values(
-        workspace_id=workspace_id,
-        context_id=context_id,
+        workspace_id=UUID(workspace_id),
+        context_id=UUID(context_id),
         hub_tags=hub_tags,
         memory_count=memory_count,
         threshold_used=threshold,

--- a/backend/tests/integration/test_signup_gate_migration.py
+++ b/backend/tests/integration/test_signup_gate_migration.py
@@ -49,7 +49,13 @@ class TestSignupGateMigration:
         _reset_alembic_state()
         with _alembic_at_test_db():
             command.upgrade(_get_alembic_config(), "head")
-            command.downgrade(_get_alembic_config(), "-1")
+            # Downgrade to the revision immediately BEFORE b04 (signup_gate)
+            # — pinning the target instead of using ``"-1"`` keeps this test
+            # correct as further migrations land on top of b04 (e.g. b05_223
+            # tag_cooccurrence). With ``"-1"`` from a later head, only the
+            # newest migration is rolled back and signup_gate tables would
+            # still exist, falsifying the assertion below.
+            command.downgrade(_get_alembic_config(), "b03_396_edges_ws_ctx_not_null")
 
         engine = _sync_engine()
         try:

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -163,3 +163,75 @@ class TestSleepMaintenanceConfig:
         assert config.sleep_llm_model == "llama3:8b"
         assert config.sleep_max_memories_per_run == 1000
         assert config.sleep_dedup_similarity_threshold == 0.95
+
+
+class TestTagCooccurrenceConfig:
+    """Test tag co-occurrence seeding configuration fields (Issue #223)."""
+
+    def test_defaults(self):
+        config = NeuralMemoryConfig()
+        assert config.tag_cooccurrence_enabled is True
+        assert config.tag_cooccurrence_min_shared == 2
+        assert config.tag_cooccurrence_max_per_remember == 10
+        assert config.tag_cooccurrence_hub_threshold == 0.30
+        assert config.tag_cooccurrence_max_degree_per_node == 50
+
+    def test_custom_values(self):
+        config = NeuralMemoryConfig(
+            tag_cooccurrence_enabled=False,
+            tag_cooccurrence_min_shared=3,
+            tag_cooccurrence_max_per_remember=20,
+            tag_cooccurrence_hub_threshold=0.25,
+            tag_cooccurrence_max_degree_per_node=100,
+        )
+        assert config.tag_cooccurrence_enabled is False
+        assert config.tag_cooccurrence_min_shared == 3
+        assert config.tag_cooccurrence_max_per_remember == 20
+        assert config.tag_cooccurrence_hub_threshold == 0.25
+        assert config.tag_cooccurrence_max_degree_per_node == 100
+
+    def test_min_shared_validation(self):
+        with pytest.raises(ValueError, match="tag_cooccurrence_min_shared"):
+            NeuralMemoryConfig(tag_cooccurrence_min_shared=0)
+        with pytest.raises(ValueError, match="tag_cooccurrence_min_shared"):
+            NeuralMemoryConfig(tag_cooccurrence_min_shared=11)
+
+    def test_max_per_remember_validation(self):
+        with pytest.raises(ValueError, match="tag_cooccurrence_max_per_remember"):
+            NeuralMemoryConfig(tag_cooccurrence_max_per_remember=0)
+        with pytest.raises(ValueError, match="tag_cooccurrence_max_per_remember"):
+            NeuralMemoryConfig(tag_cooccurrence_max_per_remember=101)
+
+    def test_hub_threshold_validation(self):
+        with pytest.raises(ValueError, match="tag_cooccurrence_hub_threshold"):
+            NeuralMemoryConfig(tag_cooccurrence_hub_threshold=-0.1)
+        with pytest.raises(ValueError, match="tag_cooccurrence_hub_threshold"):
+            NeuralMemoryConfig(tag_cooccurrence_hub_threshold=1.5)
+
+    def test_max_degree_validation(self):
+        with pytest.raises(ValueError, match="tag_cooccurrence_max_degree_per_node"):
+            NeuralMemoryConfig(tag_cooccurrence_max_degree_per_node=0)
+        with pytest.raises(ValueError, match="tag_cooccurrence_max_degree_per_node"):
+            NeuralMemoryConfig(tag_cooccurrence_max_degree_per_node=1001)
+
+    def test_from_env_defaults(self):
+        config = NeuralMemoryConfig.from_env()
+        assert config.tag_cooccurrence_enabled is True
+        assert config.tag_cooccurrence_min_shared == 2
+        assert config.tag_cooccurrence_max_per_remember == 10
+        assert config.tag_cooccurrence_hub_threshold == 0.30
+        assert config.tag_cooccurrence_max_degree_per_node == 50
+
+    def test_from_env_overrides(self, monkeypatch):
+        monkeypatch.setenv("TAG_COOCCURRENCE_ENABLED", "false")
+        monkeypatch.setenv("TAG_COOCCURRENCE_MIN_SHARED", "3")
+        monkeypatch.setenv("TAG_COOCCURRENCE_MAX_PER_REMEMBER", "25")
+        monkeypatch.setenv("TAG_COOCCURRENCE_HUB_THRESHOLD", "0.40")
+        monkeypatch.setenv("TAG_COOCCURRENCE_MAX_DEGREE_PER_NODE", "75")
+
+        config = NeuralMemoryConfig.from_env()
+        assert config.tag_cooccurrence_enabled is False
+        assert config.tag_cooccurrence_min_shared == 3
+        assert config.tag_cooccurrence_max_per_remember == 25
+        assert config.tag_cooccurrence_hub_threshold == 0.40
+        assert config.tag_cooccurrence_max_degree_per_node == 75

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -335,6 +335,29 @@ class TestIsSyntheticSeedEdge:
         edge = _make_edge("learned_from", 0.1)
         assert _is_synthetic_seed_edge(edge) is False
 
+    # ---- Issue #223: tag_cooccurrence is synthetic at any weight ----
+
+    def test_tag_cooccurrence_low_weight_is_synthetic(self):
+        """Default tag_cooccurrence weight (2 shared = 0.25) is synthetic."""
+        edge = _make_edge("tag_cooccurrence", 0.25)
+        assert _is_synthetic_seed_edge(edge) is True
+
+    def test_tag_cooccurrence_capped_weight_is_synthetic(self):
+        """4+ shared tags caps weight at 0.40 — still synthetic."""
+        edge = _make_edge("tag_cooccurrence", 0.40)
+        assert _is_synthetic_seed_edge(edge) is True
+
+    def test_tag_cooccurrence_above_threshold_is_still_synthetic(self):
+        """Unlike semantic_similarity, tag_cooccurrence has NO weight
+        threshold — even an artificially high-weight tag_cooccurrence edge
+        (which the seeding code never produces, but a backfill bug or a
+        future operator override could) is treated as synthetic. This is the
+        documented design: tag_cooccurrence is purely seeding by definition,
+        and Sleep Discovery should be free to overwrite it with a confirmed
+        ``related_to``."""
+        edge = _make_edge("tag_cooccurrence", 0.9)
+        assert _is_synthetic_seed_edge(edge) is True
+
 
 class TestFilterExistingEdges:
     """_filter_existing_edges is now edge_type-aware (Issue #248).

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -327,6 +327,292 @@ class TestDeclaredLinks:
         service.db.execute.assert_not_called()
 
 
+class TestTagCooccurrenceSeeding:
+    """Unit tests for _create_tag_cooccurrence_seed_edges (Issue #223).
+
+    Mock-based: the function lives at module scope in memory_service.py. We
+    pass a fake AsyncSession + Memory and assert which paths short-circuit vs
+    invoke create_edge_if_absent.
+    """
+
+    @pytest.fixture
+    def base_memory(self):
+        """A memory with two tags, in a fully-isolated (ws, ctx) scope."""
+        from models.memory import Memory
+
+        m = Memory(
+            id=uuid4(),
+            user_id="user-1",
+            workspace_id=uuid4(),
+            context_id=uuid4(),
+            summary="seed summary",
+            content="seed content",
+            type="note",
+            tags=["python", "backend", "memory-cloud"],
+            scope="working",
+            client="test",
+        )
+        return m
+
+    @pytest.fixture
+    def cfg(self):
+        from neural.config import NeuralMemoryConfig
+
+        return NeuralMemoryConfig()  # defaults: enabled=True, min_shared=2, etc.
+
+    def _async_session_with(self, *, hub_tags: list[str] | None, candidates: list):
+        """Build a MagicMock AsyncSession that returns the given hub-tags row
+        on the first execute() and the given candidates list on the second."""
+        session = MagicMock()
+        # hub-tag row: scalar_one_or_none() returns the hub_tags list (or None).
+        hub_result = MagicMock()
+        hub_result.scalar_one_or_none = MagicMock(return_value=hub_tags)
+        # candidate query: .all() returns the rows
+        cand_result = MagicMock()
+        cand_result.all = MagicMock(return_value=candidates)
+        # First execute = hub-tag SELECT, second = candidate SELECT
+        session.execute = AsyncMock(side_effect=[hub_result, cand_result])
+        session.commit = AsyncMock()
+        session.rollback = AsyncMock()
+        # SAVEPOINT context manager
+        savepoint = MagicMock()
+        savepoint.__aenter__ = AsyncMock(return_value=None)
+        savepoint.__aexit__ = AsyncMock(return_value=None)
+        session.begin_nested = MagicMock(return_value=savepoint)
+        return session
+
+    @pytest.mark.asyncio
+    async def test_disabled_config_is_noop(self, base_memory, cfg):
+        from services import memory_service as ms
+
+        cfg.tag_cooccurrence_enabled = False
+        session = MagicMock()
+        session.execute = AsyncMock()
+        with patch(
+            "neural.config.NeuralMemoryConfig.from_db",
+            new=AsyncMock(return_value=cfg),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+        session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_tags_is_noop(self, base_memory, cfg):
+        from services import memory_service as ms
+
+        base_memory.tags = []
+        session = MagicMock()
+        session.execute = AsyncMock()
+        with patch(
+            "neural.config.NeuralMemoryConfig.from_db",
+            new=AsyncMock(return_value=cfg),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+        session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_is_noop(self, base_memory, cfg):
+        from services import memory_service as ms
+
+        base_memory.workspace_id = None
+        session = MagicMock()
+        session.execute = AsyncMock()
+        with patch(
+            "neural.config.NeuralMemoryConfig.from_db",
+            new=AsyncMock(return_value=cfg),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+        session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_idempotency_guard_skips_when_seeded(self, base_memory, cfg):
+        """If tag_cooccurrence edges already exist for this memory, skip the
+        SQL candidate query entirely. Edge-type-scoped — knn semantic_similarity
+        edges on the same memory must NOT trigger this skip."""
+        from services import memory_service as ms
+
+        edge_repo_cls = MagicMock()
+        repo_inst = MagicMock()
+        repo_inst.get_outgoing_edges = AsyncMock(return_value=[MagicMock()])  # already seeded
+        edge_repo_cls.return_value = repo_inst
+
+        session = MagicMock()
+        session.execute = AsyncMock()
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=cfg),
+            ),
+            patch("repositories.neural_edge.NeuralEdgeRepository", new=edge_repo_cls),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+
+        # idempotency check happened, but no SQL queries (hub-tag, candidates)
+        repo_inst.get_outgoing_edges.assert_awaited_once()
+        # filter passed only the tag_cooccurrence edge_type
+        call_kwargs = repo_inst.get_outgoing_edges.call_args.kwargs
+        assert call_kwargs["edge_types"] == ["tag_cooccurrence"]
+        session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_all_tags_are_hub_skips_query(self, base_memory, cfg):
+        """When every tag on the new memory is in the hub-set for this
+        (workspace, context), there are no non-hub tags left to correlate on
+        and we short-circuit before issuing the candidate query."""
+        from services import memory_service as ms
+
+        edge_repo_cls = MagicMock()
+        repo_inst = MagicMock()
+        repo_inst.get_outgoing_edges = AsyncMock(return_value=[])
+        edge_repo_cls.return_value = repo_inst
+
+        # Every tag on the memory is in the hub set
+        session = self._async_session_with(hub_tags=list(base_memory.tags), candidates=[])
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=cfg),
+            ),
+            patch("repositories.neural_edge.NeuralEdgeRepository", new=edge_repo_cls),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+
+        # Only one execute: the hub-tag SELECT. Candidate query never fired.
+        assert session.execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_creates_edges_with_correct_weight_and_confidence(self, base_memory, cfg):
+        """Two candidates with shared=2 and shared=3 produce edges with the
+        spec'd weight (0.25, 0.35) and confidence (0.50, 0.75)."""
+        from services import memory_service as ms
+
+        cand_a_id = uuid4()
+        cand_b_id = uuid4()
+        candidates = [
+            MagicMock(id=cand_b_id, shared_count=3),  # higher shared first (ORDER BY DESC)
+            MagicMock(id=cand_a_id, shared_count=2),
+        ]
+        session = self._async_session_with(hub_tags=None, candidates=candidates)
+
+        repo_inst = MagicMock()
+        repo_inst.get_outgoing_edges = AsyncMock(return_value=[])
+        repo_inst.create_edge_if_absent = AsyncMock(side_effect=[MagicMock(), MagicMock()])
+
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=cfg),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                new=MagicMock(return_value=repo_inst),
+            ),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+
+        assert repo_inst.create_edge_if_absent.await_count == 2
+        # First call: shared=3 → weight=0.35, confidence=0.75
+        first = repo_inst.create_edge_if_absent.call_args_list[0].kwargs
+        assert first["edge_type"] == "tag_cooccurrence"
+        assert first["dst_id"] == cand_b_id
+        assert first["weight"] == pytest.approx(0.35)
+        assert first["confidence"] == pytest.approx(0.75)
+        # Second call: shared=2 → weight=0.25, confidence=0.50
+        second = repo_inst.create_edge_if_absent.call_args_list[1].kwargs
+        assert second["dst_id"] == cand_a_id
+        assert second["weight"] == pytest.approx(0.25)
+        assert second["confidence"] == pytest.approx(0.50)
+        session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_weight_capped_at_max(self, base_memory, cfg):
+        """4+ shared tags caps weight at 0.40, confidence at 1.00."""
+        from services import memory_service as ms
+
+        candidates = [MagicMock(id=uuid4(), shared_count=7)]
+        session = self._async_session_with(hub_tags=None, candidates=candidates)
+        repo_inst = MagicMock()
+        repo_inst.get_outgoing_edges = AsyncMock(return_value=[])
+        repo_inst.create_edge_if_absent = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=cfg),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                new=MagicMock(return_value=repo_inst),
+            ),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+
+        kw = repo_inst.create_edge_if_absent.call_args.kwargs
+        assert kw["weight"] == pytest.approx(0.40)
+        assert kw["confidence"] == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_degree_cap_truncates_writes(self, base_memory, cfg):
+        """At ``tag_cooccurrence_max_degree_per_node`` writes, stop creating."""
+        from services import memory_service as ms
+
+        cfg.tag_cooccurrence_max_degree_per_node = 2  # tiny cap for the test
+        candidates = [
+            MagicMock(id=uuid4(), shared_count=3),
+            MagicMock(id=uuid4(), shared_count=3),
+            MagicMock(id=uuid4(), shared_count=3),  # would exceed cap
+        ]
+        session = self._async_session_with(hub_tags=None, candidates=candidates)
+        repo_inst = MagicMock()
+        repo_inst.get_outgoing_edges = AsyncMock(return_value=[])
+        repo_inst.create_edge_if_absent = AsyncMock(return_value=MagicMock())
+
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=cfg),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                new=MagicMock(return_value=repo_inst),
+            ),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+
+        # Only 2 writes despite 3 candidates
+        assert repo_inst.create_edge_if_absent.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_per_edge_failure_does_not_abort_remaining(self, base_memory, cfg):
+        """SAVEPOINT-per-edge: one failure logs a warning but the next edge
+        still attempts."""
+        from services import memory_service as ms
+
+        candidates = [
+            MagicMock(id=uuid4(), shared_count=2),
+            MagicMock(id=uuid4(), shared_count=3),
+        ]
+        session = self._async_session_with(hub_tags=None, candidates=candidates)
+        repo_inst = MagicMock()
+        repo_inst.get_outgoing_edges = AsyncMock(return_value=[])
+        # First call raises, second succeeds
+        repo_inst.create_edge_if_absent = AsyncMock(side_effect=[RuntimeError("boom"), MagicMock()])
+
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=cfg),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                new=MagicMock(return_value=repo_inst),
+            ),
+        ):
+            # Must not raise — best-effort error swallowing.
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+
+        assert repo_inst.create_edge_if_absent.await_count == 2
+
+
 class TestForget:
     """Test forget (delete) operations."""
 

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -360,18 +360,38 @@ class TestTagCooccurrenceSeeding:
 
         return NeuralMemoryConfig()  # defaults: enabled=True, min_shared=2, etc.
 
-    def _async_session_with(self, *, hub_tags: list[str] | None, candidates: list):
-        """Build a MagicMock AsyncSession that returns the given hub-tags row
-        on the first execute() and the given candidates list on the second."""
+    def _async_session_with(
+        self,
+        *,
+        hub_tags: list[str] | None,
+        candidates: list,
+        table_exists: bool = True,
+    ):
+        """Build a MagicMock AsyncSession.
+
+        Three execute() calls happen in the happy path, in order:
+        1. ``SELECT to_regclass('hub_tag_cache')`` (pre-migration guard)
+        2. ``SELECT hub_tags FROM hub_tag_cache WHERE ...`` (hub-tag fetch)
+        3. ``SELECT id, ... FROM memories WHERE ...`` (candidate query)
+
+        ``table_exists=False`` simulates the pre-migration window where the
+        ``hub_tag_cache`` table does not yet exist; the function should
+        return immediately after the first execute().
+        """
         session = MagicMock()
+        # to_regclass result: .scalar() returns 'hub_tag_cache' or None
+        table_result = MagicMock()
+        table_result.scalar = MagicMock(return_value="hub_tag_cache" if table_exists else None)
         # hub-tag row: scalar_one_or_none() returns the hub_tags list (or None).
         hub_result = MagicMock()
         hub_result.scalar_one_or_none = MagicMock(return_value=hub_tags)
         # candidate query: .all() returns the rows
         cand_result = MagicMock()
         cand_result.all = MagicMock(return_value=candidates)
-        # First execute = hub-tag SELECT, second = candidate SELECT
-        session.execute = AsyncMock(side_effect=[hub_result, cand_result])
+        if table_exists:
+            session.execute = AsyncMock(side_effect=[table_result, hub_result, cand_result])
+        else:
+            session.execute = AsyncMock(side_effect=[table_result])
         session.commit = AsyncMock()
         session.rollback = AsyncMock()
         # SAVEPOINT context manager
@@ -424,6 +444,33 @@ class TestTagCooccurrenceSeeding:
         session.execute.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_pre_migration_skips_when_table_missing(self, base_memory, cfg):
+        """Copilot loop 1: if hub_tag_cache table does not exist (pre-migration
+        deploy window), the function returns silently after the to_regclass
+        check — no idempotency call, no hub fetch, no candidate query."""
+        from services import memory_service as ms
+
+        edge_repo_cls = MagicMock()
+        repo_inst = MagicMock()
+        repo_inst.get_outgoing_edges = AsyncMock(return_value=[])
+        edge_repo_cls.return_value = repo_inst
+
+        session = self._async_session_with(hub_tags=None, candidates=[], table_exists=False)
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=cfg),
+            ),
+            patch("repositories.neural_edge.NeuralEdgeRepository", new=edge_repo_cls),
+        ):
+            await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
+
+        # Only one execute: the to_regclass check. No edge_repo, no hub fetch,
+        # no candidate query.
+        assert session.execute.await_count == 1
+        repo_inst.get_outgoing_edges.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_idempotency_guard_skips_when_seeded(self, base_memory, cfg):
         """If tag_cooccurrence edges already exist for this memory, skip the
         SQL candidate query entirely. Edge-type-scoped — knn semantic_similarity
@@ -435,8 +482,8 @@ class TestTagCooccurrenceSeeding:
         repo_inst.get_outgoing_edges = AsyncMock(return_value=[MagicMock()])  # already seeded
         edge_repo_cls.return_value = repo_inst
 
-        session = MagicMock()
-        session.execute = AsyncMock()
+        # to_regclass returns table; idempotency then short-circuits
+        session = self._async_session_with(hub_tags=None, candidates=[])
         with (
             patch(
                 "neural.config.NeuralMemoryConfig.from_db",
@@ -446,12 +493,12 @@ class TestTagCooccurrenceSeeding:
         ):
             await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
 
-        # idempotency check happened, but no SQL queries (hub-tag, candidates)
+        # to_regclass ran (1 execute), then idempotency fired
+        assert session.execute.await_count == 1
         repo_inst.get_outgoing_edges.assert_awaited_once()
         # filter passed only the tag_cooccurrence edge_type
         call_kwargs = repo_inst.get_outgoing_edges.call_args.kwargs
         assert call_kwargs["edge_types"] == ["tag_cooccurrence"]
-        session.execute.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_all_tags_are_hub_skips_query(self, base_memory, cfg):
@@ -476,8 +523,8 @@ class TestTagCooccurrenceSeeding:
         ):
             await ms._create_tag_cooccurrence_seed_edges(session, base_memory)
 
-        # Only one execute: the hub-tag SELECT. Candidate query never fired.
-        assert session.execute.await_count == 1
+        # Two executes: to_regclass + hub-tag SELECT. Candidate query never fired.
+        assert session.execute.await_count == 2
 
     @pytest.mark.asyncio
     async def test_creates_edges_with_correct_weight_and_confidence(self, base_memory, cfg):

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -105,14 +105,14 @@ an opt-in operator action.
 
 ### Deploy order
 
-1. **Deploy code.** New `remember()` calls now invoke
-   `_create_tag_cooccurrence_seed_edges` after the existing knn seeding step.
-   With migration not yet applied, the function detects that `hub_tag_cache`
-   does not exist (via `SELECT to_regclass('hub_tag_cache')`) and returns
-   silently with a `tag_cooccurrence_skip_pre_migration` debug log — no
-   user-visible impact, no warning spam, no per-memory error rollback. The
-   `valid_edge_type` CHECK constraint extension is therefore never reached
-   in this window.
+1. **Deploy code.** The background embedding task (`process_pending_embedding`)
+   now invokes `_create_tag_cooccurrence_seed_edges` after the existing knn
+   seeding step (which runs after the Qdrant upsert succeeds). With migration
+   not yet applied, the function detects that `hub_tag_cache` does not exist
+   (via `SELECT to_regclass('hub_tag_cache')`) and returns silently with a
+   `tag_cooccurrence_skip_pre_migration` debug log — no user-visible impact,
+   no warning spam, no per-memory error rollback. The `valid_edge_type` CHECK
+   constraint extension is therefore never reached in this window.
 
 2. **Apply migration.** `make migrate` (or `alembic upgrade head`) runs
    `b05_223`, which:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -103,9 +103,12 @@ memories is an opt-in operator action.
 
 1. **Deploy code.** New `remember()` calls now invoke
    `_create_tag_cooccurrence_seed_edges` after the existing knn seeding step.
-   With migration not yet applied, the call short-circuits because the
-   `valid_edge_type` CHECK constraint rejects `tag_cooccurrence` edges and
-   the per-edge SAVEPOINT swallows the error — no user-visible impact.
+   With migration not yet applied, the function detects that `hub_tag_cache`
+   does not exist (via `SELECT to_regclass('hub_tag_cache')`) and returns
+   silently with a `tag_cooccurrence_skip_pre_migration` debug log — no
+   user-visible impact, no warning spam, no per-memory error rollback. The
+   `valid_edge_type` CHECK constraint extension is therefore never reached
+   in this window.
 
 2. **Apply migration.** `make migrate` (or `alembic upgrade head`) runs
    `b05_223`, which:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,8 +96,12 @@ NEXT_PUBLIC_APP_URL=https://your-domain.com
 ## Tag Co-Occurrence Cold-Start Seeding (Issue #223)
 
 Migration `b05_223_tag_cooccurrence` adds the schema; seeding fires
-automatically on every new `remember()` after deploy. Backfilling pre-existing
-memories is an opt-in operator action.
+automatically inside the **background embedding task** (`process_pending_embedding`)
+after each new memory's embedding completes — so it lags `remember()`'s synchronous
+return by however long the embedding pipeline takes, and is skipped when an
+embedding ultimately fails (the memory exists but no `tag_cooccurrence` edges are
+created until a future re-embed succeeds). Backfilling pre-existing memories is
+an opt-in operator action.
 
 ### Deploy order
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -92,3 +92,79 @@ NEXT_PUBLIC_APP_URL=https://your-domain.com
 # NEXT_PUBLIC_PLAN_BASIC_DISPLAY_NAME=Standard
 # NEXT_PUBLIC_PLAN_PRO_DISPLAY_NAME=Premium
 ```
+
+## Tag Co-Occurrence Cold-Start Seeding (Issue #223)
+
+Migration `b05_223_tag_cooccurrence` adds the schema; seeding fires
+automatically on every new `remember()` after deploy. Backfilling pre-existing
+memories is an opt-in operator action.
+
+### Deploy order
+
+1. **Deploy code.** New `remember()` calls now invoke
+   `_create_tag_cooccurrence_seed_edges` after the existing knn seeding step.
+   With migration not yet applied, the call short-circuits because the
+   `valid_edge_type` CHECK constraint rejects `tag_cooccurrence` edges and
+   the per-edge SAVEPOINT swallows the error — no user-visible impact.
+
+2. **Apply migration.** `make migrate` (or `alembic upgrade head`) runs
+   `b05_223`, which:
+   - Drops + recreates `valid_edge_type` CHECK on `neural_memory_edges`
+     (allows `tag_cooccurrence` going forward).
+   - Creates the GIN index `idx_memories_tags_gin` on `memories(tags)`.
+     Note: this is a plain `CREATE INDEX`, **not** `CONCURRENTLY` (the repo's
+     async Alembic env wraps every migration in a transaction). Lock duration
+     is short because `memories.tags` is not a hot-write column. If a future
+     deploy needs zero-downtime here, split the index into a dedicated
+     migration that escapes the env transaction wrapping.
+   - Creates the `hub_tag_cache` table (per `(workspace, context)` upsert).
+
+3. **Wait for first Sleep Maintenance run.** Hub-tag cache populates
+   automatically on the next nightly Sleep run (cron schedule from
+   `SLEEP_CRON_HOUR` / `SLEEP_CRON_MINUTE`, default 02:00 UTC). Until the
+   cache is populated, `remember()` proceeds with "no exclusion" — first night
+   produces slightly noisier edges that subsequent nights will tighten.
+
+4. **(Optional) Backfill existing memories.** Memories created before the
+   deploy do not get tag_cooccurrence edges automatically. To populate them:
+
+   ```bash
+   # Dry-run for a specific user (preview counts):
+   docker exec -it kagura-api \
+     python scripts/backfill_tag_cooccurrence_edges.py --user-id <uuid>
+
+   # Execute (writes edges):
+   docker exec -it kagura-api \
+     python scripts/backfill_tag_cooccurrence_edges.py \
+       --user-id <uuid> --execute --batch-size 200
+
+   # Whole-instance backfill (long-running; consider running per-user):
+   docker exec -it kagura-api \
+     python scripts/backfill_tag_cooccurrence_edges.py --all-users --execute
+   ```
+
+   The script is **idempotent** (safe to re-run after a crash or partial
+   failure) and **resumable** via stable `id` ordering. `create_edge_if_absent`
+   uses `ON CONFLICT DO NOTHING` so re-runs do not duplicate edges.
+
+### Configuration
+
+All knobs are DB-overridable via the admin UI's Neural Memory config page
+and also settable via env (env values are the fallback when DB has no entry):
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `TAG_COOCCURRENCE_ENABLED` | `true` | Master switch |
+| `TAG_COOCCURRENCE_MIN_SHARED` | `2` | Minimum shared tags to create an edge |
+| `TAG_COOCCURRENCE_MAX_PER_REMEMBER` | `10` | Top-N matches per `remember()` call |
+| `TAG_COOCCURRENCE_HUB_THRESHOLD` | `0.30` | Tag freq% above which a tag is "hub" |
+| `TAG_COOCCURRENCE_MAX_DEGREE_PER_NODE` | `50` | Per-source-node degree cap |
+
+### Disabling at runtime
+
+To turn the feature off without redeploy: set `tag_cooccurrence_enabled=false`
+in the admin Neural Memory config page (or `TAG_COOCCURRENCE_ENABLED=false`
+in env, then restart the API container). Existing edges are left alone;
+Sleep Maintenance prunes them naturally over time via the synthetic-seed
+filter (#248 + #223 extension to `_is_synthetic_seed_edge`).
+


### PR DESCRIPTION
## Summary

Implements [#223](https://github.com/kagura-ai/memory-cloud/issues/223) — adds `tag_cooccurrence` edges as **Tier 2** of the cold-start seeding strategy. Complementary to #221's k-NN Tier 1: same `_create_knn_seed_edges` template, different signal (shared tags vs vector similarity), independent commit and idempotency paths.

## What changes

**Schema** (migration `b05_223`):
- GIN index on `memories.tags` so the `tags && ARRAY[?]::text[]` overlap query scales beyond a sequential scan
- `valid_edge_type` CHECK constraint extended with `'tag_cooccurrence'`
- New `hub_tag_cache` table (per-`(workspace, context)` upsert; `Bm25IdfDriftLog` precedent)

**Runtime**:
- `_create_tag_cooccurrence_seed_edges` in `memory_service.py` — SQL-based candidate query with `cardinality(... INTERSECT ...) >= min_shared` push-down, edge-type-scoped idempotency guard, SAVEPOINT-per-edge, best-effort error swallowing
- `_is_synthetic_seed_edge` extension (#248 alignment) — Sleep Discovery may re-judge `tag_cooccurrence` pairs at any weight
- `_refresh_hub_tag_cache` side-car in `sleep_tasks.py` — runs nightly per-`(workspace, context)`, deduped at user level to avoid redundant computation

**Tooling**:
- `scripts/backfill_tag_cooccurrence_edges.py` — separate management command (NOT in migration), idempotent + resumable, `--dry-run` default
- 5 new `NeuralMemoryConfig` fields (env + DB-overridable, mirror `knn_seed_*` pattern)
- Operations runbook section in `docs/deployment.md`

## Design notes

- **`unique_edge` constraint is `(user_id, src_id, dst_id)` only** — does NOT include `edge_type`. So one ordered pair holds at most one edge regardless of type. `create_edge_if_absent` (ON CONFLICT DO NOTHING) preserves whichever edge wrote first.
- **Idempotency guard is edge-type-scoped** (`get_outgoing_edges(edge_types=[\"tag_cooccurrence\"], ...)`). The any-type guard used by knn would mutually block the two seeding paths.
- **CONCURRENTLY not used** — the repo's async Alembic env wraps every migration in a transaction, and Postgres rejects `CREATE INDEX CONCURRENTLY` inside one. `memories.tags` is a low-write column so the brief lock is acceptable. Justification in the migration docstring.
- **Per-context hub-tag scope** (NOT per-user) — for private contexts the two are equivalent; for shared contexts, same-context users share domain vocabulary so context-level popularity is a good proxy. Conservative side: a tag rare for one user but hub at context level results in *fewer* edge candidates, never more.

## Verification

- `ruff check` — all green across 14 files
- 112 tests pass (20 new + 92 pre-existing in touched files unaffected)
  - `TestTagCooccurrenceSeeding` (9): disabled / no-tags / missing isolation / idempotency guard / hub-tag exclusion / weight & confidence formulas / weight cap / degree cap / per-edge SAVEPOINT failure isolation
  - `TestTagCooccurrenceConfig` (8): defaults / custom / 4 validators / env var defaults / env var overrides
  - `TestIsSyntheticSeedEdge` extension (3): low / capped / above-threshold weights all classified synthetic

## Test plan

- [ ] CI green
- [ ] `make test-integration` exercises the new migration end-to-end against a real PostgreSQL container
- [ ] Local smoke: deploy → `make migrate` → `remember()` a memory with 2+ shared tags vs an existing one → verify `tag_cooccurrence` edge appears in `neural_memory_edges`
- [ ] Hub-tag cache: trigger a Sleep Maintenance run → verify `hub_tag_cache` is upserted for each context

## Files

**New** (3): `b05_223_tag_cooccurrence.py`, `models/hub_tag.py`, `scripts/backfill_tag_cooccurrence_edges.py`
**Modified** (11): `alembic/env.py`, `mcp_server/tools/edge.py`, `models/memory.py`, `neural/config.py`, `services/memory_service.py`, `services/sleep/edge_discovery.py`, `tasks/sleep_tasks.py`, 3 test files, `docs/deployment.md`

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)