### PR TITLE
fix(sleep): omit temperature for OpenAI gpt-5/o-series reasoning models (#424)

### DIFF
--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -92,11 +92,7 @@ class LLMService:
         client = await self._get_client(user_id, resolved_provider, context_id, workspace_id)
         try:
             response = await client.chat.completions.create(
-                model=resolved_model,
-                messages=messages,
-                temperature=temperature,
-                max_completion_tokens=max_tokens,
-                response_format={"type": "json_object"},
+                **self._build_create_kwargs(resolved_model, messages, temperature, max_tokens),
             )
             content = response.choices[0].message.content or "{}"
             tokens_used = response.usage.total_tokens if response.usage else 0
@@ -122,14 +118,10 @@ class LLMService:
                 f"LLM API call failed ({resolved_provider}/{resolved_model}): {e}"
             ) from e
 
-        # Retry with higher temperature
+        # Retry with higher temperature (no-op on reasoning models that only accept default)
         try:
             response = await client.chat.completions.create(
-                model=resolved_model,
-                messages=messages,
-                temperature=0.3,
-                max_completion_tokens=max_tokens,
-                response_format={"type": "json_object"},
+                **self._build_create_kwargs(resolved_model, messages, 0.3, max_tokens),
             )
             content = response.choices[0].message.content or "{}"
             retry_tokens = response.usage.total_tokens if response.usage else 0
@@ -150,6 +142,39 @@ class LLMService:
             raise LLMServiceError(
                 f"LLM API call failed on retry ({resolved_provider}/{resolved_model}): {e}"
             ) from e
+
+    @staticmethod
+    def _supports_custom_temperature(model: str) -> bool:
+        """OpenAI gpt-5 / o-series reasoning models reject any temperature value other than 1.
+
+        Returns False for those models so the caller omits the kwarg and lets the
+        SDK use the model's fixed default. Returns True for GPT-4o / GPT-3.5 / etc.
+        """
+        model_lower = model.lower()
+        return not any(p in model_lower for p in ("gpt-5", "o1", "o3", "o4"))
+
+    @classmethod
+    def _build_create_kwargs(
+        cls,
+        model: str,
+        messages: list[dict],
+        temperature: float,
+        max_tokens: int,
+    ) -> dict:
+        """Build kwargs for AsyncOpenAI.chat.completions.create.
+
+        Branches on the model name to omit `temperature` for reasoning models
+        (gpt-5 / o-series) which only accept the default value.
+        """
+        kwargs: dict = {
+            "model": model,
+            "messages": messages,
+            "max_completion_tokens": max_tokens,
+            "response_format": {"type": "json_object"},
+        }
+        if cls._supports_custom_temperature(model):
+            kwargs["temperature"] = temperature
+        return kwargs
 
     async def _get_client(
         self,

--- a/backend/tests/services/test_llm_service.py
+++ b/backend/tests/services/test_llm_service.py
@@ -100,6 +100,67 @@ class TestCompleteJson:
         assert "max_tokens" not in call_kwargs
 
     @pytest.mark.asyncio
+    async def test_gpt5_omits_temperature_kwarg(self, llm_service):
+        """Regression guard (#424): gpt-5 / o-series only accept temperature=1.
+
+        The SDK call must NOT include the `temperature` kwarg for these models;
+        the SDK falls back to the model's fixed default. Sending any custom
+        value (even our default 0.1) returns HTTP 400.
+        """
+        mock_response = _make_completion_response('{"ok": true}')
+
+        with patch.object(llm_service, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            await llm_service.complete_json(
+                user_id="user-1",
+                prompt="Test",
+                model="gpt-5-nano",
+                temperature=0.1,
+            )
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert "temperature" not in call_kwargs
+        assert call_kwargs["model"] == "gpt-5-nano"
+
+    @pytest.mark.asyncio
+    async def test_gpt4_includes_temperature_kwarg(self, llm_service):
+        """Regression guard (#424): GPT-4 family must still receive the temperature kwarg."""
+        mock_response = _make_completion_response('{"ok": true}')
+
+        with patch.object(llm_service, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            await llm_service.complete_json(
+                user_id="user-1",
+                prompt="Test",
+                model="gpt-4o-mini",
+                temperature=0.1,
+            )
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["temperature"] == 0.1
+
+    def test_supports_custom_temperature_helper(self):
+        """Unit test for the model-prefix detection helper (#424)."""
+        # Reasoning models — must omit temperature
+        assert LLMService._supports_custom_temperature("gpt-5-nano") is False
+        assert LLMService._supports_custom_temperature("gpt-5") is False
+        assert LLMService._supports_custom_temperature("o1-preview") is False
+        assert LLMService._supports_custom_temperature("o1-mini") is False
+        assert LLMService._supports_custom_temperature("o3-mini") is False
+        assert LLMService._supports_custom_temperature("o4-mini") is False
+        # Non-reasoning models — temperature OK
+        assert LLMService._supports_custom_temperature("gpt-4o-mini") is True
+        assert LLMService._supports_custom_temperature("gpt-4o") is True
+        assert LLMService._supports_custom_temperature("gpt-3.5-turbo") is True
+        assert LLMService._supports_custom_temperature("llama-3") is True
+
+    @pytest.mark.asyncio
     async def test_no_system_prompt(self, llm_service):
         """Test completion without system prompt."""
         mock_response = _make_completion_response('{"ok": true}')
@@ -121,7 +182,11 @@ class TestCompleteJson:
 
     @pytest.mark.asyncio
     async def test_json_parse_failure_retries(self, llm_service):
-        """Test retry on JSON parse failure with higher temperature."""
+        """Test retry on JSON parse failure with higher temperature.
+
+        Pinned to a GPT-4 family model so the temperature kwarg is actually sent
+        — GPT-5 / o-series omit it (see test_gpt5_omits_temperature_kwarg).
+        """
         bad_response = _make_completion_response("not json {", total_tokens=30)
         good_response = _make_completion_response('{"retried": true}', total_tokens=35)
 
@@ -136,12 +201,13 @@ class TestCompleteJson:
             result, tokens = await llm_service.complete_json(
                 user_id="user-1",
                 prompt="Test",
+                model="gpt-4o-mini",
             )
 
         assert result == {"retried": True}
         assert tokens == 30 + 35  # Both attempts counted
 
-        # Verify retry used higher temperature
+        # Verify retry used higher temperature (GPT-4 path, temperature kwarg present)
         calls = mock_client.chat.completions.create.call_args_list
         assert calls[0][1]["temperature"] == 0.1  # First attempt
         assert calls[1][1]["temperature"] == 0.3  # Retry


### PR DESCRIPTION
Closes #424. Follow-up to #421 / PR #423.

## Summary

After #423 deployed (`max_completion_tokens` fix), production manual sleep run on `kagura-dev` revealed a second GPT-5 constraint:

```
Error code: 400 - Unsupported value: 'temperature' does not support 0.1 with this model.
                  Only the default (1) value is supported.
```

GPT-5 / o1 / o3 / o4 reasoning models only accept `temperature=1` (their default). This PR branches on the resolved model name in `LLMService._build_create_kwargs` and omits the kwarg for those models, letting the SDK use the model's fixed default.

GPT-4o / GPT-3.5 / non-OpenAI providers continue to receive `temperature=0.1` (or 0.3 on retry) for deterministic JSON output, unchanged.

## Changes

- `LLMService._build_create_kwargs` (new helper, classmethod) — single source of truth for the OpenAI `chat.completions.create` kwargs. Two call sites (first attempt + retry) now go through it, removing duplication.
- `LLMService._supports_custom_temperature` (new helper, staticmethod) — model-prefix detection (`gpt-5`, `o1`, `o3`, `o4`).
- Both call sites in `complete_json` simplified to `**self._build_create_kwargs(...)`.

## Test changes

- **New** `test_gpt5_omits_temperature_kwarg` — passes `model="gpt-5-nano"`, asserts `"temperature" not in call_kwargs`.
- **New** `test_gpt4_includes_temperature_kwarg` — passes `model="gpt-4o-mini"`, asserts `call_kwargs["temperature"] == 0.1`.
- **New** `test_supports_custom_temperature_helper` — unit test on the prefix detector across reasoning + non-reasoning + non-OpenAI model names.
- **Updated** `test_json_parse_failure_retries` — now pins `model="gpt-4o-mini"` so the temperature-on-retry assertion still meaningfully fires. (Default `SLEEP_LLM_MODEL` is `gpt-5-nano` which omits temperature, so the original test would no longer test what it claimed to.)

`pytest tests/services/test_llm_service.py` → 13 / 13 pass. `ruff check` + `ruff format --check` clean.

## Why two PRs (#423 + this)

Both fixes are GPT-5 family API constraints, but they were caught one at a time because each 400 short-circuits the request before the next constraint is reached. Splitting them gives:

- A clean post-#423 manual-sleep verification (which is what surfaced this one)
- Independent rollback granularity

Future GPT-5 / o-series API constraints (e.g. `top_p`) would follow the same pattern — extend `_build_create_kwargs` and add a regression-guard test.

## Deploy plan

After merge: same blue-green flow as #423 (`git pull` on VM → `scripts/deploy.sh`). Manual sleep run on `kagura-dev` should then show `llm_call_failures: 0` and `llm_accepted + llm_rejected > 0`.

## Severity

v0.13.1 release blocker continuation — same impact as #421.

🤖 Generated with [Claude Code](https://claude.com/claude-code)