### PR TITLE
fix: batch #457, #458 — protect declared_link from Hebbian + refresh stale upsert ORM

### DIFF
--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -342,6 +342,12 @@ async def handle_update_edge(
                 operation_name="update_edge",
             )
 
+            # Issue #458: ON CONFLICT DO UPDATE ... RETURNING can return the cached
+            # ORM instance (loaded by the prior `repo.get_edge`) with stale Python
+            # attributes. Force a refresh so the response payload reflects the
+            # post-update DB state (weight, last_updated, edge_type).
+            await db.refresh(edge)
+
             await _log_tool_usage(
                 db, user_id, "update_edge", start_time, 200, current_context_id, workspace_id
             )

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -342,12 +342,6 @@ async def handle_update_edge(
                 operation_name="update_edge",
             )
 
-            # Issue #458: ON CONFLICT DO UPDATE ... RETURNING can return the cached
-            # ORM instance (loaded by the prior `repo.get_edge`) with stale Python
-            # attributes. Force a refresh so the response payload reflects the
-            # post-update DB state (weight, last_updated, edge_type).
-            await db.refresh(edge)
-
             await _log_tool_usage(
                 db, user_id, "update_edge", start_time, 200, current_context_id, workspace_id
             )

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -263,6 +263,16 @@ class GraphMemory(Base):
         return f"<GraphMemory(user='{self.user_id}', nodes={self.total_nodes}, edges={self.total_edges})>"
 
 
+# Edge type constants. Mirrors the CHECK constraint values below — keep in sync.
+EDGE_TYPE_NEURAL_ASSOCIATION = "neural_association"
+EDGE_TYPE_RELATED_TO = "related_to"
+EDGE_TYPE_DEPENDS_ON = "depends_on"
+EDGE_TYPE_LEARNED_FROM = "learned_from"
+EDGE_TYPE_SEMANTIC_SIMILARITY = "semantic_similarity"
+EDGE_TYPE_DECLARED_LINK = "declared_link"
+EDGE_TYPE_TAG_COOCCURRENCE = "tag_cooccurrence"
+
+
 class NeuralMemoryEdge(Base):
     """Neural Memory edge model (Issue #84 Phase 1).
 

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -18,7 +18,7 @@ from sqlalchemy import and_, case, delete, desc, func, or_, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.memory import Memory, NeuralMemoryEdge
+from models.memory import EDGE_TYPE_DECLARED_LINK, Memory, NeuralMemoryEdge
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -130,6 +130,7 @@ class NeuralEdgeRepository:
         workspace_id: str | None = None,
         context_id: str | None = None,
         protect_declared_link: bool = False,
+        return_fresh_edge: bool = True,
     ) -> NeuralMemoryEdge:
         """Create or update an edge (upsert) with 3-level isolation.
 
@@ -152,9 +153,17 @@ class NeuralEdgeRepository:
                 declared links survive co-activation retyping. User-driven
                 update_edge calls leave this False so an explicit type
                 change still works. (Issue #457)
+            return_fresh_edge: When True (default), the returned ORM is
+                refreshed from the DB so its Python attributes reflect what
+                RETURNING actually wrote (Issue #458). Hot-path callers that
+                discard the return value (Hebbian via GraphService.add_edge,
+                Sleep edge_discovery) pass False to skip the extra SELECT.
 
         Returns:
-            Created or updated edge
+            Created or updated edge. When ``return_fresh_edge=False`` the
+            returned ORM may carry stale Python attributes from the session's
+            identity map even though the DB row is correct — only safe to
+            ignore the return value.
 
         Note:
             Uses PostgreSQL ON CONFLICT DO UPDATE for atomic upsert.
@@ -185,12 +194,15 @@ class NeuralEdgeRepository:
         )
 
         # Issue #457: declared_link rows must survive Hebbian retyping.
-        # CASE keeps the existing edge_type when it is "declared_link";
+        # CASE keeps the existing edge_type when it is declared_link;
         # weight/confidence/metadata/last_updated still update so co-
         # activation can strengthen user-declared links.
         if protect_declared_link:
             edge_type_set = case(
-                (NeuralMemoryEdge.edge_type == "declared_link", "declared_link"),
+                (
+                    NeuralMemoryEdge.edge_type == EDGE_TYPE_DECLARED_LINK,
+                    EDGE_TYPE_DECLARED_LINK,
+                ),
                 else_=stmt.excluded.edge_type,
             )
         else:
@@ -211,14 +223,15 @@ class NeuralEdgeRepository:
         result = await self.db.execute(stmt)
         edge = result.scalar_one()
 
-        # Issue #458: PostgreSQL ON CONFLICT DO UPDATE ... RETURNING delivers
-        # the post-update row, but if the same primary key is already in
-        # SQLAlchemy's identity map (e.g. a prior get_edge or a prior
-        # create_or_update_edge call in the same session), result.scalar_one()
-        # returns the cached ORM instance with stale Python attributes.
-        # Refresh from the DB so the returned object reflects what RETURNING
-        # actually wrote (weight, edge_type, last_updated, ...).
-        await self.db.refresh(edge)
+        # Issue #458: ON CONFLICT DO UPDATE ... RETURNING delivers the post-
+        # update row, but when the same primary key is in SQLAlchemy's
+        # identity map (e.g. a prior get_edge or a prior call in the same
+        # session) scalar_one() returns the cached ORM instance with stale
+        # Python attributes. Refresh so callers that read the return value
+        # see what RETURNING actually wrote. Hot-path writers that discard
+        # the return (Hebbian, Sleep edge_discovery) skip this extra SELECT.
+        if return_fresh_edge:
+            await self.db.refresh(edge)
 
         logger.debug(
             "edge_upserted",

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from uuid import UUID
 
-from sqlalchemy import and_, delete, desc, func, or_, select
+from sqlalchemy import and_, case, delete, desc, func, or_, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -129,6 +129,7 @@ class NeuralEdgeRepository:
         edge_metadata: dict | None = None,
         workspace_id: str | None = None,
         context_id: str | None = None,
+        protect_declared_link: bool = False,
     ) -> NeuralMemoryEdge:
         """Create or update an edge (upsert) with 3-level isolation.
 
@@ -144,6 +145,13 @@ class NeuralEdgeRepository:
             edge_metadata: Optional edge metadata
             workspace_id: Workspace ID (for 3-level isolation)
             context_id: Context ID (for 3-level isolation)
+            protect_declared_link: When True, ON CONFLICT preserves the
+                existing edge_type if it is "declared_link" (only weight/
+                confidence/metadata/last_updated update). Used by automated
+                writers (Hebbian co-activation, edge discovery) so user-
+                declared links survive co-activation retyping. User-driven
+                update_edge calls leave this False so an explicit type
+                change still works. (Issue #457)
 
         Returns:
             Created or updated edge
@@ -176,11 +184,23 @@ class NeuralEdgeRepository:
             last_updated=utcnow(),
         )
 
+        # Issue #457: declared_link rows must survive Hebbian retyping.
+        # CASE keeps the existing edge_type when it is "declared_link";
+        # weight/confidence/metadata/last_updated still update so co-
+        # activation can strengthen user-declared links.
+        if protect_declared_link:
+            edge_type_set = case(
+                (NeuralMemoryEdge.edge_type == "declared_link", "declared_link"),
+                else_=stmt.excluded.edge_type,
+            )
+        else:
+            edge_type_set = stmt.excluded.edge_type
+
         # ON CONFLICT: Update existing edge
         stmt = stmt.on_conflict_do_update(
             constraint="unique_edge",  # (user_id, src_id, dst_id)
             set_={
-                "edge_type": stmt.excluded.edge_type,
+                "edge_type": edge_type_set,
                 "weight": stmt.excluded.weight,
                 "confidence": stmt.excluded.confidence,
                 "metadata": stmt.excluded.metadata,
@@ -190,6 +210,15 @@ class NeuralEdgeRepository:
 
         result = await self.db.execute(stmt)
         edge = result.scalar_one()
+
+        # Issue #458: PostgreSQL ON CONFLICT DO UPDATE ... RETURNING delivers
+        # the post-update row, but if the same primary key is already in
+        # SQLAlchemy's identity map (e.g. a prior get_edge or a prior
+        # create_or_update_edge call in the same session), result.scalar_one()
+        # returns the cached ORM instance with stale Python attributes.
+        # Refresh from the DB so the returned object reflects what RETURNING
+        # actually wrote (weight, edge_type, last_updated, ...).
+        await self.db.refresh(edge)
 
         logger.debug(
             "edge_upserted",

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -204,6 +204,9 @@ class GraphService:
             # Issue #457: Hebbian co-activation flows through here; never let
             # automated retyping clobber a user-declared link.
             protect_declared_link=True,
+            # Hebbian / GraphService.add_edge callers discard the return value
+            # — skip the post-upsert SELECT (Issue #458 doesn't apply here).
+            return_fresh_edge=False,
         )
 
         logger.debug(

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -201,6 +201,9 @@ class GraphService:
             edge_metadata=edge_metadata,
             workspace_id=self.workspace_id,  # Single Collection Migration
             context_id=self.context_id,  # Single Collection Migration
+            # Issue #457: Hebbian co-activation flows through here; never let
+            # automated retyping clobber a user-declared link.
+            protect_declared_link=True,
         )
 
         logger.debug(

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -467,6 +467,8 @@ class EdgeDiscoveryPhase:
                         workspace_id=workspace_id,
                         context_id=context_id,
                         edge_metadata={"source": "sleep_edge_discovery"},
+                        # Issue #457: automated writer; preserve declared_link.
+                        protect_declared_link=True,
                     )
                     edges_created += 1
                     if reporter and report_id:

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -469,6 +469,9 @@ class EdgeDiscoveryPhase:
                         edge_metadata={"source": "sleep_edge_discovery"},
                         # Issue #457: automated writer; preserve declared_link.
                         protect_declared_link=True,
+                        # Sleep edge_discovery discards the return; skip the
+                        # post-upsert SELECT for the same reason as Hebbian.
+                        return_fresh_edge=False,
                     )
                     edges_created += 1
                     if reporter and report_id:

--- a/backend/tests/integration/test_declared_link_protection.py
+++ b/backend/tests/integration/test_declared_link_protection.py
@@ -1,0 +1,210 @@
+"""Integration test for declared_link protection in upsert (#457).
+
+NeuralEdgeRepository.create_or_update_edge with protect_declared_link=True
+must keep an existing edge_type="declared_link" pinned even when the
+incoming upsert tries to set edge_type="neural_association" (e.g. Hebbian
+co-activation flowing through GraphService.add_edge).
+
+The smoke-test on v0.14.0 (2026-04-26 prod) reproduced the unprotected
+case 100% — user-declared links got retyped to neural_association as
+soon as Hebbian fired on either endpoint.
+
+The protected path must still bump weight/confidence/last_updated, so
+co-activation continues to strengthen the user-declared link.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import Context, Workspace
+from models.memory import Memory
+from repositories.neural_edge import NeuralEdgeRepository
+
+
+@pytest_asyncio.fixture
+async def declared_link_scenario(db_session: AsyncSession):
+    """Workspace + context + two memories ready for an edge between them."""
+    owner_id = f"owner_{uuid4().hex[:8]}"
+
+    ws = Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=owner_id,
+        is_private=False,
+    )
+
+    def _mk_memory() -> Memory:
+        return Memory(
+            id=uuid4(),
+            user_id=owner_id,
+            workspace_id=ws.id,
+            context_id=ctx.id,
+            summary=f"mem-{uuid4().hex[:6]}",
+            content="x",
+            type="note",
+            client="test",
+        )
+
+    mem_a = _mk_memory()
+    mem_b = _mk_memory()
+
+    db_session.add(ws)
+    await db_session.flush()
+    db_session.add(ctx)
+    await db_session.flush()
+    db_session.add_all([mem_a, mem_b])
+    await db_session.flush()
+
+    yield {
+        "owner_id": owner_id,
+        "ws_id": ws.id,
+        "ctx_id": ctx.id,
+        "mem_a": mem_a,
+        "mem_b": mem_b,
+    }
+
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_protect_declared_link_preserves_edge_type(
+    db_session: AsyncSession, declared_link_scenario
+):
+    """Hebbian-style retyping must not clobber declared_link edge_type.
+
+    Scenario: a `declared_link` edge exists (user-declared). Hebbian
+    co-activation later fires and tries to upsert the same (src, dst)
+    with edge_type="neural_association" via GraphService.add_edge,
+    which passes protect_declared_link=True. The edge_type must stay
+    "declared_link"; weight/last_updated may update.
+    """
+    repo = NeuralEdgeRepository(db_session)
+    s = declared_link_scenario
+
+    declared = await repo.create_or_update_edge(
+        user_id=s["owner_id"],
+        src_id=s["mem_a"].id,
+        dst_id=s["mem_b"].id,
+        edge_type="declared_link",
+        weight=1.0,
+        confidence=1.0,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+    )
+    assert declared.edge_type == "declared_link"
+    assert declared.weight == 1.0
+    initial_last_updated = declared.last_updated
+
+    retyped = await repo.create_or_update_edge(
+        user_id=s["owner_id"],
+        src_id=s["mem_a"].id,
+        dst_id=s["mem_b"].id,
+        edge_type="neural_association",
+        weight=1.03,
+        confidence=1.0,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+        protect_declared_link=True,
+    )
+
+    assert retyped.edge_type == "declared_link", (
+        "protect_declared_link=True must pin the existing declared_link type"
+    )
+    assert retyped.weight == 1.03, (
+        "weight must still update so co-activation continues to strengthen the link"
+    )
+    assert retyped.last_updated >= initial_last_updated
+
+
+@pytest.mark.asyncio
+async def test_unprotected_upsert_still_allows_user_driven_retype(
+    db_session: AsyncSession, declared_link_scenario
+):
+    """User-driven update_edge (protect_declared_link=False) keeps the existing contract.
+
+    The MCP `update_edge` handler calls create_or_update_edge directly
+    (not via GraphService) with the default protect=False, so an
+    explicit user-initiated edge_type change must still work — this
+    is how a user downgrades a declared_link they regret.
+    """
+    repo = NeuralEdgeRepository(db_session)
+    s = declared_link_scenario
+
+    await repo.create_or_update_edge(
+        user_id=s["owner_id"],
+        src_id=s["mem_a"].id,
+        dst_id=s["mem_b"].id,
+        edge_type="declared_link",
+        weight=1.0,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+    )
+
+    retyped = await repo.create_or_update_edge(
+        user_id=s["owner_id"],
+        src_id=s["mem_a"].id,
+        dst_id=s["mem_b"].id,
+        edge_type="neural_association",
+        weight=0.5,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+        # protect_declared_link defaults to False — user-driven path
+    )
+
+    assert retyped.edge_type == "neural_association", (
+        "Without protection, user-driven update_edge can change the type explicitly"
+    )
+    assert retyped.weight == 0.5
+
+
+@pytest.mark.asyncio
+async def test_protect_does_not_block_non_declared_retype(
+    db_session: AsyncSession, declared_link_scenario
+):
+    """protect_declared_link only pins existing declared_link rows.
+
+    A neural_association → related_to retype must still succeed when
+    protect_declared_link=True, because the existing edge_type is not
+    declared_link. This guards against an over-broad WHERE clause.
+    """
+    repo = NeuralEdgeRepository(db_session)
+    s = declared_link_scenario
+
+    await repo.create_or_update_edge(
+        user_id=s["owner_id"],
+        src_id=s["mem_a"].id,
+        dst_id=s["mem_b"].id,
+        edge_type="neural_association",
+        weight=0.5,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+    )
+
+    retyped = await repo.create_or_update_edge(
+        user_id=s["owner_id"],
+        src_id=s["mem_a"].id,
+        dst_id=s["mem_b"].id,
+        edge_type="related_to",
+        weight=0.7,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+        protect_declared_link=True,
+    )
+
+    assert retyped.edge_type == "related_to"
+    assert retyped.weight == 0.7

--- a/backend/tests/mcp_server/test_edge_tools.py
+++ b/backend/tests/mcp_server/test_edge_tools.py
@@ -1,0 +1,182 @@
+"""Tests for MCP edge CRUD tool handlers.
+
+Issue #458: handle_update_edge must refresh the ORM instance after
+create_or_update_edge so the response payload reflects post-update DB state
+(weight, last_updated, edge_type) rather than the cached pre-update snapshot
+loaded by the prior get_edge call.
+"""
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.edge import handle_update_edge
+
+
+def _mock_edge(src_id, dst_id, *, edge_type="neural_association", weight=0.5):
+    """Build a minimal NeuralMemoryEdge-shaped mock for response serialization."""
+    e = MagicMock()
+    e.src_id = src_id
+    e.dst_id = dst_id
+    e.edge_type = edge_type
+    e.weight = weight
+    e.confidence = 1.0
+    e.created_at = datetime(2026, 4, 26, 9, 0, 0, tzinfo=UTC)
+    e.last_updated = datetime(2026, 4, 26, 9, 0, 0, tzinfo=UTC)
+    return e
+
+
+class TestUpdateEdgeRefreshesORM:
+    """Issue #458 regression: response must show post-update DB state."""
+
+    @pytest.fixture
+    def user_id(self):
+        return "test_user_458"
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def context_id(self):
+        return uuid4()
+
+    @pytest.mark.asyncio
+    async def test_handle_update_edge_calls_refresh_after_upsert(
+        self, user_id, workspace_id, context_id
+    ):
+        """db.refresh(edge) must be called between create_or_update_edge and commit.
+
+        Without the refresh, the response payload can carry stale Python attributes
+        from the ORM identity map (the edge instance loaded by the prior get_edge
+        call), even though the DB row was correctly updated by the upsert.
+        """
+        src_id = uuid4()
+        dst_id = uuid4()
+        existing = _mock_edge(src_id, dst_id, edge_type="neural_association", weight=0.5)
+        post_update = _mock_edge(src_id, dst_id, edge_type="neural_association", weight=0.8)
+        post_update.last_updated = datetime(2026, 4, 26, 9, 19, 11, tzinfo=UTC)
+
+        mock_db = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.rollback = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        mock_repo = MagicMock()
+        mock_repo.get_edge = AsyncMock(return_value=existing)
+        mock_repo.create_or_update_edge = AsyncMock(return_value=post_update)
+
+        mock_ctx = MagicMock()
+        mock_ctx.id = context_id
+        mock_ctx.workspace_id = workspace_id
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "mcp_server.tools.edge._resolve_context",
+                new_callable=AsyncMock,
+                return_value=mock_ctx,
+            ),
+            patch(
+                "mcp_server.tools.edge._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "mcp_server.tools.edge._log_tool_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await handle_update_edge(
+                {
+                    "source_id": str(src_id),
+                    "target_id": str(dst_id),
+                    "weight": 0.8,
+                    "context_id": str(context_id),
+                },
+                user_id,
+                workspace_id,
+            )
+
+        mock_db.refresh.assert_awaited_once_with(post_update)
+        # Refresh must precede commit so the response sees post-update state.
+        refresh_idx = next(i for i, c in enumerate(mock_db.method_calls) if c[0] == "refresh")
+        commit_idx = next(i for i, c in enumerate(mock_db.method_calls) if c[0] == "commit")
+        assert refresh_idx < commit_idx, "db.refresh must be called before db.commit"
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["edge"]["weight"] == 0.8
+        assert data["edge"]["last_updated"] == "2026-04-26T09:19:11+00:00"
+
+    @pytest.mark.asyncio
+    async def test_handle_update_edge_returns_error_when_edge_missing(
+        self, user_id, workspace_id, context_id
+    ):
+        """No refresh should happen when the edge does not exist."""
+        src_id = uuid4()
+        dst_id = uuid4()
+
+        mock_db = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.rollback = AsyncMock()
+        mock_db.refresh = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        mock_repo = MagicMock()
+        mock_repo.get_edge = AsyncMock(return_value=None)
+        mock_repo.create_or_update_edge = AsyncMock()
+
+        mock_ctx = MagicMock()
+        mock_ctx.id = context_id
+        mock_ctx.workspace_id = workspace_id
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "mcp_server.tools.edge._resolve_context",
+                new_callable=AsyncMock,
+                return_value=mock_ctx,
+            ),
+            patch(
+                "mcp_server.tools.edge._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "mcp_server.tools.edge._log_tool_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await handle_update_edge(
+                {
+                    "source_id": str(src_id),
+                    "target_id": str(dst_id),
+                    "weight": 0.8,
+                    "context_id": str(context_id),
+                },
+                user_id,
+                workspace_id,
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "error"
+        assert data["error"] == "edge_not_found"
+        mock_repo.create_or_update_edge.assert_not_awaited()
+        mock_db.refresh.assert_not_awaited()

--- a/backend/tests/mcp_server/test_edge_tools.py
+++ b/backend/tests/mcp_server/test_edge_tools.py
@@ -1,9 +1,12 @@
 """Tests for MCP edge CRUD tool handlers.
 
-Issue #458: handle_update_edge must refresh the ORM instance after
-create_or_update_edge so the response payload reflects post-update DB state
-(weight, last_updated, edge_type) rather than the cached pre-update snapshot
-loaded by the prior get_edge call.
+Issue #458: handle_update_edge response payload must reflect post-update DB
+state (weight, last_updated, edge_type) rather than the cached pre-update
+snapshot loaded by the prior get_edge call. The fix lives at the repository
+layer (NeuralEdgeRepository.create_or_update_edge refreshes the returned
+ORM after RETURNING), so this handler-level test pins only the contract
+the MCP tool exposes: whatever ORM the repo returns is what the response
+serializes.
 """
 
 import json
@@ -29,8 +32,8 @@ def _mock_edge(src_id, dst_id, *, edge_type="neural_association", weight=0.5):
     return e
 
 
-class TestUpdateEdgeRefreshesORM:
-    """Issue #458 regression: response must show post-update DB state."""
+class TestUpdateEdgeResponsePayload:
+    """Issue #458 regression: response must serialize whatever the repo returns."""
 
     @pytest.fixture
     def user_id(self):
@@ -45,14 +48,13 @@ class TestUpdateEdgeRefreshesORM:
         return uuid4()
 
     @pytest.mark.asyncio
-    async def test_handle_update_edge_calls_refresh_after_upsert(
-        self, user_id, workspace_id, context_id
-    ):
-        """db.refresh(edge) must be called between create_or_update_edge and commit.
+    async def test_response_reflects_repo_returned_edge(self, user_id, workspace_id, context_id):
+        """The response payload mirrors the post-update edge returned by the repo.
 
-        Without the refresh, the response payload can carry stale Python attributes
-        from the ORM identity map (the edge instance loaded by the prior get_edge
-        call), even though the DB row was correctly updated by the upsert.
+        The fix lives in NeuralEdgeRepository.create_or_update_edge (refreshes
+        the ORM after RETURNING). Here we pin the handler contract: response
+        weight/last_updated equal whatever the repo returned, with no
+        intervening transformation that could re-stale the value.
         """
         src_id = uuid4()
         dst_id = uuid4()
@@ -63,7 +65,6 @@ class TestUpdateEdgeRefreshesORM:
         mock_db = AsyncMock()
         mock_db.commit = AsyncMock()
         mock_db.rollback = AsyncMock()
-        mock_db.refresh = AsyncMock()
 
         async def mock_get_db():
             yield mock_db
@@ -108,29 +109,21 @@ class TestUpdateEdgeRefreshesORM:
                 workspace_id,
             )
 
-        mock_db.refresh.assert_awaited_once_with(post_update)
-        # Refresh must precede commit so the response sees post-update state.
-        refresh_idx = next(i for i, c in enumerate(mock_db.method_calls) if c[0] == "refresh")
-        commit_idx = next(i for i, c in enumerate(mock_db.method_calls) if c[0] == "commit")
-        assert refresh_idx < commit_idx, "db.refresh must be called before db.commit"
-
         data = json.loads(result[0].text)
         assert data["status"] == "success"
         assert data["edge"]["weight"] == 0.8
         assert data["edge"]["last_updated"] == "2026-04-26T09:19:11+00:00"
+        mock_db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_handle_update_edge_returns_error_when_edge_missing(
-        self, user_id, workspace_id, context_id
-    ):
-        """No refresh should happen when the edge does not exist."""
+    async def test_returns_error_when_edge_missing(self, user_id, workspace_id, context_id):
+        """update_edge for a nonexistent edge returns edge_not_found without upsert."""
         src_id = uuid4()
         dst_id = uuid4()
 
         mock_db = AsyncMock()
         mock_db.commit = AsyncMock()
         mock_db.rollback = AsyncMock()
-        mock_db.refresh = AsyncMock()
 
         async def mock_get_db():
             yield mock_db
@@ -179,4 +172,3 @@ class TestUpdateEdgeRefreshesORM:
         assert data["status"] == "error"
         assert data["error"] == "edge_not_found"
         mock_repo.create_or_update_edge.assert_not_awaited()
-        mock_db.refresh.assert_not_awaited()

--- a/backend/tests/services/test_graph_service_declared_link.py
+++ b/backend/tests/services/test_graph_service_declared_link.py
@@ -1,0 +1,55 @@
+"""Tests for GraphService.add_edge declared_link protection (#457).
+
+GraphService.add_edge is the entry point for all automated writers
+(Hebbian co-activation via HebbianLearner._apply_update_to_edge → graph.add_edge).
+It must always pass protect_declared_link=True so user-declared links survive
+co-activation retyping.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.graph_service import GraphService
+
+
+@pytest.mark.asyncio
+async def test_add_edge_passes_protect_declared_link_true():
+    """GraphService.add_edge always sets protect_declared_link=True.
+
+    This pins the contract: any caller that goes through GraphService
+    (Hebbian, anything else built on add_edge) gets declared_link
+    protection automatically. User-driven update_edge bypasses this
+    by calling NeuralEdgeRepository.create_or_update_edge directly.
+    """
+    src_id = uuid4()
+    dst_id = uuid4()
+
+    mock_db = MagicMock()
+    mock_edge_repo = MagicMock()
+    mock_edge_repo.create_or_update_edge = AsyncMock()
+
+    graph = GraphService.__new__(GraphService)
+    graph.user_id = "test_user_457"
+    graph.workspace_id = str(uuid4())
+    graph.context_id = str(uuid4())
+    graph.db = mock_db
+    graph.edge_repo = mock_edge_repo
+
+    await graph.add_edge(
+        src_id=src_id,
+        dst_id=dst_id,
+        rel_type="neural_association",
+        weight=1.03,
+    )
+
+    mock_edge_repo.create_or_update_edge.assert_awaited_once()
+    kwargs = mock_edge_repo.create_or_update_edge.await_args.kwargs
+    assert kwargs["protect_declared_link"] is True, (
+        "GraphService.add_edge must always pass protect_declared_link=True "
+        "so Hebbian co-activation cannot retype declared_link edges."
+    )
+    assert kwargs["edge_type"] == "neural_association"
+    assert kwargs["src_id"] == src_id
+    assert kwargs["dst_id"] == dst_id


### PR DESCRIPTION
Closes #457
Closes #458

## Summary

- **#457**: `NeuralEdgeRepository.create_or_update_edge` gains `protect_declared_link` (default `False`). When `True`, the ON CONFLICT SET clause uses a CASE so an existing `edge_type='declared_link'` row keeps its type while weight/confidence/metadata/last_updated still update — Hebbian co-activation can still strengthen a user-declared link, it just cannot retype it. `GraphService.add_edge` (Hebbian hot path) and Sleep `EdgeDiscoveryPhase` pass `protect_declared_link=True`. The MCP `update_edge` handler still leaves it `False` so an explicit user-driven type change continues to work.
- **#458**: post-upsert `await self.db.refresh(edge)` in `create_or_update_edge` so callers reading the return value see what RETURNING actually wrote, not the cached pre-update ORM. Conditional via `return_fresh_edge: bool = True` (default) — Hebbian / Sleep callers pass `False` to skip the extra SELECT in the hot path.
- Extracted `EDGE_TYPE_*` constants in `models/memory.py` to mirror the `valid_edge_type` CHECK constraint values.

## Implementation notes

- Issue body's WHERE-clause Option A would also block weight bumps and doesn't actually skip the bug case (existing=declared, incoming=neural → both sides have at least one non-declared, WHERE evaluates true). The CASE on `edge_type` is the precise fix that preserves type while still updating weight.
- Tests pinning the contract at three layers: integration DB (CASE behavior + scenario), service unit (`GraphService.add_edge` always passes `protect_declared_link=True`), MCP handler unit (response payload reflects whatever the repo returns).
- `make lint` / `make type-check` / 691 backend tests pass / 0 regressions on this branch.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/457-batch-457-458.gate1.md
- ~/.claude/cache/gh-issue-driven/457-batch-457-458.gate2.md

## Follow-ups (not in this PR)

- `test(neural)`: add HebbianLearner.apply_updates end-to-end test for declared_link protection (CI pin for the chain Hebbian → graph_service → repo).
- `refactor(neural)`: unify VALID_EDGE_TYPES (`mcp_server/tools/edge.py`) and CHECK constraint with the new `EDGE_TYPE_*` constants for single source of truth.

🤖 Generated via /gh-issue-driven:ship
