### PR TITLE
test(e2e): JST display Layer 4 regression coverage (#491)

### DIFF
--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -9,7 +9,6 @@ Usage:
 
 import os
 import re
-import time
 
 import pytest
 from playwright.sync_api import Page, sync_playwright
@@ -46,15 +45,22 @@ def login_admin(page: Page) -> None:
     if admin_link.count() > 0:
         admin_link.first.click()
         page.wait_for_load_state("networkidle")
-        time.sleep(1)
 
+    # Wait deterministically for the login form input to be present —
+    # replaces the previous time.sleep(1) hard-pause after the admin-link
+    # click (which only fires on first login but is shared across every
+    # authenticated_context variant).
+    page.wait_for_selector('input[type="text"]', state="visible", timeout=10000)
     page.fill('input[type="text"]', ADMIN_LOGIN_ID)
     page.fill('input[type="password"]', ADMIN_PASSWORD)
 
     terms_checkbox = page.locator('input[type="checkbox"], button[role="checkbox"]')
     if terms_checkbox.count() > 0:
         terms_checkbox.first.click()
-        time.sleep(0.3)
+        # No explicit wait — the next click('button[type="submit"]') auto-waits
+        # for the submit button to be enabled (Playwright actionability check),
+        # which implicitly waits for the checkbox click to flip the form into
+        # a submittable state.
 
     page.click('button[type="submit"]')
     page.wait_for_url("**/workspace/**", timeout=15000)

--- a/backend/tests/e2e/conftest.py
+++ b/backend/tests/e2e/conftest.py
@@ -29,17 +29,17 @@ def browser():
         browser.close()
 
 
-@pytest.fixture(scope="session")
-def authenticated_context(browser):
-    """Create an authenticated browser context (login once per session)."""
-    context = browser.new_context(viewport={"width": 1280, "height": 800})
-    page = context.new_page()
+def login_admin(page: Page) -> None:
+    """Perform the admin login flow on the given page.
 
-    # Navigate to login page
+    Shared by every authenticated_context fixture variant so login UI
+    changes (selectors, terms checkbox, redirect target) only need updating
+    here. Terminates on the post-login `**/workspace/**` redirect; callers
+    own the page lifecycle around it.
+    """
     page.goto(f"{BASE_URL}/login")
     page.wait_for_load_state("networkidle")
 
-    # Click admin login link if present
     admin_link = page.locator(
         "a, button", has_text=re.compile(r"管理者ログイン|Admin Login|管理者")
     )
@@ -48,20 +48,24 @@ def authenticated_context(browser):
         page.wait_for_load_state("networkidle")
         time.sleep(1)
 
-    # Fill login form
     page.fill('input[type="text"]', ADMIN_LOGIN_ID)
     page.fill('input[type="password"]', ADMIN_PASSWORD)
 
-    # Check terms checkbox if present
     terms_checkbox = page.locator('input[type="checkbox"], button[role="checkbox"]')
     if terms_checkbox.count() > 0:
         terms_checkbox.first.click()
         time.sleep(0.3)
 
-    # Submit and wait for redirect
     page.click('button[type="submit"]')
     page.wait_for_url("**/workspace/**", timeout=15000)
 
+
+@pytest.fixture(scope="session")
+def authenticated_context(browser):
+    """Create an authenticated browser context (login once per session)."""
+    context = browser.new_context(viewport={"width": 1280, "height": 800})
+    page = context.new_page()
+    login_admin(page)
     page.close()
     yield context
     context.close()

--- a/backend/tests/e2e/test_datetime_tz_display.py
+++ b/backend/tests/e2e/test_datetime_tz_display.py
@@ -96,8 +96,10 @@ def test_last_activity_tooltip_displays_jst_under_non_utc_browser_tz(jst_page: P
     - `TZAwareBaseModel` is removed or bypassed → the wire-format assertion
       in step 3 fails before the UI assertion runs, with a precise diagnostic.
 
-    Skips when the admin workspace has no context with `last_activity_at` set
-    (a test-data condition, not a regression).
+    Self-sufficient on clean DB volumes: if no context yet has
+    `last_activity_at`, seeds a memory via `POST /api/v1/memory/remember`
+    and re-fetches before asserting. Skips only when the workspace has
+    zero contexts (environmental — rarer than the data-empty case).
     """
     profile_response = jst_page.request.put(
         f"{API_URL}/api/v1/users/profile",
@@ -115,12 +117,44 @@ def test_last_activity_tooltip_displays_jst_under_non_utc_browser_tz(jst_page: P
         f"Unexpected /api/v1/contexts shape: {type(payload).__name__}"
     )
 
+    # On a clean DB volume the admin workspace may have contexts with no
+    # last_activity_at yet. Seed one so the regression protection actually
+    # runs in CI / fresh local envs — Copilot review on PR #505 flagged
+    # the prior unconditional skip as silent-disablement risk.
     contexts_with_activity = [c for c in contexts if c.get("last_activity_at")]
     if not contexts_with_activity:
-        pytest.skip(
-            "No context in the admin workspace has last_activity_at set — "
-            "regression coverage requires at least one active context. "
-            "Add a memory to any context to populate last_activity_at."
+        if not contexts:
+            pytest.skip(
+                "Admin workspace has zero contexts — environmental, not a "
+                "regression. Provision the admin user's default context first."
+            )
+        seed_context_id = contexts[0]["id"]
+        seed_response = jst_page.request.post(
+            f"{API_URL}/api/v1/memory/remember",
+            data={
+                "summary": "e2e: JST tz display test seed (#491)",
+                "content": "Seeded by test_datetime_tz_display to populate last_activity_at",
+                "type": "test-seed",
+                "context": {"context_id": seed_context_id},
+            },
+        )
+        assert seed_response.ok, (
+            f"POST /api/v1/memory/remember failed while seeding last_activity_at: "
+            f"{seed_response.status} {seed_response.text()}"
+        )
+        contexts_response = jst_page.request.get(f"{API_URL}/api/v1/contexts")
+        assert contexts_response.ok, (
+            f"Re-fetch GET /api/v1/contexts failed: {contexts_response.status}"
+        )
+        payload = contexts_response.json()
+        contexts = payload.get("contexts") if isinstance(payload, dict) else payload
+        assert isinstance(contexts, list), (
+            f"Unexpected /api/v1/contexts shape after seed: {type(payload).__name__}"
+        )
+        contexts_with_activity = [c for c in contexts if c.get("last_activity_at")]
+        assert contexts_with_activity, (
+            "After seeding a memory, no context shows last_activity_at — "
+            "likely a backend bug or the seeded context_id was rejected, not a test-data issue."
         )
 
     target = contexts_with_activity[0]

--- a/backend/tests/e2e/test_datetime_tz_display.py
+++ b/backend/tests/e2e/test_datetime_tz_display.py
@@ -1,0 +1,202 @@
+"""E2E test for JST display Layer 4 regression coverage (#491).
+
+Verifies that the API serializes `last_activity_at` as a Z-suffixed UTC ISO 8601
+string (per `TZAwareBaseModel` from #489) and that the frontend tooltip on
+`/workspace/contexts` displays it in the user's `Profile.timezone`
+(`Asia/Tokyo`) regardless of the browser's local timezone.
+
+This is regression-only coverage for the "silent CI miss" class documented in
+the JST debugging checklist:
+  1. DB user.timezone column
+  2. /api/v1/auth/me response
+  3. Frontend code path (formatDateTime)
+  4. **API datetime Z suffix** ← silent in default Vitest
+
+Layer 4 cannot be caught by Vitest because Vitest defaults to UTC, so a naive
+datetime (no `Z`, no offset) round-trips to the same display in tests but
+shifts by the user's UTC offset in real non-UTC browsers. This Playwright
+test forces the browser into a non-UTC zone (`Europe/London`) so the wire
+format actually matters at parse time.
+
+Requires running Docker services:
+    docker compose up -d
+
+Run:
+    pytest tests/e2e/test_datetime_tz_display.py -m e2e -v
+"""
+
+import os
+import re
+import time
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+from playwright.sync_api import Page
+
+BASE_URL = os.environ.get("E2E_BASE_URL", "http://localhost:3000")
+API_URL = os.environ.get("E2E_API_URL", "http://localhost:8080")
+ADMIN_LOGIN_ID = os.environ.get("E2E_ADMIN_LOGIN_ID", "admin")
+ADMIN_PASSWORD = os.environ.get("E2E_ADMIN_PASSWORD", "adminPass123!!!")
+
+# `Europe/London` is chosen because GMT/BST differ from both UTC (the
+# baseline that masks the regression) and from Asia/Tokyo (the target
+# Profile.timezone). When the test fails, the diagnostic is intuitive:
+# "tooltip is shifted by ~9 hours, so JST conversion did not actually run."
+NON_UTC_BROWSER_TZ = "Europe/London"
+TARGET_PROFILE_TZ = "Asia/Tokyo"
+
+
+@pytest.fixture(scope="module")
+def jst_authenticated_context(browser):
+    """Authenticated browser context with timezone forced to a non-UTC zone.
+
+    Independent from `conftest.authenticated_context` (which uses the default
+    browser TZ) because forcing a non-default browser timezone is essential
+    to catching the Layer 4 regression — a UTC-only browser cannot
+    distinguish naive from Z-suffixed wire formats. Only this test gets the
+    override; the rest of the e2e suite keeps its default TZ.
+    """
+    context = browser.new_context(
+        viewport={"width": 1280, "height": 800},
+        timezone_id=NON_UTC_BROWSER_TZ,
+    )
+    page = context.new_page()
+
+    page.goto(f"{BASE_URL}/login")
+    page.wait_for_load_state("networkidle")
+
+    admin_link = page.locator(
+        "a, button", has_text=re.compile(r"管理者ログイン|Admin Login|管理者")
+    )
+    if admin_link.count() > 0:
+        admin_link.first.click()
+        page.wait_for_load_state("networkidle")
+        time.sleep(1)
+
+    page.fill('input[type="text"]', ADMIN_LOGIN_ID)
+    page.fill('input[type="password"]', ADMIN_PASSWORD)
+
+    terms_checkbox = page.locator('input[type="checkbox"], button[role="checkbox"]')
+    if terms_checkbox.count() > 0:
+        terms_checkbox.first.click()
+        time.sleep(0.3)
+
+    page.click('button[type="submit"]')
+    page.wait_for_url("**/workspace/**", timeout=15000)
+    page.close()
+
+    yield context
+    context.close()
+
+
+@pytest.fixture
+def jst_page(jst_authenticated_context):
+    """Per-test page in the timezone-forced authenticated context."""
+    page = jst_authenticated_context.new_page()
+    yield page
+    page.close()
+
+
+def _format_jst(utc_iso: str) -> str:
+    """Convert a Z-suffixed UTC ISO 8601 string to the page's JST tooltip format.
+
+    Mirrors the contract of `frontend/src/lib/utils/datetime.ts:26 formatDateTime()`
+    invoked with `timezone='Asia/Tokyo'` and `locale='ja'` — the production call
+    site at `frontend/src/app/(authenticated)/workspace/contexts/page.tsx:980-994`.
+
+    Frontend uses `Intl.DateTimeFormat('ja-JP', { timeZone, year, month, day,
+    hour, minute, second, hour12: false })`, which renders as
+    `YYYY/MM/DD HH:mm:ss`. We replicate that exact shape here so the assertion
+    is a literal string match.
+    """
+    dt_utc = datetime.fromisoformat(utc_iso.replace("Z", "+00:00"))
+    dt_jst = dt_utc.astimezone(ZoneInfo(TARGET_PROFILE_TZ))
+    return dt_jst.strftime("%Y/%m/%d %H:%M:%S")
+
+
+@pytest.mark.e2e
+def test_last_activity_tooltip_displays_jst_under_non_utc_browser_tz(jst_page: Page):
+    """Tooltip on /workspace/contexts shows JST consistently regardless of browser TZ.
+
+    Issue #491 Layer 4 regression coverage. The test:
+
+    1. Forces the browser timezone to `Europe/London` (non-UTC).
+    2. Sets `Profile.timezone = Asia/Tokyo` via `PUT /api/v1/users/profile`.
+    3. Reads `last_activity_at` from `GET /api/v1/contexts` and asserts the
+       wire format ends with `Z` (the `TZAwareBaseModel` contract).
+    4. Derives the expected JST display string from that UTC value.
+    5. Visits `/workspace/contexts` and asserts the rendered tooltip matches.
+
+    Failure modes this catches:
+    - The API returns a naive datetime (no `Z`, no offset). The browser
+      then parses it as `Europe/London` local time, and `Intl.DateTimeFormat`
+      converts that wrong-local time to JST → tooltip is shifted by the
+      Europe/London ↔ Asia/Tokyo offset.
+    - `TZAwareBaseModel` is removed or bypassed → the wire-format assertion
+      in step 3 fails before the UI assertion runs, with a precise diagnostic.
+
+    Skips when the admin workspace has no context with `last_activity_at` set
+    (a test-data condition, not a regression).
+    """
+    # Step 2: ensure the admin's Profile.timezone is the target JST value.
+    profile_response = jst_page.request.put(
+        f"{API_URL}/api/v1/users/profile",
+        data={"timezone": TARGET_PROFILE_TZ},
+    )
+    assert profile_response.ok, (
+        f"PUT /api/v1/users/profile failed: {profile_response.status} {profile_response.text()}"
+    )
+
+    # Step 3: read the canonical last_activity_at from the API.
+    contexts_response = jst_page.request.get(f"{API_URL}/api/v1/contexts")
+    assert contexts_response.ok, f"GET /api/v1/contexts failed: {contexts_response.status}"
+    payload = contexts_response.json()
+    contexts = payload.get("contexts") if isinstance(payload, dict) else payload
+    assert isinstance(contexts, list), (
+        f"Unexpected /api/v1/contexts shape: {type(payload).__name__}"
+    )
+
+    contexts_with_activity = [c for c in contexts if c.get("last_activity_at")]
+    if not contexts_with_activity:
+        pytest.skip(
+            "No context in the admin workspace has last_activity_at set — "
+            "regression coverage requires at least one active context. "
+            "Add a memory to any context to populate last_activity_at."
+        )
+
+    target = contexts_with_activity[0]
+    raw_last_activity = target["last_activity_at"]
+
+    # Layer 4 wire-format contract: TZAwareBaseModel guarantees a `Z` suffix
+    # on UTC datetimes. A bare ISO 8601 with no offset would be the silent-
+    # regression smoking gun.
+    assert raw_last_activity.endswith("Z"), (
+        f"last_activity_at wire format is not Z-suffixed: {raw_last_activity!r}. "
+        "TZAwareBaseModel may have been removed or bypassed for this response "
+        "schema (regression of #489)."
+    )
+
+    expected_jst = _format_jst(raw_last_activity)
+
+    # Step 5: render the page and read the tooltip via `title` attribute.
+    jst_page.goto(f"{BASE_URL}/workspace/contexts")
+    jst_page.wait_for_load_state("networkidle")
+    time.sleep(1)
+
+    # The tooltip is rendered as `title=formatDateTime(last_activity_at, ...)`
+    # on the span wrapping the relative-time text in the Last Activity column.
+    # We anchor on the exact JST string — unique enough to disambiguate even
+    # when the workspace has many contexts, since the formatted timestamp
+    # (down to seconds) is effectively a row identifier.
+    tooltip_locator = jst_page.locator(f'span[title="{expected_jst}"]')
+    assert tooltip_locator.count() > 0, (
+        f"No tooltip with the expected JST format was found on /workspace/contexts.\n"
+        f"  API last_activity_at : {raw_last_activity!r}\n"
+        f"  Expected JST tooltip : {expected_jst!r}\n"
+        f"  Browser timezone     : {NON_UTC_BROWSER_TZ}\n"
+        f"  Profile timezone     : {TARGET_PROFILE_TZ}\n"
+        "Likely cause: Layer 4 regression. If the API returned a naive datetime, "
+        "the browser parsed it as Europe/London local time and the tooltip is "
+        "now shifted by the Europe/London ↔ Asia/Tokyo offset."
+    )

--- a/backend/tests/e2e/test_datetime_tz_display.py
+++ b/backend/tests/e2e/test_datetime_tz_display.py
@@ -5,18 +5,10 @@ string (per `TZAwareBaseModel` from #489) and that the frontend tooltip on
 `/workspace/contexts` displays it in the user's `Profile.timezone`
 (`Asia/Tokyo`) regardless of the browser's local timezone.
 
-This is regression-only coverage for the "silent CI miss" class documented in
-the JST debugging checklist:
-  1. DB user.timezone column
-  2. /api/v1/auth/me response
-  3. Frontend code path (formatDateTime)
-  4. **API datetime Z suffix** ← silent in default Vitest
-
-Layer 4 cannot be caught by Vitest because Vitest defaults to UTC, so a naive
-datetime (no `Z`, no offset) round-trips to the same display in tests but
-shifts by the user's UTC offset in real non-UTC browsers. This Playwright
-test forces the browser into a non-UTC zone (`Europe/London`) so the wire
-format actually matters at parse time.
+Layer 4 of the JST debugging checklist (API datetime Z-suffix) is silent under
+default Vitest because Vitest runs in UTC; the regression only manifests in
+non-UTC browsers. This test forces the browser into `Europe/London` so the
+wire format actually matters at parse time.
 
 Requires running Docker services:
     docker compose up -d
@@ -25,8 +17,6 @@ Run:
     pytest tests/e2e/test_datetime_tz_display.py -m e2e -v
 """
 
-import os
-import re
 import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -34,58 +24,31 @@ from zoneinfo import ZoneInfo
 import pytest
 from playwright.sync_api import Page
 
-BASE_URL = os.environ.get("E2E_BASE_URL", "http://localhost:3000")
-API_URL = os.environ.get("E2E_API_URL", "http://localhost:8080")
-ADMIN_LOGIN_ID = os.environ.get("E2E_ADMIN_LOGIN_ID", "admin")
-ADMIN_PASSWORD = os.environ.get("E2E_ADMIN_PASSWORD", "adminPass123!!!")
+from tests.e2e.conftest import API_URL, BASE_URL, login_admin
 
-# `Europe/London` is chosen because GMT/BST differ from both UTC (the
-# baseline that masks the regression) and from Asia/Tokyo (the target
-# Profile.timezone). When the test fails, the diagnostic is intuitive:
-# "tooltip is shifted by ~9 hours, so JST conversion did not actually run."
+# `Europe/London` differs from both UTC (the baseline that masks the
+# regression) and Asia/Tokyo (the target Profile.timezone) — when the test
+# fails, the diagnostic is intuitive: tooltip is shifted by ~9 hours, so
+# JST conversion did not actually run.
 NON_UTC_BROWSER_TZ = "Europe/London"
 TARGET_PROFILE_TZ = "Asia/Tokyo"
 
 
 @pytest.fixture(scope="module")
 def jst_authenticated_context(browser):
-    """Authenticated browser context with timezone forced to a non-UTC zone.
+    """Authenticated context with timezone forced to a non-UTC zone.
 
-    Independent from `conftest.authenticated_context` (which uses the default
-    browser TZ) because forcing a non-default browser timezone is essential
-    to catching the Layer 4 regression — a UTC-only browser cannot
-    distinguish naive from Z-suffixed wire formats. Only this test gets the
-    override; the rest of the e2e suite keeps its default TZ.
+    Independent from the session-scoped `authenticated_context` because the
+    Layer 4 regression is invisible under a UTC browser; only this fixture
+    overrides `timezone_id`, leaving the rest of the e2e suite unchanged.
     """
     context = browser.new_context(
         viewport={"width": 1280, "height": 800},
         timezone_id=NON_UTC_BROWSER_TZ,
     )
     page = context.new_page()
-
-    page.goto(f"{BASE_URL}/login")
-    page.wait_for_load_state("networkidle")
-
-    admin_link = page.locator(
-        "a, button", has_text=re.compile(r"管理者ログイン|Admin Login|管理者")
-    )
-    if admin_link.count() > 0:
-        admin_link.first.click()
-        page.wait_for_load_state("networkidle")
-        time.sleep(1)
-
-    page.fill('input[type="text"]', ADMIN_LOGIN_ID)
-    page.fill('input[type="password"]', ADMIN_PASSWORD)
-
-    terms_checkbox = page.locator('input[type="checkbox"], button[role="checkbox"]')
-    if terms_checkbox.count() > 0:
-        terms_checkbox.first.click()
-        time.sleep(0.3)
-
-    page.click('button[type="submit"]')
-    page.wait_for_url("**/workspace/**", timeout=15000)
+    login_admin(page)
     page.close()
-
     yield context
     context.close()
 
@@ -104,11 +67,8 @@ def _format_jst(utc_iso: str) -> str:
     Mirrors the contract of `frontend/src/lib/utils/datetime.ts:26 formatDateTime()`
     invoked with `timezone='Asia/Tokyo'` and `locale='ja'` — the production call
     site at `frontend/src/app/(authenticated)/workspace/contexts/page.tsx:980-994`.
-
-    Frontend uses `Intl.DateTimeFormat('ja-JP', { timeZone, year, month, day,
-    hour, minute, second, hour12: false })`, which renders as
-    `YYYY/MM/DD HH:mm:ss`. We replicate that exact shape here so the assertion
-    is a literal string match.
+    Replicating the contract here (instead of importing a backend helper) keeps
+    the assertion independent of backend formatting code.
     """
     dt_utc = datetime.fromisoformat(utc_iso.replace("Z", "+00:00"))
     dt_jst = dt_utc.astimezone(ZoneInfo(TARGET_PROFILE_TZ))
@@ -139,7 +99,6 @@ def test_last_activity_tooltip_displays_jst_under_non_utc_browser_tz(jst_page: P
     Skips when the admin workspace has no context with `last_activity_at` set
     (a test-data condition, not a regression).
     """
-    # Step 2: ensure the admin's Profile.timezone is the target JST value.
     profile_response = jst_page.request.put(
         f"{API_URL}/api/v1/users/profile",
         data={"timezone": TARGET_PROFILE_TZ},
@@ -148,7 +107,6 @@ def test_last_activity_tooltip_displays_jst_under_non_utc_browser_tz(jst_page: P
         f"PUT /api/v1/users/profile failed: {profile_response.status} {profile_response.text()}"
     )
 
-    # Step 3: read the canonical last_activity_at from the API.
     contexts_response = jst_page.request.get(f"{API_URL}/api/v1/contexts")
     assert contexts_response.ok, f"GET /api/v1/contexts failed: {contexts_response.status}"
     payload = contexts_response.json()
@@ -179,24 +137,16 @@ def test_last_activity_tooltip_displays_jst_under_non_utc_browser_tz(jst_page: P
 
     expected_jst = _format_jst(raw_last_activity)
 
-    # Step 5: render the page and read the tooltip via `title` attribute.
     jst_page.goto(f"{BASE_URL}/workspace/contexts")
     jst_page.wait_for_load_state("networkidle")
     time.sleep(1)
 
-    # The tooltip is rendered as `title=formatDateTime(last_activity_at, ...)`
-    # on the span wrapping the relative-time text in the Last Activity column.
-    # We anchor on the exact JST string — unique enough to disambiguate even
-    # when the workspace has many contexts, since the formatted timestamp
-    # (down to seconds) is effectively a row identifier.
+    # Anchor on the exact JST string — second-precision makes it row-unique.
     tooltip_locator = jst_page.locator(f'span[title="{expected_jst}"]')
     assert tooltip_locator.count() > 0, (
         f"No tooltip with the expected JST format was found on /workspace/contexts.\n"
         f"  API last_activity_at : {raw_last_activity!r}\n"
         f"  Expected JST tooltip : {expected_jst!r}\n"
         f"  Browser timezone     : {NON_UTC_BROWSER_TZ}\n"
-        f"  Profile timezone     : {TARGET_PROFILE_TZ}\n"
-        "Likely cause: Layer 4 regression. If the API returned a naive datetime, "
-        "the browser parsed it as Europe/London local time and the tooltip is "
-        "now shifted by the Europe/London ↔ Asia/Tokyo offset."
+        f"  Profile timezone     : {TARGET_PROFILE_TZ}"
     )

--- a/backend/tests/e2e/test_datetime_tz_display.py
+++ b/backend/tests/e2e/test_datetime_tz_display.py
@@ -17,7 +17,6 @@ Run:
     pytest tests/e2e/test_datetime_tz_display.py -m e2e -v
 """
 
-import time
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
@@ -45,6 +44,12 @@ def jst_authenticated_context(browser):
     context = browser.new_context(
         viewport={"width": 1280, "height": 800},
         timezone_id=NON_UTC_BROWSER_TZ,
+        # Force navigator.language = "ja" so the i18n provider
+        # (frontend/src/i18n/config.ts:30-41) selects the ja locale and
+        # `formatDateTime` uses ja-JP `YYYY/MM/DD HH:MM:SS`. Without this
+        # override, CI envs without `kagura_locale` in localStorage default
+        # to `en` and the tooltip renders en-US format → locator miss.
+        locale="ja",
     )
     page = context.new_page()
     login_admin(page)
@@ -173,7 +178,9 @@ def test_last_activity_tooltip_displays_jst_under_non_utc_browser_tz(jst_page: P
 
     jst_page.goto(f"{BASE_URL}/workspace/contexts")
     jst_page.wait_for_load_state("networkidle")
-    time.sleep(1)
+    # Deterministic wait for the contexts table to hydrate at least one
+    # tooltip span — replaces the brittle `time.sleep(1)` flagged by Copilot.
+    jst_page.wait_for_selector("table span[title]", state="attached", timeout=15000)
 
     # Anchor on the exact JST string — second-precision makes it row-unique.
     tooltip_locator = jst_page.locator(f'span[title="{expected_jst}"]')

--- a/backend/tests/e2e/test_datetime_tz_display.py
+++ b/backend/tests/e2e/test_datetime_tz_display.py
@@ -178,16 +178,19 @@ def test_last_activity_tooltip_displays_jst_under_non_utc_browser_tz(jst_page: P
 
     jst_page.goto(f"{BASE_URL}/workspace/contexts")
     jst_page.wait_for_load_state("networkidle")
-    # Deterministic wait for the contexts table to hydrate at least one
-    # tooltip span — replaces the brittle `time.sleep(1)` flagged by Copilot.
-    jst_page.wait_for_selector("table span[title]", state="attached", timeout=15000)
 
-    # Anchor on the exact JST string — second-precision makes it row-unique.
+    # Wait deterministically for the SPECIFIC tooltip we expect to render.
+    # `count() > 0` is non-waiting and races client-side hydration; Playwright's
+    # `wait_for(state="attached")` polls until the element is in the DOM or the
+    # timeout fires. Custom diagnostic preserved via the try/except wrapper.
     tooltip_locator = jst_page.locator(f'span[title="{expected_jst}"]')
-    assert tooltip_locator.count() > 0, (
-        f"No tooltip with the expected JST format was found on /workspace/contexts.\n"
-        f"  API last_activity_at : {raw_last_activity!r}\n"
-        f"  Expected JST tooltip : {expected_jst!r}\n"
-        f"  Browser timezone     : {NON_UTC_BROWSER_TZ}\n"
-        f"  Profile timezone     : {TARGET_PROFILE_TZ}"
-    )
+    try:
+        tooltip_locator.first.wait_for(state="attached", timeout=15000)
+    except Exception as exc:
+        raise AssertionError(
+            f"No tooltip with the expected JST format was found on /workspace/contexts.\n"
+            f"  API last_activity_at : {raw_last_activity!r}\n"
+            f"  Expected JST tooltip : {expected_jst!r}\n"
+            f"  Browser timezone     : {NON_UTC_BROWSER_TZ}\n"
+            f"  Profile timezone     : {TARGET_PROFILE_TZ}"
+        ) from exc


### PR DESCRIPTION
Closes #491

## Summary

- Adds a Python pytest-playwright e2e test (`backend/tests/e2e/test_datetime_tz_display.py`) that catches Layer 4 of the JST debugging checklist — the silent CI miss class that lives in non-UTC browsers and is invisible to UTC-default Vitest.
- The test forces the browser timezone to `Europe/London` via a per-test context, sets `Profile.timezone = Asia/Tokyo` via `PUT /api/v1/users/profile`, asserts the wire format ends with `Z`, derives the expected JST display from the actual API value (no `now()`-based assertions), and matches it against the rendered tooltip on `/workspace/contexts`.
- Refactors `backend/tests/e2e/conftest.py` to extract the admin-login flow into a `login_admin(page)` helper used by both fixtures — eliminates ~25 lines of byte-for-byte duplication.
- Inverse-test verified manually before commit: temporarily setting `ContextResponse(BaseModel)` at `backend/src/api/routes/contexts.py:191` makes the test fail with the wire-format diagnostic; reverting to `TZAwareBaseModel` restores PASS.

## Implementation notes

- **TZ override**: `browser.new_context(timezone_id="Europe/London")` (Playwright Python's per-context override) — analogous to per-project TZ in TS Playwright. Only this fixture overrides; the rest of the e2e suite keeps its default TZ.
- **Profile.timezone setup**: API path (`PUT /api/v1/users/profile`) using the existing admin session cookie. DB-seed alternative was considered but rejected — the API path is what production exercises and avoids coupling the e2e test to internal user-table schema.
- **Tooltip locator**: anchors on the exact JST string via `span[title="<expected_jst>"]`. Second-precision makes the formatted timestamp effectively row-unique, so no `data-context-id` attribute is needed on the row.
- **Skip behavior**: when the admin workspace has no context with `last_activity_at`, the test `pytest.skip()`s — a test-data condition, not a regression. Worth monitoring CI skip rate so this doesn't silently turn the protection off.
- **Issue body deviation**: the original body referenced `frontend/playwright.config.ts` and `frontend/e2e/datetime-tz-display.spec.ts` (TS Playwright). This repo has Python pytest-playwright in `backend/tests/e2e/`, no TS Playwright at all. Body was updated mid-implementation to reflect actual setup; the gate1 reviewer's recommendations (per-project TZ, fixed timestamp, parser path documentation) were translated to the Python equivalent.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow → effective green via /ask (QA Lead lens; 4 adjustments applied to issue body)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/491-feat-test-e2e-playwright-with-tz-asia-tokyo-f.gate1.md
- ~/.claude/cache/gh-issue-driven/491-feat-test-e2e-playwright-with-tz-asia-tokyo-f.gate2.md

## Companion / related

- #492 (companion SDK consumer audit — closed 2026-04-29 as ALL CLEAR via comment)
- #489 (the Z-suffix wire-format fix that this test guards)
- #486 (the PR that exposed the bug by adding the tooltip)

🤖 Generated via /gh-issue-driven:ship
