### PR TITLE
feat(ui): Memories tab on contexts/[id] page (#433)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -552,6 +552,10 @@ async def list_memories(
         # naive UTC datetimes (DateTime without timezone=True). Tag the
         # serialized form with "Z" so JS clients (which parse naive ISO as
         # local time) don't render JST-shifted relative timestamps.
+        # ``updated_at`` is nullable (only set onupdate), so fall back to
+        # ``created_at`` for fresh rows that haven't been touched since
+        # insert. The frontend renders both as the row "updated" timestamp,
+        # so created_at is the correct fallback rather than null/empty.
         def _utc_iso(dt: Any) -> str:
             return dt.isoformat() + ("Z" if dt.tzinfo is None else "")
 
@@ -563,7 +567,7 @@ async def list_memories(
                 scope=m.scope,
                 importance=m.importance,
                 created_at=_utc_iso(m.created_at),
-                updated_at=_utc_iso(m.updated_at),
+                updated_at=_utc_iso(m.updated_at or m.created_at),
             )
             for m in memories
         ]

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -511,8 +511,13 @@ async def list_memories(
                 user_id=user_id, context_id=context_id
             )
 
-        # Build query
-        query = select(Memory).where(Memory.user_id == user_id)
+        # Build query. Exclude soft-deleted rows — POST /forget sets
+        # ``deleted_at`` rather than removing the row, and the list view
+        # must not surface tombstones.
+        query = select(Memory).where(
+            Memory.user_id == user_id,
+            Memory.deleted_at.is_(None),
+        )
 
         if scope:
             query = query.where(Memory.scope == scope)
@@ -524,7 +529,10 @@ async def list_memories(
             query = query.where(Memory.context_id == context_id)
 
         # Get total count (with same filters as data query)
-        count_query = select(func.count(Memory.id)).where(Memory.user_id == user_id)
+        count_query = select(func.count(Memory.id)).where(
+            Memory.user_id == user_id,
+            Memory.deleted_at.is_(None),
+        )
         if scope:
             count_query = count_query.where(Memory.scope == scope)
         if type:
@@ -540,7 +548,13 @@ async def list_memories(
         )
         memories = list(result.scalars().all())
 
-        # Convert to response
+        # Convert to response. Memory.created_at / updated_at are stored as
+        # naive UTC datetimes (DateTime without timezone=True). Tag the
+        # serialized form with "Z" so JS clients (which parse naive ISO as
+        # local time) don't render JST-shifted relative timestamps.
+        def _utc_iso(dt: Any) -> str:
+            return dt.isoformat() + ("Z" if dt.tzinfo is None else "")
+
         memory_items = [
             MemoryListItem(
                 id=str(m.id),
@@ -548,8 +562,8 @@ async def list_memories(
                 type=m.type,
                 scope=m.scope,
                 importance=m.importance,
-                created_at=m.created_at.isoformat(),
-                updated_at=m.updated_at.isoformat(),
+                created_at=_utc_iso(m.created_at),
+                updated_at=_utc_iso(m.updated_at),
             )
             for m in memories
         ]

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
 logger = logging.getLogger(__name__)
 
@@ -233,6 +233,17 @@ class ReferenceResponse(BaseModel):
     context: dict | None
     created_at: datetime
     client: str
+    # Optional origin metadata (Issue #215). Surfaced so the detail UI can
+    # show where a memory came from (vault://, file://, https://, etc.).
+    source_uri: str | None = None
+    source_type: str | None = None
+
+    @field_serializer("created_at")
+    def _serialize_created_at(self, dt: datetime) -> str:
+        # Memory.created_at is stored as naive UTC. Tag with "Z" so JS
+        # clients parse it as UTC (without it, naive ISO is interpreted
+        # as local time, which JST shifts by +9 hours).
+        return dt.isoformat() + ("Z" if dt.tzinfo is None else "")
 
 
 class ForgetRequest(BaseModel):

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -235,8 +235,10 @@ class ReferenceResponse(BaseModel):
     client: str
     # Optional origin metadata (Issue #215). Surfaced so the detail UI can
     # show where a memory came from (vault://, file://, https://, etc.).
+    # Use the same Literal as MemoryResponse / RememberRequest so the OpenAPI
+    # contract stays consistent and unexpected values can't leak to the UI.
     source_uri: str | None = None
-    source_type: str | None = None
+    source_type: Literal["file", "url", "vault", "api", "manual"] | None = None
 
     @field_serializer("created_at")
     def _serialize_created_at(self, dt: datetime) -> str:

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -563,6 +563,8 @@ class MemoryService:
             context=memory.context,
             created_at=memory.created_at,
             client=memory.client,
+            source_uri=memory.source_uri,
+            source_type=memory.source_type,
         )
 
     async def _create_declared_links(

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -130,6 +130,29 @@ class TestListMemoriesContextFilter:
             )
 
     @pytest.mark.asyncio
+    async def test_soft_deleted_memories_excluded(self):
+        """``deleted_at IS NULL`` is in WHERE on every code path (regression #433):
+        forget() is a soft-delete, so the list must hide tombstones."""
+        mock_db = _db_with_rows(total=0, rows=[])
+
+        with patch("api.routes.memory.PermissionService"):
+            await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=None,
+                limit=50,
+                offset=0,
+            )
+
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert "deleted_at IS NULL" in sql, (
+                f"deleted_at filter missing (call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
     async def test_context_id_denied_propagates_404(self):
         """PermissionService 404 on forbidden/missing context propagates as HTTPException."""
         mock_db = AsyncMock()  # must not reach .execute()

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -130,6 +130,29 @@ class TestListMemoriesContextFilter:
             )
 
     @pytest.mark.asyncio
+    async def test_null_updated_at_falls_back_to_created_at(self):
+        """Memory.updated_at is nullable (set onupdate). Fresh-insert rows have
+        updated_at=NULL; serializer must not crash and should fall back to
+        created_at to keep the response shape stable."""
+        mem = _mock_memory_row()
+        mem.updated_at = None  # simulates a never-updated row
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        with patch("api.routes.memory.PermissionService"):
+            response = await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=None,
+                limit=50,
+                offset=0,
+            )
+
+        assert response.total == 1
+        assert response.memories[0].updated_at == response.memories[0].created_at
+
+    @pytest.mark.asyncio
     async def test_soft_deleted_memories_excluded(self):
         """``deleted_at IS NULL`` is in WHERE on every code path (regression #433):
         forget() is a soft-delete, so the list must hide tombstones."""

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -193,6 +193,8 @@ class TestReference:
             workspace_id=uuid4(),
             context_id=uuid4(),
             deleted_at=None,
+            source_uri=None,
+            source_type=None,
         )
         service.memory_repo.get = AsyncMock(return_value=mock_memory)
         service.memory_repo.update_access_stats = AsyncMock()

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -36,6 +36,7 @@ import {
   AlertCircle,
 } from "lucide-react";
 import { OverviewTabPanel } from "@/components/contexts/OverviewTabPanel";
+import { MemoriesTabPanel } from "@/components/contexts/MemoriesTabPanel";
 import { ConnectionsTabPanel } from "@/components/contexts/ConnectionsTabPanel";
 import { SettingsTabPanel } from "@/components/contexts/SettingsTabPanel";
 import { SearchSettingsSection } from "@/components/contexts/SearchSettingsSection";
@@ -52,6 +53,7 @@ const GraphTabPanel = dynamic(
 
 const ADMIN_CONTEXT_TABS = [
   "overview",
+  "memories",
   "connections",
   "graph",
   "settings",
@@ -229,6 +231,7 @@ export default function ContextDetailPage() {
           {/* Issue #398: connections/graph/settings tabs are admin-only. */}
           {canSeeAdminTabs && (
             <>
+              <TabsTrigger value="memories">{t("tabs.memories")}</TabsTrigger>
               <TabsTrigger value="connections">
                 {t("tabs.connections")}
               </TabsTrigger>
@@ -248,6 +251,10 @@ export default function ContextDetailPage() {
             keeps GraphTabPanel's d3 bundle out of non-admin sessions). */}
         {canSeeAdminTabs && (
           <>
+            <TabsContent value="memories">
+              <MemoriesTabPanel contextId={contextId} />
+            </TabsContent>
+
             <TabsContent value="connections">
               <ConnectionsTabPanel contextId={contextId} />
             </TabsContent>

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -107,6 +107,7 @@ const CONTEXT_NAME_PATTERN = /^[a-z0-9_-]+$/;
 export default function ContextsPage() {
   const t = useTranslations("contexts");
   const tCommon = useTranslations("common");
+  const tDetail = useTranslations("contextDetail");
   const router = useRouter();
   const searchParams = useSearchParams();
   const { user, refetchUser } = useAuth();
@@ -1033,6 +1034,16 @@ export default function ContextsPage() {
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() =>
+                                router.push(
+                                  `/workspace/contexts/${context.id}?tab=memories`,
+                                )
+                              }
+                            >
+                              <Settings2 className="h-4 w-4 mr-2" />
+                              {tDetail("tabs.memories")}
+                            </DropdownMenuItem>
                             <DropdownMenuItem
                               onClick={() =>
                                 router.push(

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -202,7 +202,6 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
         memories={displayRows}
         loading={loading}
         onView={handleView}
-        onEdit={() => {}}
         onDelete={handleDelete}
         page={page}
         pageSize={PAGE_SIZE}

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -1,0 +1,230 @@
+/**
+ * MemoriesTabPanel
+ *
+ * Context-scoped memory list for the Memories tab on contexts/[id]
+ * (Issue #433). Lists rows via `GET /api/v1/memory/list?context_id=...`,
+ * hydrates each row to full `Memory` via `POST /reference` on view/delete,
+ * and deletes via `POST /forget`.
+ *
+ * Edit and Create are deferred — no UUID-addressed PUT endpoint exists yet
+ * (backend follow-up) and Create needs an MCP-shape form rewrite.
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { FileText } from "lucide-react";
+import { MemoriesTable } from "@/components/memories/MemoriesTable";
+import { MemoryDetailDialog } from "@/components/memories/MemoryDetailDialog";
+import { DeleteMemoryDialog } from "@/components/memories/DeleteMemoryDialog";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { EmptyState } from "@/components/ui/empty-state";
+import { useToast } from "@/hooks/use-toast";
+import { getMemories, referenceMemory } from "@/lib/api/memory";
+import type {
+  Memory,
+  MemoryListItem,
+  MemoryReference,
+} from "@/lib/types/memory";
+
+interface MemoriesTabPanelProps {
+  contextId: string;
+}
+
+const PAGE_SIZE = 50;
+
+// ``MemoryListItem`` (id-only) becomes something table-renderable here for
+// rows not yet hydrated. The table expects legacy composite-key columns
+// (key / agent_name); use the summary as a display fallback so cells aren't
+// blank. ``id`` is authoritative for row identity; other fields are cosmetic.
+function listItemAsMemory(item: MemoryListItem): Memory {
+  return {
+    id: item.id,
+    summary: item.summary,
+    key: item.summary,
+    value: "",
+    scope: item.scope,
+    type: item.type,
+    agent_name: "",
+    user_id: "",
+    importance: item.importance,
+    created_at: item.created_at,
+    updated_at: item.updated_at,
+  };
+}
+
+// ``POST /api/v1/memory/reference`` does NOT return {key, value, agent_name,
+// user_id, updated_at, access_count, metadata}. Merge the response with the
+// list item (which carries scope + updated_at) and fill the truly-absent
+// legacy fields with empty strings so the detail dialog renders without
+// crashing. This is the boundary where structural unsoundness is resolved.
+function referenceAsMemory(ref: MemoryReference, item: MemoryListItem): Memory {
+  return {
+    id: ref.memory_id,
+    summary: ref.summary,
+    key: ref.summary,
+    value: ref.content,
+    scope: item.scope,
+    type: ref.type,
+    agent_name: "",
+    user_id: "",
+    importance: ref.importance,
+    tags: ref.tags,
+    metadata: ref.details ?? undefined,
+    created_at: ref.created_at,
+    updated_at: item.updated_at,
+    source_uri: ref.source_uri,
+    source_type: ref.source_type,
+  };
+}
+
+type DialogTarget = "detail" | "delete";
+
+export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
+  const t = useTranslations("contextDetail.memoriesPanel");
+  const { toast } = useToast();
+
+  const [items, setItems] = useState<MemoryListItem[]>([]);
+  const [total, setTotal] = useState(0);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [hydrated, setHydrated] = useState<Memory | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  // Race guard: when the user clicks row A then B before A's reference() has
+  // resolved, the B-click sets `pendingHydrationRef.current = B.id`; when A
+  // finally resolves we compare and discard the stale result. Without this
+  // the last-resolving call wins, so A's data can land in a dialog opened
+  // for B.
+  const pendingHydrationRef = useRef<string | null>(null);
+
+  const fetchMemories = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const offset = (page - 1) * PAGE_SIZE;
+      const response = await getMemories({
+        context_id: contextId,
+        limit: PAGE_SIZE,
+        offset,
+      });
+      setItems(response.memories);
+      setTotal(response.total);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : t("loadFailed"));
+    } finally {
+      setLoading(false);
+    }
+  }, [contextId, page, t]);
+
+  useEffect(() => {
+    fetchMemories();
+  }, [fetchMemories]);
+
+  const openWith = useCallback(
+    async (id: string, target: DialogTarget) => {
+      const item = items.find((m) => m.id === id);
+      if (!item) return;
+
+      pendingHydrationRef.current = id;
+      try {
+        const ref = await referenceMemory(id);
+        if (pendingHydrationRef.current !== id) return;
+        setHydrated(referenceAsMemory(ref, item));
+        if (target === "detail") setDetailOpen(true);
+        else setDeleteOpen(true);
+      } catch (err) {
+        if (pendingHydrationRef.current !== id) return;
+        toast({
+          variant: "destructive",
+          title: t("hydrateFailed"),
+          description: err instanceof Error ? err.message : undefined,
+        });
+      }
+    },
+    [items, toast, t],
+  );
+
+  const handleView = useCallback(
+    (memory: Memory) => void openWith(memory.id, "detail"),
+    [openWith],
+  );
+
+  const handleDelete = useCallback(
+    (memory: Memory) => void openWith(memory.id, "delete"),
+    [openWith],
+  );
+
+  const handleDetailDelete = useCallback(() => {
+    setDetailOpen(false);
+    setDeleteOpen(true);
+  }, []);
+
+  const handleDeleteSuccess = useCallback(() => {
+    setDeleteOpen(false);
+    setDetailOpen(false);
+    setHydrated(null);
+    toast({ title: t("deleteSuccess") });
+
+    // Avoid stranding the user on an empty page when the deleted row was the
+    // last one on this page. Dropping `page` back triggers the fetch effect;
+    // otherwise re-fetch the current page.
+    if (items.length === 1 && page > 1) {
+      setPage(page - 1);
+    } else {
+      void fetchMemories();
+    }
+  }, [fetchMemories, toast, t, items.length, page]);
+
+  if (error) {
+    return <ErrorBanner error={error} />;
+  }
+
+  if (!loading && items.length === 0) {
+    return (
+      <EmptyState
+        icon={FileText}
+        title={t("emptyTitle")}
+        description={t("emptyDesc")}
+      />
+    );
+  }
+
+  const displayRows = items.map(listItemAsMemory);
+
+  return (
+    <>
+      <MemoriesTable
+        memories={displayRows}
+        loading={loading}
+        onView={handleView}
+        onEdit={() => {}}
+        onDelete={handleDelete}
+        page={page}
+        pageSize={PAGE_SIZE}
+        total={total}
+        onPageChange={setPage}
+      />
+      {hydrated && (
+        <>
+          <MemoryDetailDialog
+            memory={hydrated}
+            open={detailOpen}
+            onOpenChange={setDetailOpen}
+            onDelete={handleDetailDelete}
+          />
+          <DeleteMemoryDialog
+            memory={hydrated}
+            open={deleteOpen}
+            onOpenChange={setDeleteOpen}
+            onSuccess={handleDeleteSuccess}
+          />
+        </>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/memories/DeleteMemoryDialog.tsx
+++ b/frontend/src/components/memories/DeleteMemoryDialog.tsx
@@ -1,13 +1,14 @@
-'use client';
+"use client";
 
 /**
  * Delete Memory Dialog
  *
- * Confirmation dialog for deleting a memory
+ * Confirmation dialog for deleting a memory. Uses the UUID-addressed
+ * `forgetMemory` endpoint (Issue #433).
  */
 
-import { useState } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
+import { useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Dialog,
   DialogContent,
@@ -15,11 +16,12 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { AlertTriangle } from 'lucide-react';
-import { deleteMemory } from '@/lib/api/memory';
-import type { Memory } from '@/lib/types/memory';
+} from "@/components/ui/dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle } from "lucide-react";
+import { forgetMemory } from "@/lib/api/memory";
+import type { Memory } from "@/lib/types/memory";
 
 interface DeleteMemoryDialogProps {
   memory: Memory;
@@ -34,31 +36,18 @@ export function DeleteMemoryDialog({
   onOpenChange,
   onSuccess,
 }: DeleteMemoryDialogProps) {
-  const { user } = useAuth();
+  const t = useTranslations("contextDetail.deleteDialog");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleDelete = async () => {
-    if (!user) {
-      setError('User not authenticated');
-      return;
-    }
-
     try {
       setLoading(true);
       setError(null);
-
-      await deleteMemory(
-        memory.key,
-        user.id,
-        memory.scope,
-        memory.agent_name
-      );
-
+      await forgetMemory(memory.id);
       onSuccess();
     } catch (err) {
-      console.error('Failed to delete memory:', err);
-      setError(err instanceof Error ? err.message : 'Failed to delete memory');
+      setError(err instanceof Error ? err.message : t("failed"));
     } finally {
       setLoading(false);
     }
@@ -77,57 +66,59 @@ export function DeleteMemoryDialog({
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2 text-red-600 dark:text-red-400">
             <AlertTriangle className="h-5 w-5" />
-            Delete Memory
+            {t("title")}
           </DialogTitle>
-          <DialogDescription>
-            Are you sure you want to delete this memory? This action cannot be undone.
-          </DialogDescription>
+          <DialogDescription>{t("description")}</DialogDescription>
         </DialogHeader>
 
         <div className="space-y-3">
           {error && (
-            <div className="p-3 text-sm text-red-600 bg-red-50 dark:bg-red-900/20 rounded-md">
-              {error}
-            </div>
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
           )}
 
           <div className="p-4 bg-slate-50 dark:bg-slate-900 rounded-lg space-y-2">
             <div>
-              <span className="text-xs text-slate-500 dark:text-slate-400">Key:</span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t("keyLabel")}
+              </span>
               <p className="font-medium">{memory.key}</p>
             </div>
             <div>
-              <span className="text-xs text-slate-500 dark:text-slate-400">Scope:</span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t("scopeLabel")}
+              </span>
               <p className="text-sm">{memory.scope}</p>
             </div>
             <div>
-              <span className="text-xs text-slate-500 dark:text-slate-400">Agent:</span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t("agentLabel")}
+              </span>
               <p className="text-sm">{memory.agent_name}</p>
             </div>
             <div>
-              <span className="text-xs text-slate-500 dark:text-slate-400">Value (preview):</span>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t("previewLabel")}
+              </span>
               <p className="text-sm text-slate-600 dark:text-slate-300 truncate">
                 {memory.value.substring(0, 100)}
-                {memory.value.length > 100 && '...'}
+                {memory.value.length > 100 && "..."}
               </p>
             </div>
           </div>
         </div>
 
         <DialogFooter>
-          <Button
-            variant="outline"
-            onClick={handleClose}
-            disabled={loading}
-          >
-            Cancel
+          <Button variant="outline" onClick={handleClose} disabled={loading}>
+            {t("cancel")}
           </Button>
           <Button
             variant="destructive"
             onClick={handleDelete}
             disabled={loading}
           >
-            {loading ? 'Deleting...' : 'Delete Memory'}
+            {loading ? t("deleting") : t("confirm")}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/frontend/src/components/memories/DeleteMemoryDialog.tsx
+++ b/frontend/src/components/memories/DeleteMemoryDialog.tsx
@@ -78,12 +78,22 @@ export function DeleteMemoryDialog({
             </Alert>
           )}
 
+          {/* Preview block: identify the memory by summary + UUID. The legacy
+              composite-key fields (key/agent_name) are not populated by the
+              UUID-addressed list flow, so they are intentionally not shown.
+              Value preview is conditional — empty for list-only rows. */}
           <div className="p-4 bg-slate-50 dark:bg-slate-900 rounded-lg space-y-2">
             <div>
               <span className="text-xs text-slate-500 dark:text-slate-400">
-                {t("keyLabel")}
+                {t("summaryLabel")}
               </span>
-              <p className="font-medium">{memory.key}</p>
+              <p className="font-medium">{memory.summary || memory.key}</p>
+            </div>
+            <div>
+              <span className="text-xs text-slate-500 dark:text-slate-400">
+                {t("idLabel")}
+              </span>
+              <p className="text-xs font-mono break-all">{memory.id}</p>
             </div>
             <div>
               <span className="text-xs text-slate-500 dark:text-slate-400">
@@ -91,21 +101,17 @@ export function DeleteMemoryDialog({
               </span>
               <p className="text-sm">{memory.scope}</p>
             </div>
-            <div>
-              <span className="text-xs text-slate-500 dark:text-slate-400">
-                {t("agentLabel")}
-              </span>
-              <p className="text-sm">{memory.agent_name}</p>
-            </div>
-            <div>
-              <span className="text-xs text-slate-500 dark:text-slate-400">
-                {t("previewLabel")}
-              </span>
-              <p className="text-sm text-slate-600 dark:text-slate-300 truncate">
-                {memory.value.substring(0, 100)}
-                {memory.value.length > 100 && "..."}
-              </p>
-            </div>
+            {memory.value && (
+              <div>
+                <span className="text-xs text-slate-500 dark:text-slate-400">
+                  {t("previewLabel")}
+                </span>
+                <p className="text-sm text-slate-600 dark:text-slate-300 truncate">
+                  {memory.value.substring(0, 100)}
+                  {memory.value.length > 100 && "..."}
+                </p>
+              </div>
+            )}
           </div>
         </div>
 

--- a/frontend/src/components/memories/MemoriesTable.tsx
+++ b/frontend/src/components/memories/MemoriesTable.tsx
@@ -27,7 +27,10 @@ interface MemoriesTableProps {
   memories: Memory[];
   loading: boolean;
   onView: (memory: Memory) => void;
-  onEdit: (memory: Memory) => void;
+  // Optional: omit to hide the Edit icon. Same convention as MemoryDetailDialog
+  // — until a UUID-addressed update endpoint lands (#439), consumers without
+  // an edit path should pass nothing rather than a no-op callback.
+  onEdit?: (memory: Memory) => void;
   onDelete: (memory: Memory) => void;
   page: number;
   pageSize: number;
@@ -206,14 +209,16 @@ export function MemoriesTable({
                       >
                         <Eye className="h-4 w-4" />
                       </Button>
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => onEdit(memory)}
-                        title="Edit memory"
-                      >
-                        <Pencil className="h-4 w-4" />
-                      </Button>
+                      {onEdit && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => onEdit(memory)}
+                          title="Edit memory"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="icon"

--- a/frontend/src/components/memories/MemoriesTable.tsx
+++ b/frontend/src/components/memories/MemoriesTable.tsx
@@ -174,7 +174,7 @@ export function MemoriesTable({
                         onCheckedChange={(checked) =>
                           handleRowToggle(memory, checked)
                         }
-                        aria-label={`Select ${memory.summary || memory.key}`}
+                        aria-label={`Select ${memory.summary || memory.key || memory.id}`}
                       />
                     </TableCell>
                   )}

--- a/frontend/src/components/memories/MemoriesTable.tsx
+++ b/frontend/src/components/memories/MemoriesTable.tsx
@@ -151,9 +151,9 @@ export function MemoriesTable({
                   />
                 </TableHead>
               )}
-              <TableHead>Key</TableHead>
+              <TableHead>Summary</TableHead>
+              <TableHead>Type</TableHead>
               <TableHead>Scope</TableHead>
-              <TableHead>Agent</TableHead>
               <TableHead>Importance</TableHead>
               <TableHead>Updated</TableHead>
               <TableHead className="text-right">Actions</TableHead>
@@ -171,19 +171,23 @@ export function MemoriesTable({
                         onCheckedChange={(checked) =>
                           handleRowToggle(memory, checked)
                         }
-                        aria-label={`Select ${memory.key}`}
+                        aria-label={`Select ${memory.summary || memory.key}`}
                       />
                     </TableCell>
                   )}
                   <TableCell className="font-medium max-w-xs truncate">
-                    {memory.key}
+                    {memory.summary || memory.key}
+                  </TableCell>
+                  <TableCell>
+                    {memory.type ? (
+                      <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
+                        {memory.type}
+                      </code>
+                    ) : (
+                      <span className="text-xs text-slate-400">—</span>
+                    )}
                   </TableCell>
                   <TableCell>{getScopeBadge(memory.scope)}</TableCell>
-                  <TableCell>
-                    <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
-                      {memory.agent_name}
-                    </code>
-                  </TableCell>
                   <TableCell>{getImportanceBadge(memory.importance)}</TableCell>
                   <TableCell className="text-sm text-slate-500">
                     {formatRelativeTime(

--- a/frontend/src/components/memories/MemoriesTable.tsx
+++ b/frontend/src/components/memories/MemoriesTable.tsx
@@ -206,6 +206,7 @@ export function MemoriesTable({
                         size="icon"
                         onClick={() => onView(memory)}
                         title="View details"
+                        aria-label="View details"
                       >
                         <Eye className="h-4 w-4" />
                       </Button>
@@ -215,6 +216,7 @@ export function MemoriesTable({
                           size="icon"
                           onClick={() => onEdit(memory)}
                           title="Edit memory"
+                          aria-label="Edit memory"
                         >
                           <Pencil className="h-4 w-4" />
                         </Button>
@@ -224,6 +226,7 @@ export function MemoriesTable({
                         size="icon"
                         onClick={() => onDelete(memory)}
                         title="Delete memory"
+                        aria-label="Delete memory"
                         className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
                       >
                         <Trash2 className="h-4 w-4" />

--- a/frontend/src/components/memories/MemoryDetailDialog.tsx
+++ b/frontend/src/components/memories/MemoryDetailDialog.tsx
@@ -20,7 +20,7 @@ import type { Memory } from "@/lib/types/memory";
 import { formatDateTime } from "@/lib/utils/datetime";
 import { useState } from "react";
 import { useAuth } from "@/contexts/AuthContext";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 
 interface MemoryDetailDialogProps {
   memory: Memory;
@@ -42,6 +42,7 @@ export function MemoryDetailDialog({
 }: MemoryDetailDialogProps) {
   const { user } = useAuth();
   const locale = useLocale();
+  const t = useTranslations("contextDetail.detailDialog");
   const [copied, setCopied] = useState(false);
   const [idCopied, setIdCopied] = useState(false);
 
@@ -114,7 +115,7 @@ export function MemoryDetailDialog({
           {/* Memory ID — full row with copy button */}
           <div>
             <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
-              Memory ID
+              {t("memoryId")}
             </label>
             <div className="mt-1 flex items-center gap-2">
               <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded font-mono break-all">
@@ -125,7 +126,8 @@ export function MemoryDetailDialog({
                 size="sm"
                 onClick={copyId}
                 className="h-7 shrink-0"
-                title="Copy memory ID"
+                title={t("copyMemoryId")}
+                aria-label={t("copyMemoryId")}
               >
                 {idCopied ? (
                   <Check className="h-3.5 w-3.5" />
@@ -198,7 +200,7 @@ export function MemoryDetailDialog({
               <Separator />
               <div>
                 <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
-                  Source
+                  {t("source")}
                 </label>
                 <div className="mt-1 flex items-center gap-2">
                   {memory.source_type && (

--- a/frontend/src/components/memories/MemoryDetailDialog.tsx
+++ b/frontend/src/components/memories/MemoryDetailDialog.tsx
@@ -26,7 +26,10 @@ interface MemoryDetailDialogProps {
   memory: Memory;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onEdit: () => void;
+  // Optional: omit to hide the Edit button entirely. #433 defers edit until a
+  // UUID-addressed update endpoint lands; passing `undefined` keeps the dialog
+  // honest (no ghost button).
+  onEdit?: () => void;
   onDelete: () => void;
 }
 
@@ -40,12 +43,23 @@ export function MemoryDetailDialog({
   const { user } = useAuth();
   const locale = useLocale();
   const [copied, setCopied] = useState(false);
+  const [idCopied, setIdCopied] = useState(false);
 
   const copyValue = async () => {
     try {
       await navigator.clipboard.writeText(memory.value);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy:", error);
+    }
+  };
+
+  const copyId = async () => {
+    try {
+      await navigator.clipboard.writeText(memory.id);
+      setIdCopied(true);
+      setTimeout(() => setIdCopied(false), 2000);
     } catch (error) {
       console.error("Failed to copy:", error);
     }
@@ -97,31 +111,53 @@ export function MemoryDetailDialog({
 
           <Separator />
 
-          {/* Metadata Grid */}
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
-                Agent Name
-              </label>
-              <p className="mt-1">
-                <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
-                  {memory.agent_name}
-                </code>
-              </p>
+          {/* Memory ID — full row with copy button */}
+          <div>
+            <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
+              Memory ID
+            </label>
+            <div className="mt-1 flex items-center gap-2">
+              <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded font-mono break-all">
+                {memory.id}
+              </code>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={copyId}
+                className="h-7 shrink-0"
+                title="Copy memory ID"
+              >
+                {idCopied ? (
+                  <Check className="h-3.5 w-3.5" />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" />
+                )}
+              </Button>
             </div>
+          </div>
 
-            <div>
-              <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
-                User ID
-              </label>
-              <p className="mt-1 text-sm truncate">{memory.user_id}</p>
-            </div>
+          {/* Metadata Grid — wrapper elements use <div> not <p> so the Badge
+              children (which render as <div>) don't trigger the
+              `<p> cannot contain <div>` HTML hydration warning. */}
+          <div className="grid grid-cols-2 gap-4">
+            {memory.type && (
+              <div>
+                <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                  Type
+                </label>
+                <div className="mt-1">
+                  <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
+                    {memory.type}
+                  </code>
+                </div>
+              </div>
+            )}
 
             <div>
               <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
                 Importance
               </label>
-              <p className="mt-1">
+              <div className="mt-1">
                 <Badge
                   variant={
                     memory.importance >= 0.8
@@ -133,34 +169,50 @@ export function MemoryDetailDialog({
                 >
                   {memory.importance.toFixed(2)}
                 </Badge>
-              </p>
-            </div>
-
-            <div>
-              <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
-                Access Count
-              </label>
-              <p className="mt-1 text-sm">{memory.access_count || 0}</p>
+              </div>
             </div>
 
             <div>
               <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
                 Created At
               </label>
-              <p className="mt-1 text-sm">
+              <div className="mt-1 text-sm">
                 {formatDateTime(memory.created_at, user?.timezone, locale)}
-              </p>
+              </div>
             </div>
 
             <div>
               <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
                 Updated At
               </label>
-              <p className="mt-1 text-sm">
+              <div className="mt-1 text-sm">
                 {formatDateTime(memory.updated_at, user?.timezone, locale)}
-              </p>
+              </div>
             </div>
           </div>
+
+          {/* Source — origin URI + type for memories imported from a vault,
+              file, URL, etc. (Issue #215). Hidden if memory has no origin. */}
+          {memory.source_uri && (
+            <>
+              <Separator />
+              <div>
+                <label className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                  Source
+                </label>
+                <div className="mt-1 flex items-center gap-2">
+                  {memory.source_type && (
+                    <Badge variant="outline" className="shrink-0">
+                      {memory.source_type}
+                    </Badge>
+                  )}
+                  <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded break-all">
+                    {memory.source_uri}
+                  </code>
+                </div>
+              </div>
+            </>
+          )}
 
           {/* Tags */}
           {memory.tags && memory.tags.length > 0 && (
@@ -201,10 +253,12 @@ export function MemoryDetailDialog({
           <Button variant="outline" onClick={() => onOpenChange(false)}>
             Close
           </Button>
-          <Button variant="outline" onClick={onEdit}>
-            <Pencil className="h-4 w-4 mr-2" />
-            Edit
-          </Button>
+          {onEdit && (
+            <Button variant="outline" onClick={onEdit}>
+              <Pencil className="h-4 w-4 mr-2" />
+              Edit
+            </Button>
+          )}
           <Button variant="destructive" onClick={onDelete}>
             <Trash2 className="h-4 w-4 mr-2" />
             Delete

--- a/frontend/src/lib/api/memory.ts
+++ b/frontend/src/lib/api/memory.ts
@@ -75,8 +75,31 @@ export async function forgetMemory(memoryId: string): Promise<void> {
   });
 }
 
+// =============================================================================
+// LEGACY DEAD CODE — composite-key helpers below this banner.
+//
+// These functions target backend paths that DO NOT EXIST on the current API
+// surface (the memory router only exposes `/api/v1/memory/list`,
+// `/remember`, `/reference`, `/forget`, `/recall`, `/explore`, `/stats`,
+// `/access-patterns`). Calling any of them today returns 404.
+//
+// They remain in the file because the dialog components still import them
+// (CreateMemoryDialog → createMemory, EditMemoryDialog → updateMemory,
+// MemoriesTable → bulkDeleteMemories). Those dialogs are not yet wired to
+// any consumer. Removal is tracked alongside the dialog refactors:
+//   - createMemory / CreateMemoryDialog → needs /remember rewire
+//   - updateMemory / EditMemoryDialog   → see #439 (UUID PUT endpoint)
+//   - deleteMemory                       → superseded by forgetMemory above
+//   - bulkDeleteMemories                 → blocked on a UUID bulk-forget
+//   - searchMemoriesSemantic / Keyword / Timeline / getMemory / getMemoryStats
+//                                         → broken legacy search/stats
+//
+// Do NOT add new callers. The single-source canonical list/read/delete is
+// `getMemories` / `referenceMemory` / `forgetMemory` above.
+// =============================================================================
+
 /**
- * Get a single memory by key
+ * @deprecated Backend path /memory/{key} does not exist. Use referenceMemory(id).
  */
 export async function getMemory(
   key: string,
@@ -94,7 +117,7 @@ export async function getMemory(
 }
 
 /**
- * Create a new memory
+ * @deprecated Backend path POST /memory does not exist. Use POST /api/v1/memory/remember.
  */
 export async function createMemory(
   userId: string,
@@ -107,7 +130,7 @@ export async function createMemory(
 }
 
 /**
- * Update an existing memory
+ * @deprecated Backend path PUT /memory/{key} does not exist. See #439.
  */
 export async function updateMemory(
   key: string,
@@ -125,7 +148,7 @@ export async function updateMemory(
 }
 
 /**
- * Delete a memory
+ * @deprecated Backend path DELETE /memory/{key} does not exist. Use forgetMemory(id).
  */
 export async function deleteMemory(
   key: string,
@@ -145,7 +168,7 @@ export async function deleteMemory(
 }
 
 /**
- * Get memory statistics
+ * @deprecated Backend path is GET /api/v1/memory/stats and derives user from auth, not query.
  */
 export async function getMemoryStats(
   userId: string,
@@ -154,7 +177,7 @@ export async function getMemoryStats(
 }
 
 /**
- * Bulk delete memories (Issue #666)
+ * @deprecated Backend path POST /memory/bulk-delete does not exist. Needs UUID bulk-forget.
  */
 export async function bulkDeleteMemories(
   keys: string[],

--- a/frontend/src/lib/api/memory.ts
+++ b/frontend/src/lib/api/memory.ts
@@ -7,37 +7,72 @@
 import { apiClient } from "./base";
 import type {
   Memory,
+  MemoryScope,
   CreateMemoryRequest,
   UpdateMemoryRequest,
-  MemorySearchParams,
   MemoryListResponse,
+  MemoryListItem,
+  MemoryReference,
   MemoryStatsResponse,
 } from "../types/memory";
 
+// Issue #431/#433: Backend `GET /api/v1/memory/list` accepts only
+// {context_id, scope, type, limit, offset} — the old getMemories params
+// (query, agent_name, tags, min_importance, max_importance) don't exist
+// on this endpoint. Named params object, not the legacy `MemorySearchParams`.
+export interface ListMemoriesParams {
+  context_id?: string;
+  scope?: MemoryScope;
+  type?: string;
+  limit?: number;
+  offset?: number;
+}
+
 /**
- * Get list of memories with optional filters
+ * List memories, optionally scoped to a single context.
+ *
+ * Hits `GET /api/v1/memory/list` and returns the canonical
+ * `MemoryListItem` row shape (no legacy composite-key fields).
  */
 export async function getMemories(
-  params: MemorySearchParams = {},
-): Promise<MemoryListResponse<Memory>> {
+  params: ListMemoriesParams = {},
+): Promise<MemoryListResponse<MemoryListItem>> {
   const searchParams = new URLSearchParams();
 
-  if (params.query) searchParams.append("query", params.query);
-  if (params.scope) searchParams.append("scope", params.scope);
-  if (params.agent_name) searchParams.append("agent_name", params.agent_name);
-  if (params.tags)
-    params.tags.forEach((tag) => searchParams.append("tags", tag));
-  if (params.min_importance !== undefined)
-    searchParams.append("min_importance", params.min_importance.toString());
-  if (params.max_importance !== undefined)
-    searchParams.append("max_importance", params.max_importance.toString());
-  if (params.limit) searchParams.append("limit", params.limit.toString());
-  if (params.offset) searchParams.append("offset", params.offset.toString());
+  if (params.context_id) searchParams.set("context_id", params.context_id);
+  if (params.scope) searchParams.set("scope", params.scope);
+  if (params.type) searchParams.set("type", params.type);
+  searchParams.set("limit", String(params.limit ?? 50));
+  searchParams.set("offset", String(params.offset ?? 0));
 
-  const queryString = searchParams.toString();
-  const endpoint = `/memory${queryString ? `?${queryString}` : ""}`;
+  return apiClient.get<MemoryListResponse<MemoryListItem>>(
+    `/api/v1/memory/list?${searchParams.toString()}`,
+  );
+}
 
-  return apiClient.get<MemoryListResponse<Memory>>(endpoint);
+/**
+ * Fetch full memory detail by UUID.
+ *
+ * Returns the backend's `ReferenceResponse` shape verbatim. Consumers that
+ * need the legacy `Memory` shape must adapt — the backend does not return
+ * `key` / `value` / `agent_name` / `user_id` / `updated_at` / `access_count`.
+ */
+export async function referenceMemory(
+  memoryId: string,
+): Promise<MemoryReference> {
+  return apiClient.post<MemoryReference>("/api/v1/memory/reference", {
+    memory_id: memoryId,
+  });
+}
+
+/**
+ * Delete a memory by UUID (UUID-addressed forget, not the composite-key
+ * DELETE which doesn't exist as a REST endpoint).
+ */
+export async function forgetMemory(memoryId: string): Promise<void> {
+  await apiClient.post<unknown>("/api/v1/memory/forget", {
+    memory_id: memoryId,
+  });
 }
 
 /**
@@ -116,20 +151,6 @@ export async function getMemoryStats(
   userId: string,
 ): Promise<MemoryStatsResponse> {
   return apiClient.get<MemoryStatsResponse>(`/memory/stats?user_id=${userId}`);
-}
-
-/**
- * Search memories semantically
- */
-export async function searchMemories(
-  userId: string,
-  query: string,
-  params: Omit<MemorySearchParams, "query"> = {},
-): Promise<MemoryListResponse<Memory>> {
-  return getMemories({
-    ...params,
-    query,
-  });
 }
 
 /**

--- a/frontend/src/lib/types/memory.ts
+++ b/frontend/src/lib/types/memory.ts
@@ -42,6 +42,10 @@ export interface Memory {
   updated_at: string;
   access_count?: number;
   last_accessed?: string;
+  // Origin metadata (Issue #215). Optional — only populated for memories
+  // imported from a vault, file, URL, or other tracked source.
+  source_uri?: string | null;
+  source_type?: string | null;
 }
 
 export interface CreateMemoryRequest {
@@ -86,6 +90,28 @@ export interface MemoryListItem {
   importance: number;
   created_at: string;
   updated_at: string;
+}
+
+// Exact mirror of backend `ReferenceResponse` (schemas.py:222) — returned by
+// `POST /api/v1/memory/reference`. This is NOT structurally equal to `Memory`:
+// `key`, `value`, `agent_name`, `user_id`, `updated_at`, `access_count` are
+// absent. Callers that feed a `MemoryDetailDialog` (which reads those fields)
+// must adapt at the boundary — see ``referenceResponseToMemory`` helpers in
+// consumers.
+export interface MemoryReference {
+  memory_id: string;
+  summary: string;
+  context_summary: string | null;
+  content: string;
+  details: Record<string, unknown> | null;
+  type: string;
+  importance: number;
+  tags: string[];
+  context: Record<string, unknown> | null;
+  created_at: string;
+  client: string;
+  source_uri?: string | null;
+  source_type?: string | null;
 }
 
 // Generic over the row shape: default is `MemoryListItem` (the structurally

--- a/frontend/src/lib/types/memory.ts
+++ b/frontend/src/lib/types/memory.ts
@@ -96,8 +96,8 @@ export interface MemoryListItem {
 // `POST /api/v1/memory/reference`. This is NOT structurally equal to `Memory`:
 // `key`, `value`, `agent_name`, `user_id`, `updated_at`, `access_count` are
 // absent. Callers that feed a `MemoryDetailDialog` (which reads those fields)
-// must adapt at the boundary — see ``referenceResponseToMemory`` helpers in
-// consumers.
+// must adapt at the boundary — see ``referenceAsMemory`` in
+// ``components/contexts/MemoriesTabPanel.tsx`` for the canonical adapter.
 export interface MemoryReference {
   memory_id: string;
   summary: string;

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2662,9 +2662,29 @@
     "sharedContext": "Shared context",
     "tabs": {
       "overview": "Overview",
+      "memories": "Memories",
       "connections": "Connections",
       "graph": "Graph",
       "settings": "Settings"
+    },
+    "memoriesPanel": {
+      "emptyTitle": "No memories yet",
+      "emptyDesc": "Use the MCP remember tool to store memories in this context.",
+      "loadFailed": "Failed to load memories",
+      "hydrateFailed": "Failed to load memory details",
+      "deleteSuccess": "Memory deleted"
+    },
+    "deleteDialog": {
+      "title": "Delete Memory",
+      "description": "Are you sure you want to delete this memory? This action cannot be undone.",
+      "keyLabel": "Key:",
+      "scopeLabel": "Scope:",
+      "agentLabel": "Agent:",
+      "previewLabel": "Value (preview):",
+      "cancel": "Cancel",
+      "confirm": "Delete Memory",
+      "deleting": "Deleting...",
+      "failed": "Failed to delete memory"
     }
   },
   "contextSettings": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2682,9 +2682,9 @@
     "deleteDialog": {
       "title": "Delete Memory",
       "description": "Are you sure you want to delete this memory? This action cannot be undone.",
-      "keyLabel": "Key:",
+      "summaryLabel": "Summary:",
+      "idLabel": "Memory ID:",
       "scopeLabel": "Scope:",
-      "agentLabel": "Agent:",
       "previewLabel": "Value (preview):",
       "cancel": "Cancel",
       "confirm": "Delete Memory",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2674,6 +2674,11 @@
       "hydrateFailed": "Failed to load memory details",
       "deleteSuccess": "Memory deleted"
     },
+    "detailDialog": {
+      "memoryId": "Memory ID",
+      "copyMemoryId": "Copy memory ID",
+      "source": "Source"
+    },
     "deleteDialog": {
       "title": "Delete Memory",
       "description": "Are you sure you want to delete this memory? This action cannot be undone.",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2682,9 +2682,9 @@
     "deleteDialog": {
       "title": "メモリを削除",
       "description": "このメモリを削除してもよろしいですか? この操作は取り消せません。",
-      "keyLabel": "キー:",
+      "summaryLabel": "サマリ:",
+      "idLabel": "メモリID:",
       "scopeLabel": "スコープ:",
-      "agentLabel": "エージェント:",
       "previewLabel": "値(プレビュー):",
       "cancel": "キャンセル",
       "confirm": "メモリを削除",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2662,9 +2662,29 @@
     "sharedContext": "共有",
     "tabs": {
       "overview": "概要",
+      "memories": "メモリ",
       "connections": "接続",
       "graph": "グラフ",
       "settings": "設定"
+    },
+    "memoriesPanel": {
+      "emptyTitle": "メモリがまだありません",
+      "emptyDesc": "MCP の remember ツールでこのコンテキストにメモリを保存してください。",
+      "loadFailed": "メモリの読み込みに失敗しました",
+      "hydrateFailed": "メモリ詳細の取得に失敗しました",
+      "deleteSuccess": "メモリを削除しました"
+    },
+    "deleteDialog": {
+      "title": "メモリを削除",
+      "description": "このメモリを削除してもよろしいですか? この操作は取り消せません。",
+      "keyLabel": "Key:",
+      "scopeLabel": "Scope:",
+      "agentLabel": "Agent:",
+      "previewLabel": "値(プレビュー):",
+      "cancel": "キャンセル",
+      "confirm": "メモリを削除",
+      "deleting": "削除中...",
+      "failed": "メモリの削除に失敗しました"
     }
   },
   "contextSettings": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2674,12 +2674,17 @@
       "hydrateFailed": "メモリ詳細の取得に失敗しました",
       "deleteSuccess": "メモリを削除しました"
     },
+    "detailDialog": {
+      "memoryId": "メモリID",
+      "copyMemoryId": "メモリIDをコピー",
+      "source": "ソース"
+    },
     "deleteDialog": {
       "title": "メモリを削除",
       "description": "このメモリを削除してもよろしいですか? この操作は取り消せません。",
-      "keyLabel": "Key:",
-      "scopeLabel": "Scope:",
-      "agentLabel": "Agent:",
+      "keyLabel": "キー:",
+      "scopeLabel": "スコープ:",
+      "agentLabel": "エージェント:",
       "previewLabel": "値(プレビュー):",
       "cancel": "キャンセル",
       "confirm": "メモリを削除",


### PR DESCRIPTION
## Summary

Wires the dead-code memory dialogs into a real consumer for the v0.14.0 Memory UI cascade. New `MemoriesTabPanel` lists memories via `GET /api/v1/memory/list`, hydrates each row to full `Memory` via `POST /reference` on click, and deletes via UUID-addressed `POST /forget`. Edit / Create / bulk are deliberately deferred — see follow-up issues #439 / #440 / #441.

## What's in this PR

### Backend
- `GET /memory/list` now filters `deleted_at IS NULL` (soft-deleted rows were leaking into the list — caught during localhost verification)
- `MemoryListItem` and `ReferenceResponse` emit Z-suffixed ISO timestamps (was producing a JST +9h shift; root-caused at serialization)
- `ReferenceResponse` surfaces `source_uri` / `source_type` so the dialog can show origin metadata
- New unit test `test_soft_deleted_memories_excluded` (4/4 pass)

### Frontend
- `MemoriesTabPanel`: self-contained panel, single `contextId` prop, internal fetch + pagination + dialog state. **Race guard** via `pendingHydrationRef` so rapid clicks on different rows can't land A's data in B's dialog
- Tab registered on `contexts/[id]` (admin+ only, double-gated trigger + content) — second tab after Overview
- Kebab-menu link on the contexts list page (same `canManageContexts` admin gate)
- `MemoriesTable` columns: Summary / Type / Scope / Importance / Updated (Agent dropped — legacy concept)
- `MemoryDetailDialog`: removed empty Agent / User ID / Access Count, added Memory ID + copy button, added Source URI display, fixed `<p>` hydration warning, made `onEdit` optional (button hidden when omitted)
- `DeleteMemoryDialog`: switched to UUID-addressed `forgetMemory(id)`, full i18n, `<Alert variant="destructive">` instead of hand-rolled error div
- `lib/api/memory.ts`: rewrote `getMemories()` to hit `/api/v1/memory/list` with correct param shape; added `referenceMemory()` + `forgetMemory()`; removed dead `searchMemories()`
- New types: `MemoryListItem`, `MemoryReference`; `Memory` extended with `source_uri` / `source_type`
- i18n keys under `contextDetail.memoriesPanel` and `contextDetail.deleteDialog` (en + ja)

## Acceptance (#433)

- [x] New "memories" tab visible to admin+ users on contexts/[id]
- [x] `MemoriesTable` lists context-scoped memories
- [x] Row click opens `MemoryDetailDialog` with hydrated full `Memory` shape
- [x] Delete dialog wired (uses UUID `forget`)
- [x] `make test-frontend` passes (253/253)
- [x] Manual localhost smoke via Playwright (see test plan below)

## Out of scope (filed as follow-ups)

- **#439** — Edit dialog: needs backend UUID PATCH/PUT endpoint
- **#440** — References list in detail dialog: linked memories with click-to-open
- **#441** — Edge backfill / sleep trigger for newly-populated contexts

## Test plan

- [x] `cd backend && pytest tests/api/test_memory_list.py -v` — 4/4 pass
- [x] `make test-frontend` — 253/253 pass, tsc clean
- [x] `make lint` — clean
- [x] **Localhost E2E via Playwright**:
  - [x] `?tab=memories` direct link renders empty state
  - [x] Kebab menu → メモリ navigates correctly
  - [x] Tab order: 概要 → メモリ → 接続 → グラフ → 設定
  - [x] Type column displays (note / learning / code / bug-fix)
  - [x] Importance badges (High / Medium / Low)
  - [x] **JST relative time correct** (was 9h off before TZ fix)
  - [x] Detail dialog: Memory ID + copy, Source URI for vault-imported memory, no Agent/UserID/AccessCount, no `<p>` hydration warning
  - [x] Detail absolute time `2026/04/25 15:04:45` JST (correct +9h)
  - [x] Delete confirms → soft-deleted → refetch → EmptyState
  - [x] Soft-deleted memories excluded from list (regression caught + fixed)
  - [x] Edit button hidden in dialog (deferred to #439)
  - [x] No console errors anywhere in the flow
- [ ] (post-merge) Verify on memory.kagura-ai.com after deploy

Closes #433

🤖 Generated with [Claude Code](https://claude.com/claude-code)