### PR TITLE
fix(api): emit Z suffix on naive datetime serialization (#489)

### DIFF
--- a/.claude/rules/backend.md
+++ b/.claude/rules/backend.md
@@ -24,6 +24,11 @@ paths:
 - Synchronous engine only for OAuth2 server (Authlib requirement)
 - Pool config: `pool_size=5, max_overflow=10, pool_pre_ping=True`
 
+## Datetime / UTC
+- DB columns are TIMESTAMP WITHOUT TIME ZONE — naive UTC by convention. Until #490 migrates them, the API layer is the only place ensuring wire-format datetimes are unambiguous (#489).
+- Response Pydantic schemas with any `datetime` field MUST inherit from `models.api_base.TZAwareBaseModel` (not `BaseModel`). The base class serializes naive datetimes with a `Z` suffix; without it, JS clients parse the string as local time and JST users see times shifted by their UTC offset.
+- For `str`-typed datetime fields in handler/service code (manual ISO formatting), use `to_utc_iso(dt)` from `utils.datetime`. Never call `.isoformat()` directly on a `datetime` field that ends up in a JSON response or cached payload — `to_utc_iso` is idempotent (handles None / naive / aware UTC / aware non-UTC) so it can be applied unconditionally.
+
 ## Testing
 - Test files: `backend/tests/{module}/test_{name}.py`
 - Use `pytest-asyncio` fixtures from `conftest.py`

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import require_admin
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from models.auth import (
     APIKey,
     Context,
@@ -25,6 +26,7 @@ from models.auth import (
 )
 from models.memory import Memory
 from utils import db_transaction, get_user_id
+from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -37,20 +39,12 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 # ============================================================================
 
 
-class UserInfo(BaseModel):
+class UserInfo(TZAwareBaseModel):
     """User information for admin view.
 
     Issue #164: Extended with workspaces field.
     Issue #175: Added timezone field for user preferences.
     """
-
-    model_config = {
-        "json_encoders": {
-            datetime: lambda v: (
-                v.isoformat() + "Z" if v and v.tzinfo is None else v.isoformat() if v else None
-            )
-        }
-    }
 
     id: str
     email: str
@@ -258,7 +252,7 @@ async def list_users(
                         "workspace_name": workspace.name,
                         "role": member.role,
                         "is_primary": is_primary,
-                        "joined_at": member.joined_at.isoformat() if member.joined_at else None,
+                        "joined_at": to_utc_iso(member.joined_at),
                     }
                 )
 
@@ -519,16 +513,8 @@ async def get_user_detail(
                 "picture": target_user.picture,
                 "role": target_user.role,
                 "is_initial_admin": getattr(target_user, "is_initial_admin", False),
-                "created_at": target_user.created_at.isoformat() + "Z"
-                if target_user.created_at.tzinfo is None
-                else target_user.created_at.isoformat(),
-                "last_login_at": (
-                    target_user.last_login_at.isoformat() + "Z"
-                    if target_user.last_login_at.tzinfo is None
-                    else target_user.last_login_at.isoformat()
-                )
-                if target_user.last_login_at
-                else None,
+                "created_at": to_utc_iso(target_user.created_at),
+                "last_login_at": to_utc_iso(target_user.last_login_at),
                 "auth_provider": target_user.auth_provider,
             },
             workspaces=workspaces,

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -24,7 +24,7 @@ from models.auth import Context, PlanChange, User, Workspace, WorkspaceInvitatio
 from models.memory import Memory
 from services.effective_quota_service import EffectiveQuotaService
 from utils import db_transaction
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -375,7 +375,7 @@ async def get_plan_change_audit(
                     old_plan=audit.old_plan,
                     new_plan=audit.new_plan,
                     changed_by=user_name or audit.changed_by,
-                    changed_at=audit.changed_at.isoformat(),
+                    changed_at=to_utc_iso(audit.changed_at) or "",
                     reason=audit.reason,
                 )
             )

--- a/backend/src/api/routes/admin_signup_gate.py
+++ b/backend/src/api/routes/admin_signup_gate.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import AdminUser
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from services.signup_gate_service import SignupGateService
 from utils.github_user import GitHubUserNotFound
 from utils.logger import get_logger
@@ -57,7 +58,7 @@ class SignupGateConfigUpdate(BaseModel):
     mode: Literal["manual"]
 
 
-class AllowlistEntryResponse(BaseModel):
+class AllowlistEntryResponse(TZAwareBaseModel):
     id: UUID
     github_user_id: str
     github_username: str

--- a/backend/src/api/routes/api_keys.py
+++ b/backend/src/api/routes/api_keys.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.api_keys import APIKeyManager
 from auth.dependencies import SessionUser, get_current_user
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from models.auth import APIKey
 from utils import db_transaction, get_user_id
 from utils.datetime import utcnow
@@ -80,7 +81,7 @@ class APIKeyStats(BaseModel):
     period_end: str = Field(..., description="End date of statistics period")
 
 
-class APIKeyResponse(BaseModel):
+class APIKeyResponse(TZAwareBaseModel):
     """Response model for API key metadata."""
 
     id: int = Field(..., description="Database ID")

--- a/backend/src/api/routes/attachments.py
+++ b/backend/src/api/routes/attachments.py
@@ -16,6 +16,7 @@ from auth.dependencies import APIKeyOrSessionUser
 from db.base import get_db
 from models.auth import WorkspaceMember
 from models.memory import Attachment, Memory
+from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -154,7 +155,7 @@ async def upload_attachment(
         filename=attachment.filename,
         content_type=attachment.content_type,
         size_bytes=attachment.size_bytes,
-        created_at=attachment.created_at.isoformat(),
+        created_at=to_utc_iso(attachment.created_at) or "",
     )
 
 
@@ -180,7 +181,7 @@ async def list_attachments(
             filename=a.filename,
             content_type=a.content_type,
             size_bytes=a.size_bytes,
-            created_at=a.created_at.isoformat(),
+            created_at=to_utc_iso(a.created_at) or "",
         )
         for a in attachments
     ]

--- a/backend/src/api/routes/bm25_drift.py
+++ b/backend/src/api/routes/bm25_drift.py
@@ -14,17 +14,17 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import require_admin
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from models.auth import Context
 from models.bm25_drift import Bm25IdfDriftLog
 from services.bm25_drift.orchestrator import Bm25DriftOrchestrator
 from services.bm25_drift.psi_calculator import PsiStatus
-from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -40,7 +40,7 @@ router = APIRouter(
 # ============================================================================
 
 
-class Bm25DriftSummary(BaseModel):
+class Bm25DriftSummary(TZAwareBaseModel):
     """Drift log row, list-view shape (no top_divergent_terms)."""
 
     id: int
@@ -52,10 +52,6 @@ class Bm25DriftSummary(BaseModel):
     m_memory_points: int
     r_resource_points: int
     num_terms: int
-
-    @field_serializer("measured_at")
-    def _serialize_dt(self, dt: datetime) -> str:
-        return to_utc_iso(dt) or ""
 
 
 class Bm25DriftDetail(Bm25DriftSummary):

--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -21,7 +21,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser, SessionUser, get_current_user
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from services.context_service import ContextService
+from utils.datetime import to_utc_iso
 from utils.exceptions import NotFoundException, ValidationError
 from utils.logger import get_logger
 
@@ -186,7 +188,7 @@ class ContextUpdate(BaseModel):
     )
 
 
-class ContextResponse(BaseModel):
+class ContextResponse(TZAwareBaseModel):
     """Response model for context data."""
 
     id: UUID = Field(..., description="Context UUID")
@@ -1110,7 +1112,7 @@ async def list_context_members(
                 user_name=user_info.name if user_info else None,
                 user_email=user_info.email if user_info else None,
                 role=om.role,
-                added_at=om.joined_at.isoformat() if om.joined_at else None,
+                added_at=to_utc_iso(om.joined_at),
                 is_workspace_admin=True,
             )
         )
@@ -1130,7 +1132,7 @@ async def list_context_members(
                 user_name=user_info.name if user_info else None,
                 user_email=user_info.email if user_info else None,
                 role=cm.role,
-                added_at=cm.created_at.isoformat() if cm.created_at else None,
+                added_at=to_utc_iso(cm.created_at),
                 is_workspace_admin=False,
             )
         )
@@ -1149,7 +1151,7 @@ async def list_context_members(
                 user_name=user_info.name if user_info else None,
                 user_email=user_info.email if user_info else None,
                 role=om.role,
-                added_at=om.joined_at.isoformat() if om.joined_at else None,
+                added_at=to_utc_iso(om.joined_at),
                 is_workspace_admin=True,
             )
         )
@@ -1244,7 +1246,7 @@ async def add_context_member(
     return ContextMemberResponse(
         user_id=member.user_id,
         role=member.role,
-        added_at=member.created_at.isoformat(),
+        added_at=to_utc_iso(member.created_at),
     )
 
 
@@ -1323,7 +1325,7 @@ async def update_context_member_role(
     return ContextMemberResponse(
         user_id=member.user_id,
         role=member.role,
-        added_at=member.created_at.isoformat(),
+        added_at=to_utc_iso(member.created_at),
     )
 
 
@@ -1490,9 +1492,9 @@ async def get_memory_usage_stats(
             scope=m.scope or "persistent",
             use_count=m.use_count or 0,
             access_count=m.access_count or 0,
-            last_used_at=m.last_used_at.isoformat() if m.last_used_at else None,
+            last_used_at=to_utc_iso(m.last_used_at),
             embedding_status=m.embedding_status or "pending",
-            created_at=m.created_at.isoformat() if m.created_at else "",
+            created_at=to_utc_iso(m.created_at) or "",
         )
         for m in memories
     ]
@@ -1636,13 +1638,13 @@ async def find_duplicates(
                             id=str(a),
                             summary=mem_a.summary[:200] if mem_a.summary else "",
                             type=mem_a.type or "note",
-                            created_at=mem_a.created_at.isoformat() if mem_a.created_at else "",
+                            created_at=to_utc_iso(mem_a.created_at) or "",
                         ),
                         memory_b=DuplicateMemoryInfo(
                             id=str(b),
                             summary=mem_b.summary[:200] if mem_b.summary else "",
                             type=mem_b.type or "note",
-                            created_at=mem_b.created_at.isoformat() if mem_b.created_at else "",
+                            created_at=to_utc_iso(mem_b.created_at) or "",
                         ),
                         similarity=hit["score"],
                     )

--- a/backend/src/api/routes/external_keys.py
+++ b/backend/src/api/routes/external_keys.py
@@ -22,6 +22,7 @@ from db.constraint_names import (
 )
 from models.auth import ExternalAPIKey
 from utils import db_transaction, get_user_email, mask_secret
+from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -239,8 +240,8 @@ async def list_external_keys(
                     masked_value=masked,
                     user_id=key.user_id,
                     enabled=key.enabled,  # Issue #105
-                    created_at=key.created_at.isoformat(),
-                    updated_at=key.updated_at.isoformat(),
+                    created_at=to_utc_iso(key.created_at) or "",
+                    updated_at=to_utc_iso(key.updated_at) or "",
                 )
             )
 
@@ -390,8 +391,8 @@ async def create_external_key(
             masked_value=mask_secret(request.value),
             user_id=new_key.user_id,
             enabled=new_key.enabled,  # Issue #105
-            created_at=new_key.created_at.isoformat(),
-            updated_at=new_key.updated_at.isoformat(),
+            created_at=to_utc_iso(new_key.created_at) or "",
+            updated_at=to_utc_iso(new_key.updated_at) or "",
         )
 
 
@@ -450,8 +451,8 @@ async def update_external_key(
             masked_value=mask_secret(request.value),
             user_id=key.user_id,
             enabled=key.enabled,  # Issue #105
-            created_at=key.created_at.isoformat(),
-            updated_at=key.updated_at.isoformat(),
+            created_at=to_utc_iso(key.created_at) or "",
+            updated_at=to_utc_iso(key.updated_at) or "",
         )
 
 
@@ -575,8 +576,8 @@ async def toggle_external_key(
             masked_value=mask_secret(decrypt_value(key.encrypted_value)),
             user_id=key.user_id,
             enabled=key.enabled,
-            created_at=key.created_at.isoformat(),
-            updated_at=key.updated_at.isoformat(),
+            created_at=to_utc_iso(key.created_at) or "",
+            updated_at=to_utc_iso(key.updated_at) or "",
         )
 
 

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -16,7 +16,7 @@ from db.base import get_db
 from models.memory import Memory
 from services.graph_service import GraphService
 from services.permission_service import PermissionService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -148,7 +148,7 @@ async def get_graph_stats(
                     top_connections=[],
                     recent_edges=[],
                 ),
-                last_updated=utcnow().isoformat(),
+                last_updated=to_utc_iso(utcnow()) or "",
             )
 
         context = await PermissionService(db).resolve_context_for_workspace_read(
@@ -215,7 +215,7 @@ async def get_graph_stats(
                 top_connections=top_connections,
                 recent_edges=recent_edges,
             ),
-            last_updated=utcnow().isoformat(),
+            last_updated=to_utc_iso(utcnow()) or "",
         )
 
     except HTTPException:
@@ -346,7 +346,7 @@ async def get_graph_data(
                     type=memory.type,
                     importance=memory.importance,
                     degree=int(degree),
-                    created_at=memory.created_at.isoformat() if memory.created_at else None,
+                    created_at=to_utc_iso(memory.created_at),
                 )
             )
             included_node_ids.add(node_id_str)
@@ -365,7 +365,7 @@ async def get_graph_data(
                         target=target_str,
                         weight=edge.weight,
                         type=edge.edge_type,
-                        created_at=edge.created_at.isoformat() if edge.created_at else None,
+                        created_at=to_utc_iso(edge.created_at),
                         confidence=edge.confidence,
                     )
                 )

--- a/backend/src/api/routes/invitations.py
+++ b/backend/src/api/routes/invitations.py
@@ -29,7 +29,7 @@ from models.schemas import (
 )
 from services.invitation_service import InvitationService
 from services.permission_service import PermissionService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import NotFoundException, ValidationError
 from utils.logger import get_logger
 
@@ -495,7 +495,7 @@ async def get_invitation_info(
         return {
             "workspace_name": workspace.name,
             "role": invitation.role,
-            "expires_at": invitation.expires_at.isoformat() if invitation.expires_at else None,
+            "expires_at": to_utc_iso(invitation.expires_at),
             "email_restricted": invitation.email is not None,
         }
 

--- a/backend/src/api/routes/me_account.py
+++ b/backend/src/api/routes/me_account.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import SessionUser
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from services.account_erasure_service import AccountErasureService
 from utils.logger import get_logger
 
@@ -35,7 +36,7 @@ router = APIRouter(prefix="/me/account", tags=["account-erasure"])
 # ---------------------------------------------------------------------------
 
 
-class ErasureRequestCreateResponse(BaseModel):
+class ErasureRequestCreateResponse(TZAwareBaseModel):
     """Returned after creating a self-service erasure request.
 
     The confirmation token is delivered through one of two channels
@@ -89,7 +90,7 @@ class ErasureConfirmRequest(BaseModel):
     )
 
 
-class ErasureRequestStateResponse(BaseModel):
+class ErasureRequestStateResponse(TZAwareBaseModel):
     """Read-only view of an erasure request's lifecycle state."""
 
     request_id: UUID

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -27,7 +27,7 @@ from models.schemas import (
     RegenerateOAuthSecretResponse,
 )
 from services.member_credentials_service import MemberCredentialsService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -356,10 +356,8 @@ async def create_api_key(
             "key_prefix": new_key.key_prefix,
             "plaintext_key": plaintext_key,
             "is_visible": True,
-            "visibility_expires_at": new_key.visibility_expires_at.isoformat()
-            if new_key.visibility_expires_at
-            else None,
-            "created_at": new_key.created_at.isoformat(),
+            "visibility_expires_at": to_utc_iso(new_key.visibility_expires_at),
+            "created_at": to_utc_iso(new_key.created_at),
             "revoked_at": None,
         }
 

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -32,7 +32,7 @@ from models.schemas import (
 from services.context_service import ContextService
 from services.memory_service import MemoryService
 from services.permission_service import PermissionService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -616,9 +616,6 @@ async def list_memories(
         # ``created_at`` for fresh rows that haven't been touched since
         # insert. The frontend renders both as the row "updated" timestamp,
         # so created_at is the correct fallback rather than null/empty.
-        def _utc_iso(dt: Any) -> str:
-            return dt.isoformat() + ("Z" if dt.tzinfo is None else "")
-
         memory_items = [
             MemoryListItem(
                 id=str(m.id),
@@ -626,8 +623,8 @@ async def list_memories(
                 type=m.type,
                 scope=m.scope,
                 importance=m.importance,
-                created_at=_utc_iso(m.created_at),
-                updated_at=_utc_iso(m.updated_at or m.created_at),
+                created_at=to_utc_iso(m.created_at) or "",
+                updated_at=to_utc_iso(m.updated_at or m.created_at) or "",
             )
             for m in memories
         ]
@@ -731,7 +728,7 @@ async def get_access_patterns(
                     "summary": m.summary,
                     "type": m.type,
                     "access_count": m.access_count,
-                    "last_used_at": m.last_used_at.isoformat() if m.last_used_at else None,
+                    "last_used_at": to_utc_iso(m.last_used_at),
                 }
                 for m in most_accessed
             ],

--- a/backend/src/api/routes/neural_config.py
+++ b/backend/src/api/routes/neural_config.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import require_admin
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from models.neural import NeuralConfig
 from neural.config import NeuralMemoryConfig
 from utils import db_transaction, get_user_id
@@ -29,7 +30,7 @@ router = APIRouter(prefix="/admin/neural-config", tags=["neural-config"])
 # ============================================================================
 
 
-class NeuralConfigItem(BaseModel):
+class NeuralConfigItem(TZAwareBaseModel):
     """Neural config item response."""
 
     key: str

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -36,7 +36,7 @@ from auth.oauth2_server import create_authorization_server
 from db.base import get_db, get_sync_session
 from models.auth import OAuth2Client, OAuth2Token, User
 from models.schemas import TokenIntrospectionResponse
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.logger import get_logger
 from utils.oauth_messages import get_oauth_messages
 from utils.redirect_uri import is_valid_redirect_uri_pattern
@@ -324,14 +324,10 @@ async def list_oauth2_clients(
                     token_endpoint_auth_method=client.token_endpoint_auth_method,
                     owner_id=client.owner_id,
                     provider=client.provider,  # Migration 036
-                    created_at=client.created_at.isoformat() + "Z",  # Issue #175: UTC explicit
+                    created_at=to_utc_iso(client.created_at) or "",
                     plaintext_secret=plaintext_secret,
                     is_visible=is_visible,
-                    visibility_expires_at=(
-                        client.visibility_expires_at.isoformat() + "Z"
-                        if client.visibility_expires_at
-                        else None
-                    ),  # Issue #175: UTC explicit
+                    visibility_expires_at=to_utc_iso(client.visibility_expires_at),
                 )
             )
 
@@ -434,13 +430,12 @@ async def create_oauth2_client(
             token_endpoint_auth_method=client.token_endpoint_auth_method,
             owner_id=client.owner_id,
             provider=client.provider,  # Migration 036
-            created_at=client.created_at.isoformat() + "Z",  # Issue #175: UTC explicit
+            created_at=to_utc_iso(client.created_at) or "",
             client_secret=client_secret,  # ⚠️ Only shown once!
             # Migration 034-035: Visibility fields
             plaintext_secret=client_secret,  # Same as client_secret
             is_visible=True,  # Newly created = visible
-            visibility_expires_at=visibility_expires_at.isoformat()
-            + "Z",  # Issue #175: UTC explicit
+            visibility_expires_at=to_utc_iso(visibility_expires_at),
         )
 
     except Exception as e:
@@ -598,11 +593,11 @@ async def dynamic_client_registration(
             token_endpoint_auth_method=client.token_endpoint_auth_method,
             owner_id=client.owner_id,
             provider=client.provider,
-            created_at=client.created_at.isoformat() + "Z",
+            created_at=to_utc_iso(client.created_at) or "",
             client_secret=client_secret,
             plaintext_secret=client_secret,
             is_visible=True,
-            visibility_expires_at=visibility_expires_at.isoformat() + "Z",
+            visibility_expires_at=to_utc_iso(visibility_expires_at),
         )
 
     except Exception as e:
@@ -676,15 +671,11 @@ async def get_oauth2_client(
             token_endpoint_auth_method=client.token_endpoint_auth_method,
             owner_id=client.owner_id,
             provider=client.provider,
-            created_at=client.created_at.isoformat() + "Z",  # Issue #175: UTC explicit
+            created_at=to_utc_iso(client.created_at) or "",
             # Migration 034-035: Visibility fields
             plaintext_secret=plaintext_secret,
             is_visible=is_visible,
-            visibility_expires_at=(
-                client.visibility_expires_at.isoformat() + "Z"
-                if client.visibility_expires_at
-                else None
-            ),  # Issue #175: UTC explicit
+            visibility_expires_at=to_utc_iso(client.visibility_expires_at),
         )
 
     finally:
@@ -758,15 +749,11 @@ async def update_oauth2_client(
             token_endpoint_auth_method=client.token_endpoint_auth_method,
             owner_id=client.owner_id,
             provider=client.provider,
-            created_at=client.created_at.isoformat() + "Z",  # Issue #175: UTC explicit
+            created_at=to_utc_iso(client.created_at) or "",
             # Migration 034-035: Visibility fields (no secret on update)
             plaintext_secret=None,
             is_visible=client.hidden_at is None,
-            visibility_expires_at=(
-                client.visibility_expires_at.isoformat() + "Z"
-                if client.visibility_expires_at
-                else None
-            ),  # Issue #175: UTC explicit
+            visibility_expires_at=to_utc_iso(client.visibility_expires_at),
         )
 
     except HTTPException:
@@ -928,16 +915,12 @@ async def regenerate_oauth2_client_secret(
             token_endpoint_auth_method=client.token_endpoint_auth_method,
             owner_id=client.owner_id,
             provider=client.provider,  # Migration 036
-            created_at=client.created_at.isoformat() + "Z",  # Issue #175: UTC explicit
+            created_at=to_utc_iso(client.created_at) or "",
             client_secret=new_client_secret,  # New secret - only shown once!
             # Migration 034-035: Visibility fields
             plaintext_secret=new_client_secret,  # Same as client_secret
             is_visible=True,  # Newly regenerated = visible
-            visibility_expires_at=(
-                client.visibility_expires_at.isoformat() + "Z"
-                if client.visibility_expires_at
-                else None
-            ),  # Issue #175: UTC explicit
+            visibility_expires_at=to_utc_iso(client.visibility_expires_at),
         )
 
     except HTTPException:

--- a/backend/src/api/routes/public_search.py
+++ b/backend/src/api/routes/public_search.py
@@ -19,7 +19,7 @@ from db.redis import increment_counter
 from models.auth import Context
 from services.resource_lookup import get_latest_schema
 from services.search_service import SearchService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import AuthorizationError, NotFoundException, RateLimitError
 from utils.logger import get_logger
 from utils.usage_logger import log_usage
@@ -399,9 +399,9 @@ async def get_public_context_info(
         "schema": {
             "version": schema.schema_version,
             "field_definitions": schema.field_definitions,
-            "updated_at": schema.updated_at.isoformat(),
+            "updated_at": to_utc_iso(schema.updated_at),
         }
         if schema
         else None,
-        "created_at": context.created_at.isoformat(),
+        "created_at": to_utc_iso(context.created_at),
     }

--- a/backend/src/api/routes/resource_schema.py
+++ b/backend/src/api/routes/resource_schema.py
@@ -18,6 +18,7 @@ from models.memory import Memory
 from models.resource import ResourceSchema, ResourceToken
 from services.permission_service import PermissionService
 from services.resource_lookup import resolve_resource_pk
+from utils.datetime import to_utc_iso
 from utils.exceptions import NotFoundException, ValidationError
 from utils.logger import get_logger
 
@@ -163,7 +164,7 @@ async def get_schema(
         resource_id=schema.resource_id,
         schema_version=schema.schema_version,
         field_definitions=schema.field_definitions,
-        created_at=schema.created_at.isoformat(),
+        created_at=to_utc_iso(schema.created_at) or "",
     )
 
 
@@ -286,7 +287,7 @@ async def create_schema(
         resource_id=schema.resource_id,
         schema_version=schema.schema_version,
         field_definitions=schema.field_definitions,
-        created_at=schema.created_at.isoformat(),
+        created_at=to_utc_iso(schema.created_at) or "",
     )
 
 

--- a/backend/src/api/routes/resource_tokens.py
+++ b/backend/src/api/routes/resource_tokens.py
@@ -19,6 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import WorkspaceOwner
 from auth.resource_tokens import ResourceTokenManager
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from models.resource import ResourceToken
 from services.resource_lookup import resolve_resource_pk
 from utils.logger import get_logger
@@ -71,7 +72,7 @@ class ResourceTokenUpdate(BaseModel):
     )
 
 
-class ResourceTokenResponse(BaseModel):
+class ResourceTokenResponse(TZAwareBaseModel):
     """Response model for resource token metadata (no plaintext)."""
 
     id: int = Field(..., description="Database ID")

--- a/backend/src/api/routes/sleep_reports.py
+++ b/backend/src/api/routes/sleep_reports.py
@@ -9,15 +9,15 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, field_serializer
+from pydantic import BaseModel
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import require_admin
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from models.auth import Context
 from models.sleep import SleepAction, SleepReport
-from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -30,7 +30,7 @@ router = APIRouter(prefix="/admin/sleep-reports", tags=["sleep-reports"])
 # ============================================================================
 
 
-class SleepReportSummary(BaseModel):
+class SleepReportSummary(TZAwareBaseModel):
     """Sleep report summary for list view."""
 
     id: UUID
@@ -49,10 +49,6 @@ class SleepReportSummary(BaseModel):
     llm_calls_made: int
     llm_tokens_used: int
 
-    @field_serializer("started_at", "completed_at")
-    def _serialize_dt(self, dt: datetime | None) -> str | None:
-        return to_utc_iso(dt)
-
 
 class SleepReportDetail(SleepReportSummary):
     """Sleep report full detail."""
@@ -67,7 +63,7 @@ class SleepReportDetail(SleepReportSummary):
     reindex_result: dict[str, Any] | None
 
 
-class SleepActionItem(BaseModel):
+class SleepActionItem(TZAwareBaseModel):
     """Sleep action audit log entry."""
 
     id: int
@@ -77,10 +73,6 @@ class SleepActionItem(BaseModel):
     target_id: UUID | None
     details: dict[str, Any] | None
     created_at: datetime
-
-    @field_serializer("created_at")
-    def _serialize_dt(self, dt: datetime) -> str:
-        return to_utc_iso(dt) or ""
 
 
 class SleepReportListResponse(BaseModel):

--- a/backend/src/api/routes/workspace.py
+++ b/backend/src/api/routes/workspace.py
@@ -33,7 +33,7 @@ from db.base import get_db
 from models.auth import Context, User, Workspace, WorkspaceMember
 from models.auth import UsageStats as UsageStatsModel
 from models.memory import Memory
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 
 logger = logging.getLogger(__name__)
 
@@ -752,8 +752,8 @@ async def get_embedding_status(
                     id=str(mem.id),
                     summary=mem.summary[:200] if mem.summary else "",
                     embedding_error=mem.embedding_error,
-                    created_at=mem.created_at.isoformat() if mem.created_at else "",
-                    updated_at=mem.updated_at.isoformat() if mem.updated_at else None,
+                    created_at=to_utc_iso(mem.created_at) or "",
+                    updated_at=to_utc_iso(mem.updated_at),
                 )
             )
 

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -15,10 +15,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import get_current_user
 from db.base import get_db
+from models.api_base import TZAwareBaseModel
 from models.auth import Context, ExternalAPIKey, User
 from models.schemas import OpenAIKeyStatusResponse
 from services.permission_service import PermissionService
 from services.workspace_service import WorkspaceService
+from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -91,7 +93,7 @@ class CredentialsStatusInfo(BaseModel):
     custom_app_count: int = 0
 
 
-class ContextStatsItem(BaseModel):
+class ContextStatsItem(TZAwareBaseModel):
     """Context usage statistics item.
 
     Issue #249: Per-context statistics for workspace overview.
@@ -138,7 +140,7 @@ class DailyUsageItem(BaseModel):
     unique_users: int
 
 
-class UserActivityItem(BaseModel):
+class UserActivityItem(TZAwareBaseModel):
     """User activity statistics item.
 
     Issue #249: Per-user activity breakdown.
@@ -359,7 +361,7 @@ async def create_workspace(
         plan_name=workspace.plan_name,
         member_count=stats["member_count"],
         context_count=stats["context_count"],
-        created_at=workspace.created_at.isoformat(),
+        created_at=to_utc_iso(workspace.created_at) or "",
     )
 
 
@@ -394,7 +396,7 @@ async def list_workspaces(
                 plan_name=workspace.plan_name,
                 member_count=stats["member_count"],
                 context_count=stats["context_count"],
-                created_at=workspace.created_at.isoformat(),
+                created_at=to_utc_iso(workspace.created_at) or "",
                 current_user_role=user_role,
             )
         )
@@ -427,7 +429,7 @@ async def get_workspace(
         plan_name=workspace.plan_name,
         member_count=stats["member_count"],
         context_count=stats["context_count"],
-        created_at=workspace.created_at.isoformat(),
+        created_at=to_utc_iso(workspace.created_at) or "",
     )
 
 
@@ -467,7 +469,7 @@ async def update_workspace(
         plan_name=workspace.plan_name,
         member_count=stats["member_count"],
         context_count=stats["context_count"],
-        created_at=workspace.created_at.isoformat(),
+        created_at=to_utc_iso(workspace.created_at) or "",
     )
 
 
@@ -652,11 +654,9 @@ async def list_members(
                 user_name=user_record.name if user_record else None,
                 user_email=user_record.email if user_record else None,
                 role=m.role,
-                joined_at=m.joined_at.isoformat() if m.joined_at else None,
+                joined_at=to_utc_iso(m.joined_at),
                 credentials_status=credentials_status,
-                last_login_at=user_record.last_login_at.isoformat()
-                if user_record and user_record.last_login_at
-                else None,
+                last_login_at=to_utc_iso(user_record.last_login_at) if user_record else None,
                 allowed_context_ids=allowed_context_ids_str,
             )
         )
@@ -692,7 +692,7 @@ async def add_member(
     return WorkspaceMemberResponse(
         user_id=member.user_id,
         role=member.role,
-        joined_at=member.joined_at.isoformat() if member.joined_at else None,
+        joined_at=to_utc_iso(member.joined_at),
     )
 
 
@@ -739,7 +739,7 @@ async def update_member_role(
     return WorkspaceMemberResponse(
         user_id=member.user_id,
         role=member.role,
-        joined_at=member.joined_at.isoformat() if member.joined_at else None,
+        joined_at=to_utc_iso(member.joined_at),
     )
 
 

--- a/backend/src/auth/roles.py
+++ b/backend/src/auth/roles.py
@@ -19,7 +19,7 @@ from enum import StrEnum
 from pydantic import BaseModel, Field
 from sqlalchemy import func
 
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 
 
 class Role(StrEnum):
@@ -332,7 +332,7 @@ class RoleManager:
                         email=u.email,
                         user_id=u.user_id,
                         role=Role(u.role),
-                        assigned_at=u.created_at.isoformat() if u.created_at else "",
+                        assigned_at=to_utc_iso(u.created_at) or "",
                         assigned_by=None,  # TODO: Track who assigned role
                     )
                     for u in db_users

--- a/backend/src/models/api_base.py
+++ b/backend/src/models/api_base.py
@@ -1,11 +1,11 @@
 """Shared base classes for API response models.
 
 `TZAwareBaseModel` ensures every `datetime` field on a response model is
-serialized to ISO 8601 with an explicit `Z` (or `+00:00`) UTC marker, so JS
-clients parse the result as UTC instead of local time. The DB stores naive
-UTC (TIMESTAMP WITHOUT TIME ZONE) for now; until the column-type migration
-in #490 lands, this base class is the API-layer guarantee that wire-format
-datetimes are unambiguous.
+serialized to ISO 8601 with `Z` for UTC datetimes, while non-UTC offsets are
+preserved as `+HH:MM`, so JS clients parse the result unambiguously instead
+of local time. The DB stores naive UTC (TIMESTAMP WITHOUT TIME ZONE) for now;
+until the column-type migration in #490 lands, this base class is the
+API-layer guarantee that wire-format datetimes are unambiguous.
 """
 
 from datetime import datetime

--- a/backend/src/models/api_base.py
+++ b/backend/src/models/api_base.py
@@ -8,11 +8,11 @@ until the column-type migration in #490 lands, this base class is the
 API-layer guarantee that wire-format datetimes are unambiguous.
 """
 
+from collections.abc import Callable
 from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, field_serializer
-from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 from utils.datetime import to_utc_iso
 
@@ -32,7 +32,7 @@ class TZAwareBaseModel(BaseModel):
     """
 
     @field_serializer("*", mode="wrap", when_used="json", check_fields=False)
-    def _serialize_datetime_as_utc(self, value: Any, handler: SerializerFunctionWrapHandler) -> Any:
+    def _serialize_datetime_as_utc(self, value: Any, handler: Callable[[Any], Any]) -> Any:
         """Serialize datetime fields with an explicit UTC `Z` suffix.
 
         Fires on every field during JSON serialization (`when_used="json"`).

--- a/backend/src/models/api_base.py
+++ b/backend/src/models/api_base.py
@@ -1,0 +1,53 @@
+"""Shared base classes for API response models.
+
+`TZAwareBaseModel` ensures every `datetime` field on a response model is
+serialized to ISO 8601 with an explicit `Z` (or `+00:00`) UTC marker, so JS
+clients parse the result as UTC instead of local time. The DB stores naive
+UTC (TIMESTAMP WITHOUT TIME ZONE) for now; until the column-type migration
+in #490 lands, this base class is the API-layer guarantee that wire-format
+datetimes are unambiguous.
+"""
+
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, field_serializer
+from pydantic_core.core_schema import SerializerFunctionWrapHandler
+
+from utils.datetime import to_utc_iso
+
+
+class TZAwareBaseModel(BaseModel):
+    """Base model that serializes naive `datetime` fields with a Z suffix.
+
+    Inherit from this instead of `pydantic.BaseModel` for any response schema
+    that exposes a `datetime` field. Non-datetime fields are unaffected — they
+    pass through Pydantic's default JSON serializer via the wrap handler.
+
+    Subclasses that declare their own `@field_serializer("created_at", ...)`
+    override this wildcard for that specific field (Pydantic v2 behavior:
+    field-specific serializers win). Prefer letting this base class handle
+    datetime fields and removing per-field serializers, so the project has a
+    single canonical pattern.
+    """
+
+    @field_serializer("*", mode="wrap", when_used="json", check_fields=False)
+    def _serialize_datetime_as_utc(self, value: Any, handler: SerializerFunctionWrapHandler) -> Any:
+        """Serialize datetime fields with an explicit UTC `Z` suffix.
+
+        Fires on every field during JSON serialization (`when_used="json"`).
+        For non-datetime values, delegates to Pydantic's default serializer
+        via `handler` so the rest of the schema serializes normally.
+
+        Args:
+            value: Field value being serialized.
+            handler: Default Pydantic serializer for non-datetime field types.
+
+        Returns:
+            For datetime input: ISO 8601 string with `Z` suffix (naive treated
+            as UTC, `+00:00` normalized to `Z`, non-UTC offsets preserved).
+            For all other types: the default JSON-serialized form.
+        """
+        if isinstance(value, datetime):
+            return to_utc_iso(value)
+        return handler(value)

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -8,7 +8,9 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from models.api_base import TZAwareBaseModel
 
 logger = logging.getLogger(__name__)
 
@@ -162,7 +164,7 @@ class RecallRequest(BaseModel):
     )
 
 
-class MemoryResponse(BaseModel):
+class MemoryResponse(TZAwareBaseModel):
     """Response schema for single memory."""
 
     memory_id: UUID
@@ -219,7 +221,7 @@ class ReferenceRequest(BaseModel):
     memory_id: UUID
 
 
-class LinkedMemoryRef(BaseModel):
+class LinkedMemoryRef(TZAwareBaseModel):
     """A single declared_link reference surfaced in ReferenceResponse.
 
     Issue #440: outgoing_links / incoming_links items. Edge invariant
@@ -237,12 +239,8 @@ class LinkedMemoryRef(BaseModel):
     weight: float
     created_at: datetime
 
-    @field_serializer("created_at")
-    def _serialize_created_at(self, dt: datetime) -> str:
-        return dt.isoformat() + ("Z" if dt.tzinfo is None else "")
 
-
-class ReferenceResponse(BaseModel):
+class ReferenceResponse(TZAwareBaseModel):
     """Response schema for reference() API (full details)."""
 
     memory_id: UUID
@@ -275,13 +273,6 @@ class ReferenceResponse(BaseModel):
     outgoing_has_more: bool = False
     incoming_links: list[LinkedMemoryRef] = Field(default_factory=list)
     incoming_has_more: bool = False
-
-    @field_serializer("created_at", "updated_at")
-    def _serialize_dt(self, dt: datetime) -> str:
-        # Memory.created_at/updated_at are stored as naive UTC. Tag with "Z"
-        # so JS clients parse them as UTC (without it, naive ISO is
-        # interpreted as local time, which JST shifts by +9 hours).
-        return dt.isoformat() + ("Z" if dt.tzinfo is None else "")
 
 
 class ForgetRequest(BaseModel):
@@ -519,7 +510,7 @@ class UserResponse(BaseModel):
         from_attributes = True
 
 
-class UserProfileResponse(BaseModel):
+class UserProfileResponse(TZAwareBaseModel):
     """Response schema for user profile.
 
     Issue #175: User timezone settings
@@ -563,7 +554,7 @@ class APIKeyCreate(BaseModel):
     expires_in_days: int | None = Field(None, ge=1, le=365, description="有効期限（日数）")
 
 
-class APIKeyResponse(BaseModel):
+class APIKeyResponse(TZAwareBaseModel):
     """Response schema for API key."""
 
     id: int
@@ -593,7 +584,7 @@ class ExternalAPIKeyCreate(BaseModel):
     api_key_value: str = Field(..., min_length=1, description="API key value (will be encrypted)")
 
 
-class ExternalAPIKeyResponse(BaseModel):
+class ExternalAPIKeyResponse(TZAwareBaseModel):
     """Response schema for external API key (masked)."""
 
     id: int
@@ -612,7 +603,7 @@ class ExternalAPIKeyResponse(BaseModel):
 # ============================================================================
 
 
-class ContextSearchConfigResponse(BaseModel):
+class ContextSearchConfigResponse(TZAwareBaseModel):
     """Response schema for context search configuration.
 
     Issue #130: Context-scoped Search & Reranker Settings
@@ -696,7 +687,7 @@ class ContextSearchConfigUpdate(BaseModel):
 # ============================================================================
 
 
-class UserWithAdminFlag(BaseModel):
+class UserWithAdminFlag(TZAwareBaseModel):
     """User model with system admin flags for admin management.
 
     Issue #166: System Admin vs Workspace Admin RBAC separation.
@@ -714,14 +705,7 @@ class UserWithAdminFlag(BaseModel):
     memory_count: int
     is_active: bool
 
-    model_config = {
-        "from_attributes": True,
-        "json_encoders": {
-            datetime: lambda v: (
-                v.isoformat() + "Z" if v and v.tzinfo is None else v.isoformat() if v else None
-            )
-        },
-    }
+    model_config = {"from_attributes": True}
 
 
 class SystemAdminListResponse(BaseModel):
@@ -760,7 +744,7 @@ class PromoteToSystemAdminResponse(BaseModel):
 # ============================================================================
 
 
-class UserWorkspaceInfo(BaseModel):
+class UserWorkspaceInfo(TZAwareBaseModel):
     """Workspace membership info for a user.
 
     Issue #164: User Management拡張.
@@ -778,7 +762,7 @@ class UserWorkspaceInfo(BaseModel):
         from_attributes = True
 
 
-class UserAccessibleContext(BaseModel):
+class UserAccessibleContext(TZAwareBaseModel):
     """Context accessible to user.
 
     Issue #164: User detail - accessible contexts.
@@ -846,7 +830,7 @@ class WorkspaceInvitationCreate(BaseModel):
     )
 
 
-class WorkspaceInvitationResponse(BaseModel):
+class WorkspaceInvitationResponse(TZAwareBaseModel):
     """Workspace invitation response.
 
     Issue #165: Team Collaboration - Workspace Invitation System
@@ -915,7 +899,7 @@ class OpenAIKeyStatusResponse(BaseModel):
 # ============================================================================
 
 
-class PendingInvitationItem(BaseModel):
+class PendingInvitationItem(TZAwareBaseModel):
     """Pending invitation item for current user.
 
     Issue #179: In-app invitation notifications.

--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -72,7 +72,7 @@ from models.erasure import (
 from services.email_service import EmailService, get_email_service
 from services.stripe_service import cancel_subscription_and_delete_customer_for_erasure
 from services.system_admin_service import SystemAdminService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import (
     EmailDispatchError,
     ErasureAlreadyInProgressError,
@@ -451,14 +451,14 @@ class AccountErasureService:
         await self.email_service.send_erasure_cooling_off_started(
             to_email=target.email,
             request_id=str(request.id),
-            scheduled_for_iso=request.scheduled_for.isoformat(),
+            scheduled_for_iso=to_utc_iso(request.scheduled_for) or "",
         )
 
         logger.info(
             "erasure_request_confirmed",
             request_id=str(request.id),
             user_id=user_id,
-            scheduled_for=request.scheduled_for.isoformat(),
+            scheduled_for=to_utc_iso(request.scheduled_for),
         )
         return request
 

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from repositories.neural_edge import NeuralEdgeRepository
+from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -242,8 +243,8 @@ class GraphService:
             "weight": edge.weight,
             "confidence": edge.confidence,
             "metadata": edge.edge_metadata,
-            "created_at": edge.created_at.isoformat(),
-            "last_updated": edge.last_updated.isoformat(),
+            "created_at": to_utc_iso(edge.created_at),
+            "last_updated": to_utc_iso(edge.last_updated),
         }
 
     async def has_edge(self, src_id: str | UUID, dst_id: str | UUID) -> bool:

--- a/backend/src/services/member_credentials_service.py
+++ b/backend/src/services/member_credentials_service.py
@@ -24,7 +24,7 @@ from models.auth import (
     OAuth2Token,
     WorkspaceMember,
 )
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import ValidationError
 from utils.logger import get_logger
 
@@ -659,11 +659,7 @@ class MemberCredentialsService:
             "key_prefix": api_key.key_prefix,
             "plaintext_key": plaintext_key,
             "is_visible": is_visible,
-            "visibility_expires_at": (
-                api_key.visibility_expires_at.isoformat() + "Z"
-                if api_key.visibility_expires_at
-                else None
-            ),
-            "created_at": api_key.created_at.isoformat() + "Z",
-            "revoked_at": (api_key.revoked_at.isoformat() + "Z" if api_key.revoked_at else None),
+            "visibility_expires_at": to_utc_iso(api_key.visibility_expires_at),
+            "created_at": to_utc_iso(api_key.created_at),
+            "revoked_at": to_utc_iso(api_key.revoked_at),
         }

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -47,7 +47,7 @@ from services.context_routing import resolve_collection_name
 from services.context_service import ContextService
 from services.embedding_service import EmbeddingService
 from services.search_service import SearchService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import MemoryGoneError, NotFoundException, QuotaExceededError
 from utils.logger import get_logger
 
@@ -433,7 +433,7 @@ class MemoryService:
 
             if payload_updates:
                 # Sync updated_at to Qdrant for date range filtering (Issue #78)
-                payload_updates["updated_at"] = utcnow().isoformat() + "Z"
+                payload_updates["updated_at"] = to_utc_iso(utcnow())
                 collection = await resolve_collection_name(self.db, memory.context_id)
                 await update_memory_payload_in_qdrant(
                     memory_id=memory.id,
@@ -668,7 +668,7 @@ class MemoryService:
                 payload_updates["type"] = request.type
 
             if payload_updates:
-                payload_updates["updated_at"] = utcnow().isoformat() + "Z"
+                payload_updates["updated_at"] = to_utc_iso(utcnow())
                 try:
                     collection = await resolve_collection_name(self.db, memory.context_id)
                     await update_memory_payload_in_qdrant(
@@ -2627,9 +2627,8 @@ async def process_pending_embedding(memory_id: UUID) -> None:
                 "tags": memory.tags or [],
                 "scope": memory.scope,
                 "client": memory.client or "unknown",
-                "created_at": (memory.created_at or utcnow()).isoformat() + "Z",
-                "updated_at": (memory.updated_at or memory.created_at or utcnow()).isoformat()
-                + "Z",
+                "created_at": to_utc_iso(memory.created_at or utcnow()),
+                "updated_at": to_utc_iso(memory.updated_at or memory.created_at or utcnow()),
             }
             if memory.context:
                 payload["context"] = memory.context

--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -35,7 +35,7 @@ from models.memory import Memory  # Issue #262: Memory model for resource data s
 from models.resource import IndexerState, Resource, ResourceEvent, ResourceSchema
 from services.context_routing import resolve_context_routing
 from services.embedding_service import EmbeddingService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import QdrantError
 from utils.logger import get_logger
 from utils.sparse_vector import build_resource_sparse_vector
@@ -238,14 +238,8 @@ async def get_indexer_status_for_context(
 
         state_dict = {
             "job_status": state_row.job_status,
-            "last_run_at": last_run_at.isoformat() + "Z"
-            if last_run_at and last_run_at.tzinfo is None
-            else (last_run_at.isoformat() if last_run_at else None),
-            "next_run_at": (
-                state_row.next_run_at.isoformat() + "Z"
-                if state_row.next_run_at and state_row.next_run_at.tzinfo is None
-                else (state_row.next_run_at.isoformat() if state_row.next_run_at else None)
-            ),
+            "last_run_at": to_utc_iso(last_run_at),
+            "next_run_at": to_utc_iso(state_row.next_run_at),
             "active_version": state_row.active_version,
             "last_offset": state_row.last_offset,
             "lag_seconds": lag_seconds,
@@ -259,12 +253,7 @@ async def get_indexer_status_for_context(
 
     event_dicts = []
     for ev in events:
-        created_at = ev.created_at
-        created_iso = (
-            created_at.isoformat() + "Z"
-            if created_at and created_at.tzinfo is None
-            else (created_at.isoformat() if created_at else None)
-        )
+        created_iso = to_utc_iso(ev.created_at)
         event_dicts.append(
             {
                 "id": ev.id,
@@ -585,7 +574,7 @@ class ResourceIndexer:
                 "facets": projected["facets"],
                 "sortable": projected["sortable"],
                 "metadata": projected["metadata"],
-                "updated_at": event.created_at.isoformat(),
+                "updated_at": to_utc_iso(event.created_at),
                 "memory_id": str(memory_id),
                 "point_id_source": point_id_str,
             },
@@ -666,7 +655,7 @@ class ResourceIndexer:
                     "doc_id": event.doc_id,
                     "version": event.version,
                     # Bugfix: Keep timezone for ISO string
-                    "indexed_at": utcnow().isoformat(),
+                    "indexed_at": to_utc_iso(utcnow()),
                 }
                 # Bugfix: Remove timezone for DB compatibility
                 existing_memory.updated_at = utcnow()
@@ -702,7 +691,7 @@ class ResourceIndexer:
                         "doc_id": event.doc_id,
                         "version": event.version,
                         # Bugfix: Keep timezone for ISO string
-                        "indexed_at": utcnow().isoformat(),
+                        "indexed_at": to_utc_iso(utcnow()),
                     },
                     type="resource_data",
                     # P0-2: Fix - use 'is not None' to allow importance=0.0

--- a/backend/src/services/sleep/reindex.py
+++ b/backend/src/services/sleep/reindex.py
@@ -16,6 +16,7 @@ from db.qdrant import add_memory_to_qdrant
 from models.memory import Memory
 from services.embedding_service import EmbeddingService
 from services.sleep.reporter import PhaseResult
+from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -114,12 +115,8 @@ class ReindexPhase:
                     "importance": memory.importance,
                     "scope": memory.scope,
                     "tags": memory.tags or [],
-                    "created_at": (
-                        memory.created_at.isoformat() + "Z" if memory.created_at else None
-                    ),
-                    "updated_at": (
-                        memory.updated_at.isoformat() + "Z" if memory.updated_at else None
-                    ),
+                    "created_at": to_utc_iso(memory.created_at),
+                    "updated_at": to_utc_iso(memory.updated_at),
                 }
 
                 await add_memory_to_qdrant(

--- a/backend/tests/api/test_schema_serializers.py
+++ b/backend/tests/api/test_schema_serializers.py
@@ -1,0 +1,462 @@
+"""Tests for TZAwareBaseModel and per-schema datetime serialization.
+
+Issue #489: ensure every response schema with a datetime field produces
+JS-parseable UTC-marked ISO 8601 strings (`Z` suffix for naive/UTC inputs,
+`+HH:MM` for non-UTC inputs), and avoids the double-Z regression class.
+
+Coverage:
+- TZAwareBaseModel: None / naive / aware-UTC / aware-non-UTC inputs
+- All response schemas previously bearing per-field serializers (must NOT
+  produce `+00:00Z` double suffix on tz-aware UTC inputs)
+- Schemas with bare `datetime` fields and no per-field serializer (the
+  primary bug surface — must NOT serialize as naive ISO without Z)
+"""
+
+import json
+from datetime import UTC, datetime
+from uuid import uuid4
+from zoneinfo import ZoneInfo
+
+from api.routes.api_keys import APIKeyResponse
+from api.routes.bm25_drift import Bm25DriftSummary
+from api.routes.contexts import ContextResponse
+from api.routes.sleep_reports import SleepReportSummary
+from api.routes.workspaces import ContextStatsItem, UserActivityItem
+from models.api_base import TZAwareBaseModel
+from models.schemas import (
+    MemoryResponse,
+    ReferenceResponse,
+    UserProfileResponse,
+    UserWithAdminFlag,
+)
+
+# ============================================================================
+# TZAwareBaseModel direct tests
+# ============================================================================
+
+
+class _SchemaWithMandatoryAndNullable(TZAwareBaseModel):
+    name: str
+    created_at: datetime
+    updated_at: datetime | None
+    n: int
+
+
+class TestTZAwareBaseModel:
+    def test_naive_datetime_emits_z_suffix(self):
+        m = _SchemaWithMandatoryAndNullable(
+            name="x",
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            updated_at=None,
+            n=1,
+        )
+        body = json.loads(m.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["updated_at"] is None
+        assert body["name"] == "x"
+        assert body["n"] == 1
+
+    def test_tz_aware_utc_does_not_double_suffix(self):
+        m = _SchemaWithMandatoryAndNullable(
+            name="x",
+            created_at=datetime(2026, 4, 28, 17, 50, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 28, 17, 50, 22, tzinfo=UTC),
+            n=1,
+        )
+        body = json.loads(m.model_dump_json())
+        # Crucial regression guard: must NOT be "...:22+00:00Z" or "...:22ZZ"
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["updated_at"] == "2026-04-28T17:50:22Z"
+
+    def test_non_utc_aware_preserves_offset(self):
+        # JST input — TZAwareBaseModel's role is to mark UTC as Z, not to
+        # convert. Non-UTC offsets are kept verbatim so callers retain the
+        # original wall-clock context.
+        m = _SchemaWithMandatoryAndNullable(
+            name="x",
+            created_at=datetime(2026, 4, 28, 17, 50, 22, tzinfo=ZoneInfo("Asia/Tokyo")),
+            updated_at=None,
+            n=1,
+        )
+        body = json.loads(m.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22+09:00"
+
+    def test_nullable_datetime_none_serializes_to_null(self):
+        m = _SchemaWithMandatoryAndNullable(
+            name="x",
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            updated_at=None,
+            n=1,
+        )
+        body = json.loads(m.model_dump_json())
+        assert body["updated_at"] is None
+
+    def test_non_datetime_fields_pass_through_correctly(self):
+        # Wildcard serializer with mode='wrap' must delegate non-datetime
+        # values to the default JSON serializer.
+        m = _SchemaWithMandatoryAndNullable(
+            name="hello",
+            created_at=datetime(2026, 4, 28),
+            updated_at=None,
+            n=42,
+        )
+        body = json.loads(m.model_dump_json())
+        assert body["name"] == "hello"
+        assert body["n"] == 42
+
+    def test_python_dict_dump_does_not_apply_z_suffix(self):
+        # when_used='json' means model_dump() (Python dict) keeps the raw
+        # datetime, not the string. This preserves type info for in-process
+        # consumers (e.g. internal service-layer pass-through).
+        m = _SchemaWithMandatoryAndNullable(
+            name="x",
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            updated_at=None,
+            n=1,
+        )
+        body = m.model_dump()
+        assert isinstance(body["created_at"], datetime)
+
+
+# ============================================================================
+# Per-schema regression tests: schemas that previously had their own
+# `field_serializer` MUST still emit Z (and never double-Z) after migrating
+# to TZAwareBaseModel inheritance.
+# ============================================================================
+
+
+class TestMemoryResponseSerialization:
+    def test_naive_created_at_gets_z(self):
+        m = MemoryResponse(
+            memory_id=uuid4(),
+            summary="s",
+            context_summary=None,
+            type="note",
+            importance=0.5,
+            scope="persistent",
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            client="t",
+            tags=[],
+            context=None,
+        )
+        body = json.loads(m.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+
+    def test_aware_utc_created_at_no_double_z(self):
+        m = MemoryResponse(
+            memory_id=uuid4(),
+            summary="s",
+            context_summary=None,
+            type="note",
+            importance=0.5,
+            scope="persistent",
+            created_at=datetime(2026, 4, 28, 17, 50, 22, tzinfo=UTC),
+            client="t",
+            tags=[],
+            context=None,
+        )
+        body = json.loads(m.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert "ZZ" not in body["created_at"]
+        assert "+00:00Z" not in body["created_at"]
+
+
+class TestReferenceResponseSerialization:
+    def test_naive_created_and_updated_get_z(self):
+        r = ReferenceResponse(
+            memory_id=uuid4(),
+            summary="s",
+            context_summary=None,
+            content="c",
+            details=None,
+            type="note",
+            scope="persistent",
+            importance=0.5,
+            tags=[],
+            context=None,
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            updated_at=datetime(2026, 4, 28, 18, 0, 0),
+            client="t",
+        )
+        body = json.loads(r.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["updated_at"] == "2026-04-28T18:00:00Z"
+
+    def test_aware_utc_no_double_z(self):
+        r = ReferenceResponse(
+            memory_id=uuid4(),
+            summary="s",
+            context_summary=None,
+            content="c",
+            details=None,
+            type="note",
+            scope="persistent",
+            importance=0.5,
+            tags=[],
+            context=None,
+            created_at=datetime(2026, 4, 28, 17, 50, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 28, 18, 0, 0, tzinfo=UTC),
+            client="t",
+        )
+        body = json.loads(r.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["updated_at"] == "2026-04-28T18:00:00Z"
+
+
+class TestUserWithAdminFlagSerialization:
+    def test_naive_created_at_gets_z_and_nullable_last_login_handled(self):
+        u = UserWithAdminFlag(
+            id=1,
+            email="a@b.c",
+            user_id="u1",
+            name="Foo",
+            picture=None,
+            role="user",
+            is_initial_admin=False,
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            last_login_at=None,
+            memory_count=0,
+            is_active=True,
+        )
+        body = json.loads(u.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["last_login_at"] is None
+
+    def test_naive_last_login_at_also_gets_z(self):
+        u = UserWithAdminFlag(
+            id=1,
+            email="a@b.c",
+            user_id="u1",
+            name="Foo",
+            picture=None,
+            role="user",
+            is_initial_admin=False,
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            last_login_at=datetime(2026, 4, 28, 18, 0, 0),
+            memory_count=0,
+            is_active=True,
+        )
+        body = json.loads(u.model_dump_json())
+        assert body["last_login_at"] == "2026-04-28T18:00:00Z"
+
+
+class TestSleepReportSummarySerialization:
+    def test_naive_started_and_completed_get_z(self):
+        s = SleepReportSummary(
+            id=uuid4(),
+            user_id="u",
+            workspace_id=None,
+            context_id=None,
+            status="completed",
+            started_at=datetime(2026, 4, 28, 17, 50, 22),
+            completed_at=datetime(2026, 4, 28, 18, 0, 0),
+            memories_processed=0,
+            edges_created=0,
+            memories_merged=0,
+            memories_promoted=0,
+            memories_flagged=0,
+            llm_calls_made=0,
+            llm_tokens_used=0,
+        )
+        body = json.loads(s.model_dump_json())
+        assert body["started_at"] == "2026-04-28T17:50:22Z"
+        assert body["completed_at"] == "2026-04-28T18:00:00Z"
+
+    def test_completed_at_none_handled(self):
+        s = SleepReportSummary(
+            id=uuid4(),
+            user_id="u",
+            workspace_id=None,
+            context_id=None,
+            status="running",
+            started_at=datetime(2026, 4, 28, 17, 50, 22),
+            completed_at=None,
+            memories_processed=0,
+            edges_created=0,
+            memories_merged=0,
+            memories_promoted=0,
+            memories_flagged=0,
+            llm_calls_made=0,
+            llm_tokens_used=0,
+        )
+        body = json.loads(s.model_dump_json())
+        assert body["completed_at"] is None
+
+
+# ============================================================================
+# Schemas previously WITHOUT a per-field serializer — these are the primary
+# bug surface from issue #489. Pre-fix they emitted naive ISO without Z.
+# ============================================================================
+
+
+class TestContextResponseSerialization:
+    """Issue #489 acceptance criterion: /api/v1/contexts datetime fields with Z."""
+
+    def test_all_three_datetime_fields_get_z(self):
+        c = ContextResponse(
+            id=uuid4(),
+            name="ctx",
+            display_name=None,
+            description=None,
+            summary=None,
+            usage_guide=None,
+            is_default=False,
+            is_private=True,
+            is_public=False,
+            resource_id=None,
+            is_locked=False,
+            created_by=None,
+            created_by_name=None,
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            updated_at=datetime(2026, 4, 28, 18, 0, 0),
+            use_rerank=None,
+            reranker_provider=None,
+            embedding_model=None,
+            embedding_dimensions=None,
+            member_count=None,
+            memory_count=0,
+            last_activity_at=datetime(2026, 4, 28, 19, 0, 0),
+        )
+        body = json.loads(c.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["updated_at"] == "2026-04-28T18:00:00Z"
+        assert body["last_activity_at"] == "2026-04-28T19:00:00Z"
+
+    def test_nullable_datetime_fields_none_handled(self):
+        c = ContextResponse(
+            id=uuid4(),
+            name="ctx",
+            display_name=None,
+            description=None,
+            summary=None,
+            usage_guide=None,
+            is_default=False,
+            is_private=True,
+            is_public=False,
+            resource_id=None,
+            is_locked=False,
+            created_by=None,
+            created_by_name=None,
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            updated_at=None,
+            use_rerank=None,
+            reranker_provider=None,
+            embedding_model=None,
+            embedding_dimensions=None,
+            member_count=None,
+            memory_count=0,
+            last_activity_at=None,
+        )
+        body = json.loads(c.model_dump_json())
+        assert body["updated_at"] is None
+        assert body["last_activity_at"] is None
+
+
+class TestAPIKeyResponseSerialization:
+    def test_all_four_datetime_fields_handle_naive_and_none(self):
+        k = APIKeyResponse(
+            id=1,
+            key_prefix="prefix0123456789",
+            name="test",
+            user_id="u",
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            last_used_at=None,
+            revoked_at=None,
+            expires_at=None,
+            status="active",
+        )
+        body = json.loads(k.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["last_used_at"] is None
+        assert body["revoked_at"] is None
+        assert body["expires_at"] is None
+
+    def test_aware_utc_no_double_z(self):
+        k = APIKeyResponse(
+            id=1,
+            key_prefix="prefix0123456789",
+            name="test",
+            user_id="u",
+            created_at=datetime(2026, 4, 28, 17, 50, 22, tzinfo=UTC),
+            last_used_at=datetime(2026, 4, 28, 18, 0, 0, tzinfo=UTC),
+            revoked_at=None,
+            expires_at=None,
+            status="active",
+        )
+        body = json.loads(k.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["last_used_at"] == "2026-04-28T18:00:00Z"
+
+
+class TestUserProfileResponseSerialization:
+    def test_naive_created_and_nullable_last_login(self):
+        u = UserProfileResponse(
+            id=1,
+            email="a@b.c",
+            name=None,
+            picture=None,
+            timezone="Asia/Tokyo",
+            locale="ja",
+            role="user",
+            current_workspace_id=None,
+            created_at=datetime(2026, 4, 28, 17, 50, 22),
+            last_login_at=None,
+        )
+        body = json.loads(u.model_dump_json())
+        assert body["created_at"] == "2026-04-28T17:50:22Z"
+        assert body["last_login_at"] is None
+
+
+class TestContextStatsItemSerialization:
+    """Workspace stats endpoint: GET /api/v1/workspaces/{id}/contexts/stats."""
+
+    def test_naive_last_activity_gets_z(self):
+        item = ContextStatsItem(
+            context_id="ctx-1",
+            context_name="ctx",
+            memory_count=5,
+            last_activity=datetime(2026, 4, 28, 17, 50, 22),
+            member_count=2,
+        )
+        body = json.loads(item.model_dump_json())
+        assert body["last_activity"] == "2026-04-28T17:50:22Z"
+
+    def test_null_last_activity_handled(self):
+        item = ContextStatsItem(
+            context_id="ctx-1",
+            context_name="ctx",
+            memory_count=0,
+            last_activity=None,
+            member_count=1,
+        )
+        body = json.loads(item.model_dump_json())
+        assert body["last_activity"] is None
+
+
+class TestUserActivityItemSerialization:
+    def test_naive_last_activity_gets_z(self):
+        item = UserActivityItem(
+            user_id="u",
+            user_name=None,
+            user_email=None,
+            api_calls=10,
+            last_activity=datetime(2026, 4, 28, 17, 50, 22),
+        )
+        body = json.loads(item.model_dump_json())
+        assert body["last_activity"] == "2026-04-28T17:50:22Z"
+
+
+class TestBm25DriftSummarySerialization:
+    def test_naive_measured_at_gets_z(self):
+        s = Bm25DriftSummary(
+            id=1,
+            context_id=uuid4(),
+            measured_at=datetime(2026, 4, 28, 17, 50, 22),
+            psi=0.1,
+            psi_status="green",
+            m_memory_points=100,
+            r_resource_points=50,
+            num_terms=20,
+        )
+        body = json.loads(s.model_dump_json())
+        assert body["measured_at"] == "2026-04-28T17:50:22Z"

--- a/backend/tests/utils/test_datetime.py
+++ b/backend/tests/utils/test_datetime.py
@@ -1,0 +1,74 @@
+"""Tests for utils.datetime — to_utc_iso, utcnow, parse_iso8601_to_aware.
+
+Issue #489: serialization helpers must produce JS-parseable Z-suffixed ISO 8601
+strings regardless of input shape (None, naive, tz-aware, double-Z avoidance).
+"""
+
+from datetime import UTC, datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from utils.datetime import parse_iso8601_to_aware, to_utc_iso, utcnow
+
+
+class TestToUtcIso:
+    def test_none_returns_none(self):
+        assert to_utc_iso(None) is None
+
+    def test_naive_datetime_appends_z(self):
+        dt = datetime(2026, 4, 28, 17, 50, 22)
+        assert to_utc_iso(dt) == "2026-04-28T17:50:22Z"
+
+    def test_tz_aware_utc_replaces_offset_with_z(self):
+        dt = datetime(2026, 4, 28, 17, 50, 22, tzinfo=UTC)
+        # +00:00 must be replaced by Z, NOT both ("+00:00Z" double-suffix bug)
+        assert to_utc_iso(dt) == "2026-04-28T17:50:22Z"
+
+    def test_tz_aware_non_utc_keeps_offset(self):
+        # JST (+09:00) is preserved, not Z. Only +00:00 is normalized to Z.
+        dt = datetime(2026, 4, 28, 17, 50, 22, tzinfo=ZoneInfo("Asia/Tokyo"))
+        result = to_utc_iso(dt)
+        assert result == "2026-04-28T17:50:22+09:00"
+
+    def test_microseconds_preserved(self):
+        dt = datetime(2026, 4, 28, 17, 50, 22, 123456)
+        assert to_utc_iso(dt) == "2026-04-28T17:50:22.123456Z"
+
+    def test_already_z_suffixed_via_tz_object(self):
+        # timezone.utc and datetime.UTC produce "+00:00" in isoformat — both
+        # paths must hit the same Z-replacement.
+        dt = datetime(2026, 4, 28, 17, 50, 22, tzinfo=UTC)
+        assert to_utc_iso(dt) == "2026-04-28T17:50:22Z"
+
+
+class TestUtcnow:
+    def test_returns_naive_datetime(self):
+        dt = utcnow()
+        assert dt.tzinfo is None
+
+    def test_close_to_now(self):
+        before = datetime.now(UTC).replace(tzinfo=None)
+        dt = utcnow()
+        after = datetime.now(UTC).replace(tzinfo=None)
+        assert before <= dt <= after
+
+
+class TestParseIso8601ToAware:
+    def test_z_suffix(self):
+        dt = parse_iso8601_to_aware("2026-04-28T17:50:22Z", "field")
+        assert dt.tzinfo is not None
+        assert dt.utcoffset().total_seconds() == 0
+
+    def test_offset_form(self):
+        dt = parse_iso8601_to_aware("2026-04-28T17:50:22+09:00", "field")
+        assert dt.utcoffset().total_seconds() == 9 * 3600
+
+    def test_naive_input_assumed_utc(self):
+        dt = parse_iso8601_to_aware("2026-04-28T17:50:22", "field")
+        assert dt.tzinfo is not None
+        assert dt.utcoffset().total_seconds() == 0
+
+    def test_invalid_raises(self):
+        with pytest.raises(ValueError, match="Invalid datetime"):
+            parse_iso8601_to_aware("not-a-date", "field")


### PR DESCRIPTION
Closes #489

## Summary
- Add `TZAwareBaseModel` with a wildcard `field_serializer` calling `to_utc_iso()`, so every response schema's datetime field emits a `Z` suffix (or `+HH:MM` for non-UTC-aware inputs) — JS clients no longer parse naive ISO as local time and JST users see correct timestamps.
- Migrate ~16 response schemas (across `models/schemas.py`, `contexts.py`, `api_keys.py`, `admin.py`, `sleep_reports.py`, `bm25_drift.py`, `workspaces.py`, `me_account.py`, `resource_tokens.py`, `admin_signup_gate.py`, `neural_config.py`) from `BaseModel` to `TZAwareBaseModel`, and remove pre-existing per-field `@field_serializer` / `json_encoders` (single canonical pattern).
- Replace ~30 manual `.isoformat()` call sites in handlers and services with `to_utc_iso()`. Notable side-effect fixes: `oauth.py` previously emitted invalid `+00:00Z` double-suffix for tz-aware UTC; `account_erasure_service.send_erasure_cooling_off_started()` previously sent naive ISO in a privacy-critical email displaying the deletion deadline.
- Add canonical Datetime/UTC convention to `.claude/rules/backend.md`.

## Implementation notes
- `models/api_base.py` (53 lines): `TZAwareBaseModel` uses `@field_serializer("*", mode="wrap", when_used="json", check_fields=False)` to delegate non-datetime fields to Pydantic's default serializer via the wrap handler, applying `to_utc_iso` only to datetime values.
- `to_utc_iso(dt: datetime | None) -> str | None` (already existed in `utils/datetime.py`) is idempotent — handles None/naive/aware-UTC/aware-non-UTC uniformly. Safe to apply unconditionally in handler/service code.
- Per-field serializers were removed from `MemoryResponse`, `LinkedMemoryRef`, `ReferenceResponse`, `UserWithAdminFlag`, `UserInfo` (admin.py), `SleepReportSummary`, `SleepActionItem`, `Bm25DriftSummary`. The new wildcard handles all of them.
- DB columns are unchanged (still TIMESTAMP WITHOUT TIME ZONE / naive UTC). The full column-type migration to `DateTime(timezone=True)` is deferred to follow-up #490 targeting v0.16.0 alongside the cost ledger work (#474/#475).
- Wire-format change: `+00:00` -> `Z` for tz-aware UTC datetimes in oauth.py and admin.py user detail. Both forms are valid ISO 8601; JS `new Date()` parses both. SDK / MCP consumer audit captured in follow-up #492.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green — privacy UX improvement (erasure deadline display) + oauth double-Z bug fix are security-positive side effects; no new attack surface
- qa-lead: green — schema-level coverage sufficient for v0.14.1 hotfix; SDK smoke test (2 min) recommended before v0.14.1 release tag (part of #492)
- cto: green — Option A -> Option B sequencing is correct (#490 v0.16.0); inheritance vs Annotated trade-off accepted (perf delta < latency budget); rule placement in `.claude/rules/backend.md` is canonical
- gate1: green via /claude-c-suite:ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/489-fix-fix-api-naive-datetime-serialization-wit.gate1.md
- ~/.claude/cache/gh-issue-driven/489-fix-fix-api-naive-datetime-serialization-wit.gate2.md

## Follow-up issues (filed)
- #490 v0.16.0+ — feat(db): complete `DateTime(timezone=True)` migration for ~85 naive columns (Option B)
- #491 v0.14.1 — test(e2e): Playwright with `TZ=Asia/Tokyo` for JST display Layer 4 coverage
- #492 v0.14.1 — chore(sdk): audit MCP/SDK consumers for Z vs `+00:00` datetime parsing compatibility

## Test plan
- [x] `make lint` — All checks passed (ruff)
- [x] `make type-check` — 0 errors, 0 warnings (pyright)
- [x] `make test-local` — 1664 passed (35 new + 1629 pre-existing). 4 pre-existing Qdrant integration failures unrelated (verified by stashing on origin/main).
- [ ] Manual SDK smoke test before v0.14.1 release tag (part of #492 verification)
- [ ] Browser smoke test: `/workspace/contexts` tooltip displays JST consistently in both UTC-tz and JST-tz Chrome

🤖 Generated with [Claude Code](https://claude.com/claude-code)
