### PR TITLE
feat(db+sleep): cost-grade schema for sleep_reports (#180)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -23,6 +23,8 @@ import models.resource  # noqa: F401
 import models.neural  # noqa: F401
 import models.hub_tag  # noqa: F401
 import models.erasure  # noqa: F401
+import models.sleep  # noqa: F401  # Issue #471: SleepReportLLMUsage child added
+import models.llm_pricing  # noqa: F401  # Issue #471: cost-grade pricing master
 
 # Alembic Config object
 config = context.config

--- a/backend/alembic/versions/c02_471_cost_grade_schema.py
+++ b/backend/alembic/versions/c02_471_cost_grade_schema.py
@@ -109,9 +109,10 @@ def upgrade() -> None:
             name="valid_sleep_report_llm_usage_phase",
         ),
     )
-    # FK column is auto-indexed via ForeignKey, but the GROUP BY query in
-    # #472 will frequently filter by (provider, model) across a date range
-    # of reports. report_id at the tail covers JOIN ordering.
+    # PostgreSQL does NOT automatically index foreign-key columns, so keep
+    # an explicit index on report_id. The GROUP BY query in #472 will also
+    # frequently filter by (provider, model) across a date range of reports;
+    # report_id at the tail of the composite index helps JOIN ordering.
     op.create_index(
         "idx_sleep_report_llm_usage_report_id",
         "sleep_report_llm_usage",

--- a/backend/alembic/versions/c02_471_cost_grade_schema.py
+++ b/backend/alembic/versions/c02_471_cost_grade_schema.py
@@ -193,11 +193,12 @@ def upgrade() -> None:
             name="valid_llm_pricing_context_max_gt_min",
         ),
     )
-    op.create_index(
-        "idx_llm_pricing_lookup",
-        "llm_pricing",
-        ["provider", "model", "unit_type", "effective_from"],
-    )
+    # NOTE: no explicit ``idx_llm_pricing_lookup`` — PostgreSQL's
+    # auto-created index for the ``uq_llm_pricing_lookup_key`` UNIQUE
+    # constraint covers the lookup query (provider, model, unit_type,
+    # effective_from prefix). An additional index would just duplicate
+    # write cost and storage. See models/llm_pricing.py for the same
+    # decision documented at the model level.
 
     # 3. Embedding cost-grade columns on sleep_reports. All nullable / 0
     # default for backfill compatibility — pre-migration rows render as
@@ -228,7 +229,6 @@ def downgrade() -> None:
     op.drop_column("sleep_reports", "embedding_model")
     op.drop_column("sleep_reports", "embedding_provider")
 
-    op.drop_index("idx_llm_pricing_lookup", table_name="llm_pricing")
     op.drop_table("llm_pricing")
 
     op.drop_index(

--- a/backend/alembic/versions/c02_471_cost_grade_schema.py
+++ b/backend/alembic/versions/c02_471_cost_grade_schema.py
@@ -1,0 +1,241 @@
+"""Add cost-grade schema: sleep_report_llm_usage child table + llm_pricing master + sleep_reports embedding columns.
+
+Issue #471: Foundation for #472 (aggregation API) and #473 (dashboard UI).
+The current ``sleep_reports`` table tracks token usage as scalar totals
+(``llm_calls_made``, ``llm_tokens_used``, ``embedding_calls_made``) which
+is operational metric, not cost metric. To compute actual `$` cost the
+schema must capture model identity, input/output split, cached input,
+and a snapshot of the price-per-token at the time the run executed.
+
+This migration adds:
+
+1. ``sleep_report_llm_usage`` — child table with per-(phase, provider,
+   model) breakdown of LLM token usage. The legacy roll-up columns on
+   ``sleep_reports`` stay populated by the reporter as a sum over child
+   rows for back-compat with existing dashboards / log analyzers.
+
+2. ``llm_pricing`` — append-only master table of model rates indexed
+   by ``(provider, model, unit_type, effective_from, context_min_tokens)``.
+   Cost-aggregation joins pick the row whose ``effective_from <=
+   sleep_run.started_at`` so historical reports stay reproducible across
+   rate changes. ``unit_type`` enum (text + CHECK, intentionally NOT
+   PostgreSQL ENUM — ALTER-friendly, plays well with alembic) covers
+   input/output/cache_read/cache_write/embedding tokens AND
+   rerank_tokens / rerank_search_units. The latter two are reserved for
+   #474 (no rows seeded in #471) but the enum value must exist now to
+   avoid a CHECK-constraint migration when #474 lands.
+   ``unit_denominator`` bridges per-1M-tokens (Anthropic / OpenAI / Google)
+   and per-1k-search-units (Cohere rerank) in the same row shape.
+
+3. Embedding scalar columns on ``sleep_reports`` —
+   ``embedding_provider``, ``embedding_model``, ``embedding_tokens``.
+   Embedding is instance-global (one ``EMBEDDING_PROVIDER`` /
+   ``EMBEDDING_MODEL`` per process per ``backend/src/config/settings.py``)
+   so a single triple per run is sufficient. v0.15.0 reporter populates
+   these from the reindex phase only — phase 1 / phase 2 also call the
+   embedding API but don't increment any counter today; #475 closes that
+   gap separately.
+
+Seed pricing rows are inserted by the next migration
+(``c03_471_seed_pricing``) — splitting schema and data keeps the
+rollback path simpler.
+
+Revision ID: c02_471_cost_grade_schema
+Revises: c01_360_erasure_requests
+
+NOTE: Revision ID is 25 chars (alembic_version.version_num is VARCHAR(32)
+— asyncpg raises StringDataRightTruncationError otherwise).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c02_471_cost_grade_schema"
+down_revision: str | Sequence[str] | None = "c01_360_erasure_requests"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create cost-grade schema: child table + pricing master + sleep_reports columns."""
+    # 1. sleep_report_llm_usage — per-(phase, provider, model) child table.
+    op.create_table(
+        "sleep_report_llm_usage",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column(
+            "report_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("sleep_reports.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("phase", sa.String(30), nullable=False),
+        sa.Column("provider", sa.String(50), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        sa.Column(
+            "input_tokens",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "output_tokens",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "cached_input_tokens",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("calls", sa.Integer, nullable=False, server_default=sa.text("0")),
+        # ``tokenizer_version`` is audit only — not used as a price-lookup key.
+        sa.Column("tokenizer_version", sa.String(50), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.CheckConstraint(
+            "phase IN ('edge_discovery', 'dedup_merge', 'importance_reeval', "
+            "'consolidation', 'reindex')",
+            name="valid_sleep_report_llm_usage_phase",
+        ),
+    )
+    # FK column is auto-indexed via ForeignKey, but the GROUP BY query in
+    # #472 will frequently filter by (provider, model) across a date range
+    # of reports. report_id at the tail covers JOIN ordering.
+    op.create_index(
+        "idx_sleep_report_llm_usage_report_id",
+        "sleep_report_llm_usage",
+        ["report_id"],
+    )
+    op.create_index(
+        "idx_sleep_report_llm_usage_provider_model",
+        "sleep_report_llm_usage",
+        ["provider", "model", "report_id"],
+    )
+
+    # 2. llm_pricing — append-only master table.
+    op.create_table(
+        "llm_pricing",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        sa.Column("provider", sa.String(50), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        sa.Column("unit_type", sa.String(30), nullable=False),
+        # Naive DateTime to match ``sleep_reports.started_at`` and the
+        # rest of the codebase (UTC-by-convention). Avoids tz-aware vs
+        # tz-naive TypeError at the SQLAlchemy expression level when
+        # #472 joins on ``effective_from <= started_at``.
+        sa.Column("effective_from", sa.DateTime, nullable=False),
+        sa.Column(
+            "context_min_tokens",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column("context_max_tokens", sa.Integer, nullable=True),
+        sa.Column("price_per_unit", sa.Numeric(14, 10), nullable=False),
+        sa.Column(
+            "currency",
+            sa.String(3),
+            nullable=False,
+            server_default=sa.text("'USD'"),
+        ),
+        sa.Column(
+            "unit_denominator",
+            sa.BigInteger,
+            nullable=False,
+            server_default=sa.text("1000000"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.UniqueConstraint(
+            "provider",
+            "model",
+            "unit_type",
+            "effective_from",
+            "context_min_tokens",
+            name="uq_llm_pricing_lookup_key",
+        ),
+        sa.CheckConstraint(
+            "unit_type IN ('input_tokens', 'output_tokens', "
+            "'cache_read_tokens', 'cache_write_tokens', "
+            "'embedding_tokens', 'rerank_tokens', 'rerank_search_units')",
+            name="valid_llm_pricing_unit_type",
+        ),
+        sa.CheckConstraint(
+            "price_per_unit >= 0",
+            name="valid_llm_pricing_price_nonneg",
+        ),
+        sa.CheckConstraint(
+            "unit_denominator > 0",
+            name="valid_llm_pricing_unit_denominator_positive",
+        ),
+        sa.CheckConstraint(
+            "context_min_tokens >= 0",
+            name="valid_llm_pricing_context_min_nonneg",
+        ),
+        sa.CheckConstraint(
+            "context_max_tokens IS NULL OR context_max_tokens > context_min_tokens",
+            name="valid_llm_pricing_context_max_gt_min",
+        ),
+    )
+    op.create_index(
+        "idx_llm_pricing_lookup",
+        "llm_pricing",
+        ["provider", "model", "unit_type", "effective_from"],
+    )
+
+    # 3. Embedding cost-grade columns on sleep_reports. All nullable / 0
+    # default for backfill compatibility — pre-migration rows render as
+    # "cost unknown" in #473's dashboard.
+    op.add_column(
+        "sleep_reports",
+        sa.Column("embedding_provider", sa.String(50), nullable=True),
+    )
+    op.add_column(
+        "sleep_reports",
+        sa.Column("embedding_model", sa.String(100), nullable=True),
+    )
+    op.add_column(
+        "sleep_reports",
+        sa.Column(
+            "embedding_tokens",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    """Drop cost-grade schema in reverse order."""
+    # Reverse order: columns on sleep_reports → llm_pricing → child table.
+    op.drop_column("sleep_reports", "embedding_tokens")
+    op.drop_column("sleep_reports", "embedding_model")
+    op.drop_column("sleep_reports", "embedding_provider")
+
+    op.drop_index("idx_llm_pricing_lookup", table_name="llm_pricing")
+    op.drop_table("llm_pricing")
+
+    op.drop_index(
+        "idx_sleep_report_llm_usage_provider_model",
+        table_name="sleep_report_llm_usage",
+    )
+    op.drop_index(
+        "idx_sleep_report_llm_usage_report_id",
+        table_name="sleep_report_llm_usage",
+    )
+    op.drop_table("sleep_report_llm_usage")

--- a/backend/alembic/versions/c03_471_seed_pricing.py
+++ b/backend/alembic/versions/c03_471_seed_pricing.py
@@ -1,0 +1,206 @@
+"""Seed initial llm_pricing rows with 2026-04-28 provider rates.
+
+Issue #471: separates pricing data from schema so a rollback / re-run can
+target just the seed rows without dropping the table. Per
+``CLAUDE.md`` and gate1 review (key suggestion #3), this is the
+ALTER-friendly migration pattern preferred for billing-grade data.
+
+Seeded rates (USD, all effective_from = ``2026-04-28T00:00:00Z``):
+
+Anthropic (cache_write ≈ 1.25× input, cache_read ≈ 0.1× input):
+- claude-opus-4-7   : input $5 / output $25 / cache_read $0.50 / cache_write $6.25 per 1M tokens
+- claude-sonnet-4-6 : input $3 / output $15 / cache_read $0.30 / cache_write $3.75 per 1M
+- claude-haiku-4-5  : input $1 / output $5 / cache_read $0.10 / cache_write $1.25 per 1M
+
+OpenAI:
+- gpt-5.5      : input $5 / output $30 / cache_read $0.50 per 1M tokens (no separate cache_write rate; OpenAI rolls write into input)
+- gpt-5-nano   : input $0.20 / output $1.25 / cache_read $0.02 per 1M (the repo's default ``SLEEP_LLM_MODEL``; rates align with the gpt-5.4-nano tier)
+- text-embedding-3-small : $0.02 per 1M tokens (this repo's default embedding model)
+- text-embedding-3-large : $0.13 per 1M tokens
+
+Ollama (local, free — embedding models registered in
+``backend/src/config/constants.py`` ``EMBEDDING_MODEL_REGISTRY``):
+- nomic-embed-text       : $0
+- mxbai-embed-large      : $0
+- qwen3-embedding:0.6b   : $0
+- qwen3-embedding:4b     : $0
+- qwen3-embedding:8b     : $0
+
+Rerank pricing (Voyage / Cohere) is intentionally NOT seeded here —
+``reranker_service.py`` is called only from the recall path
+(``mcp_server/tools/memory.py:236``), which is outside Sleep
+Maintenance scope. #474 (comprehensive ledger for non-Sleep paths)
+seeds those rows when it ships.
+
+Downgrade deletes ALL rows with this exact ``effective_from`` so a
+re-seed of the same date doesn't pile up duplicates. If a price changes
+later we INSERT a new row with a later ``effective_from`` rather than
+mutating these seed rows — the lookup query picks the most recent row
+whose ``effective_from <= started_at``.
+
+Revision ID: c03_471_seed_pricing
+Revises: c02_471_cost_grade_schema
+
+NOTE: Revision ID is 21 chars (under the 32-char alembic limit).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c03_471_seed_pricing"
+down_revision: str | Sequence[str] | None = "c02_471_cost_grade_schema"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Single source of truth for the seed effective_from. Used by both
+# upgrade() (for INSERTs) and downgrade() (for the targeted DELETE).
+# Naive UTC to match ``llm_pricing.effective_from`` (DateTime, naive)
+# and the rest of the codebase's "store UTC, ignore tz metadata" pattern.
+_SEED_EFFECTIVE_FROM = "2026-04-28 00:00:00"
+
+
+# Parameterized INSERT — bind params keep the migration aligned with
+# ``.claude/rules/security.md`` ("NEVER use f-strings for SQL"). Even
+# though every seed value here is a hardcoded Python literal, the
+# blanket no-f-string-SQL rule means we use bound params anyway so a
+# future contributor doesn't copy-paste this pattern with an external
+# variable and accidentally introduce an injection vector.
+_INSERT_PRICING_SQL = sa.text("""
+    INSERT INTO llm_pricing (
+        provider, model, unit_type, effective_from,
+        context_min_tokens, context_max_tokens,
+        price_per_unit, currency, unit_denominator
+    ) VALUES (
+        :provider, :model, :unit_type, :effective_from,
+        0, NULL,
+        :price_per_unit, 'USD', 1000000
+    )
+""")
+
+
+def _insert_pricing_row(
+    *,
+    provider: str,
+    model: str,
+    unit_type: str,
+    price_per_unit: str,
+) -> None:
+    """Emit a single parameterized INSERT for an llm_pricing row.
+
+    All seed rows share ``effective_from`` (`_SEED_EFFECTIVE_FROM`),
+    ``unit_denominator=1000000``, ``currency='USD'``,
+    ``context_min_tokens=0``, ``context_max_tokens=NULL``.
+
+    Pass ``price_per_unit`` as a string to keep the value deterministic
+    across Python float repr quirks; PostgreSQL parses the string into
+    NUMERIC(14,10) at INSERT time.
+    """
+    op.execute(
+        _INSERT_PRICING_SQL.bindparams(
+            provider=provider,
+            model=model,
+            unit_type=unit_type,
+            effective_from=_SEED_EFFECTIVE_FROM,
+            price_per_unit=price_per_unit,
+        )
+    )
+
+
+def upgrade() -> None:
+    """Seed initial 2026-04-28 pricing rows."""
+    # --- Anthropic Claude family (4 unit_types × 3 models = 12 rows) ---
+    for model, rates in (
+        ("claude-opus-4-7", ("5", "25", "0.5", "6.25")),
+        ("claude-sonnet-4-6", ("3", "15", "0.3", "3.75")),
+        ("claude-haiku-4-5", ("1", "5", "0.1", "1.25")),
+    ):
+        input_rate, output_rate, cache_read_rate, cache_write_rate = rates
+        _insert_pricing_row(
+            provider="anthropic", model=model, unit_type="input_tokens", price_per_unit=input_rate
+        )
+        _insert_pricing_row(
+            provider="anthropic",
+            model=model,
+            unit_type="output_tokens",
+            price_per_unit=output_rate,
+        )
+        _insert_pricing_row(
+            provider="anthropic",
+            model=model,
+            unit_type="cache_read_tokens",
+            price_per_unit=cache_read_rate,
+        )
+        _insert_pricing_row(
+            provider="anthropic",
+            model=model,
+            unit_type="cache_write_tokens",
+            price_per_unit=cache_write_rate,
+        )
+
+    # --- OpenAI LLM (gpt-5.5, gpt-5-nano: input/output/cache_read = 3 rows each) ---
+    for model, rates in (
+        ("gpt-5.5", ("5", "30", "0.5")),
+        # gpt-5-nano = repo default; rates align with gpt-5.4-nano tier per
+        # 2026-04-28 OpenAI pricing snapshot.
+        ("gpt-5-nano", ("0.2", "1.25", "0.02")),
+    ):
+        input_rate, output_rate, cache_read_rate = rates
+        _insert_pricing_row(
+            provider="openai", model=model, unit_type="input_tokens", price_per_unit=input_rate
+        )
+        _insert_pricing_row(
+            provider="openai", model=model, unit_type="output_tokens", price_per_unit=output_rate
+        )
+        _insert_pricing_row(
+            provider="openai",
+            model=model,
+            unit_type="cache_read_tokens",
+            price_per_unit=cache_read_rate,
+        )
+
+    # --- OpenAI embedding (this repo's defaults) ---
+    _insert_pricing_row(
+        provider="openai",
+        model="text-embedding-3-small",
+        unit_type="embedding_tokens",
+        price_per_unit="0.02",
+    )
+    _insert_pricing_row(
+        provider="openai",
+        model="text-embedding-3-large",
+        unit_type="embedding_tokens",
+        price_per_unit="0.13",
+    )
+
+    # --- Ollama (local, free) — match EMBEDDING_MODEL_REGISTRY in constants.py ---
+    for model in (
+        "nomic-embed-text",
+        "mxbai-embed-large",
+        "qwen3-embedding:0.6b",
+        "qwen3-embedding:4b",
+        "qwen3-embedding:8b",
+    ):
+        _insert_pricing_row(
+            provider="ollama",
+            model=model,
+            unit_type="embedding_tokens",
+            price_per_unit="0",
+        )
+
+
+def downgrade() -> None:
+    """Remove only the seed rows from this migration.
+
+    Targeting by ``effective_from`` lets a price-change INSERT (with a
+    later effective_from) survive a downgrade of just the initial seed.
+    """
+    op.execute(
+        sa.text("DELETE FROM llm_pricing WHERE effective_from = :effective_from").bindparams(
+            effective_from=_SEED_EFFECTIVE_FROM,
+        )
+    )

--- a/backend/src/models/llm_pricing.py
+++ b/backend/src/models/llm_pricing.py
@@ -50,7 +50,6 @@ from sqlalchemy import (
     CheckConstraint,
     Column,
     DateTime,
-    Index,
     Integer,
     Numeric,
     String,
@@ -172,13 +171,14 @@ class LLMPricing(Base):
             "context_max_tokens IS NULL OR context_max_tokens > context_min_tokens",
             name="valid_llm_pricing_context_max_gt_min",
         ),
-        Index(
-            "idx_llm_pricing_lookup",
-            "provider",
-            "model",
-            "unit_type",
-            "effective_from",
-        ),
+        # NOTE: no explicit ``idx_llm_pricing_lookup`` — PostgreSQL's
+        # auto-created index for ``uq_llm_pricing_lookup_key`` covers the
+        # lookup query as a prefix index (provider, model, unit_type,
+        # effective_from, context_min_tokens). An additional 4-column
+        # index would just duplicate write cost and storage with no
+        # measured query benefit. Add an explicit index later if EXPLAIN
+        # ANALYZE on #472's queries shows the prefix index isn't being
+        # picked up.
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/llm_pricing.py
+++ b/backend/src/models/llm_pricing.py
@@ -1,0 +1,189 @@
+"""SQLAlchemy model for LLM pricing master table.
+
+Issue #471: append-only price snapshot table that powers cost-grade
+reporting on top of ``sleep_report_llm_usage`` (and, in #474, the broader
+``llm_call_log`` ledger). Rows are NEVER updated or deleted in normal
+operation — a price change inserts a new row with a later
+``effective_from``, and the cost-aggregation join picks the row whose
+``effective_from <= started_at`` of the consuming sleep run / call. This
+keeps historical reports reproducible across rate changes.
+
+Why a generalized ``unit_type`` axis: per-token billing (Anthropic /
+OpenAI / Google) and per-search-unit billing (Cohere rerank, $2 / 1k SU)
+do not share a base unit. Storing them in separate tables would split
+the join in #472. Instead this table carries:
+
+- ``unit_type`` enum that names the dimension being priced
+  (``input_tokens``, ``output_tokens``, ``cache_read_tokens``,
+  ``cache_write_tokens``, ``embedding_tokens``, ``rerank_tokens``,
+  ``rerank_search_units``).
+- ``unit_denominator`` to express "per N units" in the same column for
+  every row — Anthropic / OpenAI / Google rows store ``1_000_000``
+  (per 1M tokens), Cohere rerank rows store ``1_000`` (per 1k search
+  units). Cost = ``input_tokens * price_per_unit / unit_denominator``.
+
+The reranker enum values exist from day 1 even though #471 does not seed
+any rerank rows. #474 will seed them without a CHECK-constraint
+migration.
+
+Tier breakpoints are encoded as multiple rows for the same
+``(provider, model, unit_type, effective_from)`` differing only by
+``context_min_tokens`` (and optionally ``context_max_tokens``). The PK
+includes ``context_min_tokens`` so multiple tiers coexist. Gemini 2.5
+Pro doubles past 200k context — that scenario is exactly two rows with
+``context_min_tokens=0, context_max_tokens=200000`` and
+``context_min_tokens=200000, context_max_tokens=NULL``.
+
+``currency`` defaults to ``USD`` and exists from day 1 even though
+multi-currency display is OOS for #471. Adding the column now costs one
+default value; adding it later would force an ALTER TABLE on a
+production-sized table.
+
+``unit_type`` is a text + CHECK constraint (intentionally NOT a
+PostgreSQL ENUM) — the rest of this codebase uses the same pattern
+(see ``sleep_reports.status``, ``erasure_requests.status`` etc) because
+PG ENUMs are painful to ALTER and don't play nicely with alembic.
+"""
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    UniqueConstraint,
+    func,
+)
+
+from db.base import Base
+
+# Public list of allowed ``unit_type`` values. Imported by:
+# - The CHECK constraint below.
+# - Migrations that seed rows.
+# - ``services/llm_pricing_service.py`` for input validation (defense in
+#   depth — the DB CHECK is the source of truth).
+LLM_PRICING_UNIT_TYPES: tuple[str, ...] = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+    "embedding_tokens",
+    "rerank_tokens",
+    "rerank_search_units",
+)
+
+
+class LLMPricing(Base):
+    """Append-only price snapshot for an LLM/embedding/rerank model unit.
+
+    See module docstring for the design rationale (append-only,
+    ``effective_from``-driven temporal join, ``unit_denominator`` to bridge
+    per-1M-tokens and per-1k-search-units, ``currency`` forward-compat,
+    text + CHECK enum).
+
+    Lookup pattern (implemented in ``services/llm_pricing_service.py``):
+
+        SELECT * FROM llm_pricing
+        WHERE provider = :provider
+          AND model = :model
+          AND unit_type = :unit_type
+          AND effective_from <= :started_at
+          AND context_min_tokens <= :context_tokens
+          AND (context_max_tokens IS NULL OR context_max_tokens > :context_tokens)
+        ORDER BY effective_from DESC, context_min_tokens DESC
+        LIMIT 1;
+
+    A miss returns ``None``; the caller is expected to write
+    ``cost_usd = NULL`` for that breakdown row, which the UI surfaces as
+    "cost unknown" (the same treatment as legacy NULL-model rows from
+    before this issue).
+    """
+
+    __tablename__ = "llm_pricing"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    provider = Column(String(50), nullable=False)
+    model = Column(String(100), nullable=False)
+    unit_type = Column(String(30), nullable=False)
+    # Naive ``DateTime`` to match the codebase convention (everything stored
+    # in UTC; see ``sleep_reports.started_at`` and the rest of
+    # ``backend/src/models/``). Mixing tz-aware and tz-naive datetimes in
+    # SQLAlchemy comparisons raises TypeError at the Python layer, so the
+    # column type must agree with the join target. Callers pass naive UTC
+    # datetimes (e.g. ``utils.datetime.utcnow()``).
+    effective_from = Column(DateTime, nullable=False)
+
+    # Tier breakpoint columns. ``context_min_tokens`` defaults to 0 (no
+    # lower bound). ``context_max_tokens`` is nullable for "no upper bound";
+    # most rows have NULL here. Gemini 2.5 Pro is the canonical multi-tier
+    # case in the 2026-04-28 seed.
+    context_min_tokens = Column(Integer, nullable=False, default=0)
+    context_max_tokens = Column(Integer, nullable=True)
+
+    # NUMERIC(14, 10) gives 4 digits before the decimal and 10 after — enough
+    # for prices like 25.0000000000 (Claude Opus output, $25/1M) down to
+    # 0.0000200000 (text-embedding-3-small, $0.02/1M) without rounding.
+    price_per_unit = Column(Numeric(14, 10), nullable=False)
+    currency = Column(String(3), nullable=False, default="USD")
+
+    # Bridges per-1M-tokens (1_000_000) and per-1k-search-units (1_000)
+    # so both fit the same row shape. Default 1_000_000 matches the
+    # majority-case (token-based providers).
+    unit_denominator = Column(BigInteger, nullable=False, default=1_000_000)
+
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        # Composite uniqueness — multiple rows for the same
+        # (provider, model, unit_type, effective_from) only differ by
+        # ``context_min_tokens`` (multi-tier), and we never want two rows
+        # with identical (provider, model, unit_type, effective_from,
+        # context_min_tokens) since the lookup query would be ambiguous.
+        UniqueConstraint(
+            "provider",
+            "model",
+            "unit_type",
+            "effective_from",
+            "context_min_tokens",
+            name="uq_llm_pricing_lookup_key",
+        ),
+        CheckConstraint(
+            "unit_type IN ('input_tokens', 'output_tokens', "
+            "'cache_read_tokens', 'cache_write_tokens', "
+            "'embedding_tokens', 'rerank_tokens', 'rerank_search_units')",
+            name="valid_llm_pricing_unit_type",
+        ),
+        CheckConstraint(
+            "price_per_unit >= 0",
+            name="valid_llm_pricing_price_nonneg",
+        ),
+        CheckConstraint(
+            "unit_denominator > 0",
+            name="valid_llm_pricing_unit_denominator_positive",
+        ),
+        CheckConstraint(
+            "context_min_tokens >= 0",
+            name="valid_llm_pricing_context_min_nonneg",
+        ),
+        CheckConstraint(
+            "context_max_tokens IS NULL OR context_max_tokens > context_min_tokens",
+            name="valid_llm_pricing_context_max_gt_min",
+        ),
+        Index(
+            "idx_llm_pricing_lookup",
+            "provider",
+            "model",
+            "unit_type",
+            "effective_from",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<LLMPricing({self.provider}/{self.model} "
+            f"{self.unit_type}=${self.price_per_unit}/{self.unit_denominator} "
+            f"{self.currency} from={self.effective_from})>"
+        )

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -198,11 +198,16 @@ class SleepReportLLMUsage(Base):
     __tablename__ = "sleep_report_llm_usage"
 
     id = Column(BigInteger, primary_key=True, autoincrement=True)
+    # report_id has an explicit ``Index`` in __table_args__ below to match
+    # the migration's ``idx_sleep_report_llm_usage_report_id`` name.
+    # ``index=True`` here would create an auto-named index
+    # (``ix_sleep_report_llm_usage_report_id``) and cause schema-drift
+    # noise on alembic autogenerate or duplicate indexes when
+    # Base.metadata.create_all is used in tests.
     report_id = Column(
         UUID(as_uuid=True),
         ForeignKey("sleep_reports.id", ondelete="CASCADE"),
         nullable=False,
-        index=True,
     )
 
     phase = Column(String(30), nullable=False)
@@ -218,6 +223,13 @@ class SleepReportLLMUsage(Base):
     created_at = Column(DateTime, nullable=False, server_default=func.now())
 
     __table_args__ = (
+        # Single-column index on report_id (FK join key). PostgreSQL does
+        # NOT auto-index FK columns, and the explicit name here matches
+        # the migration so model + migration agree on a single index.
+        Index(
+            "idx_sleep_report_llm_usage_report_id",
+            "report_id",
+        ),
         # Composite index supports the #472 aggregation queries that
         # ``GROUP BY provider, model`` after filtering by report period.
         Index(

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -77,10 +77,28 @@ class SleepReport(Base):
     consolidation_result = Column(JSON, nullable=True)
     reindex_result = Column(JSON, nullable=True)
 
-    # Cost tracking
+    # Cost tracking — legacy roll-up totals (#101).
+    # Issue #471 split per-(phase, provider, model) LLM usage into the
+    # ``sleep_report_llm_usage`` child table (see below). These three columns
+    # remain populated by the reporter as a sum of child rows for back-compat:
+    # any reader that selects them directly (legacy dashboards, log analyzers,
+    # MCP tools) continues to work without change.
     llm_calls_made = Column(Integer, nullable=False, default=0)
     llm_tokens_used = Column(Integer, nullable=False, default=0)
     embedding_calls_made = Column(Integer, nullable=False, default=0)
+
+    # Embedding cost-grade columns (#471). Embedding is instance-global per
+    # ``backend/src/config/settings.py`` (one EMBEDDING_PROVIDER /
+    # EMBEDDING_MODEL per process), so a single (provider, model, tokens)
+    # triple per run is sufficient — no child table needed.
+    #
+    # NOTE for v0.15.0: these columns track ONLY the reindex phase's embedding
+    # API calls today, mirroring the existing ``embedding_calls_made``
+    # behavior. Sleep phases 1 (edge_discovery) and 2 (dedup_merge) also call
+    # the embedding API but don't increment any counter; #475 closes that gap.
+    embedding_provider = Column(String(50), nullable=True)
+    embedding_model = Column(String(100), nullable=True)
+    embedding_tokens = Column(Integer, nullable=False, default=0)
 
     # Activity counters
     memories_processed = Column(Integer, nullable=False, default=0)
@@ -147,3 +165,80 @@ class SleepAction(Base):
 
     def __repr__(self) -> str:
         return f"<SleepAction(id={self.id}, phase={self.phase}, action={self.action_type})>"
+
+
+class SleepReportLLMUsage(Base):
+    """Per-(phase, provider, model) LLM call breakdown for a sleep run.
+
+    Issue #471: cost-grade telemetry. Captures the dimensions needed to
+    compute actual `$` cost from token counts:
+
+    - ``provider`` + ``model`` → joined against ``llm_pricing`` to resolve
+      the per-token rate active at the parent run's ``started_at``.
+    - ``input_tokens`` / ``output_tokens`` / ``cached_input_tokens`` →
+      separate counters because output is typically ~5× input rate and
+      Anthropic's prompt cache discounts cached input by ~90%.
+    - ``tokenizer_version`` is **audit only**; it is not a price-lookup key
+      and the system never re-prices on a tokenizer change. It exists so
+      analysts can spot the case where a provider ships a new tokenizer
+      under an unchanged-rate model (Anthropic Opus 4.7 issued ~35% more
+      tokens than 4.6 for the same text).
+
+    A run typically emits one row per phase × model. Today all phases use
+    a single ``config.sleep_llm_model``, so a typical run produces 4-5 rows
+    (one per LLM-using phase). The schema is per-(phase, provider, model)
+    to remain correct if a future change lets phases pick different models.
+
+    Phases that don't call the LLM (currently only ``reindex``) emit no
+    row. The aggregation API in #472 uses these rows directly via
+    ``GROUP BY provider, model`` joins; the legacy roll-up columns on
+    ``sleep_reports`` are computed as the sum of these rows for back-compat.
+    """
+
+    __tablename__ = "sleep_report_llm_usage"
+
+    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    report_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("sleep_reports.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+
+    phase = Column(String(30), nullable=False)
+    provider = Column(String(50), nullable=False)
+    model = Column(String(100), nullable=False)
+
+    input_tokens = Column(Integer, nullable=False, default=0)
+    output_tokens = Column(Integer, nullable=False, default=0)
+    cached_input_tokens = Column(Integer, nullable=False, default=0)
+    calls = Column(Integer, nullable=False, default=0)
+    tokenizer_version = Column(String(50), nullable=True)
+
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    __table_args__ = (
+        # Composite index supports the #472 aggregation queries that
+        # ``GROUP BY provider, model`` after filtering by report period.
+        Index(
+            "idx_sleep_report_llm_usage_provider_model",
+            "provider",
+            "model",
+            "report_id",
+        ),
+        # CHECK on phase keeps the audit trail readable even if a future
+        # phase name slips in via reporter changes — same defensive pattern
+        # as ``valid_sleep_report_status`` on ``sleep_reports``.
+        CheckConstraint(
+            "phase IN ('edge_discovery', 'dedup_merge', 'importance_reeval', "
+            "'consolidation', 'reindex')",
+            name="valid_sleep_report_llm_usage_phase",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<SleepReportLLMUsage(report={self.report_id}, "
+            f"phase={self.phase}, model={self.model}, "
+            f"in={self.input_tokens}, out={self.output_tokens})>"
+        )

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -227,6 +227,11 @@ class EmbeddingService:
     ) -> list[float]:
         """Generate embedding for text with Redis caching.
 
+        Thin wrapper around ``embed_with_usage()`` that discards the
+        token count — kept for callers that don't need cost attribution
+        (recall, search). Issue #475 will migrate the remaining callers
+        to ``embed_with_usage()`` directly.
+
         Args:
             text: Text to embed (summary)
             user_id: User ID (to retrieve API key)
@@ -239,34 +244,52 @@ class EmbeddingService:
         Raises:
             OpenAIError: If embedding generation fails
             ConfigurationError: If API key not configured
+        """
+        vector, _ = await self.embed_with_usage(
+            text,
+            user_id=user_id,
+            context_id=context_id,
+            workspace_id=workspace_id,
+        )
+        return vector
 
-        Example:
-            >>> service = EmbeddingService(db)
-            >>> vector = await service.embed("認証エラー修正", user_id="kiyota")
-            >>> len(vector)
-            512
+    async def embed_with_usage(
+        self,
+        text: str,
+        user_id: str,
+        context_id: str | None = None,
+        workspace_id: str | None = None,
+    ) -> tuple[list[float], int]:
+        """Generate embedding and return token usage for cost tracking (#471).
 
-        Note:
-            Issue #84 Phase 2A: Uses Redis cache (TTL: 24h) to reduce API calls by 50-80%
+        Like ``embed()`` but also returns the input token count from the
+        provider's API response, so callers can attribute embedding cost
+        per-(provider, model) via ``llm_pricing``. Cache hits return
+        ``(vector, 0)`` because cached responses consume no API tokens.
+
+        This is an additive companion to ``embed()`` rather than a
+        breaking signature change — ``embed()`` keeps working for callers
+        that don't track cost (recall path, search service). #475 will
+        migrate the remaining callers as part of the
+        full-pipeline embedding-cost rollout.
+
+        Args:
+            text: Text to embed.
+            user_id: User ID for API key lookup.
+            context_id: Optional context ID for scoped API key.
+            workspace_id: Optional workspace ID for scoped API key.
+
+        Returns:
+            ``(vector, tokens_used)``. ``tokens_used`` is 0 for cache
+            hits and for providers that don't expose ``response.usage``.
+
+        Raises:
+            OpenAIError: If embedding generation fails.
+            ConfigurationError: If API key not configured.
         """
         try:
-            # ============================================================================
-            # BUG FIX #122-2: Unicode normalization for consistent cache keys
-            # ============================================================================
-            # Problem: Same Japanese text with different Unicode normalization
-            #          (NFC vs NFD) produces different xxHash digests, causing
-            #          cache misses for identical content.
-            #
-            # Example: "が" can be encoded as:
-            #   - NFC: U+304C (single codepoint) → one xxHash
-            #   - NFD: U+304B + U+3099 (two codepoints) → different xxHash
-            #
-            # Solution: Always normalize to NFC before hashing.
-            # ============================================================================
             normalized_text = unicodedata.normalize("NFC", text)
 
-            # Issue #84 Phase 2A: Check cache first (xxHash for 4x speed/space improvement)
-            # Include model in cache key to avoid cross-model collisions
             text_hash = xxhash.xxh64(normalized_text.encode()).hexdigest()[:16]
             cache_key = f"emb:{self.model}:{text_hash}"
             cached = await get_cache(cache_key)
@@ -279,17 +302,28 @@ class EmbeddingService:
                     text_length=len(text),
                     cache_key=cache_key[:16] + "...",
                 )
-                return vector
+                return vector, 0
 
-            # Cache miss - generate embedding (use normalized text for consistency)
             client = await self._get_client(user_id, context_id, workspace_id)
             response = await client.embeddings.create(
                 **self._build_embedding_kwargs(normalized_text)
             )
 
             vector = response.data[0].embedding
+            # Embeddings only have an "input" side — no completion tokens.
+            # OpenAI returns ``usage.prompt_tokens`` (and the same value as
+            # ``total_tokens``); Ollama returns 0 because it has no usage
+            # accounting. Read defensively — older provider SDKs may omit
+            # the usage object entirely.
+            usage = getattr(response, "usage", None)
+            tokens_used = 0
+            if usage is not None:
+                tokens_used = (
+                    getattr(usage, "prompt_tokens", None)
+                    or getattr(usage, "total_tokens", None)
+                    or 0
+                )
 
-            # Cache for 24 hours (86400 seconds)
             await set_cache(cache_key, json.dumps(vector), ttl=86400)
 
             logger.debug(
@@ -297,10 +331,11 @@ class EmbeddingService:
                 user_id=user_id,
                 text_length=len(text),
                 vector_dim=len(vector),
+                tokens=tokens_used,
                 cached=True,
             )
 
-            return vector
+            return vector, tokens_used
 
         except ConfigurationError:
             raise

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -332,7 +332,7 @@ class EmbeddingService:
                 text_length=len(text),
                 vector_dim=len(vector),
                 tokens=tokens_used,
-                cached=True,
+                cached=False,
             )
 
             return vector, tokens_used

--- a/backend/src/services/llm_pricing_service.py
+++ b/backend/src/services/llm_pricing_service.py
@@ -1,0 +1,184 @@
+"""LLM pricing lookup service (Issue #471).
+
+Resolves the price-per-unit row from ``llm_pricing`` for a given
+``(provider, model, unit_type)`` tuple at a specific point in time and
+context-token tier. Used by the sleep reporter (and, in #474, the
+broader cost ledger) to compute ``cost_usd`` from token counts.
+
+Design rationale:
+
+- Returns ``LLMPricing | None`` — never raises on miss. Callers treat
+  missing pricing as ``cost_usd = NULL`` ("cost unknown") so a
+  newly-deployed model that hasn't been seeded yet still produces a
+  valid ``sleep_report_llm_usage`` row; only the cost number is blank.
+  This matches the ``RerankerService`` / ``EmbeddingService`` pattern
+  for graceful absence.
+
+- Uses the append-only ``effective_from`` snapshot to keep historical
+  reports reproducible: a re-run of last month's cost aggregation
+  produces the same ``$`` figure regardless of any rate changes that
+  shipped in between.
+
+- Tier breakpoints (Gemini 2.5 Pro: 0..200k vs >200k) are encoded as
+  multiple rows for the same ``(provider, model, unit_type,
+  effective_from)`` differing by ``context_min_tokens``. The lookup
+  picks the tier whose ``[context_min_tokens, context_max_tokens)``
+  interval contains the run's ``context_tokens``.
+
+- Class-based with ``AsyncSession`` injected in ``__init__``, matching
+  the rest of ``backend/src/services/`` (compare ``RerankerService``,
+  ``EmbeddingService``).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import and_, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.llm_pricing import LLM_PRICING_UNIT_TYPES, LLMPricing
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class LLMPricingService:
+    """Resolve price-per-unit rows from the ``llm_pricing`` master table.
+
+    Stateless from the caller's perspective — the only mutable state is
+    the injected ``AsyncSession``. Reuse one service instance per request
+    / sleep run; each ``lookup()`` call is one DB round-trip.
+    """
+
+    def __init__(self, db: AsyncSession) -> None:
+        """Initialize the service.
+
+        Args:
+            db: Async SQLAlchemy session; the same session pattern as
+                every other service in this layer.
+        """
+        self.db = db
+
+    async def lookup(
+        self,
+        *,
+        provider: str,
+        model: str,
+        unit_type: str,
+        started_at: datetime,
+        context_tokens: int = 0,
+    ) -> LLMPricing | None:
+        """Resolve the pricing row active for a call.
+
+        Args:
+            provider: Provider identifier (e.g. ``'anthropic'``,
+                ``'openai'``, ``'ollama'``).
+            model: Model identifier (e.g. ``'claude-sonnet-4-6'``,
+                ``'text-embedding-3-small'``).
+            unit_type: Pricing dimension — one of
+                ``LLM_PRICING_UNIT_TYPES``.
+            started_at: When the consuming run / call began. Used to
+                pick the snapshot row whose ``effective_from <= started_at``,
+                which keeps historical reports reproducible across rate
+                changes.
+            context_tokens: Total context-window tokens for the call;
+                used to pick the right tier when a model has multiple
+                tier rows (default 0, i.e. the lowest tier).
+
+        Returns:
+            The matching ``LLMPricing`` row, or ``None`` if no row
+            matches. The latter is the documented "cost unknown" path —
+            callers should write ``cost_usd = NULL`` and let the UI
+            render that as a "cost unknown" cell.
+        """
+        # Defense in depth — the DB has the same CHECK, but failing
+        # fast at the service boundary turns a typo into a clear
+        # ValueError instead of an unrelated 500 from the COMMIT path.
+        if unit_type not in LLM_PRICING_UNIT_TYPES:
+            raise ValueError(
+                f"Invalid unit_type {unit_type!r}; must be one of {LLM_PRICING_UNIT_TYPES}"
+            )
+
+        # Pick the most-recent ``effective_from`` row whose tier
+        # contains ``context_tokens``. Sorting on
+        # ``context_min_tokens DESC`` after ``effective_from DESC``
+        # means a multi-tier model returns the *highest matching*
+        # tier — e.g. for Gemini 2.5 Pro at 250k tokens, the
+        # ``context_min_tokens=200000`` row wins over the
+        # ``context_min_tokens=0`` row.
+        stmt = (
+            select(LLMPricing)
+            .where(
+                and_(
+                    LLMPricing.provider == provider,
+                    LLMPricing.model == model,
+                    LLMPricing.unit_type == unit_type,
+                    LLMPricing.effective_from <= started_at,
+                    LLMPricing.context_min_tokens <= context_tokens,
+                    or_(
+                        LLMPricing.context_max_tokens.is_(None),
+                        LLMPricing.context_max_tokens > context_tokens,
+                    ),
+                )
+            )
+            .order_by(
+                LLMPricing.effective_from.desc(),
+                LLMPricing.context_min_tokens.desc(),
+            )
+            .limit(1)
+        )
+        result = await self.db.execute(stmt)
+        row = result.scalar_one_or_none()
+
+        if row is None:
+            # Debug-level: misses are expected (new model, exotic
+            # provider, typo). Caller writes cost_usd=NULL.
+            logger.debug(
+                "llm_pricing_lookup_miss",
+                provider=provider,
+                model=model,
+                unit_type=unit_type,
+                started_at=started_at.isoformat(),
+                context_tokens=context_tokens,
+            )
+
+        return row
+
+    async def compute_cost_usd(
+        self,
+        *,
+        provider: str,
+        model: str,
+        unit_type: str,
+        started_at: datetime,
+        units: int,
+        context_tokens: int = 0,
+    ) -> float | None:
+        """Convenience wrapper: lookup price + multiply by units.
+
+        Equivalent to ``lookup(...)`` followed by
+        ``units * row.price_per_unit / row.unit_denominator``. Returns
+        ``None`` on a lookup miss (caller writes ``cost_usd = NULL``).
+
+        Floats are sufficient for cost computation at this granularity —
+        ``Decimal`` would buy precision we don't need (cost rows in
+        ``sleep_reports`` are stored as plain float32 / NULL today and
+        the dashboard displays 4 decimal places). If finer accounting
+        ever becomes a concern (sub-cent billing across millions of
+        calls), this returns to the conversation in #474.
+        """
+        if units <= 0:
+            return 0.0
+
+        row = await self.lookup(
+            provider=provider,
+            model=model,
+            unit_type=unit_type,
+            started_at=started_at,
+            context_tokens=context_tokens,
+        )
+        if row is None:
+            return None
+
+        return float(units) * float(row.price_per_unit) / float(row.unit_denominator)

--- a/backend/src/services/llm_pricing_service.py
+++ b/backend/src/services/llm_pricing_service.py
@@ -168,7 +168,9 @@ class LLMPricingService:
         ever becomes a concern (sub-cent billing across millions of
         calls), this returns to the conversation in #474.
         """
-        if units <= 0:
+        if units < 0:
+            raise ValueError(f"units must be >= 0, got {units}")
+        if units == 0:
             return 0.0
 
         row = await self.lookup(

--- a/backend/src/services/llm_pricing_service.py
+++ b/backend/src/services/llm_pricing_service.py
@@ -170,6 +170,14 @@ class LLMPricingService:
         """
         if units < 0:
             raise ValueError(f"units must be >= 0, got {units}")
+        # Validate ``unit_type`` BEFORE the ``units == 0`` fast-path so a
+        # typo gets the same ValueError it would in ``lookup()``. Otherwise
+        # ``compute_cost_usd(unit_type='input_tokens_typo', units=0)`` would
+        # silently return 0.0 and hide the bug until the next non-zero call.
+        if unit_type not in LLM_PRICING_UNIT_TYPES:
+            raise ValueError(
+                f"Invalid unit_type {unit_type!r}; must be one of {LLM_PRICING_UNIT_TYPES}"
+            )
         if units == 0:
             return 0.0
 

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import os
+from dataclasses import dataclass
 
 from openai import AsyncOpenAI
 from sqlalchemy import and_, select
@@ -28,6 +29,152 @@ logger = get_logger(__name__)
 
 class LLMServiceError(Exception):
     """Error from LLM service (parse failure, API error, etc.)."""
+
+
+@dataclass(frozen=True)
+class LLMResponse:
+    """Cost-grade LLM response payload (Issue #471).
+
+    Replaces the prior ``tuple[dict, int]`` return shape so callers can
+    record per-(provider, model) cost breakdowns without re-deriving which
+    model was used. Dropping a field would have meant another tuple-unpack
+    refactor across every phase; the dataclass scales cleanly.
+
+    **Back-compat**: this dataclass also unpacks as
+    ``(parsed, total_tokens)`` via ``__iter__`` below, so any caller
+    that still uses the legacy tuple shape (``parsed, tokens = await
+    complete_json(...)``) keeps working. New code should use the named
+    fields directly to avoid silently dropping per-class token data.
+
+    Token counts decompose ``response.usage`` for billing purposes:
+
+    - ``input_tokens``: ``prompt_tokens`` - ``cached_input_tokens`` (the
+      portion billed at the standard input rate).
+    - ``cached_input_tokens``: from
+      ``response.usage.prompt_tokens_details.cached_tokens`` when the
+      provider exposes it (OpenAI / Anthropic prompt caching). 0 otherwise.
+    - ``output_tokens``: ``response.usage.completion_tokens``.
+    - ``total_tokens``: legacy aggregate (``prompt_tokens +
+      completion_tokens``) — kept for the back-compat
+      ``sleep_reports.llm_tokens_used`` roll-up column. New cost code
+      should use the per-class fields, not this one.
+
+    ``tokenizer_version`` is None today (OpenAI does not expose the
+    tokenizer version in the API response). The field exists so future
+    Anthropic-SDK or per-deployment-pinned model paths can fill it in
+    without another return-shape change.
+    """
+
+    parsed: dict
+    total_tokens: int
+    input_tokens: int
+    output_tokens: int
+    cached_input_tokens: int
+    provider: str
+    model: str
+    tokenizer_version: str | None = None
+
+    def __iter__(self):
+        """Yield (parsed, total_tokens) so tuple-unpacking callers still work.
+
+        Pre-#471 the function returned ``tuple[dict, int]`` and callers
+        wrote ``parsed, tokens = await complete_json(...)``. Yielding
+        exactly two fields keeps that pattern functional. Three-element
+        unpacking would raise the standard ValueError, which is fine —
+        there was no 3-tuple legacy contract.
+        """
+        yield self.parsed
+        yield self.total_tokens
+
+
+@dataclass(frozen=True)
+class _Usage:
+    """Per-attempt token counts extracted from an OpenAI-compatible response.
+
+    Internal to ``LLMService``. Decomposes ``response.usage`` into the
+    billing-relevant classes (input net of cache, cached input, output)
+    and a pre-summed ``total`` for back-compat logging.
+    """
+
+    total: int
+    input: int
+    output: int
+    cached: int
+
+
+_ZERO_USAGE = _Usage(total=0, input=0, output=0, cached=0)
+
+
+def _extract_usage(response) -> _Usage:
+    """Read per-class token counts out of an OpenAI-compatible response.
+
+    Cached tokens come from ``response.usage.prompt_tokens_details.
+    cached_tokens`` when the provider exposes the field (modern OpenAI;
+    Ollama returns 0 because it has no cache concept). The cached portion
+    is *included in* ``prompt_tokens``, so the standard-rate input is
+    ``prompt_tokens - cached``.
+
+    PROVIDER-SPECIFIC: this function reads the OpenAI SDK response shape.
+    When a future provider with its own SDK is wired in (Anthropic
+    direct, etc.), branch on a provider parameter or split into
+    ``_extract_usage_openai`` / ``_extract_usage_anthropic``. Anthropic
+    in particular reports caching separately as
+    ``usage.cache_read_input_tokens`` / ``cache_creation_input_tokens``
+    and won't fit through this OpenAI-shaped reader without changes.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return _ZERO_USAGE
+
+    prompt = getattr(usage, "prompt_tokens", 0) or 0
+    completion = getattr(usage, "completion_tokens", 0) or 0
+    total = getattr(usage, "total_tokens", prompt + completion) or (prompt + completion)
+
+    details = getattr(usage, "prompt_tokens_details", None)
+    cached = getattr(details, "cached_tokens", 0) if details is not None else 0
+    cached = cached or 0
+
+    # Cached tokens are reported as a subset of prompt_tokens. The
+    # standard-rate input is what's left after subtracting cache.
+    standard_input = max(prompt - cached, 0)
+
+    return _Usage(total=total, input=standard_input, output=completion, cached=cached)
+
+
+def _build_response(
+    *,
+    parsed: dict,
+    first: _Usage,
+    retry: _Usage | None,
+    provider: str,
+    model: str,
+) -> LLMResponse:
+    """Combine first-attempt and (optional) retry usage into one LLMResponse.
+
+    Retries inflate the token bill (we paid for the failed attempt too);
+    matching the legacy behavior of ``tokens_used + retry_tokens`` for the
+    aggregate total. Per-class fields sum the same way.
+    """
+    if retry is None:
+        return LLMResponse(
+            parsed=parsed,
+            total_tokens=first.total,
+            input_tokens=first.input,
+            output_tokens=first.output,
+            cached_input_tokens=first.cached,
+            provider=provider,
+            model=model,
+        )
+
+    return LLMResponse(
+        parsed=parsed,
+        total_tokens=first.total + retry.total,
+        input_tokens=first.input + retry.input,
+        output_tokens=first.output + retry.output,
+        cached_input_tokens=first.cached + retry.cached,
+        provider=provider,
+        model=model,
+    )
 
 
 class LLMService:
@@ -58,8 +205,8 @@ class LLMService:
         provider: str | None = None,
         temperature: float = 0.1,
         max_tokens: int = 1024,
-    ) -> tuple[dict, int]:
-        """Call LLM with JSON mode and return parsed response.
+    ) -> LLMResponse:
+        """Call LLM with JSON mode and return cost-grade response.
 
         Args:
             user_id: User ID for API key retrieval
@@ -73,7 +220,9 @@ class LLMService:
             max_tokens: Max response tokens
 
         Returns:
-            Tuple of (parsed_json_dict, tokens_used)
+            LLMResponse — parsed JSON + per-class token counts +
+            (provider, model) identity. See ``LLMResponse`` docstring for
+            field semantics.
 
         Raises:
             LLMServiceError: On API error or JSON parse failure after retry
@@ -88,22 +237,31 @@ class LLMService:
 
         # First attempt
         content = ""
-        tokens_used = 0
+        first_usage = _ZERO_USAGE
         client = await self._get_client(user_id, resolved_provider, context_id, workspace_id)
         try:
             response = await client.chat.completions.create(
                 **self._build_create_kwargs(resolved_model, messages, temperature, max_tokens),
             )
             content = response.choices[0].message.content or "{}"
-            tokens_used = response.usage.total_tokens if response.usage else 0
+            first_usage = _extract_usage(response)
 
             parsed = json.loads(content)
             logger.debug(
                 "llm_complete_json_success",
                 model=resolved_model,
-                tokens=tokens_used,
+                tokens=first_usage.total,
+                input=first_usage.input,
+                cached=first_usage.cached,
+                output=first_usage.output,
             )
-            return parsed, tokens_used
+            return _build_response(
+                parsed=parsed,
+                first=first_usage,
+                retry=None,
+                provider=resolved_provider,
+                model=resolved_model,
+            )
 
         except json.JSONDecodeError:
             # Retry once with slightly higher temperature
@@ -124,15 +282,21 @@ class LLMService:
                 **self._build_create_kwargs(resolved_model, messages, 0.3, max_tokens),
             )
             content = response.choices[0].message.content or "{}"
-            retry_tokens = response.usage.total_tokens if response.usage else 0
+            retry_usage = _extract_usage(response)
 
             parsed = json.loads(content)
             logger.info(
                 "llm_complete_json_retry_success",
                 model=resolved_model,
-                tokens=tokens_used + retry_tokens,
+                tokens=first_usage.total + retry_usage.total,
             )
-            return parsed, tokens_used + retry_tokens
+            return _build_response(
+                parsed=parsed,
+                first=first_usage,
+                retry=retry_usage,
+                provider=resolved_provider,
+                model=resolved_model,
+            )
 
         except json.JSONDecodeError as e:
             raise LLMServiceError(

--- a/backend/src/services/sleep/consolidation.py
+++ b/backend/src/services/sleep/consolidation.py
@@ -33,7 +33,12 @@ from repositories.memory import MemoryRepository
 from services.graph_service import GraphService
 from services.llm_service import LLMService
 from services.sleep.prompts import CONSOLIDATION_JUDGE_SYSTEM, CONSOLIDATION_JUDGE_USER
-from services.sleep.reporter import PhaseResult, SleepBudget
+from services.sleep.reporter import (
+    LLMCallBreakdown,
+    PhaseResult,
+    SleepBudget,
+    accumulate_llm_response,
+)
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -69,6 +74,8 @@ class ConsolidationPhase:
         result = PhaseResult(phase_name="consolidation")
         llm_calls_before = budget.llm_calls_used
         self._tokens_used = 0
+        # #471: per-(provider, model) accumulator (lazy-init).
+        self._llm_breakdown: LLMCallBreakdown | None = None
 
         # Fetch working memories
         working = await self._fetch_working_memories(user_id, workspace_id, context_id)
@@ -216,6 +223,9 @@ class ConsolidationPhase:
         result.memories_processed = len(working)
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
+        # #471: attach per-(provider, model) breakdown.
+        if self._llm_breakdown is not None:
+            result.llm_breakdown = [self._llm_breakdown]
         result.details = {
             "working_count": len(working),
             "rule_promoted": promoted,
@@ -313,7 +323,7 @@ class ConsolidationPhase:
         prompt = CONSOLIDATION_JUDGE_USER.format(memories="\n".join(memory_lines))
 
         try:
-            response, tokens = await self.llm_service.complete_json(
+            llm_resp = await self.llm_service.complete_json(
                 user_id=user_id,
                 prompt=prompt,
                 system_prompt=CONSOLIDATION_JUDGE_SYSTEM,
@@ -323,14 +333,15 @@ class ConsolidationPhase:
                 provider=config.sleep_llm_provider,
             )
             budget.consume(llm_calls=1)
-            self._tokens_used += tokens
+            self._tokens_used += llm_resp.total_tokens
+            self._llm_breakdown = accumulate_llm_response(self._llm_breakdown, llm_resp)
         except Exception as e:
             logger.warning("consolidation_llm_failed", error=str(e))
             return {}
 
         # Parse with label validation
         decisions: dict[UUID, str] = {}
-        for item in response.get("decisions", []):
+        for item in llm_resp.parsed.get("decisions", []):
             label = item.get("label")
             action = item.get("action")
             if label not in label_to_id:

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -37,7 +37,12 @@ from repositories.neural_edge import NeuralEdgeRepository
 from services.embedding_service import EmbeddingService
 from services.llm_service import LLMService
 from services.sleep.prompts import DEDUP_JUDGE_SYSTEM, DEDUP_JUDGE_USER
-from services.sleep.reporter import PhaseResult, SleepBudget
+from services.sleep.reporter import (
+    LLMCallBreakdown,
+    PhaseResult,
+    SleepBudget,
+    accumulate_llm_response,
+)
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -132,6 +137,8 @@ class DedupMergePhase:
         result = PhaseResult(phase_name="dedup_merge")
         llm_calls_before = budget.llm_calls_used
         self._tokens_used = 0
+        # #471: per-(provider, model) accumulator (lazy-init).
+        self._llm_breakdown: LLMCallBreakdown | None = None
 
         if not config.sleep_dedup_enabled:
             result.skipped = True
@@ -237,6 +244,9 @@ class DedupMergePhase:
 
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
+        # #471: attach per-(provider, model) breakdown for child-row write.
+        if self._llm_breakdown is not None:
+            result.llm_breakdown = [self._llm_breakdown]
 
         logger.info(
             "dedup_merge_phase_completed",
@@ -407,7 +417,7 @@ class DedupMergePhase:
         )
 
         try:
-            response, tokens = await self.llm_service.complete_json(
+            llm_resp = await self.llm_service.complete_json(
                 user_id=user_id,
                 prompt=prompt,
                 system_prompt=DEDUP_JUDGE_SYSTEM,
@@ -417,9 +427,10 @@ class DedupMergePhase:
                 provider=config.sleep_llm_provider,
             )
             budget.consume(llm_calls=1)
-            self._tokens_used += tokens
+            self._tokens_used += llm_resp.total_tokens
+            self._llm_breakdown = accumulate_llm_response(self._llm_breakdown, llm_resp)
 
-            return self._parse_dedup_response(response, label_to_id)
+            return self._parse_dedup_response(llm_resp.parsed, label_to_id)
 
         except Exception as e:
             logger.warning("dedup_llm_judge_failed", error=str(e))

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -44,7 +44,12 @@ from services.sleep.prompts import (
     EDGE_DISCOVERY_SYSTEM,
     EDGE_DISCOVERY_USER,
 )
-from services.sleep.reporter import PhaseResult, SleepBudget
+from services.sleep.reporter import (
+    LLMCallBreakdown,
+    PhaseResult,
+    SleepBudget,
+    accumulate_llm_response,
+)
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -349,6 +354,10 @@ class EdgeDiscoveryPhase:
         # Reset on every execute(); init here so _llm_judge_batch can be called
         # in isolation (e.g. from unit tests) without AttributeError (#306).
         self._tokens_used = 0
+        # #471: per-(provider, model) cost-grade accumulator. Lazily
+        # initialized on the first LLM call so we don't fabricate empty
+        # rows for runs that early-return before any LLM use.
+        self._llm_breakdown: LLMCallBreakdown | None = None
 
     async def execute(
         self,
@@ -365,6 +374,7 @@ class EdgeDiscoveryPhase:
         result = PhaseResult(phase_name="edge_discovery")
         llm_calls_before = budget.llm_calls_used
         self._tokens_used = 0
+        self._llm_breakdown = None
 
         if not config.sleep_edge_discovery_enabled:
             result.skipped = True
@@ -503,6 +513,9 @@ class EdgeDiscoveryPhase:
         result.memories_processed = len(sampled)
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
+        # #471: attach per-(provider, model) breakdown for child-row write.
+        if self._llm_breakdown is not None:
+            result.llm_breakdown = [self._llm_breakdown]
         result.details = {
             "sampled": len(sampled),
             "candidates": len(candidates),
@@ -767,7 +780,7 @@ class EdgeDiscoveryPhase:
         # failed). Addresses Copilot review #371 finding (loop 2).
         budget.consume(llm_calls=1)
         try:
-            response, tokens = await self.llm_service.complete_json(
+            llm_resp = await self.llm_service.complete_json(
                 user_id=user_id,
                 prompt=prompt,
                 system_prompt=EDGE_DISCOVERY_SYSTEM,
@@ -776,7 +789,9 @@ class EdgeDiscoveryPhase:
                 model=config.sleep_llm_model,
                 provider=config.sleep_llm_provider,
             )
-            self._tokens_used += tokens
+            response = llm_resp.parsed
+            self._tokens_used += llm_resp.total_tokens
+            self._llm_breakdown = accumulate_llm_response(self._llm_breakdown, llm_resp)
 
         except Exception as e:
             logger.warning("edge_discovery_llm_failed", error=str(e))

--- a/backend/src/services/sleep/importance_reeval.py
+++ b/backend/src/services/sleep/importance_reeval.py
@@ -32,7 +32,12 @@ from db.qdrant import update_memory_payload_in_qdrant
 from models.memory import Memory
 from services.llm_service import LLMService
 from services.sleep.prompts import IMPORTANCE_REEVAL_SYSTEM, IMPORTANCE_REEVAL_USER
-from services.sleep.reporter import PhaseResult, SleepBudget
+from services.sleep.reporter import (
+    LLMCallBreakdown,
+    PhaseResult,
+    SleepBudget,
+    accumulate_llm_response,
+)
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -75,6 +80,8 @@ class ImportanceReevalPhase:
         result = PhaseResult(phase_name="importance_reeval")
         llm_calls_before = budget.llm_calls_used
         self._tokens_used = 0
+        # #471: per-(provider, model) accumulator (lazy-init).
+        self._llm_breakdown: LLMCallBreakdown | None = None
 
         if not config.sleep_importance_reeval_enabled:
             result.skipped = True
@@ -152,6 +159,9 @@ class ImportanceReevalPhase:
         result.memories_processed = updated_count
         result.llm_calls_used = budget.llm_calls_used - llm_calls_before
         result.tokens_used = self._tokens_used
+        # #471: attach per-(provider, model) breakdown.
+        if self._llm_breakdown is not None:
+            result.llm_breakdown = [self._llm_breakdown]
         result.details = {
             "candidates": len(candidates),
             "updated": updated_count,
@@ -218,7 +228,7 @@ class ImportanceReevalPhase:
         prompt = IMPORTANCE_REEVAL_USER.format(memories="\n".join(memory_lines))
 
         try:
-            response, tokens = await self.llm_service.complete_json(
+            llm_resp = await self.llm_service.complete_json(
                 user_id=user_id,
                 prompt=prompt,
                 system_prompt=IMPORTANCE_REEVAL_SYSTEM,
@@ -228,14 +238,15 @@ class ImportanceReevalPhase:
                 provider=config.sleep_llm_provider,
             )
             budget.consume(llm_calls=1)
-            self._tokens_used += tokens
+            self._tokens_used += llm_resp.total_tokens
+            self._llm_breakdown = accumulate_llm_response(self._llm_breakdown, llm_resp)
         except Exception as e:
             logger.warning("importance_reeval_llm_failed", error=str(e))
             return {}
 
         # Parse with label validation
         scores: dict[UUID, float] = {}
-        for item in response.get("scores", []):
+        for item in llm_resp.parsed.get("scores", []):
             label = item.get("label")
             importance = item.get("importance")
             if label not in label_to_id:

--- a/backend/src/services/sleep/reindex.py
+++ b/backend/src/services/sleep/reindex.py
@@ -84,13 +84,26 @@ class ReindexPhase:
                 continue
 
             try:
-                vector = await self.embedding_service.embed(
+                # #471: use embed_with_usage() to capture token count for
+                # cost-grade reporting. Cache hits return (vector, 0) which
+                # is the correct cost attribution — cached responses don't
+                # bill API tokens.
+                vector, tokens = await self.embedding_service.embed_with_usage(
                     memory.summary,
                     user_id=user_id,
                     context_id=context_id,
                     workspace_id=workspace_id,
                 )
                 result.embedding_calls_used += 1
+                result.embedding_tokens += tokens
+                # Embedding model is instance-global per the
+                # ``EmbeddingService`` config; capture the (provider, model)
+                # identity from the service on the first call so the
+                # reporter can populate the scalar columns on
+                # ``sleep_reports``.
+                if result.embedding_provider is None:
+                    result.embedding_provider = self.embedding_service.provider
+                    result.embedding_model = self.embedding_service.model
 
                 # Payload aligned with memory_service.py canonical format
                 payload = {

--- a/backend/src/services/sleep/reporter.py
+++ b/backend/src/services/sleep/reporter.py
@@ -1,6 +1,9 @@
 """Sleep Maintenance Phase 6: Report.
 
 Issue #101: Tracks sleep maintenance execution in sleep_reports table.
+Issue #471: Per-(provider, model) cost-grade breakdown via the
+``LLMCallBreakdown`` dataclass and ``embedding_*`` fields, persisted to
+``sleep_report_llm_usage`` / ``sleep_reports`` by ``complete_report()``.
 """
 
 from __future__ import annotations
@@ -10,7 +13,7 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.sleep import SleepAction, SleepReport
+from models.sleep import SleepAction, SleepReport, SleepReportLLMUsage
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -18,10 +21,100 @@ logger = get_logger(__name__)
 
 
 @dataclass
+class LLMCallBreakdown:
+    """Per-(provider, model) token usage from one or more LLM calls (#471).
+
+    Phases append one entry per (provider, model) actually used during the
+    phase. With today's single-model architecture (every phase reads
+    ``config.sleep_llm_model``), each phase produces exactly one entry,
+    and a typical sleep run produces 4 entries (one per LLM-using phase).
+    The schema and reporter are designed to scale to per-call multi-model
+    use without changing the call-site contract.
+
+    ``tokenizer_version`` is audit-only — never used as a price-lookup
+    key. See ``models/llm_pricing.py`` and #471 design references.
+    """
+
+    provider: str
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cached_input_tokens: int = 0
+    calls: int = 0
+    tokenizer_version: str | None = None
+
+    @property
+    def total_tokens(self) -> int:
+        """Reconstruct ``prompt_tokens + completion_tokens`` for the back-compat roll-up.
+
+        ``input_tokens`` here is the *standard-rate* portion
+        (``prompt_tokens - cached_input_tokens``) — see ``LLMResponse``
+        docstring. Adding the three back together rebuilds
+        ``prompt_tokens + completion_tokens``, which is what the
+        pre-#471 ``sleep_reports.llm_tokens_used`` column carried. This
+        is intentionally NOT a sum of "independent token classes" —
+        ``cached_input_tokens`` is a sub-component of ``prompt_tokens``,
+        not an additional axis. Use the per-class fields directly when
+        computing cost.
+        """
+        return self.input_tokens + self.output_tokens + self.cached_input_tokens
+
+    def add_call(
+        self,
+        *,
+        input_tokens: int,
+        output_tokens: int,
+        cached_input_tokens: int,
+    ) -> None:
+        """Accumulate one LLM call's tokens into this breakdown.
+
+        Used by phases that make multiple LLM calls against the same
+        (provider, model) within a single phase (e.g. edge_discovery
+        running N batches of pair judgments).
+        """
+        self.input_tokens += input_tokens
+        self.output_tokens += output_tokens
+        self.cached_input_tokens += cached_input_tokens
+        self.calls += 1
+
+
+def accumulate_llm_response(
+    breakdown: LLMCallBreakdown | None,
+    resp,  # services.llm_service.LLMResponse — late-bound to avoid import cycle
+) -> LLMCallBreakdown:
+    """Lazy-init + add_call combined for the four sleep phases (#471).
+
+    Phases all share the same single-(provider, model) accumulation
+    pattern — null-check, construct on first call, add tokens. Wrapping
+    that in a helper means a future field rename on ``LLMResponse``
+    only needs to be applied here, not in four phase files.
+    """
+    if breakdown is None:
+        breakdown = LLMCallBreakdown(
+            provider=resp.provider,
+            model=resp.model,
+            tokenizer_version=resp.tokenizer_version,
+        )
+    breakdown.add_call(
+        input_tokens=resp.input_tokens,
+        output_tokens=resp.output_tokens,
+        cached_input_tokens=resp.cached_input_tokens,
+    )
+    return breakdown
+
+
+@dataclass
 class PhaseResult:
     """Result from a single sleep phase execution.
 
     Used by all phases to report back to the orchestrator.
+
+    Issue #471 added the per-(provider, model) ``llm_breakdown`` list and
+    the ``embedding_*`` cost-grade fields. The legacy scalar counters
+    (``llm_calls_used`` / ``tokens_used`` / ``embedding_calls_used``)
+    remain the source of the back-compat roll-up columns on
+    ``sleep_reports``; reporter writes both. New code should consume
+    ``llm_breakdown`` directly for cost computation.
     """
 
     phase_name: str
@@ -35,6 +128,11 @@ class PhaseResult:
     memories_processed: int = 0
     changed_memory_ids: set[UUID] = field(default_factory=set)
     details: dict | None = None
+    # #471: cost-grade fields.
+    llm_breakdown: list[LLMCallBreakdown] = field(default_factory=list)
+    embedding_provider: str | None = None
+    embedding_model: str | None = None
+    embedding_tokens: int = 0
 
 
 @dataclass
@@ -123,23 +221,90 @@ class SleepReporter:
         report: SleepReport,
         phase_results: list[PhaseResult],
     ) -> None:
-        """Finalize a report with aggregated phase results."""
+        """Finalize a report with aggregated phase results.
+
+        Writes three layers of cost telemetry (#471):
+
+        1. ``sleep_report_llm_usage`` child rows — one per
+           (phase, provider, model) actually used. Drives #472's
+           ``GROUP BY`` cost-aggregation queries.
+        2. Embedding scalar columns on ``sleep_reports`` — captures
+           the (instance-global) embedding provider/model + token total,
+           sourced from any phase that populated them
+           (currently only reindex; #475 closes the phase 1/2 gap).
+        3. Legacy roll-up columns (``llm_calls_made``, ``llm_tokens_used``,
+           ``embedding_calls_made``) — populated as the sum of child rows
+           for back-compat with existing dashboards / log analyzers.
+        """
         report.status = "completed"
         report.completed_at = utcnow()
 
-        # Aggregate stats from all phases
+        # Single pass over phase_results: write child rows + per-phase
+        # JSON blob + accumulate roll-ups + embedding scalars + the
+        # divergence sanity check, all colocated. Phases that didn't
+        # call the LLM (today: only reindex) contribute no child rows.
+        # Embedding is instance-global per
+        # ``backend/src/config/settings.py:86-93`` — one provider/model
+        # per process, so we take the first non-empty pair and sum
+        # tokens (today only reindex contributes; phase 1/2 gap is #475).
+        # Legacy roll-up columns aggregate from ``result.llm_calls_used``
+        # / ``result.tokens_used`` (post-#471 phases populate both the
+        # legacy fields AND ``llm_breakdown`` — the divergence check
+        # below catches the case where they disagree).
         total_llm_calls = 0
         total_tokens = 0
         total_embedding_calls = 0
         total_memories = 0
+        embedding_tokens_total = 0
 
         for result in phase_results:
+            for breakdown in result.llm_breakdown:
+                self.db.add(
+                    SleepReportLLMUsage(
+                        report_id=report.id,
+                        phase=result.phase_name,
+                        provider=breakdown.provider,
+                        model=breakdown.model,
+                        input_tokens=breakdown.input_tokens,
+                        output_tokens=breakdown.output_tokens,
+                        cached_input_tokens=breakdown.cached_input_tokens,
+                        calls=breakdown.calls,
+                        tokenizer_version=breakdown.tokenizer_version,
+                    )
+                )
+
+            embedding_tokens_total += result.embedding_tokens
+            if report.embedding_provider is None and result.embedding_provider is not None:
+                report.embedding_provider = result.embedding_provider
+                report.embedding_model = result.embedding_model
+
             total_llm_calls += result.llm_calls_used
             total_tokens += result.tokens_used
             total_embedding_calls += result.embedding_calls_used
             total_memories += result.memories_processed
 
-            # Store per-phase results as JSON
+            # Sanity invariant: ``breakdown`` counts only successful
+            # LLM calls (the accumulate_llm_response() call is inside
+            # the ``try`` block, after the response is parsed).
+            # ``llm_calls_used`` / ``tokens_used`` are populated from the
+            # ``budget`` tracker, which in edge_discovery's pre-consume
+            # pattern (``edge_discovery.py`` line 768) counts FAILED
+            # calls too. So ``breakdown <= legacy`` is invariant; only
+            # ``breakdown > legacy`` is a real bug (would mean the
+            # phase is incorrectly accumulating breakdown for a call
+            # the budget didn't track — a future-arch regression).
+            breakdown_calls = sum(b.calls for b in result.llm_breakdown)
+            breakdown_tokens = sum(b.total_tokens for b in result.llm_breakdown)
+            if breakdown_calls > result.llm_calls_used or breakdown_tokens > result.tokens_used:
+                logger.warning(
+                    "phase_breakdown_exceeds_legacy",
+                    phase=result.phase_name,
+                    legacy_llm_calls=result.llm_calls_used,
+                    breakdown_calls=breakdown_calls,
+                    legacy_tokens=result.tokens_used,
+                    breakdown_tokens=breakdown_tokens,
+                )
+
             phase_data = {
                 "success": result.success,
                 "skipped": result.skipped,
@@ -148,6 +313,17 @@ class SleepReporter:
                 "llm_calls": result.llm_calls_used,
                 "memories_processed": result.memories_processed,
                 "details": result.details,
+                "llm_breakdown": [
+                    {
+                        "provider": b.provider,
+                        "model": b.model,
+                        "input_tokens": b.input_tokens,
+                        "output_tokens": b.output_tokens,
+                        "cached_input_tokens": b.cached_input_tokens,
+                        "calls": b.calls,
+                    }
+                    for b in result.llm_breakdown
+                ],
             }
 
             if result.phase_name == "edge_discovery":
@@ -161,6 +337,7 @@ class SleepReporter:
             elif result.phase_name == "reindex":
                 report.reindex_result = phase_data
 
+        report.embedding_tokens = embedding_tokens_total
         report.llm_calls_made = total_llm_calls
         report.llm_tokens_used = total_tokens
         report.embedding_calls_made = total_embedding_calls
@@ -185,6 +362,7 @@ class SleepReporter:
             report_id=str(report.id),
             llm_calls=total_llm_calls,
             tokens=total_tokens,
+            embedding_tokens=embedding_tokens_total,
             memories=total_memories,
         )
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -11,6 +11,14 @@ from sqlalchemy.pool import NullPool
 from models.auth import Base as AuthBase
 from models.memory import Base as MemoryBase
 
+# Issue #471: import the cost-grade pricing model so its table is
+# registered with the shared declarative ``Base.metadata`` and gets
+# created by ``create_all`` below. Sleep models are picked up
+# transitively via service imports today; importing explicitly here
+# keeps the test setup robust to future import-graph changes.
+import models.llm_pricing  # noqa: F401  isort: skip
+import models.sleep  # noqa: F401  isort: skip
+
 
 def pytest_configure(config: pytest.Config) -> None:
     """Validate asyncio_default_test_loop_scope matches fixture loop scope.

--- a/backend/tests/integration/test_llm_pricing.py
+++ b/backend/tests/integration/test_llm_pricing.py
@@ -62,14 +62,22 @@ async def test_lookup_picks_most_recent_effective_from(db_session):
                 provider="anthropic",
                 model="claude-sonnet-4-6",
                 unit_type="input_tokens",
-                effective_from=datetime(2026, 1, 1, ),
+                effective_from=datetime(
+                    2026,
+                    1,
+                    1,
+                ),
                 price_per_unit="2.50",
             ),
             _make_row(
                 provider="anthropic",
                 model="claude-sonnet-4-6",
                 unit_type="input_tokens",
-                effective_from=datetime(2026, 4, 1, ),
+                effective_from=datetime(
+                    2026,
+                    4,
+                    1,
+                ),
                 price_per_unit="3.00",
             ),
         ]
@@ -83,7 +91,11 @@ async def test_lookup_picks_most_recent_effective_from(db_session):
         provider="anthropic",
         model="claude-sonnet-4-6",
         unit_type="input_tokens",
-        started_at=datetime(2026, 2, 15, ),
+        started_at=datetime(
+            2026,
+            2,
+            15,
+        ),
     )
     assert early is not None
     assert float(early.price_per_unit) == 2.50
@@ -93,7 +105,11 @@ async def test_lookup_picks_most_recent_effective_from(db_session):
         provider="anthropic",
         model="claude-sonnet-4-6",
         unit_type="input_tokens",
-        started_at=datetime(2026, 4, 28, ),
+        started_at=datetime(
+            2026,
+            4,
+            28,
+        ),
     )
     assert late is not None
     assert float(late.price_per_unit) == 3.00
@@ -102,7 +118,11 @@ async def test_lookup_picks_most_recent_effective_from(db_session):
 @pytest.mark.asyncio
 async def test_lookup_picks_correct_context_tier(db_session):
     """Gemini-shaped multi-tier model: lookup picks the matching tier row."""
-    effective = datetime(2026, 4, 28, )
+    effective = datetime(
+        2026,
+        4,
+        28,
+    )
     db_session.add_all(
         [
             _make_row(
@@ -158,7 +178,11 @@ async def test_lookup_miss_returns_none(db_session):
         provider="exotic",
         model="never-seeded",
         unit_type="input_tokens",
-        started_at=datetime(2026, 4, 28, ),
+        started_at=datetime(
+            2026,
+            4,
+            28,
+        ),
     )
     assert result is None
 
@@ -176,7 +200,11 @@ async def test_lookup_rerank_search_units_schema_supports_no_rows(db_session):
         provider="cohere",
         model="rerank-3.5",
         unit_type="rerank_search_units",
-        started_at=datetime(2026, 4, 28, ),
+        started_at=datetime(
+            2026,
+            4,
+            28,
+        ),
     )
     assert result is None
 
@@ -190,7 +218,11 @@ async def test_lookup_invalid_unit_type_raises(db_session):
             provider="anthropic",
             model="claude-sonnet-4-6",
             unit_type="not_a_real_unit_type",  # type: ignore[arg-type]
-            started_at=datetime(2026, 4, 28, ),
+            started_at=datetime(
+                2026,
+                4,
+                28,
+            ),
         )
 
 
@@ -202,7 +234,11 @@ async def test_compute_cost_usd_per_million_tokens(db_session):
             provider="anthropic",
             model="claude-sonnet-4-6",
             unit_type="input_tokens",
-            effective_from=datetime(2026, 4, 28, ),
+            effective_from=datetime(
+                2026,
+                4,
+                28,
+            ),
             price_per_unit="3.00",
         )
     )
@@ -213,7 +249,11 @@ async def test_compute_cost_usd_per_million_tokens(db_session):
         provider="anthropic",
         model="claude-sonnet-4-6",
         unit_type="input_tokens",
-        started_at=datetime(2026, 4, 28, ),
+        started_at=datetime(
+            2026,
+            4,
+            28,
+        ),
         units=100_000,
     )
     assert cost is not None
@@ -224,7 +264,11 @@ async def test_compute_cost_usd_per_million_tokens(db_session):
         provider="anthropic",
         model="claude-sonnet-4-6",
         unit_type="input_tokens",
-        started_at=datetime(2026, 4, 28, ),
+        started_at=datetime(
+            2026,
+            4,
+            28,
+        ),
         units=1_000_000,
     )
     assert cost_full == pytest.approx(3.00)
@@ -238,7 +282,11 @@ async def test_compute_cost_usd_per_thousand_search_units(db_session):
             provider="cohere",
             model="rerank-3.5",
             unit_type="rerank_search_units",
-            effective_from=datetime(2026, 4, 28, ),
+            effective_from=datetime(
+                2026,
+                4,
+                28,
+            ),
             price_per_unit="2.00",
             unit_denominator=1_000,
         )
@@ -250,7 +298,11 @@ async def test_compute_cost_usd_per_thousand_search_units(db_session):
         provider="cohere",
         model="rerank-3.5",
         unit_type="rerank_search_units",
-        started_at=datetime(2026, 4, 28, ),
+        started_at=datetime(
+            2026,
+            4,
+            28,
+        ),
         units=500,
     )
     assert cost == pytest.approx(1.00)
@@ -264,7 +316,11 @@ async def test_compute_cost_usd_zero_units(db_session):
         provider="ollama",
         model="never-seeded",
         unit_type="embedding_tokens",
-        started_at=datetime(2026, 4, 28, ),
+        started_at=datetime(
+            2026,
+            4,
+            28,
+        ),
         units=0,
     )
     assert cost == 0.0
@@ -278,7 +334,11 @@ async def test_compute_cost_usd_lookup_miss_returns_none(db_session):
         provider="exotic",
         model="never-seeded",
         unit_type="output_tokens",
-        started_at=datetime(2026, 4, 28, ),
+        started_at=datetime(
+            2026,
+            4,
+            28,
+        ),
         units=1000,
     )
     assert cost is None
@@ -292,7 +352,11 @@ async def test_check_constraint_invalid_unit_type(db_session):
             provider="anthropic",
             model="claude-sonnet-4-6",
             unit_type="bogus_type",
-            effective_from=datetime(2026, 4, 28, ),
+            effective_from=datetime(
+                2026,
+                4,
+                28,
+            ),
             price_per_unit="1.00",
         )
     )
@@ -309,13 +373,53 @@ async def test_check_constraint_negative_price(db_session):
             provider="anthropic",
             model="claude-sonnet-4-6",
             unit_type="input_tokens",
-            effective_from=datetime(2026, 4, 28, ),
+            effective_from=datetime(
+                2026,
+                4,
+                28,
+            ),
             price_per_unit="-1.00",
         )
     )
     with pytest.raises(IntegrityError):
         await db_session.flush()
     await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_zero_unit_denominator(db_session):
+    """DB CHECK rejects unit_denominator=0 (would produce divide-by-zero in cost math)."""
+    db_session.add(
+        LLMPricing(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            unit_type="input_tokens",
+            effective_from=datetime(2026, 4, 28),
+            price_per_unit="3.00",
+            unit_denominator=0,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_usd_negative_units_raises(db_session):
+    """Negative ``units`` should raise ValueError (not silently return 0).
+
+    Hides upstream bugs and silently under-reports cost. The fast-path for
+    ``units == 0`` returning 0.0 is preserved.
+    """
+    svc = LLMPricingService(db_session)
+    with pytest.raises(ValueError, match="units must be >= 0"):
+        await svc.compute_cost_usd(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            unit_type="input_tokens",
+            started_at=datetime(2026, 4, 28),
+            units=-1,
+        )
 
 
 @pytest.mark.asyncio
@@ -326,7 +430,11 @@ async def test_check_constraint_tier_max_must_exceed_min(db_session):
             provider="google",
             model="gemini-2.5-pro",
             unit_type="input_tokens",
-            effective_from=datetime(2026, 4, 28, ),
+            effective_from=datetime(
+                2026,
+                4,
+                28,
+            ),
             price_per_unit="1.25",
             context_min_tokens=200_000,
             context_max_tokens=200_000,  # equal — must be strictly greater

--- a/backend/tests/integration/test_llm_pricing.py
+++ b/backend/tests/integration/test_llm_pricing.py
@@ -1,0 +1,337 @@
+"""Integration tests for the cost-grade pricing schema (Issue #471).
+
+Covers:
+
+- ``LLMPricingService.lookup()`` — temporal validity (``effective_from``),
+  context tier breakpoints, ``unit_type`` selection, and the documented
+  miss-returns-None behavior.
+- ``LLMPricingService.compute_cost_usd()`` — math correctness across
+  per-1M-tokens (``unit_denominator=1000000``) and per-1k-search-units
+  (``unit_denominator=1000``) rows.
+- CHECK constraints on ``llm_pricing`` — invalid ``unit_type``,
+  negative ``price_per_unit``, zero ``unit_denominator``, and the tier
+  ``context_max_tokens > context_min_tokens`` invariant.
+- Schema-supports-rerank-but-no-rows: a lookup for
+  ``unit_type='rerank_search_units'`` must return ``None`` cleanly
+  (#471 reserves the enum value for #474).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from models.llm_pricing import LLMPricing
+from services.llm_pricing_service import LLMPricingService
+
+
+def _make_row(
+    *,
+    provider: str,
+    model: str,
+    unit_type: str,
+    effective_from: datetime,
+    price_per_unit: str,
+    context_min_tokens: int = 0,
+    context_max_tokens: int | None = None,
+    unit_denominator: int = 1_000_000,
+    currency: str = "USD",
+) -> LLMPricing:
+    """Test-helper constructor for ``LLMPricing`` rows."""
+    return LLMPricing(
+        provider=provider,
+        model=model,
+        unit_type=unit_type,
+        effective_from=effective_from,
+        price_per_unit=price_per_unit,
+        context_min_tokens=context_min_tokens,
+        context_max_tokens=context_max_tokens,
+        unit_denominator=unit_denominator,
+        currency=currency,
+    )
+
+
+@pytest.mark.asyncio
+async def test_lookup_picks_most_recent_effective_from(db_session):
+    """A re-priced model returns the snapshot active at started_at."""
+    db_session.add_all(
+        [
+            _make_row(
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                unit_type="input_tokens",
+                effective_from=datetime(2026, 1, 1, ),
+                price_per_unit="2.50",
+            ),
+            _make_row(
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                unit_type="input_tokens",
+                effective_from=datetime(2026, 4, 1, ),
+                price_per_unit="3.00",
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    svc = LLMPricingService(db_session)
+
+    # Run started before the rate change → old rate.
+    early = await svc.lookup(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        unit_type="input_tokens",
+        started_at=datetime(2026, 2, 15, ),
+    )
+    assert early is not None
+    assert float(early.price_per_unit) == 2.50
+
+    # Run started after the change → new rate.
+    late = await svc.lookup(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        unit_type="input_tokens",
+        started_at=datetime(2026, 4, 28, ),
+    )
+    assert late is not None
+    assert float(late.price_per_unit) == 3.00
+
+
+@pytest.mark.asyncio
+async def test_lookup_picks_correct_context_tier(db_session):
+    """Gemini-shaped multi-tier model: lookup picks the matching tier row."""
+    effective = datetime(2026, 4, 28, )
+    db_session.add_all(
+        [
+            _make_row(
+                provider="google",
+                model="gemini-2.5-pro",
+                unit_type="input_tokens",
+                effective_from=effective,
+                price_per_unit="1.25",
+                context_min_tokens=0,
+                context_max_tokens=200_000,
+            ),
+            _make_row(
+                provider="google",
+                model="gemini-2.5-pro",
+                unit_type="input_tokens",
+                effective_from=effective,
+                price_per_unit="2.50",
+                context_min_tokens=200_000,
+                context_max_tokens=None,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    svc = LLMPricingService(db_session)
+
+    low = await svc.lookup(
+        provider="google",
+        model="gemini-2.5-pro",
+        unit_type="input_tokens",
+        started_at=effective,
+        context_tokens=50_000,
+    )
+    assert low is not None
+    assert float(low.price_per_unit) == 1.25
+
+    high = await svc.lookup(
+        provider="google",
+        model="gemini-2.5-pro",
+        unit_type="input_tokens",
+        started_at=effective,
+        context_tokens=300_000,
+    )
+    assert high is not None
+    assert float(high.price_per_unit) == 2.50
+
+
+@pytest.mark.asyncio
+async def test_lookup_miss_returns_none(db_session):
+    """Lookup for an unseeded model returns None — caller writes cost_usd=NULL."""
+    svc = LLMPricingService(db_session)
+    result = await svc.lookup(
+        provider="exotic",
+        model="never-seeded",
+        unit_type="input_tokens",
+        started_at=datetime(2026, 4, 28, ),
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_rerank_search_units_schema_supports_no_rows(db_session):
+    """The rerank_search_units enum exists in #471 but no rows are seeded.
+
+    This verifies the schema accepts the enum value without breaking
+    token-based queries — #474 will seed actual rerank rows. The lookup
+    must return ``None`` cleanly, not raise.
+    """
+    svc = LLMPricingService(db_session)
+    result = await svc.lookup(
+        provider="cohere",
+        model="rerank-3.5",
+        unit_type="rerank_search_units",
+        started_at=datetime(2026, 4, 28, ),
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_invalid_unit_type_raises(db_session):
+    """Service-layer validation rejects typos before they hit the DB."""
+    svc = LLMPricingService(db_session)
+    with pytest.raises(ValueError, match="Invalid unit_type"):
+        await svc.lookup(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            unit_type="not_a_real_unit_type",  # type: ignore[arg-type]
+            started_at=datetime(2026, 4, 28, ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_usd_per_million_tokens(db_session):
+    """1M tokens at $3/1M → $3.00; 100k tokens → $0.30."""
+    db_session.add(
+        _make_row(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            unit_type="input_tokens",
+            effective_from=datetime(2026, 4, 28, ),
+            price_per_unit="3.00",
+        )
+    )
+    await db_session.flush()
+
+    svc = LLMPricingService(db_session)
+    cost = await svc.compute_cost_usd(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        unit_type="input_tokens",
+        started_at=datetime(2026, 4, 28, ),
+        units=100_000,
+    )
+    assert cost is not None
+    assert cost == pytest.approx(0.30)
+
+    # 1M tokens → exactly $3.
+    cost_full = await svc.compute_cost_usd(
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+        unit_type="input_tokens",
+        started_at=datetime(2026, 4, 28, ),
+        units=1_000_000,
+    )
+    assert cost_full == pytest.approx(3.00)
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_usd_per_thousand_search_units(db_session):
+    """Cohere-shaped per-1k-SU pricing: 500 search units at $2/1k → $1.00."""
+    db_session.add(
+        _make_row(
+            provider="cohere",
+            model="rerank-3.5",
+            unit_type="rerank_search_units",
+            effective_from=datetime(2026, 4, 28, ),
+            price_per_unit="2.00",
+            unit_denominator=1_000,
+        )
+    )
+    await db_session.flush()
+
+    svc = LLMPricingService(db_session)
+    cost = await svc.compute_cost_usd(
+        provider="cohere",
+        model="rerank-3.5",
+        unit_type="rerank_search_units",
+        started_at=datetime(2026, 4, 28, ),
+        units=500,
+    )
+    assert cost == pytest.approx(1.00)
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_usd_zero_units(db_session):
+    """Zero units → $0.00 without hitting the DB."""
+    svc = LLMPricingService(db_session)
+    cost = await svc.compute_cost_usd(
+        provider="ollama",
+        model="never-seeded",
+        unit_type="embedding_tokens",
+        started_at=datetime(2026, 4, 28, ),
+        units=0,
+    )
+    assert cost == 0.0
+
+
+@pytest.mark.asyncio
+async def test_compute_cost_usd_lookup_miss_returns_none(db_session):
+    """Lookup miss propagates as None (caller writes cost_usd=NULL)."""
+    svc = LLMPricingService(db_session)
+    cost = await svc.compute_cost_usd(
+        provider="exotic",
+        model="never-seeded",
+        unit_type="output_tokens",
+        started_at=datetime(2026, 4, 28, ),
+        units=1000,
+    )
+    assert cost is None
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_invalid_unit_type(db_session):
+    """DB CHECK rejects unknown unit_type values (defense in depth)."""
+    db_session.add(
+        LLMPricing(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            unit_type="bogus_type",
+            effective_from=datetime(2026, 4, 28, ),
+            price_per_unit="1.00",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_negative_price(db_session):
+    """DB CHECK rejects negative prices."""
+    db_session.add(
+        LLMPricing(
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            unit_type="input_tokens",
+            effective_from=datetime(2026, 4, 28, ),
+            price_per_unit="-1.00",
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_tier_max_must_exceed_min(db_session):
+    """DB CHECK rejects context_max <= context_min."""
+    db_session.add(
+        LLMPricing(
+            provider="google",
+            model="gemini-2.5-pro",
+            unit_type="input_tokens",
+            effective_from=datetime(2026, 4, 28, ),
+            price_per_unit="1.25",
+            context_min_tokens=200_000,
+            context_max_tokens=200_000,  # equal — must be strictly greater
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -82,24 +82,37 @@ def _make_edge(edge_type, weight, dst_id=None):
 
 
 def _make_llm_response(edges, tokens=100):
-    """Build a canned `complete_json` return value: (response_dict, tokens).
+    """Build a canned ``complete_json`` return value (Issue #471 LLMResponse).
 
     Each entry in ``edges`` is a tuple of:
         (label_a, label_b, related: bool, edge_type: str, confidence: float)
+
+    The returned ``LLMResponse`` mirrors the new cost-grade signature: it
+    provides ``parsed`` (the JSON dict the prod code reads), ``total_tokens``
+    (the legacy aggregate the budget tracker reads), and zeroed per-class
+    counters since these tests don't assert on cost.
     """
-    return (
-        {
-            "edges": [
-                {
-                    "pair": [a, b],
-                    "related": related,
-                    "edge_type": edge_type,
-                    "confidence": confidence,
-                }
-                for (a, b, related, edge_type, confidence) in edges
-            ]
-        },
-        tokens,
+    from services.llm_service import LLMResponse
+
+    parsed = {
+        "edges": [
+            {
+                "pair": [a, b],
+                "related": related,
+                "edge_type": edge_type,
+                "confidence": confidence,
+            }
+            for (a, b, related, edge_type, confidence) in edges
+        ]
+    }
+    return LLMResponse(
+        parsed=parsed,
+        total_tokens=tokens,
+        input_tokens=tokens,
+        output_tokens=0,
+        cached_input_tokens=0,
+        provider="openai",
+        model="gpt-5-nano",
     )
 
 
@@ -886,8 +899,11 @@ class TestDirectedEdgeOrientation:
         labels = _labels_for(memory_map)
 
         # Build the response by hand — _make_llm_response only takes str.
-        llm_judge_phase.llm_service.complete_json.return_value = (
-            {
+        # Issue #471: complete_json now returns LLMResponse, not a tuple.
+        from services.llm_service import LLMResponse
+
+        llm_judge_phase.llm_service.complete_json.return_value = LLMResponse(
+            parsed={
                 "edges": [
                     {
                         "pair": [labels[batch[0][0]], labels[batch[0][1]]],
@@ -905,7 +921,12 @@ class TestDirectedEdgeOrientation:
                     },
                 ]
             },
-            100,
+            total_tokens=100,
+            input_tokens=100,
+            output_tokens=0,
+            cached_input_tokens=0,
+            provider="openai",
+            model="gpt-5-nano",
         )
 
         confirmed, stats = await llm_judge_phase._llm_judge_batch(

--- a/backend/tests/services/sleep/test_reindex.py
+++ b/backend/tests/services/sleep/test_reindex.py
@@ -76,7 +76,8 @@ class TestReindexPhase:
         changed_ids = {mem1.id, mem2.id}
 
         _mock_batch_fetch(mock_db, [mem1, mem2])
-        reindex_phase.embedding_service.embed = AsyncMock(return_value=[0.1] * 768)
+        # #471: reindex now calls embed_with_usage() returning (vector, tokens).
+        reindex_phase.embedding_service.embed_with_usage = AsyncMock(return_value=([0.1] * 768, 50))
 
         result = await reindex_phase.execute(
             changed_memory_ids=changed_ids,
@@ -120,8 +121,8 @@ class TestReindexPhase:
         _mock_batch_fetch(mock_db, [mem_fail, mem_ok])
 
         # First embed fails, second succeeds
-        reindex_phase.embedding_service.embed = AsyncMock(
-            side_effect=[RuntimeError("embed failed"), [0.1] * 768]
+        reindex_phase.embedding_service.embed_with_usage = AsyncMock(
+            side_effect=[RuntimeError("embed failed"), ([0.1] * 768, 50)]
         )
 
         result = await reindex_phase.execute(
@@ -144,7 +145,9 @@ class TestReindexPhase:
 
         _mock_batch_fetch(mock_db, [mem])
 
-        reindex_phase.embedding_service.embed = AsyncMock(side_effect=RuntimeError("embed failed"))
+        reindex_phase.embedding_service.embed_with_usage = AsyncMock(
+            side_effect=RuntimeError("embed failed")
+        )
 
         result = await reindex_phase.execute(
             changed_memory_ids=changed_ids,

--- a/backend/tests/services/sleep/test_reporter_cost_grade.py
+++ b/backend/tests/services/sleep/test_reporter_cost_grade.py
@@ -1,0 +1,185 @@
+"""Cost-grade reporter tests (Issue #471).
+
+Companions to ``test_reporter.py`` — these specifically cover the new
+behaviors:
+
+- ``LLMCallBreakdown.add_call`` accumulation semantics.
+- Per-(phase, provider, model) child rows are written to
+  ``sleep_report_llm_usage`` when ``llm_breakdown`` is populated.
+- Embedding scalar columns on ``sleep_reports`` are populated when any
+  phase reports an embedding provider/model/tokens triple.
+- Legacy roll-up columns (``llm_calls_made``, ``llm_tokens_used``,
+  ``embedding_calls_made``) stay populated for back-compat — the
+  pre-#471 contract is preserved.
+
+These run as plain unit tests with a mocked DB (matching the existing
+``test_reporter.py`` style), so no Docker container is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from models.sleep import SleepReportLLMUsage
+from services.sleep.reporter import (
+    LLMCallBreakdown,
+    PhaseResult,
+    SleepReporter,
+)
+
+
+class TestLLMCallBreakdown:
+    def test_default_values(self):
+        b = LLMCallBreakdown(provider="anthropic", model="claude-sonnet-4-6")
+        assert b.input_tokens == 0
+        assert b.output_tokens == 0
+        assert b.cached_input_tokens == 0
+        assert b.calls == 0
+        assert b.tokenizer_version is None
+        assert b.total_tokens == 0
+
+    def test_add_call_accumulates(self):
+        b = LLMCallBreakdown(provider="anthropic", model="claude-sonnet-4-6")
+        b.add_call(input_tokens=100, output_tokens=50, cached_input_tokens=10)
+        b.add_call(input_tokens=200, output_tokens=80, cached_input_tokens=20)
+        assert b.input_tokens == 300
+        assert b.output_tokens == 130
+        assert b.cached_input_tokens == 30
+        assert b.calls == 2
+        assert b.total_tokens == 460  # 300 + 130 + 30
+
+
+class TestReporterCostGradeChildRows:
+    """Reporter writes ``sleep_report_llm_usage`` rows from ``llm_breakdown``."""
+
+    @pytest.fixture
+    def mock_db(self):
+        db = AsyncMock()
+        db.add = MagicMock()
+        db.flush = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def reporter(self, mock_db):
+        return SleepReporter(mock_db)
+
+    @pytest.mark.asyncio
+    async def test_complete_report_writes_child_rows(self, reporter, mock_db):
+        """One ``SleepReportLLMUsage`` row per (phase, provider, model) breakdown."""
+        report = MagicMock()
+        report.id = uuid4()
+        report.embedding_provider = None
+        report.embedding_model = None
+
+        edge_breakdown = LLMCallBreakdown(
+            provider="openai",
+            model="gpt-5-nano",
+            input_tokens=400,
+            output_tokens=120,
+            cached_input_tokens=50,
+            calls=3,
+        )
+        dedup_breakdown = LLMCallBreakdown(
+            provider="openai",
+            model="gpt-5-nano",
+            input_tokens=200,
+            output_tokens=60,
+            cached_input_tokens=0,
+            calls=2,
+        )
+
+        results = [
+            PhaseResult(
+                phase_name="edge_discovery",
+                llm_calls_used=3,
+                tokens_used=570,  # 400 + 120 + 50
+                memories_processed=20,
+                llm_breakdown=[edge_breakdown],
+            ),
+            PhaseResult(
+                phase_name="dedup_merge",
+                llm_calls_used=2,
+                tokens_used=260,  # 200 + 60
+                memories_processed=10,
+                llm_breakdown=[dedup_breakdown],
+            ),
+            # Reindex contributes no LLM but populates embedding triple.
+            PhaseResult(
+                phase_name="reindex",
+                embedding_calls_used=8,
+                memories_processed=8,
+                embedding_provider="openai",
+                embedding_model="text-embedding-3-small",
+                embedding_tokens=4096,
+            ),
+        ]
+
+        await reporter.complete_report(report, results)
+
+        # Two LLM child rows written (one per phase × model).
+        added = [
+            call.args[0]
+            for call in mock_db.add.call_args_list
+            if isinstance(call.args[0], SleepReportLLMUsage)
+        ]
+        assert len(added) == 2
+        phase_names = {row.phase for row in added}
+        assert phase_names == {"edge_discovery", "dedup_merge"}
+
+        edge_row = next(r for r in added if r.phase == "edge_discovery")
+        assert edge_row.provider == "openai"
+        assert edge_row.model == "gpt-5-nano"
+        assert edge_row.input_tokens == 400
+        assert edge_row.output_tokens == 120
+        assert edge_row.cached_input_tokens == 50
+        assert edge_row.calls == 3
+
+        # Embedding scalar columns populated from reindex.
+        assert report.embedding_provider == "openai"
+        assert report.embedding_model == "text-embedding-3-small"
+        assert report.embedding_tokens == 4096
+
+        # Legacy roll-up columns stay populated for back-compat.
+        assert report.llm_calls_made == 5  # 3 + 2
+        assert report.llm_tokens_used == 830  # 570 + 260
+        assert report.embedding_calls_made == 8
+
+    @pytest.mark.asyncio
+    async def test_complete_report_no_breakdown_no_child_rows(self, reporter, mock_db):
+        """Phases without ``llm_breakdown`` produce no child rows.
+
+        The legacy roll-up still aggregates from
+        ``llm_calls_used`` / ``tokens_used`` so legacy tests stay green
+        and unmigrated phases still report sensible totals.
+        """
+        report = MagicMock()
+        report.id = uuid4()
+        report.embedding_provider = None
+        report.embedding_model = None
+
+        results = [
+            PhaseResult(
+                phase_name="edge_discovery",
+                llm_calls_used=5,
+                tokens_used=500,
+                memories_processed=20,
+                # No llm_breakdown — pre-#471 phase.
+            ),
+        ]
+
+        await reporter.complete_report(report, results)
+
+        # No SleepReportLLMUsage rows added.
+        added_usage = [
+            call.args[0]
+            for call in mock_db.add.call_args_list
+            if isinstance(call.args[0], SleepReportLLMUsage)
+        ]
+        assert added_usage == []
+
+        # Legacy roll-up still populated (back-compat path).
+        assert report.llm_calls_made == 5
+        assert report.llm_tokens_used == 500

--- a/backend/tests/services/test_llm_service.py
+++ b/backend/tests/services/test_llm_service.py
@@ -24,10 +24,35 @@ def llm_service(mock_db):
     return LLMService(mock_db)
 
 
-def _make_completion_response(content: str, total_tokens: int = 42):
-    """Create a mock chat completion response."""
+def _make_completion_response(
+    content: str,
+    total_tokens: int = 42,
+    *,
+    prompt_tokens: int | None = None,
+    completion_tokens: int | None = None,
+    cached_tokens: int = 0,
+):
+    """Create a mock chat completion response.
+
+    Defaults split ``total_tokens`` evenly into prompt+completion when the
+    caller doesn't specify, so the new ``LLMResponse`` extractor (#471)
+    can decompose into per-class counters without hitting MagicMock
+    arithmetic. Pass ``prompt_tokens`` / ``completion_tokens`` explicitly
+    to test the decomposition.
+    """
+    if prompt_tokens is None:
+        prompt_tokens = total_tokens // 2
+    if completion_tokens is None:
+        completion_tokens = total_tokens - prompt_tokens
+
+    details = MagicMock()
+    details.cached_tokens = cached_tokens
+
     usage = MagicMock()
     usage.total_tokens = total_tokens
+    usage.prompt_tokens = prompt_tokens
+    usage.completion_tokens = completion_tokens
+    usage.prompt_tokens_details = details
 
     message = MagicMock()
     message.content = content
@@ -56,14 +81,14 @@ class TestCompleteJson:
             mock_client.chat.completions.create.return_value = mock_response
             mock_get_client.return_value = mock_client
 
-            result, tokens = await llm_service.complete_json(
+            resp = await llm_service.complete_json(
                 user_id="user-1",
                 prompt="Test prompt",
                 system_prompt="You are a judge.",
             )
 
-        assert result == {"result": "ok", "score": 0.95}
-        assert tokens == 50
+        assert resp.parsed == {"result": "ok", "score": 0.95}
+        assert resp.total_tokens == 50
 
         # Verify system + user messages
         call_kwargs = mock_client.chat.completions.create.call_args[1]
@@ -199,12 +224,12 @@ class TestCompleteJson:
             mock_client.chat.completions.create.return_value = mock_response
             mock_get_client.return_value = mock_client
 
-            result, _ = await llm_service.complete_json(
+            resp = await llm_service.complete_json(
                 user_id="user-1",
                 prompt="Test",
             )
 
-        assert result == {"ok": True}
+        assert resp.parsed == {"ok": True}
         call_kwargs = mock_client.chat.completions.create.call_args[1]
         assert len(call_kwargs["messages"]) == 1
         assert call_kwargs["messages"][0]["role"] == "user"
@@ -227,14 +252,14 @@ class TestCompleteJson:
             ]
             mock_get_client.return_value = mock_client
 
-            result, tokens = await llm_service.complete_json(
+            resp = await llm_service.complete_json(
                 user_id="user-1",
                 prompt="Test",
                 model="gpt-4o-mini",
             )
 
-        assert result == {"retried": True}
-        assert tokens == 30 + 35  # Both attempts counted
+        assert resp.parsed == {"retried": True}
+        assert resp.total_tokens == 30 + 35  # Both attempts counted
 
         # Verify retry used higher temperature (GPT-4 path, temperature kwarg present)
         calls = mock_client.chat.completions.create.call_args_list
@@ -311,12 +336,12 @@ class TestCompleteJson:
             mock_client.chat.completions.create.return_value = response
             mock_get_client.return_value = mock_client
 
-            _, tokens = await llm_service.complete_json(
+            resp = await llm_service.complete_json(
                 user_id="user-1",
                 prompt="Test",
             )
 
-        assert tokens == 0
+        assert resp.total_tokens == 0
 
 
 class TestGetClient:


### PR DESCRIPTION
Closes #471

## Summary
- Schema-first foundation for the LLM cost dashboard chain (#471 → #472 API → #473 UI). Replaces the single-int `llm_tokens_used` operational metric with a cost-grade telemetry layer.
- New child table `sleep_report_llm_usage` carries per-(phase, provider, model) breakdown — drives #472's `GROUP BY` cost-aggregation queries cleanly.
- New append-only `llm_pricing` master table with `unit_type` enum (text + CHECK), `unit_denominator` (1M tokens / 1k SU), and tier breakpoints. Append-only `effective_from` snapshots keep historical reports reproducible across rate changes.
- `LLMResponse` dataclass replaces the prior `tuple[dict, int]` return shape with per-class token decomposition (input/output/cached_input). Backward-compatible via `__iter__`.
- Sleep reporter writes per-(phase, provider, model) child rows AND maintains legacy roll-up columns (`llm_tokens_used` etc) for back-compat.

## Implementation notes
- **Migrations**: `c02_471_cost_grade_schema` (tables + columns) and `c03_471_seed_pricing` (2026-04-28 prices for Anthropic Claude family, OpenAI gpt-5.5/gpt-5-nano, text-embedding-3-{small,large}, Ollama). Seed uses `sa.text().bindparams()` per the no-f-string-SQL rule. Both reversible via `downgrade()`.
- **Naive `DateTime`** for `effective_from` to match `sleep_reports.started_at` and the rest of the codebase (UTC-by-convention) — avoids tz-aware/naive `TypeError` on JOINs in #472.
- **`accumulate_llm_response()` helper** in `services/sleep/reporter.py` centralizes the lazy-init + add_call accumulation pattern across the 4 LLM-using sleep phases.
- **`embed_with_usage()` additive method** on EmbeddingService captures embedding token count for cost attribution. `embed()` now thin-delegates to it.
- **Reranker (Voyage / Cohere) and non-Sleep LLM call sites** (recall path, future `ask()`) are explicitly out of scope — captured in #474 (comprehensive ledger). The `llm_pricing.unit_type` enum reserves `rerank_tokens` / `rerank_search_units` from day 1 to avoid CHECK-constraint migration when #474 lands.
- **Out of scope**: aggregation API (#472), dashboard UI (#473), backfilling historical NULL-model rows, free-tier quota tracking, multi-currency display, Claude subscription mode (cap-based metering, deferred to kagura-agent project), retroactive rebill on tokenizer change, full-pipeline embedding tracking (#475).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CIO lens, 2 rounds — yellow → body patch → green)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/471-feat-feat-db-sleep-cost-grade-schema-for-slee.gate1.md
- ~/.claude/cache/gh-issue-driven/471-feat-feat-db-sleep-cost-grade-schema-for-slee.gate2.md

## Test plan
- [x] `make lint` — All checks passed
- [x] `make type-check` — pyright 0 errors / 0 warnings
- [x] `pytest tests/services/sleep/ tests/services/test_llm_service.py` — 141 passed
- [x] `pytest tests/services/ tests/utils/ tests/auth/ tests/neural/` — 807 passed, 5 skipped (DB-dependent)
- [ ] CI: `make test-integration` runs the 12 new pricing integration tests

🤖 Generated via /gh-issue-driven:ship
