### PR TITLE
feat(mcp): Device Authorization Grant (RFC 8628) (#536)

### DIFF
--- a/backend/alembic/versions/d08_536_device_code_grant.py
+++ b/backend/alembic/versions/d08_536_device_code_grant.py
@@ -1,0 +1,74 @@
+"""Device Authorization Grant (RFC 8628) — oauth_device_codes table (Issue #536).
+
+Revision ID: d08_536_device_code_grant
+Revises: d08_496_analyses_cancellation
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+from sqlalchemy import Column, DateTime, Integer, String, text
+
+revision: str = "d08_536_device_code_grant"
+down_revision: str | Sequence[str] | None = "d08_496_analyses_cancellation"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "oauth_device_codes",
+        Column("id", Integer, primary_key=True, autoincrement=True),
+        Column("device_code", String(255), nullable=False, unique=True),
+        Column("user_code", String(8), nullable=False, unique=True),
+        Column(
+            "client_id",
+            String(48),
+            nullable=False,
+        ),
+        Column("user_id", String(255), nullable=True),
+        Column("scope", String(255), nullable=True),
+        Column("expires_at", DateTime, nullable=False),
+        Column("last_polled_at", DateTime, nullable=True),
+        Column("denied_at", DateTime, nullable=True),
+        Column("authorized_at", DateTime, nullable=True),
+        Column(
+            "created_at",
+            DateTime,
+            nullable=False,
+            server_default=text("NOW()"),
+        ),
+    )
+
+    op.create_index(
+        "ix_oauth_device_codes_device_code",
+        "oauth_device_codes",
+        ["device_code"],
+    )
+    op.create_index(
+        "ix_oauth_device_codes_user_code",
+        "oauth_device_codes",
+        ["user_code"],
+    )
+    op.create_index(
+        "ix_oauth_device_codes_expires_at",
+        "oauth_device_codes",
+        ["expires_at"],
+    )
+    op.create_index(
+        "ix_oauth_device_codes_client_id",
+        "oauth_device_codes",
+        ["client_id"],
+    )
+    op.create_foreign_key(
+        "fk_oauth_device_codes_client_id",
+        "oauth_device_codes",
+        "oauth_clients",
+        ["client_id"],
+        ["client_id"],
+        ondelete="CASCADE",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("oauth_device_codes")

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -23,6 +23,7 @@ import hashlib
 import os
 import secrets
 import unicodedata
+from datetime import timedelta
 from pathlib import Path
 from urllib.parse import parse_qsl, urlencode, urlparse, urlsplit, urlunsplit
 
@@ -33,9 +34,11 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import SessionUser, require_admin
-from auth.oauth2_server import create_authorization_server
+from auth.oauth2_server import _OAuthUser, create_authorization_server
+from config.settings import get_settings
 from db.base import get_db, get_sync_session
-from models.auth import OAuth2Client, OAuth2Token, User
+from models.api_base import TZAwareBaseModel
+from models.auth import OAuth2Client, OAuth2DeviceCode, OAuth2Token, User, generate_user_code
 from models.schemas import TokenIntrospectionResponse
 from utils.datetime import to_utc_iso, utcnow
 from utils.logger import get_logger
@@ -211,6 +214,60 @@ class OAuth2ProviderResponse(BaseModel):
     scopes: list[str]
     enabled: bool
     configured: bool  # Alias for enabled (frontend compatibility)
+
+
+# ============================================================================
+# Device Authorization Grant Schemas (RFC 8628, Issue #536)
+# ============================================================================
+
+
+class DeviceAuthorizationRequest(BaseModel):
+    """Device Authorization Request (RFC 8628 Section 3.1)."""
+
+    client_id: str = Field(..., description="OAuth2 client identifier")
+    scope: str | None = Field(None, description="Requested scope (space-separated)")
+
+
+class DeviceAuthorizationResponse(TZAwareBaseModel):
+    """Device Authorization Response (RFC 8628 Section 3.2)."""
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str
+    expires_in: int
+    interval: int
+
+
+class DeviceVerifyRequest(BaseModel):
+    """Request to look up pending device authorization by user_code."""
+
+    user_code: str = Field(..., min_length=8, max_length=8)
+
+
+class DeviceVerifyResponse(TZAwareBaseModel):
+    """Pending device authorization info returned for the consent screen."""
+
+    user_code: str
+    client_name: str
+    scope: str | None
+    expires_at: str  # ISO 8601 with Z suffix (manually formatted via to_utc_iso)
+    is_authorized: bool
+    is_expired: bool
+
+
+class DeviceConfirmRequest(BaseModel):
+    """User consent decision for a pending device authorization."""
+
+    user_code: str = Field(..., min_length=8, max_length=8)
+    approve: bool = Field(True)
+
+
+class DeviceConfirmResponse(TZAwareBaseModel):
+    """Result of user consent decision."""
+
+    status: str  # "approved" or "denied"
+    user_code: str
 
 
 # ============================================================================
@@ -1194,37 +1251,27 @@ async def list_oauth2_providers(
 
 
 # Helper function: Get current user from session
-def get_current_user_from_session(request: Request):
+def get_current_user_from_session(request: Request) -> _OAuthUser | None:
     """Get authenticated user from SessionMiddleware.
 
     Args:
         request: FastAPI request with request.state.user
 
     Returns:
-        User object
-
-    Raises:
-        HTTPException: If not authenticated
+        _OAuthUser or None if not authenticated
     """
     if not hasattr(request.state, "user") or not request.state.user:
         return None
 
-    # Get user from request.state
     user_data = request.state.user
 
-    # Create user-like object for OAuth2 server
-    class UserStub:
-        def __init__(self, user_id: str, email: str):
-            self.user_id = user_id
-            self.email = email
-
     if isinstance(user_data, dict):
-        return UserStub(
+        return _OAuthUser(
             user_id=user_data.get("user_id") or user_data.get("sub") or user_data.get("email"),
             email=user_data.get("email"),
         )
     else:
-        return UserStub(
+        return _OAuthUser(
             user_id=getattr(user_data, "user_id", None) or getattr(user_data, "email", None),
             email=getattr(user_data, "email", None),
         )
@@ -1540,18 +1587,18 @@ async def oauth_authorize_get(
         db_session.close()
 
 
-def _handle_authorize_sync(request, user_dict):
-    """Synchronous OAuth2 authorization handler.
+def _run_oauth_sync(action: str, request, **kwargs):
+    """Run an OAuth2 server operation in a synchronous session.
 
-    Runs in thread pool to avoid blocking FastAPI event loop.
-    Session is created and closed within this function.
+    Shared helper for ``_handle_authorize_sync`` and ``_handle_token_sync``.
+    Creates/closes the session internally so callers don't manage lifecycle.
     """
     db_session = get_sync_session()
     try:
         server = create_authorization_server(db_session)
-        response = server.create_authorization_response(request, grant_user=user_dict)
+        result = getattr(server, action)(request, **kwargs)
         db_session.commit()
-        return response
+        return result
     except Exception:
         db_session.rollback()
         raise
@@ -1617,7 +1664,9 @@ async def oauth_authorize_post(
 
     # Run Authlib operations in thread pool to avoid blocking event loop
     try:
-        response = await asyncio.to_thread(_handle_authorize_sync, request, user)
+        response = await asyncio.to_thread(
+            _run_oauth_sync, "create_authorization_response", request, grant_user=user
+        )
 
         # Use 303 See Other to convert POST to GET redirect
         # Claude.ai callback expects GET, not POST
@@ -1663,25 +1712,6 @@ async def oauth_authorize_post(
         return RedirectResponse(_append_query_params(redirect_uri, params), status_code=303)
 
 
-def _handle_token_sync(request):
-    """Synchronous OAuth2 token handler.
-
-    Runs in thread pool to avoid blocking FastAPI event loop.
-    Session is created and closed within this function.
-    """
-    db_session = get_sync_session()
-    try:
-        server = create_authorization_server(db_session)
-        authlib_resp = server.create_token_response(request)
-        db_session.commit()
-        return authlib_resp
-    except Exception:
-        db_session.rollback()
-        raise
-    finally:
-        db_session.close()
-
-
 @router.post("/token", include_in_schema=False)
 @router.post("/token/")
 async def oauth_token(request: Request):
@@ -1708,7 +1738,7 @@ async def oauth_token(request: Request):
     logger.info("token_request_form", form=request.state.form_data)
 
     # Run Authlib operations in thread pool to avoid blocking event loop
-    authlib_resp = await asyncio.to_thread(_handle_token_sync, request)
+    authlib_resp = await asyncio.to_thread(_run_oauth_sync, "create_token_response", request)
 
     # Extract status, body, headers from Authlib response
     if isinstance(authlib_resp, tuple) and len(authlib_resp) == 3:
@@ -1750,6 +1780,217 @@ async def oauth_token(request: Request):
         headers=headers_dict,
         media_type=headers_dict.get("content-type", "application/json"),
     )
+
+
+# ============================================================================
+# Device Authorization Grant Endpoints (RFC 8628, Issue #536)
+# ============================================================================
+
+
+@router.post("/device/authorize", response_model=DeviceAuthorizationResponse)
+async def device_authorize(body: DeviceAuthorizationRequest) -> DeviceAuthorizationResponse:
+    """Device Authorization endpoint (RFC 8628 Section 3.1).
+
+    Called by CLI clients to obtain a device_code + user_code pair.
+    No authentication required — this is a public endpoint.
+    """
+    settings = get_settings()
+    db_session = get_sync_session()
+
+    try:
+        client = db_session.query(OAuth2Client).filter_by(client_id=body.client_id).first()
+        if not client:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Unknown client_id",
+            )
+
+        device_code = secrets.token_urlsafe(32)
+        user_code = generate_user_code()
+
+        scope = client.get_allowed_scope(body.scope or "")
+
+        expires_at_val = utcnow() + timedelta(seconds=settings.oauth_device_code_expires_in)
+
+        device = OAuth2DeviceCode(
+            device_code=device_code,
+            user_code=user_code,
+            client_id=client.client_id,
+            scope=scope,
+            expires_at=expires_at_val,
+        )
+        db_session.add(device)
+        db_session.commit()
+
+        verification_uri = f"{settings.frontend_url}/device"
+        verification_uri_complete = f"{verification_uri}?user_code={user_code}"
+
+        logger.info(
+            "device_authorization_created",
+            client_id=body.client_id,
+            device_code_prefix=device_code[:8],
+        )
+
+        return DeviceAuthorizationResponse(
+            device_code=device_code,
+            user_code=user_code,
+            verification_uri=verification_uri,
+            verification_uri_complete=verification_uri_complete,
+            expires_in=settings.oauth_device_code_expires_in,
+            interval=settings.oauth_device_polling_interval,
+        )
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        db_session.rollback()
+        logger.error("device_authorize_failed", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create device authorization",
+        ) from e
+    finally:
+        db_session.close()
+
+
+@router.post("/device/verify", response_model=DeviceVerifyResponse)
+async def device_verify(body: DeviceVerifyRequest) -> DeviceVerifyResponse:
+    """Look up a pending device authorization by user_code.
+
+    Returns enough information for the browser consent screen to render
+    (client_name, scope). No authentication required — possession of the
+    user_code is the bearer token for this lookup.
+    """
+    db_session = get_sync_session()
+
+    try:
+        device = (
+            db_session.query(OAuth2DeviceCode).filter_by(user_code=body.user_code.upper()).first()
+        )
+
+        if not device:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Invalid user code",
+            )
+
+        client = db_session.query(OAuth2Client).filter_by(client_id=device.client_id).first()
+        client_name = client.client_name if client else "Unknown"
+
+        is_expired = device.is_expired()
+        is_authorized = (
+            not is_expired and device.authorized_at is not None and device.user_id is not None
+        )
+
+        return DeviceVerifyResponse(
+            user_code=device.user_code,
+            client_name=client_name,
+            scope=device.scope,
+            expires_at=to_utc_iso(device.expires_at) or "",
+            is_authorized=is_authorized,
+            is_expired=is_expired,
+        )
+
+    except HTTPException:
+        raise
+    finally:
+        db_session.close()
+
+
+def _get_user_from_session(request: Request) -> dict | None:
+    """Extract user info from session (delegates to get_current_user_from_session)."""
+    user_stub = get_current_user_from_session(request)
+    if user_stub is None:
+        return None
+    return {"user_id": user_stub.user_id, "email": user_stub.email}
+
+
+@router.post("/device/confirm", response_model=DeviceConfirmResponse)
+async def device_confirm(
+    request: Request,
+    body: DeviceConfirmRequest,
+) -> DeviceConfirmResponse:
+    """User consent endpoint for device authorization.
+
+    Requires session authentication. Sets authorized_at or denied_at on the
+    device code record so the polling CLI receives the decision.
+    """
+    user = _get_user_from_session(request)
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Authentication required",
+        )
+
+    db_session = get_sync_session()
+
+    try:
+        device = (
+            db_session.query(OAuth2DeviceCode)
+            .filter_by(user_code=body.user_code.upper())
+            .with_for_update()
+            .first()
+        )
+
+        if not device:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Invalid user code",
+            )
+
+        if device.is_expired():
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="This code has expired",
+            )
+
+        if device.authorized_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This code has already been authorized",
+            )
+
+        if device.denied_at is not None:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="This code has already been denied",
+            )
+
+        if body.approve:
+            user_id = user.get("user_id") or user.get("sub")
+            if not user_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="User ID not found in session",
+                )
+            device.user_id = user_id
+            device.authorized_at = utcnow()
+            status_str = "approved"
+        else:
+            device.denied_at = utcnow()
+            status_str = "denied"
+
+        db_session.commit()
+
+        logger.info(
+            "device_authorization_" + status_str,
+            user_code=body.user_code,
+            user_id=device.user_id,
+        )
+
+        return DeviceConfirmResponse(status=status_str, user_code=body.user_code)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        db_session.rollback()
+        logger.error("device_confirm_failed", error=str(e))
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to process device authorization",
+        ) from e
+    finally:
+        db_session.close()
 
 
 @router.post("/introspect", response_model=TokenIntrospectionResponse)

--- a/backend/src/auth/oauth2_server.py
+++ b/backend/src/auth/oauth2_server.py
@@ -36,14 +36,32 @@ from typing import Any
 from authlib.oauth2 import OAuth2Request
 from authlib.oauth2.rfc6749 import grants
 from authlib.oauth2.rfc7636 import CodeChallenge
+from authlib.oauth2.rfc8628 import DeviceCodeGrant as _DeviceCodeGrant
 from sqlalchemy.orm import Session
 
 from config.settings import get_settings
-from models.auth import OAuth2AuthorizationCode, OAuth2Client, OAuth2Token
+from models.auth import OAuth2AuthorizationCode, OAuth2Client, OAuth2DeviceCode, OAuth2Token
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+_TOKEN_ENDPOINT_AUTH_METHODS = ["none", "client_secret_post", "client_secret_basic"]
+
+
+class _OAuthUser:
+    """Minimal user object for Authlib grant interfaces.
+
+    Provides both ``user_id`` attribute (used by ``save_token``) and
+    ``get_user_id()`` method (used by ``DeviceCodeGrant.query_user_grant``).
+    """
+
+    def __init__(self, user_id: str = "", email: str | None = None):
+        self.user_id = user_id
+        self.email = email
+
+    def get_user_id(self) -> str:
+        return self.user_id
 
 
 # ============================================================================
@@ -189,13 +207,7 @@ class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
     """
 
     # Token endpoint auth methods (Issue #157: Public Client + PKCE support)
-    TOKEN_ENDPOINT_AUTH_METHODS = [
-        "none",  # Public clients (ChatGPT/Claude) with PKCE
-        "client_secret_post",
-        "client_secret_basic",
-    ]
-
-    # Token expires in 1 hour (3600 seconds)
+    TOKEN_ENDPOINT_AUTH_METHODS = _TOKEN_ENDPOINT_AUTH_METHODS
     TOKEN_EXPIRES_IN = 3600
 
     def generate_token(
@@ -206,30 +218,11 @@ class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
         expires_in=None,
         include_refresh_token=True,
     ) -> dict[str, Any]:
-        """Generate OAuth2 token with explicit expires_in.
-
-        Authlib calls this with keyword arguments only.
-        Client is obtained from self.request.client (not passed as parameter).
-
-        Args:
-            user: User object (optional)
-            scope: Scope string (optional)
-            grant_type: Grant type (optional, uses self.GRANT_TYPE if not provided)
-            expires_in: Token expiration seconds (optional, uses self.TOKEN_EXPIRES_IN if not provided)
-            include_refresh_token: Whether to include refresh token (not used)
-
-        Returns:
-            Token dict with access_token, refresh_token, expires_in, etc.
-        """
-        # Get client from request (Authlib pattern)
         client = self.request.client
-
-        # Use class-level defaults if not provided
         if expires_in is None:
             expires_in = self.TOKEN_EXPIRES_IN
         if grant_type is None:
             grant_type = self.GRANT_TYPE
-
         return _generate_token_with_expiry(grant_type, client, expires_in, scope)
 
     def save_authorization_code(self, code: str, request: OAuth2Request) -> OAuth2AuthorizationCode:
@@ -397,12 +390,7 @@ class AuthorizationCodeGrant(grants.AuthorizationCodeGrant):
             User object (must have user_id attribute)
         """
 
-        # Return a minimal user object
-        class UserStub:
-            def __init__(self, user_id: str):
-                self.user_id = user_id
-
-        return UserStub(user_id=authorization_code.user_id)
+        return _OAuthUser(user_id=authorization_code.user_id)
 
 
 # ============================================================================
@@ -427,13 +415,7 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
     """
 
     # Token endpoint auth methods (Issue #157: Public Client + PKCE support)
-    TOKEN_ENDPOINT_AUTH_METHODS = [
-        "none",  # Public clients (ChatGPT/Claude) with PKCE
-        "client_secret_post",
-        "client_secret_basic",
-    ]
-
-    # Token expires in 1 hour (3600 seconds)
+    TOKEN_ENDPOINT_AUTH_METHODS = _TOKEN_ENDPOINT_AUTH_METHODS
     TOKEN_EXPIRES_IN = 3600
 
     def generate_token(
@@ -444,30 +426,11 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
         expires_in=None,
         include_refresh_token=True,
     ) -> dict[str, Any]:
-        """Generate OAuth2 token with explicit expires_in.
-
-        Authlib calls this with keyword arguments only.
-        Client is obtained from self.request.client (not passed as parameter).
-
-        Args:
-            user: User object (optional)
-            scope: Scope string (optional)
-            grant_type: Grant type (optional, uses self.GRANT_TYPE if not provided)
-            expires_in: Token expiration seconds (optional, uses self.TOKEN_EXPIRES_IN if not provided)
-            include_refresh_token: Whether to include refresh token (not used)
-
-        Returns:
-            Token dict with access_token, refresh_token, expires_in, etc.
-        """
-        # Get client from request (Authlib pattern)
         client = self.request.client
-
-        # Use class-level defaults if not provided
         if expires_in is None:
             expires_in = self.TOKEN_EXPIRES_IN
         if grant_type is None:
             grant_type = self.GRANT_TYPE
-
         return _generate_token_with_expiry(grant_type, client, expires_in, scope)
 
     def authenticate_refresh_token(self, refresh_token: str) -> OAuth2Token | None:
@@ -509,11 +472,7 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
             User object (must have user_id attribute)
         """
 
-        class UserStub:
-            def __init__(self, user_id: str):
-                self.user_id = user_id
-
-        return UserStub(user_id=credential.user_id)
+        return _OAuthUser(user_id=credential.user_id)
 
     def revoke_old_credential(self, credential: OAuth2Token) -> None:
         """Revoke old access and refresh tokens.
@@ -535,6 +494,52 @@ class RefreshTokenGrant(grants.RefreshTokenGrant):
             credential.client_id,
             credential.user_id,
         )
+
+
+# ============================================================================
+# Device Authorization Grant (RFC 8628, Issue #536)
+# ============================================================================
+
+
+class DeviceAuthorizationGrant(_DeviceCodeGrant):
+    """Device Authorization Grant for CLI tools (Claude Code, etc.).
+
+    Implements steps (E) and (F) of RFC 8628 — the polling loop where
+    a CLI client repeatedly asks the token endpoint whether the user
+    has completed browser-based authorization.
+    """
+
+    TOKEN_ENDPOINT_AUTH_METHODS = _TOKEN_ENDPOINT_AUTH_METHODS
+
+    def query_device_credential(self, device_code: str) -> OAuth2DeviceCode | None:
+        return (
+            self.server.db_session.query(OAuth2DeviceCode)
+            .filter_by(device_code=device_code)
+            .first()
+        )
+
+    def query_user_grant(self, user_code: str) -> tuple[Any, bool] | None:
+        device = (
+            self.server.db_session.query(OAuth2DeviceCode).filter_by(user_code=user_code).first()
+        )
+        if device is None or device.is_expired():
+            return None
+        if device.denied_at is not None:
+            return _OAuthUser(), False
+        if device.authorized_at is not None and device.user_id:
+            return _OAuthUser(user_id=device.user_id), True
+        return None
+
+    def should_slow_down(self, credential: OAuth2DeviceCode) -> bool:
+        if credential.last_polled_at is None:
+            credential.last_polled_at = utcnow()
+            self.server.db_session.commit()
+            return False
+        interval = get_settings().oauth_device_polling_interval
+        elapsed = (utcnow() - credential.last_polled_at).total_seconds()
+        credential.last_polled_at = utcnow()
+        self.server.db_session.commit()
+        return elapsed < interval
 
 
 # ============================================================================
@@ -700,9 +705,16 @@ class OAuth2AuthorizationServer:
         # Refresh Token Grant
         self.server.register_grant(RefreshTokenGrant)
 
+        # Device Authorization Grant (RFC 8628, Issue #536) — no PKCE
+        self.server.register_grant(DeviceAuthorizationGrant)
+
         logger.info(
             "oauth2_server_initialized",
-            grants=["authorization_code", "refresh_token"],
+            grants=[
+                "authorization_code",
+                "refresh_token",
+                "urn:ietf:params:oauth:grant-type:device_code",
+            ],
             pkce_required=pkce_required,
         )
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -37,6 +37,16 @@ class Settings(BaseSettings):
         description="Enforce PKCE (RFC 7636) at /token for public clients",
     )
 
+    # OAuth2 - Device Authorization Grant (RFC 8628, Issue #536)
+    oauth_device_code_expires_in: int = Field(
+        default=600,
+        description="Device code lifetime in seconds (default: 10 min per RFC 8628)",
+    )
+    oauth_device_polling_interval: int = Field(
+        default=5,
+        description="Minimum polling interval in seconds for device code grant",
+    )
+
     # OAuth2 - Google
     google_client_id: str = Field(default="", description="Google OAuth2 Client ID")
     google_client_secret: str = Field(default="", description="Google OAuth2 Client Secret")

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -707,6 +707,83 @@ class OAuth2AuthorizationCode(Base):
         return utcnow() > self.expires_at
 
 
+def generate_user_code(length: int = 8) -> str:
+    """Generate a random user code for Device Authorization Grant.
+
+    Returns an uppercase alphanumeric string of the given length.
+    Used by the device authorization endpoint to create human-typable codes.
+
+    Args:
+        length: Code length (default 8, per RFC 8628 recommendations).
+
+    Returns:
+        Random uppercase alphanumeric string.
+    """
+    import string
+
+    alphabet = string.ascii_uppercase + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(length))
+
+
+class OAuth2DeviceCode(Base):
+    """OAuth2 Device Authorization Code model (RFC 8628, Issue #536).
+
+    Stores pending device authorization requests. Created when a CLI client
+    calls the device authorization endpoint; updated when the user approves
+    or denies via the browser consent flow.
+
+    Authlib Integration:
+        Implements the required interface for Authlib's DeviceCodeGrant:
+        - get_client_id(): Returns client_id
+        - get_user_code(): Returns user_code
+        - get_scope(): Returns scope
+        - is_expired(): Checks if device code is expired
+    """
+
+    __tablename__ = "oauth_device_codes"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+
+    device_code = Column(String(255), nullable=False, unique=True, index=True)
+    user_code = Column(String(8), nullable=False, unique=True, index=True)
+    client_id = Column(
+        String(48),
+        ForeignKey("oauth_clients.client_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id = Column(String(255), nullable=True)
+    scope = Column(String(255), nullable=True)
+
+    expires_at = Column(DateTime, nullable=False, index=True)
+    last_polled_at = Column(DateTime, nullable=True)
+    denied_at = Column(DateTime, nullable=True)
+    authorized_at = Column(DateTime, nullable=True)
+
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+    client = relationship("OAuth2Client")
+
+    def __repr__(self) -> str:
+        return f"<OAuth2DeviceCode(device_code='{self.device_code[:8]}...', client='{self.client_id}')>"
+
+    # ========================================================================
+    # Authlib Interface Methods
+    # ========================================================================
+
+    def get_client_id(self) -> str:
+        return self.client_id
+
+    def get_user_code(self) -> str:
+        return self.user_code
+
+    def get_scope(self) -> str | None:
+        return self.scope
+
+    def is_expired(self) -> bool:
+        return utcnow() > self.expires_at
+
+
 class OAuth2Token(Base):
     """OAuth2 Access Token model.
 

--- a/backend/tests/api/test_device_code_endpoints.py
+++ b/backend/tests/api/test_device_code_endpoints.py
@@ -1,0 +1,355 @@
+"""Integration tests for Device Authorization Grant endpoints (Issue #536).
+
+Tests the three RFC 8628 endpoints:
+- POST /api/v1/oauth/device/authorize
+- POST /api/v1/oauth/device/verify
+- POST /api/v1/oauth/device/confirm
+"""
+
+import sys
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api.main import app  # noqa: E402
+from models.auth import OAuth2Client, OAuth2DeviceCode  # noqa: E402
+from utils.datetime import utcnow  # noqa: E402
+
+
+@pytest.fixture
+def test_oauth_client():
+    return OAuth2Client(
+        client_id="oauth_test_dev_536",
+        client_secret_hash="sha256_test_secret_hash_placeholder",
+        client_name="Test CLI Client",
+        grant_types=[
+            "authorization_code",
+            "refresh_token",
+            "urn:ietf:params:oauth:grant-type:device_code",
+        ],
+        scope="memory:read memory:write offline_access",
+        redirect_uris=["http://localhost:60801/callback"],
+        token_endpoint_auth_method="client_secret_post",
+        provider="claude",
+    )
+
+
+@pytest.fixture
+def test_device_code(test_oauth_client):
+    return OAuth2DeviceCode(
+        device_code="full-device-code-for-testing-abc123",
+        user_code="TST12345",
+        client_id=test_oauth_client.client_id,
+        scope="memory:read memory:write",
+        expires_at=utcnow() + timedelta(seconds=600),
+    )
+
+
+class TestDeviceAuthorizeEndpoint:
+    def test_authorize_success(self, test_oauth_client):
+        with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+            mock_db = MagicMock()
+            mock_db.query().filter_by().first.return_value = test_oauth_client
+            mock_db.add.return_value = None
+            mock_db.commit.return_value = None
+            mock_db.close.return_value = None
+            mock_session_fn.return_value = mock_db
+
+            with patch("api.routes.oauth.get_settings") as mock_settings:
+                mock_settings.return_value = MagicMock(
+                    oauth_device_code_expires_in=600,
+                    oauth_device_polling_interval=5,
+                    frontend_url="https://memory.kagura-ai.com",
+                )
+
+                client = TestClient(app)
+                resp = client.post(
+                    "/api/v1/oauth/device/authorize",
+                    json={"client_id": "oauth_test_dev_536", "scope": "memory:read"},
+                )
+
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "device_code" in data
+            assert len(data["user_code"]) == 8
+            assert data["verification_uri"] == "https://memory.kagura-ai.com/device"
+            assert data["expires_in"] == 600
+            assert data["interval"] == 5
+
+    def test_authorize_unknown_client(self):
+        with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+            mock_db = MagicMock()
+            mock_db.query().filter_by().first.return_value = None
+            mock_db.close.return_value = None
+            mock_session_fn.return_value = mock_db
+
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/oauth/device/authorize",
+                json={"client_id": "unknown_client", "scope": "memory:read"},
+            )
+
+        assert resp.status_code == 400
+        assert "Unknown client_id" in resp.json()["detail"]
+
+    def test_authorize_scope_intersection(self, test_oauth_client):
+        with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+            mock_db = MagicMock()
+            mock_db.query().filter_by().first.return_value = test_oauth_client
+            mock_db.commit.return_value = None
+            mock_db.close.return_value = None
+            mock_session_fn.return_value = mock_db
+
+            with patch("api.routes.oauth.get_settings") as mock_settings:
+                mock_settings.return_value = MagicMock(
+                    oauth_device_code_expires_in=600,
+                    oauth_device_polling_interval=5,
+                    frontend_url="https://memory.kagura-ai.com",
+                )
+
+                client = TestClient(app)
+                resp = client.post(
+                    "/api/v1/oauth/device/authorize",
+                    json={
+                        "client_id": "oauth_test_dev_536",
+                        "scope": "memory:read memory:admin",
+                    },
+                )
+
+            assert resp.status_code == 200
+            # memory:admin not in client's allowed scope
+            assert "device_code" in resp.json()
+
+
+class TestDeviceVerifyEndpoint:
+    def test_verify_success(self, test_device_code, test_oauth_client):
+        with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+            mock_db = MagicMock()
+
+            def query_side_effect(model):
+                mock_q = MagicMock()
+                if model is OAuth2DeviceCode:
+                    mock_q.filter_by().first.return_value = test_device_code
+                elif model is OAuth2Client:
+                    mock_q.filter_by().first.return_value = test_oauth_client
+                return mock_q
+
+            mock_db.query.side_effect = query_side_effect
+            mock_db.close.return_value = None
+            mock_session_fn.return_value = mock_db
+
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/oauth/device/verify",
+                json={"user_code": "TST12345"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["user_code"] == "TST12345"
+        assert data["client_name"] == "Test CLI Client"
+        assert data["is_authorized"] is False
+        assert data["is_expired"] is False
+
+    def test_verify_not_found(self):
+        with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+            mock_db = MagicMock()
+            mock_q = MagicMock()
+            mock_q.filter_by().first.return_value = None
+            mock_db.query.return_value = mock_q
+            mock_db.close.return_value = None
+            mock_session_fn.return_value = mock_db
+
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/oauth/device/verify",
+                json={"user_code": "NONEXIST"},
+            )
+
+        assert resp.status_code == 404
+
+    def test_verify_expired(self, test_device_code, test_oauth_client):
+        test_device_code.expires_at = utcnow() - timedelta(seconds=1)
+
+        with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+            mock_db = MagicMock()
+
+            def query_side_effect(model):
+                mock_q = MagicMock()
+                if model is OAuth2DeviceCode:
+                    mock_q.filter_by().first.return_value = test_device_code
+                elif model is OAuth2Client:
+                    mock_q.filter_by().first.return_value = test_oauth_client
+                return mock_q
+
+            mock_db.query.side_effect = query_side_effect
+            mock_db.close.return_value = None
+            mock_session_fn.return_value = mock_db
+
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/oauth/device/verify",
+                json={"user_code": "TST12345"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_expired"] is True
+
+    def test_verify_already_authorized(self, test_device_code, test_oauth_client):
+        test_device_code.authorized_at = utcnow() - timedelta(seconds=30)
+        test_device_code.user_id = "test_user_123"
+
+        with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+            mock_db = MagicMock()
+
+            def query_side_effect(model):
+                mock_q = MagicMock()
+                if model is OAuth2DeviceCode:
+                    mock_q.filter_by().first.return_value = test_device_code
+                elif model is OAuth2Client:
+                    mock_q.filter_by().first.return_value = test_oauth_client
+                return mock_q
+
+            mock_db.query.side_effect = query_side_effect
+            mock_db.close.return_value = None
+            mock_session_fn.return_value = mock_db
+
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/oauth/device/verify",
+                json={"user_code": "TST12345"},
+            )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["is_authorized"] is True
+
+
+class TestDeviceConfirmEndpoint:
+    def test_confirm_approve(self, test_device_code):
+        with patch("api.routes.oauth._get_user_from_session") as mock_get_user:
+            mock_get_user.return_value = {
+                "user_id": "test_user_123",
+                "email": "test@example.com",
+            }
+
+            with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+                mock_db = MagicMock()
+                mock_q = MagicMock()
+                mock_q.filter_by().with_for_update().first.return_value = test_device_code
+                mock_db.query.return_value = mock_q
+                mock_db.commit.return_value = None
+                mock_db.close.return_value = None
+                mock_session_fn.return_value = mock_db
+
+                client = TestClient(app)
+                resp = client.post(
+                    "/api/v1/oauth/device/confirm",
+                    json={"user_code": "TST12345", "approve": True},
+                )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "approved"
+        assert test_device_code.authorized_at is not None
+        assert test_device_code.user_id == "test_user_123"
+
+    def test_confirm_deny(self, test_device_code):
+        with patch("api.routes.oauth._get_user_from_session") as mock_get_user:
+            mock_get_user.return_value = {
+                "user_id": "test_user_123",
+                "email": "test@example.com",
+            }
+
+            with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+                mock_db = MagicMock()
+                mock_q = MagicMock()
+                mock_q.filter_by().with_for_update().first.return_value = test_device_code
+                mock_db.query.return_value = mock_q
+                mock_db.commit.return_value = None
+                mock_db.close.return_value = None
+                mock_session_fn.return_value = mock_db
+
+                client = TestClient(app)
+                resp = client.post(
+                    "/api/v1/oauth/device/confirm",
+                    json={"user_code": "TST12345", "approve": False},
+                )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["status"] == "denied"
+        assert test_device_code.denied_at is not None
+
+    def test_confirm_unauthenticated(self):
+        with patch("api.routes.oauth._get_user_from_session") as mock_get_user:
+            mock_get_user.return_value = None
+
+            with patch("api.routes.oauth.get_sync_session"):
+                client = TestClient(app)
+                resp = client.post(
+                    "/api/v1/oauth/device/confirm",
+                    json={"user_code": "TST12345", "approve": True},
+                )
+
+        assert resp.status_code == 401
+
+    def test_confirm_expired_code(self, test_device_code):
+        test_device_code.expires_at = utcnow() - timedelta(seconds=1)
+
+        with patch("api.routes.oauth._get_user_from_session") as mock_get_user:
+            mock_get_user.return_value = {
+                "user_id": "test_user_123",
+                "email": "test@example.com",
+            }
+
+            with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+                mock_db = MagicMock()
+                mock_q = MagicMock()
+                mock_q.filter_by().with_for_update().first.return_value = test_device_code
+                mock_db.query.return_value = mock_q
+                mock_db.close.return_value = None
+                mock_session_fn.return_value = mock_db
+
+                client = TestClient(app)
+                resp = client.post(
+                    "/api/v1/oauth/device/confirm",
+                    json={"user_code": "TST12345", "approve": True},
+                )
+
+        assert resp.status_code == 404
+        assert "expired" in resp.json()["detail"].lower()
+
+    def test_confirm_already_processed(self, test_device_code):
+        test_device_code.authorized_at = utcnow() - timedelta(seconds=30)
+        test_device_code.user_id = "test_user_123"
+
+        with patch("api.routes.oauth._get_user_from_session") as mock_get_user:
+            mock_get_user.return_value = {
+                "user_id": "other_user",
+                "email": "other@example.com",
+            }
+
+            with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
+                mock_db = MagicMock()
+                mock_q = MagicMock()
+                mock_q.filter_by().with_for_update().first.return_value = test_device_code
+                mock_db.query.return_value = mock_q
+                mock_db.close.return_value = None
+                mock_session_fn.return_value = mock_db
+
+                client = TestClient(app)
+                resp = client.post(
+                    "/api/v1/oauth/device/confirm",
+                    json={"user_code": "TST12345", "approve": True},
+                )
+
+        assert resp.status_code == 409

--- a/backend/tests/api/test_oauth_authorize_redirect_uri_precheck.py
+++ b/backend/tests/api/test_oauth_authorize_redirect_uri_precheck.py
@@ -344,7 +344,7 @@ class TestPostAuthorizeExceptionBranches:
             patch("api.routes.oauth.get_current_user_from_session", return_value=fake_user),
             patch("api.routes.oauth.get_sync_session") as mock_sess,
             patch(
-                "api.routes.oauth._handle_authorize_sync",
+                "api.routes.oauth._run_oauth_sync",
                 side_effect=InvalidScopeError(description="bad scope"),
             ),
         ):
@@ -380,7 +380,7 @@ class TestPostAuthorizeExceptionBranches:
             patch("api.routes.oauth.get_current_user_from_session", return_value=fake_user),
             patch("api.routes.oauth.get_sync_session") as mock_sess,
             patch(
-                "api.routes.oauth._handle_authorize_sync",
+                "api.routes.oauth._run_oauth_sync",
                 side_effect=RuntimeError("boom"),
             ),
         ):

--- a/backend/tests/auth/test_device_code_grant.py
+++ b/backend/tests/auth/test_device_code_grant.py
@@ -1,0 +1,135 @@
+"""Tests for DeviceAuthorizationGrant (RFC 8628 grant implementation, Issue #536)."""
+
+import sys
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import MagicMock
+
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+import pytest  # noqa: E402, F401
+
+from auth.oauth2_server import (  # noqa: E402
+    DeviceAuthorizationGrant,
+    OAuth2AuthorizationServer,
+)
+from models.auth import OAuth2DeviceCode  # noqa: E402
+from utils.datetime import utcnow  # noqa: E402
+
+
+def _make_device(**overrides):
+    kwargs = {
+        "device_code": "test-device-code-abc123",
+        "user_code": "ABCD1234",
+        "client_id": "oauth_test123",
+        "user_id": None,
+        "scope": "memory:read",
+        "expires_at": utcnow() + timedelta(seconds=600),
+        "last_polled_at": None,
+        "denied_at": None,
+        "authorized_at": None,
+    }
+    kwargs.update(overrides)
+    return OAuth2DeviceCode(**kwargs)
+
+
+def _make_grant():
+    grant = DeviceAuthorizationGrant.__new__(DeviceAuthorizationGrant)
+    grant.server = MagicMock()
+    grant.server.db_session = MagicMock()
+    return grant
+
+
+class TestDeviceAuthorizationGrant:
+    def test_query_device_credential_found(self):
+        grant = _make_grant()
+        device = _make_device()
+        grant.server.db_session.query().filter_by().first.return_value = device
+
+        result = grant.query_device_credential("test-device-code-abc123")
+        assert result is device
+
+    def test_query_device_credential_not_found(self):
+        grant = _make_grant()
+        grant.server.db_session.query().filter_by().first.return_value = None
+
+        result = grant.query_device_credential("nonexistent")
+        assert result is None
+
+    def test_query_user_grant_authorized(self):
+        grant = _make_grant()
+        device = _make_device(
+            authorized_at=utcnow() - timedelta(seconds=30),
+            user_id="test_user_123",
+        )
+        grant.server.db_session.query().filter_by().first.return_value = device
+
+        user, approved = grant.query_user_grant("ABCD1234")
+        assert user.get_user_id() == "test_user_123"
+        assert approved is True
+
+    def test_query_user_grant_denied(self):
+        grant = _make_grant()
+        device = _make_device(denied_at=utcnow() - timedelta(seconds=30))
+        grant.server.db_session.query().filter_by().first.return_value = device
+
+        _user, approved = grant.query_user_grant("ABCD1234")
+        assert approved is False
+        # _user is a _DeniedUser stub created by the grant for Authlib
+
+    def test_query_user_grant_pending(self):
+        grant = _make_grant()
+        device = _make_device()
+        grant.server.db_session.query().filter_by().first.return_value = device
+
+        result = grant.query_user_grant("ABCD1234")
+        assert result is None
+
+    def test_query_user_grant_not_found(self):
+        grant = _make_grant()
+        grant.server.db_session.query().filter_by().first.return_value = None
+
+        result = grant.query_user_grant("NONEXIST")
+        assert result is None
+
+    def test_should_slow_down_first_poll(self):
+        grant = _make_grant()
+        device = _make_device()
+
+        result = grant.should_slow_down(device)
+        assert result is False
+        assert device.last_polled_at is not None
+
+    def test_should_slow_down_rapid_poll(self):
+        grant = _make_grant()
+        device = _make_device(last_polled_at=utcnow() - timedelta(seconds=2))
+
+        result = grant.should_slow_down(device)
+        assert result is True
+
+    def test_should_slow_down_after_interval(self):
+        grant = _make_grant()
+        device = _make_device(last_polled_at=utcnow() - timedelta(seconds=6))
+
+        result = grant.should_slow_down(device)
+        assert result is False
+
+    def test_token_endpoint_auth_methods(self):
+        assert "none" in DeviceAuthorizationGrant.TOKEN_ENDPOINT_AUTH_METHODS
+        assert "client_secret_post" in DeviceAuthorizationGrant.TOKEN_ENDPOINT_AUTH_METHODS
+        assert "client_secret_basic" in DeviceAuthorizationGrant.TOKEN_ENDPOINT_AUTH_METHODS
+
+
+class TestDeviceGrantRegistration:
+    def test_device_grant_registered_in_server(self):
+        """Verify DeviceAuthorizationGrant is registered in _register_grants."""
+        wrapper = OAuth2AuthorizationServer.__new__(OAuth2AuthorizationServer)
+        wrapper.session = MagicMock()
+        wrapper.server = MagicMock()
+
+        wrapper._register_grants()
+
+        registered_classes = [call.args[0] for call in wrapper.server.register_grant.call_args_list]
+        assert DeviceAuthorizationGrant in registered_classes

--- a/backend/tests/auth/test_device_code_model.py
+++ b/backend/tests/auth/test_device_code_model.py
@@ -1,0 +1,61 @@
+"""Tests for OAuth2DeviceCode model and generate_user_code utility (Issue #536)."""
+
+import sys
+from datetime import timedelta
+from pathlib import Path
+
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+import pytest  # noqa: E402, F401
+
+from models.auth import OAuth2DeviceCode, generate_user_code  # noqa: E402
+from utils.datetime import utcnow  # noqa: E402
+
+
+class TestGenerateUserCode:
+    def test_default_length_is_8(self):
+        code = generate_user_code()
+        assert len(code) == 8
+
+    def test_custom_length(self):
+        code = generate_user_code(length=12)
+        assert len(code) == 12
+
+    def test_only_uppercase_alphanumeric(self):
+        for _ in range(100):
+            code = generate_user_code()
+            assert all(c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789" for c in code)
+
+    def test_codes_are_random(self):
+        codes = {generate_user_code() for _ in range(20)}
+        assert len(codes) > 1
+
+
+class TestOAuth2DeviceCode:
+    def test_get_client_id(self):
+        device = OAuth2DeviceCode(client_id="oauth_test123")
+        assert device.get_client_id() == "oauth_test123"
+
+    def test_get_user_code(self):
+        device = OAuth2DeviceCode(user_code="ABCD1234")
+        assert device.get_user_code() == "ABCD1234"
+
+    def test_get_scope(self):
+        device = OAuth2DeviceCode(scope="memory:read memory:write")
+        assert device.get_scope() == "memory:read memory:write"
+
+    def test_get_scope_none(self):
+        device = OAuth2DeviceCode(scope=None)
+        assert device.get_scope() is None
+
+    def test_is_expired_false_when_future(self):
+        future = utcnow() + timedelta(seconds=600)
+        device = OAuth2DeviceCode(expires_at=future)
+        assert device.is_expired() is False
+
+    def test_is_expired_true_when_past(self):
+        past = utcnow() - timedelta(seconds=1)
+        device = OAuth2DeviceCode(expires_at=past)
+        assert device.is_expired() is True

--- a/frontend/src/app/device/page.test.tsx
+++ b/frontend/src/app/device/page.test.tsx
@@ -14,6 +14,7 @@ import {
   waitFor,
 } from "@testing-library/react";
 
+import { ApiError } from "@/lib/api";
 import DevicePage from "./page";
 
 // ---------- Mocks ------------------------------------------------------------
@@ -225,6 +226,68 @@ describe("DevicePage", () => {
 
     await waitFor(() => {
       expect(screen.getByText("device.successTitle")).toBeDefined();
+    });
+  });
+
+  it("transitions to success on 409 already-authorized during confirm", async () => {
+    mockVerifyDeviceCode.mockResolvedValue({
+      user_code: "ABCD1234",
+      client_name: "Test CLI",
+      scope: "memory:read",
+      expires_at: "2026-01-01T00:00:00Z",
+      is_authorized: false,
+      is_expired: false,
+    });
+    mockConfirmDevice.mockRejectedValue(
+      new ApiError({
+        message: "This code has already been authorized",
+        status: 409,
+      }),
+    );
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "ABCD1234" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.approve")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("device.approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("device.successTitle")).toBeDefined();
+    });
+  });
+
+  it("transitions to denied on 409 already-denied during confirm", async () => {
+    mockVerifyDeviceCode.mockResolvedValue({
+      user_code: "ABCD1234",
+      client_name: "Test CLI",
+      scope: "memory:read",
+      expires_at: "2026-01-01T00:00:00Z",
+      is_authorized: false,
+      is_expired: false,
+    });
+    mockConfirmDevice.mockRejectedValue(
+      new ApiError({
+        message: "This code has already been denied",
+        status: 409,
+      }),
+    );
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "ABCD1234" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.deny")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("device.deny"));
+
+    await waitFor(() => {
+      expect(screen.getByText("device.deniedTitle")).toBeDefined();
     });
   });
 });

--- a/frontend/src/app/device/page.test.tsx
+++ b/frontend/src/app/device/page.test.tsx
@@ -1,0 +1,230 @@
+/**
+ * Tests for Device Authorization page (Issue #536).
+ *
+ * Covers: code input, auto-verify from URL param, consent approve/deny,
+ * and terminal states (success, denied, error, expired).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+
+import DevicePage from "./page";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockVerifyDeviceCode = vi.fn();
+const mockConfirmDevice = vi.fn();
+
+vi.mock("@/lib/auth/auth", () => ({
+  getAuthUrl: vi.fn(),
+  getGitHubAuthUrl: vi.fn(),
+  getAuthConfig: vi.fn(),
+  loginWithPassword: vi.fn(),
+  verifyMfa: vi.fn(),
+  verifyDeviceCode: (...args: unknown[]) => mockVerifyDeviceCode(...args),
+  confirmDevice: (...args: unknown[]) => mockConfirmDevice(...args),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (k: string, params?: Record<string, string>) => {
+    if (params?.scope) return k.replace("{scope}", params.scope);
+    return k;
+  },
+}));
+
+const mockSearchParams = new URLSearchParams();
+vi.mock("next/navigation", () => ({
+  useRouter: vi.fn(),
+  useSearchParams: () => mockSearchParams,
+}));
+
+// ---------- Helpers ----------------------------------------------------------
+
+function typeCode(code: string) {
+  const input = screen.getByLabelText("device.codeLabel");
+  for (const char of code) {
+    fireEvent.change(input, {
+      target: { value: input.getAttribute("value") + char },
+    });
+  }
+  return input;
+}
+
+beforeEach(() => {
+  mockVerifyDeviceCode.mockReset();
+  mockConfirmDevice.mockReset();
+  // Clear URL params between tests
+  for (const key of [...mockSearchParams.keys()]) {
+    mockSearchParams.delete(key);
+  }
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+// ---------- Tests ------------------------------------------------------------
+
+describe("DevicePage", () => {
+  it("renders code input form", () => {
+    render(<DevicePage />);
+    expect(screen.getByText("device.title")).toBeDefined();
+    expect(screen.getByText("device.description")).toBeDefined();
+    expect(screen.getByLabelText("device.codeLabel")).toBeDefined();
+  });
+
+  it("shows verifying state while checking code", async () => {
+    mockVerifyDeviceCode.mockImplementation(
+      () => new Promise(() => {}), // never resolves
+    );
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "ABCD1234" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.verifying")).toBeDefined();
+    });
+  });
+
+  it("shows consent screen with client info", async () => {
+    mockVerifyDeviceCode.mockResolvedValue({
+      user_code: "ABCD1234",
+      client_name: "Test CLI",
+      scope: "memory:read memory:write",
+      expires_at: "2026-01-01T00:00:00Z",
+      is_authorized: false,
+      is_expired: false,
+    });
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "ABCD1234" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.consentTitle")).toBeDefined();
+      expect(screen.getByText("Test CLI")).toBeDefined();
+      expect(screen.getByText("device.approve")).toBeDefined();
+      expect(screen.getByText("device.deny")).toBeDefined();
+    });
+  });
+
+  it("shows success screen after approve", async () => {
+    mockVerifyDeviceCode.mockResolvedValue({
+      user_code: "ABCD1234",
+      client_name: "Test CLI",
+      scope: "memory:read",
+      expires_at: "2026-01-01T00:00:00Z",
+      is_authorized: false,
+      is_expired: false,
+    });
+    mockConfirmDevice.mockResolvedValue({
+      status: "approved",
+      user_code: "ABCD1234",
+    });
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "ABCD1234" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.approve")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("device.approve"));
+
+    await waitFor(() => {
+      expect(screen.getByText("device.successTitle")).toBeDefined();
+      expect(screen.getByText("device.successMessage")).toBeDefined();
+    });
+  });
+
+  it("shows denied screen after deny", async () => {
+    mockVerifyDeviceCode.mockResolvedValue({
+      user_code: "ABCD1234",
+      client_name: "Test CLI",
+      scope: "memory:read",
+      expires_at: "2026-01-01T00:00:00Z",
+      is_authorized: false,
+      is_expired: false,
+    });
+    mockConfirmDevice.mockResolvedValue({
+      status: "denied",
+      user_code: "ABCD1234",
+    });
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "ABCD1234" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.deny")).toBeDefined();
+    });
+    fireEvent.click(screen.getByText("device.deny"));
+
+    await waitFor(() => {
+      expect(screen.getByText("device.deniedTitle")).toBeDefined();
+      expect(screen.getByText("device.deniedMessage")).toBeDefined();
+    });
+  });
+
+  it("shows error when code is invalid", async () => {
+    mockVerifyDeviceCode.mockRejectedValue(new Error("not found"));
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "XXXXXXXX" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.invalidCode")).toBeDefined();
+    });
+  });
+
+  it("auto-verifies from URL user_code param", async () => {
+    mockSearchParams.set("user_code", "URL12345");
+    mockVerifyDeviceCode.mockResolvedValue({
+      user_code: "URL12345",
+      client_name: "URL Client",
+      scope: "memory:read",
+      expires_at: "2026-01-01T00:00:00Z",
+      is_authorized: false,
+      is_expired: false,
+    });
+    render(<DevicePage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("URL Client")).toBeDefined();
+    });
+  });
+
+  it("shows success immediately for already-authorized code", async () => {
+    mockVerifyDeviceCode.mockResolvedValue({
+      user_code: "AUTH1234",
+      client_name: "Test CLI",
+      scope: "memory:read",
+      expires_at: "2026-01-01T00:00:00Z",
+      is_authorized: true,
+      is_expired: false,
+    });
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "AUTH1234" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.successTitle")).toBeDefined();
+    });
+  });
+});

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+/**
+ * Device Authorization Page (RFC 8628 — Issue #536)
+ *
+ * User enters an 8-character user_code displayed in their CLI, then approves
+ * or denies the device authorization request on the consent screen.
+ */
+
+import { useEffect, useRef, useState, Suspense } from "react";
+import { useTranslations } from "next-intl";
+import { useSearchParams } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  verifyDeviceCode,
+  confirmDevice,
+  type DeviceVerifyResponse,
+} from "@/lib/auth/auth";
+import { AlertCircle, CheckCircle2, XCircle, Monitor } from "lucide-react";
+
+type Phase =
+  | "input"
+  | "verifying"
+  | "consent"
+  | "submitting"
+  | "success"
+  | "denied"
+  | "error";
+
+const SCOPE_LABEL_MAP: Record<string, string> = {
+  "memory:read": "device.scopeRead",
+  "memory:write": "device.scopeWrite",
+  "memory:delete": "device.scopeDelete",
+  "memory:admin": "device.scopeAdmin",
+  offline_access: "device.scopeOffline",
+};
+
+function DevicePageInner() {
+  const t = useTranslations();
+  const searchParams = useSearchParams();
+
+  const [phase, setPhase] = useState<Phase>("input");
+  const [userCode, setUserCode] = useState(searchParams.get("user_code") ?? "");
+  const [deviceInfo, setDeviceInfo] = useState<DeviceVerifyResponse | null>(
+    null,
+  );
+  const [error, setError] = useState<string | null>(null);
+  const submittingRef = useRef(false);
+
+  useEffect(() => {
+    const codeFromUrl = searchParams.get("user_code");
+    if (codeFromUrl && codeFromUrl.length === 8) {
+      setUserCode(codeFromUrl);
+      verifyCode(codeFromUrl);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams]);
+
+  async function verifyCode(code: string) {
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    setPhase("verifying");
+    setError(null);
+
+    try {
+      const info = await verifyDeviceCode(code);
+      if (info.is_authorized) {
+        setPhase("success");
+      } else if (info.is_expired) {
+        setError(t("device.expired"));
+        setPhase("error");
+      } else {
+        setDeviceInfo(info);
+        setPhase("consent");
+      }
+    } catch {
+      setError(t("device.invalidCode"));
+      setPhase("error");
+    } finally {
+      submittingRef.current = false;
+    }
+  }
+
+  async function handleConfirm(approve: boolean) {
+    if (submittingRef.current || !deviceInfo) return;
+    submittingRef.current = true;
+    setPhase("submitting");
+    setError(null);
+
+    try {
+      const result = await confirmDevice(deviceInfo.user_code, approve);
+      setPhase(result.status === "approved" ? "success" : "denied");
+    } catch (err) {
+      const detail =
+        (err as { detail?: string })?.detail ?? t("device.errorMessage");
+      if (detail.includes("already been authorized")) {
+        setPhase("success");
+      } else if (detail.includes("already been denied")) {
+        setPhase("denied");
+      } else if (detail.includes("already been processed")) {
+        // Double-submit race: re-verify to determine actual state
+        try {
+          const info = await verifyDeviceCode(deviceInfo.user_code);
+          setPhase(info.is_authorized ? "success" : "denied");
+        } catch {
+          setError(detail);
+          setPhase("error");
+        }
+      } else {
+        setError(detail);
+        setPhase("error");
+      }
+    } finally {
+      submittingRef.current = false;
+    }
+  }
+
+  function handleCodeChange(value: string) {
+    const cleaned = value.replace(/[^a-zA-Z0-9]/g, "").toUpperCase();
+    setUserCode(cleaned);
+    setError(null);
+    if (phase === "error") setPhase("input");
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && userCode.length === 8 && phase === "input") {
+      e.preventDefault();
+      verifyCode(userCode);
+    }
+  }
+
+  function resetToInput() {
+    setPhase("input");
+    setUserCode("");
+    setDeviceInfo(null);
+    setError(null);
+  }
+
+  function renderScopeBadges(scopes: string | null) {
+    if (!scopes) return null;
+    return (
+      <div className="flex flex-wrap gap-2 justify-center">
+        {scopes
+          .split(" ")
+          .filter(Boolean)
+          .map((scope) => {
+            const labelKey = SCOPE_LABEL_MAP[scope];
+            return (
+              <Badge key={scope} variant="secondary">
+                {labelKey ? t(labelKey) : t("device.unknownScope", { scope })}
+              </Badge>
+            );
+          })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <Card className="w-full max-w-md">
+        <CardContent className="pt-8 pb-8 space-y-6">
+          {phase === "success" && (
+            <div className="text-center space-y-4">
+              <CheckCircle2 className="mx-auto h-12 w-12 text-green-500" />
+              <h1 className="text-xl font-semibold text-gray-900">
+                {t("device.successTitle")}
+              </h1>
+              <p className="text-sm text-gray-600">
+                {t("device.successMessage")}
+              </p>
+            </div>
+          )}
+
+          {phase === "denied" && (
+            <div className="text-center space-y-4">
+              <XCircle className="mx-auto h-12 w-12 text-red-500" />
+              <h1 className="text-xl font-semibold text-gray-900">
+                {t("device.deniedTitle")}
+              </h1>
+              <p className="text-sm text-gray-600">
+                {t("device.deniedMessage")}
+              </p>
+              <Button variant="outline" onClick={resetToInput} className="mt-4">
+                {t("device.backToVerify")}
+              </Button>
+            </div>
+          )}
+
+          {(phase === "input" ||
+            phase === "verifying" ||
+            phase === "error") && (
+            <div className="text-center space-y-4">
+              <Monitor className="mx-auto h-10 w-10 text-gray-400" />
+              <div>
+                <h1 className="text-xl font-semibold text-gray-900">
+                  {t("device.title")}
+                </h1>
+                <p className="mt-1 text-sm text-gray-600">
+                  {t("device.description")}
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="userCode" className="text-gray-700">
+                  {t("device.codeLabel")}
+                </Label>
+                <Input
+                  id="userCode"
+                  type="text"
+                  maxLength={8}
+                  value={userCode}
+                  onChange={(e) => handleCodeChange(e.target.value)}
+                  onKeyDown={handleKeyDown}
+                  placeholder={t("device.codePlaceholder")}
+                  className="bg-white text-gray-900 text-center text-2xl tracking-[0.3em]"
+                  autoFocus
+                  autoComplete="off"
+                  disabled={phase === "verifying"}
+                />
+              </div>
+
+              {phase === "verifying" && (
+                <p className="text-sm text-gray-500">{t("device.verifying")}</p>
+              )}
+
+              {phase === "error" && error && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>{error}</AlertDescription>
+                </Alert>
+              )}
+
+              {phase === "error" && (
+                <Button variant="outline" onClick={resetToInput}>
+                  {t("device.backToVerify")}
+                </Button>
+              )}
+            </div>
+          )}
+
+          {phase === "consent" && deviceInfo && (
+            <div className="text-center space-y-4">
+              <div>
+                <h1 className="text-xl font-semibold text-gray-900">
+                  {t("device.consentTitle")}
+                </h1>
+                <p className="mt-2 text-sm text-gray-600">
+                  {t("device.consentDescription")}
+                </p>
+              </div>
+
+              <p className="text-lg font-medium text-gray-900">
+                {deviceInfo.client_name}
+              </p>
+
+              {renderScopeBadges(deviceInfo.scope)}
+
+              <div className="flex gap-3 justify-center pt-2">
+                <Button
+                  variant="outline"
+                  onClick={() => handleConfirm(false)}
+                  disabled={phase === "submitting"}
+                  className="min-w-[120px]"
+                >
+                  {phase === "submitting"
+                    ? t("device.denying")
+                    : t("device.deny")}
+                </Button>
+                <Button
+                  onClick={() => handleConfirm(true)}
+                  disabled={phase === "submitting"}
+                  className="min-w-[120px] bg-gradient-to-r from-brand-green-600 to-emerald-600 text-white shadow-lg hover:from-brand-green-700 hover:to-emerald-700 disabled:opacity-50"
+                >
+                  {phase === "submitting"
+                    ? t("device.approving")
+                    : t("device.approve")}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {(phase === "submitting" || (phase === "error" && error)) &&
+            deviceInfo && (
+              <div className="text-center space-y-4">
+                {phase === "error" && error && (
+                  <>
+                    <Alert variant="destructive">
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertDescription>{error}</AlertDescription>
+                    </Alert>
+                    <div className="flex gap-3 justify-center">
+                      <Button variant="outline" onClick={resetToInput}>
+                        {t("device.backToVerify")}
+                      </Button>
+                      <Button
+                        variant="default"
+                        onClick={() => {
+                          setPhase("consent");
+                          setError(null);
+                        }}
+                      >
+                        {t("device.tryAgain")}
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default function DevicePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-gray-50">
+          <Card className="w-full max-w-md">
+            <CardContent className="pt-8 pb-8 text-center">
+              <p className="text-sm text-gray-500">Loading...</p>
+            </CardContent>
+          </Card>
+        </div>
+      }
+    >
+      <DevicePageInner />
+    </Suspense>
+  );
+}

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -17,6 +17,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { SpinnerLoading } from "@/components/common/LoadingState";
+import { ApiError } from "@/lib/api";
 import {
   verifyDeviceCode,
   confirmDevice,
@@ -98,7 +99,7 @@ function DevicePageInner() {
       setPhase(result.status === "approved" ? "success" : "denied");
     } catch (err) {
       const detail =
-        (err as { detail?: string })?.detail ?? t("device.errorMessage");
+        err instanceof ApiError ? err.message : t("device.errorMessage");
       if (detail.includes("already been authorized")) {
         setPhase("success");
       } else if (detail.includes("already been denied")) {

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -16,6 +16,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import { SpinnerLoading } from "@/components/common/LoadingState";
 import {
   verifyDeviceCode,
   confirmDevice,
@@ -319,17 +320,7 @@ function DevicePageInner() {
 
 export default function DevicePage() {
   return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-screen items-center justify-center bg-gray-50">
-          <Card className="w-full max-w-md">
-            <CardContent className="pt-8 pb-8 text-center">
-              <p className="text-sm text-gray-500">Loading...</p>
-            </CardContent>
-          </Card>
-        </div>
-      }
-    >
+    <Suspense fallback={<SpinnerLoading size="lg" />}>
       <DevicePageInner />
     </Suspense>
   );

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -244,7 +244,7 @@ function DevicePageInner() {
             </div>
           )}
 
-          {phase === "consent" && deviceInfo && (
+          {(phase === "consent" || phase === "submitting") && deviceInfo && (
             <div className="text-center space-y-4">
               <div>
                 <h1 className="text-xl font-semibold text-gray-900">
@@ -285,33 +285,28 @@ function DevicePageInner() {
             </div>
           )}
 
-          {(phase === "submitting" || (phase === "error" && error)) &&
-            deviceInfo && (
-              <div className="text-center space-y-4">
-                {phase === "error" && error && (
-                  <>
-                    <Alert variant="destructive">
-                      <AlertCircle className="h-4 w-4" />
-                      <AlertDescription>{error}</AlertDescription>
-                    </Alert>
-                    <div className="flex gap-3 justify-center">
-                      <Button variant="outline" onClick={resetToInput}>
-                        {t("device.backToVerify")}
-                      </Button>
-                      <Button
-                        variant="default"
-                        onClick={() => {
-                          setPhase("consent");
-                          setError(null);
-                        }}
-                      >
-                        {t("device.tryAgain")}
-                      </Button>
-                    </div>
-                  </>
-                )}
+          {phase === "error" && error && deviceInfo && (
+            <div className="text-center space-y-4">
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
+              <div className="flex gap-3 justify-center">
+                <Button variant="outline" onClick={resetToInput}>
+                  {t("device.backToVerify")}
+                </Button>
+                <Button
+                  variant="default"
+                  onClick={() => {
+                    setPhase("consent");
+                    setError(null);
+                  }}
+                >
+                  {t("device.tryAgain")}
+                </Button>
               </div>
-            )}
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>

--- a/frontend/src/lib/auth/auth.ts
+++ b/frontend/src/lib/auth/auth.ts
@@ -175,3 +175,45 @@ export async function verifyMfa(
     { mfa_session_token: mfaSessionToken, totp_code: totpCode },
   );
 }
+
+// ============================================================================
+// Device Authorization Grant (RFC 8628 — Issue #536)
+// ============================================================================
+
+export interface DeviceVerifyResponse {
+  user_code: string;
+  client_name: string;
+  scope: string | null;
+  expires_at: string;
+  is_authorized: boolean;
+  is_expired: boolean;
+}
+
+export interface DeviceConfirmResponse {
+  status: "approved" | "denied";
+  user_code: string;
+}
+
+/**
+ * Verify a device user code and get client info for consent screen.
+ */
+export async function verifyDeviceCode(
+  userCode: string,
+): Promise<DeviceVerifyResponse> {
+  return apiClient.post<DeviceVerifyResponse>("/api/v1/oauth/device/verify", {
+    user_code: userCode,
+  });
+}
+
+/**
+ * Confirm (approve or deny) a device authorization request.
+ */
+export async function confirmDevice(
+  userCode: string,
+  approve: boolean,
+): Promise<DeviceConfirmResponse> {
+  return apiClient.post<DeviceConfirmResponse>("/api/v1/oauth/device/confirm", {
+    user_code: userCode,
+    approve,
+  });
+}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3194,5 +3194,36 @@
       },
       "loadFailed": "Failed to load analyses — check connection and try again."
     }
+  },
+  "device": {
+    "title": "Device Authorization",
+    "description": "Enter the code displayed in your CLI to authorize this device.",
+    "codeLabel": "Device Code",
+    "codePlaceholder": "XXXX-XXXX",
+    "verify": "Verify",
+    "verifying": "Verifying...",
+    "invalidCode": "The code you entered is invalid or has expired. Check your CLI and try again.",
+    "alreadyAuthorized": "This device has already been authorized.",
+    "alreadyDenied": "This device request has already been denied.",
+    "expired": "This authorization request has expired. Start a new one from your CLI.",
+    "consentTitle": "Authorize Device",
+    "consentDescription": "Allow this application to access your Kagura Memory Cloud workspace:",
+    "scopeRead": "Read memories",
+    "scopeWrite": "Write memories",
+    "scopeDelete": "Delete memories",
+    "scopeAdmin": "Manage workspace",
+    "scopeOffline": "Offline access",
+    "unknownScope": "Unknown permission: {scope}",
+    "approve": "Approve",
+    "approving": "Approving...",
+    "deny": "Deny",
+    "denying": "Denying...",
+    "successTitle": "Device Authorized",
+    "successMessage": "Your device has been authorized. You can close this page and return to your CLI.",
+    "deniedTitle": "Authorization Denied",
+    "deniedMessage": "You have denied this device authorization request. You can close this page.",
+    "errorTitle": "Something went wrong",
+    "errorMessage": "An unexpected error occurred. Please try again.",
+    "backToVerify": "Enter a different code"
   }
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3224,6 +3224,7 @@
     "deniedMessage": "You have denied this device authorization request. You can close this page.",
     "errorTitle": "Something went wrong",
     "errorMessage": "An unexpected error occurred. Please try again.",
-    "backToVerify": "Enter a different code"
+    "backToVerify": "Enter a different code",
+    "tryAgain": "Try again"
   }
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3199,7 +3199,7 @@
     "title": "Device Authorization",
     "description": "Enter the code displayed in your CLI to authorize this device.",
     "codeLabel": "Device Code",
-    "codePlaceholder": "XXXX-XXXX",
+    "codePlaceholder": "XXXXXXXX",
     "verify": "Verify",
     "verifying": "Verifying...",
     "invalidCode": "The code you entered is invalid or has expired. Check your CLI and try again.",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3224,6 +3224,7 @@
     "deniedMessage": "デバイス認証リクエストを拒否しました。このページを閉じてください。",
     "errorTitle": "エラーが発生しました",
     "errorMessage": "予期しないエラーが発生しました。もう一度お試しください。",
-    "backToVerify": "別のコードを入力"
+    "backToVerify": "別のコードを入力",
+    "tryAgain": "再試行"
   }
 }

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3199,7 +3199,7 @@
     "title": "デバイス認証",
     "description": "CLIに表示されたコードを入力してデバイスを認証してください。",
     "codeLabel": "デバイスコード",
-    "codePlaceholder": "XXXX-XXXX",
+    "codePlaceholder": "XXXXXXXX",
     "verify": "確認",
     "verifying": "確認中...",
     "invalidCode": "入力されたコードは無効、または期限切れです。CLIを確認して再度お試しください。",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3194,5 +3194,36 @@
       },
       "loadFailed": "Analyses の読み込みに失敗しました — 接続を確認してください。"
     }
+  },
+  "device": {
+    "title": "デバイス認証",
+    "description": "CLIに表示されたコードを入力してデバイスを認証してください。",
+    "codeLabel": "デバイスコード",
+    "codePlaceholder": "XXXX-XXXX",
+    "verify": "確認",
+    "verifying": "確認中...",
+    "invalidCode": "入力されたコードは無効、または期限切れです。CLIを確認して再度お試しください。",
+    "alreadyAuthorized": "このデバイスはすでに認証済みです。",
+    "alreadyDenied": "このデバイスリクエストはすでに拒否されています。",
+    "expired": "この認証リクエストは期限切れです。CLIから新しいリクエストを開始してください。",
+    "consentTitle": "デバイスを認証",
+    "consentDescription": "このアプリケーションにKagura Memory Cloudワークスペースへのアクセスを許可しますか？",
+    "scopeRead": "メモリーの読み取り",
+    "scopeWrite": "メモリーの作成・更新",
+    "scopeDelete": "メモリーの削除",
+    "scopeAdmin": "ワークスペースの管理",
+    "scopeOffline": "オフラインアクセス",
+    "unknownScope": "不明な権限: {scope}",
+    "approve": "認証する",
+    "approving": "認証中...",
+    "deny": "拒否する",
+    "denying": "拒否中...",
+    "successTitle": "デバイス認証完了",
+    "successMessage": "デバイスの認証が完了しました。このページを閉じてCLIに戻ってください。",
+    "deniedTitle": "認証が拒否されました",
+    "deniedMessage": "デバイス認証リクエストを拒否しました。このページを閉じてください。",
+    "errorTitle": "エラーが発生しました",
+    "errorMessage": "予期しないエラーが発生しました。もう一度お試しください。",
+    "backToVerify": "別のコードを入力"
   }
 }


### PR DESCRIPTION
Closes #536

## Summary
- RFC 8628 Device Authorization Grant implementation for MCP OAuth authentication
- 3 new API endpoints: POST /device/authorize (public), /device/verify (public), /device/confirm (session-auth)
- New oauth_device_codes table with OAuth2DeviceCode model and DeviceAuthorizationGrant class
- Shared abstractions: _OAuthUser, _run_oauth_sync, _TOKEN_ENDPOINT_AUTH_METHODS
- Frontend consent page at /device with code input → consent → approve/deny state machine

## Implementation notes
- Authlib's DeviceCodeGrant base class with 3 required methods: query_device_credential, query_user_grant, should_slow_down
- SELECT FOR UPDATE (.with_for_update()) for TOCTOU protection on device_confirm
- _OAuthUser replaces 3 inline UserStub classes across AuthorizationCodeGrant, RefreshTokenGrant, and DeviceAuthorizationGrant
- _run_oauth_sync replaces _handle_authorize_sync and _handle_token_sync duplicate sync wrappers
- Existing token endpoint and _verify_oauth2_token require no changes — device flow tokens are standard OAuth2Token records
- 33 backend tests + 8 frontend tests

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/536-feat-feat-mcp-device-authorization-grant-rfc.gate1.md
- ~/.claude/cache/gh-issue-driven/536-feat-feat-mcp-device-authorization-grant-rfc.gate2.md

🤖 Generated via /gh-issue-driven:ship
