### PR TITLE
fix(api+resource): ingest_events fails on freshly setup_resource'd resources (resource_pk not populated) (#456)

### DIFF
--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -30,6 +30,7 @@ from models.schemas import (
     ResourceEventResponse,
 )
 from services.permission_service import PermissionService
+from services.resource_lookup import resolve_resource_pk
 from services.resource_quota_service import check_event_quota
 from utils.datetime import utcnow
 from utils.exceptions import ConflictError, ValidationError
@@ -381,7 +382,7 @@ async def ingest_event(
         )
 
         # 4. Schedule indexer run (find all contexts using this resource)
-        await _schedule_indexer_for_resource(db, resource_id)
+        await _schedule_indexer_for_resource(db, context.workspace_id, resource_id)
 
         # 5. Log usage statistics (Issue #242)
         from utils.usage_logger import log_usage
@@ -622,7 +623,7 @@ async def ingest_batch(
 
     # 5. Schedule indexer run
     if created_ids:
-        await _schedule_indexer_for_resource(db, resource_id)
+        await _schedule_indexer_for_resource(db, context.workspace_id, resource_id)
 
         # 6. Log usage statistics (Issue #242)
         from utils.usage_logger import log_usage
@@ -659,17 +660,39 @@ async def ingest_batch(
 # ============================================================================
 
 
-async def _schedule_indexer_for_resource(db: AsyncSession, resource_id: str) -> None:
+async def _schedule_indexer_for_resource(
+    db: AsyncSession,
+    workspace_id: UUID,
+    resource_id: str,
+) -> None:
     """Schedule indexer runs for all contexts using this resource.
+
+    Resolves the workspace-scoped ``resource_pk`` and writes it onto every
+    IndexerState row, satisfying the Phase 2 writer contract enforced at
+    ``models/resource.py:_enforce_resource_pk_invariant`` (#323) and avoiding
+    the slug-only filter that is a CWE-639 cross-tenant leak vector when slug
+    reuse is possible (recall PR #347 iter 1).
 
     Args:
         db: Database session
-        resource_id: Resource identifier
+        workspace_id: Authoritative workspace scope for the slug lookup
+        resource_id: Resource identifier (slug)
     """
     from datetime import timedelta
 
     from models.auth import Context
     from models.resource import IndexerState
+
+    resource_pk = await resolve_resource_pk(db, workspace_id, resource_id)
+    if resource_pk is None:
+        # Fail-safe: missing Resource row indicates an orphan or cross-workspace
+        # probe; do not schedule against a resource we cannot bind.
+        logger.debug(
+            "schedule_indexer_skip_unknown_resource",
+            resource_id=resource_id,
+            workspace_id=str(workspace_id),
+        )
+        return
 
     # Find all public contexts using this resource
     result = await db.execute(
@@ -687,18 +710,31 @@ async def _schedule_indexer_for_resource(db: AsyncSession, resource_id: str) -> 
 
     # Schedule indexer for each context
     for context in contexts:
-        # Get or create indexer state
+        # Get or create indexer state. Prefer rows with resource_pk populated;
+        # fall back to legacy ``resource_pk IS NULL`` rows scoped by slug +
+        # context_id so Phase 1 → Phase 2 in-flight rows still match.
         state_result = await db.execute(
-            select(IndexerState).where(
-                IndexerState.resource_id == resource_id,
+            select(IndexerState)
+            .where(
                 IndexerState.context_id == context.id,
+                or_(
+                    IndexerState.resource_pk == resource_pk,
+                    (IndexerState.resource_pk.is_(None))
+                    & (IndexerState.resource_id == resource_id),
+                ),
             )
+            .order_by(
+                IndexerState.resource_pk.is_(None).asc(),
+                IndexerState.id.desc(),
+            )
+            .limit(1)
         )
         state = state_result.scalar_one_or_none()
 
         if not state:
             # Create new state
             state = IndexerState(
+                resource_pk=resource_pk,
                 resource_id=resource_id,
                 context_id=context.id,
                 last_offset=0,

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -694,9 +694,15 @@ async def _schedule_indexer_for_resource(
         )
         return
 
-    # Find all public contexts using this resource
+    # Find all public contexts using this resource. Scope to ``workspace_id``
+    # so a slug reused in another workspace cannot pull foreign Contexts into
+    # the iteration — every IndexerState row written below carries the caller's
+    # ``resource_pk`` and a ``context_id`` from the same workspace, keeping
+    # the (resource_pk, context_id) pairing consistent (Copilot review on PR
+    # for #456 + gate2 CSO note).
     result = await db.execute(
         select(Context).where(
+            Context.workspace_id == workspace_id,
             Context.resource_id == resource_id,
             Context.is_public.is_(True),
             Context.deleted_at.is_(None),

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -692,7 +692,7 @@ async def handle_ingest_events(
             if created_ids:
                 from api.routes.resource_ingest import _schedule_indexer_for_resource
 
-                await _schedule_indexer_for_resource(db, resource_id)
+                await _schedule_indexer_for_resource(db, workspace_id, resource_id)
                 await db.commit()
 
             await _log_tool_usage(

--- a/backend/tests/api/test_resource_ingest.py
+++ b/backend/tests/api/test_resource_ingest.py
@@ -544,3 +544,136 @@ class TestResourceIngestWorkspaceBoundary:
             call_kwargs = mock_logger.warning.call_args.kwargs
             assert call_kwargs.get("token_workspace_id") == str(mismatched_workspace_id)
             assert call_kwargs.get("context_workspace_id") == str(mock_context.workspace_id)
+
+
+class TestScheduleIndexerForResource:
+    """#456: Phase 2 ``resource_pk`` writer contract for IndexerState.
+
+    Original bug: ``_schedule_indexer_for_resource`` created IndexerState rows
+    without populating ``resource_pk``, violating the validator at
+    ``models/resource.py:_enforce_resource_pk_invariant`` (#323). This made
+    ``setup_resource → ingest_events`` 100% fail in v0.14.0 production.
+
+    The fix resolves ``resource_pk`` via ``services/resource_lookup.resolve_resource_pk``
+    (workspace-scoped per CWE-639 hardening from PR #347) and writes it on
+    both the SELECT (with legacy NULL fallback) and the INSERT.
+
+    The model-level invariant in ``backend/tests/db/test_resource_pk_invariant.py``
+    pinned the validator but didn't exercise this route's writer — these
+    integration-shaped unit tests close that gap so the bug class can't
+    silently re-introduce.
+    """
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def resource_id(self):
+        return "test_resource_id"
+
+    @pytest.fixture
+    def resource_pk(self):
+        return uuid4()
+
+    @pytest.fixture
+    def context_pk(self):
+        return uuid4()
+
+    @pytest.fixture
+    def mock_db(self):
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        return db
+
+    @pytest.mark.asyncio
+    async def test_creates_indexer_state_with_resource_pk(
+        self, mock_db, workspace_id, resource_id, resource_pk, context_pk
+    ):
+        """#456 regression: IndexerState INSERT must carry ``resource_pk`` to
+        satisfy the Phase 2 writer contract validator. Pre-fix this insert
+        omitted ``resource_pk`` and the validator raised ValueError.
+        """
+        from api.routes.resource_ingest import _schedule_indexer_for_resource
+
+        # First execute() returns the contexts list (one public context bound to the resource)
+        contexts_result = MagicMock()
+        contexts_result.scalars.return_value.all.return_value = [
+            SimpleNamespace(
+                id=context_pk,
+                resource_id=resource_id,
+                workspace_id=workspace_id,
+            )
+        ]
+        # Second execute() returns no existing IndexerState row (forces INSERT path)
+        state_result = MagicMock()
+        state_result.scalar_one_or_none.return_value = None
+
+        mock_db.execute.side_effect = [contexts_result, state_result]
+
+        with patch(
+            "api.routes.resource_ingest.resolve_resource_pk",
+            new=AsyncMock(return_value=resource_pk),
+        ):
+            await _schedule_indexer_for_resource(mock_db, workspace_id, resource_id)
+
+        mock_db.add.assert_called_once()
+        added = mock_db.add.call_args.args[0]
+        assert added.resource_pk == resource_pk, (
+            "IndexerState must be created with resource_pk to satisfy Phase 2 writer contract"
+        )
+        assert added.resource_id == resource_id
+        assert added.context_id == context_pk
+        assert added.job_status == "queued"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_resource_pk_unresolved(self, mock_db, workspace_id, resource_id):
+        """#456 fail-safe: a missing ``Resource`` row indicates an orphan or
+        cross-workspace probe (CWE-639). Must short-circuit BEFORE any DB
+        writes rather than fall back to a slug-only INSERT (which would both
+        violate the validator and surface another tenant's IndexerState).
+        """
+        from api.routes.resource_ingest import _schedule_indexer_for_resource
+
+        with (
+            patch(
+                "api.routes.resource_ingest.resolve_resource_pk",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("api.routes.resource_ingest.logger") as mock_logger,
+        ):
+            await _schedule_indexer_for_resource(mock_db, workspace_id, resource_id)
+
+        mock_db.add.assert_not_called()
+        mock_db.execute.assert_not_called()
+        mock_logger.debug.assert_called_with(
+            "schedule_indexer_skip_unknown_resource",
+            resource_id=resource_id,
+            workspace_id=str(workspace_id),
+        )
+
+    @pytest.mark.asyncio
+    async def test_resolves_resource_pk_with_workspace_scope(
+        self, mock_db, workspace_id, resource_id, resource_pk
+    ):
+        """Cross-tenant safety: ``resolve_resource_pk`` must receive
+        ``workspace_id`` so slug reuse across workspaces does not surface
+        another tenant's IndexerState (CWE-639 hardening, PR #347 lineage).
+        """
+        from api.routes.resource_ingest import _schedule_indexer_for_resource
+
+        # Empty contexts list short-circuits after the resolve, keeping the
+        # mock setup minimal.
+        contexts_result = MagicMock()
+        contexts_result.scalars.return_value.all.return_value = []
+        mock_db.execute.return_value = contexts_result
+
+        with patch(
+            "api.routes.resource_ingest.resolve_resource_pk",
+            new=AsyncMock(return_value=resource_pk),
+        ) as mock_resolve:
+            await _schedule_indexer_for_resource(mock_db, workspace_id, resource_id)
+
+        mock_resolve.assert_awaited_once_with(mock_db, workspace_id, resource_id)

--- a/backend/tests/mcp_server/test_resource_tools.py
+++ b/backend/tests/mcp_server/test_resource_tools.py
@@ -714,7 +714,7 @@ class TestIngestEventsHappyPath:
         async def mock_get_db():
             yield mock_db
 
-        async def mock_schedule(db, resource_id):
+        async def mock_schedule(db, workspace_id, resource_id):
             return None
 
         with (


### PR DESCRIPTION
Closes #456

## Summary
- Populate `resource_pk` on IndexerState INSERT in `_schedule_indexer_for_resource`, satisfying the Phase 2 writer contract validator at `models/resource.py:_enforce_resource_pk_invariant` (#323) — closes the 100% failure for `setup_resource → ingest_events` in v0.14.0
- Switch the SELECT to the `resource_pk`-aware pattern (with OR-fallback for legacy `resource_pk IS NULL` rows) — closes the CWE-639 cross-tenant leak vector PR #347 caught for sibling code
- Resolve `resource_pk` via `services.resource_lookup.resolve_resource_pk(db, workspace_id, resource_id)`; fail-safe (no DB writes) when the slug doesn't bind in the caller's workspace

## Implementation notes
- 2 atomic commits: production fix + tests
- `_schedule_indexer_for_resource` signature change: now takes `(db, workspace_id, resource_id)` — required to scope `resource_pk` lookup to the caller's workspace
- Three call sites updated, all with non-None UUID workspace_id available locally:
  - `backend/src/api/routes/resource_ingest.py:385` (single ingest) — `context.workspace_id`
  - `backend/src/api/routes/resource_ingest.py:626` (batch ingest) — `context.workspace_id`
  - `backend/src/mcp_server/tools/resource.py:695` (MCP `handle_ingest_events`) — `workspace_id` (validated non-None at line 500)
- No migration required — application-layer fix, schema unchanged
- OR-fallback for legacy `resource_pk IS NULL` rows mirrors `services/resource_indexer.py:_get_indexer_state`, preserving Phase 1 → Phase 2 in-flight compatibility
- 3 new unit tests (`TestScheduleIndexerForResource`):
  - `test_creates_indexer_state_with_resource_pk` (regression for the validator violation)
  - `test_skips_when_resource_pk_unresolved` (CWE-639 fail-safe)
  - `test_resolves_resource_pk_with_workspace_scope` (cross-tenant guard contract)
- Model-level invariant tests at `tests/db/test_resource_pk_invariant.py` (12 tests) still pass — backward compatibility preserved

## Verification
- `make lint` PASS
- `make type-check` PASS (0 errors, 0 warnings)
- `pytest tests/api/test_resource_ingest.py` 25/25 PASSED
- `pytest tests/db/test_resource_pk_invariant.py` 12/12 PASSED
- `/kagura-memory:smoke-test` step 28 (the live canary that surfaced this bug) will go from FAIL → PASS post-deploy

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green (validator hole + CWE-639 closed; 1 latent pre-existing issue flagged for follow-up)
- qa-lead: green (3 tests pin the bug class; coverage gaps noted as v0.15.0 work)
- cto: green (Option A is correct hotfix scope; duplicate writer dedupe deferred to v0.15.0)
- gate1: green via /claude-c-suite:ask (CTO lens; 100% confirmed root cause via source dive)
- review provider: copilot

## Follow-up issues recommended (post-merge)
- v0.15.0 refactor: move `_schedule_indexer_for_resource` to `services/`, dedupe with `_get_indexer_state`
- Latent: clarify slug-shared indexing intent for the contexts query OR add workspace_id filter
- v0.14.1 follow-up tests: UPDATE path + legacy NULL row OR-fallback unit tests
- v0.15.0: real-DB integration test for IndexerState writers

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/456-fix-fix-api-resource-ingest-events-fails-on.gate1.md`
- `~/.claude/cache/gh-issue-driven/456-fix-fix-api-resource-ingest-events-fails-on.gate2.md`

Generated via /gh-issue-driven:ship
