### PR TITLE
feat(observability): rejected-side confidence retention for edge_discovery (#372)

### DIFF
--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -151,44 +151,52 @@ class ConfirmedEdge:
 
 @dataclass
 class BatchStats:
-    """Per-batch LLM Judge stats from `_llm_judge_batch` (#306).
+    """Per-batch LLM Judge stats from `_llm_judge_batch` (#306, #372).
 
     Aggregated across batches in `execute()` before being unpacked into
     `PhaseResult.details`. Per-batch invariant: `failures in {0, 1}` because
     each batch makes exactly one `complete_json` call.
 
-    `confidences` holds raw confidence values for **accepted edges only** —
-    rejected-side confidence is not retained by the parser. This is a known
-    limitation: the resulting metrics represent `P(confidence | decision=accept)`
-    not the marginal `P(confidence)` over all judgments. See #372 for the
-    rejected-side retention follow-up that enables decision-boundary analysis.
+    `confidences` / `rejected_confidences` hold raw confidence values for
+    accepted / rejected edges respectively (#372). Retaining both sides
+    enables decision-boundary analysis: comparing `P(confidence | accept)`
+    against `P(confidence | reject)` exposes bimodality at the judgment
+    boundary (pilot #249 evidence-light vs evidence-strict split), which
+    the accept-only histogram alone could not reveal.
 
     `edge_type_counts` covers accepted edges only.
 
-    `confidence_imputed` counts how many parsed edges had their confidence
-    field replaced with the 0.5 default because the LLM returned a non-finite
-    value (NaN, Inf) or a non-numeric type. Surfaces silent imputation so
-    operators can detect prompt/model issues from production observability.
+    `confidence_imputed` / `confidence_imputed_rejected` count parsed edges
+    whose confidence field was replaced with the 0.5 default because the
+    LLM returned a non-finite value (NaN, Inf) or a non-numeric type.
+    Separated per-side (#372) so an operator can tell whether malformed
+    confidence clusters on the accept path, the reject path, or both —
+    the skew itself is a prompt/model signal independent of bimodality.
     """
 
     accepted: int = 0
     rejected: int = 0
     failures: int = 0
     confidence_imputed: int = 0
+    confidence_imputed_rejected: int = 0
     edge_type_counts: dict[str, int] = field(default_factory=dict)
     confidences: list[float] = field(default_factory=list)
+    rejected_confidences: list[float] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
 class ConfidenceSummary:
-    """5-number summary for accepted-edge confidences (#306).
+    """5-number summary for edge-confidence distributions (#306, #372).
 
-    `avg` (mean) is reported but is structurally inadequate for bimodal data
+    Computed independently for accepted-edge and rejected-edge confidences;
+    the shape is identical so the same dataclass serves both sides. `avg`
+    (mean) is reported but is structurally inadequate for bimodal data
     (textbook example: bimodal mean = midpoint of valley). `median`, `p25`,
-    `p75` give a robust picture of the distribution shape. Pair with
-    `confidence_histogram` for visual inspection. `n` lets readers gauge
-    sample-size noise (per-run N is typically small ≤ 30 — formal bimodality
-    detection requires cross-run aggregation, see #372).
+    `p75` give a robust picture of the distribution shape. Pair with the
+    matching `confidence_histogram` / `confidence_histogram_rejected` for
+    visual inspection. `n` lets readers gauge sample-size noise (per-run N
+    is typically small ≤ 30 — formal bimodality detection requires
+    cross-run aggregation, deferred to a separate follow-up).
     """
 
     avg: float
@@ -229,20 +237,30 @@ def _metrics_from_agg(
     auto_accepted: int,
     confidence_summary: ConfidenceSummary,
     confidence_histogram: dict[str, int],
+    rejected_confidence_summary: ConfidenceSummary,
+    rejected_confidence_histogram: dict[str, int],
     config: NeuralMemoryConfig,
 ) -> dict[str, object]:
-    """Build the #306 metric dict from aggregated values.
+    """Build the #306/#372 metric dict from aggregated values.
 
     Single source of truth for the metric key names — `_empty_metrics()` and
     `execute()`'s success-path `result.details` both go through here, so a key
     rename or addition only requires editing this one function.
 
-    Mutable fields (`edge_type_counts`, `confidence_histogram`) are
-    **defensive-copied** so that the returned dict is decoupled from the
-    caller's `agg` and any local working state. Without this, the result dict
-    would alias the caller's mutable structures and any post-emit mutation
-    would silently corrupt `result.details`. The copy cost is negligible
-    (O(3) for edge_type, O(4) for histogram).
+    Accept-side and reject-side metrics (#372) share the same shape. Accept-
+    side keys keep the bare `confidence` names (`avg_confidence`, etc.) for
+    backward compatibility with pre-#372 sleep_reports and reader code;
+    reject-side keys carry the `_rejected` suffix so alphabetical ordering
+    places them adjacent to their accept-side counterparts in admin UIs and
+    simplifies side-by-side comparison.
+
+    Mutable fields (`edge_type_counts`, `confidence_histogram`,
+    `confidence_histogram_rejected`) are **defensive-copied** so that the
+    returned dict is decoupled from the caller's `agg` and any local working
+    state. Without this, the result dict would alias the caller's mutable
+    structures and any post-emit mutation would silently corrupt
+    `result.details`. The copy cost is negligible (O(3) for edge_type,
+    O(4) per histogram).
 
     Directional semantics (#373): `edge_type_dist` only counts edges that
     survived the parser's directional canonicalization in `_llm_judge_batch`.
@@ -267,6 +285,13 @@ def _metrics_from_agg(
         "confidence_n": confidence_summary.n,
         "confidence_imputed": agg.confidence_imputed,
         "confidence_histogram": dict(confidence_histogram),  # defensive copy
+        "avg_confidence_rejected": rejected_confidence_summary.avg,
+        "median_confidence_rejected": rejected_confidence_summary.median,
+        "p25_confidence_rejected": rejected_confidence_summary.p25,
+        "p75_confidence_rejected": rejected_confidence_summary.p75,
+        "confidence_n_rejected": rejected_confidence_summary.n,
+        "confidence_imputed_rejected": agg.confidence_imputed_rejected,
+        "confidence_histogram_rejected": dict(rejected_confidence_histogram),  # defensive copy
         "llm_model": config.sleep_llm_model,
         "prompt_revision": EDGE_DISCOVERY_PROMPT_REVISION,
     }
@@ -285,6 +310,8 @@ def _empty_metrics(config: NeuralMemoryConfig) -> dict[str, object]:
         auto_accepted=0,
         confidence_summary=_summarize_confidences([]),
         confidence_histogram=dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0),
+        rejected_confidence_summary=_summarize_confidences([]),
+        rejected_confidence_histogram=dict.fromkeys(CONFIDENCE_HISTOGRAM_KEYS, 0),
         config=config,
     )
 
@@ -413,9 +440,11 @@ class EdgeDiscoveryPhase:
                 agg.rejected += batch_stats.rejected
                 agg.failures += batch_stats.failures
                 agg.confidence_imputed += batch_stats.confidence_imputed
+                agg.confidence_imputed_rejected += batch_stats.confidence_imputed_rejected
                 for k, v in batch_stats.edge_type_counts.items():
                     agg.edge_type_counts[k] = agg.edge_type_counts.get(k, 0) + v
                 agg.confidences.extend(batch_stats.confidences)
+                agg.rejected_confidences.extend(batch_stats.rejected_confidences)
             else:
                 # Without LLM, accept all candidates with default confidence.
                 # Tracked separately as `auto_accepted` so it does NOT pollute
@@ -463,6 +492,8 @@ class EdgeDiscoveryPhase:
 
         confidence_summary = _summarize_confidences(agg.confidences)
         confidence_histogram = _build_confidence_histogram(agg.confidences)
+        rejected_confidence_summary = _summarize_confidences(agg.rejected_confidences)
+        rejected_confidence_histogram = _build_confidence_histogram(agg.rejected_confidences)
 
         result.memories_processed = len(sampled)
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
@@ -473,7 +504,13 @@ class EdgeDiscoveryPhase:
             "filtered": len(filtered),
             "edges_created": edges_created,
             **_metrics_from_agg(
-                agg, auto_accepted, confidence_summary, confidence_histogram, config
+                agg,
+                auto_accepted,
+                confidence_summary,
+                confidence_histogram,
+                rejected_confidence_summary,
+                rejected_confidence_histogram,
+                config,
             ),
         }
 
@@ -492,6 +529,11 @@ class EdgeDiscoveryPhase:
             confidence_n=confidence_summary.n,
             confidence_imputed=agg.confidence_imputed,
             confidence_histogram=confidence_histogram,
+            avg_confidence_rejected=rejected_confidence_summary.avg,
+            median_confidence_rejected=rejected_confidence_summary.median,
+            confidence_n_rejected=rejected_confidence_summary.n,
+            confidence_imputed_rejected=agg.confidence_imputed_rejected,
+            confidence_histogram_rejected=rejected_confidence_histogram,
             prompt_revision=EDGE_DISCOVERY_PROMPT_REVISION,
         )
 
@@ -789,8 +831,20 @@ class EdgeDiscoveryPhase:
             ):
                 continue
 
+            # #372: retain rejected-side confidence with the same NaN/Inf
+            # guard + clamp as the accept path. `confidence_imputed_rejected`
+            # is a separate counter so operators can tell whether malformed
+            # confidence values cluster on accept, reject, or both — the
+            # per-side skew is a prompt/model signal independent of the
+            # bimodality observable from the histograms themselves.
             if not edge.get("related", False):
+                raw_conf = edge.get("confidence", 0.5)
+                if not isinstance(raw_conf, (int, float)) or not math.isfinite(raw_conf):
+                    raw_conf = 0.5
+                    stats.confidence_imputed_rejected += 1
+                rejected_confidence = max(0.0, min(1.0, float(raw_conf)))
                 stats.rejected += 1
+                stats.rejected_confidences.append(rejected_confidence)
                 continue
 
             raw_conf = edge.get("confidence", 0.5)

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -831,12 +831,6 @@ class EdgeDiscoveryPhase:
             ):
                 continue
 
-            # #372: retain rejected-side confidence with the same NaN/Inf
-            # guard + clamp as the accept path. `confidence_imputed_rejected`
-            # is a separate counter so operators can tell whether malformed
-            # confidence values cluster on accept, reject, or both — the
-            # per-side skew is a prompt/model signal independent of the
-            # bimodality observable from the histograms themselves.
             if not edge.get("related", False):
                 raw_conf = edge.get("confidence", 0.5)
                 if not isinstance(raw_conf, (int, float)) or not math.isfinite(raw_conf):

--- a/backend/tests/mcp_server/test_sleep_tools.py
+++ b/backend/tests/mcp_server/test_sleep_tools.py
@@ -231,15 +231,14 @@ class TestGetSleepReport:
 
     @pytest.mark.asyncio
     async def test_get_sleep_report_includes_edge_discovery_metrics(self, user_id, workspace_id):
-        """Issue #306: edge_discovery_result JSON column passes new metric keys
-        through `_report_to_detail` to the MCP response untouched.
+        """Issues #306 / #372: edge_discovery_result JSON column passes new
+        metric keys through `_report_to_detail` to the MCP response untouched.
 
         Verifies that the JSON column contract — sleep_reports.details written
         by `execute()` → SQLAlchemy JSON serialize → `_report_to_detail` read —
-        round-trips the new keys (`llm_accepted`, `llm_rejected`,
-        `llm_call_failures`, `auto_accepted`, `edge_type_dist`,
-        `avg_confidence`, `confidence_histogram`, `llm_model`,
-        `prompt_revision`) without filtering or reshaping.
+        round-trips every documented metric key without filtering or reshaping.
+        Covers the accept-side (#306) keys and the parallel reject-side
+        (#372) `_rejected` suffix keys.
         """
         report_id = uuid4()
         report = self._mock_report(report_id, user_id)
@@ -273,6 +272,19 @@ class TestGetSleepReport:
                     "0.5-0.7": 1,
                     "0.7-0.85": 1,
                     "0.85-1.0": 1,
+                },
+                # #372: reject-side parallel metrics must round-trip identically.
+                "avg_confidence_rejected": 0.42,
+                "median_confidence_rejected": 0.40,
+                "p25_confidence_rejected": 0.35,
+                "p75_confidence_rejected": 0.50,
+                "confidence_n_rejected": 2,
+                "confidence_imputed_rejected": 0,
+                "confidence_histogram_rejected": {
+                    "0.0-0.5": 1,
+                    "0.5-0.7": 1,
+                    "0.7-0.85": 0,
+                    "0.85-1.0": 0,
                 },
                 "llm_model": "gpt-5-nano",
                 "prompt_revision": EDGE_DISCOVERY_PROMPT_REVISION,
@@ -325,6 +337,21 @@ class TestGetSleepReport:
         assert ed["p75_confidence"] == 0.92
         assert ed["confidence_n"] == 3
         assert ed["confidence_imputed"] == 0
+        # #372 reject-side parallel keys — dropping any of these from
+        # `_report_to_detail` would silently hide half of the decision-
+        # boundary signal that #372 was specifically filed to restore.
+        assert ed["avg_confidence_rejected"] == 0.42
+        assert ed["median_confidence_rejected"] == 0.40
+        assert ed["p25_confidence_rejected"] == 0.35
+        assert ed["p75_confidence_rejected"] == 0.50
+        assert ed["confidence_n_rejected"] == 2
+        assert ed["confidence_imputed_rejected"] == 0
+        assert ed["confidence_histogram_rejected"] == {
+            "0.0-0.5": 1,
+            "0.5-0.7": 1,
+            "0.7-0.85": 0,
+            "0.85-1.0": 0,
+        }
 
 
 class TestRollbackSleepRun:

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -184,6 +184,16 @@ class TestEdgeDiscoveryPhase:
         assert result.details["p75_confidence"] == 0.0
         assert result.details["confidence_n"] == 0
         assert result.details["confidence_imputed"] == 0
+        # #372: rejected-side metric keys also zero-init on early return.
+        assert result.details["avg_confidence_rejected"] == 0.0
+        assert result.details["median_confidence_rejected"] == 0.0
+        assert result.details["p25_confidence_rejected"] == 0.0
+        assert result.details["p75_confidence_rejected"] == 0.0
+        assert result.details["confidence_n_rejected"] == 0
+        assert result.details["confidence_imputed_rejected"] == 0
+        assert result.details["confidence_histogram_rejected"] == dict.fromkeys(
+            CONFIDENCE_HISTOGRAM_KEYS, 0
+        )
 
     @pytest.mark.asyncio
     async def test_no_candidates(self, edge_phase):
@@ -534,6 +544,9 @@ class TestLLMJudgeBatch:
         assert stats.failures == 0
         assert stats.edge_type_counts == {}
         assert stats.confidences == []
+        # #372: rejected-side confidence is retained for decision-boundary analysis.
+        assert stats.rejected_confidences == [0.2, 0.3]
+        assert stats.confidence_imputed_rejected == 0
 
     @pytest.mark.asyncio
     async def test_mixed_accept_reject(self, llm_judge_phase):
@@ -558,6 +571,8 @@ class TestLLMJudgeBatch:
         assert stats.rejected == 1
         assert stats.edge_type_counts == {"learned_from": 1}
         assert stats.confidences == [0.75]
+        # #372: rejected-side confidence captured in parallel.
+        assert stats.rejected_confidences == [0.4]
 
     @pytest.mark.asyncio
     async def test_invalid_edge_type_coerced_to_related_to(self, llm_judge_phase):
@@ -1052,6 +1067,159 @@ class TestConfidenceImputed:
         assert stats.confidences == [0.5, 0.5]
 
 
+class TestRejectedSideConfidence:
+    """Rejected-side confidence retention (#372).
+
+    PR #371 retained accepted-edge confidence only, which produced a
+    structurally censored `P(confidence | accept)` distribution. #372 mirrors
+    the parser logic for rejected edges so both sides of the decision boundary
+    are observable. The counter `confidence_imputed_rejected` is separate from
+    accept-side `confidence_imputed` so operators can detect per-side skew
+    (prompt/model signal independent of bimodality itself).
+    """
+
+    @pytest.mark.asyncio
+    async def test_rejected_confidence_clamped_and_retained(self, llm_judge_phase):
+        """Rejected-edge confidence is clamped to [0.0, 1.0] and retained.
+
+        The parallel accept-side guarantees (clamp + NaN imputation) apply
+        symmetrically; `_make_llm_response` populates `confidence` for every
+        edge per the `EDGE_DISCOVERY_USER` prompt contract (prompts.py:116-118).
+        """
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=3)
+        labels = _labels_for(memory_map)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                (labels[batch[0][0]], labels[batch[0][1]], False, "related_to", 1.7),  # over
+                (labels[batch[1][0]], labels[batch[1][1]], False, "related_to", -0.2),  # under
+            ]
+        )
+
+        _, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert stats.rejected == 2
+        assert stats.rejected_confidences == [1.0, 0.0]
+        # No imputation path — both inputs were finite, just out-of-range.
+        assert stats.confidence_imputed_rejected == 0
+        assert stats.confidence_imputed == 0
+
+    @pytest.mark.asyncio
+    async def test_rejected_nan_imputed_to_separate_counter(self, llm_judge_phase):
+        """NaN/Inf in rejected-edge confidence imputes to 0.5 and increments
+        the reject-side counter only — accept-side `confidence_imputed` stays 0.
+
+        This is the per-side observability signal: a non-zero
+        `confidence_imputed_rejected` with zero `confidence_imputed` tells the
+        operator the LLM returns malformed confidence specifically when
+        rejecting, which is distinct information from overall imputation rate.
+        """
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=3)
+        labels = _labels_for(memory_map)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                (labels[batch[0][0]], labels[batch[0][1]], True, "related_to", 0.9),
+                (labels[batch[1][0]], labels[batch[1][1]], False, "related_to", float("nan")),
+            ]
+        )
+
+        _, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert stats.accepted == 1
+        assert stats.rejected == 1
+        assert stats.confidences == [0.9]
+        # NaN on the reject side → imputed to 0.5 on reject counter, not accept.
+        assert stats.rejected_confidences == [0.5]
+        assert stats.confidence_imputed_rejected == 1
+        assert stats.confidence_imputed == 0
+
+    @pytest.mark.asyncio
+    async def test_rejected_confidence_skip_filter_regression(self, llm_judge_phase):
+        """#369 regression guard: rejected-side parser must not reach unguarded
+        label indexing. Labels outside `label_to_id` are skipped BEFORE the
+        `related` branch, so they cannot populate `rejected_confidences`.
+
+        Without this ordering, an LLM returning a reject for a hallucinated
+        pair would trip the KeyError that closed #369 on the accept side.
+        """
+        config = _make_config()
+        budget = SleepBudget()
+        _, batch, memory_map = _make_batch_pair(n=2)
+        labels = _labels_for(memory_map)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                (labels[batch[0][0]], labels[batch[0][1]], False, "related_to", 0.3),
+                # Out-of-range labels — skipped before the reject branch runs.
+                ("X", "Y", False, "related_to", 0.1),
+            ]
+        )
+
+        _, stats = await llm_judge_phase._llm_judge_batch(
+            batch, memory_map, "user-1", "ctx-1", "ws-1", budget, config
+        )
+
+        assert stats.rejected == 1
+        # The malformed (X, Y) pair was skipped — only the valid reject is retained.
+        assert stats.rejected_confidences == [0.3]
+
+    @pytest.mark.asyncio
+    async def test_execute_aggregates_rejected_histogram_and_summary(self, llm_judge_phase):
+        """End-to-end: full `execute()` path emits rejected-side histogram,
+        summary quartiles, and per-side imputation counter in `result.details`.
+        """
+        config = _make_config(sample_size=4)
+        budget = SleepBudget()
+
+        mems = [_make_memory() for _ in range(4)]
+        edges = [(mems[i].id, mems[i + 1].id, 0.75) for i in range(3)]
+
+        llm_judge_phase._sample_memories = AsyncMock(return_value=mems)
+        llm_judge_phase._find_candidates = AsyncMock(return_value=edges)
+        llm_judge_phase._filter_existing_edges = AsyncMock(return_value=edges)
+        llm_judge_phase.edge_repo.create_or_update_edge = AsyncMock()
+
+        memory_map = {m.id: m for m in mems}
+        labels = _labels_for(memory_map)
+
+        llm_judge_phase.llm_service.complete_json.return_value = _make_llm_response(
+            [
+                (labels[edges[0][0]], labels[edges[0][1]], True, "related_to", 0.9),
+                (labels[edges[1][0]], labels[edges[1][1]], False, "related_to", 0.3),
+                (labels[edges[2][0]], labels[edges[2][1]], False, "related_to", 0.6),
+            ]
+        )
+
+        result = await llm_judge_phase.execute(config, "user-1", "ws-1", "ctx-1", budget)
+
+        # Accept side unchanged
+        assert result.details["llm_accepted"] == 1
+        assert result.details["llm_rejected"] == 2
+        assert result.details["confidence_histogram"]["0.85-1.0"] == 1
+
+        # Reject side — 0.3 → [0.0, 0.5) bucket, 0.6 → [0.5, 0.7) bucket.
+        rejected_hist = result.details["confidence_histogram_rejected"]
+        assert rejected_hist["0.0-0.5"] == 1
+        assert rejected_hist["0.5-0.7"] == 1
+        assert rejected_hist["0.7-0.85"] == 0
+        assert rejected_hist["0.85-1.0"] == 0
+
+        # Reject side summary: n=2 with [0.3, 0.6], avg 0.45, median 0.45.
+        assert result.details["confidence_n_rejected"] == 2
+        assert result.details["avg_confidence_rejected"] == pytest.approx(0.45)
+        assert result.details["median_confidence_rejected"] == pytest.approx(0.45)
+        assert result.details["confidence_imputed_rejected"] == 0
+
+
 class TestMetricsAliasing:
     """Defensive copy in _metrics_from_agg prevents result.details from
     aliasing the live BatchStats / histogram (#306 PhD-review fix).
@@ -1098,8 +1266,8 @@ class TestMetricsAliasing:
         assert s1.p75 == 0.7
 
     def test_metrics_from_agg_returns_independent_dicts(self):
-        """Direct test: _metrics_from_agg copies edge_type_counts and the
-        histogram so callers can mutate freely."""
+        """Direct test: _metrics_from_agg copies edge_type_counts and both
+        confidence histograms (accept + rejected) so callers can mutate freely."""
         from services.sleep.edge_discovery import (
             _build_confidence_histogram,
             _metrics_from_agg,
@@ -1108,22 +1276,28 @@ class TestMetricsAliasing:
 
         agg = BatchStats(
             accepted=2,
+            rejected=1,
             edge_type_counts={"related_to": 1, "depends_on": 1},
             confidences=[0.6, 0.9],
+            rejected_confidences=[0.3],
         )
         hist = _build_confidence_histogram(agg.confidences)
         summary = _summarize_confidences(agg.confidences)
+        rejected_hist = _build_confidence_histogram(agg.rejected_confidences)
+        rejected_summary = _summarize_confidences(agg.rejected_confidences)
         config = _make_config()
 
-        emitted = _metrics_from_agg(agg, 0, summary, hist, config)
+        emitted = _metrics_from_agg(agg, 0, summary, hist, rejected_summary, rejected_hist, config)
 
-        # Mutate the emitted dict's mutable fields.
+        # Mutate the emitted dict's mutable fields (all three).
         emitted["edge_type_dist"]["NEW_KEY"] = 42
         emitted["confidence_histogram"]["0.0-0.5"] = 999
+        emitted["confidence_histogram_rejected"]["0.0-0.5"] = 888
 
-        # Source data MUST be unchanged (defensive copy worked).
+        # Source data MUST be unchanged (defensive copy worked on all three).
         assert "NEW_KEY" not in agg.edge_type_counts
         assert hist["0.0-0.5"] == 0
+        assert rejected_hist["0.0-0.5"] == 1  # 0.3 sits in first bucket, untouched
 
 
 class TestConfidenceHistogram:


### PR DESCRIPTION
Closes #372

## Summary
- Mirror accept-side confidence aggregation onto the reject branch of `_llm_judge_batch` so `P(confidence | reject)` is observable alongside `P(confidence | accept)` — the precondition for detecting evidence-light vs evidence-strict bimodality (pilot #249) from production sleep_reports.
- Add 7 `_rejected` suffix metrics (histogram, summary quartiles, n, imputed) to `sleep_reports.edge_discovery_result.details`. Backward-compat additive — existing keys and readers unchanged.
- Per-side imputation counter separation (`confidence_imputed` vs `confidence_imputed_rejected`) surfaces per-side malformed-confidence skew as a prompt/model signal independent of the bimodality observable from the histograms themselves.

## Implementation notes
- `BatchStats`: +2 fields — `rejected_confidences: list[float]`, `confidence_imputed_rejected: int`.
- `_llm_judge_batch` reject branch: NaN/Inf guard + `[0.0, 1.0]` clamp + append, mirroring the accept path. Lives AFTER the existing `pair[0] not in label_to_id` validation and frozenset hallucination guard, so no new KeyError surface (#369 regression guarded — covered by `test_rejected_confidence_skip_filter_regression`).
- `_metrics_from_agg`: +2 positional params (`rejected_confidence_summary`, `rejected_confidence_histogram`) + 7 dict keys with `_rejected` suffix. Suffix naming chosen for alphabetical adjacency in admin UIs (side-by-side comparison) + backward compat for existing readers.
- `execute()`: parallel summary/histogram computation for rejected-side. Logger expanded with 5 rejected-side fields for runtime visibility.
- Schema evolution is additive — no migrations required (JSON column is schemaless), no new dependencies, no new routes.

## Test coverage
- 4 new tests in `TestRejectedSideConfidence`: clamp+retention, NaN imputation to separate counter, `#369` regression via out-of-range labels, end-to-end `execute()` aggregation.
- Existing `test_all_reject` / `test_mixed_accept_reject` extended with `rejected_confidences` assertions.
- `test_no_memories` extended to assert all 7 `_rejected` keys zero-init on early-return paths.
- `test_metrics_from_agg_returns_independent_dicts` extended to verify defensive copy on the new `confidence_histogram_rejected` dict.
- `test_sleep_tools.py::test_get_sleep_report_includes_edge_discovery_metrics` extended so the MCP round-trip contract covers every `_rejected` key alongside the accept-side keys.
- 230 tests pass (62 edge_discovery + 13 mcp_server + adjacent unchanged). Lint (ruff) clean. pyright 0 errors.

## Scope notes
The original issue bundled a Part 2 (cross-run bimodality detection tooling — Hartigan's dip test / Silverman bandwidth / admin UI or MCP tool). That was trimmed before implementation: no concrete consumer exists yet, the statistical method and surface (MCP vs admin UI) were TBD, and the new-dependency footprint (diptest, etc.) is out of scope for a parser-layer retention change. Issue body was updated to reflect the narrower Part 1 scope. Future Part 2 work can additively extend the schema (raw confidence arrays or aggregated histograms) without reshaping the per-run metrics landed here.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (resolved via scope-trim — Part 2 removed from issue before implementation)
- review provider: copilot

Full reviews saved in plugin cache:
- `~/.claude/cache/gh-issue-driven/372-feat-feat-observability-rejected-side-confide.gate1.md`
- `~/.claude/cache/gh-issue-driven/372-feat-feat-observability-rejected-side-confide.gate2.md`

🤖 Generated via /gh-issue-driven:ship
