### PR TITLE
docs(infra): document AUDIT_PSEUDO_SALT and AUDIT_HMAC_KEY (refs #407, #481)

### DIFF
--- a/terraform/single-server/.env.prod.example
+++ b/terraform/single-server/.env.prod.example
@@ -40,6 +40,19 @@ JWT_SECRET=change-me-jwt-secret
 JWT_ALGORITHM=HS256
 JWT_EXPIRE_MINUTES=60
 
+# Per-deployment salt for audit_logs pseudonymization on account erasure
+# (Issue #407). Generate with: openssl rand -hex 16. Rotating this value
+# breaks cross-correlation between rows pseudonymized before vs after the
+# rotation boundary.
+AUDIT_PSEUDO_SALT=change-me-audit-pseudo-salt
+
+# HMAC-SHA256 key for keyed hashing of email values in audit_logs old/new
+# value columns (Issue #481, OAuth email-sync events). Distinct from
+# API_KEY_SECRET so each can rotate independently. Generate with:
+# openssl rand -hex 32. Rotating breaks comparability of email hashes
+# across the rotation boundary (acceptable trade-off for forward security).
+AUDIT_HMAC_KEY=change-me-audit-hmac-key
+
 # -----------------------------------------------------------------------------
 # API Settings
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Add `AUDIT_PSEUDO_SALT` and `AUDIT_HMAC_KEY` to the Terraform single-server `.env.prod.example` template so self-host operators see them when configuring a deployment.

Both env vars are already actively used in production code:
- `AUDIT_PSEUDO_SALT` → `services/account_erasure_service.py:122` (issue #407, GDPR Art.17 / APPI right-to-erasure salt for `audit_logs` pseudonymization)
- `AUDIT_HMAC_KEY` → `auth/roles.py:334,374` (issue #481, HMAC-SHA256 key for hashing email values written to `audit_logs` from the OAuth email-sync flow)

Without these documented in the template, an operator deploying via the published Terraform module silently inherits the dev defaults defined in `Settings` — the wrong security posture for production.

## What's added

13 lines to `terraform/single-server/.env.prod.example`:

```bash
# Per-deployment salt for audit_logs pseudonymization on account erasure
# (Issue #407). Generate with: openssl rand -hex 16. Rotating this value
# breaks cross-correlation between rows pseudonymized before vs after the
# rotation boundary.
AUDIT_PSEUDO_SALT=change-me-audit-pseudo-salt

# HMAC-SHA256 key for keyed hashing of email values in audit_logs old/new
# value columns (Issue #481, OAuth email-sync events). Distinct from
# API_KEY_SECRET so each can rotate independently. Generate with:
# openssl rand -hex 32. Rotating breaks comparability of email hashes
# across the rotation boundary (acceptable trade-off for forward security).
AUDIT_HMAC_KEY=change-me-audit-hmac-key
```

Generation guidance (`openssl rand -hex N`) and rotation trade-off for each is documented inline.

## Out of scope

- No code change. This PR only updates the `.env.prod.example` documentation file.
- No issue is being filed because the underlying functionality (#407 + #481) is already merged; this is a docs gap follow-up that fits into a single small PR.

Refs #407, #481.

🤖 Generated via /gh-issue-driven (no-issue light path)
