### PR TITLE
fix(frontend): bypass RootPage on logout (Next.js 16 Turbopack TypeError) (#466)

### DIFF
--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 /**
  * Authentication Context
@@ -6,9 +6,19 @@
  * Provides user authentication state and methods throughout the application.
  */
 
-import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
-import { useRouter } from 'next/navigation';
-import { getCurrentUser, logout as logoutApi, type User } from '@/lib/auth/auth';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  ReactNode,
+} from "react";
+import { useRouter } from "next/navigation";
+import {
+  getCurrentUser,
+  logout as logoutApi,
+  type User,
+} from "@/lib/auth/auth";
 
 interface AuthContextType {
   user: User | null;
@@ -27,8 +37,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Mock auth for development (controlled by environment variable)
   const useMockAuth =
-    process.env.NODE_ENV === 'development' &&
-    process.env.NEXT_PUBLIC_ENABLE_MOCK_AUTH === 'true';
+    process.env.NODE_ENV === "development" &&
+    process.env.NEXT_PUBLIC_ENABLE_MOCK_AUTH === "true";
 
   const fetchUser = async () => {
     try {
@@ -36,13 +46,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
       // Use mock user if enabled
       if (useMockAuth) {
-        console.warn('⚠️ MOCK AUTH ENABLED - Development only!');
+        console.warn("⚠️ MOCK AUTH ENABLED - Development only!");
         setUser({
-          id: 'mock-dev-user-001',
-          email: 'dev@localhost',
-          name: 'Developer (Mock)',
-          picture: '',
-          role: 'admin',
+          id: "mock-dev-user-001",
+          email: "dev@localhost",
+          name: "Developer (Mock)",
+          picture: "",
+          role: "admin",
         });
         setIsLoading(false);
         return;
@@ -51,7 +61,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const currentUser = await getCurrentUser();
       setUser(currentUser);
     } catch (error) {
-      console.error('Failed to fetch user:', error);
+      console.error("Failed to fetch user:", error);
       setUser(null);
     } finally {
       setIsLoading(false);
@@ -63,15 +73,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const logout = async () => {
+    // Push to /login directly instead of '/' to bypass the RootPage redirect.
+    // RootPage's synchronous Server Component redirect interacts badly with
+    // Next.js 16 Turbopack perf instrumentation, raising a TypeError on
+    // `performance.measure('​RootPage', ...)` with a negative time stamp
+    // when the navigation happens via client-side router.push.
     try {
       await logoutApi();
       setUser(null);
-      router.push('/');
+      router.push("/login");
     } catch (error) {
-      console.error('Logout failed:', error);
-      // Force logout on frontend even if backend fails
+      console.error("Logout failed:", error);
       setUser(null);
-      router.push('/');
+      router.push("/login");
     }
   };
 
@@ -93,7 +107,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 export function useAuth() {
   const context = useContext(AuthContext);
   if (context === undefined) {
-    throw new Error('useAuth must be used within an AuthProvider');
+    throw new Error("useAuth must be used within an AuthProvider");
   }
   return context;
 }


### PR DESCRIPTION
Closes #466

## Summary
- Push to `/login` directly from `AuthContext.logout()` instead of `/`, bypassing the `RootPage` Server Component whose synchronous `redirect('/login')` triggers Next.js 16 Turbopack's perf instrumentation bug (`Performance.measure('​RootPage', ...)` with a negative time delta → TypeError).
- `RootPage` (`src/app/page.tsx`) is preserved unchanged — it still handles direct unauthenticated visits to `/`. SSR direct-visit path doesn't exercise the client-side instrumentation that fails.

## Implementation notes
- 1-line semantic change: `router.push('/')` → `router.push('/login')` in both the success and failure branches of `AuthContext.logout()`.
- Comment block added at the call site explaining the Turbopack instrumentation interaction so a future reader doesn't "fix" it back to `/` and regress.
- Other logout sites unaffected:
  - `src/app/invite/[token]/page.tsx:177` uses `window.location.reload()` (full reload, not router.push) — different code path.
  - `src/app/(authenticated)/workspace/settings/general/page.tsx:193` calls `useAuth().logout()` so it inherits this fix.

## Drive-by formatter cleanup
The on-save formatter normalized this file's single quotes to double quotes, matching the convention used in every other file under `src/contexts/`, `src/components/`, and `src/lib/`. `AuthContext.tsx` was the single outlier (untouched since the v0.1.0 initial commit). No semantic change beyond the logout target.

## Test plan
- [ ] Manual: log in as Owner, click logout in sidebar, verify no `Performance.measure` TypeError appears in browser console
- [ ] Manual: direct visit to `/` while unauthenticated → still redirects to `/login` (RootPage path)
- [ ] Manual: invite-page email-mismatch logout → still works (different code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)