### PR TITLE
chore: ignore docs/superpowers/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -261,3 +261,4 @@ backend/=*
 backend/uv.lock
 .playwright-mcp/
 .superpowers/
+docs/superpowers/


### PR DESCRIPTION
## Summary

- Adds `docs/superpowers/` to `.gitignore` so personal planning artifacts under that path stay local-only.
- Matches the existing `.superpowers/` ignore pattern (line 263 of `.gitignore`); these are sibling working directories used by the superpowers skill.

## Why now

`/gh-issue-driven:start` blocked on a dirty working tree caused by a local edit under `docs/superpowers/plans/`. Ignoring the directory removes the recurring friction without affecting any tracked content (no files under `docs/superpowers/` exist on `origin/main` — earlier additions were local-only and will be dropped from local `main` after this PR merges).

## Test plan

- [ ] CI passes (lint, type-check)
- [ ] `git status` clean after creating a new file under `docs/superpowers/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)