### PR TITLE
fix(auth): drop NOT NULL on oauth_clients.owner_id (#519)

### DIFF
--- a/backend/alembic/versions/d04_519_oauth_clients_owner_id_nullable.py
+++ b/backend/alembic/versions/d04_519_oauth_clients_owner_id_nullable.py
@@ -24,15 +24,20 @@ Downgrade re-applies ``SET NOT NULL``. Any existing rows with
 that is the correct fail-loud behavior; the operator must either delete
 the DCR rows or backfill an owner before downgrading.
 
-Revision ID: d04_519_oauth_clients_owner_id_nullable
+Revision ID: d04_519_oauth_owner_nullable
 Revises: c03_471_seed_pricing
 
 NOTE: Revision IDs are capped at 32 chars because
 ``alembic_version.version_num`` is ``VARCHAR(32)`` in this database
 (asyncpg raises ``StringDataRightTruncationError`` otherwise).
-``d04_519_oauth_clients_owner_id_nullable`` is exactly 41 chars; using
-the shorter ``d04_519_oauth_owner_nullable`` (29 chars) instead.
+The longer candidate ``d04_519_oauth_clients_owner_id_nullable`` is
+39 chars — still over the cap — so this migration uses the shorter
+``d04_519_oauth_owner_nullable`` (29 chars). The Python filename is
+allowed to be longer than the revision id, so we keep the descriptive
+filename for grep-ability.
 """
+
+import sqlalchemy as sa
 
 from alembic import op
 
@@ -48,6 +53,7 @@ def upgrade() -> None:
     op.alter_column(
         "oauth_clients",
         "owner_id",
+        existing_type=sa.String(length=255),
         nullable=True,
     )
 
@@ -62,5 +68,6 @@ def downgrade() -> None:
     op.alter_column(
         "oauth_clients",
         "owner_id",
+        existing_type=sa.String(length=255),
         nullable=False,
     )

--- a/backend/alembic/versions/d04_519_oauth_clients_owner_id_nullable.py
+++ b/backend/alembic/versions/d04_519_oauth_clients_owner_id_nullable.py
@@ -1,0 +1,66 @@
+"""Drop NOT NULL on oauth_clients.owner_id (#519, #513 follow-up).
+
+Issue #513 (PR #518) added Dynamic Client Registration (RFC 7591) and
+adjusted the response model so DCR-registered clients (which have no human
+owner) can serialize ``owner_id=None``. The underlying SQLAlchemy column
+and DB constraint were left as ``NOT NULL``, so any successful DCR INSERT
+fails with::
+
+    psycopg2.errors.NotNullViolation: null value in column "owner_id"
+    of relation "oauth_clients" violates not-null constraint
+
+DCR rejection paths still work end-to-end (they short-circuit before the
+INSERT), but DCR accept paths are broken in production. This migration
+aligns the DB constraint with the model + response shape so DCR can
+register a public client with no owner.
+
+Admin-managed clients (``POST /api/v1/oauth/clients``) continue to record
+``owner_id=current_user_id``; the relaxation only opens the door for the
+DCR path. The accompanying model change in ``models/auth.py`` flips
+``OAuth2Client.owner_id`` to ``nullable=True``.
+
+Downgrade re-applies ``SET NOT NULL``. Any existing rows with
+``owner_id IS NULL`` (DCR-registered clients) will block the downgrade —
+that is the correct fail-loud behavior; the operator must either delete
+the DCR rows or backfill an owner before downgrading.
+
+Revision ID: d04_519_oauth_clients_owner_id_nullable
+Revises: c03_471_seed_pricing
+
+NOTE: Revision IDs are capped at 32 chars because
+``alembic_version.version_num`` is ``VARCHAR(32)`` in this database
+(asyncpg raises ``StringDataRightTruncationError`` otherwise).
+``d04_519_oauth_clients_owner_id_nullable`` is exactly 41 chars; using
+the shorter ``d04_519_oauth_owner_nullable`` (29 chars) instead.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d04_519_oauth_owner_nullable"
+down_revision = "c03_471_seed_pricing"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Drop NOT NULL on oauth_clients.owner_id."""
+    op.alter_column(
+        "oauth_clients",
+        "owner_id",
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    """Restore NOT NULL on oauth_clients.owner_id.
+
+    This will fail if any rows have ``owner_id IS NULL`` (DCR-registered
+    clients). Operators must delete those rows or backfill an owner before
+    downgrading.
+    """
+    op.alter_column(
+        "oauth_clients",
+        "owner_id",
+        nullable=False,
+    )

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -353,7 +353,12 @@ class OAuth2Client(Base):
         client_id: OAuth2 client identifier (unique, public)
         client_secret_hash: SHA256 hash of client secret (confidential, always required)
         client_name: Human-readable name (e.g., "ChatGPT Connector")
-        owner_id: User ID who registered this client
+        owner_id: User ID who registered this client. ``None`` for clients
+            created via Dynamic Client Registration (RFC 7591) — DCR is a
+            public, owner-less endpoint, so the workspace context is resolved
+            from the consenting user's session at ``/authorize`` time
+            rather than from the client record. See migration revision
+            ``d04_519_oauth_owner_nullable`` (issue #519).
         redirect_uris: Allowed redirect URIs (JSON array)
         grant_types: Allowed grant types (JSON array: authorization_code, refresh_token)
         response_types: Allowed response types (JSON array: code)

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -386,8 +386,8 @@ class OAuth2Client(Base):
     # Issue #519 (#513 follow-up): DCR-registered clients (RFC 7591) have no
     # human owner — ``dynamic_client_registration`` creates them with
     # ``owner_id=None``. Admin-managed clients still record the creating
-    # user's id. Migration ``d04_519_oauth_clients_owner_id_nullable``
-    # drops the corresponding NOT NULL DB constraint.
+    # user's id. Migration revision ``d04_519_oauth_owner_nullable`` drops
+    # the corresponding NOT NULL DB constraint.
     owner_id = Column(String(255), nullable=True, index=True)
 
     # Issue #169: Workspace-scoped OAuth clients (access all contexts in workspace)

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -383,7 +383,12 @@ class OAuth2Client(Base):
     client_id = Column(String(48), nullable=False, unique=True, index=True)
     client_secret_hash = Column(String(64), nullable=False)  # SHA256 hash (always required)
     client_name = Column(String(100), nullable=False)
-    owner_id = Column(String(255), nullable=False, index=True)
+    # Issue #519 (#513 follow-up): DCR-registered clients (RFC 7591) have no
+    # human owner — ``dynamic_client_registration`` creates them with
+    # ``owner_id=None``. Admin-managed clients still record the creating
+    # user's id. Migration ``d04_519_oauth_clients_owner_id_nullable``
+    # drops the corresponding NOT NULL DB constraint.
+    owner_id = Column(String(255), nullable=True, index=True)
 
     # Issue #169: Workspace-scoped OAuth clients (access all contexts in workspace)
     # Migration 034: context_id removed (deprecated)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -1,0 +1,59 @@
+"""Pytest conftest for the integration test suite.
+
+Steers ``DATABASE_URL`` at ``TEST_DATABASE_URL`` deterministically before
+any test module imports ``config.database`` or ``api.main``, so the route
+handler's ``get_sync_session()`` connects to the test DB regardless of
+which module is collected first.
+
+The mutation happens at **conftest import time** (module top, below the
+imports) because ``config.database.DATABASE_URL`` and
+``api.main`` read the env at their own import time. A session-scoped
+autouse fixture restores the prior value at session end so a leaked
+override doesn't follow the user out of pytest.
+
+Mirrors the env-steering pattern in
+``tests/integration/test_alembic_migrations.py:_alembic_at_test_db`` —
+that one is per-call (context manager) for the migration tests; this
+conftest applies the same idea suite-wide.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator
+
+import pytest
+
+_DEFAULT_TEST_DB_URL = "postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test"
+
+# CRITICAL: this assignment runs at conftest *import* time, which pytest
+# does before collecting test modules. ``api.main`` and ``config.database``
+# read ``DATABASE_URL`` at their own import time, so the override must
+# happen before they are imported. ``_PREV_DATABASE_URL`` captures the
+# original value (if any) so the session-scoped fixture below can restore
+# it on exit.
+_PREV_DATABASE_URL = os.environ.get("DATABASE_URL")
+os.environ["DATABASE_URL"] = os.environ.get("TEST_DATABASE_URL", _DEFAULT_TEST_DB_URL)
+
+# Test-only fallbacks for OAuth/encryption secrets so the integration suite
+# runs hermetically when ``.env.local`` was not sourced. ``setdefault`` is
+# intentional — when the operator already exports real values (e.g. they
+# sourced ``.env.local``), preserve those.
+os.environ.setdefault("API_KEY_SECRET", "integration-test-api-key-secret-not-for-prod")
+os.environ.setdefault("JWT_SECRET", "integration-test-jwt-secret-not-for-prod")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _restore_database_url_after_session() -> Generator[None, None, None]:
+    """Restore ``DATABASE_URL`` to its prior value at session end.
+
+    The env mutation that paired this fixture happens at conftest *import*
+    time (above) because that's when it must take effect; the restoration
+    is best-effort cleanup so subsequent invocations / processes that
+    inherit the env do not see a leaked override.
+    """
+    yield
+    if _PREV_DATABASE_URL is None:
+        os.environ.pop("DATABASE_URL", None)
+    else:
+        os.environ["DATABASE_URL"] = _PREV_DATABASE_URL

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -82,9 +82,19 @@ def _reset_db_base_state() -> None:
 
     for engine_name in ("engine", "sync_engine"):
         existing = getattr(db_base, engine_name, None)
-        if existing is not None and hasattr(existing, "dispose"):
+        if existing is not None:
+            # ``db.base.engine`` is an ``AsyncEngine`` whose ``.dispose()``
+            # returns a coroutine — calling it without ``await`` here would
+            # leak an un-awaited coroutine and never actually release the
+            # pool. Dispose via the underlying ``sync_engine`` attribute
+            # for async engines (``AsyncEngine.sync_engine.dispose()`` is
+            # synchronous and releases the same pool); fall back to plain
+            # ``.dispose()`` for the sync engine in ``db.base.sync_engine``.
             try:
-                existing.dispose()
+                if hasattr(existing, "sync_engine") and hasattr(existing.sync_engine, "dispose"):
+                    existing.sync_engine.dispose()
+                elif hasattr(existing, "dispose"):
+                    existing.dispose()
             except Exception:  # noqa: BLE001 — best-effort cleanup
                 pass
         if hasattr(db_base, engine_name):

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -45,17 +45,60 @@ os.environ.setdefault("JWT_SECRET", "integration-test-jwt-secret-not-for-prod")
 # If a sibling test directory (e.g. ``tests/api/``) was collected before
 # ``tests/integration/`` and already imported ``config.database``, the
 # module-level ``DATABASE_URL`` constant in that module is frozen at the
-# pre-override value. Reload the affected modules so they re-read the env
-# we just set. This is defensive — when integration tests are run via
+# pre-override value. Reload only the configuration module so it re-reads
+# the env we just set. For ``db.base``, do NOT reload the module because
+# that would recreate ``Base = declarative_base()`` and split the
+# declarative metadata registry from the model modules that already
+# imported the original ``Base`` (alembic ``target_metadata`` and any
+# ``Base.metadata.create_all`` would then see only an empty registry).
+# Instead, reset the lazy-init globals (``engine``, ``async_session_factory``,
+# ``sync_engine``, ``sync_session_factory``) in place so the next call
+# to ``_get_engine()`` / ``_get_sync_engine()`` rebuilds them against the
+# freshly reloaded ``config.database.DATABASE_URL`` (those getters do
+# ``from config.database import DATABASE_URL`` at call time, so the
+# new value is picked up automatically).
+#
+# This is defensive — when integration tests are run via
 # ``make test-integration`` (which does NOT mix with unit tests), no
-# reload is needed; the guard only fires in mixed-suite invocations
+# reload/reset is needed; the guard only fires in mixed-suite invocations
 # (``pytest tests/``).
 import importlib  # noqa: E402
 import sys  # noqa: E402
 
-for _modname in ("config.database", "db.base"):
-    if _modname in sys.modules:
-        importlib.reload(sys.modules[_modname])
+
+def _reset_db_base_state() -> None:
+    """Clear cached engines/session factories on ``db.base`` without reloading.
+
+    ``db.base`` lazily creates engines on first access via the
+    ``from config.database import DATABASE_URL`` pattern inside its getter
+    functions. Setting the cached globals to ``None`` (and disposing the
+    engines first to release pooled connections) makes the next access
+    rebuild them with the freshly reloaded config — without touching the
+    declarative ``Base`` that model modules already hold a reference to.
+    """
+    db_base = sys.modules.get("db.base")
+    if db_base is None:
+        return
+
+    for engine_name in ("engine", "sync_engine"):
+        existing = getattr(db_base, engine_name, None)
+        if existing is not None and hasattr(existing, "dispose"):
+            try:
+                existing.dispose()
+            except Exception:  # noqa: BLE001 — best-effort cleanup
+                pass
+        if hasattr(db_base, engine_name):
+            setattr(db_base, engine_name, None)
+
+    for factory_name in ("async_session_factory", "sync_session_factory"):
+        if hasattr(db_base, factory_name):
+            setattr(db_base, factory_name, None)
+
+
+if "config.database" in sys.modules:
+    importlib.reload(sys.modules["config.database"])
+
+_reset_db_base_state()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/backend/tests/integration/conftest.py
+++ b/backend/tests/integration/conftest.py
@@ -27,11 +27,11 @@ import pytest
 _DEFAULT_TEST_DB_URL = "postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test"
 
 # CRITICAL: this assignment runs at conftest *import* time, which pytest
-# does before collecting test modules. ``api.main`` and ``config.database``
-# read ``DATABASE_URL`` at their own import time, so the override must
-# happen before they are imported. ``_PREV_DATABASE_URL`` captures the
-# original value (if any) so the session-scoped fixture below can restore
-# it on exit.
+# does before collecting test modules in this directory. ``api.main`` and
+# ``config.database`` read ``DATABASE_URL`` at their own import time, so the
+# override must happen before they are imported. ``_PREV_DATABASE_URL``
+# captures the original value (if any) so the session-scoped fixture below
+# can restore it on exit.
 _PREV_DATABASE_URL = os.environ.get("DATABASE_URL")
 os.environ["DATABASE_URL"] = os.environ.get("TEST_DATABASE_URL", _DEFAULT_TEST_DB_URL)
 
@@ -41,6 +41,21 @@ os.environ["DATABASE_URL"] = os.environ.get("TEST_DATABASE_URL", _DEFAULT_TEST_D
 # sourced ``.env.local``), preserve those.
 os.environ.setdefault("API_KEY_SECRET", "integration-test-api-key-secret-not-for-prod")
 os.environ.setdefault("JWT_SECRET", "integration-test-jwt-secret-not-for-prod")
+
+# If a sibling test directory (e.g. ``tests/api/``) was collected before
+# ``tests/integration/`` and already imported ``config.database``, the
+# module-level ``DATABASE_URL`` constant in that module is frozen at the
+# pre-override value. Reload the affected modules so they re-read the env
+# we just set. This is defensive — when integration tests are run via
+# ``make test-integration`` (which does NOT mix with unit tests), no
+# reload is needed; the guard only fires in mixed-suite invocations
+# (``pytest tests/``).
+import importlib  # noqa: E402
+import sys  # noqa: E402
+
+for _modname in ("config.database", "db.base"):
+    if _modname in sys.modules:
+        importlib.reload(sys.modules[_modname])
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/backend/tests/integration/test_oauth_dcr_integration.py
+++ b/backend/tests/integration/test_oauth_dcr_integration.py
@@ -29,24 +29,12 @@ import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
-# ---------------------------------------------------------------------------
-# Hermetic environment setup — must happen BEFORE importing the FastAPI app /
-# db modules, which read DATABASE_URL / API_KEY_SECRET at import time.
-#
-# - Force ``DATABASE_URL`` to ``TEST_DATABASE_URL`` (or the project default
-#   ``..._test`` DB) so a developer with a dev-DB ``DATABASE_URL`` exported
-#   in their shell cannot have this test write to or DELETE FROM the wrong
-#   database. Mirrors the safety pattern in
-#   ``tests/integration/test_alembic_migrations.py``.
-# - Provide test-only fallbacks for ``API_KEY_SECRET`` / ``JWT_SECRET`` via
-#   ``setdefault`` (do NOT override real values when the operator sourced
-#   ``.env.local`` themselves) so the test passes hermetically when run
-#   under bare ``pytest tests/integration/...`` without ``.env.local``.
-# ---------------------------------------------------------------------------
-_DEFAULT_TEST_DB_URL = "postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test"
-os.environ["DATABASE_URL"] = os.environ.get("TEST_DATABASE_URL", _DEFAULT_TEST_DB_URL)
-os.environ.setdefault("API_KEY_SECRET", "integration-test-api-key-secret-not-for-prod")
-os.environ.setdefault("JWT_SECRET", "integration-test-jwt-secret-not-for-prod")
+# ``DATABASE_URL``/``API_KEY_SECRET``/``JWT_SECRET`` are steered at
+# ``TEST_DATABASE_URL`` (and test-only fallbacks) by
+# ``backend/tests/integration/conftest.py`` at conftest-import time —
+# that runs before any test module is collected, so by the time this
+# module is imported (and ``api.main`` / ``config.database`` read the env)
+# the override is already in place. See conftest.py for rationale.
 
 # Match the sys.path layout the rest of the backend tests use.
 _BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
@@ -88,6 +76,31 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _assert_alembic_target_is_test_db() -> None:
+    """Refuse to run ``alembic upgrade head`` against a non-test database.
+
+    Mirrors the ``_reset_alembic_state`` safety guard in
+    ``tests/integration/test_alembic_migrations.py``. A misconfigured
+    ``TEST_DATABASE_URL`` (despite the conftest steering) must not be
+    able to migrate a dev or prod DB during fixture setup.
+    """
+    sync_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+    import psycopg2
+
+    conn = psycopg2.connect(sync_url, connect_timeout=3)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT current_database()")
+            row = cur.fetchone()
+            db_name = row[0] if row else None
+            assert db_name and db_name.endswith("_test"), (
+                f"Refusing to run 'alembic upgrade head' against non-test "
+                f"database '{db_name}'. Set TEST_DATABASE_URL to a *_test database."
+            )
+    finally:
+        conn.close()
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _ensure_oauth_clients_schema():
     """Apply alembic migrations so the test DB matches the production schema.
@@ -100,14 +113,12 @@ def _ensure_oauth_clients_schema():
     the regression-pin purpose. Only ``alembic upgrade head`` proves the
     migration itself produces the expected DB constraint.
 
-    Mirrors the ``_alembic_at_test_db`` pattern in
-    ``tests/integration/test_alembic_migrations.py``: alembic's ``env.py``
-    re-reads ``get_database_url()`` on import and clobbers any
-    ``Config.set_main_option("sqlalchemy.url", ...)``, so the test DB URL
-    must be in the process env at command time. The module-level
-    ``os.environ["DATABASE_URL"]`` override above is already in place;
-    ``alembic.ini`` is at ``backend/alembic.ini``.
+    The DATABASE_URL steering happens in
+    ``backend/tests/integration/conftest.py`` at conftest-import time. Verify
+    the resolved DB is a ``*_test`` DB before invoking ``command.upgrade()``
+    so a misconfigured env cannot apply migrations to dev/prod.
     """
+    _assert_alembic_target_is_test_db()
     backend_dir = Path(__file__).resolve().parents[2]
     config = Config(str(backend_dir / "alembic.ini"))
     command.upgrade(config, "head")

--- a/backend/tests/integration/test_oauth_dcr_integration.py
+++ b/backend/tests/integration/test_oauth_dcr_integration.py
@@ -1,0 +1,141 @@
+"""Integration tests for the DCR endpoint against a real Postgres session.
+
+Issue #519 (#513 follow-up): the unit tests in ``tests/api/test_oauth_dcr.py``
+mock ``api.routes.oauth.get_sync_session`` and never reach the actual DB
+engine, so the layer mismatch between the Pydantic response model
+(``owner_id: str | None``) and the DB column (``oauth_clients.owner_id NOT
+NULL``) was not caught until a self-hosted operator tried ``claude mcp add
+http://localhost:8080/mcp`` against the merged code and saw a 500 from
+``psycopg2.errors.NotNullViolation``.
+
+This test exercises the full ``POST /api/v1/oauth/register`` path against
+a real Postgres test database (TEST_DATABASE_URL). It pins three things:
+
+1. DCR loopback path returns 201 (not 500) and persists ``owner_id=None``
+   to the DB.
+2. The serialized response includes ``owner_id: null`` (Pydantic Optional
+   path round-trips).
+3. The constraint relaxation does not regress the admin-managed path —
+   ``OAuth2Client(owner_id="user-...")`` still inserts cleanly.
+
+This test runs in ``backend/tests/integration/`` because it touches the DB.
+``make test-integration`` (per dev-environment.md) runs this suite.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+# Match the sys.path layout the rest of the backend tests use.
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy import text  # noqa: E402
+
+from api.main import app  # noqa: E402
+from db.base import get_sync_session  # noqa: E402
+from models.auth import OAuth2Client  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def sync_db():
+    """Yield a real sync DB session and clean up oauth_clients rows."""
+    session = get_sync_session()
+    try:
+        yield session
+    finally:
+        # Clean up any oauth_clients rows this test class created.
+        session.execute(
+            text(
+                "DELETE FROM oauth_clients WHERE client_id LIKE 'oauth_%' "
+                "AND client_name IN ("
+                "  'IntegrationTest Claude Code Loopback', "
+                "  'IntegrationTest Admin Path'"
+                ")"
+            )
+        )
+        session.commit()
+        session.close()
+
+
+class TestDcrLoopbackPersistsNullOwnerId:
+    """Issue #519: ``oauth_clients.owner_id`` must allow NULL for DCR clients."""
+
+    def test_dcr_loopback_returns_201_and_persists_null_owner(self, client, sync_db):
+        # Mock the rate-limit counter so this test doesn't share quota with
+        # adjacent runs. The DB session and encryptor are real.
+        rate_limit = AsyncMock(return_value=1)
+        with patch("db.redis.increment_counter", rate_limit):
+            response = client.post(
+                "/api/v1/oauth/register",
+                json={
+                    "client_name": "IntegrationTest Claude Code Loopback",
+                    "redirect_uris": ["http://localhost:54321/callback"],
+                    "token_endpoint_auth_method": "none",
+                },
+            )
+
+        assert response.status_code == 201, (
+            f"DCR loopback INSERT should succeed end-to-end now that #519 has "
+            f"flipped oauth_clients.owner_id to NULLable; got {response.status_code} "
+            f"{response.text}"
+        )
+        body = response.json()
+        assert body["owner_id"] is None
+        assert body["provider"] == "claude"
+        assert body["token_endpoint_auth_method"] == "none"
+
+        # Confirm the row actually landed in the DB with owner_id NULL.
+        client_id = body["client_id"]
+        row = sync_db.execute(
+            text("SELECT owner_id, client_name FROM oauth_clients WHERE client_id = :cid"),
+            {"cid": client_id},
+        ).first()
+        assert row is not None, f"DCR row missing for client_id={client_id}"
+        assert row.owner_id is None, f"DB row should have owner_id=NULL, got {row.owner_id!r}"
+        assert row.client_name == "IntegrationTest Claude Code Loopback"
+
+    def test_admin_path_with_string_owner_still_works(self, sync_db):
+        """The constraint relaxation must not regress the admin-managed path.
+
+        Admin clients (``POST /api/v1/oauth/clients``) call
+        ``OAuth2Client(owner_id=user.id)`` directly; #519 only relaxes the
+        constraint, it does not change the admin handler. Insert a row with
+        a non-null ``owner_id`` directly through the ORM to pin the
+        regression.
+        """
+        c = OAuth2Client(
+            client_id="oauth_integration_admin_test",
+            client_secret_hash="0" * 64,
+            client_name="IntegrationTest Admin Path",
+            owner_id="user-integration-test-12345",
+            redirect_uris=["https://chatgpt.com/cb"],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            scope="memory:read",
+            token_endpoint_auth_method="client_secret_post",
+            provider="chatgpt",
+        )
+        sync_db.add(c)
+        sync_db.commit()
+        sync_db.refresh(c)
+
+        assert c.id is not None
+        # Re-read to confirm round-trip
+        fetched = sync_db.execute(
+            text("SELECT owner_id FROM oauth_clients WHERE client_id = :cid"),
+            {"cid": "oauth_integration_admin_test"},
+        ).first()
+        assert fetched is not None
+        assert fetched.owner_id == "user-integration-test-12345"

--- a/backend/tests/integration/test_oauth_dcr_integration.py
+++ b/backend/tests/integration/test_oauth_dcr_integration.py
@@ -24,9 +24,29 @@ This test runs in ``backend/tests/integration/`` because it touches the DB.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
+
+# ---------------------------------------------------------------------------
+# Hermetic environment setup — must happen BEFORE importing the FastAPI app /
+# db modules, which read DATABASE_URL / API_KEY_SECRET at import time.
+#
+# - Force ``DATABASE_URL`` to ``TEST_DATABASE_URL`` (or the project default
+#   ``..._test`` DB) so a developer with a dev-DB ``DATABASE_URL`` exported
+#   in their shell cannot have this test write to or DELETE FROM the wrong
+#   database. Mirrors the safety pattern in
+#   ``tests/integration/test_alembic_migrations.py``.
+# - Provide test-only fallbacks for ``API_KEY_SECRET`` / ``JWT_SECRET`` via
+#   ``setdefault`` (do NOT override real values when the operator sourced
+#   ``.env.local`` themselves) so the test passes hermetically when run
+#   under bare ``pytest tests/integration/...`` without ``.env.local``.
+# ---------------------------------------------------------------------------
+_DEFAULT_TEST_DB_URL = "postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test"
+os.environ["DATABASE_URL"] = os.environ.get("TEST_DATABASE_URL", _DEFAULT_TEST_DB_URL)
+os.environ.setdefault("API_KEY_SECRET", "integration-test-api-key-secret-not-for-prod")
+os.environ.setdefault("JWT_SECRET", "integration-test-jwt-secret-not-for-prod")
 
 # Match the sys.path layout the rest of the backend tests use.
 _BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
@@ -35,11 +55,51 @@ if str(_BACKEND_SRC) not in sys.path:
 
 import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
-from sqlalchemy import text  # noqa: E402
+from sqlalchemy import create_engine, text  # noqa: E402
 
 from api.main import app  # noqa: E402
 from db.base import get_sync_session  # noqa: E402
+from models.auth import Base as AuthBase  # noqa: E402
 from models.auth import OAuth2Client  # noqa: E402
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ensure_oauth_clients_schema():
+    """Ensure ``oauth_clients`` exists in the test DB.
+
+    Other integration tests rely on ``conftest.py``'s session-scoped async
+    engine fixture which calls ``Base.metadata.create_all`` — but this test
+    uses ``get_sync_session()`` so its DB visibility is independent. Create
+    the auth tables directly through a sync engine before the suite runs;
+    this is idempotent (``checkfirst=True`` is the default).
+    """
+    sync_url = os.environ["DATABASE_URL"].replace("+asyncpg", "")
+    engine = create_engine(sync_url, future=True)
+    try:
+        # ``oauth_clients`` has a FK to ``workspaces``, which itself FKs to
+        # ``users``. ``create_all()`` (no ``tables=`` arg) walks the dependency
+        # graph and creates all auth tables in FK-safe order. Idempotent
+        # via ``checkfirst=True`` (the default).
+        AuthBase.metadata.create_all(engine)
+        yield
+    finally:
+        engine.dispose()
+
+
+def _assert_test_db(session) -> None:
+    """Refuse to run destructive cleanup on non-test databases.
+
+    Mirrors the safety pattern in ``test_alembic_migrations.py``. A
+    misconfigured ``DATABASE_URL`` (despite the module-level override above)
+    must not be able to ``DELETE FROM oauth_clients`` against a dev or prod
+    database. The check fires at fixture teardown immediately before the
+    cleanup statement runs.
+    """
+    db_name = session.execute(text("SELECT current_database()")).scalar()
+    assert db_name and db_name.endswith("_test"), (
+        f"Refusing to run integration test cleanup against non-test database "
+        f"'{db_name}'. Set TEST_DATABASE_URL to a *_test database."
+    )
 
 
 @pytest.fixture
@@ -50,11 +110,18 @@ def client():
 
 @pytest.fixture
 def sync_db():
-    """Yield a real sync DB session and clean up oauth_clients rows."""
+    """Yield a real sync DB session bound to the test database.
+
+    Asserts the connected DB name ends with ``_test`` before yielding; the
+    same guard runs again at teardown immediately before the cleanup DELETE
+    so a config drift cannot wipe oauth_clients rows from a dev/prod DB.
+    """
     session = get_sync_session()
+    _assert_test_db(session)
     try:
         yield session
     finally:
+        _assert_test_db(session)
         # Clean up any oauth_clients rows this test class created.
         session.execute(
             text(

--- a/backend/tests/integration/test_oauth_dcr_integration.py
+++ b/backend/tests/integration/test_oauth_dcr_integration.py
@@ -54,36 +54,92 @@ if str(_BACKEND_SRC) not in sys.path:
     sys.path.insert(0, str(_BACKEND_SRC))
 
 import pytest  # noqa: E402
+from alembic.config import Config  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
-from sqlalchemy import create_engine, text  # noqa: E402
+from sqlalchemy import text  # noqa: E402
 
+from alembic import command  # noqa: E402
 from api.main import app  # noqa: E402
 from db.base import get_sync_session  # noqa: E402
-from models.auth import Base as AuthBase  # noqa: E402
 from models.auth import OAuth2Client  # noqa: E402
+
+
+def _check_db_available() -> bool:
+    """Return ``True`` iff the test Postgres at ``DATABASE_URL`` accepts a connection.
+
+    Mirrors the ``_check_db_available()`` helper in
+    ``tests/api/test_api_integration.py`` so this module skips cleanly
+    when the test DB isn't running, instead of erroring at fixture setup.
+    """
+    try:
+        import psycopg2
+
+        url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+        conn = psycopg2.connect(url, connect_timeout=3)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _check_db_available(),
+    reason="Test database not available (set TEST_DATABASE_URL)",
+)
 
 
 @pytest.fixture(scope="module", autouse=True)
 def _ensure_oauth_clients_schema():
-    """Ensure ``oauth_clients`` exists in the test DB.
+    """Apply alembic migrations so the test DB matches the production schema.
 
-    Other integration tests rely on ``conftest.py``'s session-scoped async
-    engine fixture which calls ``Base.metadata.create_all`` — but this test
-    uses ``get_sync_session()`` so its DB visibility is independent. Create
-    the auth tables directly through a sync engine before the suite runs;
-    this is idempotent (``checkfirst=True`` is the default).
+    Critical: setting up the schema via ``alembic upgrade head`` (instead of
+    ``Base.metadata.create_all``) means this test actually exercises migration
+    ``d04_519_oauth_owner_nullable``. Using ``create_all`` would build tables
+    from the *current ORM models* (which already have ``owner_id`` nullable),
+    so a missing or buggy migration would still let the test pass — defeating
+    the regression-pin purpose. Only ``alembic upgrade head`` proves the
+    migration itself produces the expected DB constraint.
+
+    Mirrors the ``_alembic_at_test_db`` pattern in
+    ``tests/integration/test_alembic_migrations.py``: alembic's ``env.py``
+    re-reads ``get_database_url()`` on import and clobbers any
+    ``Config.set_main_option("sqlalchemy.url", ...)``, so the test DB URL
+    must be in the process env at command time. The module-level
+    ``os.environ["DATABASE_URL"]`` override above is already in place;
+    ``alembic.ini`` is at ``backend/alembic.ini``.
     """
-    sync_url = os.environ["DATABASE_URL"].replace("+asyncpg", "")
-    engine = create_engine(sync_url, future=True)
+    backend_dir = Path(__file__).resolve().parents[2]
+    config = Config(str(backend_dir / "alembic.ini"))
+    command.upgrade(config, "head")
+    yield
+
+
+def _assert_oauth_clients_owner_id_nullable() -> None:
+    """Pin that ``oauth_clients.owner_id`` is nullable post-migration.
+
+    Reads ``information_schema.columns`` directly so the assertion does not
+    depend on the ORM model's view of the column — this catches the case
+    where the migration is missing or wrong even though the model still says
+    ``nullable=True``.
+    """
+    sync_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+    import psycopg2
+
+    conn = psycopg2.connect(sync_url, connect_timeout=3)
     try:
-        # ``oauth_clients`` has a FK to ``workspaces``, which itself FKs to
-        # ``users``. ``create_all()`` (no ``tables=`` arg) walks the dependency
-        # graph and creates all auth tables in FK-safe order. Idempotent
-        # via ``checkfirst=True`` (the default).
-        AuthBase.metadata.create_all(engine)
-        yield
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT is_nullable FROM information_schema.columns "
+                "WHERE table_name = 'oauth_clients' AND column_name = 'owner_id'"
+            )
+            row = cur.fetchone()
+            assert row is not None, "oauth_clients.owner_id column missing"
+            assert row[0] == "YES", (
+                f"oauth_clients.owner_id must be nullable post-migration; "
+                f"information_schema reports is_nullable={row[0]!r}"
+            )
     finally:
-        engine.dispose()
+        conn.close()
 
 
 def _assert_test_db(session) -> None:
@@ -138,6 +194,17 @@ def sync_db():
 
 class TestDcrLoopbackPersistsNullOwnerId:
     """Issue #519: ``oauth_clients.owner_id`` must allow NULL for DCR clients."""
+
+    def test_migration_made_owner_id_nullable(self):
+        """Pin the migration's DB-level effect via information_schema.
+
+        This is the regression check that catches "migration is missing or
+        wrong" — independent of the ORM model's view of the column. If
+        ``d04_519_oauth_owner_nullable`` were dropped, the rest of the suite
+        would still pass (because Pydantic + SQLAlchemy say nullable=True),
+        but this assertion would fail on a freshly migrated DB.
+        """
+        _assert_oauth_clients_owner_id_nullable()
 
     def test_dcr_loopback_returns_201_and_persists_null_owner(self, client, sync_db):
         # Mock the rate-limit counter so this test doesn't share quota with

--- a/backend/tests/integration/test_oauth_dcr_integration.py
+++ b/backend/tests/integration/test_oauth_dcr_integration.py
@@ -101,6 +101,40 @@ def _assert_alembic_target_is_test_db() -> None:
         conn.close()
 
 
+def _reset_alembic_state() -> None:
+    """Drop the public schema so ``alembic upgrade head`` starts clean.
+
+    Mirrors the helper of the same name in
+    ``tests/integration/test_alembic_migrations.py``. Needed when another
+    fixture (e.g. ``tests/conftest.py``'s session-scoped ``async_engine``
+    that does ``Base.metadata.create_all``) has already created tables
+    in the test DB but did not stamp ``alembic_version`` — running
+    ``command.upgrade()`` then fails because migrations attempt to
+    create tables that already exist.
+
+    Safety guard: refuses to drop a non-test database; the
+    ``_assert_alembic_target_is_test_db`` check above must already have
+    passed before this is invoked.
+    """
+    from sqlalchemy import create_engine, text
+
+    sync_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+    db_name = sync_url.rsplit("/", 1)[-1].split("?")[0]
+    if not db_name.endswith("_test"):
+        raise RuntimeError(
+            f"Refusing to DROP SCHEMA on non-test database '{db_name}'. "
+            f"Set TEST_DATABASE_URL to a *_test database."
+        )
+
+    engine = create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("DROP SCHEMA public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+    finally:
+        engine.dispose()
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _ensure_oauth_clients_schema():
     """Apply alembic migrations so the test DB matches the production schema.
@@ -116,9 +150,13 @@ def _ensure_oauth_clients_schema():
     The DATABASE_URL steering happens in
     ``backend/tests/integration/conftest.py`` at conftest-import time. Verify
     the resolved DB is a ``*_test`` DB before invoking ``command.upgrade()``
-    so a misconfigured env cannot apply migrations to dev/prod.
+    so a misconfigured env cannot apply migrations to dev/prod, then drop
+    and recreate the public schema so alembic starts from a clean state
+    even if a sibling test fixture (e.g. ``tests/conftest.py``'s async
+    engine fixture) already did ``create_all`` in this session.
     """
     _assert_alembic_target_is_test_db()
+    _reset_alembic_state()
     backend_dir = Path(__file__).resolve().parents[2]
     config = Config(str(backend_dir / "alembic.ini"))
     command.upgrade(config, "head")
@@ -171,7 +209,12 @@ def _assert_test_db(session) -> None:
 
 @pytest.fixture
 def client():
-    with TestClient(app) as c:
+    # ``raise_server_exceptions=False`` lets the test inspect HTTP 5xx
+    # responses (e.g. the original ``NotNullViolation`` regression that
+    # this test pins) instead of having TestClient re-raise the underlying
+    # exception. Matches the convention used by other integration tests
+    # in this repo.
+    with TestClient(app, raise_server_exceptions=False) as c:
         yield c
 
 


### PR DESCRIPTION
Closes #519

## Summary

PR #518 (closes #513) shipped DCR loopback support but the **DCR accept path was still broken in production** — the Pydantic response model was fixed (`owner_id: str | None`) but the underlying SQLAlchemy column and DB constraint were still `NOT NULL`. Any successful DCR INSERT immediately failed with `psycopg2.errors.NotNullViolation`.

This PR aligns the three layers so DCR-registered clients (`owner_id=None`) work end-to-end:

| Layer | Before | After |
|---|---|---|
| `OAuth2ClientResponse.owner_id` (Pydantic) | `str \| None` ✓ (#513) | `str \| None` (unchanged) |
| `OAuth2Client.owner_id` (SQLAlchemy column) | `Column(String(255), nullable=False, index=True)` | `nullable=True` |
| `oauth_clients.owner_id` (DB column) | `character varying(255) NOT NULL` | nullable (migration) |

## Why this slipped past #513

The DCR test suite in `tests/api/test_oauth_dcr.py` mocks `api.routes.oauth.get_sync_session` and `utils.encryption.get_encryptor`, so the OAuth2Client INSERT never reaches the DB engine. The `model_dump()` / `response_model=OAuth2ClientWithSecretResponse` validation passed because the Pydantic-level Optional change was correct. The constraint mismatch only surfaces when an actual DB session attempts the INSERT — which the new integration test in this PR exercises.

## Local validation

Reproduced with `claude mcp add --transport http kagura-test http://localhost:8080/mcp` against a fresh kagura-memory-cloud (post-#518 merge):

```
HTTP/1.1 500 Internal Server Error
{"detail":"Failed to register client: (psycopg2.errors.NotNullViolation) null value in column \"owner_id\" of relation \"oauth_clients\" violates not-null constraint\n..."}
```

Applied the migration in this PR (`d04_519_oauth_owner_nullable`), restarted nothing (the model change is pure Pydantic/SQLAlchemy semantics, no behavior shift in the route handler), and re-ran the same call:

```
HTTP/1.1 201 Created
{"owner_id": null, "provider": "claude", "client_id": "oauth_...", ...}
```

All three DCR scenarios verified: `http://localhost:54321/callback`, `http://[::1]:54321/cb`, and `https://chatgpt.com/connector_platform_oauth_redirect`.

## Migration semantics

`d04_519_oauth_owner_nullable` is reversible:
- `upgrade()`: `ALTER COLUMN owner_id DROP NOT NULL`.
- `downgrade()`: `ALTER COLUMN owner_id SET NOT NULL`. **Will fail loudly if any rows have `owner_id IS NULL`** (DCR-registered clients). Operators must either delete those rows or backfill an owner before downgrading — that's the correct fail-loud behavior, not a bug.

The migration follows the project's revision-id 32-char cap convention (`alembic_version.version_num` is `VARCHAR(32)`). Filename is longer; revision id is `d04_519_oauth_owner_nullable` (29 chars).

## Tests

New integration test class `TestDcrLoopbackPersistsNullOwnerId` in `backend/tests/integration/test_oauth_dcr_integration.py` covers both shapes against a real Postgres test session:

1. **DCR loopback round-trip** — `POST /api/v1/oauth/register` with `client_name="IntegrationTest Claude Code Loopback"` + `redirect_uris=["http://localhost:54321/callback"]` returns 201, the response carries `owner_id: null`, and the DB row also has `owner_id IS NULL`. This is the regression pin — without the migration, this test fails with the 500 reproduced above.
2. **Admin path with non-null owner_id** — direct ORM insert of `OAuth2Client(owner_id="user-...", ...)` still succeeds, pinning that the constraint relaxation does not regress the admin-managed path.

Sweep: 128/128 OAuth-adjacent tests pass (`test_oauth_dcr` + `test_oauth_pkce_enforcement` + new `test_oauth_dcr_integration` + `test_oauth_authorize_template` + `test_oauth_authorize_redirect_uri_precheck` + `test_redirect_uri` + `test_well_known`).

The unrelated `test_alembic_migrations.py::TestB03NeuralEdgesBackfillMigration` failures are pre-existing on `main` — verified by running the same test from the base branch.

## Out of scope

- DCR endpoint logic (already covered by #513).
- Other OAuth2 routes (token, authorize, revoke, introspect).
- Workspace scoping (`workspace_id` is already nullable).

🤖 Generated via /gh-issue-driven (519 follow-up)
