### PR TITLE
refactor(api): ConfirmedEdge dataclass for _llm_judge_batch (#374)

### DIFF
--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -24,7 +24,7 @@ import random
 import statistics
 import string
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal, get_args
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -116,6 +116,33 @@ CONFIDENCE_HISTOGRAM_KEYS: tuple[str, ...] = ("0.0-0.5", "0.5-0.7", "0.7-0.85", 
 # in the wrong direction (PR #371 PhD-pl review finding). Module-level so
 # tests can import the same source of truth.
 DIRECTED_EDGE_TYPES: frozenset[str] = frozenset({"depends_on", "learned_from"})
+
+# Issue #374: `EdgeType` is the type-level source of truth for valid
+# `NeuralMemoryEdge.edge_type` values. `VALID_EDGE_TYPES` is derived via
+# `get_args` so the runtime membership check and the type annotation cannot
+# drift. Adding a new edge_type only requires editing the Literal.
+EdgeType = Literal["related_to", "depends_on", "learned_from"]
+VALID_EDGE_TYPES: frozenset[EdgeType] = frozenset(get_args(EdgeType))
+
+
+@dataclass(frozen=True, slots=True)
+class ConfirmedEdge:
+    """A single edge accepted by `_llm_judge_batch` (#374).
+
+    Replaces the prior positional 4-tuple `(src_id, dst_id, edge_type,
+    confidence)`. `frozen=True` prevents post-construction mutation;
+    `slots=True` shaves per-edge memory on the batch hot path. Named access
+    eliminates src/dst swap bugs and is robust to future field additions.
+
+    `confidence` is constrained to `[0.0, 1.0]` by the parser's clamp (and by
+    the auto-accept path's literal `0.5`); Python's type system cannot express
+    the range, so the invariant lives in the runtime clamp and this docstring.
+    """
+
+    src_id: UUID
+    dst_id: UUID
+    edge_type: EdgeType
+    confidence: float
 
 
 @dataclass
@@ -389,18 +416,21 @@ class EdgeDiscoveryPhase:
                 # Without LLM, accept all candidates with default confidence.
                 # Tracked separately as `auto_accepted` so it does NOT pollute
                 # avg_confidence / confidence_histogram / edge_type_dist (#306).
-                confirmed = [(src, dst, "related_to", 0.5) for src, dst, _score in batch]
+                confirmed = [
+                    ConfirmedEdge(src_id=src, dst_id=dst, edge_type="related_to", confidence=0.5)
+                    for src, dst, _score in batch
+                ]
                 auto_accepted += len(confirmed)
 
-            for src_id, dst_id, edge_type, confidence in confirmed:
+            for edge in confirmed:
                 try:
                     await self.edge_repo.create_or_update_edge(
                         user_id=user_id,
-                        src_id=src_id,
-                        dst_id=dst_id,
-                        edge_type=edge_type,
+                        src_id=edge.src_id,
+                        dst_id=edge.dst_id,
+                        edge_type=edge.edge_type,
                         weight=DISCOVERY_EDGE_WEIGHT,
-                        confidence=confidence,
+                        confidence=edge.confidence,
                         workspace_id=workspace_id,
                         context_id=context_id,
                         edge_metadata={"source": "sleep_edge_discovery"},
@@ -411,19 +441,19 @@ class EdgeDiscoveryPhase:
                             report_id=report_id,
                             phase="edge_discovery",
                             action_type="create_edge",
-                            memory_id=src_id,
-                            target_id=dst_id,
+                            memory_id=edge.src_id,
+                            target_id=edge.dst_id,
                             details={
-                                "edge_type": edge_type,
-                                "confidence": confidence,
+                                "edge_type": edge.edge_type,
+                                "confidence": edge.confidence,
                                 "weight": DISCOVERY_EDGE_WEIGHT,
                             },
                         )
                 except Exception as e:
                     logger.warning(
                         "edge_creation_failed",
-                        src=str(src_id),
-                        dst=str(dst_id),
+                        src=str(edge.src_id),
+                        dst=str(edge.dst_id),
                         error=str(e),
                     )
 
@@ -586,13 +616,12 @@ class EdgeDiscoveryPhase:
         workspace_id: str | None,
         budget: SleepBudget,
         config: NeuralMemoryConfig,
-    ) -> tuple[list[tuple[UUID, UUID, str, float]], BatchStats]:
+    ) -> tuple[list[ConfirmedEdge], BatchStats]:
         """Use LLM to judge edge candidates.
 
         Returns:
             Tuple of (confirmed_edges, stats):
-              - confirmed_edges: list of (src_id, dst_id, edge_type, confidence)
-                for accepted edges.
+              - confirmed_edges: list of `ConfirmedEdge` for accepted edges.
               - stats: BatchStats with per-batch counts. `failures` is 0 or 1
                 (one LLM call per batch).
         """
@@ -704,8 +733,7 @@ class EdgeDiscoveryPhase:
             return [], stats
 
         # Parse response with label validation
-        confirmed: list[tuple[UUID, UUID, str, float]] = []
-        valid_edge_types = {"related_to", "depends_on", "learned_from"}
+        confirmed: list[ConfirmedEdge] = []
         for edge in response.get("edges", []):
             pair = edge.get("pair", [])
             if len(pair) != 2 or pair[0] not in label_to_id or pair[1] not in label_to_id:
@@ -732,9 +760,9 @@ class EdgeDiscoveryPhase:
             # Treat non-strings as invalid and coerce to `related_to`,
             # matching the existing fallback for unknown string values.
             raw_type = edge.get("edge_type", "related_to")
-            edge_type = (
+            edge_type: EdgeType = (
                 raw_type
-                if isinstance(raw_type, str) and raw_type in valid_edge_types
+                if isinstance(raw_type, str) and raw_type in VALID_EDGE_TYPES
                 else "related_to"
             )
 
@@ -774,11 +802,11 @@ class EdgeDiscoveryPhase:
             stats.confidences.append(confidence)
 
             confirmed.append(
-                (
-                    label_to_id[pair[0]],
-                    label_to_id[pair[1]],
-                    edge_type,
-                    confidence,
+                ConfirmedEdge(
+                    src_id=label_to_id[pair[0]],
+                    dst_id=label_to_id[pair[1]],
+                    edge_type=edge_type,
+                    confidence=confidence,
                 )
             )
 

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -24,7 +24,7 @@ import random
 import statistics
 import string
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Literal, get_args
+from typing import TYPE_CHECKING, Literal, cast, get_args
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -108,21 +108,25 @@ def _is_synthetic_seed_edge(edge: NeuralMemoryEdge) -> bool:
 # `dict.fromkeys(KEYS, 0)` widens to `dict[str, int]` for downstream consumers.
 CONFIDENCE_HISTOGRAM_KEYS: tuple[str, ...] = ("0.0-0.5", "0.5-0.7", "0.7-0.85", "0.85-1.0")
 
+# Issue #374: `EdgeType` is the type-level source of truth for valid
+# `NeuralMemoryEdge.edge_type` values emitted by the LLM judge (a deliberate
+# subset of the DB CHECK constraint in `models/memory.py` — the DB accepts
+# additional non-LLM types like `tag_cooccurrence`). `VALID_EDGE_TYPES` is
+# derived via `get_args` so the runtime membership check and the type
+# annotation cannot drift. Adding a new LLM-emittable edge type only requires
+# editing the Literal.
+EdgeType = Literal["related_to", "depends_on", "learned_from"]
+VALID_EDGE_TYPES: frozenset[EdgeType] = frozenset(get_args(EdgeType))
+
 # Issue #373: edge_type directionality semantics.
 # `related_to` is undirected (A related_to B ⇔ B related_to A); the parser
 # accepts the LLM's pair order as-is. `depends_on` and `learned_from` are
 # directed (A depends_on B ≠ B depends_on A); the parser MUST reject pairs
 # where the LLM flipped the input order, otherwise edges are silently stored
 # in the wrong direction (PR #371 PhD-pl review finding). Module-level so
-# tests can import the same source of truth.
-DIRECTED_EDGE_TYPES: frozenset[str] = frozenset({"depends_on", "learned_from"})
-
-# Issue #374: `EdgeType` is the type-level source of truth for valid
-# `NeuralMemoryEdge.edge_type` values. `VALID_EDGE_TYPES` is derived via
-# `get_args` so the runtime membership check and the type annotation cannot
-# drift. Adding a new edge_type only requires editing the Literal.
-EdgeType = Literal["related_to", "depends_on", "learned_from"]
-VALID_EDGE_TYPES: frozenset[EdgeType] = frozenset(get_args(EdgeType))
+# tests can import the same source of truth. Typed as `frozenset[EdgeType]`
+# so adding a typo'd member is caught by pyright (#374).
+DIRECTED_EDGE_TYPES: frozenset[EdgeType] = frozenset({"depends_on", "learned_from"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -760,8 +764,12 @@ class EdgeDiscoveryPhase:
             # Treat non-strings as invalid and coerce to `related_to`,
             # matching the existing fallback for unknown string values.
             raw_type = edge.get("edge_type", "related_to")
+            # `frozenset.__contains__` does not narrow `raw_type` to `EdgeType`
+            # for type checkers, so the membership check is promoted to a
+            # `cast` — the `in VALID_EDGE_TYPES` predicate is the runtime
+            # guarantee that the cast is sound.
             edge_type: EdgeType = (
-                raw_type
+                cast(EdgeType, raw_type)
                 if isinstance(raw_type, str) and raw_type in VALID_EDGE_TYPES
                 else "related_to"
             )

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -952,6 +952,14 @@ class TestExecuteAggregation:
 
         # Stub _llm_judge_batch directly so we control batch_stats per call.
         async def fake_judge(batch, *args, **kwargs):
+            def edge(i, edge_type, confidence):
+                return ConfirmedEdge(
+                    src_id=batch[i][0],
+                    dst_id=batch[i][1],
+                    edge_type=edge_type,
+                    confidence=confidence,
+                )
+
             if len(batch) == 5:
                 # First batch: 3 accepted, 2 rejected
                 stats = BatchStats(
@@ -961,24 +969,9 @@ class TestExecuteAggregation:
                     confidences=[0.9, 0.7, 0.55],
                 )
                 confirmed = [
-                    ConfirmedEdge(
-                        src_id=batch[0][0],
-                        dst_id=batch[0][1],
-                        edge_type="related_to",
-                        confidence=0.9,
-                    ),
-                    ConfirmedEdge(
-                        src_id=batch[1][0],
-                        dst_id=batch[1][1],
-                        edge_type="related_to",
-                        confidence=0.7,
-                    ),
-                    ConfirmedEdge(
-                        src_id=batch[2][0],
-                        dst_id=batch[2][1],
-                        edge_type="depends_on",
-                        confidence=0.55,
-                    ),
+                    edge(0, "related_to", 0.9),
+                    edge(1, "related_to", 0.7),
+                    edge(2, "depends_on", 0.55),
                 ]
                 return confirmed, stats
             # Second batch: 1 accepted, 0 rejected
@@ -988,14 +981,7 @@ class TestExecuteAggregation:
                 edge_type_counts={"learned_from": 1},
                 confidences=[0.95],
             )
-            confirmed = [
-                ConfirmedEdge(
-                    src_id=batch[0][0],
-                    dst_id=batch[0][1],
-                    edge_type="learned_from",
-                    confidence=0.95,
-                )
-            ]
+            confirmed = [edge(0, "learned_from", 0.95)]
             return confirmed, stats
 
         llm_judge_phase._llm_judge_batch = fake_judge

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -17,6 +17,7 @@ from services.sleep.edge_discovery import (
     SIMILARITY_MAX,
     SIMILARITY_MIN,
     BatchStats,
+    ConfirmedEdge,
     EdgeDiscoveryPhase,
     _build_confidence_histogram,
     _is_synthetic_seed_edge,
@@ -580,7 +581,7 @@ class TestLLMJudgeBatch:
         )
 
         assert len(confirmed) == 1
-        assert confirmed[0][2] == "related_to"
+        assert confirmed[0].edge_type == "related_to"
         assert stats.edge_type_counts == {"related_to": 1}
         # "garbage_type" must NOT appear in dist
         assert "garbage_type" not in stats.edge_type_counts
@@ -633,8 +634,8 @@ class TestLLMJudgeBatch:
 
         assert stats.accepted == 2
         assert stats.confidences == [1.0, 0.0]
-        assert confirmed[0][3] == 1.0
-        assert confirmed[1][3] == 0.0
+        assert confirmed[0].confidence == 1.0
+        assert confirmed[1].confidence == 0.0
 
     @pytest.mark.asyncio
     async def test_complete_json_raises_increments_failures(self, llm_judge_phase):
@@ -813,9 +814,9 @@ class TestDirectedEdgeOrientation:
         assert stats.edge_type_counts == {directed_edge_type: 1}
         # src/dst preserved in the order the LLM returned (which equals the
         # input order, by construction of this test).
-        assert confirmed[0][0] == batch[0][0]
-        assert confirmed[0][1] == batch[0][1]
-        assert confirmed[0][2] == directed_edge_type
+        assert confirmed[0].src_id == batch[0][0]
+        assert confirmed[0].dst_id == batch[0][1]
+        assert confirmed[0].edge_type == directed_edge_type
 
     @pytest.mark.asyncio
     async def test_undirected_pair_flipped_still_accepted(self, llm_judge_phase):
@@ -844,8 +845,8 @@ class TestDirectedEdgeOrientation:
         # The parser uses the LLM's pair order verbatim for undirected edges,
         # so src/dst here reflect the flipped order. Semantically equivalent
         # to (src=A, dst=B) for the consumer because `related_to` is symmetric.
-        assert confirmed[0][0] == batch[0][1]
-        assert confirmed[0][1] == batch[0][0]
+        assert confirmed[0].src_id == batch[0][1]
+        assert confirmed[0].dst_id == batch[0][0]
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -926,7 +927,7 @@ class TestDirectedEdgeOrientation:
         )
 
         assert len(confirmed) == 1
-        assert confirmed[0][2] == "related_to"
+        assert confirmed[0].edge_type == "related_to"
         assert stats.edge_type_counts == {"related_to": 1}
 
 
@@ -960,9 +961,24 @@ class TestExecuteAggregation:
                     confidences=[0.9, 0.7, 0.55],
                 )
                 confirmed = [
-                    (batch[0][0], batch[0][1], "related_to", 0.9),
-                    (batch[1][0], batch[1][1], "related_to", 0.7),
-                    (batch[2][0], batch[2][1], "depends_on", 0.55),
+                    ConfirmedEdge(
+                        src_id=batch[0][0],
+                        dst_id=batch[0][1],
+                        edge_type="related_to",
+                        confidence=0.9,
+                    ),
+                    ConfirmedEdge(
+                        src_id=batch[1][0],
+                        dst_id=batch[1][1],
+                        edge_type="related_to",
+                        confidence=0.7,
+                    ),
+                    ConfirmedEdge(
+                        src_id=batch[2][0],
+                        dst_id=batch[2][1],
+                        edge_type="depends_on",
+                        confidence=0.55,
+                    ),
                 ]
                 return confirmed, stats
             # Second batch: 1 accepted, 0 rejected
@@ -972,7 +988,14 @@ class TestExecuteAggregation:
                 edge_type_counts={"learned_from": 1},
                 confidences=[0.95],
             )
-            confirmed = [(batch[0][0], batch[0][1], "learned_from", 0.95)]
+            confirmed = [
+                ConfirmedEdge(
+                    src_id=batch[0][0],
+                    dst_id=batch[0][1],
+                    edge_type="learned_from",
+                    confidence=0.95,
+                )
+            ]
             return confirmed, stats
 
         llm_judge_phase._llm_judge_batch = fake_judge


### PR DESCRIPTION
## Summary

- Replace positional `tuple[UUID, UUID, str, float]` return from `EdgeDiscoveryPhase._llm_judge_batch` with a `@dataclass(frozen=True, slots=True) ConfirmedEdge` — named access, illegal-state classes (src/dst swap, garbage `edge_type`) reduced from 5 → 1 at the type level.
- Introduce `EdgeType = Literal["related_to", "depends_on", "learned_from"]` as the single source of truth; derive `VALID_EDGE_TYPES = frozenset(get_args(EdgeType))` so the runtime membership check and the type annotation cannot drift.
- Narrow `DIRECTED_EDGE_TYPES` to `frozenset[EdgeType]` (was `frozenset[str]`) — pyright now catches typo'd members.
- Update `execute()` caller and both test fixtures (`TestLLMJudgeBatch`, `TestDirectedEdgeOrientation`, `fake_judge` in `TestExecuteAggregation`) to use named attribute access.
- **No runtime behavior change.** Pure type-level refactor + dead-code removal (the local `valid_edge_types` set inside `_llm_judge_batch` is deleted in favor of `VALID_EDGE_TYPES`).

## Trade-offs addressed during review

- **`cast(EdgeType, raw_type)` after `in VALID_EDGE_TYPES`**: pyright does not narrow through `frozenset.__contains__`, so the predicate is promoted to an explicit cast — the `in` check is the runtime guarantee that the cast is sound. Future strict-mode migration costs nothing.
- **`DIRECTED_EDGE_TYPES` co-located below `EdgeType`**: the two sets are now jointly maintainable; adding a new edge_type to the `Literal` without updating directionality is at least flagged visually by their adjacency.
- **`VALID_EDGE_TYPES` vs DB CHECK constraint**: intentional subset — DB accepts `neural_association`, `semantic_similarity`, `declared_link`, `tag_cooccurrence` for non-LLM origins; the `Literal` covers only what `_llm_judge_batch` is allowed to emit. Documented at definition site.

## Out of scope (per #374)

- Range-typed `confidence` — Python's type system can't express `[0.0, 1.0]`; runtime clamp preserved and documented on the dataclass.
- Other 4-tuples in `edge_discovery.py` (`(memory.id, hit_id, score)` triples in `_find_candidates`) — each is a separate decision.
- Wrapping the return in a `BatchResult` — current `tuple[list[T], BatchStats]` is idiomatic for 2-element returns.

## Test plan

- [x] `make lint` — ruff green
- [x] `make type-check` — pyright `0 errors, 0 warnings`
- [x] `pytest tests/services/sleep/test_edge_discovery.py` — **58 passed**
- [x] `pytest tests/services/sleep/` (full sleep phase suite) — **119 passed**
- [x] Manual diff audit of all 8 `src_id`/`dst_id`/`edge_type`/`confidence` positional references in `execute()` caller — all rewritten to `edge.*`
- [x] Manual diff audit of 7 `confirmed[i][N]` positional assertions in tests — all rewritten to named access

## Related

- Closes #374
- Parent: PR #371 (merged 2026-04-18, squash a5d258b). PhD Panel `/pl` review spawned this issue.
- Milestone: v0.13.1 (Neural Intelligence — Continued, Phase B)
- Does NOT touch the other `_llm_judge_batch` in `consolidation.py` (separate class, separate return type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)