### PR TITLE
fix: investigate(analysis): broadlistening pipeline pilot run hangs after Qdrant client init (#533)

### DIFF
--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -37,6 +37,14 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
+# Pre-warm umap + sklearn at module level. Both project_to_2d and
+# cluster_high_dim use lazy imports; if two asyncio.to_thread workers
+# race to import the same modules concurrently, CPython's per-module
+# importlib lock deadlocks (umap imports sklearn internally,
+# cluster_high_dim also imports sklearn — circular wait).
+import umap  # noqa: F401
+from sklearn.cluster import KMeans  # noqa: F401
+from sklearn.metrics import silhouette_score  # noqa: F401
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -62,15 +70,6 @@ from services.analysis.vector_pull import (
 )
 from utils.exceptions import ConfigurationError, ConflictError, ValidationError
 from utils.logger import get_logger
-
-# Pre-warm umap + sklearn at module level. Both project_to_2d and
-# cluster_high_dim use lazy imports; if two asyncio.to_thread workers
-# race to import the same modules concurrently, CPython's per-module
-# importlib lock deadlocks (umap imports sklearn internally,
-# cluster_high_dim also imports sklearn — circular wait).
-import umap  # noqa: F401
-from sklearn.cluster import KMeans  # noqa: F401
-from sklearn.metrics import silhouette_score  # noqa: F401
 
 logger = get_logger(__name__)
 

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -378,6 +378,16 @@ class AnalysisOrchestrator:
             # ~2-20s compute window. (Per Copilot review on PR #530.)
             await self.db.commit()
 
+            # Pre-warm umap + sklearn before spawning threads. Both stage
+            # functions use lazy imports; if two OS threads race to import the
+            # same module, CPython's per-module importlib lock deadlocks
+            # (umap imports sklearn internally, cluster_high_dim also imports
+            # sklearn — circular wait, silent hang). Populating sys.modules
+            # here ensures threads hit the cached fast path, not the lock.
+            import umap as _umap_prewarm  # noqa: F401
+            from sklearn.cluster import KMeans as _kmeans_prewarm  # noqa: F401
+            from sklearn.metrics import silhouette_score as _sil_prewarm  # noqa: F401
+
             # Stages [D] and [E] are CPU-bound (sklearn KMeans + UMAP).
             # Run them concurrently in worker threads so the asyncio
             # event loop is not blocked for the combined ~2-20s of

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -63,6 +63,15 @@ from services.analysis.vector_pull import (
 from utils.exceptions import ConfigurationError, ConflictError, ValidationError
 from utils.logger import get_logger
 
+# Pre-warm umap + sklearn at module level. Both project_to_2d and
+# cluster_high_dim use lazy imports; if two asyncio.to_thread workers
+# race to import the same modules concurrently, CPython's per-module
+# importlib lock deadlocks (umap imports sklearn internally,
+# cluster_high_dim also imports sklearn — circular wait).
+import umap  # noqa: F401
+from sklearn.cluster import KMeans  # noqa: F401
+from sklearn.metrics import silhouette_score  # noqa: F401
+
 logger = get_logger(__name__)
 
 
@@ -377,16 +386,6 @@ class AnalysisOrchestrator:
             # the connection would stay checked out for the whole
             # ~2-20s compute window. (Per Copilot review on PR #530.)
             await self.db.commit()
-
-            # Pre-warm umap + sklearn before spawning threads. Both stage
-            # functions use lazy imports; if two OS threads race to import the
-            # same module, CPython's per-module importlib lock deadlocks
-            # (umap imports sklearn internally, cluster_high_dim also imports
-            # sklearn — circular wait, silent hang). Populating sys.modules
-            # here ensures threads hit the cached fast path, not the lock.
-            import umap as _umap_prewarm  # noqa: F401
-            from sklearn.cluster import KMeans as _kmeans_prewarm  # noqa: F401
-            from sklearn.metrics import silhouette_score as _sil_prewarm  # noqa: F401
 
             # Stages [D] and [E] are CPU-bound (sklearn KMeans + UMAP).
             # Run them concurrently in worker threads so the asyncio

--- a/scripts/pilot_b2.py
+++ b/scripts/pilot_b2.py
@@ -1,0 +1,116 @@
+"""Pilot script: broadlistening pipeline end-to-end run (#533).
+
+Usage (inside kagura-api container):
+    PYTHONPATH=src PYTHONUNBUFFERED=1 python -u /tmp/pilot_b2.py
+
+Env vars:
+    NUMBA_DISABLE_JIT=1   — disable numba JIT to test hypothesis 3
+"""
+
+import asyncio
+import os
+import sys
+import time
+from uuid import UUID
+
+# Diagnostics
+print(f"Python: {sys.version}", flush=True)
+print(
+    f"NUMBA_DISABLE_JIT: {os.environ.get('NUMBA_DISABLE_JIT', 'not set')}", flush=True
+)
+
+WORKSPACE_ID = UUID("e4b22965-77b0-4a5d-a23e-10c15b6590b8")
+CONTEXT_ID = UUID("700a6873-ade0-44ba-beca-95e8cda3ad82")
+USER_ID = "local:admin"
+
+
+async def main() -> None:
+    from db.base import get_db
+    from services.analysis.orchestrator import AnalysisOrchestrator, AnalysisParams
+
+    from sqlalchemy import text
+
+    # Avoid importlib deadlock when to_thread workers race on lazy imports.
+    print("Pre-warming umap + sklearn...", flush=True)
+    t_prewarm = time.monotonic()
+    import umap  # noqa: F401
+    from sklearn.cluster import KMeans  # noqa: F401
+    from sklearn.metrics import silhouette_score  # noqa: F401
+
+    print(f"Pre-warm done in {time.monotonic() - t_prewarm:.2f}s", flush=True)
+
+    t0 = time.monotonic()
+    analysis = None
+
+    print("Connecting to DB...", flush=True)
+    async for db in get_db():
+        orchestrator = AnalysisOrchestrator(db)
+
+        # Phase 1: start() — BYOK check, idempotency, row create
+        print("Phase 1: start()...", flush=True)
+        analysis = await orchestrator.start(
+            workspace_id=WORKSPACE_ID,
+            context_id=CONTEXT_ID,
+            user_id=USER_ID,
+            params=AnalysisParams(),
+        )
+        await db.commit()
+        print(
+            f"Phase 1 done in {time.monotonic() - t0:.2f}s — "
+            f"run_id={analysis.id} status={analysis.status}",
+            flush=True,
+        )
+
+    if analysis is None:
+        print("ERROR: Phase 1 did not complete", flush=True)
+        return
+
+    # Phase 2: run() — fresh session (mirrors production task pattern)
+    print("Phase 2: run()...", flush=True)
+    t1 = time.monotonic()
+    async for db2 in get_db():
+        orchestrator2 = AnalysisOrchestrator(db2)
+        await orchestrator2.run(analysis_id=analysis.id)
+        print(f"Phase 2 done in {time.monotonic() - t1:.2f}s", flush=True)
+
+    # Result check
+    print("Checking DB result...", flush=True)
+    async for db3 in get_db():
+        from models.analysis import MemoryAnalysis
+
+        row = await db3.get(MemoryAnalysis, analysis.id)
+        if row is None:
+            print("ERROR: analysis row not found", flush=True)
+            return
+
+        print(f"status: {row.status}", flush=True)
+        print(f"cost_actual_cents: {row.cost_actual_cents}", flush=True)
+        print(f"error: {row.error}", flush=True)
+
+        clusters = await db3.execute(
+            text(
+                "SELECT count(*) FROM memory_analysis_clusters WHERE analysis_id = :id"
+            ),
+            {"id": str(analysis.id)},
+        )
+        assignments = await db3.execute(
+            text(
+                "SELECT count(*) FROM memory_analysis_assignments WHERE analysis_id = :id"
+            ),
+            {"id": str(analysis.id)},
+        )
+        print(f"clusters: {clusters.scalar()}", flush=True)
+        print(f"assignments: {assignments.scalar()}", flush=True)
+
+        sr = await db3.execute(
+            text(
+                "SELECT count(*) FROM sleep_reports WHERE source = 'analysis' AND paid_by = 'byok'"
+            ),
+        )
+        print(f"sleep_reports(analysis/byok): {sr.scalar()}", flush=True)
+
+    print(f"\nTotal: {time.monotonic() - t0:.2f}s", flush=True)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/pilot_b2.py
+++ b/scripts/pilot_b2.py
@@ -1,7 +1,8 @@
 """Pilot script: broadlistening pipeline end-to-end run (#533).
 
-Usage (inside kagura-api container):
-    PYTHONPATH=src PYTHONUNBUFFERED=1 python -u /tmp/pilot_b2.py
+Usage (inside kagura-api container, after docker cp):
+    docker cp scripts/pilot_b2.py kagura-api:/tmp/pilot_b2.py
+    docker exec kagura-api bash -c "cd /app && PYTHONPATH=src PYTHONUNBUFFERED=1 python -u /tmp/pilot_b2.py"
 
 Env vars:
     NUMBA_DISABLE_JIT=1   — disable numba JIT to test hypothesis 3


### PR DESCRIPTION
Closes #533

## Summary
- CPython importlib deadlock identified as root cause: concurrent `asyncio.to_thread` workers racing to lazy-import sklearn modules (umap imports sklearn internally, cluster_high_dim also imports sklearn — circular wait on per-module import locks)
- Fix: move umap+sklearn pre-warm imports from inside `run()` to module level in orchestrator.py, so sys.modules is populated before threads spawn
- Pilot run confirmed: status=succeeded, 9 clusters, 65 assignments, no hang
- Investigation pilot script (`scripts/pilot_b2.py`) committed as diagnostic artifact

## Implementation notes
- `backend/src/services/analysis/orchestrator.py` — 3 imports added at module level (umap, KMeans, silhouette_score)
- `scripts/pilot_b2.py` — investigation pilot script for end-to-end reproduction
- `silhouette_score` is lazy-imported inside `cluster_high_dim()` at clusterer.py:108; pre-warming prevents the same deadlock class
- No new dependencies, no schema changes, no API changes
- Ruff import ordering fix applied in follow-up commit

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/533-fix-investigate-analysis-broadlistening-pipe.gate1.md
- ~/.claude/cache/gh-issue-driven/533-fix-investigate-analysis-broadlistening-pipe.gate2.md

🤖 Generated via /gh-issue-driven:ship