### PR TITLE
fix(sleep): match transfer_edges conflict check to DB unique_edge constraint (#428)

### DIFF
--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -1054,12 +1054,25 @@ class NeuralEdgeRepository:
                 await self.db.delete(edge)
                 continue
 
-            # Check for conflicting edge (unique_edge constraint)
+            # Check for conflicting edge (unique_edge constraint).
+            #
+            # The DB `unique_edge` UNIQUE constraint covers
+            # `(user_id, src_id, dst_id)` only — NOT `edge_type`
+            # (see `models/memory.py` UniqueConstraint definition and
+            # alembic migration `d18bcb6512e2_add_unique_edge_constraint_*`).
+            # Including `edge_type` here previously caused #428: a transfer
+            # that produced (C, B, related_to) when (C, B, depends_on) already
+            # existed was reported as "no conflict" by this 4-col check, then
+            # rejected by the DB 3-col constraint as IntegrityError, aborting
+            # the entire sleep run on contexts where any such pair existed.
+            #
+            # If the existing edge has a different `edge_type`, the
+            # weight-based winner-keeping logic below still applies (one
+            # edge per (src, dst) pair, matching DB semantics).
             conflict_conditions = [
                 NeuralMemoryEdge.user_id == user_id,
                 NeuralMemoryEdge.src_id == new_src,
                 NeuralMemoryEdge.dst_id == new_dst,
-                NeuralMemoryEdge.edge_type == edge.edge_type,
             ]
             if workspace_id:
                 conflict_conditions.append(NeuralMemoryEdge.workspace_id == UUID(workspace_id))


### PR DESCRIPTION
Closes #428.

## Summary

The `transfer_edges` conflict check in `repositories/neural_edge.py` used a 4-column predicate `(user_id, src_id, dst_id, edge_type)`, but the actual DB `unique_edge` UNIQUE constraint covers only 3 columns `(user_id, src_id, dst_id)`. When a transfer produced an edge with the same `(src, dst)` but different `edge_type` as one already in DB, the application reported "no conflict" → issued the UPDATE → DB rejected as IntegrityError → orchestrator caught the rolled-back transaction → entire sleep run failed.

## Diff

```python
# Before (4-col check, mismatched with DB)
conflict_conditions = [
    NeuralMemoryEdge.user_id == user_id,
    NeuralMemoryEdge.src_id == new_src,
    NeuralMemoryEdge.dst_id == new_dst,
    NeuralMemoryEdge.edge_type == edge.edge_type,
]

# After (3-col, matching DB unique_edge)
conflict_conditions = [
    NeuralMemoryEdge.user_id == user_id,
    NeuralMemoryEdge.src_id == new_src,
    NeuralMemoryEdge.dst_id == new_dst,
]
```

The existing weight-based winner-keeping logic below the conflict check is unchanged — when the existing edge has a different `edge_type`, the same code now correctly detects the conflict and keeps the higher-weight edge, deleting the other. Net effect: at most one edge per `(user_id, src_id, dst_id)` triple, matching DB semantics.

## Why this surfaced now

Found while verifying the #421/#424/#426 sleep-LLM hot fix chain. After all three LLM fixes deployed, `kagura-dev` (the dogfood / drift-anchor context for #407) was the only context that still failed sleep — with the IntegrityError above. Other contexts had no `(src, dst)` pairs that produced conflicting `edge_type`s, so they completed cleanly. Production failure scenario (extracted from `c73e562a` at 2026-04-23T16:53):

```
phase: dedup_merge
DETAIL: Key (user_id, src_id, dst_id)=(local:admin, 0e74141f-..., 7feff7d4-...) already exists.
SQL: UPDATE neural_memory_edges SET src_id=$1, last_updated=$2 WHERE id = $3
```

## Test plan

- [x] `make lint` passes (ruff check + format clean on `repositories/neural_edge.py`)
- [x] Existing `tests/repositories/test_neural_edge_upsert.py` (asserting the 3-col DB constraint) continues to pass — no schema change.
- [ ] After deploy, manual sleep run on `kagura-dev` completes (status=completed, no IntegrityError on dedup_merge phase).

## Scope clarifications

- **Schema unchanged.** This PR only updates application code to match the existing DB constraint.
- **No test update.** The schema test is already in place. Integration coverage for "two edges with same (src, dst) but different edge_type → transfer collapses to one via weight comparison" is desirable but a separate scope (requires DB fixture + setup of 2 conflicting edges); will file a follow-up if Copilot/review flags it.
- **Long-term decision (out of scope).** If product wants to retain different `edge_type` rows for the same memory pair (e.g., A→B can be both `related_to` and `depends_on`), the right fix is to **expand the DB constraint to 4 cols** — that's a migration + auditing every other call site (insert, upsert, ON CONFLICT clauses keyed on `unique_edge`). Out of scope for v0.13.1; file a follow-up if the merged behavior turns out to be lossy in practice.

## Severity

v0.13.1 release blocker — sleep on `kagura-dev` (the dogfood / drift-anchor context for #407 W+1 measurement) fails completely without this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)