### PR TITLE
fix(db): correct alembic down_revision to match actual revision ID

### DIFF
--- a/backend/alembic/versions/d08_536_device_code_grant.py
+++ b/backend/alembic/versions/d08_536_device_code_grant.py
@@ -1,7 +1,7 @@
 """Device Authorization Grant (RFC 8628) — oauth_device_codes table (Issue #536).
 
 Revision ID: d08_536_device_code_grant
-Revises: d08_496_analyses_cancellation
+Revises: d08_496_analyses_cancel
 """
 
 from collections.abc import Sequence
@@ -10,7 +10,7 @@ from alembic import op
 from sqlalchemy import Column, DateTime, Integer, String, text
 
 revision: str = "d08_536_device_code_grant"
-down_revision: str | Sequence[str] | None = "d08_496_analyses_cancellation"
+down_revision: str | Sequence[str] | None = "d08_496_analyses_cancel"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Summary
Fixes alembic `KeyError: 'd08_496_analyses_cancellation'` that blocked production deploy.

## Root cause
`d08_536_device_code_grant.py` declared `down_revision = \"d08_496_analyses_cancellation\"` but the preceding migration file (`d08_496_analyses_cancellation.py`) declares `revision = \"d08_496_analyses_cancel\"` (intentionally truncated to 24 chars to stay within the `VARCHAR(32)` cap). Alembic indexes migrations by their internal `revision` variable, not by filename, so the reference mismatch caused a `KeyError`.

## Fix
Update `down_revision` in `d08_536_device_code_grant.py` to reference the actual revision ID `d08_496_analyses_cancel`.

## Verification
```
$ alembic history
d07_495_cluster_label_phase -> d08_496_analyses_cancel ...
d08_496_analyses_cancel -> d08_536_device_code_grant (head) ...
```

🤖 Generated with [Claude Code](https://claude.com/code)