### PR TITLE
chore(auth): audit_pseudo_salt → Settings + get_session_manager (#463)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,11 @@ JWT_SECRET=change-me-jwt-secret
 JWT_ALGORITHM=HS256
 JWT_EXPIRE_MINUTES=60
 
+# Per-deployment salt for audit_logs pseudonymization on account erasure.
+# Override in production (use: openssl rand -hex 16). Rotating this value
+# breaks cross-correlation between rows pseudonymized before vs after.
+AUDIT_PSEUDO_SALT=kagura-erasure-v1
+
 # -----------------------------------------------------------------------------
 # API Settings
 # -----------------------------------------------------------------------------

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -67,6 +67,16 @@ def initialize_auth_routes(oauth2_manager: OAuth2Manager, session_manager: Sessi
     _session_manager = session_manager
 
 
+def get_session_manager() -> SessionManager | None:
+    """Return the active SessionManager instance (or None if not initialized).
+
+    Use this in code that lives outside ``api.routes.auth`` instead of
+    importing the private ``_session_manager`` module attribute directly.
+    Returns ``None`` if called before :func:`initialize_auth_routes`.
+    """
+    return _session_manager
+
+
 # Models
 class LoginResponse(BaseModel):
     """OAuth2 login response."""

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -51,6 +51,10 @@ class Settings(BaseSettings):
     )
     jwt_algorithm: str = Field(default="HS256", description="JWT algorithm")
     jwt_expire_minutes: int = Field(default=60, description="JWT expiration (minutes)")
+    audit_pseudo_salt: str = Field(
+        default="kagura-erasure-v1",
+        description="Per-deployment salt for audit_logs pseudonymization on account erasure (override in production)",
+    )
 
     # Session
     session_ttl_seconds: int = Field(

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -41,6 +41,7 @@ from sqlalchemy import delete, select, update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from config.settings import get_settings
 from db.qdrant import delete_user_points
 from db.redis import clear_co_activations, clear_user_rate_limits, get_redis_client
 from models.auth import (
@@ -99,14 +100,14 @@ CONFIRM_TOKEN_TTL_SECONDS = 3600
 # column stores SHA256(token); the raw token only ever lives here.
 _CONFIRM_TOKEN_KEY_PREFIX = "erasure_token:"
 
+
 # Salt used when pseudonymizing audit_log rows for an erased user. A
 # stable per-deployment salt (not per-row) lets ops cross-correlate audit
 # rows belonging to the same erased user without revealing the email/sub.
-# In a real deployment the salt would come from settings; for v0.14.1
-# this constant is acceptable because the goal is irreversibility, not
-# rainbow-table protection — once the user row is gone there's nothing to
-# rainbow-attack against.
-_AUDIT_PSEUDO_SALT = "kagura-erasure-v1"
+# Goal is irreversibility, not rainbow-table protection — once the user
+# row is gone there is no plaintext to recover.
+def _audit_salt() -> str:
+    return get_settings().audit_pseudo_salt
 
 
 _sha256_hex = sha256_hex  # backward-compat alias for tests + this module
@@ -870,7 +871,7 @@ class AccountErasureService:
         must survive but the personal-data link to the deleted user must
         not.
         """
-        pseudonym = sha256_hex(user_id, salt=_AUDIT_PSEUDO_SALT)
+        pseudonym = sha256_hex(user_id, salt=_audit_salt())
         result = await self.db.execute(
             update(model).where(column == user_id).values({column: pseudonym})
         )
@@ -906,8 +907,9 @@ class AccountErasureService:
         """
         from sqlalchemy import case, func
 
-        user_pseudonym = sha256_hex(user_id, salt=_AUDIT_PSEUDO_SALT)
-        email_pseudonym = sha256_hex(email, salt=_AUDIT_PSEUDO_SALT)
+        salt = _audit_salt()
+        user_pseudonym = sha256_hex(user_id, salt=salt)
+        email_pseudonym = sha256_hex(email, salt=salt)
         # Replace email first (longer / more specific), then user_id, so a
         # row whose resource contains both is fully scrubbed.
         scrubbed_resource = func.replace(
@@ -935,12 +937,13 @@ class AccountErasureService:
     async def _clear_redis(self, user_id: str) -> dict[str, int]:
         """Best-effort Redis cleanup. Failures are logged inside helpers."""
         # SessionManager uses a sync Redis client — fetch the live instance
-        # via the auth module's getter so we go through the same setup.
-        from api.routes.auth import _session_manager  # type: ignore
+        # via the auth module's public accessor so we go through the same setup.
+        from api.routes.auth import get_session_manager
 
         sessions_deleted = 0
-        if _session_manager is not None:
-            sessions_deleted = _session_manager.delete_user_sessions(user_id)
+        session_manager = get_session_manager()
+        if session_manager is not None:
+            sessions_deleted = session_manager.delete_user_sessions(user_id)
 
         return {
             "sessions": sessions_deleted,
@@ -958,8 +961,9 @@ class AccountErasureService:
         guarantees no plaintext email or user_id ever lands in audit_logs
         for this event — required for GDPR Art.5(1)(c) compliance.
         """
-        user_pseudonym = _sha256_hex(target.user_id, salt=_AUDIT_PSEUDO_SALT)
-        email_pseudonym = _sha256_hex(target.email, salt=_AUDIT_PSEUDO_SALT)
+        salt = _audit_salt()
+        user_pseudonym = _sha256_hex(target.user_id, salt=salt)
+        email_pseudonym = _sha256_hex(target.email, salt=salt)
         # Self-service `initiated_by` IS the subject's raw user_id (the
         # user clicked their own delete button). Storing it verbatim in
         # audit_logs.user_metadata would re-introduce a stable plaintext

--- a/backend/tests/integration/test_account_erasure_integration.py
+++ b/backend/tests/integration/test_account_erasure_integration.py
@@ -154,8 +154,9 @@ def patched_external_stores():
         "services.account_erasure_service.cancel_subscription_and_delete_customer_for_erasure",
         new=AsyncMock(return_value={"subscription_cancelled": False, "customer_deleted": False}),
     )
-    # SessionManager (sync Redis) — make the import resolve to None so the
-    # service skips the session-cleanup branch.
+    # SessionManager: patch the underlying module attribute the public
+    # get_session_manager() accessor reads, forcing the service to skip
+    # the session-cleanup branch.
     session_manager_patch = patch(
         "api.routes.auth._session_manager",
         new=None,

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -515,3 +515,39 @@ def test_sha256_hex_is_stable_and_salt_aware():
     assert _sha256_hex("a") == _sha256_hex("a")
     assert _sha256_hex("a") != _sha256_hex("a", salt="x")
     assert len(_sha256_hex("anything")) == 64
+
+
+# ---------------------------------------------------------------------------
+# AUDIT_PSEUDO_SALT settings sourcing + SessionManager accessor
+# ---------------------------------------------------------------------------
+
+
+def test_audit_salt_reads_from_settings(monkeypatch):
+    """`_audit_salt()` must reflect the active Settings.audit_pseudo_salt."""
+    from services import account_erasure_service
+
+    fake_settings = SimpleNamespace(audit_pseudo_salt="prod-rotated-salt-2026Q2")
+    monkeypatch.setattr(account_erasure_service, "get_settings", lambda: fake_settings)
+
+    assert account_erasure_service._audit_salt() == "prod-rotated-salt-2026Q2"
+
+    pseudo_a = _sha256_hex("u-1", salt=account_erasure_service._audit_salt())
+    monkeypatch.setattr(
+        account_erasure_service,
+        "get_settings",
+        lambda: SimpleNamespace(audit_pseudo_salt="different-salt"),
+    )
+    pseudo_b = _sha256_hex("u-1", salt=account_erasure_service._audit_salt())
+    assert pseudo_a != pseudo_b, "rotating the salt must change downstream pseudonyms"
+
+
+def test_get_session_manager_returns_module_state(monkeypatch):
+    """`get_session_manager()` must expose the live `_session_manager` module attribute."""
+    from api.routes import auth as auth_module
+
+    sentinel = object()
+    monkeypatch.setattr(auth_module, "_session_manager", sentinel)
+    assert auth_module.get_session_manager() is sentinel
+
+    monkeypatch.setattr(auth_module, "_session_manager", None)
+    assert auth_module.get_session_manager() is None


### PR DESCRIPTION
Closes #463 (items 1 + 3 only — items 2 and 4 deferred to follow-up PRs per gate1)

## Summary
- Move `_AUDIT_PSEUDO_SALT` constant to `Settings.audit_pseudo_salt`; default preserves prior hardcoded value byte-for-byte so existing deployments stay deterministic across the upgrade.
- Replace private `_session_manager` import + `# type: ignore` in `account_erasure_service._clear_redis` with a public `get_session_manager()` accessor in `api/routes/auth.py`, mirroring the existing `get_role_manager()` pattern.
- `.env.example` documents `AUDIT_PSEUDO_SALT` with `openssl rand -hex 16` guidance and a rotation warning (rotating breaks cross-correlation of pre/post rows).

## Implementation notes
- `_audit_salt()` helper does the lazy `get_settings().audit_pseudo_salt` read at each pseudonymize-operation site (3 production call sites: `_pseudonymize_field`, `_pseudonymize_audit_logs`, `_write_audit_log`). Two of the three hoist `salt = _audit_salt()` once and reuse — row iteration is in PostgreSQL via `func.replace`, so the helper fires per operation, not per row.
- `get_session_manager()` returns `SessionManager | None` (rather than raising `RuntimeError` like `get_role_manager`) because `_clear_redis` is a best-effort cleanup that legitimately needs to skip when SessionManager is unavailable.
- New unit tests cover the **behavioral guarantee** (downstream pseudonym actually changes when the salt changes), not just the mechanical accessor return.
- Existing integration test still patches `api.routes.auth._session_manager` directly — works correctly because `get_session_manager()` reads that module attribute. Comment updated to make the linkage explicit.

## Scope (per gate1 PR-A/PR-B/PR-C split)
This PR ships **#463 items 1 + 3 only**. Deferred to follow-up PRs:
- **Item 2** (Stripe sync-in-async, all 4 call sites in `stripe_service.py`) — needs an architecture decision between `asyncio.to_thread + isolated executor` vs `stripe.AsyncStripe` migration; larger review surface.
- **Item 4** (`confirm_token` response-body gate for OAuth users) — couples to real email provider migration (`LoggingEmailService` replacement); avoids blocking 1+3 merge.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green — defense-in-depth improvement, no new attack surface, irreversibility preserved for upgrading deployments
- qa-lead: green — behavioral assertion present, edge cases scope-defer-able, no flakiness vectors
- cto: green — abstraction justified, accessor pattern matches `get_role_manager()`, no architectural smells, scope split is correct
- gate1: green via /claude-c-suite:ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/463-feat-chore-auth-right-to-erasure-follow-ups-3.gate1.md`
- `~/.claude/cache/gh-issue-driven/463-feat-chore-auth-right-to-erasure-follow-ups-3.gate2.md`

## Test plan
- [x] `make lint` — passes
- [x] `make type-check` (`pyright src/`) — 0 errors, 0 warnings
- [x] `pytest backend/tests/services/test_account_erasure_service.py` — 27/27 pass (25 prior + 2 new)
- [x] `pytest backend/tests/integration/test_account_erasure_integration.py` — 2/2 pass

🤖 Generated via /gh-issue-driven:ship
