### PR TITLE
perf(stripe): wrap sync stripe-python calls in asyncio.to_thread (#468)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -100,25 +100,15 @@ async def lifespan(app: FastAPI):
     logger.info("scheduler_stopped")
 
     # Stop the dedicated Stripe erasure ThreadPoolExecutor (Issue #468).
-    # No-op when billing is disabled (the executor is lazy-initialized).
-    # Bounded by a 30s timeout so an erasure mid-shutdown cannot hold the
-    # lifespan past typical orchestrator grace periods (e.g. Kubernetes
-    # terminationGracePeriodSeconds=30). Orphaned in-flight Stripe calls
-    # are equivalent to the SIGKILL fallback that would have fired anyway.
+    # ``wait=False`` returns immediately so lifespan shutdown is not held
+    # by in-flight Stripe HTTP calls — k8s SIGKILL after the grace period
+    # is the existing process-exit fallback either way, and erasure is
+    # best-effort (Stripe processes the request server-side regardless of
+    # whether we read the ack). No-op when billing is disabled.
     from services.stripe_service import shutdown_erasure_executor
 
-    stripe_erasure_shutdown_timeout_seconds = 30
-    try:
-        await asyncio.wait_for(
-            asyncio.to_thread(shutdown_erasure_executor),
-            timeout=stripe_erasure_shutdown_timeout_seconds,
-        )
-        logger.info("stripe_erasure_executor_stopped")
-    except TimeoutError:
-        logger.warning(
-            "stripe_erasure_executor_shutdown_timed_out",
-            timeout_seconds=stripe_erasure_shutdown_timeout_seconds,
-        )
+    shutdown_erasure_executor()
+    logger.info("stripe_erasure_executor_stopped")
 
     # Close database
     from db.base import close_db

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -99,6 +99,13 @@ async def lifespan(app: FastAPI):
     shutdown_scheduler()
     logger.info("scheduler_stopped")
 
+    # Stop the dedicated Stripe erasure ThreadPoolExecutor (Issue #468).
+    # No-op when billing is disabled (the executor is lazy-initialized).
+    from services.stripe_service import shutdown_erasure_executor
+
+    shutdown_erasure_executor()
+    logger.info("stripe_erasure_executor_stopped")
+
     # Close database
     from db.base import close_db
 

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -101,10 +101,24 @@ async def lifespan(app: FastAPI):
 
     # Stop the dedicated Stripe erasure ThreadPoolExecutor (Issue #468).
     # No-op when billing is disabled (the executor is lazy-initialized).
+    # Bounded by a 30s timeout so an erasure mid-shutdown cannot hold the
+    # lifespan past typical orchestrator grace periods (e.g. Kubernetes
+    # terminationGracePeriodSeconds=30). Orphaned in-flight Stripe calls
+    # are equivalent to the SIGKILL fallback that would have fired anyway.
     from services.stripe_service import shutdown_erasure_executor
 
-    shutdown_erasure_executor()
-    logger.info("stripe_erasure_executor_stopped")
+    stripe_erasure_shutdown_timeout_seconds = 30
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(shutdown_erasure_executor),
+            timeout=stripe_erasure_shutdown_timeout_seconds,
+        )
+        logger.info("stripe_erasure_executor_stopped")
+    except TimeoutError:
+        logger.warning(
+            "stripe_erasure_executor_shutdown_timed_out",
+            timeout_seconds=stripe_erasure_shutdown_timeout_seconds,
+        )
 
     # Close database
     from db.base import close_db

--- a/backend/src/services/stripe_service.py
+++ b/backend/src/services/stripe_service.py
@@ -52,20 +52,23 @@ def _get_erasure_executor() -> ThreadPoolExecutor:
 
 
 def shutdown_erasure_executor() -> None:
-    """Tear down the erasure executor cleanly on app shutdown.
+    """Tear down the erasure executor on app shutdown.
 
     Registered from ``api.main.lifespan``. Safe to call when the executor
     was never created (no-op) and safe to call twice (second call is a
     no-op).
 
-    ``cancel_futures=True`` drops queued (not-yet-started) tasks so the
-    shutdown latency is bounded by ``max_workers × stripe_default_timeout``
-    (~160s) instead of ``pending_count × stripe_default_timeout``. In-flight
-    Stripe calls still finish so customer-deletion isn't half-committed.
+    Uses ``wait=False`` so this returns immediately rather than blocking
+    the lifespan on in-flight Stripe HTTP calls. ``cancel_futures=True``
+    drops queued (not-yet-started) tasks. Any in-flight Stripe call
+    keeps running in its worker thread until either the call completes
+    or the process is killed by the orchestrator's SIGKILL after grace
+    period — erasure is best-effort, so an orphaned ack is acceptable
+    (Stripe processes the cancel/delete server-side regardless).
     """
     global _erasure_executor
     if _erasure_executor is not None:
-        _erasure_executor.shutdown(wait=True, cancel_futures=True)
+        _erasure_executor.shutdown(wait=False, cancel_futures=True)
         _erasure_executor = None
 
 

--- a/backend/src/services/stripe_service.py
+++ b/backend/src/services/stripe_service.py
@@ -1,9 +1,16 @@
 """Stripe billing service.
 
 Issue #351: Stripe integration for SaaS deployments.
+Issue #468: synchronous stripe-python calls are wrapped via asyncio
+(see in-body docs at the executor declaration).
 Only active when BILLING_ENABLED=true.
 """
 
+import asyncio
+import functools
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, TypeVar
 from uuid import UUID
 
 import stripe
@@ -14,12 +21,74 @@ from config.plan_tiers import get_plan_tier
 from config.settings import get_settings
 from models.auth import PlanChange, Workspace
 from utils.datetime import utcnow
+from utils.exceptions import StripeError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
 # Plan name → Stripe Price ID mapping
 _PLAN_PRICE_MAP: dict[str, str] = {}
+
+# Issue #468: dedicated ThreadPoolExecutor for the GDPR erasure sweep so a
+# burst of erasure requests cannot starve checkout/portal traffic on the
+# default ``asyncio.to_thread`` pool. The sweep is internally serialized
+# (one workspace at a time, cancel → delete in order), so workers=2 is
+# enough to allow concurrent erasures across users while keeping the pool
+# small. Lazy-initialized to avoid creating threads when billing is off.
+_erasure_executor: ThreadPoolExecutor | None = None
+
+T = TypeVar("T")
+
+
+def _get_erasure_executor() -> ThreadPoolExecutor:
+    """Lazily create and return the dedicated erasure ThreadPoolExecutor."""
+    global _erasure_executor
+    if _erasure_executor is None:
+        _erasure_executor = ThreadPoolExecutor(
+            max_workers=2,
+            thread_name_prefix="stripe-erasure",
+        )
+    return _erasure_executor
+
+
+def shutdown_erasure_executor() -> None:
+    """Tear down the erasure executor cleanly on app shutdown.
+
+    Registered from ``api.main.lifespan``. Safe to call when the executor
+    was never created (no-op) and safe to call twice (second call is a
+    no-op).
+
+    ``cancel_futures=True`` drops queued (not-yet-started) tasks so the
+    shutdown latency is bounded by ``max_workers × stripe_default_timeout``
+    (~160s) instead of ``pending_count × stripe_default_timeout``. In-flight
+    Stripe calls still finish so customer-deletion isn't half-committed.
+    """
+    global _erasure_executor
+    if _erasure_executor is not None:
+        _erasure_executor.shutdown(wait=True, cancel_futures=True)
+        _erasure_executor = None
+
+
+async def _run_stripe(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Run a synchronous stripe-python call on the default thread pool.
+
+    Suitable for low-rate user-initiated calls (checkout, portal). Use
+    ``_run_stripe_erasure`` for the erasure sweep so a burst of
+    erasures cannot starve checkout/portal.
+    """
+    return await asyncio.to_thread(func, *args, **kwargs)
+
+
+async def _run_stripe_erasure(func: Callable[..., T], *args: Any, **kwargs: Any) -> T:
+    """Run a synchronous stripe-python call on the dedicated erasure pool.
+
+    ``functools.partial`` is required so ``**kwargs`` survive the
+    ``run_in_executor`` boundary (which only forwards positionals).
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        _get_erasure_executor(), functools.partial(func, *args, **kwargs)
+    )
 
 
 def _init_stripe() -> None:
@@ -85,7 +154,14 @@ async def create_checkout_session(
     else:
         checkout_params["customer_creation"] = "always"
 
-    session = stripe.checkout.Session.create(**checkout_params)
+    session = await _run_stripe(stripe.checkout.Session.create, **checkout_params)
+    if session.url is None:
+        # ``Session.url`` is typed ``Optional[str]`` in stripe-python because
+        # non-redirect modes (``ui_mode="embedded"``, certain ``mode`` values)
+        # do not populate it. We always pass ``mode="subscription"`` with
+        # ``success_url``/``cancel_url`` here, so a ``None`` means an
+        # unexpected upstream change — surface as a typed 502.
+        raise StripeError("checkout Session.create returned no URL")
 
     logger.info(
         "stripe_checkout_created",
@@ -114,7 +190,8 @@ async def create_portal_session(
     if not workspace or not workspace.stripe_customer_id:
         raise ValueError("No Stripe customer linked to this workspace")
 
-    session = stripe.billing_portal.Session.create(
+    session = await _run_stripe(
+        stripe.billing_portal.Session.create,
         customer=workspace.stripe_customer_id,
         return_url=return_url,
     )
@@ -295,7 +372,7 @@ async def cancel_subscription_and_delete_customer_for_erasure(
 
     if workspace.stripe_subscription_id:
         try:
-            stripe.Subscription.cancel(workspace.stripe_subscription_id)
+            await _run_stripe_erasure(stripe.Subscription.cancel, workspace.stripe_subscription_id)
             result["subscription_cancelled"] = True
             logger.info(
                 "stripe_subscription_cancelled_for_erasure",
@@ -312,7 +389,7 @@ async def cancel_subscription_and_delete_customer_for_erasure(
 
     if workspace.stripe_customer_id:
         try:
-            stripe.Customer.delete(workspace.stripe_customer_id)
+            await _run_stripe_erasure(stripe.Customer.delete, workspace.stripe_customer_id)
             result["customer_deleted"] = True
             logger.info(
                 "stripe_customer_deleted_for_erasure",

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -261,6 +261,19 @@ class VoyageError(ExternalServiceError):
         super().__init__("Voyage", message, error_code="EXT-203")
 
 
+class StripeError(ExternalServiceError):
+    """Stripe API error (502).
+
+    Issue #468: raised when stripe-python returns an unexpected shape
+    (e.g. a successful Session.create with no ``url`` populated) so the
+    failure routes through ``memory_cloud_exception_handler`` instead of
+    bubbling as an unhandled 500.
+    """
+
+    def __init__(self, message: str | None = None):
+        super().__init__("Stripe", message, error_code="EXT-204")
+
+
 # OAuth2 Token Errors (401) - RFC 6750
 
 

--- a/backend/tests/services/test_stripe_service.py
+++ b/backend/tests/services/test_stripe_service.py
@@ -8,6 +8,8 @@ ThreadPoolExecutor used by the GDPR erasure sweep.
 import asyncio
 import threading
 import time
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 
@@ -15,8 +17,10 @@ import services.stripe_service as stripe_service
 from services.stripe_service import (
     _run_stripe,
     _run_stripe_erasure,
+    create_checkout_session,
     shutdown_erasure_executor,
 )
+from utils.exceptions import StripeError
 
 
 @pytest.fixture(autouse=True)
@@ -142,6 +146,44 @@ def test_shutdown_erasure_executor_is_noop_when_uninitialized():
     shutdown_erasure_executor()
     shutdown_erasure_executor()
     assert stripe_service._erasure_executor is None
+
+
+@pytest.mark.asyncio
+async def test_create_checkout_session_raises_stripe_error_on_missing_url():
+    """Boundary guard: stripe-python types ``Session.url`` as
+    ``Optional[str]`` because non-redirect modes leave it unset. We
+    always pass ``mode="subscription"`` with ``success_url``/``cancel_url``,
+    so a ``None`` here means an unexpected upstream change — raise
+    ``StripeError`` (typed 502) instead of returning ``None`` into the
+    redirect path.
+    """
+    workspace_id = uuid4()
+    workspace = MagicMock()
+    workspace.id = workspace_id
+    workspace.stripe_customer_id = None
+
+    result_proxy = MagicMock()
+    result_proxy.scalar_one_or_none.return_value = workspace
+    db = AsyncMock()
+    db.execute.return_value = result_proxy
+
+    fake_session = MagicMock()
+    fake_session.id = "cs_test_123"
+    fake_session.url = None
+
+    with (
+        patch("services.stripe_service._init_stripe"),
+        patch("services.stripe_service.get_price_id", return_value="price_test"),
+        patch("stripe.checkout.Session.create", return_value=fake_session),
+    ):
+        with pytest.raises(StripeError, match="checkout Session.create returned no URL"):
+            await create_checkout_session(
+                db,
+                workspace_id,
+                "basic",
+                "https://example.com/success",
+                "https://example.com/cancel",
+            )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_stripe_service.py
+++ b/backend/tests/services/test_stripe_service.py
@@ -7,7 +7,6 @@ ThreadPoolExecutor used by the GDPR erasure sweep.
 
 import asyncio
 import threading
-import time
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -33,39 +32,39 @@ def reset_erasure_executor():
 
 @pytest.mark.asyncio
 async def test_run_stripe_does_not_block_event_loop():
-    """A 100ms sync call must not block a 50ms concurrent asyncio.sleep.
+    """The wrapped sync call must run without preventing async progress.
 
-    Flake budget: the asyncio.sleep target is 50ms; we accept up to 90ms
-    real wall-clock for it to complete, which leaves 40ms of CI jitter
-    headroom while still catching a regression that would push it past
-    the 100ms ``time.sleep`` boundary.
+    Causal (not temporal) test: the sync call blocks on
+    ``allow_sync_finish`` until a concurrent asyncio task sets
+    ``async_progress`` and releases it. If the wrapper blocked the event
+    loop, ``allow_sync_finish.wait`` would time out and the test would
+    fail fast — no wall-clock thresholds, no CI flake budget.
     """
 
+    sync_started = threading.Event()
+    async_progress = threading.Event()
+    allow_sync_finish = threading.Event()
+
     def slow_sync_call() -> str:
-        time.sleep(0.1)
+        sync_started.set()
+        assert allow_sync_finish.wait(timeout=1), (
+            "sync call was never unblocked by the concurrent asyncio task"
+        )
+        assert async_progress.is_set(), "concurrent asyncio task never made progress"
         return "ok"
 
-    asyncio_done_at: list[float] = []
+    async def unblock_sync_call() -> None:
+        await asyncio.to_thread(sync_started.wait)
+        await asyncio.sleep(0)
+        async_progress.set()
+        allow_sync_finish.set()
 
-    async def measure_asyncio_sleep() -> None:
-        await asyncio.sleep(0.05)
-        asyncio_done_at.append(time.monotonic())
-
-    start = time.monotonic()
-    sleep_task = asyncio.create_task(measure_asyncio_sleep())
+    unblock_task = asyncio.create_task(unblock_sync_call())
     result = await _run_stripe(slow_sync_call)
-    stripe_done_at = time.monotonic()
-    await sleep_task
+    await unblock_task
 
     assert result == "ok"
-    assert asyncio_done_at, "concurrent asyncio.sleep never ran"
-    asyncio_elapsed = asyncio_done_at[0] - start
-    assert asyncio_elapsed < 0.09, (
-        f"asyncio.sleep appears blocked: completed at {asyncio_elapsed:.3f}s, "
-        "expected < 0.09s — the event loop did not yield during the wrapped "
-        "synchronous call"
-    )
-    assert stripe_done_at - start >= 0.1
+    assert async_progress.is_set(), "concurrent asyncio task never ran"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_stripe_service.py
+++ b/backend/tests/services/test_stripe_service.py
@@ -1,0 +1,162 @@
+"""Tests for Stripe service async wrappers (Issue #468).
+
+Covers the two ``_run_stripe*`` helpers introduced to keep synchronous
+``stripe-python`` calls off the asyncio event loop, and the dedicated
+ThreadPoolExecutor used by the GDPR erasure sweep.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+import services.stripe_service as stripe_service
+from services.stripe_service import (
+    _run_stripe,
+    _run_stripe_erasure,
+    shutdown_erasure_executor,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_erasure_executor():
+    """Each test starts and ends with no live erasure executor."""
+    shutdown_erasure_executor()
+    yield
+    shutdown_erasure_executor()
+
+
+@pytest.mark.asyncio
+async def test_run_stripe_does_not_block_event_loop():
+    """A 100ms sync call must not block a 50ms concurrent asyncio.sleep.
+
+    Flake budget: the asyncio.sleep target is 50ms; we accept up to 90ms
+    real wall-clock for it to complete, which leaves 40ms of CI jitter
+    headroom while still catching a regression that would push it past
+    the 100ms ``time.sleep`` boundary.
+    """
+
+    def slow_sync_call() -> str:
+        time.sleep(0.1)
+        return "ok"
+
+    asyncio_done_at: list[float] = []
+
+    async def measure_asyncio_sleep() -> None:
+        await asyncio.sleep(0.05)
+        asyncio_done_at.append(time.monotonic())
+
+    start = time.monotonic()
+    sleep_task = asyncio.create_task(measure_asyncio_sleep())
+    result = await _run_stripe(slow_sync_call)
+    stripe_done_at = time.monotonic()
+    await sleep_task
+
+    assert result == "ok"
+    assert asyncio_done_at, "concurrent asyncio.sleep never ran"
+    asyncio_elapsed = asyncio_done_at[0] - start
+    assert asyncio_elapsed < 0.09, (
+        f"asyncio.sleep appears blocked: completed at {asyncio_elapsed:.3f}s, "
+        "expected < 0.09s — the event loop did not yield during the wrapped "
+        "synchronous call"
+    )
+    assert stripe_done_at - start >= 0.1
+
+
+@pytest.mark.asyncio
+async def test_run_stripe_preserves_args_and_kwargs():
+    """The wrapper must forward both positional and keyword args verbatim."""
+    captured: dict = {}
+
+    def fake_create(*args, **kwargs) -> str:
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+        return "session-id"
+
+    result = await _run_stripe(
+        fake_create,
+        "pos1",
+        "pos2",
+        idempotency_key="ik-123",
+        expand=["customer"],
+    )
+
+    assert result == "session-id"
+    assert captured["args"] == ("pos1", "pos2")
+    assert captured["kwargs"] == {"idempotency_key": "ik-123", "expand": ["customer"]}
+
+
+@pytest.mark.asyncio
+async def test_run_stripe_erasure_preserves_kwargs_via_partial():
+    """``_run_stripe_erasure`` uses ``functools.partial`` so kwargs survive
+    the ``run_in_executor`` boundary (which only forwards positional args)."""
+    captured: dict = {}
+
+    def fake_cancel(sub_id: str, *, idempotency_key: str | None = None) -> dict:
+        captured["sub_id"] = sub_id
+        captured["idempotency_key"] = idempotency_key
+        return {"cancelled": True}
+
+    result = await _run_stripe_erasure(fake_cancel, "sub_123", idempotency_key="erasure-1")
+
+    assert result == {"cancelled": True}
+    assert captured == {"sub_id": "sub_123", "idempotency_key": "erasure-1"}
+
+
+@pytest.mark.asyncio
+async def test_run_stripe_erasure_uses_dedicated_executor():
+    """The dedicated executor's threads carry the ``stripe-erasure`` prefix."""
+    thread_names: list[str] = []
+
+    def capture_thread_name() -> None:
+        thread_names.append(threading.current_thread().name)
+
+    await _run_stripe_erasure(capture_thread_name)
+
+    assert thread_names, "wrapped call did not run"
+    assert thread_names[0].startswith("stripe-erasure"), (
+        f"expected dedicated erasure thread, got {thread_names[0]!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_stripe_uses_default_pool_not_erasure_pool():
+    """``_run_stripe`` must NOT borrow threads from the dedicated erasure pool."""
+    thread_names: list[str] = []
+
+    def capture_thread_name() -> None:
+        thread_names.append(threading.current_thread().name)
+
+    await _run_stripe(capture_thread_name)
+
+    assert thread_names, "wrapped call did not run"
+    assert not thread_names[0].startswith("stripe-erasure"), (
+        f"_run_stripe should use the default pool, got {thread_names[0]!r}"
+    )
+
+
+def test_shutdown_erasure_executor_is_noop_when_uninitialized():
+    """Calling shutdown before any wrapped erasure call must be safe."""
+    assert stripe_service._erasure_executor is None
+    shutdown_erasure_executor()
+    shutdown_erasure_executor()
+    assert stripe_service._erasure_executor is None
+
+
+@pytest.mark.asyncio
+async def test_shutdown_erasure_executor_after_use_is_idempotent():
+    """After a real call the executor exists; shutdown clears it and the
+    second shutdown is a no-op (mirrors the lifespan re-entry path)."""
+
+    def noop() -> None:
+        return None
+
+    await _run_stripe_erasure(noop)
+    assert stripe_service._erasure_executor is not None
+
+    shutdown_erasure_executor()
+    assert stripe_service._erasure_executor is None
+
+    shutdown_erasure_executor()
+    assert stripe_service._erasure_executor is None


### PR DESCRIPTION
Closes #468

## Summary

- Wraps the four synchronous `stripe-python` calls in `backend/src/services/stripe_service.py` (L88, L117, L298, L315) with asyncio so they no longer block the event loop during 200-800ms Stripe HTTP round-trips.
- Adds a dedicated `ThreadPoolExecutor(max_workers=2, thread_name_prefix="stripe-erasure")` for the GDPR right-to-erasure sweep so a burst of erasure requests cannot starve checkout/portal traffic on the default `asyncio.to_thread` pool.
- Registers `executor.shutdown(wait=False, cancel_futures=True)` in the FastAPI app lifespan: queued work is dropped, the lifespan returns immediately, and any in-flight Stripe call keeps running in its worker thread until either the call completes or the orchestrator sends SIGKILL after grace period (k8s default 30s). Erasure is best-effort — Stripe processes cancel/delete server-side regardless of whether we read the ack.
- Adds `StripeError(ExternalServiceError, error_code="EXT-204")` to `utils/exceptions.py` so a defensive boundary check on `session.url is None` (Stripe types it `Optional[str]`) routes through `memory_cloud_exception_handler` as a typed 502 instead of an unhandled 500.

## Implementation notes

- Two helper functions in `stripe_service.py`:
  - `_run_stripe(func, *args, **kwargs)` — `asyncio.to_thread` for low-rate user-initiated checkout/portal calls.
  - `_run_stripe_erasure(func, *args, **kwargs)` — `loop.run_in_executor(dedicated_pool, functools.partial(...))` for the erasure sweep. `functools.partial` is required because `run_in_executor` only forwards positional args.
- `_get_erasure_executor()` lazy-initializes the dedicated pool so no threads are created when `BILLING_ENABLED=false`. `shutdown_erasure_executor()` is idempotent (safe before init, safe to call twice).
- `stripe.Webhook.construct_event` (L139) is **explicitly NOT wrapped** — it is HMAC + JSON parse, CPU-only with no I/O, so wrapping would only add context-switch overhead.
- Pattern matches existing repo conventions (`tasks/scheduler.py`, `db/redis.py`, `db/qdrant.py` all use the same `get_X() / shutdown_X()` lazy-singleton shape).

## Scope explicitly OUT

- **AsyncStripe migration** (Option B in the issue) — deferred. `stripe>=11.0.0` pin unchanged. AsyncStripe needs `stripe>=12.0.0` and rewriting every call site. Same wrappers can swap to AsyncStripe internally as a future drop-in.
- **Erasure sweep wall-clock parallelization** — out of scope. The sweep is still N workspaces × 200-800ms sequential. This change unblocks the *event loop* only; parallelization is a separate decision (would need a Semaphore for Stripe's 100 req/sec rate limit).

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped (no binary gate configured)
- binary_gate: (none)
- cso: green
- qa-lead: green (one info-level note: `StripeError` boundary raise is not directly unit-tested — small follow-up candidate, non-blocking)
- cto: green
- gate1: green via /claude-c-suite:ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/468-feat-perf-stripe-wrap-sync-stripe-python-calls.gate1.md
- ~/.claude/cache/gh-issue-driven/468-feat-perf-stripe-wrap-sync-stripe-python-calls.gate2.md

## Test plan

- [x] 7 new unit tests in `backend/tests/services/test_stripe_service.py` cover: event-loop unblocking (100ms vs 50ms timing test with 40ms CI jitter headroom), kwargs preservation through both wrappers, dedicated-pool thread-name isolation, default-pool routing, idempotent shutdown (uninitialized + post-use)
- [x] 25 existing erasure regression tests pass (`tests/services/test_account_erasure_service.py`)
- [x] 4 existing billing RBAC tests pass (`tests/api/test_billing_rbac.py`)
- [x] `make lint` — All checks passed
- [x] `make type-check` — 0 errors, 0 warnings

🤖 Generated via /gh-issue-driven:ship

