### PR TITLE
feat(db): cost-grade source + paid_by dimensions on sleep_reports (#523)

### DIFF
--- a/backend/alembic/versions/d05_523_costgrade_source_paid_by.py
+++ b/backend/alembic/versions/d05_523_costgrade_source_paid_by.py
@@ -17,12 +17,17 @@ required. On PostgreSQL >= 11 (production runs ``postgres:15-alpine``)
 adding a ``NOT NULL`` column with a constant ``DEFAULT`` is a metadata-
 only catalog change; no table rewrite occurs even on a populated table.
 
-DB-level CHECK constraints (separate ``op.create_check_constraint``
-calls, matching the codebase's idiom for ``ADD COLUMN`` on existing
-tables) enforce the enum sets:
+DB-level CHECK constraints enforce the enum sets:
 
     source  IN ('sleep', 'analysis')
     paid_by IN ('platform', 'byok')
+
+The constraints are added via raw ``op.execute(sa.text(...))`` calls of
+``ALTER TABLE ... ADD CONSTRAINT ... NOT VALID`` followed by
+``ALTER TABLE ... VALIDATE CONSTRAINT ...`` — the zero-downtime two-step
+that mirrors the ``b03_396_neural_edges_ws_ctx_not_null`` precedent so
+the validation scan runs under SHARE UPDATE EXCLUSIVE rather than
+ACCESS EXCLUSIVE on populated tables.
 
 A composite index ``idx_sleep_reports_workspace_source_started`` on
 ``(workspace_id, source, started_at DESC)`` supports the #472 cost

--- a/backend/alembic/versions/d05_523_costgrade_source_paid_by.py
+++ b/backend/alembic/versions/d05_523_costgrade_source_paid_by.py
@@ -1,0 +1,138 @@
+"""Add source/paid_by cost-grade dimensions to sleep_reports (#523).
+
+Issue #523 extends the cost-grade reporting table introduced by #471 with
+two billing-classification columns:
+
+- ``source`` — distinguishes scheduler-driven sleep runs (``'sleep'``)
+  from on-demand memory-broadlistening analysis runs (``'analysis'``).
+- ``paid_by`` — separates platform-billed runs (``'platform'``) from
+  workspace-BYOK runs (``'byok'``). v1 broadlistening writes
+  ``paid_by='byok'`` because the workspace's external API key handles the
+  cost; sleep runs continue to write ``paid_by='platform'``.
+
+Both columns are ``NOT NULL`` with a ``server_default`` so existing rows
+are immediately classified as scheduler-driven platform-billed runs — the
+only mode that existed before this migration — with no data backfill
+required. On PostgreSQL >= 11 (production runs ``postgres:15-alpine``)
+adding a ``NOT NULL`` column with a constant ``DEFAULT`` is a metadata-
+only catalog change; no table rewrite occurs even on a populated table.
+
+DB-level CHECK constraints (separate ``op.create_check_constraint``
+calls, matching the codebase's idiom for ``ADD COLUMN`` on existing
+tables) enforce the enum sets:
+
+    source  IN ('sleep', 'analysis')
+    paid_by IN ('platform', 'byok')
+
+A composite index ``idx_sleep_reports_workspace_source_started`` on
+``(workspace_id, source, started_at DESC)`` supports the #472 cost
+aggregation queries that filter by workspace + run type and order newest-
+first; the explicit DESC matches the ORM declaration so EXPLAIN can use
+the index without a separate sort step.
+
+This migration unblocks both #472 (cost aggregation API surfacing the
+new axes) and #495 (broadlistening pipeline emitting analysis cost rows
+in the same persist transaction).
+
+Revision ID: d05_523_source_paid_by
+Revises: d04_519_oauth_owner_nullable
+
+NOTE: Revision IDs are capped at 32 chars because
+``alembic_version.version_num`` is ``VARCHAR(32)`` in this database
+(asyncpg raises ``StringDataRightTruncationError`` otherwise). This
+migration uses ``d05_523_source_paid_by`` (22 chars) — well within the
+cap. The Python filename is allowed to be longer than the revision id,
+so the descriptive ``d05_523_costgrade_source_paid_by.py`` is kept for
+grep-ability.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d05_523_source_paid_by"
+down_revision = "d04_519_oauth_owner_nullable"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add source, paid_by columns + composite index to sleep_reports."""
+    # 1. Columns (NOT NULL with server_default — populates existing rows).
+    op.add_column(
+        "sleep_reports",
+        sa.Column(
+            "source",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'sleep'"),
+        ),
+    )
+    op.add_column(
+        "sleep_reports",
+        sa.Column(
+            "paid_by",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'platform'"),
+        ),
+    )
+
+    # 2. CHECK constraints — zero-downtime two-step (matches `b03_396`
+    # precedent). ADD CONSTRAINT NOT VALID skips the synchronous full-table
+    # scan and only checks new writes; VALIDATE CONSTRAINT then proves
+    # historic rows under SHARE UPDATE EXCLUSIVE (does not block
+    # reads/writes). Existing rows already satisfy both constraints because
+    # the server_default in step 1 wrote 'sleep' / 'platform'.
+    op.execute(
+        sa.text(
+            "ALTER TABLE sleep_reports "
+            "ADD CONSTRAINT valid_sleep_report_source "
+            "CHECK (source IN ('sleep', 'analysis')) NOT VALID"
+        )
+    )
+    op.execute(sa.text("ALTER TABLE sleep_reports VALIDATE CONSTRAINT valid_sleep_report_source"))
+    op.execute(
+        sa.text(
+            "ALTER TABLE sleep_reports "
+            "ADD CONSTRAINT valid_sleep_report_paid_by "
+            "CHECK (paid_by IN ('platform', 'byok')) NOT VALID"
+        )
+    )
+    op.execute(sa.text("ALTER TABLE sleep_reports VALIDATE CONSTRAINT valid_sleep_report_paid_by"))
+
+    # 3. Composite index for #472 aggregation queries. ``sa.text`` is used
+    # for the DESC sort because op.create_index does not accept ORM
+    # ``sa.desc(...)`` expressions in its column list.
+    op.create_index(
+        "idx_sleep_reports_workspace_source_started",
+        "sleep_reports",
+        ["workspace_id", "source", sa.text("started_at DESC")],
+    )
+
+
+def downgrade() -> None:
+    """Drop composite index, CHECK constraints, and columns in reverse order.
+
+    Explicit drops are used even though PostgreSQL would cascade them when
+    the underlying columns are dropped — this matches the codebase's
+    established downgrade pattern (see ``c02_471_cost_grade_schema``) and
+    keeps the migration symmetric with ``upgrade``.
+    """
+    op.drop_index(
+        "idx_sleep_reports_workspace_source_started",
+        table_name="sleep_reports",
+    )
+    op.drop_constraint(
+        "valid_sleep_report_paid_by",
+        "sleep_reports",
+        type_="check",
+    )
+    op.drop_constraint(
+        "valid_sleep_report_source",
+        "sleep_reports",
+        type_="check",
+    )
+    op.drop_column("sleep_reports", "paid_by")
+    op.drop_column("sleep_reports", "source")

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -17,10 +17,22 @@ from sqlalchemy import (
     String,
     Text,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 
 from db.base import Base
+
+# Allowed values for the sleep_reports cost-grade dimensions (#523).
+# Mirror the ``LLM_PRICING_UNIT_TYPES`` pattern: the DB CHECK constraint is
+# the source of truth, these tuples exist for service-layer validation and
+# are imported by future call sites (#495 broadlistening pipeline) to
+# validate inputs cleanly with ValueError rather than IntegrityError.
+# Keep in sync with the ``valid_sleep_report_source`` /
+# ``valid_sleep_report_paid_by`` CHECK strings in ``SleepReport.__table_args__``
+# and the matching ``op.create_check_constraint`` strings in the migration.
+SLEEP_REPORT_SOURCES: tuple[str, ...] = ("sleep", "analysis")
+SLEEP_REPORT_PAID_BY_VALUES: tuple[str, ...] = ("platform", "byok")
 
 
 class SleepReport(Base):
@@ -100,6 +112,23 @@ class SleepReport(Base):
     embedding_model = Column(String(100), nullable=True)
     embedding_tokens = Column(Integer, nullable=False, default=0)
 
+    # Cost-grade dimensions (#523). Both columns carry a Python-side
+    # ``default`` (in-memory ORM objects readable after flush without
+    # refresh) AND a ``server_default`` (raw INSERT paths that bypass the
+    # ORM still satisfy NOT NULL). #472 aggregates by these axes.
+    source = Column(
+        String(20),
+        nullable=False,
+        default="sleep",
+        server_default=text("'sleep'"),
+    )
+    paid_by = Column(
+        String(20),
+        nullable=False,
+        default="platform",
+        server_default=text("'platform'"),
+    )
+
     # Activity counters
     memories_processed = Column(Integer, nullable=False, default=0)
     edges_created = Column(Integer, nullable=False, default=0)
@@ -115,8 +144,26 @@ class SleepReport(Base):
             "status IN ('running', 'completed', 'failed', 'cancelled', 'rolled_back')",
             name="valid_sleep_report_status",
         ),
+        # #523 cost-grade dimensions
+        CheckConstraint(
+            "source IN ('sleep', 'analysis')",
+            name="valid_sleep_report_source",
+        ),
+        CheckConstraint(
+            "paid_by IN ('platform', 'byok')",
+            name="valid_sleep_report_paid_by",
+        ),
         Index("idx_sleep_reports_user_status", "user_id", "status"),
         Index("idx_sleep_reports_started_at", "started_at"),
+        # #523 supports #472 aggregation queries that filter by workspace+source
+        # and order newest-first. ``text("started_at DESC")`` mirrors the
+        # migration so alembic autogenerate sees identical AST nodes.
+        Index(
+            "idx_sleep_reports_workspace_source_started",
+            "workspace_id",
+            "source",
+            text("started_at DESC"),
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -30,7 +30,8 @@ from db.base import Base
 # validate inputs cleanly with ValueError rather than IntegrityError.
 # Keep in sync with the ``valid_sleep_report_source`` /
 # ``valid_sleep_report_paid_by`` CHECK strings in ``SleepReport.__table_args__``
-# and the matching ``op.create_check_constraint`` strings in the migration.
+# and the matching ``ALTER TABLE ... ADD CONSTRAINT ... NOT VALID`` strings in
+# the migration (raw ``op.execute(sa.text(...))`` form, see d05_523).
 SLEEP_REPORT_SOURCES: tuple[str, ...] = ("sleep", "analysis")
 SLEEP_REPORT_PAID_BY_VALUES: tuple[str, ...] = ("platform", "byok")
 

--- a/backend/src/services/sleep/reporter.py
+++ b/backend/src/services/sleep/reporter.py
@@ -184,6 +184,9 @@ class SleepReporter:
             workspace_id=UUID(workspace_id) if workspace_id else None,
             context_id=UUID(context_id) if context_id else None,
             status="running",
+            # #523: broadlistening (#495) overrides these at its own call site.
+            source="sleep",
+            paid_by="platform",
         )
         self.db.add(report)
         await self.db.flush()

--- a/backend/tests/integration/test_sleep_report_schema.py
+++ b/backend/tests/integration/test_sleep_report_schema.py
@@ -56,16 +56,18 @@ async def test_check_rejects_invalid_paid_by(db_session):
 
 
 @pytest.mark.asyncio
-async def test_orm_defaults_populate_in_memory_before_flush(db_session):
+async def test_orm_defaults_populate_after_flush_without_refresh(db_session):
     """A SleepReport built without source/paid_by persists with the Python defaults.
 
-    Verifies the Python-side ``default=`` fires at construction time so the
-    in-memory object is readable without a post-flush ``refresh()``.
+    Verifies the Python-side ``default=`` fires during ``flush()`` and the
+    resulting value is visible on the in-memory object without a separate
+    ``refresh()`` round-trip. (SQLAlchemy applies scalar ``default=`` at
+    INSERT time, not at ``__init__``; the guarantee here is "no refresh
+    needed", not "no flush needed".)
     """
     report = SleepReport(user_id="test-user", status="completed")
     db_session.add(report)
     await db_session.flush()
-    await db_session.refresh(report)
 
     assert report.source == "sleep"
     assert report.paid_by == "platform"

--- a/backend/tests/integration/test_sleep_report_schema.py
+++ b/backend/tests/integration/test_sleep_report_schema.py
@@ -1,0 +1,114 @@
+"""Integration tests for the source/paid_by schema additions to sleep_reports (#523).
+
+Covers:
+
+- CHECK constraint on ``source`` rejects values outside ``('sleep', 'analysis')``.
+- CHECK constraint on ``paid_by`` rejects values outside ``('platform', 'byok')``.
+- ORM Python-side default: a row constructed without ``source``/``paid_by``
+  has them set on the in-memory object before flush (no refresh needed).
+- ``server_default``: ``information_schema.columns.column_default`` confirms
+  both columns carry the expected DEFAULT clause in the catalog. Guards
+  against a malformed expression (e.g. ``text("sleep")`` without inner
+  quotes) that ORM-only tests would silently mask.
+- BYOK round-trip: ``source='analysis'`` + ``paid_by='byok'`` persists and
+  reads back unchanged. This is the path #495 broadlistening pipeline writes.
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+from models.sleep import SleepReport
+
+
+def _make_report(**overrides: object) -> SleepReport:
+    """Minimal SleepReport constructor; callers override columns under test.
+
+    No ``source``/``paid_by`` defaults injected — those are filled by the
+    ORM column ``default=`` so this helper exercises the production path.
+    """
+    defaults: dict[str, object] = {
+        "user_id": "test-user",
+        "status": "completed",
+    }
+    defaults.update(overrides)
+    return SleepReport(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_invalid_source(db_session):
+    """source outside ('sleep', 'analysis') must raise IntegrityError."""
+    db_session.add(_make_report(source="manual"))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_invalid_paid_by(db_session):
+    """paid_by outside ('platform', 'byok') must raise IntegrityError."""
+    db_session.add(_make_report(paid_by="user"))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_orm_defaults_populate_in_memory_before_flush(db_session):
+    """A SleepReport built without source/paid_by persists with the Python defaults.
+
+    Verifies the Python-side ``default=`` fires at construction time so the
+    in-memory object is readable without a post-flush ``refresh()``.
+    """
+    report = SleepReport(user_id="test-user", status="completed")
+    db_session.add(report)
+    await db_session.flush()
+    await db_session.refresh(report)
+
+    assert report.source == "sleep"
+    assert report.paid_by == "platform"
+
+
+@pytest.mark.asyncio
+async def test_server_default_clause_present_in_schema(db_session):
+    """``server_default`` is declared in the schema for both new columns.
+
+    Reads ``information_schema.columns.column_default`` directly. Catches a
+    malformed ``server_default`` expression (e.g. ``text("sleep")`` without
+    inner quotes) where the ORM-derived schema would either fail to create
+    or carry the wrong DEFAULT clause — the Python-side ``default=``-only
+    tests would mask either failure mode.
+    """
+    rows = (
+        await db_session.execute(
+            sa.text(
+                "SELECT column_name, column_default "
+                "FROM information_schema.columns "
+                "WHERE table_name = 'sleep_reports' "
+                "AND column_name IN ('source', 'paid_by') "
+                "ORDER BY column_name"
+            )
+        )
+    ).all()
+
+    defaults = {r.column_name: r.column_default for r in rows}
+    assert "'platform'::character varying" in defaults["paid_by"]
+    assert "'sleep'::character varying" in defaults["source"]
+
+
+@pytest.mark.asyncio
+async def test_byok_override_round_trips(db_session):
+    """source='analysis' + paid_by='byok' persists and reads back unchanged.
+
+    This is the exact pair of values #495 broadlistening pipeline writes
+    in its persist transaction.
+    """
+    report = _make_report(source="analysis", paid_by="byok")
+    db_session.add(report)
+    await db_session.flush()
+    await db_session.refresh(report)
+
+    assert report.source == "analysis"
+    assert report.paid_by == "byok"


### PR DESCRIPTION
Closes #523

## Summary
- Adds `source` (`sleep`/`analysis`) and `paid_by` (`platform`/`byok`) NOT NULL columns to `sleep_reports` so #472 cost aggregation can split by run type and billing party, and #495 broadlistening pipeline can emit cost rows in the same persist transaction.
- Migration uses `ADD CONSTRAINT NOT VALID` + `VALIDATE CONSTRAINT` (mirrors the `b03_396` precedent) so the CHECK validation runs under SHARE UPDATE EXCLUSIVE rather than ACCESS EXCLUSIVE on populated tables.
- New composite index `(workspace_id, source, started_at DESC)` covers the anticipated #472 query shape; reporter constructor explicitly sets the new columns to mirror defaults and document the `#495` divergence point.

## Implementation notes
- ORM (`backend/src/models/sleep.py`): both columns carry Python `default=` AND `server_default=text("'X'")`. Module-level `SLEEP_REPORT_SOURCES` and `SLEEP_REPORT_PAID_BY_VALUES` tuples mirror the `LLM_PRICING_UNIT_TYPES` pattern for service-layer validation; the DB CHECK is the source of truth.
- Migration (`backend/alembic/versions/d05_523_costgrade_source_paid_by.py`): revision `d05_523_source_paid_by` (22 chars, ≤32 cap), down_revision `d04_519_oauth_owner_nullable`. PG 15 fast-path: NOT NULL + constant DEFAULT is metadata-only, no table rewrite.
- Tests (`backend/tests/integration/test_sleep_report_schema.py`): 5 integration tests cover CHECK rejection × 2, ORM in-memory default population, server_default DDL clause via `information_schema.columns`, and BYOK round-trip.
- Verified manually: `alembic upgrade head` → `downgrade -1` → `upgrade head` round-trip clean on `kagura` DB; resulting schema has `idx_sleep_reports_workspace_source_started btree (workspace_id, source, started_at DESC)` plus both CHECK constraints.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped (binary_gate=null)
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: not run (ship-only mode — issue had no /start state)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/523-feat-cost-grade-source-paid-by.gate2.md

🤖 Generated via /gh-issue-driven:ship
