### PR TITLE
feat(api+ui): UUID-addressed memory PATCH endpoint + wire EditMemoryDialog (#439)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -21,6 +21,7 @@ from models.schemas import (
     ForgetRequest,
     ForgetResponse,
     MemoryStatsResponse,
+    PatchMemoryRequest,
     RecallRequest,
     RecallResponse,
     ReferenceRequest,
@@ -224,6 +225,58 @@ async def recall(
     )
 
     return result
+
+
+@router.patch("/{memory_id}", response_model=ReferenceResponse)
+async def patch_memory(
+    memory_id: UUID,
+    request: PatchMemoryRequest,
+    user: APIKeyOrSessionUser,
+    memory_service: MemoryServiceDep,
+):
+    """Partial update of a memory by UUID (Issue #439).
+
+    Accepts any subset of ``summary``/``content``/``type``/``importance``/
+    ``tags``/``details``. Omitted fields preserve their current value;
+    ``tags`` follows replace-all semantics.
+
+    Status codes:
+        200: Updated successfully. Body is the full ``ReferenceResponse``.
+        404: Memory does not exist OR the caller lacks access (existence
+             is intentionally not leaked).
+        410: Memory was soft-deleted; the tombstone exists but the resource
+             is gone. Distinguishing 410 from 404 lets clients stop retrying.
+        422: Request body validation failed (empty patch, importance out of
+             range, summary < 10 chars, etc.).
+
+    Permission: same envelope as ``forget`` — ``PermissionService.
+    can_access_memory`` (workspace member for shared, creator for private).
+
+    Embedding regeneration: triggered only when ``summary`` or ``content``
+    changes. Runs on the same async-task pipeline as the ``remember`` path
+    (``process_pending_embedding``); this PATCH does not block on embedding
+    completion. Neural edges anchored on this memory are invalidated when
+    re-embed fires.
+
+    Example:
+        PATCH /api/v1/memory/550e8400-e29b-41d4-a716-446655440000
+        Authorization: Bearer <session_token>
+        Content-Type: application/json
+
+        {"importance": 0.9, "tags": ["python", "auth"]}
+    """
+    logger.info(
+        "patch_memory_request",
+        user_id=user["user_id"],
+        memory_id=str(memory_id),
+        fields=list(request.model_dump(exclude_unset=True).keys()),
+    )
+
+    return await memory_service.patch_memory(
+        memory_id=memory_id,
+        request=request,
+        user_id=user["user_id"],
+    )
 
 
 @router.post("/forget", response_model=ForgetResponse)

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -248,6 +248,8 @@ async def patch_memory(
              is gone. Distinguishing 410 from 404 lets clients stop retrying.
         422: Request body validation failed (empty patch, importance out of
              range, summary < 10 chars, etc.).
+        429: The patched memory's post-patch size exceeds ``MAX_CONTENT_SIZE``
+             (1MB) — same envelope as ``remember`` / ``update_memory``.
 
     Permission: same envelope as ``forget`` — ``PermissionService.
     can_access_memory`` (workspace member for shared, creator for private).

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -269,7 +269,7 @@ async def patch_memory(
         "patch_memory_request",
         user_id=user["user_id"],
         memory_id=str(memory_id),
-        fields=list(request.model_dump(exclude_unset=True).keys()),
+        fields=sorted(request.model_fields_set),
     )
 
     return await memory_service.patch_memory(

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -384,12 +384,27 @@ class PatchMemoryRequest(BaseModel):
     content: str | None = Field(None, min_length=1)
     type: str | None = Field(None, min_length=1, max_length=50)
     importance: float | None = Field(None, ge=0.0, le=1.0)
-    # `max_length=100` caps the tag array. Tags-only patches skip the
+    # `max_length=100` caps the tag array length; per-tag string length is
+    # capped via `_validate_tag_strings` below. Tags-only patches skip the
     # MAX_CONTENT_SIZE guard (simplify deferred it to summary/content/details
-    # paths only), so without this cap an authenticated workspace member could
-    # send `tags=["x"]*1_000_000` and bloat the row's PG ARRAY column.
+    # paths only), so without these caps an authenticated workspace member
+    # could either send 1M tags OR 100 tags of 1MB each to bloat the row's
+    # PG ARRAY column. Both surfaces are now closed.
     tags: list[str] | None = Field(None, max_length=100)
     details: dict | None = None
+
+    @field_validator("tags")
+    @classmethod
+    def _validate_tag_strings(cls, v: list[str] | None) -> list[str] | None:
+        """Cap per-tag string length at 64 chars (Copilot loop 3 finding)."""
+        if v is None:
+            return v
+        for idx, tag in enumerate(v):
+            if len(tag) > 64:
+                raise ValueError(
+                    f"tag at index {idx} exceeds 64 chars (got {len(tag)}): '{tag[:32]}…'"
+                )
+        return v
 
     @model_validator(mode="after")
     def _at_least_one_field(self) -> "PatchMemoryRequest":

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -395,6 +395,20 @@ class PatchMemoryRequest(BaseModel):
     def _at_least_one_field(self) -> "PatchMemoryRequest":
         if not self.model_dump(exclude_unset=True):
             raise ValueError("PATCH request must include at least one field to update")
+        # Reject explicit `null` for fields that either map to NOT NULL DB
+        # columns (`summary`/`content`/`type`/`importance`) — would 500 with a
+        # PG integrity error — or would otherwise duplicate semantics with
+        # field omission (`tags`: omit = preserve, `[]` = clear, `null` is
+        # ambiguous). `details: null` is the only legitimate explicit-null
+        # value (clears the JSONB column).
+        non_nullable = ("summary", "content", "type", "importance", "tags")
+        invalid_null = [
+            f for f in non_nullable if f in self.model_fields_set and getattr(self, f) is None
+        ]
+        if invalid_null:
+            raise ValueError(
+                "PATCH request fields must not be null when provided: " + ", ".join(invalid_null)
+            )
         return self
 
 

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -384,7 +384,11 @@ class PatchMemoryRequest(BaseModel):
     content: str | None = Field(None, min_length=1)
     type: str | None = Field(None, min_length=1, max_length=50)
     importance: float | None = Field(None, ge=0.0, le=1.0)
-    tags: list[str] | None = None
+    # `max_length=100` caps the tag array. Tags-only patches skip the
+    # MAX_CONTENT_SIZE guard (simplify deferred it to summary/content/details
+    # paths only), so without this cap an authenticated workspace member could
+    # send `tags=["x"]*1_000_000` and bloat the row's PG ARRAY column.
+    tags: list[str] | None = Field(None, max_length=100)
     details: dict | None = None
 
     @model_validator(mode="after")

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -408,7 +408,12 @@ class PatchMemoryRequest(BaseModel):
 
     @model_validator(mode="after")
     def _at_least_one_field(self) -> "PatchMemoryRequest":
-        if not self.model_dump(exclude_unset=True):
+        # `model_fields_set` is a name-only set; cheap. The previous
+        # `model_dump(exclude_unset=True)` form deep-serialized the full
+        # request (including `details` JSON) just to check emptiness — the
+        # service layer already prefers `model_fields_set` for the same
+        # reason, so the validator is now consistent with it.
+        if not self.model_fields_set:
             raise ValueError("PATCH request must include at least one field to update")
         # Reject explicit `null` for fields that either map to NOT NULL DB
         # columns (`summary`/`content`/`type`/`importance`) — would 500 with a

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -366,6 +366,34 @@ class UpdateMemoryResponse(BaseModel):
     scope: str
 
 
+class PatchMemoryRequest(BaseModel):
+    """Request schema for ``PATCH /api/v1/memory/{memory_id}`` (Issue #439).
+
+    UUID-addressed partial update. ``memory_id`` is the URL path param, not a
+    body field — there is intentionally no ``external_id`` upsert mode here
+    (use the existing ``update_memory`` MCP tool for that).
+
+    All fields are optional. Only fields explicitly provided are updated;
+    omitted fields preserve their current value. ``tags`` follows replace-all
+    semantics (an empty list clears tags; a non-empty list replaces the
+    whole list). ``scope`` and ``context_id`` are intentionally excluded —
+    they have orthogonal lifecycles handled by separate operations.
+    """
+
+    summary: str | None = Field(None, min_length=10, max_length=500)
+    content: str | None = Field(None, min_length=1)
+    type: str | None = Field(None, min_length=1, max_length=50)
+    importance: float | None = Field(None, ge=0.0, le=1.0)
+    tags: list[str] | None = None
+    details: dict | None = None
+
+    @model_validator(mode="after")
+    def _at_least_one_field(self) -> "PatchMemoryRequest":
+        if not self.model_dump(exclude_unset=True):
+            raise ValueError("PATCH request must include at least one field to update")
+        return self
+
+
 class ExploreRequest(BaseModel):
     """Request schema for explore() API.
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -525,42 +525,42 @@ class MemoryService:
         if memory.deleted_at is not None:
             raise MemoryGoneError("Memory", str(memory_id))
 
-        # `exclude_unset=True` keeps None values that the client EXPLICITLY
-        # sent, so `{"details": null}` lands in `provided` and clears the
-        # column, while a body that simply omits `details` does not.
-        provided = request.model_dump(exclude_unset=True)
+        # `model_fields_set` is the set of field names the client EXPLICITLY
+        # sent (including those set to None), so `{"details": null}` puts
+        # "details" in the set and a body that simply omits `details` does
+        # not. Cheaper than `model_dump(exclude_unset=True)` for large
+        # `details` payloads — no deep serialization, just a name set.
+        provided_fields = request.model_fields_set
 
         normalized_summary = (
-            normalize_for_search(request.summary) if "summary" in provided else None
+            normalize_for_search(request.summary) if "summary" in provided_fields else None
         )
 
         needs_reembed = False
         if normalized_summary is not None and normalized_summary != memory.summary:
             needs_reembed = True
-        if "content" in provided and request.content != memory.content:
+        if "content" in provided_fields and request.content != memory.content:
             needs_reembed = True
 
         # Skip the size guard on metadata-only patches: `tags`/`importance`/`type`
         # cannot move the row across the byte limit, so the four `len()` calls
         # are pure waste on the most common PATCH shape.
-        if {"summary", "content", "details"} & provided.keys():
+        if {"summary", "content", "details"} & provided_fields:
             from config.constants import MAX_CONTENT_SIZE
 
-            # Compute the post-patch size from the would-be values (using
-            # `in provided` instead of `or`-falsy fallback). The truthy-fallback
-            # form silently kept the OLD value when the caller explicitly sent
-            # `None` or `{}` to CLEAR a field — making patches that shrink or
-            # clear `details`/`content`/`summary` get rejected against the
-            # pre-patch size instead of the (smaller) post-patch size.
-            next_summary = normalized_summary if "summary" in provided else memory.summary
-            next_content = request.content if "content" in provided else memory.content
-            next_details = request.details if "details" in provided else memory.details
+            # Compute the post-patch size from the would-be values. Use
+            # explicit `is None` rather than truthy fallback so empty-but-
+            # provided values like `details = {}` count as themselves
+            # (`len("{}") = 2`) instead of being collapsed to 0.
+            next_summary = normalized_summary if "summary" in provided_fields else memory.summary
+            next_content = request.content if "content" in provided_fields else memory.content
+            next_details = request.details if "details" in provided_fields else memory.details
 
             content_size = (
-                len(next_summary or "")
-                + len(memory.context_summary or "")
-                + len(next_content or "")
-                + len(str(next_details or ""))
+                len(next_summary if next_summary is not None else "")
+                + len(memory.context_summary if memory.context_summary is not None else "")
+                + len(next_content if next_content is not None else "")
+                + len(str(next_details) if next_details is not None else "")
             )
             if content_size > MAX_CONTENT_SIZE:
                 raise QuotaExceededError(
@@ -570,15 +570,15 @@ class MemoryService:
 
         if normalized_summary is not None:
             memory.summary = normalized_summary
-        if "content" in provided:
+        if "content" in provided_fields:
             memory.content = request.content
-        if "type" in provided:
+        if "type" in provided_fields:
             memory.type = request.type
-        if "importance" in provided:
+        if "importance" in provided_fields:
             memory.importance = request.importance
-        if "tags" in provided:
+        if "tags" in provided_fields:
             memory.tags = request.tags
-        if "details" in provided:
+        if "details" in provided_fields:
             # Explicit null clears the column; non-null replaces it.
             memory.details = request.details
 
@@ -654,11 +654,11 @@ class MemoryService:
             await self.db.commit()
 
             payload_updates: dict[str, object] = {}
-            if "tags" in provided:
+            if "tags" in provided_fields:
                 payload_updates["tags"] = request.tags
-            if "importance" in provided:
+            if "importance" in provided_fields:
                 payload_updates["importance"] = request.importance
-            if "type" in provided:
+            if "type" in provided_fields:
                 payload_updates["type"] = request.type
 
             if payload_updates:

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -591,6 +591,15 @@ class MemoryService:
             # vector. NULL workspace/context skips invalidation but emits a
             # warning so operators can spot pre-Migration-063 rows that drift
             # silently.
+            #
+            # `NeuralEdgeRepository.delete_node_edges` issues a SQL DELETE via
+            # `self.db.execute(...)` but does NOT commit internally — without
+            # an explicit commit here the DELETE would never persist (the
+            # memory commit above closed the prior transaction; the DELETE
+            # lands in a fresh implicit transaction that is discarded on
+            # session close). Best-effort: commit on success, rollback on
+            # failure so the (incomplete) DELETE doesn't leak into the next
+            # statement on this session.
             if memory_workspace_id and memory_context_id:
                 from repositories.neural_edge import NeuralEdgeRepository
 
@@ -602,6 +611,7 @@ class MemoryService:
                         workspace_id=memory_workspace_id,
                         context_id=memory_context_id,
                     )
+                    await self.db.commit()
                     if edges_deleted > 0:
                         logger.info(
                             "memory_patch_edges_invalidated",
@@ -610,6 +620,7 @@ class MemoryService:
                             user_id=user_id,
                         )
                 except Exception as exc:  # noqa: BLE001
+                    await self.db.rollback()
                     logger.error(
                         "memory_patch_edge_invalidation_failed",
                         memory_id=str(memory.id),

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -546,11 +546,21 @@ class MemoryService:
         if {"summary", "content", "details"} & provided.keys():
             from config.constants import MAX_CONTENT_SIZE
 
+            # Compute the post-patch size from the would-be values (using
+            # `in provided` instead of `or`-falsy fallback). The truthy-fallback
+            # form silently kept the OLD value when the caller explicitly sent
+            # `None` or `{}` to CLEAR a field — making patches that shrink or
+            # clear `details`/`content`/`summary` get rejected against the
+            # pre-patch size instead of the (smaller) post-patch size.
+            next_summary = normalized_summary if "summary" in provided else memory.summary
+            next_content = request.content if "content" in provided else memory.content
+            next_details = request.details if "details" in provided else memory.details
+
             content_size = (
-                len(request.summary or memory.summary or "")
+                len(next_summary or "")
                 + len(memory.context_summary or "")
-                + len(request.content or memory.content or "")
-                + len(str(request.details or memory.details or ""))
+                + len(next_content or "")
+                + len(str(next_details or ""))
             )
             if content_size > MAX_CONTENT_SIZE:
                 raise QuotaExceededError(

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -7,6 +7,8 @@ Issue #82: Context-based multi-collection support.
 
 from __future__ import annotations
 
+import asyncio
+import functools
 from uuid import UUID, uuid4
 
 from sqlalchemy import and_, select
@@ -29,6 +31,7 @@ from models.schemas import (
     LinkedMemoryRef,
     MemoryResponse,
     MemoryStatsResponse,
+    PatchMemoryRequest,
     RecallRequest,
     RecallResponse,
     ReferenceResponse,
@@ -45,10 +48,35 @@ from services.context_service import ContextService
 from services.embedding_service import EmbeddingService
 from services.search_service import SearchService
 from utils.datetime import utcnow
-from utils.exceptions import NotFoundException
+from utils.exceptions import MemoryGoneError, NotFoundException, QuotaExceededError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+
+def _log_embedding_task_result(task: asyncio.Task, memory_id: str) -> None:
+    """Done-callback for `process_pending_embedding` tasks (memory write paths).
+
+    Promotes asyncio task failures into structured `error` log events so they
+    surface in observability instead of being lost as unhandled task exceptions.
+    Cancellation is logged at warn level — typically a shutdown signal.
+
+    Used by every memory write path that fires `process_pending_embedding` as a
+    fire-and-forget task: `remember`, `_update_in_place`, and `patch_memory`.
+    Bind via `functools.partial(_log_embedding_task_result, memory_id=...)` so
+    the callback receives a stable id even after the surrounding scope unwinds.
+    """
+    if task.cancelled():
+        logger.warning("embedding_task_cancelled", memory_id=memory_id)
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            "embedding_task_exception",
+            memory_id=memory_id,
+            error=str(exc),
+            exc_info=exc,
+        )
 
 
 class MemoryService:
@@ -246,27 +274,10 @@ class MemoryService:
                 context_id=context_id_str,
             )
 
-            import asyncio
-
-            def _log_embedding_task_result(t: asyncio.Task) -> None:
-                if t.cancelled():
-                    logger.warning(
-                        "embedding_task_cancelled",
-                        memory_id=str(memory_id),
-                    )
-                    return
-
-                exc = t.exception()
-                if exc is not None:
-                    logger.error(
-                        "embedding_task_exception",
-                        memory_id=str(memory_id),
-                        error=str(exc),
-                        exc_info=exc,
-                    )
-
             task = asyncio.create_task(process_pending_embedding(memory_id))
-            task.add_done_callback(_log_embedding_task_result)
+            task.add_done_callback(
+                functools.partial(_log_embedding_task_result, memory_id=str(memory_id))
+            )
 
             return RememberResponse(memory_id=memory_id, scope="working")
 
@@ -404,23 +415,10 @@ class MemoryService:
             await self.db.flush()
             await self.db.commit()
 
-            import asyncio
-
-            def _log_embedding_task_result(t: asyncio.Task) -> None:
-                if t.cancelled():
-                    logger.warning("embedding_task_cancelled", memory_id=str(memory.id))
-                    return
-                exc = t.exception()
-                if exc is not None:
-                    logger.error(
-                        "embedding_task_exception",
-                        memory_id=str(memory.id),
-                        error=str(exc),
-                        exc_info=exc,
-                    )
-
             task = asyncio.create_task(process_pending_embedding(memory.id))
-            task.add_done_callback(_log_embedding_task_result)
+            task.add_done_callback(
+                functools.partial(_log_embedding_task_result, memory_id=str(memory.id))
+            )
         else:
             # Metadata-only update: patch Qdrant payload without re-embedding
             payload_updates: dict = {}
@@ -457,6 +455,254 @@ class MemoryService:
             operation="updated",
             re_embedded=needs_reembed,
             scope=memory.scope,
+        )
+
+    async def patch_memory(
+        self,
+        memory_id: UUID,
+        request: PatchMemoryRequest,
+        user_id: str,
+    ) -> ReferenceResponse:
+        """Partial update of a memory by UUID (Issue #439).
+
+        Mirrors `_update_in_place` but with four #439-specific behaviors:
+
+        - Soft-deleted memories raise ``MemoryGoneError`` so the route can
+          return 410 (vs `_update_in_place`'s 404 NotFound, which hides the
+          tombstone). Distinguishing 410 from 404 lets clients detect a
+          known-but-deleted memory and stop retrying.
+        - Permission denial returns 404 (not silent 200, unlike forget) so
+          UUID existence is not leaked.
+        - When ``summary`` or ``content`` changes, neural edges anchored on
+          this memory are invalidated (forget's pattern). Edge weights were
+          computed against the previous embedding; the next sleep run rebuilds
+          them against the new vector.
+        - Qdrant payload-only updates run AFTER the PG commit and only emit a
+          structured error log on failure (drift visibility, no rollback). The
+          re-embed path keeps the existing async-task pattern, so qdrant
+          errors there continue to be surfaced via `_log_embedding_task_result`.
+
+        Field-presence semantics: ``model_dump(exclude_unset=True)`` is used to
+        distinguish "field omitted" from "field explicitly null". This matters
+        for ``details`` — sending ``{"details": null}`` clears the existing JSON,
+        while omitting ``details`` preserves it. ``tags`` follows the same
+        contract (None/missing = preserve, [] = clear, [...] = replace).
+
+        Returns the updated memory as ``ReferenceResponse`` (full detail). The
+        response is constructed inline from the in-scope ORM object to avoid
+        a second permission check + extra commit round-trip that delegating
+        to ``self.reference()`` would incur (and PATCH should not bump
+        access-stats — that semantic only fits read paths).
+        """
+        from services.permission_service import (
+            CallerId,
+            MemoryAuthorId,
+            PermissionService,
+        )
+        from utils.text import normalize_for_search
+
+        memory = await self.memory_repo.get(memory_id)
+        if not memory:
+            raise NotFoundException("Memory", str(memory_id))
+
+        if memory.deleted_at is not None:
+            raise MemoryGoneError("Memory", str(memory_id))
+
+        perm_service = PermissionService(self.db)
+        can_access = await perm_service.can_access_memory(
+            user_id=CallerId(user_id),
+            memory_user_id=MemoryAuthorId(memory.user_id),
+            workspace_id=memory.workspace_id,
+            context_id=memory.context_id,
+        )
+        if not can_access:
+            raise NotFoundException("Memory", str(memory_id))
+
+        # `exclude_unset=True` keeps None values that the client EXPLICITLY
+        # sent, so `{"details": null}` lands in `provided` and clears the
+        # column, while a body that simply omits `details` does not.
+        provided = request.model_dump(exclude_unset=True)
+
+        normalized_summary = (
+            normalize_for_search(request.summary) if "summary" in provided else None
+        )
+
+        needs_reembed = False
+        if normalized_summary is not None and normalized_summary != memory.summary:
+            needs_reembed = True
+        if "content" in provided and request.content != memory.content:
+            needs_reembed = True
+
+        # Skip the size guard on metadata-only patches: `tags`/`importance`/`type`
+        # cannot move the row across the byte limit, so the four `len()` calls
+        # are pure waste on the most common PATCH shape.
+        if {"summary", "content", "details"} & provided.keys():
+            from config.constants import MAX_CONTENT_SIZE
+
+            content_size = (
+                len(request.summary or memory.summary or "")
+                + len(memory.context_summary or "")
+                + len(request.content or memory.content or "")
+                + len(str(request.details or memory.details or ""))
+            )
+            if content_size > MAX_CONTENT_SIZE:
+                raise QuotaExceededError(
+                    f"Memory size {content_size:,} bytes exceeds limit "
+                    f"{MAX_CONTENT_SIZE:,} bytes (1MB)."
+                )
+
+        if normalized_summary is not None:
+            memory.summary = normalized_summary
+        if "content" in provided:
+            memory.content = request.content
+        if "type" in provided:
+            memory.type = request.type
+        if "importance" in provided:
+            memory.importance = request.importance
+        if "tags" in provided:
+            memory.tags = request.tags
+        if "details" in provided:
+            # Explicit null clears the column; non-null replaces it.
+            memory.details = request.details
+
+        memory.updated_at = utcnow()
+
+        memory_workspace_id = str(memory.workspace_id) if memory.workspace_id else None
+        memory_context_id = str(memory.context_id) if memory.context_id else None
+
+        if needs_reembed:
+            memory.embedding_status = "pending"
+            await self.db.flush()
+            await self.db.commit()
+
+            task = asyncio.create_task(process_pending_embedding(memory.id))
+            task.add_done_callback(
+                functools.partial(_log_embedding_task_result, memory_id=str(memory.id))
+            )
+
+            # Invalidate neural edges. Sleep run rebuilds against the new
+            # vector. NULL workspace/context skips invalidation but emits a
+            # warning so operators can spot pre-Migration-063 rows that drift
+            # silently.
+            if memory_workspace_id and memory_context_id:
+                from repositories.neural_edge import NeuralEdgeRepository
+
+                edge_repo = NeuralEdgeRepository(self.db)
+                try:
+                    edges_deleted = await edge_repo.delete_node_edges(
+                        user_id=user_id,
+                        node_id=memory.id,
+                        workspace_id=memory_workspace_id,
+                        context_id=memory_context_id,
+                    )
+                    if edges_deleted > 0:
+                        logger.info(
+                            "memory_patch_edges_invalidated",
+                            memory_id=str(memory.id),
+                            edges_deleted=edges_deleted,
+                            user_id=user_id,
+                        )
+                except Exception as exc:  # noqa: BLE001
+                    logger.error(
+                        "memory_patch_edge_invalidation_failed",
+                        memory_id=str(memory.id),
+                        user_id=user_id,
+                        error=str(exc),
+                        exc_info=exc,
+                    )
+            else:
+                logger.warning(
+                    "memory_patch_edges_invalidation_skipped",
+                    memory_id=str(memory.id),
+                    user_id=user_id,
+                    reason="missing_workspace_or_context_id",
+                )
+        else:
+            # Metadata-only path: PG commit first, qdrant after. Qdrant
+            # failure is logged (not raised) for drift visibility — the PG
+            # write stays durable. Forget uses single-commit-at-end; this
+            # deviation is by Issue #439's design.
+            await self.db.flush()
+            await self.db.commit()
+
+            payload_updates: dict[str, object] = {}
+            if "tags" in provided:
+                payload_updates["tags"] = request.tags
+            if "importance" in provided:
+                payload_updates["importance"] = request.importance
+            if "type" in provided:
+                payload_updates["type"] = request.type
+
+            if payload_updates:
+                payload_updates["updated_at"] = utcnow().isoformat() + "Z"
+                try:
+                    collection = await resolve_collection_name(self.db, memory.context_id)
+                    await update_memory_payload_in_qdrant(
+                        memory_id=memory.id,
+                        payload_updates=payload_updates,
+                        collection_name=collection,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.error(
+                        "memory_patch_qdrant_payload_failed",
+                        memory_id=str(memory.id),
+                        user_id=user_id,
+                        error=str(exc),
+                        exc_info=exc,
+                    )
+
+        logger.info(
+            "memory_patched",
+            memory_id=str(memory.id),
+            user_id=user_id,
+            re_embedded=needs_reembed,
+        )
+
+        # Build the response inline from the in-scope ORM row. Delegating to
+        # ``self.reference(...)`` here would re-fetch the row, re-run the
+        # permission check, bump access-stats (a write — wrong for PATCH),
+        # and issue a second commit. We still want the declared_link refs,
+        # which `_fetch_declared_link_refs` provides without those side
+        # effects. NULL workspace_id/context_id rows skip the link fetch and
+        # return empty link arrays (the helper's signature requires non-null
+        # FKs).
+        if memory.workspace_id and memory.context_id:
+            (
+                outgoing_links,
+                outgoing_has_more,
+                incoming_links,
+                incoming_has_more,
+            ) = await self._fetch_declared_link_refs(
+                memory_id=memory.id,
+                workspace_id=memory.workspace_id,
+                context_id=memory.context_id,
+            )
+        else:
+            outgoing_links = []
+            outgoing_has_more = False
+            incoming_links = []
+            incoming_has_more = False
+
+        return ReferenceResponse(
+            memory_id=memory.id,
+            summary=memory.summary,
+            context_summary=memory.context_summary,
+            content=memory.content,
+            details=memory.details,
+            type=memory.type,
+            scope=memory.scope,
+            importance=memory.importance,
+            tags=memory.tags or [],
+            context=memory.context,
+            created_at=memory.created_at,
+            updated_at=memory.updated_at or memory.created_at,
+            client=memory.client,
+            source_uri=memory.source_uri,
+            source_type=memory.source_type,
+            outgoing_links=outgoing_links,
+            outgoing_has_more=outgoing_has_more,
+            incoming_links=incoming_links,
+            incoming_has_more=incoming_has_more,
         )
 
     async def _upsert_by_external_id(

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -505,9 +505,13 @@ class MemoryService:
         if not memory:
             raise NotFoundException("Memory", str(memory_id))
 
-        if memory.deleted_at is not None:
-            raise MemoryGoneError("Memory", str(memory_id))
-
+        # Permission check BEFORE soft-delete check: a non-member must not be
+        # able to distinguish a soft-deleted memory (would-be 410) from a
+        # never-existed UUID (404). Returning 410 first would let an attacker
+        # who guesses (or harvests) a UUID confirm "this memory was once
+        # real" — meaningful for GDPR-style "we used to have a record about
+        # you" leaks. 410 is reserved for authorized callers who need to
+        # distinguish tombstones from never-existed.
         perm_service = PermissionService(self.db)
         can_access = await perm_service.can_access_memory(
             user_id=CallerId(user_id),
@@ -517,6 +521,9 @@ class MemoryService:
         )
         if not can_access:
             raise NotFoundException("Memory", str(memory_id))
+
+        if memory.deleted_at is not None:
+            raise MemoryGoneError("Memory", str(memory_id))
 
         # `exclude_unset=True` keeps None values that the client EXPLICITLY
         # sent, so `{"details": null}` lands in `provided` and clears the

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -482,11 +482,17 @@ class MemoryService:
           re-embed path keeps the existing async-task pattern, so qdrant
           errors there continue to be surfaced via `_log_embedding_task_result`.
 
-        Field-presence semantics: ``model_dump(exclude_unset=True)`` is used to
-        distinguish "field omitted" from "field explicitly null". This matters
-        for ``details`` — sending ``{"details": null}`` clears the existing JSON,
-        while omitting ``details`` preserves it. ``tags`` follows the same
-        contract (None/missing = preserve, [] = clear, [...] = replace).
+        Field-presence semantics: ``request.model_fields_set`` (the set of
+        fields the client EXPLICITLY sent, including those set to ``None``)
+        distinguishes "field omitted" from "field explicitly null". This
+        matters for ``details`` — sending ``{"details": null}`` clears the
+        existing JSON, while omitting ``details`` preserves it. ``tags``
+        follows the same omit/clear contract (None/missing = preserve,
+        [] = clear, [...] = replace), enforced by the schema's null-reject
+        validator. ``model_fields_set`` is preferred over
+        ``model_dump(exclude_unset=True)`` because the latter deep-serializes
+        the full request body (including ``details`` JSON) just to extract
+        a key set — wasteful for our use case.
 
         Returns the updated memory as ``ReferenceResponse`` (full detail). The
         response is constructed inline from the in-scope ORM object to avoid

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -119,6 +119,21 @@ class NotFoundException(MemoryCloudException):
         super().__init__(message, status_code=404, error_code="RES-001")
 
 
+class MemoryGoneError(MemoryCloudException):
+    """Resource existed but was soft-deleted (410 Gone).
+
+    Distinct from NotFoundException so clients can stop retrying instead of
+    interpreting 404 as "maybe transient". Used by Issue #439's PATCH path
+    when the target memory has ``deleted_at IS NOT NULL``.
+    """
+
+    def __init__(self, resource: str, resource_id: str | None = None):
+        message = f"{resource} has been deleted"
+        if resource_id:
+            message += f": {resource_id}"
+        super().__init__(message, status_code=410, error_code="RES-003")
+
+
 class ConflictError(MemoryCloudException):
     """Resource conflict (409)."""
 

--- a/backend/tests/services/test_memory_patch.py
+++ b/backend/tests/services/test_memory_patch.py
@@ -1,0 +1,369 @@
+"""Tests for MemoryService.patch_memory (Issue #439).
+
+Covers the four #439-specific behaviors that diverge from `_update_in_place`:
+  - Soft-deleted memory raises MemoryGoneError (410), not NotFoundException (404)
+  - Permission denial raises NotFoundException (no leak), not silent success
+  - summary/content change invalidates neural edges (forget's pattern)
+  - Qdrant payload-only failure logs error but does not raise (drift visibility)
+
+Plus the explicit-null `details` clear semantic (`{"details": null}` clears the
+column; omitting `details` preserves it).
+"""
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import PatchMemoryRequest
+from services.memory_service import MemoryService
+from utils.exceptions import MemoryGoneError, NotFoundException
+
+
+def _make_memory(**overrides):
+    """Mock Memory with sensible defaults and the columns patch_memory touches.
+
+    Fields populated to valid types so the inline ReferenceResponse
+    construction at the end of `patch_memory` passes Pydantic validation
+    without needing extra wiring per test.
+    """
+    memory = MagicMock()
+    memory.id = overrides.get("id", uuid4())
+    memory.user_id = overrides.get("user_id", "test_user")
+    memory.workspace_id = overrides.get("workspace_id", uuid4())
+    memory.context_id = overrides.get("context_id", uuid4())
+    memory.summary = overrides.get("summary", "Original summary for testing edits")
+    memory.context_summary = overrides.get("context_summary", None)
+    memory.content = overrides.get("content", "Original content body")
+    memory.details = overrides.get("details", None)
+    memory.type = overrides.get("type", "normal")
+    memory.importance = overrides.get("importance", 0.5)
+    memory.tags = overrides.get("tags", ["original"])
+    memory.context = overrides.get("context", None)
+    memory.scope = overrides.get("scope", "working")
+    memory.client = overrides.get("client", "mcp")
+    memory.created_at = overrides.get("created_at", datetime(2026, 4, 25, 10, 0, 0))
+    memory.updated_at = overrides.get("updated_at", datetime(2026, 4, 25, 10, 0, 0))
+    memory.deleted_at = overrides.get("deleted_at", None)
+    memory.deleted_by = overrides.get("deleted_by", None)
+    memory.embedding_status = overrides.get("embedding_status", "success")
+    memory.source_uri = overrides.get("source_uri", None)
+    memory.source_type = overrides.get("source_type", None)
+    return memory
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def service(mock_db):
+    return MemoryService(mock_db)
+
+
+class TestPatchMemoryNotFound:
+    """Memory does not exist or is unreachable."""
+
+    @pytest.mark.asyncio
+    async def test_missing_row_raises_not_found(self, service):
+        service.memory_repo.get = AsyncMock(return_value=None)
+
+        with pytest.raises(NotFoundException):
+            await service.patch_memory(
+                memory_id=uuid4(),
+                request=PatchMemoryRequest(importance=0.9),
+                user_id="test_user",
+            )
+
+    @pytest.mark.asyncio
+    async def test_permission_denied_raises_not_found(self, service):
+        """Access check failure must NOT silently succeed (forget's pattern is wrong here)."""
+        memory = _make_memory()
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        with patch("services.permission_service.PermissionService") as mock_perm_cls:
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=False)
+
+            with pytest.raises(NotFoundException):
+                await service.patch_memory(
+                    memory_id=memory.id,
+                    request=PatchMemoryRequest(importance=0.9),
+                    user_id="other_user",
+                )
+
+
+class TestPatchMemorySoftDeleted:
+    """Soft-deleted memories must surface as 410 Gone, not 404."""
+
+    @pytest.mark.asyncio
+    async def test_soft_deleted_raises_memory_gone(self, service):
+        from datetime import datetime
+
+        memory = _make_memory(deleted_at=datetime(2026, 4, 20))
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        with pytest.raises(MemoryGoneError) as excinfo:
+            await service.patch_memory(
+                memory_id=memory.id,
+                request=PatchMemoryRequest(importance=0.9),
+                user_id="test_user",
+            )
+        assert excinfo.value.status_code == 410
+
+
+class TestPatchMemoryEmbeddingRegen:
+    """summary / content changes trigger re-embed + neural edge invalidation."""
+
+    @pytest.mark.asyncio
+    async def test_summary_change_invalidates_neural_edges(self, service, mock_db):
+        memory = _make_memory()
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        edge_repo_instance = MagicMock()
+        edge_repo_instance.delete_node_edges = AsyncMock(return_value=3)
+
+        with (
+            patch("services.permission_service.PermissionService") as mock_perm_cls,
+            patch(
+                "services.memory_service.process_pending_embedding",
+                new=AsyncMock(),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=edge_repo_instance,
+            ),
+            patch.object(
+                service,
+                "_fetch_declared_link_refs",
+                new=AsyncMock(return_value=([], False, [], False)),
+            ),
+        ):
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+
+            await service.patch_memory(
+                memory_id=memory.id,
+                request=PatchMemoryRequest(
+                    summary="A completely new summary that triggers re-embedding",
+                ),
+                user_id="test_user",
+            )
+
+            edge_repo_instance.delete_node_edges.assert_awaited_once()
+            mock_db.commit.assert_called()
+            assert memory.embedding_status == "pending"
+
+    @pytest.mark.asyncio
+    async def test_content_change_triggers_reembed(self, service):
+        memory = _make_memory()
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        edge_repo_instance = MagicMock()
+        edge_repo_instance.delete_node_edges = AsyncMock(return_value=0)
+
+        with (
+            patch("services.permission_service.PermissionService") as mock_perm_cls,
+            patch(
+                "services.memory_service.process_pending_embedding",
+                new=AsyncMock(),
+            ),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=edge_repo_instance,
+            ),
+            patch.object(
+                service,
+                "_fetch_declared_link_refs",
+                new=AsyncMock(return_value=([], False, [], False)),
+            ),
+        ):
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+
+            await service.patch_memory(
+                memory_id=memory.id,
+                request=PatchMemoryRequest(content="Brand new content body"),
+                user_id="test_user",
+            )
+
+            assert memory.embedding_status == "pending"
+            edge_repo_instance.delete_node_edges.assert_awaited_once()
+
+
+class TestPatchMemoryMetadataOnly:
+    """tags / importance / type / details changes do NOT re-embed."""
+
+    @pytest.mark.asyncio
+    async def test_metadata_only_no_reembed(self, service, mock_db):
+        memory = _make_memory()
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        with (
+            patch("services.permission_service.PermissionService") as mock_perm_cls,
+            patch(
+                "services.memory_service.update_memory_payload_in_qdrant",
+                new=AsyncMock(),
+            ) as mock_payload_update,
+            patch(
+                "services.memory_service.resolve_collection_name",
+                new=AsyncMock(return_value="kagura_memories"),
+            ),
+            patch.object(
+                service,
+                "_fetch_declared_link_refs",
+                new=AsyncMock(return_value=([], False, [], False)),
+            ),
+        ):
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+
+            await service.patch_memory(
+                memory_id=memory.id,
+                request=PatchMemoryRequest(
+                    importance=0.9,
+                    tags=["new", "tags"],
+                ),
+                user_id="test_user",
+            )
+
+            assert memory.embedding_status == "success"  # unchanged
+            mock_payload_update.assert_awaited_once()
+            mock_db.commit.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_qdrant_payload_failure_does_not_raise(self, service):
+        """Drift visibility: qdrant fail after PG commit logs error, no rollback."""
+        memory = _make_memory()
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        failing_qdrant = AsyncMock(side_effect=RuntimeError("qdrant down"))
+
+        with (
+            patch("services.permission_service.PermissionService") as mock_perm_cls,
+            patch(
+                "services.memory_service.update_memory_payload_in_qdrant",
+                new=failing_qdrant,
+            ),
+            patch(
+                "services.memory_service.resolve_collection_name",
+                new=AsyncMock(return_value="kagura_memories"),
+            ),
+            patch.object(
+                service,
+                "_fetch_declared_link_refs",
+                new=AsyncMock(return_value=([], False, [], False)),
+            ),
+        ):
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+
+            # Must NOT raise even though qdrant errored.
+            await service.patch_memory(
+                memory_id=memory.id,
+                request=PatchMemoryRequest(importance=0.9),
+                user_id="test_user",
+            )
+
+
+class TestPatchMemoryDetailsClear:
+    """Issue #439: explicitly setting `details: null` must clear the column."""
+
+    @pytest.mark.asyncio
+    async def test_details_explicit_null_clears_column(self, service):
+        memory = _make_memory(details={"existing": "value"})
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        with (
+            patch("services.permission_service.PermissionService") as mock_perm_cls,
+            patch(
+                "services.memory_service.update_memory_payload_in_qdrant",
+                new=AsyncMock(),
+            ),
+            patch(
+                "services.memory_service.resolve_collection_name",
+                new=AsyncMock(return_value="kagura_memories"),
+            ),
+            patch.object(
+                service,
+                "_fetch_declared_link_refs",
+                new=AsyncMock(return_value=([], False, [], False)),
+            ),
+        ):
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+
+            await service.patch_memory(
+                memory_id=memory.id,
+                request=PatchMemoryRequest(details=None),
+                user_id="test_user",
+            )
+
+            # Explicit None must clear the JSON column.
+            assert memory.details is None
+
+    @pytest.mark.asyncio
+    async def test_details_omitted_preserves_column(self, service):
+        existing = {"keep_me": "yes"}
+        memory = _make_memory(details=existing)
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        with (
+            patch("services.permission_service.PermissionService") as mock_perm_cls,
+            patch(
+                "services.memory_service.update_memory_payload_in_qdrant",
+                new=AsyncMock(),
+            ),
+            patch(
+                "services.memory_service.resolve_collection_name",
+                new=AsyncMock(return_value="kagura_memories"),
+            ),
+            patch.object(
+                service,
+                "_fetch_declared_link_refs",
+                new=AsyncMock(return_value=([], False, [], False)),
+            ),
+        ):
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+
+            # Patch only `importance`; omit `details`.
+            await service.patch_memory(
+                memory_id=memory.id,
+                request=PatchMemoryRequest(importance=0.8),
+                user_id="test_user",
+            )
+
+            assert memory.details == existing
+
+
+class TestPatchMemoryRequestValidation:
+    """Pydantic-level validation of the request body."""
+
+    def test_empty_patch_rejected(self):
+        with pytest.raises(ValueError, match="at least one field"):
+            PatchMemoryRequest()
+
+    def test_importance_out_of_range_rejected(self):
+        with pytest.raises(ValueError):
+            PatchMemoryRequest(importance=1.5)
+
+    def test_summary_too_short_rejected(self):
+        with pytest.raises(ValueError):
+            PatchMemoryRequest(summary="short")
+
+    def test_type_too_long_rejected(self):
+        with pytest.raises(ValueError):
+            PatchMemoryRequest(type="x" * 51)
+
+    def test_minimal_valid_patch(self):
+        req = PatchMemoryRequest(importance=0.7)
+        assert req.importance == 0.7
+        assert req.summary is None

--- a/backend/tests/services/test_memory_patch.py
+++ b/backend/tests/services/test_memory_patch.py
@@ -101,22 +101,47 @@ class TestPatchMemoryNotFound:
 
 
 class TestPatchMemorySoftDeleted:
-    """Soft-deleted memories must surface as 410 Gone, not 404."""
+    """Soft-deleted memories must surface as 410 Gone — but only to authorized callers.
+
+    Permission denial fires BEFORE the soft-delete check (CSO security review):
+    a non-member must not distinguish "soft-deleted" (would-be 410) from
+    "never existed" (404), or they could confirm a memory was once real
+    just by guessing a UUID.
+    """
 
     @pytest.mark.asyncio
-    async def test_soft_deleted_raises_memory_gone(self, service):
-        from datetime import datetime
-
+    async def test_soft_deleted_raises_memory_gone_when_authorized(self, service):
         memory = _make_memory(deleted_at=datetime(2026, 4, 20))
         service.memory_repo.get = AsyncMock(return_value=memory)
 
-        with pytest.raises(MemoryGoneError) as excinfo:
-            await service.patch_memory(
-                memory_id=memory.id,
-                request=PatchMemoryRequest(importance=0.9),
-                user_id="test_user",
-            )
-        assert excinfo.value.status_code == 410
+        with patch("services.permission_service.PermissionService") as mock_perm_cls:
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+
+            with pytest.raises(MemoryGoneError) as excinfo:
+                await service.patch_memory(
+                    memory_id=memory.id,
+                    request=PatchMemoryRequest(importance=0.9),
+                    user_id="test_user",
+                )
+            assert excinfo.value.status_code == 410
+
+    @pytest.mark.asyncio
+    async def test_soft_deleted_to_unauthorized_returns_not_found(self, service):
+        """Existence-leak guard: 404 (not 410) for non-members on a deleted memory."""
+        memory = _make_memory(deleted_at=datetime(2026, 4, 20))
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        with patch("services.permission_service.PermissionService") as mock_perm_cls:
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=False)
+
+            with pytest.raises(NotFoundException):
+                await service.patch_memory(
+                    memory_id=memory.id,
+                    request=PatchMemoryRequest(importance=0.9),
+                    user_id="other_user",
+                )
 
 
 class TestPatchMemoryEmbeddingRegen:
@@ -367,3 +392,12 @@ class TestPatchMemoryRequestValidation:
         req = PatchMemoryRequest(importance=0.7)
         assert req.importance == 0.7
         assert req.summary is None
+
+    def test_tags_array_max_length_enforced(self):
+        """CSO #2: prevent unbounded PG ARRAY bloat from authenticated members."""
+        with pytest.raises(ValueError):
+            PatchMemoryRequest(tags=["x"] * 101)
+
+    def test_tags_array_at_max_length_accepted(self):
+        req = PatchMemoryRequest(tags=["x"] * 100)
+        assert len(req.tags) == 100

--- a/backend/tests/services/test_memory_patch.py
+++ b/backend/tests/services/test_memory_patch.py
@@ -268,6 +268,49 @@ class TestPatchMemoryMetadataOnly:
             mock_db.commit.assert_called()
 
     @pytest.mark.asyncio
+    async def test_quota_check_uses_post_patch_size_for_clear(self, service):
+        """Copilot loop 2: clearing details on a near-quota memory must not 422.
+
+        The pre-fix `len(str(request.details or memory.details or ""))` form
+        kept the OLD value when `request.details` was `None` or `{}`, so a
+        patch that intended to SHRINK the row was rejected against the
+        pre-shrink size.
+        """
+        from config.constants import MAX_CONTENT_SIZE
+
+        # Memory with details near the quota — clearing them should pass.
+        big_details = {"k": "x" * (MAX_CONTENT_SIZE - 100)}
+        memory = _make_memory(details=big_details, summary="ok summary baseline")
+        service.memory_repo.get = AsyncMock(return_value=memory)
+
+        with (
+            patch("services.permission_service.PermissionService") as mock_perm_cls,
+            patch(
+                "services.memory_service.update_memory_payload_in_qdrant",
+                new=AsyncMock(),
+            ),
+            patch(
+                "services.memory_service.resolve_collection_name",
+                new=AsyncMock(return_value="kagura_memories"),
+            ),
+            patch.object(
+                service,
+                "_fetch_declared_link_refs",
+                new=AsyncMock(return_value=([], False, [], False)),
+            ),
+        ):
+            mock_perm = mock_perm_cls.return_value
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+
+            # Send `details: null` to clear — must NOT raise QuotaExceededError.
+            await service.patch_memory(
+                memory_id=memory.id,
+                request=PatchMemoryRequest(details=None),
+                user_id="test_user",
+            )
+            assert memory.details is None
+
+    @pytest.mark.asyncio
     async def test_qdrant_payload_failure_does_not_raise(self, service):
         """Drift visibility: qdrant fail after PG commit logs error, no rollback."""
         memory = _make_memory()

--- a/backend/tests/services/test_memory_patch.py
+++ b/backend/tests/services/test_memory_patch.py
@@ -148,7 +148,8 @@ class TestPatchMemoryEmbeddingRegen:
     """summary / content changes trigger re-embed + neural edge invalidation."""
 
     @pytest.mark.asyncio
-    async def test_summary_change_invalidates_neural_edges(self, service, mock_db):
+    async def test_summary_change_invalidates_neural_edges_and_commits(self, service, mock_db):
+        """Copilot loop 1: edge DELETE must be committed (repo doesn't commit internally)."""
         memory = _make_memory()
         service.memory_repo.get = AsyncMock(return_value=memory)
 
@@ -183,7 +184,10 @@ class TestPatchMemoryEmbeddingRegen:
             )
 
             edge_repo_instance.delete_node_edges.assert_awaited_once()
-            mock_db.commit.assert_called()
+            # Two commits expected: (1) memory update, (2) edge invalidation.
+            assert mock_db.commit.await_count >= 2, (
+                "edge invalidation must commit; otherwise the DELETE is discarded"
+            )
             assert memory.embedding_status == "pending"
 
     @pytest.mark.asyncio
@@ -401,3 +405,14 @@ class TestPatchMemoryRequestValidation:
     def test_tags_array_at_max_length_accepted(self):
         req = PatchMemoryRequest(tags=["x"] * 100)
         assert len(req.tags) == 100
+
+    def test_explicit_null_rejected_for_non_clearable_fields(self):
+        """Copilot loop 1: sending `{field: null}` for NOT NULL columns must 422, not 500."""
+        for field in ("summary", "content", "type", "importance", "tags"):
+            with pytest.raises(ValueError):
+                PatchMemoryRequest(**{field: None})
+
+    def test_explicit_null_accepted_only_for_details(self):
+        req = PatchMemoryRequest(details=None)
+        assert "details" in req.model_fields_set
+        assert req.details is None

--- a/backend/tests/services/test_memory_patch.py
+++ b/backend/tests/services/test_memory_patch.py
@@ -265,7 +265,7 @@ class TestPatchMemoryMetadataOnly:
 
             assert memory.embedding_status == "success"  # unchanged
             mock_payload_update.assert_awaited_once()
-            mock_db.commit.assert_called()
+            mock_db.commit.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_quota_check_uses_post_patch_size_for_clear(self, service):

--- a/backend/tests/services/test_memory_patch.py
+++ b/backend/tests/services/test_memory_patch.py
@@ -459,3 +459,13 @@ class TestPatchMemoryRequestValidation:
         req = PatchMemoryRequest(details=None)
         assert "details" in req.model_fields_set
         assert req.details is None
+
+    def test_per_tag_length_cap_enforced(self):
+        """Copilot loop 3: per-tag length cap (64 chars) — not just array length."""
+        with pytest.raises(ValueError, match="exceeds 64 chars"):
+            PatchMemoryRequest(tags=["x" * 65])
+
+    def test_per_tag_length_at_cap_accepted(self):
+        req = PatchMemoryRequest(tags=["x" * 64, "y" * 64])
+        assert len(req.tags) == 2
+        assert all(len(t) == 64 for t in req.tags)

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -3,11 +3,11 @@
  *
  * Context-scoped memory list for the Memories tab on contexts/[id]
  * (Issue #433). Lists rows via `GET /api/v1/memory/list?context_id=...`,
- * hydrates each row to full `Memory` via `POST /reference` on view/delete,
- * and deletes via `POST /forget`.
+ * hydrates each row to full `Memory` via `POST /reference` on view/edit/delete,
+ * deletes via `POST /forget`, and edits via `PATCH /api/v1/memory/{id}`
+ * (Issue #439).
  *
- * Edit and Create are deferred — no UUID-addressed PUT endpoint exists yet
- * (backend follow-up) and Create needs an MCP-shape form rewrite.
+ * Create is still deferred — needs an MCP-shape form rewrite.
  */
 
 "use client";
@@ -19,6 +19,7 @@ import { FileText } from "lucide-react";
 import { MemoriesTable } from "@/components/memories/MemoriesTable";
 import { MemoryDetailDialog } from "@/components/memories/MemoryDetailDialog";
 import { DeleteMemoryDialog } from "@/components/memories/DeleteMemoryDialog";
+import { EditMemoryDialog } from "@/components/memories/EditMemoryDialog";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useToast } from "@/hooks/use-toast";
@@ -82,7 +83,7 @@ function referenceAsMemory(ref: MemoryReference): Memory {
   };
 }
 
-type DialogTarget = "detail" | "delete";
+type DialogTarget = "detail" | "delete" | "edit";
 
 interface LinkedRefsState {
   outgoing: LinkedMemoryRef[];
@@ -113,11 +114,19 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   const [error, setError] = useState<string | null>(null);
 
   const [hydrated, setHydrated] = useState<Memory | null>(null);
+  // Issue #439: keep the raw `MemoryReference` alongside the adapted
+  // `Memory`. The Edit dialog needs the canonical 6-field shape (summary /
+  // content / type / importance / tags / details), which `referenceAsMemory`
+  // discards (`details` lands in `metadata?`, `content` lands in `value`).
+  // Storing both avoids a round-trip refetch when opening Edit and makes
+  // patch responses cheap to swap in via a single `setHydratedRaw` call.
+  const [hydratedRaw, setHydratedRaw] = useState<MemoryReference | null>(null);
   const [linkedRefs, setLinkedRefs] =
     useState<LinkedRefsState>(EMPTY_LINKED_REFS);
   const [detailOpen, setDetailOpen] = useState(false);
   const [detailNotFound, setDetailNotFound] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
 
   // Race guard: when the user clicks row A then B before A's reference() has
   // resolved, the B-click sets `pendingHydrationRef.current = B.id`; when A
@@ -191,6 +200,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
         const ref = await referenceMemory(id);
         if (pendingHydrationRef.current !== id) return;
         setHydrated(referenceAsMemory(ref));
+        setHydratedRaw(ref);
         setLinkedRefs({
           outgoing: ref.outgoing_links ?? [],
           outgoingHasMore: !!ref.outgoing_has_more,
@@ -199,11 +209,13 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
         });
         setDetailNotFound(false);
         if (target === "detail") setDetailOpen(true);
+        else if (target === "edit") setEditOpen(true);
         else setDeleteOpen(true);
       } catch (err) {
         if (pendingHydrationRef.current !== id) return;
         if (viaUrl && target === "detail") {
           setHydrated(null);
+          setHydratedRaw(null);
           setLinkedRefs(EMPTY_LINKED_REFS);
           setDetailNotFound(true);
           setDetailOpen(true);
@@ -239,6 +251,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
       // a late URL-driven referenceMemory response can't re-open the dialog
       // after the param has been removed.
       setHydrated(null);
+      setHydratedRaw(null);
       setLinkedRefs(EMPTY_LINKED_REFS);
       pendingHydrationRef.current = null;
       return;
@@ -309,6 +322,35 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     setDeleteOpen(true);
   }, []);
 
+  // Issue #439: Edit affordance. The detail dialog already has a hydrated
+  // memory in `hydratedRaw`, so opening Edit is a synchronous state flip
+  // (no extra fetch). The detail dialog stays open underneath so the user
+  // can return to it with a single Cancel.
+  const handleDetailEdit = useCallback(() => {
+    if (!hydratedRaw) return;
+    setEditOpen(true);
+  }, [hydratedRaw]);
+
+  const handleEditOpenChange = useCallback((next: boolean) => {
+    setEditOpen(next);
+  }, []);
+
+  const handleEditSuccess = useCallback(
+    (updated: MemoryReference) => {
+      // Swap in the patched ref: dialog closes, detail dialog re-renders
+      // against the fresh data. `fetchMemories()` refreshes the table row
+      // so summary/type/importance changes show without manual refresh.
+      // Toast surfaces the success — frontend rule: button-driven mutation
+      // success → toast (not banner).
+      setHydratedRaw(updated);
+      setHydrated(referenceAsMemory(updated));
+      setEditOpen(false);
+      toast({ title: t("editSuccess") });
+      void fetchMemories();
+    },
+    [fetchMemories, toast, t],
+  );
+
   const handleDeleteOpenChange = useCallback(
     (next: boolean) => {
       setDeleteOpen(next);
@@ -329,6 +371,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     setDeleteOpen(false);
     setDetailOpen(false);
     setHydrated(null);
+    setHydratedRaw(null);
     setLinkedRefs(EMPTY_LINKED_REFS);
     if (memoryIdParam) setMemoryIdParam(null);
     toast({ title: t("deleteSuccess") });
@@ -383,6 +426,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
         memory={hydrated}
         open={detailOpen}
         onOpenChange={handleDetailOpenChange}
+        onEdit={hydratedRaw ? handleDetailEdit : undefined}
         onDelete={handleDetailDelete}
         notFound={detailNotFound}
         outgoingLinks={linkedRefs.outgoing}
@@ -397,6 +441,19 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
           open={deleteOpen}
           onOpenChange={handleDeleteOpenChange}
           onSuccess={handleDeleteSuccess}
+        />
+      )}
+      {/* Both hydrated state slices are mutated together (see `openWith`,
+          `handleEditSuccess`, `handleDeleteSuccess`); guarding on both
+          keeps the EditMemoryDialog mount aligned with the DeleteMemoryDialog
+          mount above and prevents a render with stale `hydratedRaw` if a
+          future code path forgets to clear one of the slices. */}
+      {hydrated && hydratedRaw && (
+        <EditMemoryDialog
+          memory={hydratedRaw}
+          open={editOpen}
+          onOpenChange={handleEditOpenChange}
+          onSuccess={handleEditSuccess}
         />
       )}
     </>

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -245,14 +245,19 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     if (!memoryIdParam) {
       setDetailOpen(false);
       setDetailNotFound(false);
-      // URL-driven dismiss (back/forward, manual edit) bypasses
-      // ``handleDetailOpenChange``, so the in-flight cleanup needs to fire
-      // here too: reset hydrated state and clear ``pendingHydrationRef`` so
-      // a late URL-driven referenceMemory response can't re-open the dialog
-      // after the param has been removed.
+      // URL-driven dismiss (back/forward, manual edit) bypasses every
+      // dialog's onOpenChange, so the cleanup must reset the same flags
+      // those handlers do. ``editOpen`` belongs here: leaving it `true`
+      // while ``hydratedRaw`` is null causes EditMemoryDialog to mount
+      // already-open the next time hydration completes for any memory
+      // (Copilot post-loop finding). Same risk applies to ``deleteOpen``
+      // for symmetry, even though DeleteMemoryDialog is guarded by
+      // ``hydrated`` and the URL flow currently goes detail-first.
       setHydrated(null);
       setHydratedRaw(null);
       setLinkedRefs(EMPTY_LINKED_REFS);
+      setEditOpen(false);
+      setDeleteOpen(false);
       pendingHydrationRef.current = null;
       return;
     }

--- a/frontend/src/components/memories/EditMemoryDialog.test.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.test.tsx
@@ -1,0 +1,257 @@
+/**
+ * Tests for EditMemoryDialog (Issue #439).
+ *
+ * Covers:
+ *   - i18n: every user-visible label resolves through useTranslations
+ *   - Initial render shows current values for all 6 patchable fields
+ *   - Dirty detection: submitting unchanged form shows "no changes"
+ *   - Submitting a real change calls updateMemoryById with only the diff
+ *   - onSuccess receives the updated MemoryReference
+ *   - API error surfaces as <Alert variant="destructive">
+ *   - Invalid details JSON surfaces as field-adjacent error (not the Alert)
+ *   - Unknown type values render as read-only (UI-recognized values use Select)
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EditMemoryDialog } from "./EditMemoryDialog";
+import type { MemoryReference } from "@/lib/types/memory";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const stableT = (key: string, vars?: Record<string, unknown>) => {
+  if (vars && typeof vars.id === "string") {
+    return `${key}:${vars.id}`;
+  }
+  return key;
+};
+
+vi.mock("next-intl", () => ({
+  useTranslations: (_ns: string) => stableT,
+}));
+
+const mockUpdate = vi.fn();
+vi.mock("@/lib/api/memory", () => ({
+  updateMemoryById: (...args: unknown[]) => mockUpdate(...args),
+}));
+
+beforeEach(() => {
+  mockUpdate.mockReset();
+});
+
+// ---------- Fixtures ---------------------------------------------------------
+
+function makeRef(overrides: Partial<MemoryReference> = {}): MemoryReference {
+  return {
+    memory_id: "11111111-1111-1111-1111-111111111111",
+    summary: "Sample summary that is more than ten chars",
+    context_summary: null,
+    content: "Sample content body",
+    details: null,
+    type: "normal",
+    scope: "working",
+    importance: 0.5,
+    tags: ["alpha", "beta"],
+    context: null,
+    created_at: "2026-04-25T00:00:00Z",
+    updated_at: "2026-04-25T00:00:00Z",
+    client: "mcp",
+    source_uri: null,
+    source_type: null,
+    ...overrides,
+  };
+}
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("EditMemoryDialog — initial render", () => {
+  it("populates all 6 patchable fields from memory", () => {
+    render(
+      <EditMemoryDialog
+        memory={makeRef()}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/summaryLabel/)).toHaveValue(
+      "Sample summary that is more than ten chars",
+    );
+    expect(screen.getByLabelText(/contentLabel/)).toHaveValue(
+      "Sample content body",
+    );
+    expect(screen.getByLabelText(/importanceLabel/)).toHaveValue(0.5);
+    expect(screen.getByLabelText(/tagsLabel/)).toHaveValue("alpha, beta");
+  });
+
+  it("renders all i18n keys for static labels", () => {
+    render(
+      <EditMemoryDialog
+        memory={makeRef()}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("title")).toBeInTheDocument();
+    expect(
+      screen.getByText(/description:11111111-1111-1111-1111-111111111111/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "cancel" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "confirm" })).toBeInTheDocument();
+  });
+});
+
+describe("EditMemoryDialog — type field", () => {
+  it("shows read-only display + helper note when type is unknown to the UI", () => {
+    render(
+      <EditMemoryDialog
+        memory={makeRef({ type: "decision" })}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    const typeInput = screen.getByLabelText(/typeLabel/);
+    expect(typeInput).toBeDisabled();
+    expect(typeInput).toHaveValue("decision");
+    expect(screen.getByText("typeUnknownReadonly")).toBeInTheDocument();
+  });
+});
+
+describe("EditMemoryDialog — submit", () => {
+  it("blocks submit and shows 'no changes' when nothing was edited", async () => {
+    const onSuccess = vi.fn();
+    render(
+      <EditMemoryDialog
+        memory={makeRef()}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={onSuccess}
+      />,
+    );
+
+    const confirmBtn = screen.getByRole("button", { name: "confirm" });
+    const form = confirmBtn.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(screen.getByText("noChanges")).toBeInTheDocument();
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it("submits only the dirty fields", async () => {
+    const updated = makeRef({ importance: 0.95 });
+    mockUpdate.mockResolvedValue(updated);
+    const onSuccess = vi.fn();
+
+    render(
+      <EditMemoryDialog
+        memory={makeRef()}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={onSuccess}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/importanceLabel/), {
+      target: { value: "0.95" },
+    });
+    const confirmBtn = screen.getByRole("button", { name: "confirm" });
+    const form = confirmBtn.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(
+        "11111111-1111-1111-1111-111111111111",
+        { importance: 0.95 },
+      );
+    });
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith(updated);
+    });
+  });
+
+  it("surfaces API errors via the destructive Alert", async () => {
+    mockUpdate.mockRejectedValue(new Error("server unavailable"));
+
+    render(
+      <EditMemoryDialog
+        memory={makeRef()}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/importanceLabel/), {
+      target: { value: "0.95" },
+    });
+    const confirmBtn = screen.getByRole("button", { name: "confirm" });
+    const form = confirmBtn.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(screen.getByText("server unavailable")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("EditMemoryDialog — details JSON validation", () => {
+  it("blocks submit on invalid JSON and shows field-adjacent error", async () => {
+    render(
+      <EditMemoryDialog
+        memory={makeRef()}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/detailsLabel/), {
+      target: { value: "{ not json" },
+    });
+    const confirmBtn = screen.getByRole("button", { name: "confirm" });
+    const form = confirmBtn.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(screen.getByText("detailsParseError")).toBeInTheDocument();
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it("rejects details that parse to a non-object value", async () => {
+    render(
+      <EditMemoryDialog
+        memory={makeRef()}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/detailsLabel/), {
+      target: { value: "[1, 2, 3]" },
+    });
+    const confirmBtn = screen.getByRole("button", { name: "confirm" });
+    const form = confirmBtn.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(screen.getByText("detailsMustBeObject")).toBeInTheDocument();
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/memories/EditMemoryDialog.test.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.test.tsx
@@ -261,6 +261,32 @@ describe("EditMemoryDialog — details JSON validation", () => {
     expect(patch).not.toHaveProperty("details");
   });
 
+  it("rejects empty importance input as validation error (Copilot loop 2)", async () => {
+    // Number("") === 0 in JS — without an explicit empty-string guard,
+    // clearing the field then submitting would silently send importance=0.
+    render(
+      <EditMemoryDialog
+        memory={makeRef()}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/importanceLabel/), {
+      target: { value: "" },
+    });
+    const confirmBtn = screen.getByRole("button", { name: "confirm" });
+    const form = confirmBtn.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(screen.getByText("importanceOutOfRange")).toBeInTheDocument();
+    });
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
   it("rejects details that parse to a non-object value", async () => {
     render(
       <EditMemoryDialog

--- a/frontend/src/components/memories/EditMemoryDialog.test.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.test.tsx
@@ -231,6 +231,36 @@ describe("EditMemoryDialog — details JSON validation", () => {
     expect(mockUpdate).not.toHaveBeenCalled();
   });
 
+  it("does not falsely dirty an existing empty-object details when user does nothing", async () => {
+    // Copilot loop 1: detailsToText({}) used to collapse to "" which the
+    // submit logic interpreted as `null`, accidentally clearing the column.
+    mockUpdate.mockResolvedValue(makeRef());
+    render(
+      <EditMemoryDialog
+        memory={makeRef({ details: {} })}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    // Touch some unrelated field to make submit go through.
+    fireEvent.change(screen.getByLabelText(/importanceLabel/), {
+      target: { value: "0.95" },
+    });
+    const confirmBtn = screen.getByRole("button", { name: "confirm" });
+    const form = confirmBtn.closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form!);
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalled();
+    });
+    // The patch should NOT include `details` — the existing `{}` was untouched.
+    const [, patch] = mockUpdate.mock.calls[0];
+    expect(patch).not.toHaveProperty("details");
+  });
+
   it("rejects details that parse to a non-object value", async () => {
     render(
       <EditMemoryDialog

--- a/frontend/src/components/memories/EditMemoryDialog.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.tsx
@@ -212,12 +212,16 @@ export function EditMemoryDialog({
       }
     }
     setDetailsParseError(null);
-    // Canonical (no pretty-print) JSON for the dirty check so round-tripped
-    // objects with different key spacing don't fire false positives. The
-    // human-readable pretty-print is only for the textarea display.
-    const currentDetailsCanonical = JSON.stringify(memory.details ?? null);
-    const newDetailsCanonical = JSON.stringify(parsedDetails ?? null);
-    if (newDetailsCanonical !== currentDetailsCanonical) {
+    // Minified JSON (no pretty-print whitespace) for the dirty check so
+    // round-tripped objects with different INDENTATION don't fire false
+    // positives. NOT canonicalized across key order — `JSON.stringify`
+    // preserves insertion order, so a backend that re-orders keys could
+    // still trigger a spurious "dirty" diff. Acceptable for now since
+    // PostgreSQL JSONB preserves key order on round-trip and the form
+    // assembles JSON from a single textarea (no key-order ambiguity).
+    const currentDetailsMinified = JSON.stringify(memory.details ?? null);
+    const newDetailsMinified = JSON.stringify(parsedDetails ?? null);
+    if (newDetailsMinified !== currentDetailsMinified) {
       patch.details = parsedDetails ?? null;
     }
 

--- a/frontend/src/components/memories/EditMemoryDialog.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.tsx
@@ -33,7 +33,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import { updateMemoryById } from "@/lib/api/memory";
+import { updateMemoryById, type UpdateMemoryByIdPatch } from "@/lib/api/memory";
 import type { KnownMemoryType, MemoryReference } from "@/lib/types/memory";
 
 interface EditMemoryDialogProps {
@@ -65,7 +65,10 @@ function csvToTags(csv: string): string[] {
 function detailsToText(
   details: Record<string, unknown> | null | undefined,
 ): string {
-  if (!details || Object.keys(details).length === 0) return "";
+  // Distinguish `null`/undefined (no details — empty textarea) from `{}`
+  // (explicit empty object — show as "{}" so the dirty check doesn't false-
+  // positive convert `{}` to `null` on submit).
+  if (details == null) return "";
   return JSON.stringify(details, null, 2);
 }
 
@@ -89,12 +92,14 @@ export function EditMemoryDialog({
     null,
   );
 
-  // Reset form when the dialog is reopened on a different memory. Depend on
-  // `memory.memory_id` only — depending on the whole `memory` object would
-  // reset user edits on every parent re-render that produces a referentially
-  // new object. (`memory` itself is not referentially stable across the
-  // panel's hydration cycle.)
+  // Reset form on (a) memory id changing or (b) the dialog opening. The
+  // component stays mounted across open/close cycles; without the `open`
+  // dependency, closing mid-edit then reopening on the same memory would
+  // resurrect the prior in-progress edits + error state — Cancel is
+  // expected to discard, mirroring DeleteMemoryDialog and the rest of the
+  // dialog set. The `if (!open) return` guard skips the closing transition.
   useEffect(() => {
+    if (!open) return;
     setSummary(memory.summary);
     setContent(memory.content);
     setType(memory.type);
@@ -104,7 +109,7 @@ export function EditMemoryDialog({
     setDetailsParseError(null);
     setError(null);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [memory.memory_id]);
+  }, [memory.memory_id, open]);
 
   const typeIsKnown = useMemo<boolean>(
     () => KNOWN_TYPES.some((t) => t === memory.type),
@@ -121,7 +126,9 @@ export function EditMemoryDialog({
     if (loading) return;
 
     // Compute dirty fields. Only changed values are included in the patch.
-    const patch: Record<string, unknown> = {};
+    // Type as `UpdateMemoryByIdPatch` (not `Record<string, unknown>`) so the
+    // request body matches the helper's contract and tsc catches typos.
+    const patch: UpdateMemoryByIdPatch = {};
 
     const summaryTrimmed = summary.trim();
     if (summaryTrimmed !== memory.summary) {

--- a/frontend/src/components/memories/EditMemoryDialog.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.tsx
@@ -1,13 +1,18 @@
-'use client';
+"use client";
 
 /**
  * Edit Memory Dialog
  *
- * Form for editing an existing memory
+ * Form for editing an existing memory via the UUID-addressed
+ * `PATCH /api/v1/memory/{memory_id}` endpoint (Issue #439).
+ *
+ * Replaces the legacy composite-key form. Operates on `MemoryReference`
+ * (full detail) and submits only fields that differ from the initial
+ * value (client-side dirty detection) so an empty PATCH is never sent.
  */
 
-import { useState, useEffect } from 'react';
-import { useAuth } from '@/contexts/AuthContext';
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import {
   Dialog,
   DialogContent,
@@ -15,19 +20,53 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
-import { updateMemory } from '@/lib/api/memory';
-import type { Memory } from '@/lib/types/memory';
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { updateMemoryById } from "@/lib/api/memory";
+import type { KnownMemoryType, MemoryReference } from "@/lib/types/memory";
 
 interface EditMemoryDialogProps {
-  memory: Memory;
+  memory: MemoryReference;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSuccess: () => void;
+  onSuccess: (updated: MemoryReference) => void;
+}
+
+// `MemoryType` is a free string at the column level (`String(50)`), but the
+// UI ships with two known values for styling/badges. The Select offers these
+// two options when the current value matches one of them; an unknown current
+// value (e.g. `"code"`, `"decision"`) is shown as read-only with a helper
+// note so editing this dialog does not accidentally overwrite values the UI
+// has no opinion about. Source of truth is `KnownMemoryType` in `lib/types/memory`.
+const KNOWN_TYPES: readonly KnownMemoryType[] = ["normal", "coding"] as const;
+
+function tagsToCsv(tags: string[] | undefined | null): string {
+  return (tags ?? []).join(", ");
+}
+
+function csvToTags(csv: string): string[] {
+  return csv
+    .split(",")
+    .map((t) => t.trim())
+    .filter(Boolean);
+}
+
+function detailsToText(
+  details: Record<string, unknown> | null | undefined,
+): string {
+  if (!details || Object.keys(details).length === 0) return "";
+  return JSON.stringify(details, null, 2);
 }
 
 export function EditMemoryDialog({
@@ -36,136 +75,263 @@ export function EditMemoryDialog({
   onOpenChange,
   onSuccess,
 }: EditMemoryDialogProps) {
-  const { user } = useAuth();
+  const t = useTranslations("contextDetail.editDialog");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Form state
-  const [value, setValue] = useState(memory.value);
-  const [importance, setImportance] = useState(memory.importance.toString());
-  const [tags, setTags] = useState(memory.tags?.join(', ') || '');
+  const [summary, setSummary] = useState(memory.summary);
+  const [content, setContent] = useState(memory.content);
+  const [type, setType] = useState(memory.type);
+  const [importance, setImportance] = useState(String(memory.importance));
+  const [tagsCsv, setTagsCsv] = useState(tagsToCsv(memory.tags));
+  const [detailsText, setDetailsText] = useState(detailsToText(memory.details));
+  const [detailsParseError, setDetailsParseError] = useState<string | null>(
+    null,
+  );
 
-  // Reset form when memory changes
+  // Reset form when the dialog is reopened on a different memory. Depend on
+  // `memory.memory_id` only — depending on the whole `memory` object would
+  // reset user edits on every parent re-render that produces a referentially
+  // new object. (`memory` itself is not referentially stable across the
+  // panel's hydration cycle.)
   useEffect(() => {
-    setValue(memory.value);
-    setImportance(memory.importance.toString());
-    setTags(memory.tags?.join(', ') || '');
-  }, [memory]);
+    setSummary(memory.summary);
+    setContent(memory.content);
+    setType(memory.type);
+    setImportance(String(memory.importance));
+    setTagsCsv(tagsToCsv(memory.tags));
+    setDetailsText(detailsToText(memory.details));
+    setDetailsParseError(null);
+    setError(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [memory.memory_id]);
+
+  const typeIsKnown = useMemo<boolean>(
+    () => KNOWN_TYPES.some((t) => t === memory.type),
+    [memory.type],
+  );
+
+  const handleClose = () => {
+    if (loading) return;
+    onOpenChange(false);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (loading) return;
 
-    if (!user) {
-      setError('User not authenticated');
-      return;
+    // Compute dirty fields. Only changed values are included in the patch.
+    const patch: Record<string, unknown> = {};
+
+    const summaryTrimmed = summary.trim();
+    if (summaryTrimmed !== memory.summary) {
+      if (summaryTrimmed.length < 10) {
+        setError(t("summaryTooShort"));
+        return;
+      }
+      patch.summary = summaryTrimmed;
     }
 
-    if (!value.trim()) {
-      setError('Value is required');
+    if (content !== memory.content) {
+      if (content.trim().length === 0) {
+        setError(t("contentRequired"));
+        return;
+      }
+      patch.content = content;
+    }
+
+    if (typeIsKnown && type !== memory.type) {
+      patch.type = type;
+    }
+
+    const importanceNum = Number(importance);
+    if (
+      Number.isFinite(importanceNum) &&
+      Math.abs(importanceNum - memory.importance) > 1e-9
+    ) {
+      if (importanceNum < 0 || importanceNum > 1) {
+        setError(t("importanceOutOfRange"));
+        return;
+      }
+      patch.importance = importanceNum;
+    }
+
+    // Order-insensitive tag comparison: backend may normalize tag order on
+    // round-trip (PostgreSQL ARRAY ordering is not guaranteed stable across
+    // updates), so a positional diff would fire spurious PATCH calls when
+    // the user types the same set in a different order.
+    const newTags = csvToTags(tagsCsv);
+    const currentTags = memory.tags ?? [];
+    const newTagsSorted = [...newTags].sort();
+    const currentTagsSorted = [...currentTags].sort();
+    const tagsDiffer =
+      newTagsSorted.length !== currentTagsSorted.length ||
+      newTagsSorted.some((tag, idx) => tag !== currentTagsSorted[idx]);
+    if (tagsDiffer) {
+      patch.tags = newTags;
+    }
+
+    let parsedDetails: Record<string, unknown> | null | undefined;
+    const detailsTrimmed = detailsText.trim();
+    if (detailsTrimmed.length === 0) {
+      parsedDetails = null;
+    } else {
+      try {
+        const parsed = JSON.parse(detailsTrimmed);
+        if (
+          typeof parsed !== "object" ||
+          parsed === null ||
+          Array.isArray(parsed)
+        ) {
+          setDetailsParseError(t("detailsMustBeObject"));
+          return;
+        }
+        parsedDetails = parsed as Record<string, unknown>;
+      } catch {
+        setDetailsParseError(t("detailsParseError"));
+        return;
+      }
+    }
+    setDetailsParseError(null);
+    // Canonical (no pretty-print) JSON for the dirty check so round-tripped
+    // objects with different key spacing don't fire false positives. The
+    // human-readable pretty-print is only for the textarea display.
+    const currentDetailsCanonical = JSON.stringify(memory.details ?? null);
+    const newDetailsCanonical = JSON.stringify(parsedDetails ?? null);
+    if (newDetailsCanonical !== currentDetailsCanonical) {
+      patch.details = parsedDetails ?? null;
+    }
+
+    if (Object.keys(patch).length === 0) {
+      setError(t("noChanges"));
       return;
     }
 
     try {
       setLoading(true);
       setError(null);
-
-      await updateMemory(
-        memory.key,
-        user.id,
-        {
-          value: value.trim(),
-          importance: parseFloat(importance),
-          tags: tags.trim() ? tags.split(',').map(t => t.trim()).filter(Boolean) : undefined,
-        },
-        memory.scope,
-        memory.agent_name
-      );
-
-      onSuccess();
+      const updated = await updateMemoryById(memory.memory_id, patch);
+      onSuccess(updated);
     } catch (err) {
-      console.error('Failed to update memory:', err);
-      setError(err instanceof Error ? err.message : 'Failed to update memory');
+      setError(err instanceof Error ? err.message : t("failed"));
     } finally {
       setLoading(false);
     }
   };
 
-  const handleClose = () => {
-    if (!loading) {
-      onOpenChange(false);
-      setError(null);
-    }
-  };
-
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle>Edit Memory</DialogTitle>
+          <DialogTitle>{t("title")}</DialogTitle>
           <DialogDescription>
-            Update memory: <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">{memory.key}</code>
+            {t("description", { id: memory.memory_id })}
           </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (
-            <div className="p-3 text-sm text-red-600 bg-red-50 dark:bg-red-900/20 rounded-md">
-              {error}
-            </div>
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
           )}
 
-          {/* Read-only fields */}
-          <div className="grid grid-cols-2 gap-4 p-3 bg-slate-50 dark:bg-slate-900 rounded-lg">
-            <div>
-              <Label className="text-xs text-slate-500">Scope</Label>
-              <p className="text-sm font-medium">{memory.scope}</p>
-            </div>
-            <div>
-              <Label className="text-xs text-slate-500">Agent</Label>
-              <p className="text-sm font-medium">{memory.agent_name}</p>
-            </div>
-          </div>
-
-          {/* Value */}
+          {/* Summary */}
           <div className="space-y-2">
-            <Label htmlFor="value">
-              Value <span className="text-red-500">*</span>
+            <Label htmlFor="edit-summary">
+              {t("summaryLabel")} <span className="text-red-500">*</span>
             </Label>
             <Textarea
-              id="value"
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              placeholder="Enter memory value..."
+              id="edit-summary"
+              value={summary}
+              onChange={(e) => setSummary(e.target.value)}
+              rows={2}
+              maxLength={500}
+              required
+            />
+          </div>
+
+          {/* Content */}
+          <div className="space-y-2">
+            <Label htmlFor="edit-content">
+              {t("contentLabel")} <span className="text-red-500">*</span>
+            </Label>
+            <Textarea
+              id="edit-content"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
               rows={6}
               required
             />
           </div>
 
-          {/* Importance */}
+          {/* Type — Select for known values, read-only display otherwise */}
           <div className="space-y-2">
-            <Label htmlFor="importance">
-              Importance (0.0 - 1.0)
-            </Label>
-            <Input
-              id="importance"
-              type="number"
-              min="0"
-              max="1"
-              step="0.1"
-              value={importance}
-              onChange={(e) => setImportance(e.target.value)}
-            />
+            <Label htmlFor="edit-type">{t("typeLabel")}</Label>
+            {typeIsKnown ? (
+              <Select value={type} onValueChange={setType}>
+                <SelectTrigger id="edit-type">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="normal">{t("typeNormal")}</SelectItem>
+                  <SelectItem value="coding">{t("typeCoding")}</SelectItem>
+                </SelectContent>
+              </Select>
+            ) : (
+              <div className="space-y-1">
+                <Input id="edit-type" value={memory.type} disabled />
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  {t("typeUnknownReadonly")}
+                </p>
+              </div>
+            )}
           </div>
 
-          {/* Tags */}
+          {/* Importance + Tags side-by-side */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="edit-importance">{t("importanceLabel")}</Label>
+              <Input
+                id="edit-importance"
+                type="number"
+                min="0"
+                max="1"
+                step="0.1"
+                value={importance}
+                onChange={(e) => setImportance(e.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="edit-tags">{t("tagsLabel")}</Label>
+              <Input
+                id="edit-tags"
+                value={tagsCsv}
+                onChange={(e) => setTagsCsv(e.target.value)}
+                placeholder={t("tagsPlaceholder")}
+              />
+            </div>
+          </div>
+
+          {/* Details — JSON */}
           <div className="space-y-2">
-            <Label htmlFor="tags">Tags (comma-separated)</Label>
-            <Input
-              id="tags"
-              value={tags}
-              onChange={(e) => setTags(e.target.value)}
-              placeholder="tag1, tag2, tag3"
+            <Label htmlFor="edit-details">{t("detailsLabel")}</Label>
+            <Textarea
+              id="edit-details"
+              value={detailsText}
+              onChange={(e) => {
+                setDetailsText(e.target.value);
+                if (detailsParseError) setDetailsParseError(null);
+              }}
+              rows={4}
+              placeholder={t("detailsPlaceholder")}
+              className="font-mono text-xs"
             />
+            {detailsParseError && (
+              <p className="text-xs text-red-600 dark:text-red-400">
+                {detailsParseError}
+              </p>
+            )}
           </div>
 
           <DialogFooter>
@@ -175,10 +341,10 @@ export function EditMemoryDialog({
               onClick={handleClose}
               disabled={loading}
             >
-              Cancel
+              {t("cancel")}
             </Button>
             <Button type="submit" disabled={loading}>
-              {loading ? 'Updating...' : 'Update Memory'}
+              {loading ? t("saving") : t("confirm")}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/memories/EditMemoryDialog.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.tsx
@@ -151,16 +151,28 @@ export function EditMemoryDialog({
       patch.type = type;
     }
 
-    const importanceNum = Number(importance);
-    if (
-      Number.isFinite(importanceNum) &&
-      Math.abs(importanceNum - memory.importance) > 1e-9
-    ) {
+    // `Number("") === 0` in JS — without this guard, clearing the importance
+    // input then submitting would silently set the column to 0 (and treat it
+    // as a real change vs the prior 0.5 default). Treat empty / non-finite
+    // as a validation error so the user has to type a number to commit.
+    const importanceTrimmed = importance.trim();
+    if (importanceTrimmed !== String(memory.importance)) {
+      if (importanceTrimmed.length === 0) {
+        setError(t("importanceOutOfRange"));
+        return;
+      }
+      const importanceNum = Number(importanceTrimmed);
+      if (!Number.isFinite(importanceNum)) {
+        setError(t("importanceOutOfRange"));
+        return;
+      }
       if (importanceNum < 0 || importanceNum > 1) {
         setError(t("importanceOutOfRange"));
         return;
       }
-      patch.importance = importanceNum;
+      if (Math.abs(importanceNum - memory.importance) > 1e-9) {
+        patch.importance = importanceNum;
+      }
     }
 
     // Order-insensitive tag comparison: backend may normalize tag order on

--- a/frontend/src/components/memories/EditMemoryDialog.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.tsx
@@ -215,10 +215,15 @@ export function EditMemoryDialog({
     // Minified JSON (no pretty-print whitespace) for the dirty check so
     // round-tripped objects with different INDENTATION don't fire false
     // positives. NOT canonicalized across key order — `JSON.stringify`
-    // preserves insertion order, so a backend that re-orders keys could
-    // still trigger a spurious "dirty" diff. Acceptable for now since
-    // PostgreSQL JSONB preserves key order on round-trip and the form
-    // assembles JSON from a single textarea (no key-order ambiguity).
+    // preserves the in-memory key order, but PostgreSQL JSONB does NOT
+    // preserve key order on round-trip (jsonb stores a decomposed binary
+    // representation and may emit keys in a normalized order). A spurious
+    // "dirty" diff can therefore fire if the user re-edits a memory whose
+    // details were saved with different key insertion order than the
+    // backend returned. Acceptable for v0.14.0 — the false-positive sends
+    // a valid (semantically-identical) PATCH; not a correctness bug, just
+    // an extra round-trip. Stable-sort stringify is the proper fix and
+    // is tracked alongside the v0.14.1 dialog refactor (#446).
     const currentDetailsMinified = JSON.stringify(memory.details ?? null);
     const newDetailsMinified = JSON.stringify(parsedDetails ?? null);
     if (newDetailsMinified !== currentDetailsMinified) {

--- a/frontend/src/lib/api/memory.ts
+++ b/frontend/src/lib/api/memory.ts
@@ -75,6 +75,42 @@ export async function forgetMemory(memoryId: string): Promise<void> {
   });
 }
 
+/**
+ * Partial update of a memory by UUID (Issue #439).
+ *
+ * Issue #439: Replaces the legacy `updateMemory()` composite-key path
+ * (deprecated, calls a 404 endpoint). Backend route is
+ * `PATCH /api/v1/memory/{memory_id}` and accepts any subset of the
+ * patchable fields. Omitted fields preserve their current value;
+ * `tags` follows replace-all semantics (an empty array clears tags).
+ *
+ * Status code surfacing:
+ *   - 200: returns the full `MemoryReference`
+ *   - 404: memory does not exist OR caller lacks access (existence not leaked)
+ *   - 410: memory was soft-deleted (distinct from 404 so retries can stop)
+ *   - 422: validation error (empty patch, importance > 1, etc.)
+ *
+ * Caller propagates errors as `ApiError` (see `lib/api/base.ts`).
+ */
+export interface UpdateMemoryByIdPatch {
+  summary?: string;
+  content?: string;
+  type?: string;
+  importance?: number;
+  tags?: string[];
+  details?: Record<string, unknown> | null;
+}
+
+export async function updateMemoryById(
+  memoryId: string,
+  patch: UpdateMemoryByIdPatch,
+): Promise<MemoryReference> {
+  return apiClient.patch<MemoryReference>(
+    `/api/v1/memory/${encodeURIComponent(memoryId)}`,
+    patch,
+  );
+}
+
 // =============================================================================
 // LEGACY DEAD CODE — composite-key helpers below this banner.
 //

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2672,7 +2672,8 @@
       "emptyDesc": "Use the MCP remember tool to store memories in this context.",
       "loadFailed": "Failed to load memories",
       "hydrateFailed": "Failed to load memory details",
-      "deleteSuccess": "Memory deleted"
+      "deleteSuccess": "Memory deleted",
+      "editSuccess": "Memory updated"
     },
     "memoriesTable": {
       "loading": "Loading memories...",
@@ -2739,6 +2740,31 @@
       "confirm": "Delete Memory",
       "deleting": "Deleting...",
       "failed": "Failed to delete memory"
+    },
+    "editDialog": {
+      "title": "Edit Memory",
+      "description": "Update memory fields. Memory ID: {id}",
+      "summaryLabel": "Summary",
+      "contentLabel": "Content",
+      "typeLabel": "Type",
+      "typeNormal": "Normal",
+      "typeCoding": "Coding",
+      "typeUnknownReadonly": "Type editing is read-only for values the UI doesn't recognize.",
+      "importanceLabel": "Importance (0.0–1.0)",
+      "tagsLabel": "Tags (comma-separated)",
+      "tagsPlaceholder": "tag1, tag2, tag3",
+      "detailsLabel": "Details (JSON object)",
+      "detailsPlaceholder": "'{'\"key\": \"value\"'}'",
+      "detailsParseError": "Details must be valid JSON",
+      "detailsMustBeObject": "Details must be a JSON object (not array or primitive)",
+      "summaryTooShort": "Summary must be at least 10 characters",
+      "contentRequired": "Content is required",
+      "importanceOutOfRange": "Importance must be between 0.0 and 1.0",
+      "noChanges": "No changes to save",
+      "cancel": "Cancel",
+      "confirm": "Save Changes",
+      "saving": "Saving...",
+      "failed": "Failed to update memory"
     }
   },
   "contextSettings": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2754,7 +2754,7 @@
       "tagsLabel": "Tags (comma-separated)",
       "tagsPlaceholder": "tag1, tag2, tag3",
       "detailsLabel": "Details (JSON object)",
-      "detailsPlaceholder": "'{'\"key\": \"value\"'}'",
+      "detailsPlaceholder": "JSON object — e.g. \"key\": \"value\"",
       "detailsParseError": "Details must be valid JSON",
       "detailsMustBeObject": "Details must be a JSON object (not array or primitive)",
       "summaryTooShort": "Summary must be at least 10 characters",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2672,7 +2672,8 @@
       "emptyDesc": "MCP の remember ツールでこのコンテキストにメモリを保存してください。",
       "loadFailed": "メモリの読み込みに失敗しました",
       "hydrateFailed": "メモリ詳細の取得に失敗しました",
-      "deleteSuccess": "メモリを削除しました"
+      "deleteSuccess": "メモリを削除しました",
+      "editSuccess": "メモリを更新しました"
     },
     "memoriesTable": {
       "loading": "メモリを読み込み中...",
@@ -2739,6 +2740,31 @@
       "confirm": "メモリを削除",
       "deleting": "削除中...",
       "failed": "メモリの削除に失敗しました"
+    },
+    "editDialog": {
+      "title": "メモリを編集",
+      "description": "メモリのフィールドを更新します。メモリID: {id}",
+      "summaryLabel": "サマリ",
+      "contentLabel": "コンテンツ",
+      "typeLabel": "種別",
+      "typeNormal": "ノーマル",
+      "typeCoding": "コーディング",
+      "typeUnknownReadonly": "UI が認識しない種別は読み取り専用です。",
+      "importanceLabel": "重要度 (0.0–1.0)",
+      "tagsLabel": "タグ(カンマ区切り)",
+      "tagsPlaceholder": "tag1, tag2, tag3",
+      "detailsLabel": "詳細 (JSON オブジェクト)",
+      "detailsPlaceholder": "'{'\"key\": \"value\"'}'",
+      "detailsParseError": "詳細は有効な JSON で入力してください",
+      "detailsMustBeObject": "詳細は JSON オブジェクトで入力してください(配列やプリミティブは不可)",
+      "summaryTooShort": "サマリは 10 文字以上必要です",
+      "contentRequired": "コンテンツは必須です",
+      "importanceOutOfRange": "重要度は 0.0 〜 1.0 の範囲で入力してください",
+      "noChanges": "変更がありません",
+      "cancel": "キャンセル",
+      "confirm": "変更を保存",
+      "saving": "保存中...",
+      "failed": "メモリの更新に失敗しました"
     }
   },
   "contextSettings": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2754,7 +2754,7 @@
       "tagsLabel": "タグ(カンマ区切り)",
       "tagsPlaceholder": "tag1, tag2, tag3",
       "detailsLabel": "詳細 (JSON オブジェクト)",
-      "detailsPlaceholder": "'{'\"key\": \"value\"'}'",
+      "detailsPlaceholder": "JSON オブジェクト — 例: \"key\": \"value\"",
       "detailsParseError": "詳細は有効な JSON で入力してください",
       "detailsMustBeObject": "詳細は JSON オブジェクトで入力してください(配列やプリミティブは不可)",
       "summaryTooShort": "サマリは 10 文字以上必要です",


### PR DESCRIPTION
Closes #439

## Summary
- New `PATCH /api/v1/memory/{memory_id}` endpoint for UUID-addressed partial updates (summary / content / type / importance / tags / details). Permission denial returns 404 (no leak); soft-deleted returns 410 only to authorized callers; neural edges are invalidated when summary/content changes; qdrant payload-only failures log a structured error but do not roll back the PG write.
- Full rewrite of `EditMemoryDialog` from the legacy 3-field `Memory` shape to the canonical 6-field `MemoryReference` shape, with client-side dirty detection (order-insensitive tags, canonical-JSON details), Alert-based dialog errors, field-adjacent JSON parse errors, and a `Select` for known type values with read-only display for unknown values.
- `MemoryGoneError` (410, RES-003) added — consistent with the existing `MemoryCloudException` global handler and the prior 410 usage in `invitations.py` / MCP transport.
- `_log_embedding_task_result` extracted from 3 inline closures (`remember` / `_update_in_place` / `patch_memory`) to a single module-level helper bound via `functools.partial`.
- i18n: `contextDetail.editDialog` namespace mirroring `deleteDialog` (en + ja).

## Implementation notes
- Permission check runs **before** the soft-delete check so a non-member who guesses a UUID cannot distinguish `deleted` (would-be 410) from `never existed` (404). `_update_in_place` uses the opposite order — left as-is per CSO scope (MCP-internal, low exposure); flagged for v0.14.x defense-in-depth alignment.
- Embedding regeneration uses the existing async-task pattern (`process_pending_embedding`) — issue body's "synchronous" wording was deviated from for consistency with `_update_in_place`. PR description supersedes that wording.
- `model_dump(exclude_unset=True)` distinguishes "field omitted" from "field explicitly null"; sending `{"details": null}` clears the JSONB column, omitting `details` preserves it.
- ReferenceResponse is constructed inline at the end of `patch_memory` instead of delegating to `self.reference()` — avoids a redundant permission check, an extra commit, and a wrong access-stat bump on a write path.
- `tags: list[str] | None = Field(None, max_length=100)` caps the array against insider DoS — the `MAX_CONTENT_SIZE` guard now skips metadata-only patches (simplify pass) so this Pydantic-level cap is the load-bearing protection.
- Frontend `MemoriesTabPanel` carries `[hydrated, hydratedRaw]` to feed both legacy-shape dialogs (`MemoryDetailDialog`, `DeleteMemoryDialog`) and the new `MemoryReference`-shape `EditMemoryDialog`. Dual-state is interim — follow-up #446 (v0.14.1) will collapse it.

## Test coverage
- Backend: 17 new tests in `backend/tests/services/test_memory_patch.py` covering all 4 design contracts plus `details: null` clear / omit semantics, `tags` length cap, validation error paths.
- Frontend: 8 new tests in `frontend/src/components/memories/EditMemoryDialog.test.tsx` covering render, dirty submission, API errors via Alert, field-adjacent JSON parse errors, and unknown-type read-only display.
- Total: `make lint` clean, all 17 patch_memory tests + 49 existing memory backend tests + 270 existing frontend tests + 8 EditMemoryDialog tests pass. `tsc --noEmit` clean.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green (post-fix re-review — existence-leak ordering + tags cap fixed in 17c4b8a)
- qa-lead: green
- cto: green
- gate1: yellow via /ask (routed to PM, batch coherence flag — operator chose split, then continued with #439 alone)
- review provider: copilot

## Follow-ups filed
- #446 (v0.14.1): `refactor(frontend): remove legacy Memory shape, switch dialogs to MemoryReference` — collapses the interim dual-state pattern.

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/439-feat-feat-api-ui-uuid-addressed-memory-update.gate1.md`
- `~/.claude/cache/gh-issue-driven/439-feat-feat-api-ui-uuid-addressed-memory-update.gate2.md`

🤖 Generated via /gh-issue-driven:ship
