### PR TITLE
fix(sleep): add reasoning_effort=minimal for OpenAI gpt-5/o-series (#426)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "numpy>=1.24.0",           # Cosine similarity in neural memory (neural/utils.py)
 
     # LLM APIs (DB管理されたKeysを使用)
-    "openai>=1.54.0",       # Embedding
+    "openai>=1.99.2",       # Embedding + Sleep LLM (reasoning_effort kwarg requires 1.99.2+, #426)
     "cohere>=5.11.0",       # Reranking (optional)
     "voyageai>=0.3.0",      # Reranking (Issue #105: Voyage AI alternative)
 

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -167,11 +167,12 @@ class LLMService:
         - GPT-4o / GPT-3.5 / non-OpenAI: pass `temperature` as given.
         - GPT-5 / o-series reasoning models: omit `temperature` (only default
           accepted) AND pass `reasoning_effort="minimal"` (#426). Without the
-          latter, reasoning consumes the entire `max_completion_tokens` budget
-          and the visible JSON output is empty, breaking the JSON-mode pipeline
-          silently (LLM call succeeds, but `response.edges` is missing).
-          `minimal` matches OpenAI's recommended setting for deterministic
-          extraction/classification tasks.
+          latter, reasoning tokens consume the entire `max_completion_tokens`
+          budget and `response.choices[0].message.content` comes back empty
+          (or `"{}"`). The downstream JSON-mode pipeline then parses an empty
+          dict, the parser sees no `edges` key, and edge_discovery silently
+          classifies nothing. `minimal` matches OpenAI's recommended setting
+          for deterministic extraction/classification tasks.
         """
         kwargs: dict = {
             "model": model,

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -163,8 +163,15 @@ class LLMService:
     ) -> dict:
         """Build kwargs for AsyncOpenAI.chat.completions.create.
 
-        Branches on the model name to omit `temperature` for reasoning models
-        (gpt-5 / o-series) which only accept the default value.
+        Branches on the model name:
+        - GPT-4o / GPT-3.5 / non-OpenAI: pass `temperature` as given.
+        - GPT-5 / o-series reasoning models: omit `temperature` (only default
+          accepted) AND pass `reasoning_effort="minimal"` (#426). Without the
+          latter, reasoning consumes the entire `max_completion_tokens` budget
+          and the visible JSON output is empty, breaking the JSON-mode pipeline
+          silently (LLM call succeeds, but `response.edges` is missing).
+          `minimal` matches OpenAI's recommended setting for deterministic
+          extraction/classification tasks.
         """
         kwargs: dict = {
             "model": model,
@@ -174,6 +181,8 @@ class LLMService:
         }
         if cls._supports_custom_temperature(model):
             kwargs["temperature"] = temperature
+        else:
+            kwargs["reasoning_effort"] = "minimal"
         return kwargs
 
     async def _get_client(

--- a/backend/tests/services/test_llm_service.py
+++ b/backend/tests/services/test_llm_service.py
@@ -126,8 +126,36 @@ class TestCompleteJson:
         assert call_kwargs["model"] == "gpt-5-nano"
 
     @pytest.mark.asyncio
+    async def test_gpt5_includes_reasoning_effort_minimal(self, llm_service):
+        """Regression guard (#426): gpt-5 / o-series must receive reasoning_effort=minimal.
+
+        Without it, reasoning tokens exhaust max_completion_tokens and the
+        visible JSON output is empty. `minimal` is OpenAI's recommended
+        setting for deterministic JSON-mode tasks like edge_discovery.
+        """
+        mock_response = _make_completion_response('{"ok": true}')
+
+        with patch.object(llm_service, "_get_client") as mock_get_client:
+            mock_client = AsyncMock()
+            mock_client.chat.completions.create.return_value = mock_response
+            mock_get_client.return_value = mock_client
+
+            await llm_service.complete_json(
+                user_id="user-1",
+                prompt="Test",
+                model="gpt-5-nano",
+            )
+
+        call_kwargs = mock_client.chat.completions.create.call_args[1]
+        assert call_kwargs["reasoning_effort"] == "minimal"
+
+    @pytest.mark.asyncio
     async def test_gpt4_includes_temperature_kwarg(self, llm_service):
-        """Regression guard (#424): GPT-4 family must still receive the temperature kwarg."""
+        """Regression guard (#424): GPT-4 family must still receive the temperature kwarg.
+
+        Also (#426): GPT-4 family must NOT receive reasoning_effort
+        (parameter is unknown to non-reasoning models and would 400).
+        """
         mock_response = _make_completion_response('{"ok": true}')
 
         with patch.object(llm_service, "_get_client") as mock_get_client:
@@ -144,6 +172,7 @@ class TestCompleteJson:
 
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert call_kwargs["temperature"] == 0.1
+        assert "reasoning_effort" not in call_kwargs
 
     def test_supports_custom_temperature_helper(self):
         """Unit test for the model-prefix detection helper (#424)."""


### PR DESCRIPTION
Closes #426. Third hot fix in the v0.13.1 sleep-LLM regression chain (#421 → #424 → this).

## Summary

After PR #423 (`max_completion_tokens`) and PR #425 (`temperature` omit) deployed, the OpenAI API call **succeeded** but the visible JSON output was empty — gpt-5-nano spent the entire `max_completion_tokens` budget on reasoning tokens, leaving no room for the actual `{"edges": [...]}` output. The parser in `_llm_judge_batch` saw nothing to classify, so `llm_accepted=0`, `llm_rejected=0`, `edges_created=0` across all batches.

Latest manual sleep run on `kagura-dev` (post-#425) — report `8b6a08e0`:
```
llm_calls_made:    12
llm_tokens_used:   22,814         ← API succeeds, tokens consumed
llm_call_failures: 0              ← #421 + #424 fixes still working
llm_accepted:      0
llm_rejected:      0
edges_created:     0
```

22,814 / 12 ≈ **1,900 tokens/call**, well above the visible-output budget of `max_completion_tokens=1024` because OpenAI counts reasoning tokens against the same budget.

## Fix

Extend `_build_create_kwargs` to add `reasoning_effort="minimal"` for gpt-5/o-series. Non-reasoning models (gpt-4o, gpt-3.5) do NOT get the kwarg (would 400 as unknown parameter).

```python
if cls._supports_custom_temperature(model):
    kwargs["temperature"] = temperature
else:
    # Reasoning models: cap reasoning so JSON output fits in max_completion_tokens
    kwargs["reasoning_effort"] = "minimal"
```

`reasoning_effort="minimal"` is OpenAI's recommended setting for deterministic JSON-mode tasks like edge_discovery (no chain-of-thought needed — just `{"edges": [{"pair": [...], "related": ..., "confidence": ...}]}`).

## Sources

- [OpenAI Cookbook: GPT-5 New Params and Tools](https://developers.openai.com/cookbook/examples/gpt-5/gpt-5_new_params_and_tools) — "Minimal Reasoning runs GPT-5 with few or no reasoning tokens. Use it for deterministic, lightweight tasks (extraction, formatting, short rewrites, simple classification) where explanations aren't needed."
- [OpenAI Developer Community — gpt-5-nano accepted parameters](https://community.openai.com/t/gpt-5-nano-accepted-parameters/1355086) — Maintainer-confirmed: Chat Completions uses top-level `reasoning_effort="minimal"` (the nested `reasoning={"effort": "minimal"}` form is Responses-API only and 400s on Chat Completions).

SDK version requirement is openai 1.99.2+; production has 2.30.0 (verified).

## Test changes

- **New** `test_gpt5_includes_reasoning_effort_minimal` — passes `model="gpt-5-nano"`, asserts `call_kwargs["reasoning_effort"] == "minimal"`.
- **Extended** `test_gpt4_includes_temperature_kwarg` — also asserts `"reasoning_effort" not in call_kwargs` for `gpt-4o-mini` (regression guard against accidentally sending it to non-reasoning models).

`pytest tests/services/test_llm_service.py` → 14 / 14 pass. `ruff check` + `ruff format --check` clean.

## Test plan (post-deploy)

- [x] `make lint` + `make test-local` pass (14/14)
- [ ] After deploy + manual sleep run on `kagura-dev`: `llm_accepted + llm_rejected > 0` (LLM actually classifies)
- [ ] If the LLM accepts ≥ 1 pair: `edges_created > 0` and `confidence_n > 0` (depends on actual judgment, not plumbing)

## Why three sequential hot fixes

GPT-5 family API constraints surfaced one at a time because each error short-circuits the request before the next is reached:

1. **#421** — `max_tokens` rejected (HTTP 400 unsupported_parameter)
2. **#424** — custom `temperature` rejected (HTTP 400 unsupported_value)
3. **This** — reasoning consumes budget → silent empty output (no error)

Long-term, OpenAI recommends migrating to the **Responses API** for reasoning models. That is a larger refactor (different SDK surface, different message format) and is filed for v0.14+ consideration. For v0.13.1 the surgical Chat Completions fix is sufficient.

## Severity

v0.13.1 release blocker — neural memory edge discovery is functionally non-operational without this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)