### PR TITLE
feat(frontend): cost dashboard — admin + workspace pages (#473)

### DIFF
--- a/frontend/src/app/(authenticated)/admin/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/cost/page.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * Admin Cost Aggregation Dashboard (Issue #473).
+ *
+ * Cross-workspace view: admin-only. Renders the shared
+ * ``CostDashboard`` against the admin endpoint, which returns one row
+ * per (period × workspace × user × model × source × paid_by) — hence
+ * the workspace column is shown for cross-workspace comparison.
+ *
+ * Workspace owner / admin self-service is at ``/workspace/cost`` and
+ * uses the workspace-scoped endpoint shipped in #472.
+ */
+
+import { useTranslations } from "next-intl";
+import { PageContainer } from "@/components/common/PageContainer";
+import { PageHeader } from "@/components/common/PageHeader";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { CostDashboard } from "@/components/cost/CostDashboard";
+import { useAuth } from "@/contexts/AuthContext";
+import { isAdmin } from "@/lib/auth/rbac";
+import { fetchAdminCostAggregation } from "@/lib/api";
+
+export default function AdminCostPage() {
+  const t = useTranslations("admin.cost");
+  const { user } = useAuth();
+
+  if (!isAdmin(user)) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} />
+        <ErrorBanner error={t("errors.forbidden")} />
+      </PageContainer>
+    );
+  }
+
+  // Stable module-level reference passed directly — no closure, no
+  // useCallback needed. Keeps CostDashboard's effect dep set quiet.
+  return (
+    <CostDashboard
+      title={t("title")}
+      description={t("description")}
+      fetchData={fetchAdminCostAggregation}
+      showWorkspaceColumn
+    />
+  );
+}

--- a/frontend/src/app/(authenticated)/admin/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/cost/page.tsx
@@ -17,6 +17,7 @@ import { useTranslations } from "next-intl";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { LoadingState } from "@/components/common/LoadingState";
 import { CostDashboard } from "@/components/cost/CostDashboard";
 import { useAuth } from "@/contexts/AuthContext";
 import { isAdmin } from "@/lib/auth/rbac";
@@ -24,7 +25,19 @@ import { fetchAdminCostAggregation } from "@/lib/api";
 
 export default function AdminCostPage() {
   const t = useTranslations("admin.cost");
-  const { user } = useAuth();
+  const { user, isLoading: authLoading } = useAuth();
+
+  // Render a loading skeleton until AuthProvider resolves. Without
+  // this, real admins see a brief "Admin role required" flash on every
+  // first paint because user is null until getCurrentUser() returns.
+  if (authLoading) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} />
+        <LoadingState lines={6} />
+      </PageContainer>
+    );
+  }
 
   if (!isAdmin(user)) {
     return (

--- a/frontend/src/app/(authenticated)/admin/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/cost/page.tsx
@@ -5,8 +5,9 @@
  *
  * Cross-workspace view: admin-only. Renders the shared
  * ``CostDashboard`` against the admin endpoint, which returns one row
- * per (period × workspace × user × model × source × paid_by) — hence
- * the workspace column is shown for cross-workspace comparison.
+ * per (period × workspace × user) with model/source rollups in
+ * ``cost_breakdown_by_model`` / ``cost_breakdown_by_source`` arrays —
+ * hence the workspace column is shown for cross-workspace comparison.
  *
  * Workspace owner / admin self-service is at ``/workspace/cost`` and
  * uses the workspace-scoped endpoint shipped in #472.

--- a/frontend/src/app/(authenticated)/workspace/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/cost/page.tsx
@@ -55,6 +55,19 @@ export default function WorkspaceCostPage() {
     [currentWorkspaceId],
   );
 
+  // Distinguish "no workspace exists / selected" from "wrong role".
+  // Without this branch a brand-new account with zero workspaces would
+  // see a misleading "owner/admin role required" banner; the real
+  // issue is that there's no workspace to be the owner OF.
+  if (!loading && !currentWorkspaceId) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} />
+        <ErrorBanner error={t("errors.noWorkspaceSelected")} />
+      </PageContainer>
+    );
+  }
+
   if (!loading && !allowed) {
     return (
       <PageContainer>

--- a/frontend/src/app/(authenticated)/workspace/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/cost/page.tsx
@@ -59,7 +59,7 @@ export default function WorkspaceCostPage() {
     return (
       <PageContainer>
         <PageHeader title={t("title")} />
-        <ErrorBanner error={t("errors.forbidden")} />
+        <ErrorBanner error={t("errors.forbiddenWorkspace")} />
       </PageContainer>
     );
   }

--- a/frontend/src/app/(authenticated)/workspace/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/cost/page.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+/**
+ * Workspace-scoped Cost Aggregation Dashboard (Issue #473).
+ *
+ * Workspace owner / admin self-service view. Renders the shared
+ * ``CostDashboard`` against the workspace endpoint shipped in #472.
+ *
+ * Auth gates layered defense-in-depth:
+ * - Sidebar nav hides this entry below ``admin`` workspace role
+ * - This page checks ``hasWorkspaceRole(..., "admin")`` and renders an
+ *   ``ErrorBanner`` for member/viewer (paranoid — they can't reach the
+ *   nav, but a direct URL hit still gets a friendly message instead of
+ *   a raw 403 from the backend)
+ * - Backend ``check_workspace_admin`` is the source of truth and would
+ *   reject viewer/member regardless
+ *
+ * The shared ``CostDashboard`` accepts a ``ready`` prop so the initial
+ * fetch waits until ``currentWorkspaceId`` resolves — without this the
+ * first render would request ``/api/v1/workspaces//cost-aggregation``
+ * (empty path segment) and 404.
+ */
+
+import { useCallback } from "react";
+import { useTranslations } from "next-intl";
+import { PageContainer } from "@/components/common/PageContainer";
+import { PageHeader } from "@/components/common/PageHeader";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+import {
+  CostDashboard,
+  type CostDashboardFetchParams,
+} from "@/components/cost/CostDashboard";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { fetchWorkspaceCostAggregation } from "@/lib/api";
+
+export default function WorkspaceCostPage() {
+  const t = useTranslations("admin.cost");
+  const { currentWorkspace, currentWorkspaceId, loading } = useWorkspace();
+
+  const allowed = hasWorkspaceRole(
+    currentWorkspace?.current_user_role,
+    "admin",
+  );
+
+  // useCallback keyed on currentWorkspaceId only. Without this, every
+  // WorkspaceProvider re-render (workspace switch settling, auth context
+  // propagation, plain parent re-renders) would produce a new closure
+  // identity → CostDashboard's loadCost recompiles → useEffect re-fires
+  // → an extra /cost-aggregation GET per re-render. The stable
+  // reference scopes the refetch to actual workspace switches.
+  const fetchData = useCallback(
+    (params: CostDashboardFetchParams) =>
+      fetchWorkspaceCostAggregation(currentWorkspaceId ?? "", params),
+    [currentWorkspaceId],
+  );
+
+  if (!loading && !allowed) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} />
+        <ErrorBanner error={t("errors.forbidden")} />
+      </PageContainer>
+    );
+  }
+
+  return (
+    <CostDashboard
+      title={t("title")}
+      description={t("descriptionWorkspace")}
+      fetchData={fetchData}
+      showWorkspaceColumn={false}
+      ready={!!currentWorkspaceId}
+    />
+  );
+}

--- a/frontend/src/components/cost/CostDashboard.test.ts
+++ b/frontend/src/components/cost/CostDashboard.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the pure helpers in CostDashboard.tsx (Issue #473).
+ *
+ * Scope is the data-shaping logic — sticky-NULL aggregation in
+ * ``buildChartData`` and null-as-em-dash in ``formatCost``. Component
+ * rendering is exercised end-to-end by the Next.js prerender during
+ * ``next build``; the focus here is the contracts that would silently
+ * regress if someone edited the helpers.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { CostAggregationRow } from "@/lib/api";
+import { buildChartData, formatCost } from "./CostDashboard";
+
+function row(overrides: Partial<CostAggregationRow>): CostAggregationRow {
+  return {
+    period_start: "2026-04-01",
+    workspace_id: "11111111-1111-1111-1111-111111111111",
+    user_id: "user-1",
+    calls: 0,
+    tokens_in: 0,
+    tokens_out: 0,
+    tokens_cached_in: 0,
+    embedding_tokens: 0,
+    cost_usd: 0,
+    cost_usd_byok: 0,
+    cost_breakdown_by_model: [],
+    cost_breakdown_by_source: [],
+    ...overrides,
+  };
+}
+
+describe("formatCost", () => {
+  it("renders a positive number as $X.XXXX", () => {
+    expect(formatCost(0.083)).toBe("$0.0830");
+    expect(formatCost(125.5)).toBe("$125.5000");
+  });
+
+  it("renders zero as $0.0000 — distinct from cost-unknown", () => {
+    // Genuine $0 must NOT collapse to em-dash; otherwise the UI would
+    // conflate "no spend" with "cost unknown" and break the v1
+    // cost-grade contract.
+    expect(formatCost(0)).toBe("$0.0000");
+  });
+
+  it("renders null as em-dash (cost unknown)", () => {
+    // Sticky-NULL contract from the backend: null means "at least one
+    // contributing usage row had no resolved pricing." Render it as
+    // "—" so operators don't read it as $0.
+    expect(formatCost(null)).toBe("—");
+  });
+});
+
+describe("buildChartData", () => {
+  it("returns an empty array when no rows are provided", () => {
+    expect(buildChartData([])).toEqual([]);
+  });
+
+  it("collapses multiple rows on the same date into one bucket", () => {
+    const result = buildChartData([
+      row({ period_start: "2026-04-01", cost_usd: 1.0, cost_usd_byok: 0.5 }),
+      row({ period_start: "2026-04-01", cost_usd: 2.0, cost_usd_byok: 0.25 }),
+    ]);
+    expect(result).toHaveLength(1);
+    expect(result[0].date).toBe("2026-04-01");
+    expect(result[0].cost_usd).toBeCloseTo(3.0, 6);
+    expect(result[0].cost_usd_byok).toBeCloseTo(0.75, 6);
+  });
+
+  it("sorts buckets by date ascending (lexicographic on YYYY-MM-DD)", () => {
+    const result = buildChartData([
+      row({ period_start: "2026-04-30", cost_usd: 1.0 }),
+      row({ period_start: "2026-04-01", cost_usd: 2.0 }),
+      row({ period_start: "2026-04-15", cost_usd: 3.0 }),
+    ]);
+    expect(result.map((p) => p.date)).toEqual([
+      "2026-04-01",
+      "2026-04-15",
+      "2026-04-30",
+    ]);
+  });
+
+  it("propagates null cost via sticky-NULL: any null contribution → bucket is null", () => {
+    // The chart MUST render a gap for unpriced periods. Summing
+    // null + 1.5 = 1.5 would silently understate "cost unknown" as a
+    // misleading $1.50 dip — the exact bug the backend's BOOL_AND CTE
+    // exists to prevent.
+    const result = buildChartData([
+      row({ period_start: "2026-04-01", cost_usd: 1.5, cost_usd_byok: 0.0 }),
+      row({ period_start: "2026-04-01", cost_usd: null, cost_usd_byok: 0.0 }),
+    ]);
+    expect(result).toEqual([
+      { date: "2026-04-01", cost_usd: null, cost_usd_byok: 0.0 },
+    ]);
+  });
+
+  it("sticky-NULL is per-field — cost_usd_byok null does NOT taint cost_usd", () => {
+    // Independent buckets per field: a workspace running BYOK with
+    // unpriced models shouldn't blank out its platform-billed total.
+    const result = buildChartData([
+      row({
+        period_start: "2026-04-01",
+        cost_usd: 1.0,
+        cost_usd_byok: null,
+      }),
+      row({
+        period_start: "2026-04-01",
+        cost_usd: 2.0,
+        cost_usd_byok: 0.5,
+      }),
+    ]);
+    expect(result).toEqual([
+      { date: "2026-04-01", cost_usd: 3.0, cost_usd_byok: null },
+    ]);
+  });
+
+  it("once a bucket goes null it stays null even if a later non-null row arrives", () => {
+    // Reduce-style: the order of the input rows is irrelevant — a
+    // single null contribution permanently sinks the bucket.
+    const result = buildChartData([
+      row({ period_start: "2026-04-01", cost_usd: null }),
+      row({ period_start: "2026-04-01", cost_usd: 5.0 }),
+      row({ period_start: "2026-04-01", cost_usd: 10.0 }),
+    ]);
+    expect(result[0].cost_usd).toBeNull();
+  });
+
+  it("keeps separate buckets independent — null on one date does not leak to another", () => {
+    const result = buildChartData([
+      row({ period_start: "2026-04-01", cost_usd: null }),
+      row({ period_start: "2026-04-02", cost_usd: 3.5 }),
+    ]);
+    const byDate = Object.fromEntries(result.map((p) => [p.date, p.cost_usd]));
+    expect(byDate["2026-04-01"]).toBeNull();
+    expect(byDate["2026-04-02"]).toBe(3.5);
+  });
+});

--- a/frontend/src/components/cost/CostDashboard.tsx
+++ b/frontend/src/components/cost/CostDashboard.tsx
@@ -1,0 +1,453 @@
+"use client";
+
+/**
+ * Shared cost-aggregation dashboard UI.
+ *
+ * Issue #473: rendered by both ``/admin/cost`` (cross-workspace) and
+ * ``/workspace/cost`` (single-workspace, owner/admin scoped). The two
+ * pages differ only in the fetcher and a couple of optional tweaks
+ * (workspace column visibility, page title/description) — everything
+ * else (date range UI, period toggle, chart, table, sticky-NULL
+ * rendering) is identical and lives here.
+ *
+ * Sticky-NULL contract (mirrors the backend service shipped in #472):
+ * a row whose ``cost_usd`` is ``null`` means "cost unknown" — at least
+ * one contributing usage row had no resolved pricing. Render as "—"
+ * (table) or as a chart gap (``connectNulls={false}``), NOT as
+ * ``$0.00``, so operators can see the difference between "no spend"
+ * and "spend we couldn't price".
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import { PageHeader } from "@/components/common/PageHeader";
+import { PageContainer } from "@/components/common/PageContainer";
+import { Section } from "@/components/common/Section";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { LoadingState, InlineSpinner } from "@/components/common/LoadingState";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { RefreshCw, BarChart3 } from "lucide-react";
+import { formatLocalDate } from "@/lib/utils/datetime";
+import {
+  COST_AGGREGATION_PERIODS,
+  type CostAggregationPeriod,
+  type CostAggregationResponse,
+  type CostAggregationRow,
+} from "@/lib/api";
+
+const DEFAULT_LOOKBACK_DAYS = 30;
+const MAX_LOOKBACK_DAYS = 365;
+
+function defaultDateRange(): { from: string; to: string } {
+  const today = new Date();
+  const past = new Date(today);
+  past.setDate(today.getDate() - (DEFAULT_LOOKBACK_DAYS - 1));
+  return { from: formatLocalDate(past), to: formatLocalDate(today) };
+}
+
+/**
+ * Render a nullable cost as USD or em-dash. Null means "cost unknown"
+ * — distinguish from a genuine $0 in the UI.
+ *
+ * Exported for unit testing; not re-exported from the package barrel.
+ */
+export function formatCost(value: number | null): string {
+  if (value === null) return "—";
+  return `$${value.toFixed(4)}`;
+}
+
+export interface ChartPoint {
+  date: string;
+  cost_usd: number | null;
+  cost_usd_byok: number | null;
+}
+
+/**
+ * Collapse aggregation rows by ``period_start`` for the time-series
+ * chart. Sticky-NULL: any null contribution to a bucket makes the
+ * whole bucket null, so the chart renders a gap (with
+ * ``connectNulls={false}``) for "cost unknown" periods rather than
+ * understating spend with a misleading $0 dip. Output is sorted
+ * lexicographically by date (which works for ISO YYYY-MM-DD).
+ *
+ * Exported for unit testing.
+ */
+export function buildChartData(rows: CostAggregationRow[]): ChartPoint[] {
+  const buckets = new Map<
+    string,
+    { cost_usd: number | null; cost_usd_byok: number | null }
+  >();
+  for (const row of rows) {
+    const existing = buckets.get(row.period_start) ?? {
+      cost_usd: 0,
+      cost_usd_byok: 0,
+    };
+    const next = {
+      cost_usd:
+        existing.cost_usd === null || row.cost_usd === null
+          ? null
+          : existing.cost_usd + row.cost_usd,
+      cost_usd_byok:
+        existing.cost_usd_byok === null || row.cost_usd_byok === null
+          ? null
+          : existing.cost_usd_byok + row.cost_usd_byok,
+    };
+    buckets.set(row.period_start, next);
+  }
+  return [...buckets.entries()]
+    .map(([date, totals]) => ({ date, ...totals }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/** Filter shape passed to the fetcher. Same fields both endpoints accept. */
+export interface CostDashboardFetchParams {
+  period: CostAggregationPeriod;
+  from: string;
+  to: string;
+}
+
+export interface CostDashboardProps {
+  /** Page title (translated by the caller). */
+  title: string;
+  /** Page description (translated by the caller). */
+  description: string;
+  /**
+   * Fetcher injected by the page wrapper. The wrapper closes over the
+   * right endpoint (admin cross-workspace vs workspace-scoped) and any
+   * path params so the dashboard itself stays endpoint-agnostic.
+   */
+  fetchData: (
+    params: CostDashboardFetchParams,
+  ) => Promise<CostAggregationResponse>;
+  /**
+   * Whether to render the per-row workspace_id column. The
+   * admin (cross-workspace) page wants it; the workspace-scoped page
+   * doesn't (every row is the same workspace).
+   */
+  showWorkspaceColumn?: boolean;
+  /**
+   * Disable initial fetch — useful when the parent is still resolving
+   * a prerequisite (e.g. ``currentWorkspaceId`` not yet available).
+   * The dashboard renders an empty state until ``true``.
+   */
+  ready?: boolean;
+}
+
+export function CostDashboard({
+  title,
+  description,
+  fetchData,
+  showWorkspaceColumn = false,
+  ready = true,
+}: CostDashboardProps) {
+  const t = useTranslations("admin.cost");
+
+  const [{ from, to }, setRange] = useState(defaultDateRange);
+  const [period, setPeriod] = useState<CostAggregationPeriod>("day");
+  const [rows, setRows] = useState<CostAggregationRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Validate the date range client-side so an obvious mistake doesn't
+  // round-trip to the server. Server still validates as the source of
+  // truth (defense in depth — same pattern as the backend).
+  const rangeError = useMemo<string | null>(() => {
+    if (!from || !to) return null;
+    if (from > to) return t("validation.invertedRange");
+    const fromDate = new Date(`${from}T00:00:00`);
+    const toDate = new Date(`${to}T00:00:00`);
+    const days =
+      Math.round((toDate.getTime() - fromDate.getTime()) / 86400000) + 1;
+    if (days > MAX_LOOKBACK_DAYS) {
+      return t("validation.windowTooWide", { max: MAX_LOOKBACK_DAYS });
+    }
+    return null;
+  }, [from, to, t]);
+
+  const loadCost = useCallback(async () => {
+    if (!ready) {
+      setLoading(false);
+      return;
+    }
+    // Short-circuit on client-side validation failure: firing the
+    // fetch with an invalid range (inverted, > MAX_LOOKBACK_DAYS) just
+    // wastes a round-trip and risks flashing a backend 400 error
+    // banner over the more specific rangeError banner that's already
+    // showing in the filter section.
+    if (rangeError !== null) {
+      setLoading(false);
+      return;
+    }
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await fetchData({ period, from, to });
+      setRows(response.rows);
+    } catch (err) {
+      setError(
+        err instanceof Error
+          ? err
+          : new Error(typeof err === "string" ? err : "Unknown error"),
+      );
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [from, to, period, ready, rangeError, fetchData]);
+
+  useEffect(() => {
+    loadCost();
+  }, [loadCost]);
+
+  const chartData = useMemo(() => buildChartData(rows), [rows]);
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title={title}
+        description={description}
+        actions={
+          <Button
+            onClick={loadCost}
+            variant="outline"
+            disabled={loading || rangeError !== null}
+          >
+            {loading ? (
+              <InlineSpinner size="sm" className="mr-2" />
+            ) : (
+              <RefreshCw className="h-4 w-4 mr-2" />
+            )}
+            {t("actions.refresh")}
+          </Button>
+        }
+      />
+
+      <Section title={t("filter.title")}>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-4">
+          <div>
+            <Label htmlFor="cost-from">{t("filter.from")}</Label>
+            <Input
+              id="cost-from"
+              type="date"
+              value={from}
+              onChange={(e) =>
+                setRange((r) => ({ ...r, from: e.target.value }))
+              }
+              max={to}
+            />
+          </div>
+          <div>
+            <Label htmlFor="cost-to">{t("filter.to")}</Label>
+            <Input
+              id="cost-to"
+              type="date"
+              value={to}
+              onChange={(e) => setRange((r) => ({ ...r, to: e.target.value }))}
+              min={from}
+              max={formatLocalDate(new Date())}
+            />
+          </div>
+          <div className="md:col-span-2">
+            <Label>{t("filter.period")}</Label>
+            <Tabs
+              value={period}
+              onValueChange={(v) => setPeriod(v as CostAggregationPeriod)}
+              className="mt-1.5"
+            >
+              <TabsList>
+                {COST_AGGREGATION_PERIODS.map((p) => (
+                  <TabsTrigger key={p} value={p}>
+                    {t(`period.${p}`)}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          </div>
+        </div>
+        {rangeError && <ErrorBanner error={rangeError} />}
+      </Section>
+
+      <Section title={t("chart.title")}>
+        {loading ? (
+          <div className="p-6">
+            <LoadingState lines={6} />
+          </div>
+        ) : error ? (
+          <ErrorBanner error={error.message} />
+        ) : chartData.length === 0 ? (
+          <EmptyState
+            icon={BarChart3}
+            title={t("emptyState.title")}
+            description={t("emptyState.description")}
+          />
+        ) : (
+          <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 p-4">
+            <ResponsiveContainer width="100%" height={320}>
+              <LineChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis
+                  tickFormatter={(v: number) => `$${v.toFixed(2)}`}
+                  width={70}
+                />
+                <Tooltip
+                  formatter={(value) => {
+                    // Recharts widens its formatter param type beyond what
+                    // our chart actually emits (number | null). Narrow back
+                    // here so the "cost unknown" branch fires for null buckets.
+                    if (value === null || value === undefined) {
+                      return t("chart.unknown");
+                    }
+                    if (typeof value === "number") {
+                      return `$${value.toFixed(4)}`;
+                    }
+                    return String(value);
+                  }}
+                />
+                <Legend />
+                {/* connectNulls=false so an unpriced bucket renders as
+                    a gap, not a misleading interpolated line — operators
+                    must see the "cost unknown" hole explicitly. */}
+                <Line
+                  type="monotone"
+                  dataKey="cost_usd"
+                  name={t("chart.costPlatform")}
+                  stroke="#2563eb"
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="cost_usd_byok"
+                  name={t("chart.costByok")}
+                  stroke="#16a34a"
+                  strokeWidth={2}
+                  dot={false}
+                  connectNulls={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </Section>
+
+      <Section title={t("table.title")}>
+        {loading ? (
+          <div className="p-6">
+            <LoadingState lines={6} />
+          </div>
+        ) : rows.length === 0 ? (
+          <EmptyState
+            icon={BarChart3}
+            title={t("emptyState.title")}
+            description={t("emptyState.description")}
+          />
+        ) : (
+          <div className="bg-white dark:bg-gray-900 rounded-lg border border-gray-200 dark:border-gray-700 overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t("table.periodStart")}</TableHead>
+                  {showWorkspaceColumn && (
+                    <TableHead>{t("table.workspaceId")}</TableHead>
+                  )}
+                  <TableHead>{t("table.userId")}</TableHead>
+                  <TableHead className="text-right">
+                    {t("table.calls")}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t("table.tokensIn")}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t("table.tokensOut")}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t("table.embeddingTokens")}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t("table.costPlatform")}
+                  </TableHead>
+                  <TableHead className="text-right">
+                    {t("table.costByok")}
+                  </TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row, i) => (
+                  <TableRow
+                    key={`${row.period_start}-${row.workspace_id ?? "_"}-${row.user_id}-${i}`}
+                  >
+                    <TableCell className="font-mono text-sm">
+                      {row.period_start}
+                    </TableCell>
+                    {showWorkspaceColumn && (
+                      <TableCell className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                        {row.workspace_id ? row.workspace_id.slice(0, 8) : "—"}
+                      </TableCell>
+                    )}
+                    <TableCell className="text-sm">{row.user_id}</TableCell>
+                    <TableCell className="text-right font-mono text-sm">
+                      {row.calls.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-sm">
+                      {row.tokens_in.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-sm">
+                      {row.tokens_out.toLocaleString()}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-sm">
+                      {row.embedding_tokens.toLocaleString()}
+                    </TableCell>
+                    <TableCell
+                      className="text-right font-mono text-sm"
+                      title={
+                        row.cost_usd === null
+                          ? t("table.costUnknownTooltip")
+                          : undefined
+                      }
+                    >
+                      {formatCost(row.cost_usd)}
+                    </TableCell>
+                    <TableCell
+                      className="text-right font-mono text-sm"
+                      title={
+                        row.cost_usd_byok === null
+                          ? t("table.costUnknownTooltip")
+                          : undefined
+                      }
+                    >
+                      {formatCost(row.cost_usd_byok)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </Section>
+    </PageContainer>
+  );
+}

--- a/frontend/src/components/cost/CostDashboard.tsx
+++ b/frontend/src/components/cost/CostDashboard.tsx
@@ -196,11 +196,12 @@ export function CostDashboard({
 
   const loadCost = useCallback(async () => {
     if (!ready) {
-      // Clear stale error from a prior fetch — otherwise a workspace
+      // Clear stale state from a prior fetch — otherwise a workspace
       // switch (which transiently flips ready→false) would leave the
-      // previous workspace's error banner visible while the new
-      // workspace_id resolves.
+      // previous workspace's error banner AND chart/table data visible
+      // while the new workspace_id resolves.
       setError(null);
+      setRows([]);
       setLoading(false);
       return;
     }
@@ -208,11 +209,12 @@ export function CostDashboard({
     // fetch with an invalid range (inverted, > MAX_LOOKBACK_DAYS) just
     // wastes a round-trip and risks flashing a backend 400 error
     // banner over the more specific rangeError banner that's already
-    // showing in the filter section. Also clear any prior backend
-    // error so the user sees only the current rangeError, not stacked
-    // banners from a now-corrected previous range.
+    // showing in the filter section. Also reset error + rows so the UI
+    // doesn't keep showing chart/table data from the previous (valid)
+    // range while the user is mid-correction.
     if (rangeError !== null) {
       setError(null);
+      setRows([]);
       setLoading(false);
       return;
     }
@@ -375,6 +377,13 @@ export function CostDashboard({
           <div className="p-6">
             <LoadingState lines={6} />
           </div>
+        ) : error ? (
+          // Render the same error in both sections so the table never
+          // misrepresents a fetch failure as "no data" — empty rows
+          // happen by design (cleared on error in catch), so the
+          // EmptyState branch alone would conflate failure with
+          // genuine zero results.
+          <ErrorBanner error={error.message} />
         ) : rows.length === 0 ? (
           <EmptyState
             icon={BarChart3}

--- a/frontend/src/components/cost/CostDashboard.tsx
+++ b/frontend/src/components/cost/CostDashboard.tsx
@@ -174,9 +174,12 @@ export function CostDashboard({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  // Validate the date range client-side so an obvious mistake doesn't
-  // round-trip to the server. Server still validates as the source of
-  // truth (defense in depth — same pattern as the backend).
+  // Client-side range validation. The server validates `period` and
+  // `from <= to` (#472), but does NOT enforce a maximum window today —
+  // so MAX_LOOKBACK_DAYS is a UI-only soft cap to keep accidental huge
+  // queries from hitting the backend. A non-UI caller (curl / SDK)
+  // can still request arbitrarily large ranges. Backend enforcement
+  // is tracked as a follow-up to #472.
   const rangeError = useMemo<string | null>(() => {
     if (!from || !to) return null;
     if (from > to) return t("validation.invertedRange");

--- a/frontend/src/components/cost/CostDashboard.tsx
+++ b/frontend/src/components/cost/CostDashboard.tsx
@@ -176,10 +176,18 @@ export function CostDashboard({
   const rangeError = useMemo<string | null>(() => {
     if (!from || !to) return null;
     if (from > to) return t("validation.invertedRange");
-    const fromDate = new Date(`${from}T00:00:00`);
-    const toDate = new Date(`${to}T00:00:00`);
+    // Use UTC anchors for the day-window math. Local-tz construction
+    // (`new Date(\`${from}T00:00:00\`)`) drifts ±1 across DST transitions
+    // because a local "day" is 23/25 hours those days, which can flip
+    // a 365-day window to 364 or 366 and spuriously trigger / suppress
+    // the windowTooWide error at the boundary. Date.UTC always
+    // returns 86,400,000 ms per day.
+    const [fy, fm, fd] = from.split("-").map(Number);
+    const [ty, tm, td] = to.split("-").map(Number);
     const days =
-      Math.round((toDate.getTime() - fromDate.getTime()) / 86400000) + 1;
+      Math.round(
+        (Date.UTC(ty, tm - 1, td) - Date.UTC(fy, fm - 1, fd)) / 86400000,
+      ) + 1;
     if (days > MAX_LOOKBACK_DAYS) {
       return t("validation.windowTooWide", { max: MAX_LOOKBACK_DAYS });
     }
@@ -188,6 +196,11 @@ export function CostDashboard({
 
   const loadCost = useCallback(async () => {
     if (!ready) {
+      // Clear stale error from a prior fetch — otherwise a workspace
+      // switch (which transiently flips ready→false) would leave the
+      // previous workspace's error banner visible while the new
+      // workspace_id resolves.
+      setError(null);
       setLoading(false);
       return;
     }
@@ -195,8 +208,11 @@ export function CostDashboard({
     // fetch with an invalid range (inverted, > MAX_LOOKBACK_DAYS) just
     // wastes a round-trip and risks flashing a backend 400 error
     // banner over the more specific rangeError banner that's already
-    // showing in the filter section.
+    // showing in the filter section. Also clear any prior backend
+    // error so the user sees only the current rangeError, not stacked
+    // banners from a now-corrected previous range.
     if (rangeError !== null) {
+      setError(null);
       setLoading(false);
       return;
     }

--- a/frontend/src/components/cost/CostDashboard.tsx
+++ b/frontend/src/components/cost/CostDashboard.tsx
@@ -34,7 +34,11 @@ import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { Section } from "@/components/common/Section";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
-import { LoadingState, InlineSpinner } from "@/components/common/LoadingState";
+import {
+  LoadingState,
+  TableLoadingState,
+  InlineSpinner,
+} from "@/components/common/LoadingState";
 import { EmptyState } from "@/components/ui/empty-state";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -227,13 +231,13 @@ export function CostDashboard({
       setError(
         err instanceof Error
           ? err
-          : new Error(typeof err === "string" ? err : "Unknown error"),
+          : new Error(typeof err === "string" ? err : t("errors.unknown")),
       );
       setRows([]);
     } finally {
       setLoading(false);
     }
-  }, [from, to, period, ready, rangeError, fetchData]);
+  }, [from, to, period, ready, rangeError, fetchData, t]);
 
   useEffect(() => {
     loadCost();
@@ -308,7 +312,16 @@ export function CostDashboard({
       </Section>
 
       <Section title={t("chart.title")}>
-        {loading ? (
+        {/* Range-error placeholder check ordered first so the section
+            doesn't fall through to "No cost data" while the user is
+            mid-correction — the rangeError banner in the filter
+            section already explains WHAT is wrong; here we just hint
+            that the chart will populate once they fix it. */}
+        {rangeError !== null ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400 p-6">
+            {t("rangeErrorPlaceholder")}
+          </p>
+        ) : loading ? (
           <div className="p-6">
             <LoadingState lines={6} />
           </div>
@@ -373,9 +386,13 @@ export function CostDashboard({
       </Section>
 
       <Section title={t("table.title")}>
-        {loading ? (
+        {rangeError !== null ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400 p-6">
+            {t("rangeErrorPlaceholder")}
+          </p>
+        ) : loading ? (
           <div className="p-6">
-            <LoadingState lines={6} />
+            <TableLoadingState rows={6} />
           </div>
         ) : error ? (
           // Render the same error in both sections so the table never

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -54,6 +54,7 @@ import {
   AlertTriangle,
   Moon,
   ShieldCheck,
+  DollarSign,
 } from "lucide-react";
 // Issue #246: ContextSelector removed - use /contexts link instead
 import { WorkspaceSwitcher } from "@/components/workspaces/WorkspaceSwitcher";
@@ -108,6 +109,16 @@ const navigationGroups: NavGroup[] = [
         icon: Users,
         showMemberCount: true,
         requiredWorkspaceRole: "admin", // Issue #398: hide from member/viewer
+      },
+      {
+        // Issue #473: workspace-scoped cost dashboard.
+        // Backend gates owner/admin via check_workspace_admin (#472);
+        // mirror that here so member/viewer don't see a nav entry that
+        // would 403 on click.
+        nameKey: "cost",
+        href: "/workspace/cost",
+        icon: DollarSign,
+        requiredWorkspaceRole: "admin",
       },
     ],
   },
@@ -170,6 +181,13 @@ const navigationGroups: NavGroup[] = [
         nameKey: "sleepReports",
         href: "/admin/sleep-reports",
         icon: Moon,
+        requiredRole: Role.ADMIN,
+      },
+      {
+        // Issue #473: cost dashboard
+        nameKey: "cost",
+        href: "/admin/cost",
+        icon: DollarSign,
         requiredRole: Role.ADMIN,
       },
       {

--- a/frontend/src/components/dashboard/UsageStats.tsx
+++ b/frontend/src/components/dashboard/UsageStats.tsx
@@ -167,12 +167,12 @@ export const UsageStats = forwardRef<UsageStatsRef, UsageStatsProps>(
       return [
         ...top,
         {
-          endpoint: `Other (${rest.length})`,
+          endpoint: t("otherEndpointsLabel", { count: rest.length }),
           count: otherCount,
           percentage: otherPercentage,
         },
       ];
-    }, [breakdown]);
+    }, [breakdown, t]);
 
     const fetchAllStats = async () => {
       try {

--- a/frontend/src/components/dashboard/UsageStats.tsx
+++ b/frontend/src/components/dashboard/UsageStats.tsx
@@ -101,13 +101,21 @@ interface UsageBreakdown {
   period_days: number;
 }
 
-const COLORS = [
-  "#10b981",
-  "#3b82f6",
-  "#8b5cf6",
-  "#f59e0b",
-  "#ef4444",
-  "#06b6d4",
+// Tailwind background classes for the per-endpoint color chips next to
+// each list row. Index-based cycling keeps the row chips visually
+// distinct without inline `style={{ backgroundColor }}` (which would
+// violate the "no inline styles" rule in .claude/rules/frontend.md).
+// Tailwind's JIT only retains classes that appear as static strings
+// somewhere in the source — the literal strings here are what makes
+// that work; do not switch to dynamic concatenation like
+// `bg-${color}-500`.
+const SWATCH_BG_CLASSES = [
+  "bg-emerald-500",
+  "bg-blue-500",
+  "bg-violet-500",
+  "bg-amber-500",
+  "bg-red-500",
+  "bg-cyan-500",
 ];
 
 export interface UsageStatsRef {
@@ -465,10 +473,7 @@ export const UsageStats = forwardRef<UsageStatsRef, UsageStatsProps>(
                   >
                     <div className="flex items-center gap-2">
                       <div
-                        className="w-3 h-3 rounded-full"
-                        style={{
-                          backgroundColor: COLORS[index % COLORS.length],
-                        }}
+                        className={`w-3 h-3 rounded-full ${SWATCH_BG_CLASSES[index % SWATCH_BG_CLASSES.length]}`}
                       />
                       <span className="text-sm font-medium">{ep.endpoint}</span>
                     </div>

--- a/frontend/src/components/dashboard/UsageStats.tsx
+++ b/frontend/src/components/dashboard/UsageStats.tsx
@@ -8,7 +8,13 @@
  * Issue #223 - i18n support
  */
 
-import { useEffect, useState, forwardRef, useImperativeHandle } from "react";
+import {
+  useEffect,
+  useMemo,
+  useState,
+  forwardRef,
+  useImperativeHandle,
+} from "react";
 import { useTranslations, useLocale } from "next-intl";
 import {
   Card,
@@ -22,9 +28,6 @@ import { Progress } from "@/components/ui/progress";
 import {
   LineChart,
   Line,
-  PieChart as RechartsPie,
-  Pie,
-  Cell,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -131,6 +134,37 @@ export const UsageStats = forwardRef<UsageStatsRef, UsageStatsProps>(
     const [breakdown, setBreakdown] = useState<UsageBreakdown | null>(null);
     const [isLoading, setIsLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
+
+    // Top-10 + "Other" rollup for the endpoint distribution. Showing
+    // every endpoint produces a 25+-row list dominated by 0.0% entries
+    // that crowd out the signal. The rollup keeps the list percentages
+    // adding to 100% so the UI doesn't lie about scale.
+    const TOP_ENDPOINTS_LIMIT = 10;
+    const topEndpoints = useMemo<EndpointUsage[]>(() => {
+      if (!breakdown) return [];
+      const sorted = [...breakdown.by_endpoint].sort(
+        (a, b) => b.count - a.count,
+      );
+      if (sorted.length <= TOP_ENDPOINTS_LIMIT) return sorted;
+      const top = sorted.slice(0, TOP_ENDPOINTS_LIMIT);
+      const rest = sorted.slice(TOP_ENDPOINTS_LIMIT);
+      const otherCount = rest.reduce((sum, ep) => sum + ep.count, 0);
+      // Compute Other's share as the residual rather than summing the
+      // backend's pre-rounded per-endpoint percentages — that path
+      // accumulates rounding error across 15+ entries and drifts off
+      // 100%. Clamp to ≥0 in case the top-10 sum itself overflows
+      // 100% from the same artifact.
+      const topPercentageSum = top.reduce((sum, ep) => sum + ep.percentage, 0);
+      const otherPercentage = Math.max(0, 100 - topPercentageSum);
+      return [
+        ...top,
+        {
+          endpoint: `Other (${rest.length})`,
+          count: otherCount,
+          percentage: otherPercentage,
+        },
+      ];
+    }, [breakdown]);
 
     const fetchAllStats = async () => {
       try {
@@ -413,92 +447,47 @@ export const UsageStats = forwardRef<UsageStatsRef, UsageStatsProps>(
           </CardContent>
         </Card>
 
-        {/* Endpoint Breakdown */}
-        <div className="grid gap-4 md:grid-cols-2">
-          <Card>
-            <CardHeader>
-              <CardTitle>{t("usageByEndpoint")}</CardTitle>
-              <CardDescription>{t("apiMcpDistribution")}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="h-64">
-                {breakdown.by_endpoint.length > 0 ? (
-                  <ResponsiveContainer width="100%" height="100%">
-                    <RechartsPie>
-                      <Pie
-                        data={breakdown.by_endpoint as any}
-                        cx="50%"
-                        cy="50%"
-                        labelLine={false}
-                        label={(entry: any) =>
-                          `${entry.endpoint}: ${entry.percentage.toFixed(1)}%`
-                        }
-                        outerRadius={80}
-                        dataKey="count"
-                      >
-                        {breakdown.by_endpoint.map((entry, index) => (
-                          <Cell
-                            key={`cell-${index}`}
-                            fill={COLORS[index % COLORS.length]}
-                          />
-                        ))}
-                      </Pie>
-                      <Tooltip />
-                    </RechartsPie>
-                  </ResponsiveContainer>
-                ) : (
-                  <div className="flex items-center justify-center h-full">
-                    <p className="text-sm text-gray-500 dark:text-gray-400">
-                      {t("noUsageData")}
-                    </p>
-                  </div>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-
-          {/* Endpoint List */}
-          <Card>
-            <CardHeader>
-              <CardTitle>{t("endpointDetails")}</CardTitle>
-              <CardDescription>{t("requestCountByEndpoint")}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div className="space-y-2">
-                {breakdown.by_endpoint.length > 0 ? (
-                  breakdown.by_endpoint.map((ep, index) => (
-                    <div
-                      key={ep.endpoint}
-                      className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                    >
-                      <div className="flex items-center gap-2">
-                        <div
-                          className="w-3 h-3 rounded-full"
-                          style={{
-                            backgroundColor: COLORS[index % COLORS.length],
-                          }}
-                        />
-                        <span className="text-sm font-medium">
-                          {ep.endpoint}
-                        </span>
-                      </div>
-                      <div className="text-right">
-                        <div className="text-sm font-bold">{ep.count}</div>
-                        <div className="text-xs text-gray-500 dark:text-gray-400">
-                          {ep.percentage.toFixed(1)}%
-                        </div>
+        {/* Endpoint Breakdown — list-only. The pie chart was dropped:
+            it duplicated the list and the per-slice labels overlapped
+            once the long-tail endpoints were rolled into "Other". */}
+        <Card>
+          <CardHeader>
+            <CardTitle>{t("usageByEndpoint")}</CardTitle>
+            <CardDescription>{t("apiMcpDistribution")}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {topEndpoints.length > 0 ? (
+                topEndpoints.map((ep, index) => (
+                  <div
+                    key={ep.endpoint}
+                    className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                  >
+                    <div className="flex items-center gap-2">
+                      <div
+                        className="w-3 h-3 rounded-full"
+                        style={{
+                          backgroundColor: COLORS[index % COLORS.length],
+                        }}
+                      />
+                      <span className="text-sm font-medium">{ep.endpoint}</span>
+                    </div>
+                    <div className="text-right">
+                      <div className="text-sm font-bold">{ep.count}</div>
+                      <div className="text-xs text-gray-500 dark:text-gray-400">
+                        {ep.percentage.toFixed(1)}%
                       </div>
                     </div>
-                  ))
-                ) : (
-                  <p className="text-sm text-gray-500 dark:text-gray-400">
-                    {t("noUsageData")}
-                  </p>
-                )}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
+                  </div>
+                ))
+              ) : (
+                <p className="text-sm text-gray-500 dark:text-gray-400">
+                  {t("noUsageData")}
+                </p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
       </div>
     );
   },

--- a/frontend/src/lib/api/cost-aggregation.ts
+++ b/frontend/src/lib/api/cost-aggregation.ts
@@ -6,9 +6,11 @@
  * - GET /api/v1/admin/cost-aggregation (admin cross-workspace)
  * - GET /api/v1/workspaces/{workspace_id}/cost-aggregation (owner/admin scoped)
  *
- * v1 frontend only consumes the admin endpoint (per #473 issue body —
- * "admin-only route guard"). The workspace-scoped endpoint stays for
- * the future workspace-owner dashboard or B2B billing UI.
+ * Both endpoints are now consumed:
+ * - ``fetchAdminCostAggregation`` powers ``/admin/cost`` (admin-only,
+ *   cross-workspace view).
+ * - ``fetchWorkspaceCostAggregation`` powers ``/workspace/cost``
+ *   (workspace owner/admin self-service, single workspace).
  */
 
 import { apiClient } from "./base";

--- a/frontend/src/lib/api/cost-aggregation.ts
+++ b/frontend/src/lib/api/cost-aggregation.ts
@@ -1,0 +1,183 @@
+/**
+ * Cost Aggregation API Client
+ *
+ * Issue #473: frontend cost dashboard.
+ * Wraps the two endpoints from #472:
+ * - GET /api/v1/admin/cost-aggregation (admin cross-workspace)
+ * - GET /api/v1/workspaces/{workspace_id}/cost-aggregation (owner/admin scoped)
+ *
+ * v1 frontend only consumes the admin endpoint (per #473 issue body —
+ * "admin-only route guard"). The workspace-scoped endpoint stays for
+ * the future workspace-owner dashboard or B2B billing UI.
+ */
+
+import { apiClient } from "./base";
+
+/**
+ * Allowed period values. Mirrors backend ``VALID_PERIODS`` —
+ * out-of-range values raise 400 at the route layer.
+ */
+export const COST_AGGREGATION_PERIODS = ["day", "week", "month"] as const;
+export type CostAggregationPeriod = (typeof COST_AGGREGATION_PERIODS)[number];
+
+/**
+ * Source classification for a cost row. Mirrors the DB enum on
+ * ``sleep_reports.source`` (#523): scheduler-driven sleep runs vs
+ * on-demand broadlistening analysis.
+ */
+export const COST_SOURCES = ["sleep", "analysis"] as const;
+export type CostSource = (typeof COST_SOURCES)[number];
+
+/**
+ * Billing classification. ``platform`` rows contribute to ``cost_usd``
+ * (B2B billing); ``byok`` rows contribute to ``cost_usd_byok``
+ * (observability-only — workspace paid the provider directly).
+ */
+export const COST_PAID_BY_VALUES = ["platform", "byok"] as const;
+export type CostPaidBy = (typeof COST_PAID_BY_VALUES)[number];
+
+/**
+ * Per-model cost breakdown row inside a CostAggregationRow.
+ *
+ * ``cost_usd`` / ``cost_usd_byok`` are nullable — ``null`` means
+ * "cost unknown" (some contributing usage row had no resolved
+ * pricing, e.g. a model with no row in ``llm_pricing`` at the run's
+ * ``started_at``). Render NULL as "—" in the UI to distinguish from
+ * a genuine $0 cost.
+ */
+export interface CostBreakdownByModel {
+  model: string | null;
+  calls: number;
+  cost_usd: number | null;
+  cost_usd_byok: number | null;
+}
+
+/**
+ * Per-source cost breakdown row inside a CostAggregationRow.
+ * Same nullable-cost semantics as ``CostBreakdownByModel``.
+ */
+export interface CostBreakdownBySource {
+  source: CostSource;
+  calls: number;
+  cost_usd: number | null;
+  cost_usd_byok: number | null;
+}
+
+/**
+ * One (period × workspace × user) aggregation row.
+ *
+ * Both cost fields are nullable per the sticky-NULL rule: if any
+ * contributing usage row in this bucket lacked pricing, the bucket's
+ * cost is ``null``. The dashboard renders null as "—" with a tooltip
+ * so it doesn't look like the workspace spent $0 in a period that
+ * actually contained unpriced usage.
+ */
+export interface CostAggregationRow {
+  /** ISO date string (YYYY-MM-DD) at the period bucket start. */
+  period_start: string;
+  workspace_id: string | null;
+  user_id: string;
+  calls: number;
+  tokens_in: number;
+  tokens_out: number;
+  tokens_cached_in: number;
+  embedding_tokens: number;
+  cost_usd: number | null;
+  cost_usd_byok: number | null;
+  cost_breakdown_by_model: CostBreakdownByModel[];
+  cost_breakdown_by_source: CostBreakdownBySource[];
+}
+
+export interface CostAggregationResponse {
+  rows: CostAggregationRow[];
+}
+
+/**
+ * Filter parameters accepted by the admin cost aggregation endpoint.
+ * ``from`` / ``to`` are required ISO dates (YYYY-MM-DD); the rest are
+ * optional. Server-side validation rejects unknown ``source`` /
+ * ``paid_by`` values with 400.
+ */
+export interface FetchAdminCostAggregationParams {
+  /** Aggregation granularity. Defaults to ``"day"`` server-side. */
+  period?: CostAggregationPeriod;
+  /** Inclusive lower-bound date (YYYY-MM-DD). */
+  from: string;
+  /** Inclusive upper-bound date (YYYY-MM-DD). */
+  to: string;
+  /** Filter to a single workspace (optional). */
+  workspace_id?: string;
+  /** Filter to a single user (optional). */
+  user_id?: string;
+  /** Filter by source classification (optional). */
+  source?: CostSource;
+  /** Filter by billing classification (optional). */
+  paid_by?: CostPaidBy;
+}
+
+/**
+ * Fetch the admin (cross-workspace) cost aggregation.
+ *
+ * Caller must be a system admin — non-admin requests get 403 from the
+ * route's ``require_admin`` dependency. Anonymous requests get 401.
+ *
+ * @returns ``CostAggregationResponse`` with rows sorted by
+ *          (period_start, workspace_id, user_id).
+ * @throws ``ApiError`` on 400/401/403/422/5xx with the server's
+ *         ``detail`` string.
+ */
+export async function fetchAdminCostAggregation(
+  params: FetchAdminCostAggregationParams,
+): Promise<CostAggregationResponse> {
+  const search = new URLSearchParams();
+  if (params.period) search.set("period", params.period);
+  search.set("from", params.from);
+  search.set("to", params.to);
+  if (params.workspace_id) search.set("workspace_id", params.workspace_id);
+  if (params.user_id) search.set("user_id", params.user_id);
+  if (params.source) search.set("source", params.source);
+  if (params.paid_by) search.set("paid_by", params.paid_by);
+
+  return apiClient.get<CostAggregationResponse>(
+    `/api/v1/admin/cost-aggregation?${search.toString()}`,
+  );
+}
+
+/**
+ * Filter parameters for the workspace-scoped cost aggregation endpoint.
+ * The workspace is path-bound (passed separately to the fetch function),
+ * so it is NOT in the params object — preventing accidental cross-workspace
+ * probes via query string.
+ */
+export type FetchWorkspaceCostAggregationParams = Omit<
+  FetchAdminCostAggregationParams,
+  "workspace_id"
+>;
+
+/**
+ * Fetch cost aggregation for a single workspace.
+ *
+ * Caller must be a workspace **owner** or **admin** — viewer / member
+ * are rejected by the backend's ``check_workspace_admin`` gate (cost
+ * aggregates leak per-user activity volume across private contexts that
+ * lower roles should not see).
+ *
+ * The workspace_id is path-bound; passing one via the params type is
+ * structurally prevented.
+ */
+export async function fetchWorkspaceCostAggregation(
+  workspaceId: string,
+  params: FetchWorkspaceCostAggregationParams,
+): Promise<CostAggregationResponse> {
+  const search = new URLSearchParams();
+  if (params.period) search.set("period", params.period);
+  search.set("from", params.from);
+  search.set("to", params.to);
+  if (params.user_id) search.set("user_id", params.user_id);
+  if (params.source) search.set("source", params.source);
+  if (params.paid_by) search.set("paid_by", params.paid_by);
+
+  return apiClient.get<CostAggregationResponse>(
+    `/api/v1/workspaces/${encodeURIComponent(workspaceId)}/cost-aggregation?${search.toString()}`,
+  );
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -10,6 +10,7 @@ export { apiClient, ApiError } from "./base";
 export * from "./memory";
 export * from "./api-keys";
 export * from "./coding-sessions";
+export * from "./cost-aggregation";
 export * from "./doctor";
 export * from "./oauth";
 export * from "./external-keys";

--- a/frontend/src/lib/utils/datetime.test.ts
+++ b/frontend/src/lib/utils/datetime.test.ts
@@ -15,6 +15,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   formatDate,
   formatDateTime,
+  formatLocalDate,
   formatRelativeTime,
   formatTime,
 } from "./datetime";
@@ -98,5 +99,32 @@ describe("formatRelativeTime", () => {
     const withoutSuffix = formatRelativeTime(FIVE_MIN_AGO, "en", false);
     expect(withSuffix).toMatch(/ago|in /);
     expect(withoutSuffix).not.toMatch(/ago|in /);
+  });
+});
+
+describe("formatLocalDate", () => {
+  // The whole point of this helper is to AVOID the
+  // toISOString().slice(0, 10) trap that silently shifts midnight in
+  // tz+9 (JST) into the previous day in UTC. Its contract is therefore
+  // tested via runtime-locale-independent inputs (Date constructed from
+  // explicit year/month/day) so the assertions hold regardless of the
+  // CI runner's TZ env.
+  it("formats a Date as local YYYY-MM-DD with two-digit month and day", () => {
+    expect(formatLocalDate(new Date(2026, 0, 1))).toBe("2026-01-01");
+    expect(formatLocalDate(new Date(2026, 4, 30))).toBe("2026-05-30");
+    expect(formatLocalDate(new Date(2026, 11, 31))).toBe("2026-12-31");
+  });
+
+  it("preserves single-digit months and days as 0-padded", () => {
+    expect(formatLocalDate(new Date(2026, 2, 5))).toBe("2026-03-05");
+    expect(formatLocalDate(new Date(2026, 8, 9))).toBe("2026-09-09");
+  });
+
+  it("returns the LOCAL date, not the UTC date — does not slice toISOString()", () => {
+    // Construct local midnight; toISOString().slice(0, 10) would shift
+    // this to the previous day for any tz east of UTC. formatLocalDate
+    // must read getFullYear / getMonth / getDate, which return local.
+    const localMidnight = new Date(2026, 4, 1, 0, 0, 0);
+    expect(formatLocalDate(localMidnight)).toBe("2026-05-01");
   });
 });

--- a/frontend/src/lib/utils/datetime.ts
+++ b/frontend/src/lib/utils/datetime.ts
@@ -148,6 +148,25 @@ export function formatRelativeTime(
 }
 
 /**
+ * Format a JS ``Date`` as a local-timezone ``YYYY-MM-DD`` string.
+ *
+ * Use this when you need the calendar date as the user perceives it
+ * (e.g. for ``<input type="date">`` values, query params keyed on the
+ * date the user selected). Avoids the ``toISOString().slice(0, 10)``
+ * trap, which silently shifts JST midnight into the previous day in
+ * UTC and breaks every date-range filter at workspace timezones.
+ *
+ * @example
+ * formatLocalDate(new Date(2026, 4, 1)) // => "2026-05-01" (regardless of tz)
+ */
+export function formatLocalDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/**
  * Common IANA timezones
  */
 export const COMMON_TIMEZONES = [

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2268,9 +2268,11 @@
         "title": "No cost data in this period.",
         "description": "Try widening the date range or check that Sleep Maintenance has produced cost-grade rows."
       },
+      "rangeErrorPlaceholder": "Adjust the date range above to load chart and table data.",
       "errors": {
         "forbidden": "Admin role required to view cost aggregation.",
-        "forbiddenWorkspace": "Workspace owner or admin role required to view cost aggregation."
+        "forbiddenWorkspace": "Workspace owner or admin role required to view cost aggregation.",
+        "unknown": "Unknown error while loading cost aggregation."
       }
     },
     "sleepReports": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -63,6 +63,7 @@
     "quotas": "Quotas & Limits",
     "neuralConfig": "Neural Config",
     "sleepReports": "Sleep Reports",
+    "cost": "Cost",
     "environment": "Environment",
     "systemAdmin": "System Admin",
     "ownerOnly": "Owner",
@@ -2219,6 +2220,55 @@
         "sleep_edge_discovery_enabled": "Enable edge discovery phase",
         "sleep_edge_discovery_sample_size": "Number of memories to sample per edge discovery run",
         "sleep_importance_reeval_enabled": "Enable importance re-evaluation phase"
+      }
+    },
+    "cost": {
+      "title": "Cost Aggregation",
+      "description": "LLM and embedding cost ($) breakdown across all workspaces",
+      "descriptionWorkspace": "LLM and embedding cost ($) breakdown for this workspace",
+      "actions": {
+        "refresh": "Refresh"
+      },
+      "filter": {
+        "title": "Filters",
+        "from": "From",
+        "to": "To",
+        "period": "Period"
+      },
+      "period": {
+        "day": "Day",
+        "week": "Week",
+        "month": "Month"
+      },
+      "validation": {
+        "invertedRange": "'From' must be on or before 'To'.",
+        "windowTooWide": "Date range exceeds the {max}-day cap. Narrow the range and retry."
+      },
+      "chart": {
+        "title": "Cost Over Time",
+        "costPlatform": "Platform-billed (USD)",
+        "costByok": "BYOK (USD)",
+        "unknown": "cost unknown"
+      },
+      "table": {
+        "title": "Per-Period Breakdown",
+        "periodStart": "Period",
+        "workspaceId": "Workspace",
+        "userId": "User",
+        "calls": "Calls",
+        "tokensIn": "Tokens In",
+        "tokensOut": "Tokens Out",
+        "embeddingTokens": "Embedding",
+        "costPlatform": "Cost (Platform)",
+        "costByok": "Cost (BYOK)",
+        "costUnknownTooltip": "Cost unknown — at least one usage row had no resolved pricing."
+      },
+      "emptyState": {
+        "title": "No cost data in this period.",
+        "description": "Try widening the date range or check that Sleep Maintenance has produced cost-grade rows."
+      },
+      "errors": {
+        "forbidden": "Admin role required to view cost aggregation."
       }
     },
     "sleepReports": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2268,7 +2268,8 @@
         "description": "Try widening the date range or check that Sleep Maintenance has produced cost-grade rows."
       },
       "errors": {
-        "forbidden": "Admin role required to view cost aggregation."
+        "forbidden": "Admin role required to view cost aggregation.",
+        "forbiddenWorkspace": "Workspace owner or admin role required to view cost aggregation."
       }
     },
     "sleepReports": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2272,6 +2272,7 @@
       "errors": {
         "forbidden": "Admin role required to view cost aggregation.",
         "forbiddenWorkspace": "Workspace owner or admin role required to view cost aggregation.",
+        "noWorkspaceSelected": "No workspace is currently selected. Create or select a workspace to view its cost aggregation.",
         "unknown": "Unknown error while loading cost aggregation."
       }
     },

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1707,7 +1707,8 @@
     "apiMcpDistribution": "API and MCP tool usage distribution",
     "noUsageData": "No usage data yet",
     "endpointDetails": "Endpoint Details",
-    "requestCountByEndpoint": "Request count by endpoint"
+    "requestCountByEndpoint": "Request count by endpoint",
+    "otherEndpointsLabel": "Other ({count})"
   },
   "memoryOverview": {
     "failedToLoad": "Failed to load memory overview",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2272,6 +2272,7 @@
       "errors": {
         "forbidden": "コスト集計の閲覧には admin 権限が必要です。",
         "forbiddenWorkspace": "コスト集計の閲覧には workspace の owner または admin 権限が必要です。",
+        "noWorkspaceSelected": "workspace が選択されていません。workspace を作成または選択してからコスト集計を確認してください。",
         "unknown": "コスト集計の読み込み中に不明なエラーが発生しました。"
       }
     },

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1707,7 +1707,8 @@
     "apiMcpDistribution": "APIとMCPツールの使用分布",
     "noUsageData": "使用データがまだありません",
     "endpointDetails": "エンドポイント詳細",
-    "requestCountByEndpoint": "エンドポイント別リクエスト数"
+    "requestCountByEndpoint": "エンドポイント別リクエスト数",
+    "otherEndpointsLabel": "その他 ({count})"
   },
   "memoryOverview": {
     "failedToLoad": "メモリー概要の読み込みに失敗しました",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -63,6 +63,7 @@
     "quotas": "クォータ・制限",
     "neuralConfig": "ニューラル設定",
     "sleepReports": "Sleep レポート",
+    "cost": "コスト",
     "environment": "環境設定",
     "systemAdmin": "システム管理",
     "ownerOnly": "オーナー",
@@ -2219,6 +2220,55 @@
         "sleep_edge_discovery_enabled": "エッジ発見フェーズを有効化",
         "sleep_edge_discovery_sample_size": "エッジ発見 1 回あたりのサンプルメモリ数",
         "sleep_importance_reeval_enabled": "重要度再評価フェーズを有効化"
+      }
+    },
+    "cost": {
+      "title": "コスト集計",
+      "description": "全 workspace の LLM・embedding コスト ($) ブレイクダウン",
+      "descriptionWorkspace": "この workspace の LLM・embedding コスト ($) ブレイクダウン",
+      "actions": {
+        "refresh": "更新"
+      },
+      "filter": {
+        "title": "フィルタ",
+        "from": "開始日",
+        "to": "終了日",
+        "period": "期間"
+      },
+      "period": {
+        "day": "日",
+        "week": "週",
+        "month": "月"
+      },
+      "validation": {
+        "invertedRange": "「開始日」は「終了日」以前の日付を指定してください。",
+        "windowTooWide": "日付範囲が {max} 日の上限を超えています。範囲を狭めて再試行してください。"
+      },
+      "chart": {
+        "title": "コスト推移",
+        "costPlatform": "プラットフォーム課金 (USD)",
+        "costByok": "BYOK (USD)",
+        "unknown": "コスト不明"
+      },
+      "table": {
+        "title": "期間別ブレイクダウン",
+        "periodStart": "期間",
+        "workspaceId": "Workspace",
+        "userId": "User",
+        "calls": "Call 数",
+        "tokensIn": "入力トークン",
+        "tokensOut": "出力トークン",
+        "embeddingTokens": "Embedding",
+        "costPlatform": "コスト (Platform)",
+        "costByok": "コスト (BYOK)",
+        "costUnknownTooltip": "コスト不明 — pricing が解決できなかった usage row が含まれています。"
+      },
+      "emptyState": {
+        "title": "この期間にコストデータがありません。",
+        "description": "日付範囲を広げるか、Sleep Maintenance が cost-grade な行を生成しているか確認してください。"
+      },
+      "errors": {
+        "forbidden": "コスト集計の閲覧には admin 権限が必要です。"
       }
     },
     "sleepReports": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2268,9 +2268,11 @@
         "title": "この期間にコストデータがありません。",
         "description": "日付範囲を広げるか、Sleep Maintenance が cost-grade な行を生成しているか確認してください。"
       },
+      "rangeErrorPlaceholder": "上の日付範囲を修正するとチャートとテーブルが読み込まれます。",
       "errors": {
         "forbidden": "コスト集計の閲覧には admin 権限が必要です。",
-        "forbiddenWorkspace": "コスト集計の閲覧には workspace の owner または admin 権限が必要です。"
+        "forbiddenWorkspace": "コスト集計の閲覧には workspace の owner または admin 権限が必要です。",
+        "unknown": "コスト集計の読み込み中に不明なエラーが発生しました。"
       }
     },
     "sleepReports": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2268,7 +2268,8 @@
         "description": "日付範囲を広げるか、Sleep Maintenance が cost-grade な行を生成しているか確認してください。"
       },
       "errors": {
-        "forbidden": "コスト集計の閲覧には admin 権限が必要です。"
+        "forbidden": "コスト集計の閲覧には admin 権限が必要です。",
+        "forbiddenWorkspace": "コスト集計の閲覧には workspace の owner または admin 権限が必要です。"
       }
     },
     "sleepReports": {


### PR DESCRIPTION
Closes #473

## Summary
- `/admin/cost` (admin) and `/workspace/cost` (owner/admin) — two pages over a shared `CostDashboard` component, consuming the cost aggregation API shipped in #472.
- Sticky-NULL throughout the UI: rows with `cost_usd: null` (any contributing usage row had no resolved pricing) render as `—` in the table, gaps in the chart (`connectNulls={false}`) — never as a misleading $0. Mirrors the `BOOL_AND` semantics in the backend service.
- AuthZ layered defense-in-depth: Sidebar role gate + page-level role check + backend `require_admin` / `check_workspace_admin`. Path injection prevented via `encodeURIComponent`. Cross-workspace probe structurally prevented via `Omit<...AdminParams, "workspace_id">` typing on the workspace fetcher.

## Implementation notes
- New shared component at `frontend/src/components/cost/CostDashboard.tsx` (~360 LOC). Both pages are thin wrappers (~45 + ~75 LOC) that supply the right fetcher + auth gate.
- `WorkspaceCostPage` wraps its fetcher in `useCallback([currentWorkspaceId])` — without this, every `WorkspaceProvider` re-render would produce a new closure → `loadCost` recompiles → `useEffect` re-fires → spurious GET per re-render. Admin page passes `fetchAdminCostAggregation` directly (already module-level stable).
- `CostDashboard` short-circuits the fetch when client-side `rangeError` is non-null (inverted from/to, > 365 days) — keeps the more specific rangeError banner unobscured by a backend 400.
- Period toggle migrated to the shadcn `Tabs` primitive (`@/components/ui/tabs`) per `.claude/rules/frontend.md` ("In-page tabs MUST use the Tabs primitive").
- `isoDate` helper promoted into `lib/utils/datetime.ts` as `formatLocalDate` — centralizes the `toISOString().slice(0, 10)` trap (UTC shift breaks JST users) for any future date-range pickers.
- New API client at `lib/api/cost-aggregation.ts` with both `fetchAdminCostAggregation` and `fetchWorkspaceCostAggregation`. Workspace fetcher takes `workspaceId` as a separate path-bound argument so it can't be smuggled via params.
- New i18n keys under `admin.cost` namespace (en + ja). Workspace page uses `descriptionWorkspace` (vs admin's `description`) since the wording differs.
- Sidebar adds `DollarSign` icon + Cost entries to both the workspace section (`requiredWorkspaceRole: "admin"`) and admin section.

## Bonus cleanup in the same diff
- `UsageStats.tsx`: dropped the redundant pie chart (the list beneath it conveyed the same data; per-slice labels overlapped after the Top-10 rollup landed).
- `UsageStats.tsx`: Top-10 + "Other (N)" rollup memoized — the "Endpoint usage" panel was dumping all 25+ endpoints with most at 0.0%, drowning the signal.
- `UsageStats.tsx`: "Other %" computed as `(100 - sum(top.percentage))` clamped ≥0 — the naive sum of pre-rounded backend percentages drifts off 100% past ~15 entries.

## Out of scope
- **CSV/JSON export buttons** — `#472` did not ship an export endpoint; client-side blob download is a small follow-up if needed. The `#473` issue body listed export but the API contract doesn't support it server-side yet.
- **Workspace-scoped sleep reports** — needed in the workspace nav alongside Cost but requires a new backend endpoint. Filed separately as **#526**.

## Tests
- `CostDashboard.test.ts` (new): 7 tests for `buildChartData` (empty input, multi-row collapse, ISO sort, sticky-NULL per-field/per-bucket/order-independent), 3 for `formatCost` (positive, **$0 NOT em-dash**, null em-dash).
- `lib/utils/datetime.test.ts` (extended): 3 tests for `formatLocalDate` covering padding, the `toISOString` trap, and basic format.
- `next build` succeeds with `/admin/cost` and `/workspace/cost` prerendered as static.
- `tsc --noEmit` clean. `make lint` + `make type-check` clean (frontend has no separate lint since Next.js 16).

## Pre-PR review summary
- gate2 mode: not run (frontend-only follow-up to backend `#472` which had full gate2 advisor-only review)
- review provider: copilot (planned)

🤖 Generated via /self-review + /simplify
