### PR TITLE
fix(i18n): rename Broadlistening Analyses to Meta Analysis, add missing noReportsHint (#547)

### DIFF
--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2441,6 +2441,7 @@
       "messages": {
         "loadError": "Failed to load sleep reports",
         "noReports": "No sleep reports found.",
+        "noReportsHint": "Sleep maintenance runs automatically. Reports will appear here after the first run completes.",
         "notFound": "Sleep report not found.",
         "runStarted": "Sleep run started",
         "runStartedDesc": "Maintenance is running in the background. The list will refresh shortly.",
@@ -3126,7 +3127,7 @@
   "analyses": {
     "tabLabel": "Analyses",
     "header": {
-      "title": "Broadlistening Analyses",
+      "title": "Meta Analysis",
       "subtitle": "Survey the shape of your memories with cluster overview · Owner only"
     },
     "actions": {
@@ -3248,7 +3249,7 @@
       },
       "notEnabled": {
         "title": "Analyses are not yet enabled for this workspace",
-        "description": "Memory Broadlistening is gated to selected workspaces during the v1 rollout. Reach out if you would like access."
+        "description": "Meta analysis is gated to selected workspaces during the v1 rollout. Reach out if you would like access."
       },
       "loadFailed": "Failed to load analyses — check connection and try again."
     }

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2441,6 +2441,7 @@
       "messages": {
         "loadError": "Sleep レポートの読み込みに失敗しました",
         "noReports": "Sleep レポートが見つかりません。",
+        "noReportsHint": "Sleep メンテナンスは自動的に実行されます。最初の実行が完了すると、ここにレポートが表示されます。",
         "notFound": "Sleep レポートが見つかりません。",
         "runStarted": "Sleep 実行を開始しました",
         "runStartedDesc": "バックグラウンドで Maintenance を実行中です。一覧はまもなく更新されます。",
@@ -3126,7 +3127,7 @@
   "analyses": {
     "tabLabel": "分析",
     "header": {
-      "title": "ブロードリスニング分析",
+      "title": "メタ分析",
       "subtitle": "クラスタ俯瞰で memory の地形を見る · Owner のみ"
     },
     "actions": {
@@ -3248,7 +3249,7 @@
       },
       "notEnabled": {
         "title": "この workspace では Analyses はまだ有効化されていません",
-        "description": "Memory Broadlistening は v1 ロールアウト中、選定された workspace に限定されています。アクセスをご希望の場合はお問い合わせください。"
+        "description": "メタ分析は v1 ロールアウト中、選定された workspace に限定されています。アクセスをご希望の場合はお問い合わせください。"
       },
       "loadFailed": "Analyses の読み込みに失敗しました — 接続を確認してください。"
     }


### PR DESCRIPTION
## Summary
- Rename "ブロードリスニング分析" → "メタ分析" (ja) / "Broadlistening Analyses" → "Meta Analysis" (en)
- Add missing `admin.sleepReports.messages.noReportsHint` key to both locales
- Update allowlist gate description text to use the new naming

## Test plan
- [x] Open Analyses tab → heading reads "メタ分析" (ja) / "Meta Analysis" (en)
- [x] Open Sleep Reports page with no reports → empty state hint renders without MISSING_MESSAGE error

🤖 Generated with [Claude Code](https://claude.com/claude-code)