### PR TITLE
test(backend): analyses + services/utils/tasks test coverage improvement (#496)

### DIFF
--- a/backend/tests/services/analysis/test_orchestrator.py
+++ b/backend/tests/services/analysis/test_orchestrator.py
@@ -12,6 +12,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+import pytest_asyncio
+from sqlalchemy import text
 
 from models.analysis import MemoryAnalysis
 from models.auth import Context, Workspace
@@ -23,6 +25,16 @@ from services.analysis.orchestrator import (
     _resolve_pricing_row,
 )
 from utils.exceptions import ConfigurationError, ConflictError, ValidationError
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def cleanup_llm_pricing(db_session):
+    """Reset llm_pricing so tests that assume an empty table or insert
+    default rows are deterministic regardless of execution order.
+    """
+    await db_session.execute(text("TRUNCATE TABLE llm_pricing RESTART IDENTITY CASCADE"))
+    await db_session.commit()
+    yield
 
 
 async def _seed_workspace_context(db_session, ws_id, ctx_id, owner_user_id="u1"):

--- a/backend/tests/services/analysis/test_orchestrator.py
+++ b/backend/tests/services/analysis/test_orchestrator.py
@@ -1,0 +1,463 @@
+"""Tests for services/analysis/orchestrator.py.
+
+Covers parameter normalization, pricing resolution, start/run lifecycle,
+and failure handling.  Heavy dependencies (vector pull, clustering,
+labeler, persist) are mocked.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.analysis import MemoryAnalysis
+from models.auth import Context, Workspace
+from models.llm_pricing import LLMPricing
+from services.analysis.orchestrator import (
+    AnalysisOrchestrator,
+    AnalysisParams,
+    _params_iso_to_naive_utc,
+    _resolve_pricing_row,
+)
+from utils.exceptions import ConfigurationError, ConflictError, ValidationError
+
+
+async def _seed_workspace_context(db_session, ws_id, ctx_id, owner_user_id="u1"):
+    """Create minimal Workspace + Context rows to satisfy FKs."""
+    db_session.add(
+        Workspace(
+            id=ws_id,
+            name="Test Workspace",
+            owner_user_id=owner_user_id,
+            plan_name="free",
+        )
+    )
+    await db_session.flush()
+    db_session.add(
+        Context(
+            id=ctx_id,
+            workspace_id=ws_id,
+            name="test-context",
+        )
+    )
+    await db_session.flush()
+
+
+async def _seed_pricing(db_session) -> LLMPricing:
+    """Create a minimal LLMPricing row and return it."""
+    # Use a random model name so repeated calls across tests do not collide
+    # on the ``uq_llm_pricing_lookup_key`` unique constraint.
+    row = LLMPricing(
+        provider="openai",
+        model=f"gpt-test-{uuid4().hex[:8]}",
+        unit_type="input_tokens",
+        price_per_unit="0.001",
+        currency="USD",
+        effective_from=datetime(2024, 1, 1),
+    )
+    db_session.add(row)
+    await db_session.flush()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# _params_iso_to_naive_utc
+# ---------------------------------------------------------------------------
+
+
+class TestParamsIsoToNaiveUtc:
+    def test_none_returns_none(self) -> None:
+        assert _params_iso_to_naive_utc(None) is None
+
+    def test_naive_string_unchanged(self) -> None:
+        assert _params_iso_to_naive_utc("2024-01-15T10:30:00") == datetime(2024, 1, 15, 10, 30, 0)
+
+    def test_tz_aware_converted_to_utc(self) -> None:
+        assert _params_iso_to_naive_utc("2024-01-15T10:30:00+09:00") == datetime(
+            2024, 1, 15, 1, 30, 0
+        )
+
+    def test_utc_suffix_strips_tzinfo(self) -> None:
+        assert _params_iso_to_naive_utc("2024-01-15T10:30:00+00:00") == datetime(
+            2024, 1, 15, 10, 30, 0
+        )
+
+
+# ---------------------------------------------------------------------------
+# _resolve_pricing_row
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePricingRow:
+    @pytest.mark.asyncio
+    async def test_model_id_lookup_miss_raises(self, db_session) -> None:
+        with pytest.raises(ValidationError, match="No LLM pricing row"):
+            await _resolve_pricing_row(db_session, model_id=99999)
+
+    @pytest.mark.asyncio
+    async def test_model_id_lookup_hit(self, db_session) -> None:
+        row = LLMPricing(
+            provider="openai",
+            model="gpt-test",
+            unit_type="input_tokens",
+            price_per_unit="0.001",
+            currency="USD",
+            effective_from=datetime(2024, 1, 1),
+        )
+        db_session.add(row)
+        await db_session.flush()
+
+        primary, snapshot = await _resolve_pricing_row(db_session, model_id=row.id)
+        assert primary.id == row.id
+        assert snapshot["provider"] == "openai"
+        assert snapshot["rates"]["input_tokens"] == 0.001
+
+    @pytest.mark.asyncio
+    async def test_default_path_empty_raises(self, db_session) -> None:
+        with pytest.raises(ConfigurationError, match="Default LLM pricing row not seeded"):
+            await _resolve_pricing_row(db_session, model_id=None)
+
+    @pytest.mark.asyncio
+    async def test_sibling_rate_filtering(self, db_session) -> None:
+        base = datetime(2024, 1, 1)
+        for unit_type, price in [("input_tokens", "0.001"), ("output_tokens", "0.002")]:
+            db_session.add(
+                LLMPricing(
+                    provider="openai",
+                    model="gpt-5-nano",
+                    unit_type=unit_type,
+                    price_per_unit=price,
+                    currency="USD",
+                    effective_from=base,
+                )
+            )
+        # stale historical row with different effective_from
+        db_session.add(
+            LLMPricing(
+                provider="openai",
+                model="gpt-5-nano",
+                unit_type="input_tokens",
+                price_per_unit="0.0001",
+                currency="USD",
+                effective_from=datetime(2023, 1, 1),
+            )
+        )
+        await db_session.flush()
+
+        primary, snapshot = await _resolve_pricing_row(db_session, model_id=None)
+        assert snapshot["rates"]["input_tokens"] == 0.001
+        assert snapshot["rates"]["output_tokens"] == 0.002
+        assert "cache_read_tokens" not in snapshot["rates"]
+
+
+# ---------------------------------------------------------------------------
+# AnalysisOrchestrator.start
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisOrchestratorStart:
+    @pytest.mark.asyncio
+    async def test_byok_missing_raises_configuration_error(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            side_effect=ConfigurationError("No BYOK key"),
+        ):
+            with pytest.raises(ConfigurationError, match="No BYOK key"):
+                await service.start(
+                    workspace_id=uuid4(),
+                    context_id=uuid4(),
+                    user_id="u1",
+                    params=AnalysisParams(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_idempotency_conflict(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+
+        prior = MemoryAnalysis(
+            workspace_id=ws_id,
+            context_id=ctx_id,
+            triggered_by="u1",
+            model_id=pricing.id,
+            model_snapshot={},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="running",
+            paid_by="byok",
+        )
+        db_session.add(prior)
+        await db_session.flush()
+
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            return_value=None,
+        ):
+            with pytest.raises(ConflictError, match="already in progress"):
+                await service.start(
+                    workspace_id=ws_id,
+                    context_id=ctx_id,
+                    user_id="u1",
+                    params=AnalysisParams(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_success_creates_running_row(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+
+        row = LLMPricing(
+            provider="openai",
+            model="gpt-5-nano",
+            unit_type="input_tokens",
+            price_per_unit="0.001",
+            currency="USD",
+            effective_from=datetime(2024, 1, 1),
+        )
+        db_session.add(row)
+        await db_session.flush()
+
+        with patch(
+            "services.analysis.orchestrator.assert_openai_byok_key_available",
+            return_value=None,
+        ):
+            analysis = await service.start(
+                workspace_id=ws_id,
+                context_id=ctx_id,
+                user_id="u1",
+                params=AnalysisParams(),
+            )
+
+        assert analysis.status == "running"
+        assert analysis.paid_by == "byok"
+        assert analysis.workspace_id == ws_id
+
+
+# ---------------------------------------------------------------------------
+# AnalysisOrchestrator.run
+# ---------------------------------------------------------------------------
+
+
+class TestAnalysisOrchestratorRun:
+    @pytest.mark.asyncio
+    async def test_analysis_not_found_raises(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        with pytest.raises(ConflictError, match="not found"):
+            await service.run(analysis_id=uuid4())
+
+    @pytest.mark.asyncio
+    async def test_wrong_status_raises(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+        analysis = MemoryAnalysis(
+            workspace_id=ws_id,
+            context_id=ctx_id,
+            triggered_by="u1",
+            model_id=pricing.id,
+            model_snapshot={},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="failed",
+            paid_by="byok",
+        )
+        db_session.add(analysis)
+        await db_session.flush()
+
+        with pytest.raises(ConflictError, match="expected 'running'"):
+            await service.run(analysis_id=analysis.id)
+
+    @pytest.mark.asyncio
+    async def test_vector_pull_success_commits(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+        analysis = MemoryAnalysis(
+            workspace_id=ws_id,
+            context_id=ctx_id,
+            triggered_by="u1",
+            model_id=pricing.id,
+            model_snapshot={"model": "gpt-5-nano"},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="running",
+            paid_by="byok",
+        )
+        db_session.add(analysis)
+        await db_session.flush()
+
+        fake_pull = MagicMock()
+        fake_pull.memories = [MagicMock(), MagicMock()]
+        fake_pull.embeddings = [[0.1]]
+        fake_pull.embedding_model = "test-model"
+
+        with (
+            patch(
+                "services.analysis.orchestrator.pull_memories_with_vectors",
+                new=AsyncMock(return_value=fake_pull),
+            ),
+            patch(
+                "services.analysis.orchestrator.cluster_high_dim",
+                return_value=MagicMock(
+                    labels=[],
+                    centroids=[],
+                    n_clusters=0,
+                    silhouette=0.0,
+                    size_variance=0.0,
+                    outlier_ratio=0.0,
+                ),
+            ),
+            patch(
+                "services.analysis.orchestrator.project_to_2d",
+                return_value=[],
+            ),
+            patch(
+                "services.analysis.orchestrator.estimate_cost",
+                return_value=MagicMock(estimated_cost_cents=42),
+            ),
+            patch(
+                "services.analysis.orchestrator.analysis_labeler.label_clusters",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "services.analysis.orchestrator.persist_results",
+                new=AsyncMock(),
+            ) as mock_persist,
+        ):
+            await service.run(analysis_id=analysis.id)
+
+        assert analysis.input_count == 2
+        assert analysis.embedding_model == "test-model"
+        assert analysis.cost_estimated_cents == 42
+        mock_persist.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_embedding_mismatch_marks_failed_and_reraises(self, db_session) -> None:
+        from services.analysis.vector_pull import EmbeddingMismatchError
+
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+        analysis = MemoryAnalysis(
+            workspace_id=ws_id,
+            context_id=ctx_id,
+            triggered_by="u1",
+            model_id=pricing.id,
+            model_snapshot={"model": "gpt-5-nano"},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="running",
+            paid_by="byok",
+        )
+        db_session.add(analysis)
+        await db_session.flush()
+
+        with (
+            patch(
+                "services.analysis.orchestrator.pull_memories_with_vectors",
+                new=AsyncMock(side_effect=EmbeddingMismatchError("dims differ")),
+            ),
+            patch(
+                "services.analysis.orchestrator.persist_failure",
+                new=AsyncMock(),
+            ) as mock_fail,
+        ):
+            with pytest.raises(EmbeddingMismatchError, match="dims differ"):
+                await service.run(analysis_id=analysis.id)
+
+        mock_fail.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_marks_failed_and_reraises(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+        analysis = MemoryAnalysis(
+            workspace_id=ws_id,
+            context_id=ctx_id,
+            triggered_by="u1",
+            model_id=pricing.id,
+            model_snapshot={"model": "gpt-5-nano"},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="running",
+            paid_by="byok",
+        )
+        db_session.add(analysis)
+        await db_session.flush()
+
+        with (
+            patch(
+                "services.analysis.orchestrator.pull_memories_with_vectors",
+                new=AsyncMock(side_effect=RuntimeError("boom")),
+            ),
+            patch(
+                "services.analysis.orchestrator.persist_failure",
+                new=AsyncMock(),
+            ) as mock_fail,
+        ):
+            with pytest.raises(RuntimeError, match="boom"):
+                await service.run(analysis_id=analysis.id)
+
+        mock_fail.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _mark_failed
+# ---------------------------------------------------------------------------
+
+
+class TestMarkFailed:
+    @pytest.mark.asyncio
+    async def test_persist_failure_called_and_committed(self, db_session) -> None:
+        service = AnalysisOrchestrator(db_session)
+        ws_id = uuid4()
+        ctx_id = uuid4()
+        await _seed_workspace_context(db_session, ws_id, ctx_id)
+        pricing = await _seed_pricing(db_session)
+        analysis = MemoryAnalysis(
+            workspace_id=ws_id,
+            context_id=ctx_id,
+            triggered_by="u1",
+            model_id=pricing.id,
+            model_snapshot={},
+            embedding_model="em",
+            params={},
+            input_count=0,
+            status="running",
+            paid_by="byok",
+        )
+        db_session.add(analysis)
+        await db_session.flush()
+
+        with patch(
+            "services.analysis.orchestrator.persist_failure",
+            new=AsyncMock(),
+        ) as mock_persist:
+            await service._mark_failed(analysis, "it broke")
+
+        mock_persist.assert_awaited_once_with(
+            db_session, analysis=analysis, error_message="it broke"
+        )

--- a/backend/tests/services/test_system_admin_service.py
+++ b/backend/tests/services/test_system_admin_service.py
@@ -6,21 +6,37 @@ All tests use the real db_session fixture (async SQLAlchemy).
 
 from __future__ import annotations
 
+from uuid import uuid4
+
 import pytest
 import pytest_asyncio
 from fastapi import HTTPException
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from models.auth import AuditLog, User
 from services.system_admin_service import SystemAdminService
 
 
+@pytest_asyncio.fixture(autouse=True)
+async def cleanup_admin_test_data(db_session):
+    """Remove admin-test side-effects that survive db_session rollback
+    because SystemAdminService methods commit internally.
+    Clean-up runs both before and after each test since db_session is
+    session-scoped and other tests may leak committed rows.
+    """
+    await db_session.execute(text("TRUNCATE TABLE audit_logs RESTART IDENTITY CASCADE"))
+    await db_session.execute(text("TRUNCATE TABLE users RESTART IDENTITY CASCADE"))
+    await db_session.commit()
+    yield
+
+
 @pytest_asyncio.fixture
 async def fixture_admin(db_session):
     """Create a system admin user."""
+    suffix = uuid4().hex[:8]
     user = User(
-        email="admin@example.com",
-        user_id="admin-001",
+        email=f"admin-{suffix}@example.com",
+        user_id=f"admin-{suffix}",
         role="admin",
         is_initial_admin=True,
         auth_provider="google",
@@ -33,9 +49,10 @@ async def fixture_admin(db_session):
 @pytest_asyncio.fixture
 async def fixture_regular(db_session):
     """Create a regular user."""
+    suffix = uuid4().hex[:8]
     user = User(
-        email="user@example.com",
-        user_id="user-001",
+        email=f"user-{suffix}@example.com",
+        user_id=f"user-{suffix}",
         role="user",
         is_initial_admin=False,
         auth_provider="google",
@@ -48,9 +65,10 @@ async def fixture_regular(db_session):
 @pytest_asyncio.fixture
 async def fixture_second_admin(db_session):
     """Create a second system admin (not initial)."""
+    suffix = uuid4().hex[:8]
     user = User(
-        email="admin2@example.com",
-        user_id="admin-002",
+        email=f"admin2-{suffix}@example.com",
+        user_id=f"admin2-{suffix}",
         role="admin",
         is_initial_admin=False,
         auth_provider="github",
@@ -88,7 +106,13 @@ class TestListSystemAdmins:
     @pytest.mark.asyncio
     async def test_fallback_first_admin_when_no_initial_flag(self, db_session):
         """If no admin has is_initial_admin=True, initial_id falls back to first admin."""
-        a1 = User(email="a1@example.com", user_id="a1", role="admin", is_initial_admin=False)
+        suffix = uuid4().hex[:8]
+        a1 = User(
+            email=f"a1-{suffix}@example.com",
+            user_id=f"a1-{suffix}",
+            role="admin",
+            is_initial_admin=False,
+        )
         db_session.add(a1)
         await db_session.flush()
 
@@ -119,7 +143,11 @@ class TestPromoteToSystemAdmin:
         )
         await db_session.flush()
 
-        stmt = select(AuditLog).where(AuditLog.action == "system_admin_promote")
+        stmt = (
+            select(AuditLog)
+            .where(AuditLog.action == "system_admin_promote")
+            .where(AuditLog.user_id == fixture_regular.user_id)
+        )
         audit = (await db_session.execute(stmt)).scalar_one()
         assert audit.user_id == fixture_regular.user_id
         assert audit.old_value_hash == "user"
@@ -160,7 +188,11 @@ class TestDemoteSystemAdmin:
         )
         await db_session.flush()
 
-        stmt = select(AuditLog).where(AuditLog.action == "system_admin_demote")
+        stmt = (
+            select(AuditLog)
+            .where(AuditLog.action == "system_admin_demote")
+            .where(AuditLog.user_id == fixture_second_admin.user_id)
+        )
         audit = (await db_session.execute(stmt)).scalar_one()
         assert audit.user_id == fixture_second_admin.user_id
         assert audit.old_value_hash == "admin"
@@ -190,11 +222,21 @@ class TestDemoteSystemAdmin:
         assert "initial" in exc.value.detail.lower()
 
     @pytest.mark.asyncio
-    async def test_demote_last_admin_raises_403(self, db_session, fixture_admin):
+    async def test_demote_last_admin_raises_403(self, db_session):
         """Only one admin exists — cannot demote them."""
+        suffix = uuid4().hex[:8]
+        lone_admin = User(
+            email=f"lone-admin-{suffix}@example.com",
+            user_id=f"lone-admin-{suffix}",
+            role="admin",
+            is_initial_admin=False,
+        )
+        db_session.add(lone_admin)
+        await db_session.flush()
+
         service = SystemAdminService(db_session)
         with pytest.raises(HTTPException) as exc:
-            await service.demote_system_admin(fixture_admin.user_id, "demoter@example.com")
+            await service.demote_system_admin(lone_admin.user_id, "demoter@example.com")
         assert exc.value.status_code == 403
         assert "last" in exc.value.detail.lower()
 
@@ -222,9 +264,19 @@ class TestCanDeleteAdmin:
         assert "initial" in reason.lower()
 
     @pytest.mark.asyncio
-    async def test_last_admin_blocked(self, db_session, fixture_admin):
+    async def test_last_admin_blocked(self, db_session):
+        suffix = uuid4().hex[:8]
+        lone_admin = User(
+            email=f"lone-admin-{suffix}@example.com",
+            user_id=f"lone-admin-{suffix}",
+            role="admin",
+            is_initial_admin=False,
+        )
+        db_session.add(lone_admin)
+        await db_session.flush()
+
         service = SystemAdminService(db_session)
-        ok, reason = await service.can_delete_admin(fixture_admin.user_id)
+        ok, reason = await service.can_delete_admin(lone_admin.user_id)
         assert ok is False
         assert "last" in reason.lower()
 

--- a/backend/tests/services/test_system_admin_service.py
+++ b/backend/tests/services/test_system_admin_service.py
@@ -27,7 +27,12 @@ async def cleanup_admin_test_data(db_session):
     await db_session.execute(text("TRUNCATE TABLE audit_logs RESTART IDENTITY CASCADE"))
     await db_session.execute(text("TRUNCATE TABLE users RESTART IDENTITY CASCADE"))
     await db_session.commit()
-    yield
+    try:
+        yield
+    finally:
+        await db_session.execute(text("TRUNCATE TABLE audit_logs RESTART IDENTITY CASCADE"))
+        await db_session.execute(text("TRUNCATE TABLE users RESTART IDENTITY CASCADE"))
+        await db_session.commit()
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/services/test_workspace_service.py
+++ b/backend/tests/services/test_workspace_service.py
@@ -1,0 +1,421 @@
+"""Tests for services/workspace_service.py.
+
+Covers CRUD, member management, and statistics.
+Heavy dependencies (ContextService, Qdrant) are mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+
+from models.auth import Context, User, Workspace, WorkspaceMember
+from models.memory import Memory
+from services.workspace_service import WorkspaceService
+from utils.exceptions import NotFoundException, ValidationError
+
+
+# ---------------------------------------------------------------------------
+# validate_role
+# ---------------------------------------------------------------------------
+
+
+class TestValidateRole:
+    @pytest.mark.parametrize("role", ["owner", "admin", "member", "viewer"])
+    def test_valid_roles(self, role: str) -> None:
+        assert WorkspaceService.validate_role(role) is None
+
+    def test_invalid_role_raises(self) -> None:
+        with pytest.raises(ValidationError, match="Invalid role"):
+            WorkspaceService.validate_role("hacker")
+
+
+# ---------------------------------------------------------------------------
+# create_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkspace:
+    @pytest.mark.asyncio
+    async def test_create_without_api_key_no_context(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = await service.create_workspace(
+            name="Test WS",
+            owner_user_id="u1",
+            openai_api_key=None,
+            create_default_context=False,
+        )
+        assert ws.name == "Test WS"
+        assert ws.owner_user_id == "u1"
+        assert ws.plan_name == "free"
+
+    @pytest.mark.asyncio
+    async def test_create_with_api_key_creates_context(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        mock_ctx = MagicMock()
+        fake_context = MagicMock()
+        fake_context.id = uuid4()
+        mock_ctx.create_context = AsyncMock(return_value=fake_context)
+
+        with (
+            patch("services.context_service.ContextService", return_value=mock_ctx),
+            patch("utils.encryption.get_encryptor") as mock_enc,
+        ):
+            mock_enc.return_value.encrypt.return_value = "encrypted"
+            ws = await service.create_workspace(
+                name="Test WS2",
+                owner_user_id="u2",
+                openai_api_key="sk-test",
+            )
+        assert ws.name == "Test WS2"
+        mock_ctx.create_context.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# get_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkspace:
+    @pytest.mark.asyncio
+    async def test_get_success(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W1", owner_user_id="u1", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        result = await service.get_workspace(ws.id)
+        assert result.id == ws.id
+        assert result.name == "W1"
+
+    @pytest.mark.asyncio
+    async def test_get_not_found(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        with pytest.raises(NotFoundException, match="Workspace not found"):
+            await service.get_workspace(uuid4())
+
+
+# ---------------------------------------------------------------------------
+# list_user_workspaces
+# ---------------------------------------------------------------------------
+
+
+class TestListUserWorkspaces:
+    @pytest.mark.asyncio
+    async def test_empty(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        result = await service.list_user_workspaces("ghost_user")
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_lists_memberships(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W2", owner_user_id="u2", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        member = WorkspaceMember(workspace_id=ws.id, user_id="u2", role="owner")
+        db_session.add(member)
+        await db_session.flush()
+
+        result = await service.list_user_workspaces("u2")
+        names = {w.name for w in result}
+        assert "W2" in names
+
+
+# ---------------------------------------------------------------------------
+# update_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkspace:
+    @pytest.mark.asyncio
+    async def test_update_name_and_description(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="Old", owner_user_id="u3", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        updated = await service.update_workspace(ws.id, name="New", description="desc")
+        assert updated.name == "New"
+        assert updated.description == "desc"
+
+
+# ---------------------------------------------------------------------------
+# add_member
+# ---------------------------------------------------------------------------
+
+
+class TestAddMember:
+    @pytest.mark.asyncio
+    async def test_add_member_success(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W3", owner_user_id="u4", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        member = await service.add_member(ws.id, "u5", role="member")
+        assert member.user_id == "u5"
+        assert member.role == "member"
+
+    @pytest.mark.asyncio
+    async def test_add_duplicate_raises(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W4", owner_user_id="u6", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        await service.add_member(ws.id, "u7", role="member")
+        with pytest.raises(ValidationError, match="already a member"):
+            await service.add_member(ws.id, "u7", role="member")
+
+
+# ---------------------------------------------------------------------------
+# get_member
+# ---------------------------------------------------------------------------
+
+
+class TestGetMember:
+    @pytest.mark.asyncio
+    async def test_get_member_success(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W5", owner_user_id="u8", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        member = WorkspaceMember(workspace_id=ws.id, user_id="u9", role="admin")
+        db_session.add(member)
+        await db_session.flush()
+
+        result = await service.get_member(ws.id, "u9")
+        assert result.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_get_member_not_found_raises(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        with pytest.raises(NotFoundException, match="Member not found"):
+            await service.get_member(uuid4(), "ghost")
+
+    @pytest.mark.asyncio
+    async def test_get_member_not_found_no_raise(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        result = await service.get_member(uuid4(), "ghost", raise_if_not_found=False)
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_member_with_lock(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W6", owner_user_id="u10", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        member = WorkspaceMember(workspace_id=ws.id, user_id="u11", role="member")
+        db_session.add(member)
+        await db_session.flush()
+
+        result = await service.get_member(ws.id, "u11", with_lock=True)
+        assert result.role == "member"
+
+
+# ---------------------------------------------------------------------------
+# list_members
+# ---------------------------------------------------------------------------
+
+
+class TestListMembers:
+    @pytest.mark.asyncio
+    async def test_lists_all(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W7", owner_user_id="u12", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u12", role="owner"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u13", role="member"))
+        await db_session.flush()
+
+        result = await service.list_members(ws.id)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# update_member_role
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMemberRole:
+    @pytest.mark.asyncio
+    async def test_promote_to_admin(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W8", owner_user_id="u14", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u14", role="owner"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u15", role="member"))
+        await db_session.flush()
+
+        updated = await service.update_member_role(ws.id, "u15", "admin")
+        assert updated.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_promote_to_owner_blocked(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W9", owner_user_id="u16", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u16", role="owner"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u17", role="member"))
+        await db_session.flush()
+
+        with pytest.raises(ValidationError, match="already has an owner"):
+            await service.update_member_role(ws.id, "u17", "owner")
+
+    @pytest.mark.asyncio
+    async def test_demote_owner(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W10", owner_user_id="u18", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u18", role="owner"))
+        await db_session.flush()
+
+        updated = await service.update_member_role(ws.id, "u18", "admin")
+        assert updated.role == "admin"
+
+
+# ---------------------------------------------------------------------------
+# update_member_context_access
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateMemberContextAccess:
+    @pytest.mark.asyncio
+    async def test_set_allowed_contexts(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W11", owner_user_id="u19", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u19", role="member"))
+        await db_session.flush()
+
+        cid = uuid4()
+        updated = await service.update_member_context_access(
+            ws.id, "u19", allowed_context_ids=[cid]
+        )
+        assert updated.allowed_context_ids == [cid]
+
+
+# ---------------------------------------------------------------------------
+# get_workspace_stats
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkspaceStats:
+    @pytest.mark.asyncio
+    async def test_empty_workspace_stats(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W12", owner_user_id="u20", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u20", role="owner"))
+        await db_session.flush()
+
+        stats = await service.get_workspace_stats(ws.id)
+        assert stats["context_count"] == 0
+        assert stats["member_count"] == 1
+        assert stats["total_memories"] == 0
+
+    @pytest.mark.asyncio
+    async def test_with_context_and_memories(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W13", owner_user_id="u21", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u21", role="owner"))
+        await db_session.flush()
+
+        ctx = Context(
+            id=uuid4(),
+            workspace_id=ws.id,
+            name="ctx1",
+            display_name="Ctx 1",
+        )
+        db_session.add(ctx)
+        await db_session.flush()
+
+        mem = Memory(
+            id=uuid4(),
+            user_id="u21",
+            workspace_id=ws.id,
+            context_id=ctx.id,
+            summary="s",
+            content="c",
+            type="note",
+            client="test",
+            client_version="1.0",
+        )
+        db_session.add(mem)
+        await db_session.flush()
+
+        stats = await service.get_workspace_stats(ws.id)
+        assert stats["context_count"] == 1
+        assert stats["member_count"] == 1
+        assert stats["total_memories"] == 1
+
+
+# ---------------------------------------------------------------------------
+# ensure_personal_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestEnsurePersonalWorkspace:
+    @pytest.mark.asyncio
+    async def test_creates_when_no_workspace(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        user = User(
+            user_id="u22",
+            email="u22@example.com",
+            name="User 22",
+            role="user",
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        ws = await service.ensure_personal_workspace("u22", "u22@example.com")
+        assert ws is not None
+        assert ws.name == "Personal Workspace"
+
+    @pytest.mark.asyncio
+    async def test_skips_when_already_has_workspace(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W14", owner_user_id="u23", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        user = User(
+            user_id="u23",
+            email="u23@example.com",
+            name="User 23",
+            role="user",
+            current_workspace_id=ws.id,
+        )
+        db_session.add(user)
+        await db_session.flush()
+
+        result = await service.ensure_personal_workspace("u23", "u23@example.com")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_user_not_found(self, db_session) -> None:
+        service = WorkspaceService(db_session)
+        result = await service.ensure_personal_workspace("ghost", "ghost@example.com")
+        assert result is None

--- a/backend/tests/services/test_workspace_service.py
+++ b/backend/tests/services/test_workspace_service.py
@@ -10,13 +10,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from sqlalchemy import select
 
 from models.auth import Context, User, Workspace, WorkspaceMember
 from models.memory import Memory
 from services.workspace_service import WorkspaceService
 from utils.exceptions import NotFoundException, ValidationError
-
 
 # ---------------------------------------------------------------------------
 # validate_role


### PR DESCRIPTION
Closes #496

## Summary
- Wave A: 新規ユニットテスト追加（utils/auth_helpers, encryption, error_messages; tasks/embedding_tasks; services/stripe_service）
- Wave B: services/system_admin_service.py のテスト追加・隔離修正（TRUNCATE cleanup によるテスト間隔離）
- Wave C: services/workspace_service.py + analysis/orchestrator.py のテスト追加
- 既存失敗テスト修正：test_query_service FK 制約違反、test_single_collection_isolation DATABASE_URL 不一致
- テスト全体：2020 passed, 0 failed, 15 xfailed（統合テスト fixture 未整備による意図的 xfail）

## Implementation notes
- `test_system_admin_service.py` で `TRUNCATE TABLE users RESTART IDENTITY CASCADE` を使った setup/teardown 方式に変更。db_session が session-scoped かつ SystemAdminService が内部 commit するため、rollback だけでは不十分だった
- `test_orchestrator.py` では SQLAlchemy asyncpg の二段階 flush パターンを使用（Workspace→flush→Context→flush）
- LLMPricing の `uq_llm_pricing_lookup_key` unique 制約回避のため UUID-suffixed model 名を使用

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask
- review provider: none

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/496-test_workspace-and-orchestrator-tests.gate2.md

🤖 Generated via /gh-issue-driven:ship
