### PR TITLE
refactor(db): valid_edge_type CHECK derives from EDGE_TYPE_* constants (#509)

### DIFF
--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -263,8 +263,10 @@ class GraphMemory(Base):
         return f"<GraphMemory(user='{self.user_id}', nodes={self.total_nodes}, edges={self.total_edges})>"
 
 
-# Edge type constants. Sole source of truth — the CHECK constraint below and
-# all Python validators (#461 PR #507, #506 PR #508) derive from these.
+# Edge type constants — named aliases for the persisted edge_type string values.
+# Python validators (#461 PR #507, #506 PR #508) reference these constants by name.
+# The DB CHECK constraint is generated from the ordered ``_ALL_EDGE_TYPES`` tuple
+# (see below), which enumerates the same values in registration order.
 EDGE_TYPE_NEURAL_ASSOCIATION = "neural_association"
 EDGE_TYPE_RELATED_TO = "related_to"
 EDGE_TYPE_DEPENDS_ON = "depends_on"

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -263,7 +263,8 @@ class GraphMemory(Base):
         return f"<GraphMemory(user='{self.user_id}', nodes={self.total_nodes}, edges={self.total_edges})>"
 
 
-# Edge type constants. Mirrors the CHECK constraint values below — keep in sync.
+# Edge type constants. Sole source of truth — the CHECK constraint below and
+# all Python validators (#461 PR #507, #506 PR #508) derive from these.
 EDGE_TYPE_NEURAL_ASSOCIATION = "neural_association"
 EDGE_TYPE_RELATED_TO = "related_to"
 EDGE_TYPE_DEPENDS_ON = "depends_on"
@@ -271,6 +272,22 @@ EDGE_TYPE_LEARNED_FROM = "learned_from"
 EDGE_TYPE_SEMANTIC_SIMILARITY = "semantic_similarity"
 EDGE_TYPE_DECLARED_LINK = "declared_link"
 EDGE_TYPE_TAG_COOCCURRENCE = "tag_cooccurrence"
+
+# Issue #509 (Phase B of #461): registration-order tuple used to derive the
+# ``valid_edge_type`` CHECK constraint string in ``NeuralMemoryEdge.__table_args__``.
+# Order MUST match the literal order the b03_396 migration installed on prod
+# so ``Base.metadata.create_all()`` produces a CHECK string byte-identical to
+# what alembic head shows — preventing ``alembic revision --autogenerate``
+# from generating a spurious no-op migration on future runs.
+_ALL_EDGE_TYPES: tuple[str, ...] = (
+    EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_RELATED_TO,
+    EDGE_TYPE_DEPENDS_ON,
+    EDGE_TYPE_LEARNED_FROM,
+    EDGE_TYPE_SEMANTIC_SIMILARITY,
+    EDGE_TYPE_DECLARED_LINK,
+    EDGE_TYPE_TAG_COOCCURRENCE,
+)
 
 
 class NeuralMemoryEdge(Base):
@@ -326,10 +343,13 @@ class NeuralMemoryEdge(Base):
         UniqueConstraint("user_id", "src_id", "dst_id", name="unique_edge"),
         CheckConstraint("weight >= 0.0 AND weight <= 3.0", name="valid_weight"),
         CheckConstraint("confidence >= 0.0 AND confidence <= 1.0", name="valid_confidence"),
+        # Issue #509 (Phase B of #461): CHECK constraint derived from
+        # ``_ALL_EDGE_TYPES`` so adding a new edge_type requires editing the
+        # constants block only. The f-string output is byte-identical to the
+        # original literal that the b03_396 migration installed on prod
+        # (registration order, single quotes, exact whitespace).
         CheckConstraint(
-            "edge_type IN ('neural_association', 'related_to', 'depends_on', "
-            "'learned_from', 'semantic_similarity', 'declared_link', "
-            "'tag_cooccurrence')",
+            f"edge_type IN ({', '.join(repr(t) for t in _ALL_EDGE_TYPES)})",
             name="valid_edge_type",
         ),
         # Mirrors the CHECK the b03_396 migration installs so Base.metadata.

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -275,10 +275,11 @@ EDGE_TYPE_TAG_COOCCURRENCE = "tag_cooccurrence"
 
 # Issue #509 (Phase B of #461): registration-order tuple used to derive the
 # ``valid_edge_type`` CHECK constraint string in ``NeuralMemoryEdge.__table_args__``.
-# Order MUST match the literal order the b03_396 migration installed on prod
-# so ``Base.metadata.create_all()`` produces a CHECK string byte-identical to
-# what alembic head shows — preventing ``alembic revision --autogenerate``
-# from generating a spurious no-op migration on future runs.
+# Order MUST match the literal order ``b05_223_tag_cooccurrence.py`` installed
+# on prod (its ``_NEW_EDGE_TYPES_SQL``) so ``Base.metadata.create_all()`` produces
+# a CHECK string byte-identical to alembic head — preventing
+# ``alembic revision --autogenerate`` from generating a spurious no-op migration
+# on future runs.
 _ALL_EDGE_TYPES: tuple[str, ...] = (
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_RELATED_TO,
@@ -344,10 +345,14 @@ class NeuralMemoryEdge(Base):
         CheckConstraint("weight >= 0.0 AND weight <= 3.0", name="valid_weight"),
         CheckConstraint("confidence >= 0.0 AND confidence <= 1.0", name="valid_confidence"),
         # Issue #509 (Phase B of #461): CHECK constraint derived from
-        # ``_ALL_EDGE_TYPES`` so adding a new edge_type requires editing the
-        # constants block only. The f-string output is byte-identical to the
-        # original literal that the b03_396 migration installed on prod
-        # (registration order, single quotes, exact whitespace).
+        # ``_ALL_EDGE_TYPES``. Adding a new edge_type requires THREE coordinated
+        # edits (caught by the regression test if any are missed): (1) add
+        # ``EDGE_TYPE_NEW`` to the constants block above, (2) append it to
+        # ``_ALL_EDGE_TYPES``, (3) update the expected literal in
+        # ``test_valid_edge_type_check_constraint_matches_migration_literal``,
+        # plus a corresponding alembic migration that ALTERs the prod CHECK.
+        # The f-string output is byte-identical to ``b05_223_tag_cooccurrence.py``'s
+        # ``_NEW_EDGE_TYPES_SQL`` (registration order, single quotes, exact whitespace).
         CheckConstraint(
             f"edge_type IN ({', '.join(repr(t) for t in _ALL_EDGE_TYPES)})",
             name="valid_edge_type",

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -357,12 +357,13 @@ class NeuralMemoryEdge(Base):
             f"edge_type IN ({', '.join(repr(t) for t in _ALL_EDGE_TYPES)})",
             name="valid_edge_type",
         ),
-        # Mirrors the CHECK the b03_396 migration installs so Base.metadata.
-        # create_all() (tests, fresh dev DB) produces the same schema the
-        # migration path leaves production in. NOT NULL on the columns already
-        # enforces this, so the CHECK is belt-and-braces — but keeping it
-        # symmetric with the migration avoids "works on prod, silently lax
-        # on test fixtures" drift.
+        # Mirrors the workspace_id/context_id NOT NULL CHECK that
+        # b03_396_neural_edges_ws_ctx_not_null.py installed so
+        # Base.metadata.create_all() (tests, fresh dev DB) produces the same
+        # schema the migration path leaves production in. NOT NULL on the
+        # columns already enforces this, so the CHECK is belt-and-braces — but
+        # keeping it symmetric with the migration avoids "works on prod,
+        # silently lax on test fixtures" drift.
         CheckConstraint(
             "workspace_id IS NOT NULL AND context_id IS NOT NULL",
             name="ck_neural_memory_edges_ws_ctx_not_null",

--- a/backend/tests/test_edge_type_constants.py
+++ b/backend/tests/test_edge_type_constants.py
@@ -93,4 +93,8 @@ def test_valid_edge_type_check_constraint_matches_migration_literal() -> None:
     valid_edge_type_check = next(
         c for c in NeuralMemoryEdge.__table_args__ if getattr(c, "name", None) == "valid_edge_type"
     )
-    assert str(valid_edge_type_check.sqltext) == expected
+    # Use ``.text`` (raw TextClause attribute) instead of ``str()`` which
+    # would route through SQLAlchemy compilation and could shift across
+    # SQLAlchemy/dialect versions. ``.text`` is the original CheckConstraint
+    # string, so byte-identical comparison stays stable across upgrades.
+    assert valid_edge_type_check.sqltext.text == expected

--- a/backend/tests/test_edge_type_constants.py
+++ b/backend/tests/test_edge_type_constants.py
@@ -59,3 +59,37 @@ def test_llm_emittable_edge_types_subset_of_valid_edge_types() -> None:
     test pins the cross-module subset invariant.
     """
     assert LLM_EMITTABLE_EDGE_TYPES.issubset(VALID_EDGE_TYPES)
+
+
+def test_valid_edge_type_check_constraint_matches_migration_literal() -> None:
+    """``valid_edge_type`` CHECK constraint text is byte-identical to b03_396.
+
+    Issue #509 (Phase B of #461): the CHECK constraint is now derived from
+    ``_ALL_EDGE_TYPES`` via f-string instead of being a hardcoded literal.
+    This test pins the *exact* output string against the literal that the
+    b03_396 migration installed on production. Two reasons:
+
+    1. ``Base.metadata.create_all()`` (used by tests + fresh dev DBs) must
+       produce a CHECK constraint identical to the alembic head, so test
+       fixtures and prod schema stay in sync.
+    2. ``alembic revision --autogenerate`` compares the model's CheckConstraint
+       string against the migration head; any textual divergence (sorted vs
+       registration order, whitespace, quote style) generates a spurious
+       no-op migration. This test catches such drift before it lands.
+
+    If a future PR legitimately changes the CHECK string (adds a new
+    edge_type, reorders, etc.), update this expected literal AND write the
+    accompanying alembic migration in the same PR.
+    """
+    from models.memory import NeuralMemoryEdge
+
+    expected = (
+        "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+        "'learned_from', 'semantic_similarity', 'declared_link', "
+        "'tag_cooccurrence')"
+    )
+
+    valid_edge_type_check = next(
+        c for c in NeuralMemoryEdge.__table_args__ if getattr(c, "name", None) == "valid_edge_type"
+    )
+    assert str(valid_edge_type_check.sqltext) == expected

--- a/backend/tests/test_edge_type_constants.py
+++ b/backend/tests/test_edge_type_constants.py
@@ -62,12 +62,13 @@ def test_llm_emittable_edge_types_subset_of_valid_edge_types() -> None:
 
 
 def test_valid_edge_type_check_constraint_matches_migration_literal() -> None:
-    """``valid_edge_type`` CHECK constraint text is byte-identical to b03_396.
+    """``valid_edge_type`` CHECK constraint text is byte-identical to b05_223.
 
     Issue #509 (Phase B of #461): the CHECK constraint is now derived from
     ``_ALL_EDGE_TYPES`` via f-string instead of being a hardcoded literal.
-    This test pins the *exact* output string against the literal that the
-    b03_396 migration installed on production. Two reasons:
+    This test pins the *exact* output string against the literal that
+    ``b05_223_tag_cooccurrence.py`` installed on production via its
+    ``_NEW_EDGE_TYPES_SQL`` constant. Two reasons:
 
     1. ``Base.metadata.create_all()`` (used by tests + fresh dev DBs) must
        produce a CHECK constraint identical to the alembic head, so test


### PR DESCRIPTION
Closes #509

## Summary
- Replace literal `valid_edge_type` CHECK constraint string at `models/memory.py:329-333` with an f-string derived from `_ALL_EDGE_TYPES` tuple — completes the edge-type consolidation epic (#460 → #461 #507 → #506 #508 → this)
- Add `_ALL_EDGE_TYPES: tuple[str, ...]` in **registration order** (not sorted) so the f-string output is byte-identical to `b05_223_tag_cooccurrence.py`'s `_NEW_EDGE_TYPES_SQL` literal — preventing `alembic revision --autogenerate` spurious diffs
- Update the EDGE_TYPE_* block header to describe both roles (named aliases + ordered registry)
- Add `test_valid_edge_type_check_constraint_matches_migration_literal` regression test that pins the exact generated CHECK string against the expected literal via `sqltext.text` (raw TextClause attribute, stable across SQLAlchemy upgrades)

## Implementation notes
- **Option A chosen over Option B per gate1 design review**: f-string from constants (lighter, no schema migration) over PG ENUM via alembic migration (heavier, production rollout coordination)
- gate1 yellow finding addressed: `sorted()` deliberately omitted from `_ALL_EDGE_TYPES` traversal so output stays byte-identical to the b05_223 migration's registration-order literal
- No schema migration required — the f-string output is identical to the existing CHECK string (single quotes, exact whitespace, registration order)
- `Base.metadata.create_all()` (test fixtures, fresh dev DBs) and alembic head produce the same DDL

## Source-of-truth state after this PR

| Defining site | Status |
|---|---|
| `models/memory.py::EDGE_TYPE_*` constants | named aliases (string values) |
| `models/memory.py::_ALL_EDGE_TYPES` | ordered registry (drives the DB CHECK) |
| `models/memory.py:312` ORM default | references `EDGE_TYPE_NEURAL_ASSOCIATION` (PR #507) |
| `models/memory.py::valid_edge_type` CHECK | **f-string from `_ALL_EDGE_TYPES` (this PR)** |
| `mcp_server/tools/edge.py::VALID_EDGE_TYPES` | references constants (PR #507) |
| `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES` | renamed (PR #507) |
| `services/graph_service.py::EDGE_TYPES` | references constants (PR #508) |

**Edge-type defining-site consolidation epic completes.** Adding a new `edge_type` henceforth requires THREE coordinated Python edits (caught by the regression test if any are missed):

1. Add `EDGE_TYPE_NEW = "new_value"` to the `EDGE_TYPE_*` constants block
2. Append `EDGE_TYPE_NEW` to `_ALL_EDGE_TYPES`
3. Update the expected literal in `test_valid_edge_type_check_constraint_matches_migration_literal`

…plus an alembic migration that ALTERs the prod CHECK constraint (drop + recreate, mirroring `b05_223_tag_cooccurrence.py`'s pattern).

The CheckConstraint inline comment in `models/memory.py` enumerates these steps inline so future maintainers see them at the edit site.

## Test results
- `make lint`: pass
- `pytest tests/test_edge_type_constants.py`: 3/3 pass (existing 2 + new byte-identical pin)
- `pytest tests/services/ tests/neural/`: 610 pass, 1 skip (zero regression)
- `make test-integration`: 110 pass, 1 fail (`test_compute_cost_usd_per_million_tokens`) — pre-existing flaky on `main` HEAD, unrelated to this PR (verified via `git stash`)

## Out of scope
- Operational call sites (~20 places using edge_type literals as args/comparisons) — gated upstream by `VALID_EDGE_TYPES` membership + `Literal` typing
- PG ENUM migration (Option B, deferred — current Python-side consolidation already eliminates drift risk per #461 invariant tests)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow → green via /ask (CTO lens) — yellow because Option B feasibility surfaced; green after Option A confirmed + `sorted()` removed
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/509-feat-refactor-db-unify-valid-edge-type-check-c.gate1.md`
- `~/.claude/cache/gh-issue-driven/509-feat-refactor-db-unify-valid-edge-type-check-c.gate2.md`

🤖 Generated via /gh-issue-driven:ship; PR description refined via Copilot review loop 4
