### PR TITLE
fix(db): c03 seed migration TIMESTAMP/NUMERIC asyncpg bind types (#487)

### DIFF
--- a/backend/alembic/versions/c03_471_seed_pricing.py
+++ b/backend/alembic/versions/c03_471_seed_pricing.py
@@ -45,6 +45,8 @@ NOTE: Revision ID is 21 chars (under the 32-char alembic limit).
 """
 
 from collections.abc import Sequence
+from datetime import datetime
+from decimal import Decimal
 
 import sqlalchemy as sa
 
@@ -61,7 +63,12 @@ depends_on: str | Sequence[str] | None = None
 # upgrade() (for INSERTs) and downgrade() (for the targeted DELETE).
 # Naive UTC to match ``llm_pricing.effective_from`` (DateTime, naive)
 # and the rest of the codebase's "store UTC, ignore tz metadata" pattern.
-_SEED_EFFECTIVE_FROM = "2026-04-28 00:00:00"
+#
+# MUST be a ``datetime`` not a ``str``: asyncpg infers bind types from the
+# Python value, so a string would render as ``$N::VARCHAR`` and PostgreSQL
+# refuses to coerce VARCHAR into TIMESTAMP WITHOUT TIME ZONE without an
+# explicit cast — the upgrade INSERT (and the downgrade DELETE) blow up.
+_SEED_EFFECTIVE_FROM = datetime(2026, 4, 28, 0, 0, 0)
 
 
 # Parameterized INSERT — bind params keep the migration aligned with
@@ -96,9 +103,12 @@ def _insert_pricing_row(
     ``unit_denominator=1000000``, ``currency='USD'``,
     ``context_min_tokens=0``, ``context_max_tokens=NULL``.
 
-    Pass ``price_per_unit`` as a string to keep the value deterministic
-    across Python float repr quirks; PostgreSQL parses the string into
-    NUMERIC(14,10) at INSERT time.
+    Call sites pass ``price_per_unit`` as a string for literal-precision
+    ergonomics (``"0.5"`` reads cleanly, no float repr quirk). It is
+    converted to ``Decimal`` here before binding so asyncpg infers
+    ``NUMERIC`` instead of ``VARCHAR`` — without the cast, PostgreSQL
+    refuses to coerce VARCHAR into NUMERIC(14,10) at INSERT time and
+    the migration aborts.
     """
     op.execute(
         _INSERT_PRICING_SQL.bindparams(
@@ -106,7 +116,7 @@ def _insert_pricing_row(
             model=model,
             unit_type=unit_type,
             effective_from=_SEED_EFFECTIVE_FROM,
-            price_per_unit=price_per_unit,
+            price_per_unit=Decimal(price_per_unit),
         )
     )
 


### PR DESCRIPTION
Closes #487

## Summary

Hotfix for the `c03_471_seed_pricing` migration that blocked production deploy. Two same-class bugs: bind values were Python `str` where the destination columns were `TIMESTAMP` and `NUMERIC`. asyncpg infers bind types from the runtime Python value, so the rendered SQL emitted `$N::VARCHAR` and PostgreSQL refused implicit coercion.

## What broke

Production `./scripts/deploy.sh` aborted on `alembic upgrade head` of the green container with:

```
asyncpg.exceptions.DatatypeMismatchError:
  column "effective_from" is of type timestamp without time zone
  but expression is of type character varying
```

After fixing `effective_from`, the next column had the same shape:

```
column "price_per_unit" is of type numeric
but expression is of type character varying
```

Both surfaced because we run asyncpg in production. psycopg2 (sync driver) would have papered over the type mismatch by sending strings as cstring, which PostgreSQL parses for legacy compatibility. asyncpg uses prepared statements with explicit type codes, so VARCHAR-into-TIMESTAMP is a hard reject.

## The fix

`backend/alembic/versions/c03_471_seed_pricing.py`:

```diff
+from datetime import datetime
+from decimal import Decimal

-_SEED_EFFECTIVE_FROM = "2026-04-28 00:00:00"
+_SEED_EFFECTIVE_FROM = datetime(2026, 4, 28, 0, 0, 0)

 def _insert_pricing_row(...):
-            price_per_unit=price_per_unit,
+            price_per_unit=Decimal(price_per_unit),
```

Call sites still pass literal strings (`"0.5"`, `"6.25"`) at the call boundary for ergonomics — no float-repr quirks, no `Decimal("...")` clutter at every row. The conversion happens once inside `_insert_pricing_row`. Same pattern applies to `_SEED_EFFECTIVE_FROM` (single source of truth, fixed once).

## Verification

```bash
TEST_DATABASE_URL="postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test" \
  pytest tests/integration/test_alembic_migrations.py -v --no-cov
```

Result: **9/9 pass** (was 8/9 fail). Migration up → downgrade → re-upgrade all clean.

## Why CI didn't catch this

`.github/workflows/ci.yml`'s `backend-unit` job uses `--ignore=tests/integration`. The migration walker (`test_alembic_migrations.py`) lives in `tests/integration/`, so any migration regression slips past CI silently. **This needs a follow-up issue** to either (a) wire integration tests into CI, or (b) carve out a `migration-only` job that runs the walker against a fresh PostgreSQL service container.

That follow-up is intentionally out of scope here — keep the hotfix small.

## Pre-PR review summary
- gate1: skipped (single-line hotfix discovered during production deploy of PR #486; no design ambiguity)
- gate2: skipped (same reason)
- review provider: copilot

## Test plan

- [x] `pytest backend/tests/integration/test_alembic_migrations.py` — 9/9 pass
- [x] `pytest backend/tests/integration/test_llm_pricing.py` — 13/14 pass (1 pre-existing test-isolation issue: test inserts rows that now collide with seed data; separate follow-up needed for that test, NOT a regression from this PR)
- [x] `npx tsc --noEmit` — N/A (no frontend changes)
- [ ] Re-deploy to production via `./scripts/deploy.sh` — alembic upgrade head succeeds, Caddy switches blue → green

## Why no commit-message re-deploy

After this lands, I'll re-run `./scripts/deploy.sh` against the production VM. The deploy includes the previously-staged 11 commits from `6a1d712..d1e9d80` plus this hotfix.

🤖 Generated via /gh-issue-driven (hotfix path)
