### PR TITLE
feat(db): memory_analyses schema for broadlistening (#494)

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -25,6 +25,7 @@ import models.hub_tag  # noqa: F401
 import models.erasure  # noqa: F401
 import models.sleep  # noqa: F401  # Issue #471: SleepReportLLMUsage child added
 import models.llm_pricing  # noqa: F401  # Issue #471: cost-grade pricing master
+import models.analysis  # noqa: F401  # Issue #494: Memory Broadlistening tables
 
 # Alembic Config object
 config = context.config

--- a/backend/alembic/versions/d06_494_memory_analyses.py
+++ b/backend/alembic/versions/d06_494_memory_analyses.py
@@ -315,6 +315,21 @@ def downgrade() -> None:
     constraint recreate at the end of downgrade would otherwise fail
     validation against existing rows, so we delete those rows first —
     same destructive pattern documented in b05_223 for tag_cooccurrence.
+
+    OPS WARNING: ``extra_analysis_runs`` is a Stripe-backed paid SKU, NOT a
+    regenerable artifact like b05_223's tag-cooccurrence edges. Deleting
+    these rows on rollback severs a paying-customer addon from the
+    workspace and the Stripe webhook will NOT re-insert it (subscription
+    history is retained Stripe-side, but the DB linkage is lost). Before
+    running this downgrade against production:
+
+        SELECT count(*) FROM workspace_addons
+         WHERE addon_type = 'extra_analysis_runs';
+
+    If the count is non-zero, do NOT downgrade — coordinate Stripe-side
+    cancellation first, or accept that re-applying the migration later
+    will leave those workspaces without their paid bonus until manually
+    re-inserted.
     """
     # 5'. Restore old CHECK. Delete any rows that the old constraint
     #     would reject so the recreate succeeds.

--- a/backend/alembic/versions/d06_494_memory_analyses.py
+++ b/backend/alembic/versions/d06_494_memory_analyses.py
@@ -1,0 +1,361 @@
+"""Add Memory Broadlistening schema (#494, umbrella #493).
+
+Issue #494 (B1 of the Broadlistening v1 atomic split): the persistence
+foundation for the kouchou-ai-style clustering analyses introduced in
+the v0.15.0 cycle. All later phases (B2 #495 pipeline, B3 #496 API+MCP,
+F4 #497 frontend) depend on these tables existing.
+
+This migration is intentionally atomic: workspace ALTERs, the three new
+tables, and the WorkspaceAddon CHECK extension that registers the new
+``extra_analysis_runs`` Stripe SKU all ship together. Splitting them
+would leave the addon column without a matching CHECK extension — a
+Stripe webhook trying to insert ``extra_analysis_runs`` between the
+two PRs would IntegrityError on the existing constraint.
+
+Schema additions:
+
+1. ``workspaces`` — three new columns:
+
+   - ``analysis_default_model_id BIGINT REFERENCES llm_pricing(id)
+     ON DELETE SET NULL`` (nullable). Per-workspace default model for
+     run-time analyses. SET NULL on pricing-row deletion so a future
+     pricing cleanup never cascade-deletes a workspace.
+   - ``analysis_quality_model_id BIGINT REFERENCES llm_pricing(id)
+     ON DELETE SET NULL`` (nullable). Optional higher-quality variant
+     for runs that opt into it (UI selection in #497).
+   - ``addon_analysis_bonus INTEGER NOT NULL DEFAULT 0``. Mirrors the
+     six other ``addon_*_bonus`` columns. ``server_default="0"`` makes
+     this a metadata-only catalog change on PG ≥ 11 — no rewrite.
+
+2. ``memory_analyses`` — one row per run. Frozen ``model_snapshot``
+   (JSONB) keeps cost reports reproducible across pricing changes.
+   ``status`` and ``paid_by`` carry both Python-side ``default=`` and
+   ``server_default`` (dual-default pattern, see ``models/sleep.py``)
+   so flush() and raw INSERT both satisfy NOT NULL.
+
+3. ``memory_analysis_clusters`` — flat cluster set per run.
+   ``parent_id`` is nullable on day 1 so the v2 hierarchical layer
+   lands without another migration.
+
+4. ``memory_analysis_assignments`` — composite PK
+   ``(analysis_id, memory_id)``: a memory can appear in many runs, but
+   exactly once per run.
+
+5. ``workspace_addons.check_addon_type`` CHECK rewrite — extends the
+   IN list with ``'extra_analysis_runs'``. PostgreSQL has no
+   ALTER CONSTRAINT for CHECK clauses; drop + recreate is the
+   established pattern (b05_223 precedent). For the small populated
+   ``workspace_addons`` table the brief ACCESS EXCLUSIVE during
+   recreate is acceptable — no zero-downtime two-step needed here.
+
+Revision ID: d06_494_memory_analyses
+Revises: d05_523_source_paid_by
+
+NOTE: Revision ID is 23 chars (alembic_version.version_num is
+VARCHAR(32) — asyncpg raises StringDataRightTruncationError otherwise).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d06_494_memory_analyses"
+down_revision: str | Sequence[str] | None = "d05_523_source_paid_by"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Derive the new IN-list from the old one so the delta is unambiguous —
+# adding another SKU later means appending to the new tuple, no
+# hand-editing of two parallel string literals. Frozen here (not
+# imported from analysis.py) because alembic migrations must remain
+# stable under future model edits.
+_OLD_ADDON_TYPES: tuple[str, ...] = (
+    "extra_storage",
+    "extra_memory",
+    "extra_mcp_quota",
+    "extra_rest_quota",
+    "extra_public_quota",
+    "extra_members",
+    "extra_contexts",
+)
+_NEW_ADDON_TYPES: tuple[str, ...] = _OLD_ADDON_TYPES + ("extra_analysis_runs",)
+
+
+def _addon_check_sql(types: tuple[str, ...]) -> str:
+    return f"addon_type IN ({', '.join(repr(t) for t in types)})"
+
+
+_OLD_ADDON_TYPES_SQL = _addon_check_sql(_OLD_ADDON_TYPES)
+_NEW_ADDON_TYPES_SQL = _addon_check_sql(_NEW_ADDON_TYPES)
+
+
+def upgrade() -> None:
+    """Add Memory Broadlistening schema."""
+    # 1. workspaces ALTERs — three new columns. All metadata-only on PG ≥ 11
+    #    (NOT NULL + server_default for the integer; nullable for the FKs).
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "analysis_default_model_id",
+            sa.BigInteger,
+            sa.ForeignKey("llm_pricing.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "analysis_quality_model_id",
+            sa.BigInteger,
+            sa.ForeignKey("llm_pricing.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "addon_analysis_bonus",
+            sa.Integer,
+            nullable=False,
+            # Bare ``"0"`` matches the existing ``addon_*_bonus`` columns in
+            # auth.py:1127-1132 so the autogenerate diff stays clean.
+            server_default="0",
+        ),
+    )
+
+    # 2. memory_analyses — one row per run.
+    op.create_table(
+        "memory_analyses",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "context_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "started_at",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("finished_at", sa.DateTime, nullable=True),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'running'"),
+        ),
+        # ``triggered_by`` follows the codebase convention for user_id columns
+        # — String(255), no FK, mirroring ``sleep_reports.user_id`` and
+        # documented in the c01_360 migration.
+        sa.Column("triggered_by", sa.String(255), nullable=False),
+        sa.Column(
+            "model_id",
+            sa.BigInteger,
+            sa.ForeignKey("llm_pricing.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column("model_snapshot", JSONB, nullable=False),
+        sa.Column("embedding_model", sa.String(100), nullable=False),
+        sa.Column("params", JSONB, nullable=False),
+        sa.Column("input_count", sa.Integer, nullable=False),
+        sa.Column("cost_estimated_cents", sa.Integer, nullable=True),
+        sa.Column("cost_actual_cents", sa.Integer, nullable=True),
+        sa.Column(
+            "paid_by",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'byok'"),
+        ),
+        sa.Column("quality", JSONB, nullable=True),
+        sa.Column("overview", sa.Text, nullable=True),
+        sa.Column("error", sa.Text, nullable=True),
+        sa.CheckConstraint(
+            "status IN ('running', 'succeeded', 'failed', 'cancelled')",
+            name="valid_memory_analysis_status",
+        ),
+        sa.CheckConstraint(
+            "paid_by IN ('byok', 'platform')",
+            name="valid_memory_analysis_paid_by",
+        ),
+    )
+    op.create_index(
+        "idx_memory_analyses_workspace_started",
+        "memory_analyses",
+        ["workspace_id", "started_at"],
+    )
+    op.create_index(
+        "idx_memory_analyses_context_started",
+        "memory_analyses",
+        ["context_id", "started_at"],
+    )
+
+    # 3. memory_analysis_clusters — flat cluster rows; parent_id nullable
+    #    for the future v2 hierarchical layer (writes NULL on v1).
+    op.create_table(
+        "memory_analysis_clusters",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "analysis_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("memory_analyses.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "parent_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("memory_analysis_clusters.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("cluster_index", sa.Integer, nullable=False),
+        sa.Column("label", sa.Text, nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("count", sa.Integer, nullable=False),
+        # ``centroid_2d`` is a length-2 float array; PostgreSQL doesn't enforce
+        # the size constraint and a CHECK on every insert isn't worth the cost.
+        # The pipeline (#495) is responsible for emitting exactly two values.
+        sa.Column("centroid_2d", ARRAY(sa.Float), nullable=False),
+        sa.Column(
+            "representative_memory_ids",
+            ARRAY(UUID(as_uuid=True)),
+            nullable=False,
+        ),
+        sa.Column("property_stats", JSONB, nullable=False),
+        sa.Column("label_confidence", sa.Float, nullable=False),
+        sa.CheckConstraint(
+            "label_confidence >= 0 AND label_confidence <= 1",
+            name="valid_memory_analysis_cluster_label_confidence",
+        ),
+    )
+    op.create_index(
+        "idx_memory_analysis_clusters_analysis",
+        "memory_analysis_clusters",
+        ["analysis_id"],
+    )
+
+    # 4. memory_analysis_assignments — composite PK (analysis_id, memory_id).
+    op.create_table(
+        "memory_analysis_assignments",
+        sa.Column(
+            "analysis_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("memory_analyses.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "memory_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("memories.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "cluster_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("memory_analysis_clusters.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("x", sa.Float, nullable=False),
+        sa.Column("y", sa.Float, nullable=False),
+        # Composite PK named by SQLAlchemy default (``<table>_pkey``) so it
+        # matches the constraint that ``Base.metadata.create_all`` produces
+        # in tests — avoids drift between alembic-applied and test-fixture
+        # DBs that referencing the PK name in a future migration would trip.
+        sa.PrimaryKeyConstraint("analysis_id", "memory_id"),
+    )
+    op.create_index(
+        "idx_memory_analysis_assignments_cluster",
+        "memory_analysis_assignments",
+        ["cluster_id"],
+    )
+
+    # 5. workspace_addons.check_addon_type — drop + recreate with the new
+    #    'extra_analysis_runs' SKU. Mirrors the b05_223 precedent
+    #    (valid_edge_type extension) — PostgreSQL has no ALTER CONSTRAINT
+    #    for CHECK clauses, drop + recreate is the only path.
+    op.drop_constraint(
+        "check_addon_type",
+        "workspace_addons",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "check_addon_type",
+        "workspace_addons",
+        _NEW_ADDON_TYPES_SQL,
+    )
+
+
+def downgrade() -> None:
+    """Drop Memory Broadlistening schema in reverse order.
+
+    Rolling back is destructive: any rows in the three new tables (and
+    in any existing ``workspace_addons`` row with
+    ``addon_type='extra_analysis_runs'``) will be lost. The CHECK
+    constraint recreate at the end of downgrade would otherwise fail
+    validation against existing rows, so we delete those rows first —
+    same destructive pattern documented in b05_223 for tag_cooccurrence.
+    """
+    # 5'. Restore old CHECK. Delete any rows that the old constraint
+    #     would reject so the recreate succeeds.
+    op.execute(sa.text("DELETE FROM workspace_addons WHERE addon_type = 'extra_analysis_runs'"))
+    op.drop_constraint(
+        "check_addon_type",
+        "workspace_addons",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "check_addon_type",
+        "workspace_addons",
+        _OLD_ADDON_TYPES_SQL,
+    )
+
+    # 4'. assignments → clusters → analyses (reverse FK order).
+    op.drop_index(
+        "idx_memory_analysis_assignments_cluster",
+        table_name="memory_analysis_assignments",
+    )
+    op.drop_table("memory_analysis_assignments")
+
+    # 3'.
+    op.drop_index(
+        "idx_memory_analysis_clusters_analysis",
+        table_name="memory_analysis_clusters",
+    )
+    op.drop_table("memory_analysis_clusters")
+
+    # 2'.
+    op.drop_index(
+        "idx_memory_analyses_context_started",
+        table_name="memory_analyses",
+    )
+    op.drop_index(
+        "idx_memory_analyses_workspace_started",
+        table_name="memory_analyses",
+    )
+    op.drop_table("memory_analyses")
+
+    # 1'. workspaces columns.
+    op.drop_column("workspaces", "addon_analysis_bonus")
+    op.drop_column("workspaces", "analysis_quality_model_id")
+    op.drop_column("workspaces", "analysis_default_model_id")

--- a/backend/src/config/plan_tiers.py
+++ b/backend/src/config/plan_tiers.py
@@ -66,6 +66,7 @@ class PlanTier:
     rest_calls_per_week: int = 0  # Issue #238: REST API quota
     public_calls_per_day: int = 0  # Issue #238: Public REST API quota
     public_calls_per_week: int = 0  # Issue #238: Public REST API quota
+    analysis_runs_per_day: int = 0  # Issue #494: Memory Broadlistening analyses/day
     allows_shared_contexts: bool = False  # Issue #271: Shared context feature (Pro only)
     features: frozenset[str] = field(default_factory=frozenset)
 
@@ -131,6 +132,7 @@ PLAN_PRO = PlanTier(
     rest_calls_per_week=25000,
     public_calls_per_day=1000,
     public_calls_per_week=5000,
+    analysis_runs_per_day=3,  # Issue #494: Memory Broadlistening (Pro only; FREE/BASIC=0)
     features=frozenset(
         {
             "api_keys",

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -1,0 +1,275 @@
+"""SQLAlchemy models for Memory Broadlistening analyses.
+
+Issue #494 (umbrella #493): persistence layer for memory clustering
+analyses. v1 is flat + snapshot-only — one ``memory_analyses`` row per
+run, ``memory_analysis_clusters`` rows for the flat cluster set, and
+``memory_analysis_assignments`` rows for the per-memory 2D coordinate +
+cluster assignment. ``parent_id`` on clusters is nullable to leave room
+for the v2 hierarchical layer without another migration.
+
+Cost rows are NOT in this module — analysis runs emit a
+``sleep_reports`` row with ``source='analysis'`` / ``paid_by='byok'``
+through the cost-grade plumbing introduced by #523.
+"""
+
+from uuid import uuid4
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+
+from db.base import Base
+
+# Service-layer validation tuples so #495 pipeline can raise ValueError
+# instead of catching IntegrityError after the DB round-trip. The DB
+# CHECK constraint is the authoritative source — the ``__table_args__``
+# CHECK strings below are built from these tuples so the two paths can
+# never drift.
+MEMORY_ANALYSIS_STATUSES: tuple[str, ...] = (
+    "running",
+    "succeeded",
+    "failed",
+    "cancelled",
+)
+MEMORY_ANALYSIS_PAID_BY_VALUES: tuple[str, ...] = ("byok", "platform")
+
+
+def _check_in_sql(column: str, values: tuple[str, ...]) -> str:
+    """Render a ``column IN ('a', 'b', ...)`` CHECK clause from a tuple."""
+    return f"{column} IN ({', '.join(repr(v) for v in values)})"
+
+
+class MemoryAnalysis(Base):
+    """One broadlistening run over a context's memories.
+
+    Attributes:
+        id: UUID primary key
+        workspace_id: Owning workspace (CASCADE on delete)
+        context_id: Target context (CASCADE on delete)
+        started_at: Run start time
+        finished_at: Run completion time (NULL while running)
+        status: running / succeeded / failed / cancelled
+        triggered_by: User id that triggered the run
+        model_id: FK to ``llm_pricing`` (BIGINT) — RESTRICT on delete
+        model_snapshot: Pricing row frozen at run start (JSONB)
+        embedding_model: Single embedding model used for this run
+        params: Run parameters (filters, query, etc., JSONB)
+        input_count: Number of memories included
+        cost_estimated_cents: Pre-flight cost estimate
+        cost_actual_cents: Actual measured cost
+        paid_by: byok / platform (v1 = byok-only)
+        quality: Cluster-quality metrics (silhouette, label_confidence...)
+        overview: LLM-generated narrative
+        error: Failure detail when status='failed'
+    """
+
+    __tablename__ = "memory_analyses"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    context_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    started_at = Column(DateTime, nullable=False, server_default=func.now())
+    finished_at = Column(DateTime, nullable=True)
+    # Dual default (Python + server) so flush() reads ``running`` without
+    # a refresh AND raw INSERT paths satisfy NOT NULL.
+    status = Column(
+        String(20),
+        nullable=False,
+        default="running",
+        server_default=text("'running'"),
+    )
+    triggered_by = Column(String(255), nullable=False)
+
+    model_id = Column(
+        BigInteger,
+        ForeignKey("llm_pricing.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    model_snapshot = Column(JSONB, nullable=False)
+    embedding_model = Column(String(100), nullable=False)
+    params = Column(JSONB, nullable=False)
+    input_count = Column(Integer, nullable=False)
+
+    cost_estimated_cents = Column(Integer, nullable=True)
+    cost_actual_cents = Column(Integer, nullable=True)
+
+    # ``platform`` reserved for v2 platform-paid mode; all v1 runs are BYOK.
+    paid_by = Column(
+        String(20),
+        nullable=False,
+        default="byok",
+        server_default=text("'byok'"),
+    )
+
+    quality = Column(JSONB, nullable=True)
+    overview = Column(Text, nullable=True)
+    error = Column(Text, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            _check_in_sql("status", MEMORY_ANALYSIS_STATUSES),
+            name="valid_memory_analysis_status",
+        ),
+        CheckConstraint(
+            _check_in_sql("paid_by", MEMORY_ANALYSIS_PAID_BY_VALUES),
+            name="valid_memory_analysis_paid_by",
+        ),
+        Index(
+            "idx_memory_analyses_workspace_started",
+            "workspace_id",
+            "started_at",
+        ),
+        Index(
+            "idx_memory_analyses_context_started",
+            "context_id",
+            "started_at",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<MemoryAnalysis(id={self.id}, context={self.context_id}, "
+            f"status={self.status}, started_at={self.started_at})>"
+        )
+
+
+class MemoryAnalysisCluster(Base):
+    """One cluster within an analysis run.
+
+    ``parent_id`` is nullable so the v2 hierarchical layer can land
+    without another migration. v1 always writes NULL.
+
+    Attributes:
+        id: UUID primary key
+        analysis_id: Parent run (CASCADE on delete)
+        parent_id: Self-reference for v2 hierarchy (NULL on v1)
+        cluster_index: Stable ordering within an analysis run
+        label: LLM-generated cluster label
+        description: Optional longer description
+        count: Number of memories in this cluster
+        centroid_2d: 2D-projected centroid for the scatter view
+        representative_memory_ids: Top-k memory ids that exemplify the cluster
+        property_stats: Aggregated facets (JSONB)
+        label_confidence: 0..1 score so the UI can gate weak labels
+    """
+
+    __tablename__ = "memory_analysis_clusters"
+
+    id = Column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    analysis_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("memory_analyses.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    parent_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("memory_analysis_clusters.id", ondelete="CASCADE"),
+        nullable=True,
+    )
+    cluster_index = Column(Integer, nullable=False)
+    label = Column(Text, nullable=False)
+    description = Column(Text, nullable=True)
+    count = Column(Integer, nullable=False)
+    centroid_2d = Column(ARRAY(Float), nullable=False)
+    representative_memory_ids = Column(
+        ARRAY(UUID(as_uuid=True)),
+        nullable=False,
+    )
+    property_stats = Column(JSONB, nullable=False)
+    label_confidence = Column(Float, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            "label_confidence >= 0 AND label_confidence <= 1",
+            name="valid_memory_analysis_cluster_label_confidence",
+        ),
+        Index(
+            "idx_memory_analysis_clusters_analysis",
+            "analysis_id",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<MemoryAnalysisCluster(id={self.id}, analysis={self.analysis_id}, "
+            f"label={self.label!r}, count={self.count})>"
+        )
+
+
+class MemoryAnalysisAssignment(Base):
+    """Per-memory 2D coordinate + cluster assignment for an analysis run.
+
+    Composite PK ``(analysis_id, memory_id)`` because the same memory
+    can appear in many different runs but exactly once per run.
+
+    Attributes:
+        analysis_id: Parent run (CASCADE on delete)
+        memory_id: Target memory (CASCADE on delete)
+        cluster_id: Cluster the memory was assigned to (CASCADE on delete)
+        x: 2D-projected x coordinate
+        y: 2D-projected y coordinate
+    """
+
+    __tablename__ = "memory_analysis_assignments"
+
+    analysis_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("memory_analyses.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    memory_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("memories.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    cluster_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("memory_analysis_clusters.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    x = Column(Float, nullable=False)
+    y = Column(Float, nullable=False)
+
+    __table_args__ = (
+        Index(
+            "idx_memory_analysis_assignments_cluster",
+            "cluster_id",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<MemoryAnalysisAssignment(analysis={self.analysis_id}, "
+            f"memory={self.memory_id}, cluster={self.cluster_id})>"
+        )

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -202,6 +202,10 @@ class MemoryAnalysisCluster(Base):
     description = Column(Text, nullable=True)
     count = Column(Integer, nullable=False)
     centroid_2d = Column(ARRAY(Float), nullable=False)
+    # NOTE: PostgreSQL cannot enforce FK on array elements, so a memory
+    # deleted after a run lands here as a stale UUID. Read paths
+    # (#496 API / #497 frontend) MUST LEFT JOIN against ``memories`` and
+    # filter out NULLs rather than trusting every ID resolves.
     representative_memory_ids = Column(
         ARRAY(UUID(as_uuid=True)),
         nullable=False,

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -21,6 +21,7 @@ from functools import cached_property
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     CheckConstraint,
     Column,
@@ -1130,6 +1131,23 @@ class Workspace(Base):
     addon_public_quota_bonus = Column(Integer, nullable=False, server_default="0")
     addon_member_bonus = Column(Integer, nullable=False, server_default="0")
     addon_context_bonus = Column(Integer, nullable=False, server_default="0")  # Issue #15
+    addon_analysis_bonus = Column(Integer, nullable=False, server_default="0")  # Issue #494
+
+    # Issue #494: per-workspace default + quality model selection for
+    # Memory Broadlistening analyses. Both nullable — analysis is gated
+    # by a separate allowlist; until a workspace is opted-in there's no
+    # need for a model choice. SET NULL on llm_pricing delete so a
+    # pricing row removal does not cascade into the workspace.
+    analysis_default_model_id = Column(
+        BigInteger,
+        ForeignKey("llm_pricing.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    analysis_quality_model_id = Column(
+        BigInteger,
+        ForeignKey("llm_pricing.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
     @cached_property
     def _plan_tier(self):
@@ -1182,6 +1200,11 @@ class Workspace(Base):
     def effective_max_members(self) -> int:
         """Max members: plan tier base + addon."""
         return self._plan_tier.max_members_per_workspace + (self.addon_member_bonus or 0)
+
+    @property
+    def effective_analysis_runs_per_day(self) -> int:
+        """Memory Broadlistening analysis runs/day: plan tier base + addon (Issue #494)."""
+        return self._plan_tier.analysis_runs_per_day + (self.addon_analysis_bonus or 0)
 
     # Stripe billing (Issue #351)
     stripe_customer_id = Column(String(255), nullable=True)

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -373,7 +373,7 @@ class WorkspaceAddon(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "addon_type IN ('extra_storage', 'extra_memory', 'extra_mcp_quota', 'extra_rest_quota', 'extra_public_quota', 'extra_members', 'extra_contexts')",
+            "addon_type IN ('extra_storage', 'extra_memory', 'extra_mcp_quota', 'extra_rest_quota', 'extra_public_quota', 'extra_members', 'extra_contexts', 'extra_analysis_runs')",
             name="check_addon_type",
         ),
         CheckConstraint("quantity > 0", name="check_quantity_positive"),

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -31,6 +31,7 @@ ADDON_UNIT_VALUES = {
     "extra_public_quota": 500,  # calls/day per unit
     "extra_members": 5,  # members per unit
     "extra_contexts": 5,  # contexts per unit
+    "extra_analysis_runs": 1,  # Issue #494: +1 broadlistening run/day per unit
 }
 
 
@@ -75,6 +76,7 @@ class AddonCalculatorService:
             "addon_public_quota_bonus": 0,
             "addon_member_bonus": 0,
             "addon_context_bonus": 0,
+            "addon_analysis_bonus": 0,
         }
 
         for addon in active_addons:
@@ -97,6 +99,8 @@ class AddonCalculatorService:
                 bonuses["addon_member_bonus"] += total_bonus
             elif addon_type == "extra_contexts":
                 bonuses["addon_context_bonus"] += total_bonus
+            elif addon_type == "extra_analysis_runs":
+                bonuses["addon_analysis_bonus"] += total_bonus
 
         # Update workspace table
         result = await self.db.execute(select(Workspace).where(Workspace.id == workspace_id))
@@ -113,6 +117,7 @@ class AddonCalculatorService:
         workspace.addon_public_quota_bonus = bonuses["addon_public_quota_bonus"]
         workspace.addon_member_bonus = bonuses["addon_member_bonus"]
         workspace.addon_context_bonus = bonuses["addon_context_bonus"]
+        workspace.addon_analysis_bonus = bonuses["addon_analysis_bonus"]
 
         await self.db.commit()
 

--- a/backend/src/services/effective_quota_service.py
+++ b/backend/src/services/effective_quota_service.py
@@ -55,7 +55,8 @@ class EffectiveQuotaService:
                 "public_calls_per_day": int,
                 "public_calls_per_week": int,
                 "max_members": int,
-                "max_contexts": int
+                "max_contexts": int,
+                "analysis_runs_per_day": int  # Issue #494
             }
 
         Raises:
@@ -77,6 +78,7 @@ class EffectiveQuotaService:
             and workspace.addon_public_quota_bonus == 0
             and workspace.addon_member_bonus == 0
             and workspace.addon_context_bonus == 0
+            and workspace.addon_analysis_bonus == 0
         ):
             # Import here to avoid circular dependency
             from services.addon_calculator_service import AddonCalculatorService
@@ -101,6 +103,7 @@ class EffectiveQuotaService:
             "public_calls_per_week": workspace.effective_public_calls_per_week,
             "max_members": workspace.effective_max_members,
             "max_contexts": workspace.effective_max_contexts,
+            "analysis_runs_per_day": workspace.effective_analysis_runs_per_day,
         }
 
         logger.debug(
@@ -127,7 +130,9 @@ class EffectiveQuotaService:
                 "addon_mcp_quota_bonus": int,
                 "addon_rest_quota_bonus": int,
                 "addon_public_quota_bonus": int,
-                "addon_member_bonus": int
+                "addon_member_bonus": int,
+                "addon_context_bonus": int,
+                "addon_analysis_bonus": int  # Issue #494
             }
         """
         result = await self.db.execute(select(Workspace).where(Workspace.id == workspace_id))
@@ -143,4 +148,5 @@ class EffectiveQuotaService:
             "addon_public_quota_bonus": workspace.addon_public_quota_bonus,
             "addon_member_bonus": workspace.addon_member_bonus,
             "addon_context_bonus": workspace.addon_context_bonus,
+            "addon_analysis_bonus": workspace.addon_analysis_bonus,
         }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -18,6 +18,7 @@ from models.memory import Base as MemoryBase
 # keeps the test setup robust to future import-graph changes.
 import models.llm_pricing  # noqa: F401  isort: skip
 import models.sleep  # noqa: F401  isort: skip
+import models.analysis  # noqa: F401  isort: skip  # Issue #494: Memory Broadlistening tables
 
 # Configure structlog the same way api/main.py does at app startup so
 # logger.info("event", key=value) calls inside route modules work in

--- a/backend/tests/integration/test_memory_analyses_schema.py
+++ b/backend/tests/integration/test_memory_analyses_schema.py
@@ -184,6 +184,29 @@ async def test_workspace_default_model_fk_enforced(
 
 
 @pytest.mark.asyncio
+async def test_workspace_default_model_set_null_on_pricing_delete(
+    db_session: AsyncSession,
+) -> None:
+    """Deleting the pricing row clears ``analysis_default_model_id`` to NULL.
+
+    Verifies the ``ON DELETE SET NULL`` semantics — a pricing-row cleanup
+    must not cascade-delete the workspace, only clear its model selection.
+    """
+    ws, _, pricing, _ = await _seed_workspace_context_pricing(db_session)
+
+    ws.analysis_default_model_id = pricing.id
+    await db_session.flush()
+    assert ws.analysis_default_model_id == pricing.id
+
+    await db_session.delete(pricing)
+    await db_session.flush()
+    await db_session.refresh(ws)
+
+    assert ws.analysis_default_model_id is None
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
 async def test_assignment_composite_pk_blocks_duplicate(
     db_session: AsyncSession,
 ) -> None:

--- a/backend/tests/integration/test_memory_analyses_schema.py
+++ b/backend/tests/integration/test_memory_analyses_schema.py
@@ -1,0 +1,356 @@
+"""Schema integrity tests for Memory Broadlistening tables (#494).
+
+Covers the acceptance criteria from issue #494:
+
+- alembic upgrade head clean (forward then rollback) is exercised by the
+  generic ``test_alembic_migrations.TestAlembicMigrations`` suite; this
+  module focuses on the post-upgrade *behavior* of the new schema.
+- CHECK constraint on ``memory_analyses.status`` rejects invalid values.
+- CHECK constraint on ``memory_analyses.paid_by`` rejects values outside
+  the ``byok | platform`` set.
+- ``memory_analysis_assignments`` PK is composite ``(analysis_id, memory_id)``.
+- FK from ``workspaces.analysis_default_model_id`` to ``llm_pricing(id)``
+  is enforced.
+- ``Workspace.effective_analysis_runs_per_day`` returns
+  ``tier_base + addon_analysis_bonus`` (FREE=0, BASIC=0, PRO=3 + bonus).
+- ``addon_calculator_service`` recognizes the ``extra_analysis_runs`` SKU
+  and writes ``addon_analysis_bonus``.
+
+The session-scoped fixtures from ``tests/conftest.py`` create the schema
+via ``Base.metadata.create_all`` rather than ``alembic upgrade``; that
+keeps these tests fast and isolated from migration version state, while
+``test_alembic_migrations`` exercises the migration paths separately.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.analysis import (
+    MemoryAnalysis,
+    MemoryAnalysisAssignment,
+    MemoryAnalysisCluster,
+)
+from models.auth import Context, Workspace
+from models.llm_pricing import LLMPricing
+from models.memory import Memory
+from models.resource import WorkspaceAddon
+
+
+async def _seed_workspace_context_pricing(
+    db: AsyncSession,
+    *,
+    plan: str = "pro",
+) -> tuple[Workspace, Context, LLMPricing, str]:
+    """Insert workspace + context + a unique llm_pricing row; return them.
+
+    Flush between workspace and context: ``contexts.workspace_id`` FK
+    has no ``relationship()`` to drive insert order, so a single flush
+    can attempt the child row first.
+    """
+    owner_id = f"user-{uuid4().hex[:8]}"
+    ws = Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name=plan,
+        owner_user_id=owner_id,
+        memory_limit=100000,
+        daily_api_limit=10000,
+        weekly_api_limit=50000,
+    )
+    db.add(ws)
+    await db.flush()
+
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=owner_id,
+    )
+    db.add(ctx)
+
+    # Unique model name per call avoids collisions on
+    # uq_llm_pricing_lookup_key when other tests in the same DB session
+    # have inserted pricing rows.
+    pricing = LLMPricing(
+        provider="google",
+        model=f"gemini-test-{uuid4().hex[:8]}",
+        unit_type="input_tokens",
+        effective_from=datetime(2026, 1, 1),
+        price_per_unit=Decimal("0.075"),
+        currency="USD",
+        unit_denominator=1_000_000,
+        context_min_tokens=0,
+    )
+    db.add(pricing)
+
+    await db.flush()
+    return ws, ctx, pricing, owner_id
+
+
+def _build_analysis(
+    ws: Workspace,
+    ctx: Context,
+    pricing: LLMPricing,
+    owner_id: str,
+    *,
+    status: str = "running",
+    paid_by: str = "byok",
+) -> MemoryAnalysis:
+    """Construct a minimal ``MemoryAnalysis`` ORM object (no DB write)."""
+    return MemoryAnalysis(
+        id=uuid4(),
+        workspace_id=ws.id,
+        context_id=ctx.id,
+        status=status,
+        triggered_by=owner_id,
+        model_id=pricing.id,
+        model_snapshot={},
+        embedding_model="text-embedding-3-small",
+        params={},
+        input_count=100,
+        paid_by=paid_by,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CHECK constraints on memory_analyses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_status_check_rejects_invalid_value(db_session: AsyncSession) -> None:
+    """``status`` outside the allowed set raises IntegrityError."""
+    ws, ctx, pricing, owner_id = await _seed_workspace_context_pricing(db_session)
+
+    db_session.add(_build_analysis(ws, ctx, pricing, owner_id, status="bogus"))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_status_check_accepts_each_valid_value(
+    db_session: AsyncSession,
+) -> None:
+    """All four allowed status values insert cleanly."""
+    ws, ctx, pricing, owner_id = await _seed_workspace_context_pricing(db_session)
+
+    for status in ("running", "succeeded", "failed", "cancelled"):
+        db_session.add(_build_analysis(ws, ctx, pricing, owner_id, status=status))
+    await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_paid_by_check_rejects_invalid_value(
+    db_session: AsyncSession,
+) -> None:
+    """``paid_by`` outside ``{byok, platform}`` raises IntegrityError."""
+    ws, ctx, pricing, owner_id = await _seed_workspace_context_pricing(db_session)
+
+    db_session.add(_build_analysis(ws, ctx, pricing, owner_id, paid_by="bogus"))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# FK + composite PK + label_confidence CHECK
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_workspace_default_model_fk_enforced(
+    db_session: AsyncSession,
+) -> None:
+    """Setting ``analysis_default_model_id`` to a non-existent llm_pricing.id fails."""
+    ws, _, pricing, _ = await _seed_workspace_context_pricing(db_session)
+
+    # ``pricing.id + 1`` is provably non-existent — the just-flushed pricing
+    # row holds the highest sequence value and we have not inserted further
+    # rows. Avoids a hard-coded sentinel that could collide on a busy
+    # shared test DB where the BIGINT sequence has advanced past it.
+    ws.analysis_default_model_id = pricing.id + 1
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_assignment_composite_pk_blocks_duplicate(
+    db_session: AsyncSession,
+) -> None:
+    """Inserting the same (analysis_id, memory_id) twice raises IntegrityError."""
+    ws, ctx, pricing, owner_id = await _seed_workspace_context_pricing(db_session)
+    analysis = _build_analysis(ws, ctx, pricing, owner_id)
+    db_session.add(analysis)
+    await db_session.flush()
+
+    cluster = MemoryAnalysisCluster(
+        id=uuid4(),
+        analysis_id=analysis.id,
+        cluster_index=0,
+        label="cluster-0",
+        count=1,
+        centroid_2d=[0.0, 0.0],
+        representative_memory_ids=[],
+        property_stats={},
+        label_confidence=0.9,
+    )
+    db_session.add(cluster)
+
+    memory = Memory(
+        id=uuid4(),
+        workspace_id=ws.id,
+        context_id=ctx.id,
+        user_id=owner_id,
+        summary="test",
+        content="test",
+        type="note",
+        client="test",
+    )
+    db_session.add(memory)
+    await db_session.flush()
+
+    db_session.add(
+        MemoryAnalysisAssignment(
+            analysis_id=analysis.id,
+            memory_id=memory.id,
+            cluster_id=cluster.id,
+            x=0.0,
+            y=0.0,
+        )
+    )
+    await db_session.flush()
+
+    db_session.add(
+        MemoryAnalysisAssignment(
+            analysis_id=analysis.id,
+            memory_id=memory.id,
+            cluster_id=cluster.id,
+            x=1.0,
+            y=1.0,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_label_confidence_check_rejects_out_of_range(
+    db_session: AsyncSession,
+) -> None:
+    """``label_confidence`` outside [0, 1] raises IntegrityError."""
+    ws, ctx, pricing, owner_id = await _seed_workspace_context_pricing(db_session)
+    analysis = _build_analysis(ws, ctx, pricing, owner_id)
+    db_session.add(analysis)
+    await db_session.flush()
+
+    db_session.add(
+        MemoryAnalysisCluster(
+            id=uuid4(),
+            analysis_id=analysis.id,
+            cluster_index=0,
+            label="bad",
+            count=1,
+            centroid_2d=[0.0, 0.0],
+            representative_memory_ids=[],
+            property_stats={},
+            label_confidence=1.5,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# addon_analysis_bonus column + WorkspaceAddon CHECK extension
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_addon_analysis_bonus_default_zero(
+    db_session: AsyncSession,
+) -> None:
+    """A newly inserted workspace has ``addon_analysis_bonus = 0`` by default."""
+    ws, _, _, _ = await _seed_workspace_context_pricing(db_session)
+    await db_session.refresh(ws)
+    assert ws.addon_analysis_bonus == 0
+
+
+@pytest.mark.asyncio
+async def test_workspace_addon_check_accepts_extra_analysis_runs(
+    db_session: AsyncSession,
+) -> None:
+    """The CHECK extension lets a Stripe webhook insert the new SKU."""
+    ws, _, _, owner_id = await _seed_workspace_context_pricing(db_session)
+    db_session.add(
+        WorkspaceAddon(
+            workspace_id=ws.id,
+            addon_type="extra_analysis_runs",
+            quantity=1,
+            created_by=owner_id,
+        )
+    )
+    await db_session.flush()
+
+
+@pytest.mark.asyncio
+async def test_workspace_addon_check_still_rejects_unknown(
+    db_session: AsyncSession,
+) -> None:
+    """Unknown addon_type values still fail (constraint not weakened)."""
+    ws, _, _, owner_id = await _seed_workspace_context_pricing(db_session)
+    db_session.add(
+        WorkspaceAddon(
+            workspace_id=ws.id,
+            addon_type="extra_bogus_quota",
+            quantity=1,
+            created_by=owner_id,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Workspace.effective_analysis_runs_per_day math
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("plan", "bonus", "expected"),
+    [
+        ("pro", 0, 3),  # PRO base
+        ("pro", 5, 8),  # PRO + addon offset
+        ("free", 0, 0),  # FREE base
+        ("basic", 0, 0),  # BASIC base
+        ("free", 2, 2),  # FREE + addon (base stays 0, bonus surfaces)
+    ],
+)
+def test_effective_analysis_runs(plan: str, bonus: int, expected: int) -> None:
+    """``effective_analysis_runs_per_day`` = plan-tier base + addon bonus."""
+    ws = Workspace(plan_name=plan, addon_analysis_bonus=bonus)
+    assert ws.effective_analysis_runs_per_day == expected
+
+
+# ---------------------------------------------------------------------------
+# AddonCalculatorService.extra_analysis_runs SKU
+# ---------------------------------------------------------------------------
+
+
+def test_addon_unit_values_includes_extra_analysis_runs() -> None:
+    """The Stripe SKU is registered with a +1 unit value."""
+    from services.addon_calculator_service import ADDON_UNIT_VALUES
+
+    assert ADDON_UNIT_VALUES["extra_analysis_runs"] == 1

--- a/backend/tests/services/test_effective_quota_service.py
+++ b/backend/tests/services/test_effective_quota_service.py
@@ -139,6 +139,7 @@ class TestDashboardAddonReflection:
         ws.addon_public_quota_bonus = 50
         ws.addon_member_bonus = 3
         ws.addon_context_bonus = 5
+        ws.addon_analysis_bonus = 2  # Issue #494
         from config.plan_tiers import get_plan_tier
 
         tier = get_plan_tier("pro")
@@ -151,6 +152,7 @@ class TestDashboardAddonReflection:
         ws.effective_public_calls_per_week = tier.public_calls_per_week + 50
         ws.effective_max_contexts = tier.max_contexts_per_workspace + 5
         ws.effective_max_members = tier.max_members_per_workspace + 3
+        ws.effective_analysis_runs_per_day = tier.analysis_runs_per_day + 2
 
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = ws
@@ -166,3 +168,5 @@ class TestDashboardAddonReflection:
         assert quotas["mcp_calls_per_week"] == tier.mcp_calls_per_week + 200
         assert quotas["rest_calls_per_week"] == tier.rest_calls_per_week + 100
         assert quotas["public_calls_per_week"] == tier.public_calls_per_week + 50
+        # Issue #494: broadlistening analysis runs/day surfaces here too.
+        assert quotas["analysis_runs_per_day"] == tier.analysis_runs_per_day + 2


### PR DESCRIPTION
Closes #494

## Summary
- 3 new tables (`memory_analyses`, `memory_analysis_clusters`, `memory_analysis_assignments`) — Memory Broadlistening v1 persistence layer (B1 of umbrella #493)
- `workspaces` ALTERs: `analysis_default_model_id`, `analysis_quality_model_id` (BIGINT FK → `llm_pricing.id`, ON DELETE SET NULL), `addon_analysis_bonus` (NOT NULL DEFAULT 0)
- Plan tier: `analysis_runs_per_day` field, PRO=3 (FREE/BASIC=0); Stripe SKU `extra_analysis_runs` (+1 run/day per unit)
- 16 schema integration tests + parametrized property test; forward+rollback verified on fresh DB

## Implementation notes
- **Atomic single migration** (`d06_494_memory_analyses.py`) — workspace ALTERs + 3 new tables + `workspace_addons.check_addon_type` extension all together. Splitting would leave a Stripe webhook `IntegrityError` window where `extra_analysis_runs` rows could be inserted before the CHECK accepts them.
- **FK ondelete chosen per semantics**: `workspace_id`/`context_id`/`memory_id`/`cluster_id`/`parent_id` CASCADE (lifecycle), `model_id` RESTRICT (cost-anchor — preserves historical analysis runs even if a pricing row is removed), `analysis_default_model_id`/`analysis_quality_model_id` SET NULL (avoids cascade-deleting workspaces if a pricing row is removed).
- **Migration filename**: `d06_494_memory_analyses.py` (head was `d05_523_source_paid_by`). Issue body's suggested `d01_493_*` was outdated.
- **`llm_pricing.id` is BigInteger autoincrement, not UUID** — issue body's `uuid REFERENCES llm_pricing(id)` was wrong; corrected to `BIGINT` in both ORM + migration.
- **Patterns mirrored**: `sleep.py` (multi-table file layout, dual `default=` + `server_default=text(...)`); `llm_pricing.py` (BigInteger PK + UnitTypes export tuple); `c02_471_cost_grade_schema` (`op.create_table` style); `b05_223_tag_cooccurrence` (CHECK constraint drop+recreate); `test_attachments.py` (async ORM-based integration tests).
- **Service plumbing**: `EffectiveQuotaService` returns `analysis_runs_per_day` + `addon_analysis_bonus`; `AddonCalculatorService` recognizes `extra_analysis_runs`; `WorkspaceAddon` CHECK extended.
- **Composite PK**: `memory_analysis_assignments(analysis_id, memory_id)` named via SQLAlchemy default (`<table>_pkey`) so alembic-applied DBs and `Base.metadata.create_all` test DBs agree.

## Pre-PR review summary
- gate2 mode: advisor-only (`gate2.binary_gate=null`)
- audit: skipped
- binary_gate: (none)
- /claude-c-suite:cso: green (initial yellow → fixup 6fb0476b → re-review green)
- /claude-c-suite:qa-lead: green (initial yellow → fixup 6fb0476b → re-review green)
- /claude-c-suite:cto: green (unchanged)
- gate1: skipped (ship-only mode; no `/gh-issue-driven:start` was run)
- review provider: copilot

Fixup commit `6fb0476b` addressed the initial yellow findings (1-to-1 mapping):
- CSO WARN-1 (downgrade Stripe-row destructiveness not documented) → migration `downgrade()` docstring extended with OPS WARNING + count-check query
- CSO WARN-2 (`representative_memory_ids` stale-UUID risk not noted) → `# NOTE:` comment in `analysis.py` documenting PG array-FK limitation + #496/#497 LEFT JOIN requirement
- QA W1 (`ondelete="SET NULL"` not tested) → new `test_workspace_default_model_set_null_on_pricing_delete`
- QA W2 (`analysis_runs_per_day` key not asserted in `EffectiveQuotaService` test) → assertion added to `test_effective_limits_with_addons`
- QA I1 (downgrade seeded-state test) — deferred per QA's own P3 ranking

Full reviews saved in plugin cache:
- `~/.claude/cache/gh-issue-driven/494-feat-memory-analyses-schema.gate2.md`

## Test plan
- [x] `make lint` — clean
- [x] `make test-integration` — 22 tests pass (16 schema + 6 service)
- [x] `alembic upgrade head` clean on fresh DB
- [x] `alembic downgrade d05 → upgrade head` round-trip clean
- [x] Schema verified in PostgreSQL: all CHECK constraints, FK ondelete actions, composite PK, indexes, server_defaults present as spec'd

🤖 Generated via /gh-issue-driven:ship
