### PR TITLE
refactor(frontend): resolve bulk delete UI/backend mismatch in MemoriesTable (#450)

### DIFF
--- a/frontend/src/components/memories/MemoriesTable.tsx
+++ b/frontend/src/components/memories/MemoriesTable.tsx
@@ -2,12 +2,10 @@
  * Memories Table Component
  *
  * Displays memories in a table with pagination
- * Issue #666: Phase 2 - Added bulk delete checkbox support
  */
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Checkbox } from "@/components/ui/checkbox";
 import {
   Table,
   TableBody,
@@ -36,10 +34,6 @@ interface MemoriesTableProps {
   pageSize: number;
   total: number;
   onPageChange: (page: number) => void;
-  // Bulk delete (Issue #666): wiring is the parent's responsibility.
-  // Currently blocked on a UUID bulk-forget endpoint backend-side.
-  selectedIds?: string[];
-  onSelectionChange?: (ids: string[]) => void;
 }
 
 export function MemoriesTable({
@@ -52,48 +46,11 @@ export function MemoriesTable({
   pageSize,
   total,
   onPageChange,
-  selectedIds = [],
-  onSelectionChange,
 }: MemoriesTableProps) {
   const { user } = useAuth();
   const locale = useLocale();
   const t = useTranslations("contextDetail.memoriesTable");
   const totalPages = Math.ceil(total / pageSize);
-  const bulkDeleteEnabled = !!onSelectionChange;
-
-  const allVisibleSelected =
-    memories.length > 0 && memories.every((m) => selectedIds.includes(m.id));
-
-  // Radix Checkbox `onCheckedChange` emits `boolean | "indeterminate"`.
-  // Coerce explicitly so the "indeterminate" branch is treated as unchecked,
-  // not as a silent truthy "select all".
-  const handleSelectAll = (checked: boolean | "indeterminate") => {
-    if (!onSelectionChange) return;
-
-    if (checked === true) {
-      const visibleIds = memories.map((m) => m.id);
-      onSelectionChange([...new Set([...selectedIds, ...visibleIds])]);
-    } else {
-      const visibleIds = new Set(memories.map((m) => m.id));
-      onSelectionChange(selectedIds.filter((id) => !visibleIds.has(id)));
-    }
-  };
-
-  const handleRowToggle = (
-    memory: MemoryListItem,
-    checked: boolean | "indeterminate",
-  ) => {
-    if (!onSelectionChange) return;
-
-    if (checked === true) {
-      // Dedup via Set — Radix Checkbox can re-fire `onCheckedChange(true)`
-      // on repeated clicks / re-renders, which would otherwise pile up
-      // duplicate entries in `selectedIds`.
-      onSelectionChange([...new Set([...selectedIds, memory.id])]);
-    } else {
-      onSelectionChange(selectedIds.filter((id) => id !== memory.id));
-    }
-  };
 
   const getImportanceBadge = (importance: number) => {
     if (importance >= 0.8)
@@ -135,15 +92,6 @@ export function MemoriesTable({
         <Table>
           <TableHeader>
             <TableRow>
-              {bulkDeleteEnabled && (
-                <TableHead className="w-12">
-                  <Checkbox
-                    checked={allVisibleSelected}
-                    onCheckedChange={handleSelectAll}
-                    aria-label={t("selectAll")}
-                  />
-                </TableHead>
-              )}
               <TableHead>{t("columnSummary")}</TableHead>
               <TableHead>{t("columnType")}</TableHead>
               <TableHead>{t("columnScope")}</TableHead>
@@ -153,81 +101,65 @@ export function MemoriesTable({
             </TableRow>
           </TableHeader>
           <TableBody>
-            {memories.map((memory) => {
-              const isSelected = selectedIds.includes(memory.id);
-              return (
-                <TableRow key={memory.id}>
-                  {bulkDeleteEnabled && (
-                    <TableCell>
-                      <Checkbox
-                        checked={isSelected}
-                        onCheckedChange={(checked) =>
-                          handleRowToggle(memory, checked)
-                        }
-                        aria-label={t("selectRow", {
-                          summary: memory.summary,
-                        })}
-                      />
-                    </TableCell>
+            {memories.map((memory) => (
+              <TableRow key={memory.id}>
+                <TableCell className="font-medium max-w-xs truncate">
+                  {memory.summary}
+                </TableCell>
+                <TableCell>
+                  {memory.type ? (
+                    <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
+                      {memory.type}
+                    </code>
+                  ) : (
+                    <span className="text-xs text-slate-400">—</span>
                   )}
-                  <TableCell className="font-medium max-w-xs truncate">
-                    {memory.summary}
-                  </TableCell>
-                  <TableCell>
-                    {memory.type ? (
-                      <code className="text-xs bg-slate-100 dark:bg-slate-800 px-2 py-1 rounded">
-                        {memory.type}
-                      </code>
-                    ) : (
-                      <span className="text-xs text-slate-400">—</span>
-                    )}
-                  </TableCell>
-                  <TableCell>{getScopeBadge(memory.scope)}</TableCell>
-                  <TableCell>{getImportanceBadge(memory.importance)}</TableCell>
-                  <TableCell className="text-sm text-slate-500">
-                    {formatRelativeTime(
-                      memory.updated_at,
-                      user?.timezone,
-                      locale,
-                    )}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <div className="flex items-center justify-end gap-2">
+                </TableCell>
+                <TableCell>{getScopeBadge(memory.scope)}</TableCell>
+                <TableCell>{getImportanceBadge(memory.importance)}</TableCell>
+                <TableCell className="text-sm text-slate-500">
+                  {formatRelativeTime(
+                    memory.updated_at,
+                    user?.timezone,
+                    locale,
+                  )}
+                </TableCell>
+                <TableCell className="text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onView(memory)}
+                      title={t("actionView")}
+                      aria-label={t("actionView")}
+                    >
+                      <Eye className="h-4 w-4" />
+                    </Button>
+                    {onEdit && (
                       <Button
                         variant="ghost"
                         size="icon"
-                        onClick={() => onView(memory)}
-                        title={t("actionView")}
-                        aria-label={t("actionView")}
+                        onClick={() => onEdit(memory)}
+                        title={t("actionEdit")}
+                        aria-label={t("actionEdit")}
                       >
-                        <Eye className="h-4 w-4" />
+                        <Pencil className="h-4 w-4" />
                       </Button>
-                      {onEdit && (
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          onClick={() => onEdit(memory)}
-                          title={t("actionEdit")}
-                          aria-label={t("actionEdit")}
-                        >
-                          <Pencil className="h-4 w-4" />
-                        </Button>
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => onDelete(memory)}
-                        title={t("actionDelete")}
-                        aria-label={t("actionDelete")}
-                        className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </Button>
-                    </div>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
+                    )}
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => onDelete(memory)}
+                      title={t("actionDelete")}
+                      aria-label={t("actionDelete")}
+                      className="text-red-600 hover:text-red-700 hover:bg-red-50 dark:hover:bg-red-900/20"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
           </TableBody>
         </Table>
       </div>

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2684,8 +2684,6 @@
       "loading": "Loading memories...",
       "emptyTitle": "No memories found",
       "emptyDesc": "Try adjusting your search or filters",
-      "selectAll": "Select all",
-      "selectRow": "Select {summary}",
       "columnSummary": "Summary",
       "columnType": "Type",
       "columnScope": "Scope",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2684,8 +2684,6 @@
       "loading": "メモリを読み込み中...",
       "emptyTitle": "メモリが見つかりません",
       "emptyDesc": "検索条件やフィルターを変更してください",
-      "selectAll": "すべて選択",
-      "selectRow": "{summary} を選択",
       "columnSummary": "サマリ",
       "columnType": "種別",
       "columnScope": "スコープ",


### PR DESCRIPTION
Closes #450

## Summary
- Remove dormant bulk-delete UI surface (selectedIds/onSelectionChange props, checkbox JSX, Checkbox import, derived bulkDeleteEnabled flag, handleSelectAll/handleRowToggle handlers) from MemoriesTable.tsx
- Backend `bulkDeleteMemories()` API stub was deleted in #446 — the UI had nothing to wire to (parent MemoriesTabPanel never passed selection props, so the checkbox surface was hidden in practice)
- Drop unused `selectAll`/`selectRow` i18n keys from the `contextDetail.memoriesTable` namespace (preserves `selectAll` at line 1012 in en.json/ja.json — that one is a different namespace used by `workspace/members/page.tsx`)
- Path A from the issue body, validated by gate1 PM lens with #422 precedent

## Implementation notes
- 2 atomic commits (squash merge will collapse to one): `refactor(frontend)` for the UI removal, `chore(i18n)` for the dead translation keys
- `MemoriesTable.tsx`: -125 / +53 LOC (props, handlers, conditional JSX, Checkbox import all gone; `memories.map` simplified from block-with-isSelected to implicit-return arrow)
- `en.json` / `ja.json`: -2 lines each (memoriesTable namespace only)
- `#666` references removed from the JSDoc and the prop comment (`gh issue view 666` returned 404 — placeholder reference, never an actual issue)
- Reversibility: `git revert` of the 2 commits restores the surface in under a minute if Path B (backend bulk-forget endpoint + UI wire-up) becomes a priority later

## Manual smoke checklist (recommended before merge)
- [ ] `/contexts/<id>?tab=memories` renders the table without console errors
- [ ] View / Edit / Delete actions on individual rows still work
- [ ] No checkbox column appears (it was hidden before; verify it stays hidden)
- [ ] `workspace/members` page still renders correctly (its `selectAll` i18n key was preserved)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green (attack surface reduced; no auth/secret/CORS changes)
- qa-lead: green (no new behavior to test; sibling components untouched; preexisting MemoriesTable.test.tsx gap noted as separate work)
- cto: green (genuine cleanup, atomic commits, reversible, no architectural smell)
- gate1: green via /claude-c-suite:ask (PM lens; #422 precedent)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/450-feat-refactor-frontend-resolve-bulk-delete-ui.gate1.md`
- `~/.claude/cache/gh-issue-driven/450-feat-refactor-frontend-resolve-bulk-delete-ui.gate2.md`

Generated via /gh-issue-driven:ship
