### PR TITLE
feat(api): expose created_at + confidence on graph edge response (#430)

### DIFF
--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -62,12 +62,21 @@ class GraphNode(BaseModel):
 
 
 class GraphEdge(BaseModel):
-    """Graph edge for visualization."""
+    """Graph edge for visualization.
+
+    `created_at` and `confidence` are surfaced for downstream UI consumers
+    (#430 — graph edge metadata overlay, future #435). They were already
+    on the underlying `NeuralMemoryEdge` row but previously stripped at
+    this response model. Both stay optional so existing API clients that
+    don't read the new fields continue to deserialize unchanged.
+    """
 
     source: str
     target: str
     weight: float
     type: str
+    created_at: str | None = None
+    confidence: float | None = None
 
 
 class GraphDataResponse(BaseModel):
@@ -356,6 +365,8 @@ async def get_graph_data(
                         target=target_str,
                         weight=edge.weight,
                         type=edge.edge_type,
+                        created_at=edge.created_at.isoformat() if edge.created_at else None,
+                        confidence=edge.confidence,
                     )
                 )
 

--- a/frontend/src/lib/types/graph.ts
+++ b/frontend/src/lib/types/graph.ts
@@ -17,6 +17,13 @@ export interface GraphEdge {
   target: string;
   weight: number;
   type: string;
+  // #430: surfaced from the backend response so downstream UI consumers
+  // (e.g. the future graph edge metadata overlay #435) can render edge
+  // creation time + LLM-judge confidence. Both stay optional for response-
+  // shape compatibility — older API clients without these fields continue
+  // to deserialize unchanged.
+  created_at?: string;
+  confidence?: number;
 }
 
 export interface GraphData {


### PR DESCRIPTION
Closes #430. Lifted from the just-closed #422 (umbrella) re-scope.

## Summary

- `backend/src/api/routes/graph.py` `GraphEdge` Pydantic model now includes `created_at: str | None` and `confidence: float | None`. Both stay optional so existing API clients without these fields continue to deserialize unchanged.
- `edges.append(GraphEdge(...))` in the `/graph/data` endpoint populates the new fields from the underlying `NeuralMemoryEdge` row.
- `frontend/src/lib/types/graph.ts` `GraphEdge` interface mirrors with optional fields.

## Why

The DB `NeuralMemoryEdge` row already carries `created_at`, `confidence`, `last_updated`, `edge_metadata` (`backend/src/models/memory.py:266-343`), but they were stripped at the API boundary. The downstream UI work split into #432-#435 (edge metadata overlay #435 specifically) needs these fields. Shipping the API surface independently — ahead of the UI consumers — unblocks each frontend issue and keeps the v0.13.1 release anchor (#407 W+1 on 2026-04-27) clear.

## Test plan

- [x] `make lint` passes (ruff check + format clean on `graph.py` and `types/graph.ts`)
- [x] `make test-local` — `tests/repositories/test_graph_repository.py` 12/12 pass (no GraphEdge model regression)
- [x] Frontend — `npx vitest run src/lib/graph/nodeFilter.test.ts` 9/9 pass (GraphEdge type still satisfies all consumers in `nodeFilter.ts`, `useForceSimulation.ts`, `nodeFilter.test.ts`)
- [ ] After deploy: GET /api/v1/graph/data response includes the two new fields on each edge

## Compatibility

Additive change only:

- Pydantic model: new fields default to `None`, no migration needed
- Frontend type: new fields are optional, no type-narrowing breakage
- API JSON: existing clients ignore unknown fields (and the new fields are optional anyway)

🤖 Generated with [Claude Code](https://claude.com/claude-code)