### PR TITLE
feat(api): add context_id filter to GET /memory/list (#431)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -30,6 +30,7 @@ from models.schemas import (
 )
 from services.context_service import ContextService
 from services.memory_service import MemoryService
+from services.permission_service import PermissionService
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -467,6 +468,9 @@ async def list_memories(
     db: AsyncSession = Depends(get_db),
     scope: str | None = Query(None, pattern="^(working|persistent)$"),
     type: str | None = Query(None),
+    context_id: UUID | None = Query(
+        None, description="Optional context ID to scope results to a single context"
+    ),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
@@ -477,6 +481,11 @@ async def list_memories(
         db: Database session
         scope: Filter by scope (working or persistent)
         type: Filter by memory type
+        context_id: Optional context ID. When present, results are restricted
+            to that context and the caller must have workspace-read access to
+            it (uniform 404 via ``PermissionService`` on denial / non-existence).
+            The ``user_id`` filter is applied unchanged — ``context_id`` is
+            additive, not a bypass.
         limit: Maximum number of memories to return
         offset: Pagination offset
 
@@ -495,6 +504,13 @@ async def list_memories(
         if not user_id:
             raise ValueError("user_id or sub not found in user object")
 
+        if context_id is not None:
+            # Raises 404 on non-existent context, non-member, or private-context
+            # non-creator (CWE-639 uniform disclosure). Matches the graph routes.
+            await PermissionService(db).resolve_context_for_workspace_read(
+                user_id=user_id, context_id=context_id
+            )
+
         # Build query
         query = select(Memory).where(Memory.user_id == user_id)
 
@@ -504,12 +520,17 @@ async def list_memories(
         if type:
             query = query.where(Memory.type == type)
 
+        if context_id is not None:
+            query = query.where(Memory.context_id == context_id)
+
         # Get total count (with same filters as data query)
         count_query = select(func.count(Memory.id)).where(Memory.user_id == user_id)
         if scope:
             count_query = count_query.where(Memory.scope == scope)
         if type:
             count_query = count_query.where(Memory.type == type)
+        if context_id is not None:
+            count_query = count_query.where(Memory.context_id == context_id)
         count_result = await db.execute(count_query)
         total = count_result.scalar() or 0
 
@@ -539,6 +560,8 @@ async def list_memories(
 
         return MemoryListResponse(memories=memory_items, total=total, has_more=has_more)
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("list_memories_failed", error=str(e))
         raise HTTPException(

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -1,0 +1,127 @@
+"""Tests for GET /memory/list endpoint (Issue #431).
+
+Covers the new ``context_id`` query-param filter:
+  - Omitted: legacy behavior, no PermissionService call.
+  - Provided: PermissionService.resolve_context_for_workspace_read enforces
+    access and ``Memory.context_id`` is added to both data and count queries.
+  - Provided but context denied / not found: HTTPException 404 propagates.
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.memory import list_memories
+
+MOCK_USER = {"user_id": "test_user_123"}
+
+
+def _mock_memory_row():
+    mem = MagicMock()
+    mem.id = uuid4()
+    mem.summary = "Test memory"
+    mem.type = "note"
+    mem.scope = "persistent"
+    mem.importance = 0.8
+    mem.created_at = datetime(2026, 4, 1)
+    mem.updated_at = datetime(2026, 4, 2)
+    return mem
+
+
+def _db_with_rows(total: int, rows: list):
+    """Build an AsyncMock db whose .execute() returns count then row results."""
+    mock_db = AsyncMock()
+
+    mock_count_result = MagicMock()
+    mock_count_result.scalar.return_value = total
+
+    mock_rows_result = MagicMock()
+    mock_scalars = MagicMock()
+    mock_scalars.all.return_value = rows
+    mock_rows_result.scalars.return_value = mock_scalars
+
+    mock_db.execute.side_effect = [mock_count_result, mock_rows_result]
+    return mock_db
+
+
+class TestListMemoriesContextFilter:
+    """Issue #431: context_id filter on GET /memory/list."""
+
+    @pytest.mark.asyncio
+    async def test_no_context_id_skips_permission_check(self):
+        """Without context_id, legacy behavior holds — no PermissionService call."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        with patch("api.routes.memory.PermissionService") as mock_perm_cls:
+            response = await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=None,
+                limit=50,
+                offset=0,
+            )
+
+        mock_perm_cls.assert_not_called()
+        assert response.total == 1
+        assert len(response.memories) == 1
+
+    @pytest.mark.asyncio
+    async def test_context_id_enforces_permission_and_filters(self):
+        """With context_id, PermissionService is invoked and the filter is applied."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+        context_id = uuid4()
+
+        mock_perm_instance = MagicMock()
+        mock_perm_instance.resolve_context_for_workspace_read = AsyncMock()
+
+        with patch(
+            "api.routes.memory.PermissionService", return_value=mock_perm_instance
+        ) as mock_perm_cls:
+            response = await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=context_id,
+                limit=50,
+                offset=0,
+            )
+
+        mock_perm_cls.assert_called_once_with(mock_db)
+        mock_perm_instance.resolve_context_for_workspace_read.assert_awaited_once_with(
+            user_id="test_user_123", context_id=context_id
+        )
+        assert response.total == 1
+
+    @pytest.mark.asyncio
+    async def test_context_id_denied_propagates_404(self):
+        """PermissionService 404 on forbidden/missing context propagates as HTTPException."""
+        mock_db = AsyncMock()  # must not reach .execute()
+        context_id = uuid4()
+
+        mock_perm_instance = MagicMock()
+        mock_perm_instance.resolve_context_for_workspace_read = AsyncMock(
+            side_effect=HTTPException(status_code=404, detail=f"Context {context_id} not found")
+        )
+
+        with patch("api.routes.memory.PermissionService", return_value=mock_perm_instance):
+            with pytest.raises(HTTPException) as exc:
+                await list_memories(
+                    user=MOCK_USER,
+                    db=mock_db,
+                    scope=None,
+                    type=None,
+                    context_id=context_id,
+                    limit=50,
+                    offset=0,
+                )
+
+        assert exc.value.status_code == 404
+        mock_db.execute.assert_not_called()

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -47,6 +47,18 @@ def _db_with_rows(total: int, rows: list):
     return mock_db
 
 
+def _where_sql(mock_db, call_index: int) -> str:
+    """Return the compiled WHERE clause for the Select passed to mock_db.execute(...).
+
+    We target just the WHERE subtree (not the full SELECT) because the column
+    list of ``select(Memory)`` always expands to include ``memories.context_id``
+    as a projected column — a whole-statement string match would be useless.
+    """
+    stmt = mock_db.execute.call_args_list[call_index].args[0]
+    whereclause = stmt.whereclause
+    return str(whereclause.compile(compile_kwargs={"literal_binds": False}))
+
+
 class TestListMemoriesContextFilter:
     """Issue #431: context_id filter on GET /memory/list."""
 
@@ -70,6 +82,14 @@ class TestListMemoriesContextFilter:
         mock_perm_cls.assert_not_called()
         assert response.total == 1
         assert len(response.memories) == 1
+
+        # Regression guard: when context_id is omitted, the predicate must
+        # NOT be present in either the count query or the data query.
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert "context_id" not in sql, (
+                f"context_id unexpectedly appears in SQL when param omitted: {sql}"
+            )
 
     @pytest.mark.asyncio
     async def test_context_id_enforces_permission_and_filters(self):
@@ -99,6 +119,15 @@ class TestListMemoriesContextFilter:
             user_id="test_user_123", context_id=context_id
         )
         assert response.total == 1
+
+        # Regression guard: the context_id predicate must land in BOTH the
+        # count query and the data query — asymmetric filtering would surface
+        # as `total=N, memories=[]` or broken pagination.
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert "context_id" in sql, (
+                f"context_id predicate missing from SQL (call_index={call_index}): {sql}"
+            )
 
     @pytest.mark.asyncio
     async def test_context_id_denied_propagates_404(self):


### PR DESCRIPTION
## Summary

- Adds `context_id: UUID | None` query param to `GET /api/v1/memory/list`. Pre-requisite for the v0.14.0 Memories tab UI cascade (#433).
- Enforces workspace-read access via `PermissionService.resolve_context_for_workspace_read` — uniform 404 on denial / non-existence (CWE-639), matching graph routes.
- `user_id` filter is retained — `context_id` is additive, not a bypass.
- HTTPException passes through the generic 500 handler so PermissionService's 404 isn't swallowed.

## Acceptance (#431)

- [x] `context_id` query param filters correctly when present
- [x] `user_id` filter still applied (additive, not substitute)
- [x] PermissionService check enforces context access
- [x] `make lint` passes
- [x] Tests added: with context_id (perm + filter), without (legacy), denied (404 propagates)

## Test plan

- [x] `cd backend && pytest tests/api/test_memory_list.py -v` — 3/3 pass
- [x] `cd backend && pytest tests/api/test_memory_stats.py tests/services/test_memory_service.py` — 0 regressions
- [x] `make lint` — clean
- [ ] (post-merge) UI wiring in #432/#433 consumes the new filter

Closes #431

🤖 Generated with [Claude Code](https://claude.com/claude-code)