### PR TITLE
feat(neural): Phase B — EmbeddingCalibration model + runtime integration (#406)

### DIFF
--- a/backend/alembic/versions/b06_406_embedding_calibration.py
+++ b/backend/alembic/versions/b06_406_embedding_calibration.py
@@ -80,7 +80,16 @@ def upgrade() -> None:
         ),
         sa.Column("model_name", sa.String(100), nullable=False),
         sa.Column("dimensions", sa.Integer, nullable=False),
-        sa.Column("context_id", UUID(as_uuid=True), nullable=True),
+        # FK to contexts.id with ON DELETE CASCADE so per-context calibration
+        # rows (v2) are auto-cleaned when a context is deleted. Nullable
+        # because model-global rows use NULL here (the v1 runtime lookup path).
+        # Copilot review PR #420 loop 2 finding.
+        sa.Column(
+            "context_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
         sa.Column("p25", sa.Float, nullable=False),
         sa.Column("p50", sa.Float, nullable=False),
         sa.Column("p75", sa.Float, nullable=False),

--- a/backend/alembic/versions/b06_406_embedding_calibration.py
+++ b/backend/alembic/versions/b06_406_embedding_calibration.py
@@ -1,0 +1,170 @@
+"""Add embedding_calibrations table + reset knn_seed_min_similarity=0.4 rows.
+
+Issue #406 (Phase B runtime integration of #240 knn_seed calibration): two
+coupled schema changes that let the runtime fallback chain in
+``_create_knn_seed_edges`` switch from hardcoded 0.4 to percentile-based
+calibration lookup.
+
+1. Create ``embedding_calibrations`` table per #240 D5 schema. Stores a
+   5-number summary (p25/p50/p75/p90/p95/p99) of top-k neighbor cosine
+   similarity for each ``(model_name, dimensions, context_id)`` combination.
+   ``context_id`` is nullable — a NULL row means the calibration is
+   model-global (applies to every context using that model + dimensions).
+   Per-context rows are allowed by the schema but not populated in v1 (D5
+   v2 follow-up — the runtime lookup in ``neural/calibration.py`` has a
+   TODO(v2) marker for the per-context path).
+
+   Uniqueness is enforced with two complementary indexes because Postgres
+   treats NULL as distinct in a regular UNIQUE constraint — ``(model, dims,
+   NULL)`` could otherwise be inserted multiple times:
+
+   - ``uq_calibration_model_dims_nonnull``: UNIQUE on ``(model_name,
+     dimensions, context_id)`` where ``context_id IS NOT NULL`` (handles
+     the per-context v2 case without collision).
+   - ``uq_calibration_model_dims_global``: UNIQUE on ``(model_name,
+     dimensions)`` where ``context_id IS NULL`` (at most one global row
+     per model+dims).
+
+2. Reset ``knn_seed_min_similarity = 0.4`` rows in ``neural_config``. The
+   Python default in ``NeuralMemoryConfig`` changes from ``0.4`` to ``None``
+   in the same PR; ``None`` tells the runtime to use the calibration path.
+   Operators who tuned the value to anything other than 0.4 (e.g. 0.35,
+   0.5) have their explicit rows **preserved** — those rows take priority
+   over calibration per D6. The exact value ``0.4`` is deleted because it
+   is indistinguishable from the old default and would silently block the
+   calibration path.
+
+   This is the known provenance ambiguity flagged in the issue's gate1
+   design review: an operator who had explicitly set 0.4 (i.e. confirmed
+   the default) loses that setting and falls into the calibration path.
+   The CHANGELOG entry for v0.13.1 documents this — operators should
+   re-apply their value post-migration if they relied on 0.4 specifically.
+
+Revision ID: b06_406_embedding_calibration
+Revises: b05_223_tag_cooccurrence
+
+DOWNGRADE WARNING: the ``knn_seed_min_similarity = 0.4`` row reset is
+**not reversible** — we don't know which operators had explicitly set 0.4
+vs. inherited the default. Downgrade drops the new table and indexes but
+does NOT re-insert deleted rows; callers who need their 0.4 back must
+re-apply via admin UI or direct DB update.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "b06_406_embedding_calibration"
+down_revision = "b05_223_tag_cooccurrence"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create embedding_calibrations + reset knn_seed default rows."""
+    # 1. Create embedding_calibrations table.
+    #
+    # valid_until is NOT given a server_default — the app computes it as
+    # sampled_at + NeuralMemoryConfig.calibration_ttl_days (default 30).
+    # Keeping the TTL in code config (not hardcoded here) means operators
+    # can tighten it via env var without a schema change. See #240 D7.
+    op.create_table(
+        "embedding_calibrations",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("model_name", sa.String(100), nullable=False),
+        sa.Column("dimensions", sa.Integer, nullable=False),
+        sa.Column("context_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("p25", sa.Float, nullable=False),
+        sa.Column("p50", sa.Float, nullable=False),
+        sa.Column("p75", sa.Float, nullable=False),
+        sa.Column("p90", sa.Float, nullable=False),
+        sa.Column("p95", sa.Float, nullable=False),
+        sa.Column("p99", sa.Float, nullable=False),
+        sa.Column("sample_size", sa.Integer, nullable=False),
+        sa.Column(
+            "sampled_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("valid_until", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            "p25 >= 0.0 AND p25 <= 1.0 AND "
+            "p50 >= 0.0 AND p50 <= 1.0 AND "
+            "p75 >= 0.0 AND p75 <= 1.0 AND "
+            "p90 >= 0.0 AND p90 <= 1.0 AND "
+            "p95 >= 0.0 AND p95 <= 1.0 AND "
+            "p99 >= 0.0 AND p99 <= 1.0",
+            name="embedding_calibrations_percentiles_in_range",
+        ),
+        sa.CheckConstraint(
+            "sample_size >= 0",
+            name="embedding_calibrations_nonneg_sample_size",
+        ),
+        sa.CheckConstraint(
+            "valid_until > sampled_at",
+            name="embedding_calibrations_valid_until_future",
+        ),
+    )
+
+    # 2. Two partial-unique indexes so NULL context_id = "at most one global
+    #    row per (model, dims)" while non-NULL context_id allows one row per
+    #    (model, dims, context_id).
+    op.create_index(
+        "uq_calibration_model_dims_global",
+        "embedding_calibrations",
+        ["model_name", "dimensions"],
+        unique=True,
+        postgresql_where=sa.text("context_id IS NULL"),
+    )
+    op.create_index(
+        "uq_calibration_model_dims_nonnull",
+        "embedding_calibrations",
+        ["model_name", "dimensions", "context_id"],
+        unique=True,
+        postgresql_where=sa.text("context_id IS NOT NULL"),
+    )
+
+    # 3. Reset knn_seed_min_similarity=0.4 rows in neural_config. The Python
+    #    default flips from 0.4 to None in the same PR; deleting the row lets
+    #    the code default take over. Rows with other values (operator tuning)
+    #    are preserved — they win over calibration per D6.
+    #
+    #    CAST to float handles operators who stored "0.40" or "0.4000" (value
+    #    column is varchar). We compare numerically to catch all equivalent
+    #    string forms of 0.4.
+    op.execute(
+        """
+        DELETE FROM neural_config
+        WHERE key = 'knn_seed_min_similarity'
+          AND value_type = 'float'
+          AND CAST(value AS FLOAT) = 0.4
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop the new table + indexes.
+
+    Non-reversible: the ``knn_seed_min_similarity = 0.4`` row DELETE cannot
+    be undone because post-migration state does not record which operators
+    had explicitly set 0.4 vs. inherited the default. Operators needing
+    0.4 back must re-apply it after downgrade (admin UI or direct
+    ``INSERT INTO neural_config``).
+    """
+    op.drop_index(
+        "uq_calibration_model_dims_nonnull",
+        table_name="embedding_calibrations",
+    )
+    op.drop_index(
+        "uq_calibration_model_dims_global",
+        table_name="embedding_calibrations",
+    )
+    op.drop_table("embedding_calibrations")

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -322,6 +322,7 @@ for _exc_cls in (
 
 from api.routes import (  # noqa: E402
     admin,
+    admin_neural,  # Issue #406: Manual kNN calibration recalibrate trigger
     admin_plans,
     admin_signup_gate,  # Issue #358: admin-configurable signup gate
     admin_sleep,  # Issue #247: Manual Sleep Maintenance trigger
@@ -401,6 +402,9 @@ app.include_router(sleep_reports.router, prefix="/api/v1")
 
 # Admin Sleep trigger (Issue #247 - Manual Sleep Maintenance trigger)
 app.include_router(admin_sleep.router, prefix="/api/v1")
+
+# Admin Neural calibrate trigger (Issue #406 Phase B - Manual kNN recalibration)
+app.include_router(admin_neural.router, prefix="/api/v1")
 
 # Admin signup gate (Issue #358: admin-configurable signup gate)
 app.include_router(admin_signup_gate.router, prefix="/api/v1")

--- a/backend/src/api/routes/admin_neural.py
+++ b/backend/src/api/routes/admin_neural.py
@@ -1,6 +1,6 @@
 """Admin endpoint for manually triggering kNN-seed calibration (#406 Phase B).
 
-POST /api/admin/neural/recalibrate?model=<name>&dimensions=<N>
+POST /api/v1/admin/neural/recalibrate?model=<name>&dimensions=<N>
 
 Enqueues a model-global calibration job for the given ``(model_name,
 dimensions)`` pair. This is the third of three calibration triggers

--- a/backend/src/api/routes/admin_neural.py
+++ b/backend/src/api/routes/admin_neural.py
@@ -11,8 +11,9 @@ hasn't fired yet and the operator wants a fresh threshold immediately.
 
 The actual compute runs in an ``asyncio.create_task`` spawned by
 :func:`~tasks.neural_calibration.enqueue_recalibration_dedup`; this
-handler returns 202 as soon as the job is enqueued (or 200 with
-``accepted=false`` when the dedup lock rejects a duplicate).
+handler always returns 202, with ``accepted=true`` when a new job was
+enqueued and ``accepted=false`` when the dedup lock rejects a duplicate
+(idempotent — callers can safely retry without hammering the compute).
 """
 
 from __future__ import annotations

--- a/backend/src/api/routes/admin_neural.py
+++ b/backend/src/api/routes/admin_neural.py
@@ -1,0 +1,104 @@
+"""Admin endpoint for manually triggering kNN-seed calibration (#406 Phase B).
+
+POST /api/admin/neural/recalibrate?model=<name>&dimensions=<N>
+
+Enqueues a model-global calibration job for the given ``(model_name,
+dimensions)`` pair. This is the third of three calibration triggers
+(bootstrap / admin-manual / lazy-TTL) defined in #240 C2 — the admin
+path exists for operational recovery: e.g. after swapping an embedding
+provider, after a corpus-wide re-embed, or when the lazy-TTL signal
+hasn't fired yet and the operator wants a fresh threshold immediately.
+
+The actual compute runs in an ``asyncio.create_task`` spawned by
+:func:`~tasks.neural_calibration.enqueue_recalibration_dedup`; this
+handler returns 202 as soon as the job is enqueued (or 200 with
+``accepted=false`` when the dedup lock rejects a duplicate).
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel
+
+from auth.dependencies import AdminUser
+from tasks.neural_calibration import enqueue_recalibration_dedup
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/admin/neural", tags=["admin-neural"])
+
+
+# Allow-list of supported embedding model names. Open-list by design —
+# adding a new provider means shipping the embedding service, not
+# touching this router — but we reject obviously invalid input (empty
+# string, very long string, path-looking values) at the edge so the
+# downstream dedup-key construction and logs stay clean. The actual
+# model-dimension validity is enforced by the calibration task itself
+# (it aborts when no context uses the pair).
+_MODEL_NAME_MAX_LEN = 100
+
+
+class RecalibrateResponse(BaseModel):
+    """202 response body for the admin recalibrate endpoint.
+
+    Attributes:
+        accepted: ``True`` when the dedup lock was acquired and a
+            calibration task was spawned. ``False`` when a prior job is
+            still in-flight for the same ``(model, dimensions)`` —
+            idempotent; no error raised.
+        model_name: Echo of the requested model.
+        dimensions: Echo of the requested dimensionality.
+    """
+
+    accepted: bool
+    model_name: str
+    dimensions: int
+
+
+@router.post(
+    "/recalibrate",
+    response_model=RecalibrateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def recalibrate(
+    current_user: AdminUser,
+    model: str = Query(..., min_length=1, max_length=_MODEL_NAME_MAX_LEN),
+    dimensions: int = Query(..., ge=1, le=65536),
+) -> RecalibrateResponse:
+    """Enqueue a deduped model-global calibration job.
+
+    The ``AdminUser`` dependency rejects non-admins with 403 before this
+    handler runs. ``model`` is length-bounded and ``dimensions`` is
+    range-bounded by FastAPI validation. No rate limiting is applied at
+    this layer — the Redis dedup lock is the single source of truth for
+    "one job per (model, dims) in flight at a time", and admins can
+    self-serve retries without hammering the compute.
+    """
+    # Defensive: reject obviously-malformed model names (path separators,
+    # whitespace) even if they pass length validation. FastAPI's Query
+    # validator doesn't enforce a regex because we want to stay open to
+    # new providers without churning this file.
+    if "/" in model or "\\" in model or any(c.isspace() for c in model):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="invalid_model_name",
+        )
+
+    accepted = await enqueue_recalibration_dedup(
+        model_name=model,
+        dimensions=dimensions,
+        context_id=None,
+    )
+    logger.info(
+        "admin_recalibrate_requested",
+        admin_email=current_user.get("email"),
+        model=model,
+        dimensions=dimensions,
+        accepted=accepted,
+    )
+    return RecalibrateResponse(
+        accepted=accepted,
+        model_name=model,
+        dimensions=dimensions,
+    )

--- a/backend/src/models/neural.py
+++ b/backend/src/models/neural.py
@@ -6,7 +6,18 @@ Issue #406: Add EmbeddingCalibration for knn_seed percentile calibration
 
 from datetime import UTC, datetime
 
-from sqlalchemy import CheckConstraint, Column, DateTime, Float, Index, Integer, String, Text, func
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import expression
 
@@ -143,7 +154,14 @@ class EmbeddingCalibration(Base):
     )
     model_name = Column(String(100), nullable=False)
     dimensions = Column(Integer, nullable=False)
-    context_id = Column(UUID(as_uuid=True), nullable=True)
+    # FK to contexts.id with ON DELETE CASCADE so per-context calibration
+    # rows (v2) get cleaned up automatically when a context is deleted.
+    # Nullable because model-global rows use NULL here (v1 runtime path).
+    context_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="CASCADE"),
+        nullable=True,
+    )
 
     p25 = Column(Float, nullable=False)
     p50 = Column(Float, nullable=False)

--- a/backend/src/models/neural.py
+++ b/backend/src/models/neural.py
@@ -263,8 +263,15 @@ class EmbeddingCalibration(Base):
         """
         current = now if now is not None else datetime.now(UTC)
         valid_until = self.valid_until
-        # SQLAlchemy returns naive datetimes for some adapters; coerce to UTC
-        # to make comparison deterministic.
+        # Treat naive datetimes as UTC on both sides. SQLAlchemy returns
+        # naive datetimes for some adapters, and callers in this repo
+        # frequently go through ``utils.datetime.utcnow()`` which is naive
+        # by project convention. Comparing a naive datetime to a timezone-
+        # aware one raises TypeError; normalize both so this helper is
+        # robust regardless of which side is naive.
+        # (Copilot review PR #420 loop 8.)
+        if current.tzinfo is None:
+            current = current.replace(tzinfo=UTC)
         if valid_until.tzinfo is None:
             valid_until = valid_until.replace(tzinfo=UTC)
         return current >= valid_until

--- a/backend/src/models/neural.py
+++ b/backend/src/models/neural.py
@@ -1,9 +1,14 @@
 """SQLAlchemy models for Neural Memory configuration.
 
 Issue #107: Move neural config from env vars to database
+Issue #406: Add EmbeddingCalibration for knn_seed percentile calibration
 """
 
-from sqlalchemy import Column, DateTime, Float, Integer, String, Text, func
+from datetime import UTC, datetime
+
+from sqlalchemy import CheckConstraint, Column, DateTime, Float, Index, Integer, String, Text, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.sql import expression
 
 from db.base import Base
 
@@ -89,3 +94,166 @@ class NeuralConfig(Base):
 
         except ValueError as e:
             return False, f"Invalid {self.value_type} value: {e}"
+
+
+class EmbeddingCalibration(Base):
+    """Per-model percentile calibration of top-k neighbor cosine similarity.
+
+    Issue #406 / #240 Phase B. Stores the 5-number summary of the distribution
+    of top-k neighbor cosine similarity for a given embedding model. Written
+    by the calibration job (bootstrap / admin-manual / lazy-TTL triggers),
+    read by ``neural.calibration.resolve_knn_threshold`` at ``remember()``
+    time to set the runtime ``semantic_similarity`` seeding threshold
+    without hardcoding a per-model value.
+
+    ``context_id`` is nullable:
+
+    - ``NULL`` = model-global calibration. At most one row per ``(model_name,
+      dimensions)`` combination (enforced by partial unique index
+      ``uq_calibration_model_dims_global``).
+    - non-NULL = per-context calibration (D5 v2). Schema allows it, but the
+      v1 runtime lookup only reads the global row — see the ``TODO(v2)``
+      in ``neural/calibration.py``. Per-(model, dims, context_id) uniqueness
+      is enforced by ``uq_calibration_model_dims_nonnull``.
+
+    ``valid_until`` drives the lazy TTL recalibration trigger. Default TTL
+    is ``NeuralMemoryConfig.calibration_ttl_days`` (30 days in v1), computed
+    by the calibration job and stored absolute so readers don't need to
+    recompute. Kept in app config rather than hardcoded in the migration so
+    #407 Task 2's drift-measurement can tune it via env var without a schema
+    change.
+
+    Attributes:
+        id: Primary key (UUID)
+        model_name: Embedding model name (e.g. "text-embedding-3-small")
+        dimensions: Vector dimensionality (e.g. 512, 4096)
+        context_id: Optional context UUID; NULL = model-global
+        p25-p99: Percentile values from top-k neighbor distribution
+        sample_size: Number of observations (top-k calls * k) used to fit
+        sampled_at: When the calibration was computed
+        valid_until: sampled_at + calibration_ttl_days; lazy-recal trigger
+    """
+
+    __tablename__ = "embedding_calibrations"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=expression.text("gen_random_uuid()"),
+    )
+    model_name = Column(String(100), nullable=False)
+    dimensions = Column(Integer, nullable=False)
+    context_id = Column(UUID(as_uuid=True), nullable=True)
+
+    p25 = Column(Float, nullable=False)
+    p50 = Column(Float, nullable=False)
+    p75 = Column(Float, nullable=False)
+    p90 = Column(Float, nullable=False)
+    p95 = Column(Float, nullable=False)
+    p99 = Column(Float, nullable=False)
+
+    sample_size = Column(Integer, nullable=False)
+    sampled_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    valid_until = Column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "p25 >= 0.0 AND p25 <= 1.0 AND "
+            "p50 >= 0.0 AND p50 <= 1.0 AND "
+            "p75 >= 0.0 AND p75 <= 1.0 AND "
+            "p90 >= 0.0 AND p90 <= 1.0 AND "
+            "p95 >= 0.0 AND p95 <= 1.0 AND "
+            "p99 >= 0.0 AND p99 <= 1.0",
+            name="embedding_calibrations_percentiles_in_range",
+        ),
+        CheckConstraint(
+            "sample_size >= 0",
+            name="embedding_calibrations_nonneg_sample_size",
+        ),
+        CheckConstraint(
+            "valid_until > sampled_at",
+            name="embedding_calibrations_valid_until_future",
+        ),
+        Index(
+            "uq_calibration_model_dims_global",
+            "model_name",
+            "dimensions",
+            unique=True,
+            postgresql_where=expression.text("context_id IS NULL"),
+        ),
+        Index(
+            "uq_calibration_model_dims_nonnull",
+            "model_name",
+            "dimensions",
+            "context_id",
+            unique=True,
+            postgresql_where=expression.text("context_id IS NOT NULL"),
+        ),
+    )
+
+    # Ordered percentile pairs for percentile() linear interpolation.
+    _STORED_PERCENTILES: tuple[tuple[float, str], ...] = (
+        (25.0, "p25"),
+        (50.0, "p50"),
+        (75.0, "p75"),
+        (90.0, "p90"),
+        (95.0, "p95"),
+        (99.0, "p99"),
+    )
+
+    def percentile(self, p: float) -> float:
+        """Interpolate a percentile from the stored 5-number summary.
+
+        Linear interpolation between the two stored percentiles bracketing
+        ``p``. The stored grid is ``[25, 50, 75, 90, 95, 99]``. For ``p``
+        outside this range (below 25 or above 99), the nearest stored value
+        is returned — extrapolation on a probability is not meaningful for
+        this use case (the runtime threshold falls back to the D2 floor for
+        degenerate distributions anyway).
+
+        Args:
+            p: Target percentile in ``[0.0, 100.0]``. Common value is 90.0.
+
+        Returns:
+            Interpolated similarity value in ``[0.0, 1.0]`` (same range as
+            the stored percentiles; never extrapolates outside).
+        """
+        if p <= self._STORED_PERCENTILES[0][0]:
+            return float(getattr(self, self._STORED_PERCENTILES[0][1]))
+        if p >= self._STORED_PERCENTILES[-1][0]:
+            return float(getattr(self, self._STORED_PERCENTILES[-1][1]))
+        for i in range(len(self._STORED_PERCENTILES) - 1):
+            lo_p, lo_attr = self._STORED_PERCENTILES[i]
+            hi_p, hi_attr = self._STORED_PERCENTILES[i + 1]
+            if lo_p <= p <= hi_p:
+                lo_v = float(getattr(self, lo_attr))
+                hi_v = float(getattr(self, hi_attr))
+                if hi_p == lo_p:
+                    return lo_v
+                frac = (p - lo_p) / (hi_p - lo_p)
+                return lo_v + frac * (hi_v - lo_v)
+        # Unreachable given the bounds checks above, but keep the type checker happy.
+        return float(self.p90)
+
+    def is_expired(self, now: datetime | None = None) -> bool:
+        """Return True iff the calibration is past its ``valid_until``.
+
+        Used by the lazy-TTL recalibration trigger in
+        ``neural.calibration.resolve_knn_threshold``: an expired row still
+        serves its stored value (fail-open on stale calibration), while the
+        lookup enqueues a background recalibration task (deduped).
+        """
+        current = now if now is not None else datetime.now(UTC)
+        valid_until = self.valid_until
+        # SQLAlchemy returns naive datetimes for some adapters; coerce to UTC
+        # to make comparison deterministic.
+        if valid_until.tzinfo is None:
+            valid_until = valid_until.replace(tzinfo=UTC)
+        return current >= valid_until
+
+    def __repr__(self) -> str:
+        ctx = "global" if self.context_id is None else str(self.context_id)[:8]
+        return (
+            f"<EmbeddingCalibration(model={self.model_name!r}, "
+            f"dims={self.dimensions}, context={ctx}, p90={self.p90:.4f})>"
+        )

--- a/backend/src/neural/calibration.py
+++ b/backend/src/neural/calibration.py
@@ -41,6 +41,14 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+# Strong references to the lazy-TTL enqueue coroutines so Python does not GC
+# them mid-flight. ``asyncio.create_task`` returns a Task that the event
+# loop holds only a weak reference to — without an explicit strong ref the
+# enqueue coroutine can vanish before it reaches Redis. Mirrors the pattern
+# in ``tasks.neural_calibration._IN_FLIGHT_TASKS``. (Copilot review PR #420
+# loop 5, mirror of loop 1's fix for the task-side set.)
+_LAZY_TTL_TASKS: set[asyncio.Task] = set()
+
 
 async def resolve_knn_threshold(
     db: AsyncSession,
@@ -94,9 +102,11 @@ async def resolve_knn_threshold(
             # its own error handling and strong-ref retention; here we
             # only need to spawn it. (Copilot review PR #420 loop 3.)
             try:
-                asyncio.create_task(
+                task = asyncio.create_task(
                     _enqueue_lazy_recalibration(model_name, dimensions, context_id=None)
                 )
+                _LAZY_TTL_TASKS.add(task)
+                task.add_done_callback(_LAZY_TTL_TASKS.discard)
             except RuntimeError:
                 # ``asyncio.create_task`` raises if no event loop is running
                 # (e.g. the caller is driving via ``asyncio.run`` in a test

--- a/backend/src/neural/calibration.py
+++ b/backend/src/neural/calibration.py
@@ -123,11 +123,8 @@ async def _enqueue_lazy_recalibration(
     try:
         # Imported lazily (a) to avoid a circular dependency between
         # ``neural`` and ``tasks`` packages and (b) so ``resolve_knn_threshold``
-        # remains unit-testable without the full tasks/Redis machinery. The
-        # type: ignore guards against pyright warning while chunk B's
-        # ``tasks/neural_calibration.py`` is not yet on disk — remove once
-        # that file lands.
-        from tasks.neural_calibration import enqueue_recalibration_dedup  # type: ignore[import-not-found] # noqa: PLC0415
+        # remains unit-testable without the full tasks/Redis machinery.
+        from tasks.neural_calibration import enqueue_recalibration_dedup  # noqa: PLC0415
     except ImportError:
         logger.debug(
             "knn_seed_lazy_ttl_enqueue_unavailable",

--- a/backend/src/neural/calibration.py
+++ b/backend/src/neural/calibration.py
@@ -25,6 +25,7 @@ every remember() call while we wait for Qdrant to re-measure 10k points.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -87,8 +88,25 @@ async def resolve_knn_threshold(
     if calibration is not None:
         if calibration.is_expired():
             # Lazy TTL trigger — see tasks/neural_calibration.py for dedup.
-            # Serve the stale value while the refresh runs in the background.
-            await _enqueue_lazy_recalibration(model_name, dimensions, context_id=None)
+            # Fire-and-forget so ``remember()`` does NOT wait on the Redis
+            # round-trip (or its timeout) while we serve the stale value.
+            # The background task path ``tasks.neural_calibration`` owns
+            # its own error handling and strong-ref retention; here we
+            # only need to spawn it. (Copilot review PR #420 loop 3.)
+            try:
+                asyncio.create_task(
+                    _enqueue_lazy_recalibration(model_name, dimensions, context_id=None)
+                )
+            except RuntimeError:
+                # ``asyncio.create_task`` raises if no event loop is running
+                # (e.g. the caller is driving via ``asyncio.run`` in a test
+                # teardown). In that narrow case the expired value is still
+                # served; the next scheduled recalibration will catch up.
+                logger.debug(
+                    "knn_seed_lazy_ttl_enqueue_no_loop",
+                    model=model_name,
+                    dimensions=dimensions,
+                )
         percentile_value = calibration.percentile(config.knn_seed_min_percentile)
         return max(percentile_value, config.knn_seed_min_similarity_floor)
 

--- a/backend/src/neural/calibration.py
+++ b/backend/src/neural/calibration.py
@@ -1,0 +1,138 @@
+"""Runtime resolution of the kNN-seed similarity threshold (#406 Phase B).
+
+Implements the D4 fallback chain from issue #240:
+
+    Step 1  Operator-set ``knn_seed_min_similarity`` non-null → raw override,
+            skip calibration entirely (D6 preserves operator intent).
+    Step 2  Model-global calibration row (``context_id IS NULL``) for the
+            current ``(model, dimensions)`` → ``max(percentile(p), floor)``
+            where p = ``knn_seed_min_percentile`` (default 90.0) and floor =
+            ``knn_seed_min_similarity_floor`` (default 0.3).
+    Step 3  No calibration row → return ``None`` so the caller disables kNN
+            seeding for this call. The calibration job will bootstrap later
+            (triggered by remember() when the context crosses the D3 gate).
+
+Per-context calibration (D5 v2 / C1) is **schema-allowed but runtime-dead**
+in v1: the lookup below hard-codes ``context_id=None``. The v2 follow-up
+flips Step 2 to try per-context first, then fall through to model-global.
+
+Lazy TTL trigger (C2, third trigger): if Step 2's row is past ``valid_until``,
+enqueue a background recalibration task (deduped by ``(model, dims,
+context_id)``) and serve the stale value anyway — fail-open on stale
+calibration, because a fresh threshold matters less than not stalling
+every remember() call while we wait for Qdrant to re-measure 10k points.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import select
+
+from models.neural import EmbeddingCalibration
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from neural.config import NeuralMemoryConfig
+
+logger = get_logger(__name__)
+
+
+async def resolve_knn_threshold(
+    db: AsyncSession,
+    config: NeuralMemoryConfig,
+    model_name: str,
+    dimensions: int,
+    context_id: UUID | None = None,  # noqa: ARG001 — TODO(v2): per-context lookup
+) -> float | None:
+    """Resolve the runtime kNN similarity threshold for ``(model, dimensions)``.
+
+    Returns the similarity cosine at or above which a Qdrant neighbor
+    should be accepted as a ``semantic_similarity`` seed edge. Returns
+    ``None`` iff step 3 of the D4 fallback chain fires — kNN seeding
+    should be disabled for this call (the calibration path has not been
+    bootstrapped yet).
+
+    Args:
+        db: AsyncSession for the calibration table lookup.
+        config: Resolved ``NeuralMemoryConfig`` (already loaded from DB).
+        model_name: Embedding model name (e.g. ``text-embedding-3-small``).
+        dimensions: Vector dimensionality (e.g. 512, 4096).
+        context_id: Reserved for D5 v2 per-context calibration. Currently
+            ignored (see module docstring).
+
+    Returns:
+        Similarity threshold in ``[0.0, 1.0]``, or ``None`` to disable.
+    """
+    # Step 1: operator override (D6). None means "use calibration".
+    if config.knn_seed_min_similarity is not None:
+        return config.knn_seed_min_similarity
+
+    # Step 2: model-global calibration (context_id IS NULL).
+    # TODO(v2): try context_id first, fall through to NULL on miss.
+    stmt = (
+        select(EmbeddingCalibration)
+        .where(
+            EmbeddingCalibration.model_name == model_name,
+            EmbeddingCalibration.dimensions == dimensions,
+            EmbeddingCalibration.context_id.is_(None),
+        )
+        .limit(1)
+    )
+    calibration = (await db.execute(stmt)).scalar_one_or_none()
+
+    if calibration is not None:
+        if calibration.is_expired():
+            # Lazy TTL trigger — see tasks/neural_calibration.py for dedup.
+            # Serve the stale value while the refresh runs in the background.
+            await _enqueue_lazy_recalibration(model_name, dimensions, context_id=None)
+        percentile_value = calibration.percentile(config.knn_seed_min_percentile)
+        return max(percentile_value, config.knn_seed_min_similarity_floor)
+
+    # Step 3: no calibration yet → disable seeding. Bootstrap trigger in the
+    # remember() path will populate the row once the context crosses D3.
+    logger.warning(
+        "knn_seed_disabled_no_calibration",
+        model=model_name,
+        dimensions=dimensions,
+        hint=(
+            "Calibration row missing for this (model, dimensions). "
+            "Bootstrap fires when the context has >=200 memories or "
+            ">=10k top-k observations. Admin-manual recalibrate is "
+            "available via /api/admin/neural/recalibrate."
+        ),
+    )
+    return None
+
+
+async def _enqueue_lazy_recalibration(
+    model_name: str,
+    dimensions: int,
+    context_id: UUID | None,
+) -> None:
+    """Lazy-TTL recalibration enqueue with dedup.
+
+    Deliberately imported lazily so ``neural/calibration.py`` can be used in
+    unit tests that don't need the task/Redis machinery. When the trigger
+    module isn't available (tests, thin environments), log and continue —
+    the next scheduled recalibration will catch up.
+    """
+    try:
+        # Imported lazily (a) to avoid a circular dependency between
+        # ``neural`` and ``tasks`` packages and (b) so ``resolve_knn_threshold``
+        # remains unit-testable without the full tasks/Redis machinery. The
+        # type: ignore guards against pyright warning while chunk B's
+        # ``tasks/neural_calibration.py`` is not yet on disk — remove once
+        # that file lands.
+        from tasks.neural_calibration import enqueue_recalibration_dedup  # type: ignore[import-not-found] # noqa: PLC0415
+    except ImportError:
+        logger.debug(
+            "knn_seed_lazy_ttl_enqueue_unavailable",
+            model=model_name,
+            dimensions=dimensions,
+        )
+        return
+    await enqueue_recalibration_dedup(model_name, dimensions, context_id)

--- a/backend/src/neural/calibration.py
+++ b/backend/src/neural/calibration.py
@@ -121,9 +121,13 @@ async def _enqueue_lazy_recalibration(
     the next scheduled recalibration will catch up.
     """
     try:
-        # Imported lazily (a) to avoid a circular dependency between
-        # ``neural`` and ``tasks`` packages and (b) so ``resolve_knn_threshold``
-        # remains unit-testable without the full tasks/Redis machinery.
+        # Deferred import so ``resolve_knn_threshold`` remains unit-testable
+        # without the full tasks / Redis machinery pulled in transitively
+        # (e.g. ``tests/neural/test_calibration.py`` can exercise this
+        # module against a stubbed AsyncSession). The dependency graph is
+        # acyclic — ``tasks.neural_calibration`` imports from
+        # ``neural.config`` but not from this module — so the lazy import
+        # is about test ergonomics, not breaking a cycle.
         from tasks.neural_calibration import enqueue_recalibration_dedup  # noqa: PLC0415
     except ImportError:
         logger.debug(

--- a/backend/src/neural/calibration.py
+++ b/backend/src/neural/calibration.py
@@ -94,16 +94,17 @@ async def resolve_knn_threshold(
 
     # Step 3: no calibration yet → disable seeding. Bootstrap trigger in the
     # remember() path will populate the row once the context crosses D3.
-    logger.warning(
+    # Logged at debug level so new contexts (or freshly migrated deployments)
+    # don't emit a WARNING on every ``remember()`` call until the bootstrap
+    # gate is reached — that would create alert fatigue at no operational
+    # benefit (bootstrap emits its own one-shot log when it enqueues).
+    # Operators can still observe the disabled state via the bootstrap
+    # trigger logs and the absence of an ``embedding_calibrations`` row.
+    # (Copilot review PR #420 loop 2.)
+    logger.debug(
         "knn_seed_disabled_no_calibration",
         model=model_name,
         dimensions=dimensions,
-        hint=(
-            "Calibration row missing for this (model, dimensions). "
-            "Bootstrap fires when the context has >=200 memories or "
-            ">=10k top-k observations. Admin-manual recalibrate is "
-            "available via /api/admin/neural/recalibrate."
-        ),
     )
     return None
 

--- a/backend/src/neural/calibration.py
+++ b/backend/src/neural/calibration.py
@@ -125,10 +125,10 @@ async def resolve_knn_threshold(
     # Logged at debug level so new contexts (or freshly migrated deployments)
     # don't emit a WARNING on every ``remember()`` call until the bootstrap
     # gate is reached — that would create alert fatigue at no operational
-    # benefit (bootstrap emits its own one-shot log when it enqueues).
-    # Operators can still observe the disabled state via the bootstrap
-    # trigger logs and the absence of an ``embedding_calibrations`` row.
-    # (Copilot review PR #420 loop 2.)
+    # benefit. Operators can observe the disabled state via this debug
+    # event and the absence of an ``embedding_calibrations`` row for the
+    # (model, dimensions) pair.
+    # (Copilot review PR #420 loop 2 & 6.)
     logger.debug(
         "knn_seed_disabled_no_calibration",
         model=model_name,

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -397,17 +397,23 @@ class NeuralMemoryConfig:
         def get_float(key: str, default: float) -> float:
             return float(os.getenv(key, str(default)))
 
-        def get_float_or_none(key: str) -> float | None:
+        def get_float_or_none(key: str, default: float | None = None) -> float | None:
             """Parse a float-or-None env var.
 
-            Unset env var → ``None`` (use default which may itself be None).
-            Empty / "none" / "null" / "auto" (case-insensitive) → ``None``
-            explicitly. Any other string parses as float. Used for config
-            fields where ``None`` means "delegate to calibration path".
+            - Unset env var → ``default`` (``None`` unless caller overrides).
+            - Empty / ``"none"`` / ``"null"`` / ``"auto"`` (case-insensitive)
+              → ``None`` explicitly.
+            - Any other string → parsed as float.
+
+            Used for config fields where ``None`` means "delegate to calibration
+            path" (Issue #406). The ``default`` parameter lets callers pick
+            their own "unset" sentinel — the knn_seed_min_similarity call site
+            passes ``None`` so that unset means "use calibration", but future
+            optional-float fields can override. (Copilot review PR #420 loop 8.)
             """
             raw = os.getenv(key)
             if raw is None:
-                return None
+                return default
             stripped = raw.strip().lower()
             if stripped in ("", "none", "null", "auto"):
                 return None

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -154,20 +154,33 @@ class NeuralMemoryConfig:
     async_update_delay_ms: int = 2000  # 2 seconds
     max_candidates_k: int = 64
 
-    # k-NN Cold-Start Seeding (Issue #221)
+    # k-NN Cold-Start Seeding (Issue #221, #406 Phase B)
     # On remember(), search for k nearest neighbors and create weak
     # `semantic_similarity` edges so new memories are not born as isolated nodes.
     knn_seed_enabled: bool = True
     knn_seed_k: int = 5  # Neighbors per new memory (1-20)
-    # Cosine threshold. Validated for OpenAI text-embedding-3-small via dogfood
-    # on 2026-04-07 (memory.kagura-ai.com): strongly related memories typically
-    # cluster around 0.40-0.50 cosine, so 0.4 is the right floor for that model.
-    # Other embedding models (Ollama qwen3, etc.) have different distributions
-    # and may need a different threshold — see #236 for per-model defaults.
-    # Sleep Edge Discovery uses 0.6 because it has LLM judgment downstream as a
-    # quality filter; kNN seeding has no such filter, so use a lower threshold
-    # and let Sleep Maintenance prune low-quality edges later.
-    knn_seed_min_similarity: float = 0.4
+    # Cosine threshold override. None (default) → use `embedding_calibrations`
+    # percentile path; non-None → raw operator override (D6). Prior to #406,
+    # this was hardcoded 0.4, which is over-permissive for text-embedding-3-
+    # small (production p90 = 0.6322 per Phase A acceptance) and wrong-
+    # dimension for other models (qwen3-8b top-k p90 = 0.5816 per #407 Task 1).
+    # See #240 D1 for why the calibration path uses top-k neighbor distribution
+    # rather than random-pair baseline.
+    knn_seed_min_similarity: float | None = None
+    # Percentile of the top-k neighbor distribution that serves as the default
+    # runtime threshold when `knn_seed_min_similarity` is None (#240 D2, D4).
+    # 90.0 = top decile = reject bottom 90% as "not a high-quality seeding
+    # candidate". Validated across text-embedding-3-small (512d) and qwen3-
+    # embedding:8b (4096d) in Phase A and #407 Task 1 respectively.
+    knn_seed_min_percentile: float = 90.0
+    # Hard lower bound for the calibration-derived threshold (#240 D2). Protects
+    # sparse/anomalous corpora where p90 < 0.3 would mean "accept everything".
+    # Applied as `max(percentile(p90), floor)` in `resolve_knn_threshold`.
+    knn_seed_min_similarity_floor: float = 0.3
+    # TTL for embedding_calibrations rows (#240 D7, gate1 review). Kept in code
+    # config rather than hardcoded in migration so #407 Task 2's drift signal
+    # can tune it via env var without a schema change.
+    calibration_ttl_days: int = 30
     knn_seed_weight: float = (
         0.3  # Intentionally low — synthetic signal, Sleep Maintenance prunes if unused
     )
@@ -281,12 +294,28 @@ class NeuralMemoryConfig:
         if not self.max_candidates_k > 0:
             raise ValueError(f"max_candidates_k must be positive, got {self.max_candidates_k}")
 
-        # k-NN Cold-Start Seeding validation (Issue #221)
+        # k-NN Cold-Start Seeding validation (Issue #221, #406)
         if not (1 <= self.knn_seed_k <= 20):
             raise ValueError(f"knn_seed_k must be in [1, 20], got {self.knn_seed_k}")
-        if not (0.0 <= self.knn_seed_min_similarity <= 1.0):
+        if self.knn_seed_min_similarity is not None and not (
+            0.0 <= self.knn_seed_min_similarity <= 1.0
+        ):
             raise ValueError(
-                f"knn_seed_min_similarity must be in [0, 1], got {self.knn_seed_min_similarity}"
+                f"knn_seed_min_similarity must be in [0, 1] or None, "
+                f"got {self.knn_seed_min_similarity}"
+            )
+        if not (0.0 < self.knn_seed_min_percentile < 100.0):
+            raise ValueError(
+                f"knn_seed_min_percentile must be in (0, 100), got {self.knn_seed_min_percentile}"
+            )
+        if not (0.0 <= self.knn_seed_min_similarity_floor <= 1.0):
+            raise ValueError(
+                f"knn_seed_min_similarity_floor must be in [0, 1], "
+                f"got {self.knn_seed_min_similarity_floor}"
+            )
+        if not self.calibration_ttl_days > 0:
+            raise ValueError(
+                f"calibration_ttl_days must be positive, got {self.calibration_ttl_days}"
             )
         if not (0.0 <= self.knn_seed_weight <= 1.0):
             raise ValueError(f"knn_seed_weight must be in [0, 1], got {self.knn_seed_weight}")
@@ -368,6 +397,22 @@ class NeuralMemoryConfig:
         def get_float(key: str, default: float) -> float:
             return float(os.getenv(key, str(default)))
 
+        def get_float_or_none(key: str) -> float | None:
+            """Parse a float-or-None env var.
+
+            Unset env var → ``None`` (use default which may itself be None).
+            Empty / "none" / "null" / "auto" (case-insensitive) → ``None``
+            explicitly. Any other string parses as float. Used for config
+            fields where ``None`` means "delegate to calibration path".
+            """
+            raw = os.getenv(key)
+            if raw is None:
+                return None
+            stripped = raw.strip().lower()
+            if stripped in ("", "none", "null", "auto"):
+                return None
+            return float(raw)
+
         def get_int(key: str, default: int) -> int:
             return int(os.getenv(key, str(default)))
 
@@ -417,10 +462,13 @@ class NeuralMemoryConfig:
             batch_update_size=get_int("BATCH_UPDATE_SIZE", 100),
             async_update_delay_ms=get_int("ASYNC_UPDATE_DELAY_MS", 2000),
             max_candidates_k=get_int("MAX_CANDIDATES_K", 64),
-            # k-NN Cold-Start Seeding (Issue #221)
+            # k-NN Cold-Start Seeding (Issue #221, #406)
             knn_seed_enabled=get_bool("KNN_SEED_ENABLED", True),
             knn_seed_k=get_int("KNN_SEED_K", 5),
-            knn_seed_min_similarity=get_float("KNN_SEED_MIN_SIMILARITY", 0.4),
+            knn_seed_min_similarity=get_float_or_none("KNN_SEED_MIN_SIMILARITY"),
+            knn_seed_min_percentile=get_float("KNN_SEED_MIN_PERCENTILE", 90.0),
+            knn_seed_min_similarity_floor=get_float("KNN_SEED_MIN_SIMILARITY_FLOOR", 0.3),
+            calibration_ttl_days=get_int("CALIBRATION_TTL_DAYS", 30),
             knn_seed_weight=get_float("KNN_SEED_WEIGHT", 0.3),
             # Tag Co-Occurrence Cold-Start Seeding (Issue #223)
             tag_cooccurrence_enabled=get_bool("TAG_COOCCURRENCE_ENABLED", True),
@@ -536,11 +584,24 @@ class NeuralMemoryConfig:
                 "async_update_delay_ms", base_config.async_update_delay_ms
             ),
             max_candidates_k=configs.get("max_candidates_k", base_config.max_candidates_k),
-            # k-NN Cold-Start Seeding (Issue #221) — DB-overridable
+            # k-NN Cold-Start Seeding (Issue #221, #406) — DB-overridable
             knn_seed_enabled=configs.get("knn_seed_enabled", base_config.knn_seed_enabled),
             knn_seed_k=configs.get("knn_seed_k", base_config.knn_seed_k),
+            # A DB row for knn_seed_min_similarity is an operator override that
+            # wins over calibration (D6). Post-#406 migration deletes rows with
+            # value=0.4, so only genuinely-tuned values survive here; absent
+            # row → base_config default (None) → calibration path.
             knn_seed_min_similarity=configs.get(
                 "knn_seed_min_similarity", base_config.knn_seed_min_similarity
+            ),
+            knn_seed_min_percentile=configs.get(
+                "knn_seed_min_percentile", base_config.knn_seed_min_percentile
+            ),
+            knn_seed_min_similarity_floor=configs.get(
+                "knn_seed_min_similarity_floor", base_config.knn_seed_min_similarity_floor
+            ),
+            calibration_ttl_days=configs.get(
+                "calibration_ttl_days", base_config.calibration_ttl_days
             ),
             knn_seed_weight=configs.get("knn_seed_weight", base_config.knn_seed_weight),
             # Tag Co-Occurrence Cold-Start Seeding (Issue #223) — DB-overridable

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1687,6 +1687,29 @@ async def _create_knn_seed_edges(
                 model=model_name,
                 dimensions=len(vector),
             )
+            # Bootstrap trigger (#406 C2 trigger 1): if this (model, dims)
+            # has crossed D3, enqueue a deduped calibration job so
+            # subsequent remember() calls find a populated row and exit
+            # step 3. Dedup (Redis SET NX, 1h TTL) ensures at most one
+            # enqueue per hour regardless of concurrent ingestion.
+            try:
+                from tasks.neural_calibration import maybe_trigger_bootstrap
+
+                await maybe_trigger_bootstrap(
+                    db=db,
+                    model_name=model_name,
+                    dimensions=len(vector),
+                )
+            except Exception as exc:
+                # Bootstrap is best-effort. A failure here must not block
+                # memory creation — log and move on; the next remember()
+                # will retry the trigger.
+                logger.warning(
+                    "knn_seed_bootstrap_trigger_failed",
+                    memory_id=str(memory.id),
+                    model=model_name,
+                    error=str(exc),
+                )
             return
 
         workspace_id_str = str(memory.workspace_id)

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1627,6 +1627,7 @@ async def _create_knn_seed_edges(
     memory: Memory,
     vector: list[float],
     collection_name: str,
+    model_name: str,
 ) -> None:
     """Create k-NN cold-start seed edges for a newly embedded memory.
 
@@ -1635,6 +1636,14 @@ async def _create_knn_seed_edges(
     `semantic_similarity` edges. This prevents new memories from being born as
     isolated nodes (graph cold-start UX failure).
 
+    Issue #406 (Phase B): the similarity threshold is resolved via
+    ``neural.calibration.resolve_knn_threshold`` which implements the D4
+    fallback chain (operator override → model-global calibration percentile →
+    disabled). When ``resolve_knn_threshold`` returns ``None`` (no
+    calibration row yet), seeding is skipped for this call — the bootstrap
+    trigger in the remember() path will populate the row once the context
+    crosses D3, and subsequent calls will use the calibrated threshold.
+
     Best-effort: any failure is logged and swallowed — must not affect memory
     creation. Edge creation uses an isolated commit so partial failures do not
     roll back unrelated work.
@@ -1642,10 +1651,14 @@ async def _create_knn_seed_edges(
     Args:
         db: AsyncSession (already bound to memory's transaction context)
         memory: The freshly created Memory entity
-        vector: The dense embedding vector that was upserted to Qdrant
+        vector: The dense embedding vector that was upserted to Qdrant.
+            Its length is the embedding dimensionality passed to calibration.
         collection_name: Qdrant collection name (varies by embedding model)
+        model_name: Embedding model name (e.g. ``text-embedding-3-small``).
+            Combined with ``len(vector)`` to key the calibration lookup.
     """
     from db.qdrant import search_memories_qdrant
+    from neural.calibration import resolve_knn_threshold
     from neural.config import NeuralMemoryConfig
     from repositories.neural_edge import NeuralEdgeRepository
 
@@ -1657,6 +1670,23 @@ async def _create_knn_seed_edges(
 
         if not memory.workspace_id or not memory.context_id:
             # Defensive: 3-level isolation requires both
+            return
+
+        # Resolve the threshold via the D4 fallback chain (#406). None means
+        # "disable seeding for this call" — bootstrap will catch up later.
+        threshold = await resolve_knn_threshold(
+            db=db,
+            config=config,
+            model_name=model_name,
+            dimensions=len(vector),
+        )
+        if threshold is None:
+            logger.debug(
+                "knn_seed_skip_no_threshold",
+                memory_id=str(memory.id),
+                model=model_name,
+                dimensions=len(vector),
+            )
             return
 
         workspace_id_str = str(memory.workspace_id)
@@ -1696,11 +1726,9 @@ async def _create_knn_seed_edges(
             collection_name=collection_name,
         )
 
-        # Filter: exclude self, apply similarity threshold, cap at k
+        # Filter: exclude self, apply resolved (calibrated) similarity threshold, cap at k
         seed_neighbors = [
-            c
-            for c in candidates
-            if str(c["id"]) != memory_id_str and c["score"] >= config.knn_seed_min_similarity
+            c for c in candidates if str(c["id"]) != memory_id_str and c["score"] >= threshold
         ][: config.knn_seed_k]
 
         if not seed_neighbors:
@@ -1708,7 +1736,7 @@ async def _create_knn_seed_edges(
                 "knn_seed_no_neighbors",
                 memory_id=memory_id_str,
                 candidates=len(candidates),
-                threshold=config.knn_seed_min_similarity,
+                threshold=threshold,
             )
             return
 
@@ -2199,6 +2227,7 @@ async def process_pending_embedding(memory_id: UUID) -> None:
                 memory=memory,
                 vector=vector,
                 collection_name=collection,
+                model_name=embed_svc.model,
             )
 
             # ================================================================

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -1,0 +1,401 @@
+"""Background calibration task for kNN-seed percentile threshold (#406 Phase B).
+
+Runs on three triggers (issue #240 C2 / #406 step 5):
+
+- **Bootstrap**: the first time a context with ``(model, dimensions)``
+  crosses the D3 gate (≥ 200 effective memories OR ≥ 10k observations),
+  ``_create_knn_seed_edges`` enqueues a one-shot calibration here.
+- **Admin manual**: ``POST /api/admin/neural/recalibrate`` enqueues from
+  the HTTP handler.
+- **Lazy TTL**: ``resolve_knn_threshold`` enqueues when it serves a
+  ``valid_until``-expired row.
+
+All three paths funnel through :func:`enqueue_recalibration_dedup` so
+concurrent requests produce at most one running task per ``(model_name,
+dimensions, context_id)`` combination. The dedup key is a Redis
+``SETNX`` with a 1-hour TTL — the compute itself typically completes in
+seconds (200 memories × 50 top-k = 10k Qdrant queries), and the 1-hour
+window just absorbs retry storms while a task is in-flight.
+
+The actual compute reuses the helpers from
+``scripts/measure_embedding_threshold.py``. For model-global
+calibration (``context_id=None``) the job picks the **largest context**
+that uses this ``(model, dimensions)`` pair and samples from it, on the
+assumption (D1) that the similarity distribution is broadly context-
+independent for a given embedding model. A per-context calibration
+(``context_id != None``) would sample from exactly that context — the
+schema supports it, the runtime lookup in :mod:`neural.calibration`
+does not (D5 v2 follow-up).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from uuid import UUID
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_db
+from db.qdrant import get_qdrant_client
+from db.redis import get_redis_client
+from models.config import ContextSearchConfig
+from models.memory import Memory
+from models.neural import EmbeddingCalibration
+from neural.config import NeuralMemoryConfig
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Dedup lock TTL. A calibration compute is short (seconds), but the lock
+# lives long enough to absorb retry storms while the compute is in-flight.
+_DEDUP_LOCK_TTL_SEC = 3600
+
+# D3 gate thresholds — also defined in the Phase A script but duplicated
+# here so the task module doesn't import from the ``scripts/`` tree at
+# runtime (only ``scripts/measure_embedding_threshold.py`` imports are
+# deferred and treated as pure helpers).
+BOOTSTRAP_MIN_MEMORIES = 200
+BOOTSTRAP_MIN_OBSERVATIONS = 10_000
+
+# Sampling parameters for the in-process calibration run. Match Phase A's
+# acceptance defaults (``--memories 200 --top-k 50``) so the production
+# values we ship with are statistically consistent with what the CLI
+# script produced.
+SAMPLE_MEMORIES = 200
+SAMPLE_TOP_K = 50
+
+
+def _dedup_key(model_name: str, dimensions: int, context_id: UUID | None) -> str:
+    """Redis dedup key for a calibration job.
+
+    Unique per ``(model_name, dimensions, context_id)`` — a per-context
+    job does not preempt a pending model-global job and vice versa.
+    """
+    ctx_part = str(context_id) if context_id is not None else "global"
+    return f"neural:calibrate:{model_name}:{dimensions}:{ctx_part}"
+
+
+async def enqueue_recalibration_dedup(
+    model_name: str,
+    dimensions: int,
+    context_id: UUID | None,
+) -> bool:
+    """Enqueue a calibration task with Redis-backed dedup.
+
+    Returns ``True`` when this call acquired the lock and spawned the
+    task; ``False`` when another caller is already running (or about to
+    run) a job for the same key — the duplicate is silently dropped.
+    Always returns quickly; the compute runs in an ``asyncio.create_task``.
+
+    Args:
+        model_name: Embedding model name (e.g. ``text-embedding-3-small``).
+        dimensions: Vector dimensionality.
+        context_id: Reserved for D5 v2 per-context calibration. Currently
+            the call sites always pass ``None`` (model-global).
+    """
+    key = _dedup_key(model_name, dimensions, context_id)
+    try:
+        client = get_redis_client()
+        acquired = await client.set(key, "1", nx=True, ex=_DEDUP_LOCK_TTL_SEC)
+    except Exception as exc:
+        # Redis unavailable → fail-open (run anyway). A duplicate compute
+        # is wasteful but not incorrect, whereas skipping compute on a
+        # Redis hiccup would stall the calibration path indefinitely.
+        logger.warning(
+            "calibration_dedup_redis_error",
+            key=key,
+            error=str(exc),
+        )
+        acquired = True
+
+    if not acquired:
+        logger.debug("calibration_dedup_skipped", key=key)
+        return False
+
+    asyncio.create_task(_run_calibration(model_name, dimensions, context_id, dedup_key=key))
+    return True
+
+
+async def _run_calibration(
+    model_name: str,
+    dimensions: int,
+    context_id: UUID | None,
+    dedup_key: str,
+) -> None:
+    """Execute the calibration compute + upsert, then release the dedup lock.
+
+    Wraps :func:`compute_calibration` so the lock is always released even
+    on exception paths. Any logging/observability happens inside
+    ``compute_calibration``; this wrapper only handles the try/finally.
+    """
+    try:
+        async for db in get_db():
+            await compute_calibration(db, model_name, dimensions, context_id)
+            break
+    except Exception as exc:
+        logger.error(
+            "calibration_task_failed",
+            model=model_name,
+            dimensions=dimensions,
+            context_id=str(context_id) if context_id else None,
+            error=str(exc),
+            exc_info=True,
+        )
+    finally:
+        try:
+            client = get_redis_client()
+            await client.delete(dedup_key)
+        except Exception as exc:
+            # Leaving the lock to TTL out is acceptable — next recalibration
+            # fires in at most _DEDUP_LOCK_TTL_SEC.
+            logger.warning(
+                "calibration_dedup_release_failed",
+                key=dedup_key,
+                error=str(exc),
+            )
+
+
+async def compute_calibration(
+    db: AsyncSession,
+    model_name: str,
+    dimensions: int,
+    context_id: UUID | None,
+) -> EmbeddingCalibration | None:
+    """Measure percentiles + upsert the calibration row.
+
+    Returns the upserted ``EmbeddingCalibration`` instance on success, or
+    ``None`` if the D3 gate fails (insufficient sample) — the fallback
+    chain keeps step 3 (disabled) in that case until the context grows.
+
+    The model-global case picks the largest context using this ``(model,
+    dimensions)`` pair as the sampling source. This is a v1 simplification
+    of the "sample from all contexts" ideal — D1 says the distribution is
+    broadly context-independent, so sampling from one large context is an
+    acceptable proxy.
+    """
+    # Defer the script import so test environments don't need numpy etc.
+    # if they never exercise this path. The script lives under ``scripts/``
+    # which is not on the default ``sys.path``; add it temporarily.
+    backend_root = Path(__file__).resolve().parent.parent.parent
+    scripts_path = str(backend_root / "scripts")
+    if scripts_path not in sys.path:
+        sys.path.insert(0, scripts_path)
+    from measure_embedding_threshold import (  # type: ignore[import-not-found] # noqa: PLC0415
+        compute_percentiles,
+        fetch_vectors,
+        measure_top_k,
+        sample_memories,
+    )
+
+    sample_context_id = context_id
+    if sample_context_id is None:
+        sample_context_id = await _pick_largest_context_for_model(db, model_name, dimensions)
+    if sample_context_id is None:
+        logger.warning(
+            "calibration_no_context_for_model",
+            model=model_name,
+            dimensions=dimensions,
+            hint="No context has any memories with this (model, dimensions) yet.",
+        )
+        return None
+
+    # Resolve the correct collection for Qdrant lookups.
+    from db.qdrant import get_collection_name  # noqa: PLC0415
+
+    collection = get_collection_name(model_name, dimensions)
+
+    sampled = await sample_memories(db, sample_context_id, SAMPLE_MEMORIES)
+    if not sampled:
+        logger.warning(
+            "calibration_no_memories_sampled",
+            model=model_name,
+            dimensions=dimensions,
+            context_id=str(sample_context_id),
+        )
+        return None
+
+    qdrant = get_qdrant_client()
+    vectors = await fetch_vectors(qdrant, collection, [m.id for m in sampled])
+    scores, effective = await measure_top_k(sampled, vectors, collection, SAMPLE_TOP_K)
+
+    observations = len(scores)
+    if effective < BOOTSTRAP_MIN_MEMORIES and observations < BOOTSTRAP_MIN_OBSERVATIONS:
+        # D3 gate fails — distribution estimate too noisy. Don't write a
+        # row, leave the runtime fallback chain at step 3 (disabled).
+        logger.warning(
+            "calibration_d3_gate_failed",
+            model=model_name,
+            dimensions=dimensions,
+            effective_memories=effective,
+            observations=observations,
+            min_memories=BOOTSTRAP_MIN_MEMORIES,
+            min_observations=BOOTSTRAP_MIN_OBSERVATIONS,
+        )
+        return None
+
+    percentiles = compute_percentiles(scores)
+    if not percentiles:
+        logger.warning(
+            "calibration_no_scores",
+            model=model_name,
+            dimensions=dimensions,
+            context_id=str(sample_context_id),
+        )
+        return None
+
+    config = await NeuralMemoryConfig.from_db(db)
+    now = datetime.now(UTC)
+    valid_until = now + timedelta(days=config.calibration_ttl_days)
+
+    # Upsert: delete any existing row for this key, then insert fresh. Two
+    # partial unique indexes (one for NULL context_id, one for non-NULL)
+    # enforce at-most-one row per key from the DB side; the explicit
+    # delete-then-insert is simpler than an ON CONFLICT dance because the
+    # partial indexes don't participate in INSERT ... ON CONFLICT.
+    del_stmt = delete(EmbeddingCalibration).where(
+        EmbeddingCalibration.model_name == model_name,
+        EmbeddingCalibration.dimensions == dimensions,
+    )
+    if context_id is None:
+        del_stmt = del_stmt.where(EmbeddingCalibration.context_id.is_(None))
+    else:
+        del_stmt = del_stmt.where(EmbeddingCalibration.context_id == context_id)
+    await db.execute(del_stmt)
+
+    row = EmbeddingCalibration(
+        model_name=model_name,
+        dimensions=dimensions,
+        context_id=context_id,
+        p25=percentiles["p25"],
+        p50=percentiles["p50"],
+        p75=percentiles["p75"],
+        p90=percentiles["p90"],
+        p95=percentiles["p95"],
+        p99=percentiles["p99"],
+        sample_size=observations,
+        sampled_at=now,
+        valid_until=valid_until,
+    )
+    db.add(row)
+    await db.commit()
+
+    logger.info(
+        "calibration_upserted",
+        model=model_name,
+        dimensions=dimensions,
+        context_id=str(context_id) if context_id else None,
+        p90=percentiles["p90"],
+        sample_size=observations,
+        valid_until=valid_until.isoformat(),
+    )
+    return row
+
+
+async def _pick_largest_context_for_model(
+    db: AsyncSession,
+    model_name: str,
+    dimensions: int,
+) -> UUID | None:
+    """Find the context with the most memories for a ``(model, dimensions)``.
+
+    Model-global calibration samples from one representative context
+    because D1 claims the distribution is broadly context-independent
+    for a given embedding model. We pick the largest existing context so
+    the sample has the best chance of clearing the D3 gate.
+
+    Returns the chosen ``context_id``, or ``None`` if no context uses
+    this ``(model, dimensions)`` pair yet (no row in
+    ``ContextSearchConfig`` or the default-routed legacy path's context
+    has zero successful memories).
+    """
+    stmt = (
+        select(Memory.context_id, func.count(Memory.id).label("n"))
+        .join(
+            ContextSearchConfig,
+            ContextSearchConfig.context_id == Memory.context_id,
+            isouter=True,
+        )
+        .where(
+            Memory.deleted_at.is_(None),
+            Memory.embedding_status == "success",
+            Memory.context_id.is_not(None),
+            _model_dims_where(model_name, dimensions),
+        )
+        .group_by(Memory.context_id)
+        .order_by(func.count(Memory.id).desc())
+        .limit(1)
+    )
+    row = (await db.execute(stmt)).first()
+    if row is None:
+        return None
+    return row[0]
+
+
+def _model_dims_where(model_name: str, dimensions: int):
+    """Build the WHERE predicate matching a context's ``(model, dimensions)``.
+
+    The legacy default ``text-embedding-3-small / 512`` path has no
+    ``ContextSearchConfig`` row — contexts that predate per-context
+    routing simply fall through to the application default. Match them
+    by treating a NULL config as the legacy default.
+    """
+    from sqlalchemy import and_, or_  # noqa: PLC0415
+
+    is_legacy_default = model_name == "text-embedding-3-small" and dimensions == 512
+    if is_legacy_default:
+        return or_(
+            ContextSearchConfig.context_id.is_(None),
+            and_(
+                ContextSearchConfig.embedding_model == model_name,
+                ContextSearchConfig.embedding_dimensions == dimensions,
+            ),
+        )
+    return and_(
+        ContextSearchConfig.embedding_model == model_name,
+        ContextSearchConfig.embedding_dimensions == dimensions,
+    )
+
+
+async def maybe_trigger_bootstrap(
+    db: AsyncSession,
+    model_name: str,
+    dimensions: int,
+) -> bool:
+    """Enqueue a bootstrap calibration if the D3 gate is newly crossed.
+
+    Called from ``_create_knn_seed_edges`` when
+    ``resolve_knn_threshold`` returns ``None`` (step 3 of D4 — no
+    calibration row yet). Counts memories across contexts that use this
+    ``(model, dimensions)``; if the count is at or above
+    :data:`BOOTSTRAP_MIN_MEMORIES`, kicks off a deduped job.
+
+    This is the only path that runs per remember() call, so the cost of
+    the count is kept small via the dedup lock: at most one bootstrap
+    attempt per ``_DEDUP_LOCK_TTL_SEC`` (1 hour), even under heavy
+    concurrent ingestion.
+
+    Returns ``True`` if a job was enqueued by this call, ``False`` if
+    the gate did not fire or a dedup skip occurred.
+    """
+    count_stmt = (
+        select(func.count(Memory.id))
+        .join(
+            ContextSearchConfig,
+            ContextSearchConfig.context_id == Memory.context_id,
+            isouter=True,
+        )
+        .where(
+            Memory.deleted_at.is_(None),
+            Memory.embedding_status == "success",
+            _model_dims_where(model_name, dimensions),
+        )
+    )
+    count = int((await db.execute(count_stmt)).scalar_one() or 0)
+    if count < BOOTSTRAP_MIN_MEMORIES:
+        return False
+
+    return await enqueue_recalibration_dedup(model_name, dimensions, context_id=None)

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import asyncio
 import importlib.util
 from datetime import UTC, datetime, timedelta
+from functools import cache
 from pathlib import Path
 from types import ModuleType
 from uuid import UUID
@@ -55,25 +56,19 @@ logger = get_logger(__name__)
 # lives long enough to absorb retry storms while the compute is in-flight.
 _DEDUP_LOCK_TTL_SEC = 3600
 
-# Cache the imported script module so the importlib-load path runs once.
-# After first call the real importlib ``exec_module`` runs; subsequent calls
-# return this cached reference without touching the filesystem.
-_MEASURE_SCRIPT_MODULE: ModuleType | None = None
 
-
+@cache
 def _load_measure_script() -> ModuleType:
     """Load ``scripts/measure_embedding_threshold.py`` as a module.
 
     Uses ``importlib.util.spec_from_file_location`` with an explicit path so
     ``sys.path`` stays unmodified — avoids the module-shadowing + import-
     order hazards of ``sys.path.insert`` in a long-running API worker.
-    Cached after first call so subsequent ``compute_calibration`` invocations
-    don't re-execute the module's top-level imports (numpy, sqlalchemy,
+    ``functools.cache`` memoizes the no-argument call so subsequent
+    ``compute_calibration`` invocations reuse the already-loaded module
+    without re-executing its top-level imports (numpy, sqlalchemy,
     qdrant-client etc.).
     """
-    global _MEASURE_SCRIPT_MODULE  # noqa: PLW0603 — intentional lazy-init cache
-    if _MEASURE_SCRIPT_MODULE is not None:
-        return _MEASURE_SCRIPT_MODULE
     backend_root = Path(__file__).resolve().parent.parent.parent
     script_file = backend_root / "scripts" / "measure_embedding_threshold.py"
     spec = importlib.util.spec_from_file_location(
@@ -85,7 +80,6 @@ def _load_measure_script() -> ModuleType:
         )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
-    _MEASURE_SCRIPT_MODULE = module
     return module
 
 
@@ -109,6 +103,17 @@ BOOTSTRAP_MIN_OBSERVATIONS = 10_000
 # script produced.
 SAMPLE_MEMORIES = 200
 SAMPLE_TOP_K = 50
+
+# In-process bootstrap-count throttle. ``maybe_trigger_bootstrap`` fires on
+# every ``remember()`` that hits D4 step 3 (pre-calibration phase), and each
+# call runs a full-table ``COUNT(*)``. The Redis dedup lock prevents
+# duplicate compute jobs but not duplicate counts. Cache the last attempt
+# timestamp per (model, dimensions) and skip the count when seen recently.
+# 5 minutes is long enough to absorb a burst of ingestion at a new
+# context's cold start, short enough that a near-D3 context crosses the
+# threshold within one dedup lock lifetime (1h).
+_BOOTSTRAP_COUNT_THROTTLE_SEC = 300
+_BOOTSTRAP_LAST_ATTEMPT: dict[tuple[str, int], datetime] = {}
 
 
 def _dedup_key(model_name: str, dimensions: int, context_id: UUID | None) -> str:
@@ -424,8 +429,25 @@ async def maybe_trigger_bootstrap(
     concurrent ingestion.
 
     Returns ``True`` if a job was enqueued by this call, ``False`` if
-    the gate did not fire or a dedup skip occurred.
+    the gate did not fire, the in-process throttle suppressed the count,
+    or a Redis dedup skip occurred.
     """
+    # In-process throttle: skip the COUNT entirely when the same
+    # (model, dimensions) was attempted within the throttle window. On a
+    # freshly-migrated deployment every ``remember()`` hits step 3 → this
+    # function is called unconditionally; without the throttle we would
+    # run a full-table COUNT on every call even though the Redis dedup
+    # lock already prevents duplicate compute jobs. 5 min window is short
+    # enough that a near-D3 context still bootstraps within a single
+    # dedup lock lifetime (1h) but collapses bursts into one count.
+    # (Copilot review PR #420 loop 3.)
+    throttle_key = (model_name, dimensions)
+    now = datetime.now(UTC)
+    last = _BOOTSTRAP_LAST_ATTEMPT.get(throttle_key)
+    if last is not None and (now - last).total_seconds() < _BOOTSTRAP_COUNT_THROTTLE_SEC:
+        return False
+    _BOOTSTRAP_LAST_ATTEMPT[throttle_key] = now
+
     count_stmt = (
         select(func.count(Memory.id))
         .join(

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -400,6 +400,14 @@ async def maybe_trigger_bootstrap(
         .where(
             Memory.deleted_at.is_(None),
             Memory.embedding_status == "success",
+            # Exclude NULL-context memories so the count matches the set
+            # ``_pick_largest_context_for_model`` samples from. Without this
+            # filter a large NULL-context backfill (legacy pre-context
+            # migrations or admin-inserted system rows) could prematurely
+            # trip BOOTSTRAP_MIN_MEMORIES without any real context crossing
+            # the D3 gate — the calibration job would then abort at
+            # ``_pick_largest_context_for_model`` with no_context_for_model.
+            Memory.context_id.is_not(None),
             _model_dims_where(model_name, dimensions),
         )
     )

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -500,10 +500,21 @@ async def maybe_trigger_bootstrap(
     ``(model, dimensions)``; if the count is at or above
     :data:`BOOTSTRAP_MIN_MEMORIES`, kicks off a deduped job.
 
-    This is the only path that runs per remember() call, so the cost of
-    the count is kept small via the dedup lock: at most one bootstrap
-    attempt per ``_DEDUP_LOCK_TTL_SEC`` (1 hour), even under heavy
-    concurrent ingestion.
+    This is the only path that runs per remember() call, so two layers
+    limit redundant work under heavy concurrent ingestion:
+
+    - **in-process throttle** (``_BOOTSTRAP_LAST_ATTEMPT`` +
+      ``_BOOTSTRAP_COUNT_THROTTLE_SEC``) suppresses repeated COUNT
+      queries from the same worker to at most one per throttle window
+      (5 minutes by default). This is the layer that keeps DB cost
+      small per worker.
+    - **Redis SETNX dedup** (inside ``enqueue_recalibration_dedup``)
+      suppresses duplicate calibration jobs across workers / restarts
+      for ``_DEDUP_LOCK_TTL_SEC`` (1 hour).
+
+    The dedup lock does NOT prevent repeated COUNT queries on its own
+    — the COUNT runs above the enqueue — which is why both layers are
+    needed. (Copilot review PR #420 loop 6.)
 
     Returns ``True`` if a job was enqueued by this call, ``False`` if
     the gate did not fire, the in-process throttle suppressed the count,

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -320,21 +320,33 @@ async def compute_calibration(
 
     sample_context_id = context_id
     if sample_context_id is None:
-        sample_context_id = await _pick_largest_context_for_model(db, model_name, dimensions)
-    if sample_context_id is None:
-        logger.warning(
-            "calibration_no_context_for_model",
-            model=model_name,
-            dimensions=dimensions,
-            hint="No context has any memories with this (model, dimensions) yet.",
-        )
-        return None
+        picked = await _pick_largest_context_for_model(db, model_name, dimensions)
+        if picked is None:
+            logger.warning(
+                "calibration_no_context_for_model",
+                model=model_name,
+                dimensions=dimensions,
+                hint="No context has any memories with this (model, dimensions) yet.",
+            )
+            return None
+        sample_context_id, _ = picked
 
     # Resolve the correct collection for Qdrant lookups.
     from db.qdrant import get_collection_name  # noqa: PLC0415
 
     collection = get_collection_name(model_name, dimensions)
 
+    # NOTE: ``sample_memories`` uses ``ORDER BY random()`` which forces a
+    # full scan + sort on the filtered row set. That's acceptable for the
+    # script's CLI use case (manual, off-peak) but a background path
+    # running hourly / on bootstrap against large contexts (10^5+ memories)
+    # can create a measurable DB spike. A TABLESAMPLE BERNOULLI(p) +
+    # LIMIT N strategy (or tsm_system_rows extension for exact N) would
+    # be cheaper. Deferred as v0.14.0+ follow-up because kagura-dev
+    # production is ~500 memories where ORDER BY random() is negligible
+    # and the D3 gate elsewhere keeps this off small contexts anyway.
+    # Copilot review PR #420 loop 7.
+    # TODO(v0.14.0+): switch to TABLESAMPLE-based sampler for large contexts.
     sampled = await sample_memories(db, sample_context_id, SAMPLE_MEMORIES)
     if not sampled:
         logger.warning(
@@ -426,7 +438,7 @@ async def _pick_largest_context_for_model(
     db: AsyncSession,
     model_name: str,
     dimensions: int,
-) -> UUID | None:
+) -> tuple[UUID, int] | None:
     """Find the context with the most memories for a ``(model, dimensions)``.
 
     Model-global calibration samples from one representative context
@@ -434,10 +446,13 @@ async def _pick_largest_context_for_model(
     for a given embedding model. We pick the largest existing context so
     the sample has the best chance of clearing the D3 gate.
 
-    Returns the chosen ``context_id``, or ``None`` if no context uses
-    this ``(model, dimensions)`` pair yet (no row in
-    ``ContextSearchConfig`` or the default-routed legacy path's context
-    has zero successful memories).
+    Returns ``(context_id, memory_count)`` for the largest context, or
+    ``None`` if no context uses this ``(model, dimensions)`` pair yet.
+    The count is returned alongside the id so callers like
+    ``maybe_trigger_bootstrap`` can pre-check the single-context D3 gate
+    rather than a cross-context global count (the compute path samples
+    from ONE context, so the global is the wrong pre-check — see
+    Copilot review PR #420 loop 7).
     """
     stmt = (
         select(Memory.context_id, func.count(Memory.id).label("n"))
@@ -459,7 +474,7 @@ async def _pick_largest_context_for_model(
     row = (await db.execute(stmt)).first()
     if row is None:
         return None
-    return row[0]
+    return (row[0], int(row[1]))
 
 
 def _model_dims_where(model_name: str, dimensions: int):
@@ -520,20 +535,20 @@ async def maybe_trigger_bootstrap(
     the gate did not fire, the in-process throttle suppressed the count,
     or a Redis dedup skip occurred.
     """
-    # In-process throttle on the COUNT query itself. Responsibility split:
+    # In-process throttle on the pre-check query itself. Responsibility split:
     #
-    #   - **this throttle** (in-process dict) collapses redundant COUNT
-    #     queries from the same worker process into one DB round-trip
-    #     per 5 minutes.
+    #   - **this throttle** (in-process dict) collapses redundant pre-check
+    #     queries from the same worker process into one DB round-trip per
+    #     5 minutes.
     #   - **Redis SETNX dedup** (inside ``enqueue_recalibration_dedup``
     #     one layer deeper) collapses redundant calibration compute jobs
     #     across workers and restarts into one running task per hour.
     #
     # Both layers are needed: the in-process throttle doesn't help a
     # second API worker (separate dict), and the Redis dedup lives below
-    # this call site so it can't avoid the COUNT. 5 min window is short
-    # enough that a near-D3 context still bootstraps within a single
-    # Redis dedup lifetime (1h). (Copilot review PR #420 loop 3-4.)
+    # this call site so it can't avoid the pre-check. 5 min window is
+    # short enough that a near-D3 context still bootstraps within a
+    # single Redis dedup lifetime (1h). (Copilot review PR #420 loop 3-4.)
     throttle_key = (model_name, dimensions)
     now = datetime.now(UTC)
     last = _BOOTSTRAP_LAST_ATTEMPT.get(throttle_key)
@@ -541,29 +556,19 @@ async def maybe_trigger_bootstrap(
         return False
     _BOOTSTRAP_LAST_ATTEMPT[throttle_key] = now
 
-    count_stmt = (
-        select(func.count(Memory.id))
-        .join(
-            ContextSearchConfig,
-            ContextSearchConfig.context_id == Memory.context_id,
-            isouter=True,
-        )
-        .where(
-            Memory.deleted_at.is_(None),
-            Memory.embedding_status == "success",
-            # Exclude NULL-context memories so the count matches the set
-            # ``_pick_largest_context_for_model`` samples from. Without this
-            # filter a large NULL-context backfill (legacy pre-context
-            # migrations or admin-inserted system rows) could prematurely
-            # trip BOOTSTRAP_MIN_MEMORIES without any real context crossing
-            # the D3 gate — the calibration job would then abort at
-            # ``_pick_largest_context_for_model`` with no_context_for_model.
-            Memory.context_id.is_not(None),
-            _model_dims_where(model_name, dimensions),
-        )
-    )
-    count = int((await db.execute(count_stmt)).scalar_one() or 0)
-    if count < BOOTSTRAP_MIN_MEMORIES:
+    # Gate on the LARGEST single context's count, not a cross-context global
+    # sum. ``compute_calibration`` samples from exactly one context (the
+    # largest one), so its D3 gate is a per-context check. If we enqueued
+    # on a global-sum pre-check, a (model, dims) pair spread across many
+    # small contexts (each < 200 memories) would pass the pre-check but
+    # fail D3 inside the task — wasting a Qdrant + DB round-trip per hour.
+    # Using the same helper ``compute_calibration`` uses keeps the pre-
+    # check and the actual D3 gate aligned. (Copilot review PR #420 loop 7.)
+    picked = await _pick_largest_context_for_model(db, model_name, dimensions)
+    if picked is None:
+        return False
+    _, largest_context_count = picked
+    if largest_context_count < BOOTSTRAP_MIN_MEMORIES:
         return False
 
     return await enqueue_recalibration_dedup(model_name, dimensions, context_id=None)

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -54,6 +54,13 @@ logger = get_logger(__name__)
 # lives long enough to absorb retry storms while the compute is in-flight.
 _DEDUP_LOCK_TTL_SEC = 3600
 
+# Strong references to in-flight calibration tasks. ``asyncio.create_task``
+# returns a task that the event loop only holds a weak reference to, so
+# without keeping a strong ref the task can be garbage-collected mid-flight
+# and the compute silently vanishes (see Python asyncio docs). We drop the
+# reference via ``add_done_callback`` once the task finishes.
+_IN_FLIGHT_TASKS: set[asyncio.Task] = set()
+
 # D3 gate thresholds — also defined in the Phase A script but duplicated
 # here so the task module doesn't import from the ``scripts/`` tree at
 # runtime (only ``scripts/measure_embedding_threshold.py`` imports are
@@ -116,7 +123,9 @@ async def enqueue_recalibration_dedup(
         logger.debug("calibration_dedup_skipped", key=key)
         return False
 
-    asyncio.create_task(_run_calibration(model_name, dimensions, context_id, dedup_key=key))
+    task = asyncio.create_task(_run_calibration(model_name, dimensions, context_id, dedup_key=key))
+    _IN_FLIGHT_TASKS.add(task)
+    task.add_done_callback(_IN_FLIGHT_TASKS.discard)
     return True
 
 

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -14,8 +14,9 @@ All three paths funnel through :func:`enqueue_recalibration_dedup` so
 concurrent requests produce at most one running task per ``(model_name,
 dimensions, context_id)`` combination. The dedup key is a Redis
 ``SETNX`` with a 1-hour TTL — the compute itself typically completes in
-seconds (200 memories × 50 top-k = 10k Qdrant queries), and the 1-hour
-window just absorbs retry storms while a task is in-flight.
+seconds (200 Qdrant top-k searches, each returning up to 50 neighbors;
+total observations ≤ 10k), and the 1-hour window just absorbs retry
+storms while a task is in-flight.
 
 The actual compute reuses the helpers from
 ``scripts/measure_embedding_threshold.py``. For model-global
@@ -39,6 +40,7 @@ from types import ModuleType
 from uuid import UUID
 
 from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_db
@@ -61,14 +63,20 @@ _DEDUP_LOCK_TTL_SEC = 3600
 def _load_measure_script() -> ModuleType:
     """Load ``scripts/measure_embedding_threshold.py`` as a module.
 
-    Uses ``importlib.util.spec_from_file_location`` with an explicit path so
-    ``sys.path`` stays unmodified — avoids the module-shadowing + import-
-    order hazards of ``sys.path.insert`` in a long-running API worker.
+    Uses ``importlib.util.spec_from_file_location`` with an explicit path
+    rather than a ``sys.path`` insert. The script itself also calls
+    ``sys.path.insert(0, "src")`` at import time (it's written as a
+    standalone CLI), so we snapshot/restore ``sys.path`` around
+    ``exec_module`` to ensure the long-running API worker's import path
+    ends exactly as it started.
+
     ``functools.cache`` memoizes the no-argument call so subsequent
     ``compute_calibration`` invocations reuse the already-loaded module
     without re-executing its top-level imports (numpy, sqlalchemy,
     qdrant-client etc.).
     """
+    import sys  # noqa: PLC0415 — local to the snapshot/restore window
+
     backend_root = Path(__file__).resolve().parent.parent.parent
     script_file = backend_root / "scripts" / "measure_embedding_threshold.py"
     spec = importlib.util.spec_from_file_location(
@@ -79,7 +87,14 @@ def _load_measure_script() -> ModuleType:
             f"unable to build import spec for {script_file} — calibration cannot run"
         )
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    original_sys_path = list(sys.path)
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        # Restore even if the script mutated sys.path during import. Copy
+        # the list so later mutations by anyone else don't affect the
+        # snapshot we saved.
+        sys.path[:] = original_sys_path
     return module
 
 
@@ -185,6 +200,22 @@ async def _run_calibration(
         async for db in get_db():
             await compute_calibration(db, model_name, dimensions, context_id)
             break
+    except IntegrityError as exc:
+        # Partial-unique-index collision. The Redis fail-open path and a
+        # brief Redis outage can allow two workers to run ``compute_
+        # calibration`` concurrently — both DELETE + INSERT race, and one
+        # loses on the partial unique index. The other worker's row is
+        # already correct, so log at info level and move on rather than
+        # as a scary "calibration_task_failed" error. (Copilot review
+        # PR #420 loop 4.)
+        logger.info(
+            "calibration_concurrent_upsert_race",
+            model=model_name,
+            dimensions=dimensions,
+            context_id=str(context_id) if context_id else None,
+            error=str(exc),
+            hint="another worker won the upsert; the row is already correct",
+        )
     except Exception as exc:
         logger.error(
             "calibration_task_failed",
@@ -432,15 +463,20 @@ async def maybe_trigger_bootstrap(
     the gate did not fire, the in-process throttle suppressed the count,
     or a Redis dedup skip occurred.
     """
-    # In-process throttle: skip the COUNT entirely when the same
-    # (model, dimensions) was attempted within the throttle window. On a
-    # freshly-migrated deployment every ``remember()`` hits step 3 → this
-    # function is called unconditionally; without the throttle we would
-    # run a full-table COUNT on every call even though the Redis dedup
-    # lock already prevents duplicate compute jobs. 5 min window is short
+    # In-process throttle on the COUNT query itself. Responsibility split:
+    #
+    #   - **this throttle** (in-process dict) collapses redundant COUNT
+    #     queries from the same worker process into one DB round-trip
+    #     per 5 minutes.
+    #   - **Redis SETNX dedup** (inside ``enqueue_recalibration_dedup``
+    #     one layer deeper) collapses redundant calibration compute jobs
+    #     across workers and restarts into one running task per hour.
+    #
+    # Both layers are needed: the in-process throttle doesn't help a
+    # second API worker (separate dict), and the Redis dedup lives below
+    # this call site so it can't avoid the COUNT. 5 min window is short
     # enough that a near-D3 context still bootstraps within a single
-    # dedup lock lifetime (1h) but collapses bursts into one count.
-    # (Copilot review PR #420 loop 3.)
+    # Redis dedup lifetime (1h). (Copilot review PR #420 loop 3-4.)
     throttle_key = (model_name, dimensions)
     now = datetime.now(UTC)
     last = _BOOTSTRAP_LAST_ATTEMPT.get(throttle_key)

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import secrets
 from datetime import UTC, datetime, timedelta
 from functools import cache
 from pathlib import Path
@@ -160,25 +161,37 @@ async def enqueue_recalibration_dedup(
             the call sites always pass ``None`` (model-global).
     """
     key = _dedup_key(model_name, dimensions, context_id)
+    # Write a unique token (not a dummy "1") so release can check we still
+    # own the lock via compare-and-delete. Without this, the finally branch
+    # could blindly DELETE a key that another worker re-acquired after our
+    # TTL expired mid-compute, defeating dedup under load.
+    # (Copilot review PR #420 loop 5.)
+    token = secrets.token_hex(16)
     try:
         client = get_redis_client()
-        acquired = await client.set(key, "1", nx=True, ex=_DEDUP_LOCK_TTL_SEC)
+        acquired = await client.set(key, token, nx=True, ex=_DEDUP_LOCK_TTL_SEC)
     except Exception as exc:
         # Redis unavailable → fail-open (run anyway). A duplicate compute
         # is wasteful but not incorrect, whereas skipping compute on a
         # Redis hiccup would stall the calibration path indefinitely.
+        # Signal "we never owned a lock" by clearing the token so the
+        # release branch skips the DEL entirely — it had nothing to
+        # release and could only corrupt another worker's lock.
         logger.warning(
             "calibration_dedup_redis_error",
             key=key,
             error=str(exc),
         )
         acquired = True
+        token = ""
 
     if not acquired:
         logger.debug("calibration_dedup_skipped", key=key)
         return False
 
-    task = asyncio.create_task(_run_calibration(model_name, dimensions, context_id, dedup_key=key))
+    task = asyncio.create_task(
+        _run_calibration(model_name, dimensions, context_id, dedup_key=key, token=token)
+    )
     _IN_FLIGHT_TASKS.add(task)
     task.add_done_callback(_IN_FLIGHT_TASKS.discard)
     return True
@@ -189,12 +202,20 @@ async def _run_calibration(
     dimensions: int,
     context_id: UUID | None,
     dedup_key: str,
+    token: str,
 ) -> None:
     """Execute the calibration compute + upsert, then release the dedup lock.
 
     Wraps :func:`compute_calibration` so the lock is always released even
     on exception paths. Any logging/observability happens inside
     ``compute_calibration``; this wrapper only handles the try/finally.
+
+    ``token`` is the value written when :func:`enqueue_recalibration_dedup`
+    acquired the lock. Release uses a compare-and-delete Lua script so we
+    only remove keys we still own (TTL expiration + re-acquisition by
+    another worker is the hazard this guards against). An empty token
+    signals the fail-open path — we never acquired a lock, so we must not
+    DELETE. (Copilot review PR #420 loop 5.)
     """
     try:
         async for db in get_db():
@@ -226,17 +247,42 @@ async def _run_calibration(
             exc_info=True,
         )
     finally:
-        try:
-            client = get_redis_client()
-            await client.delete(dedup_key)
-        except Exception as exc:
-            # Leaving the lock to TTL out is acceptable — next recalibration
-            # fires in at most _DEDUP_LOCK_TTL_SEC.
-            logger.warning(
-                "calibration_dedup_release_failed",
-                key=dedup_key,
-                error=str(exc),
-            )
+        await _release_dedup_lock(dedup_key, token)
+
+
+# Compare-and-delete so a worker whose lock TTL expired (and was re-acquired
+# by another worker) does NOT blow away that other worker's lock. Standard
+# Redis SETNX lock release idiom. Returns 1 when we deleted our key, 0 when
+# the key was missing, held by someone else, or already released.
+_DEDUP_RELEASE_SCRIPT = (
+    "if redis.call('get', KEYS[1]) == ARGV[1] "
+    "then return redis.call('del', KEYS[1]) "
+    "else return 0 end"
+)
+
+
+async def _release_dedup_lock(key: str, token: str) -> None:
+    """Compare-and-delete the Redis dedup lock.
+
+    Skips the release entirely when ``token`` is empty (the fail-open
+    path never acquired a lock and DEL would corrupt another worker's
+    lock if one exists). Any Redis error during release is logged and
+    swallowed — the TTL guarantees eventual release.
+    """
+    if not token:
+        return
+    try:
+        client = get_redis_client()
+        release_script = client.register_script(_DEDUP_RELEASE_SCRIPT)
+        await release_script(keys=[key], args=[token])
+    except Exception as exc:
+        # Leaving the lock to TTL out is acceptable — next recalibration
+        # fires in at most _DEDUP_LOCK_TTL_SEC.
+        logger.warning(
+            "calibration_dedup_release_failed",
+            key=key,
+            error=str(exc),
+        )
 
 
 async def compute_calibration(

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -31,9 +31,10 @@ does not (D5 v2 follow-up).
 from __future__ import annotations
 
 import asyncio
-import sys
+import importlib.util
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from types import ModuleType
 from uuid import UUID
 
 from sqlalchemy import delete, func, select
@@ -53,6 +54,40 @@ logger = get_logger(__name__)
 # Dedup lock TTL. A calibration compute is short (seconds), but the lock
 # lives long enough to absorb retry storms while the compute is in-flight.
 _DEDUP_LOCK_TTL_SEC = 3600
+
+# Cache the imported script module so the importlib-load path runs once.
+# After first call the real importlib ``exec_module`` runs; subsequent calls
+# return this cached reference without touching the filesystem.
+_MEASURE_SCRIPT_MODULE: ModuleType | None = None
+
+
+def _load_measure_script() -> ModuleType:
+    """Load ``scripts/measure_embedding_threshold.py`` as a module.
+
+    Uses ``importlib.util.spec_from_file_location`` with an explicit path so
+    ``sys.path`` stays unmodified — avoids the module-shadowing + import-
+    order hazards of ``sys.path.insert`` in a long-running API worker.
+    Cached after first call so subsequent ``compute_calibration`` invocations
+    don't re-execute the module's top-level imports (numpy, sqlalchemy,
+    qdrant-client etc.).
+    """
+    global _MEASURE_SCRIPT_MODULE  # noqa: PLW0603 — intentional lazy-init cache
+    if _MEASURE_SCRIPT_MODULE is not None:
+        return _MEASURE_SCRIPT_MODULE
+    backend_root = Path(__file__).resolve().parent.parent.parent
+    script_file = backend_root / "scripts" / "measure_embedding_threshold.py"
+    spec = importlib.util.spec_from_file_location(
+        "_kagura_measure_embedding_threshold", script_file
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(
+            f"unable to build import spec for {script_file} — calibration cannot run"
+        )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _MEASURE_SCRIPT_MODULE = module
+    return module
+
 
 # Strong references to in-flight calibration tasks. ``asyncio.create_task``
 # returns a task that the event loop only holds a weak reference to, so
@@ -188,17 +223,18 @@ async def compute_calibration(
     """
     # Defer the script import so test environments don't need numpy etc.
     # if they never exercise this path. The script lives under ``scripts/``
-    # which is not on the default ``sys.path``; add it temporarily.
-    backend_root = Path(__file__).resolve().parent.parent.parent
-    scripts_path = str(backend_root / "scripts")
-    if scripts_path not in sys.path:
-        sys.path.insert(0, scripts_path)
-    from measure_embedding_threshold import (  # type: ignore[import-not-found] # noqa: PLC0415
-        compute_percentiles,
-        fetch_vectors,
-        measure_top_k,
-        sample_memories,
-    )
+    # which is not on the default ``sys.path``. Load it via importlib with an
+    # explicit file-path spec so we don't mutate global ``sys.path`` — a
+    # long-running API worker would otherwise accumulate a path entry that
+    # can cause hard-to-debug module shadowing and makes imports depend on
+    # call order (Copilot review PR #420 loop 2). After the first call the
+    # module is cached in ``sys.modules`` under its own name, so subsequent
+    # calls reuse the cached module for free.
+    _script_module = _load_measure_script()
+    compute_percentiles = _script_module.compute_percentiles
+    fetch_vectors = _script_module.fetch_vectors
+    measure_top_k = _script_module.measure_top_k
+    sample_memories = _script_module.sample_memories
 
     sample_context_id = context_id
     if sample_context_id is None:

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -511,9 +511,14 @@ async def maybe_trigger_bootstrap(
 
     Called from ``_create_knn_seed_edges`` when
     ``resolve_knn_threshold`` returns ``None`` (step 3 of D4 — no
-    calibration row yet). Counts memories across contexts that use this
-    ``(model, dimensions)``; if the count is at or above
-    :data:`BOOTSTRAP_MIN_MEMORIES`, kicks off a deduped job.
+    calibration row yet). Uses the **largest single context** for this
+    ``(model, dimensions)`` pair (via ``_pick_largest_context_for_model``)
+    and enqueues only when that context's memory count is at or above
+    :data:`BOOTSTRAP_MIN_MEMORIES`. The same helper is used by
+    ``compute_calibration`` to pick the sampling source, so the pre-check
+    here and the actual D3 check there operate on the same count — no
+    hourly wasted work when the global cross-context total reaches 200
+    but no single context does (Copilot review PR #420 loop 7).
 
     This is the only path that runs per remember() call, so two layers
     limit redundant work under heavy concurrent ingestion:

--- a/backend/tests/api/test_admin_neural.py
+++ b/backend/tests/api/test_admin_neural.py
@@ -39,8 +39,15 @@ def admin_client():
 
 @pytest.fixture
 def unauth_client():
-    """TestClient without any auth overrides — exercises the 401 path."""
-    # Do not override require_admin; the dependency's real 401 behavior fires.
+    """TestClient without any auth overrides — exercises the 401 path.
+
+    Explicitly clears ``app.dependency_overrides`` before yielding so a
+    prior test's leaked override (e.g., a prior admin fixture that
+    errored before its teardown ran) cannot suppress the real auth
+    dependency and mask a 401/403 regression. Copilot review PR #420
+    loop 4 flagged the order-dependency.
+    """
+    app.dependency_overrides.clear()
     yield TestClient(app, raise_server_exceptions=False)
     app.dependency_overrides.clear()
 

--- a/backend/tests/api/test_admin_neural.py
+++ b/backend/tests/api/test_admin_neural.py
@@ -1,0 +1,163 @@
+"""API tests for admin kNN calibration recalibrate endpoint (#406 Phase B).
+
+Pure HTTP / auth / serialization checks — the task-layer behavior
+(``enqueue_recalibration_dedup`` Redis + asyncio mechanics) is covered
+separately by ``tests/neural/test_calibration.py`` and the integration
+harness. We patch the task module at the endpoint's call site so these
+tests don't touch Redis or spawn real asyncio tasks.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from auth.dependencies import require_admin
+from db.base import get_db
+
+
+def _mock_admin_user() -> dict:
+    return {"user_id": "admin_user_1", "email": "admin@test.com", "role": "admin"}
+
+
+@pytest.fixture
+def admin_client():
+    """TestClient with admin auth override."""
+
+    async def mock_admin():
+        return _mock_admin_user()
+
+    async def mock_db():
+        yield MagicMock()
+
+    app.dependency_overrides[require_admin] = mock_admin
+    app.dependency_overrides[get_db] = mock_db
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def unauth_client():
+    """TestClient without any auth overrides — exercises the 401 path."""
+    # Do not override require_admin; the dependency's real 401 behavior fires.
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+class TestAuth:
+    """Copilot review PR #420 / QA advisor finding: endpoint is admin-only."""
+
+    def test_unauthenticated_rejected(self, unauth_client):
+        response = unauth_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "text-embedding-3-small", "dimensions": 512},
+        )
+        # Exact status depends on whether the dep short-circuits before reaching
+        # the handler; both 401 and 403 are valid rejection signals.
+        assert response.status_code in (401, 403)
+
+
+class TestInputValidation:
+    """FastAPI Query validators + defensive model_name sanitization."""
+
+    def test_empty_model_rejected(self, admin_client):
+        response = admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "", "dimensions": 512},
+        )
+        # min_length=1 on Query → 422 (FastAPI's validation error).
+        assert response.status_code == 422
+
+    def test_model_with_path_separator_rejected(self, admin_client):
+        response = admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "bad/model", "dimensions": 512},
+        )
+        # Defensive handler-level check → 400.
+        assert response.status_code == 400
+        assert response.json()["detail"] == "invalid_model_name"
+
+    def test_model_with_backslash_rejected(self, admin_client):
+        response = admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "bad\\model", "dimensions": 512},
+        )
+        assert response.status_code == 400
+
+    def test_model_with_whitespace_rejected(self, admin_client):
+        response = admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "bad model", "dimensions": 512},
+        )
+        assert response.status_code == 400
+
+    def test_dimensions_below_minimum_rejected(self, admin_client):
+        response = admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "text-embedding-3-small", "dimensions": 0},
+        )
+        # ge=1 on Query → 422.
+        assert response.status_code == 422
+
+    def test_dimensions_above_maximum_rejected(self, admin_client):
+        response = admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "text-embedding-3-small", "dimensions": 100000},
+        )
+        # le=65536 on Query → 422.
+        assert response.status_code == 422
+
+
+class TestDedupBehavior:
+    """``accepted`` flag reflects the dedup lock outcome — always HTTP 202."""
+
+    def test_accepted_true_spawns_task(self, admin_client, monkeypatch):
+        enqueue = AsyncMock(return_value=True)
+        monkeypatch.setattr("api.routes.admin_neural.enqueue_recalibration_dedup", enqueue)
+
+        response = admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "text-embedding-3-small", "dimensions": 512},
+        )
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body == {
+            "accepted": True,
+            "model_name": "text-embedding-3-small",
+            "dimensions": 512,
+        }
+        enqueue.assert_awaited_once()
+
+    def test_accepted_false_on_dedup_skip(self, admin_client, monkeypatch):
+        """Dedup rejected duplicate → accepted=false, still 202 (idempotent)."""
+        enqueue = AsyncMock(return_value=False)
+        monkeypatch.setattr("api.routes.admin_neural.enqueue_recalibration_dedup", enqueue)
+
+        response = admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "text-embedding-3-small", "dimensions": 512},
+        )
+
+        assert response.status_code == 202
+        body = response.json()
+        assert body["accepted"] is False
+        assert body["model_name"] == "text-embedding-3-small"
+        assert body["dimensions"] == 512
+
+    def test_enqueue_called_with_context_id_none(self, admin_client, monkeypatch):
+        """Admin endpoint only enqueues model-global jobs (per-context is v2)."""
+        enqueue = AsyncMock(return_value=True)
+        monkeypatch.setattr("api.routes.admin_neural.enqueue_recalibration_dedup", enqueue)
+
+        admin_client.post(
+            "/api/v1/admin/neural/recalibrate",
+            params={"model": "qwen3-embedding:8b", "dimensions": 4096},
+        )
+
+        enqueue.assert_awaited_once_with(
+            model_name="qwen3-embedding:8b",
+            dimensions=4096,
+            context_id=None,
+        )

--- a/backend/tests/neural/test_calibration.py
+++ b/backend/tests/neural/test_calibration.py
@@ -1,0 +1,193 @@
+"""Unit tests for the D4 fallback chain and calibration model (#406 Phase B).
+
+Covers ``neural.calibration.resolve_knn_threshold`` and the
+``EmbeddingCalibration`` model's ``percentile()`` / ``is_expired()``.
+Integration tests for the runtime wiring in ``_create_knn_seed_edges``
+live alongside ``tests/services/test_knn_seeding.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.neural import EmbeddingCalibration
+from neural.calibration import resolve_knn_threshold
+from neural.config import NeuralMemoryConfig
+
+
+def _make_config(
+    min_similarity: float | None = None,
+    min_percentile: float = 90.0,
+    floor: float = 0.3,
+) -> NeuralMemoryConfig:
+    """Build a NeuralMemoryConfig with the fields this module reads.
+
+    Uses ``from_env()`` to pick up the full default surface, then
+    overrides the three knn-seed-calibration fields that the D4 chain
+    cares about. Other fields (hebbian, scoring, etc.) keep their
+    defaults.
+    """
+    cfg = NeuralMemoryConfig.from_env()
+    cfg.knn_seed_min_similarity = min_similarity
+    cfg.knn_seed_min_percentile = min_percentile
+    cfg.knn_seed_min_similarity_floor = floor
+    return cfg
+
+
+def _make_calibration(
+    p90: float = 0.6322,
+    expired: bool = False,
+) -> EmbeddingCalibration:
+    """Build a calibration row with the given p90 and expiry state.
+
+    Other percentiles are placeholder values that keep the row valid
+    (ascending p25→p99) but are not read by the p90-only resolve path.
+    """
+    now = datetime.now(UTC)
+    valid_until = now - timedelta(minutes=1) if expired else now + timedelta(days=30)
+    return EmbeddingCalibration(
+        model_name="text-embedding-3-small",
+        dimensions=512,
+        context_id=None,
+        p25=0.40,
+        p50=0.50,
+        p75=0.55,
+        p90=p90,
+        p95=min(p90 + 0.05, 1.0),
+        p99=min(p90 + 0.12, 1.0),
+        sample_size=10000,
+        sampled_at=now,
+        valid_until=valid_until,
+    )
+
+
+def _mock_db(calibration_result: EmbeddingCalibration | None) -> AsyncMock:
+    """AsyncSession mock whose execute() returns the given calibration row.
+
+    ``calibration_result`` is what ``scalar_one_or_none()`` yields on
+    the row returned by ``db.execute(...)`` — pass ``None`` to simulate
+    "no calibration row exists".
+    """
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=calibration_result)
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+class TestResolveKnnThresholdOperatorOverride:
+    """D4 Step 1: operator-set ``knn_seed_min_similarity`` wins over calibration."""
+
+    @pytest.mark.asyncio
+    async def test_operator_value_returned_verbatim(self):
+        cfg = _make_config(min_similarity=0.35)
+        db = _mock_db(calibration_result=None)
+        result = await resolve_knn_threshold(db, cfg, "text-embedding-3-small", 512)
+        assert result == 0.35
+        # Step 1 should short-circuit — no calibration lookup hit the DB.
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_operator_value_ignores_calibration(self):
+        """Even with a fresh calibration row, operator override wins (D6)."""
+        cfg = _make_config(min_similarity=0.50)
+        db = _mock_db(calibration_result=_make_calibration(p90=0.63))
+        result = await resolve_knn_threshold(db, cfg, "text-embedding-3-small", 512)
+        assert result == 0.50
+        db.execute.assert_not_called()
+
+
+class TestResolveKnnThresholdCalibrationPath:
+    """D4 Step 2: calibration row present → ``max(percentile(p), floor)``."""
+
+    @pytest.mark.asyncio
+    async def test_p90_above_floor_returns_p90(self):
+        cfg = _make_config(min_similarity=None, min_percentile=90.0, floor=0.3)
+        db = _mock_db(calibration_result=_make_calibration(p90=0.6322))
+        result = await resolve_knn_threshold(db, cfg, "text-embedding-3-small", 512)
+        assert result == pytest.approx(0.6322)
+
+    @pytest.mark.asyncio
+    async def test_p90_below_floor_returns_floor(self):
+        """Floor protects sparse corpora where the distribution collapses."""
+        cfg = _make_config(min_similarity=None, min_percentile=90.0, floor=0.4)
+        db = _mock_db(calibration_result=_make_calibration(p90=0.25))
+        result = await resolve_knn_threshold(db, cfg, "text-embedding-3-small", 512)
+        assert result == 0.4
+
+    @pytest.mark.asyncio
+    async def test_different_percentile_setting(self):
+        """``knn_seed_min_percentile`` picks p50 → interpolates from stored grid."""
+        cfg = _make_config(min_similarity=None, min_percentile=50.0, floor=0.2)
+        db = _mock_db(calibration_result=_make_calibration(p90=0.6322))
+        result = await resolve_knn_threshold(db, cfg, "text-embedding-3-small", 512)
+        # _make_calibration fixes p50 = 0.50 > floor 0.2
+        assert result == pytest.approx(0.50)
+
+    @pytest.mark.asyncio
+    async def test_expired_row_still_serves_value(self):
+        """Lazy-TTL: expired row is served (fail-open) while refresh enqueues."""
+        cfg = _make_config(min_similarity=None)
+        db = _mock_db(calibration_result=_make_calibration(p90=0.55, expired=True))
+        result = await resolve_knn_threshold(db, cfg, "text-embedding-3-small", 512)
+        # Expired rows are still returned; enqueue happens as a side effect
+        # (swallowed by ImportError guard when tasks module is absent).
+        assert result == pytest.approx(0.55)
+
+
+class TestResolveKnnThresholdDisabled:
+    """D4 Step 3: no calibration row → ``None`` (disable seeding)."""
+
+    @pytest.mark.asyncio
+    async def test_missing_calibration_returns_none(self):
+        cfg = _make_config(min_similarity=None)
+        db = _mock_db(calibration_result=None)
+        result = await resolve_knn_threshold(db, cfg, "qwen3-embedding:8b", 4096)
+        assert result is None
+
+
+class TestEmbeddingCalibrationPercentile:
+    """``EmbeddingCalibration.percentile()`` linear-interp helper."""
+
+    def test_direct_stored_percentiles(self):
+        row = _make_calibration(p90=0.60)
+        # Stored grid values are returned directly (no interpolation).
+        assert row.percentile(25.0) == pytest.approx(row.p25)
+        assert row.percentile(90.0) == pytest.approx(0.60)
+        assert row.percentile(99.0) == pytest.approx(row.p99)
+
+    def test_interpolate_between_p75_and_p90(self):
+        row = _make_calibration(p90=0.60)
+        # p75=0.55, p90=0.60 → midpoint p=82.5 → 0.575
+        mid = row.percentile(82.5)
+        assert mid == pytest.approx((row.p75 + row.p90) / 2)
+
+    def test_clamp_below_p25(self):
+        row = _make_calibration(p90=0.60)
+        assert row.percentile(10.0) == pytest.approx(row.p25)
+
+    def test_clamp_above_p99(self):
+        row = _make_calibration(p90=0.60)
+        assert row.percentile(99.9) == pytest.approx(row.p99)
+
+
+class TestEmbeddingCalibrationIsExpired:
+    """``EmbeddingCalibration.is_expired()`` drives the lazy-TTL trigger."""
+
+    def test_fresh_row_not_expired(self):
+        row = _make_calibration(expired=False)
+        assert row.is_expired() is False
+
+    def test_expired_row_flagged(self):
+        row = _make_calibration(expired=True)
+        assert row.is_expired() is True
+
+    def test_naive_valid_until_coerced_to_utc(self):
+        """Some DB drivers return naive datetimes; the helper must still work."""
+        row = _make_calibration(expired=False)
+        # Strip tzinfo to simulate a naive datetime coming back from the DB.
+        row.valid_until = row.valid_until.replace(tzinfo=None)
+        assert row.is_expired() is False

--- a/backend/tests/neural/test_calibration.py
+++ b/backend/tests/neural/test_calibration.py
@@ -128,14 +128,25 @@ class TestResolveKnnThresholdCalibrationPath:
         assert result == pytest.approx(0.50)
 
     @pytest.mark.asyncio
-    async def test_expired_row_still_serves_value(self):
-        """Lazy-TTL: expired row is served (fail-open) while refresh enqueues."""
+    async def test_expired_row_still_serves_value(self, monkeypatch):
+        """Lazy-TTL: expired row is served (fail-open) while refresh enqueues.
+
+        Monkeypatches ``_enqueue_lazy_recalibration`` so the test doesn't
+        trigger the real Redis + asyncio task path (Copilot review PR #420
+        loop 2 finding). We only assert the returned threshold.
+        """
+        from unittest.mock import AsyncMock as _AsyncMock
+
+        import neural.calibration as calibration_module
+
+        enqueue_stub = _AsyncMock(return_value=None)
+        monkeypatch.setattr(calibration_module, "_enqueue_lazy_recalibration", enqueue_stub)
+
         cfg = _make_config(min_similarity=None)
         db = _mock_db(calibration_result=_make_calibration(p90=0.55, expired=True))
         result = await resolve_knn_threshold(db, cfg, "text-embedding-3-small", 512)
-        # Expired rows are still returned; enqueue happens as a side effect
-        # (swallowed by ImportError guard when tasks module is absent).
         assert result == pytest.approx(0.55)
+        enqueue_stub.assert_awaited_once()
 
 
 class TestResolveKnnThresholdDisabled:

--- a/backend/tests/neural/test_calibration.py
+++ b/backend/tests/neural/test_calibration.py
@@ -146,7 +146,12 @@ class TestResolveKnnThresholdCalibrationPath:
         db = _mock_db(calibration_result=_make_calibration(p90=0.55, expired=True))
         result = await resolve_knn_threshold(db, cfg, "text-embedding-3-small", 512)
         assert result == pytest.approx(0.55)
-        enqueue_stub.assert_awaited_once()
+        # The lazy-TTL enqueue is fire-and-forget via ``asyncio.create_task``
+        # (loop 3 fix so ``remember()`` doesn't block on the Redis round-
+        # trip). The coroutine is CREATED (mock called) but may not have
+        # been AWAITED by the time the test returns — scheduling a task
+        # doesn't yield to the event loop. Assert the call, not the await.
+        enqueue_stub.assert_called_once()
 
 
 class TestResolveKnnThresholdDisabled:

--- a/backend/tests/services/test_knn_seeding.py
+++ b/backend/tests/services/test_knn_seeding.py
@@ -97,7 +97,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -129,7 +129,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -168,7 +168,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -210,7 +210,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -248,7 +248,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -285,7 +285,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -325,7 +325,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -362,7 +362,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -405,7 +405,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -432,7 +432,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -472,7 +472,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -513,7 +513,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -553,7 +553,7 @@ class TestKnnSeeding:
             await _create_knn_seed_edges(
                 db=db,
                 memory=memory,
-                vector=[0.1] * 1536,
+                vector=[0.1] * 512,
                 collection_name="kagura_memories",
                 model_name="text-embedding-3-small",
             )
@@ -564,3 +564,61 @@ class TestKnnSeeding:
         mock_search.assert_not_called()
         mock_repo.create_edge_if_absent.assert_not_called()
         db.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_none_threshold_skips_search_and_triggers_bootstrap(self):
+        """D4 step 3: ``resolve_knn_threshold`` → None disables seeding
+        for this call and invokes ``maybe_trigger_bootstrap`` (best-effort).
+
+        Guards the Phase B fallback-chain wiring in ``_create_knn_seed_edges``
+        so a regression that silently skips the bootstrap trigger (or keeps
+        issuing Qdrant searches with a broken threshold) is caught early.
+        (Copilot review PR #420 loop 6.)
+        """
+        memory = _make_memory()
+        db = _make_db()
+        mock_repo = _make_edge_repo()
+
+        with (
+            patch(
+                "neural.config.NeuralMemoryConfig.from_db",
+                new=AsyncMock(return_value=_make_config()),
+            ),
+            patch(
+                "neural.calibration.resolve_knn_threshold",
+                new=AsyncMock(return_value=None),
+            ) as mock_resolve,
+            patch(
+                "db.qdrant.search_memories_qdrant",
+                new=AsyncMock(),
+            ) as mock_search,
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "tasks.neural_calibration.maybe_trigger_bootstrap",
+                new=AsyncMock(return_value=True),
+            ) as mock_bootstrap,
+        ):
+            await _create_knn_seed_edges(
+                db=db,
+                memory=memory,
+                vector=[0.1] * 512,
+                collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
+            )
+
+        # Threshold resolver was consulted with the right dimensions.
+        mock_resolve.assert_awaited_once()
+        # No Qdrant search: step 3 disables seeding for this call.
+        mock_search.assert_not_called()
+        # No edges created.
+        mock_repo.create_edge_if_absent.assert_not_called()
+        # Bootstrap trigger WAS invoked — subsequent remember() calls can
+        # find a populated calibration row once D3 is crossed.
+        mock_bootstrap.assert_awaited_once()
+        # dimensions argument plumbed correctly (len(vector) = 512)
+        call_kwargs = mock_bootstrap.await_args.kwargs
+        assert call_kwargs["model_name"] == "text-embedding-3-small"
+        assert call_kwargs["dimensions"] == 512

--- a/backend/tests/services/test_knn_seeding.py
+++ b/backend/tests/services/test_knn_seeding.py
@@ -99,6 +99,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         mock_search.assert_not_called()
@@ -130,6 +131,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         mock_repo.create_edge_if_absent.assert_not_called()
@@ -168,6 +170,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         # 2 edges created (self excluded)
@@ -209,6 +212,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         # Only 2 edges (0.9 and 0.7 pass the 0.6 threshold)
@@ -246,6 +250,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         # Capped at k=3
@@ -282,6 +287,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         mock_repo.create_edge_if_absent.assert_called_once()
@@ -321,6 +327,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         mock_search.assert_called_once()
@@ -357,6 +364,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         # Rollback called as part of best-effort cleanup
@@ -399,6 +407,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         # All 3 attempts made
@@ -425,6 +434,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         mock_search.assert_not_called()
@@ -464,6 +474,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         # All 2 attempted, but none counted as "created" since DO NOTHING fired
@@ -504,6 +515,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         # begin_nested() called once per edge attempt (3 candidates)
@@ -543,6 +555,7 @@ class TestKnnSeeding:
                 memory=memory,
                 vector=[0.1] * 1536,
                 collection_name="kagura_memories",
+                model_name="text-embedding-3-small",
             )
 
         # Idempotency guard: get_outgoing_edges was called, returned existing edges,


### PR DESCRIPTION
Closes #406

## Summary
- Replace the hardcoded `knn_seed_min_similarity=0.4` default with a three-step D4 fallback chain: operator override → model-global calibration percentile (p90 by default) → disabled. The current 0.4 threshold is over-permissive (Phase A acceptance showed the bottom 25% of seeded edges is statistically indistinguishable from random pairs); the calibration path lands at ~0.63 for text-embedding-3-small and ~0.58 for qwen3-8b (#407 Task 1 evidence).
- Introduce `embedding_calibrations` table (model_name, dimensions, nullable context_id, 5-number summary, sample_size, TTL) with partial unique indexes that correctly handle NULL context_id distinctness. Schema allows per-context calibration (#240 D5 v2) but the runtime lookup is v1-global-only with a `TODO(v2)` marker.
- Add three calibration triggers funneled through one deduped asyncio task pipeline (Redis `SETNX` 1h TTL): Bootstrap (fires from `remember()` when (model, dims) crosses D3 = 200 memories), Admin manual (`POST /api/v1/admin/neural/recalibrate`), and Lazy TTL (fires when `resolve_knn_threshold` reads an expired row). Stale values are served fail-open while the refresh runs in the background.
- Configuration surface adds `knn_seed_min_percentile` (default 90.0), `knn_seed_min_similarity_floor` (default 0.3, D2 hard floor), and `calibration_ttl_days` (default 30). The TTL is intentionally a config value rather than hardcoded in the migration so #407 Task 2's drift measurement can tune it via env var without a schema change.

## Implementation notes
- **Alembic migration `b06_406_embedding_calibration`**: creates the table with CHECK constraints (percentile range [0, 1], nonneg sample_size, valid_until > sampled_at) and two partial unique indexes (`uq_calibration_model_dims_global` WHERE context_id IS NULL, `uq_calibration_model_dims_nonnull` WHERE context_id IS NOT NULL) so PostgreSQL's "NULL is distinct" semantics don't permit duplicate globals. The migration also DELETEs `knn_seed_min_similarity=0.4` rows from `neural_config` via `CAST(value AS FLOAT) = 0.4` so the flipped Python default (`float | None = None`) activates the calibration path. Operator-tuned non-0.4 rows are preserved (D6). **Non-reversible on downgrade** — operators who had explicitly set 0.4 cannot be distinguished from pre-v0.13.1 default inheritors; downgrade drops the table but does NOT re-insert the deleted rows.
- **Runtime hot path** (`neural/calibration.py::resolve_knn_threshold` called from `_create_knn_seed_edges`): hits the partial unique index for O(1) lookup. Returns `None` on Step 3 (no calibration yet), which the caller treats as "disable seeding for this remember()". The bootstrap trigger fires on that same Step 3 return so subsequent calls find a populated row.
- **Background task**: `tasks/neural_calibration.py` uses `asyncio.create_task` + a module-level `_IN_FLIGHT_TASKS: set[asyncio.Task]` with `add_done_callback(discard)` so Python doesn't GC the task mid-compute (self-review caught this in `292de91` — the event loop only holds weak refs to tasks). Compute samples 200 memories from the largest context using the (model, dims) pair, measures top-k 50 neighbors, runs the D3 gate (≥200 memories or ≥10k observations), then upserts via explicit `DELETE + INSERT` because partial unique indexes don't participate in `ON CONFLICT`.
- **Admin endpoint** `POST /api/v1/admin/neural/recalibrate?model=X&dimensions=N`: `AdminUser` dep gates 401/403; FastAPI `Query` validators bound model length (1–100) and dimensions (1–65536); defensive rejection of path separators / whitespace in model_name to keep the Redis dedup key clean. Returns 202 with `accepted: true|false` (false = dedup skip, idempotent). No rate limit — Redis dedup is the sole gate (admin-only endpoint; compute is bounded to 1x/hour per (model, dims, context) by the lock).
- **Script helper reuse**: `compute_calibration` lazily adds `backend/scripts/` to `sys.path` and imports `compute_percentiles`, `sample_memories`, `fetch_vectors`, `measure_top_k` from `measure_embedding_threshold.py`. Pragmatic v1 choice; follow-up candidate to promote these helpers to `src/neural/measurement.py`.

## Test coverage
- 14 new unit tests in `tests/neural/test_calibration.py`: D4 fallback chain (operator override verbatim + short-circuits DB, calibration p90 above/below floor, interpolation for non-stored percentiles, expired row still serves value), `EmbeddingCalibration.percentile()` (direct grid + linear interp + clamp), `is_expired()` (fresh / expired / naive datetime).
- 13 existing `tests/services/test_knn_seeding.py` updated to pass `model_name` kwarg; their `_make_config(min_similarity=0.4)` pattern now exercises operator-override Step 1 semantics.
- 605 total tests pass (14 new + 591 existing). Lint (ruff) clean. pyright 0 errors. Migration upgrade + downgrade + re-upgrade roundtrip verified on localhost. Admin endpoint 401 verified without auth.

## Deferred items (tracked, not blocking)
This PR ships with explicit operator approval despite two gate2 advisors returning yellow. The yellow drivers are AC items that can be addressed post-merge without rework:

- **Manual verification (localhost)**: run admin recalibrate against localhost and confirm the written `embedding_calibrations` row matches Phase A script output within 1e-3. Post-merge acceptance check.
- **Manual verification (production)**: run bootstrap on production kagura-dev (text-embedding-3-small/512) and confirm threshold lands at ~0.6322 per Phase A anchor. Post-deploy acceptance check.
- **Migration preservation integration test**: automated test that a `knn_seed_min_similarity=0.35` operator row survives the migration while `0.4` rows are removed. Follow-up issue candidate.
- **#407 Task 2 drift detection runbook (2026-04-27)**: document the flow for reading Task 2's kagura-dev drift measurement and deciding whether to tighten `CALIBRATION_TTL_DAYS` via env var. TTL is config-tunable so any adjustment is non-destructive (no schema migration required).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (deferred AC items)
- cto: yellow (deferred AC items + Task 2 runbook)
- operator_override: green (explicit approval after review)
- gate1: green (via /ask — #406 design review)
- review provider: copilot

Full reviews saved in plugin cache:
- `~/.claude/cache/gh-issue-driven/406-feat-feat-neural-phase-b-embeddingcalibration.gate1.md`
- `~/.claude/cache/gh-issue-driven/406-feat-feat-neural-phase-b-embeddingcalibration.gate2.md`

Also: operators who explicitly set `knn_seed_min_similarity=0.4` (the pre-v0.13.1 default) should re-apply that value post-merge — the migration cannot distinguish explicit 0.4 from inherited default and deletes both.

🤖 Generated via /gh-issue-driven:ship
