### PR TITLE
feat(analysis): broadlistening tab + cluster/position APIs (#497)

### DIFF
--- a/backend/src/api/routes/analyses.py
+++ b/backend/src/api/routes/analyses.py
@@ -213,6 +213,55 @@ class AnalysisListResponse(BaseModel):
     next_cursor: str | None
 
 
+class ClusterRow(BaseModel):
+    """One cluster within an analysis run.
+
+    Mirrors ``MemoryAnalysisCluster`` columns the API contract surfaces
+    (#497 frontend). Internal columns (``analysis_id``, ``parent_id``,
+    cluster ``id`` UUID PK) are omitted: the wire identifier is the
+    user-visible ``cluster_index`` ordinal, not the DB UUID.
+
+    ``representative_memory_ids`` is the raw list as stored — the
+    frontend resolves these to memory summaries via a follow-up
+    ``recall(filters={"id": [...]})`` call rather than embedding the
+    summaries in this response (keeps the cluster list payload small
+    and lets the recall layer apply its own importance / freshness
+    sorting).
+    """
+
+    cluster_index: int
+    label: str
+    description: str | None
+    count: int
+    centroid_2d: list[float]
+    representative_memory_ids: list[UUID]
+    property_stats: dict[str, Any]
+    label_confidence: float
+
+    model_config = {"from_attributes": True}
+
+
+class ClusterListResponse(BaseModel):
+    """All clusters for a run, ordered by ``cluster_index``."""
+
+    items: list[ClusterRow]
+
+
+class PositionRow(BaseModel):
+    """One ``(memory_id, x, y, cluster_index)`` row for scatter rendering."""
+
+    memory_id: UUID
+    x: float
+    y: float
+    cluster_index: int
+
+
+class PositionListResponse(BaseModel):
+    """All scatter positions for a run, ordered by ``cluster_index``."""
+
+    items: list[PositionRow]
+
+
 class AnalysisCancelResponse(TZAwareBaseModel):
     """DELETE /{run_id} response — confirms the soft-cancel.
 
@@ -485,6 +534,101 @@ async def get_run(
     if row is None or row.context_id != context_id:
         raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
     return AnalysisRow.model_validate(row)
+
+
+# ============================================================================
+# GET /{run_id}/clusters — flat cluster list for scatter / drill-down (#497)
+# ============================================================================
+
+
+@router.get(
+    "/{run_id}/clusters",
+    response_model=ClusterListResponse,
+    summary="List all clusters for an analysis run",
+)
+async def list_run_clusters(
+    context_id: UUID,
+    run_id: UUID,
+    access: AnalysisReadAccess,
+    db: AsyncSession = Depends(get_db),
+) -> ClusterListResponse:
+    """Returns every cluster row for the run, ordered by ``cluster_index``.
+
+    Powers the #497 frontend cluster list, scatter centroids, and the
+    per-cluster property-stats panel. Cluster count is bounded
+    server-side by ``ceil(sqrt(memory_count))`` (≈ 90 on an 8000-memory
+    run), so the endpoint returns the full set with no pagination — the
+    frontend would otherwise have to make up-to-N round-trips to render
+    the cluster list which dominates the latency budget on this page.
+
+    A run that is still ``running`` or that ``failed`` before the
+    labeler stage may have zero cluster rows; the response is then
+    ``items: []`` rather than 404 (matches the running-status semantics
+    of the run-level read).
+    """
+    _user_id, workspace_id, _tz = access
+    await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    # Verify the run belongs to *this* context (not just this workspace).
+    # The cluster list itself is bound by analysis_id, but the URL
+    # advertises a context_id — silently returning another context's
+    # clusters when the URLs cross would violate the principle of least
+    # surprise even if no tenancy boundary was crossed.
+    row = await query_service.get_analysis(db, workspace_id=workspace_id, run_id=run_id)
+    if row is None or row.context_id != context_id:
+        raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
+
+    clusters = await query_service.list_clusters(db, workspace_id=workspace_id, run_id=run_id)
+    if clusters is None:
+        # Defense-in-depth: ``get_analysis`` already established the run
+        # belongs to this workspace, so list_clusters' boundary check
+        # cannot return None at this point. Treat as 404 just in case
+        # the row was deleted between the two SELECTs.
+        raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
+
+    return ClusterListResponse(items=[ClusterRow.model_validate(c) for c in clusters])
+
+
+# ============================================================================
+# GET /{run_id}/positions — per-memory 2D coords for scatter rendering (#497)
+# ============================================================================
+
+
+@router.get(
+    "/{run_id}/positions",
+    response_model=PositionListResponse,
+    summary="List per-memory 2D positions for an analysis run",
+)
+async def list_run_positions(
+    context_id: UUID,
+    run_id: UUID,
+    access: AnalysisReadAccess,
+    db: AsyncSession = Depends(get_db),
+) -> PositionListResponse:
+    """Returns every ``(memory_id, x, y, cluster_index)`` for the scatter dots.
+
+    Bounded by ``MemoryAnalysis.input_count`` (capped at 10k memories
+    in the orchestrator). Returns ~640 KB worst-case JSON which is
+    acceptable on an explicit page open. No pagination — splitting
+    forces the frontend to coordinate progressive renders for very
+    little user-visible benefit, and the tab is gated by 4-stage
+    auth so the audience is small.
+
+    Same context-boundary check as ``/clusters``: the URL's
+    ``context_id`` must match the run's stored ``context_id``.
+    """
+    _user_id, workspace_id, _tz = access
+    await _verify_context_in_workspace(db, workspace_id=workspace_id, context_id=context_id)
+
+    row = await query_service.get_analysis(db, workspace_id=workspace_id, run_id=run_id)
+    if row is None or row.context_id != context_id:
+        raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
+
+    positions = await query_service.list_positions(db, workspace_id=workspace_id, run_id=run_id)
+    if positions is None:
+        raise HTTPException(status_code=404, detail=f"Analysis run {run_id} not found")
+
+    return PositionListResponse(items=[PositionRow(**p) for p in positions])
 
 
 # ============================================================================

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.analysis_gates import check_workspace_in_allowlist
+from auth.analysis_allowlist import check_workspace_in_allowlist
 from auth.dependencies import get_current_user
 from db.base import get_db
 from models.api_base import TZAwareBaseModel

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.analysis_gates import check_workspace_in_allowlist
 from auth.dependencies import get_current_user
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
@@ -78,6 +79,7 @@ class WorkspaceResponse(BaseModel):
     context_count: int
     created_at: str
     current_user_role: str | None = None  # Current user's role in this workspace
+    analyses_enabled: bool = False  # Memory broadlistening allowlist (#497)
 
     class Config:
         from_attributes = True
@@ -362,6 +364,7 @@ async def create_workspace(
         member_count=stats["member_count"],
         context_count=stats["context_count"],
         created_at=to_utc_iso(workspace.created_at) or "",
+        analyses_enabled=check_workspace_in_allowlist(workspace.id),
     )
 
 
@@ -398,6 +401,7 @@ async def list_workspaces(
                 context_count=stats["context_count"],
                 created_at=to_utc_iso(workspace.created_at) or "",
                 current_user_role=user_role,
+                analyses_enabled=check_workspace_in_allowlist(workspace.id),
             )
         )
 
@@ -430,6 +434,7 @@ async def get_workspace(
         member_count=stats["member_count"],
         context_count=stats["context_count"],
         created_at=to_utc_iso(workspace.created_at) or "",
+        analyses_enabled=check_workspace_in_allowlist(workspace.id),
     )
 
 
@@ -470,6 +475,7 @@ async def update_workspace(
         member_count=stats["member_count"],
         context_count=stats["context_count"],
         created_at=to_utc_iso(workspace.created_at) or "",
+        analyses_enabled=check_workspace_in_allowlist(workspace.id),
     )
 
 

--- a/backend/src/auth/analysis_allowlist.py
+++ b/backend/src/auth/analysis_allowlist.py
@@ -1,0 +1,33 @@
+"""Pure allowlist primitive for the Memory Broadlistening kill switch.
+
+Split out of ``auth.analysis_gates`` (PR #538 / #497 review) so callers
+that only need the membership check (e.g. ``api.routes.workspaces``
+exposing ``analyses_enabled`` on the workspace response) do not pull
+in the gate module's quota / tier / BYOK dependency tree.
+
+The function reads ``settings.analysis_enabled_workspace_ids_list``
+and is otherwise side-effect-free, so it remains safe to call from
+unit tests via ``monkeypatch.setenv`` without a DB session.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from config.settings import get_settings
+
+
+def check_workspace_in_allowlist(workspace_id: UUID | str) -> bool:
+    """Return True iff the workspace is permitted to run analyses.
+
+    Empty ``ANALYSIS_ENABLED_WORKSPACE_IDS`` (default) → returns False
+    for every workspace, i.e. the feature is disabled platform-wide.
+    Populated → only listed workspace UUIDs return True.
+    """
+    settings = get_settings()
+    allowed = settings.analysis_enabled_workspace_ids_list
+    if not allowed:
+        return False
+    # Both sides lower-cased so ops can paste env values in either case
+    # without a silent kill-switch lockout (see settings property comment).
+    return str(workspace_id).lower() in allowed

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -52,8 +52,13 @@ from fastapi import Depends, HTTPException
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# Re-exported from ``auth.analysis_allowlist`` so existing callers
+# (gate functions below + tests) keep working unchanged. The pure
+# helper lives in its own module to avoid pulling the rest of this
+# module's quota/tier/BYOK dependency tree into callers that only
+# need the membership check (PR #538 / #497 review).
+from auth.analysis_allowlist import check_workspace_in_allowlist  # noqa: F401
 from auth.dependencies import get_user_from_api_key_or_session
-from config.settings import get_settings
 from db.base import get_db
 from models.auth import User
 from services.analysis.query_service import day_window_utc
@@ -61,30 +66,6 @@ from utils.exceptions import ConfigurationError, FeatureNotAvailableError, Quota
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
-
-
-# ============================================================================
-# Allowlist kill switch
-# ============================================================================
-
-
-def check_workspace_in_allowlist(workspace_id: UUID | str) -> bool:
-    """Return True iff the workspace is permitted to run analyses.
-
-    Empty ``ANALYSIS_ENABLED_WORKSPACE_IDS`` (default) → returns False
-    for every workspace, i.e. the feature is disabled platform-wide.
-    Populated → only listed workspace UUIDs return True.
-
-    Pure function (settings is a global singleton). Safe to call from
-    tests via ``monkeypatch.setenv`` without DB.
-    """
-    settings = get_settings()
-    allowed = settings.analysis_enabled_workspace_ids_list
-    if not allowed:
-        return False
-    # Both sides lower-cased so ops can paste env values in either case
-    # without a silent kill-switch lockout (see settings property comment).
-    return str(workspace_id).lower() in allowed
 
 
 # ============================================================================

--- a/backend/src/services/analysis/query_service.py
+++ b/backend/src/services/analysis/query_service.py
@@ -447,6 +447,144 @@ async def get_cluster(
     }
 
 
+async def list_clusters(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    run_id: UUID,
+) -> list[MemoryAnalysisCluster] | None:
+    """Return every cluster row for a run, ordered by ``cluster_index``.
+
+    Used by the REST surface in #497 to render the cluster list, scatter
+    centroids, and per-cluster property stats. The MCP tool
+    ``get_cluster`` already paginates the *member* memories of a single
+    cluster; this helper is the complementary "list all clusters of a
+    run" read that the frontend needs to bootstrap the scatter view.
+
+    Tenancy invariant matches ``get_cluster``: workspace boundary is
+    enforced by checking ``MemoryAnalysis.workspace_id == workspace_id``
+    BEFORE fetching cluster rows. Returns:
+
+    - ``None`` when the run does not exist or belongs to a foreign
+      workspace (callers map to 404 — same disclosure shape as the
+      run-level read).
+    - ``[]`` when the run exists but has no cluster rows yet (a still-
+      running or failed run that never completed the labeler stage).
+    - ``list[MemoryAnalysisCluster]`` ordered by ``cluster_index ASC``
+      otherwise. Cluster count is bounded by
+      ``ceil(sqrt(memory_count))`` ≈ 90 clusters on an 8000-memory run,
+      so no pagination is offered.
+    """
+    boundary = (
+        await db.execute(
+            select(MemoryAnalysis.id).where(
+                and_(
+                    MemoryAnalysis.id == run_id,
+                    MemoryAnalysis.workspace_id == workspace_id,
+                )
+            )
+        )
+    ).scalar_one_or_none()
+    if boundary is None:
+        return None
+
+    stmt = (
+        select(MemoryAnalysisCluster)
+        .where(MemoryAnalysisCluster.analysis_id == run_id)
+        .order_by(MemoryAnalysisCluster.cluster_index.asc())
+    )
+    return list((await db.execute(stmt)).scalars().all())
+
+
+async def list_positions(
+    db: AsyncSession,
+    *,
+    workspace_id: UUID,
+    run_id: UUID,
+) -> list[dict[str, Any]] | None:
+    """Return every ``(memory_id, x, y, cluster_index)`` for the scatter plot.
+
+    Joins ``memory_analysis_assignments`` → ``memory_analysis_clusters``
+    so the frontend can render dots colored by ``cluster_index`` without
+    a second round-trip per cluster. Sorted by
+    ``(cluster_index, memory_id)`` for deterministic z-order.
+
+    Tenancy invariant: ``workspace_id`` is verified via the
+    ``memory_analyses`` row before any assignment SELECT. A stolen
+    run UUID from another workspace returns ``None``.
+
+    Payload sizing: each row is ~80 bytes JSON; an 8000-memory run
+    produces ~640 KB which is acceptable for an analyses UI page that
+    the operator explicitly opens (not on hover or background poll).
+    No pagination is offered for v1 — split if a run ever exceeds 50k
+    memories.
+
+    Returns:
+
+    - ``None`` if the run is foreign / unknown (callers map to 404).
+    - ``[]`` if the run exists but has no assignments (still running).
+    - ``list[dict]`` of ``{memory_id, x, y, cluster_index}`` otherwise.
+    """
+    boundary = (
+        await db.execute(
+            select(MemoryAnalysis.id).where(
+                and_(
+                    MemoryAnalysis.id == run_id,
+                    MemoryAnalysis.workspace_id == workspace_id,
+                )
+            )
+        )
+    ).scalar_one_or_none()
+    if boundary is None:
+        return None
+
+    # Filter out soft-deleted memories so the scatter does not render
+    # orphan dots for memories the user has since forgotten — matches
+    # ``get_cluster``'s ``Memory.deleted_at.is_(None)`` discipline so
+    # the two read paths agree on which assignments are visible.
+    # ``Memory.workspace_id == workspace_id`` is defense-in-depth: the
+    # boundary was already verified above, but if a future repair
+    # script ever inserts a foreign-workspace ``memory_id`` into an
+    # assignment row this predicate would still keep tenancy intact.
+    stmt = (
+        select(
+            MemoryAnalysisAssignment.memory_id,
+            MemoryAnalysisAssignment.x,
+            MemoryAnalysisAssignment.y,
+            MemoryAnalysisCluster.cluster_index,
+        )
+        .join(
+            MemoryAnalysisCluster,
+            MemoryAnalysisCluster.id == MemoryAnalysisAssignment.cluster_id,
+        )
+        .join(
+            Memory,
+            Memory.id == MemoryAnalysisAssignment.memory_id,
+        )
+        .where(
+            and_(
+                MemoryAnalysisAssignment.analysis_id == run_id,
+                Memory.deleted_at.is_(None),
+                Memory.workspace_id == workspace_id,
+            )
+        )
+        .order_by(
+            MemoryAnalysisCluster.cluster_index.asc(),
+            MemoryAnalysisAssignment.memory_id.asc(),
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+    return [
+        {
+            "memory_id": str(memory_id),
+            "x": float(x),
+            "y": float(y),
+            "cluster_index": int(cluster_index),
+        }
+        for (memory_id, x, y, cluster_index) in rows
+    ]
+
+
 async def get_memory_ids_in_cluster(
     db: AsyncSession,
     *,

--- a/backend/src/services/llm_service.py
+++ b/backend/src/services/llm_service.py
@@ -24,6 +24,12 @@ from utils.encryption import get_encryptor
 from utils.exceptions import ConfigurationError
 from utils.logger import get_logger
 
+# Bound LLM request duration so a hung / unreachable provider cannot
+# stall the analysis pipeline indefinitely (Issue #533 silent-hang
+# mitigation; matches OpenAI SDK's `timeout=` kwarg semantics —
+# applies to each underlying HTTP request including streaming chunks).
+_LLM_REQUEST_TIMEOUT_S = 60.0
+
 logger = get_logger(__name__)
 
 
@@ -394,11 +400,12 @@ class LLMService:
             return AsyncOpenAI(
                 base_url=f"{ollama_base_url}/v1",
                 api_key="ollama",
+                timeout=_LLM_REQUEST_TIMEOUT_S,
             )
 
         # OpenAI (default)
         api_key = await self._get_user_api_key(user_id, context_id, workspace_id)
-        return AsyncOpenAI(api_key=api_key)
+        return AsyncOpenAI(api_key=api_key, timeout=_LLM_REQUEST_TIMEOUT_S)
 
     async def _get_user_api_key(
         self,

--- a/backend/tests/api/test_analyses_routes.py
+++ b/backend/tests/api/test_analyses_routes.py
@@ -236,6 +236,168 @@ class TestGetRun:
 
 
 # ============================================================================
+# GET /{run_id}/clusters (#497 list_run_clusters)
+# ============================================================================
+
+
+class TestListRunClusters:
+    def test_returns_clusters_ordered_by_index(self, client, db_mock):
+        """Happy path: existing run, non-empty cluster list."""
+        run_id = uuid4()
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        fake_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="succeeded",
+        )
+        fake_clusters = [
+            MagicMock(
+                cluster_index=0,
+                label="Cluster A",
+                description="first cluster",
+                count=42,
+                centroid_2d=[0.1, 0.2],
+                representative_memory_ids=[uuid4(), uuid4()],
+                property_stats={"top_tags": []},
+                label_confidence=0.91,
+            ),
+            MagicMock(
+                cluster_index=1,
+                label="Cluster B",
+                description=None,
+                count=15,
+                centroid_2d=[1.5, -0.4],
+                representative_memory_ids=[],
+                property_stats={},
+                label_confidence=0.78,
+            ),
+        ]
+        with (
+            patch(
+                "services.analysis.query_service.get_analysis",
+                AsyncMock(return_value=fake_run),
+            ),
+            patch(
+                "services.analysis.query_service.list_clusters",
+                AsyncMock(return_value=fake_clusters),
+            ),
+        ):
+            response = client.get(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}/clusters")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert len(body["items"]) == 2
+        assert body["items"][0]["cluster_index"] == 0
+        assert body["items"][0]["label"] == "Cluster A"
+        assert body["items"][0]["centroid_2d"] == [0.1, 0.2]
+        assert body["items"][1]["description"] is None
+
+    def test_returns_empty_items_for_running_run(self, client, db_mock):
+        """No 404 when the labeler has not produced clusters yet."""
+        run_id = uuid4()
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        fake_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="running",
+        )
+        with (
+            patch(
+                "services.analysis.query_service.get_analysis",
+                AsyncMock(return_value=fake_run),
+            ),
+            patch(
+                "services.analysis.query_service.list_clusters",
+                AsyncMock(return_value=[]),
+            ),
+        ):
+            response = client.get(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}/clusters")
+        assert response.status_code == 200, response.text
+        assert response.json()["items"] == []
+
+    def test_404_when_run_belongs_to_another_context(self, client, db_mock):
+        """Cross-context run lookup returns 404, not the foreign clusters."""
+        run_id = uuid4()
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        foreign_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=uuid4(),  # different context
+            status="succeeded",
+        )
+        with patch(
+            "services.analysis.query_service.get_analysis",
+            AsyncMock(return_value=foreign_run),
+        ):
+            response = client.get(f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}/clusters")
+        assert response.status_code == 404
+
+
+# ============================================================================
+# GET /{run_id}/positions (#497 list_run_positions)
+# ============================================================================
+
+
+class TestListRunPositions:
+    def test_returns_position_rows(self, client, db_mock):
+        run_id = uuid4()
+        memory_a, memory_b = uuid4(), uuid4()
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        fake_run = MagicMock(
+            id=run_id,
+            workspace_id=_TEST_WORKSPACE_ID,
+            context_id=_TEST_CONTEXT_ID,
+            status="succeeded",
+        )
+        fake_positions = [
+            {
+                "memory_id": str(memory_a),
+                "x": 1.23,
+                "y": -0.45,
+                "cluster_index": 0,
+            },
+            {
+                "memory_id": str(memory_b),
+                "x": 0.0,
+                "y": 0.0,
+                "cluster_index": 1,
+            },
+        ]
+        with (
+            patch(
+                "services.analysis.query_service.get_analysis",
+                AsyncMock(return_value=fake_run),
+            ),
+            patch(
+                "services.analysis.query_service.list_positions",
+                AsyncMock(return_value=fake_positions),
+            ),
+        ):
+            response = client.get(
+                f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}/positions"
+            )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert len(body["items"]) == 2
+        assert body["items"][0]["memory_id"] == str(memory_a)
+        assert body["items"][0]["x"] == 1.23
+        assert body["items"][1]["cluster_index"] == 1
+
+    def test_404_when_run_unknown(self, client, db_mock):
+        run_id = uuid4()
+        db_mock.execute.side_effect = [_scalar_one(_TEST_CONTEXT_ID)]
+        with patch(
+            "services.analysis.query_service.get_analysis",
+            AsyncMock(return_value=None),
+        ):
+            response = client.get(
+                f"/api/v1/contexts/{_TEST_CONTEXT_ID}/analyses/{run_id}/positions"
+            )
+        assert response.status_code == 404
+
+
+# ============================================================================
 # DELETE /{run_id} (soft cancel)
 # ============================================================================
 

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -51,6 +51,16 @@ const GraphTabPanel = dynamic(
     })),
   { ssr: false },
 );
+// Issue #497: analyses tab — lazy-loaded so the broadlistening bundle
+// (recharts placeholder + scatter SVG + modal) stays out of the
+// non-owner sessions even though the tab itself is owner-gated upstream.
+const AnalysesTabPanel = dynamic(
+  () =>
+    import("@/components/contexts/analyses/AnalysesTabPanel").then((m) => ({
+      default: m.AnalysesTabPanel,
+    })),
+  { ssr: false },
+);
 
 const ADMIN_CONTEXT_TABS = [
   "overview",
@@ -59,17 +69,30 @@ const ADMIN_CONTEXT_TABS = [
   "graph",
   "settings",
 ] as const;
+const OWNER_CONTEXT_TABS = [
+  "overview",
+  "memories",
+  "connections",
+  "graph",
+  "analyses",
+  "settings",
+] as const;
 const NON_ADMIN_CONTEXT_TABS = ["overview"] as const;
 
 export default function ContextDetailPage() {
   const params = useParams();
   const contextId = params.id as string;
   const t = useTranslations("contextDetail");
+  // Issue #497: analyses namespace is top-level, so a second hook
+  // call is needed for the tab label. next-intl supports multiple
+  // useTranslations() in one component.
+  const tAnalyses = useTranslations("analyses");
   const { user } = useAuth();
   const { currentContext } = useMemoryContext();
   const { currentWorkspace } = useWorkspace();
 
   // Issue #398: member/viewer only see Overview. Admin+ see all four tabs.
+  // Issue #497: owner additionally sees the Analyses tab.
   // hasWorkspaceRole returns false while currentWorkspace hydrates — the
   // admin tabs stay hidden until role is known, preventing a flash where
   // a member briefly sees admin-only triggers.
@@ -77,9 +100,18 @@ export default function ContextDetailPage() {
     currentWorkspace?.current_user_role,
     "admin",
   );
-  const visibleTabs = canSeeAdminTabs
-    ? ADMIN_CONTEXT_TABS
-    : NON_ADMIN_CONTEXT_TABS;
+  // Analyses tab gating: requires owner role AND workspace allowlist
+  // membership (#497). Hiding the tab entirely for non-allowlisted owners
+  // keeps the UX honest — there is no path forward inside the tab until
+  // the workspace is on the allowlist.
+  const canSeeAnalysesTab =
+    hasWorkspaceRole(currentWorkspace?.current_user_role, "owner") &&
+    currentWorkspace?.analyses_enabled === true;
+  const visibleTabs = canSeeAnalysesTab
+    ? OWNER_CONTEXT_TABS
+    : canSeeAdminTabs
+      ? ADMIN_CONTEXT_TABS
+      : NON_ADMIN_CONTEXT_TABS;
 
   // Passing visibleTabs as allowedValues makes useTabParam clamp unknown
   // URL values (e.g. member lands on ?tab=settings via deep-link) back to
@@ -239,7 +271,10 @@ export default function ContextDetailPage() {
       <Tabs value={tab} onValueChange={setTab}>
         <TabsList>
           <TabsTrigger value="overview">{t("tabs.overview")}</TabsTrigger>
-          {/* Issue #398: connections/graph/settings tabs are admin-only. */}
+          {/* Issue #398: memories/connections/graph tabs are admin-only.
+              Settings is rendered separately below so the analyses tab
+              (owner-only, #497) can land between graph and settings —
+              matching the ordering in OWNER_CONTEXT_TABS. */}
           {canSeeAdminTabs && (
             <>
               <TabsTrigger value="memories">{t("tabs.memories")}</TabsTrigger>
@@ -247,8 +282,17 @@ export default function ContextDetailPage() {
                 {t("tabs.connections")}
               </TabsTrigger>
               <TabsTrigger value="graph">{t("tabs.graph")}</TabsTrigger>
-              <TabsTrigger value="settings">{t("tabs.settings")}</TabsTrigger>
             </>
+          )}
+          {/* Analyses tab is owner-only AND requires allowlist membership.
+              Owners whose workspace is not on the allowlist do not see
+              the tab at all (#497 — operator preference). */}
+          {canSeeAnalysesTab && (
+            <TabsTrigger value="analyses">{tAnalyses("tabLabel")}</TabsTrigger>
+          )}
+          {/* Settings stays last — admin-only. */}
+          {canSeeAdminTabs && (
+            <TabsTrigger value="settings">{t("tabs.settings")}</TabsTrigger>
           )}
         </TabsList>
 
@@ -292,6 +336,16 @@ export default function ContextDetailPage() {
               <ProtectionSection context={context} />
             </TabsContent>
           </>
+        )}
+        {/* Analyses TabsContent gated on tab visibility so the scatter
+            bundle never enters non-owner / non-allowlisted sessions. */}
+        {canSeeAnalysesTab && (
+          <TabsContent value="analyses">
+            <AnalysesTabPanel
+              contextId={contextId}
+              contextName={context.display_name || context.name}
+            />
+          </TabsContent>
         )}
       </Tabs>
     </PageContainer>

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -170,6 +170,13 @@ export default function ContextsPage() {
     currentWorkspace?.current_user_role,
     "admin",
   );
+  // The kebab "Analysis" entry mirrors the analyses tab gating in
+  // [id]/page.tsx: owner role AND workspace allowlist membership.
+  // Both must be true for the menu to appear (#497).
+  const canStartAnalysis =
+    hasWorkspaceRole(currentWorkspace?.current_user_role, "owner") &&
+    currentWorkspace?.analyses_enabled === true;
+  const tAnalyses = useTranslations("analyses");
 
   const fetchContexts = useCallback(async () => {
     try {
@@ -1070,6 +1077,21 @@ export default function ContextsPage() {
                               <Settings2 className="h-4 w-4 mr-2" />
                               {t("graph")}
                             </DropdownMenuItem>
+                            {/* Issue #497: owner-only entry — placed
+                                before Settings so the kebab order matches
+                                the tab order (analyses → settings). */}
+                            {canStartAnalysis && (
+                              <DropdownMenuItem
+                                onClick={() =>
+                                  router.push(
+                                    `/workspace/contexts/${context.id}?tab=analyses&new=1`,
+                                  )
+                                }
+                              >
+                                <BarChart className="h-4 w-4 mr-2" />
+                                {tAnalyses("actions.newAnalysis")}
+                              </DropdownMenuItem>
+                            )}
                             <DropdownMenuItem
                               onClick={() =>
                                 router.push(

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -28,11 +28,15 @@
     --chart-3: 197 37% 44%;
     --chart-4: 43 74% 56%;
     --chart-5: 27 87% 57%;
-    /* Issue #497 (broadlistening cluster palette extension)
-     * KMeans n_clusters is variable per run (typical 5-20). The first
-     * 5 vars stay as-is so existing chart consumers (cost dashboard,
-     * neural graph) are unchanged; chart-6..12 below give the analyses
-     * tab room for up to 12 distinct cluster colors before wrapping. */
+    /* Issue #497 (broadlistening cluster palette).
+     * chart-3/4/5 lightness was nudged from the prior 24%/66%/67%
+     * values so the small (2.5px radius) scatter dots stay legible
+     * against the grey grid background — chart-3 too dark, chart-4/5
+     * too pastel at the smaller dot size. Existing chart consumers
+     * (cost dashboard line/area, neural graph nodes) keep the same
+     * hue families; the brightness change is intentional and applies
+     * to all of them. chart-6..12 are net-new for variable KMeans
+     * n_clusters (typical 5-20 — wraps at 12). */
     --chart-6: 262 52% 60%;
     --chart-7: 142 70% 38%;
     --chart-8: 220 8% 60%;
@@ -90,6 +94,24 @@
 }
 
 @layer utilities {
+  /* Memory broadlistening scatter focus mode (#497).
+   * The cluster-layer transitions + parent-state-driven dim live here
+   * because Tailwind utility classes cannot express
+   * ``.scatter.focused .cluster-layer:not(.is-focused)`` without a
+   * per-cluster variant. Single class flip on the SVG root → cheap
+   * CSS opacity transition, no per-dot React re-render. */
+  .scatter .cluster-layer {
+    transition:
+      opacity 0.25s ease,
+      transform 0.35s ease;
+  }
+  .scatter.focused .cluster-layer {
+    opacity: 0.12;
+  }
+  .scatter.focused .cluster-layer.is-focused {
+    opacity: 1;
+  }
+
   /* Grid pattern background */
   .bg-grid-pattern {
     background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32' width='32' height='32' fill='none' stroke='rgb(0 0 0 / 0.03)'%3e%3cpath d='M0 .5H31.5V32'/%3e%3c/svg%3e");

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -25,9 +25,21 @@
     --ring: 0 0% 3.9%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
+    --chart-3: 197 37% 44%;
+    --chart-4: 43 74% 56%;
+    --chart-5: 27 87% 57%;
+    /* Issue #497 (broadlistening cluster palette extension)
+     * KMeans n_clusters is variable per run (typical 5-20). The first
+     * 5 vars stay as-is so existing chart consumers (cost dashboard,
+     * neural graph) are unchanged; chart-6..12 below give the analyses
+     * tab room for up to 12 distinct cluster colors before wrapping. */
+    --chart-6: 262 52% 60%;
+    --chart-7: 142 70% 38%;
+    --chart-8: 220 8% 60%;
+    --chart-9: 332 70% 55%;
+    --chart-10: 95 55% 45%;
+    --chart-11: 195 80% 50%;
+    --chart-12: 38 90% 55%;
     --radius: 0.5rem
   }
   .dark {
@@ -54,7 +66,17 @@
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%
+    --chart-5: 340 75% 55%;
+    /* Dark-mode counterparts for #497 cluster palette. Same hue order
+     * as light-mode chart-6..12 so a cluster keeps its identity when
+     * the user toggles theme. */
+    --chart-6: 262 55% 65%;
+    --chart-7: 142 60% 50%;
+    --chart-8: 220 12% 70%;
+    --chart-9: 332 65% 65%;
+    --chart-10: 95 50% 60%;
+    --chart-11: 195 75% 60%;
+    --chart-12: 38 80% 65%
   }
 }
 

--- a/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
@@ -164,7 +164,6 @@ export function AnalysesTabPanel({
       }
 
       if (activeRun) {
-        setActiveRunId(activeRun.run_id);
         const [clusterRes, positionRes] = await Promise.all([
           listRunClusters(contextId, activeRun.run_id),
           listRunPositions(contextId, activeRun.run_id),
@@ -175,6 +174,16 @@ export function AnalysesTabPanel({
 
       const historyRes = await historyPromise;
       history = historyRes.items;
+      // ``getActiveAnalysis`` only returns the most-recent SUCCEEDED
+      // run, so a run still in flight (e.g. started from another
+      // session, or the page was refreshed mid-run) would otherwise
+      // be invisible to the polling hook. Scan the history page for a
+      // running row and prefer it as the polling target so the banner
+      // + Cancel button surface even after a refresh. The succeeded
+      // run from ``activeRun`` continues to drive the scatter view
+      // (clusters / positions).
+      const inFlight = history.find((r) => r.status === "running") ?? null;
+      setActiveRunId(inFlight?.run_id ?? activeRun?.run_id ?? null);
       if (historyAllowlistDenied && !activeRun) {
         // Allowlist denied AND no active run — render the friendly
         // notEnabled empty state. (When activeRun exists from a cached

--- a/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
@@ -251,6 +251,7 @@ export function AnalysesTabPanel({
     onTerminal: () => {
       bootstrap();
     },
+    fallbackErrorMessage: t("running.errorFallback"),
   });
 
   const handleCancelRun = useCallback(async () => {

--- a/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
@@ -1,0 +1,476 @@
+"use client";
+
+/**
+ * AnalysesTabPanel — orchestrator for the analyses tab (Issue #497).
+ *
+ * Owns:
+ *  - Active run loading (``getActiveAnalysis``).
+ *  - Cluster list + positions for the active run (``listRunClusters`` /
+ *    ``listRunPositions``), gated to only succeed when there IS an
+ *    active succeeded run.
+ *  - Past run history (``listAnalysisRuns``).
+ *  - URL-driven modal trigger (``?new=1``).
+ *  - URL-synced focused cluster state via ``useFocusedClusterId``.
+ *  - Active in-flight run polling (``useActiveAnalysisPolling``) when a
+ *    new run was just started or one was already running on mount.
+ *
+ * Allowlist 403: the API gate returns 403 when the workspace is not on
+ * the allowlist. We render a friendly empty state — flat copy that
+ * does not reveal the allowlist exists (CDO advice from gate1).
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { ApiError } from "@/lib/api/base";
+import {
+  cancelAnalysisRun,
+  getActiveAnalysis,
+  listAnalysisRuns,
+  listRunClusters,
+  listRunPositions,
+  type AnalysisCluster,
+  type AnalysisRunRow,
+  type ScatterPosition,
+} from "@/lib/api/analyses";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+import {
+  CardLoadingState,
+  InlineSpinner,
+  TableLoadingState,
+} from "@/components/common/LoadingState";
+import { EmptyState } from "@/components/ui/empty-state";
+import { KpiCard } from "@/components/ui/kpi-card";
+import { Button } from "@/components/ui/button";
+import {
+  Lock,
+  Plus,
+  Sparkles,
+  Activity,
+  DollarSign,
+  Award,
+  Clock,
+} from "lucide-react";
+import { ScatterPlot } from "./ScatterPlot";
+import { ClusterList } from "./ClusterList";
+import { RepresentativesPanel } from "./RepresentativesPanel";
+import { PropertyStats } from "./PropertyStats";
+import { AnalysisHistory } from "./AnalysisHistory";
+import { NewAnalysisModal } from "./NewAnalysisModal";
+import { useFocusedClusterId } from "./useFocusedClusterId";
+import { useActiveAnalysisPolling } from "./useActiveAnalysisPolling";
+import { formatCostCents, formatConfidence } from "./analysisFormatters";
+
+interface AnalysesTabPanelProps {
+  contextId: string;
+  contextName: string;
+}
+
+interface BootstrapState {
+  activeRun: AnalysisRunRow | null;
+  clusters: AnalysisCluster[];
+  positions: ScatterPosition[];
+  history: AnalysisRunRow[];
+  error: string | null;
+  notEnabled: boolean;
+  loading: boolean;
+}
+
+const EMPTY_BOOTSTRAP: BootstrapState = {
+  activeRun: null,
+  clusters: [],
+  positions: [],
+  history: [],
+  error: null,
+  notEnabled: false,
+  loading: true,
+};
+
+export function AnalysesTabPanel({
+  contextId,
+  contextName,
+}: AnalysesTabPanelProps) {
+  const t = useTranslations("analyses");
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const [state, setState] = useState<BootstrapState>(EMPTY_BOOTSTRAP);
+  const [activeRunId, setActiveRunId] = useState<string | null>(null);
+
+  // Modal state is URL-driven (?new=1). Reading + writing the URL is
+  // the single source of truth so back/forward keeps the modal closed
+  // / open consistently.
+  const showModal = searchParams.get("new") === "1";
+
+  const setShowModal = useCallback(
+    (next: boolean) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next) params.set("new", "1");
+      else params.delete("new");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname);
+    },
+    [searchParams, pathname, router],
+  );
+
+  // Bootstrap: active + clusters + positions + history. Errors fall
+  // into the friendly empty-state path on 403 (allowlist) or
+  // "no run yet" path on 404 from /active.
+  const bootstrap = useCallback(async () => {
+    setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    let activeRun: AnalysisRunRow | null = null;
+    let clusters: AnalysisCluster[] = [];
+    let positions: ScatterPosition[] = [];
+    let history: AnalysisRunRow[] = [];
+
+    // History is independent of active-run resolution — fetch in
+    // parallel so the user sees past runs even when the active call
+    // 404s. ``.catch`` swallows non-403 errors directly (no rethrow)
+    // so the early-return notEnabled path doesn't abandon a rejected
+    // promise. 403 is treated as the allowlist signal AND triggers
+    // the same notEnabled state below.
+    let historyAllowlistDenied = false;
+    const historyPromise = listAnalysisRuns(contextId, { limit: 12 }).catch(
+      (err) => {
+        if (err instanceof ApiError && err.status === 403) {
+          historyAllowlistDenied = true;
+        }
+        return { items: [], next_cursor: null };
+      },
+    );
+
+    try {
+      try {
+        activeRun = await getActiveAnalysis(contextId);
+      } catch (err) {
+        if (err instanceof ApiError && err.status === 404) {
+          activeRun = null;
+        } else if (err instanceof ApiError && err.status === 403) {
+          // Even on early notEnabled return, drain the in-flight
+          // history promise so we don't abandon a rejected promise
+          // and surface an unhandled-rejection warning.
+          await historyPromise;
+          setState({
+            ...EMPTY_BOOTSTRAP,
+            notEnabled: true,
+            loading: false,
+          });
+          return;
+        } else {
+          throw err;
+        }
+      }
+
+      if (activeRun) {
+        setActiveRunId(activeRun.run_id);
+        const [clusterRes, positionRes] = await Promise.all([
+          listRunClusters(contextId, activeRun.run_id),
+          listRunPositions(contextId, activeRun.run_id),
+        ]);
+        clusters = clusterRes.items;
+        positions = positionRes.items;
+      }
+
+      const historyRes = await historyPromise;
+      history = historyRes.items;
+      if (historyAllowlistDenied && !activeRun) {
+        // Allowlist denied AND no active run — render the friendly
+        // notEnabled empty state. (When activeRun exists from a cached
+        // succeeded run, the panel still shows the run; the history
+        // list is just empty.)
+        setState({
+          ...EMPTY_BOOTSTRAP,
+          notEnabled: true,
+          loading: false,
+        });
+        return;
+      }
+
+      setState({
+        activeRun,
+        clusters,
+        positions,
+        history,
+        error: null,
+        notEnabled: false,
+        loading: false,
+      });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 403) {
+        setState({
+          ...EMPTY_BOOTSTRAP,
+          notEnabled: true,
+          loading: false,
+        });
+        return;
+      }
+      setState({
+        ...EMPTY_BOOTSTRAP,
+        error: err instanceof Error ? err.message : t("states.loadFailed"),
+        loading: false,
+      });
+    }
+  }, [contextId, t]);
+
+  useEffect(() => {
+    bootstrap();
+  }, [bootstrap]);
+
+  // Polling: armed only when activeRunId points at a *running* run.
+  // The terminal callback re-runs bootstrap so the cluster+position
+  // payload of the just-finished run lands.
+  const pollingRunId = useMemo(() => {
+    if (!activeRunId) return null;
+    // Only poll the active run id when it's *known* to be running.
+    // For an already-succeeded ``getActiveAnalysis`` result, polling
+    // would burn quota for nothing.
+    if (
+      state.activeRun &&
+      state.activeRun.run_id === activeRunId &&
+      state.activeRun.status !== "running"
+    ) {
+      return null;
+    }
+    return activeRunId;
+  }, [activeRunId, state.activeRun]);
+
+  const polling = useActiveAnalysisPolling({
+    contextId,
+    runId: pollingRunId,
+    onTerminal: () => {
+      bootstrap();
+    },
+  });
+
+  const handleCancelRun = useCallback(async () => {
+    if (!polling.run || polling.run.status !== "running") return;
+    try {
+      await cancelAnalysisRun(contextId, polling.run.run_id);
+      polling.refetch();
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn("cancelAnalysisRun failed", err);
+    }
+  }, [contextId, polling]);
+
+  const allowedClusterIndexes = useMemo(
+    () => state.clusters.map((c) => c.cluster_index),
+    [state.clusters],
+  );
+  const { focusedClusterId, setFocusedClusterId, toggleFocusedClusterId } =
+    useFocusedClusterId(allowedClusterIndexes);
+
+  // ``focusedCluster`` is null when no cluster is focused — the
+  // RepresentativesPanel renders an "all clusters" empty state instead
+  // of silently surfacing the largest cluster's reps and burning
+  // ``referenceMemory`` calls before the user has chosen anything.
+  const focusedCluster = useMemo(() => {
+    if (focusedClusterId === null) return null;
+    return (
+      state.clusters.find((c) => c.cluster_index === focusedClusterId) ?? null
+    );
+  }, [focusedClusterId, state.clusters]);
+
+  const handleRunStarted = useCallback(
+    (runId: string) => {
+      setActiveRunId(runId);
+      setShowModal(false);
+      // bootstrap() will be re-triggered by the polling onTerminal
+      // when the run finishes; until then the polling hook displays
+      // the in-flight status.
+    },
+    [setShowModal],
+  );
+
+  // ----- render -----
+
+  if (state.loading) {
+    // Skeleton stack instead of a spinner — preserves layout (no CLS)
+    // and matches the rule in .claude/rules/frontend.md ("Prefer
+    // skeletons over spinners for first paint").
+    return (
+      <div className="space-y-6" role="status" aria-label={t("states.loading")}>
+        <CardLoadingState count={4} />
+        <TableLoadingState rows={6} />
+      </div>
+    );
+  }
+
+  if (state.notEnabled) {
+    return (
+      <EmptyState
+        icon={Lock}
+        title={t("states.notEnabled.title")}
+        description={t("states.notEnabled.description")}
+      />
+    );
+  }
+
+  if (state.error) {
+    return <ErrorBanner error={state.error} />;
+  }
+
+  const runInProgress =
+    polling.run && polling.run.status === "running" ? polling.run : null;
+
+  return (
+    <div className="space-y-6">
+      {/* top action row */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+            {t("header.title")}
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {t("header.subtitle")}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            onClick={() => setShowModal(true)}
+            disabled={!!runInProgress}
+            className="gap-1.5"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            {t("actions.newAnalysis")}
+          </Button>
+        </div>
+      </div>
+
+      {/* Running banner — visible while a run is in progress so the
+          page does not look frozen during the (possibly minutes-long)
+          LLM labeling stage. Cancel button soft-cancels via DELETE. */}
+      {runInProgress && (
+        <div className="flex items-center justify-between gap-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-800 dark:bg-blue-900/30">
+          <div className="flex items-center gap-3">
+            <InlineSpinner size="sm" variant="brand" />
+            <div className="text-sm">
+              <div className="font-medium text-gray-900 dark:text-gray-100">
+                {t("running.title")}
+              </div>
+              <div className="text-xs text-gray-600 dark:text-gray-400">
+                {t("running.startedAt", {
+                  when: new Date(runInProgress.started_at).toLocaleString(),
+                })}
+              </div>
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleCancelRun}
+            className="shrink-0"
+          >
+            {t("running.cancel")}
+          </Button>
+        </div>
+      )}
+
+      {/* KPI strip */}
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <KpiCard
+          icon={Clock}
+          label={t("kpi.lastRun")}
+          value={
+            state.activeRun
+              ? new Date(state.activeRun.started_at).toLocaleString()
+              : t("kpi.neverRun")
+          }
+          tone={state.activeRun ? "primary" : "muted"}
+        />
+        <KpiCard
+          icon={Activity}
+          label={t("kpi.memoriesSurveyed")}
+          value={state.activeRun ? state.activeRun.input_count : "—"}
+        />
+        <KpiCard
+          icon={DollarSign}
+          label={t("kpi.runCost")}
+          value={
+            state.activeRun
+              ? formatCostCents(
+                  state.activeRun.cost_actual_cents ??
+                    state.activeRun.cost_estimated_cents,
+                )
+              : "—"
+          }
+        />
+        <KpiCard
+          icon={Award}
+          label={t("kpi.quality")}
+          value={
+            state.clusters.length === 0
+              ? t("kpi.qualityNoData")
+              : `conf ${formatConfidence(
+                  state.clusters
+                    .map((c) => c.label_confidence)
+                    .reduce((acc, n) => acc + n, 0) / state.clusters.length,
+                )}`
+          }
+          tone={state.clusters.length === 0 ? "muted" : "secondary"}
+        />
+      </div>
+
+      {/* main scatter + cluster list grid */}
+      {state.clusters.length === 0 ? (
+        <EmptyState
+          icon={Sparkles}
+          title={t("states.empty.title")}
+          description={t("states.empty.description")}
+          // Hide the action button while a run is in flight — the
+          // running banner above already provides the visual signal
+          // and a Cancel control. Re-enabling on terminal lets the
+          // user fire a follow-up run if the first one failed.
+          actionLabel={runInProgress ? undefined : t("actions.newAnalysis")}
+          onAction={runInProgress ? undefined : () => setShowModal(true)}
+        />
+      ) : (
+        <>
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.55fr)_minmax(0,1fr)]">
+            <div className="space-y-4">
+              <ScatterPlot
+                clusters={state.clusters}
+                positions={state.positions}
+                focusedClusterId={focusedClusterId}
+                focusedCluster={focusedCluster}
+                onClearFocus={() => setFocusedClusterId(null)}
+              />
+              <RepresentativesPanel
+                cluster={focusedCluster}
+                totalCount={focusedCluster?.count ?? 0}
+              />
+            </div>
+            <ClusterList
+              clusters={state.clusters}
+              focusedClusterId={focusedClusterId}
+              onToggleFocus={toggleFocusedClusterId}
+              onClearFocus={() => setFocusedClusterId(null)}
+            />
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+            <AnalysisHistory
+              runs={state.history}
+              total={state.history.length}
+              activeRunId={state.activeRun?.run_id ?? null}
+            />
+            <PropertyStats
+              clusters={state.clusters}
+              focusedCluster={focusedCluster}
+            />
+          </div>
+        </>
+      )}
+
+      <NewAnalysisModal
+        open={showModal}
+        contextId={contextId}
+        contextName={contextName}
+        onClose={() => setShowModal(false)}
+        onStarted={handleRunStarted}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
@@ -403,11 +403,13 @@ export function AnalysesTabPanel({
           value={
             state.clusters.length === 0
               ? t("kpi.qualityNoData")
-              : `conf ${formatConfidence(
-                  state.clusters
-                    .map((c) => c.label_confidence)
-                    .reduce((acc, n) => acc + n, 0) / state.clusters.length,
-                )}`
+              : t("kpi.qualityValue", {
+                  value: formatConfidence(
+                    state.clusters
+                      .map((c) => c.label_confidence)
+                      .reduce((acc, n) => acc + n, 0) / state.clusters.length,
+                  ),
+                })
           }
           tone={state.clusters.length === 0 ? "muted" : "secondary"}
         />

--- a/frontend/src/components/contexts/analyses/AnalysisHistory.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysisHistory.tsx
@@ -1,0 +1,107 @@
+"use client";
+
+/**
+ * AnalysisHistory — past run table for the analyses tab (Issue #497).
+ *
+ * Renders the paginated ``listAnalysisRuns`` payload as a small read-
+ * only table. Sticky-NULL on cost columns: an unpriced run shows "—"
+ * via ``formatCostCents`` rather than a misleading $0.000.
+ */
+
+import { useTranslations } from "next-intl";
+import { EmptyState } from "@/components/ui/empty-state";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { History } from "lucide-react";
+import { formatLocalDate } from "@/lib/utils/datetime";
+import { formatCostCents } from "./analysisFormatters";
+import type { AnalysisRunRow } from "@/lib/api/analyses";
+
+interface AnalysisHistoryProps {
+  runs: AnalysisRunRow[];
+  total: number | null;
+  activeRunId: string | null;
+}
+
+function statusLabel(run: AnalysisRunRow): string {
+  if (run.cancellation_reason) return `cancelled · ${run.cancellation_reason}`;
+  return run.status;
+}
+
+export function AnalysisHistory({
+  runs,
+  total,
+  activeRunId,
+}: AnalysisHistoryProps) {
+  const t = useTranslations("analyses.history");
+
+  if (runs.length === 0) {
+    return (
+      <EmptyState
+        compact
+        icon={History}
+        title={t("noRunsTitle")}
+        description={t("noRunsDescription")}
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <header className="border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          {t("title")}
+        </h3>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {total !== null && total !== runs.length
+            ? t("subtitle", { visible: runs.length, total })
+            : t("subtitleAtMost", { visible: runs.length })}
+        </p>
+      </header>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>{t("headerDate")}</TableHead>
+            <TableHead>{t("headerStatus")}</TableHead>
+            <TableHead className="text-right">{t("headerMemories")}</TableHead>
+            <TableHead className="text-right">{t("headerCost")}</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {runs.map((run) => {
+            const isActive = activeRunId === run.run_id;
+            return (
+              <TableRow
+                key={run.run_id}
+                className={
+                  isActive ? "bg-emerald-50/40 dark:bg-emerald-900/20" : ""
+                }
+              >
+                <TableCell className="font-mono text-xs">
+                  {formatLocalDate(new Date(run.started_at))}
+                </TableCell>
+                <TableCell className="text-xs text-gray-600 dark:text-gray-400">
+                  {statusLabel(run)}
+                </TableCell>
+                <TableCell className="text-right font-medium">
+                  {run.input_count.toLocaleString()}
+                </TableCell>
+                <TableCell className="text-right">
+                  {formatCostCents(
+                    run.cost_actual_cents ?? run.cost_estimated_cents,
+                  )}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/frontend/src/components/contexts/analyses/AnalysisHistory.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysisHistory.tsx
@@ -29,10 +29,11 @@ interface AnalysisHistoryProps {
   activeRunId: string | null;
 }
 
-function statusLabel(run: AnalysisRunRow): string {
-  if (run.cancellation_reason) return `cancelled · ${run.cancellation_reason}`;
-  return run.status;
-}
+// Translatable status labels — keyed by the canonical
+// ``ANALYSIS_STATUSES`` enum from ``lib/api/analyses``. Anything
+// outside the enum (e.g. a future ``timeout`` taxonomy) falls back
+// to the ``unknown`` key with the raw status interpolated.
+const KNOWN_STATUSES = new Set(["running", "succeeded", "failed", "cancelled"]);
 
 export function AnalysisHistory({
   runs,
@@ -87,7 +88,18 @@ export function AnalysisHistory({
                   {formatLocalDate(new Date(run.started_at))}
                 </TableCell>
                 <TableCell className="text-xs text-gray-600 dark:text-gray-400">
-                  {statusLabel(run)}
+                  {run.status === "cancelled"
+                    ? t("status.cancelled", {
+                        reason: run.cancellation_reason ?? "",
+                      })
+                    : KNOWN_STATUSES.has(run.status)
+                      ? t(
+                          `status.${run.status}` as
+                            | "status.running"
+                            | "status.succeeded"
+                            | "status.failed",
+                        )
+                      : t("status.unknown", { raw: run.status })}
                 </TableCell>
                 <TableCell className="text-right font-medium">
                   {run.input_count.toLocaleString()}

--- a/frontend/src/components/contexts/analyses/ClusterList.tsx
+++ b/frontend/src/components/contexts/analyses/ClusterList.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+/**
+ * ClusterList — sortable cluster overview with click-to-focus (Issue #497).
+ *
+ * Sorted by ``count DESC`` (largest cluster first). Clicking a row
+ * toggles focus: same row again clears focus and returns to the
+ * "All clusters" view. The state itself lives in
+ * ``useFocusedClusterId`` and is URL-synced.
+ */
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Layers, ArrowLeft } from "lucide-react";
+import { getClusterColor } from "./clusterColors";
+import { classifyQuality, formatConfidence } from "./analysisFormatters";
+import type { AnalysisCluster } from "@/lib/api/analyses";
+
+interface ClusterListProps {
+  clusters: AnalysisCluster[];
+  focusedClusterId: number | null;
+  onToggleFocus: (clusterIndex: number) => void;
+  onClearFocus: () => void;
+}
+
+export function ClusterList({
+  clusters,
+  focusedClusterId,
+  onToggleFocus,
+  onClearFocus,
+}: ClusterListProps) {
+  const t = useTranslations("analyses.clusters");
+
+  const sorted = useMemo(
+    () => [...clusters].sort((a, b) => b.count - a.count),
+    [clusters],
+  );
+
+  if (sorted.length === 0) {
+    return (
+      <EmptyState
+        compact
+        icon={Layers}
+        title={t("noClustersTitle")}
+        description={t("noClustersDescription")}
+      />
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <header className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {t("title")}
+          </h3>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {t("subtitle", { count: sorted.length })}
+          </p>
+        </div>
+        {focusedClusterId !== null && (
+          <button
+            type="button"
+            onClick={onClearFocus}
+            className="inline-flex items-center gap-1 rounded-md border border-gray-200 bg-white px-2 py-1 text-xs text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            {t("allClusters")}
+          </button>
+        )}
+      </header>
+      <ul className="divide-y divide-gray-100 dark:divide-gray-800">
+        {sorted.map((cluster) => {
+          const isActive = cluster.cluster_index === focusedClusterId;
+          const tier = classifyQuality(cluster.label_confidence);
+          const tierClass =
+            tier === "good"
+              ? "text-emerald-700 dark:text-emerald-400"
+              : tier === "fair"
+                ? "text-amber-700 dark:text-amber-400"
+                : "text-red-700 dark:text-red-400";
+          return (
+            <li key={cluster.cluster_index}>
+              <button
+                type="button"
+                onClick={() => onToggleFocus(cluster.cluster_index)}
+                aria-pressed={isActive}
+                className={`flex w-full cursor-pointer items-start gap-3 px-5 py-3 text-left transition-colors hover:bg-gray-50 dark:hover:bg-gray-800/60 ${
+                  isActive ? "bg-gray-50 dark:bg-gray-800/60" : ""
+                }`}
+              >
+                <span
+                  className="mt-1.5 h-2.5 w-2.5 shrink-0 rounded-full"
+                  style={{
+                    backgroundColor: getClusterColor(cluster.cluster_index),
+                  }}
+                  aria-hidden
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate text-sm font-semibold text-gray-900 dark:text-gray-100">
+                      {cluster.label || t("outlierLabel")}
+                    </span>
+                    <span className="font-mono text-xs text-gray-400">
+                      #{cluster.cluster_index}
+                    </span>
+                  </div>
+                  {cluster.description && (
+                    <p className="mt-0.5 line-clamp-1 text-xs text-gray-500 dark:text-gray-400">
+                      {cluster.description}
+                    </p>
+                  )}
+                </div>
+                <div className="shrink-0 text-right">
+                  <div className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                    {cluster.count}
+                  </div>
+                  <div className={`text-[10px] font-medium ${tierClass}`}>
+                    {t("confidence", {
+                      value: formatConfidence(cluster.label_confidence),
+                    })}
+                  </div>
+                </div>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -1,0 +1,322 @@
+"use client";
+
+/**
+ * NewAnalysisModal — pre-flight + start trigger for a new run (Issue #497).
+ *
+ * Filters: ``period`` (from / to), ``tags`` (chip selector), ``types``
+ * (single select), ``min_importance`` (range slider), ``query`` (text).
+ * Runs ``previewAnalysis`` whenever the form changes (debounced) so the
+ * preflight strip shows live ``estimated_cost_cents`` and
+ * ``memory_count``.
+ *
+ * Submit posts ``startAnalysis`` and on 202 calls ``onStarted(run_id)``
+ * so the parent can pivot into "watching the active run" mode.
+ *
+ * URL state: this modal is driven by ``?new=1`` on the URL — opening
+ * and closing is owned by the parent (AnalysesTabPanel) which sets /
+ * removes the query param. The modal itself is a pure
+ * controlled component.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { InlineSpinner } from "@/components/common/LoadingState";
+import { CheckCircle2 } from "lucide-react";
+import { ApiError } from "@/lib/api/base";
+import {
+  previewAnalysis,
+  startAnalysis,
+  type AnalysisFilters,
+  type AnalysisPreviewResponse,
+} from "@/lib/api/analyses";
+import { formatCostCents } from "./analysisFormatters";
+
+interface NewAnalysisModalProps {
+  open: boolean;
+  contextId: string;
+  contextName: string;
+  onClose: () => void;
+  onStarted: (runId: string) => void;
+}
+
+const DEFAULT_TYPES = [
+  "all",
+  "decision",
+  "pattern",
+  "note",
+  "feature-design",
+  "learning",
+] as const;
+
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function isoDaysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString().slice(0, 10);
+}
+
+export function NewAnalysisModal({
+  open,
+  contextId,
+  contextName,
+  onClose,
+  onStarted,
+}: NewAnalysisModalProps) {
+  const t = useTranslations("analyses.modal");
+  // ``actions.cancel`` lives one namespace up; a separate hook reaches it
+  // without re-keying the modal namespace.
+  const tActions = useTranslations("analyses.actions");
+
+  const [from, setFrom] = useState(() => isoDaysAgo(30));
+  const [to, setTo] = useState(() => todayIso());
+  const [type, setType] = useState<string>("all");
+  const [minImportance, setMinImportance] = useState(50);
+  const [query, setQuery] = useState("");
+
+  const [preview, setPreview] = useState<AnalysisPreviewResponse | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [previewError, setPreviewError] = useState<string | null>(null);
+
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Build filter payload from form. Memo so the preview effect's deps
+  // are content-stable.
+  const filters = useMemo<AnalysisFilters>(() => {
+    const out: AnalysisFilters = { from, to };
+    if (type !== "all") out.types = [type];
+    if (minImportance > 0) out.min_importance = minImportance / 100;
+    if (query.trim().length > 0) out.query = query.trim();
+    return out;
+  }, [from, to, type, minImportance, query]);
+
+  // Debounced preview: 300ms after the form settles. Cancels a stale
+  // request when the user keeps typing.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setPreviewLoading(true);
+    setPreviewError(null);
+    const timer = window.setTimeout(async () => {
+      try {
+        const result = await previewAnalysis(contextId, filters);
+        if (cancelled) return;
+        setPreview(result);
+      } catch (err) {
+        if (cancelled) return;
+        setPreviewError(
+          err instanceof ApiError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : "preview failed",
+        );
+      } finally {
+        if (!cancelled) setPreviewLoading(false);
+      }
+    }, 300);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, [open, contextId, filters]);
+
+  // Reset state when modal closes so the next open starts fresh.
+  useEffect(() => {
+    if (!open) {
+      setSubmitting(false);
+      setSubmitError(null);
+    }
+  }, [open]);
+
+  const handleSubmit = useCallback(async () => {
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      const res = await startAnalysis(contextId, filters);
+      onStarted(res.run_id);
+    } catch (err) {
+      setSubmitError(
+        err instanceof ApiError
+          ? err.message
+          : err instanceof Error
+            ? err.message
+            : "start failed",
+      );
+    } finally {
+      setSubmitting(false);
+    }
+  }, [contextId, filters, onStarted]);
+
+  const previewMemoryCount = preview?.memory_count ?? null;
+  const previewCostCents = preview?.estimated_cost_cents ?? null;
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+          <DialogDescription>
+            {t("subtitle", { contextName })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <Label>{t("period")}</Label>
+            <div className="mt-1.5 grid grid-cols-2 gap-2">
+              <Input
+                type="date"
+                value={from}
+                onChange={(e) => setFrom(e.target.value)}
+              />
+              <Input
+                type="date"
+                value={to}
+                onChange={(e) => setTo(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <Label>{t("types")}</Label>
+              <Select value={type} onValueChange={setType}>
+                <SelectTrigger className="mt-1.5">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {DEFAULT_TYPES.map((opt) => (
+                    <SelectItem key={opt} value={opt}>
+                      {opt === "all" ? t("typesAll") : opt}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label>
+                {t("minImportance")} ·{" "}
+                <span className="font-mono text-emerald-700 dark:text-emerald-400">
+                  {(minImportance / 100).toFixed(2)}
+                </span>
+              </Label>
+              <input
+                type="range"
+                min={0}
+                max={100}
+                value={minImportance}
+                onChange={(e) => setMinImportance(Number(e.target.value))}
+                className="mt-3 h-2 w-full accent-gray-900 dark:accent-gray-100"
+                aria-label={t("minImportance")}
+              />
+            </div>
+          </div>
+
+          <div>
+            <Label>
+              {t("narrativeQuery")}{" "}
+              <span className="font-normal text-gray-400">
+                {t("narrativeQueryHint")}
+              </span>
+            </Label>
+            <Input
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder={t("narrativeQueryPlaceholder")}
+              className="mt-1.5"
+            />
+          </div>
+        </div>
+
+        <div className="rounded-md border border-gray-200 bg-gray-50 px-4 py-3 text-sm dark:border-gray-700 dark:bg-gray-800/50">
+          <div className="flex items-center justify-between gap-4">
+            <div>
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                {t("preflight.memoriesCount")}
+              </div>
+              <div className="font-semibold text-gray-900 dark:text-gray-100">
+                {previewLoading || previewMemoryCount === null
+                  ? t("preflight.loading")
+                  : previewMemoryCount.toLocaleString()}
+              </div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-500 dark:text-gray-400">
+                {t("preflight.estimatedCost")}
+              </div>
+              <div className="font-semibold text-emerald-700 dark:text-emerald-400">
+                {previewLoading
+                  ? t("preflight.loading")
+                  : formatCostCents(previewCostCents)}
+              </div>
+            </div>
+            <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-600 dark:text-emerald-400" />
+          </div>
+          {previewError && (
+            <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+              {t("errorLoadingPreview")}: {previewError}
+            </p>
+          )}
+        </div>
+
+        {submitError && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              {t("errorStarting")}: {submitError}
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <DialogFooter>
+          <p className="mr-auto text-xs text-gray-500 dark:text-gray-400">
+            {t("footerHint")}
+          </p>
+          <Button variant="outline" onClick={onClose} disabled={submitting}>
+            {tActions("cancel")}
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={submitting || previewLoading || preview === null}
+          >
+            {submitting ? (
+              <>
+                <InlineSpinner size="sm" />
+                <span className="ml-2">{t("submitting")}</span>
+              </>
+            ) : (
+              t("submit")
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -139,7 +139,7 @@ export function NewAnalysisModal({
             ? err.message
             : err instanceof Error
               ? err.message
-              : "preview failed",
+              : t("errorPreviewFallback"),
         );
       } finally {
         if (!cancelled) setPreviewLoading(false);
@@ -171,7 +171,7 @@ export function NewAnalysisModal({
           ? err.message
           : err instanceof Error
             ? err.message
-            : "start failed",
+            : t("errorStartFallback"),
       );
     } finally {
       setSubmitting(false);

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -3,8 +3,11 @@
 /**
  * NewAnalysisModal — pre-flight + start trigger for a new run (Issue #497).
  *
- * Filters: ``period`` (from / to), ``tags`` (chip selector), ``types``
- * (single select), ``min_importance`` (range slider), ``query`` (text).
+ * Filters: ``period`` (from / to), ``types`` (single select),
+ * ``min_importance`` (range slider), ``query`` (text). The ``tags``
+ * field is supported on the API surface but the modal does not yet
+ * expose a chip selector — follow-up work, see
+ * ``analyses.modal.tags*`` i18n keys reserved for that UI.
  * Runs ``previewAnalysis`` whenever the form changes (debounced) so the
  * preflight strip shows live ``estimated_cost_cents`` and
  * ``memory_count``.

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -48,6 +48,7 @@ import {
   type AnalysisFilters,
   type AnalysisPreviewResponse,
 } from "@/lib/api/analyses";
+import { formatLocalDate } from "@/lib/utils/datetime";
 import { formatCostCents } from "./analysisFormatters";
 
 interface NewAnalysisModalProps {
@@ -67,14 +68,18 @@ const DEFAULT_TYPES = [
   "learning",
 ] as const;
 
+// ``toISOString().slice(0, 10)`` shifts the date for users east/west
+// of UTC (e.g. JST users at 23:30 see "tomorrow"). ``formatLocalDate``
+// uses local-tz components — the same helper the cost dashboard uses
+// for ``<input type="date">`` defaults (#473 / PR #527 convention).
 function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
+  return formatLocalDate(new Date());
 }
 
 function isoDaysAgo(n: number): string {
   const d = new Date();
   d.setDate(d.getDate() - n);
-  return d.toISOString().slice(0, 10);
+  return formatLocalDate(d);
 }
 
 export function NewAnalysisModal({

--- a/frontend/src/components/contexts/analyses/PropertyStats.tsx
+++ b/frontend/src/components/contexts/analyses/PropertyStats.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+/**
+ * PropertyStats — tag bar / type pie / importance histogram / time series.
+ *
+ * Driven by the ``property_stats`` JSONB blob persisted on each cluster
+ * row. ``focusedClusterId === null`` → render the full-context aggregate
+ * (sum across all clusters). Otherwise render the focused cluster's
+ * stats directly.
+ */
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { EmptyState } from "@/components/ui/empty-state";
+import { BarChart3 } from "lucide-react";
+import { getClusterColor } from "./clusterColors";
+import {
+  normalizePropertyStats,
+  type NormalizedPropertyStats,
+} from "./analysisFormatters";
+import type { AnalysisCluster } from "@/lib/api/analyses";
+
+interface PropertyStatsProps {
+  clusters: AnalysisCluster[];
+  focusedCluster: AnalysisCluster | null;
+}
+
+/** Sum two normalized stat blobs into one. Used for the "All clusters" view. */
+function aggregateStats(
+  blobs: NormalizedPropertyStats[],
+): NormalizedPropertyStats {
+  if (blobs.length === 0) {
+    return {
+      topTags: [],
+      typeDistribution: [],
+      importanceBuckets: [],
+      timeSeries: [],
+    };
+  }
+  const tagSums = new Map<string, number>();
+  for (const blob of blobs) {
+    for (const t of blob.topTags) {
+      tagSums.set(t.tag, (tagSums.get(t.tag) ?? 0) + t.count);
+    }
+  }
+  const topTags = [...tagSums.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 8)
+    .map(([tag, count]) => ({ tag, count }));
+
+  const typeSums = new Map<string, number>();
+  for (const blob of blobs) {
+    for (const ty of blob.typeDistribution) {
+      typeSums.set(ty.type, (typeSums.get(ty.type) ?? 0) + ty.ratio);
+    }
+  }
+  const typeTotal = [...typeSums.values()].reduce((a, b) => a + b, 0);
+  const typeDistribution =
+    typeTotal === 0
+      ? []
+      : [...typeSums.entries()]
+          .sort(([, a], [, b]) => b - a)
+          .slice(0, 6)
+          .map(([type, sum]) => ({ type, ratio: sum / typeTotal }));
+
+  const bucketLen = blobs[0].importanceBuckets.length;
+  const importanceBuckets =
+    bucketLen === 0
+      ? []
+      : Array.from({ length: bucketLen }, (_, i) =>
+          blobs.reduce((acc, b) => acc + (b.importanceBuckets[i] ?? 0), 0),
+        );
+
+  const tsSums = new Map<string, number>();
+  for (const blob of blobs) {
+    for (const t of blob.timeSeries) {
+      tsSums.set(t.bucket, (tsSums.get(t.bucket) ?? 0) + t.count);
+    }
+  }
+  const timeSeries = [...tsSums.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([bucket, count]) => ({ bucket, count }));
+
+  return { topTags, typeDistribution, importanceBuckets, timeSeries };
+}
+
+export function PropertyStats({
+  clusters,
+  focusedCluster,
+}: PropertyStatsProps) {
+  const t = useTranslations("analyses.propertyStats");
+
+  const stats = useMemo(() => {
+    if (focusedCluster) {
+      return normalizePropertyStats(focusedCluster.property_stats);
+    }
+    return aggregateStats(
+      clusters.map((c) => normalizePropertyStats(c.property_stats)),
+    );
+  }, [focusedCluster, clusters]);
+
+  const accent = focusedCluster
+    ? getClusterColor(focusedCluster.cluster_index)
+    : "hsl(var(--chart-1))";
+
+  const isEmpty =
+    stats.topTags.length === 0 &&
+    stats.typeDistribution.length === 0 &&
+    stats.importanceBuckets.length === 0 &&
+    stats.timeSeries.length === 0;
+
+  if (isEmpty) {
+    return (
+      <EmptyState
+        compact
+        icon={BarChart3}
+        title={t("title")}
+        description={t("empty")}
+      />
+    );
+  }
+
+  const subtitle = focusedCluster
+    ? t("subtitleCluster", {
+        index: focusedCluster.cluster_index,
+        label: focusedCluster.label,
+      })
+    : t("subtitleAll");
+
+  const maxTagCount = Math.max(...stats.topTags.map((t) => t.count), 1);
+  const maxBucket = Math.max(...stats.importanceBuckets, 1);
+  const maxTs = Math.max(...stats.timeSeries.map((p) => p.count), 1);
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <header className="border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+          {t("title")}
+        </h3>
+        <p className="inline-flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-400">
+          <span
+            className="h-2 w-2 rounded-full"
+            style={{ backgroundColor: accent }}
+            aria-hidden
+          />
+          {subtitle}
+        </p>
+      </header>
+      <div className="grid grid-cols-1 gap-x-6 gap-y-4 px-5 py-4 text-sm md:grid-cols-2">
+        {stats.topTags.length > 0 && (
+          <div>
+            <div className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+              {t("topTags")}
+            </div>
+            <div className="space-y-1.5">
+              {stats.topTags.map((row) => (
+                <div key={row.tag} className="flex items-center gap-2">
+                  <div className="w-24 truncate text-xs text-gray-700 dark:text-gray-300">
+                    {row.tag}
+                  </div>
+                  <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                    <div
+                      className="h-full"
+                      style={{
+                        width: `${(row.count / maxTagCount) * 100}%`,
+                        backgroundColor: accent,
+                      }}
+                    />
+                  </div>
+                  <div className="w-8 text-right font-mono text-xs text-gray-500 dark:text-gray-400">
+                    {row.count}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {(stats.typeDistribution.length > 0 ||
+          stats.importanceBuckets.length > 0) && (
+          <div>
+            {stats.typeDistribution.length > 0 && (
+              <>
+                <div className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                  {t("byType")}
+                </div>
+                <div className="space-y-1.5">
+                  {stats.typeDistribution.map((row) => (
+                    <div key={row.type} className="flex items-center gap-2">
+                      <div className="w-24 truncate text-xs text-gray-700 dark:text-gray-300">
+                        {row.type}
+                      </div>
+                      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                        <div
+                          className="h-full bg-gray-700 dark:bg-gray-300"
+                          style={{ width: `${row.ratio * 100}%` }}
+                        />
+                      </div>
+                      <div className="w-8 text-right font-mono text-xs text-gray-500 dark:text-gray-400">
+                        {Math.round(row.ratio * 100)}%
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+
+            {stats.importanceBuckets.length > 0 && (
+              <>
+                <div className="mb-2 mt-4 text-xs text-gray-500 dark:text-gray-400">
+                  {t("importance")}
+                </div>
+                <div className="flex h-12 items-end gap-1.5">
+                  {stats.importanceBuckets.map((count, i) => (
+                    <div
+                      key={i}
+                      className="flex flex-1 flex-col items-center justify-end"
+                    >
+                      <div
+                        className="w-full rounded-sm bg-emerald-400 dark:bg-emerald-500"
+                        style={{
+                          height: `${(count / maxBucket) * 100}%`,
+                          minHeight: 2,
+                        }}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {stats.timeSeries.length > 0 && (
+          <div className="md:col-span-2">
+            <div className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+              {t("activity")}
+            </div>
+            <div className="flex h-10 items-end gap-0.5">
+              {stats.timeSeries.map((p) => (
+                <div
+                  key={p.bucket}
+                  className="flex-1 rounded-sm bg-gray-300 dark:bg-gray-600"
+                  style={{
+                    height: `${(p.count / maxTs) * 100}%`,
+                    minHeight: 2,
+                  }}
+                  title={`${p.bucket}: ${p.count}`}
+                />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/contexts/analyses/PropertyStats.tsx
+++ b/frontend/src/components/contexts/analyses/PropertyStats.tsx
@@ -48,20 +48,21 @@ function aggregateStats(
     .slice(0, 8)
     .map(([tag, count]) => ({ tag, count }));
 
+  // Aggregate types by summing the underlying COUNTS, not the per-
+  // cluster ratios — ratio-of-ratios would weight a 5-memory cluster
+  // and a 500-memory cluster equally, distorting the all-clusters
+  // view. Ratios for the bar widths are computed at render time
+  // from the summed counts (see render block below).
   const typeSums = new Map<string, number>();
   for (const blob of blobs) {
     for (const ty of blob.typeDistribution) {
-      typeSums.set(ty.type, (typeSums.get(ty.type) ?? 0) + ty.ratio);
+      typeSums.set(ty.type, (typeSums.get(ty.type) ?? 0) + ty.count);
     }
   }
-  const typeTotal = [...typeSums.values()].reduce((a, b) => a + b, 0);
-  const typeDistribution =
-    typeTotal === 0
-      ? []
-      : [...typeSums.entries()]
-          .sort(([, a], [, b]) => b - a)
-          .slice(0, 6)
-          .map(([type, sum]) => ({ type, ratio: sum / typeTotal }));
+  const typeDistribution = [...typeSums.entries()]
+    .sort(([, a], [, b]) => b - a)
+    .slice(0, 6)
+    .map(([type, count]) => ({ type, count }));
 
   const bucketLen = blobs[0].importanceBuckets.length;
   const importanceBuckets =
@@ -179,31 +180,49 @@ export function PropertyStats({
         {(stats.typeDistribution.length > 0 ||
           stats.importanceBuckets.length > 0) && (
           <div>
-            {stats.typeDistribution.length > 0 && (
-              <>
-                <div className="mb-2 text-xs text-gray-500 dark:text-gray-400">
-                  {t("byType")}
-                </div>
-                <div className="space-y-1.5">
-                  {stats.typeDistribution.map((row) => (
-                    <div key={row.type} className="flex items-center gap-2">
-                      <div className="w-24 truncate text-xs text-gray-700 dark:text-gray-300">
-                        {row.type}
-                      </div>
-                      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
-                        <div
-                          className="h-full bg-gray-700 dark:bg-gray-300"
-                          style={{ width: `${row.ratio * 100}%` }}
-                        />
-                      </div>
-                      <div className="w-8 text-right font-mono text-xs text-gray-500 dark:text-gray-400">
-                        {Math.round(row.ratio * 100)}%
-                      </div>
+            {stats.typeDistribution.length > 0 &&
+              (() => {
+                // Compute ratios from the summed counts at the render
+                // boundary so the per-cluster + all-clusters views
+                // share the same denominator math (see aggregateStats
+                // for why counts are carried instead of ratios).
+                const typeTotal = stats.typeDistribution.reduce(
+                  (acc, r) => acc + r.count,
+                  0,
+                );
+                if (typeTotal === 0) return null;
+                return (
+                  <>
+                    <div className="mb-2 text-xs text-gray-500 dark:text-gray-400">
+                      {t("byType")}
                     </div>
-                  ))}
-                </div>
-              </>
-            )}
+                    <div className="space-y-1.5">
+                      {stats.typeDistribution.map((row) => {
+                        const ratio = row.count / typeTotal;
+                        return (
+                          <div
+                            key={row.type}
+                            className="flex items-center gap-2"
+                          >
+                            <div className="w-24 truncate text-xs text-gray-700 dark:text-gray-300">
+                              {row.type}
+                            </div>
+                            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                              <div
+                                className="h-full bg-gray-700 dark:bg-gray-300"
+                                style={{ width: `${ratio * 100}%` }}
+                              />
+                            </div>
+                            <div className="w-8 text-right font-mono text-xs text-gray-500 dark:text-gray-400">
+                              {Math.round(ratio * 100)}%
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </>
+                );
+              })()}
 
             {stats.importanceBuckets.length > 0 && (
               <>

--- a/frontend/src/components/contexts/analyses/RepresentativesPanel.tsx
+++ b/frontend/src/components/contexts/analyses/RepresentativesPanel.tsx
@@ -119,7 +119,7 @@ export function RepresentativesPanel({
           </h4>
         </div>
         <span className="text-xs text-gray-500 dark:text-gray-400">
-          {t("viewAll", { count: totalCount })}
+          {t("totalInCluster", { count: totalCount })}
         </span>
       </header>
       <div className="px-5 py-4">

--- a/frontend/src/components/contexts/analyses/RepresentativesPanel.tsx
+++ b/frontend/src/components/contexts/analyses/RepresentativesPanel.tsx
@@ -149,8 +149,11 @@ export function RepresentativesPanel({
                     {rep.summary}
                   </div>
                   <div className="mt-0.5 font-mono text-xs text-gray-400">
-                    {rep.memory_id.slice(0, 8)} · {rep.type} · importance{" "}
-                    {rep.importance.toFixed(2)}
+                    {t("metaLine", {
+                      idShort: rep.memory_id.slice(0, 8),
+                      type: rep.type,
+                      importance: rep.importance.toFixed(2),
+                    })}
                   </div>
                 </div>
               </li>

--- a/frontend/src/components/contexts/analyses/RepresentativesPanel.tsx
+++ b/frontend/src/components/contexts/analyses/RepresentativesPanel.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+/**
+ * RepresentativesPanel — top-k representative memories of focused cluster.
+ *
+ * Issue #497: the cluster row carries ``representative_memory_ids`` (UUID
+ * array, capped at 5 by the labeler). This panel resolves them to
+ * memory summaries via ``referenceMemory(uuid)`` so the cluster list
+ * stays small (no embedded summaries) and importance / freshness
+ * filtering can be added later without touching the analyses API.
+ *
+ * Defensive resolution: a representative_memory_id can become stale
+ * if the underlying memory was soft-deleted post-run (model docstring
+ * note on ``representative_memory_ids``). Failed lookups are silently
+ * skipped — matching the backend's filter-out-stale semantics in
+ * ``query_service.get_cluster``.
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { EmptyState } from "@/components/ui/empty-state";
+import { LoadingState } from "@/components/common/LoadingState";
+import { Users } from "lucide-react";
+import { referenceMemory } from "@/lib/api/memory";
+import { getClusterColor } from "./clusterColors";
+import type { AnalysisCluster } from "@/lib/api/analyses";
+
+interface RepresentativesPanelProps {
+  cluster: AnalysisCluster | null;
+  totalCount: number;
+}
+
+interface ResolvedRep {
+  memory_id: string;
+  summary: string;
+  type: string;
+  importance: number;
+}
+
+export function RepresentativesPanel({
+  cluster,
+  totalCount,
+}: RepresentativesPanelProps) {
+  const t = useTranslations("analyses.representatives");
+
+  const ids = useMemo(
+    () => (cluster ? cluster.representative_memory_ids.slice(0, 5) : []),
+    [cluster],
+  );
+  // Stable key so the load effect doesn't re-fire on identical id lists.
+  const idsKey = useMemo(() => ids.join(","), [ids]);
+
+  const [resolved, setResolved] = useState<ResolvedRep[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (ids.length === 0) {
+      setResolved([]);
+      setLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+
+    Promise.allSettled(ids.map((id) => referenceMemory(id))).then((results) => {
+      if (cancelled) return;
+      const next: ResolvedRep[] = [];
+      for (const r of results) {
+        if (r.status === "fulfilled") {
+          const ref = r.value;
+          next.push({
+            memory_id: ref.memory_id,
+            summary: ref.summary,
+            type: ref.type,
+            importance: ref.importance,
+          });
+        }
+        // Rejected lookups are dropped — likely soft-deleted post-run.
+      }
+      setResolved(next);
+      setLoading(false);
+    });
+
+    return () => {
+      cancelled = true;
+    };
+    // idsKey captures content; depending on `ids` directly would
+    // re-fire on identical-content array references.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [idsKey]);
+
+  if (!cluster) {
+    return (
+      <EmptyState
+        compact
+        icon={Users}
+        title={t("headerLabel")}
+        description={t("emptyNoFocus")}
+      />
+    );
+  }
+
+  const accent = getClusterColor(cluster.cluster_index);
+
+  return (
+    <div className="rounded-xl border border-gray-200 bg-white shadow-sm dark:border-gray-700 dark:bg-gray-900">
+      <header className="flex items-center justify-between border-b border-gray-100 px-5 py-4 dark:border-gray-800">
+        <div className="flex items-center gap-2">
+          <span
+            className="h-2 w-2 rounded-full"
+            style={{ backgroundColor: accent }}
+            aria-hidden
+          />
+          <h4 className="text-xs font-semibold uppercase tracking-wide text-gray-700 dark:text-gray-300">
+            {t("headerLabel")} ·{" "}
+            <span className="text-sm font-medium normal-case tracking-normal text-gray-900 dark:text-gray-100">
+              {cluster.label}
+            </span>
+          </h4>
+        </div>
+        <span className="text-xs text-gray-500 dark:text-gray-400">
+          {t("viewAll", { count: totalCount })}
+        </span>
+      </header>
+      <div className="px-5 py-4">
+        {loading ? (
+          <LoadingState lines={3} />
+        ) : resolved.length === 0 ? (
+          <EmptyState
+            compact
+            icon={Users}
+            title={t("empty")}
+            description={t("emptyAfterLoad")}
+          />
+        ) : (
+          <ul className="space-y-2">
+            {resolved.map((rep) => (
+              <li
+                key={rep.memory_id}
+                className="flex items-start gap-2.5 text-sm"
+              >
+                <span
+                  className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full"
+                  style={{ backgroundColor: accent }}
+                  aria-hidden
+                />
+                <div className="min-w-0">
+                  <div className="truncate text-gray-900 dark:text-gray-100">
+                    {rep.summary}
+                  </div>
+                  <div className="mt-0.5 font-mono text-xs text-gray-400">
+                    {rep.memory_id.slice(0, 8)} · {rep.type} · importance{" "}
+                    {rep.importance.toFixed(2)}
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/contexts/analyses/ScatterPlot.tsx
+++ b/frontend/src/components/contexts/analyses/ScatterPlot.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+/**
+ * ScatterPlot — UMAP scatter for the analyses tab (Issue #497).
+ *
+ * SVG-based, per-cluster ``<g data-c="N">`` grouping so focus mode is
+ * a CSS class toggle (``.scatter.focused .cluster-layer { opacity: .12 }``)
+ * rather than an O(N) re-render. The render budget for v1 is bounded
+ * by ``MemoryAnalysis.input_count`` ≤ 10k, which SVG handles as long as
+ * every dot stays in a per-cluster group (browsers fold the opacity
+ * toggle into a single GPU layer per cluster).
+ *
+ * Coordinate normalization: UMAP outputs arbitrary float ranges; we
+ * normalize to ``[0, 1]`` against the run's bounding box, then scale
+ * to the viewBox. ``computePositionBox`` + ``normalize01`` keep this
+ * branch-free for the degenerate "everything at one coord" case.
+ */
+
+import { useMemo } from "react";
+import { useTranslations } from "next-intl";
+import { EmptyState } from "@/components/ui/empty-state";
+import { Sparkles } from "lucide-react";
+import { computePositionBox, normalize01 } from "./analysisFormatters";
+import { getClusterColor } from "./clusterColors";
+import type { AnalysisCluster, ScatterPosition } from "@/lib/api/analyses";
+
+interface ScatterPlotProps {
+  clusters: AnalysisCluster[];
+  positions: ScatterPosition[];
+  focusedClusterId: number | null;
+  focusedCluster: AnalysisCluster | null;
+  onClearFocus: () => void;
+}
+
+const VIEW_W = 800;
+const VIEW_H = 520;
+const PAD = 24;
+
+export function ScatterPlot({
+  clusters,
+  positions,
+  focusedClusterId,
+  focusedCluster,
+  onClearFocus,
+}: ScatterPlotProps) {
+  const t = useTranslations("analyses.scatter");
+
+  const box = useMemo(() => computePositionBox(positions), [positions]);
+
+  // Group positions by cluster_index so the SVG renders one <g> per
+  // cluster — focus mode is then a single CSS class toggle on the
+  // outer <svg>, no per-dot DOM diffing.
+  const dotsByCluster = useMemo(() => {
+    const map = new Map<number, ScatterPosition[]>();
+    for (const p of positions) {
+      const arr = map.get(p.cluster_index);
+      if (arr) arr.push(p);
+      else map.set(p.cluster_index, [p]);
+    }
+    return map;
+  }, [positions]);
+
+  if (clusters.length === 0 || positions.length === 0) {
+    return (
+      <EmptyState
+        compact
+        icon={Sparkles}
+        title={t("title")}
+        description={t("noPositions")}
+      />
+    );
+  }
+
+  const project = (x: number, y: number): [number, number] => {
+    const nx = normalize01(x, box.minX, box.maxX);
+    // Flip y so positive UMAP y goes up (SVG y grows downward).
+    const ny = 1 - normalize01(y, box.minY, box.maxY);
+    return [PAD + nx * (VIEW_W - PAD * 2), PAD + ny * (VIEW_H - PAD * 2)];
+  };
+
+  return (
+    <div className="relative aspect-[1.55/1] w-full overflow-hidden rounded-lg border border-gray-100 bg-gray-50/40 dark:border-gray-800 dark:bg-gray-900/30">
+      <svg
+        viewBox={`0 0 ${VIEW_W} ${VIEW_H}`}
+        className={`scatter h-full w-full ${
+          focusedClusterId !== null ? "focused" : ""
+        }`}
+        preserveAspectRatio="xMidYMid meet"
+        role="img"
+        aria-label={t("title")}
+      >
+        {clusters.map((cluster) => {
+          const dots = dotsByCluster.get(cluster.cluster_index) ?? [];
+          const color = getClusterColor(cluster.cluster_index);
+          const [cx, cy] = project(
+            cluster.centroid_2d[0],
+            cluster.centroid_2d[1],
+          );
+          const isFocused = cluster.cluster_index === focusedClusterId;
+          return (
+            <g
+              key={cluster.cluster_index}
+              data-c={cluster.cluster_index}
+              className={`cluster-layer ${isFocused ? "is-focused" : ""}`}
+            >
+              {dots.map((d) => {
+                const [px, py] = project(d.x, d.y);
+                return (
+                  <circle
+                    key={d.memory_id}
+                    cx={px}
+                    cy={py}
+                    r={2.5}
+                    fill={color}
+                    opacity={0.85}
+                  />
+                );
+              })}
+              <circle
+                cx={cx}
+                cy={cy}
+                r={5}
+                fill={color}
+                stroke="white"
+                strokeWidth={2}
+              />
+              <text
+                x={cx}
+                y={cy - 12}
+                fontSize={10}
+                fontWeight={600}
+                fill="currentColor"
+                textAnchor="middle"
+                className="pointer-events-none select-none fill-gray-900 dark:fill-gray-100"
+              >
+                {cluster.cluster_index}
+              </text>
+            </g>
+          );
+        })}
+      </svg>
+
+      {focusedCluster && (
+        <div className="pointer-events-none absolute left-3 right-3 top-3 flex items-center justify-between">
+          <div className="pointer-events-auto inline-flex items-center gap-2 rounded-md border border-gray-200 bg-white/95 px-3 py-1.5 text-xs shadow-sm backdrop-blur dark:border-gray-700 dark:bg-gray-900/95">
+            <span
+              className="h-2 w-2 rounded-full"
+              style={{
+                backgroundColor: getClusterColor(focusedCluster.cluster_index),
+              }}
+            />
+            <span className="text-gray-500 dark:text-gray-400">
+              {t("focusedOn")}
+            </span>
+            <span className="font-medium text-gray-900 dark:text-gray-100">
+              {focusedCluster.label}
+            </span>
+            <span className="font-mono text-gray-400">
+              · {focusedCluster.count}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClearFocus}
+            className="pointer-events-auto inline-flex items-center gap-1 rounded-md border border-gray-200 bg-white/95 px-3 py-1.5 text-xs text-gray-700 shadow-sm backdrop-blur hover:bg-white dark:border-gray-700 dark:bg-gray-900/95 dark:text-gray-200 dark:hover:bg-gray-900"
+          >
+            ← {t("showAllClusters")}
+          </button>
+        </div>
+      )}
+
+      {/* Focus mode dimming via CSS — one rule, applied to the SVG root.
+          Inline <style> is intentional: the rule is component-scoped and
+          tightly coupled to the SVG class names above; promoting it to
+          globals.css would orphan the rule from its single use site. */}
+      <style jsx>{`
+        :global(.scatter .cluster-layer) {
+          transition:
+            opacity 0.25s ease,
+            transform 0.35s ease;
+        }
+        :global(.scatter.focused .cluster-layer) {
+          opacity: 0.12;
+        }
+        :global(.scatter.focused .cluster-layer.is-focused) {
+          opacity: 1;
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/components/contexts/analyses/ScatterPlot.tsx
+++ b/frontend/src/components/contexts/analyses/ScatterPlot.tsx
@@ -169,23 +169,12 @@ export function ScatterPlot({
         </div>
       )}
 
-      {/* Focus mode dimming via CSS — one rule, applied to the SVG root.
-          Inline <style> is intentional: the rule is component-scoped and
-          tightly coupled to the SVG class names above; promoting it to
-          globals.css would orphan the rule from its single use site. */}
-      <style jsx>{`
-        :global(.scatter .cluster-layer) {
-          transition:
-            opacity 0.25s ease,
-            transform 0.35s ease;
-        }
-        :global(.scatter.focused .cluster-layer) {
-          opacity: 0.12;
-        }
-        :global(.scatter.focused .cluster-layer.is-focused) {
-          opacity: 1;
-        }
-      `}</style>
+      {/* Focus mode dimming uses three rules in ``app/globals.css``
+          (.scatter / .cluster-layer / .is-focused) — pure CSS so the
+          opacity toggle is a single class flip on the outer SVG, no
+          per-dot DOM diffing. Tailwind utility classes can't express
+          the parent-state-driven child opacity without an arbitrary
+          variant per cluster index. */}
     </div>
   );
 }

--- a/frontend/src/components/contexts/analyses/analysisFormatters.test.ts
+++ b/frontend/src/components/contexts/analyses/analysisFormatters.test.ts
@@ -103,14 +103,14 @@ describe("normalizePropertyStats", () => {
       { tag: "kouchou-ai", count: 38 },
       { tag: "design", count: 12 },
     ]);
-    // dict-of-counts → list-of-ratios sorted by count desc, normalized so sum=1
-    expect(out.typeDistribution.map((r) => r.type)).toEqual([
-      "feature-design",
-      "decision",
-      "pattern",
+    // dict-of-counts → list-of-counts sorted by count desc; ratios
+    // are computed at render time from the summed counts so the
+    // per-cluster + all-clusters aggregations share denominator math.
+    expect(out.typeDistribution).toEqual([
+      { type: "feature-design", count: 71 },
+      { type: "decision", count: 18 },
+      { type: "pattern", count: 11 },
     ]);
-    expect(out.typeDistribution[0].ratio).toBeCloseTo(71 / 100, 6);
-    expect(out.typeDistribution[1].ratio).toBeCloseTo(18 / 100, 6);
     expect(out.importanceBuckets).toEqual([3, 5, 8, 7]);
     // time bucket: keep ``start`` as the rendered label for the bar chart
     expect(out.timeSeries).toEqual([
@@ -145,8 +145,8 @@ describe("normalizePropertyStats", () => {
       { tag: "kouchou-ai", count: 38 },
       { tag: "design", count: 12 },
     ]);
-    // Only ``pattern`` remained valid → 100% of the distribution.
-    expect(out.typeDistribution).toEqual([{ type: "pattern", ratio: 1 }]);
+    // Only ``pattern`` remained valid (string ``not-a-number`` filtered out).
+    expect(out.typeDistribution).toEqual([{ type: "pattern", count: 5 }]);
     expect(out.importanceBuckets).toEqual([]);
     expect(out.timeSeries).toHaveLength(2);
   });

--- a/frontend/src/components/contexts/analyses/analysisFormatters.test.ts
+++ b/frontend/src/components/contexts/analyses/analysisFormatters.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Pure-helper unit tests for the analyses formatters.
+ *
+ * Following the PR #527 cost-dashboard convention: no component
+ * render here — only data transforms.
+ */
+
+import { describe, it, expect } from "vitest";
+import {
+  formatCostCents,
+  formatConfidence,
+  classifyQuality,
+  normalizePropertyStats,
+  normalize01,
+  computePositionBox,
+} from "./analysisFormatters";
+
+describe("formatCostCents", () => {
+  it("renders dollars with three decimals", () => {
+    expect(formatCostCents(1100)).toBe("$11.000");
+    expect(formatCostCents(11)).toBe("$0.110");
+    expect(formatCostCents(0)).toBe("$0.000");
+  });
+
+  it("renders sticky-NULL as em-dash", () => {
+    // Critical: a null cost must NOT render as $0.000 (would mislead
+    // operator into thinking the run was free vs unpriced).
+    expect(formatCostCents(null)).toBe("—");
+    expect(formatCostCents(undefined)).toBe("—");
+  });
+});
+
+describe("formatConfidence", () => {
+  it("renders confidence to 2 decimals", () => {
+    expect(formatConfidence(0.91)).toBe("0.91");
+    expect(formatConfidence(0.5)).toBe("0.50");
+    expect(formatConfidence(1)).toBe("1.00");
+  });
+
+  it("returns em-dash for null", () => {
+    expect(formatConfidence(null)).toBe("—");
+    expect(formatConfidence(undefined)).toBe("—");
+  });
+});
+
+describe("classifyQuality", () => {
+  it("maps 0.85+ to good", () => {
+    expect(classifyQuality(0.85)).toBe("good");
+    expect(classifyQuality(0.91)).toBe("good");
+    expect(classifyQuality(1)).toBe("good");
+  });
+
+  it("maps 0.7..0.85 to fair", () => {
+    expect(classifyQuality(0.7)).toBe("fair");
+    expect(classifyQuality(0.78)).toBe("fair");
+    expect(classifyQuality(0.849)).toBe("fair");
+  });
+
+  it("maps below 0.7 to poor", () => {
+    expect(classifyQuality(0.69)).toBe("poor");
+    expect(classifyQuality(0.4)).toBe("poor");
+  });
+
+  it("returns null for missing input", () => {
+    expect(classifyQuality(null)).toBeNull();
+    expect(classifyQuality(undefined)).toBeNull();
+  });
+});
+
+describe("normalizePropertyStats", () => {
+  it("returns empty shape for null/undefined", () => {
+    const out = normalizePropertyStats(null);
+    expect(out.topTags).toEqual([]);
+    expect(out.typeDistribution).toEqual([]);
+    expect(out.importanceBuckets).toEqual([]);
+    expect(out.timeSeries).toEqual([]);
+  });
+
+  it("filters non-conforming entries from each list", () => {
+    // Backend stores property_stats as JSONB so the runtime shape can
+    // drift if the labeler emits a malformed entry. The helper must
+    // tolerate this by dropping bad rows rather than throwing.
+    const out = normalizePropertyStats({
+      top_tags: [
+        { tag: "kouchou-ai", count: 38 },
+        { tag: "missing-count" }, // dropped
+        "string-not-object", // dropped
+        { tag: "design", count: 12 },
+      ],
+      type_distribution: [
+        { type: "feature-design", ratio: 0.71 },
+        { type: "decision" }, // dropped
+      ],
+      importance_buckets: [0.3, 0.55, 0.85, 0.7, "ignored"], // strings skipped → array rejected entirely
+      time_series: [
+        { bucket: "2026-04-21", count: 4 },
+        { bucket: "2026-04-22", count: 8 },
+      ],
+    });
+    expect(out.topTags).toEqual([
+      { tag: "kouchou-ai", count: 38 },
+      { tag: "design", count: 12 },
+    ]);
+    expect(out.typeDistribution).toEqual([
+      { type: "feature-design", ratio: 0.71 },
+    ]);
+    expect(out.importanceBuckets).toEqual([]); // mixed type → all-or-nothing
+    expect(out.timeSeries).toHaveLength(2);
+  });
+
+  it("caps the lists to bounded sizes", () => {
+    // Defense against a runaway labeler emitting hundreds of tags.
+    const out = normalizePropertyStats({
+      top_tags: Array.from({ length: 50 }, (_, i) => ({
+        tag: `t${i}`,
+        count: i,
+      })),
+      type_distribution: Array.from({ length: 50 }, (_, i) => ({
+        type: `tp${i}`,
+        ratio: i / 100,
+      })),
+      time_series: Array.from({ length: 100 }, (_, i) => ({
+        bucket: `b${i}`,
+        count: i,
+      })),
+    });
+    expect(out.topTags).toHaveLength(8);
+    expect(out.typeDistribution).toHaveLength(6);
+    expect(out.timeSeries).toHaveLength(24);
+  });
+});
+
+describe("normalize01", () => {
+  it("maps value to [0,1] within range", () => {
+    expect(normalize01(0, 0, 10)).toBeCloseTo(0, 6);
+    expect(normalize01(5, 0, 10)).toBeCloseTo(0.5, 6);
+    expect(normalize01(10, 0, 10)).toBeCloseTo(1, 6);
+  });
+
+  it("clamps out-of-range to [0,1]", () => {
+    expect(normalize01(-5, 0, 10)).toBe(0);
+    expect(normalize01(15, 0, 10)).toBe(1);
+  });
+
+  it("returns 0.5 on degenerate range", () => {
+    // SVG layout would otherwise divide by zero; centering is the
+    // safest visual fallback for a single-cluster run.
+    expect(normalize01(5, 5, 5)).toBe(0.5);
+    expect(normalize01(NaN, 0, 10)).toBe(0.5);
+  });
+});
+
+describe("computePositionBox", () => {
+  it("computes bounding box in one pass", () => {
+    const box = computePositionBox([
+      { x: 1, y: -2 },
+      { x: 3, y: 5 },
+      { x: -1, y: 0 },
+    ]);
+    expect(box.minX).toBe(-1);
+    expect(box.maxX).toBe(3);
+    expect(box.minY).toBe(-2);
+    expect(box.maxY).toBe(5);
+  });
+
+  it("returns degenerate unit box on empty input", () => {
+    // Avoids returning Infinity so normalize01 callers always see a
+    // finite range without an extra guard.
+    const box = computePositionBox([]);
+    expect(box.minX).toBe(0);
+    expect(box.maxX).toBe(1);
+    expect(box.minY).toBe(0);
+    expect(box.maxY).toBe(1);
+  });
+});

--- a/frontend/src/components/contexts/analyses/analysisFormatters.test.ts
+++ b/frontend/src/components/contexts/analyses/analysisFormatters.test.ts
@@ -76,51 +76,93 @@ describe("normalizePropertyStats", () => {
     expect(out.timeSeries).toEqual([]);
   });
 
-  it("filters non-conforming entries from each list", () => {
-    // Backend stores property_stats as JSONB so the runtime shape can
-    // drift if the labeler emits a malformed entry. The helper must
-    // tolerate this by dropping bad rows rather than throwing.
+  it("normalizes backend-shape payload (tags / types / importance / time)", () => {
+    // Mirror the actual ``property_stats`` JSONB written by
+    // ``backend/src/services/analysis/property_stats.py:aggregate_cluster_stats``.
     const out = normalizePropertyStats({
-      top_tags: [
+      tags: [
         { tag: "kouchou-ai", count: 38 },
-        { tag: "missing-count" }, // dropped
-        "string-not-object", // dropped
         { tag: "design", count: 12 },
       ],
-      type_distribution: [
-        { type: "feature-design", ratio: 0.71 },
-        { type: "decision" }, // dropped
-      ],
-      importance_buckets: [0.3, 0.55, 0.85, 0.7, "ignored"], // strings skipped → array rejected entirely
-      time_series: [
-        { bucket: "2026-04-21", count: 4 },
-        { bucket: "2026-04-22", count: 8 },
+      types: { "feature-design": 71, decision: 18, pattern: 11 },
+      importance: [3, 5, 8, 7],
+      time: [
+        {
+          start: "2026-04-21T00:00:00Z",
+          end: "2026-04-22T00:00:00Z",
+          count: 4,
+        },
+        {
+          start: "2026-04-22T00:00:00Z",
+          end: "2026-04-23T00:00:00Z",
+          count: 8,
+        },
       ],
     });
     expect(out.topTags).toEqual([
       { tag: "kouchou-ai", count: 38 },
       { tag: "design", count: 12 },
     ]);
-    expect(out.typeDistribution).toEqual([
-      { type: "feature-design", ratio: 0.71 },
+    // dict-of-counts → list-of-ratios sorted by count desc, normalized so sum=1
+    expect(out.typeDistribution.map((r) => r.type)).toEqual([
+      "feature-design",
+      "decision",
+      "pattern",
     ]);
-    expect(out.importanceBuckets).toEqual([]); // mixed type → all-or-nothing
+    expect(out.typeDistribution[0].ratio).toBeCloseTo(71 / 100, 6);
+    expect(out.typeDistribution[1].ratio).toBeCloseTo(18 / 100, 6);
+    expect(out.importanceBuckets).toEqual([3, 5, 8, 7]);
+    // time bucket: keep ``start`` as the rendered label for the bar chart
+    expect(out.timeSeries).toEqual([
+      { bucket: "2026-04-21T00:00:00Z", count: 4 },
+      { bucket: "2026-04-22T00:00:00Z", count: 8 },
+    ]);
+  });
+
+  it("filters non-conforming entries from each list", () => {
+    // Backend stores property_stats as JSONB so the runtime shape can
+    // drift if the labeler emits a malformed entry. The helper must
+    // tolerate this by dropping bad rows rather than throwing.
+    const out = normalizePropertyStats({
+      tags: [
+        { tag: "kouchou-ai", count: 38 },
+        { tag: "missing-count" }, // dropped — no count
+        "string-not-object", // dropped
+        { tag: "design", count: 12 },
+      ],
+      types: { decision: "not-a-number", pattern: 5 }, // string value silently dropped
+      importance: [0.3, 0.55, 0.85, 0.7, "ignored"], // mixed type → all-or-nothing
+      time: [
+        { start: "2026-04-21T00:00:00Z", count: 4 }, // ``end`` is optional
+        {
+          start: "2026-04-22T00:00:00Z",
+          end: "2026-04-23T00:00:00Z",
+          count: 8,
+        },
+      ],
+    });
+    expect(out.topTags).toEqual([
+      { tag: "kouchou-ai", count: 38 },
+      { tag: "design", count: 12 },
+    ]);
+    // Only ``pattern`` remained valid → 100% of the distribution.
+    expect(out.typeDistribution).toEqual([{ type: "pattern", ratio: 1 }]);
+    expect(out.importanceBuckets).toEqual([]);
     expect(out.timeSeries).toHaveLength(2);
   });
 
   it("caps the lists to bounded sizes", () => {
     // Defense against a runaway labeler emitting hundreds of tags.
+    const types: Record<string, number> = {};
+    for (let i = 0; i < 50; i++) types[`tp${i}`] = i;
     const out = normalizePropertyStats({
-      top_tags: Array.from({ length: 50 }, (_, i) => ({
+      tags: Array.from({ length: 50 }, (_, i) => ({
         tag: `t${i}`,
         count: i,
       })),
-      type_distribution: Array.from({ length: 50 }, (_, i) => ({
-        type: `tp${i}`,
-        ratio: i / 100,
-      })),
-      time_series: Array.from({ length: 100 }, (_, i) => ({
-        bucket: `b${i}`,
+      types,
+      time: Array.from({ length: 100 }, (_, i) => ({
+        start: `2026-04-${String(i + 1).padStart(2, "0")}T00:00:00Z`,
         count: i,
       })),
     });

--- a/frontend/src/components/contexts/analyses/analysisFormatters.ts
+++ b/frontend/src/components/contexts/analyses/analysisFormatters.ts
@@ -1,0 +1,180 @@
+/**
+ * Pure formatting helpers for the analyses tab (Issue #497).
+ *
+ * Following the PR #527 cost-dashboard convention: extract pure data
+ * transforms here, unit-test them in ``analysisFormatters.test.ts``,
+ * leave the React components as thin presentational layers.
+ */
+
+/**
+ * Render an integer-cents cost as a USD-prefixed dollar string with
+ * 3 decimal places. Sticky-NULL: a ``null`` value renders as ``"—"``
+ * (em-dash) so an unpriced run does NOT visually equal a $0.000 run.
+ *
+ * Mirrors ``formatCost`` from ``components/cost/CostDashboard.tsx``
+ * but accepts integer cents (the analyses API surface) rather than
+ * USD floats.
+ *
+ * @example
+ *   formatCostCents(1100) === "$11.000"
+ *   formatCostCents(11)   === "$0.110"
+ *   formatCostCents(0)    === "$0.000"
+ *   formatCostCents(null) === "—"
+ */
+export function formatCostCents(value: number | null | undefined): string {
+  if (value == null) return "—";
+  return `$${(value / 100).toFixed(3)}`;
+}
+
+/**
+ * Render a confidence/quality score (0..1) as a 2-decimal string.
+ * Sticky-NULL: ``null`` becomes ``"—"`` to match the cost rendering.
+ */
+export function formatConfidence(value: number | null | undefined): string {
+  if (value == null) return "—";
+  return value.toFixed(2);
+}
+
+/**
+ * Bin a label-confidence score into a quality badge token.
+ *
+ * The 0.85 / 0.7 thresholds are picked to match the prototype's three-
+ * tier visual ("good" / "fair" / "poor") and the labeler's typical
+ * output distribution on Gemini Flash Lite (most legitimate clusters
+ * land at 0.78+; outlier / weak clusters fall below 0.7).
+ */
+export type QualityTier = "good" | "fair" | "poor";
+
+export function classifyQuality(
+  confidence: number | null | undefined,
+): QualityTier | null {
+  if (confidence == null) return null;
+  if (confidence >= 0.85) return "good";
+  if (confidence >= 0.7) return "fair";
+  return "poor";
+}
+
+/**
+ * Coerce arbitrary ``property_stats`` payloads into a typed shape the
+ * UI can render without ``any``. Backend stores property_stats as
+ * ``JSONB`` so the wire type is ``Record<string, unknown>``; this
+ * helper does the runtime narrowing in one place.
+ */
+export interface NormalizedPropertyStats {
+  topTags: Array<{ tag: string; count: number }>;
+  typeDistribution: Array<{ type: string; ratio: number }>;
+  importanceBuckets: number[];
+  timeSeries: Array<{ bucket: string; count: number }>;
+}
+
+const EMPTY_STATS: NormalizedPropertyStats = {
+  topTags: [],
+  typeDistribution: [],
+  importanceBuckets: [],
+  timeSeries: [],
+};
+
+function isStringNumberPair(v: unknown): v is { tag: string; count: number } {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    typeof (v as Record<string, unknown>).tag === "string" &&
+    typeof (v as Record<string, unknown>).count === "number"
+  );
+}
+
+function isTypeRatioPair(v: unknown): v is { type: string; ratio: number } {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    typeof (v as Record<string, unknown>).type === "string" &&
+    typeof (v as Record<string, unknown>).ratio === "number"
+  );
+}
+
+function isTimeSeriesPair(v: unknown): v is { bucket: string; count: number } {
+  return (
+    typeof v === "object" &&
+    v !== null &&
+    typeof (v as Record<string, unknown>).bucket === "string" &&
+    typeof (v as Record<string, unknown>).count === "number"
+  );
+}
+
+export function normalizePropertyStats(
+  raw: Record<string, unknown> | null | undefined,
+): NormalizedPropertyStats {
+  if (!raw) return EMPTY_STATS;
+
+  const topTagsRaw = raw.top_tags;
+  const topTags = Array.isArray(topTagsRaw)
+    ? topTagsRaw.filter(isStringNumberPair).slice(0, 8)
+    : [];
+
+  const typesRaw = raw.type_distribution;
+  const typeDistribution = Array.isArray(typesRaw)
+    ? typesRaw.filter(isTypeRatioPair).slice(0, 6)
+    : [];
+
+  const importanceRaw = raw.importance_buckets;
+  const importanceBuckets =
+    Array.isArray(importanceRaw) &&
+    importanceRaw.every((n) => typeof n === "number")
+      ? (importanceRaw as number[]).slice(0, 4)
+      : [];
+
+  const seriesRaw = raw.time_series;
+  const timeSeries = Array.isArray(seriesRaw)
+    ? seriesRaw.filter(isTimeSeriesPair).slice(0, 24)
+    : [];
+
+  return { topTags, typeDistribution, importanceBuckets, timeSeries };
+}
+
+/**
+ * Project an arbitrary numeric range to ``[0, 1]`` for SVG layout.
+ * Returns 0.5 when the range is degenerate (min === max) so the dot
+ * lands at the center rather than NaN or +Infinity.
+ *
+ * Used by ``ScatterPlot`` to map UMAP coordinates to viewport ratios.
+ */
+export function normalize01(value: number, min: number, max: number): number {
+  if (!Number.isFinite(value)) return 0.5;
+  if (max <= min) return 0.5;
+  const t = (value - min) / (max - min);
+  if (t < 0) return 0;
+  if (t > 1) return 1;
+  return t;
+}
+
+/**
+ * Compute the bounding box of a position list in a single pass.
+ *
+ * Returns a degenerate ``{0, 0, 1, 1}`` box when the input is empty
+ * so ``normalize01`` callers always have a finite range to work with.
+ */
+export interface PositionBox {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+export function computePositionBox(
+  positions: Array<{ x: number; y: number }>,
+): PositionBox {
+  if (positions.length === 0) {
+    return { minX: 0, maxX: 1, minY: 0, maxY: 1 };
+  }
+  let minX = Infinity;
+  let maxX = -Infinity;
+  let minY = Infinity;
+  let maxY = -Infinity;
+  for (const p of positions) {
+    if (p.x < minX) minX = p.x;
+    if (p.x > maxX) maxX = p.x;
+    if (p.y < minY) minY = p.y;
+    if (p.y > maxY) maxY = p.y;
+  }
+  return { minX, maxX, minY, maxY };
+}

--- a/frontend/src/components/contexts/analyses/analysisFormatters.ts
+++ b/frontend/src/components/contexts/analyses/analysisFormatters.ts
@@ -74,7 +74,7 @@ const EMPTY_STATS: NormalizedPropertyStats = {
   timeSeries: [],
 };
 
-function isStringNumberPair(v: unknown): v is { tag: string; count: number } {
+function isTagCountPair(v: unknown): v is { tag: string; count: number } {
   return (
     typeof v === "object" &&
     v !== null &&
@@ -83,49 +83,77 @@ function isStringNumberPair(v: unknown): v is { tag: string; count: number } {
   );
 }
 
-function isTypeRatioPair(v: unknown): v is { type: string; ratio: number } {
+function isTimeBucketRow(
+  v: unknown,
+): v is { start: string; end?: string; count: number } {
   return (
     typeof v === "object" &&
     v !== null &&
-    typeof (v as Record<string, unknown>).type === "string" &&
-    typeof (v as Record<string, unknown>).ratio === "number"
-  );
-}
-
-function isTimeSeriesPair(v: unknown): v is { bucket: string; count: number } {
-  return (
-    typeof v === "object" &&
-    v !== null &&
-    typeof (v as Record<string, unknown>).bucket === "string" &&
+    typeof (v as Record<string, unknown>).start === "string" &&
     typeof (v as Record<string, unknown>).count === "number"
   );
 }
 
+/**
+ * Convert ``backend/src/services/analysis/property_stats.py``'s
+ * persisted ``property_stats`` JSONB into the shape PropertyStats.tsx
+ * renders. Backend writes:
+ *
+ *   { tags: [{tag,count}], types: {type→count},
+ *     importance: [int,int,int,int], time: [{start,end,count}, ...] }
+ *
+ * The UI expects:
+ *
+ *   { topTags, typeDistribution: [{type,ratio}],
+ *     importanceBuckets: number[], timeSeries: [{bucket,count}] }
+ *
+ * Type counts are converted to ratios on the frontend so the bar chart
+ * always sums to 1.0 even if the persisted dict has a partial set of
+ * types. Time buckets keep ``start`` as the rendered ``bucket`` label
+ * (the SVG bar chart does not need the explicit ``end``).
+ */
 export function normalizePropertyStats(
   raw: Record<string, unknown> | null | undefined,
 ): NormalizedPropertyStats {
   if (!raw) return EMPTY_STATS;
 
-  const topTagsRaw = raw.top_tags;
-  const topTags = Array.isArray(topTagsRaw)
-    ? topTagsRaw.filter(isStringNumberPair).slice(0, 8)
+  const tagsRaw = raw.tags;
+  const topTags = Array.isArray(tagsRaw)
+    ? tagsRaw.filter(isTagCountPair).slice(0, 8)
     : [];
 
-  const typesRaw = raw.type_distribution;
-  const typeDistribution = Array.isArray(typesRaw)
-    ? typesRaw.filter(isTypeRatioPair).slice(0, 6)
-    : [];
+  const typesRaw = raw.types;
+  let typeDistribution: NormalizedPropertyStats["typeDistribution"] = [];
+  if (
+    typesRaw !== null &&
+    typeof typesRaw === "object" &&
+    !Array.isArray(typesRaw)
+  ) {
+    const entries = Object.entries(typesRaw as Record<string, unknown>).filter(
+      ([, count]) => typeof count === "number" && (count as number) >= 0,
+    ) as Array<[string, number]>;
+    const total = entries.reduce((acc, [, c]) => acc + c, 0);
+    if (total > 0) {
+      typeDistribution = entries
+        .sort(([, a], [, b]) => b - a)
+        .slice(0, 6)
+        .map(([type, count]) => ({ type, ratio: count / total }));
+    }
+  }
 
-  const importanceRaw = raw.importance_buckets;
+  const importanceRaw = raw.importance;
   const importanceBuckets =
     Array.isArray(importanceRaw) &&
     importanceRaw.every((n) => typeof n === "number")
       ? (importanceRaw as number[]).slice(0, 4)
       : [];
 
-  const seriesRaw = raw.time_series;
+  const seriesRaw = raw.time;
   const timeSeries = Array.isArray(seriesRaw)
-    ? seriesRaw.filter(isTimeSeriesPair).slice(0, 24)
+    ? seriesRaw
+        .filter(isTimeBucketRow)
+        .slice(0, 24)
+        .map((row) => ({ bucket: row.start, count: row.count }))
     : [];
 
   return { topTags, typeDistribution, importanceBuckets, timeSeries };

--- a/frontend/src/components/contexts/analyses/analysisFormatters.ts
+++ b/frontend/src/components/contexts/analyses/analysisFormatters.ts
@@ -62,7 +62,14 @@ export function classifyQuality(
  */
 export interface NormalizedPropertyStats {
   topTags: Array<{ tag: string; count: number }>;
-  typeDistribution: Array<{ type: string; ratio: number }>;
+  /**
+   * Per-type counts. Ratios are computed at render time from the
+   * (possibly aggregated across clusters) counts so the per-cluster
+   * vs all-clusters views can share the same denominator math —
+   * carrying ratios at the per-cluster layer would size-weight
+   * incorrectly when summing across clusters of different sizes.
+   */
+  typeDistribution: Array<{ type: string; count: number }>;
   importanceBuckets: number[];
   timeSeries: Array<{ bucket: string; count: number }>;
 }
@@ -132,13 +139,10 @@ export function normalizePropertyStats(
     const entries = Object.entries(typesRaw as Record<string, unknown>).filter(
       ([, count]) => typeof count === "number" && (count as number) >= 0,
     ) as Array<[string, number]>;
-    const total = entries.reduce((acc, [, c]) => acc + c, 0);
-    if (total > 0) {
-      typeDistribution = entries
-        .sort(([, a], [, b]) => b - a)
-        .slice(0, 6)
-        .map(([type, count]) => ({ type, ratio: count / total }));
-    }
+    typeDistribution = entries
+      .sort(([, a], [, b]) => b - a)
+      .slice(0, 6)
+      .map(([type, count]) => ({ type, count }));
   }
 
   const importanceRaw = raw.importance;

--- a/frontend/src/components/contexts/analyses/clusterColors.ts
+++ b/frontend/src/components/contexts/analyses/clusterColors.ts
@@ -1,0 +1,30 @@
+/**
+ * Deterministic cluster color palette (Issue #497).
+ *
+ * Maps a 0-based ``cluster_index`` to a tailwind ``chart-N`` CSS
+ * variable. The first 12 clusters get distinct hues from the palette
+ * extended in ``app/globals.css`` (chart-1 .. chart-12); higher
+ * indices wrap modulo 12 — KMeans n_clusters in v1 is bounded by
+ * ``ceil(sqrt(memory_count))`` ≈ 90, but the visual contrast budget
+ * runs out well before that and re-using hues is honest about the
+ * eye-distinction limit rather than synthesizing arbitrary near-
+ * identical colors at index 13+.
+ *
+ * Returned colors are CSS ``hsl(var(--chart-N))`` strings so dark
+ * mode automatically applies the corresponding dark palette without
+ * a JS-side theme observer.
+ */
+
+export const CLUSTER_PALETTE_SIZE = 12;
+
+/**
+ * Resolve a cluster index to its CSS color string.
+ *
+ * @example
+ *   <circle fill={getClusterColor(3)} />
+ *   <span style={{ backgroundColor: getClusterColor(cluster.cluster_index) }} />
+ */
+export function getClusterColor(clusterIndex: number): string {
+  const slot = (clusterIndex % CLUSTER_PALETTE_SIZE) + 1;
+  return `hsl(var(--chart-${slot}))`;
+}

--- a/frontend/src/components/contexts/analyses/useActiveAnalysisPolling.ts
+++ b/frontend/src/components/contexts/analyses/useActiveAnalysisPolling.ts
@@ -1,0 +1,149 @@
+"use client";
+
+/**
+ * useActiveAnalysisPolling — fixed 3-second polling for an in-flight run (#497).
+ *
+ * Polls ``getAnalysisRun(contextId, runId)`` while the run's status
+ * is ``"running"`` and stops as soon as it transitions to a terminal
+ * state (succeeded / failed / cancelled). ``visibilitychange`` pause:
+ * when the tab is hidden we skip polls to avoid burning quota / cost
+ * on a background tab the user does not see — the next visible tick
+ * triggers an immediate refetch.
+ *
+ * Cadence: 3 seconds (fixed). Reasoning is documented in the
+ * #497 design HITL — a single fixed cadence is simpler than backoff
+ * for v1 runs that typically complete within tens of seconds, and
+ * does not penalize "long" runs that are still on the order of a
+ * few minutes.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getAnalysisRun, type AnalysisRunRow } from "@/lib/api/analyses";
+
+const POLL_INTERVAL_MS = 3000;
+
+interface UseActiveAnalysisPollingArgs {
+  contextId: string;
+  runId: string | null;
+  /**
+   * Called once when the polled run transitions to a terminal state.
+   * Use this to refresh the run history list / re-fetch clusters.
+   * Receives the final run row.
+   */
+  onTerminal?: (finalRun: AnalysisRunRow) => void;
+}
+
+interface UseActiveAnalysisPollingResult {
+  run: AnalysisRunRow | null;
+  loading: boolean;
+  error: string | null;
+  /** Manual refetch — used by the "Refresh" button. */
+  refetch: () => void;
+}
+
+/**
+ * Returns the latest snapshot of the polled run plus a manual
+ * ``refetch`` for user-driven refreshes. ``run`` is null while the
+ * first poll is in flight or when ``runId`` is null.
+ */
+export function useActiveAnalysisPolling(
+  args: UseActiveAnalysisPollingArgs,
+): UseActiveAnalysisPollingResult {
+  const { contextId, runId, onTerminal } = args;
+
+  const [run, setRun] = useState<AnalysisRunRow | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Track whether the onTerminal callback has fired for the current
+  // (contextId, runId) pair so we don't fire it twice if the polling
+  // cycle catches the same terminal state twice (race between manual
+  // refetch and the interval tick).
+  const terminalFiredRef = useRef<string | null>(null);
+
+  // Stash the latest onTerminal in a ref so the polling loop's
+  // useEffect doesn't re-establish itself every time the parent
+  // passes a fresh callback identity.
+  const onTerminalRef = useRef(onTerminal);
+  useEffect(() => {
+    onTerminalRef.current = onTerminal;
+  }, [onTerminal]);
+
+  // Track the live interval handle so the post-fetch terminal check
+  // can clear it from inside ``fetchOnce``. Using a ref means the
+  // handle survives across renders without being a useEffect dep.
+  const intervalRef = useRef<number | null>(null);
+
+  const fetchOnce = useCallback(async () => {
+    if (!runId) return;
+    try {
+      setLoading(true);
+      setError(null);
+      const row = await getAnalysisRun(contextId, runId);
+      setRun(row);
+      if (
+        row.status !== "running" &&
+        terminalFiredRef.current !== `${contextId}:${runId}`
+      ) {
+        terminalFiredRef.current = `${contextId}:${runId}`;
+        // Stop the poll loop NOW that the run is terminal — the
+        // earlier "interval cleanup happens on runId change" path
+        // would have left this interval live for the lifetime of
+        // the parent component (potentially hours).
+        if (intervalRef.current !== null) {
+          window.clearInterval(intervalRef.current);
+          intervalRef.current = null;
+        }
+        onTerminalRef.current?.(row);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load run.");
+    } finally {
+      setLoading(false);
+    }
+  }, [contextId, runId]);
+
+  // Reset state on (contextId, runId) change so a stale "succeeded"
+  // run does not flash while the new one's first poll is in flight.
+  useEffect(() => {
+    terminalFiredRef.current = null;
+    setRun(null);
+    setError(null);
+    setLoading(runId !== null);
+  }, [contextId, runId]);
+
+  // Poll loop. ``runId === null`` short-circuits — no interval armed.
+  useEffect(() => {
+    if (!runId) return;
+
+    let cancelled = false;
+    const tick = async () => {
+      if (cancelled) return;
+      if (typeof document !== "undefined" && document.hidden) return;
+      await fetchOnce();
+    };
+
+    // Kick off the first poll immediately.
+    tick();
+
+    intervalRef.current = window.setInterval(tick, POLL_INTERVAL_MS);
+
+    const onVisibilityChange = () => {
+      if (typeof document !== "undefined" && !document.hidden) {
+        tick();
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      if (intervalRef.current !== null) {
+        window.clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [runId, fetchOnce]);
+
+  return { run, loading, error, refetch: fetchOnce };
+}

--- a/frontend/src/components/contexts/analyses/useActiveAnalysisPolling.ts
+++ b/frontend/src/components/contexts/analyses/useActiveAnalysisPolling.ts
@@ -31,6 +31,12 @@ interface UseActiveAnalysisPollingArgs {
    * Receives the final run row.
    */
   onTerminal?: (finalRun: AnalysisRunRow) => void;
+  /**
+   * User-facing fallback message when ``getAnalysisRun`` rejects with
+   * a non-Error (no ``.message``). Caller passes the translated string
+   * so the hook stays free of next-intl coupling.
+   */
+  fallbackErrorMessage?: string;
 }
 
 interface UseActiveAnalysisPollingResult {
@@ -49,7 +55,7 @@ interface UseActiveAnalysisPollingResult {
 export function useActiveAnalysisPolling(
   args: UseActiveAnalysisPollingArgs,
 ): UseActiveAnalysisPollingResult {
-  const { contextId, runId, onTerminal } = args;
+  const { contextId, runId, onTerminal, fallbackErrorMessage } = args;
 
   const [run, setRun] = useState<AnalysisRunRow | null>(null);
   const [loading, setLoading] = useState(false);
@@ -97,11 +103,15 @@ export function useActiveAnalysisPolling(
         onTerminalRef.current?.(row);
       }
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load run.");
+      setError(
+        err instanceof Error
+          ? err.message
+          : (fallbackErrorMessage ?? "Failed to load run."),
+      );
     } finally {
       setLoading(false);
     }
-  }, [contextId, runId]);
+  }, [contextId, runId, fallbackErrorMessage]);
 
   // Reset state on (contextId, runId) change so a stale "succeeded"
   // run does not flash while the new one's first poll is in flight.

--- a/frontend/src/components/contexts/analyses/useFocusedClusterId.test.ts
+++ b/frontend/src/components/contexts/analyses/useFocusedClusterId.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Unit tests for parseClusterParam — the pure half of the hook.
+ *
+ * The full hook integration (URL round-trip, useEffect strip) is
+ * exercised at the page-render level rather than here; following the
+ * PR #527 convention this file stays at pure-helper scope.
+ */
+
+import { describe, it, expect } from "vitest";
+import { parseClusterParam } from "./useFocusedClusterId";
+
+describe("parseClusterParam", () => {
+  it("returns null on missing input", () => {
+    expect(parseClusterParam(null)).toBeNull();
+    expect(parseClusterParam("")).toBeNull();
+    expect(parseClusterParam("   ")).toBeNull();
+  });
+
+  it("parses non-negative integers", () => {
+    expect(parseClusterParam("0")).toBe(0);
+    expect(parseClusterParam("3")).toBe(3);
+    expect(parseClusterParam("12")).toBe(12);
+  });
+
+  it("rejects negatives and non-integers", () => {
+    // Critical: a deep-link with garbage like ?cluster=-1 must NOT
+    // produce a NaN-driven focus state that crashes the SVG render.
+    expect(parseClusterParam("-1")).toBeNull();
+    expect(parseClusterParam("1.5")).toBeNull();
+    expect(parseClusterParam("abc")).toBeNull();
+    expect(parseClusterParam("Infinity")).toBeNull();
+    expect(parseClusterParam("NaN")).toBeNull();
+  });
+
+  it("trims whitespace before parsing", () => {
+    expect(parseClusterParam(" 4 ")).toBe(4);
+  });
+});

--- a/frontend/src/components/contexts/analyses/useFocusedClusterId.ts
+++ b/frontend/src/components/contexts/analyses/useFocusedClusterId.ts
@@ -1,0 +1,138 @@
+"use client";
+
+/**
+ * useFocusedClusterId — URL-synced cluster focus state for #497.
+ *
+ * Owns the ``focusedClusterId: number | null`` state for the analyses
+ * tab. Reads / writes the ``?cluster=N`` URL search param so:
+ *
+ *  - Browser back / forward restore the previous focus.
+ *  - Deep-links like ``?tab=analyses&cluster=3`` open with cluster 3
+ *    pre-focused, sharable across users.
+ *  - The state is single source of truth — no duplicate React state
+ *    in children that could drift out of sync.
+ *
+ * Validation: the ``allowedIndexes`` argument lets the caller specify
+ * which cluster indices are valid for the active run. Invalid values
+ * (cluster_index that no longer exists in the run, NaN, negative)
+ * silently fall back to ``null`` and a single ``console.warn`` fires
+ * in development. Production silently ignores — the UX guidance for
+ * #497 is to render the "All clusters" view rather than a broken
+ * focus state.
+ */
+
+import { useCallback, useEffect, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+const CLUSTER_PARAM = "cluster";
+
+/**
+ * Parse a raw URL value to a non-negative integer. Returns null on
+ * empty / NaN / negative — the caller decides what to do with null.
+ */
+export function parseClusterParam(raw: string | null): number | null {
+  if (raw === null) return null;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return null;
+  return n;
+}
+
+interface UseFocusedClusterIdResult {
+  /** Currently focused cluster index, or null when "All clusters" is active. */
+  focusedClusterId: number | null;
+  /** Set the focused cluster (or null to clear). Updates the URL. */
+  setFocusedClusterId: (next: number | null) => void;
+  /** Toggle: if the given index is already focused, clear; otherwise focus it. */
+  toggleFocusedClusterId: (next: number) => void;
+}
+
+/**
+ * Hook signature designed for AnalysesTabPanel:
+ *
+ *   const { focusedClusterId, setFocusedClusterId, toggleFocusedClusterId } =
+ *     useFocusedClusterId(allowedIndexes);
+ *
+ * Pass an empty array on first paint (clusters not loaded yet) — the
+ * hook then accepts any URL value as ``null`` (no validation possible
+ * yet) and re-evaluates once the cluster list resolves and the
+ * caller passes the populated array.
+ */
+export function useFocusedClusterId(
+  allowedIndexes: readonly number[],
+): UseFocusedClusterIdResult {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const raw = searchParams.get(CLUSTER_PARAM);
+
+  // Memo allowedIndexes by content so callers passing a fresh array
+  // each render don't trigger a useEffect storm. Cluster index lists
+  // are tiny (typically ≤ 20), JSON.stringify is cheap.
+  const allowedKey = useMemo(
+    () => JSON.stringify(allowedIndexes),
+    [allowedIndexes],
+  );
+
+  const focusedClusterId = useMemo<number | null>(() => {
+    const parsed = parseClusterParam(raw);
+    if (parsed === null) return null;
+    if (allowedIndexes.length === 0) {
+      // Allow-list not yet known — defer validation. Treat as null
+      // so children don't render a focus mode for a cluster that may
+      // not exist; the URL value is preserved (we don't strip it).
+      return null;
+    }
+    if (!allowedIndexes.includes(parsed)) return null;
+    return parsed;
+    // allowedKey is the stable shape signal; using it instead of the
+    // raw array reference avoids re-running on identical content.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [raw, allowedKey]);
+
+  const setFocusedClusterId = useCallback(
+    (next: number | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next === null) {
+        params.delete(CLUSTER_PARAM);
+      } else {
+        params.set(CLUSTER_PARAM, String(next));
+      }
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname);
+    },
+    [searchParams, pathname, router],
+  );
+
+  const toggleFocusedClusterId = useCallback(
+    (next: number) => {
+      setFocusedClusterId(focusedClusterId === next ? null : next);
+    },
+    [focusedClusterId, setFocusedClusterId],
+  );
+
+  // Strip an invalid ?cluster=N from the URL once the cluster list
+  // has resolved — keeps the browser address bar honest after the
+  // user navigated to a stale deep-link. Only strips after the list
+  // is known (allowedIndexes.length > 0); during first paint we
+  // preserve the URL so the focus can resolve once data arrives.
+  useEffect(() => {
+    if (raw === null) return;
+    if (allowedIndexes.length === 0) return;
+    const parsed = parseClusterParam(raw);
+    if (parsed !== null && allowedIndexes.includes(parsed)) return;
+    setFocusedClusterId(null);
+    if (process.env.NODE_ENV === "development") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[useFocusedClusterId] dropping invalid ?cluster=${raw} (allowed: [${[...allowedIndexes].join(", ")}])`,
+      );
+    }
+    // raw + allowedKey is the stable signal — a fresh allowedIndexes
+    // array reference with identical content should not re-run.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [raw, allowedKey]);
+
+  return { focusedClusterId, setFocusedClusterId, toggleFocusedClusterId };
+}

--- a/frontend/src/lib/api/analyses.ts
+++ b/frontend/src/lib/api/analyses.ts
@@ -122,9 +122,11 @@ export interface AnalysisPositionListResponse {
  * The backend accepts the same shape for both (intentional — the modal
  * submits one body twice: once to preview, once to confirm).
  *
- * ``from`` / ``to`` are ISO-8601 strings. Use ``toUtcIso`` from
- * ``lib/utils/datetime`` to normalize ``Date`` instances before
- * passing.
+ * ``from`` / ``to`` are ISO-8601 date strings (YYYY-MM-DD form for
+ * `<input type="date">`, or full datetime). Use ``formatLocalDate``
+ * from ``lib/utils/datetime`` to derive the date from a ``Date``
+ * instance without UTC-shifting (the cost dashboard uses the same
+ * helper).
  */
 export interface AnalysisFilters {
   from?: string;

--- a/frontend/src/lib/api/analyses.ts
+++ b/frontend/src/lib/api/analyses.ts
@@ -1,0 +1,250 @@
+/**
+ * Memory Broadlistening Analyses API Client (Issue #497)
+ *
+ * Wraps the REST surface from #496 plus the cluster + position
+ * endpoints added in #497 (extending the run-level reads with the
+ * cluster-level data the frontend needs to render the scatter view).
+ */
+
+import { apiClient } from "./base";
+
+// ============================================================================
+// Constants (mirror backend enums)
+// ============================================================================
+
+export const ANALYSIS_STATUSES = [
+  "running",
+  "succeeded",
+  "failed",
+  "cancelled",
+] as const;
+export type AnalysisStatus = (typeof ANALYSIS_STATUSES)[number];
+
+// ============================================================================
+// Types
+// ============================================================================
+
+/**
+ * One analysis run row. Mirrors the backend ``AnalysisRow`` model.
+ *
+ * Cost fields (``cost_estimated_cents`` / ``cost_actual_cents``) are
+ * nullable — render NULL as "—" via ``formatCostCents`` so an unpriced
+ * run does not visually equal a $0.00 run.
+ */
+export interface AnalysisRunRow {
+  run_id: string;
+  workspace_id: string;
+  context_id: string;
+  status: AnalysisStatus;
+  triggered_by: string;
+  started_at: string;
+  finished_at: string | null;
+  input_count: number;
+  cost_estimated_cents: number | null;
+  cost_actual_cents: number | null;
+  error: string | null;
+  cancellation_reason: string | null;
+}
+
+export interface AnalysisListResponse {
+  items: AnalysisRunRow[];
+  next_cursor: string | null;
+}
+
+export interface AnalysisStartResponse {
+  run_id: string;
+  status: AnalysisStatus;
+  started_at: string;
+}
+
+export interface AnalysisCancelResponse {
+  run_id: string;
+  status: AnalysisStatus;
+  cancellation_reason: string | null;
+  finished_at: string | null;
+}
+
+export interface AnalysisPreviewResponse {
+  memory_count: number;
+  cluster_count_estimate: number;
+  estimated_cost_cents: number;
+  model_id: string;
+  breakdown: Record<string, number>;
+}
+
+/**
+ * One cluster within an analysis run. Mirrors backend ``ClusterRow``.
+ *
+ * ``representative_memory_ids`` is the raw UUID list as stored on the
+ * cluster row. Resolve to memory summaries via a separate
+ * ``recall(filters={"id": [...]})`` call rather than embedding here.
+ *
+ * ``centroid_2d`` is ``[x, y]`` in the same UMAP coordinate space as
+ * ``ScatterPosition.x/y`` returned from ``listRunPositions``.
+ */
+export interface AnalysisCluster {
+  cluster_index: number;
+  label: string;
+  description: string | null;
+  count: number;
+  centroid_2d: [number, number];
+  representative_memory_ids: string[];
+  property_stats: Record<string, unknown>;
+  label_confidence: number;
+}
+
+export interface AnalysisClusterListResponse {
+  items: AnalysisCluster[];
+}
+
+/**
+ * One ``(memory_id, x, y, cluster_index)`` row for the scatter plot.
+ * Coordinates are in the run's UMAP 2D space — render scaled to the
+ * scatter viewport via min/max normalization on the client.
+ */
+export interface ScatterPosition {
+  memory_id: string;
+  x: number;
+  y: number;
+  cluster_index: number;
+}
+
+export interface AnalysisPositionListResponse {
+  items: ScatterPosition[];
+}
+
+// ============================================================================
+// Request bodies
+// ============================================================================
+
+/**
+ * Filter parameters used by both ``previewAnalysis`` and ``startAnalysis``.
+ * The backend accepts the same shape for both (intentional — the modal
+ * submits one body twice: once to preview, once to confirm).
+ *
+ * ``from`` / ``to`` are ISO-8601 strings. Use ``toUtcIso`` from
+ * ``lib/utils/datetime`` to normalize ``Date`` instances before
+ * passing.
+ */
+export interface AnalysisFilters {
+  from?: string;
+  to?: string;
+  types?: string[];
+  tags?: string[];
+  min_importance?: number;
+  query?: string;
+  model_id?: number;
+}
+
+// ============================================================================
+// Endpoints
+// ============================================================================
+
+const base = (contextId: string) =>
+  `/api/v1/contexts/${encodeURIComponent(contextId)}/analyses`;
+
+/**
+ * Pre-flight cost estimate. No row is created. Goes through the
+ * full 4-stage gate so a non-Pro / quota-exhausted caller receives
+ * 403/429 here rather than after typing the modal form.
+ */
+export async function previewAnalysis(
+  contextId: string,
+  body: AnalysisFilters,
+): Promise<AnalysisPreviewResponse> {
+  return apiClient.post<AnalysisPreviewResponse>(
+    `${base(contextId)}/preview`,
+    body,
+  );
+}
+
+/**
+ * Kick off a background analysis run. Returns 202 with the new
+ * ``run_id``. Poll ``getAnalysisRun`` for status transitions.
+ *
+ * 409 (ConflictError) → a prior run for the same (workspace, context)
+ * is still running. The error body carries the existing ``run_id`` so
+ * the client can switch into "watching that run" mode.
+ */
+export async function startAnalysis(
+  contextId: string,
+  body: AnalysisFilters,
+): Promise<AnalysisStartResponse> {
+  return apiClient.post<AnalysisStartResponse>(base(contextId), body);
+}
+
+export interface ListAnalysisRunsParams {
+  cursor?: string;
+  limit?: number;
+}
+
+export async function listAnalysisRuns(
+  contextId: string,
+  params: ListAnalysisRunsParams = {},
+): Promise<AnalysisListResponse> {
+  const search = new URLSearchParams();
+  if (params.cursor) search.set("cursor", params.cursor);
+  if (params.limit !== undefined) search.set("limit", String(params.limit));
+  const query = search.toString();
+  return apiClient.get<AnalysisListResponse>(
+    query ? `${base(contextId)}?${query}` : base(contextId),
+  );
+}
+
+/**
+ * Most recent succeeded run for a context. 404 when none exists yet.
+ */
+export async function getActiveAnalysis(
+  contextId: string,
+): Promise<AnalysisRunRow> {
+  return apiClient.get<AnalysisRunRow>(`${base(contextId)}/active`);
+}
+
+export async function getAnalysisRun(
+  contextId: string,
+  runId: string,
+): Promise<AnalysisRunRow> {
+  return apiClient.get<AnalysisRunRow>(
+    `${base(contextId)}/${encodeURIComponent(runId)}`,
+  );
+}
+
+/**
+ * Soft-cancel a running run. Idempotent on terminal runs (200 with
+ * the current state). Cancellation does NOT decrement the daily quota.
+ */
+export async function cancelAnalysisRun(
+  contextId: string,
+  runId: string,
+): Promise<AnalysisCancelResponse> {
+  return apiClient.delete<AnalysisCancelResponse>(
+    `${base(contextId)}/${encodeURIComponent(runId)}`,
+  );
+}
+
+/**
+ * List all clusters for a run. No pagination — bounded by
+ * ``ceil(sqrt(memory_count))``. Empty array when the run is still
+ * running or did not reach the labeler stage.
+ */
+export async function listRunClusters(
+  contextId: string,
+  runId: string,
+): Promise<AnalysisClusterListResponse> {
+  return apiClient.get<AnalysisClusterListResponse>(
+    `${base(contextId)}/${encodeURIComponent(runId)}/clusters`,
+  );
+}
+
+/**
+ * List all per-memory 2D positions for the scatter plot. Bounded by
+ * the run's ``input_count``. Empty array when no assignments yet.
+ */
+export async function listRunPositions(
+  contextId: string,
+  runId: string,
+): Promise<AnalysisPositionListResponse> {
+  return apiClient.get<AnalysisPositionListResponse>(
+    `${base(contextId)}/${encodeURIComponent(runId)}/positions`,
+  );
+}

--- a/frontend/src/lib/api/index.ts
+++ b/frontend/src/lib/api/index.ts
@@ -10,6 +10,7 @@ export { apiClient, ApiError } from "./base";
 export * from "./memory";
 export * from "./api-keys";
 export * from "./coding-sessions";
+export * from "./analyses";
 export * from "./cost-aggregation";
 export * from "./doctor";
 export * from "./oauth";

--- a/frontend/src/lib/api/workspaces.ts
+++ b/frontend/src/lib/api/workspaces.ts
@@ -21,6 +21,15 @@ export interface Workspace {
   context_count: number;
   created_at: string;
   current_user_role?: string | null; // Current user's role in this workspace
+  /**
+   * Memory broadlistening allowlist gate (#497). True iff this workspace
+   * is in ANALYSIS_ENABLED_WORKSPACE_IDS on the server. The other 3 gates
+   * (Pro tier / BYOK / quota) are evaluated lazily on the actual API call;
+   * this flag exists purely so the UI can hide the analyses tab + kebab
+   * entry for non-allowlisted workspaces (cleaner UX than showing an
+   * empty state).
+   */
+  analyses_enabled?: boolean;
 }
 
 export interface CredentialsStatusInfo {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3067,5 +3067,120 @@
     "message": "Your account is not on the allowlist. Contact the administrator to request access.",
     "contact": "If you believe you should have access, please reach out to the administrator.",
     "backToLogin": "Back to Login"
+  },
+  "analyses": {
+    "tabLabel": "Analyses",
+    "header": {
+      "title": "Broadlistening Analyses",
+      "subtitle": "Survey the shape of your memories with cluster overview · Owner only"
+    },
+    "actions": {
+      "newAnalysis": "Analysis",
+      "exportJson": "Export JSON",
+      "refresh": "Refresh",
+      "cancel": "Cancel"
+    },
+    "kpi": {
+      "lastRun": "Last run",
+      "memoriesSurveyed": "Memories surveyed",
+      "runCost": "Run cost",
+      "quality": "Quality",
+      "neverRun": "Never run",
+      "qualityNoData": "no data yet"
+    },
+    "scatter": {
+      "title": "Memory map",
+      "subtitle": "UMAP projection · KMeans clustering on high-dim embeddings",
+      "legendMemory": "memory",
+      "legendCentroid": "cluster centroid",
+      "legendBoundary": "cluster boundary",
+      "focusedOn": "Focused on",
+      "showAllClusters": "Show all clusters",
+      "noPositions": "No positions yet — the run did not produce a scatter projection."
+    },
+    "clusters": {
+      "title": "Clusters",
+      "subtitleZero": "0 regions",
+      "subtitle": "{count} regions · click to focus the map · sorted by size",
+      "allClusters": "All clusters",
+      "memberCount": "{count} memories",
+      "confidence": "conf {value}",
+      "noClustersTitle": "No clusters yet",
+      "noClustersDescription": "The active run has not produced clusters. Run a new analysis to see the cluster overview.",
+      "outlierLabel": "Outlier cluster"
+    },
+    "representatives": {
+      "headerLabel": "Representatives",
+      "viewAll": "View all {count} →",
+      "loading": "Loading representatives…",
+      "empty": "No representative memories for this cluster.",
+      "emptyAfterLoad": "All representative memories were removed since this run completed.",
+      "emptyNoFocus": "Click a cluster to see its representative memories."
+    },
+    "propertyStats": {
+      "title": "Properties",
+      "subtitleAll": "All clusters · full-context aggregate",
+      "subtitleCluster": "Cluster {index} · {label}",
+      "topTags": "Top tags",
+      "byType": "By type",
+      "importance": "Importance",
+      "activity": "Activity over period",
+      "empty": "No property stats available."
+    },
+    "history": {
+      "title": "Past runs",
+      "subtitle": "Last {visible} of {total}",
+      "subtitleAtMost": "Last {visible} runs",
+      "headerDate": "Date",
+      "headerStatus": "Status",
+      "headerMemories": "Memories",
+      "headerCost": "Cost",
+      "noRunsTitle": "No runs yet",
+      "noRunsDescription": "Run your first analysis to populate the history."
+    },
+    "modal": {
+      "title": "Analysis",
+      "subtitle": "{contextName} · run cluster analysis on filtered memories",
+      "period": "Period",
+      "tags": "Tags",
+      "tagsHint": "(any of, optional)",
+      "tagsAddPlaceholder": "+ add",
+      "types": "Types",
+      "typesAll": "All types",
+      "minImportance": "Min importance",
+      "narrativeQuery": "Narrative query",
+      "narrativeQueryHint": "(optional)",
+      "narrativeQueryPlaceholder": "restrict to memories matching this phrase",
+      "model": "Model",
+      "preflight": {
+        "memoriesCount": "Memories that will be analyzed",
+        "estimatedCost": "Estimated cost",
+        "quotaRemaining": "Quota",
+        "embeddingUniform": "embedding uniform",
+        "loading": "Calculating…"
+      },
+      "footerHint": "Owner only · gated by workspace allowlist",
+      "submit": "Run analysis",
+      "submitting": "Starting run…",
+      "errorLoadingPreview": "Could not estimate cost — check connection and try again.",
+      "errorStarting": "Could not start the run — see details below."
+    },
+    "running": {
+      "title": "Run in progress",
+      "startedAt": "Started {when} — clustering and labeling memories…",
+      "cancel": "Cancel run"
+    },
+    "states": {
+      "loading": "Loading analyses…",
+      "empty": {
+        "title": "No analyses yet",
+        "description": "Run your first analysis to surface the cluster overview, scatter map, and per-cluster property stats."
+      },
+      "notEnabled": {
+        "title": "Analyses are not yet enabled for this workspace",
+        "description": "Memory Broadlistening is gated to selected workspaces during the v1 rollout. Reach out if you would like access."
+      },
+      "loadFailed": "Failed to load analyses — check connection and try again."
+    }
   }
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3138,7 +3138,14 @@
       "headerMemories": "Memories",
       "headerCost": "Cost",
       "noRunsTitle": "No runs yet",
-      "noRunsDescription": "Run your first analysis to populate the history."
+      "noRunsDescription": "Run your first analysis to populate the history.",
+      "status": {
+        "running": "running",
+        "succeeded": "succeeded",
+        "failed": "failed",
+        "cancelled": "cancelled · {reason}",
+        "unknown": "{raw}"
+      }
     },
     "modal": {
       "title": "Analysis",
@@ -3165,7 +3172,9 @@
       "submit": "Run analysis",
       "submitting": "Starting run…",
       "errorLoadingPreview": "Could not estimate cost — check connection and try again.",
-      "errorStarting": "Could not start the run — see details below."
+      "errorStarting": "Could not start the run — see details below.",
+      "errorPreviewFallback": "preview failed",
+      "errorStartFallback": "start failed"
     },
     "running": {
       "title": "Run in progress",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3112,7 +3112,7 @@
     },
     "representatives": {
       "headerLabel": "Representatives",
-      "viewAll": "View all {count} →",
+      "totalInCluster": "{count} memories in cluster",
       "loading": "Loading representatives…",
       "empty": "No representative memories for this cluster.",
       "emptyAfterLoad": "All representative memories were removed since this run completed.",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3085,6 +3085,7 @@
       "memoriesSurveyed": "Memories surveyed",
       "runCost": "Run cost",
       "quality": "Quality",
+      "qualityValue": "conf {value}",
       "neverRun": "Never run",
       "qualityNoData": "no data yet"
     },
@@ -3115,7 +3116,8 @@
       "loading": "Loading representatives…",
       "empty": "No representative memories for this cluster.",
       "emptyAfterLoad": "All representative memories were removed since this run completed.",
-      "emptyNoFocus": "Click a cluster to see its representative memories."
+      "emptyNoFocus": "Click a cluster to see its representative memories.",
+      "metaLine": "{idShort} · {type} · importance {importance}"
     },
     "propertyStats": {
       "title": "Properties",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3179,7 +3179,8 @@
     "running": {
       "title": "Run in progress",
       "startedAt": "Started {when} — clustering and labeling memories…",
-      "cancel": "Cancel run"
+      "cancel": "Cancel run",
+      "errorFallback": "Failed to load run."
     },
     "states": {
       "loading": "Loading analyses…",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3138,7 +3138,14 @@
       "headerMemories": "Memories",
       "headerCost": "Cost",
       "noRunsTitle": "まだ run がありません",
-      "noRunsDescription": "最初の分析を実行すると履歴がここに表示されます。"
+      "noRunsDescription": "最初の分析を実行すると履歴がここに表示されます。",
+      "status": {
+        "running": "実行中",
+        "succeeded": "成功",
+        "failed": "失敗",
+        "cancelled": "キャンセル · {reason}",
+        "unknown": "{raw}"
+      }
     },
     "modal": {
       "title": "分析を実行",
@@ -3165,7 +3172,9 @@
       "submit": "分析を実行",
       "submitting": "Run を起動中…",
       "errorLoadingPreview": "コスト推定に失敗しました — 接続を確認して再試行してください。",
-      "errorStarting": "Run の起動に失敗しました — 詳細は下記を確認してください。"
+      "errorStarting": "Run の起動に失敗しました — 詳細は下記を確認してください。",
+      "errorPreviewFallback": "preview に失敗しました",
+      "errorStartFallback": "起動に失敗しました"
     },
     "running": {
       "title": "Run 実行中",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3085,6 +3085,7 @@
       "memoriesSurveyed": "対象 memory 数",
       "runCost": "コスト",
       "quality": "品質",
+      "qualityValue": "conf {value}",
       "neverRun": "未実行",
       "qualityNoData": "データなし"
     },
@@ -3115,7 +3116,8 @@
       "loading": "代表 memory を読み込み中…",
       "empty": "このクラスタには代表 memory がありません。",
       "emptyAfterLoad": "代表 memory はこの run の完了後に全て削除されています。",
-      "emptyNoFocus": "クラスタをクリックして代表 memory を表示。"
+      "emptyNoFocus": "クラスタをクリックして代表 memory を表示。",
+      "metaLine": "{idShort} · {type} · importance {importance}"
     },
     "propertyStats": {
       "title": "Properties",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3071,47 +3071,47 @@
   "analyses": {
     "tabLabel": "分析",
     "header": {
-      "title": "Broadlistening Analyses",
+      "title": "ブロードリスニング分析",
       "subtitle": "クラスタ俯瞰で memory の地形を見る · Owner のみ"
     },
     "actions": {
       "newAnalysis": "分析を実行",
-      "exportJson": "Export JSON",
+      "exportJson": "JSON をエクスポート",
       "refresh": "更新",
       "cancel": "キャンセル"
     },
     "kpi": {
-      "lastRun": "Last run",
+      "lastRun": "前回の run",
       "memoriesSurveyed": "対象 memory 数",
       "runCost": "コスト",
       "quality": "品質",
-      "qualityValue": "conf {value}",
+      "qualityValue": "信頼度 {value}",
       "neverRun": "未実行",
       "qualityNoData": "データなし"
     },
     "scatter": {
-      "title": "Memory map",
-      "subtitle": "UMAP projection · 高次元 embedding を KMeans クラスタリング",
+      "title": "Memory マップ",
+      "subtitle": "UMAP 射影 · 高次元 embedding を KMeans クラスタリング",
       "legendMemory": "memory",
       "legendCentroid": "クラスタ重心",
       "legendBoundary": "クラスタ境界",
       "focusedOn": "Focus 中",
-      "showAllClusters": "すべてのクラスタ表示",
+      "showAllClusters": "すべてのクラスタを表示",
       "noPositions": "scatter 座標が未生成です。run が完了していないか projection が失敗した可能性があります。"
     },
     "clusters": {
-      "title": "Clusters",
+      "title": "クラスタ",
       "subtitleZero": "0 個",
       "subtitle": "{count} 個 · クリックで地図を focus · サイズ順",
-      "allClusters": "All clusters",
-      "memberCount": "{count} memories",
-      "confidence": "conf {value}",
+      "allClusters": "全クラスタ",
+      "memberCount": "{count} 件",
+      "confidence": "信頼度 {value}",
       "noClustersTitle": "クラスタがまだありません",
       "noClustersDescription": "active run がクラスタを生成していません。新しい分析を実行するとクラスタ俯瞰が表示されます。",
       "outlierLabel": "外れ値クラスタ"
     },
     "representatives": {
-      "headerLabel": "Representatives",
+      "headerLabel": "代表 memory",
       "totalInCluster": "クラスタ内 {count} 件",
       "loading": "代表 memory を読み込み中…",
       "empty": "このクラスタには代表 memory がありません。",
@@ -3120,12 +3120,12 @@
       "metaLine": "{idShort} · {type} · importance {importance}"
     },
     "propertyStats": {
-      "title": "Properties",
+      "title": "プロパティ",
       "subtitleAll": "全クラスタ · context 全体の集計",
-      "subtitleCluster": "Cluster {index} · {label}",
-      "topTags": "Top tags",
-      "byType": "Type 別",
-      "importance": "Importance",
+      "subtitleCluster": "クラスタ {index} · {label}",
+      "topTags": "上位タグ",
+      "byType": "タイプ別",
+      "importance": "重要度",
       "activity": "期間内のアクティビティ",
       "empty": "プロパティ統計はありません。"
     },
@@ -3133,10 +3133,10 @@
       "title": "過去の run",
       "subtitle": "直近 {visible} / 全 {total} 件",
       "subtitleAtMost": "直近 {visible} 件",
-      "headerDate": "Date",
-      "headerStatus": "Status",
-      "headerMemories": "Memories",
-      "headerCost": "Cost",
+      "headerDate": "日付",
+      "headerStatus": "ステータス",
+      "headerMemories": "Memory 数",
+      "headerCost": "コスト",
       "noRunsTitle": "まだ run がありません",
       "noRunsDescription": "最初の分析を実行すると履歴がここに表示されます。",
       "status": {
@@ -3150,21 +3150,21 @@
     "modal": {
       "title": "分析を実行",
       "subtitle": "{contextName} · フィルタ済みの memory にクラスタ分析を実行",
-      "period": "Period",
-      "tags": "Tags",
-      "tagsHint": "(any of, optional)",
+      "period": "期間",
+      "tags": "タグ",
+      "tagsHint": "(いずれか、任意)",
       "tagsAddPlaceholder": "+ 追加",
-      "types": "Types",
-      "typesAll": "すべての type",
-      "minImportance": "最低 importance",
-      "narrativeQuery": "Narrative query",
-      "narrativeQueryHint": "(optional)",
+      "types": "タイプ",
+      "typesAll": "すべてのタイプ",
+      "minImportance": "最低重要度",
+      "narrativeQuery": "ナラティブクエリ",
+      "narrativeQueryHint": "(任意)",
       "narrativeQueryPlaceholder": "このフレーズに合致する memory に絞り込む",
-      "model": "Model",
+      "model": "モデル",
       "preflight": {
         "memoriesCount": "対象になる memory 数",
         "estimatedCost": "推定コスト",
-        "quotaRemaining": "Quota",
+        "quotaRemaining": "クォータ",
         "embeddingUniform": "embedding が統一されている",
         "loading": "計算中…"
       },
@@ -3177,9 +3177,10 @@
       "errorStartFallback": "起動に失敗しました"
     },
     "running": {
-      "title": "Run 実行中",
+      "title": "実行中",
       "startedAt": "開始: {when} — クラスタリング + LLM ラベリング処理中…",
-      "cancel": "Run をキャンセル"
+      "cancel": "実行をキャンセル",
+      "errorFallback": "Run の取得に失敗しました。"
     },
     "states": {
       "loading": "Analyses を読み込み中…",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3112,7 +3112,7 @@
     },
     "representatives": {
       "headerLabel": "Representatives",
-      "viewAll": "すべて表示 ({count}) →",
+      "totalInCluster": "クラスタ内 {count} 件",
       "loading": "代表 memory を読み込み中…",
       "empty": "このクラスタには代表 memory がありません。",
       "emptyAfterLoad": "代表 memory はこの run の完了後に全て削除されています。",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3067,5 +3067,120 @@
     "message": "このアカウントは許可リストに登録されていません。アクセスをご希望の場合は管理者にお問い合わせください。",
     "contact": "アクセス権限が必要な場合は、管理者までご連絡ください。",
     "backToLogin": "ログインに戻る"
+  },
+  "analyses": {
+    "tabLabel": "分析",
+    "header": {
+      "title": "Broadlistening Analyses",
+      "subtitle": "クラスタ俯瞰で memory の地形を見る · Owner のみ"
+    },
+    "actions": {
+      "newAnalysis": "分析を実行",
+      "exportJson": "Export JSON",
+      "refresh": "更新",
+      "cancel": "キャンセル"
+    },
+    "kpi": {
+      "lastRun": "Last run",
+      "memoriesSurveyed": "対象 memory 数",
+      "runCost": "コスト",
+      "quality": "品質",
+      "neverRun": "未実行",
+      "qualityNoData": "データなし"
+    },
+    "scatter": {
+      "title": "Memory map",
+      "subtitle": "UMAP projection · 高次元 embedding を KMeans クラスタリング",
+      "legendMemory": "memory",
+      "legendCentroid": "クラスタ重心",
+      "legendBoundary": "クラスタ境界",
+      "focusedOn": "Focus 中",
+      "showAllClusters": "すべてのクラスタ表示",
+      "noPositions": "scatter 座標が未生成です。run が完了していないか projection が失敗した可能性があります。"
+    },
+    "clusters": {
+      "title": "Clusters",
+      "subtitleZero": "0 個",
+      "subtitle": "{count} 個 · クリックで地図を focus · サイズ順",
+      "allClusters": "All clusters",
+      "memberCount": "{count} memories",
+      "confidence": "conf {value}",
+      "noClustersTitle": "クラスタがまだありません",
+      "noClustersDescription": "active run がクラスタを生成していません。新しい分析を実行するとクラスタ俯瞰が表示されます。",
+      "outlierLabel": "外れ値クラスタ"
+    },
+    "representatives": {
+      "headerLabel": "Representatives",
+      "viewAll": "すべて表示 ({count}) →",
+      "loading": "代表 memory を読み込み中…",
+      "empty": "このクラスタには代表 memory がありません。",
+      "emptyAfterLoad": "代表 memory はこの run の完了後に全て削除されています。",
+      "emptyNoFocus": "クラスタをクリックして代表 memory を表示。"
+    },
+    "propertyStats": {
+      "title": "Properties",
+      "subtitleAll": "全クラスタ · context 全体の集計",
+      "subtitleCluster": "Cluster {index} · {label}",
+      "topTags": "Top tags",
+      "byType": "Type 別",
+      "importance": "Importance",
+      "activity": "期間内のアクティビティ",
+      "empty": "プロパティ統計はありません。"
+    },
+    "history": {
+      "title": "過去の run",
+      "subtitle": "直近 {visible} / 全 {total} 件",
+      "subtitleAtMost": "直近 {visible} 件",
+      "headerDate": "Date",
+      "headerStatus": "Status",
+      "headerMemories": "Memories",
+      "headerCost": "Cost",
+      "noRunsTitle": "まだ run がありません",
+      "noRunsDescription": "最初の分析を実行すると履歴がここに表示されます。"
+    },
+    "modal": {
+      "title": "分析を実行",
+      "subtitle": "{contextName} · フィルタ済みの memory にクラスタ分析を実行",
+      "period": "Period",
+      "tags": "Tags",
+      "tagsHint": "(any of, optional)",
+      "tagsAddPlaceholder": "+ 追加",
+      "types": "Types",
+      "typesAll": "すべての type",
+      "minImportance": "最低 importance",
+      "narrativeQuery": "Narrative query",
+      "narrativeQueryHint": "(optional)",
+      "narrativeQueryPlaceholder": "このフレーズに合致する memory に絞り込む",
+      "model": "Model",
+      "preflight": {
+        "memoriesCount": "対象になる memory 数",
+        "estimatedCost": "推定コスト",
+        "quotaRemaining": "Quota",
+        "embeddingUniform": "embedding が統一されている",
+        "loading": "計算中…"
+      },
+      "footerHint": "Owner のみ · workspace allowlist で制限",
+      "submit": "分析を実行",
+      "submitting": "Run を起動中…",
+      "errorLoadingPreview": "コスト推定に失敗しました — 接続を確認して再試行してください。",
+      "errorStarting": "Run の起動に失敗しました — 詳細は下記を確認してください。"
+    },
+    "running": {
+      "title": "Run 実行中",
+      "startedAt": "開始: {when} — クラスタリング + LLM ラベリング処理中…",
+      "cancel": "Run をキャンセル"
+    },
+    "states": {
+      "loading": "Analyses を読み込み中…",
+      "empty": {
+        "title": "まだ分析がありません",
+        "description": "最初の分析を実行するとクラスタ俯瞰、scatter map、各クラスタのプロパティ統計が表示されます。"
+      },
+      "notEnabled": {
+        "title": "この workspace では Analyses はまだ有効化されていません",
+        "description": "Memory Broadlistening は v1 ロールアウト中、選定された workspace に限定されています。アクセスをご希望の場合はお問い合わせください。"
+      },
+      "loadFailed": "Analyses の読み込みに失敗しました — 接続を確認してください。"
+    }
   }
 }

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,108 +1,115 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
-    darkMode: ["class"],
-    content: [
+  darkMode: ["class"],
+  content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
   theme: {
-  	extend: {
-  		borderRadius: {
-  			lg: 'var(--radius)',
-  			md: 'calc(var(--radius) - 2px)',
-  			sm: 'calc(var(--radius) - 4px)'
-  		},
-  		colors: {
-  			background: 'hsl(var(--background))',
-  			foreground: 'hsl(var(--foreground))',
-  			card: {
-  				DEFAULT: 'hsl(var(--card))',
-  				foreground: 'hsl(var(--card-foreground))'
-  			},
-  			popover: {
-  				DEFAULT: 'hsl(var(--popover))',
-  				foreground: 'hsl(var(--popover-foreground))'
-  			},
-  			primary: {
-  				DEFAULT: 'hsl(var(--primary))',
-  				foreground: 'hsl(var(--primary-foreground))'
-  			},
-  			secondary: {
-  				DEFAULT: 'hsl(var(--secondary))',
-  				foreground: 'hsl(var(--secondary-foreground))'
-  			},
-  			muted: {
-  				DEFAULT: 'hsl(var(--muted))',
-  				foreground: 'hsl(var(--muted-foreground))'
-  			},
-  			accent: {
-  				DEFAULT: 'hsl(var(--accent))',
-  				foreground: 'hsl(var(--accent-foreground))'
-  			},
-  			destructive: {
-  				DEFAULT: 'hsl(var(--destructive))',
-  				foreground: 'hsl(var(--destructive-foreground))'
-  			},
-  			border: 'hsl(var(--border))',
-  			input: 'hsl(var(--input))',
-  			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			},
-  			brand: {
-  				green: {
-  					50: '#f0fdf4',
-  					100: '#dcfce7',
-  					200: '#bbf7d0',
-  					300: '#86efac',
-  					400: '#4ade80',
-  					500: '#059669',
-  					600: '#047857',
-  					700: '#065f46',
-  					800: '#064e3b',
-  					900: '#022c22'
-  				},
-  				red: {
-  					50: '#fef2f2',
-  					100: '#fee2e2',
-  					200: '#fecaca',
-  					300: '#fca5a5',
-  					400: '#f87171',
-  					500: '#DC2626',
-  					600: '#B91C1C',
-  					700: '#991B1B',
-  					800: '#7F1D1D',
-  					900: '#450a0a'
-  				}
-  			}
-  		},
-  		animation: {
-  			'fade-in': 'fadeIn 0.6s ease-in-out',
-  			'slide-up': 'slideUp 0.6s ease-out',
-  			'float': 'float 3s ease-in-out infinite',
-  			'pulse-slow': 'pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite'
-  		},
-  		keyframes: {
-  			fadeIn: {
-  				'0%': { opacity: '0' },
-  				'100%': { opacity: '1' }
-  			},
-  			slideUp: {
-  				'0%': { transform: 'translateY(20px)', opacity: '0' },
-  				'100%': { transform: 'translateY(0)', opacity: '1' }
-  			},
-  			float: {
-  				'0%, 100%': { transform: 'translateY(0)' },
-  				'50%': { transform: 'translateY(-10px)' }
-  			}
-  		}
-  	}
+    extend: {
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      colors: {
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        chart: {
+          "1": "hsl(var(--chart-1))",
+          "2": "hsl(var(--chart-2))",
+          "3": "hsl(var(--chart-3))",
+          "4": "hsl(var(--chart-4))",
+          "5": "hsl(var(--chart-5))",
+          "6": "hsl(var(--chart-6))",
+          "7": "hsl(var(--chart-7))",
+          "8": "hsl(var(--chart-8))",
+          "9": "hsl(var(--chart-9))",
+          "10": "hsl(var(--chart-10))",
+          "11": "hsl(var(--chart-11))",
+          "12": "hsl(var(--chart-12))",
+        },
+        brand: {
+          green: {
+            50: "#f0fdf4",
+            100: "#dcfce7",
+            200: "#bbf7d0",
+            300: "#86efac",
+            400: "#4ade80",
+            500: "#059669",
+            600: "#047857",
+            700: "#065f46",
+            800: "#064e3b",
+            900: "#022c22",
+          },
+          red: {
+            50: "#fef2f2",
+            100: "#fee2e2",
+            200: "#fecaca",
+            300: "#fca5a5",
+            400: "#f87171",
+            500: "#DC2626",
+            600: "#B91C1C",
+            700: "#991B1B",
+            800: "#7F1D1D",
+            900: "#450a0a",
+          },
+        },
+      },
+      animation: {
+        "fade-in": "fadeIn 0.6s ease-in-out",
+        "slide-up": "slideUp 0.6s ease-out",
+        float: "float 3s ease-in-out infinite",
+        "pulse-slow": "pulse 3s cubic-bezier(0.4, 0, 0.6, 1) infinite",
+      },
+      keyframes: {
+        fadeIn: {
+          "0%": { opacity: "0" },
+          "100%": { opacity: "1" },
+        },
+        slideUp: {
+          "0%": { transform: "translateY(20px)", opacity: "0" },
+          "100%": { transform: "translateY(0)", opacity: "1" },
+        },
+        float: {
+          "0%, 100%": { transform: "translateY(0)" },
+          "50%": { transform: "translateY(-10px)" },
+        },
+      },
+    },
   },
   plugins: [require("tailwindcss-animate")],
 };


### PR DESCRIPTION
## Summary

Adds the Memory Broadlistening **analyses tab** to the context detail page. Owner-only, allowlist-gated, with scatter plot + cluster drill-down + on-demand run trigger.

This is **F4** of the Memory Broadlistening v1 umbrella (#493). Builds on #494 schema, #495 pipeline, and #496 API+MCP (PR #535).

## What ships

### Backend (extends #496)
- `GET /contexts/{id}/analyses/{run_id}/clusters` — full cluster list per run (label, count, centroid_2d, representative_memory_ids, property_stats, label_confidence)
- `GET /contexts/{id}/analyses/{run_id}/positions` — per-memory `(memory_id, x, y, cluster_index)` for scatter rendering, soft-deleted memories filtered out
- `WorkspaceResponse.analyses_enabled: bool` — exposes allowlist membership so the frontend can hide the tab/menu for non-allowlisted owners (cleaner UX than empty state)
- `LLMService` passes `timeout=60.0` to `AsyncOpenAI` — bounds silent hangs in cluster labeling (#533 mitigation, not full fix)
- 5 new pytest cases (cluster list happy path / running run / foreign-context 404; positions happy path / unknown-run 404)

### Frontend
**7 new components** under `frontend/src/components/contexts/analyses/`:
- `AnalysesTabPanel` — orchestrator (bootstrap, polling, modal, banner)
- `ScatterPlot` — SVG with per-cluster `<g>` groups + CSS focus mode (no per-dot DOM diffing)
- `ClusterList` — clickable rows, sorted by count
- `RepresentativesPanel` — top-5 reps, on-demand `referenceMemory` resolution
- `PropertyStats` — tags / types / importance / time series
- `AnalysisHistory` — past run table with sticky-NULL cost display
- `NewAnalysisModal` — debounced preview + Run trigger

**2 custom hooks**:
- `useFocusedClusterId` — URL `?cluster=N` sync, integer parsing, invalid-value strip
- `useActiveAnalysisPolling` — fixed 3s polling, `visibilitychange` pause, terminal-state auto-stop, manual refetch

**Foundation**:
- `globals.css` + `tailwind.config.ts` — chart palette extended to `--chart-12` (light + dark) for variable KMeans n_clusters
- `analyses.*` i18n namespace (en + ja, ~40 keys), tab label `分析`, modal `分析を実行`
- Pure helpers + Vitest unit tests (formatters 16 cases, parser 4)

**Integration**:
- Owner-only `分析` tab in context detail page, between Graph and Settings
- Owner-only kebab item `分析を実行` in contexts list (links to `?tab=analyses&new=1`)
- Lazy-loaded `AnalysesTabPanel` so the bundle never enters non-owner sessions

### UX details
- **Running banner** (blue, with InlineSpinner + Cancel button) while pipeline is in flight — replaces the previous "page looks frozen" experience
- **Both Run buttons disable** during in-flight runs (top action + EmptyState CTA)
- **Allowlist gating**: tab + kebab hidden when `analyses_enabled === false`, no leak via empty state
- **Sticky-NULL cost** display (`null → "—"`) so unpriced runs don't visually equal $0.000

## Quality

| Check | Result |
|---|---|
| Backend ruff | All checks passed |
| Backend pyright | 0 errors, 0 warnings |
| Backend pytest | 39/39 (analyses scope) |
| Frontend TypeScript | 0 errors |
| Frontend Vitest | 73/73 (analyses 20 + contexts 53) |
| Frontend Next.js compile | ✓ Compiled successfully |

`/quality` + `/simplify` + `/self-review` all complete. 9 review findings addressed; 3 deferred to follow-up issues (Card primitive consolidation, RepresentativesPanel AbortController, formatCostCents shared util).

## Test plan

- [ ] `make test-local` passes (backend pytest)
- [ ] `make test-frontend` passes (frontend Vitest)
- [ ] `npm run build` succeeds (Next.js compile + page collection — known Node 20.18.0 build-worker quirk on host, runs clean inside docker)
- [ ] Manual: owner workspace with allowlist sees `分析` tab and kebab entry; non-allowlisted owner does not
- [ ] Manual: Cluster row click toggles focus mode, browser back restores
- [ ] Manual: Modal preview cost updates as filters change
- [ ] Manual: Run button → 202 → running banner → terminal state refreshes view

## Out of scope / follow-ups

- **#533 deeper fix**: pipeline hangs at `asyncio.to_thread` despite the LLM 60s timeout added here. Backend silent-hang investigation needs separate PR.
- **Card primitive consolidation** across the 4 panel components (cosmetic, ~15 line reduction)
- **AbortController** for in-flight `referenceMemory` calls on rapid cluster switches (low impact: capped at 5 reps per cluster)
- **`formatCostCents`** shared utility with `CostDashboard.formatCost` (touches PR #527 territory)

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)