### PR TITLE
fix(ui,analysis): broadlistening UI/UX improvements and locale-aware cluster labeling (#542)

### DIFF
--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -69,6 +69,7 @@ class QuotaBreakdown(BaseModel):
     mcp_calls_per_day: int
     max_contexts: int
     max_members: int
+    analysis_runs_per_day: int
 
 
 class AddonValues(BaseModel):
@@ -78,6 +79,7 @@ class AddonValues(BaseModel):
     mcp_quota_bonus: int = 0
     member_bonus: int = 0
     context_bonus: int = 0
+    analysis_bonus: int = 0
 
 
 class UsageValues(BaseModel):
@@ -107,6 +109,7 @@ class UpdateAddonRequest(BaseModel):
     addon_mcp_quota_bonus: int = Field(0, ge=0)
     addon_member_bonus: int = Field(0, ge=0)
     addon_context_bonus: int = Field(0, ge=0)
+    addon_analysis_bonus: int = Field(0, ge=0)
 
 
 class PlanChangeAuditEntry(BaseModel):
@@ -456,18 +459,21 @@ async def get_workspace_quotas(
                 mcp_calls_per_day=plan_tier.mcp_calls_per_day,
                 max_contexts=plan_tier.max_contexts_per_workspace,
                 max_members=plan_tier.max_members_per_workspace,
+                analysis_runs_per_day=plan_tier.analysis_runs_per_day,
             ),
             addon=AddonValues(
                 memory_bonus=workspace.addon_memory_bonus,
                 mcp_quota_bonus=workspace.addon_mcp_quota_bonus,
                 member_bonus=workspace.addon_member_bonus,
                 context_bonus=workspace.addon_context_bonus,
+                analysis_bonus=workspace.addon_analysis_bonus,
             ),
             effective=QuotaBreakdown(
                 memory_limit=effective["memory_limit"],
                 mcp_calls_per_day=effective["mcp_calls_per_day"],
                 max_contexts=effective["max_contexts"],
                 max_members=effective["max_members"],
+                analysis_runs_per_day=effective["analysis_runs_per_day"],
             ),
             usage=UsageValues(
                 memories=memory_count,
@@ -542,12 +548,14 @@ async def update_workspace_quotas(
         old_mcp_bonus = workspace.addon_mcp_quota_bonus
         old_member_bonus = workspace.addon_member_bonus
         old_context_bonus = workspace.addon_context_bonus
+        old_analysis_bonus = workspace.addon_analysis_bonus
 
         # Update addon bonuses
         workspace.addon_memory_bonus = request.addon_memory_bonus
         workspace.addon_mcp_quota_bonus = request.addon_mcp_quota_bonus
         workspace.addon_member_bonus = request.addon_member_bonus
         workspace.addon_context_bonus = request.addon_context_bonus
+        workspace.addon_analysis_bonus = request.addon_analysis_bonus
 
         await db.commit()
 
@@ -560,6 +568,7 @@ async def update_workspace_quotas(
                 "mcp_quota_bonus": f"{old_mcp_bonus} -> {request.addon_mcp_quota_bonus}",
                 "member_bonus": f"{old_member_bonus} -> {request.addon_member_bonus}",
                 "context_bonus": f"{old_context_bonus} -> {request.addon_context_bonus}",
+                "analysis_bonus": f"{old_analysis_bonus} -> {request.addon_analysis_bonus}",
             },
         )
 

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -729,6 +729,7 @@ async def get_current_user_info(
             "picture": user.get("picture"),
             "role": user.get("role", "user"),
             "timezone": db_user.timezone if db_user else "UTC",  # Issue #175
+            "locale": db_user.locale if db_user else "en",  # Issue #221: i18n locale
             "current_workspace_id": str(user["current_workspace_id"])
             if user.get("current_workspace_id")
             else None,

--- a/backend/src/services/analysis/labeler.py
+++ b/backend/src/services/analysis/labeler.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass
+from string import Template
 
 import numpy as np
 
@@ -177,12 +178,14 @@ async def _label_one_cluster(
     rep_ids = [str(r.id) for r in reps]
 
     # Locale-aware prompt selection (Issue #542)
-    if locale == "ja":
-        system_prompt = CLUSTER_LABEL_SYSTEM_JA
-        prompt = CLUSTER_LABEL_USER_JA.format(representatives=rep_block)
-    else:
-        system_prompt = CLUSTER_LABEL_SYSTEM
-        prompt = CLUSTER_LABEL_USER.format(representatives=rep_block)
+    # Mapping table so new languages only need a prompts.py entry.
+    _PROMPT_MAP = {
+        "ja": (CLUSTER_LABEL_SYSTEM_JA, CLUSTER_LABEL_USER_JA),
+    }
+    system_prompt, user_template = _PROMPT_MAP.get(
+        locale, (CLUSTER_LABEL_SYSTEM, CLUSTER_LABEL_USER)
+    )
+    prompt = Template(user_template).substitute(representatives=rep_block)
 
     async with sem:
         # Per-task session — each LLMService gets its own AsyncSession

--- a/backend/src/services/analysis/labeler.py
+++ b/backend/src/services/analysis/labeler.py
@@ -52,7 +52,12 @@ from services.analysis.llm_caller import (
     call_with_fallback,
     filter_hallucinated_ids,
 )
-from services.analysis.prompts import CLUSTER_LABEL_SYSTEM, CLUSTER_LABEL_USER
+from services.analysis.prompts import (
+    CLUSTER_LABEL_SYSTEM,
+    CLUSTER_LABEL_SYSTEM_JA,
+    CLUSTER_LABEL_USER,
+    CLUSTER_LABEL_USER_JA,
+)
 from services.analysis.vector_pull import MemoryRecord
 from services.llm_service import LLMService
 from services.sleep.reporter import LLMCallBreakdown, accumulate_llm_response
@@ -148,6 +153,7 @@ async def _label_one_cluster(
     workspace_id: str,
     context_id: str | None,
     sem: asyncio.Semaphore,
+    locale: str = "en",
 ) -> ClusterLabel:
     """Single-cluster labeling with semaphore + frozenset guard.
 
@@ -170,6 +176,14 @@ async def _label_one_cluster(
     rep_block = _format_representatives(reps)
     rep_ids = [str(r.id) for r in reps]
 
+    # Locale-aware prompt selection (Issue #542)
+    if locale == "ja":
+        system_prompt = CLUSTER_LABEL_SYSTEM_JA
+        prompt = CLUSTER_LABEL_USER_JA.format(representatives=rep_block)
+    else:
+        system_prompt = CLUSTER_LABEL_SYSTEM
+        prompt = CLUSTER_LABEL_USER.format(representatives=rep_block)
+
     async with sem:
         # Per-task session — each LLMService gets its own AsyncSession
         # so concurrent BYOK lookups don't race the orchestrator's
@@ -184,8 +198,8 @@ async def _label_one_cluster(
                     user_id=user_id,
                     workspace_id=workspace_id,
                     context_id=context_id,
-                    system_prompt=CLUSTER_LABEL_SYSTEM,
-                    prompt=CLUSTER_LABEL_USER.format(representatives=rep_block),
+                    system_prompt=system_prompt,
+                    prompt=prompt,
                     fallback_chain=OPENAI_FALLBACK_CHAIN,
                 )
             except AnalysisLLMUpstreamError as e:
@@ -243,6 +257,7 @@ async def label_clusters(
     workspace_id: str,
     context_id: str | None,
     concurrency: int = _LLM_CONCURRENCY,
+    locale: str = "en",
 ) -> list[ClusterLabel]:
     """Label every cluster in parallel (semaphore-bounded).
 
@@ -290,6 +305,7 @@ async def label_clusters(
                     workspace_id=workspace_id,
                     context_id=context_id,
                     sem=sem,
+                    locale=locale,
                 )
             )
         )

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -404,10 +404,10 @@ class AnalysisOrchestrator:
             # shared session. See labeler.py for the per-task pattern.
             # Issue #542: resolve user's locale for prompt language.
             user_result = await self.db.execute(
-                select(User).where(User.user_id == analysis.triggered_by)
+                select(User.locale).where(User.user_id == analysis.triggered_by)
             )
-            db_user = user_result.scalar_one_or_none()
-            label_locale = db_user.locale if db_user else "en"
+            db_locale = user_result.scalar_one_or_none()
+            label_locale = db_locale if db_locale else "en"
             cluster_label_results = await analysis_labeler.label_clusters(
                 cluster_labels=cluster_result.labels,
                 centroids=cluster_result.centroids,

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -53,6 +53,7 @@ from models.analysis import (
     MEMORY_ANALYSIS_STATUSES,
     MemoryAnalysis,
 )
+from models.auth import User
 from models.llm_pricing import LLMPricing
 from services.analysis import labeler as analysis_labeler
 from services.analysis.byok_resolver import assert_openai_byok_key_available
@@ -401,6 +402,12 @@ class AnalysisOrchestrator:
             # cluster task opens its own ``AsyncSession`` to avoid the
             # SQLAlchemy concurrent-ops violation on the orchestrator's
             # shared session. See labeler.py for the per-task pattern.
+            # Issue #542: resolve user's locale for prompt language.
+            user_result = await self.db.execute(
+                select(User).where(User.user_id == analysis.triggered_by)
+            )
+            db_user = user_result.scalar_one_or_none()
+            label_locale = db_user.locale if db_user else "en"
             cluster_label_results = await analysis_labeler.label_clusters(
                 cluster_labels=cluster_result.labels,
                 centroids=cluster_result.centroids,
@@ -409,6 +416,7 @@ class AnalysisOrchestrator:
                 user_id=analysis.triggered_by,
                 workspace_id=str(analysis.workspace_id),
                 context_id=str(analysis.context_id),
+                locale=label_locale,
             )
 
             # Stage [J] — atomic persist. The transaction here wraps

--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -379,6 +379,16 @@ class AnalysisOrchestrator:
             )
             analysis.cost_estimated_cents = estimate.estimated_cost_cents
 
+            # Issue #542: resolve user's locale for prompt language.
+            # Fetch while we still have the read transaction open;
+            # committing immediately after releases the connection
+            # before the long-running compute stages below.
+            user_result = await self.db.execute(
+                select(User.locale).where(User.user_id == analysis.triggered_by)
+            )
+            db_locale = user_result.scalar_one_or_none()
+            label_locale = db_locale if db_locale else "en"
+
             # Commit the read + vector_pull state, releasing the
             # orchestrator's connection. Compute stages below run with
             # NO open transaction; ``persist_results`` autobegins a
@@ -402,12 +412,6 @@ class AnalysisOrchestrator:
             # cluster task opens its own ``AsyncSession`` to avoid the
             # SQLAlchemy concurrent-ops violation on the orchestrator's
             # shared session. See labeler.py for the per-task pattern.
-            # Issue #542: resolve user's locale for prompt language.
-            user_result = await self.db.execute(
-                select(User.locale).where(User.user_id == analysis.triggered_by)
-            )
-            db_locale = user_result.scalar_one_or_none()
-            label_locale = db_locale if db_locale else "en"
             cluster_label_results = await analysis_labeler.label_clusters(
                 cluster_labels=cluster_result.labels,
                 centroids=cluster_result.centroids,

--- a/backend/src/services/analysis/prompts.py
+++ b/backend/src/services/analysis/prompts.py
@@ -46,3 +46,33 @@ CLUSTER_LABEL_USER = """Cluster representatives:
 {representatives}
 
 Output the JSON object now."""
+
+# ---------------------------------------------------------------------------
+# Japanese prompts (Issue #542 — locale-aware labeling)
+# ---------------------------------------------------------------------------
+# Japanese text is denser per token (1–2 tokens per kanji/kana vs ~0.75
+# tokens per English word). The word-count constraints are relaxed:
+# label 1–3 words → 1–3 語 (roughly 2–6 characters of kanji/kana),
+# description 25 words → 40 characters (mixed kanji + kana).
+
+CLUSTER_LABEL_SYSTEM_JA = """あなたはmemoryクラスターに短い説明的なラベルを付ける専門家です。
+
+共通テーマを持つ5つの代表memory summaryが与えられたら、以下のJSONオブジェクトを出力してください：
+
+{
+  "label": "<1〜3語の名詞句（日本語）>",
+  "description": "<1文、最大40文字（日本語）>",
+  "label_confidence": <0.0から1.0のfloat>
+}
+
+制約：
+- "label" は1〜3語の名詞句。動詞や全文は使用不可。
+- "description" はこれらのmemoryを統一するテーマを説明する1文。
+- "label_confidence" はテーマの一貫性に対する主観的な確信度：1.0=明確な共有テーマ、0.0=検出できないテーマ。
+- JSONオブジェクトのみ出力。前後に散文を含めない。"""
+
+CLUSTER_LABEL_USER_JA = """クラスター代表：
+
+{representatives}
+
+JSONオブジェクトを出力してください。"""

--- a/backend/src/services/analysis/prompts.py
+++ b/backend/src/services/analysis/prompts.py
@@ -43,7 +43,7 @@ Constraints:
 
 CLUSTER_LABEL_USER = """Cluster representatives:
 
-{representatives}
+$representatives
 
 Output the JSON object now."""
 
@@ -73,6 +73,6 @@ CLUSTER_LABEL_SYSTEM_JA = """あなたはmemoryクラスターに短い説明的
 
 CLUSTER_LABEL_USER_JA = """クラスター代表：
 
-{representatives}
+$representatives
 
 JSONオブジェクトを出力してください。"""

--- a/backend/src/services/analysis/prompts.py
+++ b/backend/src/services/analysis/prompts.py
@@ -2,8 +2,8 @@
 
 Mirrors ``services/sleep/prompts.py`` style: module-level constants,
 no Python string interpolation in the constants themselves —
-templates use ``{name}`` placeholders that the labeler fills with
-``str.format(**kwargs)``.
+templates use ``$name`` placeholders that the labeler fills with
+``string.Template.substitute()``.
 
 The labeler prompt is single-shot per cluster: 5 representative
 memory summaries → one ``{label, description, label_confidence}``

--- a/backend/tests/api/test_auth_me_signin_method.py
+++ b/backend/tests/api/test_auth_me_signin_method.py
@@ -43,6 +43,7 @@ def _db_user(*, auth_method: str, auth_provider: str | None) -> SimpleNamespace:
     """
     return SimpleNamespace(
         timezone="UTC",
+        locale="en",
         auth_method=auth_method,
         auth_provider=auth_provider,
     )

--- a/backend/tests/api/test_auth_me_signin_method.py
+++ b/backend/tests/api/test_auth_me_signin_method.py
@@ -72,6 +72,7 @@ class TestAuthMeSignInMethod:
 
         assert result["user"]["auth_method"] == "oauth"
         assert result["user"]["auth_provider"] == "google"
+        assert result["user"]["locale"] == "en"
 
     @pytest.mark.asyncio
     async def test_oauth_github_user_exposes_provider(self):
@@ -81,6 +82,7 @@ class TestAuthMeSignInMethod:
 
         assert result["user"]["auth_method"] == "oauth"
         assert result["user"]["auth_provider"] == "github"
+        assert result["user"]["locale"] == "en"
 
     @pytest.mark.asyncio
     async def test_password_user_provider_is_null(self):
@@ -96,6 +98,7 @@ class TestAuthMeSignInMethod:
 
         assert result["user"]["auth_method"] == "password"
         assert result["user"]["auth_provider"] is None
+        assert result["user"]["locale"] == "en"
 
     @pytest.mark.asyncio
     async def test_legacy_oauth_user_with_null_provider(self):
@@ -111,6 +114,7 @@ class TestAuthMeSignInMethod:
 
         assert result["user"]["auth_method"] == "oauth"
         assert result["user"]["auth_provider"] is None
+        assert result["user"]["locale"] == "en"
 
     @pytest.mark.asyncio
     async def test_db_user_missing_falls_back_to_oauth_default(self):
@@ -124,3 +128,19 @@ class TestAuthMeSignInMethod:
 
         assert result["user"]["auth_method"] == "oauth"
         assert result["user"]["auth_provider"] is None
+        assert result["user"]["locale"] == "en"
+
+    @pytest.mark.asyncio
+    async def test_oauth_user_with_ja_locale(self):
+        """Japanese locale user → locale='ja' exposed in response (Issue #542)."""
+        db = _mock_db(
+            SimpleNamespace(
+                timezone="Asia/Tokyo",
+                locale="ja",
+                auth_method="oauth",
+                auth_provider="google",
+            )
+        )
+        result = await get_current_user_info(user=_session(), db=db)
+
+        assert result["user"]["locale"] == "ja"

--- a/backend/tests/api/test_profile_locale_validation.py
+++ b/backend/tests/api/test_profile_locale_validation.py
@@ -1,0 +1,99 @@
+"""Route-level tests for PUT /api/v1/users/profile locale validation (Issue #542).
+
+Extends the auth/me locale coverage by verifying that the profile update
+endpoint rejects invalid locale codes at the schema layer (FastAPI/Pydantic
+pattern validation) before they reach the DB.
+
+Direct-handler tests (same style as ``test_auth_me_signin_method.py``) —
+no TestClient or real DB required.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from api.routes.users import update_user_profile
+from models.schemas import UpdateUserProfileRequest
+
+
+def _user_session(*, user_id: str = "u-1") -> dict:
+    """Minimal SessionUser dict."""
+    return {"user_id": user_id}
+
+
+def _db_user(*, locale: str = "en") -> SimpleNamespace:
+    """Stand-in for the ``User`` ORM row with mutable locale."""
+    return SimpleNamespace(
+        id=1,
+        user_id="u-1",
+        email="u@example.com",
+        name="Test",
+        picture=None,
+        timezone="UTC",
+        locale=locale,
+        role="user",
+        current_workspace_id=None,
+        created_at=datetime.now(UTC),
+        last_login_at=None,
+        auth_method="oauth",
+        auth_provider="google",
+    )
+
+
+def _mock_db(db_user: SimpleNamespace | None) -> AsyncMock:
+    """Build an ``AsyncSession`` mock whose ``execute()`` returns the
+    given row (or None for the "user missing" branch).
+    """
+    db = AsyncMock()
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = db_user
+    db.execute.return_value = result
+    return db
+
+
+class TestProfileLocaleValidation:
+    """PUT /api/v1/users/profile must reject locale outside {en, ja}."""
+
+    @pytest.mark.asyncio
+    async def test_valid_en_locale_accepted(self):
+        """English locale is valid and persisted."""
+        user = _db_user(locale="en")
+        db = _mock_db(user)
+        data = UpdateUserProfileRequest(locale="en")
+        result = await update_user_profile(data=data, user=_user_session(), db=db)
+        assert result.locale == "en"
+
+    @pytest.mark.asyncio
+    async def test_valid_ja_locale_accepted(self):
+        """Japanese locale is valid and persisted."""
+        user = _db_user(locale="en")
+        db = _mock_db(user)
+        data = UpdateUserProfileRequest(locale="ja")
+        result = await update_user_profile(data=data, user=_user_session(), db=db)
+        assert result.locale == "ja"
+
+    def test_invalid_locale_rejected_at_schema(self):
+        """Locale 'fr' fails Pydantic pattern validation → ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            UpdateUserProfileRequest(locale="fr")
+        assert "locale" in str(exc_info.value)
+
+    def test_empty_locale_rejected_at_schema(self):
+        """Empty locale fails Pydantic pattern validation → ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            UpdateUserProfileRequest(locale="")
+        assert "locale" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_null_locale_is_noop(self):
+        """Null locale is omitted — existing value preserved."""
+        user = _db_user(locale="ja")
+        db = _mock_db(user)
+        data = UpdateUserProfileRequest(locale=None)
+        result = await update_user_profile(data=data, user=_user_session(), db=db)
+        assert result.locale == "ja"

--- a/backend/tests/services/analysis/test_orchestrator.py
+++ b/backend/tests/services/analysis/test_orchestrator.py
@@ -346,7 +346,7 @@ class TestAnalysisOrchestratorRun:
             patch(
                 "services.analysis.orchestrator.analysis_labeler.label_clusters",
                 new=AsyncMock(return_value=[]),
-            ),
+            ) as mock_label_clusters,
             patch(
                 "services.analysis.orchestrator.persist_results",
                 new=AsyncMock(),
@@ -358,6 +358,9 @@ class TestAnalysisOrchestratorRun:
         assert analysis.embedding_model == "test-model"
         assert analysis.cost_estimated_cents == 42
         mock_persist.assert_awaited_once()
+        # Issue #542: locale fallback to "en" when no DB user
+        mock_label_clusters.assert_awaited_once()
+        assert mock_label_clusters.call_args.kwargs.get("locale") == "en"
 
     @pytest.mark.asyncio
     async def test_embedding_mismatch_marks_failed_and_reraises(self, db_session) -> None:

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -733,7 +733,7 @@ export default function AdminPlansPage() {
               <Label htmlFor="addon-memory">
                 {t("addonDialog.memory")}{" "}
                 <span className="text-xs text-muted-foreground font-normal">
-                  (+10,000 / unit)
+                  {t("addonDialog.perUnit", { count: 10000 })}
                 </span>
               </Label>
               <div className="flex items-center gap-2 mt-1">
@@ -758,7 +758,7 @@ export default function AdminPlansPage() {
               <Label htmlFor="addon-mcp">
                 {t("addonDialog.mcp")}{" "}
                 <span className="text-xs text-muted-foreground font-normal">
-                  (+5,000 / unit)
+                  {t("addonDialog.perUnit", { count: 5000 })}
                 </span>
               </Label>
               <div className="flex items-center gap-2 mt-1">
@@ -783,7 +783,7 @@ export default function AdminPlansPage() {
               <Label htmlFor="addon-member">
                 {t("addonDialog.members")}{" "}
                 <span className="text-xs text-muted-foreground font-normal">
-                  (+5 / unit)
+                  {t("addonDialog.perUnit", { count: 5 })}
                 </span>
               </Label>
               <div className="flex items-center gap-2 mt-1">
@@ -809,7 +809,7 @@ export default function AdminPlansPage() {
               <Label htmlFor="addon-context">
                 {t("addonDialog.contexts")}{" "}
                 <span className="text-xs text-muted-foreground font-normal">
-                  (+5 / unit)
+                  {t("addonDialog.perUnit", { count: 5 })}
                 </span>
               </Label>
               <div className="flex items-center gap-2 mt-1">
@@ -835,7 +835,7 @@ export default function AdminPlansPage() {
               <Label htmlFor="addon-analysis">
                 {t("addonDialog.analysis")}{" "}
                 <span className="text-xs text-muted-foreground font-normal">
-                  (+1 / unit)
+                  {t("addonDialog.perUnit", { count: 1 })}
                 </span>
               </Label>
               <div className="flex items-center gap-2 mt-1">

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -304,7 +304,9 @@ export default function AdminPlansPage() {
                                   </div>
                                   {workspace.owner_name && (
                                     <div className="text-xs text-muted-foreground mt-1">
-                                      Owner: {workspace.owner_name}
+                                      {t("workspacesTable.owner", {
+                                        name: workspace.owner_name,
+                                      })}
                                     </div>
                                   )}
                                 </div>
@@ -367,13 +369,16 @@ export default function AdminPlansPage() {
                                       workspace.id ? (
                                     <div className="space-y-3">
                                       <div className="grid grid-cols-4 gap-2 text-xs font-medium text-muted-foreground border-b pb-2">
-                                        <div>Resource</div>
+                                        <div>{t("quota.resource")}</div>
                                         <div className="text-right">
-                                          Base ({quotaDetail.plan_name})
+                                          {t("quota.base")} (
+                                          {quotaDetail.plan_name})
                                         </div>
-                                        <div className="text-right">Addon</div>
                                         <div className="text-right">
-                                          Effective / Usage
+                                          {t("quota.addon")}
+                                        </div>
+                                        <div className="text-right">
+                                          {t("quota.effectiveUsage")}
                                         </div>
                                       </div>
                                       {[
@@ -470,7 +475,7 @@ export default function AdminPlansPage() {
                                           }}
                                         >
                                           <Settings className="h-4 w-4 mr-1" />
-                                          Edit Addons
+                                          {t("workspacesTable.editAddons")}
                                         </Button>
                                       </div>
                                     </div>

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -98,6 +98,7 @@ export default function AdminPlansPage() {
   const [addonMcp, setAddonMcp] = useState(0);
   const [addonMember, setAddonMember] = useState(0);
   const [addonContext, setAddonContext] = useState(0);
+  const [addonAnalysis, setAddonAnalysis] = useState(0);
   const { toast } = useToast();
   const [tab, setTab] = useTabParam("workspaces", "tab", PLAN_TABS);
 
@@ -183,6 +184,7 @@ export default function AdminPlansPage() {
     setAddonMcp(quotaDetail.addon.mcp_quota_bonus);
     setAddonMember(quotaDetail.addon.member_bonus);
     setAddonContext(quotaDetail.addon.context_bonus);
+    setAddonAnalysis(quotaDetail.addon.analysis_bonus);
     setAddonDialogOpen(true);
   };
 
@@ -194,6 +196,7 @@ export default function AdminPlansPage() {
         addon_mcp_quota_bonus: addonMcp,
         addon_member_bonus: addonMember,
         addon_context_bonus: addonContext,
+        addon_analysis_bonus: addonAnalysis,
       });
       toast({ title: tCommon("success"), description: "Quota addons updated" });
       setAddonDialogOpen(false);
@@ -375,7 +378,7 @@ export default function AdminPlansPage() {
                                       </div>
                                       {[
                                         {
-                                          label: "Memories",
+                                          label: t("quota.memory"),
                                           base: quotaDetail.base.memory_limit,
                                           addon: quotaDetail.addon.memory_bonus,
                                           effective:
@@ -383,7 +386,7 @@ export default function AdminPlansPage() {
                                           usage: quotaDetail.usage.memories,
                                         },
                                         {
-                                          label: "MCP Calls/day",
+                                          label: t("quota.mcp"),
                                           base: quotaDetail.base
                                             .mcp_calls_per_day,
                                           addon:
@@ -394,7 +397,7 @@ export default function AdminPlansPage() {
                                           usage: null,
                                         },
                                         {
-                                          label: "Contexts",
+                                          label: t("quota.contexts"),
                                           base: quotaDetail.base.max_contexts,
                                           addon:
                                             quotaDetail.addon.context_bonus,
@@ -403,12 +406,23 @@ export default function AdminPlansPage() {
                                           usage: quotaDetail.usage.contexts,
                                         },
                                         {
-                                          label: "Members",
+                                          label: t("quota.members"),
                                           base: quotaDetail.base.max_members,
                                           addon: quotaDetail.addon.member_bonus,
                                           effective:
                                             quotaDetail.effective.max_members,
                                           usage: quotaDetail.usage.members,
+                                        },
+                                        {
+                                          label: t("quota.analysis"),
+                                          base: quotaDetail.base
+                                            .analysis_runs_per_day,
+                                          addon:
+                                            quotaDetail.addon.analysis_bonus,
+                                          effective:
+                                            quotaDetail.effective
+                                              .analysis_runs_per_day,
+                                          usage: null,
                                         },
                                       ].map((row) => (
                                         <div
@@ -440,7 +454,7 @@ export default function AdminPlansPage() {
                                               <span className="text-muted-foreground">
                                                 {" "}
                                                 / {row.usage.toLocaleString()}{" "}
-                                                used
+                                                {t("quota.used")}
                                               </span>
                                             )}
                                           </div>
@@ -516,6 +530,14 @@ export default function AdminPlansPage() {
                     <TableCell>100</TableCell>
                     <TableCell>2,000</TableCell>
                     <TableCell>10,000</TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell className="font-medium">
+                      {t("tiersTable.analysisRuns")}
+                    </TableCell>
+                    <TableCell>-</TableCell>
+                    <TableCell>-</TableCell>
+                    <TableCell>3</TableCell>
                   </TableRow>
                   <TableRow>
                     <TableCell className="font-medium">
@@ -691,26 +713,32 @@ export default function AdminPlansPage() {
       <Dialog open={addonDialogOpen} onOpenChange={setAddonDialogOpen}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Edit Quota Addons</DialogTitle>
+            <DialogTitle>{t("addonDialog.title")}</DialogTitle>
             <DialogDescription>
-              Adjust addon bonuses for{" "}
+              {t("addonDialog.description")}{" "}
               <strong>{quotaDetail?.workspace_name}</strong>
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-4 py-4">
             <div>
-              <Label htmlFor="addon-memory">Memory Bonus</Label>
+              <Label htmlFor="addon-memory">
+                {t("addonDialog.memory")}{" "}
+                <span className="text-xs text-muted-foreground font-normal">
+                  (+10,000 / unit)
+                </span>
+              </Label>
               <div className="flex items-center gap-2 mt-1">
                 <Input
                   id="addon-memory"
                   type="number"
                   min={0}
+                  step={10000}
                   value={addonMemory}
                   onChange={(e) => setAddonMemory(Number(e.target.value))}
                 />
                 <span className="text-xs text-muted-foreground whitespace-nowrap">
-                  Effective:{" "}
+                  {t("addonDialog.effective")}:{" "}
                   {(
                     (quotaDetail?.base.memory_limit ?? 0) + addonMemory
                   ).toLocaleString()}
@@ -719,17 +747,23 @@ export default function AdminPlansPage() {
             </div>
 
             <div>
-              <Label htmlFor="addon-mcp">MCP Calls/day Bonus</Label>
+              <Label htmlFor="addon-mcp">
+                {t("addonDialog.mcp")}{" "}
+                <span className="text-xs text-muted-foreground font-normal">
+                  (+5,000 / unit)
+                </span>
+              </Label>
               <div className="flex items-center gap-2 mt-1">
                 <Input
                   id="addon-mcp"
                   type="number"
                   min={0}
+                  step={5000}
                   value={addonMcp}
                   onChange={(e) => setAddonMcp(Number(e.target.value))}
                 />
                 <span className="text-xs text-muted-foreground whitespace-nowrap">
-                  Effective:{" "}
+                  {t("addonDialog.effective")}:{" "}
                   {(
                     (quotaDetail?.base.mcp_calls_per_day ?? 0) + addonMcp
                   ).toLocaleString()}
@@ -738,41 +772,79 @@ export default function AdminPlansPage() {
             </div>
 
             <div>
-              <Label htmlFor="addon-member">Member Bonus</Label>
+              <Label htmlFor="addon-member">
+                {t("addonDialog.members")}{" "}
+                <span className="text-xs text-muted-foreground font-normal">
+                  (+5 / unit)
+                </span>
+              </Label>
               <div className="flex items-center gap-2 mt-1">
                 <Input
                   id="addon-member"
                   type="number"
                   min={0}
+                  step={5}
                   value={addonMember}
                   onChange={(e) => setAddonMember(Number(e.target.value))}
                 />
                 <span className="text-xs text-muted-foreground whitespace-nowrap">
-                  Effective:{" "}
+                  {t("addonDialog.effective")}:{" "}
                   {(
                     (quotaDetail?.base.max_members ?? 0) + addonMember
                   ).toLocaleString()}{" "}
-                  ({quotaDetail?.usage.members ?? 0} used)
+                  ({quotaDetail?.usage.members ?? 0} {t("addonDialog.used")})
                 </span>
               </div>
             </div>
 
             <div>
-              <Label htmlFor="addon-context">Extra Contexts</Label>
+              <Label htmlFor="addon-context">
+                {t("addonDialog.contexts")}{" "}
+                <span className="text-xs text-muted-foreground font-normal">
+                  (+5 / unit)
+                </span>
+              </Label>
               <div className="flex items-center gap-2 mt-1">
                 <Input
                   id="addon-context"
                   type="number"
                   min={0}
+                  step={5}
                   value={addonContext}
                   onChange={(e) => setAddonContext(Number(e.target.value))}
                 />
                 <span className="text-xs text-muted-foreground whitespace-nowrap">
-                  Effective:{" "}
+                  {t("addonDialog.effective")}:{" "}
                   {(
                     (quotaDetail?.base.max_contexts ?? 0) + addonContext
                   ).toLocaleString()}{" "}
-                  ({quotaDetail?.usage.contexts ?? 0} used)
+                  ({quotaDetail?.usage.contexts ?? 0} {t("addonDialog.used")})
+                </span>
+              </div>
+            </div>
+
+            <div>
+              <Label htmlFor="addon-analysis">
+                {t("addonDialog.analysis")}{" "}
+                <span className="text-xs text-muted-foreground font-normal">
+                  (+1 / unit)
+                </span>
+              </Label>
+              <div className="flex items-center gap-2 mt-1">
+                <Input
+                  id="addon-analysis"
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={addonAnalysis}
+                  onChange={(e) => setAddonAnalysis(Number(e.target.value))}
+                />
+                <span className="text-xs text-muted-foreground whitespace-nowrap">
+                  {t("addonDialog.effective")}:{" "}
+                  {(
+                    (quotaDetail?.base.analysis_runs_per_day ?? 0) +
+                    addonAnalysis
+                  ).toLocaleString()}
                 </span>
               </div>
             </div>
@@ -782,10 +854,10 @@ export default function AdminPlansPage() {
                 addonContext < quotaDetail.addon.context_bonus) && (
                 <div className="bg-yellow-50 dark:bg-yellow-950 p-3 rounded-md">
                   <p className="text-sm text-yellow-800 dark:text-yellow-100">
-                    Reducing member or context addons will be rejected if
-                    current usage exceeds the new effective limit. (Members:{" "}
-                    {quotaDetail.usage.members} used, Contexts:{" "}
-                    {quotaDetail.usage.contexts} used)
+                    {t("addonDialog.reductionWarning", {
+                      members: quotaDetail.usage.members,
+                      contexts: quotaDetail.usage.contexts,
+                    })}
                   </p>
                 </div>
               )}
@@ -793,11 +865,11 @@ export default function AdminPlansPage() {
 
           <DialogFooter>
             <Button variant="outline" onClick={() => setAddonDialogOpen(false)}>
-              Cancel
+              {tCommon("cancel")}
             </Button>
             <Button onClick={handleUpdateAddons}>
               <CheckCircle className="h-4 w-4 mr-2" />
-              Save Addons
+              {t("addonDialog.save")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -198,7 +198,10 @@ export default function AdminPlansPage() {
         addon_context_bonus: addonContext,
         addon_analysis_bonus: addonAnalysis,
       });
-      toast({ title: tCommon("success"), description: "Quota addons updated" });
+      toast({
+        title: tCommon("success"),
+        description: t("messages.addonUpdateSuccess"),
+      });
       setAddonDialogOpen(false);
       // Refresh detail
       const detail = await getWorkspaceQuotas(quotaDetail.workspace_id);

--- a/frontend/src/app/(authenticated)/profile/page.tsx
+++ b/frontend/src/app/(authenticated)/profile/page.tsx
@@ -167,13 +167,13 @@ export default function ProfilePage() {
   const [name, setName] = useState(user?.name || "");
   const email = user?.email || "";
   const [timezone, setTimezone] = useState(user?.timezone || "UTC");
-  const [locale, setLocale] = useState(user?.locale || "ja");
+  const [locale, setLocale] = useState(user?.locale || "en");
 
   useEffect(() => {
     if (user) {
       setName(user.name || "");
       setTimezone(user.timezone || "UTC");
-      setLocale(user.locale || "ja");
+      setLocale(user.locale || "en");
     }
   }, [user]);
 
@@ -397,6 +397,8 @@ export default function ProfilePage() {
                     onClick={() => {
                       setIsEditMode(false);
                       setName(user.name || "");
+                      setTimezone(user.timezone || "UTC");
+                      setLocale(user.locale || "en");
                     }}
                   >
                     {tCommon("cancel")}

--- a/frontend/src/app/(authenticated)/profile/page.tsx
+++ b/frontend/src/app/(authenticated)/profile/page.tsx
@@ -167,11 +167,13 @@ export default function ProfilePage() {
   const [name, setName] = useState(user?.name || "");
   const email = user?.email || "";
   const [timezone, setTimezone] = useState(user?.timezone || "UTC");
+  const [locale, setLocale] = useState(user?.locale || "ja");
 
   useEffect(() => {
     if (user) {
       setName(user.name || "");
       setTimezone(user.timezone || "UTC");
+      setLocale(user.locale || "ja");
     }
   }, [user]);
 
@@ -180,6 +182,7 @@ export default function ProfilePage() {
       await apiClient.put("/api/v1/users/profile", {
         name,
         timezone,
+        locale,
       });
 
       // Refresh user data to get updated timezone
@@ -348,6 +351,24 @@ export default function ProfilePage() {
                   </SelectContent>
                 </Select>
                 <p className="text-xs text-slate-500">{t("timezoneDesc")}</p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="locale">{t("locale")}</Label>
+                <Select
+                  value={locale}
+                  onValueChange={setLocale}
+                  disabled={!isEditMode}
+                >
+                  <SelectTrigger id="locale">
+                    <SelectValue placeholder={t("selectLocale")} />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="ja">{t("localeJa")}</SelectItem>
+                    <SelectItem value="en">{t("localeEn")}</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-slate-500">{t("localeDesc")}</p>
               </div>
 
               {user.role === "admin" && (

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -1084,7 +1084,7 @@ export default function ContextsPage() {
                               <DropdownMenuItem
                                 onClick={() =>
                                   router.push(
-                                    `/workspace/contexts/${context.id}?tab=analyses&new=1`,
+                                    `/workspace/contexts/${context.id}?tab=analyses`,
                                   )
                                 }
                               >

--- a/frontend/src/components/contexts/analyses/ClusterList.tsx
+++ b/frontend/src/components/contexts/analyses/ClusterList.tsx
@@ -107,7 +107,7 @@ export function ClusterList({
                     </span>
                   </div>
                   {cluster.description && (
-                    <p className="mt-0.5 line-clamp-1 text-xs text-gray-500 dark:text-gray-400">
+                    <p className="mt-0.5 line-clamp-3 text-xs text-gray-500 dark:text-gray-400">
                       {cluster.description}
                     </p>
                   )}

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -107,10 +107,6 @@ export function NewAnalysisModal({
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
   const [previewErrorCode, setPreviewErrorCode] = useState<string | null>(null);
-  const [previewErrorDetails, setPreviewErrorDetails] = useState<Record<
-    string,
-    unknown
-  > | null>(null);
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -106,6 +106,11 @@ export function NewAnalysisModal({
   const [preview, setPreview] = useState<AnalysisPreviewResponse | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewError, setPreviewError] = useState<string | null>(null);
+  const [previewErrorCode, setPreviewErrorCode] = useState<string | null>(null);
+  const [previewErrorDetails, setPreviewErrorDetails] = useState<Record<
+    string,
+    unknown
+  > | null>(null);
 
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -134,13 +139,30 @@ export function NewAnalysisModal({
         setPreview(result);
       } catch (err) {
         if (cancelled) return;
-        setPreviewError(
-          err instanceof ApiError
-            ? err.message
-            : err instanceof Error
-              ? err.message
-              : t("errorPreviewFallback"),
-        );
+        if (err instanceof ApiError) {
+          setPreviewErrorCode(err.error ?? null);
+          setPreviewErrorDetails(
+            (err.details as Record<string, unknown>) ?? null,
+          );
+          // Use translated message for known error codes; fallback to raw message
+          if (err.error === "QUOTA-001" && err.details) {
+            const d = err.details as Record<string, unknown>;
+            setPreviewError(
+              t("errors.QUOTA-001", {
+                used: d.used_today ?? "?",
+                limit: d.limit_today ?? "?",
+                addon: d.addon_bonus ?? 0,
+                resetsAt: d.resets_at ?? "?",
+              }),
+            );
+          } else {
+            setPreviewError(err.message);
+          }
+        } else {
+          setPreviewError(
+            err instanceof Error ? err.message : t("errorPreviewFallback"),
+          );
+        }
       } finally {
         if (!cancelled) setPreviewLoading(false);
       }
@@ -156,6 +178,9 @@ export function NewAnalysisModal({
     if (!open) {
       setSubmitting(false);
       setSubmitError(null);
+      setPreviewError(null);
+      setPreviewErrorCode(null);
+      setPreviewErrorDetails(null);
     }
   }, [open]);
 
@@ -290,7 +315,9 @@ export function NewAnalysisModal({
           </div>
           {previewError && (
             <p className="mt-2 text-xs text-red-600 dark:text-red-400">
-              {t("errorLoadingPreview")}: {previewError}
+              {previewErrorCode === "QUOTA-001"
+                ? previewError
+                : `${t("errorLoadingPreview")}: ${previewError}`}
             </p>
           )}
         </div>

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -137,9 +137,6 @@ export function NewAnalysisModal({
         if (cancelled) return;
         if (err instanceof ApiError) {
           setPreviewErrorCode(err.error ?? null);
-          setPreviewErrorDetails(
-            (err.details as Record<string, unknown>) ?? null,
-          );
           // Use translated message for known error codes; fallback to raw message
           if (err.error === "QUOTA-001" && err.details) {
             const d = err.details as Record<string, unknown>;
@@ -176,7 +173,6 @@ export function NewAnalysisModal({
       setSubmitError(null);
       setPreviewError(null);
       setPreviewErrorCode(null);
-      setPreviewErrorDetails(null);
     }
   }, [open]);
 

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -149,10 +149,10 @@ export function NewAnalysisModal({
             const d = err.details as Record<string, unknown>;
             setPreviewError(
               t("errors.QUOTA-001", {
-                used: d.used_today ?? "?",
-                limit: d.limit_today ?? "?",
-                addon: d.addon_bonus ?? 0,
-                resetsAt: d.resets_at ?? "?",
+                used: String(d.used_today ?? "?"),
+                limit: String(d.limit_today ?? "?"),
+                addon: String(d.addon_bonus ?? 0),
+                resetsAt: String(d.resets_at ?? "?"),
               }),
             );
           } else {

--- a/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
+++ b/frontend/src/components/contexts/analyses/NewAnalysisModal.tsx
@@ -128,6 +128,7 @@ export function NewAnalysisModal({
     let cancelled = false;
     setPreviewLoading(true);
     setPreviewError(null);
+    setPreviewErrorCode(null);
     const timer = window.setTimeout(async () => {
       try {
         const result = await previewAnalysis(contextId, filters);
@@ -152,6 +153,7 @@ export function NewAnalysisModal({
             setPreviewError(err.message);
           }
         } else {
+          setPreviewErrorCode(null);
           setPreviewError(
             err instanceof Error ? err.message : t("errorPreviewFallback"),
           );

--- a/frontend/src/components/contexts/analyses/RepresentativesPanel.tsx
+++ b/frontend/src/components/contexts/analyses/RepresentativesPanel.tsx
@@ -145,7 +145,7 @@ export function RepresentativesPanel({
                   aria-hidden
                 />
                 <div className="min-w-0">
-                  <div className="truncate text-gray-900 dark:text-gray-100">
+                  <div className="line-clamp-3 text-sm text-gray-900 dark:text-gray-100">
                     {rep.summary}
                   </div>
                   <div className="mt-0.5 font-mono text-xs text-gray-400">

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -75,6 +75,7 @@ export interface QuotaBreakdown {
   mcp_calls_per_day: number;
   max_contexts: number;
   max_members: number;
+  analysis_runs_per_day: number;
 }
 
 export interface WorkspaceQuotaDetail {
@@ -87,6 +88,7 @@ export interface WorkspaceQuotaDetail {
     mcp_quota_bonus: number;
     member_bonus: number;
     context_bonus: number;
+    analysis_bonus: number;
   };
   effective: QuotaBreakdown;
   usage: { memories: number; contexts: number; members: number };
@@ -97,6 +99,7 @@ export interface UpdateAddonRequest {
   addon_mcp_quota_bonus: number;
   addon_member_bonus: number;
   addon_context_bonus: number;
+  addon_analysis_bonus: number;
 }
 
 /**

--- a/frontend/src/lib/auth/auth.ts
+++ b/frontend/src/lib/auth/auth.ts
@@ -13,6 +13,7 @@ export interface User {
   picture?: string;
   role?: string;
   timezone?: string; // Issue #175: User timezone
+  locale?: string; // Issue #221: User locale
   current_workspace_id?: string;
   current_context_id?: string;
   // Issue #514: sign-in method display

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2118,7 +2118,8 @@
       "messages": {
         "loadError": "Failed to load workspaces",
         "changeSuccess": "Tier changed from {oldPlan} to {newPlan}",
-        "changeError": "Failed to change tier"
+        "changeError": "Failed to change tier",
+        "addonUpdateSuccess": "Quota addons updated"
       }
     },
     "users": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2095,6 +2095,7 @@
         "effective": "Effective",
         "used": "used",
         "save": "Save Addons",
+        "perUnit": "(+{count} / unit)",
         "reductionWarning": "Reducing member or context addons will be rejected if current usage exceeds the new effective limit. (Members: {members} used, Contexts: {contexts} used)"
       },
       "auditTable": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -409,7 +409,11 @@
         "cta": "Get Started"
       },
       "common": {
-        "mostPopular": "Most Popular"
+        "mostPopular": "Most Popular",
+        "cancel": "Cancel",
+        "success": "Success",
+        "error": "Error",
+        "refresh": "Refresh"
       }
     },
     "features": {
@@ -811,6 +815,11 @@
     "timezone": "Timezone",
     "selectTimezone": "Select timezone",
     "timezoneDesc": "Used for displaying dates and times",
+    "locale": "Language",
+    "selectLocale": "Select language",
+    "localeDesc": "Interface display language",
+    "localeJa": "日本語",
+    "localeEn": "English",
     "systemRole": "System Role",
     "systemAdmin": "System Administrator",
     "elevatedPrivileges": "You have elevated system privileges",
@@ -2017,6 +2026,7 @@
   "admin": {
     "common": {
       "refresh": "Refresh",
+      "cancel": "Cancel",
       "loading": "Loading...",
       "noResults": "No results found",
       "noWorkspaces": "No workspaces found",
@@ -2054,10 +2064,32 @@
         "memories": "Memories",
         "storage": "Storage",
         "apiCalls": "API Calls (Daily)",
+        "analysisRuns": "Analysis Runs (Daily)",
         "reranking": "Reranking",
         "mcpAppCredentials": "MCP App Credentials (OAuth)",
         "memoryAgent": "Memory Agent",
         "unlimited": "Unlimited"
+      },
+      "quota": {
+        "memory": "Memories",
+        "mcp": "MCP Calls/day",
+        "contexts": "Contexts",
+        "members": "Members",
+        "analysis": "Analysis Runs/day",
+        "used": "used"
+      },
+      "addonDialog": {
+        "title": "Edit Addons",
+        "description": "Adjust addon bonuses for",
+        "memory": "Memory Bonus",
+        "mcp": "MCP Calls/day Bonus",
+        "members": "Member Bonus",
+        "contexts": "Extra Contexts",
+        "analysis": "Analysis Runs Bonus",
+        "effective": "Effective",
+        "used": "used",
+        "save": "Save Addons",
+        "reductionWarning": "Reducing member or context addons will be rejected if current usage exceeds the new effective limit. (Members: {members} used, Contexts: {contexts} used)"
       },
       "auditTable": {
         "title": "Change Audit Log",
@@ -3189,7 +3221,10 @@
       "errorLoadingPreview": "Could not estimate cost — check connection and try again.",
       "errorStarting": "Could not start the run — see details below.",
       "errorPreviewFallback": "preview failed",
-      "errorStartFallback": "start failed"
+      "errorStartFallback": "start failed",
+      "errors": {
+        "QUOTA-001": "Analysis daily quota exceeded: {used}/{limit} runs (addon bonus: {addon}). Resets at {resetsAt}."
+      }
     },
     "running": {
       "title": "Run in progress",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2051,7 +2051,9 @@
         "storage": "Storage (MB)",
         "usage": "Usage %",
         "actions": "Actions",
-        "changePlan": "Change Tier"
+        "changePlan": "Change Tier",
+        "editAddons": "Edit Addons",
+        "owner": "Owner: {name}"
       },
       "tiersTable": {
         "title": "Tier Comparison",
@@ -2076,7 +2078,11 @@
         "contexts": "Contexts",
         "members": "Members",
         "analysis": "Analysis Runs/day",
-        "used": "used"
+        "used": "used",
+        "resource": "Resource",
+        "base": "Base",
+        "addon": "Addon",
+        "effectiveUsage": "Effective / Usage"
       },
       "addonDialog": {
         "title": "Edit Addons",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -409,7 +409,11 @@
         "cta": "今すぐ始める"
       },
       "common": {
-        "mostPopular": "最も人気"
+        "mostPopular": "最も人気",
+        "cancel": "キャンセル",
+        "success": "成功",
+        "error": "エラー",
+        "refresh": "更新"
       }
     },
     "features": {
@@ -811,6 +815,11 @@
     "timezone": "タイムゾーン",
     "selectTimezone": "タイムゾーンを選択",
     "timezoneDesc": "日時の表示に使用されます",
+    "locale": "言語",
+    "selectLocale": "言語を選択",
+    "localeDesc": "インターフェースの表示言語",
+    "localeJa": "日本語",
+    "localeEn": "English",
     "systemRole": "システムロール",
     "systemAdmin": "システム管理者",
     "elevatedPrivileges": "管理者権限を持っています",
@@ -2017,6 +2026,7 @@
   "admin": {
     "common": {
       "refresh": "更新",
+      "cancel": "キャンセル",
       "loading": "読み込み中...",
       "noResults": "結果が見つかりません",
       "noWorkspaces": "ワークスペースが見つかりません",
@@ -2054,10 +2064,32 @@
         "memories": "メモリー",
         "storage": "ストレージ",
         "apiCalls": "API呼び出し（日次）",
+        "analysisRuns": "メモリー分析回数（日次）",
         "reranking": "リランキング",
         "mcpAppCredentials": "MCPアプリ認証情報（OAuth）",
         "memoryAgent": "メモリーエージェント",
         "unlimited": "無制限"
+      },
+      "quota": {
+        "memory": "Memories",
+        "mcp": "MCP Calls/day",
+        "contexts": "Contexts",
+        "members": "Members",
+        "analysis": "Analysis Runs/day",
+        "used": "used"
+      },
+      "addonDialog": {
+        "title": "アドオン編集",
+        "description": "アドオンボーナスを調整 —",
+        "memory": "Memory Bonus",
+        "mcp": "MCP Calls/day Bonus",
+        "members": "Member Bonus",
+        "contexts": "Extra Contexts",
+        "analysis": "Analysis Runs Bonus",
+        "effective": "Effective",
+        "used": "used",
+        "save": "保存",
+        "reductionWarning": "メンバーまたはコンテキストのアドオンを減らすと、現在の使用量が新しい有効制限を超える場合は拒否されます。（メンバー: {members} 使用中、コンテキスト: {contexts} 使用中）"
       },
       "auditTable": {
         "title": "変更監査ログ",
@@ -3090,7 +3122,7 @@
       "subtitle": "クラスタ俯瞰で memory の地形を見る · Owner のみ"
     },
     "actions": {
-      "newAnalysis": "分析を実行",
+      "newAnalysis": "分析",
       "exportJson": "JSON をエクスポート",
       "refresh": "更新",
       "cancel": "キャンセル"
@@ -3189,7 +3221,10 @@
       "errorLoadingPreview": "コスト推定に失敗しました — 接続を確認して再試行してください。",
       "errorStarting": "Run の起動に失敗しました — 詳細は下記を確認してください。",
       "errorPreviewFallback": "preview に失敗しました",
-      "errorStartFallback": "起動に失敗しました"
+      "errorStartFallback": "起動に失敗しました",
+      "errors": {
+        "QUOTA-001": "分析の日次クォータを超過しました: {used}/{limit} 回（アドオン追加: {addon}）。{resetsAt}にリセットされます。"
+      }
     },
     "running": {
       "title": "実行中",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2095,6 +2095,7 @@
         "effective": "有効値",
         "used": "使用中",
         "save": "保存",
+        "perUnit": "(+{count} / 単位)",
         "reductionWarning": "メンバーまたはコンテキストのアドオンを減らすと、現在の使用量が新しい有効制限を超える場合は拒否されます。（メンバー: {members} 使用中、コンテキスト: {contexts} 使用中）"
       },
       "auditTable": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2051,7 +2051,9 @@
         "storage": "ストレージ (MB)",
         "usage": "使用率 %",
         "actions": "操作",
-        "changePlan": "ティア変更"
+        "changePlan": "ティア変更",
+        "editAddons": "アドオン編集",
+        "owner": "所有者: {name}"
       },
       "tiersTable": {
         "title": "ティア比較",
@@ -2071,23 +2073,27 @@
         "unlimited": "無制限"
       },
       "quota": {
-        "memory": "Memories",
-        "mcp": "MCP Calls/day",
-        "contexts": "Contexts",
-        "members": "Members",
-        "analysis": "Analysis Runs/day",
-        "used": "used"
+        "memory": "メモリー",
+        "mcp": "MCP 呼び出し/日",
+        "contexts": "コンテキスト",
+        "members": "メンバー",
+        "analysis": "分析実行/日",
+        "used": "使用中",
+        "resource": "リソース",
+        "base": "ベース",
+        "addon": "アドオン",
+        "effectiveUsage": "有効値 / 使用量"
       },
       "addonDialog": {
         "title": "アドオン編集",
         "description": "アドオンボーナスを調整 —",
-        "memory": "Memory Bonus",
-        "mcp": "MCP Calls/day Bonus",
-        "members": "Member Bonus",
-        "contexts": "Extra Contexts",
-        "analysis": "Analysis Runs Bonus",
-        "effective": "Effective",
-        "used": "used",
+        "memory": "メモリーボーナス",
+        "mcp": "MCP 呼び出しボーナス",
+        "members": "メンバーボーナス",
+        "contexts": "追加コンテキスト",
+        "analysis": "分析実行ボーナス",
+        "effective": "有効値",
+        "used": "使用中",
         "save": "保存",
         "reductionWarning": "メンバーまたはコンテキストのアドオンを減らすと、現在の使用量が新しい有効制限を超える場合は拒否されます。（メンバー: {members} 使用中、コンテキスト: {contexts} 使用中）"
       },

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2118,7 +2118,8 @@
       "messages": {
         "loadError": "ワークスペースの読み込みに失敗しました",
         "changeSuccess": "プランを{oldPlan}から{newPlan}に変更しました",
-        "changeError": "ティアの変更に失敗しました"
+        "changeError": "ティアの変更に失敗しました",
+        "addonUpdateSuccess": "アドオンを更新しました"
       }
     },
     "users": {


### PR DESCRIPTION
Closes #542

## Summary
- Locale-aware cluster labeling: backend resolves user locale and switches LLM prompts between English and Japanese (Issue #542)
- Profile page: add locale Select (en/ja) with save/cancel support, matching backend fallback
- Admin plans page: i18n-ize hardcoded English strings (quota headers, addon dialog, owner display)
- Analysis UI: fix cluster description truncation, quota error i18n, representative summary formatting
- Addon dialog: add analysis_runs bonus field and unit-price labels

## Implementation notes
- `backend/src/services/analysis/labeler.py` uses `string.Template.substitute()` instead of `.format()` to avoid KeyError from user-generated memory summaries
- Locale prompt selection uses a `_PROMPT_MAP` dict for future language extensibility
- Orchestrator selects `User.locale` only (not full row) before calling labeler
- `UpdateUserProfileRequest.locale` has `pattern="^(en|ja)$"` schema validation
- `String()` cast on next-intl params prevents type errors for quota error display

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: not run (ship-only mode)
- review provider: copilot

🤖 Generated via /gh-issue-driven:ship
