### PR TITLE
chore(plugin): bump kagura-memory plugin version 0.12.0 → 0.14.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI",


### PR DESCRIPTION
## Summary
- Sync `.claude-plugin/plugin.json` version from `0.12.0` → `0.14.0` to align with today's project release
- Catch-up bump: plugin manifest had been stuck at 0.12.0 since the v0.12.0 release while the project went through v0.12.3 / v0.13.0 / v0.14.0 (today)
- The repo's `claude-skills/` already contains all the latest content (resource section added in v0.12.0, graph endpoint changes in v0.13.0+, etc.) — this PR just signals "new version available" to the marketplace

## Why
Discovered during today's `/kagura-memory:smoke-test` run: the operator's installed plugin (cached at v0.11.1) was running an outdated smoke-test spec without the resource section. Investigation showed:
- Repo `claude-skills/smoke-test.md` already has resource section (added 2026-04-14, commit 3f0210a)
- `.claude-plugin/plugin.json` version field never bumped past 0.12.0 even as the project moved on
- Operators have no signal to refresh their plugin install → they run stale specs

See memory `20e22509-cd6b-4784-8380-5fac91bf2d1b` for the full root-cause analysis and the proposed `/release` skill improvement (6-file bump instead of 5).

## Test plan
- [ ] CI passes (lint, type-check, etc.)
- [ ] After merge, operator runs `/plugin update kagura-memory` to pull v0.14.0
- [ ] Verify next `/kagura-memory:smoke-test` invocation runs the comprehensive spec (32 rows including resource section)

## Follow-up (separate work)
- Update `/release` skill to bump `.claude-plugin/plugin.json` alongside the existing 5 files. Tracked in memory `20e22509`.

Generated via Claude Code session 2026-04-26