### PR TITLE
fix(graph): graph_service.EDGE_TYPES references EDGE_TYPE_* constants (#506)

### DIFF
--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -14,6 +14,15 @@ from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from models.memory import (
+    EDGE_TYPE_DECLARED_LINK,
+    EDGE_TYPE_DEPENDS_ON,
+    EDGE_TYPE_LEARNED_FROM,
+    EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_SEMANTIC_SIMILARITY,
+    EDGE_TYPE_TAG_COOCCURRENCE,
+)
 from repositories.neural_edge import NeuralEdgeRepository
 from utils.datetime import to_utc_iso
 from utils.logger import get_logger
@@ -36,11 +45,14 @@ class GraphService:
         - topic: Topic/entity nodes (Phase 3)
         - user: User nodes (future)
 
-    Edge Types:
+    Edge Types (mirrors the DB CHECK constraint and ``EDGE_TYPE_*`` constants):
         - neural_association: Learned associations (Hebbian)
         - related_to: Semantic relationship
         - depends_on: Dependency relationship
         - learned_from: Learning source
+        - semantic_similarity: k-NN cold-start seeding (#221)
+        - declared_link: Client-declared explicit link (#215)
+        - tag_cooccurrence: Tag co-occurrence cold-start seeding (#223)
 
     Attributes:
         user_id: Owner user ID (GDPR compliance)
@@ -57,14 +69,22 @@ class GraphService:
     _STATS_OWNER_DEFAULT: Any = object()
 
     NODE_TYPES = ["memory", "user", "topic"]
-    EDGE_TYPES = [
-        "neural_association",
-        "related_to",
-        "depends_on",
-        "learned_from",
-        "semantic_similarity",
-        "declared_link",
-    ]
+    # Issue #506: full set of edge_types accepted by the DB CHECK constraint
+    # (mirrors ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` from PR #507).
+    # ``frozenset`` for immutability + O(1) ``not in`` lookup at the validator
+    # in ``add_edge``. Sourced from ``EDGE_TYPE_*`` constants so this set
+    # cannot drift from the schema literal.
+    EDGE_TYPES: frozenset[str] = frozenset(
+        {
+            EDGE_TYPE_NEURAL_ASSOCIATION,
+            EDGE_TYPE_RELATED_TO,
+            EDGE_TYPE_DEPENDS_ON,
+            EDGE_TYPE_LEARNED_FROM,
+            EDGE_TYPE_SEMANTIC_SIMILARITY,
+            EDGE_TYPE_DECLARED_LINK,
+            EDGE_TYPE_TAG_COOCCURRENCE,
+        }
+    )
 
     def __init__(
         self,
@@ -168,7 +188,7 @@ class GraphService:
         self,
         src_id: str | UUID,
         dst_id: str | UUID,
-        rel_type: str = "neural_association",
+        rel_type: str = EDGE_TYPE_NEURAL_ASSOCIATION,
         weight: float = 1.0,
         edge_metadata: dict[str, Any] | None = None,
         confidence: float = 1.0,

--- a/backend/tests/services/test_graph_service_edge_types.py
+++ b/backend/tests/services/test_graph_service_edge_types.py
@@ -1,0 +1,125 @@
+"""Tests for GraphService.EDGE_TYPES drift fix (#506).
+
+PR #460 introduced ``EDGE_TYPE_*`` constants in ``models/memory.py`` to
+mirror the DB CHECK constraint values. PR #507 (#461 Phase A) wired
+``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` and the LLM-emittable
+subset in ``services/sleep/edge_discovery.py`` to those constants.
+
+This issue (#506) closes the last defining-site drift: ``GraphService.EDGE_TYPES``
+was missing ``tag_cooccurrence`` (introduced in #223), causing
+``add_edge(rel_type="tag_cooccurrence")`` to raise ``ValueError`` at the
+``:189`` validator. The production tag_cooccurrence write path goes through
+``NeuralEdgeRepository`` directly (memory_service), so this was a latent
+bug — but any future caller using ``GraphService`` for tag_cooccurrence
+edges would have hit it.
+
+Tests pin both invariants:
+
+1. ``GraphService.EDGE_TYPES`` equals the union of all ``EDGE_TYPE_*``
+   constants (matching the DB CHECK constraint), so future drift between
+   the constants block and this validator set fails CI before the
+   inconsistency can ship.
+
+2. ``add_edge(rel_type="tag_cooccurrence")`` no longer raises — the
+   behavior change that motivated the atomic split from #461.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from models.memory import (
+    EDGE_TYPE_DECLARED_LINK,
+    EDGE_TYPE_DEPENDS_ON,
+    EDGE_TYPE_LEARNED_FROM,
+    EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_SEMANTIC_SIMILARITY,
+    EDGE_TYPE_TAG_COOCCURRENCE,
+)
+from services.graph_service import GraphService
+
+
+def test_edge_types_matches_constants() -> None:
+    """``GraphService.EDGE_TYPES`` is the union of all ``EDGE_TYPE_*``.
+
+    Mirrors ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` (PR #507) and
+    the DB CHECK constraint in ``models/memory.py::valid_edge_type``.
+    Adding a new edge_type must update both the constants block and this
+    set in lock-step; this test enforces the lock.
+    """
+    assert GraphService.EDGE_TYPES == frozenset(
+        {
+            EDGE_TYPE_NEURAL_ASSOCIATION,
+            EDGE_TYPE_RELATED_TO,
+            EDGE_TYPE_DEPENDS_ON,
+            EDGE_TYPE_LEARNED_FROM,
+            EDGE_TYPE_SEMANTIC_SIMILARITY,
+            EDGE_TYPE_DECLARED_LINK,
+            EDGE_TYPE_TAG_COOCCURRENCE,
+        }
+    )
+
+
+@pytest.mark.asyncio
+async def test_add_edge_accepts_tag_cooccurrence() -> None:
+    """``add_edge(rel_type="tag_cooccurrence")`` no longer raises ``ValueError``.
+
+    Pre-#506 behavior: ``GraphService.EDGE_TYPES`` was missing
+    ``tag_cooccurrence`` (drifted from the DB CHECK constraint), so the
+    ``:189`` validator (``if rel_type not in self.EDGE_TYPES: raise``)
+    rejected legitimate tag_cooccurrence writes. Post-#506: validator
+    accepts and the call propagates to ``NeuralEdgeRepository``.
+    """
+    src_id = uuid4()
+    dst_id = uuid4()
+
+    mock_db = MagicMock()
+    mock_edge_repo = MagicMock()
+    mock_edge_repo.create_or_update_edge = AsyncMock()
+
+    graph = GraphService.__new__(GraphService)
+    graph.user_id = "test_user_506"
+    graph.workspace_id = str(uuid4())
+    graph.context_id = str(uuid4())
+    graph.db = mock_db
+    graph.edge_repo = mock_edge_repo
+
+    # Pre-#506 this would raise ValueError at graph_service.py:189.
+    await graph.add_edge(
+        src_id=src_id,
+        dst_id=dst_id,
+        rel_type=EDGE_TYPE_TAG_COOCCURRENCE,
+        weight=0.3,
+    )
+
+    mock_edge_repo.create_or_update_edge.assert_awaited_once()
+    kwargs = mock_edge_repo.create_or_update_edge.await_args.kwargs
+    assert kwargs["edge_type"] == EDGE_TYPE_TAG_COOCCURRENCE
+
+
+@pytest.mark.asyncio
+async def test_add_edge_rejects_unknown_rel_type() -> None:
+    """Validator still rejects values outside ``EDGE_TYPES``.
+
+    Negative-side complement to ``test_add_edge_accepts_tag_cooccurrence``:
+    confirms #506 widened the accepted set without disabling the validator.
+    """
+    src_id = uuid4()
+    dst_id = uuid4()
+
+    graph = GraphService.__new__(GraphService)
+    graph.user_id = "test_user_506_neg"
+    graph.workspace_id = str(uuid4())
+    graph.context_id = str(uuid4())
+    graph.db = MagicMock()
+    graph.edge_repo = MagicMock()
+
+    with pytest.raises(ValueError, match="Invalid rel_type"):
+        await graph.add_edge(
+            src_id=src_id,
+            dst_id=dst_id,
+            rel_type="not_a_real_edge_type",
+            weight=1.0,
+        )


### PR DESCRIPTION
Closes #506

## Summary
- Migrate `services/graph_service.py::EDGE_TYPES` from `list` (6 elements, missing `tag_cooccurrence`) to `frozenset` sourced from the 7 `EDGE_TYPE_*` constants in `models/memory.py`
- Companion fix: `add_edge()` default `rel_type` now uses `EDGE_TYPE_NEURAL_ASSOCIATION` constant (matches PR #507 pattern at `models/memory.py:312`)
- Class docstring updated from 4 listed edge types to all 7 (third drift dimension fixed)
- Add 3 regression + behavior tests pinning the invariants

## Implementation notes
- **Latent bug, not active**: pre-#506 the validator at `:189-190` raised `ValueError` for `add_edge(rel_type="tag_cooccurrence")`, but production tag_cooccurrence writes go through `NeuralEdgeRepository.create_or_update_edge` directly (memory_service path), not through `GraphService.add_edge`. Confirmed via grep over all 5 callers (`tasks/neural_tasks`, `memory_service`, `sleep/consolidation`, `api/routes/graph`, `repositories/neural_edge` docstring ref). Fix closes the latent path.
- **Atomic split from #461 (PR #507 merged 2026-04-29)**: this is the runtime-behavior-change companion to the pure naming-consolidation work in #461, intentionally separated so each PR's risk profile stays clean.
- **Source-of-truth state after merge**: defining-site drift remains only at `models/memory.py:329-333` (CHECK constraint string literal), tracked as Phase B follow-up issue (TBD post-merge).

## Test results
- `make lint`: pass
- `pytest tests/services/test_graph_service_edge_types.py`: 3/3 pass (new — full-set equality, tag_cooccurrence accept, unknown rejected)
- `pytest tests/services/test_graph_service_declared_link.py`: 1/1 pass (rename impact verified, no regression)
- `pytest tests/services/ tests/neural/`: 607 pass, 1 skip (zero regression)

## Out of scope
- `models/memory.py:329-333` CHECK constraint string → Phase B (alembic ENUM migration; future issue)
- `GraphService.NODE_TYPES` (still a `list`) → no constants source exists for node types yet; separate consolidation if/when needed
- Docstring claim ↔ EDGE_TYPES pin test → ROI too low (CR catches docstring drift; runtime test would be brittle)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/506-feat-fix-graph-graph-service-edge-types-drift.gate1.md`
- `~/.claude/cache/gh-issue-driven/506-feat-fix-graph-graph-service-edge-types-drift.gate2.md`

🤖 Generated via /gh-issue-driven:ship
