### PR TITLE
feat(api+mcp): /analyses endpoints + 5 MCP tools + recall analysis_cluster filter (#496)

### DIFF
--- a/backend/alembic/versions/d08_496_analyses_cancellation.py
+++ b/backend/alembic/versions/d08_496_analyses_cancellation.py
@@ -1,0 +1,82 @@
+"""Add cancellation_reason column + composite (analysis_id, cluster_id) index (#496).
+
+Issue #496 (B3 of the Broadlistening v1 atomic split): the API + MCP
+exposure layer needs two schema additions on top of #494's base tables:
+
+1. ``memory_analyses.cancellation_reason TEXT NULL`` — populated when
+   the DELETE soft-cancel endpoint flips ``status`` from ``running`` to
+   ``cancelled``. Distinct from ``error`` so the future taxonomy
+   (``user`` / ``admin`` / ``timeout`` / ``cost_cap``) can branch
+   without overloading the failure column.
+
+2. ``idx_memory_analysis_assignments_analysis_cluster`` on
+   ``(analysis_id, cluster_id)`` — supports the
+   ``recall(filters={"analysis_cluster": ...})`` filter chain that
+   does ``WHERE analysis_id = :run_id AND cluster_id = :cid``.
+   The existing single-column ``idx_memory_analysis_assignments_cluster``
+   is kept (used by the reporter at write time to look up centroid
+   neighborhoods) — the new composite index narrows the recall lookup
+   without invalidating that path. Composite vs swap was the right
+   call: dropping the single-column index would force the reporter
+   to scan ``cluster_id`` via the composite, paying for the
+   ``analysis_id`` prefix it doesn't filter on.
+
+Both changes are catalog-only on PostgreSQL >= 11 — adding a NULL
+column without a default is a metadata change, and ``CREATE INDEX``
+with the default ``CONCURRENTLY=False`` is a brief ACCESS EXCLUSIVE
+lock; cluster row counts are bounded (Pro daily quota is 3 runs,
+each with O(sqrt(memories)) clusters), so the lock window is sub-
+second on production-sized tables.
+
+Revision ID: d08_496_analyses_cancel
+Revises: d07_495_cluster_label_phase
+
+NOTE: Revision IDs are capped at 32 chars because
+``alembic_version.version_num`` is ``VARCHAR(32)`` in this database.
+This migration uses ``d08_496_analyses_cancel`` (24 chars) — well
+within the cap. The Python filename is allowed to be longer.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d08_496_analyses_cancel"
+down_revision = "d07_495_cluster_label_phase"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Apply the schema changes."""
+    # 1. memory_analyses.cancellation_reason — NULL for non-cancelled rows.
+    op.add_column(
+        "memory_analyses",
+        sa.Column(
+            "cancellation_reason",
+            sa.Text(),
+            nullable=True,
+            comment=(
+                "Human-readable reason when status='cancelled'. "
+                "NULL for running/succeeded/failed rows. Issue #496."
+            ),
+        ),
+    )
+
+    # 2. Composite index for the recall analysis_cluster filter
+    #    (`WHERE analysis_id = ? AND cluster_id = ?` lookups).
+    op.create_index(
+        "idx_memory_analysis_assignments_analysis_cluster",
+        "memory_analysis_assignments",
+        ["analysis_id", "cluster_id"],
+    )
+
+
+def downgrade() -> None:
+    """Reverse the schema changes."""
+    op.drop_index(
+        "idx_memory_analysis_assignments_analysis_cluster",
+        table_name="memory_analysis_assignments",
+    )
+    op.drop_column("memory_analyses", "cancellation_reason")

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -155,6 +155,15 @@ openapi_tags = [
     {"name": "resource-ingest", "description": "External data ingestion API"},
     {"name": "resource-schema", "description": "Resource schema registry"},
     {"name": "resource-indexer", "description": "Resource indexer runtime state"},
+    {
+        "name": "analyses",
+        "description": (
+            "Memory Broadlistening analysis runs. REST companion to the "
+            "5 MCP tools (analyze_context / get_analysis / list_analyses "
+            "/ get_active_analysis / get_cluster). Behind a 4-stage gate: "
+            "workspace owner + Pro tier + per-day quota + workspace allowlist."
+        ),
+    },
     # Public API
     {"name": "public-search", "description": "Public REST API for search"},
     {"name": "mcp-api", "description": "MCP server tools listing and status"},
@@ -346,6 +355,7 @@ from api.routes import (  # noqa: E402
     admin_plans,
     admin_signup_gate,  # Issue #358: admin-configurable signup gate
     admin_sleep,  # Issue #247: Manual Sleep Maintenance trigger
+    analyses,  # Issue #496: Memory Broadlistening API endpoints
     api_keys,
     attachments,  # Issue #330: File attachment support
     auth,
@@ -431,6 +441,9 @@ app.include_router(sleep_reports.router, prefix="/api/v1")
 
 # Cost Aggregation routes (Issue #472 - admin cross-workspace + workspace-scoped)
 app.include_router(cost_aggregation.router, prefix="/api/v1")
+
+# Memory Broadlistening API (Issue #496 - 4-stage gate + 6 endpoints)
+app.include_router(analyses.router, prefix="/api/v1")
 
 # Admin Sleep trigger (Issue #247 - Manual Sleep Maintenance trigger)
 app.include_router(admin_sleep.router, prefix="/api/v1")

--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -35,7 +35,7 @@ from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.analysis_gates import AnalysisReadAccess, AnalysisWriteAccess
@@ -117,6 +117,33 @@ class AnalysisPreviewRequest(BaseModel):
     model_id: int | None = None
 
     model_config = {"populate_by_name": True}
+
+    @field_validator("from_dt", "to_dt", mode="after")
+    @classmethod
+    def _validate_iso8601(cls, v: str | None) -> str | None:
+        """Reject non-ISO-8601 ``from``/``to`` strings at the boundary.
+
+        Without this, an invalid datetime string flows through to
+        ``AnalysisOrchestrator.run`` and raises during
+        ``_params_iso_to_naive_utc`` AFTER the ``memory_analyses`` row
+        has already been INSERTed at ``status='running'``. The run
+        would stay stuck in ``running`` (until a manual cancel) AND
+        count toward the daily quota — silent UX failure. Catching at
+        Pydantic boundary returns a clean 422 BEFORE the row is
+        created, so the quota window is preserved. Issue #496 Copilot
+        review.
+        """
+        if v is None:
+            return v
+        try:
+            datetime.fromisoformat(v)
+        except ValueError as e:
+            raise ValueError(
+                f"Invalid ISO-8601 datetime: {v!r}. "
+                "Expected forms: '2026-05-02T00:00:00Z', "
+                "'2026-05-02T09:00:00+09:00', or naive 'YYYY-MM-DDTHH:MM:SS'."
+            ) from e
+        return v
 
 
 class AnalysisPreviewResponse(BaseModel):

--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -30,6 +30,8 @@ spamming retries (matches the orchestrator's
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime
+from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -58,6 +60,32 @@ _CANCEL_REASON_USER = "user"
 assert _STATUS_RUNNING in MEMORY_ANALYSIS_STATUSES
 assert _STATUS_CANCELLED in MEMORY_ANALYSIS_STATUSES
 assert _CANCEL_REASON_USER in MEMORY_ANALYSIS_CANCELLATION_REASONS
+
+# Strong-ref set for ``asyncio.create_task`` — without this, the task
+# can be garbage-collected before the event loop schedules it. Same
+# pattern as ``api/routes/admin_sleep.py:_log_background_task_result``
+# but module-scoped so multiple in-flight kick-offs are tracked.
+_BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _log_background_task_result(task: asyncio.Task[Any]) -> None:
+    """Surface any exception that escaped the analysis background task.
+
+    Mirrors ``admin_sleep.py:_log_background_task_result``. Cancellation
+    is normal (run status flipped to ``cancelled`` by DELETE handler);
+    other exceptions are logged so the failure is observable in
+    monitoring even though the request response was already 202.
+    """
+    _BACKGROUND_TASKS.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            "analysis_background_task_crashed",
+            error=str(exc),
+            exc_info=exc,
+        )
 
 
 router = APIRouter(
@@ -106,11 +134,20 @@ class AnalysisStartRequest(AnalysisPreviewRequest):
 
 
 class AnalysisStartResponse(TZAwareBaseModel):
-    """202 Accepted body."""
+    """202 Accepted body.
 
-    run_id: UUID
+    Constructed via ``model_validate(analysis)`` so the ORM row's
+    ``id`` column maps to ``run_id`` (matches the issue spec naming)
+    and SQLAlchemy ``Column[datetime]`` ↔ Python ``datetime`` is
+    bridged by Pydantic's ``from_attributes`` rather than manual
+    cast at every call site.
+    """
+
+    run_id: UUID = Field(validation_alias="id")
     status: str
-    started_at: object
+    started_at: datetime
+
+    model_config = {"populate_by_name": True, "from_attributes": True}
 
 
 class AnalysisRow(TZAwareBaseModel):
@@ -131,8 +168,8 @@ class AnalysisRow(TZAwareBaseModel):
     context_id: UUID
     status: str
     triggered_by: str
-    started_at: object
-    finished_at: object | None
+    started_at: datetime
+    finished_at: datetime | None
     input_count: int
     cost_estimated_cents: int | None
     cost_actual_cents: int | None
@@ -150,12 +187,18 @@ class AnalysisListResponse(BaseModel):
 
 
 class AnalysisCancelResponse(TZAwareBaseModel):
-    """DELETE /{run_id} response — confirms the soft-cancel."""
+    """DELETE /{run_id} response — confirms the soft-cancel.
 
-    run_id: UUID
+    Same ``model_validate(row)`` pattern as AnalysisStartResponse so
+    SQLAlchemy column types are bridged via Pydantic ``from_attributes``.
+    """
+
+    run_id: UUID = Field(validation_alias="id")
     status: str
     cancellation_reason: str | None
-    finished_at: object | None
+    finished_at: datetime | None
+
+    model_config = {"populate_by_name": True, "from_attributes": True}
 
 
 # ============================================================================
@@ -305,9 +348,13 @@ async def start_analysis(
 
     await db.commit()
 
-    # Background pipeline. Fire-and-forget — the task opens its own
-    # AsyncSession (see tasks/analysis_tasks.py).
-    asyncio.create_task(run_analysis_task(analysis.id))
+    # Background pipeline. The task opens its own AsyncSession (see
+    # tasks/analysis_tasks.py). Strong-ref + done callback so the task
+    # is not GC'd before the loop schedules it AND any exception is
+    # surfaced in logs.
+    task = asyncio.create_task(run_analysis_task(analysis.id))
+    _BACKGROUND_TASKS.add(task)
+    task.add_done_callback(_log_background_task_result)
 
     logger.info(
         "analysis_run_kicked_off",
@@ -316,11 +363,7 @@ async def start_analysis(
         context_id=str(context_id),
         triggered_by=user_id,
     )
-    return AnalysisStartResponse(
-        run_id=analysis.id,
-        status=analysis.status,
-        started_at=analysis.started_at,
-    )
+    return AnalysisStartResponse.model_validate(analysis)
 
 
 # ============================================================================
@@ -473,9 +516,4 @@ async def cancel_run(
         )
     # else: already terminal → return current state without flipping anything.
 
-    return AnalysisCancelResponse(
-        run_id=row.id,
-        status=row.status,
-        cancellation_reason=row.cancellation_reason,
-        finished_at=row.finished_at,
-    )
+    return AnalysisCancelResponse.model_validate(row)

--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -1,0 +1,481 @@
+"""Memory Broadlistening API routes (Issue #496).
+
+REST surface for the analysis pipeline (#495 backend) sitting behind the
+4-stage gate composed in ``auth.analysis_gates``:
+
+    POST   /api/v1/contexts/{context_id}/analyses/preview
+    POST   /api/v1/contexts/{context_id}/analyses          (202)
+    GET    /api/v1/contexts/{context_id}/analyses
+    GET    /api/v1/contexts/{context_id}/analyses/active
+    GET    /api/v1/contexts/{context_id}/analyses/{run_id}
+    DELETE /api/v1/contexts/{context_id}/analyses/{run_id} (soft cancel)
+
+The route handlers are intentionally thin: gates → orchestrator/query
+service → response. POST is the only side-effectful path; everything
+else is a pure read or a status flip.
+
+Context-boundary verification: the gate dependency already verified
+workspace ownership, but the caller's URL ``context_id`` could belong
+to another workspace. Each handler runs ``_verify_context_in_workspace``
+to reject mismatches with 404 (deliberately not 403 so we don't leak
+the existence of a context the caller cannot see).
+
+Idempotency: POST /analyses raises ``ConflictError`` (409) when a prior
+run for the same (workspace, context) is still ``running``. The 409
+body carries the existing ``run_id`` so the client can poll instead of
+spamming retries (matches the orchestrator's
+``ConflictError`` contract).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.analysis_gates import AnalysisReadAccess, AnalysisWriteAccess
+from db.base import get_db
+from models.analysis import MEMORY_ANALYSIS_CANCELLATION_REASONS, MEMORY_ANALYSIS_STATUSES
+from models.api_base import TZAwareBaseModel
+from services.analysis import query_service
+from services.analysis.orchestrator import AnalysisOrchestrator, AnalysisParams
+from services.analysis.preview import DEFAULT_MODEL_ID, estimate_cost
+from tasks.analysis_tasks import run_analysis_task
+from utils.exceptions import ConflictError, ValidationError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Pinned status / reason constants — assert they remain members of the
+# canonical tuples so a future tuple reorder fires loud at import time
+# rather than silently sending an INSERT through the DB CHECK.
+_STATUS_RUNNING = "running"
+_STATUS_CANCELLED = "cancelled"
+_CANCEL_REASON_USER = "user"
+assert _STATUS_RUNNING in MEMORY_ANALYSIS_STATUSES
+assert _STATUS_CANCELLED in MEMORY_ANALYSIS_STATUSES
+assert _CANCEL_REASON_USER in MEMORY_ANALYSIS_CANCELLATION_REASONS
+
+
+router = APIRouter(
+    prefix="/contexts/{context_id}/analyses",
+    tags=["analyses"],
+)
+
+
+# ============================================================================
+# Schemas
+# ============================================================================
+
+
+class AnalysisPreviewRequest(BaseModel):
+    """Pre-flight cost-estimate request body.
+
+    Mirrors the POST body so the modal in #497 can submit the same
+    payload twice (preview, then run on confirm) without re-shaping.
+    Empty body is valid — the preview falls back to the count of
+    every memory in the context.
+    """
+
+    from_dt: str | None = Field(None, alias="from")
+    to_dt: str | None = Field(None, alias="to")
+    types: list[str] | None = None
+    tags: list[str] | None = None
+    min_importance: float | None = Field(None, ge=0.0, le=1.0)
+    query: str | None = None
+    model_id: int | None = None
+
+    model_config = {"populate_by_name": True}
+
+
+class AnalysisPreviewResponse(BaseModel):
+    """Cost-estimate output (Stage [A] from preview.py)."""
+
+    memory_count: int
+    cluster_count_estimate: int
+    estimated_cost_cents: int
+    model_id: str
+    breakdown: dict[str, int]
+
+
+class AnalysisStartRequest(AnalysisPreviewRequest):
+    """POST /analyses body — same shape as preview (intentional)."""
+
+
+class AnalysisStartResponse(TZAwareBaseModel):
+    """202 Accepted body."""
+
+    run_id: UUID
+    status: str
+    started_at: object
+
+
+class AnalysisRow(TZAwareBaseModel):
+    """One row in list / single-fetch responses.
+
+    Fields mirror ``MemoryAnalysis`` columns the API contract surfaces
+    (#496 spec). Internal columns like ``model_snapshot`` are omitted
+    on purpose — the snapshot is a debugging artifact, not part of
+    the public contract, and adds ~500B per row to the list payload.
+
+    ``validation_alias="id"`` (input-only) maps the ORM column ``id``
+    → ``run_id`` field while keeping the wire-format key as ``run_id``
+    for clients (matches the issue spec naming).
+    """
+
+    run_id: UUID = Field(validation_alias="id")
+    workspace_id: UUID
+    context_id: UUID
+    status: str
+    triggered_by: str
+    started_at: object
+    finished_at: object | None
+    input_count: int
+    cost_estimated_cents: int | None
+    cost_actual_cents: int | None
+    error: str | None
+    cancellation_reason: str | None
+
+    model_config = {"populate_by_name": True, "from_attributes": True}
+
+
+class AnalysisListResponse(BaseModel):
+    """Paginated list of runs."""
+
+    items: list[AnalysisRow]
+    next_cursor: str | None
+
+
+class AnalysisCancelResponse(TZAwareBaseModel):
+    """DELETE /{run_id} response — confirms the soft-cancel."""
+
+    run_id: UUID
+    status: str
+    cancellation_reason: str | None
+    finished_at: object | None
+
+
+# ============================================================================
+# Internal helpers
+# ============================================================================
+
+
+async def _verify_context_in_workspace(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+) -> None:
+    """Raise 404 if the context does not belong to the caller's workspace.
+
+    Thin wrapper over ``query_service.verify_context_in_workspace`` —
+    the SELECT is shared with the MCP-side variant in
+    ``mcp_server/tools/analysis.py`` so the boundary check lives in
+    one place. 404 (not 403) so context existence is not leaked.
+    """
+    if not await query_service.verify_context_in_workspace(
+        db, workspace_id=workspace_id, context_id=context_id
+    ):
+        raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+
+
+def _params_from_body(body: AnalysisPreviewRequest) -> AnalysisParams:
+    """Convert a request body to the orchestrator's ``AnalysisParams``.
+
+    The from/to fields in ``AnalysisParams`` are ``datetime``; we leave
+    the body as ISO strings and let the orchestrator's
+    ``_params_iso_to_naive_utc`` handle tz normalization at run() time.
+    Storing strings on params keeps the ``params`` JSONB stable across
+    serialization round-trips.
+    """
+    return AnalysisParams(
+        from_dt=None,
+        to_dt=None,
+        types=body.types,
+        tags=body.tags,
+        min_importance=body.min_importance,
+        query=body.query,
+        model_id=body.model_id,
+        extra={
+            # Persist the raw ISO strings so orchestrator.run() can
+            # re-parse them with the timezone normalization rules.
+            "from": body.from_dt,
+            "to": body.to_dt,
+        },
+    )
+
+
+# ============================================================================
+# POST /preview — pre-flight cost estimate (no row created)
+# ============================================================================
+
+
+@router.post(
+    "/preview",
+    response_model=AnalysisPreviewResponse,
+    summary="Estimate analysis cost without starting a run",
+)
+async def preview_analysis(
+    context_id: UUID,
+    body: AnalysisPreviewRequest,
+    access: AnalysisWriteAccess,
+    db: AsyncSession = Depends(get_db),
+) -> AnalysisPreviewResponse:
+    """Returns the cost estimate for a hypothetical run.
+
+    Goes through the full 4-gate chain so a non-Pro / quota-exhausted
+    / non-allowlisted user gets the same 403/429 they would on POST,
+    rather than seeing the price and then being blocked at confirm.
+    """
+    _user_id, workspace_id, _tz = access
+    await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    # v1 ignores body filters in the count to keep the modal under
+    # 200ms — the actual run will apply filters. The user-facing modal
+    # text in #497 says "estimate based on full context size; actual
+    # cost may be lower if filters apply".
+    memory_count = await query_service.count_context_memories(
+        db,
+        workspace_id=workspace_id,
+        context_id=context_id,
+    )
+    # v1 only supports the default model in the cost estimator;
+    # body.model_id is forward-compat scaffolding (preview.py:73-77).
+    estimate = estimate_cost(memory_count, model_id=DEFAULT_MODEL_ID)
+    return AnalysisPreviewResponse(
+        memory_count=estimate.memory_count,
+        cluster_count_estimate=estimate.cluster_count_estimate,
+        estimated_cost_cents=estimate.estimated_cost_cents,
+        model_id=estimate.model_id,
+        breakdown=estimate.breakdown,
+    )
+
+
+# ============================================================================
+# POST / — start a run (202)
+# ============================================================================
+
+
+@router.post(
+    "",
+    response_model=AnalysisStartResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Start a memory broadlistening analysis run",
+)
+async def start_analysis(
+    context_id: UUID,
+    body: AnalysisStartRequest,
+    access: AnalysisWriteAccess,
+    db: AsyncSession = Depends(get_db),
+) -> AnalysisStartResponse:
+    """Kick off a background analysis run.
+
+    Returns 202 with the new run_id. The pipeline runs in
+    ``asyncio.create_task(run_analysis_task)``; clients poll
+    ``GET /analyses/{run_id}`` for status transitions.
+
+    Error mapping (delegated to global handler via custom exceptions):
+
+    - 409 ConflictError  — a prior run is still ``running`` for the
+      same (workspace, context). Body carries the existing run_id.
+    - 422 ValidationError — BYOK key missing (orchestrator's
+      pre-flight) OR caller-supplied ``model_id`` does not exist.
+    """
+    user_id, workspace_id, _tz = access
+    await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    params = _params_from_body(body)
+    orchestrator = AnalysisOrchestrator(db)
+    try:
+        analysis = await orchestrator.start(
+            workspace_id=workspace_id,
+            context_id=context_id,
+            user_id=user_id,
+            params=params,
+        )
+    except ConflictError:
+        # Re-raise — global handler at api/main.py converts to 409 JSON.
+        raise
+    except ValidationError:
+        # BYOK / model_id missing → 422 with VAL-001 + provider hint.
+        raise
+
+    await db.commit()
+
+    # Background pipeline. Fire-and-forget — the task opens its own
+    # AsyncSession (see tasks/analysis_tasks.py).
+    asyncio.create_task(run_analysis_task(analysis.id))
+
+    logger.info(
+        "analysis_run_kicked_off",
+        run_id=str(analysis.id),
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+        triggered_by=user_id,
+    )
+    return AnalysisStartResponse(
+        run_id=analysis.id,
+        status=analysis.status,
+        started_at=analysis.started_at,
+    )
+
+
+# ============================================================================
+# GET / — list runs (paginated, newest first)
+# ============================================================================
+
+
+@router.get(
+    "",
+    response_model=AnalysisListResponse,
+    summary="List analysis runs for a context",
+)
+async def list_runs(
+    context_id: UUID,
+    access: AnalysisReadAccess,
+    cursor: str | None = Query(None, description="Opaque pagination cursor"),
+    limit: int | None = Query(None, ge=1, le=query_service.MAX_LIST_PAGE_SIZE),
+    db: AsyncSession = Depends(get_db),
+) -> AnalysisListResponse:
+    """Return runs for the context, sorted by ``started_at DESC``."""
+    _user_id, workspace_id, _tz = access
+    await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    rows, next_cursor = await query_service.list_analyses(
+        db,
+        workspace_id=workspace_id,
+        context_id=context_id,
+        limit=limit,
+        cursor=cursor,
+    )
+    return AnalysisListResponse(
+        items=[AnalysisRow.model_validate(row) for row in rows],
+        next_cursor=next_cursor,
+    )
+
+
+# ============================================================================
+# GET /active — most recent succeeded run
+# ============================================================================
+
+
+@router.get(
+    "/active",
+    response_model=AnalysisRow,
+    summary="Most recent succeeded run for a context",
+)
+async def get_active(
+    context_id: UUID,
+    access: AnalysisReadAccess,
+    db: AsyncSession = Depends(get_db),
+) -> AnalysisRow:
+    """Returns 404 when the context has no succeeded run yet."""
+    _user_id, workspace_id, _tz = access
+    await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    row = await query_service.get_active_analysis(
+        db,
+        workspace_id=workspace_id,
+        context_id=context_id,
+    )
+    if row is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No succeeded analysis run found for context {context_id}",
+        )
+    return AnalysisRow.model_validate(row)
+
+
+# ============================================================================
+# GET /{run_id} — single run
+# ============================================================================
+
+
+@router.get(
+    "/{run_id}",
+    response_model=AnalysisRow,
+    summary="Fetch one analysis run by id",
+)
+async def get_run(
+    context_id: UUID,
+    run_id: UUID,
+    access: AnalysisReadAccess,
+    db: AsyncSession = Depends(get_db),
+) -> AnalysisRow:
+    _user_id, workspace_id, _tz = access
+    await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    row = await query_service.get_analysis(db, workspace_id=workspace_id, run_id=run_id)
+    # 404 also fires when the run belongs to a different context within
+    # the same workspace — clients should not be able to read another
+    # context's runs even if the workspace gate passed.
+    if row is None or row.context_id != context_id:
+        raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
+    return AnalysisRow.model_validate(row)
+
+
+# ============================================================================
+# DELETE /{run_id} — soft cancel
+# ============================================================================
+
+
+@router.delete(
+    "/{run_id}",
+    response_model=AnalysisCancelResponse,
+    summary="Soft-cancel a running analysis (status → cancelled)",
+)
+async def cancel_run(
+    context_id: UUID,
+    run_id: UUID,
+    access: AnalysisWriteAccess,
+    db: AsyncSession = Depends(get_db),
+) -> AnalysisCancelResponse:
+    """Mark a running run as ``cancelled``.
+
+    No-op (idempotent 200) when the run is already in a terminal
+    state — not all clients will ship a "stop polling" hook to detect
+    that the run finished between their last poll and the cancel
+    click. 409 only for the genuinely contradictory case (status not
+    in {running, succeeded, failed, cancelled}).
+
+    Cancellation does NOT decrement the daily quota — the run row
+    has already been INSERTed by orchestrator.start, and BYOK /
+    partial LLM cost may have been incurred (#496 quota AC).
+    """
+    _user_id, workspace_id, _tz = access
+    await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    row = await query_service.get_analysis(db, workspace_id=workspace_id, run_id=run_id)
+    if row is None or row.context_id != context_id:
+        raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
+
+    if row.status == _STATUS_RUNNING:
+        # Mark cancelled. Background task may still be mid-stage; it
+        # will complete and persist its own status update which the
+        # reporter will treat as a no-op since cancellation_reason is
+        # already set (status='cancelled' wins over the late update).
+        row.status = _STATUS_CANCELLED
+        row.cancellation_reason = _CANCEL_REASON_USER
+        # finished_at is naive UTC — utcnow() returns naive UTC by
+        # repo convention.
+        from utils.datetime import utcnow
+
+        row.finished_at = utcnow()
+        await db.commit()
+        logger.info(
+            "analysis_run_cancelled",
+            run_id=str(run_id),
+            workspace_id=str(workspace_id),
+            context_id=str(context_id),
+        )
+    # else: already terminal → return current state without flipping anything.
+
+    return AnalysisCancelResponse(
+        run_id=row.id,
+        status=row.status,
+        cancellation_reason=row.cancellation_reason,
+        finished_at=row.finished_at,
+    )

--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -86,11 +86,12 @@ class AnalysisUsage(BaseModel):
     limit_today: int = Field(0, description="Plan + addon daily limit")
     addon_bonus: int = Field(0, description="Addon-supplied bonus (extra_analysis_runs)")
     remaining_today: int = Field(0, description="max(0, limit_today - used_today)")
-    resets_at: str | None = Field(
-        None,
+    resets_at: str = Field(
+        ...,
         description=(
             "ISO-8601 timestamp of the next reset, in the caller's timezone "
-            "(midnight of the next day). NULL only if the user has no timezone set."
+            "(midnight of the next day). Always populated — the builder "
+            "falls back to UTC when User.timezone is unset."
         ),
     )
 

--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -5,6 +5,7 @@ Issue #48 - Usage Statistics - Plan Limits & Usage Tracking
 """
 
 from datetime import timedelta
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel, Field
@@ -73,6 +74,27 @@ class PlanLimits(BaseModel):
     public_calls_per_week: int = Field(default=0, description="Public REST API weekly limit")
 
 
+class AnalysisUsage(BaseModel):
+    """Memory broadlistening daily quota usage (Issue #496).
+
+    Mirrors the response detail shape of the 429 quota-exceeded body
+    so the dashboard, the new-analysis modal (#497), and the gate
+    rejection all read the same field names.
+    """
+
+    used_today: int = Field(0, description="Analyses started today (all statuses count)")
+    limit_today: int = Field(0, description="Plan + addon daily limit")
+    addon_bonus: int = Field(0, description="Addon-supplied bonus (extra_analysis_runs)")
+    remaining_today: int = Field(0, description="max(0, limit_today - used_today)")
+    resets_at: str | None = Field(
+        None,
+        description=(
+            "ISO-8601 timestamp of the next reset, in the caller's timezone "
+            "(midnight of the next day). NULL only if the user has no timezone set."
+        ),
+    )
+
+
 class CurrentUsage(BaseModel):
     """Current usage statistics."""
 
@@ -85,6 +107,13 @@ class CurrentUsage(BaseModel):
     rest_calls_this_week: int = Field(0, description="REST API calls this week (non-public)")
     public_calls_today: int = Field(0, description="Public REST API calls today")
     public_calls_this_week: int = Field(0, description="Public REST API calls this week")
+    analysis: AnalysisUsage | None = Field(
+        None,
+        description=(
+            "Memory broadlistening daily quota stats (Issue #496). "
+            "NULL when the caller has no current workspace selected."
+        ),
+    )
 
 
 class UsageStatus(BaseModel):
@@ -175,6 +204,64 @@ def calculate_usage_status(current: int | float, limit: int | float) -> UsageSta
 # ============================================================================
 # Endpoints
 # ============================================================================
+
+
+async def _build_analysis_usage(
+    db: AsyncSession,
+    user_id: str,
+    workspace_id: UUID | None,
+) -> "AnalysisUsage | None":
+    """Build the ``analysis`` field of /usage/current (Issue #496).
+
+    Returns None when no workspace is selected (analysis is workspace-
+    scoped). Delegates the count + tz-window math to
+    ``query_service.get_today_analysis_count`` so the gate and the
+    dashboard share one source of truth.
+    """
+    if not workspace_id:
+        return None
+
+    from models.auth import User, Workspace
+    from services.analysis import query_service
+    from services.analysis.query_service import day_window_utc
+    from services.effective_quota_service import EffectiveQuotaService
+
+    tz_name = (
+        await db.execute(select(User.timezone).where(User.user_id == user_id))
+    ).scalar_one_or_none() or "UTC"
+
+    used_today = await query_service.get_today_analysis_count(
+        db, workspace_id=workspace_id, user_timezone=tz_name
+    )
+    effective = await EffectiveQuotaService(db).get_effective_quotas(workspace_id)
+    limit_today = int(effective.get("analysis_runs_per_day", 0) or 0)
+    addon_bonus = int(
+        (
+            await db.execute(
+                select(Workspace.addon_analysis_bonus).where(Workspace.id == workspace_id)
+            )
+        ).scalar_one_or_none()
+        or 0
+    )
+
+    # Format ``resets_at`` in caller's tz so the dashboard's display
+    # matches the 429 body format (caller's local midnight).
+    from zoneinfo import ZoneInfo
+
+    _, day_end_utc = day_window_utc(tz_name)
+    try:
+        client_tz = ZoneInfo(tz_name)
+    except Exception:
+        client_tz = ZoneInfo("UTC")
+    resets_at = day_end_utc.replace(tzinfo=ZoneInfo("UTC")).astimezone(client_tz).isoformat()
+
+    return AnalysisUsage(
+        used_today=used_today,
+        limit_today=limit_today,
+        addon_bonus=addon_bonus,
+        remaining_today=max(0, limit_today - used_today),
+        resets_at=resets_at,
+    )
 
 
 @router.get("/current", response_model=UsageCurrentResponse)
@@ -303,6 +390,8 @@ async def get_current_usage(
         )
         rest_calls_week = rest_week_result.scalar() or 0
 
+        analysis_usage = await _build_analysis_usage(db, user_id, current_workspace_id)
+
         # Build response
         response = UsageCurrentResponse(
             plan=PlanLimits(
@@ -321,6 +410,7 @@ async def get_current_usage(
                 rest_calls_this_week=rest_calls_week,
                 public_calls_today=public_calls_today,
                 public_calls_this_week=public_calls_week,
+                analysis=analysis_usage,
             ),
             memory_usage=calculate_usage_status(memory_count, plan.memory_limit),
             daily_api_usage=calculate_usage_status(api_calls_today, plan.daily_api_limit),

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -1,0 +1,405 @@
+"""Memory Broadlistening access gates (Issue #496).
+
+Composes the 4 access gates that every analysis-mutating endpoint
+(REST + MCP) must pass through, in this order:
+
+    1. JWT / API-key auth          (middleware — handled upstream)
+    2. require_workspace_owner     (PermissionService — 403)
+    3. require_pro_tier            (QuotaService.check_feature_access — 403)
+    4. check_memory_analysis_quota (read-only count — 429 fail-fast,
+                                   does NOT increment)
+    5. check_workspace_in_allowlist (kill switch — 403)
+    6. byok_resolver.preflight      (route body — 422, raised inside
+                                     orchestrator.start so the gate
+                                     module does not duplicate it)
+
+GET endpoints (list / single / active) skip gates 3 + 4 — a Pro user
+who has run analyses today should always be able to read their past
+runs, even if quota=0 today (#496 issue spec).
+
+Two FastAPI dep helpers + two non-dep helpers are exposed:
+
+- ``require_memory_analysis_access`` — full 4-gate chain (POST/DELETE)
+- ``require_memory_analysis_read``   — gate 1+2 only (GET endpoints)
+- ``check_memory_analysis_quota``    — read-only count, raises 429
+- ``check_workspace_in_allowlist``   — kill switch primitive
+- ``check_memory_analysis_access_mcp`` — MCP-side composition (no Depends)
+
+The MCP variant exists because MCP tools cannot use FastAPI ``Depends``;
+they call the same underlying primitives in the same order so MCP/REST
+parity is structural, not coincidental (#332 教訓).
+
+Quota count semantics:
+
+- The day window uses the **caller's** ``User.timezone`` (default UTC).
+  Two owners in different timezones in the same workspace each see
+  their own day boundary; daily=3 makes the edge case rare in practice.
+- ``cancelled`` rows count toward the quota, by design — once the
+  pipeline has been kicked off, BYOK / partial LLM cost may already
+  be incurred. Conservative counting prevents kick-cancel spam.
+- Increment is **NOT** done here. Quota check is read-only; the row
+  is INSERTed by ``AnalysisOrchestrator.start()`` after BYOK pre-flight,
+  so a 422 BYOK failure never debits the day window.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from fastapi import Depends, HTTPException
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import get_user_from_api_key_or_session
+from config.settings import get_settings
+from db.base import get_db
+from models.auth import User
+from services.analysis.query_service import day_window_utc
+from utils.exceptions import FeatureNotAvailableError, QuotaExceededError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# ============================================================================
+# Allowlist kill switch
+# ============================================================================
+
+
+def check_workspace_in_allowlist(workspace_id: UUID | str) -> bool:
+    """Return True iff the workspace is permitted to run analyses.
+
+    Empty ``ANALYSIS_ENABLED_WORKSPACE_IDS`` (default) → returns False
+    for every workspace, i.e. the feature is disabled platform-wide.
+    Populated → only listed workspace UUIDs return True.
+
+    Pure function (settings is a global singleton). Safe to call from
+    tests via ``monkeypatch.setenv`` without DB.
+    """
+    settings = get_settings()
+    allowed = settings.analysis_enabled_workspace_ids_list
+    if not allowed:
+        return False
+    # Both sides lower-cased so ops can paste env values in either case
+    # without a silent kill-switch lockout (see settings property comment).
+    return str(workspace_id).lower() in allowed
+
+
+# ============================================================================
+# Quota check — read-only, day window in caller's timezone
+# ============================================================================
+
+
+async def _get_user_timezone(db: AsyncSession, user_id: str) -> str:
+    """Fetch the caller's timezone. Defaults to UTC when missing.
+
+    Used for both the quota count window AND the response's
+    ``resets_at`` ISO string so the user's "midnight" is consistent
+    across the API contract.
+    """
+    result = await db.execute(select(User.timezone).where(User.user_id == user_id))
+    tz = result.scalar_one_or_none()
+    return tz or "UTC"
+
+
+async def check_memory_analysis_quota(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    user_timezone: str,
+) -> None:
+    """Read-only check: raise 429 if today's analysis quota is exhausted.
+
+    "Today" = the calendar date in ``user_timezone``. Counts ALL
+    ``memory_analyses`` rows for the workspace whose ``started_at``
+    falls in the current day window — regardless of status. See module
+    docstring for why ``cancelled`` rows count.
+
+    Single workspace fetch shared with ``EffectiveQuotaService``: we
+    pre-fetch the row here (for ``addon_analysis_bonus`` + the same
+    workspace identity used downstream) so the gate does not double-
+    SELECT ``Workspace`` on every call. The COUNT remains its own
+    statement because the index path differs (``memory_analyses``
+    composite index on ``workspace_id, started_at`` vs. the workspace
+    PK lookup).
+
+    Raises:
+        QuotaExceededError: with ``QUOTA-001`` and structured details
+            (``used_today`` / ``limit_today`` / ``addon_bonus`` /
+            ``remaining_today`` / ``resets_at``) so the API layer's
+            global handler can render the 429 body without re-querying.
+    """
+    from models.analysis import MemoryAnalysis
+    from models.auth import Workspace
+    from services.effective_quota_service import EffectiveQuotaService
+
+    day_start_utc, day_end_utc = day_window_utc(user_timezone)
+
+    # Single Workspace fetch: pulls the row that ``EffectiveQuotaService``
+    # would otherwise re-SELECT plus the ``addon_analysis_bonus`` column
+    # we surface in the 429 detail. The service still validates and
+    # triggers addon recalculation if needed; passing the pre-fetched
+    # row avoids the redundant round-trip on the happy path.
+    workspace_row = (
+        await db.execute(select(Workspace).where(Workspace.id == workspace_id))
+    ).scalar_one_or_none()
+    if workspace_row is None:
+        # Defensive — owner gate already proved membership; this would
+        # only trigger on a deleted workspace mid-request.
+        raise QuotaExceededError(
+            f"Workspace {workspace_id} not found", quota_type="memory_analysis"
+        )
+
+    count_stmt = select(func.count(MemoryAnalysis.id)).where(
+        and_(
+            MemoryAnalysis.workspace_id == workspace_id,
+            MemoryAnalysis.started_at >= day_start_utc,
+            MemoryAnalysis.started_at < day_end_utc,
+        )
+    )
+    used_today = int((await db.execute(count_stmt)).scalar() or 0)
+
+    effective = await EffectiveQuotaService(db).get_effective_quotas(workspace_id)
+    limit_today = int(effective["analysis_runs_per_day"])
+    addon_bonus = int(workspace_row.addon_analysis_bonus or 0)
+
+    if used_today >= limit_today:
+        # day_end_utc is naive UTC; reformat with caller tz for the
+        # client-visible reset timestamp (matches ``resets_at`` in the
+        # AC's example body).
+        resets_at = (
+            day_end_utc.replace(tzinfo=ZoneInfo("UTC"))
+            .astimezone(ZoneInfo(user_timezone) if user_timezone else ZoneInfo("UTC"))
+            .isoformat()
+        )
+        logger.info(
+            "memory_analysis_quota_exceeded",
+            workspace_id=str(workspace_id),
+            used_today=used_today,
+            limit_today=limit_today,
+            user_timezone=user_timezone,
+        )
+        raise QuotaExceededError(
+            (
+                f"Analysis daily quota exceeded: {used_today}/{limit_today} runs today "
+                f"(addon bonus {addon_bonus}). Resets at {resets_at}."
+            ),
+            quota_type="memory_analysis",
+            used_today=used_today,
+            limit_today=limit_today,
+            addon_bonus=addon_bonus,
+            remaining_today=0,
+            resets_at=resets_at,
+        )
+
+
+# ============================================================================
+# Composed gate — REST FastAPI Depends entry points
+# ============================================================================
+
+
+async def require_memory_analysis_access(
+    user: dict = Depends(get_user_from_api_key_or_session),
+    db: AsyncSession = Depends(get_db),
+) -> tuple[str, UUID, str]:
+    """Full 4-gate chain for POST/DELETE endpoints.
+
+    Order matches the issue spec's fail-fast precedence — the FIRST
+    failing gate determines the error returned to the client:
+
+        - Gate 2 (owner)       → 403 (PermissionService.check_workspace_owner)
+        - Gate 3 (Pro tier)    → 403 with FEAT-001 detail
+        - Gate 4 (quota)       → 429 with QUOTA-001 detail
+        - Gate 5 (allowlist)   → 403 (FEAT-001 with allowlist reason)
+
+    Returns ``(user_id, workspace_id, user_timezone)`` so the route
+    handler can pass tz into the orchestrator/response without an
+    extra User round-trip.
+    """
+    user_id = user.get("user_id")
+    if not user_id:
+        # Defensive — APIKeyOrSessionUser shouldn't return this state.
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    workspace_id = user.get("current_workspace_id")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=400,
+            detail="No workspace selected. Please select a workspace first.",
+        )
+
+    # Gate 2: owner role
+    from services.permission_service import PermissionService
+
+    perm = PermissionService(db)
+    try:
+        await perm.check_workspace_owner(user_id, workspace_id)
+    except HTTPException as exc:
+        logger.warning(
+            "memory_analysis_owner_denied",
+            user_id=user_id,
+            workspace_id=str(workspace_id),
+            status_code=exc.status_code,
+        )
+        raise
+
+    # Gate 3: Pro-tier feature flag
+    from services.quota_service import QuotaService
+
+    quota = QuotaService(db)
+    has_feature, err = await quota.check_feature_access(workspace_id, "memory_analysis")
+    if not has_feature:
+        raise FeatureNotAvailableError(
+            err or "memory_analysis not available", feature="memory_analysis"
+        )
+
+    # Gate 4: daily quota — read-only, raises 429
+    user_timezone = await _get_user_timezone(db, user_id)
+    await check_memory_analysis_quota(
+        db,
+        workspace_id=workspace_id,
+        user_timezone=user_timezone,
+        raise_on_exceeded=True,
+    )
+
+    # Gate 5: allowlist kill switch
+    if not check_workspace_in_allowlist(workspace_id):
+        raise FeatureNotAvailableError(
+            "Memory analysis is not yet enabled for this workspace.",
+            feature="memory_analysis",
+        )
+
+    logger.info(
+        "memory_analysis_access_granted",
+        user_id=user_id,
+        workspace_id=str(workspace_id),
+    )
+    return user_id, workspace_id, user_timezone
+
+
+async def require_memory_analysis_read(
+    user: dict = Depends(get_user_from_api_key_or_session),
+    db: AsyncSession = Depends(get_db),
+) -> tuple[str, UUID, str]:
+    """Read-only gate (GET list / single / active).
+
+    Skips Pro-tier and quota gates so a Pro-cancelled or quota=0 user
+    can still poll past runs they own. Allowlist still applies — a
+    workspace removed from the allowlist should not be reading runs
+    either.
+    """
+    user_id = user.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    workspace_id = user.get("current_workspace_id")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=400,
+            detail="No workspace selected. Please select a workspace first.",
+        )
+
+    from services.permission_service import PermissionService
+
+    perm = PermissionService(db)
+    try:
+        await perm.check_workspace_owner(user_id, workspace_id)
+    except HTTPException as exc:
+        logger.warning(
+            "memory_analysis_read_denied",
+            user_id=user_id,
+            workspace_id=str(workspace_id),
+            status_code=exc.status_code,
+        )
+        raise
+
+    if not check_workspace_in_allowlist(workspace_id):
+        raise FeatureNotAvailableError(
+            "Memory analysis is not yet enabled for this workspace.",
+            feature="memory_analysis",
+        )
+
+    user_timezone = await _get_user_timezone(db, user_id)
+    return user_id, workspace_id, user_timezone
+
+
+# ============================================================================
+# MCP composition (non-Depends, called from tools/analysis.py)
+# ============================================================================
+
+
+async def check_memory_analysis_access_mcp(
+    db: AsyncSession,
+    *,
+    user_id: str,
+    workspace_id: UUID,
+    require_quota: bool = True,
+) -> str:
+    """MCP-side equivalent of ``require_memory_analysis_access``.
+
+    Called from ``mcp_server/tools/analysis.py`` since MCP tools
+    cannot use FastAPI ``Depends``. Mirrors the REST gate ordering
+    so MCP and REST behave identically (#332 lesson).
+
+    ``require_quota=False`` mode is used by GET-equivalent MCP tools
+    (``get_analysis``, ``list_analyses``, ``get_active_analysis``,
+    ``get_cluster``) to skip gates 3 + 4 — same parity as
+    ``require_memory_analysis_read``.
+
+    Returns the caller's ``user_timezone`` for downstream formatting.
+
+    Raises ``HTTPException`` / ``FeatureNotAvailableError`` /
+    ``QuotaExceededError`` so the caller can map to the MCP
+    error envelope at one place.
+    """
+    from services.permission_service import PermissionService
+
+    perm = PermissionService(db)
+    await perm.check_workspace_owner(user_id, workspace_id)
+
+    if require_quota:
+        from services.quota_service import QuotaService
+
+        quota = QuotaService(db)
+        has_feature, err = await quota.check_feature_access(workspace_id, "memory_analysis")
+        if not has_feature:
+            raise FeatureNotAvailableError(
+                err or "memory_analysis not available", feature="memory_analysis"
+            )
+
+        user_timezone = await _get_user_timezone(db, user_id)
+        await check_memory_analysis_quota(
+            db,
+            workspace_id=workspace_id,
+            user_timezone=user_timezone,
+            raise_on_exceeded=True,
+        )
+    else:
+        user_timezone = await _get_user_timezone(db, user_id)
+
+    if not check_workspace_in_allowlist(workspace_id):
+        raise FeatureNotAvailableError(
+            "Memory analysis is not yet enabled for this workspace.",
+            feature="memory_analysis",
+        )
+
+    return user_timezone
+
+
+# ============================================================================
+# Type aliases — REST routes import these for cleaner signatures
+# ============================================================================
+
+AnalysisWriteAccess = Annotated[
+    tuple[str, UUID, str],
+    Depends(require_memory_analysis_access),
+]
+"""Returned tuple is ``(user_id, workspace_id, user_timezone)``."""
+
+AnalysisReadAccess = Annotated[
+    tuple[str, UUID, str],
+    Depends(require_memory_analysis_read),
+]
+"""Returned tuple is ``(user_id, workspace_id, user_timezone)``."""

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -261,7 +261,6 @@ async def require_memory_analysis_access(
         db,
         workspace_id=workspace_id,
         user_timezone=user_timezone,
-        raise_on_exceeded=True,
     )
 
     # Gate 5: allowlist kill switch
@@ -374,7 +373,6 @@ async def check_memory_analysis_access_mcp(
             db,
             workspace_id=workspace_id,
             user_timezone=user_timezone,
-            raise_on_exceeded=True,
         )
     else:
         user_timezone = await _get_user_timezone(db, user_id)

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -166,6 +166,13 @@ async def check_memory_analysis_quota(
 
     effective = await EffectiveQuotaService(db).get_effective_quotas(workspace_id)
     limit_today = int(effective["analysis_runs_per_day"])
+    # Refresh the workspace row AFTER ``get_effective_quotas`` runs —
+    # the service may recalculate addon bonus columns (when all are 0)
+    # and re-fetch the workspace internally. Without this refresh the
+    # 429 detail would carry the pre-recalc addon_bonus (often 0) while
+    # ``limit_today`` reflects the recalculated effective quota,
+    # producing an inconsistent body. Issue #496 Copilot review.
+    await db.refresh(workspace_row)
     addon_bonus = int(workspace_row.addon_analysis_bonus or 0)
 
     if used_today >= limit_today:

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -57,7 +57,7 @@ from config.settings import get_settings
 from db.base import get_db
 from models.auth import User
 from services.analysis.query_service import day_window_utc
-from utils.exceptions import FeatureNotAvailableError, QuotaExceededError
+from utils.exceptions import ConfigurationError, FeatureNotAvailableError, QuotaExceededError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -147,9 +147,12 @@ async def check_memory_analysis_quota(
     ).scalar_one_or_none()
     if workspace_row is None:
         # Defensive — owner gate already proved membership; this would
-        # only trigger on a deleted workspace mid-request.
-        raise QuotaExceededError(
-            f"Workspace {workspace_id} not found", quota_type="memory_analysis"
+        # only trigger on a deleted workspace mid-request. Surface as
+        # 500 ``ConfigurationError`` (CFG-001) rather than 429
+        # QuotaExceededError, since "no workspace" is a server-side
+        # anomaly, not a quota-exhausted client signal.
+        raise ConfigurationError(
+            f"Workspace {workspace_id} disappeared mid-request — gate cannot evaluate quota"
         )
 
     count_stmt = select(func.count(MemoryAnalysis.id)).where(
@@ -168,12 +171,14 @@ async def check_memory_analysis_quota(
     if used_today >= limit_today:
         # day_end_utc is naive UTC; reformat with caller tz for the
         # client-visible reset timestamp (matches ``resets_at`` in the
-        # AC's example body).
-        resets_at = (
-            day_end_utc.replace(tzinfo=ZoneInfo("UTC"))
-            .astimezone(ZoneInfo(user_timezone) if user_timezone else ZoneInfo("UTC"))
-            .isoformat()
-        )
+        # AC's example body). Defensive ``try/except`` mirrors
+        # ``day_window_utc()``: ``User.timezone`` is varchar(50)
+        # without a CHECK, so an exotic value should not 500 the gate.
+        try:
+            client_tz = ZoneInfo(user_timezone) if user_timezone else ZoneInfo("UTC")
+        except Exception:
+            client_tz = ZoneInfo("UTC")
+        resets_at = day_end_utc.replace(tzinfo=ZoneInfo("UTC")).astimezone(client_tz).isoformat()
         logger.info(
             "memory_analysis_quota_exceeded",
             workspace_id=str(workspace_id),

--- a/backend/src/config/plan_tiers.py
+++ b/backend/src/config/plan_tiers.py
@@ -142,6 +142,7 @@ PLAN_PRO = PlanTier(
             "team_invitations",  # Issue #165: Team collaboration
             "shared_contexts",  # Issue #165: Shared contexts with role-based access
             "public_contexts",  # Issue #238: Public contexts
+            "memory_analysis",  # Issue #496: Memory Broadlistening
         }
     ),
 )
@@ -162,6 +163,7 @@ FEATURE_MIN_PLANS: dict[str, str] = {
     "team_invitations": "pro",  # Issue #165: Team collaboration requires Pro
     "shared_contexts": "pro",  # Issue #165: Shared contexts require Pro
     "public_contexts": "pro",  # Issue #242: Public contexts require PRO only
+    "memory_analysis": "pro",  # Issue #496: Memory Broadlistening (Pro only; FREE/BASIC=0)
 }
 
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -218,6 +218,38 @@ class Settings(BaseSettings):
         ),
     )
 
+    # Memory Broadlistening allowlist (Issue #496) — kill switch.
+    # Empty (default) → feature 403 globally. Comma-separated UUIDs → only listed
+    # workspaces can run analyses. Env: ANALYSIS_ENABLED_WORKSPACE_IDS.
+    # Production deploy starts empty; ops adds the kagura-dev workspace UUID first
+    # then expands gradually. Survives the new tier+quota+BYOK gates so a single
+    # env edit can stop all runs in production. v1.5 で撤去予定.
+    analysis_enabled_workspace_ids: str = Field(
+        default="",
+        description=(
+            "Comma-separated workspace UUIDs allowed to run memory analyses. "
+            "Empty = feature OFF globally (Issue #496 kill switch). "
+            "Populated = only listed workspaces. v1.5 で撤去予定."
+        ),
+    )
+
+    @property
+    def analysis_enabled_workspace_ids_list(self) -> list[str]:
+        """Parse comma-separated UUIDs into a list of lowercase strings.
+
+        Returns empty list when the setting is empty/whitespace, which the
+        gate translates into "feature 403 globally" (kill switch active).
+        UUIDs are kept as strings here; the gate compares them against
+        ``str(workspace_id).lower()`` so neither side has to construct UUID
+        objects on the hot path. Lower-casing both sides defends against
+        ops setting upper-case UUIDs in the env var (Python's ``str(UUID)``
+        always emits lower-case hex), which would otherwise silent-fail
+        with a permanent 403.
+        """
+        return [
+            s.strip().lower() for s in self.analysis_enabled_workspace_ids.split(",") if s.strip()
+        ]
+
     # Plan Tier Overrides (environment variable customization for OSS deployments)
     plan_free_max_contexts: int | None = Field(
         default=None, description="Override FREE plan max contexts per workspace"

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -39,6 +39,8 @@ _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
         "get_resource_impact",  # Uses resource_id, not context_id
         "get_resource_schema",  # Uses resource_id, not context_id
         "list_resource_tokens",  # Uses resource_id, not context_id
+        "get_analysis",  # Issue #496: uses run_id, not context_id
+        "get_cluster",  # Issue #496: uses run_id, not context_id
     }
 )
 
@@ -54,6 +56,10 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "get_resource_impact",  # Read-only resource stats
         "get_resource_schema",  # Read-only schema fetch
         "list_resource_tokens",  # Read-only token listing
+        "get_analysis",  # Issue #496: read-only analysis row fetch
+        "list_analyses",  # Issue #496: read-only analysis list
+        "get_active_analysis",  # Issue #496: read-only most-recent succeeded
+        "get_cluster",  # Issue #496: read-only cluster drill-down
     }
 )
 
@@ -68,6 +74,13 @@ _TOOL_REGISTRY: dict[str, Any] | None = None
 
 def _build_registry() -> dict[str, Any]:
     """Build tool name → handler mapping."""
+    from mcp_server.tools.analysis import (
+        handle_analyze_context,
+        handle_get_active_analysis,
+        handle_get_analysis,
+        handle_get_cluster,
+        handle_list_analyses,
+    )
     from mcp_server.tools.context import (
         handle_create_context,
         handle_delete_context,
@@ -124,6 +137,13 @@ def _build_registry() -> dict[str, Any]:
         "get_resource_impact": handle_get_resource_impact,
         "get_resource_schema": handle_get_resource_schema,
         "list_resource_tokens": handle_list_resource_tokens,
+        # Issue #496: Memory Broadlistening — 5 tools sharing the same
+        # 4-stage gate chain as REST /api/v1/contexts/{id}/analyses.
+        "analyze_context": handle_analyze_context,
+        "get_analysis": handle_get_analysis,
+        "list_analyses": handle_list_analyses,
+        "get_active_analysis": handle_get_active_analysis,
+        "get_cluster": handle_get_cluster,
     }
 
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1208,6 +1208,195 @@ Requires action recording (reports created before this feature have no actions t
                 },
             },
         },
+        # ====================================================================
+        # Memory Broadlistening Analysis Tools (Issue #496)
+        # ====================================================================
+        {
+            "name": "analyze_context",
+            "description": (
+                "Start a memory broadlistening analysis run on a context, "
+                "or preview the cost when ``dry_run=true``. The analysis "
+                "clusters memories into themes (kouchou-ai-style UMAP + "
+                "KMeans + LLM labeling) and exposes them via "
+                "``get_analysis`` / ``get_cluster`` / cluster-scoped recall.\n\n"
+                "Requires the workspace owner role + Pro plan + an enabled "
+                "OpenAI BYOK key + per-day quota available. v1 is daily=3 "
+                "for Pro; addon ``extra_analysis_runs`` increases the limit. "
+                "When ``dry_run=true``, the same gates apply but no row is "
+                "created.\n\n"
+                "Example:\n"
+                '  analyze_context(context_id="...", dry_run=True)  # cost preview\n'
+                '  analyze_context(context_id="...")                # 202 + run_id'
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["context_id"],
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "description": "Target context UUID (must belong to your workspace).",
+                    },
+                    "from": {
+                        "type": "string",
+                        "description": "Optional ISO-8601 lower bound on memory.created_at.",
+                    },
+                    "to": {
+                        "type": "string",
+                        "description": "Optional ISO-8601 upper bound on memory.created_at.",
+                    },
+                    "types": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional list of memory types to include.",
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Optional list of tags to filter on.",
+                    },
+                    "min_importance": {
+                        "type": "number",
+                        "description": "Optional importance floor (0.0–1.0).",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Reserved for v1.5 query-scoped runs (ignored in v1).",
+                    },
+                    "model_id": {
+                        "type": "integer",
+                        "description": (
+                            "Optional ``llm_pricing.id`` override. v1 default = "
+                            "openai gpt-5-nano (resolved server-side)."
+                        ),
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": (
+                            "When true, return the cost estimate without "
+                            "starting a run (default: false)."
+                        ),
+                    },
+                },
+            },
+        },
+        {
+            "name": "get_analysis",
+            "readOnly": True,
+            "description": (
+                "Fetch one analysis run by id, scoped to your workspace. "
+                "Returns ``run_not_found`` for unknown ids OR runs in "
+                "another workspace (existence is not leaked).\n\n"
+                "Example:\n"
+                '  get_analysis(run_id="...")\n'
+                "  → {run_id, status, started_at, finished_at, "
+                "cost_estimated_cents, cost_actual_cents, ...}"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["run_id"],
+                "properties": {
+                    "run_id": {
+                        "type": "string",
+                        "description": "Analysis run UUID (from analyze_context).",
+                    },
+                },
+            },
+        },
+        {
+            "name": "list_analyses",
+            "readOnly": True,
+            "description": (
+                "List analysis runs for a context, sorted newest first. "
+                "Cursor-paginated — pass the previous response's "
+                "``next_cursor`` to fetch the next page. ``next_cursor=null`` "
+                "marks the last page.\n\n"
+                "Example:\n"
+                '  list_analyses(context_id="...", limit=20)\n'
+                '  → {items: [...], next_cursor: "2026-04-30T12:34:56"}'
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["context_id"],
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "description": "Target context UUID.",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Page size (1-100, default 20).",
+                    },
+                    "cursor": {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a previous response.",
+                    },
+                },
+            },
+        },
+        {
+            "name": "get_active_analysis",
+            "readOnly": True,
+            "description": (
+                "Return the most recent ``status='succeeded'`` run for a "
+                "context, or ``no_succeeded_run`` if the context has no "
+                "completed analyses yet.\n\n"
+                "Example:\n"
+                '  get_active_analysis(context_id="...")\n'
+                '  → {run_id, status: "succeeded", finished_at, ...}'
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["context_id"],
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "description": "Target context UUID.",
+                    },
+                },
+            },
+        },
+        {
+            "name": "get_cluster",
+            "readOnly": True,
+            "description": (
+                "Drill-down view of one cluster within an analysis run. "
+                "Returns the cluster label/description/count + the top "
+                "representative memories (capped at 5) + a paginated list of "
+                "all member memories (Layer 1 + 2: summary, tags, importance).\n\n"
+                "Page size defaults to 50 (max 200). For semantic search "
+                "scoped to this cluster, call ``recall`` with "
+                '``filters={"analysis_cluster": {"run_id": ..., "cluster_index": ...}}``.\n\n'
+                "Example:\n"
+                '  get_cluster(run_id="...", cluster_index=3)\n'
+                "  → {label, description, count, representatives: [...], "
+                "memories: [...], next_cursor: ...}"
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["run_id", "cluster_index"],
+                "properties": {
+                    "run_id": {
+                        "type": "string",
+                        "description": "Analysis run UUID.",
+                    },
+                    "cluster_index": {
+                        "type": "integer",
+                        "description": (
+                            "Zero-based ordinal of the cluster within the run "
+                            "(stable across calls)."
+                        ),
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Memories per page (1-200, default 50).",
+                    },
+                    "cursor": {
+                        "type": "string",
+                        "description": "Opaque pagination cursor from a previous response.",
+                    },
+                },
+            },
+        },
     ]
 
 

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -1,0 +1,625 @@
+"""MCP tool handlers for memory broadlistening analyses (Issue #496).
+
+Five tools that mirror the REST endpoints in
+``api/routes/analyses.py`` — same gate chain, same data flow, same
+error envelope where possible — so MCP and REST behave identically
+(#332 教訓: shared composition helper, no duplicated logic).
+
+Tools:
+
+- ``analyze_context``       — POST /analyses (or preview when dry_run=true)
+- ``get_analysis``          — GET /analyses/{run_id}
+- ``list_analyses``         — GET /analyses
+- ``get_active_analysis``   — GET /analyses/active
+- ``get_cluster``           — drill-down (Layer 1+2 + paginated memories)
+
+Gate handling: all 5 call into ``auth.analysis_gates`` for the same
+4-stage chain (owner + Pro tier + quota + allowlist) that the REST
+routes use. Read-only tools pass ``require_quota=False`` so a Pro user
+who exhausted today's quota can still inspect past runs.
+
+Output shape: every handler emits ``_success_response(...)`` or
+``_error_response(...)`` from ``_helpers.py`` so MCP clients see the
+same envelope as every other tool in this codebase.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+from uuid import UUID
+
+from fastapi import HTTPException
+from mcp.types import TextContent
+
+from mcp_server.tools._helpers import (
+    _error_response,
+    _log_tool_usage,
+    _success_response,
+)
+from utils.exceptions import (
+    ConflictError,
+    FeatureNotAvailableError,
+    QuotaExceededError,
+    ValidationError,
+)
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# ============================================================================
+# Internal helpers
+# ============================================================================
+
+
+def _missing(field: str) -> list[TextContent]:
+    """Standardized response for a required-field-missing error."""
+    return _error_response("missing_fields", f"Missing required field: {field}")
+
+
+def _invalid_uuid(field: str, value: Any) -> list[TextContent]:
+    return _error_response(
+        "invalid_uuid",
+        f"Field '{field}' must be a valid UUID string (got: {value!r}).",
+    )
+
+
+def _parse_uuid(args: dict[str, Any], field: str) -> UUID | list[TextContent]:
+    """Pop a UUID-typed field from args, returning either UUID or error response."""
+    raw = args.get(field)
+    if raw is None or raw == "":
+        return _missing(field)
+    try:
+        return UUID(str(raw))
+    except (ValueError, TypeError):
+        return _invalid_uuid(field, raw)
+
+
+async def _verify_context_in_workspace_mcp(
+    db: Any,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+) -> list[TextContent] | None:
+    """MCP-side parity of routes/analyses._verify_context_in_workspace.
+
+    Thin wrapper over ``query_service.verify_context_in_workspace`` —
+    the SELECT is shared with the REST-side variant so the boundary
+    check shape lives in one place. Returns an error response when
+    the context does not belong to the workspace; None on pass.
+    404-equivalent payload (``context_not_found``) keeps existence
+    from leaking.
+    """
+    from services.analysis import query_service
+
+    if not await query_service.verify_context_in_workspace(
+        db, workspace_id=workspace_id, context_id=context_id
+    ):
+        return _error_response(
+            "context_not_found",
+            f"Context {context_id} not found or you don't have access to it.",
+            context_id=str(context_id),
+        )
+    return None
+
+
+def _gate_error_response(exc: Exception) -> list[TextContent]:
+    """Map an analysis_gates / orchestrator exception to an MCP error envelope.
+
+    Keeps gate logic identical between REST (raises) and MCP (envelope)
+    by converting at exactly one place. The REST handler relies on
+    FastAPI's global ``MemoryCloudException`` handler — this function
+    is the MCP equivalent.
+    """
+    if isinstance(exc, HTTPException):
+        # 403 from PermissionService.check_workspace_owner
+        return _error_response(
+            "permission_denied",
+            str(exc.detail) if exc.detail else "Access denied.",
+            status_code=exc.status_code,
+        )
+    if isinstance(exc, FeatureNotAvailableError):
+        return _error_response(
+            "feature_not_available",
+            exc.message,
+            feature=exc.details.get("feature", "memory_analysis"),
+        )
+    if isinstance(exc, QuotaExceededError):
+        return _error_response(
+            "quota_exceeded",
+            exc.message,
+            quota_type=exc.details.get("quota_type", "memory_analysis"),
+        )
+    if isinstance(exc, ValidationError):
+        return _error_response(
+            "validation_error",
+            exc.message,
+            **{k: v for k, v in exc.details.items() if v is not None},
+        )
+    if isinstance(exc, ConflictError):
+        # Surface ``run_id`` as a structured field so MCP clients don't
+        # have to parse the message text (Issue #496 spec: 409 body
+        # carries the existing run_id).
+        return _error_response(
+            "conflict",
+            exc.message,
+            **{k: v for k, v in exc.details.items() if v is not None},
+        )
+    # Unexpected — log + generic error.
+    logger.error("analysis_mcp_unexpected_error", error=str(exc), exc_info=True)
+    return _error_response("internal_error", str(exc))
+
+
+def _serialize_run_row(row: Any) -> dict[str, Any]:
+    """Project a ``MemoryAnalysis`` row into the MCP response dict.
+
+    Mirrors ``AnalysisRow`` in ``routes/analyses.py`` so REST and MCP
+    consumers see the same fields. Datetimes are emitted with explicit
+    UTC ``Z`` suffix via ``to_utc_iso`` (#489 wire-format guarantee).
+    """
+    from utils.datetime import to_utc_iso
+
+    return {
+        "run_id": str(row.id),
+        "workspace_id": str(row.workspace_id),
+        "context_id": str(row.context_id),
+        "status": row.status,
+        "triggered_by": row.triggered_by,
+        "started_at": to_utc_iso(row.started_at),
+        "finished_at": to_utc_iso(row.finished_at) if row.finished_at else None,
+        "input_count": int(row.input_count) if row.input_count is not None else 0,
+        "cost_estimated_cents": (
+            int(row.cost_estimated_cents) if row.cost_estimated_cents is not None else None
+        ),
+        "cost_actual_cents": (
+            int(row.cost_actual_cents) if row.cost_actual_cents is not None else None
+        ),
+        "error": row.error,
+        "cancellation_reason": row.cancellation_reason,
+    }
+
+
+# ============================================================================
+# analyze_context — POST /analyses (or dry_run preview)
+# ============================================================================
+
+
+async def handle_analyze_context(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Start a new run, or return a cost preview when ``dry_run=true``.
+
+    Shares the full 4-gate chain with REST POST /analyses via
+    ``check_memory_analysis_access_mcp(require_quota=True)``.
+    """
+    from db.base import get_db
+
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    parsed = _parse_uuid(args, "context_id")
+    if isinstance(parsed, list):
+        return parsed
+    context_id: UUID = parsed
+
+    dry_run = bool(args.get("dry_run", False))
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            # Boundary check before gate so a stolen context UUID does not
+            # leak gate behavior to the caller.
+            err = await _verify_context_in_workspace_mcp(
+                db, workspace_id=workspace_id, context_id=context_id
+            )
+            if err:
+                return err
+
+            from auth.analysis_gates import check_memory_analysis_access_mcp
+
+            try:
+                await check_memory_analysis_access_mcp(
+                    db,
+                    user_id=user_id,
+                    workspace_id=workspace_id,
+                    require_quota=True,
+                )
+            except Exception as gate_exc:
+                return _gate_error_response(gate_exc)
+
+            if dry_run:
+                # Preview path — same memory count semantics as REST /preview
+                # (delegates to ``query_service.count_context_memories``).
+                from services.analysis import query_service
+                from services.analysis.preview import DEFAULT_MODEL_ID, estimate_cost
+
+                memory_count = await query_service.count_context_memories(
+                    db, workspace_id=workspace_id, context_id=context_id
+                )
+                estimate = estimate_cost(memory_count, model_id=DEFAULT_MODEL_ID)
+                await _log_tool_usage(
+                    db,
+                    user_id,
+                    "analyze_context",
+                    start_time,
+                    200,
+                    context_id=context_id,
+                    workspace_id=workspace_id,
+                )
+                return _success_response(
+                    dry_run=True,
+                    memory_count=estimate.memory_count,
+                    cluster_count_estimate=estimate.cluster_count_estimate,
+                    estimated_cost_cents=estimate.estimated_cost_cents,
+                    model_id=estimate.model_id,
+                    breakdown=estimate.breakdown,
+                )
+
+            # Real run — orchestrator.start() + commit + create_task.
+            from services.analysis.orchestrator import (
+                AnalysisOrchestrator,
+                AnalysisParams,
+            )
+            from tasks.analysis_tasks import run_analysis_task
+
+            params = AnalysisParams(
+                from_dt=None,
+                to_dt=None,
+                types=args.get("types"),
+                tags=args.get("tags"),
+                min_importance=args.get("min_importance"),
+                query=args.get("query"),
+                model_id=args.get("model_id"),
+                extra={
+                    "from": args.get("from"),
+                    "to": args.get("to"),
+                },
+            )
+            try:
+                analysis = await AnalysisOrchestrator(db).start(
+                    workspace_id=workspace_id,
+                    context_id=context_id,
+                    user_id=user_id,
+                    params=params,
+                )
+            except (ConflictError, ValidationError) as orch_exc:
+                await db.rollback()
+                return _gate_error_response(orch_exc)
+
+            await db.commit()
+            asyncio.create_task(run_analysis_task(analysis.id))
+
+            await _log_tool_usage(
+                db,
+                user_id,
+                "analyze_context",
+                start_time,
+                202,
+                context_id=context_id,
+                workspace_id=workspace_id,
+            )
+            from utils.datetime import to_utc_iso
+
+            return _success_response(
+                run_id=str(analysis.id),
+                status=analysis.status,
+                started_at=to_utc_iso(analysis.started_at),
+            )
+
+        except Exception as e:
+            await db.rollback()
+            logger.error("analyze_context_failed", error=str(e), exc_info=True)
+            await _log_tool_usage(
+                db, user_id, "analyze_context", start_time, 500, workspace_id=workspace_id
+            )
+            return _error_response("analyze_context_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+# ============================================================================
+# get_analysis — GET /analyses/{run_id}
+# ============================================================================
+
+
+async def handle_get_analysis(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Fetch one run by id, scoped to workspace."""
+    from db.base import get_db
+
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    parsed = _parse_uuid(args, "run_id")
+    if isinstance(parsed, list):
+        return parsed
+    run_id: UUID = parsed
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            from auth.analysis_gates import check_memory_analysis_access_mcp
+
+            try:
+                await check_memory_analysis_access_mcp(
+                    db,
+                    user_id=user_id,
+                    workspace_id=workspace_id,
+                    require_quota=False,  # Read path — quota gate skipped.
+                )
+            except Exception as gate_exc:
+                return _gate_error_response(gate_exc)
+
+            from services.analysis import query_service
+
+            row = await query_service.get_analysis(db, workspace_id=workspace_id, run_id=run_id)
+            if row is None:
+                await _log_tool_usage(
+                    db, user_id, "get_analysis", start_time, 404, workspace_id=workspace_id
+                )
+                return _error_response(
+                    "run_not_found",
+                    f"Analysis run {run_id} not found.",
+                    run_id=str(run_id),
+                )
+            await _log_tool_usage(
+                db, user_id, "get_analysis", start_time, 200, workspace_id=workspace_id
+            )
+            return _success_response(**_serialize_run_row(row))
+
+        except Exception as e:
+            logger.error("get_analysis_failed", error=str(e), exc_info=True)
+            await _log_tool_usage(
+                db, user_id, "get_analysis", start_time, 500, workspace_id=workspace_id
+            )
+            return _error_response("get_analysis_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+# ============================================================================
+# list_analyses — GET /analyses
+# ============================================================================
+
+
+async def handle_list_analyses(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """List runs for a context, newest first, with cursor pagination."""
+    from db.base import get_db
+
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    parsed = _parse_uuid(args, "context_id")
+    if isinstance(parsed, list):
+        return parsed
+    context_id: UUID = parsed
+
+    limit = args.get("limit")
+    cursor = args.get("cursor")
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            err = await _verify_context_in_workspace_mcp(
+                db, workspace_id=workspace_id, context_id=context_id
+            )
+            if err:
+                return err
+
+            from auth.analysis_gates import check_memory_analysis_access_mcp
+
+            try:
+                await check_memory_analysis_access_mcp(
+                    db,
+                    user_id=user_id,
+                    workspace_id=workspace_id,
+                    require_quota=False,
+                )
+            except Exception as gate_exc:
+                return _gate_error_response(gate_exc)
+
+            from services.analysis import query_service
+
+            rows, next_cursor = await query_service.list_analyses(
+                db,
+                workspace_id=workspace_id,
+                context_id=context_id,
+                limit=int(limit) if isinstance(limit, int) else None,
+                cursor=cursor if isinstance(cursor, str) else None,
+            )
+            await _log_tool_usage(
+                db, user_id, "list_analyses", start_time, 200, workspace_id=workspace_id
+            )
+            return _success_response(
+                items=[_serialize_run_row(row) for row in rows],
+                next_cursor=next_cursor,
+            )
+
+        except Exception as e:
+            logger.error("list_analyses_failed", error=str(e), exc_info=True)
+            await _log_tool_usage(
+                db, user_id, "list_analyses", start_time, 500, workspace_id=workspace_id
+            )
+            return _error_response("list_analyses_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+# ============================================================================
+# get_active_analysis — GET /analyses/active
+# ============================================================================
+
+
+async def handle_get_active_analysis(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Return the most recent succeeded run for a context (or 404)."""
+    from db.base import get_db
+
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    parsed = _parse_uuid(args, "context_id")
+    if isinstance(parsed, list):
+        return parsed
+    context_id: UUID = parsed
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            err = await _verify_context_in_workspace_mcp(
+                db, workspace_id=workspace_id, context_id=context_id
+            )
+            if err:
+                return err
+
+            from auth.analysis_gates import check_memory_analysis_access_mcp
+
+            try:
+                await check_memory_analysis_access_mcp(
+                    db,
+                    user_id=user_id,
+                    workspace_id=workspace_id,
+                    require_quota=False,
+                )
+            except Exception as gate_exc:
+                return _gate_error_response(gate_exc)
+
+            from services.analysis import query_service
+
+            row = await query_service.get_active_analysis(
+                db, workspace_id=workspace_id, context_id=context_id
+            )
+            if row is None:
+                await _log_tool_usage(
+                    db,
+                    user_id,
+                    "get_active_analysis",
+                    start_time,
+                    404,
+                    workspace_id=workspace_id,
+                )
+                return _error_response(
+                    "no_succeeded_run",
+                    f"No succeeded analysis run found for context {context_id}.",
+                    context_id=str(context_id),
+                )
+            await _log_tool_usage(
+                db,
+                user_id,
+                "get_active_analysis",
+                start_time,
+                200,
+                workspace_id=workspace_id,
+            )
+            return _success_response(**_serialize_run_row(row))
+
+        except Exception as e:
+            logger.error("get_active_analysis_failed", error=str(e), exc_info=True)
+            await _log_tool_usage(
+                db,
+                user_id,
+                "get_active_analysis",
+                start_time,
+                500,
+                workspace_id=workspace_id,
+            )
+            return _error_response("get_active_analysis_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+# ============================================================================
+# get_cluster — drill-down with paginated memories
+# ============================================================================
+
+
+async def handle_get_cluster(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Return cluster metadata + paginated member memories (Layer 1+2)."""
+    from db.base import get_db
+
+    if not workspace_id:
+        return _error_response("workspace_required", "No active workspace.")
+
+    parsed_run = _parse_uuid(args, "run_id")
+    if isinstance(parsed_run, list):
+        return parsed_run
+    run_id: UUID = parsed_run
+
+    cluster_index_raw = args.get("cluster_index")
+    if cluster_index_raw is None:
+        return _missing("cluster_index")
+    try:
+        cluster_index = int(cluster_index_raw)
+    except (TypeError, ValueError):
+        return _error_response(
+            "invalid_cluster_index",
+            f"cluster_index must be a non-negative integer (got: {cluster_index_raw!r}).",
+        )
+    if cluster_index < 0:
+        return _error_response(
+            "invalid_cluster_index",
+            "cluster_index must be a non-negative integer.",
+        )
+
+    limit = args.get("limit")
+    cursor = args.get("cursor")
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            from auth.analysis_gates import check_memory_analysis_access_mcp
+
+            try:
+                await check_memory_analysis_access_mcp(
+                    db,
+                    user_id=user_id,
+                    workspace_id=workspace_id,
+                    require_quota=False,
+                )
+            except Exception as gate_exc:
+                return _gate_error_response(gate_exc)
+
+            from services.analysis import query_service
+
+            cluster = await query_service.get_cluster(
+                db,
+                workspace_id=workspace_id,
+                run_id=run_id,
+                cluster_index=cluster_index,
+                limit=int(limit) if isinstance(limit, int) else None,
+                cursor=cursor if isinstance(cursor, str) else None,
+            )
+            if cluster is None:
+                await _log_tool_usage(
+                    db, user_id, "get_cluster", start_time, 404, workspace_id=workspace_id
+                )
+                return _error_response(
+                    "cluster_not_found",
+                    (
+                        f"Cluster #{cluster_index} not found in run {run_id} "
+                        "(or run not in your workspace)."
+                    ),
+                    run_id=str(run_id),
+                    cluster_index=cluster_index,
+                )
+            await _log_tool_usage(
+                db, user_id, "get_cluster", start_time, 200, workspace_id=workspace_id
+            )
+            return _success_response(**cluster)
+
+        except Exception as e:
+            logger.error("get_cluster_failed", error=str(e), exc_info=True)
+            await _log_tool_usage(
+                db, user_id, "get_cluster", start_time, 500, workspace_id=workspace_id
+            )
+            return _error_response("get_cluster_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -48,6 +48,27 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Strong-ref set for ``asyncio.create_task`` — without this the task
+# can be GC'd before the loop schedules it. Mirrors the REST-side
+# pattern in ``api/routes/analyses.py`` so MCP and REST kick-offs
+# both surface background failures via the same observability path.
+# Issue #496 Copilot review (loop 3).
+_BACKGROUND_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _log_background_task_result(task: asyncio.Task[Any]) -> None:
+    """Surface any exception that escaped the analysis background task."""
+    _BACKGROUND_TASKS.discard(task)
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            "analysis_mcp_background_task_crashed",
+            error=str(exc),
+            exc_info=exc,
+        )
+
 
 # ============================================================================
 # Internal helpers
@@ -293,7 +314,12 @@ async def handle_analyze_context(
                 return _gate_error_response(orch_exc)
 
             await db.commit()
-            asyncio.create_task(run_analysis_task(analysis.id))
+            # Strong-ref + done callback so the task is not GC'd before
+            # the loop schedules it AND any background exception is
+            # logged. Same pattern as ``api/routes/analyses.py``.
+            task = asyncio.create_task(run_analysis_task(analysis.id))
+            _BACKGROUND_TASKS.add(task)
+            task.add_done_callback(_log_background_task_result)
 
             await _log_tool_usage(
                 db,

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -127,10 +127,14 @@ def _gate_error_response(exc: Exception) -> list[TextContent]:
             feature=exc.details.get("feature", "memory_analysis"),
         )
     if isinstance(exc, QuotaExceededError):
+        # Issue #496 Copilot review fix: forward the structured detail
+        # fields (used_today, limit_today, addon_bonus, remaining_today,
+        # resets_at) so MCP clients can render the same quota dashboard
+        # the REST 429 body supports — not just ``quota_type``.
         return _error_response(
             "quota_exceeded",
             exc.message,
-            quota_type=exc.details.get("quota_type", "memory_analysis"),
+            **{k: v for k, v in exc.details.items() if v is not None},
         )
     if isinstance(exc, ValidationError):
         return _error_response(

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -45,6 +45,12 @@ MEMORY_ANALYSIS_STATUSES: tuple[str, ...] = (
 )
 MEMORY_ANALYSIS_PAID_BY_VALUES: tuple[str, ...] = ("byok", "platform")
 
+# Issue #496: ``cancellation_reason`` enum-style values populated when
+# a run is soft-cancelled. Free-form for v1 (no DB CHECK), but the
+# tuple is the canonical taxonomy so route + MCP code share spelling.
+# Future taxonomy may add ``"timeout" / "admin" / "cost_cap"``.
+MEMORY_ANALYSIS_CANCELLATION_REASONS: tuple[str, ...] = ("user",)
+
 
 def _check_in_sql(column: str, values: tuple[str, ...]) -> str:
     """Render a ``column IN ('a', 'b', ...)`` CHECK clause from a tuple."""
@@ -130,6 +136,11 @@ class MemoryAnalysis(Base):
     quality = Column(JSONB, nullable=True)
     overview = Column(Text, nullable=True)
     error = Column(Text, nullable=True)
+    # Issue #496: human-readable cancellation reason when status='cancelled'.
+    # NULL for non-cancelled runs. Distinct from `error` so a future
+    # taxonomy can branch on (status='cancelled', reason='timeout' / 'admin'
+    # / 'cost_cap' / 'user') without overloading the failure column.
+    cancellation_reason = Column(Text, nullable=True)
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/src/services/analysis/byok_resolver.py
+++ b/backend/src/services/analysis/byok_resolver.py
@@ -41,6 +41,7 @@ from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import ExternalAPIKey
+from services.analysis.preview import DEFAULT_PROVIDER
 from utils.exceptions import ValidationError
 from utils.logger import get_logger
 
@@ -89,7 +90,7 @@ async def assert_openai_byok_key_available(
 
     conditions = [
         ExternalAPIKey.workspace_id == workspace_uuid,
-        ExternalAPIKey.provider == "openai",
+        ExternalAPIKey.provider == DEFAULT_PROVIDER,
         ExternalAPIKey.enabled.is_(True),
     ]
     if context_id is not None:

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -49,7 +49,7 @@ from models.llm_pricing import LLMPricing
 from services.analysis import labeler as analysis_labeler
 from services.analysis.byok_resolver import assert_openai_byok_key_available
 from services.analysis.clusterer import cluster_high_dim
-from services.analysis.preview import estimate_cost
+from services.analysis.preview import DEFAULT_MODEL_ID, DEFAULT_PROVIDER, estimate_cost
 from services.analysis.projector import project_to_2d
 from services.analysis.reporter import (
     PersistInputs,
@@ -97,11 +97,11 @@ class AnalysisParams:
         }
 
 
-# Default model when params.model_id is None — v1 default is gpt-5-nano
-# (Phase 3 clarification). v1.5 will pull this from a workspace-level
-# default like ``Workspace.analysis_default_model_id``.
-_DEFAULT_PROVIDER = "openai"
-_DEFAULT_MODEL = "gpt-5-nano"
+# Default provider / model when params.model_id is None come from
+# ``services/analysis/preview.py`` (DEFAULT_PROVIDER / DEFAULT_MODEL_ID)
+# directly — used at the only call site below (_resolve_pricing_row).
+# v1.5 will replace the constants with a per-workspace
+# ``Workspace.analysis_default_model_id`` lookup.
 
 # Status / dimension constants. Use explicit string literals (NOT
 # tuple indices) so a future tuple reordering does not silently flip
@@ -181,8 +181,8 @@ async def _resolve_pricing_row(db: AsyncSession, model_id: int | None) -> tuple[
         stmt = (
             select(LLMPricing)
             .where(
-                LLMPricing.provider == _DEFAULT_PROVIDER,
-                LLMPricing.model == _DEFAULT_MODEL,
+                LLMPricing.provider == DEFAULT_PROVIDER,
+                LLMPricing.model == DEFAULT_MODEL_ID,
             )
             .order_by(
                 LLMPricing.effective_from.desc(),
@@ -196,8 +196,8 @@ async def _resolve_pricing_row(db: AsyncSession, model_id: int | None) -> tuple[
             # migration didn't run or was rolled back → server-side
             # configuration error (500), NOT a 409 conflict.
             raise ConfigurationError(
-                f"Default LLM pricing row not seeded for {_DEFAULT_PROVIDER}/"
-                f"{_DEFAULT_MODEL}. Run alembic migrations to seed `llm_pricing`."
+                f"Default LLM pricing row not seeded for {DEFAULT_PROVIDER}/"
+                f"{DEFAULT_MODEL_ID}. Run alembic migrations to seed `llm_pricing`."
             )
         primary = all_rows[0]
 
@@ -273,9 +273,13 @@ class AnalysisOrchestrator:
         )
         prior = (await self.db.execute(running_stmt)).scalar_one_or_none()
         if prior is not None:
+            # ``run_id`` lands in ConflictError.details so #496's API/MCP
+            # handlers can surface it as a structured field (not just
+            # parsed out of the message text).
             raise ConflictError(
                 f"An analysis run is already in progress "
-                f"(run_id={prior.id}). Wait for it to finish or cancel."
+                f"(run_id={prior.id}). Wait for it to finish or cancel.",
+                run_id=str(prior.id),
             )
 
         pricing, snapshot = await _resolve_pricing_row(self.db, params.model_id)
@@ -362,7 +366,7 @@ class AnalysisOrchestrator:
             snapshot_dict = dict(analysis.model_snapshot or {})
             estimate = estimate_cost(
                 memory_count=len(pull.memories),
-                model_id=str(snapshot_dict.get("model", "gpt-5-nano")),
+                model_id=str(snapshot_dict.get("model", DEFAULT_MODEL_ID)),
             )
             analysis.cost_estimated_cents = estimate.estimated_cost_cents
 

--- a/backend/src/services/analysis/preview.py
+++ b/backend/src/services/analysis/preview.py
@@ -39,6 +39,16 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass
 
+# Default analysis provider + model (issue #496/B3 - shared by REST
+# routes, MCP tools, orchestrator's pricing FK resolution, and the
+# BYOK key assertion). v1.5 will replace these with per-workspace
+# ``Workspace.analysis_default_model_id`` / ``analysis_default_provider``
+# lookups; until then single named constants are the canonical source
+# so route code, MCP code, orchestrator, and byok_resolver never drift
+# out of sync on the provider/model pair.
+DEFAULT_PROVIDER = "openai"
+DEFAULT_MODEL_ID = "gpt-5-nano"
+
 # Per-call estimates. Tuned to match the Phase 3 cost target;
 # revisit when Gemini integration lands in v1.5.
 _INPUT_TOKENS_PER_CALL = 1500
@@ -69,7 +79,7 @@ class CostEstimate:
     breakdown: dict[str, int]
 
 
-def estimate_cost(memory_count: int, *, model_id: str = "gpt-5-nano") -> CostEstimate:
+def estimate_cost(memory_count: int, *, model_id: str = DEFAULT_MODEL_ID) -> CostEstimate:
     """Compute the pre-flight estimate for a memory_count-sized run.
 
     The model_id parameter is forward-compatibility scaffolding;

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -74,6 +74,15 @@ def day_window_utc(user_timezone: str) -> tuple[datetime, datetime]:
     back to UTC, DST transitions stay deterministic, and the
     ``replace(tzinfo=None)`` step that asyncpg requires (#489 wire-format
     convention) is applied in exactly one place.
+
+    DST handling: ``day_end_local`` is computed as ``date + 1 day`` at
+    local midnight, NOT ``day_start_local + timedelta(days=1)``. With
+    ZoneInfo timezones that observe DST, adding 24h in absolute time
+    can yield a result that is not the next local midnight (e.g. on
+    DST start the +24h would land at 01:00 local). Building from the
+    next calendar date keeps the "local calendar day" semantic intact
+    so quota counting AND ``resets_at`` align with the user's wall
+    clock. Issue #496 Copilot review.
     """
     try:
         tz = ZoneInfo(user_timezone)
@@ -84,7 +93,14 @@ def day_window_utc(user_timezone: str) -> tuple[datetime, datetime]:
 
     now_local = datetime.now(tz)
     day_start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
-    day_end_local = day_start_local + timedelta(days=1)
+    # Next local midnight via date arithmetic — DST-correct.
+    next_date = (day_start_local + timedelta(days=1)).date()
+    day_end_local = datetime(
+        next_date.year,
+        next_date.month,
+        next_date.day,
+        tzinfo=tz,
+    )
     day_start_utc = day_start_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
     day_end_utc = day_end_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
     return day_start_utc, day_end_utc
@@ -344,7 +360,19 @@ async def get_cluster(
             MemoryAnalysisAssignment,
             MemoryAnalysisAssignment.memory_id == Memory.id,
         )
-        .where(and_(*mem_conditions, Memory.deleted_at.is_(None)))
+        .where(
+            and_(
+                *mem_conditions,
+                Memory.deleted_at.is_(None),
+                # Defense-in-depth — ``memory_analysis_assignments.memory_id``
+                # FKs to ``memories.id`` only (no workspace constraint at the
+                # DB level). If a future bug ever assigns a foreign-workspace
+                # memory_id into a cluster (e.g. via direct SQL or a
+                # repair-script gone wrong), this predicate would still keep
+                # the API tenancy invariant. Issue #496 Copilot review.
+                Memory.workspace_id == workspace_id,
+            )
+        )
         .order_by(MemoryAnalysisAssignment.memory_id.asc())
         .limit(page_size + 1)
     )
@@ -373,7 +401,13 @@ async def get_cluster(
         rep_rows = (
             await db.execute(
                 select(Memory.id, Memory.summary, Memory.tags, Memory.importance).where(
-                    and_(Memory.id.in_(rep_ids), Memory.deleted_at.is_(None))
+                    and_(
+                        Memory.id.in_(rep_ids),
+                        Memory.deleted_at.is_(None),
+                        # Same defense-in-depth predicate as the page query
+                        # above — Issue #496 Copilot review.
+                        Memory.workspace_id == workspace_id,
+                    )
                 )
             )
         ).all()

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -1,0 +1,502 @@
+"""Read-path service for memory analysis runs (Issue #496).
+
+Centralizes the SELECT logic that REST routes (``api/routes/analyses.py``),
+MCP tools (``mcp_server/tools/analysis.py``), the ``recall`` filter
+extension (``services/memory_service.py``), and the ``/usage/current``
+endpoint (``api/routes/usage.py``) all need to share. Putting these in
+one module keeps three call sites grep-able and prevents the
+"workspace_id boundary check forgotten in one tool" class of leak.
+
+Tenancy invariant: every public method takes ``workspace_id`` and uses
+it as the first WHERE filter on ``memory_analyses``. ``run_id`` alone
+is never trusted — a stolen run UUID from another workspace returns
+None. The exception is the recall filter helper ``get_memory_ids_in_cluster``
+which is called *after* the ``recall`` route has already verified the
+caller's workspace context, so it accepts a bare ``run_id`` (still
+gated by FK CASCADE — a deleted workspace's runs cannot be queried).
+
+Pagination contract for ``get_cluster``:
+
+- ``limit`` clamped to ``MAX_CLUSTER_PAGE_SIZE`` (200) server-side.
+- ``cursor`` is an opaque token; v1 implementation is the last
+  ``memory_id`` UUID encoded as a string. Keyset pagination on
+  the assignments PK guarantees stable order under concurrent writes
+  (assignments are insert-only after the run finishes).
+- ``next_cursor`` is ``None`` when the page is the last one.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+from uuid import UUID
+from zoneinfo import ZoneInfo
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.analysis import (
+    MemoryAnalysis,
+    MemoryAnalysisAssignment,
+    MemoryAnalysisCluster,
+)
+from models.memory import Memory
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# Server-enforced clamp for ``get_cluster`` (Issue #496 AC). Keeps any
+# single MCP transport frame under ~200 KB even if every memory in the
+# cluster has a 500-char summary + tags array.
+MAX_CLUSTER_PAGE_SIZE = 200
+DEFAULT_CLUSTER_PAGE_SIZE = 50
+
+# Server-enforced clamp for ``list_analyses`` (mirrors the recall paging
+# convention so MCP clients can rely on a single behavior).
+MAX_LIST_PAGE_SIZE = 100
+DEFAULT_LIST_PAGE_SIZE = 20
+
+
+def _clamp_limit(value: int | None, default: int, max_value: int) -> int:
+    """Clamp a caller-supplied ``limit`` parameter."""
+    if value is None or value <= 0:
+        return default
+    return min(value, max_value)
+
+
+def day_window_utc(user_timezone: str) -> tuple[datetime, datetime]:
+    """Return ``(day_start_utc, day_end_utc)`` naive UTC for caller's tz today.
+
+    Centralized so REST gate / MCP gate / ``/usage/current`` and any
+    future caller share one tz handling — exotic tz strings safely fall
+    back to UTC, DST transitions stay deterministic, and the
+    ``replace(tzinfo=None)`` step that asyncpg requires (#489 wire-format
+    convention) is applied in exactly one place.
+    """
+    try:
+        tz = ZoneInfo(user_timezone)
+    except Exception:
+        # Defensive — User.timezone is varchar(50) without a CHECK; an
+        # exotic value should not 500 the gate.
+        tz = ZoneInfo("UTC")
+
+    now_local = datetime.now(tz)
+    day_start_local = now_local.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_end_local = day_start_local + timedelta(days=1)
+    day_start_utc = day_start_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+    day_end_utc = day_end_local.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+    return day_start_utc, day_end_utc
+
+
+async def verify_context_in_workspace(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+) -> bool:
+    """True iff the context exists and belongs to ``workspace_id``.
+
+    Single source of truth for the boundary check used by REST routes
+    (``_verify_context_in_workspace`` raises HTTPException 404) and MCP
+    tools (``_verify_context_in_workspace_mcp`` returns an error
+    envelope). Both wrappers call this helper so the SELECT shape only
+    lives in one place.
+    """
+    from models.auth import Context
+
+    result = await db.execute(
+        select(Context.id).where(
+            Context.id == context_id,
+            Context.workspace_id == workspace_id,
+            Context.deleted_at.is_(None),
+        )
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def count_context_memories(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+) -> int:
+    """Count non-deleted memories in a context for cost-preview math.
+
+    Shared by REST ``/preview`` and MCP ``analyze_context(dry_run=true)``
+    so the count semantics (filters ignored in v1, soft-delete excluded)
+    are defined in one place.
+    """
+    from models.memory import Memory
+
+    stmt = select(func.count(Memory.id)).where(
+        and_(
+            Memory.workspace_id == workspace_id,
+            Memory.context_id == context_id,
+            Memory.deleted_at.is_(None),
+        )
+    )
+    return int((await db.execute(stmt)).scalar() or 0)
+
+
+# ============================================================================
+# Run-level reads
+# ============================================================================
+
+
+async def get_analysis(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    run_id: UUID,
+) -> MemoryAnalysis | None:
+    """Fetch one run by id, scoped to ``workspace_id``.
+
+    Returns None if the run does not exist OR belongs to a different
+    workspace — callers convert None into 404 at the API layer so the
+    "exists but not yours" path does not leak existence.
+    """
+    stmt = select(MemoryAnalysis).where(
+        and_(
+            MemoryAnalysis.id == run_id,
+            MemoryAnalysis.workspace_id == workspace_id,
+        )
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def list_analyses(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> tuple[list[MemoryAnalysis], str | None]:
+    """List runs for a context, newest first, with cursor pagination.
+
+    Cursor is the ``started_at`` ISO-8601 of the last item on the
+    previous page. Newer runs that arrive between requests appear at
+    the top of page 1; the cursor walks backward in time so missing
+    them on a subsequent page is intentional (poll page 1 for the
+    freshest list).
+    """
+    page_size = _clamp_limit(limit, DEFAULT_LIST_PAGE_SIZE, MAX_LIST_PAGE_SIZE)
+
+    conditions = [
+        MemoryAnalysis.workspace_id == workspace_id,
+        MemoryAnalysis.context_id == context_id,
+    ]
+    if cursor:
+        try:
+            cursor_dt = datetime.fromisoformat(cursor)
+        except ValueError:
+            logger.warning("list_analyses_invalid_cursor", cursor=cursor)
+        else:
+            # Keyset pagination on started_at DESC — strict less-than
+            # so the cursor row itself is not duplicated on the next
+            # page. ``started_at`` is naive UTC by repo convention.
+            if cursor_dt.tzinfo is not None:
+                cursor_dt = cursor_dt.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+            conditions.append(MemoryAnalysis.started_at < cursor_dt)
+
+    stmt = (
+        select(MemoryAnalysis)
+        .where(and_(*conditions))
+        .order_by(MemoryAnalysis.started_at.desc())
+        .limit(page_size + 1)  # peek-one to detect last page
+    )
+    rows = list((await db.execute(stmt)).scalars().all())
+
+    next_cursor: str | None = None
+    if len(rows) > page_size:
+        rows = rows[:page_size]
+        # Cursor for next page is the started_at of the LAST row we
+        # returned, formatted with the project's standard ``Z`` suffix
+        # so JS clients that round-trip the cursor through their own
+        # parser don't drop the timezone info (#489 wire-format rule).
+        from utils.datetime import to_utc_iso
+
+        next_cursor = to_utc_iso(rows[-1].started_at)
+
+    return rows, next_cursor
+
+
+async def get_active_analysis(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+) -> MemoryAnalysis | None:
+    """Return the most recent ``status='succeeded'`` run for a context.
+
+    Returns None when the context has no successful runs yet — callers
+    map this to 404. Sorts by ``finished_at DESC`` so a brand-new
+    succeeded run wins over an older one even if their ``started_at``
+    are out of order (rare, but possible if a long run finishes after
+    a quick one started later).
+    """
+    stmt = (
+        select(MemoryAnalysis)
+        .where(
+            and_(
+                MemoryAnalysis.workspace_id == workspace_id,
+                MemoryAnalysis.context_id == context_id,
+                MemoryAnalysis.status == "succeeded",
+            )
+        )
+        .order_by(MemoryAnalysis.finished_at.desc())
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+# ============================================================================
+# Cluster-level reads
+# ============================================================================
+
+
+async def _resolve_cluster(
+    db: AsyncSession,
+    *,
+    run_id: UUID,
+    cluster_index: int,
+) -> MemoryAnalysisCluster | None:
+    """Look up the cluster row by ``(run_id, cluster_index)`` pair.
+
+    ``cluster_index`` is the user-visible 0-based ordinal assigned by
+    KMeans; ``cluster_id`` is the UUID PK. Routes / MCP tools / the
+    recall filter all start from ``cluster_index`` so this lookup is
+    factored out.
+    """
+    stmt = select(MemoryAnalysisCluster).where(
+        and_(
+            MemoryAnalysisCluster.analysis_id == run_id,
+            MemoryAnalysisCluster.cluster_index == cluster_index,
+        )
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def get_cluster(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    run_id: UUID,
+    cluster_index: int,
+    limit: int | None = None,
+    cursor: str | None = None,
+) -> dict[str, Any] | None:
+    """Drill-down view: cluster metadata + paginated memory list.
+
+    The workspace boundary check is enforced via a JOIN to
+    ``memory_analyses`` rather than a second SELECT: if the run does
+    not belong to ``workspace_id``, the join returns 0 rows and the
+    function returns None (404 at the API layer).
+
+    Returns a dict shaped to match the MCP tool contract directly so
+    REST and MCP can serialize the same payload.
+    """
+    # Tenant + run validity in a single query — joins ``memory_analyses``
+    # to enforce workspace_id boundary before paying for the cluster lookup.
+    boundary = (
+        await db.execute(
+            select(MemoryAnalysis.id).where(
+                and_(
+                    MemoryAnalysis.id == run_id,
+                    MemoryAnalysis.workspace_id == workspace_id,
+                )
+            )
+        )
+    ).scalar_one_or_none()
+    if boundary is None:
+        return None
+
+    cluster = await _resolve_cluster(db, run_id=run_id, cluster_index=cluster_index)
+    if cluster is None:
+        return None
+
+    page_size = _clamp_limit(limit, DEFAULT_CLUSTER_PAGE_SIZE, MAX_CLUSTER_PAGE_SIZE)
+
+    # Page through the cluster's memories. Keyset on memory_id (UUID
+    # textual order) — opaque cursor that the client should not parse.
+    mem_conditions = [
+        MemoryAnalysisAssignment.analysis_id == run_id,
+        MemoryAnalysisAssignment.cluster_id == cluster.id,
+    ]
+    if cursor:
+        try:
+            cursor_uuid = UUID(cursor)
+        except ValueError:
+            logger.warning("get_cluster_invalid_cursor", cursor=cursor)
+        else:
+            mem_conditions.append(MemoryAnalysisAssignment.memory_id > cursor_uuid)
+
+    page_stmt = (
+        select(
+            Memory.id,
+            Memory.summary,
+            Memory.tags,
+            Memory.importance,
+        )
+        .join(
+            MemoryAnalysisAssignment,
+            MemoryAnalysisAssignment.memory_id == Memory.id,
+        )
+        .where(and_(*mem_conditions, Memory.deleted_at.is_(None)))
+        .order_by(MemoryAnalysisAssignment.memory_id.asc())
+        .limit(page_size + 1)
+    )
+    rows = list((await db.execute(page_stmt)).all())
+
+    next_cursor: str | None = None
+    if len(rows) > page_size:
+        rows = rows[:page_size]
+        next_cursor = str(rows[-1].id)
+
+    memories_out = [
+        {
+            "memory_id": str(row.id),
+            "summary": row.summary,
+            "tags": list(row.tags) if row.tags else [],
+            "importance": float(row.importance) if row.importance is not None else None,
+        }
+        for row in rows
+    ]
+
+    # ``representative_memory_ids`` is an ARRAY(UUID) on the cluster row
+    # (already capped at 5 by the labeler). Filter out stale UUIDs whose
+    # memories were soft-deleted post-analysis (model docstring guard).
+    rep_ids = list(cluster.representative_memory_ids or [])
+    if rep_ids:
+        rep_rows = (
+            await db.execute(
+                select(Memory.id, Memory.summary, Memory.tags, Memory.importance).where(
+                    and_(Memory.id.in_(rep_ids), Memory.deleted_at.is_(None))
+                )
+            )
+        ).all()
+        # Preserve the order from ``representative_memory_ids`` so the UI
+        # gets stable "top-k" semantics across repeated calls.
+        rep_by_id = {r.id: r for r in rep_rows}
+        representatives = [
+            {
+                "memory_id": str(rid),
+                "summary": rep_by_id[rid].summary,
+                "tags": list(rep_by_id[rid].tags) if rep_by_id[rid].tags else [],
+                "importance": (
+                    float(rep_by_id[rid].importance)
+                    if rep_by_id[rid].importance is not None
+                    else None
+                ),
+            }
+            for rid in rep_ids
+            if rid in rep_by_id
+        ]
+    else:
+        representatives = []
+
+    return {
+        "run_id": str(run_id),
+        "cluster_index": cluster_index,
+        "cluster_id": str(cluster.id),
+        "label": cluster.label,
+        "description": cluster.description,
+        "count": int(cluster.count),
+        "label_confidence": float(cluster.label_confidence),
+        "centroid_2d": list(cluster.centroid_2d) if cluster.centroid_2d else None,
+        "property_stats": cluster.property_stats or {},
+        "representatives": representatives,
+        "memories": memories_out,
+        "next_cursor": next_cursor,
+    }
+
+
+async def get_memory_ids_in_cluster(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    run_id: UUID,
+    cluster_index: int,
+) -> list[UUID] | None:
+    """Return the memory_ids assigned to ``(run_id, cluster_index)``.
+
+    Used by the ``recall(filters={"analysis_cluster": ...})`` filter
+    chain in ``services/memory_service.py``.
+
+    **Tenancy invariant**: ``workspace_id`` is required and verified
+    via ``MemoryAnalysis.workspace_id == workspace_id``. A run UUID
+    that belongs to a foreign workspace returns ``None`` — same shape
+    as "cluster not found" so the recall filter degrades to "0
+    results" without leaking that the run exists somewhere else.
+    Closes the cross-workspace cluster lookup vector flagged in the
+    Issue #496 security review.
+
+    Returns:
+
+    - ``None`` if the run is in a foreign workspace, the run is
+      unknown, OR the cluster_index is unknown for that run.
+    - ``[]`` (empty list) if the cluster exists but contains no
+      memories — distinct from None for unit-test clarity.
+    - ``list[UUID]`` of all assignments otherwise, no pagination.
+      Cluster sizes are bounded by ``ceil(sqrt(memory_count))`` ≈
+      90 memories per cluster on an 8000-memory run, well under any
+      practical IN-list limit.
+    """
+    # Tenant boundary: ensure the run belongs to caller's workspace
+    # BEFORE resolving the cluster_index (so a stolen run_id from a
+    # foreign workspace is indistinguishable from a typo).
+    boundary = (
+        await db.execute(
+            select(MemoryAnalysis.id).where(
+                and_(
+                    MemoryAnalysis.id == run_id,
+                    MemoryAnalysis.workspace_id == workspace_id,
+                )
+            )
+        )
+    ).scalar_one_or_none()
+    if boundary is None:
+        return None
+
+    cluster = await _resolve_cluster(db, run_id=run_id, cluster_index=cluster_index)
+    if cluster is None:
+        return None
+
+    stmt = select(MemoryAnalysisAssignment.memory_id).where(
+        and_(
+            MemoryAnalysisAssignment.analysis_id == run_id,
+            MemoryAnalysisAssignment.cluster_id == cluster.id,
+        )
+    )
+    return [row for (row,) in (await db.execute(stmt)).all()]
+
+
+# ============================================================================
+# /usage support
+# ============================================================================
+
+
+async def get_today_analysis_count(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    user_timezone: str,
+) -> int:
+    """Count analyses started today (in caller's tz).
+
+    Mirrors the count semantics of
+    ``auth.analysis_gates.check_memory_analysis_quota`` (cancelled
+    rows count, day boundary follows caller's tz). The quota gate
+    raises 429; this helper just returns the integer for the
+    ``/usage/current`` ``analysis.used_today`` field.
+    """
+    day_start_utc, day_end_utc = day_window_utc(user_timezone)
+    stmt = select(func.count(MemoryAnalysis.id)).where(
+        and_(
+            MemoryAnalysis.workspace_id == workspace_id,
+            MemoryAnalysis.started_at >= day_start_utc,
+            MemoryAnalysis.started_at < day_end_utc,
+        )
+    )
+    return int((await db.execute(stmt)).scalar() or 0)

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -7,13 +7,14 @@ endpoint (``api/routes/usage.py``) all need to share. Putting these in
 one module keeps three call sites grep-able and prevents the
 "workspace_id boundary check forgotten in one tool" class of leak.
 
-Tenancy invariant: every public method takes ``workspace_id`` and uses
+Tenancy invariant: every public method (including the recall filter
+helper ``get_memory_ids_in_cluster``) takes ``workspace_id`` and uses
 it as the first WHERE filter on ``memory_analyses``. ``run_id`` alone
 is never trusted — a stolen run UUID from another workspace returns
-None. The exception is the recall filter helper ``get_memory_ids_in_cluster``
-which is called *after* the ``recall`` route has already verified the
-caller's workspace context, so it accepts a bare ``run_id`` (still
-gated by FK CASCADE — a deleted workspace's runs cannot be queried).
+None on every code path. ``recall``'s caller passes
+``current_workspace_id`` through to ``get_memory_ids_in_cluster`` so
+the cross-workspace cluster lookup vector is closed at this layer
+even though ``recall`` has already validated workspace context once.
 
 Pagination contract for ``get_cluster``:
 

--- a/backend/src/services/analysis/reporter.py
+++ b/backend/src/services/analysis/reporter.py
@@ -72,10 +72,12 @@ logger = get_logger(__name__)
 # the DB CHECK constraint).
 _STATUS_SUCCEEDED = "succeeded"
 _STATUS_FAILED = "failed"
+_STATUS_CANCELLED = "cancelled"
 _SOURCE_ANALYSIS = "analysis"
 _SLEEP_PAID_BY_BYOK = "byok"
 assert _STATUS_SUCCEEDED in MEMORY_ANALYSIS_STATUSES
 assert _STATUS_FAILED in MEMORY_ANALYSIS_STATUSES
+assert _STATUS_CANCELLED in MEMORY_ANALYSIS_STATUSES
 assert _SOURCE_ANALYSIS in SLEEP_REPORT_SOURCES
 assert _SLEEP_PAID_BY_BYOK in SLEEP_REPORT_PAID_BY_VALUES
 
@@ -348,6 +350,20 @@ async def persist_results(
     # 4. Update the memory_analyses row. embedding_model was set by
     #    the orchestrator before this transaction opened — we only
     #    finalize the run-level fields here.
+    #    First, refresh from DB to detect a concurrent soft-cancel
+    #    (DELETE /analyses/{run_id} flipped status to 'cancelled' in a
+    #    separate session while compute was running). Without this
+    #    guard the stale ORM instance would overwrite the cancellation
+    #    on flush — silent data loss for the cancellation_reason
+    #    audit trail. Issue #496 Copilot review.
+    await db.refresh(analysis)
+    if analysis.status == _STATUS_CANCELLED:
+        logger.info(
+            "analysis_persist_skipped_due_to_cancel",
+            analysis_id=str(analysis.id),
+            cancellation_reason=analysis.cancellation_reason,
+        )
+        return
     cost_actual_cents = _compute_actual_cost_cents(totals, dict(analysis.model_snapshot or {}))
     analysis.status = _STATUS_SUCCEEDED
     analysis.finished_at = utcnow()
@@ -408,6 +424,20 @@ async def persist_failure(
     the run row.
     """
     truncated_error = error_message[:_ERROR_FIELD_MAX_CHARS]
+    # Same cancellation-overwrite guard as ``persist_results`` — refresh
+    # from DB so a concurrent DELETE soft-cancel is not silently flipped
+    # to ``failed``. The compute exception is still recorded in the log
+    # below; we just avoid corrupting the status + cancellation_reason
+    # audit trail. Issue #496 Copilot review.
+    await db.refresh(analysis)
+    if analysis.status == _STATUS_CANCELLED:
+        logger.info(
+            "analysis_persist_failure_skipped_due_to_cancel",
+            analysis_id=str(analysis.id),
+            cancellation_reason=analysis.cancellation_reason,
+            compute_error=truncated_error,
+        )
+        return
     analysis.status = _STATUS_FAILED
     analysis.finished_at = utcnow()
     analysis.error = truncated_error

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -48,7 +48,12 @@ from services.context_service import ContextService
 from services.embedding_service import EmbeddingService
 from services.search_service import SearchService
 from utils.datetime import to_utc_iso, utcnow
-from utils.exceptions import MemoryGoneError, NotFoundException, QuotaExceededError
+from utils.exceptions import (
+    MemoryGoneError,
+    NotFoundException,
+    QuotaExceededError,
+    ValidationError,
+)
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -1154,23 +1159,35 @@ class MemoryService:
 
             # Issue #496 Copilot review fix: guard against non-dict shape so a
             # client sending ``analysis_cluster: "abc"`` (string) or a list
-            # surfaces as a clean 422 ValidationError instead of an internal
-            # 500 AttributeError on ``.get(...)``.
+            # surfaces as a clean 422 ``ValidationError`` instead of an
+            # internal 500 ``AttributeError`` on ``.get(...)``.
+            #
+            # ``ValidationError`` (a ``MemoryCloudException`` subclass) is the
+            # right exception type — plain ``ValueError`` is NOT caught by
+            # the global ``memory_cloud_exception_handler``, so the recall
+            # route would 500 instead of returning 422 with the structured
+            # ``{error, message, details}`` envelope. Caught by Copilot
+            # review (loop 5).
             if not isinstance(cluster_filter, dict):
-                raise ValueError(
-                    "filters.analysis_cluster must be an object with run_id + cluster_index"
+                raise ValidationError(
+                    "filters.analysis_cluster must be an object with run_id + cluster_index",
+                    field="filters.analysis_cluster",
                 )
             run_id_raw = cluster_filter.get("run_id")
             cluster_index_raw = cluster_filter.get("cluster_index")
             if run_id_raw is None or cluster_index_raw is None:
-                raise ValueError("filters.analysis_cluster requires 'run_id' and 'cluster_index'")
+                raise ValidationError(
+                    "filters.analysis_cluster requires 'run_id' and 'cluster_index'",
+                    field="filters.analysis_cluster",
+                )
             try:
                 cluster_run_id = UUID(str(run_id_raw))
                 cluster_index_int = int(cluster_index_raw)
             except (ValueError, TypeError) as e:
-                raise ValueError(
+                raise ValidationError(
                     "filters.analysis_cluster: 'run_id' must be a UUID and "
-                    "'cluster_index' must be an integer"
+                    "'cluster_index' must be an integer",
+                    field="filters.analysis_cluster",
                 ) from e
             # Issue #496 security fix: pass current_workspace_id so a
             # stolen ``run_id`` from a foreign workspace returns None

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1140,10 +1140,56 @@ class MemoryService:
         if context_ids:
             search_context_id = [str(cid) for cid in context_ids]
 
+        # Issue #496: ``analysis_cluster`` filter pre-resolves the cluster's
+        # memory_ids so we can both (a) short-circuit empty clusters before
+        # paying for the embedding+search round-trip and (b) expand the
+        # candidate pool to cover the whole cluster — without this, a small
+        # cluster may end up with zero overlap with Qdrant's top-N candidates.
+        # The actual ``Memory.id IN ...`` filter is applied at the PG SELECT
+        # below alongside the existing source_uri_prefix / source_type
+        # post-filters; rerank / hybrid scoring see only cluster members.
+        cluster_memory_ids: list[UUID] | None = None
+        if request.filters and (cluster_filter := request.filters.get("analysis_cluster")):
+            from services.analysis import query_service as _analysis_query_service
+
+            run_id_raw = cluster_filter.get("run_id")
+            cluster_index_raw = cluster_filter.get("cluster_index")
+            if run_id_raw is None or cluster_index_raw is None:
+                raise ValueError("filters.analysis_cluster requires 'run_id' and 'cluster_index'")
+            try:
+                cluster_run_id = UUID(str(run_id_raw))
+                cluster_index_int = int(cluster_index_raw)
+            except (ValueError, TypeError) as e:
+                raise ValueError(
+                    "filters.analysis_cluster: 'run_id' must be a UUID and "
+                    "'cluster_index' must be an integer"
+                ) from e
+            # Issue #496 security fix: pass current_workspace_id so a
+            # stolen ``run_id`` from a foreign workspace returns None
+            # (same shape as cluster-not-found) and the recall short-
+            # circuits to empty results without leaking existence.
+            cluster_memory_ids = await _analysis_query_service.get_memory_ids_in_cluster(
+                self.db,
+                workspace_id=current_workspace_id,
+                run_id=cluster_run_id,
+                cluster_index=cluster_index_int,
+            )
+            if not cluster_memory_ids:
+                # Cluster empty or unknown — return immediately with no candidates.
+                return RecallResponse(
+                    results=[],
+                    explore_hints=[] if request.include_explore_hints else None,
+                )
+
         # 1. Primary Retrieval: Hybrid Search (Semantic + BM25)
         # Fetch more candidates when neural is enabled for better hybrid merge
         # and to feed Hebbian learning with broader co-activation data
         candidates_k = request.k * 4 if neural_enabled else request.k
+        # When ``analysis_cluster`` filter is active, ensure the candidate
+        # pool can hold the whole cluster + a safety buffer so the post-
+        # filter does not starve a small ``k`` request.
+        if cluster_memory_ids is not None:
+            candidates_k = max(candidates_k, len(cluster_memory_ids) + 50)
         search_results = await self.search_service.hybrid_search(
             query=request.query,
             user_id=user_id,
@@ -1177,6 +1223,13 @@ class MemoryService:
                 pg_conditions.append(Memory.source_uri.like(f"{escaped}%", escape="\\"))
             if stype := request.filters.get("source_type"):
                 pg_conditions.append(Memory.source_type == stype)
+        # Issue #496: cluster-scoped recall — restrict to the
+        # cluster's member memories. ``cluster_memory_ids`` was
+        # pre-resolved above and is guaranteed non-empty by the
+        # short-circuit (empty cluster returns early without
+        # reaching this block).
+        if cluster_memory_ids is not None:
+            pg_conditions.append(Memory.id.in_(cluster_memory_ids))
         result = await self.db.execute(select(Memory).where(*pg_conditions))
         memories_list = list(result.scalars().all())
         memories = {str(m.id): m for m in memories_list}

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1152,6 +1152,14 @@ class MemoryService:
         if request.filters and (cluster_filter := request.filters.get("analysis_cluster")):
             from services.analysis import query_service as _analysis_query_service
 
+            # Issue #496 Copilot review fix: guard against non-dict shape so a
+            # client sending ``analysis_cluster: "abc"`` (string) or a list
+            # surfaces as a clean 422 ValidationError instead of an internal
+            # 500 AttributeError on ``.get(...)``.
+            if not isinstance(cluster_filter, dict):
+                raise ValueError(
+                    "filters.analysis_cluster must be an object with run_id + cluster_index"
+                )
             run_id_raw = cluster_filter.get("run_id")
             cluster_index_raw = cluster_filter.get("cluster_index")
             if run_id_raw is None or cluster_index_raw is None:

--- a/backend/src/tasks/embedding_tasks.py
+++ b/backend/src/tasks/embedding_tasks.py
@@ -58,10 +58,28 @@ async def sweep_pending_embeddings() -> None:
 
             logger.info("sweep_pending_embeddings", count=len(pending_ids))
 
+            # Per-id try/except so one stuck embedding does not abort
+            # the sweep — the next sweep tick (30s later) would re-pick
+            # only this id, but in the meantime the OTHER pending ids
+            # would sit untouched. Caught via Copilot review on #496.
+            failed = 0
             for mid in pending_ids:
-                await process_pending_embedding(mid)
+                try:
+                    await process_pending_embedding(mid)
+                except Exception as e:  # noqa: BLE001 — we want to keep going
+                    failed += 1
+                    logger.error(
+                        "sweep_pending_embeddings_item_failed",
+                        memory_id=str(mid),
+                        error=str(e),
+                        exc_info=True,
+                    )
 
-            logger.info("sweep_pending_embeddings_done", processed=len(pending_ids))
+            logger.info(
+                "sweep_pending_embeddings_done",
+                processed=len(pending_ids) - failed,
+                failed=failed,
+            )
 
         except Exception as e:
             logger.error("sweep_pending_embeddings_failed", error=str(e), exc_info=True)

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -137,8 +137,8 @@ class MemoryGoneError(MemoryCloudException):
 class ConflictError(MemoryCloudException):
     """Resource conflict (409)."""
 
-    def __init__(self, message: str = "Resource conflict"):
-        super().__init__(message, status_code=409, error_code="RES-002")
+    def __init__(self, message: str = "Resource conflict", **details: Any):
+        super().__init__(message, status_code=409, error_code="RES-002", **details)
 
 
 class ValidationError(MemoryCloudException):
@@ -171,8 +171,19 @@ class RateLimitError(MemoryCloudException):
 class QuotaExceededError(MemoryCloudException):
     """Quota exceeded (429)."""
 
-    def __init__(self, message: str = "Quota exceeded", quota_type: str | None = None) -> None:
-        super().__init__(message, status_code=429, error_code="QUOTA-001", quota_type=quota_type)
+    def __init__(
+        self,
+        message: str = "Quota exceeded",
+        quota_type: str | None = None,
+        **details: Any,
+    ) -> None:
+        super().__init__(
+            message,
+            status_code=429,
+            error_code="QUOTA-001",
+            quota_type=quota_type,
+            **details,
+        )
 
 
 class FeatureNotAvailableError(MemoryCloudException):

--- a/backend/tests/api/test_analyses_quota_precedence.py
+++ b/backend/tests/api/test_analyses_quota_precedence.py
@@ -1,0 +1,273 @@
+"""Tier+quota+allowlist precedence ordering test (Issue #496 AC).
+
+The 4-stage gate chain in ``auth.analysis_gates.require_memory_analysis_access``
+must fail fast at the FIRST applicable gate, in this order:
+
+    Gate 2 (workspace owner)          → 403 (HTTPException)
+    Gate 3 (Pro tier feature flag)    → 403 (FeatureNotAvailableError)
+    Gate 4 (daily quota)              → 429 (QuotaExceededError)
+    Gate 5 (allowlist kill switch)    → 403 (FeatureNotAvailableError)
+
+The issue spec covers four blocked states (matching ``backend/src/auth/analysis_gates.py``):
+
+    basic + no-BYOK + empty allowlist  → 403 tier_required (NOT 422 BYOK or 403 allowlist)
+    pro + quota exhausted + no-BYOK    → 429 remaining_today (NOT 422 BYOK)
+    pro + quota OK + no-BYOK           → BYOK 422 happens INSIDE orchestrator.start,
+                                          NOT in the gate chain (skipped here)
+    pro + quota OK + BYOK + empty allowlist → 403 allowlist
+
+This test suite locks the precedence into structural assertions so a future
+reorder (eg moving allowlist before quota) trips a red CI.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from auth.analysis_gates import require_memory_analysis_access
+from utils.exceptions import FeatureNotAvailableError, QuotaExceededError
+
+
+def _user_dict(workspace_id: UUID) -> dict:
+    return {"user_id": "test_user", "current_workspace_id": workspace_id}
+
+
+@pytest.mark.asyncio
+async def test_gate2_owner_failure_short_circuits():
+    """Owner check fails → HTTPException 403, gates 3-5 never run."""
+    workspace_id = uuid4()
+    user = _user_dict(workspace_id)
+    db = AsyncMock()
+
+    perm_mock = MagicMock()
+    perm_mock.check_workspace_owner = AsyncMock(
+        side_effect=HTTPException(status_code=403, detail="not owner")
+    )
+
+    quota_check_mock = AsyncMock()
+    allowlist_mock = MagicMock()
+    quota_gate_mock = AsyncMock()
+
+    with (
+        patch("services.permission_service.PermissionService", return_value=perm_mock),
+        patch("services.quota_service.QuotaService") as quota_cls,
+        patch(
+            "auth.analysis_gates.check_workspace_in_allowlist",
+            allowlist_mock,
+        ),
+        patch(
+            "auth.analysis_gates.check_memory_analysis_quota",
+            quota_gate_mock,
+        ),
+    ):
+        quota_cls.return_value.check_feature_access = quota_check_mock
+        with pytest.raises(HTTPException) as exc:
+            await require_memory_analysis_access(user=user, db=db)
+        assert exc.value.status_code == 403
+
+    quota_check_mock.assert_not_called()
+    allowlist_mock.assert_not_called()
+    quota_gate_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gate3_tier_failure_runs_before_quota_or_allowlist():
+    """Basic plan, owner OK → FeatureNotAvailableError BEFORE quota/allowlist."""
+    workspace_id = uuid4()
+    user = _user_dict(workspace_id)
+    db = AsyncMock()
+
+    perm_mock = MagicMock()
+    perm_mock.check_workspace_owner = AsyncMock(return_value=None)
+
+    feature_check_mock = AsyncMock(return_value=(False, "memory_analysis requires Pro"))
+    allowlist_mock = MagicMock()
+    quota_gate_mock = AsyncMock()
+
+    with (
+        patch("services.permission_service.PermissionService", return_value=perm_mock),
+        patch("services.quota_service.QuotaService") as quota_cls,
+        patch(
+            "auth.analysis_gates.check_workspace_in_allowlist",
+            allowlist_mock,
+        ),
+        patch(
+            "auth.analysis_gates.check_memory_analysis_quota",
+            quota_gate_mock,
+        ),
+    ):
+        quota_cls.return_value.check_feature_access = feature_check_mock
+        with pytest.raises(FeatureNotAvailableError) as exc:
+            await require_memory_analysis_access(user=user, db=db)
+        assert exc.value.status_code == 403
+        assert exc.value.details.get("feature") == "memory_analysis"
+
+    quota_gate_mock.assert_not_called()
+    allowlist_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gate4_quota_failure_runs_before_allowlist():
+    """Pro + quota exhausted → QuotaExceededError BEFORE allowlist."""
+    workspace_id = uuid4()
+    user = _user_dict(workspace_id)
+    db = AsyncMock()
+
+    perm_mock = MagicMock()
+    perm_mock.check_workspace_owner = AsyncMock(return_value=None)
+
+    feature_check_mock = AsyncMock(return_value=(True, None))
+    quota_gate_mock = AsyncMock(side_effect=QuotaExceededError("quota exhausted"))
+    allowlist_mock = MagicMock()
+    tz_mock = AsyncMock(return_value="UTC")
+
+    with (
+        patch("services.permission_service.PermissionService", return_value=perm_mock),
+        patch("services.quota_service.QuotaService") as quota_cls,
+        patch(
+            "auth.analysis_gates.check_workspace_in_allowlist",
+            allowlist_mock,
+        ),
+        patch(
+            "auth.analysis_gates.check_memory_analysis_quota",
+            quota_gate_mock,
+        ),
+        patch("auth.analysis_gates._get_user_timezone", tz_mock),
+    ):
+        quota_cls.return_value.check_feature_access = feature_check_mock
+        with pytest.raises(QuotaExceededError) as exc:
+            await require_memory_analysis_access(user=user, db=db)
+        assert exc.value.status_code == 429
+
+    allowlist_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_gate5_allowlist_failure_after_quota_pass():
+    """Pro + quota OK + allowlist empty → FeatureNotAvailableError 403 (last gate)."""
+    workspace_id = uuid4()
+    user = _user_dict(workspace_id)
+    db = AsyncMock()
+
+    perm_mock = MagicMock()
+    perm_mock.check_workspace_owner = AsyncMock(return_value=None)
+
+    feature_check_mock = AsyncMock(return_value=(True, None))
+    quota_gate_mock = AsyncMock(return_value=None)
+    allowlist_mock = MagicMock(return_value=False)
+    tz_mock = AsyncMock(return_value="UTC")
+
+    with (
+        patch("services.permission_service.PermissionService", return_value=perm_mock),
+        patch("services.quota_service.QuotaService") as quota_cls,
+        patch(
+            "auth.analysis_gates.check_workspace_in_allowlist",
+            allowlist_mock,
+        ),
+        patch(
+            "auth.analysis_gates.check_memory_analysis_quota",
+            quota_gate_mock,
+        ),
+        patch("auth.analysis_gates._get_user_timezone", tz_mock),
+    ):
+        quota_cls.return_value.check_feature_access = feature_check_mock
+        with pytest.raises(FeatureNotAvailableError) as exc:
+            await require_memory_analysis_access(user=user, db=db)
+        assert exc.value.status_code == 403
+        assert exc.value.details.get("feature") == "memory_analysis"
+
+
+@pytest.mark.asyncio
+async def test_all_gates_pass_returns_user_tuple():
+    """Happy path: all gates pass → ``(user_id, workspace_id, tz)`` returned."""
+    workspace_id = uuid4()
+    user = _user_dict(workspace_id)
+    db = AsyncMock()
+
+    perm_mock = MagicMock()
+    perm_mock.check_workspace_owner = AsyncMock(return_value=None)
+    feature_check_mock = AsyncMock(return_value=(True, None))
+    quota_gate_mock = AsyncMock(return_value=None)
+    allowlist_mock = MagicMock(return_value=True)
+    tz_mock = AsyncMock(return_value="Asia/Tokyo")
+
+    with (
+        patch("services.permission_service.PermissionService", return_value=perm_mock),
+        patch("services.quota_service.QuotaService") as quota_cls,
+        patch(
+            "auth.analysis_gates.check_workspace_in_allowlist",
+            allowlist_mock,
+        ),
+        patch(
+            "auth.analysis_gates.check_memory_analysis_quota",
+            quota_gate_mock,
+        ),
+        patch("auth.analysis_gates._get_user_timezone", tz_mock),
+    ):
+        quota_cls.return_value.check_feature_access = feature_check_mock
+        result = await require_memory_analysis_access(user=user, db=db)
+
+    assert result == ("test_user", workspace_id, "Asia/Tokyo")
+
+
+@pytest.mark.asyncio
+async def test_no_workspace_selected_short_circuits_with_400():
+    """``current_workspace_id`` missing → 400 BEFORE any gate runs."""
+    user = {"user_id": "test_user"}  # no current_workspace_id
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await require_memory_analysis_access(user=user, db=db)
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_quota_exceeded_error_carries_structured_detail():
+    """Regression test for #496: ``check_memory_analysis_quota`` raises
+    ``QuotaExceededError`` with structured kwargs (``used_today``,
+    ``limit_today``, ``addon_bonus``, ``remaining_today``,
+    ``resets_at``). If the exception class signature regresses to
+    "only accept ``message`` + ``quota_type``", every quota-exhausted
+    request 500s with TypeError instead of returning a clean 429. The
+    other gate tests mock the gate function so they would not catch
+    this — this one constructs the exception directly.
+    """
+    err = QuotaExceededError(
+        "Analysis daily quota exceeded: 3/3 runs today (addon bonus 0). "
+        "Resets at 2026-05-03T00:00:00+09:00.",
+        quota_type="memory_analysis",
+        used_today=3,
+        limit_today=3,
+        addon_bonus=0,
+        remaining_today=0,
+        resets_at="2026-05-03T00:00:00+09:00",
+    )
+    assert err.status_code == 429
+    assert err.error_code == "QUOTA-001"
+    assert err.details["used_today"] == 3
+    assert err.details["limit_today"] == 3
+    assert err.details["resets_at"] == "2026-05-03T00:00:00+09:00"
+
+
+@pytest.mark.asyncio
+async def test_check_workspace_in_allowlist_pure_function(monkeypatch):
+    """``check_workspace_in_allowlist`` is the kill-switch primitive."""
+    from auth.analysis_gates import check_workspace_in_allowlist
+    from config.settings import get_settings
+
+    workspace_id = uuid4()
+    settings = get_settings()
+    monkeypatch.setattr(
+        settings,
+        "analysis_enabled_workspace_ids",
+        f"{workspace_id},{uuid4()}",
+        raising=False,
+    )
+    assert check_workspace_in_allowlist(workspace_id) is True
+    monkeypatch.setattr(settings, "analysis_enabled_workspace_ids", "", raising=False)
+    # Empty list → False (kill switch active globally).
+    assert check_workspace_in_allowlist(workspace_id) is False

--- a/backend/tests/api/test_analyses_quota_precedence.py
+++ b/backend/tests/api/test_analyses_quota_precedence.py
@@ -226,6 +226,38 @@ async def test_no_workspace_selected_short_circuits_with_400():
 
 
 @pytest.mark.asyncio
+async def test_require_memory_analysis_access_calls_quota_with_supported_kwargs():
+    """Regression test for #496: ``require_memory_analysis_access`` must
+    invoke ``check_memory_analysis_quota`` with **only** the kwargs the
+    target function actually accepts. The other gate tests mock the
+    whole quota function so they would NOT catch a signature drift
+    between caller and callee (e.g. caller passing ``raise_on_exceeded``
+    after callee dropped that parameter — this exact bug surfaced once).
+    This test wires through to the real ``check_memory_analysis_quota``
+    via patches that only stub the *internal* DB primitives, so the
+    caller→callee kwargs contract is exercised end-to-end.
+    """
+    from inspect import signature
+
+    from auth.analysis_gates import check_memory_analysis_quota
+
+    # The function must NOT accept ``raise_on_exceeded`` — it raises
+    # unconditionally on quota exceeded. If a future refactor reintroduces
+    # the parameter, the call site contract diverges silently and gate 4
+    # 500s with TypeError. Pin the signature here so signature drift
+    # is loud at test time.
+    params = signature(check_memory_analysis_quota).parameters
+    assert "raise_on_exceeded" not in params, (
+        "raise_on_exceeded must NOT be a parameter of check_memory_analysis_quota — "
+        "the function is raise-only by design. If you need a non-raising variant, add a "
+        "separate ``check_memory_analysis_quota_status`` helper instead of overloading "
+        "this one (see auth/analysis_gates.py docstring)."
+    )
+    # Positive contract — these ARE the canonical kwargs callers must use.
+    assert set(params.keys()) >= {"db", "workspace_id", "user_timezone"}
+
+
+@pytest.mark.asyncio
 async def test_quota_exceeded_error_carries_structured_detail():
     """Regression test for #496: ``check_memory_analysis_quota`` raises
     ``QuotaExceededError`` with structured kwargs (``used_today``,

--- a/backend/tests/api/test_analyses_routes.py
+++ b/backend/tests/api/test_analyses_routes.py
@@ -1,0 +1,299 @@
+"""HTTP/serialization tests for ``api/routes/analyses.py`` (Issue #496).
+
+The full 4-stage gate behavior is covered by
+``tests/api/test_analyses_quota_precedence.py``; this suite uses
+``app.dependency_overrides`` to bypass the gate and focuses on:
+
+- Route → service wiring (POST /preview returns the cost shape, GET /list
+  paginates, GET /{run_id} 404s on unknown ids, DELETE soft-cancels).
+- Pydantic response shape (``run_id``, ``status``, ``analysis_runs_today``).
+- Context-boundary 404 on a context belonging to another workspace.
+- Idempotent DELETE when the run is already terminal.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from auth.analysis_gates import (
+    require_memory_analysis_access,
+    require_memory_analysis_read,
+)
+from db.base import get_db
+
+# ============================================================================
+# Test fixtures
+# ============================================================================
+
+
+_TEST_USER_ID = "test_user_analyses"
+_TEST_WORKSPACE_ID = uuid4()
+_TEST_CONTEXT_ID = uuid4()
+_TEST_TZ = "Asia/Tokyo"
+
+
+def _gate_payload() -> tuple[str, UUID, str]:
+    return (_TEST_USER_ID, _TEST_WORKSPACE_ID, _TEST_TZ)
+
+
+@pytest.fixture
+def db_mock():
+    """A MagicMock standing in for AsyncSession.
+
+    Per-test ``execute`` side effects are configured inside each test;
+    this fixture just supplies the bare object so the route handler's
+    ``db.execute(...)`` calls don't AttributeError.
+    """
+    m = MagicMock()
+    m.execute = AsyncMock()
+    m.commit = AsyncMock()
+    m.rollback = AsyncMock()
+    return m
+
+
+@pytest.fixture
+def client(db_mock):
+    async def _override_write_gate():
+        return _gate_payload()
+
+    async def _override_read_gate():
+        return _gate_payload()
+
+    async def _override_db():
+        yield db_mock
+
+    app.dependency_overrides[require_memory_analysis_access] = _override_write_gate
+    app.dependency_overrides[require_memory_analysis_read] = _override_read_gate
+    app.dependency_overrides[get_db] = _override_db
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def _scalar_one(value: Any) -> MagicMock:
+    """Mock ``await db.execute(...)``'s ``.scalar_one_or_none()`` return."""
+    res = MagicMock()
+    res.scalar_one_or_none = MagicMock(return_value=value)
+    res.scalar = MagicMock(return_value=value)
+    return res
+
+
+def _scalars_all(values: list) -> MagicMock:
+    """Mock ``await db.execute(...).scalars().all()``."""
+    res = MagicMock()
+    scalars = MagicMock()
+    scalars.all = MagicMock(return_value=values)
+    res.scalars = MagicMock(return_value=scalars)
+    return res
+
+
+# ============================================================================
+# POST /preview
+# ============================================================================
+
+
+class TestPreview:
+    def test_returns_cost_estimate_shape(self, client, db_mock):
+        # Boundary check passes (Context exists in workspace) → memory count = 100.
+        db_mock.execute.side_effect = [
+            _scalar_one(_TEST_CONTEXT_ID),  # Context boundary
+            _scalar_one(100),  # _count_filtered_memories
+        ]
+        response = client.post(
+            f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/preview",
+            json={},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["memory_count"] == 100
+        assert body["model_id"] == "gpt-5-nano"
+        assert body["cluster_count_estimate"] >= 1
+        assert body["estimated_cost_cents"] >= 1
+        assert "input_tokens" in body["breakdown"]
+
+
+# ============================================================================
+# POST / (start)
+# ============================================================================
+
+
+class TestStartRun:
+    def test_returns_202_with_run_id_on_success(self, client, db_mock):
+        run_id = uuid4()
+        started_at = datetime(2026, 5, 2, 0, 0, 0)
+        # Boundary check passes; orchestrator stub returns a fake row.
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+
+        fake_analysis = MagicMock(id=run_id, status="running", started_at=started_at)
+        with (
+            patch("api.routes.analyses.AnalysisOrchestrator") as orch_cls,
+            patch(
+                "api.routes.analyses.run_analysis_task",
+                AsyncMock(),
+            ),
+        ):
+            orch_cls.return_value.start = AsyncMock(return_value=fake_analysis)
+            response = client.post(
+                f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses",
+                json={},
+            )
+        assert response.status_code == 202, response.text
+        body = response.json()
+        assert body["run_id"] == str(run_id)
+        assert body["status"] == "running"
+
+    def test_404_on_foreign_context(self, client, db_mock):
+        # Boundary check returns None → context_not_found.
+        db_mock.execute.side_effect = [_scalar_one(None)]
+        response = client.post(
+            f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses",
+            json={},
+        )
+        assert response.status_code == 404
+
+
+# ============================================================================
+# GET / (list)
+# ============================================================================
+
+
+class TestListRuns:
+    def test_returns_items_and_next_cursor(self, client, db_mock):
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]  # boundary
+
+        run_id = uuid4()
+        fake_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="succeeded",
+            triggered_by=_TEST_USER_ID,
+            started_at=datetime(2026, 5, 2),
+            finished_at=datetime(2026, 5, 2),
+            input_count=10,
+            cost_estimated_cents=5,
+            cost_actual_cents=4,
+            error=None,
+            cancellation_reason=None,
+        )
+        with patch(
+            "services.analysis.query_service.list_analyses",
+            AsyncMock(return_value=([fake_run], "2026-05-01T00:00:00")),
+        ):
+            response = client.get(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses?limit=20")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert len(body["items"]) == 1
+        assert body["items"][0]["run_id"] == str(run_id)
+        assert body["next_cursor"] == "2026-05-01T00:00:00"
+
+
+# ============================================================================
+# GET /{run_id}
+# ============================================================================
+
+
+class TestGetRun:
+    def test_returns_404_for_unknown_run(self, client, db_mock):
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        with patch(
+            "services.analysis.query_service.get_analysis",
+            AsyncMock(return_value=None),
+        ):
+            response = client.get(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{uuid4()}")
+        assert response.status_code == 404
+
+    def test_returns_404_when_run_belongs_to_different_context(self, client, db_mock):
+        """Run exists in workspace but is bound to ANOTHER context."""
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        run_id = uuid4()
+        fake_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=uuid4(),  # different context
+            status="succeeded",
+            triggered_by=_TEST_USER_ID,
+            started_at=datetime(2026, 5, 2),
+            finished_at=datetime(2026, 5, 2),
+            input_count=10,
+            cost_estimated_cents=5,
+            cost_actual_cents=4,
+            error=None,
+            cancellation_reason=None,
+        )
+        with patch(
+            "services.analysis.query_service.get_analysis",
+            AsyncMock(return_value=fake_run),
+        ):
+            response = client.get(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}")
+        assert response.status_code == 404
+
+
+# ============================================================================
+# DELETE /{run_id} (soft cancel)
+# ============================================================================
+
+
+class TestCancelRun:
+    def test_soft_cancels_running_run(self, client, db_mock):
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        run_id = uuid4()
+        fake_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="running",
+            triggered_by=_TEST_USER_ID,
+            started_at=datetime(2026, 5, 2),
+            finished_at=None,
+            input_count=10,
+            cost_estimated_cents=5,
+            cost_actual_cents=None,
+            error=None,
+            cancellation_reason=None,
+        )
+        with patch(
+            "services.analysis.query_service.get_analysis",
+            AsyncMock(return_value=fake_run),
+        ):
+            response = client.delete(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["status"] == "cancelled"
+        assert body["cancellation_reason"] == "user"
+        assert fake_run.status == "cancelled"
+        assert fake_run.cancellation_reason == "user"
+
+    def test_idempotent_when_already_terminal(self, client, db_mock):
+        """Already-succeeded runs return 200 with current state, no flip."""
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        run_id = uuid4()
+        fake_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="succeeded",
+            triggered_by=_TEST_USER_ID,
+            started_at=datetime(2026, 5, 2),
+            finished_at=datetime(2026, 5, 2),
+            input_count=10,
+            cost_estimated_cents=5,
+            cost_actual_cents=4,
+            error=None,
+            cancellation_reason=None,
+        )
+        with patch(
+            "services.analysis.query_service.get_analysis",
+            AsyncMock(return_value=fake_run),
+        ):
+            response = client.delete(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "succeeded"  # NOT flipped to cancelled
+        assert fake_run.status == "succeeded"

--- a/backend/tests/integration/test_llm_pricing.py
+++ b/backend/tests/integration/test_llm_pricing.py
@@ -228,17 +228,24 @@ async def test_lookup_invalid_unit_type_raises(db_session):
 
 @pytest.mark.asyncio
 async def test_compute_cost_usd_per_million_tokens(db_session):
-    """1M tokens at $3/1M → $3.00; 100k tokens → $0.30."""
+    """1M tokens at $3/1M → $3.00; 100k tokens → $0.30.
+
+    Uses ``effective_from=2026-04-27`` (one day before the seed
+    migration's ``2026-04-28`` row) so the INSERT does not collide
+    with the seeded ``(anthropic, claude-sonnet-4-6, input_tokens,
+    2026-04-28)`` row on ``uq_llm_pricing_lookup_key`` when the
+    integration suite runs ``test_alembic_migrations`` before this
+    test. The lookup math is unchanged because ``$3/1M`` matches
+    the seeded rate; whichever row the temporal selector picks
+    produces the same expected cost.
+    """
+    insert_effective = datetime(2026, 4, 27)
     db_session.add(
         _make_row(
             provider="anthropic",
             model="claude-sonnet-4-6",
             unit_type="input_tokens",
-            effective_from=datetime(
-                2026,
-                4,
-                28,
-            ),
+            effective_from=insert_effective,
             price_per_unit="3.00",
         )
     )
@@ -249,11 +256,7 @@ async def test_compute_cost_usd_per_million_tokens(db_session):
         provider="anthropic",
         model="claude-sonnet-4-6",
         unit_type="input_tokens",
-        started_at=datetime(
-            2026,
-            4,
-            28,
-        ),
+        started_at=insert_effective,
         units=100_000,
     )
     assert cost is not None
@@ -264,11 +267,7 @@ async def test_compute_cost_usd_per_million_tokens(db_session):
         provider="anthropic",
         model="claude-sonnet-4-6",
         unit_type="input_tokens",
-        started_at=datetime(
-            2026,
-            4,
-            28,
-        ),
+        started_at=insert_effective,
         units=1_000_000,
     )
     assert cost_full == pytest.approx(3.00)
@@ -388,13 +387,19 @@ async def test_check_constraint_negative_price(db_session):
 
 @pytest.mark.asyncio
 async def test_check_constraint_zero_unit_denominator(db_session):
-    """DB CHECK rejects unit_denominator=0 (would produce divide-by-zero in cost math)."""
+    """DB CHECK rejects unit_denominator=0 (would produce divide-by-zero in cost math).
+
+    Uses ``effective_from=2026-04-27`` (off the seed migration's
+    ``2026-04-28`` row) so the IntegrityError raised on flush is the
+    expected ``unit_denominator=0`` CHECK violation, not a coincidental
+    ``uq_llm_pricing_lookup_key`` UNIQUE violation against the seed.
+    """
     db_session.add(
         LLMPricing(
             provider="anthropic",
             model="claude-sonnet-4-6",
             unit_type="input_tokens",
-            effective_from=datetime(2026, 4, 28),
+            effective_from=datetime(2026, 4, 27),
             price_per_unit="3.00",
             unit_denominator=0,
         )

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -1,0 +1,445 @@
+"""Unit tests for ``services/analysis/query_service`` (Issue #496).
+
+Covers the read-path helpers that REST routes, MCP tools, the
+``recall`` filter extension, and the ``/usage`` endpoint all share.
+
+Pagination contract (``get_cluster``):
+- ``limit`` is clamped server-side to ``MAX_CLUSTER_PAGE_SIZE`` (200).
+- ``cursor`` is the last memory_id UUID of the previous page; the next
+  query uses ``> cursor`` so the cursor row is not duplicated.
+- ``next_cursor`` is None on the last page.
+
+Tenancy invariant (``get_analysis``, ``list_analyses``,
+``get_active_analysis``, ``get_cluster``):
+- A run UUID stolen from a foreign workspace returns None instead of
+  the row, so existence is not leaked.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+
+from models.analysis import (
+    MemoryAnalysis,
+    MemoryAnalysisAssignment,
+    MemoryAnalysisCluster,
+)
+from models.memory import Memory
+from services.analysis import query_service
+from utils.datetime import utcnow
+
+
+@pytest_asyncio.fixture
+async def fixture_workspace_id(db_session) -> UUID:
+    from models.auth import Workspace
+
+    ws = Workspace(id=uuid4(), name="Test", owner_user_id="test_owner")
+    db_session.add(ws)
+    await db_session.flush()
+    return ws.id
+
+
+@pytest_asyncio.fixture
+async def fixture_other_workspace_id(db_session) -> UUID:
+    from models.auth import Workspace
+
+    ws = Workspace(id=uuid4(), name="Other", owner_user_id="other_owner")
+    db_session.add(ws)
+    await db_session.flush()
+    return ws.id
+
+
+@pytest_asyncio.fixture
+async def fixture_context_id(db_session, fixture_workspace_id) -> UUID:
+    from models.auth import Context
+
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=fixture_workspace_id,
+        name="test_ctx",
+        display_name="Test Context",
+        created_by="test_user",
+        is_private=False,
+    )
+    db_session.add(ctx)
+    await db_session.flush()
+    return ctx.id
+
+
+@pytest_asyncio.fixture
+async def fixture_pricing(db_session):
+    """Insert a stub llm_pricing row so MemoryAnalysis.model_id FK is satisfied.
+
+    The query_service tests do not exercise pricing logic; we just need
+    the FK target to exist.
+    """
+    from models.llm_pricing import LLMPricing
+
+    row = LLMPricing(
+        provider="openai",
+        model="gpt-5-nano",
+        unit_type="input_tokens",
+        price_per_unit=0.20,
+        effective_from=datetime(2026, 1, 1),
+    )
+    db_session.add(row)
+    await db_session.flush()
+    yield row
+
+
+async def _make_run(
+    db_session,
+    *,
+    workspace_id: UUID,
+    context_id: UUID,
+    pricing,
+    status: str = "succeeded",
+    started_offset_minutes: int = 0,
+) -> MemoryAnalysis:
+    """Insert a MemoryAnalysis row with reasonable defaults."""
+    started_at = utcnow() - timedelta(minutes=started_offset_minutes)
+    finished_at = (started_at + timedelta(seconds=10)) if status != "running" else None
+    run = MemoryAnalysis(
+        id=uuid4(),
+        workspace_id=workspace_id,
+        context_id=context_id,
+        triggered_by="test_user",
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+        model_id=pricing.id,
+        model_snapshot={"model": "gpt-5-nano", "rates": {}},
+        embedding_model="text-embedding-3-small",
+        params={},
+        input_count=10,
+        cost_estimated_cents=5,
+        cost_actual_cents=4 if status == "succeeded" else None,
+        paid_by="byok",
+    )
+    db_session.add(run)
+    await db_session.flush()
+    return run
+
+
+async def _make_cluster(
+    db_session,
+    *,
+    run: MemoryAnalysis,
+    cluster_index: int,
+    label: str = "test cluster",
+    rep_ids: list[UUID] | None = None,
+) -> MemoryAnalysisCluster:
+    cluster = MemoryAnalysisCluster(
+        id=uuid4(),
+        analysis_id=run.id,
+        cluster_index=cluster_index,
+        label=label,
+        description=None,
+        count=0,
+        centroid_2d=[0.0, 0.0],
+        representative_memory_ids=rep_ids or [],
+        property_stats={},
+        label_confidence=0.5,
+    )
+    db_session.add(cluster)
+    await db_session.flush()
+    return cluster
+
+
+async def _make_memory(db_session, *, workspace_id: UUID, context_id: UUID) -> Memory:
+    mem = Memory(
+        id=uuid4(),
+        workspace_id=workspace_id,
+        context_id=context_id,
+        user_id="test_user",
+        summary="test memory summary",
+        importance=0.5,
+        tags=["t1"],
+    )
+    db_session.add(mem)
+    await db_session.flush()
+    return mem
+
+
+@pytest.mark.asyncio
+async def test_get_analysis_returns_row_for_owner_workspace(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    run = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+    )
+    fetched = await query_service.get_analysis(
+        db_session, workspace_id=fixture_workspace_id, run_id=run.id
+    )
+    assert fetched is not None
+    assert fetched.id == run.id
+
+
+@pytest.mark.asyncio
+async def test_get_analysis_returns_none_for_foreign_workspace(
+    db_session,
+    fixture_workspace_id,
+    fixture_other_workspace_id,
+    fixture_context_id,
+    fixture_pricing,
+):
+    """Tenancy invariant: stolen run UUID must not leak existence."""
+    run = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+    )
+    fetched = await query_service.get_analysis(
+        db_session, workspace_id=fixture_other_workspace_id, run_id=run.id
+    )
+    assert fetched is None
+
+
+@pytest.mark.asyncio
+async def test_list_analyses_newest_first_with_cursor_pagination(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    runs = []
+    for offset in (60, 30, 10, 5):  # oldest first by minutes-ago
+        run = await _make_run(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+            pricing=fixture_pricing,
+            started_offset_minutes=offset,
+        )
+        runs.append(run)
+
+    # First page (limit=2) → 2 newest runs (5 min and 10 min ago)
+    page1, cursor = await query_service.list_analyses(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        limit=2,
+    )
+    assert len(page1) == 2
+    assert cursor is not None
+    assert page1[0].started_at > page1[1].started_at  # newest first
+
+    # Second page → remaining 2
+    page2, cursor2 = await query_service.list_analyses(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        limit=2,
+        cursor=cursor,
+    )
+    assert len(page2) == 2
+    assert cursor2 is None  # last page
+    # Pages should be disjoint
+    page1_ids = {r.id for r in page1}
+    page2_ids = {r.id for r in page2}
+    assert page1_ids.isdisjoint(page2_ids)
+
+
+@pytest.mark.asyncio
+async def test_get_active_analysis_returns_most_recent_succeeded(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    # Older succeeded
+    older = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        status="succeeded",
+        started_offset_minutes=120,
+    )
+    # Newer succeeded — this should win
+    newer = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        status="succeeded",
+        started_offset_minutes=10,
+    )
+    # Even-newer running run should NOT win (not succeeded)
+    await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+        status="running",
+        started_offset_minutes=2,
+    )
+    active = await query_service.get_active_analysis(
+        db_session, workspace_id=fixture_workspace_id, context_id=fixture_context_id
+    )
+    assert active is not None
+    assert active.id == newer.id
+    assert active.id != older.id
+
+
+@pytest.mark.asyncio
+async def test_get_memory_ids_in_cluster_returns_assignments(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    run = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+    )
+    cluster = await _make_cluster(db_session, run=run, cluster_index=3)
+    mems = [
+        await _make_memory(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+        )
+        for _ in range(3)
+    ]
+    for mem in mems:
+        db_session.add(
+            MemoryAnalysisAssignment(
+                analysis_id=run.id,
+                memory_id=mem.id,
+                cluster_id=cluster.id,
+                x=0.0,
+                y=0.0,
+            )
+        )
+    await db_session.flush()
+
+    ids = await query_service.get_memory_ids_in_cluster(db_session, run_id=run.id, cluster_index=3)
+    assert ids is not None
+    assert set(ids) == {m.id for m in mems}
+
+
+@pytest.mark.asyncio
+async def test_get_memory_ids_in_cluster_returns_none_for_unknown(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    run = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+    )
+    # cluster_index=99 was never created
+    ids = await query_service.get_memory_ids_in_cluster(db_session, run_id=run.id, cluster_index=99)
+    assert ids is None
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_returns_paginated_memories(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    run = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+    )
+    cluster = await _make_cluster(db_session, run=run, cluster_index=0, label="alpha")
+    # Create 5 memories assigned to the cluster.
+    mems = [
+        await _make_memory(
+            db_session,
+            workspace_id=fixture_workspace_id,
+            context_id=fixture_context_id,
+        )
+        for _ in range(5)
+    ]
+    for mem in mems:
+        db_session.add(
+            MemoryAnalysisAssignment(
+                analysis_id=run.id,
+                memory_id=mem.id,
+                cluster_id=cluster.id,
+                x=0.0,
+                y=0.0,
+            )
+        )
+    await db_session.flush()
+
+    # First page of 3 — expect next_cursor non-None
+    page1 = await query_service.get_cluster(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        run_id=run.id,
+        cluster_index=0,
+        limit=3,
+    )
+    assert page1 is not None
+    assert page1["label"] == "alpha"
+    assert len(page1["memories"]) == 3
+    assert page1["next_cursor"] is not None
+
+    # Second page → remaining 2, next_cursor None
+    page2 = await query_service.get_cluster(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        run_id=run.id,
+        cluster_index=0,
+        limit=3,
+        cursor=page1["next_cursor"],
+    )
+    assert page2 is not None
+    assert len(page2["memories"]) == 2
+    assert page2["next_cursor"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_returns_none_for_foreign_workspace(
+    db_session,
+    fixture_workspace_id,
+    fixture_other_workspace_id,
+    fixture_context_id,
+    fixture_pricing,
+):
+    run = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+    )
+    await _make_cluster(db_session, run=run, cluster_index=0)
+
+    cluster = await query_service.get_cluster(
+        db_session,
+        workspace_id=fixture_other_workspace_id,
+        run_id=run.id,
+        cluster_index=0,
+    )
+    assert cluster is None
+
+
+@pytest.mark.asyncio
+async def test_get_cluster_limit_clamped_to_max(
+    db_session, fixture_workspace_id, fixture_context_id, fixture_pricing
+):
+    """Server-side clamp: caller-supplied limit > MAX caps at MAX."""
+    run = await _make_run(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        context_id=fixture_context_id,
+        pricing=fixture_pricing,
+    )
+    await _make_cluster(db_session, run=run, cluster_index=0)
+    page = await query_service.get_cluster(
+        db_session,
+        workspace_id=fixture_workspace_id,
+        run_id=run.id,
+        cluster_index=0,
+        limit=500,  # > MAX_CLUSTER_PAGE_SIZE=200
+    )
+    # The clamp is internal to _clamp_limit; we verify behavior via the
+    # peek-one query: empty cluster yields 0 memories and no cursor.
+    assert page is not None
+    assert page["memories"] == []
+    assert page["next_cursor"] is None

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -157,8 +157,11 @@ async def _make_memory(db_session, *, workspace_id: UUID, context_id: UUID) -> M
         context_id=context_id,
         user_id="test_user",
         summary="test memory summary",
+        content="test memory content",
+        type="note",
         importance=0.5,
         tags=["t1"],
+        client="test",
     )
     db_session.add(mem)
     await db_session.flush()

--- a/backend/tests/services/analysis/test_query_service.py
+++ b/backend/tests/services/analysis/test_query_service.py
@@ -318,7 +318,9 @@ async def test_get_memory_ids_in_cluster_returns_assignments(
         )
     await db_session.flush()
 
-    ids = await query_service.get_memory_ids_in_cluster(db_session, run_id=run.id, cluster_index=3)
+    ids = await query_service.get_memory_ids_in_cluster(
+        db_session, workspace_id=fixture_workspace_id, run_id=run.id, cluster_index=3
+    )
     assert ids is not None
     assert set(ids) == {m.id for m in mems}
 
@@ -334,7 +336,9 @@ async def test_get_memory_ids_in_cluster_returns_none_for_unknown(
         pricing=fixture_pricing,
     )
     # cluster_index=99 was never created
-    ids = await query_service.get_memory_ids_in_cluster(db_session, run_id=run.id, cluster_index=99)
+    ids = await query_service.get_memory_ids_in_cluster(
+        db_session, workspace_id=fixture_workspace_id, run_id=run.id, cluster_index=99
+    )
     assert ids is None
 
 

--- a/backend/tests/services/test_recall_analysis_cluster_filter.py
+++ b/backend/tests/services/test_recall_analysis_cluster_filter.py
@@ -15,8 +15,11 @@ Behavior under test:
   and the PG SELECT step adds a ``Memory.id IN (cluster_member_ids)``
   predicate. The hybrid_search ranking still applies, but only over
   cluster members.
-- Invalid filter shape → ``ValueError`` (mapped to 422 at the API layer
-  by the existing validation middleware).
+- Invalid filter shape → ``ValidationError`` (a ``MemoryCloudException``
+  subclass — the global ``memory_cloud_exception_handler`` maps it to a
+  proper 422 with the structured ``{error, message, details}`` envelope.
+  Plain ``ValueError`` would 500 because the global handler doesn't
+  match it — caught by Copilot review loop 5).
 """
 
 from __future__ import annotations
@@ -27,6 +30,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from models.schemas import RecallRequest
+from utils.exceptions import ValidationError
 
 
 @pytest.fixture
@@ -132,7 +136,7 @@ async def test_analysis_cluster_filter_expands_candidates_k(fake_run_id, cluster
 
 @pytest.mark.asyncio
 async def test_analysis_cluster_filter_invalid_run_id_raises():
-    """``run_id`` not a UUID → ValueError."""
+    """``run_id`` not a UUID → ``ValidationError`` (mapped to 422 by global handler)."""
     svc, _db = _make_service()
     request = RecallRequest(
         query="test",
@@ -140,7 +144,7 @@ async def test_analysis_cluster_filter_invalid_run_id_raises():
         filters={"analysis_cluster": {"run_id": "not-a-uuid", "cluster_index": 3}},
     )
 
-    with pytest.raises(ValueError, match="run_id"):
+    with pytest.raises(ValidationError, match="run_id"):
         await svc.recall(
             request=request,
             user_id="test_user",
@@ -151,7 +155,7 @@ async def test_analysis_cluster_filter_invalid_run_id_raises():
 
 @pytest.mark.asyncio
 async def test_analysis_cluster_filter_missing_cluster_index_raises(fake_run_id):
-    """``cluster_index`` missing → ValueError."""
+    """``cluster_index`` missing → ``ValidationError`` (mapped to 422 by global handler)."""
     svc, _db = _make_service()
     request = RecallRequest(
         query="test",
@@ -159,10 +163,44 @@ async def test_analysis_cluster_filter_missing_cluster_index_raises(fake_run_id)
         filters={"analysis_cluster": {"run_id": str(fake_run_id)}},
     )
 
-    with pytest.raises(ValueError, match="cluster_index"):
+    with pytest.raises(ValidationError, match="cluster_index"):
         await svc.recall(
             request=request,
             user_id="test_user",
             current_context_id=uuid4(),
             current_workspace_id=uuid4(),
         )
+
+
+@pytest.mark.asyncio
+async def test_analysis_cluster_filter_validation_error_maps_to_422(fake_run_id):
+    """Regression: the validation exception MUST be ``ValidationError`` (a
+    ``MemoryCloudException`` subclass with ``status_code=422``) so the
+    global ``memory_cloud_exception_handler`` returns a clean 422.
+    Plain ``ValueError`` would 500 because the handler only catches
+    ``MemoryCloudException``. Caught by Copilot review loop 5.
+    """
+    svc, _db = _make_service()
+    request = RecallRequest(
+        query="test",
+        k=5,
+        filters={"analysis_cluster": "not-a-dict"},  # invalid shape — string instead of object
+    )
+
+    try:
+        await svc.recall(
+            request=request,
+            user_id="test_user",
+            current_context_id=uuid4(),
+            current_workspace_id=uuid4(),
+        )
+    except ValidationError as exc:
+        assert exc.status_code == 422
+        assert exc.error_code == "VAL-001"
+        assert "filters.analysis_cluster" in exc.details.get("field", "")
+    except Exception as exc:  # noqa: BLE001
+        raise AssertionError(
+            f"Expected ValidationError (→ 422), got {type(exc).__name__}: {exc}"
+        ) from exc
+    else:
+        raise AssertionError("Expected ValidationError, but recall() did not raise")

--- a/backend/tests/services/test_recall_analysis_cluster_filter.py
+++ b/backend/tests/services/test_recall_analysis_cluster_filter.py
@@ -1,0 +1,168 @@
+"""Recall ``analysis_cluster`` filter integration test (Issue #496).
+
+Verifies the new filter key in ``services/memory_service.py:recall``:
+
+    recall(filters={"analysis_cluster": {"run_id": "...", "cluster_index": 3}})
+
+Behavior under test:
+
+- ``analysis_cluster`` pre-resolves the cluster's memory_ids via
+  ``query_service.get_memory_ids_in_cluster``. Empty cluster → early
+  empty return without calling ``hybrid_search`` (verified by mock
+  call count).
+- Non-empty cluster → ``hybrid_search`` is called with an expanded
+  ``candidates_k`` (so the post-filter does not starve a small ``k``)
+  and the PG SELECT step adds a ``Memory.id IN (cluster_member_ids)``
+  predicate. The hybrid_search ranking still applies, but only over
+  cluster members.
+- Invalid filter shape → ``ValueError`` (mapped to 422 at the API layer
+  by the existing validation middleware).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from models.schemas import RecallRequest
+
+
+@pytest.fixture
+def fake_run_id() -> UUID:
+    return uuid4()
+
+
+@pytest.fixture
+def cluster_member_ids() -> list[UUID]:
+    return [uuid4() for _ in range(5)]
+
+
+def _make_service():
+    """Return a MemoryService instance with mocked dependencies for unit tests."""
+    from services.memory_service import MemoryService
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    svc = MemoryService(db)
+    svc.search_service = MagicMock()
+    svc.search_service.hybrid_search = AsyncMock(return_value=[])
+    svc.memory_repo = MagicMock()
+    return svc, db
+
+
+@pytest.mark.asyncio
+async def test_analysis_cluster_filter_short_circuits_when_cluster_empty(fake_run_id):
+    """Empty cluster → return early, do not call hybrid_search."""
+    svc, _db = _make_service()
+    request = RecallRequest(
+        query="test",
+        k=5,
+        filters={"analysis_cluster": {"run_id": str(fake_run_id), "cluster_index": 3}},
+    )
+
+    with patch(
+        "services.analysis.query_service.get_memory_ids_in_cluster",
+        AsyncMock(return_value=[]),
+    ):
+        response = await svc.recall(
+            request=request,
+            user_id="test_user",
+            current_context_id=uuid4(),
+            current_workspace_id=uuid4(),
+        )
+
+    assert response.results == []
+    svc.search_service.hybrid_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_analysis_cluster_filter_unknown_cluster_returns_empty(fake_run_id):
+    """Unknown cluster (None from query_service) → also early empty return."""
+    svc, _db = _make_service()
+    request = RecallRequest(
+        query="test",
+        k=5,
+        filters={"analysis_cluster": {"run_id": str(fake_run_id), "cluster_index": 999}},
+    )
+
+    with patch(
+        "services.analysis.query_service.get_memory_ids_in_cluster",
+        AsyncMock(return_value=None),
+    ):
+        response = await svc.recall(
+            request=request,
+            user_id="test_user",
+            current_context_id=uuid4(),
+            current_workspace_id=uuid4(),
+        )
+
+    assert response.results == []
+    svc.search_service.hybrid_search.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_analysis_cluster_filter_expands_candidates_k(fake_run_id, cluster_member_ids):
+    """Non-empty cluster → candidates_k bumped to cover whole cluster + buffer."""
+    svc, _db = _make_service()
+    request = RecallRequest(
+        query="test",
+        k=5,
+        filters={"analysis_cluster": {"run_id": str(fake_run_id), "cluster_index": 3}},
+    )
+
+    with patch(
+        "services.analysis.query_service.get_memory_ids_in_cluster",
+        AsyncMock(return_value=cluster_member_ids),
+    ):
+        await svc.recall(
+            request=request,
+            user_id="test_user",
+            current_context_id=uuid4(),
+            current_workspace_id=uuid4(),
+        )
+
+    # candidates_k = max(k or k*4, len(cluster) + 50). With 5 cluster members
+    # the formula gives max(5, 55) = 55. The kwargs of hybrid_search expose ``k``.
+    svc.search_service.hybrid_search.assert_called_once()
+    call_kwargs = svc.search_service.hybrid_search.call_args.kwargs
+    assert call_kwargs["k"] >= len(cluster_member_ids) + 50
+
+
+@pytest.mark.asyncio
+async def test_analysis_cluster_filter_invalid_run_id_raises():
+    """``run_id`` not a UUID → ValueError."""
+    svc, _db = _make_service()
+    request = RecallRequest(
+        query="test",
+        k=5,
+        filters={"analysis_cluster": {"run_id": "not-a-uuid", "cluster_index": 3}},
+    )
+
+    with pytest.raises(ValueError, match="run_id"):
+        await svc.recall(
+            request=request,
+            user_id="test_user",
+            current_context_id=uuid4(),
+            current_workspace_id=uuid4(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_analysis_cluster_filter_missing_cluster_index_raises(fake_run_id):
+    """``cluster_index`` missing → ValueError."""
+    svc, _db = _make_service()
+    request = RecallRequest(
+        query="test",
+        k=5,
+        filters={"analysis_cluster": {"run_id": str(fake_run_id)}},
+    )
+
+    with pytest.raises(ValueError, match="cluster_index"):
+        await svc.recall(
+            request=request,
+            user_id="test_user",
+            current_context_id=uuid4(),
+            current_workspace_id=uuid4(),
+        )

--- a/backend/tests/services/test_stripe_service.py
+++ b/backend/tests/services/test_stripe_service.py
@@ -201,3 +201,320 @@ async def test_shutdown_erasure_executor_after_use_is_idempotent():
 
     shutdown_erasure_executor()
     assert stripe_service._erasure_executor is None
+
+
+# ---------------------------------------------------------------------------
+# create_portal_session
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_portal_session_missing_customer_raises():
+    workspace_id = uuid4()
+    workspace = MagicMock()
+    workspace.id = workspace_id
+    workspace.stripe_customer_id = None
+
+    result_proxy = MagicMock()
+    result_proxy.scalar_one_or_none.return_value = workspace
+    db = AsyncMock()
+    db.execute.return_value = result_proxy
+
+    with patch("services.stripe_service._init_stripe"):
+        with pytest.raises(ValueError, match="No Stripe customer linked"):
+            from services.stripe_service import create_portal_session
+
+            await create_portal_session(db, workspace_id, "https://example.com/return")
+
+
+@pytest.mark.asyncio
+async def test_create_portal_session_success():
+    workspace_id = uuid4()
+    workspace = MagicMock()
+    workspace.id = workspace_id
+    workspace.stripe_customer_id = "cus_123"
+
+    result_proxy = MagicMock()
+    result_proxy.scalar_one_or_none.return_value = workspace
+    db = AsyncMock()
+    db.execute.return_value = result_proxy
+
+    fake_session = MagicMock()
+    fake_session.url = "https://billing.stripe.com/session/portal_123"
+
+    with (
+        patch("services.stripe_service._init_stripe"),
+        patch(
+            "services.stripe_service._run_stripe", new_callable=AsyncMock, return_value=fake_session
+        ),
+    ):
+        from services.stripe_service import create_portal_session
+
+        url = await create_portal_session(db, workspace_id, "https://example.com/return")
+        assert url == "https://billing.stripe.com/session/portal_123"
+
+
+# ---------------------------------------------------------------------------
+# handle_webhook_event
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_checkout_completed():
+    db = AsyncMock()
+    settings = MagicMock()
+    settings.stripe_webhook_secret = "whsec_test"
+
+    event = {
+        "id": "evt_123",
+        "type": "checkout.session.completed",
+        "data": {
+            "object": {
+                "metadata": {"workspace_id": str(uuid4()), "plan_name": "pro"},
+                "customer": "cus_123",
+                "subscription": "sub_123",
+            }
+        },
+    }
+
+    with (
+        patch("services.stripe_service.get_settings", return_value=settings),
+        patch("stripe.Webhook.construct_event", return_value=event),
+        patch("services.stripe_service._apply_plan_change", new_callable=AsyncMock) as mock_apply,
+    ):
+        from services.stripe_service import handle_webhook_event
+
+        result = await handle_webhook_event(db, b"payload", "sig")
+        assert result["event_type"] == "checkout.session.completed"
+        assert result["status"] == "processed"
+        mock_apply.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_subscription_deleted():
+    db = AsyncMock()
+    settings = MagicMock()
+    settings.stripe_webhook_secret = "whsec_test"
+
+    event = {
+        "id": "evt_456",
+        "type": "customer.subscription.deleted",
+        "data": {"object": {"customer": "cus_456"}},
+    }
+
+    with (
+        patch("services.stripe_service.get_settings", return_value=settings),
+        patch("stripe.Webhook.construct_event", return_value=event),
+        patch(
+            "services.stripe_service._handle_subscription_cancelled", new_callable=AsyncMock
+        ) as mock_cancel,
+    ):
+        from services.stripe_service import handle_webhook_event
+
+        result = await handle_webhook_event(db, b"payload", "sig")
+        assert result["event_type"] == "customer.subscription.deleted"
+        mock_cancel.assert_called_once_with(db, "cus_456")
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_payment_failed():
+    db = AsyncMock()
+    settings = MagicMock()
+    settings.stripe_webhook_secret = "whsec_test"
+
+    event = {
+        "id": "evt_789",
+        "type": "invoice.payment_failed",
+        "data": {"object": {"customer": "cus_789", "id": "in_789"}},
+    }
+
+    with (
+        patch("services.stripe_service.get_settings", return_value=settings),
+        patch("stripe.Webhook.construct_event", return_value=event),
+    ):
+        from services.stripe_service import handle_webhook_event
+
+        result = await handle_webhook_event(db, b"payload", "sig")
+        assert result["event_type"] == "invoice.payment_failed"
+
+
+@pytest.mark.asyncio
+async def test_handle_webhook_missing_secret_raises():
+    db = AsyncMock()
+    settings = MagicMock()
+    settings.stripe_webhook_secret = None
+
+    with patch("services.stripe_service.get_settings", return_value=settings):
+        from services.stripe_service import handle_webhook_event
+
+        with pytest.raises(ValueError, match="STRIPE_WEBHOOK_SECRET not configured"):
+            await handle_webhook_event(db, b"payload", "sig")
+
+
+# ---------------------------------------------------------------------------
+# _apply_plan_change
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_plan_change_workspace_not_found():
+    db = AsyncMock()
+    result_proxy = MagicMock()
+    result_proxy.scalar_one_or_none.return_value = None
+    db.execute.return_value = result_proxy
+
+    with patch("services.stripe_service.get_plan_tier") as mock_tier:
+        from services.stripe_service import _apply_plan_change
+
+        await _apply_plan_change(db, uuid4(), "pro", "cus_123", "sub_123")
+        mock_tier.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_apply_plan_change_success():
+    workspace = MagicMock()
+    workspace.id = uuid4()
+    workspace.plan_name = "free"
+    workspace.memory_limit = 100
+
+    result_proxy = MagicMock()
+    result_proxy.scalar_one_or_none.return_value = workspace
+    db = AsyncMock()
+    db.execute.return_value = result_proxy
+
+    tier = MagicMock()
+    tier.memory_limit = 500
+    tier.daily_api_limit = 1000
+    tier.weekly_api_limit = 5000
+
+    with patch("services.stripe_service.get_plan_tier", return_value=tier):
+        from services.stripe_service import _apply_plan_change
+
+        await _apply_plan_change(db, workspace.id, "pro", "cus_123", "sub_123")
+
+    assert workspace.plan_name == "pro"
+    assert workspace.memory_limit == 500
+    assert workspace.stripe_customer_id == "cus_123"
+    assert workspace.stripe_subscription_id == "sub_123"
+    db.add.assert_called_once()
+    db.commit.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _handle_subscription_cancelled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_handle_subscription_cancelled_downgrades_to_free():
+    workspace = MagicMock()
+    workspace.id = uuid4()
+    workspace.plan_name = "pro"
+
+    result_proxy = MagicMock()
+    result_proxy.scalar_one_or_none.return_value = workspace
+    db = AsyncMock()
+    db.execute.return_value = result_proxy
+
+    free_tier = MagicMock()
+    free_tier.memory_limit = 100
+    free_tier.daily_api_limit = 100
+    free_tier.weekly_api_limit = 500
+
+    with patch("services.stripe_service.get_plan_tier", return_value=free_tier):
+        from services.stripe_service import _handle_subscription_cancelled
+
+        await _handle_subscription_cancelled(db, "cus_123")
+
+    assert workspace.plan_name == "free"
+    assert workspace.memory_limit == 100
+    assert workspace.stripe_subscription_id is None
+    db.add.assert_called_once()
+    db.commit.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_subscription_cancelled_workspace_not_found():
+    db = AsyncMock()
+    result_proxy = MagicMock()
+    result_proxy.scalar_one_or_none.return_value = None
+    db.execute.return_value = result_proxy
+
+    from services.stripe_service import _handle_subscription_cancelled
+
+    await _handle_subscription_cancelled(db, "cus_ghost")
+    db.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# cancel_subscription_and_delete_customer_for_erasure
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_erasure_noop_when_billing_disabled():
+    workspace = MagicMock()
+    workspace.stripe_customer_id = "cus_123"
+    workspace.stripe_subscription_id = "sub_123"
+
+    with patch("plugins.billing.is_billing_enabled", return_value=False):
+        from services.stripe_service import cancel_subscription_and_delete_customer_for_erasure
+
+        result = await cancel_subscription_and_delete_customer_for_erasure(workspace)
+        assert result == {"subscription_cancelled": False, "customer_deleted": False}
+
+
+@pytest.mark.asyncio
+async def test_erasure_noop_when_no_stripe_ids():
+    workspace = MagicMock()
+    workspace.stripe_customer_id = None
+    workspace.stripe_subscription_id = None
+
+    with patch("plugins.billing.is_billing_enabled", return_value=True):
+        from services.stripe_service import cancel_subscription_and_delete_customer_for_erasure
+
+        result = await cancel_subscription_and_delete_customer_for_erasure(workspace)
+        assert result == {"subscription_cancelled": False, "customer_deleted": False}
+
+
+@pytest.mark.asyncio
+async def test_erasure_success_cancel_and_delete():
+    workspace = MagicMock()
+    workspace.id = uuid4()
+    workspace.stripe_customer_id = "cus_123"
+    workspace.stripe_subscription_id = "sub_123"
+
+    with (
+        patch("plugins.billing.is_billing_enabled", return_value=True),
+        patch("services.stripe_service._init_stripe"),
+        patch(
+            "services.stripe_service._run_stripe_erasure", new_callable=AsyncMock, return_value=None
+        ),
+    ):
+        from services.stripe_service import cancel_subscription_and_delete_customer_for_erasure
+
+        result = await cancel_subscription_and_delete_customer_for_erasure(workspace)
+        assert result == {"subscription_cancelled": True, "customer_deleted": True}
+
+
+@pytest.mark.asyncio
+async def test_erasure_partial_failure_continues():
+    workspace = MagicMock()
+    workspace.id = uuid4()
+    workspace.stripe_customer_id = "cus_123"
+    workspace.stripe_subscription_id = "sub_123"
+
+    async def fake_erasure(func, *args, **kwargs):
+        if "Subscription" in str(func):
+            raise RuntimeError("Stripe timeout")
+        return None
+
+    with (
+        patch("plugins.billing.is_billing_enabled", return_value=True),
+        patch("services.stripe_service._init_stripe"),
+        patch("services.stripe_service._run_stripe_erasure", side_effect=fake_erasure),
+    ):
+        from services.stripe_service import cancel_subscription_and_delete_customer_for_erasure
+
+        result = await cancel_subscription_and_delete_customer_for_erasure(workspace)
+        assert result == {"subscription_cancelled": False, "customer_deleted": True}

--- a/backend/tests/services/test_system_admin_service.py
+++ b/backend/tests/services/test_system_admin_service.py
@@ -1,0 +1,238 @@
+"""Tests for services/system_admin_service.py.
+
+Covers listing, promotion, demotion, and deletion-guard logic.
+All tests use the real db_session fixture (async SQLAlchemy).
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from models.auth import AuditLog, User
+from services.system_admin_service import SystemAdminService
+
+
+@pytest_asyncio.fixture
+async def fixture_admin(db_session):
+    """Create a system admin user."""
+    user = User(
+        email="admin@example.com",
+        user_id="admin-001",
+        role="admin",
+        is_initial_admin=True,
+        auth_provider="google",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def fixture_regular(db_session):
+    """Create a regular user."""
+    user = User(
+        email="user@example.com",
+        user_id="user-001",
+        role="user",
+        is_initial_admin=False,
+        auth_provider="google",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def fixture_second_admin(db_session):
+    """Create a second system admin (not initial)."""
+    user = User(
+        email="admin2@example.com",
+        user_id="admin-002",
+        role="admin",
+        is_initial_admin=False,
+        auth_provider="github",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+class TestListSystemAdmins:
+    @pytest.mark.asyncio
+    async def test_empty_list(self, db_session):
+        service = SystemAdminService(db_session)
+        admins, initial_id = await service.list_system_admins()
+        assert admins == []
+        assert initial_id == 0
+
+    @pytest.mark.asyncio
+    async def test_single_admin(self, db_session, fixture_admin):
+        service = SystemAdminService(db_session)
+        admins, initial_id = await service.list_system_admins()
+        assert len(admins) == 1
+        assert admins[0].id == fixture_admin.id
+        assert initial_id == fixture_admin.id
+
+    @pytest.mark.asyncio
+    async def test_multiple_admins_initial_preserved(
+        self, db_session, fixture_admin, fixture_second_admin
+    ):
+        service = SystemAdminService(db_session)
+        admins, initial_id = await service.list_system_admins()
+        assert len(admins) == 2
+        assert initial_id == fixture_admin.id
+
+    @pytest.mark.asyncio
+    async def test_fallback_first_admin_when_no_initial_flag(self, db_session):
+        """If no admin has is_initial_admin=True, initial_id falls back to first admin."""
+        a1 = User(email="a1@example.com", user_id="a1", role="admin", is_initial_admin=False)
+        db_session.add(a1)
+        await db_session.flush()
+
+        service = SystemAdminService(db_session)
+        admins, initial_id = await service.list_system_admins()
+        assert initial_id == a1.id
+
+
+class TestPromoteToSystemAdmin:
+    @pytest.mark.asyncio
+    async def test_promote_success(self, db_session, fixture_regular):
+        service = SystemAdminService(db_session)
+        result = await service.promote_to_system_admin(
+            fixture_regular.user_id, promoted_by="promoter@example.com"
+        )
+        assert result.role == "admin"
+
+        # Verify via DB
+        stmt = select(User).where(User.user_id == fixture_regular.user_id)
+        user = (await db_session.execute(stmt)).scalar_one()
+        assert user.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_promote_creates_audit_log(self, db_session, fixture_regular):
+        service = SystemAdminService(db_session)
+        await service.promote_to_system_admin(
+            fixture_regular.user_id, promoted_by="promoter@example.com"
+        )
+        await db_session.flush()
+
+        stmt = select(AuditLog).where(AuditLog.action == "system_admin_promote")
+        audit = (await db_session.execute(stmt)).scalar_one()
+        assert audit.user_id == fixture_regular.user_id
+        assert audit.old_value_hash == "user"
+        assert audit.new_value_hash == "admin"
+        assert audit.user_metadata["promoted_by"] == "promoter@example.com"
+
+    @pytest.mark.asyncio
+    async def test_promote_user_not_found_raises_404(self, db_session):
+        service = SystemAdminService(db_session)
+        with pytest.raises(HTTPException) as exc:
+            await service.promote_to_system_admin("nonexistent", "promoter@example.com")
+        assert exc.value.status_code == 404
+        assert "User not found" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_promote_already_admin_raises_400(self, db_session, fixture_admin):
+        service = SystemAdminService(db_session)
+        with pytest.raises(HTTPException) as exc:
+            await service.promote_to_system_admin(fixture_admin.user_id, "promoter@example.com")
+        assert exc.value.status_code == 400
+        assert "already a system admin" in exc.value.detail
+
+
+class TestDemoteSystemAdmin:
+    @pytest.mark.asyncio
+    async def test_demote_success(self, db_session, fixture_admin, fixture_second_admin):
+        service = SystemAdminService(db_session)
+        result = await service.demote_system_admin(
+            fixture_second_admin.user_id, demoted_by="demoter@example.com"
+        )
+        assert result.role == "user"
+
+    @pytest.mark.asyncio
+    async def test_demote_creates_audit_log(self, db_session, fixture_admin, fixture_second_admin):
+        service = SystemAdminService(db_session)
+        await service.demote_system_admin(
+            fixture_second_admin.user_id, demoted_by="demoter@example.com"
+        )
+        await db_session.flush()
+
+        stmt = select(AuditLog).where(AuditLog.action == "system_admin_demote")
+        audit = (await db_session.execute(stmt)).scalar_one()
+        assert audit.user_id == fixture_second_admin.user_id
+        assert audit.old_value_hash == "admin"
+        assert audit.new_value_hash == "user"
+
+    @pytest.mark.asyncio
+    async def test_demote_user_not_found_raises_404(self, db_session):
+        service = SystemAdminService(db_session)
+        with pytest.raises(HTTPException) as exc:
+            await service.demote_system_admin("nonexistent", "demoter@example.com")
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_demote_not_admin_raises_400(self, db_session, fixture_regular):
+        service = SystemAdminService(db_session)
+        with pytest.raises(HTTPException) as exc:
+            await service.demote_system_admin(fixture_regular.user_id, "demoter@example.com")
+        assert exc.value.status_code == 400
+        assert "not a system admin" in exc.value.detail
+
+    @pytest.mark.asyncio
+    async def test_demote_initial_admin_raises_403(self, db_session, fixture_admin):
+        service = SystemAdminService(db_session)
+        with pytest.raises(HTTPException) as exc:
+            await service.demote_system_admin(fixture_admin.user_id, "demoter@example.com")
+        assert exc.value.status_code == 403
+        assert "initial" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_demote_last_admin_raises_403(self, db_session, fixture_admin):
+        """Only one admin exists — cannot demote them."""
+        service = SystemAdminService(db_session)
+        with pytest.raises(HTTPException) as exc:
+            await service.demote_system_admin(fixture_admin.user_id, "demoter@example.com")
+        assert exc.value.status_code == 403
+        assert "last" in exc.value.detail.lower()
+
+
+class TestCanDeleteAdmin:
+    @pytest.mark.asyncio
+    async def test_not_admin_returns_allowed(self, db_session, fixture_regular):
+        service = SystemAdminService(db_session)
+        ok, reason = await service.can_delete_admin(fixture_regular.user_id)
+        assert ok is True
+        assert reason == ""
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_returns_allowed(self, db_session):
+        service = SystemAdminService(db_session)
+        ok, reason = await service.can_delete_admin("ghost")
+        assert ok is True
+        assert reason == ""
+
+    @pytest.mark.asyncio
+    async def test_initial_admin_blocked(self, db_session, fixture_admin):
+        service = SystemAdminService(db_session)
+        ok, reason = await service.can_delete_admin(fixture_admin.user_id)
+        assert ok is False
+        assert "initial" in reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_last_admin_blocked(self, db_session, fixture_admin):
+        service = SystemAdminService(db_session)
+        ok, reason = await service.can_delete_admin(fixture_admin.user_id)
+        assert ok is False
+        assert "last" in reason.lower()
+
+    @pytest.mark.asyncio
+    async def test_allowed_when_multiple_admins(
+        self, db_session, fixture_admin, fixture_second_admin
+    ):
+        service = SystemAdminService(db_session)
+        ok, reason = await service.can_delete_admin(fixture_second_admin.user_id)
+        assert ok is True
+        assert reason == ""

--- a/backend/tests/tasks/test_embedding_tasks.py
+++ b/backend/tests/tasks/test_embedding_tasks.py
@@ -110,22 +110,45 @@ class TestSweepPendingEmbeddings:
 
     @pytest.mark.asyncio
     async def test_exception_during_single_embedding_is_logged(self):
-        """One failing process_pending_embedding must not abort the rest."""
+        """One failing process_pending_embedding must not abort the rest.
+
+        Asserts the iteration *actually* keeps going past the first
+        failure: if the loop short-circuits on exception, ``call_count``
+        would be 1 (only the failed first id ever attempted) and the
+        test would silently pass without this assertion. Pin
+        ``call_count == len(ids)`` and explicit verification that the
+        second id was attempted, so a regression that aborts the sweep
+        on first error fails loud.
+        """
         ids = [uuid4(), uuid4()]
         mock_db = MagicMock()
         mock_result = MagicMock()
         mock_result.all.return_value = [(i,) for i in ids]
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        async def flaky_process(mid):
+        flaky_process = AsyncMock()
+
+        async def flaky_side_effect(mid):
             if mid == ids[0]:
                 raise RuntimeError("embedding failed")
 
+        flaky_process.side_effect = flaky_side_effect
+
         with (
             patch("db.base.get_db", _mock_get_db(mock_db)),
-            patch("services.memory_service.process_pending_embedding", side_effect=flaky_process),
+            patch("services.memory_service.process_pending_embedding", flaky_process),
         ):
             await sweep_pending_embeddings()
 
-        # Both should have been attempted
-        # (the second continues despite first failure)
+        # Both should have been attempted (the second continues despite
+        # first failure). Without these asserts the test silently passes
+        # even if the sweep aborts on first exception.
+        assert flaky_process.call_count == len(ids), (
+            f"Expected {len(ids)} attempts (one per id) but only "
+            f"{flaky_process.call_count} happened — sweep aborted early."
+        )
+        attempted_ids = {call.args[0] for call in flaky_process.call_args_list}
+        assert ids[1] in attempted_ids, (
+            "Second id was not attempted after first id raised — sweep "
+            "failed to recover and continue iteration."
+        )

--- a/backend/tests/tasks/test_embedding_tasks.py
+++ b/backend/tests/tasks/test_embedding_tasks.py
@@ -1,0 +1,131 @@
+"""Tests for tasks/embedding_tasks.py.
+
+Covers sweep logic and scheduler registration.  All heavy dependencies
+(DB, embedding service) are patched so tests run without Docker.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from tasks.embedding_tasks import schedule_embedding_tasks, sweep_pending_embeddings
+
+
+def _mock_get_db(mock_db):
+    """Return an async generator that yields mock_db once."""
+
+    async def get_db():
+        yield mock_db
+
+    return get_db
+
+
+class TestScheduleEmbeddingTasks:
+    def test_registers_job_with_correct_interval(self):
+        scheduler = MagicMock()
+        schedule_embedding_tasks(scheduler)
+
+        scheduler.add_job.assert_called_once()
+        call = scheduler.add_job.call_args
+        assert call.kwargs["id"] == "sweep_pending_embeddings"
+        assert call.kwargs["name"] == "Sweep Pending Embeddings"
+        assert call.kwargs["replace_existing"] is True
+        # IntervalTrigger(seconds=30)
+        trigger = call.kwargs["trigger"]
+        assert trigger.interval.total_seconds() == 30
+
+
+class TestSweepPendingEmbeddings:
+    @pytest.mark.asyncio
+    async def test_no_stale_memories_exits_early(self):
+        """When query returns nothing, function returns after the empty check."""
+        mock_db = MagicMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with patch("db.base.get_db", _mock_get_db(mock_db)):
+            await sweep_pending_embeddings()
+
+        mock_db.execute.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_processes_pending_ids(self):
+        """Each pending memory ID triggers process_pending_embedding."""
+        ids = [uuid4(), uuid4()]
+        mock_db = MagicMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = [(i,) for i in ids]
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        with (
+            patch("db.base.get_db", _mock_get_db(mock_db)),
+            patch(
+                "services.memory_service.process_pending_embedding", new=AsyncMock()
+            ) as mock_process,
+        ):
+            await sweep_pending_embeddings()
+
+        assert mock_process.call_count == 2
+        mock_process.assert_any_call(ids[0])
+        mock_process.assert_any_call(ids[1])
+
+    @pytest.mark.asyncio
+    async def test_limit_respected(self):
+        """The query uses LIMIT 20."""
+        mock_db = MagicMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        captured_stmt = None
+
+        async def capture_execute(stmt):
+            nonlocal captured_stmt
+            captured_stmt = stmt
+            return mock_result
+
+        mock_db.execute.side_effect = capture_execute
+
+        with patch("db.base.get_db", _mock_get_db(mock_db)):
+            await sweep_pending_embeddings()
+
+        assert captured_stmt is not None
+        # Compiled SQL should contain LIMIT
+        compiled = str(captured_stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "LIMIT" in compiled.upper()
+
+    @pytest.mark.asyncio
+    async def test_exception_during_sweep_is_logged(self):
+        """Errors inside the sweep are caught and logged, not re-raised."""
+        mock_db = MagicMock()
+        mock_db.execute = AsyncMock(side_effect=RuntimeError("DB exploded"))
+
+        with patch("db.base.get_db", _mock_get_db(mock_db)):
+            # Should not raise despite DB error
+            await sweep_pending_embeddings()
+
+    @pytest.mark.asyncio
+    async def test_exception_during_single_embedding_is_logged(self):
+        """One failing process_pending_embedding must not abort the rest."""
+        ids = [uuid4(), uuid4()]
+        mock_db = MagicMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = [(i,) for i in ids]
+        mock_db.execute = AsyncMock(return_value=mock_result)
+
+        async def flaky_process(mid):
+            if mid == ids[0]:
+                raise RuntimeError("embedding failed")
+
+        with (
+            patch("db.base.get_db", _mock_get_db(mock_db)),
+            patch("services.memory_service.process_pending_embedding", side_effect=flaky_process),
+        ):
+            await sweep_pending_embeddings()
+
+        # Both should have been attempted
+        # (the second continues despite first failure)

--- a/backend/tests/test_single_collection_isolation.py
+++ b/backend/tests/test_single_collection_isolation.py
@@ -16,6 +16,29 @@ from models.schemas import ExploreRequest, RecallRequest, RememberRequest
 from services.memory_service import MemoryService
 
 
+@pytest.fixture(autouse=True)
+def patch_database_url(monkeypatch):
+    """Ensure DATABASE_URL points to the test DB so background embedding tasks find rows.
+
+    process_pending_embedding creates its own DB session via get_db(), which
+    imports DATABASE_URL from config.database. That constant is set at module
+    import time, so monkeypatching os.environ alone is not enough — we must
+    also patch the module-level constant and reset the engine singleton so
+    the background task creates a fresh engine pointing at the test DB.
+    """
+    import config.database
+    import db.base
+    from tests.conftest import TEST_DATABASE_URL
+
+    monkeypatch.setattr(config.database, "DATABASE_URL", TEST_DATABASE_URL)
+    monkeypatch.setenv("DATABASE_URL", TEST_DATABASE_URL)
+
+    # Reset engine singletons so get_db() recreates them with the patched URL
+    db.base.engine = None
+    db.base.async_session_factory = None
+    db.base.sync_engine = None
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def reset_redis_singleton():
     """Reset Redis singleton before each test to avoid event loop mismatch.

--- a/backend/tests/utils/test_auth_helpers.py
+++ b/backend/tests/utils/test_auth_helpers.py
@@ -1,0 +1,160 @@
+"""Tests for utils/auth_helpers.py.
+
+Pure utility — no DB or external services required.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from utils.auth_helpers import (
+    get_user_email,
+    get_user_id,
+    get_user_role,
+    is_admin,
+    verify_ownership,
+)
+
+
+class TestGetUserId:
+    def test_dict_with_user_id(self):
+        user = {"user_id": "abc123", "email": "user@example.com"}
+        assert get_user_id(user) == "abc123"
+
+    def test_dict_with_sub(self):
+        user = {"sub": "oauth-sub-456", "email": "user@example.com"}
+        assert get_user_id(user) == "oauth-sub-456"
+
+    def test_dict_with_id(self):
+        user = {"id": "orm-id-789", "email": "user@example.com"}
+        assert get_user_id(user) == "orm-id-789"
+
+    def test_dict_missing_keys_raises_401(self):
+        user = {"email": "user@example.com"}
+        with pytest.raises(HTTPException) as exc:
+            get_user_id(user)
+        assert exc.value.status_code == 401
+        assert "User ID not found" in exc.value.detail
+
+    def test_userlike_object(self):
+        user = MagicMock()
+        user.id = "obj-id-111"
+        user.email = "obj@example.com"
+        user.role = "member"
+        assert get_user_id(user) == "obj-id-111"
+
+    def test_arbitrary_object_raises_401(self):
+        user = object()
+        with pytest.raises(HTTPException) as exc:
+            get_user_id(user)
+        assert exc.value.status_code == 401
+
+
+class TestGetUserEmail:
+    def test_dict_with_email(self):
+        user = {"user_id": "abc", "email": "user@example.com"}
+        assert get_user_email(user) == "user@example.com"
+
+    def test_dict_without_email(self):
+        user = {"user_id": "abc"}
+        assert get_user_email(user) is None
+
+    def test_userlike_object(self):
+        user = MagicMock()
+        user.id = "obj-id"
+        user.email = "obj@example.com"
+        user.role = "member"
+        assert get_user_email(user) == "obj@example.com"
+
+    def test_userlike_object_none_email(self):
+        user = MagicMock()
+        user.id = "obj-id"
+        user.email = None
+        user.role = "member"
+        assert get_user_email(user) is None
+
+    def test_arbitrary_object_returns_none(self):
+        assert get_user_email(object()) is None
+
+
+class TestGetUserRole:
+    def test_dict_with_role(self):
+        user = {"user_id": "abc", "role": "admin"}
+        assert get_user_role(user) == "admin"
+
+    def test_dict_defaults_to_user(self):
+        user = {"user_id": "abc"}
+        assert get_user_role(user) == "user"
+
+    def test_userlike_object(self):
+        user = MagicMock()
+        user.id = "obj-id"
+        user.email = "obj@example.com"
+        user.role = "owner"
+        assert get_user_role(user) == "owner"
+
+    def test_arbitrary_object_defaults_to_user(self):
+        assert get_user_role(object()) == "user"
+
+
+class TestIsAdmin:
+    def test_admin_role(self):
+        user = {"user_id": "abc", "role": "admin"}
+        assert is_admin(user) is True
+
+    def test_non_admin_role(self):
+        user = {"user_id": "abc", "role": "user"}
+        assert is_admin(user) is False
+
+    def test_userlike_admin(self):
+        user = MagicMock()
+        user.id = "obj-id"
+        user.email = "obj@example.com"
+        user.role = "admin"
+        assert is_admin(user) is True
+
+    def test_userlike_non_admin(self):
+        user = MagicMock()
+        user.id = "obj-id"
+        user.email = "obj@example.com"
+        user.role = "member"
+        assert is_admin(user) is False
+
+
+class TestVerifyOwnership:
+    def test_none_resource_user_id_raises_404(self):
+        user = {"user_id": "abc", "role": "user"}
+        with pytest.raises(HTTPException) as exc:
+            verify_ownership(None, user, resource_name="memory")
+        assert exc.value.status_code == 404
+        assert "Memory not found" in exc.value.detail
+
+    def test_matching_owner(self):
+        user = {"user_id": "abc", "role": "user"}
+        # Should not raise
+        verify_ownership("abc", user)
+
+    def test_mismatching_owner_raises_404(self):
+        user = {"user_id": "abc", "role": "user"}
+        with pytest.raises(HTTPException) as exc:
+            verify_ownership("def", user, resource_name="context")
+        assert exc.value.status_code == 404
+        assert "Context not found or not owned by you" in exc.value.detail
+
+    def test_admin_bypass_mismatch(self):
+        user = {"user_id": "admin1", "role": "admin"}
+        # Admin should bypass ownership check
+        verify_ownership("def", user, allow_admin=True)
+
+    def test_admin_bypass_disabled(self):
+        user = {"user_id": "admin1", "role": "admin"}
+        with pytest.raises(HTTPException) as exc:
+            verify_ownership("def", user, allow_admin=False)
+        assert exc.value.status_code == 404
+
+    def test_custom_resource_name(self):
+        user = {"user_id": "abc", "role": "user"}
+        with pytest.raises(HTTPException) as exc:
+            verify_ownership(None, user, resource_name="workspace")
+        assert "Workspace not found" in exc.value.detail

--- a/backend/tests/utils/test_encryption.py
+++ b/backend/tests/utils/test_encryption.py
@@ -1,0 +1,112 @@
+"""Tests for utils/encryption.py.
+
+Pure utility — no DB or external services required.
+"""
+
+import base64
+from unittest.mock import patch
+
+import pytest
+
+from utils.encryption import APIKeyEncryption, generate_fernet_key, get_encryptor
+
+
+class TestAPIKeyEncryption:
+    def test_init_with_valid_fernet_key(self):
+        key = generate_fernet_key()
+        encryptor = APIKeyEncryption(key)
+        assert encryptor is not None
+
+    def test_init_with_raw_string_derives_key(self):
+        encryptor = APIKeyEncryption("my-secret-password-123")
+        assert encryptor is not None
+
+    def test_init_empty_secret_raises(self):
+        with pytest.raises(ValueError, match="Encryption secret key is required"):
+            APIKeyEncryption("")
+
+    def test_encrypt_decrypt_roundtrip(self):
+        key = generate_fernet_key()
+        encryptor = APIKeyEncryption(key)
+        plaintext = "sk-proj-abc123-secret"
+        encrypted = encryptor.encrypt(plaintext)
+        assert encrypted != plaintext
+        decrypted = encryptor.decrypt(encrypted)
+        assert decrypted == plaintext
+
+    def test_encrypt_empty_raises(self):
+        key = generate_fernet_key()
+        encryptor = APIKeyEncryption(key)
+        with pytest.raises(ValueError, match="Cannot encrypt empty value"):
+            encryptor.encrypt("")
+
+    def test_decrypt_empty_raises(self):
+        key = generate_fernet_key()
+        encryptor = APIKeyEncryption(key)
+        with pytest.raises(ValueError, match="Cannot decrypt empty value"):
+            encryptor.decrypt("")
+
+    def test_decrypt_wrong_key_raises(self):
+        key1 = generate_fernet_key()
+        key2 = generate_fernet_key()
+        encryptor1 = APIKeyEncryption(key1)
+        encryptor2 = APIKeyEncryption(key2)
+        encrypted = encryptor1.encrypt("secret-data")
+        with pytest.raises(ValueError, match="Invalid encrypted value or wrong encryption key"):
+            encryptor2.decrypt(encrypted)
+
+    def test_decrypt_tampered_data_raises(self):
+        key = generate_fernet_key()
+        encryptor = APIKeyEncryption(key)
+        encrypted = encryptor.encrypt("secret-data")
+        tampered = encrypted[:-5] + "XXXXX"
+        with pytest.raises(ValueError, match="Invalid encrypted value or wrong encryption key"):
+            encryptor.decrypt(tampered)
+
+    def test_mask_value_delegates_to_masking(self):
+        key = generate_fernet_key()
+        encryptor = APIKeyEncryption(key)
+        with patch("utils.masking.mask_prefix_only") as mock_mask:
+            mock_mask.return_value = "sk-proj-***"
+            result = encryptor.mask_value("sk-proj-abc123", show_chars=8)
+            mock_mask.assert_called_once_with("sk-proj-abc123", 8)
+            assert result == "sk-proj-***"
+
+
+class TestGetEncryptor:
+    def test_raises_without_api_key_secret(self, monkeypatch):
+        monkeypatch.delenv("API_KEY_SECRET", raising=False)
+        # Reset singleton to force re-evaluation
+        import utils.encryption as enc_module
+
+        enc_module._encryptor = None
+        with pytest.raises(ValueError, match="API_KEY_SECRET environment variable not set"):
+            get_encryptor()
+
+    def test_returns_singleton(self, monkeypatch):
+        key = generate_fernet_key()
+        monkeypatch.setenv("API_KEY_SECRET", key)
+        import utils.encryption as enc_module
+
+        enc_module._encryptor = None
+        e1 = get_encryptor()
+        e2 = get_encryptor()
+        assert e1 is e2
+
+    def test_uses_env_secret(self, monkeypatch):
+        key = generate_fernet_key()
+        monkeypatch.setenv("API_KEY_SECRET", key)
+        import utils.encryption as enc_module
+
+        enc_module._encryptor = None
+        encryptor = get_encryptor()
+        encrypted = encryptor.encrypt("test-secret")
+        assert encrypted != "test-secret"
+
+
+class TestGenerateFernetKey:
+    def test_returns_44_char_base64_string(self):
+        key = generate_fernet_key()
+        assert len(key) == 44
+        decoded = base64.urlsafe_b64decode(key.encode())
+        assert len(decoded) == 32

--- a/backend/tests/utils/test_error_messages.py
+++ b/backend/tests/utils/test_error_messages.py
@@ -1,0 +1,33 @@
+"""Tests for utils/error_messages.py.
+
+Pure constants — a single test mechanically covers all lines.
+"""
+
+from utils.error_messages import ErrorMessages
+
+
+def test_error_messages_exist_and_are_non_empty():
+    """All public error message constants must be non-empty strings."""
+    constants = [
+        ErrorMessages.NO_ORG_SELECTED,
+        ErrorMessages.DIFFERENT_ORG,
+        ErrorMessages.NOT_ORG_MEMBER,
+        ErrorMessages.CONTEXT_NOT_FOUND,
+        ErrorMessages.CONTEXT_DIFFERENT_ORG,
+        ErrorMessages.PRIVATE_CONTEXT_ONLY_CREATOR,
+        ErrorMessages.CANNOT_ADD_MEMBERS_TO_PRIVATE,
+        ErrorMessages.RESOURCE_TOKEN_NOT_FOUND,
+        ErrorMessages.RESOURCE_NOT_IN_ORG,
+        ErrorMessages.TOKEN_DIFFERENT_ORG,
+        ErrorMessages.SHARED_CONTEXTS_REQUIRE_PRO,
+        ErrorMessages.FEATURE_REQUIRES_PLAN,
+        ErrorMessages.INSUFFICIENT_PERMISSIONS,
+        ErrorMessages.OWNER_ONLY,
+        ErrorMessages.ADMIN_REQUIRED,
+        ErrorMessages.INVALID_INPUT,
+        ErrorMessages.RESOURCE_ID_DUPLICATE,
+        ErrorMessages.RESOURCE_ID_IN_USE,
+    ]
+    for msg in constants:
+        assert isinstance(msg, str)
+        assert len(msg) > 0

--- a/backend/tests/utils/test_error_messages.py
+++ b/backend/tests/utils/test_error_messages.py
@@ -1,33 +1,30 @@
 """Tests for utils/error_messages.py.
 
-Pure constants — a single test mechanically covers all lines.
+Pure constants — a single test mechanically covers all lines via
+introspection so newly added constants are picked up automatically
+(no manual list to keep in sync).
 """
 
 from utils.error_messages import ErrorMessages
 
 
-def test_error_messages_exist_and_are_non_empty():
-    """All public error message constants must be non-empty strings."""
-    constants = [
-        ErrorMessages.NO_ORG_SELECTED,
-        ErrorMessages.DIFFERENT_ORG,
-        ErrorMessages.NOT_ORG_MEMBER,
-        ErrorMessages.CONTEXT_NOT_FOUND,
-        ErrorMessages.CONTEXT_DIFFERENT_ORG,
-        ErrorMessages.PRIVATE_CONTEXT_ONLY_CREATOR,
-        ErrorMessages.CANNOT_ADD_MEMBERS_TO_PRIVATE,
-        ErrorMessages.RESOURCE_TOKEN_NOT_FOUND,
-        ErrorMessages.RESOURCE_NOT_IN_ORG,
-        ErrorMessages.TOKEN_DIFFERENT_ORG,
-        ErrorMessages.SHARED_CONTEXTS_REQUIRE_PRO,
-        ErrorMessages.FEATURE_REQUIRES_PLAN,
-        ErrorMessages.INSUFFICIENT_PERMISSIONS,
-        ErrorMessages.OWNER_ONLY,
-        ErrorMessages.ADMIN_REQUIRED,
-        ErrorMessages.INVALID_INPUT,
-        ErrorMessages.RESOURCE_ID_DUPLICATE,
-        ErrorMessages.RESOURCE_ID_IN_USE,
-    ]
-    for msg in constants:
-        assert isinstance(msg, str)
-        assert len(msg) > 0
+def test_all_public_error_messages_are_non_empty_strings():
+    """Every UPPER_SNAKE_CASE class attribute on ``ErrorMessages`` must
+    be a non-empty string. Iterating via ``vars()`` rather than a hand-
+    maintained list ensures that adding a new constant to
+    ``ErrorMessages`` immediately gains coverage — without iteration,
+    the previous test silently missed any newly added constant because
+    its hard-coded list never grew.
+    """
+    public_attrs = {
+        name: value
+        for name, value in vars(ErrorMessages).items()
+        if name.isupper() and not name.startswith("_")
+    }
+    assert public_attrs, (
+        "ErrorMessages exposes no UPPER_SNAKE_CASE public constants — "
+        "either the class is empty or the discovery convention changed."
+    )
+    for name, msg in public_attrs.items():
+        assert isinstance(msg, str), f"{name} must be a str, got {type(msg).__name__}"
+        assert len(msg) > 0, f"{name} must be a non-empty string"


### PR DESCRIPTION
Closes #496

## Summary

- Phase B3 of #493 (Memory Broadlistening v1) — exposes the #495 pipeline to HTTP + MCP behind a 4-stage gate (workspace owner + Pro tier + per-day quota + workspace allowlist), adds the cluster drill-down filter, and surfaces daily quota stats to `/usage/current`.
- 6 REST endpoints under `/api/v1/contexts/{context_id}/analyses` (preview / start / list / active / get / soft-cancel) + 5 MCP tools (`analyze_context`, `get_analysis`, `list_analyses`, `get_active_analysis`, `get_cluster`) sharing the same gate composition helper so MCP/REST parity is structural, not coincidental (#332 lesson).
- `recall(filters={"analysis_cluster": {"run_id": ..., "cluster_index": ...}})` for cluster-scoped semantic search, with workspace boundary check so a stolen `run_id` from a foreign workspace returns empty results (same shape as cluster-not-found, no existence leak).
- New migration `d08_496_analyses_cancellation` adds `memory_analyses.cancellation_reason TEXT NULL` + a composite `(analysis_id, cluster_id)` index. Both changes are catalog-only on PostgreSQL >= 11.

## Implementation notes

**Gate ordering** (locked in by `tests/api/test_analyses_quota_precedence.py`):

```
1. JWT/API-key auth        (middleware - handled upstream)
2. require_workspace_owner (PermissionService - 403)
3. require_pro_tier        (FEATURE_MIN_PLANS["memory_analysis"] - 403)
4. check_memory_analysis_quota (read-only count, raise-only - 429)
5. check_workspace_in_allowlist (kill switch - 403)
6. byok_resolver.preflight (orchestrator.start - 422)
7. INSERT INTO memory_analyses (route body - quota increment lives
                                here so 422 never debits the day window)
```

**Quota count semantics**: day boundary follows the caller's `User.timezone` so the dashboard's `resets_at` matches the 429 body. `cancelled` rows count toward the quota by design - once the pipeline has been kicked off, BYOK / partial LLM cost may already be incurred.

**`ANALYSIS_ENABLED_WORKSPACE_IDS`** env var is the v1 kill switch; empty (default) means feature OFF globally. Lower-cased on both sides so ops can paste either-case UUIDs without silent failure.

**Refactors carried by this PR**:

- `services/analysis/preview.py` exposes `DEFAULT_PROVIDER` and `DEFAULT_MODEL_ID` so REST routes / MCP tools / orchestrator / byok_resolver all share one source of truth (replaces the orchestrator's private `_DEFAULT_PROVIDER` / `_DEFAULT_MODEL` aliases).
- `ConflictError` and `QuotaExceededError` accept `**details` so the 409/429 bodies can carry the existing `run_id` (idempotency) and `used_today` / `limit_today` / `addon_bonus` / `remaining_today` / `resets_at` (quota detail) without re-querying. Regression test covers the constructor signature.
- `cancel_run` uses pinned `_STATUS_RUNNING` / `_STATUS_CANCELLED` / `_CANCEL_REASON_USER` constants with import-time `assert ... in MEMORY_ANALYSIS_STATUSES` guards - same defense-in-depth pattern as orchestrator.py.

**Drive-by fix**: `tests/integration/test_llm_pricing.py` had two cases that INSERTed the exact composite key the `c03_471_seed_pricing` migration commits, causing pre-existing `uq_llm_pricing_lookup_key` flakes on full integration runs. Shifted both to `effective_from=2026-04-27` so the unique constraint is satisfied; lookup math is unchanged.

## Pre-PR review summary

- **gate2 mode**: advisor-only
- **audit**: skipped (binary_gate=null in config)
- **binary_gate**: (none)
- **/claude-c-suite:cso**: yellow -> critical fix `4409ecfe` applied (raise_on_exceeded signature drift causing fail-closed 500 on every gate-passed POST/DELETE/MCP write; signature pinning regression test added)
- **/claude-c-suite:qa-lead**: green
- **/claude-c-suite:cto**: green
- **gate1**: green (via /claude-c-suite:ask, CTO lens)
- **review provider**: copilot

Tests: 22 unit + 147 integration pass. `make lint` OK / `make type-check` OK (0 errors / 0 warnings).

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/496-feat-feat-api-mcp-analyses-endpoints-5-mcp-to.gate1.md`
- `~/.claude/cache/gh-issue-driven/496-feat-feat-api-mcp-analyses-endpoints-5-mcp-to.gate2.md`

Generated via /gh-issue-driven:ship
