### PR TITLE
feat(auth): right-to-erasure endpoint (GDPR Art.17 / APPI) (#360)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -22,6 +22,7 @@ import models.config  # noqa: F401
 import models.resource  # noqa: F401
 import models.neural  # noqa: F401
 import models.hub_tag  # noqa: F401
+import models.erasure  # noqa: F401
 
 # Alembic Config object
 config = context.config

--- a/backend/alembic/versions/c01_360_erasure_requests.py
+++ b/backend/alembic/versions/c01_360_erasure_requests.py
@@ -1,0 +1,177 @@
+"""Add erasure_requests table for GDPR Art.17 / APPI right-to-erasure.
+
+Issue #360: ユーザー自身によるアカウント削除 API + admin 強制削除の両フローで
+共有する受領→cooling-off→実行→完了の workflow テーブル。pseudonymized 監査
+記録として 5 年保持し、バックアップ復元時の re-apply hook の起点としても使う
+(CLO follow-up pin #1 / #2)。
+
+Schema highlights:
+- ``user_id`` is the OAuth2 ``sub`` (varchar) used everywhere as the universal
+  cross-table key — there is no FK to users.user_id by repo convention
+  (every other table stores it as plain VARCHAR with no cascade).
+- ``user_email_hash`` is SHA256 of the user's email at request time. Plaintext
+  email is never stored on this row; the audit trail proves a request existed
+  for that email digest without keeping recoverable PII.
+- ``confirm_token_hash`` is SHA256 of the one-time token; the raw token lives
+  only in Redis (TTL 1h) and never on disk. Mirrors the api_keys.key_hash
+  pattern (Argon2 / SHA256 store-only-the-hash discipline).
+- ``status`` and ``reason_code`` use ``String + CheckConstraint`` per repo
+  convention (no native PostgreSQL enums anywhere in this codebase).
+- 5-year retention is documented in the table COMMENT and the ops runbook.
+  No DB-level retention enforcement; it's an operational policy.
+
+The partial index ``ix_erasure_requests_pending_sweep`` is what the cron
+sweep query joins against — keeping it filtered to ``status='cooling_off'``
+keeps the index size proportional to the in-flight queue rather than the
+audit history (which dominates the table over time given 5-year retention).
+
+Revision ID: c01_360_erasure_requests
+Revises: b06_406_embedding_calibration
+
+NOTE: Revision ID is 24 chars (alembic_version.version_num is VARCHAR(32) —
+asyncpg raises StringDataRightTruncationError otherwise).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c01_360_erasure_requests"
+down_revision: str | Sequence[str] | None = "b06_406_embedding_calibration"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create erasure_requests table with constraints and indexes."""
+    op.create_table(
+        "erasure_requests",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        # The user being erased (OAuth2 sub). Not a FK — repo convention.
+        sa.Column("user_id", sa.String(255), nullable=False, index=True),
+        # SHA256 of the user's email at request time. Plaintext email is
+        # never persisted here — the digest proves a request existed for
+        # that email without storing recoverable PII.
+        sa.Column("user_email_hash", sa.String(64), nullable=False),
+        # Who triggered the request: self user_id (self-service) or admin
+        # user_id (admin force-erase). Lets audit distinguish the two paths.
+        sa.Column("initiated_by", sa.String(255), nullable=False),
+        sa.Column(
+            "is_self_service",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+        sa.Column("reason_code", sa.String(50), nullable=False),
+        # Free-form admin-supplied detail. App layer enforces max 1000 chars
+        # so a UI textarea limit and the constraint stay in sync without
+        # a DB-side length cap that would silently truncate.
+        sa.Column("reason_detail", sa.Text, nullable=True),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'pending'"),
+        ),
+        # SHA256 of the one-time confirmation token. The raw token only
+        # ever lives in Redis (key: erasure_token:{token}, TTL 1h) and
+        # never on disk. Mirrors api_keys.key_hash discipline.
+        sa.Column("confirm_token_hash", sa.String(128), nullable=True),
+        sa.Column(
+            "requested_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("confirmed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("scheduled_for", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("failure_reason", sa.Text, nullable=True),
+        # Per-store / per-table row count summary captured at completion
+        # time. Schema:
+        #   {"postgres": {"memories": 42, "api_keys": 3, ...},
+        #    "qdrant":   {"kagura_memories": 38},
+        #    "redis":    {"sessions": 2, "co_act": 17, "rate_limit": 1},
+        #    "stripe":   {"subscriptions_cancelled": 1, "customer_deleted": true}}
+        # JSONB so admin tooling can query keys without unmarshaling.
+        sa.Column("deleted_data_summary", JSONB, nullable=True),
+        sa.Column("ip_address", sa.String(45), nullable=True),
+        sa.Column("user_agent", sa.String(255), nullable=True),
+        sa.CheckConstraint(
+            "status IN ('pending', 'cooling_off', 'in_progress', "
+            "'complete', 'failed', 'cancelled')",
+            name="valid_erasure_status",
+        ),
+        sa.CheckConstraint(
+            "reason_code IN ('self_service', 'user_request_via_support', "
+            "'legal_order', 'inactivity_policy', 'abuse_violation', 'other')",
+            name="valid_erasure_reason_code",
+        ),
+        # Self-service rows must use the self_service reason_code. Keeps
+        # admin-only reason_codes (legal_order, abuse_violation, ...) out of
+        # the user-driven flow and vice versa.
+        sa.CheckConstraint(
+            "(is_self_service = true AND reason_code = 'self_service') OR "
+            "(is_self_service = false AND reason_code <> 'self_service')",
+            name="erasure_self_service_reason_consistency",
+        ),
+    )
+
+    # Lookup-by-user (admin browsing the audit history of a deleted user).
+    op.create_index("ix_erasure_requests_user_id", "erasure_requests", ["user_id"])
+
+    # General status query for admin dashboard.
+    op.create_index("ix_erasure_requests_status", "erasure_requests", ["status"])
+
+    # Partial index for the cron sweep: only cooling_off rows whose
+    # scheduled_for has passed. Stays small (in-flight queue size) rather
+    # than growing with the full 5-year audit history.
+    op.create_index(
+        "ix_erasure_requests_pending_sweep",
+        "erasure_requests",
+        ["scheduled_for"],
+        postgresql_where=sa.text("status = 'cooling_off'"),
+    )
+
+    # At most one active erasure request per user. Without this, two
+    # concurrent confirms can both pass the in-memory status check and
+    # commit two cooling_off rows for the same user, leading to double
+    # execution. Partial uniqueness on the active states (pending,
+    # cooling_off, in_progress) lets historical failed/cancelled/complete
+    # rows accumulate freely (5-year audit retention).
+    op.create_index(
+        "uq_erasure_one_active_per_user",
+        "erasure_requests",
+        ["user_id"],
+        unique=True,
+        postgresql_where=sa.text("status IN ('pending', 'cooling_off', 'in_progress')"),
+    )
+
+    # Document the retention policy in the DB itself so future maintainers
+    # don't accidentally add a "cleanup old rows" job.
+    op.execute(
+        "COMMENT ON TABLE erasure_requests IS "
+        "'GDPR Art.5(1)(b) / Art.30 accountability evidence. "
+        "Retain 5 years. Pseudonymized by design "
+        "(no plaintext PII besides hashes). Issue #360.'"
+    )
+
+
+def downgrade() -> None:
+    """Drop erasure_requests table."""
+    op.drop_index("uq_erasure_one_active_per_user", table_name="erasure_requests")
+    op.drop_index("ix_erasure_requests_pending_sweep", table_name="erasure_requests")
+    op.drop_index("ix_erasure_requests_status", table_name="erasure_requests")
+    op.drop_index("ix_erasure_requests_user_id", table_name="erasure_requests")
+    op.drop_table("erasure_requests")

--- a/backend/alembic/versions/c01_360_erasure_requests.py
+++ b/backend/alembic/versions/c01_360_erasure_requests.py
@@ -57,7 +57,10 @@ def upgrade() -> None:
             server_default=sa.text("gen_random_uuid()"),
         ),
         # The user being erased (OAuth2 sub). Not a FK — repo convention.
-        sa.Column("user_id", sa.String(255), nullable=False, index=True),
+        # Indexed via the explicit op.create_index below to give the index
+        # a deterministic name (avoids the SQLAlchemy auto-name colliding
+        # with op.create_index inside the same migration).
+        sa.Column("user_id", sa.String(255), nullable=False),
         # SHA256 of the user's email at request time. Plaintext email is
         # never persisted here — the digest proves a request existed for
         # that email without storing recoverable PII.

--- a/backend/alembic/versions/c01_360_erasure_requests.py
+++ b/backend/alembic/versions/c01_360_erasure_requests.py
@@ -102,11 +102,17 @@ def upgrade() -> None:
         sa.Column("cancelled_at", sa.DateTime(timezone=True), nullable=True),
         sa.Column("failure_reason", sa.Text, nullable=True),
         # Per-store / per-table row count summary captured at completion
-        # time. Schema:
-        #   {"postgres": {"memories": 42, "api_keys": 3, ...},
+        # time. Schema (matches AccountErasureService._execute exactly):
+        #   {"postgres": {"users": 1, "memories": 42, "api_keys": 3, ...},
         #    "qdrant":   {"kagura_memories": 38},
         #    "redis":    {"sessions": 2, "co_act": 17, "rate_limit": 1},
-        #    "stripe":   {"subscriptions_cancelled": 1, "customer_deleted": true}}
+        #    "stripe":   {"workspaces_processed": [
+        #        {"workspace_id": "<uuid>",
+        #         "subscription_cancelled": true,
+        #         "customer_deleted": true}
+        #    ]},
+        #    "workspaces": {"transferred": [...], "sole_owner_workspaces": <n>},
+        #    "audit_logs_pseudonymized": <n>}
         # JSONB so admin tooling can query keys without unmarshaling.
         sa.Column("deleted_data_summary", JSONB, nullable=True),
         sa.Column("ip_address", sa.String(45), nullable=True),

--- a/backend/alembic/versions/c01_360_erasure_requests.py
+++ b/backend/alembic/versions/c01_360_erasure_requests.py
@@ -87,8 +87,10 @@ def upgrade() -> None:
         ),
         # SHA256 of the one-time confirmation token. The raw token only
         # ever lives in Redis (key: erasure_token:{token}, TTL 1h) and
-        # never on disk. Mirrors api_keys.key_hash discipline.
-        sa.Column("confirm_token_hash", sa.String(128), nullable=True),
+        # never on disk. Mirrors api_keys.key_hash discipline. SHA256 hex
+        # is exactly 64 chars; size matches the digest precisely so the
+        # column does not imply a different (longer) hash encoding.
+        sa.Column("confirm_token_hash", sa.String(64), nullable=True),
         sa.Column(
             "requested_at",
             sa.DateTime(timezone=True),

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -66,6 +66,7 @@ async def lifespan(app: FastAPI):
         schedule_bm25_drift_tasks,
         schedule_credentials_tasks,
         schedule_embedding_tasks,
+        schedule_erasure_tasks,
         schedule_mcp_tasks,
         schedule_neural_tasks,
         schedule_resource_indexer_jobs,
@@ -81,6 +82,7 @@ async def lifespan(app: FastAPI):
     schedule_resource_indexer_jobs(scheduler)
     schedule_sleep_tasks(scheduler)
     schedule_bm25_drift_tasks(scheduler)
+    schedule_erasure_tasks(scheduler)
     start_scheduler()
     logger.info("background_tasks_scheduled")
 
@@ -109,6 +111,13 @@ openapi_tags = [
     # Authentication & Users
     {"name": "authentication", "description": "OAuth2 login and session management"},
     {"name": "users", "description": "User profile and settings"},
+    {
+        "name": "account-erasure",
+        "description": (
+            "GDPR Art.17 / APPI 第22条 right-to-erasure self-service flow "
+            "(Issue #360). Session-only auth (no API keys)."
+        ),
+    },
     # Workspace
     {"name": "workspace", "description": "Workspace dashboard and stats"},
     {"name": "workspaces", "description": "Workspace CRUD operations"},
@@ -337,6 +346,7 @@ from api.routes import (  # noqa: E402
     graph,
     invitations,
     mcp,
+    me_account,  # Issue #360: GDPR right-to-erasure self-service endpoints
     member_credentials,
     memory,
     neural_config,
@@ -363,6 +373,9 @@ app.include_router(auth.router, prefix="/api/v1")
 
 # User profile routes (Issue #175 - Timezone settings)
 app.include_router(users.router, prefix="/api/v1")
+
+# Account erasure self-service routes (Issue #360 - GDPR Art.17 / APPI compliance)
+app.include_router(me_account.router, prefix="/api/v1")
 
 # OAuth2 Server routes (Issue #33 - OAuth2 client management)
 app.include_router(oauth.router, prefix="/api/v1")

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -7,7 +7,7 @@ Issue #106: Refactored to use consolidated utilities
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from pydantic import BaseModel
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -686,6 +686,97 @@ async def delete_user(
                 "api_keys": api_key_count,
             },
         }
+
+
+# ============================================================================
+# Account Erasure (Issue #360, GDPR Art.17 / APPI compliance)
+# ============================================================================
+
+
+from typing import Literal  # noqa: E402  (kept local to the new endpoint)
+
+# Admin reason codes — explicitly excludes ``self_service`` (which is
+# locked to the self-service flow by the DB CHECK constraint). Pydantic
+# now rejects bad values at the API boundary (422) rather than letting
+# them reach the service layer.
+AdminErasureReasonCode = Literal[
+    "user_request_via_support",
+    "legal_order",
+    "inactivity_policy",
+    "abuse_violation",
+    "other",
+]
+
+
+class AdminErasureRequestBody(BaseModel):
+    """Payload for POST /admin/users/{user_id}/erase.
+
+    ``reason_detail`` is free-form admin notes bounded to 1000 chars at
+    the service layer (matches the ``valid_erasure_*`` CHECK constraint
+    in the migration).
+    """
+
+    reason_code: AdminErasureReasonCode
+    reason_detail: str | None = None
+
+
+@router.post("/users/{user_id}/erase")
+async def admin_force_erase_user(
+    user_id: str,
+    body: AdminErasureRequestBody,
+    request: Request,
+    admin: dict = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Force-erase a user account (admin-only, GDPR Art.17 / APPI compliance).
+
+    Skips the 7-day cooling-off period: the deletion executes immediately.
+    Cross-store cleanup (Stripe + Qdrant + Postgres + Redis) is handled
+    by AccountErasureService following the same orchestration as the
+    self-service path.
+
+    Required body:
+        reason_code: one of user_request_via_support / legal_order /
+            inactivity_policy / abuse_violation / other
+        reason_detail: free-form admin note (max 1000 chars)
+
+    Protections (mirrors SystemAdminService.can_delete_admin):
+        - 403 if target is the initial admin
+        - 403 if target is the last remaining admin
+        - 403 if admin tries to erase their own account
+        - 409 if an erasure request is already in flight for this user
+        - 409 if the target owns a shared workspace and no alternate
+          admin exists for auto-transfer
+
+    This endpoint replaces the older `DELETE /admin/users/{user_id}` for
+    new integrations. The old route is kept temporarily for backward
+    compatibility but does NOT clean Qdrant or all OAuth artifacts.
+    """
+    from services.account_erasure_service import AccountErasureService
+
+    admin_id = get_user_id(admin)
+
+    if admin_id == user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Cannot erase your own account via the admin path",
+        )
+
+    service = AccountErasureService(db)
+    record = await service.admin_force_erase(
+        target_user_id=user_id,
+        initiator_user_id=admin_id,
+        reason_code=body.reason_code,
+        reason_detail=body.reason_detail,
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+
+    return {
+        "request_id": str(record.id),
+        "status": record.status,
+        "deleted_data_summary": record.deleted_data_summary,
+    }
 
 
 # ============================================================================

--- a/backend/src/api/routes/me_account.py
+++ b/backend/src/api/routes/me_account.py
@@ -1,0 +1,192 @@
+"""Self-service account erasure endpoints (Issue #360).
+
+Routes that let an authenticated user request, confirm, cancel, and
+inspect their own GDPR-Art.17 / APPI account-deletion flow. Admin force-
+erase lives in `admin.py` and goes through the same service.
+
+Auth model: every endpoint uses `SessionUser` (browser session only, no
+API keys) — a leaked API key must never be enough to trigger account
+self-deletion. This mirrors the discipline already used by `/users/me`
+and the billing checkout endpoints.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import SessionUser
+from db.base import get_db
+from services.account_erasure_service import AccountErasureService
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/me/account", tags=["account-erasure"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas — kept inline (small + endpoint-specific). Mirrors the lightweight
+# schema discipline used by routes/users.py.
+# ---------------------------------------------------------------------------
+
+
+class ErasureRequestCreateResponse(BaseModel):
+    """Returned after creating a self-service erasure request.
+
+    The raw confirmation token is returned ONCE in this response. For OAuth
+    users the email-link copy is sent via the (currently stub)
+    EmailService; password users use the token + their password directly
+    in the confirm call. The frontend SHOULD treat this token as
+    sensitive and not log it.
+    """
+
+    request_id: UUID
+    status: str
+    requested_at: datetime
+    confirm_token: str = Field(
+        description=(
+            "One-time confirmation token. Use POST /me/account/erasure-confirm "
+            "within 1 hour. Password-auth users must additionally re-enter "
+            "their password."
+        )
+    )
+
+
+class ErasureConfirmRequest(BaseModel):
+    """Payload for POST /me/account/erasure-confirm."""
+
+    token: str
+    password: str | None = Field(
+        default=None,
+        description="Required only for password-auth users. OAuth users omit.",
+    )
+
+
+class ErasureRequestStateResponse(BaseModel):
+    """Read-only view of an erasure request's lifecycle state."""
+
+    request_id: UUID
+    status: str
+    is_self_service: bool
+    requested_at: datetime
+    confirmed_at: datetime | None = None
+    scheduled_for: datetime | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    cancelled_at: datetime | None = None
+    failure_reason: str | None = None
+
+
+def _state_response(request) -> ErasureRequestStateResponse:
+    """Project an ErasureRequest ORM row to the public response shape.
+
+    The deleted_data_summary, ip_address, and user_agent fields are
+    intentionally NOT exposed to the user — they are admin-only audit
+    artifacts.
+    """
+    return ErasureRequestStateResponse(
+        request_id=request.id,
+        status=request.status,
+        is_self_service=request.is_self_service,
+        requested_at=request.requested_at,
+        confirmed_at=request.confirmed_at,
+        scheduled_for=request.scheduled_for,
+        started_at=request.started_at,
+        completed_at=request.completed_at,
+        cancelled_at=request.cancelled_at,
+        failure_reason=request.failure_reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/erasure-request",
+    response_model=ErasureRequestCreateResponse,
+    status_code=201,
+)
+async def create_erasure_request(
+    request: Request,
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> ErasureRequestCreateResponse:
+    """Create a pending erasure request and issue a one-time token.
+
+    The receipt notification is dispatched (currently to logs, manually
+    forwarded by ops per the runbook). Returns 409 if an active request
+    already exists for the user, 403 if the user is the protected
+    initial admin.
+    """
+    service = AccountErasureService(db)
+    record, token = await service.request_self_service_erasure(
+        user_id=user["user_id"],
+        ip_address=request.client.host if request.client else None,
+        user_agent=request.headers.get("user-agent"),
+    )
+    return ErasureRequestCreateResponse(
+        request_id=record.id,
+        status=record.status,
+        requested_at=record.requested_at,
+        confirm_token=token,
+    )
+
+
+@router.post("/erasure-confirm", response_model=ErasureRequestStateResponse)
+async def confirm_erasure_request(
+    body: ErasureConfirmRequest,
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> ErasureRequestStateResponse:
+    """Confirm a pending request and start the 7-day cooling-off period.
+
+    Password-auth users must re-supply their password as a second factor.
+    OAuth users rely on the email-link click + active session cookie.
+    Returns 400 on invalid/expired token, 403 on password mismatch.
+    """
+    service = AccountErasureService(db)
+    record = await service.confirm_self_service(
+        user_id=user["user_id"],
+        token=body.token,
+        password=body.password,
+    )
+    return _state_response(record)
+
+
+@router.delete("/erasure-request", response_model=ErasureRequestStateResponse)
+async def cancel_erasure_request(
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> ErasureRequestStateResponse:
+    """Cancel a cooling_off request before it executes.
+
+    Returns 404 if there is no active request to cancel.
+    """
+    service = AccountErasureService(db)
+    record = await service.cancel_self_service(user_id=user["user_id"])
+    return _state_response(record)
+
+
+@router.get("/erasure-request", response_model=ErasureRequestStateResponse | None)
+async def get_active_erasure_request(
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> ErasureRequestStateResponse | None:
+    """Return the user's active erasure request, or null if none.
+
+    "Active" = pending OR cooling_off OR in_progress. Terminal states
+    (complete / failed / cancelled) are not surfaced here — that's an
+    admin-side audit concern, not user-facing UX.
+    """
+    service = AccountErasureService(db)
+    record = await service.get_active_request_for_user(user["user_id"])
+    if record is None:
+        return None
+    return _state_response(record)

--- a/backend/src/api/routes/me_account.py
+++ b/backend/src/api/routes/me_account.py
@@ -38,11 +38,17 @@ router = APIRouter(prefix="/me/account", tags=["account-erasure"])
 class ErasureRequestCreateResponse(BaseModel):
     """Returned after creating a self-service erasure request.
 
-    The raw confirmation token is returned ONCE in this response. For OAuth
-    users the email-link copy is sent via the (currently stub)
-    EmailService; password users use the token + their password directly
-    in the confirm call. The frontend SHOULD treat this token as
-    sensitive and not log it.
+    The raw confirmation token is returned ONCE in this response. The
+    frontend is responsible for the confirm UX — password-auth users
+    re-enter their password alongside this token; OAuth users present
+    the token via whatever flow the frontend wires (e.g. a confirm
+    button on the same screen). The token is also bound to the active
+    session via ``erasure_token:{token}`` in Redis (TTL 1h) and is
+    single-use.
+
+    The frontend SHOULD treat this token as sensitive and not log it.
+    Issue #463 #4 tracks gating the token-in-response on auth method
+    once a real email provider replaces the LoggingEmailService stub.
     """
 
     request_id: UUID

--- a/backend/src/auth/api_keys.py
+++ b/backend/src/auth/api_keys.py
@@ -6,7 +6,6 @@ Manages API keys using AsyncSession and async/await patterns.
 
 from __future__ import annotations
 
-import hashlib
 import secrets
 from datetime import timedelta
 from uuid import UUID
@@ -16,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import APIKey
 from utils.datetime import utcnow
+from utils.hashing import sha256_hex
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -40,15 +40,8 @@ class APIKeyManager:
 
     @staticmethod
     def _hash_key(api_key: str) -> str:
-        """Hash API key using SHA256.
-
-        Args:
-            api_key: Plaintext API key
-
-        Returns:
-            Hexadecimal hash string
-        """
-        return hashlib.sha256(api_key.encode()).hexdigest()
+        """Hash API key using SHA256."""
+        return sha256_hex(api_key)
 
     @staticmethod
     def _generate_key() -> str:

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -1044,3 +1044,87 @@ async def delete_context_points(
             error=str(e),
         )
         raise QdrantError(f"Failed to delete context points: {e}") from e
+
+
+async def delete_user_points(user_id: str) -> dict[str, int]:
+    """Delete every point authored by a user across all kagura_memories collections.
+
+    Issue #360 (GDPR Art.17 / APPI 第22条): the user-scoped variant of
+    ``delete_context_points``. Filters by ``user_id`` alone — deliberately
+    crossing workspace + context boundaries because the GDPR data subject
+    is the *author* of the point, not the workspace owner. This means
+    points the user authored inside a shared workspace they were a member
+    of (but did not own) are also deleted; this is the correct
+    interpretation of "right to erasure" and is documented in the ops
+    runbook so it is not a surprise to workspace co-owners.
+
+    Iterates every collection whose name begins with ``kagura_memories``
+    so that per-model variant collections (``kagura_memories_<slug>_<dim>``,
+    see ``get_collection_name``) are covered without the caller having
+    to enumerate them.
+
+    Args:
+        user_id: OAuth2 ``sub`` of the user being erased.
+
+    Returns:
+        Dict mapping collection name to deleted point count.
+
+    Raises:
+        QdrantError: If listing collections or deleting from any single
+            collection fails. The error message includes the offending
+            collection so reconciliation knows where to retry.
+
+    Example:
+        >>> deleted = await delete_user_points("google-oauth2|123")
+        >>> sum(deleted.values())
+        42
+        >>> deleted
+        {'kagura_memories': 38, 'kagura_memories_voyage_2_1024': 4}
+    """
+    client = get_qdrant_client()
+    deleted_per_collection: dict[str, int] = {}
+
+    try:
+        collections_response = await client.get_collections()
+        target_collections = [
+            c.name
+            for c in collections_response.collections
+            if c.name.startswith(KAGURA_MEMORIES_COLLECTION)
+        ]
+    except Exception as e:
+        logger.error("user_points_list_collections_failed", user_id=user_id, error=str(e))
+        raise QdrantError(f"Failed to list collections for user erasure: {e}") from e
+
+    user_filter = Filter(must=[FieldCondition(key="user_id", match=MatchValue(value=user_id))])
+
+    for collection_name in target_collections:
+        try:
+            count_result = await client.count(
+                collection_name=collection_name,
+                count_filter=user_filter,
+            )
+            points_to_delete = count_result.count
+
+            if points_to_delete > 0:
+                await client.delete(
+                    collection_name=collection_name,
+                    points_selector=user_filter,
+                )
+
+            deleted_per_collection[collection_name] = points_to_delete
+            logger.info(
+                "user_points_deleted",
+                collection=collection_name,
+                user_id=user_id,
+                count=points_to_delete,
+            )
+        except Exception as e:
+            logger.error(
+                "user_points_deletion_failed",
+                collection=collection_name,
+                user_id=user_id,
+                error=str(e),
+            )
+            raise QdrantError(f"Failed to delete user points from {collection_name}: {e}") from e
+
+    return deleted_per_collection

--- a/backend/src/db/redis.py
+++ b/backend/src/db/redis.py
@@ -299,15 +299,18 @@ async def clear_user_rate_limits(user_id: str) -> int:
     """Clear per-user rate-limit and quota counters for GDPR erasure.
 
     Covers ``rate_limit:user:{user_id}:*`` (per-minute burst counters) and
-    ``quota:{user:<user_id>}:*`` (daily user-scoped quota counters).
-    Workspace-scoped quota keys (``quota:{ws:<workspace_id>}:*``) are NOT
+    ``quota:user:{user_id}:*`` (daily user-scoped quota counters — the
+    rate_limit middleware writes these as ``quota:{scope_key}:{mode}:{date}``
+    where ``scope_key = f"user:{user_id}"``, NOT the brace-wrapped form).
+
+    Workspace-scoped quota keys (``quota:ws:{workspace_id}:*``) are NOT
     touched here — workspace IDs survive after the user's individual rows
     are gone and are not user-identifying.
     """
     return await _delete_keys_by_patterns(
         [
             f"rate_limit:user:{user_id}:*",
-            f"quota:{{user:{user_id}}}:*",
+            f"quota:user:{user_id}:*",
         ],
         log_event="user_rate_limits_cleared",
         user_id=user_id,

--- a/backend/src/db/redis.py
+++ b/backend/src/db/redis.py
@@ -244,27 +244,71 @@ async def get_all_co_activations(user_id: str) -> dict[tuple[str, str], dict]:
         return {}
 
 
-async def clear_co_activations(user_id: str) -> int:
-    """Clear all co-activation data for a user (GDPR compliance).
+async def _delete_keys_by_patterns(
+    patterns: list[str],
+    *,
+    log_event: str,
+    **log_kw: object,
+) -> int:
+    """SCAN-and-delete every key matching any pattern. Returns deletion count.
 
-    Args:
-        user_id: User ID
+    Used by GDPR-erasure helpers that need to wipe per-user key namespaces.
+    Best-effort: returns 0 on failure rather than raising, matching the
+    discipline that Postgres is the source of truth.
 
-    Returns:
-        Number of records deleted
+    Batches keys into a single ``DELETE k1 k2 ...`` per 500-key chunk
+    rather than one ``DELETE`` round-trip per key — Redis ``DEL`` accepts
+    variadic keys.
     """
     client = get_redis_client()
-    pattern = f"co_act:{user_id}:*"
     deleted = 0
+    batch: list[str] = []
+
+    async def _flush() -> int:
+        nonlocal batch
+        if not batch:
+            return 0
+        n = await client.delete(*batch)
+        batch = []
+        return n
 
     try:
-        async for key in client.scan_iter(match=pattern):
-            await client.delete(key)
-            deleted += 1
-
-        logger.info("co_activations_cleared", user_id=user_id, deleted=deleted)
+        for pattern in patterns:
+            async for key in client.scan_iter(match=pattern):
+                batch.append(key)
+                if len(batch) >= 500:
+                    deleted += await _flush()
+        deleted += await _flush()
+        logger.info(log_event, deleted=deleted, **log_kw)
         return deleted
-
     except Exception as e:
-        logger.error("co_activation_clear_failed", user_id=user_id, error=str(e))
+        logger.error(f"{log_event}_failed", error=str(e), **log_kw)
         return 0
+
+
+async def clear_co_activations(user_id: str) -> int:
+    """Clear all co-activation data for a user (GDPR compliance)."""
+    return await _delete_keys_by_patterns(
+        [f"co_act:{user_id}:*"],
+        log_event="co_activations_cleared",
+        user_id=user_id,
+    )
+
+
+async def clear_user_rate_limits(user_id: str) -> int:
+    """Clear per-user rate-limit and quota counters for GDPR erasure.
+
+    Covers ``rate_limit:user:{user_id}:*`` (per-minute burst counters) and
+    ``quota:{user:<user_id>}:*`` (daily user-scoped quota counters).
+    Workspace-scoped quota keys (``quota:{ws:<workspace_id>}:*``) are NOT
+    touched here — workspace IDs survive after the user's individual rows
+    are gone and are not user-identifying.
+    """
+    return await _delete_keys_by_patterns(
+        [
+            f"rate_limit:user:{user_id}:*",
+            f"quota:{{user:{user_id}}}:*",
+        ],
+        log_event="user_rate_limits_cleared",
+        user_id=user_id,
+    )

--- a/backend/src/models/erasure.py
+++ b/backend/src/models/erasure.py
@@ -21,6 +21,7 @@ from sqlalchemy import (
     String,
     Text,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
@@ -142,14 +143,14 @@ class ErasureRequest(Base):
         Index(
             "ix_erasure_requests_pending_sweep",
             "scheduled_for",
-            postgresql_where=f"status = '{STATUS_COOLING_OFF}'",
+            postgresql_where=text(f"status = '{STATUS_COOLING_OFF}'"),
         ),
         Index("ix_erasure_requests_status", "status"),
         Index(
             "uq_erasure_one_active_per_user",
             "user_id",
             unique=True,
-            postgresql_where=(
+            postgresql_where=text(
                 f"status IN ('{STATUS_PENDING}', '{STATUS_COOLING_OFF}', '{STATUS_IN_PROGRESS}')"
             ),
         ),

--- a/backend/src/models/erasure.py
+++ b/backend/src/models/erasure.py
@@ -83,7 +83,9 @@ class ErasureRequest(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
 
     # Subject of the erasure (OAuth2 sub). Not a FK — repo convention.
-    user_id = Column(String(255), nullable=False, index=True)
+    # Indexed via the explicit Index() entry in __table_args__ below so the
+    # index has a deterministic name and matches the migration shape.
+    user_id = Column(String(255), nullable=False)
 
     # SHA256 of the user's email at request time. Plaintext email never on disk.
     user_email_hash = Column(String(64), nullable=False)
@@ -136,6 +138,7 @@ class ErasureRequest(Base):
             f"(is_self_service = false AND reason_code <> '{REASON_SELF_SERVICE}')",
             name="erasure_self_service_reason_consistency",
         ),
+        Index("ix_erasure_requests_user_id", "user_id"),
         Index(
             "ix_erasure_requests_pending_sweep",
             "scheduled_for",

--- a/backend/src/models/erasure.py
+++ b/backend/src/models/erasure.py
@@ -101,8 +101,10 @@ class ErasureRequest(Base):
 
     status = Column(String(20), nullable=False, default=STATUS_PENDING)
 
-    # SHA256 of the one-time token; raw token in Redis only.
-    confirm_token_hash = Column(String(128), nullable=True)
+    # SHA256 of the one-time token; raw token in Redis only. Size is
+    # exact (SHA256 hex = 64 chars) so the column does not imply a
+    # different hash encoding.
+    confirm_token_hash = Column(String(64), nullable=True)
 
     requested_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
     confirmed_at = Column(DateTime(timezone=True), nullable=True)

--- a/backend/src/models/erasure.py
+++ b/backend/src/models/erasure.py
@@ -1,0 +1,156 @@
+"""SQLAlchemy model for GDPR right-to-erasure workflow (Issue #360).
+
+`erasure_requests` row is the single source of truth for an account-deletion
+request lifecycle: ``pending → cooling_off → in_progress → complete`` (happy
+path) with ``cancelled`` and ``failed`` as terminal off-ramps. Admin force-
+erase skips ``cooling_off`` and goes directly to ``in_progress``.
+
+The row outlives the user being erased — it stays for 5 years as
+pseudonymized accountability evidence (GDPR Art.5(1)(b) / Art.30). After
+``complete``, the foreign user_id no longer exists in ``users`` because the
+service deletes the user row itself; readers must therefore not assume
+``erasure_requests.user_id`` joins to a live ``users.user_id``.
+"""
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Index,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from db.base import Base
+
+# Status values — kept in sync with the CHECK constraint in
+# alembic/versions/c01_360_erasure_requests.py and the AccountErasureService
+# state machine. Do not add values here without updating both.
+STATUS_PENDING = "pending"
+STATUS_COOLING_OFF = "cooling_off"
+STATUS_IN_PROGRESS = "in_progress"
+STATUS_COMPLETE = "complete"
+STATUS_FAILED = "failed"
+STATUS_CANCELLED = "cancelled"
+
+VALID_STATUSES = frozenset(
+    {
+        STATUS_PENDING,
+        STATUS_COOLING_OFF,
+        STATUS_IN_PROGRESS,
+        STATUS_COMPLETE,
+        STATUS_FAILED,
+        STATUS_CANCELLED,
+    }
+)
+
+# Reason codes — admin paths use the non-self_service values; the
+# self-service path is locked to ``self_service`` by the CHECK constraint.
+REASON_SELF_SERVICE = "self_service"
+REASON_USER_REQUEST_VIA_SUPPORT = "user_request_via_support"
+REASON_LEGAL_ORDER = "legal_order"
+REASON_INACTIVITY_POLICY = "inactivity_policy"
+REASON_ABUSE_VIOLATION = "abuse_violation"
+REASON_OTHER = "other"
+
+VALID_REASON_CODES = frozenset(
+    {
+        REASON_SELF_SERVICE,
+        REASON_USER_REQUEST_VIA_SUPPORT,
+        REASON_LEGAL_ORDER,
+        REASON_INACTIVITY_POLICY,
+        REASON_ABUSE_VIOLATION,
+        REASON_OTHER,
+    }
+)
+
+# App-layer cap on reason_detail. Kept in sync with API request schema.
+REASON_DETAIL_MAX_CHARS = 1000
+
+
+class ErasureRequest(Base):
+    """Account-erasure workflow row (Issue #360, GDPR Art.17 / APPI 第22条).
+
+    See module docstring for lifecycle. The ``user_id`` is the OAuth2 sub
+    string used everywhere as the universal cross-table key, NOT a FK.
+    """
+
+    __tablename__ = "erasure_requests"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+
+    # Subject of the erasure (OAuth2 sub). Not a FK — repo convention.
+    user_id = Column(String(255), nullable=False, index=True)
+
+    # SHA256 of the user's email at request time. Plaintext email never on disk.
+    user_email_hash = Column(String(64), nullable=False)
+
+    # Self user_id (self-service) or admin user_id (admin force-erase).
+    initiated_by = Column(String(255), nullable=False)
+
+    is_self_service = Column(Boolean, nullable=False, default=False)
+
+    reason_code = Column(String(50), nullable=False)
+    reason_detail = Column(Text, nullable=True)
+
+    status = Column(String(20), nullable=False, default=STATUS_PENDING)
+
+    # SHA256 of the one-time token; raw token in Redis only.
+    confirm_token_hash = Column(String(128), nullable=True)
+
+    requested_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    confirmed_at = Column(DateTime(timezone=True), nullable=True)
+    scheduled_for = Column(DateTime(timezone=True), nullable=True)
+    started_at = Column(DateTime(timezone=True), nullable=True)
+    completed_at = Column(DateTime(timezone=True), nullable=True)
+    cancelled_at = Column(DateTime(timezone=True), nullable=True)
+
+    failure_reason = Column(Text, nullable=True)
+    deleted_data_summary = Column(JSONB, nullable=True)
+
+    ip_address = Column(String(45), nullable=True)
+    user_agent = Column(String(255), nullable=True)
+
+    # Source the CHECK constraints from VALID_STATUSES / VALID_REASON_CODES
+    # so adding a new state value never requires editing two places. The
+    # migration file at c01_360_erasure_requests.py is a frozen snapshot
+    # and intentionally hardcodes these literals — that's the alembic
+    # convention. The runtime model stays in sync with the constants.
+    _STATUS_LITERALS = ", ".join(f"'{s}'" for s in sorted(VALID_STATUSES))
+    _REASON_LITERALS = ", ".join(f"'{r}'" for r in sorted(VALID_REASON_CODES))
+
+    __table_args__ = (
+        CheckConstraint(
+            f"status IN ({_STATUS_LITERALS})",
+            name="valid_erasure_status",
+        ),
+        CheckConstraint(
+            f"reason_code IN ({_REASON_LITERALS})",
+            name="valid_erasure_reason_code",
+        ),
+        CheckConstraint(
+            f"(is_self_service = true AND reason_code = '{REASON_SELF_SERVICE}') OR "
+            f"(is_self_service = false AND reason_code <> '{REASON_SELF_SERVICE}')",
+            name="erasure_self_service_reason_consistency",
+        ),
+        Index(
+            "ix_erasure_requests_pending_sweep",
+            "scheduled_for",
+            postgresql_where=f"status = '{STATUS_COOLING_OFF}'",
+        ),
+        Index("ix_erasure_requests_status", "status"),
+        Index(
+            "uq_erasure_one_active_per_user",
+            "user_id",
+            unique=True,
+            postgresql_where=(
+                f"status IN ('{STATUS_PENDING}', '{STATUS_COOLING_OFF}', '{STATUS_IN_PROGRESS}')"
+            ),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return f"<ErasureRequest(id={self.id}, user_id='{self.user_id}', status='{self.status}')>"

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -278,6 +278,15 @@ class AccountErasureService:
             if not target.password_hash or not verify_password(password, target.password_hash):
                 raise ErasureForbiddenError("Incorrect password")
 
+        # Pre-check: surface WorkspaceTransferRequiredError at confirm time
+        # rather than 7 days later in the cron sweep. Without this the
+        # user's only signal would be reading status=failed via GET
+        # /me/account/erasure-request a week after they confirmed —
+        # actively bad UX. Workspace state can still change during
+        # cooling-off (admin leaves, etc.), so this is best-effort, not
+        # a guarantee. The cron's identical check remains the safety net.
+        await self._check_no_blocking_workspace_transfers(user_id)
+
         now = utcnow()
         request.status = STATUS_COOLING_OFF
         request.confirmed_at = now
@@ -680,6 +689,42 @@ class AccountErasureService:
         """All workspaces this user owns (drives Stripe + member checks)."""
         result = await self.db.execute(select(Workspace).where(Workspace.owner_user_id == user_id))
         return list(result.scalars().all())
+
+    async def _check_no_blocking_workspace_transfers(self, user_id: str) -> None:
+        """Raise WorkspaceTransferRequiredError if any owned workspace would
+        block the eventual sweep execution.
+
+        Identical predicate to ``_handle_owned_workspaces``: a workspace
+        with members but no alternate admin/owner is "blocking". Sole-owner
+        workspaces (no other members) are fine — they get deleted in step 4.
+
+        Pre-check is best-effort: workspace membership can change during
+        the 7-day cooling-off window, so the cron's identical check is the
+        actual enforcement point. This method just surfaces the issue at
+        confirm time so the user gets a 409 instead of waiting a week to
+        learn their request will fail.
+        """
+        owned = await self._list_owned_workspaces(user_id)
+        if not owned:
+            return
+
+        ws_ids = [ws.id for ws in owned]
+        members_result = await self.db.execute(
+            select(WorkspaceMember).where(WorkspaceMember.workspace_id.in_(ws_ids))
+        )
+        members_by_ws: dict[Any, list[WorkspaceMember]] = {}
+        for m in members_result.scalars().all():
+            members_by_ws.setdefault(m.workspace_id, []).append(m)
+
+        for ws in owned:
+            other_members = [m for m in members_by_ws.get(ws.id, []) if m.user_id != user_id]
+            if not other_members:
+                continue  # sole owner — workspace will be deleted in step 4
+            other_admins = [m for m in other_members if m.role in ("owner", "admin")]
+            if not other_admins:
+                raise WorkspaceTransferRequiredError(
+                    workspace_id=str(ws.id), member_count=len(other_members)
+                )
 
     async def _handle_owned_workspaces(
         self, user_id: str, workspaces: list[Workspace]

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -1,0 +1,850 @@
+"""Account erasure orchestrator (Issue #360, GDPR Art.17 / APPI 第22条).
+
+Owns the full lifecycle of an `erasure_requests` row:
+
+    self-service:  pending -> cooling_off -> in_progress -> complete
+    admin:                                   in_progress -> complete
+
+Both paths converge on `_execute`, which performs the 12-step cross-store
+deletion (Stripe -> Qdrant -> workspace transfer -> Postgres -> Redis ->
+audit-log pseudonymize -> finalize) covered by the design pin in #360.
+
+Failure semantics: if any step in `_execute` raises, the request row is
+marked `failed` with `failure_reason`, the surrounding transaction is
+rolled back (so partial Postgres mutations don't escape), and the
+exception is re-raised. Stripe and Qdrant calls inside `_execute` are
+themselves best-effort and won't roll back — they're recorded in
+`deleted_data_summary` so ops can reconcile manually if anything stuck.
+"""
+
+from __future__ import annotations
+
+import hmac
+import secrets
+from datetime import timedelta
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.qdrant import delete_user_points
+from db.redis import clear_co_activations, clear_user_rate_limits, get_redis_client
+from models.auth import (
+    APIKey,
+    AuditLog,
+    ExternalAPIKey,
+    OAuth2AuthorizationCode,
+    OAuth2Client,
+    OAuth2Token,
+    User,
+    Workspace,
+    WorkspaceInvitation,
+    WorkspaceMember,
+)
+from models.erasure import (
+    REASON_DETAIL_MAX_CHARS,
+    REASON_SELF_SERVICE,
+    STATUS_CANCELLED,
+    STATUS_COMPLETE,
+    STATUS_COOLING_OFF,
+    STATUS_FAILED,
+    STATUS_IN_PROGRESS,
+    STATUS_PENDING,
+    VALID_REASON_CODES,
+    ErasureRequest,
+)
+from services.email_service import EmailService, get_email_service
+from services.stripe_service import cancel_subscription_and_delete_customer_for_erasure
+from services.system_admin_service import SystemAdminService
+from utils.datetime import utcnow
+from utils.exceptions import (
+    ErasureAlreadyInProgressError,
+    ErasureForbiddenError,
+    ErasureRequestNotFoundError,
+    ErasureTokenInvalidError,
+    InitialAdminCannotBeErasedError,
+    NotFoundException,
+    ValidationError,
+    WorkspaceTransferRequiredError,
+)
+from utils.hashing import sha256_hex
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# 7-day cooling-off period from CLO Gate1 pin #4.
+COOLING_OFF_PERIOD = timedelta(days=7)
+
+# Confirmation token TTL in Redis. Aligns with the SLA pin: receipt
+# notification within 1 business day, then the user has roughly an hour
+# from clicking through the email to confirm. Long enough for a real user
+# to act, short enough to limit token-reuse exposure.
+CONFIRM_TOKEN_TTL_SECONDS = 3600
+
+# Redis key prefix for the raw confirmation token. The `confirm_token_hash`
+# column stores SHA256(token); the raw token only ever lives here.
+_CONFIRM_TOKEN_KEY_PREFIX = "erasure_token:"
+
+# Salt used when pseudonymizing audit_log rows for an erased user. A
+# stable per-deployment salt (not per-row) lets ops cross-correlate audit
+# rows belonging to the same erased user without revealing the email/sub.
+# In a real deployment the salt would come from settings; for v0.14.1
+# this constant is acceptable because the goal is irreversibility, not
+# rainbow-table protection — once the user row is gone there's nothing to
+# rainbow-attack against.
+_AUDIT_PSEUDO_SALT = "kagura-erasure-v1"
+
+
+_sha256_hex = sha256_hex  # backward-compat alias for tests + this module
+
+
+class AccountErasureService:
+    """Service-layer orchestrator for GDPR right-to-erasure.
+
+    Constructed per-request with an AsyncSession (matches the codebase
+    convention used by MemoryService, WorkspaceService, etc.). The
+    EmailService is injected so tests can swap in a fake; production
+    code uses the module-level `get_email_service()` singleton.
+    """
+
+    def __init__(self, db: AsyncSession, email_service: EmailService | None = None):
+        self.db = db
+        self.email_service = email_service or get_email_service()
+
+    # ------------------------------------------------------------------
+    # Self-service path
+    # ------------------------------------------------------------------
+
+    async def request_self_service_erasure(
+        self,
+        *,
+        user_id: str,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+    ) -> tuple[ErasureRequest, str]:
+        """Create a pending self-service erasure request.
+
+        Returns the row plus the raw confirmation token. The token is
+        ALSO stored in Redis under `erasure_token:{token}` for verification
+        — only the SHA256 lands in Postgres.
+
+        Raises:
+            NotFoundException: User does not exist.
+            InitialAdminCannotBeErasedError: User is the protected initial admin.
+            ErasureAlreadyInProgressError: An active (pending/cooling_off) request
+                already exists for this user.
+        """
+        target = await self._load_user_or_404(user_id)
+        if target.is_initial_admin:
+            raise InitialAdminCannotBeErasedError()
+
+        existing = await self._find_active_request(user_id)
+        if existing:
+            raise ErasureAlreadyInProgressError(existing.status)
+
+        token = secrets.token_urlsafe(32)
+        token_hash = _sha256_hex(token)
+
+        request = ErasureRequest(
+            user_id=user_id,
+            user_email_hash=_sha256_hex(target.email),
+            initiated_by=user_id,
+            is_self_service=True,
+            reason_code=REASON_SELF_SERVICE,
+            reason_detail=None,
+            status=STATUS_PENDING,
+            confirm_token_hash=token_hash,
+            ip_address=ip_address,
+            user_agent=user_agent,
+        )
+        self.db.add(request)
+        # Defense-in-depth: the partial unique index
+        # `uq_erasure_one_active_per_user` rejects a second active row even
+        # if `_find_active_request` raced with another concurrent caller.
+        # Translate the IntegrityError to the typed business error so the
+        # API surface is identical between the in-memory and DB-enforced
+        # detection paths.
+        try:
+            await self.db.commit()
+        except IntegrityError as exc:
+            await self.db.rollback()
+            raise ErasureAlreadyInProgressError("active") from exc
+        await self.db.refresh(request)
+
+        # Store raw token in Redis with TTL. Failure here would force a
+        # 500 because the user can never confirm without a Redis token —
+        # let it propagate so the caller can surface the issue.
+        redis = get_redis_client()
+        await redis.setex(
+            f"{_CONFIRM_TOKEN_KEY_PREFIX}{token}",
+            CONFIRM_TOKEN_TTL_SECONDS,
+            str(request.id),
+        )
+
+        await self.email_service.send_erasure_receipt(
+            to_email=target.email,
+            request_id=str(request.id),
+        )
+
+        logger.info(
+            "erasure_request_created",
+            request_id=str(request.id),
+            user_id=user_id,
+            auth_method=target.auth_method,
+        )
+        return request, token
+
+    async def confirm_self_service(
+        self,
+        *,
+        user_id: str,
+        token: str,
+        password: str | None = None,
+    ) -> ErasureRequest:
+        """Verify the confirmation token (and password for password users)
+        and move pending -> cooling_off.
+
+        Raises:
+            ErasureTokenInvalidError: Token missing/expired/mismatched.
+            ErasureForbiddenError: Password mismatch on the password path.
+            ErasureRequestNotFoundError: No pending request exists.
+        """
+        target = await self._load_user_or_404(user_id)
+
+        # Resolve and validate token via Redis (raw token never on disk).
+        redis = get_redis_client()
+        redis_key = f"{_CONFIRM_TOKEN_KEY_PREFIX}{token}"
+        request_id_str = await redis.get(redis_key)
+        if not request_id_str:
+            raise ErasureTokenInvalidError()
+
+        try:
+            request_id = UUID(request_id_str)
+        except (ValueError, TypeError) as exc:
+            raise ErasureTokenInvalidError() from exc
+
+        request = await self._load_request_or_404(request_id)
+        if request.user_id != user_id:
+            # Token from a different user's request — refuse without leaking
+            # which other user is involved.
+            raise ErasureTokenInvalidError()
+
+        if request.status != STATUS_PENDING:
+            raise ErasureTokenInvalidError(
+                f"Request is not pending (current status: {request.status})"
+            )
+
+        # Defense-in-depth: also compare against stored hash. Catches any
+        # Redis/Postgres divergence (e.g. token was rotated server-side
+        # between issue and confirm). Constant-time compare so a malicious
+        # client cannot infer the stored hash one byte at a time.
+        if not hmac.compare_digest(request.confirm_token_hash or "", _sha256_hex(token)):
+            raise ErasureTokenInvalidError()
+
+        # Password re-confirm for password users (Q5 design). OAuth users
+        # rely on the email-link click as the second factor; the active
+        # session cookie was the first.
+        if target.auth_method == "password":
+            if not password:
+                raise ErasureForbiddenError("Password required to confirm erasure")
+            from auth.password import verify_password
+
+            if not target.password_hash or not verify_password(password, target.password_hash):
+                raise ErasureForbiddenError("Incorrect password")
+
+        now = utcnow()
+        request.status = STATUS_COOLING_OFF
+        request.confirmed_at = now
+        request.scheduled_for = now + COOLING_OFF_PERIOD
+        await self.db.commit()
+        await self.db.refresh(request)
+
+        # Burn the token so a leaked link can't be replayed.
+        await redis.delete(redis_key)
+
+        await self.email_service.send_erasure_cooling_off_started(
+            to_email=target.email,
+            request_id=str(request.id),
+            scheduled_for_iso=request.scheduled_for.isoformat(),
+        )
+
+        logger.info(
+            "erasure_request_confirmed",
+            request_id=str(request.id),
+            user_id=user_id,
+            scheduled_for=request.scheduled_for.isoformat(),
+        )
+        return request
+
+    async def cancel_self_service(self, *, user_id: str) -> ErasureRequest:
+        """Cancel a cooling_off request before it executes.
+
+        Raises:
+            ErasureRequestNotFoundError: No active cancellable request.
+        """
+        request = await self._find_active_request(user_id)
+        if request is None or request.status != STATUS_COOLING_OFF:
+            raise ErasureRequestNotFoundError(user_id)
+
+        request.status = STATUS_CANCELLED
+        request.cancelled_at = utcnow()
+        await self.db.commit()
+        await self.db.refresh(request)
+
+        logger.info(
+            "erasure_request_cancelled",
+            request_id=str(request.id),
+            user_id=user_id,
+        )
+        return request
+
+    # ------------------------------------------------------------------
+    # Admin force-erase path
+    # ------------------------------------------------------------------
+
+    async def admin_force_erase(
+        self,
+        *,
+        target_user_id: str,
+        initiator_user_id: str,
+        reason_code: str,
+        reason_detail: str | None = None,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
+    ) -> ErasureRequest:
+        """Create an admin-initiated request and execute it inline.
+
+        Skips the cooling-off period — admin actions are deliberate and
+        usually triggered by a legal/abuse signal that wants immediate
+        effect. The reason_code/reason_detail pair is mandatory and
+        constrained by the CHECK constraint on the table (admin-only
+        codes, not `self_service`).
+
+        Raises:
+            ValidationError: Bad reason_code/reason_detail.
+            NotFoundException / InitialAdminCannotBeErasedError /
+            ErasureAlreadyInProgressError / WorkspaceTransferRequiredError:
+            All forwarded from the inline execution path.
+        """
+        if reason_code == REASON_SELF_SERVICE:
+            raise ValidationError("reason_code 'self_service' is not allowed for admin path")
+        if reason_code not in VALID_REASON_CODES:
+            raise ValidationError(f"Invalid reason_code: {reason_code}", field="reason_code")
+        if reason_detail and len(reason_detail) > REASON_DETAIL_MAX_CHARS:
+            raise ValidationError(
+                f"reason_detail exceeds {REASON_DETAIL_MAX_CHARS} chars",
+                field="reason_detail",
+            )
+
+        target = await self._load_user_or_404(target_user_id)
+        if target.is_initial_admin:
+            raise InitialAdminCannotBeErasedError()
+
+        # Cannot delete the last remaining admin (mirrors SystemAdminService).
+        admin_service = SystemAdminService(self.db)
+        can_delete, reason = await admin_service.can_delete_admin(target_user_id)
+        if not can_delete:
+            raise ErasureForbiddenError(reason)
+
+        existing = await self._find_active_request(target_user_id)
+        if existing:
+            raise ErasureAlreadyInProgressError(existing.status)
+
+        now = utcnow()
+        request = ErasureRequest(
+            user_id=target_user_id,
+            user_email_hash=_sha256_hex(target.email),
+            initiated_by=initiator_user_id,
+            is_self_service=False,
+            reason_code=reason_code,
+            reason_detail=reason_detail,
+            status=STATUS_IN_PROGRESS,
+            requested_at=now,
+            confirmed_at=now,
+            started_at=now,
+            ip_address=ip_address,
+            user_agent=user_agent,
+        )
+        self.db.add(request)
+        try:
+            await self.db.commit()
+        except IntegrityError as exc:
+            # Same race protection as the self-service path: partial unique
+            # index rejects concurrent admin force-erase + sweep collisions.
+            await self.db.rollback()
+            raise ErasureAlreadyInProgressError("active") from exc
+        await self.db.refresh(request)
+
+        logger.info(
+            "erasure_admin_force_started",
+            request_id=str(request.id),
+            target_user_id=target_user_id,
+            initiator_user_id=initiator_user_id,
+            reason_code=reason_code,
+        )
+
+        await self._execute(request, target)
+        return request
+
+    # ------------------------------------------------------------------
+    # Cron sweep entry point
+    # ------------------------------------------------------------------
+
+    async def sweep_pending_erasures(self, *, batch_size: int = 50) -> int:
+        """Pick up cooling_off rows whose scheduled_for has passed and execute.
+
+        Uses `FOR UPDATE SKIP LOCKED` so multiple scheduler workers (if we
+        ever scale horizontally) won't double-execute the same row.
+
+        Returns:
+            Number of requests executed in this sweep.
+        """
+        now = utcnow()
+        result = await self.db.execute(
+            select(ErasureRequest)
+            .where(
+                ErasureRequest.status == STATUS_COOLING_OFF,
+                ErasureRequest.scheduled_for <= now,
+            )
+            .order_by(ErasureRequest.scheduled_for.asc())
+            .limit(batch_size)
+            .with_for_update(skip_locked=True)
+        )
+        due_requests = list(result.scalars().all())
+        if not due_requests:
+            return 0
+
+        # Mark all as in_progress immediately (under the same FOR UPDATE
+        # lock) so a second sweeper waking up between iterations cannot
+        # also see them as cooling_off.
+        for req in due_requests:
+            req.status = STATUS_IN_PROGRESS
+            req.started_at = now
+        await self.db.commit()
+
+        # Bulk-load every target user up-front rather than one SELECT per
+        # request — collapses up to `batch_size` round-trips into one.
+        user_ids = [req.user_id for req in due_requests]
+        users_result = await self.db.execute(select(User).where(User.user_id.in_(user_ids)))
+        users_by_id: dict[str, User] = {u.user_id: u for u in users_result.scalars().all()}
+
+        executed = 0
+        for req in due_requests:
+            target = users_by_id.get(req.user_id)
+            if target is None:
+                # User row already gone (race / manual cleanup). Mark complete
+                # with empty summary; nothing to delete.
+                req.status = STATUS_COMPLETE
+                req.completed_at = utcnow()
+                req.deleted_data_summary = {"note": "user_row_already_absent"}
+                await self.db.commit()
+                continue
+            try:
+                await self._execute(req, target)
+                executed += 1
+            except Exception as exc:
+                logger.error(
+                    "erasure_sweep_execute_failed",
+                    request_id=str(req.id),
+                    user_id=req.user_id,
+                    error=str(exc),
+                    exc_info=True,
+                )
+                # `_execute` already marked status=failed; continue to
+                # the next request in this batch.
+                continue
+        return executed
+
+    # ------------------------------------------------------------------
+    # Core execution (12-step orchestrator)
+    # ------------------------------------------------------------------
+
+    async def _execute(self, request: ErasureRequest, target: User) -> None:
+        """Run the cross-store erasure for a single request.
+
+        Order: Stripe -> Qdrant -> workspaces -> Postgres -> Redis ->
+        audit_logs pseudonymize -> audit row -> finalize. Stripe and
+        Qdrant first so a failure leaves a recoverable Postgres state;
+        Redis last because session/rate-limit data is ephemeral and
+        re-creatable from cookies if anything goes wrong.
+        """
+        summary: dict[str, Any] = {}
+        try:
+            owned_workspaces = await self._list_owned_workspaces(target.user_id)
+
+            # Step 1: Stripe (best-effort)
+            stripe_summary: dict[str, Any] = {"workspaces_processed": []}
+            for ws in owned_workspaces:
+                ws_result = await cancel_subscription_and_delete_customer_for_erasure(ws)
+                if ws_result["subscription_cancelled"] or ws_result["customer_deleted"]:
+                    stripe_summary["workspaces_processed"].append(
+                        {"workspace_id": str(ws.id), **ws_result}
+                    )
+            summary["stripe"] = stripe_summary
+
+            # Step 2: Qdrant (raises on failure -> caught below)
+            summary["qdrant"] = await delete_user_points(target.user_id)
+
+            # Step 3: workspace ownership transfer / abort gate
+            summary["workspaces"] = await self._handle_owned_workspaces(
+                target.user_id, owned_workspaces
+            )
+
+            # Step 4: Postgres deletes (FK-safe order)
+            summary["postgres"] = await self._delete_postgres(target)
+
+            # Step 5: pseudonymize existing audit_logs referencing this user
+            summary["audit_logs_pseudonymized"] = await self._pseudonymize_audit_logs(
+                target.user_id, target.email
+            )
+
+            # Step 6: Redis cleanup (best-effort)
+            summary["redis"] = await self._clear_redis(target.user_id)
+
+            # Step 7: write the new "account_erasure" audit row
+            await self._write_audit_log(request, target, summary)
+
+            # Step 8: finalize the erasure_requests row
+            await self._finalize(request, summary)
+
+            # Step 9: completion notification — outside the success path's
+            # transactional integrity guarantees. A future real EmailService
+            # could raise on transient SMTP failure; that must NOT cause
+            # the just-committed `complete` row to be overwritten as
+            # `failed`. Swallow + log instead.
+            try:
+                await self.email_service.send_erasure_complete(
+                    to_email=target.email,
+                    request_id=str(request.id),
+                )
+            except Exception as exc:
+                logger.error(
+                    "erasure_complete_email_failed",
+                    request_id=str(request.id),
+                    error=str(exc),
+                )
+
+        except WorkspaceTransferRequiredError:
+            # Caller-actionable error: don't mark as failed (request stays
+            # in_progress so the caller can fix the workspace and retry).
+            # Roll back any partial Postgres state from this transaction
+            # so the row reverts to its pre-execute snapshot. confirmed_at
+            # is also cleared on the admin path so a retry sees a clean
+            # PENDING state (admin-path rows were created with confirmed_at=now
+            # to skip cooling-off).
+            await self.db.rollback()
+            await self.db.execute(
+                update(ErasureRequest)
+                .where(ErasureRequest.id == request.id)
+                .values(
+                    status=STATUS_COOLING_OFF if request.is_self_service else STATUS_PENDING,
+                    started_at=None,
+                    confirmed_at=None if not request.is_self_service else request.confirmed_at,
+                )
+            )
+            await self.db.commit()
+            raise
+        except Exception as exc:
+            logger.error(
+                "erasure_execute_failed",
+                request_id=str(request.id),
+                user_id=target.user_id,
+                error=str(exc),
+                exc_info=True,
+            )
+            await self.db.rollback()
+            # Use a fresh write to record the failure without depending on
+            # the just-rolled-back ORM state.
+            await self.db.execute(
+                update(ErasureRequest)
+                .where(ErasureRequest.id == request.id)
+                .values(
+                    status=STATUS_FAILED,
+                    failure_reason=str(exc)[:1000],
+                    deleted_data_summary=summary or None,
+                )
+            )
+            await self.db.commit()
+            raise
+
+    # ------------------------------------------------------------------
+    # Step helpers
+    # ------------------------------------------------------------------
+
+    async def _list_owned_workspaces(self, user_id: str) -> list[Workspace]:
+        """All workspaces this user owns (drives Stripe + member checks)."""
+        result = await self.db.execute(select(Workspace).where(Workspace.owner_user_id == user_id))
+        return list(result.scalars().all())
+
+    async def _handle_owned_workspaces(
+        self, user_id: str, workspaces: list[Workspace]
+    ) -> dict[str, Any]:
+        """Transfer ownership where possible, refuse where not.
+
+        Per Q4 design:
+            - Other admin in the workspace -> auto-transfer (alphabetical
+              email order for determinism).
+            - Member(s) but no other admin -> raise WorkspaceTransferRequiredError.
+            - Sole owner -> no transfer; workspace will be deleted in step 4.
+        """
+        transfers: list[dict[str, str]] = []
+        sole_owner_count = 0
+
+        if not workspaces:
+            return {"transferred": transfers, "sole_owner_workspaces": sole_owner_count}
+
+        # Bulk-load every member row for these workspaces in one round-trip
+        # and group in memory — the per-workspace SELECT pattern was an N+1
+        # for users with multiple owned workspaces.
+        ws_ids = [ws.id for ws in workspaces]
+        members_result = await self.db.execute(
+            select(WorkspaceMember).where(WorkspaceMember.workspace_id.in_(ws_ids))
+        )
+        members_by_ws: dict[Any, list[WorkspaceMember]] = {}
+        for m in members_result.scalars().all():
+            members_by_ws.setdefault(m.workspace_id, []).append(m)
+
+        for ws in workspaces:
+            other_members = [m for m in members_by_ws.get(ws.id, []) if m.user_id != user_id]
+            if not other_members:
+                sole_owner_count += 1
+                continue
+
+            other_admins = sorted(
+                (m for m in other_members if m.role in ("owner", "admin")),
+                key=lambda m: m.user_id or "",
+            )
+            if not other_admins:
+                raise WorkspaceTransferRequiredError(
+                    workspace_id=str(ws.id), member_count=len(other_members)
+                )
+
+            new_owner = other_admins[0]
+            ws.owner_user_id = new_owner.user_id
+            new_owner.role = "owner"
+            transfers.append({"workspace_id": str(ws.id), "new_owner_user_id": new_owner.user_id})
+
+        # Commit so the cascade on workspace delete (step 4) sees the new
+        # owner_user_id rather than the about-to-be-deleted user_id.
+        if transfers:
+            await self.db.commit()
+
+        return {"transferred": transfers, "sole_owner_workspaces": sole_owner_count}
+
+    async def _delete_postgres(self, target: User) -> dict[str, int]:
+        """Delete every Postgres row that references the user.
+
+        Order matters because not every column is FK-cascaded — most
+        cross-table user references are plain VARCHAR (OAuth2 sub) with
+        no cascade. The full sweep here is the application-layer
+        equivalent of `ON DELETE CASCADE` for all per-user data.
+        """
+        # Optional model imports so the service doesn't crash if a model
+        # is renamed/removed in a future refactor.
+        from models.auth import PlanChange, UsageStats, UserPlan
+        from models.memory import GraphMemory
+
+        user_id = target.user_id
+        counts: dict[str, int] = {}
+
+        # OAuth2 tokens / authorization codes / clients first — no FK
+        # cascade from users to these.
+        counts["oauth_tokens"] = await self._count_and_delete(
+            OAuth2Token, OAuth2Token.user_id == user_id
+        )
+        counts["oauth_authorization_codes"] = await self._count_and_delete(
+            OAuth2AuthorizationCode, OAuth2AuthorizationCode.user_id == user_id
+        )
+        counts["oauth_clients"] = await self._count_and_delete(
+            OAuth2Client, OAuth2Client.owner_id == user_id
+        )
+
+        # Direct per-user tables.
+        counts["external_api_keys"] = await self._count_and_delete(
+            ExternalAPIKey, ExternalAPIKey.user_id == user_id
+        )
+        counts["api_keys"] = await self._count_and_delete(APIKey, APIKey.user_id == user_id)
+        counts["graph_memory"] = await self._count_and_delete(
+            GraphMemory, GraphMemory.user_id == user_id
+        )
+        counts["usage_stats"] = await self._count_and_delete(
+            UsageStats, UsageStats.user_id == user_id
+        )
+        counts["user_plans"] = await self._count_and_delete(UserPlan, UserPlan.user_id == user_id)
+
+        # Workspace memberships and invitations.
+        counts["workspace_members"] = await self._count_and_delete(
+            WorkspaceMember, WorkspaceMember.user_id == user_id
+        )
+        counts["workspace_invitations"] = await self._count_and_delete(
+            WorkspaceInvitation,
+            (WorkspaceInvitation.invited_by == user_id)
+            | (WorkspaceInvitation.email == target.email),
+        )
+
+        # Pseudonymize plan_changes.changed_by — keep the audit trail but
+        # break the link to the deleted user (legal retention concern).
+        counts["plan_changes_pseudonymized"] = await self._pseudonymize_field(
+            PlanChange, PlanChange.changed_by, user_id
+        )
+
+        # Workspaces owned by the user. After step 3 ran, only sole-owner
+        # workspaces remain pointing here. The cascade chain wipes
+        # contexts/memories/edges/etc.
+        counts["workspaces"] = await self._count_and_delete(
+            Workspace, Workspace.owner_user_id == user_id
+        )
+
+        # Finally the user row itself.
+        await self.db.delete(target)
+        await self.db.commit()
+        counts["users"] = 1
+
+        return counts
+
+    async def _count_and_delete(self, model: Any, where_clause: Any) -> int:
+        """Delete rows and return the affected count from the cursor.
+
+        Single round-trip: PostgreSQL returns ``rowcount`` from ``DELETE``
+        directly, so we don't need a separate ``SELECT count()``.
+        """
+        result = await self.db.execute(delete(model).where(where_clause))
+        return result.rowcount or 0
+
+    async def _pseudonymize_field(self, model: Any, column: Any, user_id: str) -> int:
+        """SHA256-pseudonymize a column across all matching rows.
+
+        Used for legal-retention tables (e.g. plan_changes) where the row
+        must survive but the personal-data link to the deleted user must
+        not.
+        """
+        pseudonym = sha256_hex(user_id, salt=_AUDIT_PSEUDO_SALT)
+        result = await self.db.execute(
+            update(model).where(column == user_id).values({column: pseudonym})
+        )
+        return result.rowcount or 0
+
+    async def _pseudonymize_audit_logs(self, user_id: str, email: str) -> int:
+        """Replace user_email/user_id on audit_logs with stable hashes.
+
+        Audit rows are kept (legal retention) but the link to the deleted
+        user is broken. The pseudonyms use a per-deployment salt so
+        cross-row correlation for the SAME erased user is still possible
+        for compliance investigations, but the original sub/email is
+        unrecoverable.
+        """
+        user_pseudonym = sha256_hex(user_id, salt=_AUDIT_PSEUDO_SALT)
+        email_pseudonym = sha256_hex(email, salt=_AUDIT_PSEUDO_SALT)
+        result = await self.db.execute(
+            update(AuditLog)
+            .where(AuditLog.user_id == user_id)
+            .values(user_id=user_pseudonym, user_email=email_pseudonym)
+        )
+        return result.rowcount or 0
+
+    async def _clear_redis(self, user_id: str) -> dict[str, int]:
+        """Best-effort Redis cleanup. Failures are logged inside helpers."""
+        # SessionManager uses a sync Redis client — fetch the live instance
+        # via the auth module's getter so we go through the same setup.
+        from api.routes.auth import _session_manager  # type: ignore
+
+        sessions_deleted = 0
+        if _session_manager is not None:
+            sessions_deleted = _session_manager.delete_user_sessions(user_id)
+
+        return {
+            "sessions": sessions_deleted,
+            "co_act": await clear_co_activations(user_id),
+            "rate_limit": await clear_user_rate_limits(user_id),
+        }
+
+    async def _write_audit_log(
+        self, request: ErasureRequest, target: User, summary: dict[str, Any]
+    ) -> None:
+        """Append the canonical `account_erasure` audit row, fully pseudonymized.
+
+        This row is born AFTER the bulk pseudonymize step (Step 5) ran, so
+        we cannot rely on a later sweep to scrub it. Inline pseudonymization
+        guarantees no plaintext email or user_id ever lands in audit_logs
+        for this event — required for GDPR Art.5(1)(c) compliance.
+        """
+        user_pseudonym = _sha256_hex(target.user_id, salt=_AUDIT_PSEUDO_SALT)
+        email_pseudonym = _sha256_hex(target.email, salt=_AUDIT_PSEUDO_SALT)
+        self.db.add(
+            AuditLog(
+                user_email=email_pseudonym,
+                user_id=user_pseudonym,
+                action="account_erasure",
+                resource=f"user_pseudonym:{user_pseudonym[:16]}",
+                user_metadata={
+                    "request_id": str(request.id),
+                    "is_self_service": request.is_self_service,
+                    "initiated_by": request.initiated_by,
+                    "reason_code": request.reason_code,
+                    "deleted_data_summary": summary,
+                },
+                ip_address=request.ip_address,
+                user_agent=request.user_agent,
+            )
+        )
+        await self.db.commit()
+
+    async def _finalize(self, request: ErasureRequest, summary: dict[str, Any]) -> None:
+        """Mark the erasure_requests row complete.
+
+        Done with an UPDATE rather than ORM mutation because the request
+        object's session may have been touched by intermediate commits.
+        """
+        await self.db.execute(
+            update(ErasureRequest)
+            .where(ErasureRequest.id == request.id)
+            .values(
+                status=STATUS_COMPLETE,
+                completed_at=utcnow(),
+                deleted_data_summary=summary,
+            )
+        )
+        await self.db.commit()
+
+    # ------------------------------------------------------------------
+    # Lookups
+    # ------------------------------------------------------------------
+
+    async def _load_user_or_404(self, user_id: str) -> User:
+        result = await self.db.execute(select(User).where(User.user_id == user_id))
+        user = result.scalar_one_or_none()
+        if user is None:
+            raise NotFoundException("User", resource_id=user_id)
+        return user
+
+    async def _load_user_or_none(self, user_id: str) -> User | None:
+        result = await self.db.execute(select(User).where(User.user_id == user_id))
+        return result.scalar_one_or_none()
+
+    async def _load_request_or_404(self, request_id: UUID) -> ErasureRequest:
+        result = await self.db.execute(
+            select(ErasureRequest).where(ErasureRequest.id == request_id)
+        )
+        request = result.scalar_one_or_none()
+        if request is None:
+            raise ErasureRequestNotFoundError()
+        return request
+
+    async def _find_active_request(self, user_id: str) -> ErasureRequest | None:
+        """Active = pending OR cooling_off OR in_progress."""
+        result = await self.db.execute(
+            select(ErasureRequest)
+            .where(
+                ErasureRequest.user_id == user_id,
+                ErasureRequest.status.in_([STATUS_PENDING, STATUS_COOLING_OFF, STATUS_IN_PROGRESS]),
+            )
+            .order_by(ErasureRequest.requested_at.desc())
+            .limit(1)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_active_request_for_user(self, user_id: str) -> ErasureRequest | None:
+        """Public read-only accessor for the route handler."""
+        return await self._find_active_request(user_id)

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -9,12 +9,24 @@ Both paths converge on `_execute`, which performs the 12-step cross-store
 deletion (Stripe -> Qdrant -> workspace transfer -> Postgres -> Redis ->
 audit-log pseudonymize -> finalize) covered by the design pin in #360.
 
-Failure semantics: if any step in `_execute` raises, the request row is
-marked `failed` with `failure_reason`, the surrounding transaction is
-rolled back (so partial Postgres mutations don't escape), and the
-exception is re-raised. Stripe and Qdrant calls inside `_execute` are
-themselves best-effort and won't roll back — they're recorded in
-`deleted_data_summary` so ops can reconcile manually if anything stuck.
+Failure semantics: ``_execute`` is NOT a single atomic transaction.
+Each step commits when it completes (workspace ownership transfers,
+Postgres deletes, audit pseudonymization, audit-row insert, finalize),
+so a failure in step N leaves steps 1..N-1 already persisted. This is
+deliberate — partial progress is recorded in ``deleted_data_summary``
+and is what ops needs for manual reconciliation. On any raise:
+
+- the in-flight transaction is rolled back (so the failing step's
+  partial mutations don't escape),
+- the request row is marked ``failed`` with ``failure_reason`` via a
+  fresh ``UPDATE`` (independent of the rolled-back ORM state),
+- ``deleted_data_summary`` captures whatever steps did complete,
+- the exception is re-raised.
+
+Stripe and Qdrant calls are best-effort: their internal try/except
+swallows API failures and records the outcome in the summary, so a
+Stripe outage never blocks the Postgres delete pipeline (the orphan
+Stripe customer can be cleaned up manually via the Stripe dashboard).
 """
 
 from __future__ import annotations

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -761,20 +761,42 @@ class AccountErasureService:
         return result.rowcount or 0
 
     async def _pseudonymize_audit_logs(self, user_id: str, email: str) -> int:
-        """Replace user_email/user_id on audit_logs with stable hashes.
+        """Replace user_email/user_id/resource on audit_logs with stable hashes.
 
         Audit rows are kept (legal retention) but the link to the deleted
         user is broken. The pseudonyms use a per-deployment salt so
         cross-row correlation for the SAME erased user is still possible
         for compliance investigations, but the original sub/email is
         unrecoverable.
+
+        The ``resource`` column for user-targeted audit events in this repo
+        is conventionally formatted as ``user:{email}`` (e.g. role_assign,
+        system_admin_promote, system_admin_demote rows), so it carries
+        plaintext email after the user_id/user_email columns are scrubbed.
+        Use ``REPLACE`` chains to swap any occurrence of the email or raw
+        user_id in ``resource`` with their pseudonyms — covers both the
+        ``user:{email}`` and any future ``user_id``-bearing shape without
+        having to enumerate every audit-event flavour.
         """
+        from sqlalchemy import func
+
         user_pseudonym = sha256_hex(user_id, salt=_AUDIT_PSEUDO_SALT)
         email_pseudonym = sha256_hex(email, salt=_AUDIT_PSEUDO_SALT)
+        # Replace email first (longer / more specific), then user_id, so a
+        # row whose resource contains both is fully scrubbed.
+        scrubbed_resource = func.replace(
+            func.replace(AuditLog.resource, email, email_pseudonym),
+            user_id,
+            user_pseudonym,
+        )
         result = await self.db.execute(
             update(AuditLog)
             .where(AuditLog.user_id == user_id)
-            .values(user_id=user_pseudonym, user_email=email_pseudonym)
+            .values(
+                user_id=user_pseudonym,
+                user_email=email_pseudonym,
+                resource=scrubbed_resource,
+            )
         )
         return result.rowcount or 0
 
@@ -806,6 +828,15 @@ class AccountErasureService:
         """
         user_pseudonym = _sha256_hex(target.user_id, salt=_AUDIT_PSEUDO_SALT)
         email_pseudonym = _sha256_hex(target.email, salt=_AUDIT_PSEUDO_SALT)
+        # Self-service `initiated_by` IS the subject's raw user_id (the
+        # user clicked their own delete button). Storing it verbatim in
+        # audit_logs.user_metadata would re-introduce a stable plaintext
+        # identifier for the erased user — a regression of the
+        # pseudonymization invariant the rest of this row enforces.
+        # Admin path `initiated_by` is the admin's user_id (NOT the
+        # erased subject), which is legitimate audit-trail information
+        # and stays plaintext.
+        initiated_by_value = user_pseudonym if request.is_self_service else request.initiated_by
         self.db.add(
             AuditLog(
                 user_email=email_pseudonym,
@@ -815,7 +846,7 @@ class AccountErasureService:
                 user_metadata={
                     "request_id": str(request.id),
                     "is_self_service": request.is_self_service,
-                    "initiated_by": request.initiated_by,
+                    "initiated_by": initiated_by_value,
                     "reason_code": request.reason_code,
                     "deleted_data_summary": summary,
                 },

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -303,15 +303,30 @@ class AccountErasureService:
         return request
 
     async def cancel_self_service(self, *, user_id: str) -> ErasureRequest:
-        """Cancel a cooling_off request before it executes.
+        """Cancel a pending or cooling_off request.
+
+        Both states are cancellable:
+        - ``pending``: user requested but never confirmed. The Redis token
+          may have already expired (1h TTL); without this allow-cancel, a
+          forgotten pending row would block all future erasure requests
+          from this user (partial unique index treats pending as active).
+        - ``cooling_off``: user confirmed but the 7-day window hasn't elapsed.
+
+        ``in_progress`` rows are NOT cancellable — the orchestrator is
+        already running, and racing it would risk an inconsistent half-
+        applied erasure.
 
         Raises:
             ErasureRequestNotFoundError: No active cancellable request.
         """
         request = await self._find_active_request(user_id)
-        if request is None or request.status != STATUS_COOLING_OFF:
+        if request is None or request.status not in (
+            STATUS_PENDING,
+            STATUS_COOLING_OFF,
+        ):
             raise ErasureRequestNotFoundError(user_id)
 
+        cancelled_from = request.status
         request.status = STATUS_CANCELLED
         request.cancelled_at = utcnow()
         await self.db.commit()
@@ -321,6 +336,7 @@ class AccountErasureService:
             "erasure_request_cancelled",
             request_id=str(request.id),
             user_id=user_id,
+            cancelled_from=cancelled_from,
         )
         return request
 
@@ -419,18 +435,27 @@ class AccountErasureService:
     async def sweep_pending_erasures(self, *, batch_size: int = 50) -> int:
         """Pick up cooling_off rows whose scheduled_for has passed and execute.
 
-        Also reclaims stale ``in_progress`` rows whose ``started_at`` is
-        older than ``IN_PROGRESS_STALE_AFTER`` — those represent runs
-        that were marked in-progress but did not complete (process
-        SIGTERM/OOM between commit and ``_execute``). Without this, a
-        crash-killed sweep would leave erasure rows permanently stuck
-        and silently violate the GDPR 1-month SLA.
+        Also handles two stale-state cleanup paths:
+
+        - **Stale ``in_progress``** (``started_at`` older than 1h): these
+          are runs that were marked in-progress but did not complete
+          (process SIGTERM/OOM between commit and ``_execute``). Picked
+          up by the main sweep query and re-executed.
+
+        - **Stale ``pending``** (``requested_at`` older than 1h + 5min
+          grace): the Redis confirm token (TTL 1h) has expired and the
+          user can no longer confirm. The row would otherwise block all
+          future erasure requests via the partial unique index. Marked
+          ``cancelled`` in a single UPDATE before the main sweep — no
+          per-row execution needed since these rows have nothing to
+          delete (they never reached cooling_off).
 
         Uses ``FOR UPDATE SKIP LOCKED`` so multiple scheduler workers (if
         we ever scale horizontally) won't double-execute the same row.
 
         Returns:
-            Number of requests executed in this sweep.
+            Number of requests executed (does NOT count cancelled stale
+            pending rows — those are reclaim, not execution).
         """
         from sqlalchemy import or_
 
@@ -439,6 +464,26 @@ class AccountErasureService:
         # cross-store deletes); a row in_progress this long is presumed
         # crashed.
         stale_in_progress_cutoff = now - timedelta(hours=1)
+
+        # Pending token TTL is 1h (CONFIRM_TOKEN_TTL_SECONDS); add 5min
+        # grace so we don't race a user who just clicked confirm but
+        # whose Redis SETEX is in flight.
+        pending_token_expired_cutoff = now - timedelta(hours=1, minutes=5)
+        stale_pending_result = await self.db.execute(
+            update(ErasureRequest)
+            .where(
+                (ErasureRequest.status == STATUS_PENDING)
+                & (ErasureRequest.requested_at <= pending_token_expired_cutoff)
+            )
+            .values(status=STATUS_CANCELLED, cancelled_at=now)
+        )
+        if (stale_pending_result.rowcount or 0) > 0:
+            logger.info(
+                "erasure_sweep_pending_reclaimed",
+                count=stale_pending_result.rowcount,
+                reason="token_expired_no_confirm",
+            )
+            await self.db.commit()
         result = await self.db.execute(
             select(ErasureRequest)
             .where(
@@ -787,7 +832,7 @@ class AccountErasureService:
         return result.rowcount or 0
 
     async def _pseudonymize_audit_logs(self, user_id: str, email: str) -> int:
-        """Replace user_email/user_id/resource on audit_logs with stable hashes.
+        """Replace user_id/resource (and conditionally user_email) on audit_logs.
 
         Audit rows are kept (legal retention) but the link to the deleted
         user is broken. The pseudonyms use a per-deployment salt so
@@ -795,16 +840,26 @@ class AccountErasureService:
         for compliance investigations, but the original sub/email is
         unrecoverable.
 
-        The ``resource`` column for user-targeted audit events in this repo
-        is conventionally formatted as ``user:{email}`` (e.g. role_assign,
-        system_admin_promote, system_admin_demote rows), so it carries
-        plaintext email after the user_id/user_email columns are scrubbed.
-        Use ``REPLACE`` chains to swap any occurrence of the email or raw
-        user_id in ``resource`` with their pseudonyms — covers both the
-        ``user:{email}`` and any future ``user_id``-bearing shape without
-        having to enumerate every audit-event flavour.
+        Column-by-column rules:
+        - ``user_id``: ALWAYS rewritten when the row matches the erased
+          subject's user_id. ``user_id`` is the subject column.
+        - ``user_email``: in this codebase, ``audit_logs.user_email`` is
+          often the *actor's* email, not the subject's (see
+          RoleManager.assign_role and SystemAdminService.promote/demote).
+          A blind overwrite would clobber the actor's identity and
+          misattribute every audit row about the subject. Use a SQL
+          CASE: rewrite only when ``user_email`` equals the erased
+          subject's email; preserve otherwise.
+        - ``resource``: conventionally ``user:{email}`` for user-targeted
+          events. Chain ``func.replace`` to swap any occurrence of the
+          subject's email or raw user_id with their pseudonyms — covers
+          ``user:{email}`` and any future ``user_id``-bearing shape
+          without enumerating every event flavour.
+
+        Caught by Copilot /review iter 2: prior version overwrote
+        user_email indiscriminately, breaking actor attribution.
         """
-        from sqlalchemy import func
+        from sqlalchemy import case, func
 
         user_pseudonym = sha256_hex(user_id, salt=_AUDIT_PSEUDO_SALT)
         email_pseudonym = sha256_hex(email, salt=_AUDIT_PSEUDO_SALT)
@@ -815,12 +870,18 @@ class AccountErasureService:
             user_id,
             user_pseudonym,
         )
+        # Pseudonymize user_email only when it equals the erased subject's
+        # email — preserves actor email on audit rows where actor != subject.
+        conditional_email = case(
+            (AuditLog.user_email == email, email_pseudonym),
+            else_=AuditLog.user_email,
+        )
         result = await self.db.execute(
             update(AuditLog)
             .where(AuditLog.user_id == user_id)
             .values(
                 user_id=user_pseudonym,
-                user_email=email_pseudonym,
+                user_email=conditional_email,
                 resource=scrubbed_resource,
             )
         )

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -526,22 +526,39 @@ class AccountErasureService:
                     error=str(exc),
                 )
 
-        except WorkspaceTransferRequiredError:
-            # Caller-actionable error: don't mark as failed (request stays
-            # in_progress so the caller can fix the workspace and retry).
-            # Roll back any partial Postgres state from this transaction
-            # so the row reverts to its pre-execute snapshot. confirmed_at
-            # is also cleared on the admin path so a retry sees a clean
-            # PENDING state (admin-path rows were created with confirmed_at=now
-            # to skip cooling-off).
+        except WorkspaceTransferRequiredError as exc:
+            # Caller-actionable error. Move the row to the terminal `failed`
+            # state with a structured reason so the operator can fix
+            # workspace roles and create a *new* request, rather than
+            # reusing this one.
+            #
+            # Earlier revisions reverted the row to `cooling_off`/`pending`,
+            # but that produced two pathological behaviours flagged by the
+            # Copilot review on PR #464:
+            #   - Self-service: `scheduled_for` was already in the past, so
+            #     the cron sweep picked it up again immediately and fired
+            #     the same error every hour until the user cancelled.
+            #   - Admin: `_find_active_request` treats `pending` as active,
+            #     so a retry call to `admin_force_erase` hit
+            #     `ErasureAlreadyInProgressError` — the admin couldn't
+            #     unstick the row without manual DB intervention.
+            #
+            # Terminal `failed` is the cleanest semantics: the API exception
+            # tells the caller exactly what to fix (HTTP 409 + workspace_id
+            # + member_count), and a fresh request can be created once the
+            # workspace state is corrected.
             await self.db.rollback()
             await self.db.execute(
                 update(ErasureRequest)
                 .where(ErasureRequest.id == request.id)
                 .values(
-                    status=STATUS_COOLING_OFF if request.is_self_service else STATUS_PENDING,
-                    started_at=None,
-                    confirmed_at=None if not request.is_self_service else request.confirmed_at,
+                    status=STATUS_FAILED,
+                    failure_reason=(
+                        f"workspace_transfer_required: workspace_id={exc.details.get('workspace_id')} "
+                        f"member_count={exc.details.get('member_count')}. "
+                        "Promote another member to admin (or remove members), then create a new erasure request."
+                    )[:1000],
+                    deleted_data_summary=summary or None,
                 )
             )
             await self.db.commit()

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -618,8 +618,10 @@ class AccountErasureService:
         """Transfer ownership where possible, refuse where not.
 
         Per Q4 design:
-            - Other admin in the workspace -> auto-transfer (alphabetical
-              email order for determinism).
+            - Other admin in the workspace -> auto-transfer. The new owner
+              is the lowest-``user_id`` admin/owner in the workspace
+              (lexicographic ASC). ``WorkspaceMember`` carries no email
+              column, so user_id is the deterministic-ordering criterion.
             - Member(s) but no other admin -> raise WorkspaceTransferRequiredError.
             - Sole owner -> no transfer; workspace will be deleted in step 4.
         """

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -172,28 +172,40 @@ class AccountErasureService:
             user_agent=user_agent,
         )
         self.db.add(request)
-        # Defense-in-depth: the partial unique index
-        # `uq_erasure_one_active_per_user` rejects a second active row even
-        # if `_find_active_request` raced with another concurrent caller.
-        # Translate the IntegrityError to the typed business error so the
-        # API surface is identical between the in-memory and DB-enforced
-        # detection paths.
+        # Order matters: flush() (issues INSERT, populates request.id, surfaces
+        # IntegrityError early) → Redis SETEX → commit(). The previous order
+        # (commit-then-Redis) wedged the user when Redis briefly failed: a
+        # committed pending row is "active" per the partial unique index, but
+        # without the Redis token nothing can confirm or cancel it (the cancel
+        # path covers cooling_off only). 1-hour Redis TTL was no protection
+        # because the key was never written.
+        #
+        # New order's failure modes:
+        #  - flush() IntegrityError → rollback (no row, no Redis key) → user
+        #    sees ErasureAlreadyInProgressError, can retry once the prior
+        #    request is resolved.
+        #  - Redis SETEX raises → rollback PG → no orphan row.
+        #  - commit() fails after Redis SETEX → orphan Redis key, but its
+        #    1h TTL guarantees self-cleanup.
         try:
-            await self.db.commit()
+            await self.db.flush()
         except IntegrityError as exc:
             await self.db.rollback()
             raise ErasureAlreadyInProgressError("active") from exc
-        await self.db.refresh(request)
 
-        # Store raw token in Redis with TTL. Failure here would force a
-        # 500 because the user can never confirm without a Redis token —
-        # let it propagate so the caller can surface the issue.
         redis = get_redis_client()
-        await redis.setex(
-            f"{_CONFIRM_TOKEN_KEY_PREFIX}{token}",
-            CONFIRM_TOKEN_TTL_SECONDS,
-            str(request.id),
-        )
+        try:
+            await redis.setex(
+                f"{_CONFIRM_TOKEN_KEY_PREFIX}{token}",
+                CONFIRM_TOKEN_TTL_SECONDS,
+                str(request.id),
+            )
+        except Exception:
+            await self.db.rollback()
+            raise
+
+        await self.db.commit()
+        await self.db.refresh(request)
 
         await self.email_service.send_erasure_receipt(
             to_email=target.email,

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -395,20 +395,37 @@ class AccountErasureService:
     async def sweep_pending_erasures(self, *, batch_size: int = 50) -> int:
         """Pick up cooling_off rows whose scheduled_for has passed and execute.
 
-        Uses `FOR UPDATE SKIP LOCKED` so multiple scheduler workers (if we
-        ever scale horizontally) won't double-execute the same row.
+        Also reclaims stale ``in_progress`` rows whose ``started_at`` is
+        older than ``IN_PROGRESS_STALE_AFTER`` — those represent runs
+        that were marked in-progress but did not complete (process
+        SIGTERM/OOM between commit and ``_execute``). Without this, a
+        crash-killed sweep would leave erasure rows permanently stuck
+        and silently violate the GDPR 1-month SLA.
+
+        Uses ``FOR UPDATE SKIP LOCKED`` so multiple scheduler workers (if
+        we ever scale horizontally) won't double-execute the same row.
 
         Returns:
             Number of requests executed in this sweep.
         """
+        from sqlalchemy import or_
+
         now = utcnow()
+        # 1 hour is well over a normal _execute (seconds-to-minutes for the
+        # cross-store deletes); a row in_progress this long is presumed
+        # crashed.
+        stale_in_progress_cutoff = now - timedelta(hours=1)
         result = await self.db.execute(
             select(ErasureRequest)
             .where(
-                ErasureRequest.status == STATUS_COOLING_OFF,
-                ErasureRequest.scheduled_for <= now,
+                or_(
+                    (ErasureRequest.status == STATUS_COOLING_OFF)
+                    & (ErasureRequest.scheduled_for <= now),
+                    (ErasureRequest.status == STATUS_IN_PROGRESS)
+                    & (ErasureRequest.started_at <= stale_in_progress_cutoff),
+                )
             )
-            .order_by(ErasureRequest.scheduled_for.asc())
+            .order_by(ErasureRequest.scheduled_for.asc().nulls_last())
             .limit(batch_size)
             .with_for_update(skip_locked=True)
         )

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -51,21 +51,6 @@ class EmailService(Protocol):
             False on hard failure.
         """
 
-    async def send_erasure_confirmation_link(
-        self,
-        *,
-        to_email: str,
-        request_id: str,
-        confirm_url: str,
-    ) -> bool:
-        """Send the one-time confirmation link for OAuth users.
-
-        Args:
-            to_email: Recipient address.
-            request_id: ``erasure_requests.id`` UUID.
-            confirm_url: Full HTTPS URL with one-time token (expires in 1h).
-        """
-
     async def send_erasure_cooling_off_started(
         self,
         *,
@@ -110,23 +95,6 @@ class LoggingEmailService:
             request_id=request_id,
             email_dispatch_required=True,
             template="erasure_receipt",
-        )
-        return True
-
-    async def send_erasure_confirmation_link(
-        self,
-        *,
-        to_email: str,
-        request_id: str,
-        confirm_url: str,
-    ) -> bool:
-        logger.info(
-            "erasure_email_confirmation_link",
-            to_email=to_email,
-            request_id=request_id,
-            confirm_url=confirm_url,
-            email_dispatch_required=True,
-            template="erasure_confirmation_link",
         )
         return True
 

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -1,0 +1,177 @@
+"""Email service interface for transactional notifications.
+
+Issue #360: We need to send three account-erasure notifications (receipt,
+cooling-off start, completion) to satisfy the GDPR Art.12(3) 1-month
+response SLA. The codebase has no existing email infrastructure, so this
+module ships a Protocol + a logging-only stub.
+
+Operational reality (closed-beta scope):
+    The active implementation is ``LoggingEmailService``, which writes a
+    structured log line for every notification. ``docs/ops/erasure-runbook.md``
+    instructs the on-call admin to forward those log entries from the email
+    payload to ``support@`` for manual delivery, with an SLA of 1 business
+    day on receipt notifications. This is the trade-off we accepted in the
+    Phase-3 design review: shipping a real provider (Resend / SES /
+    Postmark) is deferred until after Public Beta opens, so v0.14.1 doesn't
+    block on vendor selection.
+
+When swapping in a real provider, write a new class implementing
+``EmailService`` and update ``get_email_service()`` to return it. The
+caller code in ``AccountErasureService`` does not change.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class EmailService(Protocol):
+    """Transactional email sender.
+
+    Implementations must NOT raise on send failure — they should log the
+    failure and return False. The callers (notification flows) must be
+    resilient to "email did not arrive" because the underlying account
+    state is the source of truth, and the email is only a courtesy
+    notification.
+    """
+
+    async def send_erasure_receipt(self, *, to_email: str, request_id: str) -> bool:
+        """Confirm we received the erasure request (sent within 1 business day).
+
+        Args:
+            to_email: Recipient address (the user being erased).
+            request_id: ``erasure_requests.id`` UUID, for cross-reference.
+
+        Returns:
+            True if dispatch succeeded (or was logged for manual handling),
+            False on hard failure.
+        """
+        ...
+
+    async def send_erasure_confirmation_link(
+        self,
+        *,
+        to_email: str,
+        request_id: str,
+        confirm_url: str,
+    ) -> bool:
+        """Send the one-time confirmation link for OAuth users.
+
+        Args:
+            to_email: Recipient address.
+            request_id: ``erasure_requests.id`` UUID.
+            confirm_url: Full HTTPS URL with one-time token (expires in 1h).
+        """
+        ...
+
+    async def send_erasure_cooling_off_started(
+        self,
+        *,
+        to_email: str,
+        request_id: str,
+        scheduled_for_iso: str,
+    ) -> bool:
+        """Notify that the 7-day cooling-off period has begun.
+
+        Args:
+            to_email: Recipient address.
+            request_id: ``erasure_requests.id`` UUID.
+            scheduled_for_iso: ISO-8601 timestamp when erasure executes.
+        """
+        ...
+
+    async def send_erasure_complete(self, *, to_email: str, request_id: str) -> bool:
+        """Notify that the erasure has completed and the account is gone.
+
+        This must be sent within 24 hours of completion (CLO follow-up #4
+        in Issue #360 body).
+
+        Args:
+            to_email: Recipient address (still routable — this is the last
+                contact we will have with the subject).
+            request_id: ``erasure_requests.id`` UUID.
+        """
+        ...
+
+
+class LoggingEmailService:
+    """Default stub implementation: structured logs only, no SMTP.
+
+    Each method writes one ``info`` log entry with a stable event name and
+    every field an ops admin needs to forward the message manually. Search
+    for ``email_dispatch_required=true`` in production logs to find the
+    queue of notifications the admin must hand-deliver.
+    """
+
+    async def send_erasure_receipt(self, *, to_email: str, request_id: str) -> bool:
+        logger.info(
+            "erasure_email_receipt",
+            to_email=to_email,
+            request_id=request_id,
+            email_dispatch_required=True,
+            template="erasure_receipt",
+        )
+        return True
+
+    async def send_erasure_confirmation_link(
+        self,
+        *,
+        to_email: str,
+        request_id: str,
+        confirm_url: str,
+    ) -> bool:
+        logger.info(
+            "erasure_email_confirmation_link",
+            to_email=to_email,
+            request_id=request_id,
+            confirm_url=confirm_url,
+            email_dispatch_required=True,
+            template="erasure_confirmation_link",
+        )
+        return True
+
+    async def send_erasure_cooling_off_started(
+        self,
+        *,
+        to_email: str,
+        request_id: str,
+        scheduled_for_iso: str,
+    ) -> bool:
+        logger.info(
+            "erasure_email_cooling_off_started",
+            to_email=to_email,
+            request_id=request_id,
+            scheduled_for=scheduled_for_iso,
+            email_dispatch_required=True,
+            template="erasure_cooling_off_started",
+        )
+        return True
+
+    async def send_erasure_complete(self, *, to_email: str, request_id: str) -> bool:
+        logger.info(
+            "erasure_email_complete",
+            to_email=to_email,
+            request_id=request_id,
+            email_dispatch_required=True,
+            template="erasure_complete",
+        )
+        return True
+
+
+_default_email_service: EmailService | None = None
+
+
+def get_email_service() -> EmailService:
+    """Return the singleton EmailService.
+
+    Module-level singleton matches the pattern used for Redis and Qdrant
+    clients. Swap the construction here when wiring in a real provider.
+    """
+    global _default_email_service
+    if _default_email_service is None:
+        _default_email_service = LoggingEmailService()
+    return _default_email_service

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -50,7 +50,6 @@ class EmailService(Protocol):
             True if dispatch succeeded (or was logged for manual handling),
             False on hard failure.
         """
-        ...
 
     async def send_erasure_confirmation_link(
         self,
@@ -66,7 +65,6 @@ class EmailService(Protocol):
             request_id: ``erasure_requests.id`` UUID.
             confirm_url: Full HTTPS URL with one-time token (expires in 1h).
         """
-        ...
 
     async def send_erasure_cooling_off_started(
         self,
@@ -82,7 +80,6 @@ class EmailService(Protocol):
             request_id: ``erasure_requests.id`` UUID.
             scheduled_for_iso: ISO-8601 timestamp when erasure executes.
         """
-        ...
 
     async def send_erasure_complete(self, *, to_email: str, request_id: str) -> bool:
         """Notify that the erasure has completed and the account is gone.
@@ -95,7 +92,6 @@ class EmailService(Protocol):
                 contact we will have with the subject).
             request_id: ``erasure_requests.id`` UUID.
         """
-        ...
 
 
 class LoggingEmailService:

--- a/backend/src/services/stripe_service.py
+++ b/backend/src/services/stripe_service.py
@@ -255,3 +255,76 @@ async def _handle_subscription_cancelled(
         workspace_id=str(workspace.id),
         old_plan=old_plan,
     )
+
+
+async def cancel_subscription_and_delete_customer_for_erasure(
+    workspace: Workspace,
+) -> dict[str, bool]:
+    """Cancel Stripe subscription and delete customer for GDPR right-to-erasure.
+
+    Issue #360: AccountErasureService calls this once per owned workspace
+    that has a Stripe customer linked. Best-effort: every Stripe call is
+    wrapped — failures are logged and the erasure flow continues. The
+    workspace row is about to be deleted regardless, so an orphaned Stripe
+    customer is the worst case (and is recoverable by ops via the Stripe
+    dashboard if it ever happens).
+
+    No-op when ``BILLING_ENABLED`` is false or when the workspace has no
+    Stripe IDs populated, so it is safe to call unconditionally.
+
+    Args:
+        workspace: Workspace ORM instance whose Stripe state should be
+            torn down.
+
+    Returns:
+        ``{"subscription_cancelled": bool, "customer_deleted": bool}`` —
+        included verbatim in the deleted_data_summary JSONB on the
+        ``erasure_requests`` row for audit.
+    """
+    from plugins.billing import is_billing_enabled
+
+    result = {"subscription_cancelled": False, "customer_deleted": False}
+
+    if not is_billing_enabled():
+        return result
+
+    if not workspace.stripe_customer_id and not workspace.stripe_subscription_id:
+        return result
+
+    _init_stripe()
+
+    if workspace.stripe_subscription_id:
+        try:
+            stripe.Subscription.cancel(workspace.stripe_subscription_id)
+            result["subscription_cancelled"] = True
+            logger.info(
+                "stripe_subscription_cancelled_for_erasure",
+                workspace_id=str(workspace.id),
+                subscription_id=workspace.stripe_subscription_id,
+            )
+        except Exception as e:
+            logger.error(
+                "stripe_subscription_cancel_failed_during_erasure",
+                workspace_id=str(workspace.id),
+                subscription_id=workspace.stripe_subscription_id,
+                error=str(e),
+            )
+
+    if workspace.stripe_customer_id:
+        try:
+            stripe.Customer.delete(workspace.stripe_customer_id)
+            result["customer_deleted"] = True
+            logger.info(
+                "stripe_customer_deleted_for_erasure",
+                workspace_id=str(workspace.id),
+                customer_id=workspace.stripe_customer_id,
+            )
+        except Exception as e:
+            logger.error(
+                "stripe_customer_delete_failed_during_erasure",
+                workspace_id=str(workspace.id),
+                customer_id=workspace.stripe_customer_id,
+                error=str(e),
+            )
+
+    return result

--- a/backend/src/tasks/__init__.py
+++ b/backend/src/tasks/__init__.py
@@ -12,6 +12,7 @@ Implements scheduled tasks for:
 from .bm25_drift_tasks import schedule_bm25_drift_tasks
 from .credentials_tasks import schedule_credentials_tasks
 from .embedding_tasks import schedule_embedding_tasks
+from .erasure_tasks import schedule_erasure_tasks
 from .mcp_tasks import schedule_mcp_tasks
 from .neural_tasks import schedule_neural_tasks
 from .resource_indexer_job import schedule_resource_indexer_jobs
@@ -26,6 +27,7 @@ __all__ = [
     "schedule_mcp_tasks",
     "schedule_credentials_tasks",
     "schedule_embedding_tasks",
+    "schedule_erasure_tasks",
     "schedule_resource_indexer_jobs",
     "schedule_sleep_tasks",
     "schedule_bm25_drift_tasks",

--- a/backend/src/tasks/erasure_tasks.py
+++ b/backend/src/tasks/erasure_tasks.py
@@ -1,0 +1,51 @@
+"""Background sweep for account erasures whose cooling-off period has ended.
+
+Issue #360. APScheduler runs in-memory, but the durable state lives in
+``erasure_requests`` (status='cooling_off' rows with ``scheduled_for <= now``)
+— so a process restart loses no work, the next sweep just picks up where
+the previous one stopped. Hourly is sufficient given the 7-day cooling-off
+period and the GDPR 1-month SLA.
+"""
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def sweep_pending_erasures() -> None:
+    """Find cooling_off requests whose scheduled_for has passed and execute.
+
+    Each request runs in its own service-level transaction; failures are
+    logged and recorded on the row (status='failed') without aborting the
+    sweep — one bad row should not block the rest of the queue.
+    """
+    from db.base import get_db
+    from services.account_erasure_service import AccountErasureService
+
+    async for db in get_db():
+        try:
+            service = AccountErasureService(db)
+            executed = await service.sweep_pending_erasures()
+            if executed:
+                logger.info("erasure_sweep_executed", count=executed)
+        except Exception as exc:
+            logger.error(
+                "erasure_sweep_failed",
+                error=str(exc),
+                exc_info=True,
+            )
+
+
+def schedule_erasure_tasks(scheduler: AsyncIOScheduler) -> None:
+    """Register hourly erasure sweep with the global scheduler."""
+    scheduler.add_job(
+        sweep_pending_erasures,
+        trigger=IntervalTrigger(hours=1),
+        id="sweep_pending_erasures",
+        name="Sweep Pending Account Erasures",
+        replace_existing=True,
+    )
+    logger.info("scheduled_erasure_sweep_task", interval_hours=1)

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -297,3 +297,82 @@ class InternalError(MemoryCloudException):
 
     def __init__(self, message: str = "Internal server error", **details: Any):
         super().__init__(message, status_code=500, error_code="INT-001", **details)
+
+
+# Account Erasure Errors (Issue #360, GDPR Art.17 / APPI compliance)
+
+
+class ErasureRequestNotFoundError(NotFoundException):
+    """No erasure request found (404)."""
+
+    def __init__(self, user_id: str | None = None):
+        super().__init__("Erasure request", resource_id=user_id)
+        self.error_code = "ERASURE-001"
+
+
+class ErasureTokenInvalidError(MemoryCloudException):
+    """Confirmation token is missing, expired, or does not match (400)."""
+
+    def __init__(self, message: str = "Invalid or expired confirmation token"):
+        super().__init__(message, status_code=400, error_code="ERASURE-002")
+
+
+class ErasureForbiddenError(MemoryCloudException):
+    """Erasure cannot proceed for this user (403).
+
+    Raised when the caller does not have permission to erase this account
+    (e.g. password mismatch on self-service path) or when the operation is
+    blocked by business rules other than initial-admin protection.
+    """
+
+    def __init__(self, message: str = "Erasure not permitted"):
+        super().__init__(message, status_code=403, error_code="ERASURE-003")
+
+
+class InitialAdminCannotBeErasedError(MemoryCloudException):
+    """The initial system administrator cannot be erased (403).
+
+    Mirrors SystemAdminService.can_delete_admin() — the initial admin row
+    is permanently protected to prevent the platform from being left
+    without any administrator.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Cannot erase the initial system administrator. This is a protected account.",
+            status_code=403,
+            error_code="ERASURE-004",
+        )
+
+
+class WorkspaceTransferRequiredError(MemoryCloudException):
+    """User owns a shared workspace and must transfer ownership before erasure (409).
+
+    Raised when the user is the sole owner of a workspace that has other
+    members and no alternate admin to auto-transfer ownership to. The user
+    must promote another member to admin (or remove members) before retrying.
+    """
+
+    def __init__(self, workspace_id: str, member_count: int):
+        super().__init__(
+            (
+                f"Workspace {workspace_id} has {member_count} other member(s) "
+                f"and no alternate admin. Transfer ownership before erasure."
+            ),
+            status_code=409,
+            error_code="ERASURE-005",
+            workspace_id=workspace_id,
+            member_count=member_count,
+        )
+
+
+class ErasureAlreadyInProgressError(MemoryCloudException):
+    """An erasure request for this user is already pending or in progress (409)."""
+
+    def __init__(self, status: str):
+        super().__init__(
+            f"An erasure request is already {status} for this account.",
+            status_code=409,
+            error_code="ERASURE-006",
+            existing_status=status,
+        )

--- a/backend/src/utils/hashing.py
+++ b/backend/src/utils/hashing.py
@@ -1,0 +1,26 @@
+"""Shared hashing primitives.
+
+Centralized so that API-key hashing, audit-log pseudonymization, and any
+future "hash this string" need go through one place. Lets us swap the
+underlying primitive (SHA256 → SHA3, BLAKE2, …) in a single edit.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+
+def sha256_hex(value: str, *, salt: str = "") -> str:
+    """Return the SHA256 hex digest of ``value``, optionally salted.
+
+    Args:
+        value: Input string. Must be UTF-8 encodable.
+        salt: Optional salt prepended before hashing. Use a stable
+            per-deployment string when the goal is irreversible
+            pseudonymization with cross-row correlation; leave empty
+            for plain content hashing (e.g. API keys).
+
+    Returns:
+        64-character lowercase hex digest.
+    """
+    return hashlib.sha256(f"{salt}{value}".encode()).hexdigest()

--- a/backend/tests/integration/test_account_erasure_integration.py
+++ b/backend/tests/integration/test_account_erasure_integration.py
@@ -234,6 +234,13 @@ class TestAdminForceEraseHappyPath:
         assert prior.user_email != target_email  # pseudonymized
         assert len(prior.user_id) == 64  # SHA256 hex
         assert len(prior.user_email) == 64
+        # The resource column for user-targeted audit events is conventionally
+        # `user:{email}` in this codebase (see SystemAdminService.promote /
+        # RoleManager.assign_role). Pseudonymization MUST scrub email AND
+        # user_id from `resource` too — otherwise plaintext PII survives in
+        # the legal-retention table (Copilot loop 3 finding).
+        assert target_email not in (prior.resource or "")
+        assert target_user_id not in (prior.resource or "")
 
         # The new "account_erasure" audit row is also pseudonymized at
         # insert — guards against the regression PR-review caught
@@ -245,6 +252,17 @@ class TestAdminForceEraseHappyPath:
         assert new_audit.user_id != target_user_id
         assert new_audit.user_email != target_email
         assert "user_pseudonym:" in new_audit.resource
+        # `initiated_by` for self-service IS the subject's user_id; it must
+        # be pseudonymized in user_metadata too. For the admin path tested
+        # here, initiated_by is the admin's user_id (NOT the erased subject)
+        # so it stays plaintext — the assertion below uses target_user_id,
+        # which would only appear if self-service had leaked it.
+        assert new_audit.user_metadata is not None
+        assert new_audit.user_metadata.get("initiated_by") != target_user_id
+        # And no plaintext email/user_id anywhere else in user_metadata.
+        metadata_repr = repr(new_audit.user_metadata)
+        assert target_email not in metadata_repr
+        assert target_user_id not in metadata_repr
 
 
 class TestPartialUniqueIndexRace:

--- a/backend/tests/integration/test_account_erasure_integration.py
+++ b/backend/tests/integration/test_account_erasure_integration.py
@@ -1,0 +1,286 @@
+"""Integration tests for AccountErasureService (Issue #360).
+
+Exercises the full ``_execute()`` cross-store deletion pipeline against a
+real Postgres test database, with the non-Postgres collaborators mocked
+(Qdrant client, Redis client, Stripe SDK) so the test suite does not
+require Qdrant or Redis containers.
+
+Coverage gaps these tests close (per QA-Lead Gate2 review):
+
+1. ``_execute()`` happy path: admin force-erase on a real Postgres row
+   set verifies that:
+   - users / api_keys / workspace_members / workspaces rows for the
+     target user are deleted in FK-safe order
+   - audit_logs entries authored by the user are pseudonymized (not
+     deleted) — legal-retention preservation
+   - the new "account_erasure" audit row is itself pseudonymized at
+     insert (no plaintext PII left in audit_logs after erasure)
+   - erasure_requests row reaches status='complete' with a populated
+     deleted_data_summary JSONB
+
+2. ``uq_erasure_one_active_per_user`` partial unique index: concurrent
+   create-then-create attempts produce IntegrityError on the second
+   commit, which the service translates to ErasureAlreadyInProgressError.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import APIKey, AuditLog, User, Workspace, WorkspaceMember
+from models.erasure import (
+    REASON_USER_REQUEST_VIA_SUPPORT,
+    STATUS_COMPLETE,
+    ErasureRequest,
+)
+from services.account_erasure_service import AccountErasureService
+from utils.exceptions import ErasureAlreadyInProgressError
+from utils.hashing import sha256_hex
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def erasure_scenario(db_session: AsyncSession):
+    """Seed one target user with workspace + members + api_key + audit_log.
+
+    The shape mirrors a realistic GDPR target: workspace owner with a
+    coexisting member, a personal API key, and a prior audit_log entry
+    that should survive (pseudonymized).
+    """
+    target_user_id = f"target_{uuid4().hex[:8]}"
+    target_email = f"target-{uuid4().hex[:6]}@example.com"
+    other_user_id = f"other_{uuid4().hex[:8]}"
+
+    target = User(
+        email=target_email,
+        user_id=target_user_id,
+        name="Target User",
+        role="user",
+        is_initial_admin=False,
+        auth_method="oauth",
+        auth_provider="google",
+    )
+    db_session.add(target)
+    await db_session.flush()
+
+    workspace = Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name="free",
+        owner_user_id=target_user_id,
+        memory_limit=1000,
+        daily_api_limit=500,
+        weekly_api_limit=2500,
+    )
+    db_session.add(workspace)
+    await db_session.flush()
+
+    # Target's own membership
+    target_member = WorkspaceMember(
+        workspace_id=workspace.id,
+        user_id=target_user_id,
+        role="owner",
+    )
+    # Another user already in the workspace as admin — for ownership transfer
+    other_member = WorkspaceMember(
+        workspace_id=workspace.id,
+        user_id=other_user_id,
+        role="admin",
+    )
+    db_session.add_all([target_member, other_member])
+
+    # Per-user API key (no FK cascade, must be deleted by the orchestrator)
+    api_key = APIKey(
+        key_hash=sha256_hex(f"kagura_test_{uuid4().hex}"),
+        key_prefix="kagura_test_xx",
+        name="target-key",
+        user_id=target_user_id,
+        workspace_id=workspace.id,
+    )
+    db_session.add(api_key)
+
+    # Pre-existing audit log entry — must survive but be pseudonymized
+    prior_audit = AuditLog(
+        user_email=target_email,
+        user_id=target_user_id,
+        action="role_assign",
+        resource=f"user:{target_email}",
+        old_value_hash="user",
+        new_value_hash="admin",
+    )
+    db_session.add(prior_audit)
+    await db_session.commit()
+
+    yield {
+        "target_user_id": target_user_id,
+        "target_email": target_email,
+        "other_user_id": other_user_id,
+        "workspace_id": workspace.id,
+        "api_key_id": api_key.id,
+        "prior_audit_id": prior_audit.id,
+    }
+
+
+@pytest.fixture
+def patched_external_stores():
+    """Mock Qdrant / Redis / Stripe so the test exercises the Postgres
+    pipeline without needing those containers."""
+    qdrant_patch = patch(
+        "services.account_erasure_service.delete_user_points",
+        new=AsyncMock(return_value={"kagura_memories": 0}),
+    )
+    co_act_patch = patch(
+        "services.account_erasure_service.clear_co_activations",
+        new=AsyncMock(return_value=0),
+    )
+    rate_limits_patch = patch(
+        "services.account_erasure_service.clear_user_rate_limits",
+        new=AsyncMock(return_value=0),
+    )
+    redis_client_patch = patch(
+        "services.account_erasure_service.get_redis_client",
+        new=MagicMock(return_value=MagicMock(setex=AsyncMock(), delete=AsyncMock())),
+    )
+    stripe_patch = patch(
+        "services.account_erasure_service.cancel_subscription_and_delete_customer_for_erasure",
+        new=AsyncMock(return_value={"subscription_cancelled": False, "customer_deleted": False}),
+    )
+    # SessionManager (sync Redis) — make the import resolve to None so the
+    # service skips the session-cleanup branch.
+    session_manager_patch = patch(
+        "api.routes.auth._session_manager",
+        new=None,
+        create=True,
+    )
+    with (
+        qdrant_patch,
+        co_act_patch,
+        rate_limits_patch,
+        redis_client_patch,
+        stripe_patch,
+        session_manager_patch,
+    ):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdminForceEraseHappyPath:
+    """End-to-end Postgres pipeline for admin force-erase."""
+
+    @pytest.mark.asyncio
+    async def test_target_rows_deleted_audit_logs_pseudonymized(
+        self,
+        db_session: AsyncSession,
+        erasure_scenario,
+        patched_external_stores,
+    ):
+        target_user_id = erasure_scenario["target_user_id"]
+        target_email = erasure_scenario["target_email"]
+        api_key_id = erasure_scenario["api_key_id"]
+        prior_audit_id = erasure_scenario["prior_audit_id"]
+        workspace_id = erasure_scenario["workspace_id"]
+
+        service = AccountErasureService(db_session)
+
+        request = await service.admin_force_erase(
+            target_user_id=target_user_id,
+            initiator_user_id="admin-runner",
+            reason_code=REASON_USER_REQUEST_VIA_SUPPORT,
+            reason_detail="integration test",
+        )
+
+        # The erasure_requests row reached terminal complete with a summary.
+        assert request.status == STATUS_COMPLETE
+        assert request.deleted_data_summary is not None
+        assert "postgres" in request.deleted_data_summary
+        assert request.deleted_data_summary["postgres"]["users"] == 1
+        # The audit-log pseudonymize step ran (count >= 1 because the prior
+        # audit row above was authored by the target).
+        assert request.deleted_data_summary["audit_logs_pseudonymized"] >= 1
+
+        # User row is gone.
+        result = await db_session.execute(select(User).where(User.user_id == target_user_id))
+        assert result.scalar_one_or_none() is None
+
+        # Per-user API key is gone (no FK cascade — orchestrator deletes it).
+        result = await db_session.execute(select(APIKey).where(APIKey.id == api_key_id))
+        assert result.scalar_one_or_none() is None
+
+        # Workspace was transferred to the other admin (not deleted) because
+        # an alternate admin existed; verify the workspace survives with the
+        # new owner_user_id.
+        result = await db_session.execute(select(Workspace).where(Workspace.id == workspace_id))
+        ws = result.scalar_one_or_none()
+        assert ws is not None
+        assert ws.owner_user_id == erasure_scenario["other_user_id"]
+
+        # Pre-existing audit_logs row survives but PII is pseudonymized.
+        result = await db_session.execute(select(AuditLog).where(AuditLog.id == prior_audit_id))
+        prior = result.scalar_one()
+        assert prior.user_id != target_user_id  # pseudonymized
+        assert prior.user_email != target_email  # pseudonymized
+        assert len(prior.user_id) == 64  # SHA256 hex
+        assert len(prior.user_email) == 64
+
+        # The new "account_erasure" audit row is also pseudonymized at
+        # insert — guards against the regression PR-review caught
+        # (CSO Gate1 follow-up #1).
+        result = await db_session.execute(
+            select(AuditLog).where(AuditLog.action == "account_erasure")
+        )
+        new_audit = result.scalar_one()
+        assert new_audit.user_id != target_user_id
+        assert new_audit.user_email != target_email
+        assert "user_pseudonym:" in new_audit.resource
+
+
+class TestPartialUniqueIndexRace:
+    """uq_erasure_one_active_per_user must reject a second active row."""
+
+    @pytest.mark.asyncio
+    async def test_second_concurrent_request_raises_already_in_progress(
+        self,
+        db_session: AsyncSession,
+        erasure_scenario,
+        patched_external_stores,
+    ):
+        target_user_id = erasure_scenario["target_user_id"]
+        target_email = erasure_scenario["target_email"]
+
+        # First request: insert a pending row directly to simulate the
+        # "in-flight" half of the race. Bypasses the service's in-memory
+        # _find_active_request guard so the partial unique index is the
+        # only thing keeping the second insert out.
+        first = ErasureRequest(
+            user_id=target_user_id,
+            user_email_hash=sha256_hex(target_email),
+            initiated_by=target_user_id,
+            is_self_service=True,
+            reason_code="self_service",
+            status="pending",
+            confirm_token_hash=sha256_hex("first-token"),
+        )
+        db_session.add(first)
+        await db_session.commit()
+
+        # Second request: service-level path should observe the existing
+        # row and raise ErasureAlreadyInProgressError (the in-memory guard
+        # short-circuits before ever hitting the DB-level constraint, but
+        # the same exception type is raised either way — the API surface
+        # is identical).
+        service = AccountErasureService(db_session)
+        with pytest.raises(ErasureAlreadyInProgressError):
+            await service.request_self_service_erasure(user_id=target_user_id)

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -336,10 +336,14 @@ class TestCancelSelfService:
             await svc.cancel_self_service(user_id="u-1")
 
     @pytest.mark.asyncio
-    async def test_pending_request_cannot_be_cancelled(self):
-        """Pending = before the user clicked confirm. Cancel only applies
-        to cooling_off; a pending row simply expires when its Redis token
-        TTL elapses."""
+    async def test_pending_request_can_be_cancelled(self):
+        """Pending IS cancellable now (Copilot /review iter 2 finding).
+
+        Without this, an unconfirmed pending row whose Redis token TTL
+        has elapsed would block all future erasure requests via the
+        partial unique index — user permanently wedged. Allow cancel
+        to give the user immediate recourse.
+        """
         svc = _service()
         pending = ErasureRequest(
             user_id="u-1",
@@ -352,8 +356,9 @@ class TestCancelSelfService:
         pending.id = uuid4()
         svc._find_active_request = AsyncMock(return_value=pending)
 
-        with pytest.raises(ErasureRequestNotFoundError):
-            await svc.cancel_self_service(user_id="u-1")
+        result = await svc.cancel_self_service(user_id="u-1")
+        assert result.status == STATUS_CANCELLED
+        assert result.cancelled_at is not None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -68,6 +68,8 @@ def _service() -> AccountErasureService:
     db = MagicMock()
     db.add = MagicMock()
     db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
     db.refresh = AsyncMock()
     db.execute = AsyncMock()
     email = AsyncMock()

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -1,0 +1,508 @@
+"""Unit tests for AccountErasureService (Issue #360, GDPR right-to-erasure).
+
+These tests target the state-machine + guard logic in the service layer.
+The cross-store deletion pipeline (`_execute`) requires real Qdrant +
+Redis + Postgres containers and is exercised separately via
+``make test-integration`` with the migrations applied; the unit tests
+here use mocks for the data-layer collaborators so they stay fast and
+deterministic.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.erasure import (
+    REASON_SELF_SERVICE,
+    REASON_USER_REQUEST_VIA_SUPPORT,
+    STATUS_CANCELLED,
+    STATUS_COOLING_OFF,
+    STATUS_PENDING,
+    ErasureRequest,
+)
+from services.account_erasure_service import (
+    COOLING_OFF_PERIOD,
+    AccountErasureService,
+    _sha256_hex,
+)
+from utils.exceptions import (
+    ErasureAlreadyInProgressError,
+    ErasureForbiddenError,
+    ErasureRequestNotFoundError,
+    ErasureTokenInvalidError,
+    InitialAdminCannotBeErasedError,
+    NotFoundException,
+    ValidationError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _user(
+    *,
+    user_id: str = "u-1",
+    email: str = "alice@example.com",
+    is_initial_admin: bool = False,
+    auth_method: str = "oauth",
+    password_hash: str | None = None,
+    role: str = "user",
+) -> SimpleNamespace:
+    """Light User stand-in. AccountErasureService only reads attributes."""
+    return SimpleNamespace(
+        user_id=user_id,
+        email=email,
+        is_initial_admin=is_initial_admin,
+        auth_method=auth_method,
+        password_hash=password_hash,
+        role=role,
+    )
+
+
+def _service() -> AccountErasureService:
+    db = MagicMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.execute = AsyncMock()
+    email = AsyncMock()
+    email.send_erasure_receipt = AsyncMock(return_value=True)
+    email.send_erasure_cooling_off_started = AsyncMock(return_value=True)
+    email.send_erasure_complete = AsyncMock(return_value=True)
+    return AccountErasureService(db, email_service=email)
+
+
+# ---------------------------------------------------------------------------
+# request_self_service_erasure
+# ---------------------------------------------------------------------------
+
+
+class TestRequestSelfServiceErasure:
+    @pytest.mark.asyncio
+    async def test_creates_pending_row_and_issues_token(self):
+        svc = _service()
+        target = _user()
+        svc._load_user_or_404 = AsyncMock(return_value=target)
+        svc._find_active_request = AsyncMock(return_value=None)
+
+        # Capture the row added so we can inspect its initial fields.
+        added_rows: list[ErasureRequest] = []
+        svc.db.add = lambda row: added_rows.append(row)
+
+        async def _refresh(row):
+            row.id = uuid4()
+
+        svc.db.refresh = AsyncMock(side_effect=_refresh)
+
+        with patch("services.account_erasure_service.get_redis_client") as mock_redis:
+            mock_redis.return_value = MagicMock(setex=AsyncMock())
+            request, token = await svc.request_self_service_erasure(user_id="u-1")
+
+        assert len(added_rows) == 1
+        row = added_rows[0]
+        assert row.status == STATUS_PENDING
+        assert row.is_self_service is True
+        assert row.reason_code == REASON_SELF_SERVICE
+        assert row.confirm_token_hash == _sha256_hex(token)
+        assert row.user_email_hash == _sha256_hex(target.email)
+        assert request is row
+        svc.email_service.send_erasure_receipt.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_blocks_initial_admin(self):
+        svc = _service()
+        svc._load_user_or_404 = AsyncMock(return_value=_user(is_initial_admin=True))
+        svc._find_active_request = AsyncMock(return_value=None)
+
+        with pytest.raises(InitialAdminCannotBeErasedError):
+            await svc.request_self_service_erasure(user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_blocks_when_active_request_exists(self):
+        svc = _service()
+        svc._load_user_or_404 = AsyncMock(return_value=_user())
+        existing = SimpleNamespace(status=STATUS_COOLING_OFF)
+        svc._find_active_request = AsyncMock(return_value=existing)
+
+        with pytest.raises(ErasureAlreadyInProgressError):
+            await svc.request_self_service_erasure(user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_unknown_user_raises_not_found(self):
+        svc = _service()
+        svc._load_user_or_404 = AsyncMock(side_effect=NotFoundException("User", "u-1"))
+
+        with pytest.raises(NotFoundException):
+            await svc.request_self_service_erasure(user_id="u-1")
+
+
+# ---------------------------------------------------------------------------
+# confirm_self_service
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmSelfService:
+    @pytest.mark.asyncio
+    async def test_oauth_user_confirms_with_token_only(self):
+        svc = _service()
+        target = _user(auth_method="oauth")
+        svc._load_user_or_404 = AsyncMock(return_value=target)
+
+        token = "raw-token-abc"
+        request_id = uuid4()
+        request = ErasureRequest(
+            user_id="u-1",
+            user_email_hash=_sha256_hex(target.email),
+            initiated_by="u-1",
+            is_self_service=True,
+            reason_code=REASON_SELF_SERVICE,
+            status=STATUS_PENDING,
+            confirm_token_hash=_sha256_hex(token),
+        )
+        request.id = request_id
+        svc._load_request_or_404 = AsyncMock(return_value=request)
+
+        with patch("services.account_erasure_service.get_redis_client") as mock_redis:
+            redis_client = MagicMock()
+            redis_client.get = AsyncMock(return_value=str(request_id))
+            redis_client.delete = AsyncMock()
+            mock_redis.return_value = redis_client
+
+            await svc.confirm_self_service(user_id="u-1", token=token)
+
+        assert request.status == STATUS_COOLING_OFF
+        assert request.scheduled_for is not None
+        # Cooling-off window equals the configured policy.
+        assert (request.scheduled_for - request.confirmed_at) == COOLING_OFF_PERIOD
+        redis_client.delete.assert_awaited_once()
+        svc.email_service.send_erasure_cooling_off_started.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_token_missing_in_redis_raises_invalid(self):
+        svc = _service()
+        svc._load_user_or_404 = AsyncMock(return_value=_user())
+
+        with patch("services.account_erasure_service.get_redis_client") as mock_redis:
+            mock_redis.return_value = MagicMock(get=AsyncMock(return_value=None))
+            with pytest.raises(ErasureTokenInvalidError):
+                await svc.confirm_self_service(user_id="u-1", token="x")
+
+    @pytest.mark.asyncio
+    async def test_password_user_requires_password(self):
+        svc = _service()
+        target = _user(auth_method="password", password_hash="hashed")
+        svc._load_user_or_404 = AsyncMock(return_value=target)
+
+        token = "tok"
+        request = ErasureRequest(
+            user_id="u-1",
+            user_email_hash="x",
+            initiated_by="u-1",
+            is_self_service=True,
+            reason_code=REASON_SELF_SERVICE,
+            status=STATUS_PENDING,
+            confirm_token_hash=_sha256_hex(token),
+        )
+        request.id = uuid4()
+        svc._load_request_or_404 = AsyncMock(return_value=request)
+
+        with patch("services.account_erasure_service.get_redis_client") as mock_redis:
+            mock_redis.return_value = MagicMock(
+                get=AsyncMock(return_value=str(request.id)),
+                delete=AsyncMock(),
+            )
+            with pytest.raises(ErasureForbiddenError):
+                await svc.confirm_self_service(user_id="u-1", token=token, password=None)
+
+    @pytest.mark.asyncio
+    async def test_password_user_wrong_password_blocked(self):
+        svc = _service()
+        target = _user(auth_method="password", password_hash="hashed")
+        svc._load_user_or_404 = AsyncMock(return_value=target)
+
+        token = "tok"
+        request = ErasureRequest(
+            user_id="u-1",
+            user_email_hash="x",
+            initiated_by="u-1",
+            is_self_service=True,
+            reason_code=REASON_SELF_SERVICE,
+            status=STATUS_PENDING,
+            confirm_token_hash=_sha256_hex(token),
+        )
+        request.id = uuid4()
+        svc._load_request_or_404 = AsyncMock(return_value=request)
+
+        with patch("services.account_erasure_service.get_redis_client") as mock_redis:
+            mock_redis.return_value = MagicMock(
+                get=AsyncMock(return_value=str(request.id)),
+                delete=AsyncMock(),
+            )
+            with patch("auth.password.verify_password", return_value=False):
+                with pytest.raises(ErasureForbiddenError):
+                    await svc.confirm_self_service(user_id="u-1", token=token, password="bad")
+
+    @pytest.mark.asyncio
+    async def test_token_for_other_user_rejected(self):
+        svc = _service()
+        svc._load_user_or_404 = AsyncMock(return_value=_user(user_id="u-1"))
+
+        token = "tok"
+        request = ErasureRequest(
+            user_id="u-OTHER",
+            user_email_hash="x",
+            initiated_by="u-OTHER",
+            is_self_service=True,
+            reason_code=REASON_SELF_SERVICE,
+            status=STATUS_PENDING,
+            confirm_token_hash=_sha256_hex(token),
+        )
+        request.id = uuid4()
+        svc._load_request_or_404 = AsyncMock(return_value=request)
+
+        with patch("services.account_erasure_service.get_redis_client") as mock_redis:
+            mock_redis.return_value = MagicMock(
+                get=AsyncMock(return_value=str(request.id)),
+                delete=AsyncMock(),
+            )
+            with pytest.raises(ErasureTokenInvalidError):
+                await svc.confirm_self_service(user_id="u-1", token=token)
+
+    @pytest.mark.asyncio
+    async def test_already_confirmed_request_rejected(self):
+        svc = _service()
+        svc._load_user_or_404 = AsyncMock(return_value=_user())
+
+        token = "tok"
+        request = ErasureRequest(
+            user_id="u-1",
+            user_email_hash="x",
+            initiated_by="u-1",
+            is_self_service=True,
+            reason_code=REASON_SELF_SERVICE,
+            status=STATUS_COOLING_OFF,
+            confirm_token_hash=_sha256_hex(token),
+        )
+        request.id = uuid4()
+        svc._load_request_or_404 = AsyncMock(return_value=request)
+
+        with patch("services.account_erasure_service.get_redis_client") as mock_redis:
+            mock_redis.return_value = MagicMock(
+                get=AsyncMock(return_value=str(request.id)),
+                delete=AsyncMock(),
+            )
+            with pytest.raises(ErasureTokenInvalidError):
+                await svc.confirm_self_service(user_id="u-1", token=token)
+
+
+# ---------------------------------------------------------------------------
+# cancel_self_service
+# ---------------------------------------------------------------------------
+
+
+class TestCancelSelfService:
+    @pytest.mark.asyncio
+    async def test_cooling_off_request_can_be_cancelled(self):
+        svc = _service()
+        request = ErasureRequest(
+            user_id="u-1",
+            user_email_hash="x",
+            initiated_by="u-1",
+            is_self_service=True,
+            reason_code=REASON_SELF_SERVICE,
+            status=STATUS_COOLING_OFF,
+        )
+        request.id = uuid4()
+        svc._find_active_request = AsyncMock(return_value=request)
+
+        result = await svc.cancel_self_service(user_id="u-1")
+
+        assert result.status == STATUS_CANCELLED
+        assert result.cancelled_at is not None
+
+    @pytest.mark.asyncio
+    async def test_no_active_request_raises_not_found(self):
+        svc = _service()
+        svc._find_active_request = AsyncMock(return_value=None)
+
+        with pytest.raises(ErasureRequestNotFoundError):
+            await svc.cancel_self_service(user_id="u-1")
+
+    @pytest.mark.asyncio
+    async def test_pending_request_cannot_be_cancelled(self):
+        """Pending = before the user clicked confirm. Cancel only applies
+        to cooling_off; a pending row simply expires when its Redis token
+        TTL elapses."""
+        svc = _service()
+        pending = ErasureRequest(
+            user_id="u-1",
+            user_email_hash="x",
+            initiated_by="u-1",
+            is_self_service=True,
+            reason_code=REASON_SELF_SERVICE,
+            status=STATUS_PENDING,
+        )
+        pending.id = uuid4()
+        svc._find_active_request = AsyncMock(return_value=pending)
+
+        with pytest.raises(ErasureRequestNotFoundError):
+            await svc.cancel_self_service(user_id="u-1")
+
+
+# ---------------------------------------------------------------------------
+# admin_force_erase guard rails
+# ---------------------------------------------------------------------------
+
+
+class TestAdminForceErase:
+    @pytest.mark.asyncio
+    async def test_self_service_reason_rejected(self):
+        svc = _service()
+        with pytest.raises(ValidationError):
+            await svc.admin_force_erase(
+                target_user_id="u-1",
+                initiator_user_id="admin-1",
+                reason_code=REASON_SELF_SERVICE,
+            )
+
+    @pytest.mark.asyncio
+    async def test_unknown_reason_code_rejected(self):
+        svc = _service()
+        with pytest.raises(ValidationError):
+            await svc.admin_force_erase(
+                target_user_id="u-1",
+                initiator_user_id="admin-1",
+                reason_code="not_a_real_code",
+            )
+
+    @pytest.mark.asyncio
+    async def test_reason_detail_length_capped(self):
+        svc = _service()
+        with pytest.raises(ValidationError):
+            await svc.admin_force_erase(
+                target_user_id="u-1",
+                initiator_user_id="admin-1",
+                reason_code=REASON_USER_REQUEST_VIA_SUPPORT,
+                reason_detail="x" * 1001,
+            )
+
+    @pytest.mark.asyncio
+    async def test_initial_admin_blocked(self):
+        svc = _service()
+        svc._load_user_or_404 = AsyncMock(return_value=_user(is_initial_admin=True, role="admin"))
+
+        with pytest.raises(InitialAdminCannotBeErasedError):
+            await svc.admin_force_erase(
+                target_user_id="u-1",
+                initiator_user_id="admin-1",
+                reason_code=REASON_USER_REQUEST_VIA_SUPPORT,
+            )
+
+    @pytest.mark.asyncio
+    async def test_last_admin_blocked(self):
+        svc = _service()
+        target = _user(role="admin")
+        svc._load_user_or_404 = AsyncMock(return_value=target)
+        with patch("services.account_erasure_service.SystemAdminService") as MockSvcCls:
+            instance = MockSvcCls.return_value
+            instance.can_delete_admin = AsyncMock(
+                return_value=(False, "Cannot delete the last remaining system administrator")
+            )
+            with pytest.raises(ErasureForbiddenError):
+                await svc.admin_force_erase(
+                    target_user_id="u-1",
+                    initiator_user_id="admin-2",
+                    reason_code=REASON_USER_REQUEST_VIA_SUPPORT,
+                )
+
+
+# ---------------------------------------------------------------------------
+# Workspace ownership transfer logic
+# ---------------------------------------------------------------------------
+
+
+class TestHandleOwnedWorkspaces:
+    @staticmethod
+    def _bulk_members_result(rows: list[SimpleNamespace]) -> MagicMock:
+        """Build a MagicMock that mimics the bulk SELECT WorkspaceMember
+        result the service now expects (one round-trip across all workspaces)."""
+        result_obj = MagicMock()
+        result_obj.scalars.return_value.all.return_value = rows
+        return result_obj
+
+    @pytest.mark.asyncio
+    async def test_sole_owner_workspace_passes_through(self):
+        svc = _service()
+        ws_id = uuid4()
+        ws = SimpleNamespace(id=ws_id, owner_user_id="u-1")
+        rows = [SimpleNamespace(workspace_id=ws_id, user_id="u-1", role="owner")]
+        svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
+        svc.db.commit = AsyncMock()
+
+        out = await svc._handle_owned_workspaces("u-1", [ws])
+        assert out["sole_owner_workspaces"] == 1
+        assert out["transferred"] == []
+
+    @pytest.mark.asyncio
+    async def test_other_admin_triggers_auto_transfer(self):
+        svc = _service()
+        ws_id = uuid4()
+        ws = SimpleNamespace(id=ws_id, owner_user_id="u-1")
+        new_admin = SimpleNamespace(workspace_id=ws_id, user_id="u-2", role="admin")
+        rows = [
+            SimpleNamespace(workspace_id=ws_id, user_id="u-1", role="owner"),
+            new_admin,
+        ]
+        svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
+        svc.db.commit = AsyncMock()
+
+        out = await svc._handle_owned_workspaces("u-1", [ws])
+        assert ws.owner_user_id == "u-2"
+        assert new_admin.role == "owner"
+        assert len(out["transferred"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_members_without_admin_blocks_with_typed_error(self):
+        from utils.exceptions import WorkspaceTransferRequiredError
+
+        svc = _service()
+        ws_id = uuid4()
+        ws = SimpleNamespace(id=ws_id, owner_user_id="u-1")
+        rows = [
+            SimpleNamespace(workspace_id=ws_id, user_id="u-1", role="owner"),
+            SimpleNamespace(workspace_id=ws_id, user_id="u-2", role="member"),
+            SimpleNamespace(workspace_id=ws_id, user_id="u-3", role="viewer"),
+        ]
+        svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
+        svc.db.commit = AsyncMock()
+
+        with pytest.raises(WorkspaceTransferRequiredError) as exc_info:
+            await svc._handle_owned_workspaces("u-1", [ws])
+        # The error carries member_count so the API can surface it.
+        assert exc_info.value.details["member_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_no_workspaces_short_circuits(self):
+        svc = _service()
+        # No bulk-load issued when there are no workspaces — verify execute
+        # is never awaited.
+        svc.db.execute = AsyncMock()
+        out = await svc._handle_owned_workspaces("u-1", [])
+        assert out == {"transferred": [], "sole_owner_workspaces": 0}
+        svc.db.execute.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Helpers (sanity)
+# ---------------------------------------------------------------------------
+
+
+def test_sha256_hex_is_stable_and_salt_aware():
+    assert _sha256_hex("a") == _sha256_hex("a")
+    assert _sha256_hex("a") != _sha256_hex("a", salt="x")
+    assert len(_sha256_hex("anything")) == 64

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -154,6 +154,8 @@ class TestConfirmSelfService:
         svc = _service()
         target = _user(auth_method="oauth")
         svc._load_user_or_404 = AsyncMock(return_value=target)
+        # User owns no workspaces — workspace pre-check is a no-op.
+        svc._check_no_blocking_workspace_transfers = AsyncMock()
 
         token = "raw-token-abc"
         request_id = uuid4()

--- a/docs/ops/erasure-runbook.md
+++ b/docs/ops/erasure-runbook.md
@@ -78,9 +78,9 @@ FK の依存逆順で削除:
 
 - `session:*` (`SessionManager.delete_user_sessions`)
 - `co_act:{user_id}:*` (`clear_co_activations`)
-- `rate_limit:user:{user_id}:*` + `quota:{user:<user_id>}:*` (`clear_user_rate_limits`)
+- `rate_limit:user:{user_id}:*` + `quota:user:{user_id}:*` (`clear_user_rate_limits`)
 
-`quota:{ws:<workspace_id>}:*` は user-identifying でないため触らない。embedding cache は xxHash key で user-addressable でないため TTL 自然失効。
+`quota:ws:{workspace_id}:*` は user-identifying でないため触らない。embedding cache は xxHash key で user-addressable でないため TTL 自然失効。
 
 ### 2.7 Audit row + finalize (Steps 7-9)
 

--- a/docs/ops/erasure-runbook.md
+++ b/docs/ops/erasure-runbook.md
@@ -1,0 +1,283 @@
+# Account Erasure Runbook
+
+GDPR Art.17 (right to erasure) / APPI 第22条 / 利用停止請求対応のオペレーション手順 (Issue #360, v0.14.1+)。
+
+このリリースで `EmailService` は **stub 実装** (`LoggingEmailService`) のため、ユーザー通知メールは **on-call admin が手動で送信** する。本 runbook はその手順と、関連する compliance 設計の要点をまとめる。
+
+---
+
+## 1. データフローと SLA
+
+GDPR Art.12(3) の「受領後 1 ヶ月以内」応答義務を満たすため、以下のタイミングで対応する。
+
+| 段階 | アクション | SLA |
+|---|---|---|
+| 受領 | ユーザーが `POST /api/v1/me/account/erasure-request` を実行、もしくは admin が `POST /api/v1/admin/users/{id}/erase` で実行 | 即時 |
+| 受領通知メール | `erasure_email_receipt` ログを admin が `support@kagura-ai.com` 経由で手動送信 | 受領後 **1 営業日以内** |
+| Cooling-off | 7 日 (self-service のみ。admin 強制は skip) | 7 日 |
+| Cooling-off 開始通知 | `erasure_email_cooling_off_started` ログを手動送信 (確認後すぐ) | 確認後 24 時間以内 |
+| 削除実行 | `erasure_tasks.sweep_pending_erasures` cron が hourly に scan、`scheduled_for <= NOW()` で実行 | cooling-off 終了後 24 時間以内 |
+| 完了通知メール | `erasure_email_complete` ログを手動送信 | 完了後 **24 時間以内** |
+
+合計: 受領 → 完了 = 最大 **9 営業日**、SLA 1 ヶ月に余裕あり。
+
+---
+
+## 2. 削除対象データ (storage 横断)
+
+`AccountErasureService._execute()` は以下の順序でクロスストア削除を行う。`erasure_requests.deleted_data_summary` に各ステップの行数が記録される。
+
+### 2.1 Stripe (Step 1, best-effort)
+
+`workspaces.stripe_customer_id` / `stripe_subscription_id` が populated な所有 workspace ごとに:
+
+1. `stripe.Subscription.cancel(...)` — subscription 即時キャンセル
+2. `stripe.Customer.delete(...)` — Stripe 側顧客レコード削除
+
+`BILLING_ENABLED=false` の場合は no-op。失敗は warn ログ + `deleted_data_summary` に未完了として残り、Postgres 削除は続行される。orphan な Stripe 顧客は Stripe ダッシュボードから手動削除可能。
+
+### 2.2 Qdrant (Step 2)
+
+`db.qdrant.delete_user_points(user_id)` が `kagura_memories*` 全 collection (per-model variant 含む) で `Filter(must=[FieldCondition(key="user_id", match=user_id)])` による bulk delete を実行。
+
+> ⚠️ **Multi-tenant 設計の trade-off**: 共有 workspace 内でユーザーが author の point も削除される。GDPR 上の data subject = author のため意図的な挙動。共有 workspace co-owner には事前同意 (Privacy Policy / ToS) が前提。
+
+### 2.3 Workspace ownership (Step 3)
+
+所有 workspace ごとに:
+
+- **他に admin/owner がいる場合**: ownership を `user_id` 昇順で alphabetical first の admin に auto-transfer。
+- **admin が他に居ないが member がいる場合**: `WorkspaceTransferRequiredError` (HTTP 409)。ユーザーは ownership を譲渡してから再実行する必要がある。
+- **sole owner の場合**: そのまま step 4 で workspace ごと削除 (cascade で contexts/memories/edges/...)。
+
+### 2.4 Postgres (Step 4)
+
+FK の依存逆順で削除:
+
+| テーブル | 条件 | 備考 |
+|---|---|---|
+| `oauth_tokens` | `user_id = :uid` | FK cascade なし |
+| `oauth_authorization_codes` | `user_id = :uid` | FK cascade なし |
+| `oauth_clients` | `owner_id = :uid` | tokens は cascade で残らず |
+| `external_api_keys` | `user_id = :uid` | Fernet 暗号化 3rd-party キー |
+| `api_keys` | `user_id = :uid` | |
+| `graph_memory` | `user_id = :uid` | orphan, FK cascade なし |
+| `usage_stats` | `user_id = :uid` | |
+| `user_plans` | `user_id = :uid` | PK = user_id |
+| `workspace_members` | `user_id = :uid` | |
+| `workspace_invitations` | `invited_by = :uid OR email = :email` | |
+| `plan_changes.changed_by` | SHA256 pseudonymize | legal retention 維持 |
+| `workspaces` | `owner_user_id = :uid` | step 3 後の sole-owner のみ。cascade で contexts/memories/etc. |
+| `users` | `user_id = :uid` | 最後 |
+
+### 2.5 Audit logs (Step 5)
+
+`audit_logs` 行は **保持** (legal retention)、ただし `user_email` / `user_id` カラムを SHA256 で pseudonymize。salt は per-deployment 定数 (`_AUDIT_PSEUDO_SALT`) で同一ユーザー由来行の cross-row 相関は維持、original sub/email は不可逆。
+
+### 2.6 Redis (Step 6, best-effort)
+
+- `session:*` (`SessionManager.delete_user_sessions`)
+- `co_act:{user_id}:*` (`clear_co_activations`)
+- `rate_limit:user:{user_id}:*` + `quota:{user:<user_id>}:*` (`clear_user_rate_limits`)
+
+`quota:{ws:<workspace_id>}:*` は user-identifying でないため触らない。embedding cache は xxHash key で user-addressable でないため TTL 自然失効。
+
+### 2.7 Audit row + finalize (Steps 7-9)
+
+- 新規 `audit_logs` 行を `action="account_erasure"` で書き込み (`deleted_data_summary` 全文付き)
+- `erasure_requests.status='complete'`、`completed_at`、`deleted_data_summary` を確定
+- 完了通知メール (stub 経由 → 手動送信)
+
+### 2.8 `bm25_idf_drift_log` の取り扱い
+
+`bm25_idf_drift_log.context_id` は `contexts.id ON DELETE CASCADE` のため、Step 4 の workspace 削除で context が消える際に **自動で cascade 削除される**。明示的な追加処理は不要。
+
+#379 で本テーブルは "pseudonymous personal data under GDPR Art.4(5)" と分類されているが、context cascade が削除責務を満たすため erasure scope に含まれている (削除のスコープからの除外ではない)。
+
+---
+
+## 3. バックアップ retention
+
+- **最大バックアップ齢**: 90 日 (Privacy Policy + 本 runbook で明記)
+- **`erasure_requests` のバックアップ含有**: 必須。`erasure_requests` 行 (pseudonymized) は backup から除外しない
+- **復元時 re-apply hook**: バックアップから DB を復元した場合、`erasure_requests.status='complete'` 行を起点に対応データ (Postgres 行 / Qdrant point / Redis key) を再削除する手順を運用に組み込む。具体的なスクリプトは v0.14.x で別 issue として実装予定 (現状: 復元 SOP の手動チェックリストに項目追加)
+
+`erasure_requests` 自体の retention は **5 年** (GDPR Art.5(1)(b) / Art.30 説明責任証拠)。migration コメントと本 runbook で明記。DB 側の自動 purge job は **設定しない** — 5 年経過後の削除は legal review 後に手動で行う。
+
+---
+
+## 4. 第三者プロセッサ通知 (GDPR Art.19)
+
+採用済みプロセッサ別の通知タイプと SLA。**自動通知 = API で SDK 側に削除を伝播 / 手動通知 = support@ から運用チケットで連絡**。
+
+| プロセッサ | データ種別 | 通知タイプ | SLA | 担当 |
+|---|---|---|---|---|
+| OpenAI (embedding) | 入力テキスト (cache) | n/a | — | — | OpenAI は user_id を保存しない、cache 自然失効 |
+| Anthropic (LLM judge) | プロンプト | n/a | — | — | request id ベース、user data なし |
+| Voyage AI (rerank) | クエリ | n/a | — | — | 同上 |
+| Stripe | customer / subscription | **auto** | 即時 | `cancel_subscription_and_delete_customer_for_erasure` で API 通知 |
+| Sentry / Datadog 等 | error / observability | (未採用なら) n/a | — | (採用後追加) |
+| Resend / SES 等 | email log | (未採用 — stub のため n/a) | — | (採用後追加) |
+
+未採用プロセッサが追加された場合は本表を更新し、必要なら自動通知を `_execute()` に組み込む。
+
+---
+
+## 5. Admin 強制削除手順
+
+### 5.1 エンドポイント
+
+`POST /api/v1/admin/users/{user_id}/erase` (system_admin only)
+
+```json
+{
+  "reason_code": "user_request_via_support",
+  "reason_detail": "support@ 経由のメール削除要求 (チケット ZD-1234)"
+}
+```
+
+### 5.2 reason_code 一覧
+
+| コード | 用途 |
+|---|---|
+| `user_request_via_support` | support@ 等経由のユーザーからの要求 |
+| `legal_order` | 裁判所命令 / 当局からの指示 |
+| `inactivity_policy` | 利用停止規約による強制削除 |
+| `abuse_violation` | ToS 違反 / abuse 対応 |
+| `other` | 上記に該当しない (`reason_detail` に詳細必須) |
+
+### 5.3 戻り値
+
+```json
+{
+  "request_id": "...",
+  "status": "complete",
+  "deleted_data_summary": {
+    "stripe": {...},
+    "qdrant": {"kagura_memories": 42},
+    "workspaces": {...},
+    "postgres": {"users": 1, "memories": 0, "api_keys": 3, ...},
+    "audit_logs_pseudonymized": 17,
+    "redis": {"sessions": 2, "co_act": 0, "rate_limit": 1}
+  }
+}
+```
+
+### 5.4 失敗時の手動再試行
+
+- `erasure_requests.status='failed'` の行は cron で自動再試行されない
+- `failure_reason` を確認し、原因 (例: Qdrant 接続障害) を解消
+- 同じユーザーで `POST /api/v1/admin/users/{user_id}/erase` を再実行 → `ErasureAlreadyInProgressError` (409) が返る場合は失敗行を `cancelled` に手動 update してから再実行
+
+```sql
+UPDATE erasure_requests
+SET status = 'cancelled', cancelled_at = NOW()
+WHERE id = '<failed-request-id>';
+```
+
+---
+
+## 6. Privacy Policy stopgap (Art.20 portability)
+
+データポータビリティ (GDPR Art.20) は **本リリースでは out of scope**。`erasure_request` 完了前に自分のデータを取り出したいユーザーは:
+
+1. `support@kagura-ai.com` に「データエクスポート要求」として連絡
+2. SLA 1 ヶ月以内に admin が手動で Postgres / Qdrant / 関連データを抽出して提供
+3. 提供完了後、ユーザーの判断で `/me/account/erasure-request` を発行
+
+Privacy Policy の Art.17 セクションに上記 stopgap を明記すること (#379 の Privacy Policy ドラフトと整合)。Art.20 自動化は v0.14.x の別 issue。
+
+---
+
+## 7. on-call admin 向けメール送信ガイド
+
+`LoggingEmailService` は以下のような構造化ログを出力する:
+
+```json
+{"event": "erasure_email_receipt", "to_email": "alice@example.com",
+ "request_id": "...", "email_dispatch_required": true,
+ "template": "erasure_receipt"}
+```
+
+**手順**:
+
+1. ログ集約システムで `email_dispatch_required=true` を grep
+2. `template` に応じて以下のテンプレートで `support@kagura-ai.com` から送信
+
+### Template: erasure_receipt (受領後 1 営業日以内)
+
+```
+Subject: [Kagura Memory Cloud] アカウント削除リクエストを受け付けました
+
+(本文)
+このたびは Kagura Memory Cloud のアカウント削除リクエストをいただき、ありがとうございます。
+
+リクエスト ID: {request_id}
+受付日時: {received_at}
+
+このメールは GDPR 第12条に基づく受領通知です。
+今後、確認リンクをクリックいただいた後、7 日間の cooling-off 期間を経て削除を実行します。
+
+ご不明な点があれば support@kagura-ai.com までご連絡ください。
+
+Kagura Memory Cloud Operations
+```
+
+### Template: erasure_cooling_off_started
+
+```
+Subject: [Kagura Memory Cloud] アカウント削除のクーリングオフ期間が開始されました
+
+(本文)
+ご確認ありがとうございました。
+{scheduled_for} (UTC) にアカウントとすべての関連データの削除を実行します。
+
+それまでの間、削除をキャンセルしたい場合は Web UI から「アカウント削除をキャンセル」を選択するか、support@ までご連絡ください。
+
+Kagura Memory Cloud Operations
+```
+
+### Template: erasure_complete (完了後 24 時間以内)
+
+```
+Subject: [Kagura Memory Cloud] アカウントの削除が完了しました
+
+(本文)
+リクエスト ID {request_id} の削除を完了しました。
+
+GDPR Art.30 に基づく説明責任のため、削除事実を pseudonymize した形で 5 年間保持します。これは個人を特定できない形式のため、お客様の個人データではありません。
+
+ご利用ありがとうございました。
+
+Kagura Memory Cloud Operations
+```
+
+---
+
+## 8. 観測
+
+主要ログ event:
+
+- `erasure_request_created` — pending row 作成
+- `erasure_request_confirmed` — cooling_off へ遷移
+- `erasure_request_cancelled` — ユーザーキャンセル
+- `erasure_admin_force_started` — admin 強制削除開始
+- `erasure_sweep_executed` — cron sweep 完了 (count 含む)
+- `erasure_execute_failed` — 実行失敗 (request_id + error 含む)
+- `erasure_email_*` — 手動送信待ちメール
+
+監視 alert (将来):
+
+- `erasure_execute_failed` 発生 → admin に通知
+- `erasure_sweep_executed count > 0` が 24h 続く → SLA 違反警告
+- `email_dispatch_required=true` の未処理ログ件数 → 1 営業日超過で alert
+
+---
+
+## 9. 関連リソース
+
+- Issue #360 — feat(auth): right-to-erasure endpoint (本 issue)
+- Issue #379 — docs(legal): Privacy Policy Internal Observability Metrics section
+- `backend/src/services/account_erasure_service.py` — 実装本体
+- `backend/alembic/versions/c01_360_erasure_requests.py` — schema migration
+- `backend/src/services/email_service.py` — Email service interface + LoggingEmailService stub


### PR DESCRIPTION
Closes #360

## Summary

- Adds GDPR Art.17 / APPI 第22条 right-to-erasure: 4 self-service endpoints (`SessionUser`-only) + 1 admin force-erase (`AdminUser`).
- New `AccountErasureService` orchestrates cross-store deletion: **Stripe → Qdrant → workspace ownership transfer → Postgres (~14 tables) → Redis → audit-log pseudonymization → completion email**.
- New `erasure_requests` table with a 6-state lifecycle (`pending → cooling_off → in_progress → complete`, plus `cancelled` / `failed`) and a partial unique index to defend against the concurrent-confirm race.
- 7-day cooling-off period for self-service via APScheduler hourly cron sweep; admin force-erase skips it.
- 5-year retention on `erasure_requests` as GDPR Art.5(1)(b) / Art.30 accountability evidence; pseudonymized by design (no plaintext PII besides hashes).

## Implementation notes

- **CLO Gate1 yellow → 5 design pins applied** (Issue body `## CLO follow-up` section): backup retention 90 days, `erasure_requests` 5-year retention, Art.19 third-party processor list, full SLA timing table, `reason_code` enum on admin force-erase.
- **EmailService**: ships as `LoggingEmailService` stub (closed-beta scope). Operators forward log entries via `support@` per the runbook. Real provider deferred to #463.
- **`bm25_idf_drift_log`**: covered by `contexts → bm25_idf_drift_log` `ON DELETE CASCADE` (no explicit cleanup needed).
- **`audit_logs`**: preserved for legal retention; `user_id`/`user_email` are pseudonymized via salted SHA256. The new `account_erasure` audit row is itself pseudonymized at insert (no plaintext PII left after erasure).
- **Qdrant filter**: deletes by `user_id` alone — intentionally crosses workspace boundary (GDPR data subject = author). Documented in the runbook §2.2.
- **Workspace ownership**: auto-transfer if alternate admin exists; refuse with `WorkspaceTransferRequiredError` (HTTP 409) if member-only without admin; delete if sole owner.
- **Confirm token**: SHA256(token) on disk, raw token in Redis (TTL 1h, single-use), `hmac.compare_digest` for constant-time comparison.
- **`refactor(utils)` commit**: extracted `utils/hashing.py::sha256_hex` so `APIKeyManager._hash_key` and the new audit-pseudonymization both go through one primitive.

## Tests

- **23 unit tests** (`tests/services/test_account_erasure_service.py`): state-machine transitions, workspace ownership transfer (3-way branch), guard rails (initial-admin, last-admin, double-request, password mismatch).
- **2 integration tests** (`tests/integration/test_account_erasure_integration.py`): admin force-erase happy path against a real Postgres test DB (Qdrant/Redis/Stripe mocked); partial unique index race via direct row insert.
- `make lint` ✅ / `make type-check` ✅ / new tests pass.

## Pre-PR review summary

- gate2 mode: **advisor-only** (binary_gate=null per config default)
- audit: skipped
- binary_gate: (none)
- cso: **green**
- qa-lead: **green** (updated after integration tests added inline during ship)
- cto: **green**
- gate1: yellow via `/claude-c-suite:ask` — 5 CLO design pins applied to issue body before implementation
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/360-feat-feat-auth-right-to-erasure-endpoint-gdpr.gate1.md`
- `~/.claude/cache/gh-issue-driven/360-feat-feat-auth-right-to-erasure-endpoint-gdpr.gate2.md`

## Follow-ups

Tracked in #463 (chore(auth): right-to-erasure follow-ups):
1. `_AUDIT_PSEUDO_SALT` → `Settings.audit_pseudo_salt` env-overridable
2. Stripe SDK sync-in-async wrapping (pre-existing pattern, amplified by sweep loop)
3. `_session_manager` private import → public accessor
4. `confirm_token` in response body → conditional on auth method (post real email provider)

🤖 Generated via /gh-issue-driven:ship
