### PR TITLE
feat(auth): sync email/name from IdP userinfo on every OAuth login (#481)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -93,6 +93,13 @@ JWT_EXPIRE_MINUTES=60
 # breaks cross-correlation between rows pseudonymized before vs after.
 AUDIT_PSEUDO_SALT=kagura-erasure-v1
 
+# HMAC-SHA256 key for keyed hashing of email values in audit_logs old/new
+# value columns (Issue #481, OAuth email-sync events). Distinct from
+# API_KEY_SECRET so each can rotate independently. Use: openssl rand -hex 32.
+# Rotating this key breaks comparability of email hashes across the rotation
+# boundary (acceptable trade-off for forward security).
+AUDIT_HMAC_KEY=change-me-audit-hmac-key
+
 # -----------------------------------------------------------------------------
 # API Settings
 # -----------------------------------------------------------------------------

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -42,6 +42,7 @@ from services.signup_gate_service import check_signup_access
 from services.workspace_service import WorkspaceService
 from utils.datetime import utcnow
 from utils.encryption import get_encryptor
+from utils.exceptions import ConflictError
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +129,13 @@ async def _check_registration_allowed(
     settings = get_settings()
 
     async def _run(session: AsyncSession) -> RedirectResponse | None:
-        # Existing users can always login
+        # Existing users can always login. NOTE (#481): an email match here
+        # also lets through cross-provider squatters (e.g. Google user
+        # alice@x.com → GitHub login with same address). That case is caught
+        # downstream by RoleManager.ensure_user, which raises ConflictError
+        # → callback redirects to /login?error=email_in_use. Don't tighten
+        # this gate to also reject cross-provider — multi-provider account
+        # linking is intentionally deferred to a separate issue.
         result = await session.execute(select(User).filter_by(email=email))
         if result.scalar_one_or_none():
             return None
@@ -161,6 +168,22 @@ async def _check_registration_allowed(
     async for session in get_db():
         return await _run(session)
     return None
+
+
+def _email_in_use_redirect() -> RedirectResponse:
+    """Redirect to the frontend login page on cross-provider email collision.
+
+    Issue #481: when ``RoleManager.ensure_user`` raises ``ConflictError`` (the
+    OAuth user's email is already bound to a different provider's account),
+    surface a stable error code on the login page rather than a JSON 409 mid-
+    redirect. Mirrors the shape of ``_check_registration_allowed``'s blocked
+    branch so both Google and GitHub callbacks end on the same UX surface.
+    """
+    frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
+    return RedirectResponse(
+        f"{frontend_url}/login?error=email_in_use",
+        status_code=303,
+    )
 
 
 # ============================================================================
@@ -272,6 +295,7 @@ async def google_login(
 
 @google_router.get("/callback")
 async def google_callback(
+    request: Request,
     code: str = Query(..., description="OAuth2 authorization code"),
     state: str = Query(..., description="CSRF state token"),
 ):
@@ -343,13 +367,23 @@ async def google_callback(
         if blocked:
             return blocked
 
-        # 4. Ensure user exists in database & assign role
+        # 4. Ensure user exists in database & assign role.
+        # Issue #481: pass email_verified from Google's userinfo response so
+        # ensure_user can sync mutable email/name without trusting the IdP
+        # blindly. Google v3 /oauth2/v3/userinfo always populates the
+        # email_verified boolean; default False here so a missing field is
+        # treated as unverified rather than implicitly trusted.
         role_manager = get_role_manager()
         role = await role_manager.ensure_user(
             email=user_info["email"],
             user_id=user_info["sub"],
             name=user_info.get("name"),
             auth_provider="google",
+            # Strict identity check (not bool coercion) so a stringly-typed
+            # "True" / "false" from a misconfigured IdP cannot pass the gate.
+            email_verified=user_info.get("email_verified") is True,
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("user-agent"),
         )
 
         # 5. Create session
@@ -454,6 +488,8 @@ async def google_callback(
 
         return redirect
 
+    except ConflictError:
+        return _email_in_use_redirect()
     except Exception as e:
         logger.error(f"OAuth2 callback failed: {e}")
         raise HTTPException(
@@ -641,43 +677,44 @@ async def _github_exchange_code(code: str) -> str:
 
 
 async def _github_get_user_info(access_token: str) -> dict[str, Any]:
-    """Get user info from GitHub API."""
+    """Get user info from GitHub API.
+
+    Always fetches ``/user/emails`` and selects the primary verified address,
+    ignoring the public-profile ``email`` field on ``/user``. The public field
+    is user-mutable in GitHub UI and verification status is not exposed there,
+    so trusting it would defeat the ``email_verified`` gate (Issue #481): a
+    user could surface an unverified address as their public email and have
+    it written into ``users.email`` on every login.
+
+    The returned dict carries ``email_verified=True`` as an invariant — if no
+    verified primary exists, the function raises ``ValueError`` and the OAuth
+    callback fails before any DB write. Callers can therefore unconditionally
+    pass ``email_verified=True`` to ``RoleManager.ensure_user`` without a
+    second-guessing branch.
+    """
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/vnd.github+json",
+    }
     async with httpx.AsyncClient() as client:
-        # Get user profile
-        user_resp = await client.get(
-            GITHUB_USER_URL,
-            headers={
-                "Authorization": f"Bearer {access_token}",
-                "Accept": "application/vnd.github+json",
-            },
-            timeout=10.0,
-        )
+        user_resp = await client.get(GITHUB_USER_URL, headers=headers, timeout=10.0)
         user_resp.raise_for_status()
         user_data = user_resp.json()
 
-        # Get primary email (may be private)
-        email = user_data.get("email")
-        if not email:
-            emails_resp = await client.get(
-                GITHUB_EMAILS_URL,
-                headers={
-                    "Authorization": f"Bearer {access_token}",
-                    "Accept": "application/vnd.github+json",
-                },
-                timeout=10.0,
-            )
-            emails_resp.raise_for_status()
-            for e in emails_resp.json():
-                if e.get("primary") and e.get("verified"):
-                    email = e["email"]
-                    break
+        emails_resp = await client.get(GITHUB_EMAILS_URL, headers=headers, timeout=10.0)
+        emails_resp.raise_for_status()
+        primary_verified = next(
+            (e["email"] for e in emails_resp.json() if e.get("primary") and e.get("verified")),
+            None,
+        )
 
-        if not email:
-            raise ValueError("GitHub account has no verified email")
+    if not primary_verified:
+        raise ValueError("GitHub account has no verified primary email")
 
     return {
         "sub": str(user_data["id"]),  # GitHub user ID as string (like Google's sub)
-        "email": email,
+        "email": primary_verified,
+        "email_verified": True,  # Invariant — only verified primary reaches here
         "name": user_data.get("name") or user_data.get("login"),
         "picture": user_data.get("avatar_url"),
         "login": user_data.get("login"),  # GitHub username for audit logging (Issue #358)
@@ -686,6 +723,7 @@ async def _github_get_user_info(access_token: str) -> dict[str, Any]:
 
 @github_router.get("/callback")
 async def github_callback(
+    request: Request,
     code: str = Query(..., description="GitHub authorization code"),
     state: str = Query(..., description="CSRF state token"),
 ):
@@ -721,32 +759,33 @@ async def github_callback(
         if blocked:
             return blocked
 
-        # 4. Ensure user exists & assign role
-        # Use GitHub's user ID for new users, but for existing users (e.g., logged in
-        # via Google before), ensure_user returns the role and we need to look up the
-        # actual DB user_id which may differ from GitHub's ID.
+        # 4. Ensure user exists & assign role.
+        # Issue #481: lookup is by user_id (GitHub sub), so the post-call DB
+        # re-query previously needed for cross-provider account linking is
+        # no longer correct — when a Google user attempts a GitHub login with
+        # the same email, ensure_user raises ConflictError(409) instead of
+        # silently linking the GitHub login to the Google row. The session
+        # subject can therefore be user_info["sub"] directly.
+        # email_verified is an invariant True here: _github_get_user_info
+        # always selects the verified primary address from /user/emails or
+        # raises before reaching this point.
         role_manager = get_role_manager()
         role = await role_manager.ensure_user(
             email=user_info["email"],
             user_id=user_info["sub"],
             name=user_info.get("name"),
             auth_provider="github",
+            # _github_get_user_info enforces the verified-primary invariant
+            # and always sets email_verified=True; KeyError on a missing key
+            # is the desired loud failure.
+            email_verified=user_info["email_verified"],
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("user-agent"),
         )
 
-        # Look up actual DB user_id (may differ from GitHub ID if user first logged in via Google)
-        from sqlalchemy import select
+        db_user_id = user_info["sub"]
 
-        from models.auth import User
-
-        db_user_id = user_info["sub"]  # fallback
-        async for db in get_db():
-            result = await db.execute(select(User).filter_by(email=user_info["email"]))
-            db_user = result.scalar_one_or_none()
-            if db_user:
-                db_user_id = db_user.user_id
-            break
-
-        # 5. Create session using DB user_id (not GitHub's sub)
+        # 5. Create session using GitHub sub as user_id
         deleted_count = _session_manager.delete_user_sessions(db_user_id)
         if deleted_count > 0:
             logger.info(f"Invalidated {deleted_count} old session(s) for {user_info['email']}")
@@ -803,6 +842,8 @@ async def github_callback(
         logger.info(f"GitHub OAuth2 login successful: {user_info['email']} (role={role})")
         return redirect
 
+    except ConflictError:
+        return _email_in_use_redirect()
     except Exception as e:
         logger.error(f"GitHub OAuth2 callback failed: {e}")
         raise HTTPException(

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -102,7 +102,7 @@ class CallbackResponse(BaseModel):
 
 
 async def _check_registration_allowed(
-    email: str, db: AsyncSession | None = None
+    email: str, db: AsyncSession | None = None, *, user_id: str | None = None
 ) -> RedirectResponse | None:
     """Check if a new user is allowed to register.
 
@@ -119,8 +119,12 @@ async def _check_registration_allowed(
         db: Optional existing session. When provided, the check runs on the
             caller's session (avoids opening a second pool connection when
             dispatched from SignupGateService's fallback path).
+        user_id: OAuth sub claim. When provided, an existing-user match on
+            *either* email or user_id counts as "existing" so a returning
+            user whose IdP email changed is still recognised as a login (not
+            blocked as a new signup).
     """
-    from sqlalchemy import func, select
+    from sqlalchemy import func, or_, select
 
     from config.settings import get_settings
     from models.auth import User
@@ -136,7 +140,15 @@ async def _check_registration_allowed(
         # → callback redirects to /login?error=email_in_use. Don't tighten
         # this gate to also reject cross-provider — multi-provider account
         # linking is intentionally deferred to a separate issue.
-        result = await session.execute(select(User).filter_by(email=email))
+        #
+        # user_id (OAuth sub) is included as an OR condition so a returning
+        # user whose email changed at the IdP is recognised as existing and
+        # never blocked — RoleManager.ensure_user handles the email sync.
+        if user_id:
+            cond = or_(User.email == email, User.user_id == user_id)
+        else:
+            cond = User.email == email
+        result = await session.execute(select(User).where(cond))
         if result.scalar_one_or_none():
             return None
 

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -144,7 +144,7 @@ async def _check_registration_allowed(
         # user_id (OAuth sub) is included as an OR condition so a returning
         # user whose email changed at the IdP is recognised as existing and
         # never blocked — RoleManager.ensure_user handles the email sync.
-        if user_id:
+        if user_id is not None and user_id:
             cond = or_(User.email == email, User.user_id == user_id)
         else:
             cond = User.email == email

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -305,9 +305,11 @@ async def google_callback(
     creates session, and sets HttpOnly cookie.
 
     Args:
-        code: OAuth2 authorization code from Google
-        state: CSRF state token (must match stored state)
-        response: FastAPI response object (for cookie setting)
+        request: FastAPI request (used for IP / User-Agent capture on the
+            audit row written by ``RoleManager.ensure_user`` when the IdP-
+            provided email differs from the stored value).
+        code: OAuth2 authorization code from Google.
+        state: CSRF state token (must match stored state).
 
     Returns:
         Redirect to dashboard with session cookie set

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -28,6 +28,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import SessionUser
@@ -504,6 +505,13 @@ async def google_callback(
 
     except ConflictError:
         return _email_in_use_redirect()
+    except SQLAlchemyError:
+        # Don't swallow DB errors as 401 — let the app-wide
+        # @app.exception_handler(SQLAlchemyError) map them to 503 so DB
+        # availability issues surface as retriable, not as auth failures.
+        # ConflictError above already handles the email-collision IntegrityError
+        # path; anything else here is unexpected DB trouble.
+        raise
     except Exception as e:
         logger.error(f"OAuth2 callback failed: {e}")
         raise HTTPException(
@@ -858,6 +866,11 @@ async def github_callback(
 
     except ConflictError:
         return _email_in_use_redirect()
+    except SQLAlchemyError:
+        # See google_callback's matching block — let DB errors hit the
+        # global SQLAlchemyError → 503 handler instead of being misclassified
+        # as 401 auth failures.
+        raise
     except Exception as e:
         logger.error(f"GitHub OAuth2 callback failed: {e}")
         raise HTTPException(

--- a/backend/src/auth/roles.py
+++ b/backend/src/auth/roles.py
@@ -49,11 +49,17 @@ def _is_email_unique_violation(exc: _IntegrityError) -> bool:
     """True iff ``exc`` is a UNIQUE violation on ``users.email``.
 
     Asyncpg surfaces UNIQUE violations with sqlstate=23505 and a
-    constraint_name. The schema declares ``email`` as ``unique=True, index=True``
-    so PostgreSQL names the unique index ``ix_users_email`` (other UNIQUE
-    columns get ``ix_users_user_id`` / ``ix_users_login_id``). Narrowing to
-    "email" prevents future constraint additions from being mis-mapped to
-    ConflictError("Email already in use") with the wrong message.
+    ``constraint_name``. The narrowing tolerates whichever name PostgreSQL
+    actually uses in this codebase: a ``Column(unique=True, index=True)``
+    declaration is realized in the alembic baseline migration as a unique
+    index named ``ix_users_email`` (verified against
+    asyncpg.exceptions.UniqueViolationError raised by the live DB —
+    constraint_name="ix_users_email"). On other Postgres + SQLAlchemy
+    deployments where ``unique=True`` produces a separate
+    ``users_email_key`` constraint instead, the substring match on
+    ``"email"`` still hits. Narrowing to "email" prevents future
+    constraint additions on other columns (e.g. UNIQUE on ``name``) from
+    being mis-mapped to ConflictError("Email already in use").
     """
     orig = getattr(exc, "orig", None)
     if orig is None:

--- a/backend/src/auth/roles.py
+++ b/backend/src/auth/roles.py
@@ -14,12 +14,54 @@ Example:
     True
 """
 
+from __future__ import annotations
+
 from enum import StrEnum
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, Field
 from sqlalchemy import func
 
+from config.settings import get_settings
 from utils.datetime import to_utc_iso, utcnow
+from utils.exceptions import ConflictError
+from utils.hashing import hmac_sha256_hex
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from sqlalchemy.exc import IntegrityError as _IntegrityError
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from models.auth import User as _UserModel
+
+logger = get_logger(__name__)
+
+
+# Sentinel actor identifier for audit_logs.user_email when the OAuth callback
+# itself initiates the row (e.g. oauth_user_email_synced). Distinct from the
+# admin/user email actor strings so audit_logs.user_email never carries the
+# subject's mutable email — the subject is identified by user_id, which is
+# pseudonymized at erasure time via _pseudonymize_audit_logs.
+_OAUTH_CALLBACK_ACTOR = "oauth-callback"
+
+
+def _is_email_unique_violation(exc: _IntegrityError) -> bool:
+    """True iff ``exc`` is a UNIQUE violation on ``users.email``.
+
+    Asyncpg surfaces UNIQUE violations with sqlstate=23505 and a
+    constraint_name. The schema declares ``email`` as ``unique=True, index=True``
+    so PostgreSQL names the unique index ``ix_users_email`` (other UNIQUE
+    columns get ``ix_users_user_id`` / ``ix_users_login_id``). Narrowing to
+    "email" prevents future constraint additions from being mis-mapped to
+    ConflictError("Email already in use") with the wrong message.
+    """
+    orig = getattr(exc, "orig", None)
+    if orig is None:
+        return False
+    if getattr(orig, "sqlstate", None) != "23505":
+        return False
+    constraint = (getattr(orig, "constraint_name", "") or "").lower()
+    return "email" in constraint
 
 
 class Role(StrEnum):
@@ -123,85 +165,233 @@ class RoleManager:
             self._roles = None  # Not used in PostgreSQL mode
 
     async def ensure_user(
-        self, email: str, user_id: str, name: str | None = None, auth_provider: str | None = None
+        self,
+        email: str,
+        user_id: str,
+        name: str | None = None,
+        auth_provider: str | None = None,
+        *,
+        email_verified: bool = False,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
     ) -> Role:
-        """Ensure user exists, create if first user or new.
+        """Ensure user exists; on existing users, sync email/name from IdP.
 
-        First user is automatically assigned ADMIN role.
-        Subsequent users are assigned USER role by default.
+        Issue #481: Lookup is keyed by ``user_id`` (OAuth ``sub`` claim), not by
+        email — ``user_id`` is the immutable identity, ``email`` is mutable
+        user-facing data. On hit, when ``email_verified=True`` and the IdP-
+        provided email differs from the stored value, the stored email is
+        updated and an ``oauth_user_email_synced`` audit row is written with
+        HMAC-SHA256 hashes of old/new values. Same-row no-op email writes and
+        ``email_verified=False`` paths skip the UPDATE entirely.
+
+        First user is automatically assigned ADMIN role. Subsequent users are
+        assigned USER role by default.
 
         Args:
-            email: User email address
-            user_id: User ID (OAuth2 sub claim)
-            name: User display name (optional)
-            auth_provider: OAuth provider used for registration (e.g., "google", "github").
-                          Only stored on new user creation; not updated on subsequent logins.
+            email: User email address (from IdP ``user_info["email"]``).
+            user_id: User ID (OAuth2 ``sub`` claim) — the lookup key.
+            name: User display name (optional). Synced on every login.
+            auth_provider: OAuth provider used for registration (e.g.,
+                ``"google"``, ``"github"``). Only stored on new user creation;
+                not updated on subsequent logins.
+            email_verified: Whether the IdP attested that ``email`` is verified.
+                Required for the email-sync UPDATE; absent or ``False`` skips
+                the email field. Name is always sync-safe regardless.
+            ip_address: Caller IP, captured for the audit log row when an email
+                change is recorded.
+            user_agent: Caller User-Agent, captured for the audit log row.
 
         Returns:
-            Assigned role
+            The user's assigned role.
+
+        Raises:
+            ConflictError: When an email UPDATE would violate the
+                ``users.email`` UNIQUE constraint (different account already
+                holds the new address). The caller's transaction is rolled
+                back; the row's prior state is preserved.
 
         Example:
-            >>> role = await role_manager.ensure_user("user@example.com", "google-123", auth_provider="google")
+            >>> role = await role_manager.ensure_user(
+            ...     email="user@example.com",
+            ...     user_id="google-123",
+            ...     auth_provider="google",
+            ...     email_verified=True,
+            ... )
         """
         if self.use_postgres:
-            # PostgreSQL backend (async)
-            from sqlalchemy import select
-            from sqlalchemy.exc import IntegrityError
+            return await self._ensure_user_postgres(
+                email=email,
+                user_id=user_id,
+                name=name,
+                auth_provider=auth_provider,
+                email_verified=email_verified,
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
 
-            from db.base import get_db
-            from models.auth import User
+        # In-memory backend (testing only) — keyed by email for backward
+        # compatibility with existing test suite. Postgres path uses user_id.
+        if self._roles is None:
+            self._roles = {}
 
-            async for db in get_db():
-                try:
-                    # Check if user exists
-                    result = await db.execute(select(User).filter_by(email=email))
-                    user = result.scalar_one_or_none()
+        if email in self._roles:
+            return self._roles[email]
 
-                    if user:
-                        # Update last_login_at
-                        user.last_login_at = utcnow()
-                        await db.commit()
-                        return Role(user.role)
+        role = Role.ADMIN if len(self._roles) == 0 else Role.USER
+        self._roles[email] = role
+        return role
 
-                    # Determine role: first user = ADMIN, others = USER
-                    count_result = await db.execute(select(func.count()).select_from(User))
-                    user_count = count_result.scalar()
-                    role = Role.ADMIN if user_count == 0 else Role.USER
+    async def _ensure_user_postgres(
+        self,
+        *,
+        email: str,
+        user_id: str,
+        name: str | None,
+        auth_provider: str | None,
+        email_verified: bool,
+        ip_address: str | None,
+        user_agent: str | None,
+    ) -> Role:
+        """PostgreSQL-backed ``ensure_user``. See ``ensure_user`` docstring."""
+        from sqlalchemy import select
+        from sqlalchemy.exc import IntegrityError
 
-                    # Create new user
-                    # Issue #166: Mark first admin as initial admin (protected from deletion/demotion)
-                    new_user = User(
-                        email=email,
-                        user_id=user_id,
-                        name=name,
-                        role=role.value,
-                        is_initial_admin=(role == Role.ADMIN and user_count == 0),
-                        last_login_at=utcnow(),
-                        auth_provider=auth_provider,
-                    )
-                    db.add(new_user)
-                    await db.commit()
+        from db.base import get_db
+        from models.auth import User
 
-                    return role
+        async for db in get_db():
+            # Lookup key: user_id (oauth_sub), not email — email is mutable.
+            result = await db.execute(select(User).filter_by(user_id=user_id))
+            user = result.scalar_one_or_none()
 
-                except IntegrityError:
-                    # Race condition: user created by another request
-                    await db.rollback()
-                    result = await db.execute(select(User).filter_by(email=email))
-                    user = result.scalar_one_or_none()
-                    return Role(user.role) if user else Role.USER
+            if user is not None:
+                return await self._sync_existing_user(
+                    db=db,
+                    user=user,
+                    new_email=email,
+                    new_name=name,
+                    auth_provider=auth_provider,
+                    email_verified=email_verified,
+                    ip_address=ip_address,
+                    user_agent=user_agent,
+                )
 
-        else:
-            # In-memory backend
-            if self._roles is None:
-                self._roles = {}
+            # New user path. Determine role: first user = ADMIN, others = USER.
+            count_result = await db.execute(select(func.count()).select_from(User))
+            user_count = count_result.scalar() or 0
+            role = Role.ADMIN if user_count == 0 else Role.USER
 
-            if email in self._roles:
-                return self._roles[email]
+            new_user = User(
+                email=email,
+                user_id=user_id,
+                name=name,
+                role=role.value,
+                # Issue #166: first admin protected from deletion/demotion.
+                is_initial_admin=(role == Role.ADMIN),
+                last_login_at=utcnow(),
+                auth_provider=auth_provider,
+            )
+            db.add(new_user)
+            try:
+                await db.commit()
+                return role
+            except IntegrityError as exc:
+                # Two collision shapes share this except:
+                #  (a) user_id race: another request just inserted the same
+                #      oauth_sub. Re-lookup by user_id and return its role.
+                #  (b) email collision: oauth_sub is novel but email belongs
+                #      to a different account (different provider, same
+                #      address). The user_id re-lookup misses; raise 409.
+                await db.rollback()
+                retry = await db.execute(select(User).filter_by(user_id=user_id))
+                existing = retry.scalar_one_or_none()
+                if existing is not None:
+                    return Role(existing.role)
+                if not _is_email_unique_violation(exc):
+                    raise
+                logger.warning(
+                    "oauth_email_collision_attempt",
+                    auth_provider=auth_provider,
+                    new_email_hmac=hmac_sha256_hex(email, get_settings().audit_hmac_key),
+                    user_id=user_id,
+                    phase="create",
+                )
+                raise ConflictError("Email address is already in use by another account") from exc
 
-            role = Role.ADMIN if len(self._roles) == 0 else Role.USER
-            self._roles[email] = role
-            return role
+        # Defensive: get_db() yields exactly once; this is unreachable in
+        # practice but satisfies the type checker.
+        return Role.USER  # pragma: no cover
+
+    async def _sync_existing_user(
+        self,
+        *,
+        db: AsyncSession,
+        user: _UserModel,
+        new_email: str,
+        new_name: str | None,
+        auth_provider: str | None,
+        email_verified: bool,
+        ip_address: str | None,
+        user_agent: str | None,
+    ) -> Role:
+        """Sync mutable attributes (email, name) on an existing user row.
+
+        Email syncs only when ``email_verified`` is True AND the value
+        differs. Name syncs whenever provided and different. UPDATE-collision
+        on ``users.email`` UNIQUE raises ``ConflictError`` (rolled back).
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        from models.auth import AuditLog
+
+        sync_email = email_verified and user.email != new_email
+        sync_name = new_name is not None and user.name != new_name
+
+        if not sync_email and not sync_name:
+            user.last_login_at = utcnow()
+            await db.commit()
+            return Role(user.role)
+
+        hmac_key = get_settings().audit_hmac_key
+        try:
+            if sync_email:
+                # Audit row written first so a failed commit rolls it back too.
+                # user_email is a sentinel actor string, not the subject's
+                # email — keeping mutable email out of audit_logs.user_email
+                # avoids stranded plaintext after the next email rotation
+                # (the subject is recoverable via user_id, which is
+                # pseudonymized at erasure time).
+                audit = AuditLog(
+                    user_email=_OAUTH_CALLBACK_ACTOR,
+                    user_id=user.user_id,
+                    action="oauth_user_email_synced",
+                    resource=f"user:{user.user_id}",
+                    old_value_hash=hmac_sha256_hex(user.email, hmac_key),
+                    new_value_hash=hmac_sha256_hex(new_email, hmac_key),
+                    user_metadata={"auth_provider": auth_provider},
+                    ip_address=ip_address,
+                    user_agent=user_agent,
+                )
+                db.add(audit)
+                user.email = new_email
+            if sync_name:
+                user.name = new_name
+            user.last_login_at = utcnow()
+            await db.commit()
+            return Role(user.role)
+        except IntegrityError as exc:
+            await db.rollback()
+            if not _is_email_unique_violation(exc):
+                raise
+            logger.warning(
+                "oauth_email_collision_attempt",
+                auth_provider=auth_provider,
+                new_email_hmac=hmac_sha256_hex(new_email, hmac_key),
+                user_id=user.user_id,
+                phase="update",
+            )
+            raise ConflictError("Email address is already in use by another account") from exc
 
     async def get_role(self, email: str) -> Role | None:
         """Get user's role.

--- a/backend/src/auth/roles.py
+++ b/backend/src/auth/roles.py
@@ -299,7 +299,10 @@ class RoleManager:
             except IntegrityError as exc:
                 # Two collision shapes share this except:
                 #  (a) user_id race: another request just inserted the same
-                #      oauth_sub. Re-lookup by user_id and return its role.
+                #      oauth_sub. Re-lookup by user_id and route the existing
+                #      row through _sync_existing_user so concurrent
+                #      first-logins still get last_login_at updated and any
+                #      email/name drift synced (Copilot review #516).
                 #  (b) email collision: oauth_sub is novel but email belongs
                 #      to a different account (different provider, same
                 #      address). The user_id re-lookup misses; raise 409.
@@ -307,7 +310,16 @@ class RoleManager:
                 retry = await db.execute(select(User).filter_by(user_id=user_id))
                 existing = retry.scalar_one_or_none()
                 if existing is not None:
-                    return Role(existing.role)
+                    return await self._sync_existing_user(
+                        db=db,
+                        user=existing,
+                        new_email=email,
+                        new_name=name,
+                        auth_provider=auth_provider,
+                        email_verified=email_verified,
+                        ip_address=ip_address,
+                        user_agent=user_agent,
+                    )
                 if not _is_email_unique_violation(exc):
                     raise
                 logger.warning(

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -57,6 +57,16 @@ class Settings(BaseSettings):
         default="kagura-erasure-v1",
         description="Per-deployment salt for audit_logs pseudonymization on account erasure (override in production)",
     )
+    audit_hmac_key: str = Field(
+        default="dev-audit-hmac-change-in-production",
+        description=(
+            "HMAC-SHA256 key for keyed hashing of mutable identifiers in "
+            "audit_logs.old_value_hash / new_value_hash columns (Issue #481, "
+            "OAuth email-sync events). Independent from API_KEY_SECRET so a "
+            "rotation of either does not invalidate the other's audit trail. "
+            "Override in production via AUDIT_HMAC_KEY (use: openssl rand -hex 32)."
+        ),
+    )
 
     # Session
     session_ttl_seconds: int = Field(

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -13,7 +13,7 @@ from typing import Literal
 from uuid import UUID
 
 from fastapi.responses import RedirectResponse
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -79,7 +79,8 @@ class SignupGateService:
         1. ``enabled=false`` → delegate to legacy env-based gate (OSS path).
         2. ``provider == "google"`` → pass through (Google-side controls signup;
            backend is a no-op for Google in Phase 1).
-        3. Existing user (users row for this email) → allowed (login, not signup).
+        3. Existing user (users row matching this email or user_id/sub) → allowed
+           (login not signup; user_id match handles email-change-at-IdP case).
         4. First user (users table empty) → allowed (initial admin bootstrap).
         5. ``mode == "manual"`` → allowed iff ``github_user_id`` is on the
            allowlist with ``state='active'``.
@@ -89,7 +90,7 @@ class SignupGateService:
         config = await self._load_config()
 
         if not config.enabled:
-            return await self._legacy_check(email)
+            return await self._legacy_check(email, oauth_sub)
 
         # Google's own OAuth + workspace configuration decides who can sign up
         # on that side — having two places (backend allowlist + Google console)
@@ -98,7 +99,7 @@ class SignupGateService:
         if provider == "google":
             return None
 
-        if await self._is_existing_user(email):
+        if await self._is_existing_user(email, oauth_sub):
             return None
 
         if await self._is_first_user():
@@ -238,8 +239,10 @@ class SignupGateService:
                 await self.db.refresh(config)
         return config
 
-    async def _is_existing_user(self, email: str) -> bool:
-        result = await self.db.execute(select(User).where(User.email == email))
+    async def _is_existing_user(self, email: str, user_id: str) -> bool:
+        result = await self.db.execute(
+            select(User).where(or_(User.email == email, User.user_id == user_id))
+        )
         return result.scalar_one_or_none() is not None
 
     async def _is_first_user(self) -> bool:
@@ -267,7 +270,7 @@ class SignupGateService:
         result = await self.db.execute(select(SignupAllowlistEntry.id).where(*filters).limit(1))
         return result.first() is not None
 
-    async def _legacy_check(self, email: str) -> RedirectResponse | None:
+    async def _legacy_check(self, email: str, user_id: str) -> RedirectResponse | None:
         """Delegate to the pre-existing env-based gate.
 
         Lazy import to avoid a circular dependency (``api.routes.auth``
@@ -277,7 +280,7 @@ class SignupGateService:
         """
         from api.routes.auth import _check_registration_allowed
 
-        return await _check_registration_allowed(email, self.db)
+        return await _check_registration_allowed(email, self.db, user_id=user_id)
 
     def _blocked_response(self) -> RedirectResponse:
         frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")

--- a/backend/src/utils/hashing.py
+++ b/backend/src/utils/hashing.py
@@ -8,6 +8,7 @@ underlying primitive (SHA256 → SHA3, BLAKE2, …) in a single edit.
 from __future__ import annotations
 
 import hashlib
+import hmac
 
 
 def sha256_hex(value: str, *, salt: str = "") -> str:
@@ -24,3 +25,24 @@ def sha256_hex(value: str, *, salt: str = "") -> str:
         64-character lowercase hex digest.
     """
     return hashlib.sha256(f"{salt}{value}".encode()).hexdigest()
+
+
+def hmac_sha256_hex(value: str, key: str) -> str:
+    """Return the HMAC-SHA256 hex digest of ``value`` keyed by ``key``.
+
+    Use this for audit-log columns where a plain salted SHA256 is too weak —
+    e.g. ``audit_logs.old_value_hash`` / ``new_value_hash`` storing email
+    address hashes (Issue #481). The keyed primitive resists rainbow-table
+    attacks against small-domain inputs (email local-part ≤ 64 chars) that
+    a public salt cannot, because the attacker would need to obtain ``key``.
+
+    Args:
+        value: Input string to hash. Must be UTF-8 encodable.
+        key: HMAC key (server secret). Must be UTF-8 encodable. Pass the
+            ``Settings.audit_hmac_key`` value, never a hard-coded constant.
+
+    Returns:
+        64-character lowercase hex digest. Same shape as ``sha256_hex`` —
+        fits the existing ``String(64)`` audit-log columns without DDL.
+    """
+    return hmac.new(key.encode(), value.encode(), hashlib.sha256).hexdigest()

--- a/backend/tests/api/test_github_provider_user_info.py
+++ b/backend/tests/api/test_github_provider_user_info.py
@@ -1,0 +1,104 @@
+"""Tests for _github_get_user_info — verified-primary-only contract.
+
+Issue #481: ``_github_get_user_info`` always fetches ``/user/emails`` and
+returns the primary verified address with ``email_verified=True``. The
+public-profile ``email`` field on ``/user`` is intentionally ignored —
+trusting it would let a user surface an unverified address as their
+sync target on every OAuth login.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.routes.auth import _github_get_user_info
+
+
+def _mock_response(json_payload):
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = MagicMock(return_value=json_payload)
+    return resp
+
+
+def _patch_httpx(user_payload, emails_payload):
+    """Yield a context that mocks httpx.AsyncClient returning the two payloads in order."""
+    client_instance = AsyncMock()
+    client_instance.__aenter__.return_value = client_instance
+    client_instance.__aexit__.return_value = None
+    client_instance.get = AsyncMock(
+        side_effect=[_mock_response(user_payload), _mock_response(emails_payload)]
+    )
+    return patch("api.routes.auth.httpx.AsyncClient", return_value=client_instance)
+
+
+class TestGithubGetUserInfo:
+    @pytest.mark.asyncio
+    async def test_returns_verified_primary_email(self):
+        """Picks the address that is BOTH primary AND verified, ignoring /user.email."""
+        user = {"id": 12345, "login": "alice", "name": "Alice", "email": "public@untrusted.io"}
+        emails = [
+            {"email": "secondary@example.com", "primary": False, "verified": True},
+            {"email": "primary@example.com", "primary": True, "verified": True},
+            {"email": "unverified@example.com", "primary": False, "verified": False},
+        ]
+        with _patch_httpx(user, emails):
+            info = await _github_get_user_info("tok")
+
+        assert info["email"] == "primary@example.com"
+        assert info["email_verified"] is True
+
+    @pytest.mark.asyncio
+    async def test_ignores_public_profile_email_even_when_present(self):
+        """The legacy bug: /user.email was trusted without verification.
+
+        After #481 the public profile email must NEVER be the chosen address.
+        Even when /user.email matches a verified row, the function still selects
+        based on /user/emails (which is what we're verifying via the unrelated
+        /user.email value below).
+        """
+        user = {"id": 1, "login": "u", "name": "U", "email": "tampered@attacker.io"}
+        emails = [
+            {"email": "real-primary@example.com", "primary": True, "verified": True},
+        ]
+        with _patch_httpx(user, emails):
+            info = await _github_get_user_info("tok")
+
+        assert info["email"] == "real-primary@example.com"
+        assert info["email"] != user["email"]
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_verified_primary(self):
+        """No primary+verified entry → ValueError (callback fails before DB write)."""
+        user = {"id": 1, "login": "u", "email": None}
+        emails = [
+            {"email": "primary@example.com", "primary": True, "verified": False},
+            {"email": "verified@example.com", "primary": False, "verified": True},
+        ]
+        with _patch_httpx(user, emails):
+            with pytest.raises(ValueError, match="no verified primary email"):
+                await _github_get_user_info("tok")
+
+    @pytest.mark.asyncio
+    async def test_raises_on_empty_email_list(self):
+        user = {"id": 1, "login": "u"}
+        emails = []
+        with _patch_httpx(user, emails):
+            with pytest.raises(ValueError, match="no verified primary email"):
+                await _github_get_user_info("tok")
+
+    @pytest.mark.asyncio
+    async def test_sub_is_stringified_int_id(self):
+        user = {"id": 999, "login": "u", "name": "U"}
+        emails = [{"email": "u@example.com", "primary": True, "verified": True}]
+        with _patch_httpx(user, emails):
+            info = await _github_get_user_info("tok")
+        assert info["sub"] == "999"
+
+    @pytest.mark.asyncio
+    async def test_name_falls_back_to_login_when_missing(self):
+        user = {"id": 1, "login": "alice", "name": None}
+        emails = [{"email": "a@example.com", "primary": True, "verified": True}]
+        with _patch_httpx(user, emails):
+            info = await _github_get_user_info("tok")
+        assert info["name"] == "alice"

--- a/backend/tests/auth/test_role_manager_postgres.py
+++ b/backend/tests/auth/test_role_manager_postgres.py
@@ -313,26 +313,38 @@ class TestCreatePath:
         assert added.is_initial_admin is False
 
     @pytest.mark.asyncio
-    async def test_user_id_race_returns_existing_role(self, role_manager):
-        race_existing = _user_row(role="admin")
-        # Sequence: lookup miss → count=0 → commit raises (race) → re-lookup hits
+    async def test_user_id_race_routes_through_sync(self, role_manager):
+        """Concurrent first-login race (CREATE → IntegrityError on user_id UNIQUE)
+        must still update last_login_at AND sync changed email/name on the existing
+        row. Returning the role bare-bones would silently skip those side-effects
+        (Copilot review on PR #516).
+        """
+        # Existing row was just inserted by another concurrent request with a
+        # stale email — the racing caller's IdP payload has the fresher value.
+        race_existing = _user_row(email="alice@old.com", name="Alice Old", role="admin")
+        # Sequence: lookup miss → count=0 → commit raises (user_id race)
+        # → re-lookup hits → sync_existing_user commits the update
         db = _make_db_mock(_execute_returns(None, {"scalar": 0}, race_existing))
-        db.commit = AsyncMock(
-            side_effect=[
-                _email_unique_violation(),
-                None,
-            ]
-        )
+        db.commit = AsyncMock(side_effect=[_email_unique_violation(), None])
 
         with _patch_get_db(db):
             role = await role_manager.ensure_user(
-                email="alice@example.com",
+                email="alice@new.com",
                 user_id="u1",
+                name="Alice New",
+                auth_provider="google",
                 email_verified=True,
             )
 
         assert role == Role.ADMIN
         db.rollback.assert_awaited_once()
+        # Race-recovered row was synced (email + name)
+        assert race_existing.email == "alice@new.com"
+        assert race_existing.name == "Alice New"
+        # Audit row written for the email change
+        added = [c.args[0] for c in db.add.call_args_list]
+        audits = [a for a in added if getattr(a, "action", None) == "oauth_user_email_synced"]
+        assert len(audits) == 1
 
     @pytest.mark.asyncio
     async def test_email_collision_on_create_raises_conflict(self, role_manager):

--- a/backend/tests/auth/test_role_manager_postgres.py
+++ b/backend/tests/auth/test_role_manager_postgres.py
@@ -1,0 +1,354 @@
+"""Unit tests for RoleManager.ensure_user Postgres path (mocked DB).
+
+Issue #481: Lookup-key swap from email to user_id, email/name sync,
+HMAC-keyed audit log, IntegrityError → ConflictError.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import structlog
+from sqlalchemy.exc import IntegrityError
+
+from auth.roles import _OAUTH_CALLBACK_ACTOR, Role, RoleManager
+from utils.exceptions import ConflictError
+
+
+class _AsyncpgUniqueViolationStub(Exception):
+    """asyncpg-shaped UNIQUE violation stub for the narrowing check.
+
+    ``_is_email_unique_violation`` reads ``exc.orig.sqlstate`` and
+    ``exc.orig.constraint_name``. Real asyncpg surfaces these as instance
+    attributes on ``UniqueViolationError``; this minimal stub mimics that
+    shape so unit tests don't need a live PostgreSQL connection.
+    """
+
+    def __init__(self, constraint_name: str = "ix_users_email"):
+        super().__init__(f"unique violation on {constraint_name}")
+        self.sqlstate = "23505"
+        self.constraint_name = constraint_name
+
+
+def _email_unique_violation() -> IntegrityError:
+    """IntegrityError with a properly-shaped ``orig`` for the email path."""
+    return IntegrityError("UNIQUE", params={}, orig=_AsyncpgUniqueViolationStub())
+
+
+def _execute_returns(*results):
+    """Build a side_effect list of MagicMock execute results.
+
+    Each entry models a single ``await db.execute(...)`` call. The result
+    object exposes ``scalar_one_or_none`` AND ``scalar`` because callers use
+    different terminators on different queries (User lookup vs count(*)).
+    """
+    side_effects = []
+    for r in results:
+        result_mock = MagicMock()
+        if isinstance(r, dict) and "scalar" in r:
+            result_mock.scalar = MagicMock(return_value=r["scalar"])
+        else:
+            result_mock.scalar_one_or_none = MagicMock(return_value=r)
+        side_effects.append(result_mock)
+    return side_effects
+
+
+def _make_db_mock(execute_results):
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=execute_results)
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+def _patch_get_db(db_mock):
+    async def _fake_get_db():
+        yield db_mock
+
+    return patch("db.base.get_db", new=_fake_get_db)
+
+
+def _user_row(*, user_id="u1", email="alice@example.com", name="Alice", role="user"):
+    """Build a minimal mock that mimics models.auth.User attribute access."""
+    user = MagicMock()
+    user.user_id = user_id
+    user.email = email
+    user.name = name
+    user.role = role
+    return user
+
+
+@pytest.fixture
+def role_manager():
+    return RoleManager(use_postgres=True)
+
+
+class TestLookupKeyIsUserId:
+    """Verify the SELECT statement filters on user_id, not email (Issue #481 core)."""
+
+    @pytest.mark.asyncio
+    async def test_lookup_uses_user_id_filter(self, role_manager):
+        existing = _user_row(user_id="github-999", email="alice@old.com")
+        db = _make_db_mock(_execute_returns(existing))
+
+        with _patch_get_db(db):
+            await role_manager.ensure_user(
+                email="alice@old.com",
+                user_id="github-999",
+                email_verified=True,
+            )
+
+        # Inspect the executed SELECT statement: must filter by user_id.
+        first_stmt = db.execute.call_args_list[0].args[0]
+        compiled = str(first_stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "users.user_id" in compiled
+        assert "WHERE" in compiled
+        # Ensure email is not the primary lookup criterion in this SELECT.
+        assert "users.email" not in compiled.split("WHERE", 1)[1]
+
+
+class TestSyncEmail:
+    @pytest.mark.asyncio
+    async def test_syncs_email_when_verified_and_changed(self, role_manager):
+        existing = _user_row(email="alice@old.com")
+        db = _make_db_mock(_execute_returns(existing))
+
+        with _patch_get_db(db):
+            role = await role_manager.ensure_user(
+                email="alice@new.com",
+                user_id="u1",
+                email_verified=True,
+            )
+
+        assert role == Role.USER
+        assert existing.email == "alice@new.com"
+        # Audit log row added before commit.
+        added = [c.args[0] for c in db.add.call_args_list]
+        audits = [a for a in added if getattr(a, "action", None) == "oauth_user_email_synced"]
+        assert len(audits) == 1
+        # user_email is a sentinel actor, NOT the subject's email — keeps
+        # plaintext PII out of audit_logs.user_email even after future syncs.
+        assert audits[0].user_email == _OAUTH_CALLBACK_ACTOR
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_sync_when_email_not_verified(self, role_manager):
+        existing = _user_row(email="alice@old.com")
+        db = _make_db_mock(_execute_returns(existing))
+
+        with _patch_get_db(db):
+            await role_manager.ensure_user(
+                email="alice@new.com",
+                user_id="u1",
+                email_verified=False,
+            )
+
+        assert existing.email == "alice@old.com"
+        db.add.assert_not_called()
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_sync_when_email_unchanged(self, role_manager):
+        existing = _user_row(email="alice@example.com")
+        db = _make_db_mock(_execute_returns(existing))
+
+        with _patch_get_db(db):
+            await role_manager.ensure_user(
+                email="alice@example.com",
+                user_id="u1",
+                email_verified=True,
+            )
+
+        db.add.assert_not_called()
+        db.commit.assert_awaited_once()
+
+
+class TestSyncName:
+    @pytest.mark.asyncio
+    async def test_syncs_name_independently_of_email(self, role_manager):
+        existing = _user_row(email="alice@example.com", name="Alice Old")
+        db = _make_db_mock(_execute_returns(existing))
+
+        with _patch_get_db(db):
+            await role_manager.ensure_user(
+                email="alice@example.com",
+                user_id="u1",
+                name="Alice New",
+                email_verified=False,  # email won't sync, name still should
+            )
+
+        assert existing.name == "Alice New"
+        assert existing.email == "alice@example.com"
+        db.add.assert_not_called()  # No audit log for name-only changes
+
+    @pytest.mark.asyncio
+    async def test_does_not_sync_name_when_unchanged(self, role_manager):
+        existing = _user_row(name="Alice")
+        db = _make_db_mock(_execute_returns(existing))
+
+        with _patch_get_db(db):
+            await role_manager.ensure_user(
+                email=existing.email,
+                user_id="u1",
+                name="Alice",
+            )
+
+        # last_login_at still updated, but no add/audit
+        db.add.assert_not_called()
+
+
+class TestAuditLogStructure:
+    @pytest.mark.asyncio
+    async def test_audit_log_uses_hmac_not_plaintext(self, role_manager):
+        existing = _user_row(email="alice@old.com")
+        db = _make_db_mock(_execute_returns(existing))
+
+        with patch.dict("os.environ", {"AUDIT_HMAC_KEY": "test-key-32"}, clear=False):
+            # Reset settings singleton so the env var is observed
+            import config.settings as cs
+
+            cs._settings = None
+            with _patch_get_db(db):
+                await role_manager.ensure_user(
+                    email="alice@new.com",
+                    user_id="u1",
+                    email_verified=True,
+                )
+            cs._settings = None  # cleanup
+
+        audit = db.add.call_args_list[0].args[0]
+        assert audit.action == "oauth_user_email_synced"
+        # No plaintext email leaked into hash columns
+        assert audit.old_value_hash != "alice@old.com"
+        assert audit.new_value_hash != "alice@new.com"
+        # HMAC-SHA256 hex is exactly 64 chars
+        assert len(audit.old_value_hash) == 64
+        assert len(audit.new_value_hash) == 64
+        # Different inputs → different digests
+        assert audit.old_value_hash != audit.new_value_hash
+
+    @pytest.mark.asyncio
+    async def test_audit_log_captures_ip_user_agent(self, role_manager):
+        existing = _user_row(email="alice@old.com")
+        db = _make_db_mock(_execute_returns(existing))
+
+        with _patch_get_db(db):
+            await role_manager.ensure_user(
+                email="alice@new.com",
+                user_id="u1",
+                auth_provider="google",
+                email_verified=True,
+                ip_address="203.0.113.1",
+                user_agent="Mozilla/5.0",
+            )
+
+        audit = db.add.call_args_list[0].args[0]
+        assert audit.ip_address == "203.0.113.1"
+        assert audit.user_agent == "Mozilla/5.0"
+        assert audit.user_metadata == {"auth_provider": "google"}
+
+
+class TestUpdateCollision:
+    @pytest.mark.asyncio
+    async def test_collision_raises_conflict_and_logs_alert(self, role_manager):
+        existing = _user_row(email="alice@old.com")
+        db = _make_db_mock(_execute_returns(existing))
+
+        # Commit raises IntegrityError (UNIQUE violation on users.email)
+        db.commit = AsyncMock(side_effect=_email_unique_violation())
+
+        with _patch_get_db(db), structlog.testing.capture_logs() as logs:
+            with pytest.raises(ConflictError) as exc_info:
+                await role_manager.ensure_user(
+                    email="taken@example.com",
+                    user_id="u1",
+                    auth_provider="google",
+                    email_verified=True,
+                )
+
+        assert exc_info.value.status_code == 409
+        assert exc_info.value.error_code == "RES-002"
+        db.rollback.assert_awaited_once()
+        alerts = [e for e in logs if e.get("event") == "oauth_email_collision_attempt"]
+        assert len(alerts) == 1
+        assert alerts[0]["phase"] == "update"
+        assert alerts[0]["auth_provider"] == "google"
+        assert "new_email_hmac" in alerts[0]
+        # No plaintext email in the alert
+        assert alerts[0]["new_email_hmac"] != "taken@example.com"
+
+
+class TestCreatePath:
+    @pytest.mark.asyncio
+    async def test_first_user_gets_admin(self, role_manager):
+        # Sequence: lookup miss → count=0 → commit succeeds
+        db = _make_db_mock(_execute_returns(None, {"scalar": 0}))
+
+        with _patch_get_db(db):
+            role = await role_manager.ensure_user(
+                email="first@example.com",
+                user_id="u1",
+                email_verified=True,
+            )
+
+        assert role == Role.ADMIN
+        added = db.add.call_args_list[0].args[0]
+        assert added.role == "admin"
+        assert added.is_initial_admin is True
+
+    @pytest.mark.asyncio
+    async def test_second_user_gets_user(self, role_manager):
+        db = _make_db_mock(_execute_returns(None, {"scalar": 1}))
+
+        with _patch_get_db(db):
+            role = await role_manager.ensure_user(
+                email="second@example.com",
+                user_id="u2",
+                email_verified=True,
+            )
+
+        assert role == Role.USER
+        added = db.add.call_args_list[0].args[0]
+        assert added.role == "user"
+        assert added.is_initial_admin is False
+
+    @pytest.mark.asyncio
+    async def test_user_id_race_returns_existing_role(self, role_manager):
+        race_existing = _user_row(role="admin")
+        # Sequence: lookup miss → count=0 → commit raises (race) → re-lookup hits
+        db = _make_db_mock(_execute_returns(None, {"scalar": 0}, race_existing))
+        db.commit = AsyncMock(
+            side_effect=[
+                _email_unique_violation(),
+                None,
+            ]
+        )
+
+        with _patch_get_db(db):
+            role = await role_manager.ensure_user(
+                email="alice@example.com",
+                user_id="u1",
+                email_verified=True,
+            )
+
+        assert role == Role.ADMIN
+        db.rollback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_email_collision_on_create_raises_conflict(self, role_manager):
+        # Sequence: lookup miss → count → commit raises → re-lookup also miss
+        db = _make_db_mock(_execute_returns(None, {"scalar": 5}, None))
+        db.commit = AsyncMock(side_effect=_email_unique_violation())
+
+        with _patch_get_db(db), structlog.testing.capture_logs() as logs:
+            with pytest.raises(ConflictError):
+                await role_manager.ensure_user(
+                    email="taken@example.com",
+                    user_id="brand-new-sub",
+                    auth_provider="github",
+                    email_verified=True,
+                )
+
+        alerts = [e for e in logs if e.get("event") == "oauth_email_collision_attempt"]
+        assert len(alerts) == 1
+        assert alerts[0]["phase"] == "create"

--- a/backend/tests/auth/test_role_manager_postgres.py
+++ b/backend/tests/auth/test_role_manager_postgres.py
@@ -34,20 +34,41 @@ def _email_unique_violation() -> IntegrityError:
     return IntegrityError("UNIQUE", params={}, orig=_AsyncpgUniqueViolationStub())
 
 
+def _user_id_unique_violation() -> IntegrityError:
+    """IntegrityError with constraint_name=ix_users_user_id (race-condition shape).
+
+    Distinct from ``_email_unique_violation`` so race-recovery tests don't
+    accidentally exercise the email-collision narrowing path inside
+    ``_is_email_unique_violation`` — using the wrong constraint name would
+    silently still pass today (the re-lookup-by-user_id branch fires before
+    the narrowing check), but a future code reorder could mask a real bug.
+    """
+    return IntegrityError(
+        "UNIQUE", params={}, orig=_AsyncpgUniqueViolationStub(constraint_name="ix_users_user_id")
+    )
+
+
 def _execute_returns(*results):
     """Build a side_effect list of MagicMock execute results.
 
     Each entry models a single ``await db.execute(...)`` call. The result
-    object exposes ``scalar_one_or_none`` AND ``scalar`` because callers use
-    different terminators on different queries (User lookup vs count(*)).
+    object exposes both ``scalar_one_or_none`` and ``scalar`` so callers can
+    use either terminator without surprise: a result built for a User-lookup
+    sets ``scalar_one_or_none`` to the row (or None) and ``scalar`` to None;
+    a result built for a count(*) sets ``scalar`` to the count and
+    ``scalar_one_or_none`` to None. This avoids depending on MagicMock's
+    auto-attribute behavior, which would silently return a fresh MagicMock
+    instead of None and could mask future refactors.
     """
     side_effects = []
     for r in results:
         result_mock = MagicMock()
         if isinstance(r, dict) and "scalar" in r:
             result_mock.scalar = MagicMock(return_value=r["scalar"])
+            result_mock.scalar_one_or_none = MagicMock(return_value=None)
         else:
             result_mock.scalar_one_or_none = MagicMock(return_value=r)
+            result_mock.scalar = MagicMock(return_value=None)
         side_effects.append(result_mock)
     return side_effects
 
@@ -322,10 +343,12 @@ class TestCreatePath:
         # Existing row was just inserted by another concurrent request with a
         # stale email — the racing caller's IdP payload has the fresher value.
         race_existing = _user_row(email="alice@old.com", name="Alice Old", role="admin")
-        # Sequence: lookup miss → count=0 → commit raises (user_id race)
+        # Sequence: lookup miss → count=0 → commit raises (user_id race —
+        # constraint_name ix_users_user_id, NOT email, so we precisely model
+        # the user_id-collision shape rather than reusing the email helper)
         # → re-lookup hits → sync_existing_user commits the update
         db = _make_db_mock(_execute_returns(None, {"scalar": 0}, race_existing))
-        db.commit = AsyncMock(side_effect=[_email_unique_violation(), None])
+        db.commit = AsyncMock(side_effect=[_user_id_unique_violation(), None])
 
         with _patch_get_db(db):
             role = await role_manager.ensure_user(

--- a/backend/tests/auth/test_role_manager_postgres.py
+++ b/backend/tests/auth/test_role_manager_postgres.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import IntegrityError
 
 from auth.roles import _OAUTH_CALLBACK_ACTOR, Role, RoleManager
 from utils.exceptions import ConflictError
+from utils.hashing import hmac_sha256_hex
 
 
 class _AsyncpgUniqueViolationStub(Exception):
@@ -223,8 +224,9 @@ class TestAuditLogStructure:
     async def test_audit_log_uses_hmac_not_plaintext(self, role_manager):
         existing = _user_row(email="alice@old.com")
         db = _make_db_mock(_execute_returns(existing))
+        test_key = "test-key-32"
 
-        with patch.dict("os.environ", {"AUDIT_HMAC_KEY": "test-key-32"}, clear=False):
+        with patch.dict("os.environ", {"AUDIT_HMAC_KEY": test_key}, clear=False):
             # Reset settings singleton so the env var is observed
             import config.settings as cs
 
@@ -239,14 +241,15 @@ class TestAuditLogStructure:
 
         audit = db.add.call_args_list[0].args[0]
         assert audit.action == "oauth_user_email_synced"
-        # No plaintext email leaked into hash columns
-        assert audit.old_value_hash != "alice@old.com"
-        assert audit.new_value_hash != "alice@new.com"
-        # HMAC-SHA256 hex is exactly 64 chars
-        assert len(audit.old_value_hash) == 64
-        assert len(audit.new_value_hash) == 64
-        # Different inputs → different digests
-        assert audit.old_value_hash != audit.new_value_hash
+        # Strong assertion: the stored hashes must be exactly the HMAC under
+        # the configured key. A regression to plain sha256_hex (or any other
+        # non-plaintext 64-char digest) would fail this check, whereas the
+        # weaker "not equal to plaintext + 64 chars" form would pass silently.
+        assert audit.old_value_hash == hmac_sha256_hex("alice@old.com", test_key)
+        assert audit.new_value_hash == hmac_sha256_hex("alice@new.com", test_key)
+        # Defense-in-depth: digests change when the key changes (proves the key
+        # actually participates in the digest, not just the value).
+        assert audit.old_value_hash != hmac_sha256_hex("alice@old.com", "different-key")
 
     @pytest.mark.asyncio
     async def test_audit_log_captures_ip_user_agent(self, role_manager):

--- a/backend/tests/integration/test_role_manager_email_sync.py
+++ b/backend/tests/integration/test_role_manager_email_sync.py
@@ -1,11 +1,19 @@
 """Integration tests for RoleManager.ensure_user against a real PostgreSQL DB.
 
-Issue #481: validates that:
-- ensure_user looks up by user_id (not email) so an IdP email change still
-  finds the existing row.
-- An UPDATE that would violate the users.email UNIQUE constraint is caught
-  inside ensure_user, the transaction is rolled back, and ConflictError is
-  raised — never IntegrityError or 503.
+Issue #481: validates that ensure_user looks up by ``user_id`` (not email) so
+an IdP email change still finds the existing row, and that the audit row +
+field update both land on a real Postgres connection.
+
+The UPDATE-collision path (`users.email` UNIQUE → ``ConflictError(409)``) is
+covered by the unit test
+``tests/auth/test_role_manager_postgres.py::TestUpdateCollision::test_collision_raises_conflict_and_logs_alert``,
+which mocks ``IntegrityError`` directly. A real-DB collision test was
+intentionally NOT included here — the asyncpg/SQLAlchemy async-session
+greenlet machinery raises ``MissingGreenlet`` during the IntegrityError
+unwind in pytest fixtures, even though the same code path works correctly
+inside the FastAPI request lifecycle (Starlette wraps each request in a
+greenlet that propagates correctly). See the inline comment after the
+remaining tests in this file for the full rationale.
 
 These run only when a Postgres test DB is reachable (``conftest.async_engine``
 skips otherwise). Each test seeds rows with uuid-suffixed identifiers so

--- a/backend/tests/integration/test_role_manager_email_sync.py
+++ b/backend/tests/integration/test_role_manager_email_sync.py
@@ -1,0 +1,144 @@
+"""Integration tests for RoleManager.ensure_user against a real PostgreSQL DB.
+
+Issue #481: validates that:
+- ensure_user looks up by user_id (not email) so an IdP email change still
+  finds the existing row.
+- An UPDATE that would violate the users.email UNIQUE constraint is caught
+  inside ensure_user, the transaction is rolled back, and ConflictError is
+  raised — never IntegrityError or 503.
+
+These run only when a Postgres test DB is reachable (``conftest.async_engine``
+skips otherwise). Each test seeds rows with uuid-suffixed identifiers so
+parallel / repeated runs don't collide on the unique columns.
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from auth.roles import Role, RoleManager
+from models.auth import AuditLog, User
+
+
+@pytest_asyncio.fixture
+async def two_users(db_session: AsyncSession):
+    """Seed two distinct users for collision scenarios."""
+    suffix = uuid4().hex[:8]
+    alice = User(
+        email=f"alice-{suffix}@example.com",
+        user_id=f"alice-sub-{suffix}",
+        name="Alice",
+        role="user",
+        auth_method="oauth",
+        auth_provider="google",
+    )
+    bob = User(
+        email=f"bob-{suffix}@example.com",
+        user_id=f"bob-sub-{suffix}",
+        name="Bob",
+        role="user",
+        auth_method="oauth",
+        auth_provider="github",
+    )
+    db_session.add(alice)
+    db_session.add(bob)
+    await db_session.commit()
+    yield {"alice": alice, "bob": bob, "suffix": suffix}
+    # Per-test rows use uuid-suffixed identifiers so they cannot collide with
+    # other tests' seeds. The session-scoped engine fixture drops all tables
+    # at session teardown, so we deliberately skip per-test row cleanup here:
+    # attempting cleanup after a ConflictError test leaves the session in a
+    # broken-greenlet state (the IntegrityError handler inside ensure_user
+    # already rolled back).
+
+
+def _patch_get_db_with_fresh_session(async_engine):
+    """Patch ``db.base.get_db`` to yield a NEW session per call.
+
+    ``ensure_user`` opens its own session via ``async for db in get_db():``
+    and commits inside. Using the test's outer ``db_session`` for that path
+    poisons the outer session when an IntegrityError fires (the aborted
+    transaction state propagates and a later ``rollback()``/``scalar()`` from
+    the test body fails with MissingGreenlet). Yielding a freshly built
+    AsyncSession keeps the failure contained inside ensure_user's own
+    short-lived session, so the outer test session can still verify state.
+    """
+    sessionmaker = async_sessionmaker(async_engine, class_=AsyncSession, expire_on_commit=False)
+
+    @asynccontextmanager
+    async def _scope():
+        async with sessionmaker() as s:
+            yield s
+
+    async def _fake():
+        async with _scope() as s:
+            yield s
+
+    return patch("db.base.get_db", new=_fake)
+
+
+class TestRealDbEmailSync:
+    @pytest.mark.asyncio
+    async def test_lookup_by_user_id_finds_row_with_changed_idp_email(
+        self, two_users, db_session: AsyncSession
+    ):
+        """When IdP returns a new email for an existing user_id, the row is found."""
+        alice = two_users["alice"]
+        original_email = alice.email
+        new_email = f"alice-renamed-{two_users['suffix']}@example.com"
+        rm = RoleManager(use_postgres=True)
+
+        with _patch_get_db_with_fresh_session(db_session.bind):
+            role = await rm.ensure_user(
+                email=new_email,
+                user_id=alice.user_id,
+                name="Alice",
+                auth_provider="google",
+                email_verified=True,
+            )
+
+        assert role == Role.USER
+        # Re-read the row from the DB to confirm the UPDATE hit.
+        await db_session.refresh(alice)
+        assert alice.email == new_email
+        assert alice.email != original_email
+
+        # Audit row exists with HMAC hashes (no plaintext).
+        audits = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(
+                        AuditLog.user_id == alice.user_id,
+                        AuditLog.action == "oauth_user_email_synced",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audits) == 1
+        audit = audits[0]
+        assert audit.old_value_hash != original_email
+        assert audit.new_value_hash != new_email
+        assert len(audit.old_value_hash) == 64
+        assert len(audit.new_value_hash) == 64
+
+    # Note: a real-DB collision test (alice tries to take bob's email and
+    # gets ConflictError(409)) is NOT included here. The asyncpg/SQLAlchemy
+    # async-session greenlet machinery raises MissingGreenlet during the
+    # IntegrityError unwind in test fixtures even though the same code path
+    # works in the FastAPI request lifecycle (where Starlette wraps each
+    # request in a greenlet that propagates correctly). The unit test in
+    # ``tests/auth/test_role_manager_postgres.py::TestUpdateCollision``
+    # exercises the same logical path with a mocked IntegrityError side_effect
+    # — it validates the rollback + ConflictError + structured-alert contract
+    # without depending on asyncpg's transaction-abort semantics. The
+    # integration test above (lookup-by-user-id with email sync) confirms the
+    # primary fix actually executes against a real PostgreSQL table.

--- a/backend/tests/services/test_signup_gate_service.py
+++ b/backend/tests/services/test_signup_gate_service.py
@@ -40,7 +40,7 @@ class TestCheckAccess:
         )
 
         assert result is None
-        svc._legacy_check.assert_awaited_once_with("a@b.com")
+        svc._legacy_check.assert_awaited_once_with("a@b.com", "1234")
 
     @pytest.mark.asyncio
     async def test_disabled_delegates_and_blocks(self):
@@ -86,6 +86,30 @@ class TestCheckAccess:
 
         assert result is None
         svc._is_allowlisted.assert_not_awaited()
+        # Ensure both email and oauth_sub are forwarded so a user whose email
+        # changed at the IdP is still found by user_id.
+        svc._is_existing_user.assert_awaited_once_with("a@b.com", "1234")
+
+    @pytest.mark.asyncio
+    async def test_existing_user_found_by_user_id_not_email(self):
+        """User whose IdP email changed is still recognised as existing (login, not signup)."""
+        svc = _svc()
+        svc._load_config = AsyncMock(return_value=_config(enabled=True, mode="manual"))
+        # Simulate: same user_id, different email (e.g. after IdP email rename).
+        svc._is_existing_user = AsyncMock(return_value=True)
+        svc._is_allowlisted = AsyncMock()
+
+        result = await svc.check_access(
+            provider="github",
+            oauth_sub="1234",
+            email="new@example.com",
+            username="octocat",
+        )
+
+        assert result is None
+        svc._is_allowlisted.assert_not_awaited()
+        # Both the new email and user_id must be passed down.
+        svc._is_existing_user.assert_awaited_once_with("new@example.com", "1234")
 
     @pytest.mark.asyncio
     async def test_first_user_bootstrap_allowed(self):
@@ -354,3 +378,69 @@ class TestIsAllowlistedSourceFiltering:
             assert not has_source_filter, f"mode=both must not filter by source: {captured['sql']}"
         else:
             assert has_source_filter, f"mode={mode} must filter by source: {captured['sql']}"
+
+
+class TestIsExistingUser:
+    """Verify _is_existing_user uses an OR condition on email + user_id."""
+
+    @pytest.mark.asyncio
+    async def test_query_includes_user_id_or_email(self):
+        """Generated SQL must include both email and user_id so a user whose
+        IdP email changed is still found by their stable OAuth sub."""
+        svc = _svc()
+        captured = {}
+
+        async def fake_execute(stmt):
+            captured["sql"] = str(stmt.compile())
+            result = MagicMock()
+            result.scalar_one_or_none = MagicMock(return_value=None)
+            return result
+
+        svc.db.execute = fake_execute
+
+        found = await svc._is_existing_user("old@example.com", "gh-sub-42")
+
+        assert found is False
+        sql = captured["sql"]
+        assert "users.email" in sql
+        assert "users.user_id" in sql
+        # OR semantics must be present (SQLAlchemy renders "OR" in uppercase)
+        assert " OR " in sql.upper()
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_row_exists(self):
+        svc = _svc()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none = MagicMock(return_value=MagicMock())
+        svc.db.execute = AsyncMock(return_value=result_mock)
+
+        assert await svc._is_existing_user("a@b.com", "sub-1") is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_row(self):
+        svc = _svc()
+        result_mock = MagicMock()
+        result_mock.scalar_one_or_none = MagicMock(return_value=None)
+        svc.db.execute = AsyncMock(return_value=result_mock)
+
+        assert await svc._is_existing_user("unknown@b.com", "sub-99") is False
+
+
+class TestLegacyCheckPassesUserIdThrough:
+    """_legacy_check must forward user_id to _check_registration_allowed."""
+
+    @pytest.mark.asyncio
+    async def test_disabled_gate_passes_user_id_to_legacy(self):
+        """When gate is disabled the legacy path is called with both email and user_id."""
+        svc = _svc()
+        svc._load_config = AsyncMock(return_value=_config(enabled=False, mode="manual"))
+        svc._legacy_check = AsyncMock(return_value=None)
+
+        await svc.check_access(
+            provider="github",
+            oauth_sub="gh-sub-99",
+            email="user@example.com",
+            username="octocat",
+        )
+
+        svc._legacy_check.assert_awaited_once_with("user@example.com", "gh-sub-99")

--- a/backend/tests/utils/test_hashing.py
+++ b/backend/tests/utils/test_hashing.py
@@ -1,0 +1,57 @@
+"""Tests for utils.hashing primitives."""
+
+import hashlib
+import hmac
+
+from utils.hashing import hmac_sha256_hex, sha256_hex
+
+
+class TestSha256Hex:
+    def test_returns_64_char_hex(self):
+        assert len(sha256_hex("anything")) == 64
+
+    def test_deterministic(self):
+        assert sha256_hex("foo") == sha256_hex("foo")
+
+    def test_salt_changes_output(self):
+        assert sha256_hex("foo", salt="a") != sha256_hex("foo", salt="b")
+
+    def test_no_salt_default(self):
+        expected = hashlib.sha256(b"foo").hexdigest()
+        assert sha256_hex("foo") == expected
+
+
+class TestHmacSha256Hex:
+    def test_returns_64_char_hex(self):
+        assert len(hmac_sha256_hex("anything", key="k")) == 64
+
+    def test_matches_stdlib_hmac(self):
+        expected = hmac.new(b"my-key", b"alice@example.com", hashlib.sha256).hexdigest()
+        assert hmac_sha256_hex("alice@example.com", key="my-key") == expected
+
+    def test_different_keys_yield_different_digest(self):
+        a = hmac_sha256_hex("alice@example.com", key="k1")
+        b = hmac_sha256_hex("alice@example.com", key="k2")
+        assert a != b
+
+    def test_resists_naive_salt_attack(self):
+        """An attacker who knows the value but not the key cannot reproduce the digest.
+
+        Contrast with sha256_hex(value, salt=public_salt): attacker who knows
+        salt + value can compute the digest. HMAC requires the key.
+        """
+        target = hmac_sha256_hex("victim@example.com", key="server-secret")
+        attacker_guesses = [
+            sha256_hex("victim@example.com"),
+            sha256_hex("victim@example.com", salt=""),
+            sha256_hex("victim@example.com", salt="kagura-erasure-v1"),
+        ]
+        assert target not in attacker_guesses
+
+    def test_empty_value_hashable(self):
+        digest = hmac_sha256_hex("", key="k")
+        assert len(digest) == 64
+
+    def test_unicode_value(self):
+        digest = hmac_sha256_hex("ユーザー@例.jp", key="k")
+        assert len(digest) == 64

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -69,6 +69,17 @@ function LoginContent() {
             "Registration is disabled. Please ask an admin for an invitation.",
         }),
       );
+    } else if (errorParam === "email_in_use") {
+      // Issue #481: cross-provider email collision. The user signed in with
+      // one provider (e.g. Google) using an email that's already bound to
+      // a different account. Account linking is intentionally not yet
+      // supported (#517) — direct the user to their original provider.
+      setError(
+        t("emailInUse", {
+          default:
+            "This email is already linked to another sign-in method. Please use the provider you originally signed in with.",
+        }),
+      );
     } else if (errorParam) {
       setError(decodeURIComponent(errorParam));
     }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -101,6 +101,7 @@
     "continueWithGitHub": "Continue with GitHub",
     "redirecting": "Redirecting...",
     "registrationDisabled": "Registration is disabled. Please ask an admin for an invitation.",
+    "emailInUse": "This email is already linked to another sign-in method. Please use the provider you originally signed in with.",
     "loginId": "Login ID",
     "password": "Password",
     "signIn": "Sign In",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -101,6 +101,7 @@
     "continueWithGitHub": "GitHubで続ける",
     "redirecting": "リダイレクト中...",
     "registrationDisabled": "新規登録は無効です。管理者に招待を依頼してください。",
+    "emailInUse": "このメールアドレスは別のサインイン方法に紐づいています。最初に登録したプロバイダでサインインしてください。",
     "loginId": "ログインID",
     "password": "パスワード",
     "signIn": "サインイン",


### PR DESCRIPTION
Closes #481

## Summary
- Switches `RoleManager.ensure_user` lookup key from `email` to `user_id` (OAuth `sub`) so an IdP email change still finds the existing user row.
- Syncs IdP-provided email/name on every OAuth login when `email_verified=True`, with HMAC-SHA256 audit logging keyed by a new `AUDIT_HMAC_KEY` env var (independent rotation from `API_KEY_SECRET`).
- Rewrites `_github_get_user_info` to always fetch `/user/emails` and select the verified primary, ignoring user-mutable `/user.email` (fixes pre-existing security bug).
- Cross-provider email collision (Google user with `alice@x.com` → GitHub login with same address) now returns `ConflictError(409)` with a redirect to `/login?error=email_in_use` instead of silently linking accounts. Account linking is intentionally deferred to a separate v0.15.0+ issue.

## Implementation notes
- **Schema unchanged.** `users.user_id` was already `UNIQUE+INDEX` — this is a code-only refactor. No migration needed.
- `RoleManager.ensure_user` split into 3 methods (`ensure_user` public dispatcher / `_ensure_user_postgres` / `_sync_existing_user`) for single-responsibility per layer.
- `IntegrityError` narrowed via `_is_email_unique_violation` (asyncpg `sqlstate=23505` AND `constraint_name` contains `"email"`). Non-email constraint violations re-raise — surfaces as 503 via the global `SQLAlchemyError` handler so a future UNIQUE addition is loud, not silently mis-mapped to "Email already in use".
- `audit_logs.user_email` records the actor sentinel `"oauth-callback"` rather than the subject's mutable email — keeps plaintext PII out of the audit row even after subsequent email rotations. The subject is identified by `user_id`, which is pseudonymized at GDPR Art.17 erasure time via the existing `_pseudonymize_audit_logs` flow.
- OAuth callbacks now inject `request: Request` for IP/User-Agent capture (matches the `admin_force_erase_user` precedent). `ConflictError` redirects centralized in `_email_in_use_redirect()` helper.
- 4 new test files (30 tests): `tests/utils/test_hashing.py`, `tests/api/test_github_provider_user_info.py`, `tests/auth/test_role_manager_postgres.py`, `tests/integration/test_role_manager_email_sync.py`.

## Behavior change (CHANGELOG)
- **Cross-provider email reuse**: a user who signs in with Google using `alice@x.com`, then later attempts a GitHub OAuth login with the same address, is now redirected to `/login?error=email_in_use` (HTTP 303) instead of being silently merged into the existing Google-bound account. Cross-provider account linking is tracked separately as a future v0.15.0+ feature.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (CSO routing) — rescope plan applied per CSO + supplementary CIO consultation
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/481-feat-feat-auth-sync-email-name-from-idp-useri.gate1.md`
- `~/.claude/cache/gh-issue-driven/481-feat-feat-auth-sync-email-name-from-idp-useri.gate2.md`

## Spawned follow-ups
- #514 — `feat(profile): show auth_provider on user profile` (v0.14.2, good first issue)
- #515 — `feat(profile): manual "re-sync from IdP" button` (v0.14.2)

🤖 Generated via /gh-issue-driven:ship
