### PR TITLE
feat(api): cost aggregation API (period × workspace × user) (#472)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -353,6 +353,7 @@ from api.routes import (  # noqa: E402
     config,
     context_search_config,
     contexts,
+    cost_aggregation,  # Issue #472: cost aggregation API (admin + workspace-scoped)
     external_keys,
     graph,
     invitations,
@@ -427,6 +428,9 @@ app.include_router(neural_config.router, prefix="/api/v1")
 
 # Sleep Reports admin routes (Issue #179 - Sleep Report admin UI)
 app.include_router(sleep_reports.router, prefix="/api/v1")
+
+# Cost Aggregation routes (Issue #472 - admin cross-workspace + workspace-scoped)
+app.include_router(cost_aggregation.router, prefix="/api/v1")
 
 # Admin Sleep trigger (Issue #247 - Manual Sleep Maintenance trigger)
 app.include_router(admin_sleep.router, prefix="/api/v1")

--- a/backend/src/api/routes/cost_aggregation.py
+++ b/backend/src/api/routes/cost_aggregation.py
@@ -39,12 +39,11 @@ from services.cost_aggregation_service import (
     CostAggregationService,
 )
 from services.permission_service import PermissionService
-from utils.logger import get_logger
-
-logger = get_logger(__name__)
 
 # No router-level tags so each route picks its own group ("admin" vs
 # "workspaces") in the OpenAPI docs without duplicating "cost-aggregation".
+# Logging happens inside CostAggregationService, not here — the route
+# layer just shapes inputs/outputs.
 router = APIRouter()
 
 

--- a/backend/src/api/routes/cost_aggregation.py
+++ b/backend/src/api/routes/cost_aggregation.py
@@ -1,0 +1,301 @@
+"""Cost aggregation API routes (Issue #472).
+
+Two endpoints share one ``CostAggregationService`` instance:
+
+- ``GET /api/v1/admin/cost-aggregation`` — admin-only, sees every
+  workspace.
+- ``GET /api/v1/workspaces/{workspace_id}/cost-aggregation`` —
+  workspace owner / admin scoped via
+  ``PermissionService.check_workspace_admin``. The path-bound
+  ``workspace_id`` is the only allowed scope.
+
+Both endpoints accept the same period / from / to / user_id / source /
+paid_by filters; the workspace-scoped one omits ``workspace_id`` from
+the query string because it comes from the path.
+
+The split (instead of a single auth-scoped route) keeps:
+
+- ``/admin/`` prefix semantics honest — only system admins can hit it.
+- Workspace path consistency with the future B2B billing endpoint
+  (``/api/v1/workspaces/{id}/invoices`` and friends).
+- Distinct OpenAPI tags so the docs render two clearly-purposed groups.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, time
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import AdminUser, get_current_user
+from db.base import get_db
+from models.api_base import TZAwareBaseModel
+from models.sleep import SLEEP_REPORT_PAID_BY_VALUES, SLEEP_REPORT_SOURCES
+from services.cost_aggregation_service import (
+    VALID_PERIODS,
+    CostAggregationRow,
+    CostAggregationService,
+)
+from services.permission_service import PermissionService
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# No router-level tags so each route picks its own group ("admin" vs
+# "workspaces") in the OpenAPI docs without duplicating "cost-aggregation".
+router = APIRouter()
+
+
+# ============================================================================
+# Schemas
+# ============================================================================
+
+
+class CostBreakdownByModelResponse(TZAwareBaseModel):
+    """Per-model cost split inside a CostAggregationRowResponse."""
+
+    model: str | None
+    calls: int
+    cost_usd: float
+    cost_usd_byok: float
+
+
+class CostBreakdownBySourceResponse(TZAwareBaseModel):
+    """Per-source cost split inside a CostAggregationRowResponse."""
+
+    source: str
+    calls: int
+    cost_usd: float
+    cost_usd_byok: float
+
+
+class CostAggregationRowResponse(TZAwareBaseModel):
+    """One (period × workspace × user) row in the aggregation response.
+
+    ``cost_usd`` is the platform-billed total (used for B2B invoicing);
+    ``cost_usd_byok`` is the workspace's BYOK observability total
+    (informational only — Kagura does not bill it). The split is
+    enforced at the SQL level so it cannot accidentally re-merge.
+    """
+
+    period_start: date
+    workspace_id: UUID | None
+    user_id: str
+    calls: int
+    tokens_in: int
+    tokens_out: int
+    tokens_cached_in: int
+    embedding_tokens: int
+    cost_usd: float
+    cost_usd_byok: float
+    cost_breakdown_by_model: list[CostBreakdownByModelResponse]
+    cost_breakdown_by_source: list[CostBreakdownBySourceResponse]
+
+
+class CostAggregationResponse(TZAwareBaseModel):
+    """Wrapper around the row list — keeps room for a future cursor /
+    summary block without breaking the response shape."""
+
+    rows: list[CostAggregationRowResponse]
+
+
+# ============================================================================
+# Shared parameter parsing
+# ============================================================================
+
+
+def _parse_window(
+    period: str,
+    from_: date,
+    to: date,
+) -> tuple[str, datetime, datetime]:
+    """Validate period + materialize the half-open [start, end) window.
+
+    The query string accepts ISO dates (``2026-04-01``); the SQL needs
+    naive UTC datetimes so the comparison column-type matches
+    ``sleep_reports.started_at`` (TIMESTAMP WITHOUT TIME ZONE, UTC by
+    convention). ``end`` is the day AFTER the caller's ``to`` to keep the
+    range half-open and avoid the "midnight is included or not?" trap.
+    """
+    if period not in VALID_PERIODS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid period {period!r}; must be one of {list(VALID_PERIODS)}",
+        )
+    if from_ > to:
+        raise HTTPException(
+            status_code=400,
+            detail=f"'from' ({from_.isoformat()}) must be <= 'to' ({to.isoformat()})",
+        )
+
+    start_dt = datetime.combine(from_, time.min)
+    # Half-open: end-of-window is the start of the day AFTER ``to``.
+    end_date = date.fromordinal(to.toordinal() + 1)
+    end_dt = datetime.combine(end_date, time.min)
+    return period, start_dt, end_dt
+
+
+def _validate_enums(source: str | None, paid_by: str | None) -> None:
+    """Reject unknown source/paid_by values with a 400 (not a 500)."""
+    if source is not None and source not in SLEEP_REPORT_SOURCES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid source {source!r}; must be one of {list(SLEEP_REPORT_SOURCES)}",
+        )
+    if paid_by is not None and paid_by not in SLEEP_REPORT_PAID_BY_VALUES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid paid_by {paid_by!r}; must be one of {list(SLEEP_REPORT_PAID_BY_VALUES)}"
+            ),
+        )
+
+
+# Cost values are rounded to 6 decimals at the API boundary — the SQL
+# carries float8 for headroom, but JSON consumers (dashboards / billing
+# exports) only need micro-USD precision. Single rounding site so we
+# never have to chase down "why does the row total differ from the
+# breakdown sum by 1e-12 ?" floating-point drift.
+_COST_DECIMALS = 6
+
+
+def _round(v: float) -> float:
+    return round(v, _COST_DECIMALS)
+
+
+def _to_response_row(row: CostAggregationRow) -> CostAggregationRowResponse:
+    """Convert the service's plain container into the response model."""
+    return CostAggregationRowResponse(
+        period_start=row.period_start,
+        workspace_id=row.workspace_id,
+        user_id=row.user_id,
+        calls=row.calls,
+        tokens_in=row.tokens_in,
+        tokens_out=row.tokens_out,
+        tokens_cached_in=row.tokens_cached_in,
+        embedding_tokens=row.embedding_tokens,
+        cost_usd=_round(row.cost_usd),
+        cost_usd_byok=_round(row.cost_usd_byok),
+        cost_breakdown_by_model=[
+            CostBreakdownByModelResponse(
+                model=b.model,
+                calls=b.calls,
+                cost_usd=_round(b.cost_usd),
+                cost_usd_byok=_round(b.cost_usd_byok),
+            )
+            for b in row.cost_breakdown_by_model
+        ],
+        cost_breakdown_by_source=[
+            CostBreakdownBySourceResponse(
+                source=b.source,
+                calls=b.calls,
+                cost_usd=_round(b.cost_usd),
+                cost_usd_byok=_round(b.cost_usd_byok),
+            )
+            for b in row.cost_breakdown_by_source
+        ],
+    )
+
+
+# ============================================================================
+# Admin (cross-workspace) endpoint
+# ============================================================================
+
+
+@router.get(
+    "/admin/cost-aggregation",
+    response_model=CostAggregationResponse,
+    summary="Cost aggregation across all workspaces (admin)",
+    tags=["admin", "cost-aggregation"],
+)
+async def admin_cost_aggregation(
+    _admin: AdminUser,  # noqa: ARG001 — FastAPI dep, access guard only
+    db: AsyncSession = Depends(get_db),
+    period: str = Query("day", description="Aggregation period: day | week | month"),
+    from_: date = Query(..., alias="from", description="Inclusive lower-bound date"),
+    to: date = Query(..., description="Inclusive upper-bound date"),
+    workspace_id: UUID | None = Query(None, description="Filter to a single workspace"),
+    user_id: str | None = Query(None, description="Filter to a single user"),
+    source: str | None = Query(None, description=f"Filter by source: {list(SLEEP_REPORT_SOURCES)}"),
+    paid_by: str | None = Query(
+        None, description=f"Filter by billing classification: {list(SLEEP_REPORT_PAID_BY_VALUES)}"
+    ),
+) -> CostAggregationResponse:
+    """Aggregate LLM + embedding cost across every workspace.
+
+    Admin-only (``require_admin``). ``workspace_id`` here is a
+    convenience filter — admins can scope to one workspace without
+    using the workspace-scoped route — but absent it, every workspace
+    is included.
+    """
+    _validate_enums(source, paid_by)
+    period_v, start_dt, end_dt = _parse_window(period, from_, to)
+
+    service = CostAggregationService(db)
+    rows = await service.aggregate(
+        period=period_v,
+        start=start_dt,
+        end=end_dt,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        source=source,
+        paid_by=paid_by,
+    )
+    return CostAggregationResponse(rows=[_to_response_row(r) for r in rows])
+
+
+# ============================================================================
+# Workspace-scoped endpoint
+# ============================================================================
+
+
+@router.get(
+    "/workspaces/{workspace_id}/cost-aggregation",
+    response_model=CostAggregationResponse,
+    summary="Cost aggregation scoped to one workspace (owner/admin)",
+    tags=["workspaces", "cost-aggregation"],
+)
+async def workspace_cost_aggregation(
+    workspace_id: UUID,
+    db: AsyncSession = Depends(get_db),
+    user: dict = Depends(get_current_user),
+    period: str = Query("day", description="Aggregation period: day | week | month"),
+    from_: date = Query(..., alias="from", description="Inclusive lower-bound date"),
+    to: date = Query(..., description="Inclusive upper-bound date"),
+    user_id: str | None = Query(None, description="Filter to a single user"),
+    source: str | None = Query(None, description=f"Filter by source: {list(SLEEP_REPORT_SOURCES)}"),
+    paid_by: str | None = Query(
+        None, description=f"Filter by billing classification: {list(SLEEP_REPORT_PAID_BY_VALUES)}"
+    ),
+) -> CostAggregationResponse:
+    """Aggregate cost for a single workspace.
+
+    Requires workspace **owner** or **admin** role — viewer / member
+    are rejected because cost aggregates leak per-user activity volume
+    across private contexts that those roles should not see. Owners
+    review billing; admins manage workspace settings.
+
+    Cross-workspace probing is impossible here: the path-bound
+    ``workspace_id`` is the only scope passed to the service, and
+    ``check_workspace_admin`` rejects callers without admin/owner
+    membership in *that specific* workspace before the query runs.
+    """
+    _validate_enums(source, paid_by)
+    period_v, start_dt, end_dt = _parse_window(period, from_, to)
+
+    perm_service = PermissionService(db)
+    await perm_service.check_workspace_admin(user["user_id"], workspace_id)
+
+    service = CostAggregationService(db)
+    rows = await service.aggregate(
+        period=period_v,
+        start=start_dt,
+        end=end_dt,
+        workspace_id=workspace_id,
+        user_id=user_id,
+        source=source,
+        paid_by=paid_by,
+    )
+    return CostAggregationResponse(rows=[_to_response_row(r) for r in rows])

--- a/backend/src/api/routes/cost_aggregation.py
+++ b/backend/src/api/routes/cost_aggregation.py
@@ -53,21 +53,33 @@ router = APIRouter()
 
 
 class CostBreakdownByModelResponse(TZAwareBaseModel):
-    """Per-model cost split inside a CostAggregationRowResponse."""
+    """Per-model cost split inside a CostAggregationRowResponse.
+
+    ``cost_usd`` / ``cost_usd_byok`` are nullable: ``null`` means
+    "cost unknown" (some contributing usage row had no resolved
+    pricing — e.g. a model with no row in ``llm_pricing`` at the
+    run's ``started_at``). Distinguishes "no pricing snapshot" from
+    "genuinely $0", same semantics as ``LLMPricingService.lookup()``
+    returning ``None`` on a miss.
+    """
 
     model: str | None
     calls: int
-    cost_usd: float
-    cost_usd_byok: float
+    cost_usd: float | None
+    cost_usd_byok: float | None
 
 
 class CostBreakdownBySourceResponse(TZAwareBaseModel):
-    """Per-source cost split inside a CostAggregationRowResponse."""
+    """Per-source cost split inside a CostAggregationRowResponse.
+
+    ``cost_usd`` / ``cost_usd_byok`` are nullable for the same
+    reason documented on ``CostBreakdownByModelResponse``.
+    """
 
     source: str
     calls: int
-    cost_usd: float
-    cost_usd_byok: float
+    cost_usd: float | None
+    cost_usd_byok: float | None
 
 
 class CostAggregationRowResponse(TZAwareBaseModel):
@@ -77,6 +89,11 @@ class CostAggregationRowResponse(TZAwareBaseModel):
     ``cost_usd_byok`` is the workspace's BYOK observability total
     (informational only — Kagura does not bill it). The split is
     enforced at the SQL level so it cannot accidentally re-merge.
+
+    Both cost fields are nullable: ``null`` means "cost unknown" (some
+    contributing usage row had no resolved pricing). The UI should
+    render NULL as "—" rather than "$0.00" to make the distinction
+    visible to operators.
     """
 
     period_start: date
@@ -87,8 +104,8 @@ class CostAggregationRowResponse(TZAwareBaseModel):
     tokens_out: int
     tokens_cached_in: int
     embedding_tokens: int
-    cost_usd: float
-    cost_usd_byok: float
+    cost_usd: float | None
+    cost_usd_byok: float | None
     cost_breakdown_by_model: list[CostBreakdownByModelResponse]
     cost_breakdown_by_source: list[CostBreakdownBySourceResponse]
 
@@ -160,8 +177,9 @@ def _validate_enums(source: str | None, paid_by: str | None) -> None:
 _COST_DECIMALS = 6
 
 
-def _round(v: float) -> float:
-    return round(v, _COST_DECIMALS)
+def _round(v: float | None) -> float | None:
+    """Round to display precision; NULL stays NULL ("cost unknown")."""
+    return None if v is None else round(v, _COST_DECIMALS)
 
 
 def _to_response_row(row: CostAggregationRow) -> CostAggregationRowResponse:

--- a/backend/src/api/routes/cost_aggregation.py
+++ b/backend/src/api/routes/cost_aggregation.py
@@ -18,7 +18,9 @@ The split (instead of a single auth-scoped route) keeps:
 - ``/admin/`` prefix semantics honest — only system admins can hit it.
 - Workspace path consistency with the future B2B billing endpoint
   (``/api/v1/workspaces/{id}/invoices`` and friends).
-- Distinct OpenAPI tags so the docs render two clearly-purposed groups.
+- Distinct OpenAPI tags (admin vs workspaces) so the docs render the
+  two endpoints in separate, semantically-named groups rather than a
+  shared "cost-aggregation" bucket.
 """
 
 from __future__ import annotations
@@ -225,7 +227,7 @@ def _to_response_row(row: CostAggregationRow) -> CostAggregationRowResponse:
     "/admin/cost-aggregation",
     response_model=CostAggregationResponse,
     summary="Cost aggregation across all workspaces (admin)",
-    tags=["admin", "cost-aggregation"],
+    tags=["admin"],
 )
 async def admin_cost_aggregation(
     _admin: AdminUser,  # noqa: ARG001 — FastAPI dep, access guard only
@@ -272,7 +274,7 @@ async def admin_cost_aggregation(
     "/workspaces/{workspace_id}/cost-aggregation",
     response_model=CostAggregationResponse,
     summary="Cost aggregation scoped to one workspace (owner/admin)",
-    tags=["workspaces", "cost-aggregation"],
+    tags=["workspaces"],
 )
 async def workspace_cost_aggregation(
     workspace_id: UUID,

--- a/backend/src/services/cost_aggregation_service.py
+++ b/backend/src/services/cost_aggregation_service.py
@@ -329,6 +329,14 @@ class CostAggregationService:
             FROM sleep_reports sr
             {_EMBEDDING_PRICING_LATERAL}
             WHERE {base_where}
+              -- Filter to rows with actual embedding usage so a "completed
+              -- run with no LLM child rows AND no embedding tokens" does
+              -- not surface as an all-zero aggregation row. This also
+              -- excludes status='running'/'failed' reports that have not
+              -- yet recorded embedding usage. Reports that legitimately
+              -- have embedding_tokens > 0 still appear, regardless of
+              -- their status (running embedding writes are observable).
+              AND sr.embedding_tokens > 0
             GROUP BY 1, 2, 3, 4, 5
         )
         SELECT
@@ -405,7 +413,25 @@ def _assemble_rows(raw_rows: Sequence[RowMapping]) -> list[CostAggregationRow]:
             aggregates[key] = agg
 
         kind = r["kind"]
-        paid_by_col = "platform" if r["paid_by"] == "platform" else "byok"
+        # Defensive validation: even with the DB CHECK constraint and the
+        # service-level allowlist guard, an unexpected paid_by value
+        # reaching this point indicates a bug (legacy NULL row, schema
+        # drift, future enum expansion not handled here). Fail loud
+        # rather than silently miscategorising billing totals.
+        paid_by_value = r["paid_by"]
+        if paid_by_value not in SLEEP_REPORT_PAID_BY_VALUES:
+            logger.error(
+                "cost_aggregation_unexpected_paid_by",
+                paid_by=paid_by_value,
+                period_start=r["period_start"].isoformat()
+                if r["period_start"] is not None
+                else None,
+                workspace_id=str(r["workspace_id"]) if r["workspace_id"] else None,
+                user_id=r["user_id"],
+                kind=kind,
+            )
+            raise ValueError(f"Unexpected paid_by value in raw row: {paid_by_value!r}")
+        paid_by_col = paid_by_value
         cost_field = "cost_usd" if paid_by_col == "platform" else "cost_usd_byok"
 
         if kind == "llm":
@@ -461,4 +487,20 @@ def _assemble_rows(raw_rows: Sequence[RowMapping]) -> list[CostAggregationRow]:
             for source, b in sorted(by_source_acc[key].items())
         ]
 
-    return list(aggregates.values())
+    # Explicit sort by (period_start, workspace_id, user_id) — the
+    # docstring promises this ordering. Dict insertion order would
+    # preserve the SQL ORDER BY in CPython 3.7+, but relying on that is
+    # brittle: a future query rewrite could drop the ORDER BY (it has
+    # no effect on the SQL semantics, only on the assembly side) and
+    # silently break the response contract. ``workspace_id is None``
+    # is the primary key for None-vs-UUID ordering so admin queries
+    # with NULL workspace rows (legacy data) sort deterministically.
+    return sorted(
+        aggregates.values(),
+        key=lambda row: (
+            row.period_start,
+            row.workspace_id is None,
+            str(row.workspace_id) if row.workspace_id is not None else "",
+            row.user_id,
+        ),
+    )

--- a/backend/src/services/cost_aggregation_service.py
+++ b/backend/src/services/cost_aggregation_service.py
@@ -67,8 +67,8 @@ class CostBreakdownByModel:
         self,
         model: str | None,
         calls: int,
-        cost_usd: float,
-        cost_usd_byok: float,
+        cost_usd: float | None,
+        cost_usd_byok: float | None,
     ) -> None:
         self.model = model
         self.calls = calls
@@ -85,8 +85,8 @@ class CostBreakdownBySource:
         self,
         source: str,
         calls: int,
-        cost_usd: float,
-        cost_usd_byok: float,
+        cost_usd: float | None,
+        cost_usd_byok: float | None,
     ) -> None:
         self.source = source
         self.calls = calls
@@ -130,8 +130,12 @@ class CostAggregationRow:
         self.tokens_out = 0
         self.tokens_cached_in = 0
         self.embedding_tokens = 0
-        self.cost_usd = 0.0
-        self.cost_usd_byok = 0.0
+        # cost_usd / cost_usd_byok are NULL ("cost unknown") if any
+        # contributing SQL row had unresolved pricing. They start at 0.0
+        # and become None on the first NULL contribution; once None, they
+        # stay None (NULL is sticky — partial cost would be misleading).
+        self.cost_usd: float | None = 0.0
+        self.cost_usd_byok: float | None = 0.0
         self.cost_breakdown_by_model: list[CostBreakdownByModel] = []
         self.cost_breakdown_by_source: list[CostBreakdownBySource] = []
 
@@ -292,7 +296,25 @@ class CostAggregationService:
         # tags rows with ``kind`` so the Python merge step knows which
         # array to populate.
         sql = f"""
-        WITH llm_per_model AS (
+        -- Two CTEs, both two-stage (per-row → per-group):
+        --
+        -- Stage 1 computes per-(report × usage) row cost as **NULLABLE** —
+        -- if any required price (e.g. input_tokens > 0 but no
+        -- llm_pricing row for that (provider, model, unit_type) at the
+        -- run's started_at) is missing, row_cost is NULL. Otherwise
+        -- it's the float8 sum across the priced unit_types.
+        --
+        -- Stage 2 collapses to (period, workspace, user, model, source,
+        -- paid_by) and propagates NULL via BOOL_AND: if EVERY row in the
+        -- group is fully priced, cost = SUM(row_cost); if ANY row is
+        -- unpriced, cost = NULL ("cost unknown" — same semantics as
+        -- LLMPricingService.lookup() returning None on a miss).
+        --
+        -- Without this, COALESCE(... * rate, 0) made unpriced usage
+        -- silently look free, breaking the existing service contract
+        -- and Issue #472 design intent (NULL-model rows surface as
+        -- "—" in the dashboard, not as "$0.00").
+        WITH llm_per_row AS (
             SELECT
                 date_trunc(:period, sr.started_at)::date AS period_start,
                 sr.workspace_id,
@@ -300,32 +322,59 @@ class CostAggregationService:
                 u.model,
                 sr.source,
                 sr.paid_by,
-                SUM(u.calls)::bigint               AS calls,
-                SUM(u.input_tokens)::bigint        AS tokens_in,
-                SUM(u.output_tokens)::bigint       AS tokens_out,
-                SUM(u.cached_input_tokens)::bigint AS tokens_cached_in,
-                SUM(
-                    COALESCE(u.input_tokens        * p_in.rate,    0) +
-                    COALESCE(u.output_tokens       * p_out.rate,   0) +
-                    COALESCE(u.cached_input_tokens * p_cache.rate, 0)
-                )::float8 AS cost
+                u.calls,
+                u.input_tokens,
+                u.output_tokens,
+                u.cached_input_tokens,
+                CASE
+                    WHEN (u.input_tokens        > 0 AND p_in.rate    IS NULL)
+                      OR (u.output_tokens       > 0 AND p_out.rate   IS NULL)
+                      OR (u.cached_input_tokens > 0 AND p_cache.rate IS NULL)
+                    THEN NULL::float8
+                    ELSE (
+                        COALESCE(u.input_tokens        * p_in.rate,    0) +
+                        COALESCE(u.output_tokens       * p_out.rate,   0) +
+                        COALESCE(u.cached_input_tokens * p_cache.rate, 0)
+                    )::float8
+                END AS row_cost
             FROM sleep_reports sr
             JOIN sleep_report_llm_usage u ON u.report_id = sr.id
             {_LLM_PRICING_LATERAL.format(unit_type="input_tokens", alias="p_in")}
             {_LLM_PRICING_LATERAL.format(unit_type="output_tokens", alias="p_out")}
             {_LLM_PRICING_LATERAL.format(unit_type="cache_read_tokens", alias="p_cache")}
             WHERE {base_where}
+        ),
+        llm_per_model AS (
+            SELECT
+                period_start,
+                workspace_id,
+                user_id,
+                model,
+                source,
+                paid_by,
+                SUM(calls)::bigint               AS calls,
+                SUM(input_tokens)::bigint        AS tokens_in,
+                SUM(output_tokens)::bigint       AS tokens_out,
+                SUM(cached_input_tokens)::bigint AS tokens_cached_in,
+                CASE
+                    WHEN BOOL_AND(row_cost IS NOT NULL) THEN SUM(row_cost)::float8
+                    ELSE NULL::float8
+                END AS cost
+            FROM llm_per_row
             GROUP BY 1, 2, 3, 4, 5, 6
         ),
-        emb_per_source AS (
+        emb_per_row AS (
             SELECT
                 date_trunc(:period, sr.started_at)::date AS period_start,
                 sr.workspace_id,
                 sr.user_id,
                 sr.source,
                 sr.paid_by,
-                SUM(sr.embedding_tokens)::bigint AS embedding_tokens,
-                SUM(COALESCE(sr.embedding_tokens * p_emb.rate, 0))::float8 AS cost
+                sr.embedding_tokens,
+                CASE
+                    WHEN sr.embedding_tokens > 0 AND p_emb.rate IS NULL THEN NULL::float8
+                    ELSE (sr.embedding_tokens * p_emb.rate)::float8
+                END AS row_cost
             FROM sleep_reports sr
             {_EMBEDDING_PRICING_LATERAL}
             WHERE {base_where}
@@ -333,10 +382,22 @@ class CostAggregationService:
               -- run with no LLM child rows AND no embedding tokens" does
               -- not surface as an all-zero aggregation row. This also
               -- excludes status='running'/'failed' reports that have not
-              -- yet recorded embedding usage. Reports that legitimately
-              -- have embedding_tokens > 0 still appear, regardless of
-              -- their status (running embedding writes are observable).
+              -- yet recorded embedding usage.
               AND sr.embedding_tokens > 0
+        ),
+        emb_per_source AS (
+            SELECT
+                period_start,
+                workspace_id,
+                user_id,
+                source,
+                paid_by,
+                SUM(embedding_tokens)::bigint AS embedding_tokens,
+                CASE
+                    WHEN BOOL_AND(row_cost IS NOT NULL) THEN SUM(row_cost)::float8
+                    ELSE NULL::float8
+                END AS cost
+            FROM emb_per_row
             GROUP BY 1, 2, 3, 4, 5
         )
         SELECT
@@ -391,15 +452,28 @@ def _assemble_rows(raw_rows: Sequence[RowMapping]) -> list[CostAggregationRow]:
     # Inner trackers: per-model cost split by paid_by; per-source cost split.
     # ``defaultdict`` keeps the per-(model | source) sub-totals tidy
     # without per-row branching.
+    # Bucket value shape: {"calls": int, "platform": float | None,
+    # "byok": float | None}. None means "cost unknown" (any contributing
+    # SQL row had unresolved pricing). Sticky — once None, stays None.
     aggregates: dict[tuple[date, UUID | None, str], CostAggregationRow] = {}
     by_model_acc: dict[
         tuple[date, UUID | None, str],
-        dict[str | None, dict[str, float | int]],
+        dict[str | None, dict[str, float | int | None]],
     ] = defaultdict(lambda: defaultdict(lambda: {"calls": 0, "platform": 0.0, "byok": 0.0}))
     by_source_acc: dict[
         tuple[date, UUID | None, str],
-        dict[str, dict[str, float | int]],
+        dict[str, dict[str, float | int | None]],
     ] = defaultdict(lambda: defaultdict(lambda: {"calls": 0, "platform": 0.0, "byok": 0.0}))
+
+    def _add_or_null(current: float | None, increment: float | None) -> float | None:
+        """Sum two cost values with sticky-NULL semantics.
+
+        If either side is None ("cost unknown"), the result is None —
+        a partial total over a partly-priced group would be misleading.
+        """
+        if current is None or increment is None:
+            return None
+        return current + increment
 
     for r in raw_rows:
         key = (r["period_start"], r["workspace_id"], r["user_id"])
@@ -434,43 +508,48 @@ def _assemble_rows(raw_rows: Sequence[RowMapping]) -> list[CostAggregationRow]:
         paid_by_col = paid_by_value
         cost_field = "cost_usd" if paid_by_col == "platform" else "cost_usd_byok"
 
+        # cost from SQL is float | None (None when CTE detected an
+        # unpriced contribution via BOOL_AND). Pass through as-is — the
+        # _add_or_null helper handles the sticky-NULL aggregation.
+        sql_cost: float | None = float(r["cost"]) if r["cost"] is not None else None
+
         if kind == "llm":
             calls = int(r["calls"] or 0)
-            cost = float(r["cost"] or 0.0)
             agg.calls += calls
             agg.tokens_in += int(r["tokens_in"] or 0)
             agg.tokens_out += int(r["tokens_out"] or 0)
             agg.tokens_cached_in += int(r["tokens_cached_in"] or 0)
-            setattr(agg, cost_field, getattr(agg, cost_field) + cost)
+            setattr(agg, cost_field, _add_or_null(getattr(agg, cost_field), sql_cost))
 
             model_bucket = by_model_acc[key][r["model"]]
-            model_bucket["calls"] = int(model_bucket["calls"]) + calls
-            model_bucket[paid_by_col] = float(model_bucket[paid_by_col]) + cost
+            model_bucket["calls"] = int(model_bucket["calls"] or 0) + calls
+            model_bucket[paid_by_col] = _add_or_null(model_bucket[paid_by_col], sql_cost)
 
             source_bucket = by_source_acc[key][r["source"]]
-            source_bucket["calls"] = int(source_bucket["calls"]) + calls
-            source_bucket[paid_by_col] = float(source_bucket[paid_by_col]) + cost
+            source_bucket["calls"] = int(source_bucket["calls"] or 0) + calls
+            source_bucket[paid_by_col] = _add_or_null(source_bucket[paid_by_col], sql_cost)
         else:
             # kind == 'emb' — embedding rows contribute tokens + cost but
             # no LLM call count (embedding is metered separately and the
             # response shape exposes embedding_tokens at the top level
             # only). They DO contribute to source-level cost so the
             # by_source breakdown matches the row-level cost_usd totals.
-            cost = float(r["cost"] or 0.0)
             agg.embedding_tokens += int(r["embedding_tokens"] or 0)
-            setattr(agg, cost_field, getattr(agg, cost_field) + cost)
+            setattr(agg, cost_field, _add_or_null(getattr(agg, cost_field), sql_cost))
 
             source_bucket = by_source_acc[key][r["source"]]
-            source_bucket[paid_by_col] = float(source_bucket[paid_by_col]) + cost
+            source_bucket[paid_by_col] = _add_or_null(source_bucket[paid_by_col], sql_cost)
 
-    # Materialize breakdowns onto each row.
+    # Materialize breakdowns onto each row. cost_usd / cost_usd_byok are
+    # ``float | None`` per the sticky-NULL rule; the route layer's
+    # response model declares the same nullable shape.
     for key, agg in aggregates.items():
         agg.cost_breakdown_by_model = [
             CostBreakdownByModel(
                 model=model,
-                calls=int(b["calls"]),
-                cost_usd=float(b["platform"]),
-                cost_usd_byok=float(b["byok"]),
+                calls=int(b["calls"] or 0),
+                cost_usd=b["platform"],  # float | None
+                cost_usd_byok=b["byok"],  # float | None
             )
             for model, b in sorted(
                 by_model_acc[key].items(),
@@ -480,9 +559,9 @@ def _assemble_rows(raw_rows: Sequence[RowMapping]) -> list[CostAggregationRow]:
         agg.cost_breakdown_by_source = [
             CostBreakdownBySource(
                 source=source,
-                calls=int(b["calls"]),
-                cost_usd=float(b["platform"]),
-                cost_usd_byok=float(b["byok"]),
+                calls=int(b["calls"] or 0),
+                cost_usd=b["platform"],
+                cost_usd_byok=b["byok"],
             )
             for source, b in sorted(by_source_acc[key].items())
         ]

--- a/backend/src/services/cost_aggregation_service.py
+++ b/backend/src/services/cost_aggregation_service.py
@@ -1,0 +1,464 @@
+"""Cost aggregation service (Issue #472).
+
+Computes LLM + embedding usage and cost (`$`) breakdowns from the
+cost-grade ``sleep_reports`` schema introduced in #471 and extended in
+#523. Powers two REST endpoints (admin cross-workspace,
+workspace-scoped) that share this service so the SQL pipeline lives in
+one place.
+
+Aggregation key: ``(period, workspace_id, user_id)`` with two breakdown
+arrays per row — by model and by source.
+
+Cost split:
+- ``cost_usd``    — sum over rows where ``paid_by='platform'``
+- ``cost_usd_byok`` — sum over rows where ``paid_by='byok'``
+
+The split is enforced at the GROUP BY level (``paid_by`` is a grouping
+column) so it cannot accidentally re-merge in application code.
+
+Pricing lookup: each LLM unit (input / output / cache_read) and the
+embedding unit are joined to the active ``llm_pricing`` row via a
+LATERAL subquery that picks the latest ``effective_from <= started_at``.
+A miss contributes 0 cost (same "cost unknown" semantics as the
+existing ``LLMPricingService``); the usage figures are still surfaced.
+
+v1 limitation: pricing-tier lookup uses ``context_min_tokens=0`` because
+``sleep_report_llm_usage`` does not store the per-call context window
+size. Multi-tier models (Gemini 2.5 Pro doubles past 200k) are
+under-estimated for the high-tier portion. The dashboard child (#473)
+will surface this caveat; a future schema iteration can add a context
+size column.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from datetime import date, datetime
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import RowMapping, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.sleep import SLEEP_REPORT_PAID_BY_VALUES, SLEEP_REPORT_SOURCES
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# Allowed period values map to PostgreSQL ``date_trunc`` precision tokens.
+# Bound to a literal allowlist before reaching the SQL — even though the
+# value is bound (not interpolated), passing arbitrary strings would 500
+# the query when ``date_trunc`` rejects them.
+VALID_PERIODS: tuple[str, ...] = ("day", "week", "month")
+
+
+class CostBreakdownByModel:
+    """Per-model cost breakdown row inside a CostAggregationRow.
+
+    Plain ``__slots__`` container — rounding to display precision and
+    JSON serialization happen at the route boundary, not here.
+    """
+
+    __slots__ = ("model", "calls", "cost_usd", "cost_usd_byok")
+
+    def __init__(
+        self,
+        model: str | None,
+        calls: int,
+        cost_usd: float,
+        cost_usd_byok: float,
+    ) -> None:
+        self.model = model
+        self.calls = calls
+        self.cost_usd = cost_usd
+        self.cost_usd_byok = cost_usd_byok
+
+
+class CostBreakdownBySource:
+    """Per-source cost breakdown row inside a CostAggregationRow."""
+
+    __slots__ = ("source", "calls", "cost_usd", "cost_usd_byok")
+
+    def __init__(
+        self,
+        source: str,
+        calls: int,
+        cost_usd: float,
+        cost_usd_byok: float,
+    ) -> None:
+        self.source = source
+        self.calls = calls
+        self.cost_usd = cost_usd
+        self.cost_usd_byok = cost_usd_byok
+
+
+class CostAggregationRow:
+    """One (period × workspace × user) aggregation row.
+
+    Plain attribute container so the route handler can convert to the
+    Pydantic response model without an extra serialization step.
+    """
+
+    __slots__ = (
+        "period_start",
+        "workspace_id",
+        "user_id",
+        "calls",
+        "tokens_in",
+        "tokens_out",
+        "tokens_cached_in",
+        "embedding_tokens",
+        "cost_usd",
+        "cost_usd_byok",
+        "cost_breakdown_by_model",
+        "cost_breakdown_by_source",
+    )
+
+    def __init__(
+        self,
+        period_start: date,
+        workspace_id: UUID | None,
+        user_id: str,
+    ) -> None:
+        self.period_start = period_start
+        self.workspace_id = workspace_id
+        self.user_id = user_id
+        self.calls = 0
+        self.tokens_in = 0
+        self.tokens_out = 0
+        self.tokens_cached_in = 0
+        self.embedding_tokens = 0
+        self.cost_usd = 0.0
+        self.cost_usd_byok = 0.0
+        self.cost_breakdown_by_model: list[CostBreakdownByModel] = []
+        self.cost_breakdown_by_source: list[CostBreakdownBySource] = []
+
+
+# ----------------------------------------------------------------------
+# SQL fragments
+# ----------------------------------------------------------------------
+
+# LATERAL pricing lookup template. The ``context_min_tokens=0`` clause
+# pins to the lowest tier (see module docstring for the v1 limitation).
+# Bound parameter ``:unit_type_X`` distinguishes the three LLM units.
+_LLM_PRICING_LATERAL = """
+LEFT JOIN LATERAL (
+    SELECT (price_per_unit / unit_denominator)::float8 AS rate
+    FROM llm_pricing
+    WHERE provider = u.provider
+      AND model = u.model
+      AND unit_type = '{unit_type}'
+      AND effective_from <= sr.started_at
+      AND context_min_tokens = 0
+    ORDER BY effective_from DESC
+    LIMIT 1
+) {alias} ON TRUE
+"""
+
+# Embedding pricing lateral — joined against sleep_reports directly,
+# guarded by NOT NULL so old rows (embedding_provider IS NULL) skip the
+# lookup entirely.
+_EMBEDDING_PRICING_LATERAL = """
+LEFT JOIN LATERAL (
+    SELECT (price_per_unit / unit_denominator)::float8 AS rate
+    FROM llm_pricing
+    WHERE provider = sr.embedding_provider
+      AND model = sr.embedding_model
+      AND unit_type = 'embedding_tokens'
+      AND effective_from <= sr.started_at
+      AND context_min_tokens = 0
+    ORDER BY effective_from DESC
+    LIMIT 1
+) p_emb ON sr.embedding_provider IS NOT NULL
+       AND sr.embedding_model IS NOT NULL
+"""
+
+
+def _build_filter_clauses(
+    *,
+    workspace_id: UUID | None,
+    user_id: str | None,
+    source: str | None,
+    paid_by: str | None,
+) -> tuple[list[str], dict[str, Any]]:
+    """Return (where-fragment list, bound-param dict) for caller filters.
+
+    Fragments are concatenated with ``AND`` into the WHERE clause; only
+    bound parameter names appear in the strings, never user input.
+    """
+    clauses: list[str] = []
+    params: dict[str, Any] = {}
+    if workspace_id is not None:
+        clauses.append("sr.workspace_id = :workspace_id")
+        params["workspace_id"] = workspace_id
+    if user_id is not None:
+        clauses.append("sr.user_id = :user_id")
+        params["user_id"] = user_id
+    if source is not None:
+        clauses.append("sr.source = :source")
+        params["source"] = source
+    if paid_by is not None:
+        clauses.append("sr.paid_by = :paid_by")
+        params["paid_by"] = paid_by
+    return clauses, params
+
+
+class CostAggregationService:
+    """Aggregate cost-grade telemetry across the cost-grade schema.
+
+    Single ``aggregate()`` entrypoint shared by both the admin and
+    workspace-scoped routes — the only difference is the caller passes
+    a fixed ``workspace_id`` for the workspace-scoped route.
+    """
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def aggregate(
+        self,
+        *,
+        period: str,
+        start: datetime,
+        end: datetime,
+        workspace_id: UUID | None = None,
+        user_id: str | None = None,
+        source: str | None = None,
+        paid_by: str | None = None,
+    ) -> list[CostAggregationRow]:
+        """Aggregate cost rows across the requested filters.
+
+        Args:
+            period: One of ``'day'`` / ``'week'`` / ``'month'``. Maps to
+                PostgreSQL ``date_trunc`` precision.
+            start: Inclusive lower bound on ``sleep_reports.started_at``
+                (naive UTC, matching the column).
+            end: Exclusive upper bound on ``sleep_reports.started_at``.
+            workspace_id: Restrict to a single workspace (the
+                workspace-scoped route always sets this; admin route
+                leaves None to see all).
+            user_id: Restrict to a single user.
+            source: Restrict to ``'sleep'`` or ``'analysis'``.
+            paid_by: Restrict to ``'platform'`` or ``'byok'``.
+
+        Returns:
+            List of ``CostAggregationRow``, one per
+            ``(period_start, workspace_id, user_id)`` triple. Sorted by
+            the same triple.
+
+        Raises:
+            ValueError: ``period``, ``source``, or ``paid_by`` outside
+                the allowed set; ``start >= end``.
+        """
+        # ---- Input validation (defense in depth) --------------------------
+        # period feeds date_trunc directly; passing junk would 500 the
+        # request. The string is bound (so SQLi is impossible) but
+        # validating against an allowlist preserves clear ValueError UX.
+        if period not in VALID_PERIODS:
+            raise ValueError(f"Invalid period {period!r}; must be one of {VALID_PERIODS}")
+        if source is not None and source not in SLEEP_REPORT_SOURCES:
+            raise ValueError(f"Invalid source {source!r}; must be one of {SLEEP_REPORT_SOURCES}")
+        if paid_by is not None and paid_by not in SLEEP_REPORT_PAID_BY_VALUES:
+            raise ValueError(
+                f"Invalid paid_by {paid_by!r}; must be one of {SLEEP_REPORT_PAID_BY_VALUES}"
+            )
+        if start >= end:
+            raise ValueError(f"start must be < end (got start={start}, end={end})")
+
+        # ---- Build filter fragments ---------------------------------------
+        filter_clauses, filter_params = _build_filter_clauses(
+            workspace_id=workspace_id,
+            user_id=user_id,
+            source=source,
+            paid_by=paid_by,
+        )
+        base_where = " AND ".join(
+            ["sr.started_at >= :start", "sr.started_at < :end", *filter_clauses]
+        )
+
+        params: dict[str, Any] = {
+            "period": period,
+            "start": start,
+            "end": end,
+            **filter_params,
+        }
+
+        # ---- Single union query: per-model LLM rows + per-source emb rows -
+        # The two CTEs keep their natural grouping shapes — LLM cost rolls
+        # up by model (because the by_model breakdown needs it), embedding
+        # cost rolls up by source only (no per-model split needed for
+        # embedding in v1; one provider/model per process). UNION ALL
+        # tags rows with ``kind`` so the Python merge step knows which
+        # array to populate.
+        sql = f"""
+        WITH llm_per_model AS (
+            SELECT
+                date_trunc(:period, sr.started_at)::date AS period_start,
+                sr.workspace_id,
+                sr.user_id,
+                u.model,
+                sr.source,
+                sr.paid_by,
+                SUM(u.calls)::bigint               AS calls,
+                SUM(u.input_tokens)::bigint        AS tokens_in,
+                SUM(u.output_tokens)::bigint       AS tokens_out,
+                SUM(u.cached_input_tokens)::bigint AS tokens_cached_in,
+                SUM(
+                    COALESCE(u.input_tokens        * p_in.rate,    0) +
+                    COALESCE(u.output_tokens       * p_out.rate,   0) +
+                    COALESCE(u.cached_input_tokens * p_cache.rate, 0)
+                )::float8 AS cost
+            FROM sleep_reports sr
+            JOIN sleep_report_llm_usage u ON u.report_id = sr.id
+            {_LLM_PRICING_LATERAL.format(unit_type="input_tokens", alias="p_in")}
+            {_LLM_PRICING_LATERAL.format(unit_type="output_tokens", alias="p_out")}
+            {_LLM_PRICING_LATERAL.format(unit_type="cache_read_tokens", alias="p_cache")}
+            WHERE {base_where}
+            GROUP BY 1, 2, 3, 4, 5, 6
+        ),
+        emb_per_source AS (
+            SELECT
+                date_trunc(:period, sr.started_at)::date AS period_start,
+                sr.workspace_id,
+                sr.user_id,
+                sr.source,
+                sr.paid_by,
+                SUM(sr.embedding_tokens)::bigint AS embedding_tokens,
+                SUM(COALESCE(sr.embedding_tokens * p_emb.rate, 0))::float8 AS cost
+            FROM sleep_reports sr
+            {_EMBEDDING_PRICING_LATERAL}
+            WHERE {base_where}
+            GROUP BY 1, 2, 3, 4, 5
+        )
+        SELECT
+            'llm'::text AS kind,
+            period_start, workspace_id, user_id,
+            model, source, paid_by,
+            calls, tokens_in, tokens_out, tokens_cached_in,
+            0::bigint AS embedding_tokens,
+            cost
+        FROM llm_per_model
+        UNION ALL
+        SELECT
+            'emb'::text AS kind,
+            period_start, workspace_id, user_id,
+            NULL::text AS model, source, paid_by,
+            0::bigint AS calls,
+            0::bigint AS tokens_in,
+            0::bigint AS tokens_out,
+            0::bigint AS tokens_cached_in,
+            embedding_tokens,
+            cost
+        FROM emb_per_source
+        ORDER BY period_start, workspace_id, user_id, kind, model, source, paid_by
+        """
+
+        result = await self.db.execute(text(sql), params)
+        rows = result.mappings().all()
+        assembled = _assemble_rows(rows)
+
+        logger.info(
+            "cost_aggregation_executed",
+            period=period,
+            start=start.isoformat(),
+            end=end.isoformat(),
+            workspace_id=str(workspace_id) if workspace_id else None,
+            user_id=user_id,
+            source=source,
+            paid_by=paid_by,
+            raw_row_count=len(rows),
+            aggregated_row_count=len(assembled),
+        )
+        return assembled
+
+
+def _assemble_rows(raw_rows: Sequence[RowMapping]) -> list[CostAggregationRow]:
+    """Group raw SQL rows into CostAggregationRow objects.
+
+    Input rows are pre-grouped by SQL — assembly here is bounded by the
+    per-(period, workspace, user) cardinality, not by raw event volume.
+    """
+    # Outer key: (period_start, workspace_id, user_id) → CostAggregationRow
+    # Inner trackers: per-model cost split by paid_by; per-source cost split.
+    # ``defaultdict`` keeps the per-(model | source) sub-totals tidy
+    # without per-row branching.
+    aggregates: dict[tuple[date, UUID | None, str], CostAggregationRow] = {}
+    by_model_acc: dict[
+        tuple[date, UUID | None, str],
+        dict[str | None, dict[str, float | int]],
+    ] = defaultdict(lambda: defaultdict(lambda: {"calls": 0, "platform": 0.0, "byok": 0.0}))
+    by_source_acc: dict[
+        tuple[date, UUID | None, str],
+        dict[str, dict[str, float | int]],
+    ] = defaultdict(lambda: defaultdict(lambda: {"calls": 0, "platform": 0.0, "byok": 0.0}))
+
+    for r in raw_rows:
+        key = (r["period_start"], r["workspace_id"], r["user_id"])
+        agg = aggregates.get(key)
+        if agg is None:
+            agg = CostAggregationRow(
+                period_start=r["period_start"],
+                workspace_id=r["workspace_id"],
+                user_id=r["user_id"],
+            )
+            aggregates[key] = agg
+
+        kind = r["kind"]
+        paid_by_col = "platform" if r["paid_by"] == "platform" else "byok"
+        cost_field = "cost_usd" if paid_by_col == "platform" else "cost_usd_byok"
+
+        if kind == "llm":
+            calls = int(r["calls"] or 0)
+            cost = float(r["cost"] or 0.0)
+            agg.calls += calls
+            agg.tokens_in += int(r["tokens_in"] or 0)
+            agg.tokens_out += int(r["tokens_out"] or 0)
+            agg.tokens_cached_in += int(r["tokens_cached_in"] or 0)
+            setattr(agg, cost_field, getattr(agg, cost_field) + cost)
+
+            model_bucket = by_model_acc[key][r["model"]]
+            model_bucket["calls"] = int(model_bucket["calls"]) + calls
+            model_bucket[paid_by_col] = float(model_bucket[paid_by_col]) + cost
+
+            source_bucket = by_source_acc[key][r["source"]]
+            source_bucket["calls"] = int(source_bucket["calls"]) + calls
+            source_bucket[paid_by_col] = float(source_bucket[paid_by_col]) + cost
+        else:
+            # kind == 'emb' — embedding rows contribute tokens + cost but
+            # no LLM call count (embedding is metered separately and the
+            # response shape exposes embedding_tokens at the top level
+            # only). They DO contribute to source-level cost so the
+            # by_source breakdown matches the row-level cost_usd totals.
+            cost = float(r["cost"] or 0.0)
+            agg.embedding_tokens += int(r["embedding_tokens"] or 0)
+            setattr(agg, cost_field, getattr(agg, cost_field) + cost)
+
+            source_bucket = by_source_acc[key][r["source"]]
+            source_bucket[paid_by_col] = float(source_bucket[paid_by_col]) + cost
+
+    # Materialize breakdowns onto each row.
+    for key, agg in aggregates.items():
+        agg.cost_breakdown_by_model = [
+            CostBreakdownByModel(
+                model=model,
+                calls=int(b["calls"]),
+                cost_usd=float(b["platform"]),
+                cost_usd_byok=float(b["byok"]),
+            )
+            for model, b in sorted(
+                by_model_acc[key].items(),
+                key=lambda kv: (kv[0] is None, kv[0] or ""),
+            )
+        ]
+        agg.cost_breakdown_by_source = [
+            CostBreakdownBySource(
+                source=source,
+                calls=int(b["calls"]),
+                cost_usd=float(b["platform"]),
+                cost_usd_byok=float(b["byok"]),
+            )
+            for source, b in sorted(by_source_acc[key].items())
+        ]
+
+    return list(aggregates.values())

--- a/backend/src/services/cost_aggregation_service.py
+++ b/backend/src/services/cost_aggregation_service.py
@@ -151,7 +151,14 @@ class CostAggregationRow:
 
 # LATERAL pricing lookup template. The ``context_min_tokens=0`` clause
 # pins to the lowest tier (see module docstring for the v1 limitation).
-# Bound parameter ``:unit_type_X`` distinguishes the three LLM units.
+# ``{unit_type}`` and ``{alias}`` are filled via Python ``.format()`` at
+# query build time — both arguments are HARDCODED constants from the
+# call sites below (``"input_tokens"``, ``"output_tokens"``,
+# ``"cache_read_tokens"`` and the matching ``p_in`` / ``p_out`` /
+# ``p_cache`` aliases), never user input. SQL injection is impossible
+# even though these are interpolated rather than bound. Filter VALUES
+# (``:start``, ``:end``, ``:workspace_id`` etc.) ARE bound parameters
+# in the outer query, per the project's ``security.md`` rule.
 _LLM_PRICING_LATERAL = """
 LEFT JOIN LATERAL (
     SELECT (price_per_unit / unit_denominator)::float8 AS rate

--- a/backend/src/services/cost_aggregation_service.py
+++ b/backend/src/services/cost_aggregation_service.py
@@ -19,8 +19,13 @@ column) so it cannot accidentally re-merge in application code.
 Pricing lookup: each LLM unit (input / output / cache_read) and the
 embedding unit are joined to the active ``llm_pricing`` row via a
 LATERAL subquery that picks the latest ``effective_from <= started_at``.
-A miss contributes 0 cost (same "cost unknown" semantics as the
-existing ``LLMPricingService``); the usage figures are still surfaced.
+A miss leaves the corresponding cost as ``NULL`` / ``None`` ("cost
+unknown" — same semantics as ``LLMPricingService.lookup()`` returning
+``None`` on a miss). NULL is sticky: if any contributing usage row
+in a (period, workspace, user, model, source, paid_by) bucket is
+unpriced, the bucket's cost is ``None`` so that partial totals don't
+look like real money. Usage figures (calls, tokens) are still surfaced
+even when cost is unknown.
 
 v1 limitation: pricing-tier lookup uses ``context_min_tokens=0`` because
 ``sleep_report_llm_usage`` does not store the per-call context window

--- a/backend/tests/api/test_cost_aggregation_routes.py
+++ b/backend/tests/api/test_cost_aggregation_routes.py
@@ -1,0 +1,358 @@
+"""Tests for cost aggregation API routes (Issue #472).
+
+Covers:
+
+- Admin route: admin sees all (200), non-admin gets 403, anonymous 401
+- Workspace route: workspace owner/admin sees their workspace, non-owner
+  gets 403, anonymous 401, cross-workspace probe gets 403
+- Query parsing: invalid period / source / paid_by → 400; missing
+  required from/to → 422
+- Response shape: rows, breakdowns, datetime serialization (Z suffix)
+
+The SQL pipeline is exercised end-to-end in
+``tests/integration/test_cost_aggregation_service.py``; here we mock the
+service so the route layer can be unit-tested without Docker/Postgres.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from api.main import app
+from auth.dependencies import get_current_user, require_admin
+from db.base import get_db
+from services.cost_aggregation_service import (
+    CostAggregationRow,
+    CostBreakdownByModel,
+    CostBreakdownBySource,
+)
+from services.permission_service import PermissionService
+
+_WORKSPACE_ID = uuid4()
+
+
+def _admin_user() -> dict:
+    return {"user_id": "admin_1", "email": "admin@test.com", "role": "admin"}
+
+
+def _regular_user() -> dict:
+    return {"user_id": "user_1", "email": "user@test.com", "role": "user"}
+
+
+def _make_canned_row() -> CostAggregationRow:
+    """A representative row covering both breakdowns."""
+    row = CostAggregationRow(
+        period_start=date(2026, 4, 5),
+        workspace_id=_WORKSPACE_ID,
+        user_id="user_1",
+    )
+    row.calls = 150
+    row.tokens_in = 18_000
+    row.tokens_out = 3_000
+    row.tokens_cached_in = 5_000
+    row.embedding_tokens = 1_000_000
+    row.cost_usd = 0.073
+    row.cost_usd_byok = 0.0
+    row.cost_breakdown_by_model = [
+        CostBreakdownByModel("claude-sonnet-4-6", 100, 0.06, 0.0),
+        CostBreakdownByModel("claude-haiku-4-5", 50, 0.013, 0.0),
+    ]
+    row.cost_breakdown_by_source = [
+        CostBreakdownBySource("sleep", 150, 0.073, 0.0),
+    ]
+    return row
+
+
+@pytest.fixture
+def client(monkeypatch):
+    """TestClient that exposes monkeypatch + auto-clears overrides.
+
+    ``monkeypatch`` is bundled into the fixture so the helpers below
+    (``_install_*``) can patch ``CostAggregationService.aggregate`` /
+    ``PermissionService.check_workspace_admin`` per-test without
+    leaking the patched method into other test modules — the failure
+    mode that originally surfaced when the integration tests ran in
+    the same session as these route tests.
+    """
+
+    class _ClientWithPatch:
+        def __init__(self, tc, mp):
+            self._tc = tc
+            self.monkeypatch = mp
+
+        def __getattr__(self, name):
+            return getattr(self._tc, name)
+
+    yield _ClientWithPatch(TestClient(app, raise_server_exceptions=False), monkeypatch)
+    app.dependency_overrides.clear()
+
+
+def _install_admin_overrides(client, canned_rows: list[CostAggregationRow]) -> AsyncMock:
+    """Wire mocks for the admin route: admin auth + db that won't be hit.
+
+    The aggregate() call is intercepted by patching CostAggregationService
+    via the import path the route uses.
+    """
+
+    async def mock_admin():
+        return _admin_user()
+
+    async def mock_db():
+        yield AsyncMock()
+
+    app.dependency_overrides[require_admin] = mock_admin
+    app.dependency_overrides[get_db] = mock_db
+    return _patch_service(client, canned_rows)
+
+
+def _install_workspace_overrides(
+    client,
+    canned_rows: list[CostAggregationRow],
+    *,
+    user: dict,
+    permission_raises: HTTPException | None = None,
+) -> AsyncMock:
+    """Wire mocks for the workspace route.
+
+    ``permission_raises`` lets a test simulate the auth gate rejecting
+    the caller (cross-workspace probe, role-too-low, deleted workspace
+    — the route should propagate the exception unchanged).
+    """
+
+    async def mock_user():
+        return user
+
+    async def mock_db():
+        yield AsyncMock()
+
+    app.dependency_overrides[get_current_user] = mock_user
+    app.dependency_overrides[get_db] = mock_db
+
+    # Patch PermissionService.check_workspace_admin so the test does not
+    # need real workspace/membership rows. The route always instantiates
+    # PermissionService(db); we stub the method on the class.
+    if permission_raises is not None:
+
+        async def mock_check_workspace_admin(self, user_id, workspace_id):
+            raise permission_raises
+    else:
+
+        async def mock_check_workspace_admin(self, user_id, workspace_id):
+            return MagicMock()  # the WorkspaceMember return value is unused by route
+
+    client.monkeypatch.setattr(
+        PermissionService,
+        "check_workspace_admin",
+        mock_check_workspace_admin,
+    )
+    return _patch_service(client, canned_rows)
+
+
+def _patch_service(client, canned_rows: list[CostAggregationRow]) -> AsyncMock:
+    """Replace ``CostAggregationService.aggregate`` with an async mock.
+
+    Uses ``monkeypatch`` so the patched class attribute is restored at
+    test teardown; without this the AsyncMock leaks into the integration
+    suite and breaks any test that exercises the real SQL pipeline.
+    """
+    import services.cost_aggregation_service as svc_module
+
+    mock_aggregate = AsyncMock(return_value=canned_rows)
+    client.monkeypatch.setattr(svc_module.CostAggregationService, "aggregate", mock_aggregate)
+    return mock_aggregate
+
+
+# ============================================================================
+# Admin route
+# ============================================================================
+
+
+class TestAdminRoute:
+    def test_returns_aggregated_rows(self, client):
+        mock_aggregate = _install_admin_overrides(client, [_make_canned_row()])
+
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data["rows"]) == 1
+        row = data["rows"][0]
+        assert row["period_start"] == "2026-04-05"
+        assert row["workspace_id"] == str(_WORKSPACE_ID)
+        assert row["calls"] == 150
+        assert row["cost_usd"] == 0.073
+        assert row["cost_usd_byok"] == 0.0
+        assert {b["model"] for b in row["cost_breakdown_by_model"]} == {
+            "claude-sonnet-4-6",
+            "claude-haiku-4-5",
+        }
+        # Service was called with the parsed window.
+        assert mock_aggregate.await_count == 1
+        kwargs = mock_aggregate.await_args.kwargs
+        assert kwargs["period"] == "day"
+        # End is exclusive: from=2026-04-01 to=2026-04-07 → end = 2026-04-08T00:00.
+        assert kwargs["start"].date() == date(2026, 4, 1)
+        assert kwargs["end"].date() == date(2026, 4, 8)
+
+    def test_non_admin_gets_403(self, client):
+        # The admin route uses require_admin which raises 403 for non-admin
+        # roles. Override get_current_user (which require_admin depends on)
+        # to return a regular user, and let require_admin do its job.
+        async def mock_user():
+            return _regular_user()
+
+        async def mock_db():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_current_user] = mock_user
+        app.dependency_overrides[get_db] = mock_db
+
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 403
+
+    def test_invalid_period_returns_400(self, client):
+        _install_admin_overrides(client, [])
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=hour&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 400
+        assert "Invalid period" in response.json()["detail"]
+
+    def test_invalid_source_returns_400(self, client):
+        _install_admin_overrides(client, [])
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-04-01&to=2026-04-07&source=manual"
+        )
+        assert response.status_code == 400
+        assert "Invalid source" in response.json()["detail"]
+
+    def test_invalid_paid_by_returns_400(self, client):
+        _install_admin_overrides(client, [])
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-04-01&to=2026-04-07&paid_by=user"
+        )
+        assert response.status_code == 400
+        assert "Invalid paid_by" in response.json()["detail"]
+
+    def test_inverted_window_returns_400(self, client):
+        _install_admin_overrides(client, [])
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-04-08&to=2026-04-01"
+        )
+        assert response.status_code == 400
+
+    def test_missing_required_query_returns_422(self, client):
+        _install_admin_overrides(client, [])
+        response = client.get("/api/v1/admin/cost-aggregation?period=day")
+        assert response.status_code == 422  # missing from/to
+
+    def test_filter_passthrough_to_service(self, client):
+        mock_aggregate = _install_admin_overrides(client, [])
+        response = client.get(
+            "/api/v1/admin/cost-aggregation"
+            "?period=week&from=2026-04-01&to=2026-04-30"
+            f"&workspace_id={_WORKSPACE_ID}&user_id=user_2"
+            "&source=analysis&paid_by=byok"
+        )
+        assert response.status_code == 200
+        kwargs = mock_aggregate.await_args.kwargs
+        assert kwargs["period"] == "week"
+        assert kwargs["workspace_id"] == _WORKSPACE_ID
+        assert kwargs["user_id"] == "user_2"
+        assert kwargs["source"] == "analysis"
+        assert kwargs["paid_by"] == "byok"
+
+
+# ============================================================================
+# Workspace-scoped route
+# ============================================================================
+
+
+class TestWorkspaceRoute:
+    def test_owner_sees_workspace_rows(self, client):
+        mock_aggregate = _install_workspace_overrides(
+            client, [_make_canned_row()], user=_regular_user()
+        )
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 200, response.text
+        data = response.json()
+        assert len(data["rows"]) == 1
+        # Service was called with the path-bound workspace_id (cannot be overridden).
+        kwargs = mock_aggregate.await_args.kwargs
+        assert kwargs["workspace_id"] == _WORKSPACE_ID
+
+    def test_non_owner_gets_403(self, client):
+        # Simulate check_workspace_admin raising 403 for a non-owner.
+        _install_workspace_overrides(
+            client,
+            [],
+            user=_regular_user(),
+            permission_raises=HTTPException(
+                status_code=403,
+                detail="Requires 'admin' role or higher",
+            ),
+        )
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 403
+
+    def test_cross_workspace_probe_gets_403(self, client):
+        # A caller hitting a workspace they aren't a member of must 403,
+        # not leak rows. The check_workspace_admin gate raises 403 BEFORE
+        # the SQL fires, so this test asserts the route propagates the
+        # exception and never invokes the service.
+        mock_aggregate = _install_workspace_overrides(
+            client,
+            [_make_canned_row()],  # would leak if route ran the query
+            user=_regular_user(),
+            permission_raises=HTTPException(
+                status_code=403,
+                detail="Not a member of workspace",
+            ),
+        )
+        other_workspace_id = uuid4()
+        response = client.get(
+            f"/api/v1/workspaces/{other_workspace_id}/cost-aggregation"
+            "?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 403
+        assert mock_aggregate.await_count == 0  # no SQL was issued
+
+    def test_workspace_route_ignores_workspace_id_query_param(self, client):
+        # The workspace route does not declare a ``workspace_id`` query
+        # arg — only a path arg. Even if a malicious client appends one
+        # to the URL, the path-bound value wins (FastAPI ignores unknown
+        # query params by default).
+        mock_aggregate = _install_workspace_overrides(
+            client, [_make_canned_row()], user=_regular_user()
+        )
+        other_workspace_id = uuid4()
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            f"?period=day&from=2026-04-01&to=2026-04-07&workspace_id={other_workspace_id}"
+        )
+        assert response.status_code == 200
+        kwargs = mock_aggregate.await_args.kwargs
+        assert kwargs["workspace_id"] == _WORKSPACE_ID  # path wins
+
+    def test_invalid_period_returns_400(self, client):
+        _install_workspace_overrides(client, [], user=_regular_user())
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=hour&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 400

--- a/backend/tests/api/test_cost_aggregation_routes.py
+++ b/backend/tests/api/test_cost_aggregation_routes.py
@@ -2,12 +2,13 @@
 
 Covers:
 
-- Admin route: admin sees all (200), non-admin gets 403, anonymous 401
-- Workspace route: workspace owner/admin sees their workspace, non-owner
-  gets 403, anonymous 401, cross-workspace probe gets 403
-- Query parsing: invalid period / source / paid_by → 400; missing
-  required from/to → 422
-- Response shape: rows, breakdowns, datetime serialization (Z suffix)
+- Admin route: admin sees all (200), non-admin gets 403, anonymous gets 401
+- Workspace route: owner/admin sees their workspace, non-owner gets 403,
+  anonymous gets 401, cross-workspace probe gets 403, query-string
+  ``workspace_id`` cannot override the path-bound value
+- Query parsing on BOTH routes: invalid ``period`` / ``source`` / ``paid_by``
+  return 400; missing required ``from`` / ``to`` return 422
+- Response shape: rows, breakdowns, JSON wire format
 
 The SQL pipeline is exercised end-to-end in
 ``tests/integration/test_cost_aggregation_service.py``; here we mock the
@@ -356,3 +357,51 @@ class TestWorkspaceRoute:
             "?period=hour&from=2026-04-01&to=2026-04-07"
         )
         assert response.status_code == 400
+
+    def test_invalid_source_returns_400(self, client):
+        _install_workspace_overrides(client, [], user=_regular_user())
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=day&from=2026-04-01&to=2026-04-07&source=manual"
+        )
+        assert response.status_code == 400
+        assert "Invalid source" in response.json()["detail"]
+
+    def test_invalid_paid_by_returns_400(self, client):
+        _install_workspace_overrides(client, [], user=_regular_user())
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=day&from=2026-04-01&to=2026-04-07&paid_by=user"
+        )
+        assert response.status_code == 400
+        assert "Invalid paid_by" in response.json()["detail"]
+
+
+# ============================================================================
+# Anonymous-access regression — both routes
+# ============================================================================
+
+
+class TestAnonymousAccess:
+    """Verify both routes reject unauthenticated callers (covers the auth gate
+    BEFORE any service or query-parsing logic runs).
+
+    These tests do NOT install dependency overrides for ``get_current_user``
+    or ``require_admin`` — the FastAPI dependency raises 401 the same way it
+    would for a real anonymous request (no session cookie, no API key).
+    """
+
+    def test_admin_route_rejects_anonymous(self, client):
+        # No auth dep override → get_current_user / require_admin raises
+        # the standard 401 from the auth middleware path.
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 401
+
+    def test_workspace_route_rejects_anonymous(self, client):
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=day&from=2026-04-01&to=2026-04-07"
+        )
+        assert response.status_code == 401

--- a/backend/tests/integration/test_cost_aggregation_service.py
+++ b/backend/tests/integration/test_cost_aggregation_service.py
@@ -440,3 +440,120 @@ async def test_inverted_window_raises_value_error(db_session):
             start=datetime(2026, 4, 8),
             end=datetime(2026, 4, 1),
         )
+
+
+@pytest.mark.asyncio
+async def test_period_week_collapses_seven_daily_reports_into_one_bucket(db_session):
+    """Seven reports across one ISO week roll into a single weekly bucket.
+
+    Postgres ``date_trunc('week', ...)`` snaps to the ISO Monday. Seeding
+    Mon–Sun in the same ISO week verifies that the bucket key is computed
+    correctly and that all seven daily reports collapse to one row, not
+    seven. Without this assertion the route layer's ``period=week``
+    contract is only exercised in SQL but never verified at the row count.
+    """
+    await _truncate_cost_grade_tables(db_session)
+    await _seed_pricing(db_session)
+
+    workspace_id = uuid4()
+    user_id = "user-weekly"
+
+    # 2026-04-06 is a Monday → 2026-04-12 is the following Sunday. All
+    # seven dates share the same ISO week, so date_trunc('week', ...)
+    # returns 2026-04-06 for every row.
+    week_dates = [datetime(2026, 4, d, 12, 0) for d in range(6, 13)]
+    reports = [
+        _make_report(user_id=user_id, workspace_id=workspace_id, started_at=ts) for ts in week_dates
+    ]
+    db_session.add_all(reports)
+    await db_session.flush()
+
+    for r in reports:
+        db_session.add(
+            _make_usage(
+                report_id=r.id,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                calls=1,
+                input_tokens=1_000_000,  # $3 each → $21 total for the week
+                output_tokens=0,
+            )
+        )
+    await db_session.flush()
+
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="week",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 15),
+        workspace_id=workspace_id,
+    )
+
+    assert len(rows) == 1, "seven daily reports must collapse into one weekly bucket"
+    row = rows[0]
+    assert row.period_start == date(2026, 4, 6)  # ISO Monday
+    assert row.calls == 7
+    assert row.tokens_in == 7_000_000
+    assert row.cost_usd == pytest.approx(21.0)
+
+
+@pytest.mark.asyncio
+async def test_window_upper_bound_includes_late_day_records(db_session):
+    """A report at 23:59:59 on the route's ``to`` day is still included.
+
+    The route layer turns ``to=YYYY-MM-DD`` into a half-open
+    ``[start, end)`` window where ``end = (to + 1 day) at 00:00:00``. A
+    record at the very end of the ``to`` day (23:59:59) MUST be included;
+    a record one second later (the next day 00:00:00) MUST be excluded.
+    Without this assertion, an off-by-one in the route's window
+    construction would silently drop the last second of every query.
+    """
+    await _truncate_cost_grade_tables(db_session)
+    await _seed_pricing(db_session)
+
+    workspace_id = uuid4()
+    user_id = "user-boundary"
+
+    # Two reports: one at the very end of the to-day (must include),
+    # one at the start of the day after (must exclude). Same workspace
+    # + user so the inclusion/exclusion shows up as a count delta.
+    in_window = _make_report(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        started_at=datetime(2026, 4, 7, 23, 59, 59),
+    )
+    out_of_window = _make_report(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        started_at=datetime(2026, 4, 8, 0, 0, 0),
+    )
+    db_session.add_all([in_window, out_of_window])
+    await db_session.flush()
+
+    for r in (in_window, out_of_window):
+        db_session.add(
+            _make_usage(
+                report_id=r.id,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                calls=1,
+                input_tokens=1_000_000,  # $3
+                output_tokens=0,
+            )
+        )
+    await db_session.flush()
+
+    service = CostAggregationService(db_session)
+    # Mirror the route's window math: to=2026-04-07 → end=2026-04-08T00:00.
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 8),
+        workspace_id=workspace_id,
+    )
+
+    assert len(rows) == 1, "only the in-window report should appear"
+    row = rows[0]
+    assert row.period_start == date(2026, 4, 7)
+    assert row.calls == 1
+    assert row.cost_usd == pytest.approx(3.0)

--- a/backend/tests/integration/test_cost_aggregation_service.py
+++ b/backend/tests/integration/test_cost_aggregation_service.py
@@ -26,7 +26,6 @@ from decimal import Decimal
 from uuid import UUID, uuid4
 
 import pytest
-import sqlalchemy as sa
 
 from models.llm_pricing import LLMPricing
 from models.sleep import SleepReport, SleepReportLLMUsage
@@ -121,23 +120,9 @@ def _make_usage(
     )
 
 
-async def _truncate_cost_grade_tables(db_session) -> None:
-    """Wipe cost-grade tables so each test starts from a known empty state.
-
-    Uses TRUNCATE ... CASCADE because session rollback is not enough —
-    the session-scoped fixture means uncommitted writes from a prior
-    test could leak across via the rollback timing in pytest-asyncio.
-    """
-    await db_session.execute(
-        sa.text("TRUNCATE TABLE sleep_report_llm_usage, sleep_reports, llm_pricing CASCADE")
-    )
-    await db_session.flush()
-
-
 @pytest.mark.asyncio
 async def test_empty_period_returns_empty_list(db_session):
     """A period with no sleep_reports rows returns an empty list."""
-    await _truncate_cost_grade_tables(db_session)
     await _seed_pricing(db_session)
 
     service = CostAggregationService(db_session)
@@ -156,7 +141,6 @@ async def test_multi_model_rolls_into_breakdown_by_model(db_session):
     Sonnet 100 calls × (10k in @ $3/1M + 2k out @ $15/1M) = $0.06
     Haiku 50 calls × (8k in @ $1/1M + 1k out @ $5/1M) = $0.013
     """
-    await _truncate_cost_grade_tables(db_session)
     await _seed_pricing(db_session)
 
     workspace_id = uuid4()
@@ -225,7 +209,6 @@ async def test_multi_model_rolls_into_breakdown_by_model(db_session):
 @pytest.mark.asyncio
 async def test_byok_never_contributes_to_cost_usd(db_session):
     """A ``paid_by='byok'`` row's cost lands in cost_usd_byok, not cost_usd."""
-    await _truncate_cost_grade_tables(db_session)
     await _seed_pricing(db_session)
 
     workspace_id = uuid4()
@@ -294,7 +277,6 @@ async def test_pricing_miss_keeps_row_with_zero_cost(db_session):
     figures are preserved so the dashboard still shows tokens spent;
     only the ``$`` column is blank.
     """
-    await _truncate_cost_grade_tables(db_session)
     await _seed_pricing(db_session)
 
     workspace_id = uuid4()
@@ -337,7 +319,6 @@ async def test_pricing_miss_keeps_row_with_zero_cost(db_session):
 @pytest.mark.asyncio
 async def test_embedding_cost_attributed_via_sleep_reports_columns(db_session):
     """``embedding_tokens`` × embedding price contributes to cost_usd."""
-    await _truncate_cost_grade_tables(db_session)
     await _seed_pricing(db_session)
 
     workspace_id = uuid4()
@@ -370,7 +351,6 @@ async def test_embedding_cost_attributed_via_sleep_reports_columns(db_session):
 @pytest.mark.asyncio
 async def test_filter_combination_source_and_paid_by(db_session):
     """``source=analysis & paid_by=byok`` returns only the intersection."""
-    await _truncate_cost_grade_tables(db_session)
     await _seed_pricing(db_session)
 
     workspace_id = uuid4()
@@ -452,7 +432,6 @@ async def test_period_week_collapses_seven_daily_reports_into_one_bucket(db_sess
     seven. Without this assertion the route layer's ``period=week``
     contract is only exercised in SQL but never verified at the row count.
     """
-    await _truncate_cost_grade_tables(db_session)
     await _seed_pricing(db_session)
 
     workspace_id = uuid4()
@@ -508,7 +487,6 @@ async def test_window_upper_bound_includes_late_day_records(db_session):
     Without this assertion, an off-by-one in the route's window
     construction would silently drop the last second of every query.
     """
-    await _truncate_cost_grade_tables(db_session)
     await _seed_pricing(db_session)
 
     workspace_id = uuid4()

--- a/backend/tests/integration/test_cost_aggregation_service.py
+++ b/backend/tests/integration/test_cost_aggregation_service.py
@@ -1,0 +1,442 @@
+"""Integration tests for ``CostAggregationService`` (Issue #472).
+
+Exercises the SQL pipeline against a real Postgres DB so the LATERAL
+joins, ``date_trunc``, ``FILTER (WHERE ...)``, and the multi-CTE
+``UNION ALL`` are all proven end-to-end. Mocked-DB unit tests would
+silently pass with the wrong SQL because asyncpg never sees the query.
+
+Coverage:
+
+- empty period → no rows returned
+- multi-model rows roll into one ``cost_breakdown_by_model`` per
+  ``(period, workspace, user)``
+- BYOK rows go into ``cost_usd_byok`` and never contribute to ``cost_usd``
+- ``source='analysis'`` rows surface in ``cost_breakdown_by_source``
+- pricing miss → row still surfaces (cost = 0), usage figures preserved
+- filter combinations: ``source=analysis & paid_by=byok`` returns the
+  intersection only
+- input validation: bad period / source / paid_by / inverted window
+  raises ``ValueError`` (the route layer maps to 400)
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from decimal import Decimal
+from uuid import UUID, uuid4
+
+import pytest
+import sqlalchemy as sa
+
+from models.llm_pricing import LLMPricing
+from models.sleep import SleepReport, SleepReportLLMUsage
+from services.cost_aggregation_service import CostAggregationService
+
+# All pricing rows in this module share one effective_from that pre-dates
+# every test report's ``started_at``. Keeps the LATERAL pricing lookup
+# deterministic across tests.
+_PRICE_EFFECTIVE = datetime(2026, 1, 1, 0, 0, 0)
+
+
+async def _seed_pricing(db_session) -> None:
+    """Seed minimal pricing rows the SQL pipeline needs to compute cost.
+
+    Per-1M tokens for clarity (matches production seed convention).
+    Only the dimensions used by the tests are seeded — keeps each test
+    cheap and the failing-query post-mortem readable.
+    """
+    rows = [
+        # claude-sonnet-4-6: input $3 / output $15 / cache_read $0.30 per 1M
+        ("anthropic", "claude-sonnet-4-6", "input_tokens", "3"),
+        ("anthropic", "claude-sonnet-4-6", "output_tokens", "15"),
+        ("anthropic", "claude-sonnet-4-6", "cache_read_tokens", "0.30"),
+        # claude-haiku-4-5: input $1 / output $5 / cache_read $0.10 per 1M
+        ("anthropic", "claude-haiku-4-5", "input_tokens", "1"),
+        ("anthropic", "claude-haiku-4-5", "output_tokens", "5"),
+        ("anthropic", "claude-haiku-4-5", "cache_read_tokens", "0.10"),
+        # text-embedding-3-small: $0.02 per 1M
+        ("openai", "text-embedding-3-small", "embedding_tokens", "0.02"),
+    ]
+    for provider, model, unit_type, price in rows:
+        db_session.add(
+            LLMPricing(
+                provider=provider,
+                model=model,
+                unit_type=unit_type,
+                effective_from=_PRICE_EFFECTIVE,
+                context_min_tokens=0,
+                price_per_unit=Decimal(price),
+                unit_denominator=1_000_000,
+            )
+        )
+    await db_session.flush()
+
+
+def _make_report(
+    *,
+    user_id: str,
+    workspace_id: UUID,
+    started_at: datetime,
+    source: str = "sleep",
+    paid_by: str = "platform",
+    embedding_tokens: int = 0,
+    embedding_provider: str | None = None,
+    embedding_model: str | None = None,
+) -> SleepReport:
+    """Construct a SleepReport for a given period bucket. status='completed'."""
+    return SleepReport(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        status="completed",
+        started_at=started_at,
+        source=source,
+        paid_by=paid_by,
+        embedding_tokens=embedding_tokens,
+        embedding_provider=embedding_provider,
+        embedding_model=embedding_model,
+    )
+
+
+def _make_usage(
+    *,
+    report_id: UUID,
+    provider: str,
+    model: str,
+    calls: int,
+    input_tokens: int,
+    output_tokens: int,
+    cached_input_tokens: int = 0,
+    phase: str = "edge_discovery",
+) -> SleepReportLLMUsage:
+    """Construct a ``sleep_report_llm_usage`` child row."""
+    return SleepReportLLMUsage(
+        report_id=report_id,
+        phase=phase,
+        provider=provider,
+        model=model,
+        calls=calls,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cached_input_tokens=cached_input_tokens,
+    )
+
+
+async def _truncate_cost_grade_tables(db_session) -> None:
+    """Wipe cost-grade tables so each test starts from a known empty state.
+
+    Uses TRUNCATE ... CASCADE because session rollback is not enough —
+    the session-scoped fixture means uncommitted writes from a prior
+    test could leak across via the rollback timing in pytest-asyncio.
+    """
+    await db_session.execute(
+        sa.text("TRUNCATE TABLE sleep_report_llm_usage, sleep_reports, llm_pricing CASCADE")
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_empty_period_returns_empty_list(db_session):
+    """A period with no sleep_reports rows returns an empty list."""
+    await _truncate_cost_grade_tables(db_session)
+    await _seed_pricing(db_session)
+
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 8),
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
+async def test_multi_model_rolls_into_breakdown_by_model(db_session):
+    """Two models in the same period bucket each emit a breakdown_by_model entry.
+
+    Sonnet 100 calls × (10k in @ $3/1M + 2k out @ $15/1M) = $0.06
+    Haiku 50 calls × (8k in @ $1/1M + 1k out @ $5/1M) = $0.013
+    """
+    await _truncate_cost_grade_tables(db_session)
+    await _seed_pricing(db_session)
+
+    workspace_id = uuid4()
+    user_id = "user-multi-model"
+
+    sonnet_report = _make_report(
+        user_id=user_id, workspace_id=workspace_id, started_at=datetime(2026, 4, 5, 3, 0)
+    )
+    haiku_report = _make_report(
+        user_id=user_id, workspace_id=workspace_id, started_at=datetime(2026, 4, 5, 4, 0)
+    )
+    db_session.add_all([sonnet_report, haiku_report])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            _make_usage(
+                report_id=sonnet_report.id,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                calls=100,
+                input_tokens=10_000,
+                output_tokens=2_000,
+            ),
+            _make_usage(
+                report_id=haiku_report.id,
+                provider="anthropic",
+                model="claude-haiku-4-5",
+                calls=50,
+                input_tokens=8_000,
+                output_tokens=1_000,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 8),
+        workspace_id=workspace_id,
+    )
+    assert len(rows) == 1
+    row = rows[0]
+
+    assert row.period_start == date(2026, 4, 5)
+    assert row.workspace_id == workspace_id
+    assert row.user_id == user_id
+    assert row.calls == 150
+    assert row.tokens_in == 18_000
+    assert row.tokens_out == 3_000
+
+    by_model = {b.model: b for b in row.cost_breakdown_by_model}
+    assert set(by_model) == {"claude-sonnet-4-6", "claude-haiku-4-5"}
+    assert by_model["claude-sonnet-4-6"].calls == 100
+    # 10000 * 3/1e6 + 2000 * 15/1e6 = 0.03 + 0.03 = 0.06
+    assert by_model["claude-sonnet-4-6"].cost_usd == pytest.approx(0.06)
+    assert by_model["claude-haiku-4-5"].calls == 50
+    # 8000 * 1/1e6 + 1000 * 5/1e6 = 0.008 + 0.005 = 0.013
+    assert by_model["claude-haiku-4-5"].cost_usd == pytest.approx(0.013)
+    assert row.cost_usd == pytest.approx(0.073)
+    assert row.cost_usd_byok == 0.0
+
+
+@pytest.mark.asyncio
+async def test_byok_never_contributes_to_cost_usd(db_session):
+    """A ``paid_by='byok'`` row's cost lands in cost_usd_byok, not cost_usd."""
+    await _truncate_cost_grade_tables(db_session)
+    await _seed_pricing(db_session)
+
+    workspace_id = uuid4()
+    user_id = "user-byok"
+
+    platform_report = _make_report(
+        user_id=user_id, workspace_id=workspace_id, started_at=datetime(2026, 4, 5, 3, 0)
+    )
+    byok_report = _make_report(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        started_at=datetime(2026, 4, 5, 4, 0),
+        source="analysis",
+        paid_by="byok",
+    )
+    db_session.add_all([platform_report, byok_report])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            _make_usage(
+                report_id=platform_report.id,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                calls=10,
+                input_tokens=1_000_000,  # $3
+                output_tokens=0,
+            ),
+            _make_usage(
+                report_id=byok_report.id,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                calls=5,
+                input_tokens=2_000_000,  # $6
+                output_tokens=0,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 8),
+        workspace_id=workspace_id,
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.cost_usd == pytest.approx(3.0)
+    assert row.cost_usd_byok == pytest.approx(6.0)
+
+    # Cross-check: the by_source totals must reconcile with the row totals.
+    by_source = {b.source: b for b in row.cost_breakdown_by_source}
+    assert by_source["sleep"].cost_usd == pytest.approx(3.0)
+    assert by_source["sleep"].cost_usd_byok == 0.0
+    assert by_source["analysis"].cost_usd == 0.0
+    assert by_source["analysis"].cost_usd_byok == pytest.approx(6.0)
+
+
+@pytest.mark.asyncio
+async def test_pricing_miss_keeps_row_with_zero_cost(db_session):
+    """A model with no pricing row emits the row anyway — cost rolls to 0.
+
+    Mirrors the documented behavior for legacy NULL-model rows: usage
+    figures are preserved so the dashboard still shows tokens spent;
+    only the ``$`` column is blank.
+    """
+    await _truncate_cost_grade_tables(db_session)
+    await _seed_pricing(db_session)
+
+    workspace_id = uuid4()
+    user_id = "user-unpriced"
+
+    report = _make_report(
+        user_id=user_id, workspace_id=workspace_id, started_at=datetime(2026, 4, 5, 3, 0)
+    )
+    db_session.add(report)
+    await db_session.flush()
+
+    db_session.add(
+        _make_usage(
+            report_id=report.id,
+            provider="exotic-vendor",
+            model="not-yet-priced-1.0",
+            calls=10,
+            input_tokens=1_000_000,
+            output_tokens=500_000,
+        )
+    )
+    await db_session.flush()
+
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 8),
+        workspace_id=workspace_id,
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.calls == 10
+    assert row.tokens_in == 1_000_000
+    assert row.tokens_out == 500_000
+    assert row.cost_usd == 0.0
+    assert row.cost_usd_byok == 0.0
+
+
+@pytest.mark.asyncio
+async def test_embedding_cost_attributed_via_sleep_reports_columns(db_session):
+    """``embedding_tokens`` × embedding price contributes to cost_usd."""
+    await _truncate_cost_grade_tables(db_session)
+    await _seed_pricing(db_session)
+
+    workspace_id = uuid4()
+    user_id = "user-embedding"
+
+    report = _make_report(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        started_at=datetime(2026, 4, 5, 3, 0),
+        embedding_tokens=10_000_000,  # 10M × $0.02/1M = $0.20
+        embedding_provider="openai",
+        embedding_model="text-embedding-3-small",
+    )
+    db_session.add(report)
+    await db_session.flush()
+
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 8),
+        workspace_id=workspace_id,
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.embedding_tokens == 10_000_000
+    assert row.cost_usd == pytest.approx(0.20)
+
+
+@pytest.mark.asyncio
+async def test_filter_combination_source_and_paid_by(db_session):
+    """``source=analysis & paid_by=byok`` returns only the intersection."""
+    await _truncate_cost_grade_tables(db_session)
+    await _seed_pricing(db_session)
+
+    workspace_id = uuid4()
+    user_id = "user-filter"
+    common = {
+        "user_id": user_id,
+        "workspace_id": workspace_id,
+        "started_at": datetime(2026, 4, 5, 3, 0),
+    }
+    reports = [
+        _make_report(**common, source="sleep", paid_by="platform"),
+        _make_report(**common, source="analysis", paid_by="platform"),
+        _make_report(**common, source="sleep", paid_by="byok"),
+        _make_report(**common, source="analysis", paid_by="byok"),  # the keep
+    ]
+    db_session.add_all(reports)
+    await db_session.flush()
+
+    for r in reports:
+        db_session.add(
+            _make_usage(
+                report_id=r.id,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                calls=1,
+                input_tokens=1_000_000,
+                output_tokens=0,
+            )
+        )
+    await db_session.flush()
+
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 8),
+        workspace_id=workspace_id,
+        source="analysis",
+        paid_by="byok",
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.calls == 1  # only the analysis × byok row, not all 4
+    assert row.cost_usd == 0.0  # filtered to BYOK so platform total = 0
+    assert row.cost_usd_byok == pytest.approx(3.0)
+
+
+@pytest.mark.asyncio
+async def test_invalid_period_raises_value_error(db_session):
+    """``period`` outside the allowlist raises ValueError before SQL fires."""
+    service = CostAggregationService(db_session)
+    with pytest.raises(ValueError, match="Invalid period"):
+        await service.aggregate(
+            period="hour",
+            start=datetime(2026, 4, 1),
+            end=datetime(2026, 4, 8),
+        )
+
+
+@pytest.mark.asyncio
+async def test_inverted_window_raises_value_error(db_session):
+    """``start >= end`` raises ValueError immediately."""
+    service = CostAggregationService(db_session)
+    with pytest.raises(ValueError, match="start must be < end"):
+        await service.aggregate(
+            period="day",
+            start=datetime(2026, 4, 8),
+            end=datetime(2026, 4, 1),
+        )

--- a/backend/tests/integration/test_cost_aggregation_service.py
+++ b/backend/tests/integration/test_cost_aggregation_service.py
@@ -270,12 +270,14 @@ async def test_byok_never_contributes_to_cost_usd(db_session):
 
 
 @pytest.mark.asyncio
-async def test_pricing_miss_keeps_row_with_zero_cost(db_session):
-    """A model with no pricing row emits the row anyway — cost rolls to 0.
+async def test_pricing_miss_surfaces_cost_unknown_as_null(db_session):
+    """A usage row with no resolved pricing yields cost_usd = None.
 
-    Mirrors the documented behavior for legacy NULL-model rows: usage
-    figures are preserved so the dashboard still shows tokens spent;
-    only the ``$`` column is blank.
+    "cost unknown" must be distinguishable from "genuinely $0" so the
+    dashboard renders "—" instead of "$0.00" for legacy / unpriced
+    models. Same semantics as ``LLMPricingService.lookup()`` returning
+    ``None`` on a miss. Usage figures (calls / tokens_in / tokens_out)
+    are still surfaced — only the cost is NULL.
     """
     await _seed_pricing(db_session)
 
@@ -309,11 +311,83 @@ async def test_pricing_miss_keeps_row_with_zero_cost(db_session):
     )
     assert len(rows) == 1
     row = rows[0]
+    # Usage preserved
     assert row.calls == 10
     assert row.tokens_in == 1_000_000
     assert row.tokens_out == 500_000
-    assert row.cost_usd == 0.0
-    assert row.cost_usd_byok == 0.0
+    # Cost is None ("cost unknown") because the model has no pricing row.
+    assert row.cost_usd is None, "unpriced usage must surface as cost_usd=None, not 0.0"
+    assert row.cost_usd_byok == 0.0  # no BYOK contribution at all → stays 0.0
+    # Breakdown also propagates None.
+    by_model = {b.model: b for b in row.cost_breakdown_by_model}
+    assert by_model["not-yet-priced-1.0"].cost_usd is None
+    by_source = {b.source: b for b in row.cost_breakdown_by_source}
+    assert by_source["sleep"].cost_usd is None
+
+
+@pytest.mark.asyncio
+async def test_pricing_miss_for_one_model_taints_full_aggregate(db_session):
+    """Mixed priced+unpriced models in one bucket → cost_usd is NULL overall.
+
+    NULL is sticky: once any contributing row is unpriced, the bucket's
+    cost_usd is None for the whole row, the matching by_source entry,
+    AND the unpriced model's by_model entry. The PRICED model's by_model
+    entry retains its real cost so the operator can see at least the
+    portion that IS computable.
+    """
+    await _seed_pricing(db_session)
+
+    workspace_id = uuid4()
+    user_id = "user-mixed"
+
+    report = _make_report(
+        user_id=user_id, workspace_id=workspace_id, started_at=datetime(2026, 4, 5, 3, 0)
+    )
+    db_session.add(report)
+    await db_session.flush()
+
+    # Two usage rows under one report — one priced model, one unpriced.
+    db_session.add_all(
+        [
+            _make_usage(
+                report_id=report.id,
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                calls=10,
+                input_tokens=1_000_000,  # $3
+                output_tokens=0,
+            ),
+            _make_usage(
+                report_id=report.id,
+                provider="exotic-vendor",
+                model="not-yet-priced-1.0",
+                calls=5,
+                input_tokens=500_000,
+                output_tokens=0,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 4, 1),
+        end=datetime(2026, 4, 8),
+        workspace_id=workspace_id,
+    )
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.calls == 15
+    # Total cost is None because the by_source aggregate sums priced+unpriced.
+    assert row.cost_usd is None
+    # Per-model breakdown: priced model keeps its $3, unpriced is None.
+    by_model = {b.model: b for b in row.cost_breakdown_by_model}
+    assert by_model["claude-sonnet-4-6"].cost_usd == pytest.approx(3.0)
+    assert by_model["not-yet-priced-1.0"].cost_usd is None
+    # Per-source breakdown collapses both → None (sticky NULL).
+    by_source = {b.source: b for b in row.cost_breakdown_by_source}
+    assert by_source["sleep"].cost_usd is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #472

## Summary
- Two cost-aggregation endpoints over the cost-grade `sleep_reports` schema (#523), sharing one `CostAggregationService.aggregate()` SQL pipeline (LATERAL pricing joins × CTE × `UNION ALL`) — single round-trip, DB-side `GROUP BY date_trunc(period, started_at), workspace_id, user_id, llm_model, source, paid_by`.
- Admin route (`GET /api/v1/admin/cost-aggregation`) sees every workspace via `require_admin`; workspace route (`GET /api/v1/workspaces/{workspace_id}/cost-aggregation`) is owner/admin-scoped via `PermissionService.check_workspace_admin` so per-user activity volume across private contexts is not leaked to viewers/members.
- `cost_usd` (platform-billed) and `cost_usd_byok` (BYOK observability) are split at the SQL `GROUP BY` level so they cannot accidentally re-merge in application code. BYOK rows surface for runaway-spend alerting only.

## Implementation notes
- New files: `backend/src/services/cost_aggregation_service.py` (shared SQL pipeline), `backend/src/api/routes/cost_aggregation.py` (both endpoints, single rounding boundary, distinct OpenAPI tags).
- Two-endpoint design (option B from a 3-way A/B/C tradeoff with the operator) keeps `/admin/` prefix semantics honest and aligns the workspace path with future B2B billing endpoints (`/api/v1/workspaces/{id}/invoices`).
- v1 limitation documented in the service docstring: pricing-tier lookup pins `context_min_tokens=0` because per-call context window size is not stored on `sleep_report_llm_usage`. Multi-tier models (Gemini 2.5 Pro >200k) are under-estimated; the dashboard child (#473) can surface the caveat.
- All filter values validated against allowlists in two layers: route layer (`HTTPException` 400) and service layer (`ValueError`, defense-in-depth). The DB CHECK constraints on `source` / `paid_by` (#523) are the third layer.

## Test coverage
- Integration suite (real Postgres, real LATERAL+CTE SQL): empty period, multi-model breakdown, BYOK never contributes to `cost_usd`, embedding cost via `sleep_reports` columns, pricing-miss preserves usage figures, filter combination intersection, **`period=week` collapses 7 daily reports into 1 ISO-Monday bucket**, **half-open window upper bound includes 23:59:59 of the `to` day**, invalid period / inverted window `ValueError`.
- Route suite (mocked auth + monkeypatch-isolated service): admin 200, non-admin 403, query parsing (period/source/paid_by 400, missing required 422), owner sees workspace, non-owner 403, cross-workspace probe 403 (asserts `await_count == 0` — auth fires before SQL), workspace_id query param ignored when path arg present.
- 23 new tests; 22 adjacent suites (sleep schema + sleep_reports admin) re-run with no regressions.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow → addressed in commit 2 (period-week + window-boundary tests)
- cto: green
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/472-feat-cost-aggregation-api.gate2.md

🤖 Generated via /gh-issue-driven:ship
