### PR TITLE
fix(frontend): MFA Enter submit + last-activity tz tooltip (#483, #484)

### DIFF
--- a/frontend/src/app/(authenticated)/admin/sleep-reports/[reportId]/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/[reportId]/page.tsx
@@ -253,11 +253,7 @@ export default function AdminSleepReportDetailPage() {
     report,
   );
 
-  const relativeStarted = formatRelativeTime(
-    report.started_at,
-    timezone,
-    locale,
-  );
+  const relativeStarted = formatRelativeTime(report.started_at, locale);
   const duration = formatDuration(report.started_at, report.completed_at);
 
   return (

--- a/frontend/src/app/(authenticated)/admin/sleep-reports/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/page.tsx
@@ -71,7 +71,6 @@ export default function AdminSleepReportsPage() {
   const tCommon = useTranslations("admin.common");
   const locale = useLocale();
   const { user } = useAuth();
-  const timezone = user?.timezone || "UTC";
 
   const [reports, setReports] = useState<SleepReportSummary[]>([]);
   const [total, setTotal] = useState(0);
@@ -271,7 +270,7 @@ export default function AdminSleepReportsPage() {
                 {reports.map((report) => (
                   <TableRow key={report.id}>
                     <TableCell className="text-sm whitespace-nowrap">
-                      {formatRelativeTime(report.started_at, timezone, locale)}
+                      {formatRelativeTime(report.started_at, locale)}
                     </TableCell>
                     <TableCell className="text-sm">
                       {report.context_name ?? "—"}

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -8,7 +8,7 @@
  */
 
 import { useEffect, useState } from "react";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { Section } from "@/components/common/Section";
@@ -80,6 +80,7 @@ interface User {
 export default function AdminUsersPage() {
   const t = useTranslations("admin.users");
   const tCommon = useTranslations("admin.common");
+  const locale = useLocale();
 
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
@@ -373,7 +374,7 @@ export default function AdminUsersPage() {
                   <TableCell>{user.memory_count}</TableCell>
                   <TableCell className="text-sm text-gray-500">
                     {user.last_login
-                      ? formatRelativeTime(user.last_login)
+                      ? formatRelativeTime(user.last_login, locale)
                       : "Never"}
                   </TableCell>
                   <TableCell className="text-right">

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -373,7 +373,7 @@ export default function AdminUsersPage() {
                   <TableCell>{user.memory_count}</TableCell>
                   <TableCell className="text-sm text-gray-500">
                     {user.last_login
-                      ? formatRelativeTime(user.last_login, user.timezone)
+                      ? formatRelativeTime(user.last_login)
                       : "Never"}
                   </TableCell>
                   <TableCell className="text-right">

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -15,7 +15,7 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations, useLocale } from "next-intl";
 import { useAuth } from "@/contexts/AuthContext";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
-import { formatRelativeTime } from "@/lib/utils/datetime";
+import { formatDateTime, formatRelativeTime } from "@/lib/utils/datetime";
 import {
   Plus,
   FolderOpen,
@@ -978,13 +978,19 @@ export default function ContextsPage() {
 
                   {/* Last Activity */}
                   <td className="px-4 py-3 text-center text-xs text-gray-500 dark:text-gray-400">
-                    {context.last_activity_at
-                      ? formatRelativeTime(
+                    {context.last_activity_at ? (
+                      <span
+                        title={formatDateTime(
                           context.last_activity_at,
                           user?.timezone,
                           locale,
-                        )
-                      : "—"}
+                        )}
+                      >
+                        {formatRelativeTime(context.last_activity_at, locale)}
+                      </span>
+                    ) : (
+                      "—"
+                    )}
                   </td>
 
                   {/* Visibility */}

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -13,7 +13,6 @@ import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { useTranslations, useLocale } from "next-intl";
-import { useAuth } from "@/contexts/AuthContext";
 import { ChevronRight, Database } from "lucide-react";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
@@ -37,9 +36,7 @@ export default function ResourcesListPage() {
   const router = useRouter();
   const t = useTranslations("resources");
   const { currentWorkspace } = useWorkspace();
-  const { user } = useAuth();
   const locale = useLocale();
-  const timezone = user?.timezone || "UTC";
   // Route number formatting through next-intl locale so grouping rules match
   // the selected UI language (e.g., 1,234 in en, 1,234 in ja for Latin digits
   // but proper grouping semantics per locale).
@@ -234,7 +231,7 @@ export default function ResourcesListPage() {
                       )}
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm">
-                      {formatRelativeTime(r.updated_at, timezone, locale)}
+                      {formatRelativeTime(r.updated_at, locale)}
                     </TableCell>
                     <TableCell className="w-8 text-muted-foreground">
                       <ChevronRight className="h-4 w-4" aria-hidden="true" />

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Tests for LoginPage MFA Enter-key submit (Issue #484).
+ *
+ * The MFA TOTP form is a single-input form with a conditionally-disabled
+ * submit button — browsers may suppress implicit form submission on Enter
+ * when the button is disabled at keypress time. The component handles
+ * Enter explicitly via onKeyDown; these tests guard that handler.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import LoginPage from "./page";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockGetAuthConfig = vi.fn();
+const mockLoginWithPassword = vi.fn();
+const mockVerifyMfa = vi.fn();
+
+vi.mock("@/lib/auth/auth", () => ({
+  getAuthUrl: vi.fn(),
+  getGitHubAuthUrl: vi.fn(),
+  getAuthConfig: (...args: unknown[]) => mockGetAuthConfig(...args),
+  loginWithPassword: (...args: unknown[]) => mockLoginWithPassword(...args),
+  verifyMfa: (...args: unknown[]) => mockVerifyMfa(...args),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (k: string) => k,
+}));
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("@/components/LanguageSelector", () => ({
+  LanguageSelector: () => null,
+}));
+
+// ---------- Helpers ----------------------------------------------------------
+
+const SESSION_TOKEN = "mfa-session-token-stub";
+
+beforeEach(() => {
+  mockGetAuthConfig.mockReset();
+  mockLoginWithPassword.mockReset();
+  mockVerifyMfa.mockReset();
+  mockPush.mockReset();
+
+  mockGetAuthConfig.mockResolvedValue({
+    password_login_enabled: true,
+    google_oauth_enabled: false,
+    github_oauth_enabled: false,
+  });
+  mockLoginWithPassword.mockResolvedValue({
+    mfa_required: true,
+    mfa_session_token: SESSION_TOKEN,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+/** Drive password → MFA-required transition and return the totp Input. */
+async function reachMfaForm(): Promise<HTMLInputElement> {
+  render(<LoginPage />);
+
+  // Wait for auth config to resolve and admin password form to render.
+  const loginIdInput = (await screen.findByLabelText(
+    "loginId",
+  )) as HTMLInputElement;
+  const passwordInput = (await screen.findByLabelText(
+    "password",
+  )) as HTMLInputElement;
+
+  fireEvent.change(loginIdInput, { target: { value: "admin@example.com" } });
+  fireEvent.change(passwordInput, { target: { value: "hunter2" } });
+
+  // Tick the terms checkbox (sign-in button is gated on it).
+  const termsCheckbox = screen.getByRole("checkbox") as HTMLInputElement;
+  fireEvent.click(termsCheckbox);
+
+  // Submit password form.
+  const signInButton = screen.getByRole("button", { name: "signIn" });
+  fireEvent.click(signInButton);
+
+  // Wait for MFA form to appear.
+  return (await screen.findByLabelText("totpCode")) as HTMLInputElement;
+}
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("LoginPage MFA form — Enter key submit (#484)", () => {
+  it("submits MFA verify when Enter is pressed after a 6-digit TOTP entry", async () => {
+    mockVerifyMfa.mockResolvedValue({ redirect_url: null });
+
+    const totpInput = await reachMfaForm();
+    fireEvent.change(totpInput, { target: { value: "123456" } });
+    fireEvent.keyDown(totpInput, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockVerifyMfa).toHaveBeenCalledTimes(1);
+    });
+    expect(mockVerifyMfa).toHaveBeenCalledWith(
+      SESSION_TOKEN,
+      "123456",
+      undefined,
+    );
+  });
+
+  it("does NOT submit when Enter is pressed with fewer than 6 digits", async () => {
+    mockVerifyMfa.mockResolvedValue({ redirect_url: null });
+
+    const totpInput = await reachMfaForm();
+    fireEvent.change(totpInput, { target: { value: "12345" } });
+    fireEvent.keyDown(totpInput, { key: "Enter" });
+
+    expect(mockVerifyMfa).not.toHaveBeenCalled();
+  });
+
+  it("does NOT re-submit when Enter is pressed while verify is in flight", async () => {
+    // verifyMfa returns a pending promise so loadingAction stays "mfa".
+    let resolveVerify!: (v: { redirect_url: string | null }) => void;
+    mockVerifyMfa.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveVerify = resolve;
+        }),
+    );
+
+    const totpInput = await reachMfaForm();
+    fireEvent.change(totpInput, { target: { value: "123456" } });
+    fireEvent.keyDown(totpInput, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockVerifyMfa).toHaveBeenCalledTimes(1);
+    });
+
+    fireEvent.keyDown(totpInput, { key: "Enter" });
+    expect(mockVerifyMfa).toHaveBeenCalledTimes(1);
+
+    resolveVerify({ redirect_url: null });
+  });
+});

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -37,9 +37,13 @@ vi.mock("next-intl", () => ({
 }));
 
 const mockPush = vi.fn();
+// Stable URLSearchParams instance — LoginPage's useEffect lists `searchParams`
+// in its dependency array, so a fresh instance per render would re-run the
+// effect (and getAuthConfig() / state updates) unnecessarily during tests.
+const mockSearchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => mockSearchParams,
 }));
 
 vi.mock("@/components/LanguageSelector", () => ({

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -122,8 +122,7 @@ function LoginContent() {
     }
   };
 
-  const handleMfaVerify = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const submitMfa = async () => {
     setLoadingAction("mfa");
     setError(null);
 
@@ -139,6 +138,11 @@ function LoginContent() {
       setLoadingAction(null);
       setError(t("invalidCredentials"));
     }
+  };
+
+  const handleMfaVerify = (e: React.FormEvent) => {
+    e.preventDefault();
+    void submitMfa();
   };
 
   const handleGoogleLogin = async () => {
@@ -252,6 +256,19 @@ function LoginContent() {
                     maxLength={6}
                     value={totpCode}
                     onChange={(e) => setTotpCode(e.target.value)}
+                    onKeyDown={(e) => {
+                      // Implicit form submit can be suppressed when the submit
+                      // button is disabled at the keypress moment; handle Enter
+                      // explicitly once the TOTP code is complete.
+                      if (
+                        e.key === "Enter" &&
+                        totpCode.length === 6 &&
+                        loadingAction === null
+                      ) {
+                        e.preventDefault();
+                        void submitMfa();
+                      }
+                    }}
                     placeholder="000000"
                     className="bg-white text-gray-900 text-center text-2xl tracking-widest"
                     autoFocus

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -142,6 +142,9 @@ function LoginContent() {
 
   const handleMfaVerify = (e: React.FormEvent) => {
     e.preventDefault();
+    if (totpCode.length !== 6 || loadingAction !== null) {
+      return;
+    }
     void submitMfa();
   };
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -10,7 +10,7 @@
  * Issue #360: Provider discovery.
  */
 
-import { useEffect, useState, Suspense } from "react";
+import { useEffect, useRef, useState, Suspense } from "react";
 import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@/components/ui/button";
@@ -49,6 +49,10 @@ function LoginContent() {
   const [mfaRequired, setMfaRequired] = useState(false);
   const [mfaSessionToken, setMfaSessionToken] = useState("");
   const [totpCode, setTotpCode] = useState("");
+  // Synchronous guard: setLoadingAction is batched, so rapid Enter key
+  // auto-repeat could fire submitMfa() multiple times before the state
+  // re-renders. A ref flag is set/read atomically within the same tick.
+  const submittingMfaRef = useRef(false);
 
   const returnTo = searchParams.get("return_to") ?? undefined;
 
@@ -123,6 +127,8 @@ function LoginContent() {
   };
 
   const submitMfa = async () => {
+    if (submittingMfaRef.current) return;
+    submittingMfaRef.current = true;
     setLoadingAction("mfa");
     setError(null);
 
@@ -137,6 +143,7 @@ function LoginContent() {
     } catch {
       setLoadingAction(null);
       setError(t("invalidCredentials"));
+      submittingMfaRef.current = false;
     }
   };
 

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -170,7 +170,7 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                   Created
                 </dt>
                 <dd className="text-sm text-gray-900 dark:text-gray-100 mt-1">
-                  {formatDate(details.user.created_at, user?.timezone)}
+                  {formatDate(details.user.created_at, user?.timezone, locale)}
                 </dd>
               </div>
               <div className="bg-gray-50 dark:bg-gray-900 rounded-lg p-3">
@@ -226,7 +226,12 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                     </div>
                     {workspace.joined_at && (
                       <div className="text-xs text-gray-500 dark:text-gray-400">
-                        Joined {formatDate(workspace.joined_at, user?.timezone)}
+                        Joined{" "}
+                        {formatDate(
+                          workspace.joined_at,
+                          user?.timezone,
+                          locale,
+                        )}
                       </div>
                     )}
                   </div>

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -177,10 +177,7 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                 </dt>
                 <dd className="text-sm text-gray-900 dark:text-gray-100 mt-1">
                   {details.user.last_login_at
-                    ? formatRelativeTime(
-                        details.user.last_login_at,
-                        user?.timezone,
-                      )
+                    ? formatRelativeTime(details.user.last_login_at)
                     : "Never"}
                 </dd>
               </div>
@@ -269,8 +266,7 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                     </div>
                     {ctx.last_used_at && (
                       <p className="text-xs text-gray-500 dark:text-gray-400">
-                        Last used{" "}
-                        {formatRelativeTime(ctx.last_used_at, user?.timezone)}
+                        Last used {formatRelativeTime(ctx.last_used_at)}
                       </p>
                     )}
                   </div>

--- a/frontend/src/components/admin/UserDetailModal.tsx
+++ b/frontend/src/components/admin/UserDetailModal.tsx
@@ -26,6 +26,7 @@ import { getUserDetails, UserDetail } from "@/lib/api/admin";
 import { SpinnerLoading } from "@/components/common/LoadingState";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/contexts/AuthContext";
+import { useLocale } from "next-intl";
 import { formatRelativeTime, formatDate } from "@/lib/utils/datetime";
 
 interface UserDetailModalProps {
@@ -35,6 +36,7 @@ interface UserDetailModalProps {
 
 export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
   const { user } = useAuth();
+  const locale = useLocale();
   const [details, setDetails] = useState<UserDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -177,7 +179,7 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                 </dt>
                 <dd className="text-sm text-gray-900 dark:text-gray-100 mt-1">
                   {details.user.last_login_at
-                    ? formatRelativeTime(details.user.last_login_at)
+                    ? formatRelativeTime(details.user.last_login_at, locale)
                     : "Never"}
                 </dd>
               </div>
@@ -266,7 +268,7 @@ export function UserDetailModal({ userId, onClose }: UserDetailModalProps) {
                     </div>
                     {ctx.last_used_at && (
                       <p className="text-xs text-gray-500 dark:text-gray-400">
-                        Last used {formatRelativeTime(ctx.last_used_at)}
+                        Last used {formatRelativeTime(ctx.last_used_at, locale)}
                       </p>
                     )}
                   </div>

--- a/frontend/src/components/contexts/OverviewTabPanel.tsx
+++ b/frontend/src/components/contexts/OverviewTabPanel.tsx
@@ -314,11 +314,7 @@ export function OverviewTabPanel({
                       </TableCell>
                       <TableCell className="text-right text-sm text-gray-500">
                         {user.last_activity
-                          ? formatRelativeTime(
-                              user.last_activity,
-                              authUser?.timezone,
-                              locale,
-                            )
+                          ? formatRelativeTime(user.last_activity, locale)
                           : t("never")}
                       </TableCell>
                     </TableRow>

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -502,7 +502,6 @@ export function APIKeysTabPanel() {
                                 ? t("hideInTime", {
                                     time: formatRelativeTime(
                                       apiKey.visibility_expires_at,
-                                      user?.timezone,
                                       locale,
                                       false,
                                     ),

--- a/frontend/src/components/dashboard/AdminSections.tsx
+++ b/frontend/src/components/dashboard/AdminSections.tsx
@@ -21,7 +21,6 @@ import {
 import { AlertCircle, Users, ChevronDown } from "lucide-react";
 import { InlineSpinner } from "@/components/common/LoadingState";
 import { formatRelativeTime } from "@/lib/utils/datetime";
-import { useAuth } from "@/contexts/AuthContext";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
 import {
   getContextUserActivity,
@@ -110,7 +109,6 @@ function UserActivitySection({
 }) {
   const t = useTranslations("workspace");
   const tCommon = useTranslations("common");
-  const { user: authUser } = useAuth();
   const locale = useLocale();
 
   const [activityDays, setActivityDays] = useState<7 | 30>(7);
@@ -220,11 +218,7 @@ function UserActivitySection({
                       </TableCell>
                       <TableCell className="text-right text-sm text-gray-500">
                         {user.last_activity
-                          ? formatRelativeTime(
-                              user.last_activity,
-                              authUser?.timezone,
-                              locale,
-                            )
+                          ? formatRelativeTime(user.last_activity, locale)
                           : "Never"}
                       </TableCell>
                     </TableRow>

--- a/frontend/src/components/dashboard/ContextBreakdownTable.tsx
+++ b/frontend/src/components/dashboard/ContextBreakdownTable.tsx
@@ -14,7 +14,6 @@ import {
 } from "@/components/ui/table";
 import { Download, ArrowUpDown, Lock, Users, Eye, EyeOff } from "lucide-react";
 import { formatRelativeTime } from "@/lib/utils/datetime";
-import { useAuth } from "@/contexts/AuthContext";
 import Link from "next/link";
 import type {
   ContextStatsResponse,
@@ -70,7 +69,6 @@ export function ContextBreakdownTable({
 }: ContextBreakdownTableProps) {
   const t = useTranslations("workspace");
   const tDashboard = useTranslations("dashboard");
-  const { user: authUser } = useAuth();
   const locale = useLocale();
 
   const [sortBy, setSortBy] = useState<SortColumn>("memory");
@@ -292,7 +290,6 @@ export function ContextBreakdownTable({
                           {contextDetail?.last_activity
                             ? formatRelativeTime(
                                 contextDetail.last_activity,
-                                authUser?.timezone,
                                 locale,
                               )
                             : "Never"}

--- a/frontend/src/components/memories/MemoriesTable.tsx
+++ b/frontend/src/components/memories/MemoriesTable.tsx
@@ -19,7 +19,6 @@ import type { MemoryListItem } from "@/lib/types/memory";
 import { formatRelativeTime } from "@/lib/utils/datetime";
 import { SpinnerLoading } from "@/components/common/LoadingState";
 import { EmptyState } from "@/components/ui/empty-state";
-import { useAuth } from "@/contexts/AuthContext";
 import { useLocale, useTranslations } from "next-intl";
 
 interface MemoriesTableProps {
@@ -47,7 +46,6 @@ export function MemoriesTable({
   total,
   onPageChange,
 }: MemoriesTableProps) {
-  const { user } = useAuth();
   const locale = useLocale();
   const t = useTranslations("contextDetail.memoriesTable");
   const totalPages = Math.ceil(total / pageSize);
@@ -118,11 +116,7 @@ export function MemoriesTable({
                 <TableCell>{getScopeBadge(memory.scope)}</TableCell>
                 <TableCell>{getImportanceBadge(memory.importance)}</TableCell>
                 <TableCell className="text-sm text-slate-500">
-                  {formatRelativeTime(
-                    memory.updated_at,
-                    user?.timezone,
-                    locale,
-                  )}
+                  {formatRelativeTime(memory.updated_at, locale)}
                 </TableCell>
                 <TableCell className="text-right">
                   <div className="flex items-center justify-end gap-2">

--- a/frontend/src/components/oauth/OAuthAppCard.tsx
+++ b/frontend/src/components/oauth/OAuthAppCard.tsx
@@ -114,7 +114,6 @@ export function OAuthAppCard({
                       ? t("hideInTime", {
                           time: formatRelativeTime(
                             app.visibility_expires_at,
-                            timezone,
                             locale,
                             false,
                           ),

--- a/frontend/src/components/resources/IndexerStatusPanel.tsx
+++ b/frontend/src/components/resources/IndexerStatusPanel.tsx
@@ -148,7 +148,7 @@ export function IndexerStatusPanel({
           label={t("indexer.lastRun")}
           value={
             state?.last_run_at
-              ? formatRelativeTime(state.last_run_at, timezone, locale)
+              ? formatRelativeTime(state.last_run_at, locale)
               : "—"
           }
           valueTitle={
@@ -250,7 +250,7 @@ function RecentEventsTable({
                 }
               >
                 {ev.created_at
-                  ? formatRelativeTime(ev.created_at, timezone, locale)
+                  ? formatRelativeTime(ev.created_at, locale)
                   : "—"}
               </TableCell>
             </TableRow>

--- a/frontend/src/components/resources/ResourceStatsStrip.tsx
+++ b/frontend/src/components/resources/ResourceStatsStrip.tsx
@@ -55,7 +55,7 @@ export function ResourceStatsStrip({ resource }: ResourceStatsStripProps) {
       <KpiCard
         icon={Clock}
         label={t("stats.lastActivity")}
-        value={formatRelativeTime(resource.updated_at, timezone, locale)}
+        value={formatRelativeTime(resource.updated_at, locale)}
         valueTitle={formatDateTime(resource.updated_at, timezone, locale)}
         tone="secondary"
       />

--- a/frontend/src/lib/utils/datetime.test.ts
+++ b/frontend/src/lib/utils/datetime.test.ts
@@ -33,7 +33,7 @@ describe("formatDateTime", () => {
     expect(out).toContain("12:56");
   });
 
-  it("renders America/New_York hour as 23 (EDT = UTC-4) on the previous day", () => {
+  it("renders America/New_York as 11:56 PM (EDT = UTC-4) on the previous day", () => {
     const out = formatDateTime(SAMPLE_UTC, "America/New_York", "en");
     expect(out).toContain("11:56");
     expect(out).toContain("PM");

--- a/frontend/src/lib/utils/datetime.test.ts
+++ b/frontend/src/lib/utils/datetime.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for datetime helpers (Issue #483).
+ *
+ * Covers:
+ *   - formatDateTime renders the correct hour for Asia/Tokyo (JST = UTC+9)
+ *     and America/New_York (EDT = UTC-4 in April), proving the timezone
+ *     argument is actually applied to Intl.DateTimeFormat.
+ *   - formatDate renders the date in the target timezone (the JST date may
+ *     differ from the UTC date for late-evening UTC moments).
+ *   - formatRelativeTime is locale-aware and timezone-independent by design.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  formatDate,
+  formatDateTime,
+  formatRelativeTime,
+  formatTime,
+} from "./datetime";
+
+// 03:56 UTC on 2026-04-29 → 12:56 JST same day, 23:56 EDT prev day.
+const SAMPLE_UTC = "2026-04-29T03:56:11Z";
+
+describe("formatDateTime", () => {
+  it("renders Asia/Tokyo hour as 12 (UTC+9) in en locale", () => {
+    const out = formatDateTime(SAMPLE_UTC, "Asia/Tokyo", "en");
+    expect(out).toContain("12:56");
+  });
+
+  it("renders Asia/Tokyo hour as 12 (UTC+9) in ja locale", () => {
+    const out = formatDateTime(SAMPLE_UTC, "Asia/Tokyo", "ja");
+    expect(out).toContain("12:56");
+  });
+
+  it("renders America/New_York hour as 23 (EDT = UTC-4) on the previous day", () => {
+    const out = formatDateTime(SAMPLE_UTC, "America/New_York", "en");
+    expect(out).toContain("11:56");
+    expect(out).toContain("PM");
+    expect(out).toContain("04/28");
+  });
+
+  it("renders UTC unchanged when timezone is UTC", () => {
+    const out = formatDateTime(SAMPLE_UTC, "UTC", "en");
+    expect(out).toContain("03:56");
+  });
+});
+
+describe("formatDate", () => {
+  it("returns the JST date when the UTC moment is late evening UTC", () => {
+    // 22:00 UTC on 04-28 → 07:00 JST on 04-29 — different calendar day.
+    const out = formatDate("2026-04-28T22:00:00Z", "Asia/Tokyo", "ja");
+    expect(out).toContain("2026");
+    expect(out).toContain("04/29");
+  });
+
+  it("passes through date-only strings without timezone conversion", () => {
+    // Backend timeline API returns date-only strings already computed in UTC;
+    // converting them through Intl with a tz would shift the calendar date.
+    const out = formatDate("2026-04-29", "Asia/Tokyo", "ja");
+    expect(out).toContain("2026");
+    expect(out).toContain("04/29");
+  });
+});
+
+describe("formatTime", () => {
+  it("renders the time component in the target timezone", () => {
+    expect(formatTime(SAMPLE_UTC, "Asia/Tokyo", "ja")).toContain("12:56");
+    expect(formatTime(SAMPLE_UTC, "UTC", "ja")).toContain("03:56");
+  });
+});
+
+describe("formatRelativeTime", () => {
+  it("returns an English relative string for en locale", () => {
+    const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(formatRelativeTime(past, "en")).toMatch(/minute/);
+  });
+
+  it("returns a Japanese relative string for ja locale", () => {
+    const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    expect(formatRelativeTime(past, "ja")).toMatch(/分/);
+  });
+
+  it("omits the suffix when addSuffix=false", () => {
+    const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+    const withSuffix = formatRelativeTime(past, "en", true);
+    const withoutSuffix = formatRelativeTime(past, "en", false);
+    expect(withSuffix).toMatch(/ago|in /);
+    expect(withoutSuffix).not.toMatch(/ago|in /);
+  });
+});

--- a/frontend/src/lib/utils/datetime.test.ts
+++ b/frontend/src/lib/utils/datetime.test.ts
@@ -10,7 +10,7 @@
  *   - formatRelativeTime is locale-aware and timezone-independent by design.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   formatDate,
@@ -71,20 +71,31 @@ describe("formatTime", () => {
 });
 
 describe("formatRelativeTime", () => {
+  // Freeze the clock so date-fns rounding boundaries (e.g. 5→4 minutes) cannot
+  // tip under slow CI or clock skew.
+  const NOW = new Date("2026-04-29T12:00:00Z");
+  const FIVE_MIN_AGO = new Date(NOW.getTime() - 5 * 60 * 1000).toISOString();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("returns an English relative string for en locale", () => {
-    const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
-    expect(formatRelativeTime(past, "en")).toMatch(/minute/);
+    expect(formatRelativeTime(FIVE_MIN_AGO, "en")).toMatch(/minute/);
   });
 
   it("returns a Japanese relative string for ja locale", () => {
-    const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
-    expect(formatRelativeTime(past, "ja")).toMatch(/分/);
+    expect(formatRelativeTime(FIVE_MIN_AGO, "ja")).toMatch(/分/);
   });
 
   it("omits the suffix when addSuffix=false", () => {
-    const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
-    const withSuffix = formatRelativeTime(past, "en", true);
-    const withoutSuffix = formatRelativeTime(past, "en", false);
+    const withSuffix = formatRelativeTime(FIVE_MIN_AGO, "en", true);
+    const withoutSuffix = formatRelativeTime(FIVE_MIN_AGO, "en", false);
     expect(withSuffix).toMatch(/ago|in /);
     expect(withoutSuffix).not.toMatch(/ago|in /);
   });

--- a/frontend/src/lib/utils/datetime.ts
+++ b/frontend/src/lib/utils/datetime.ts
@@ -11,7 +11,7 @@ import { ja } from "date-fns/locale";
 /**
  * Format UTC datetime to user's timezone
  *
- * @param utcTime - ISO datetime string in UTC. MUST include a timezone designator
+ * @param utcTime - ISO datetime string in UTC. MUST include a UTC designator
  *                  (`Z` or `+00:00`) — bare local-time strings are parsed as the
  *                  runtime's local timezone, which would silently produce wrong
  *                  output here.
@@ -52,9 +52,9 @@ export function formatDateTime(
 /**
  * Format UTC datetime to user's timezone (date only)
  *
- * @param utcTime - ISO datetime string in UTC (with `Z` suffix), or a date-only
- *                  `YYYY-MM-DD` string which is rendered as-is without timezone
- *                  conversion.
+ * @param utcTime - ISO datetime string in UTC (with `Z` or `+00:00` designator),
+ *                  or a date-only `YYYY-MM-DD` string which is rendered as-is
+ *                  without timezone conversion.
  * @param timezone - IANA timezone
  * @returns Formatted date string
  *
@@ -93,7 +93,7 @@ export function formatDate(
 /**
  * Format UTC datetime to user's timezone (time only)
  *
- * @param utcTime - ISO datetime string in UTC (with `Z` suffix)
+ * @param utcTime - ISO datetime string in UTC (with `Z` or `+00:00` designator)
  * @param timezone - IANA timezone
  * @returns Formatted time string
  *
@@ -125,7 +125,7 @@ export function formatTime(
  * reads identically in any zone. To show the absolute moment, pair this
  * with `formatDateTime(...)` in a tooltip (e.g., `<span title={...}>`).
  *
- * @param utcTime - ISO datetime string in UTC (with `Z` suffix)
+ * @param utcTime - ISO datetime string in UTC (with `Z` or `+00:00` designator)
  * @param locale - 'en' or 'ja'
  * @param addSuffix - When false, returns 'about 9 minutes' instead of 'about 9 minutes ago'
  *

--- a/frontend/src/lib/utils/datetime.ts
+++ b/frontend/src/lib/utils/datetime.ts
@@ -114,21 +114,22 @@ export function formatTime(
 }
 
 /**
- * Format relative time with timezone awareness
+ * Format relative time (e.g., '5 minutes ago'). Locale-aware.
+ *
+ * Note: relative time is timezone-independent by definition — elapsed time
+ * reads identically in any zone. To show the absolute moment, pair this
+ * with `formatDateTime(...)` in a tooltip (e.g., `<span title={...}>`).
  *
  * @param utcTime - ISO datetime string (UTC)
- * @param timezone - IANA timezone
- * @returns Relative time string (e.g., '5 minutes ago', 'about 3 hours')
+ * @param locale - 'en' or 'ja'
+ * @param addSuffix - When false, returns 'about 9 minutes' instead of 'about 9 minutes ago'
  *
  * @example
- * formatRelativeTime('2025-12-09T17:15:30', 'Asia/Tokyo')
+ * formatRelativeTime('2025-12-09T17:15:30')
  * // => 'about 9 minutes ago'
- * formatRelativeTime('2025-12-09T17:15:30', 'Asia/Tokyo', 'en', false)
- * // => 'about 9 minutes'  (no suffix, for embedding in other strings)
  */
 export function formatRelativeTime(
   utcTime: string,
-  timezone: string = "UTC",
   locale: string = "en",
   addSuffix: boolean = true,
 ): string {

--- a/frontend/src/lib/utils/datetime.ts
+++ b/frontend/src/lib/utils/datetime.ts
@@ -11,14 +11,17 @@ import { ja } from "date-fns/locale";
 /**
  * Format UTC datetime to user's timezone
  *
- * @param utcTime - ISO datetime string (UTC)
+ * @param utcTime - ISO datetime string in UTC. MUST include a timezone designator
+ *                  (`Z` or `+00:00`) — bare local-time strings are parsed as the
+ *                  runtime's local timezone, which would silently produce wrong
+ *                  output here.
  * @param timezone - IANA timezone (e.g., 'Asia/Tokyo', 'America/New_York')
  * @param options - Intl.DateTimeFormat options
  * @returns Formatted datetime string
  *
  * @example
- * formatDateTime('2025-12-09T17:15:30', 'Asia/Tokyo')
- * // => '2025/12/10 2:15:30'
+ * formatDateTime('2025-12-09T17:15:30Z', 'Asia/Tokyo')
+ * // => '2025/12/10 02:15:30'
  */
 export function formatDateTime(
   utcTime: string,
@@ -49,12 +52,14 @@ export function formatDateTime(
 /**
  * Format UTC datetime to user's timezone (date only)
  *
- * @param utcTime - ISO datetime string (UTC)
+ * @param utcTime - ISO datetime string in UTC (with `Z` suffix), or a date-only
+ *                  `YYYY-MM-DD` string which is rendered as-is without timezone
+ *                  conversion.
  * @param timezone - IANA timezone
  * @returns Formatted date string
  *
  * @example
- * formatDate('2025-12-09T17:15:30', 'Asia/Tokyo')
+ * formatDate('2025-12-09T17:15:30Z', 'Asia/Tokyo')
  * // => '2025/12/10'
  */
 export function formatDate(
@@ -88,12 +93,12 @@ export function formatDate(
 /**
  * Format UTC datetime to user's timezone (time only)
  *
- * @param utcTime - ISO datetime string (UTC)
+ * @param utcTime - ISO datetime string in UTC (with `Z` suffix)
  * @param timezone - IANA timezone
  * @returns Formatted time string
  *
  * @example
- * formatTime('2025-12-09T17:15:30', 'Asia/Tokyo')
+ * formatTime('2025-12-09T17:15:30Z', 'Asia/Tokyo')
  * // => '02:15:30'
  */
 export function formatTime(
@@ -120,12 +125,12 @@ export function formatTime(
  * reads identically in any zone. To show the absolute moment, pair this
  * with `formatDateTime(...)` in a tooltip (e.g., `<span title={...}>`).
  *
- * @param utcTime - ISO datetime string (UTC)
+ * @param utcTime - ISO datetime string in UTC (with `Z` suffix)
  * @param locale - 'en' or 'ja'
  * @param addSuffix - When false, returns 'about 9 minutes' instead of 'about 9 minutes ago'
  *
  * @example
- * formatRelativeTime('2025-12-09T17:15:30')
+ * formatRelativeTime('2025-12-09T17:15:30Z')
  * // => 'about 9 minutes ago'
  */
 export function formatRelativeTime(


### PR DESCRIPTION
Closes #483
Closes #484

## Summary

- **#484** — MFA login form now submits with **Enter** on a 6-digit TOTP entry. The submit button is conditionally disabled until 6 digits are present, which can suppress browser implicit form submit; the new explicit `onKeyDown` handler closes the gap.
- **#483** — Last-Activity column on `/workspace/contexts` now shows a **timezone-aware absolute datetime tooltip** on hover. The relative string ("5 minutes ago") stays as the primary surface — relative time is timezone-independent by definition; absolute moments belong in the tooltip.
- Drop the **silently-ignored `timezone` argument** from `formatRelativeTime` (a long-standing signature lie that masked the missing absolute-time pathway). Sweep all 13 internal call sites; remove now-unused `useAuth()` / `user` / `authUser` declarations from 5 files.

## Implementation notes

### #484 — `frontend/src/app/login/page.tsx`
- Extract `submitMfa()` (event-less) from old `handleMfaVerify`. Form `onSubmit` and the new `onKeyDown` both call it — no `as unknown as React.FormEvent` cast needed.
- `onKeyDown` triple-guards on `e.key === "Enter"` + `totpCode.length === 6` + `loadingAction === null` to prevent partial-input misfire and double-submit while in flight.
- `frontend/src/app/login/page.test.tsx` (new): 3 cases — happy path, under-6-digit no-op, in-flight no-op.

### #483 — `frontend/src/lib/utils/datetime.ts`
- Old: `formatRelativeTime(utcTime, timezone="UTC", locale="en", addSuffix=true)`
- New: `formatRelativeTime(utcTime, locale="en", addSuffix=true)`
- `frontend/src/lib/utils/datetime.test.ts` (new): 10 cases covering JST/EDT/UTC formatting, date-only passthrough, and locale + suffix behavior.
- Tooltip pattern in `workspace/contexts/page.tsx` mirrors the existing convention in `IndexerStatusPanel.tsx:154-158` and `ResourceStatsStrip.tsx:59`.

### Sweep cleanup
- 13 call sites updated (workspace/contexts, workspace/resources, admin/users, admin/sleep-reports[id], admin/sleep-reports, contexts/OverviewTabPanel, dashboard/AdminSections, dashboard/ContextBreakdownTable, memories/MemoriesTable, credentials/APIKeysTabPanel, oauth/OAuthAppCard, resources/IndexerStatusPanel, resources/ResourceStatsStrip, admin/UserDetailModal).
- 5 files had unused `useAuth()` / `user` / `authUser` / `timezone` consts removed (post-sweep dead code).
- `npx tsc --noEmit` returns clean. The other `formatRelativeTime` symbols in `@/lib/api/api-keys` and `@/lib/api/resource-tokens` are separate functions with their own `(isoString)` signature — unaffected.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/483-batch-483-484.gate1.md
- ~/.claude/cache/gh-issue-driven/483-batch-483-484.gate2.md

Follow-up candidates flagged by gate2 reviewers (out of scope for this PR):
- `formatRelativeTime` named-args refactor (CTO — long-term API safety)
- `<span title=>` → Radix Tooltip migration across all tables (CSO + CDO — a11y)
- vitest worker-pool isolation issue (QA Lead — pre-existing infra)

## Test plan

- [x] `npx tsc --noEmit` — clean (0 errors)
- [x] `npm test -- --run src/lib/utils/datetime.test.ts src/app/login/page.test.tsx` — 13/13 pass
- [x] Full vitest run — 275 pass + 3 worker-pool isolation failures (pre-existing infra, files pass in isolation)
- [ ] Manual smoke (dev box) — verify Enter-key submit on MFA form (Chrome/Safari/Firefox)
- [ ] Manual smoke (dev box) — set timezone to Asia/Tokyo, hover Last-Activity column on `/workspace/contexts`, verify JST datetime in tooltip

🤖 Generated via /gh-issue-driven:ship
