### PR TITLE
refactor(neural): unify VALID_EDGE_TYPES + EDGE_TYPE_* constants (#461)

### DIFF
--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -22,20 +22,31 @@ from mcp_server.tools._helpers import (
     _validate_memory_id,
     execute_with_timeout,
 )
+from models.memory import (
+    EDGE_TYPE_DECLARED_LINK,
+    EDGE_TYPE_DEPENDS_ON,
+    EDGE_TYPE_LEARNED_FROM,
+    EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_SEMANTIC_SIMILARITY,
+    EDGE_TYPE_TAG_COOCCURRENCE,
+)
 
+# Issue #461: full set of edge_types accepted by the DB CHECK constraint
+# (`models/memory.py::valid_edge_type`). Sourced from `EDGE_TYPE_*` constants
+# so this set cannot drift from the schema literal. Includes both LLM-emittable
+# types (#374 → see `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`)
+# and synthetic seeding types (#221 `semantic_similarity`, #223 `tag_cooccurrence`)
+# plus client-declared links (#215 `declared_link`).
 VALID_EDGE_TYPES = frozenset(
     {
-        "neural_association",
-        "related_to",
-        "depends_on",
-        "learned_from",
-        # Cold-start seeding (Issue #221): synthetic edges from k-NN at remember() time
-        "semantic_similarity",
-        # Issue #215: Explicit links from clients (Obsidian wikilinks, code imports, etc.)
-        "declared_link",
-        # Issue #223 (Tier 2 cold-start seeding): synthetic edges from
-        # tag co-occurrence at remember() time
-        "tag_cooccurrence",
+        EDGE_TYPE_NEURAL_ASSOCIATION,
+        EDGE_TYPE_RELATED_TO,
+        EDGE_TYPE_DEPENDS_ON,
+        EDGE_TYPE_LEARNED_FROM,
+        EDGE_TYPE_SEMANTIC_SIMILARITY,
+        EDGE_TYPE_DECLARED_LINK,
+        EDGE_TYPE_TAG_COOCCURRENCE,
     }
 )
 

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -309,7 +309,7 @@ class NeuralMemoryEdge(Base):
     )
 
     # Edge properties
-    edge_type = Column(String(50), nullable=False, default="neural_association")
+    edge_type = Column(String(50), nullable=False, default=EDGE_TYPE_NEURAL_ASSOCIATION)
     weight = Column(Float, nullable=False, default=0.0)
     confidence = Column(Float, nullable=False, default=1.0)
 

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -116,12 +116,17 @@ CONFIDENCE_HISTOGRAM_KEYS: tuple[str, ...] = ("0.0-0.5", "0.5-0.7", "0.7-0.85", 
 # Issue #374: `EdgeType` is the type-level source of truth for valid
 # `NeuralMemoryEdge.edge_type` values emitted by the LLM judge (a deliberate
 # subset of the DB CHECK constraint in `models/memory.py` — the DB accepts
-# additional non-LLM types like `tag_cooccurrence`). `VALID_EDGE_TYPES` is
-# derived via `get_args` so the runtime membership check and the type
+# additional non-LLM types like `tag_cooccurrence`). `LLM_EMITTABLE_EDGE_TYPES`
+# is derived via `get_args` so the runtime membership check and the type
 # annotation cannot drift. Adding a new LLM-emittable edge type only requires
 # editing the Literal.
+#
+# Issue #461: renamed from `VALID_EDGE_TYPES` to disambiguate from the
+# full DB-accepted set in `mcp_server/tools/edge.py::VALID_EDGE_TYPES`.
+# `Literal` cannot reference module-level constants, so the string literals
+# stay here; cross-module subset invariant is pinned by a regression test.
 EdgeType = Literal["related_to", "depends_on", "learned_from"]
-VALID_EDGE_TYPES: frozenset[EdgeType] = frozenset(get_args(EdgeType))
+LLM_EMITTABLE_EDGE_TYPES: frozenset[EdgeType] = frozenset(get_args(EdgeType))
 
 # Issue #373: edge_type directionality semantics.
 # `related_to` is undirected (A related_to B ⇔ B related_to A); the parser
@@ -828,11 +833,11 @@ class EdgeDiscoveryPhase:
             raw_type = edge.get("edge_type", "related_to")
             # `frozenset.__contains__` does not narrow `raw_type` to `EdgeType`
             # for type checkers, so the membership check is promoted to a
-            # `cast` — the `in VALID_EDGE_TYPES` predicate is the runtime
+            # `cast` — the `in LLM_EMITTABLE_EDGE_TYPES` predicate is the runtime
             # guarantee that the cast is sound.
             edge_type: EdgeType = (
                 cast(EdgeType, raw_type)
-                if isinstance(raw_type, str) and raw_type in VALID_EDGE_TYPES
+                if isinstance(raw_type, str) and raw_type in LLM_EMITTABLE_EDGE_TYPES
                 else "related_to"
             )
 

--- a/backend/tests/test_edge_type_constants.py
+++ b/backend/tests/test_edge_type_constants.py
@@ -1,0 +1,61 @@
+"""Regression tests for #461: cross-module edge_type constant invariants.
+
+Pins:
+
+1. ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` equals the union of the
+   seven ``EDGE_TYPE_*`` constants exported from ``models/memory.py`` — i.e.
+   the runtime set used by MCP edge tools is exactly the set the DB CHECK
+   constraint accepts (the latter is mirrored as the constants in #460).
+
+2. ``services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`` is a
+   subset of ``VALID_EDGE_TYPES`` — the LLM judge can only emit a deliberate
+   subset of the types the DB accepts (#374). A future PR widening the
+   ``Literal`` without widening the full set (or vice versa) fails this
+   test before the drift can ship.
+
+These invariants cannot be expressed at the type-checker layer because
+``Literal`` requires string literals (not module-level constants), so this
+runtime test is the next safety net after pyright.
+"""
+
+from mcp_server.tools.edge import VALID_EDGE_TYPES
+from models.memory import (
+    EDGE_TYPE_DECLARED_LINK,
+    EDGE_TYPE_DEPENDS_ON,
+    EDGE_TYPE_LEARNED_FROM,
+    EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_SEMANTIC_SIMILARITY,
+    EDGE_TYPE_TAG_COOCCURRENCE,
+)
+from services.sleep.edge_discovery import LLM_EMITTABLE_EDGE_TYPES
+
+
+def test_valid_edge_types_matches_constants() -> None:
+    """``tools/edge.py::VALID_EDGE_TYPES`` equals the union of all ``EDGE_TYPE_*``.
+
+    Mirrors the DB CHECK constraint at ``models/memory.py::valid_edge_type``.
+    Adding a new edge_type requires updating both the constants block and
+    this set in lock-step; this test makes the lock enforceable.
+    """
+    assert VALID_EDGE_TYPES == frozenset(
+        {
+            EDGE_TYPE_NEURAL_ASSOCIATION,
+            EDGE_TYPE_RELATED_TO,
+            EDGE_TYPE_DEPENDS_ON,
+            EDGE_TYPE_LEARNED_FROM,
+            EDGE_TYPE_SEMANTIC_SIMILARITY,
+            EDGE_TYPE_DECLARED_LINK,
+            EDGE_TYPE_TAG_COOCCURRENCE,
+        }
+    )
+
+
+def test_llm_emittable_edge_types_subset_of_valid_edge_types() -> None:
+    """``LLM_EMITTABLE_EDGE_TYPES`` ⊆ ``VALID_EDGE_TYPES``.
+
+    Per #374 the LLM judge emits a deliberate subset of DB-accepted types.
+    An LLM-only type would be rejected by the DB CHECK constraint; this
+    test pins the cross-module subset invariant.
+    """
+    assert LLM_EMITTABLE_EDGE_TYPES.issubset(VALID_EDGE_TYPES)


### PR DESCRIPTION
Closes #461

## Summary
- Migrate `VALID_EDGE_TYPES` (`mcp_server/tools/edge.py`) to reference 7 `EDGE_TYPE_*` constants from `models/memory.py` — single source of truth for the DB-accepted edge_type set
- Rename `services/sleep/edge_discovery.py::VALID_EDGE_TYPES` → `LLM_EMITTABLE_EDGE_TYPES` to disambiguate from the full set (#374 LLM-emittable subset semantic)
- Update `models/memory.py:312` ORM column default to use `EDGE_TYPE_NEURAL_ASSOCIATION` constant
- Add 2 regression tests pinning full-set equality + cross-module subset invariant

## Implementation notes
- Phase A scope per refined #461 (3 of 5 inventoried defining sites)
- `EdgeType = Literal[...]` stays string-based (Python language constraint: `Literal` cannot reference module-level constants); cross-module subset invariant pinned in test instead
- Out of scope:
  - Site #5 (`graph_service.py:60-67` drift, `tag_cooccurrence` missing) → split to #506 (behavior change isolated)
  - Site #2 (`models/memory.py:329-333` CHECK constraint string) → Phase B follow-up (alembic ENUM migration; deferred)
- ~20 operational call sites (memory_service.py, hebbian.py, repositories/neural_edge.py default, MCP tool JSON Schema enum at _definitions.py:500/552, prompts.py LLM prompt text) left as-is — they USE edge_type values rather than DEFINE the valid set; gated at runtime by `VALID_EDGE_TYPES` membership + `Literal` typing

## Test results
- `make lint`: pass
- `pytest tests/test_edge_type_constants.py`: 2/2 pass (new regression tests)
- `pytest tests/services/sleep/test_edge_discovery.py`: 62/62 pass (rename impact verified)
- `pytest tests/mcp_server/`: 109/109 pass
- `make test-local` full suite: 1671 pass — 4 pre-existing fails in `test_single_collection_isolation.py` (Qdrant collection state, reproduces on `main` HEAD, unrelated to this PR)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/461-feat-refactor-neural-unify-valid-edge-types-c.gate1.md`
- `~/.claude/cache/gh-issue-driven/461-feat-refactor-neural-unify-valid-edge-types-c.gate2.md`

🤖 Generated via /gh-issue-driven:ship
