### PR TITLE
fix(api): register llm_pricing/sleep/analysis models at app startup (#531)

### DIFF
--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -1,5 +1,16 @@
 """Data models for Kagura Memory Cloud."""
 
+# Registered-table imports (required for SQLAlchemy FK resolution at app
+# startup). ``models.auth.Workspace`` declares FKs to ``llm_pricing.id``
+# (added by #494) and is queried by ``/admin/plans`` routes; without
+# importing the target tables here, ``Base.metadata`` is incomplete and
+# ``NoReferencedTableError`` fires on the first SELECT that triggers
+# mapper resolution. Mirrors the explicit imports in
+# ``backend/tests/conftest.py`` so production startup matches the
+# test environment's import graph (#531).
+import models.analysis  # noqa: F401
+import models.llm_pricing  # noqa: F401
+import models.sleep  # noqa: F401
 from models.config import ContextSearchConfig
 from models.neural import NeuralConfig
 from models.resource import (


### PR DESCRIPTION
Closes #531

## Summary

`/admin/plans/...` routes returned 500 with `sqlalchemy.exc.NoReferencedTableError: Foreign key associated with column 'workspaces.analysis_default_model_id' could not find table 'llm_pricing'`. Adding three explicit imports to `backend/src/models/__init__.py` registers the target tables in `Base.metadata` before any route handler triggers SQLAlchemy mapper resolution on `Workspace`.

## Root cause

\`Workspace\` declares FK columns \`analysis_default_model_id\` and \`analysis_quality_model_id\` referencing \`llm_pricing.id\` (added by #494 / PR #529 / commit \`6d320a78\`). Because `models/__init__.py` did not import \`models.llm_pricing\`, the target table was never registered with \`Base.metadata\` at production startup.

The test setup (\`backend/tests/conftest.py:19-21\`) already imports the three modules explicitly:
\`\`\`python
import models.llm_pricing  # noqa: F401  isort: skip
import models.sleep        # noqa: F401  isort: skip
import models.analysis     # noqa: F401  isort: skip
\`\`\`
which is why the integration test suite passed but production hit the bug. This PR mirrors the same imports in production.

## Verification (local)

After \`make restart\` + new container start:

\`\`\`bash
$ docker exec kagura-api bash -c \"cd /app && PYTHONPATH=src python -c '...'\"
total tables registered: 17
  YES  llm_pricing
  YES  sleep_reports
  YES  sleep_report_llm_usage
  YES  memory_analyses
  YES  memory_analysis_clusters
  YES  memory_analysis_assignments
analysis_default_model_id -> llm_pricing.id

$ curl -s -o /dev/null -w \"HTTP %{http_code}\\\\n\" \\\\
    http://localhost:8080/api/v1/admin/plans/workspaces/c56644c1-.../quotas
HTTP 401     # was HTTP 500 NoReferencedTableError
\`\`\`

## Test plan

- [x] \`make lint\` passes (ruff)
- [x] \`make type-check\` passes (pyright 0 errors)
- [x] \`docker exec ... PYTHONPATH=src python -c 'import models; ...'\` shows \`llm_pricing\` in \`Base.metadata.tables\`
- [x] \`Workspace.analysis_default_model_id\` FK resolves to \`llm_pricing.id\`
- [x] Previously-500 endpoint returns 401 (auth-required) without auth header — proves SQLAlchemy mapper is healthy
- [ ] Admin user reproduces the original handleChangePlan flow successfully (operator verification)
- [ ] PUT \`/api/v1/admin/plans/workspaces/{id}/plan\` with admin auth returns 200

🤖 Generated via /gh-issue-driven:ship pattern