### PR TITLE
feat(api,observability): admin BM25 drift term reveal endpoint + cron enablement (#377, #378)

### DIFF
--- a/backend/src/api/routes/bm25_drift.py
+++ b/backend/src/api/routes/bm25_drift.py
@@ -441,6 +441,51 @@ async def reveal_drift_terms(
         # is an upstream bug, not a routable identity.
         raise HTTPException(status_code=500, detail="Admin identity missing sub/user_id.")
 
+    # Rate limit FIRST, before any DB/Qdrant work. Otherwise an attacker
+    # can probe row_ids without consuming budget and add load to the DB.
+    try:
+        count = await increment_counter(f"rate:bm25_reveal:{user_sub}", ttl=3600)
+    except RedisError:
+        # Fail-closed: rate limit is part of the threat model for this admin
+        # endpoint, so treat Redis unavailability as a deny. Audit the
+        # attempt with outcome=rate_limit_unavailable so security teams can
+        # distinguish "user was rate-limited" from "rate-limit infra broke".
+        await _write_reveal_audit(
+            db,
+            admin,
+            user_sub,
+            row_id,
+            outcome="rate_limit_unavailable",
+            reason=body.reason,
+            context_id=None,
+            num_terms_resolved=0,
+            num_terms_total=0,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Rate limit service unavailable.",
+        ) from None
+    if count > settings.bm25_reveal_rate_limit_per_hour:
+        await _write_reveal_audit(
+            db,
+            admin,
+            user_sub,
+            row_id,
+            outcome="rate_limited",
+            reason=body.reason,
+            context_id=None,
+            num_terms_resolved=0,
+            num_terms_total=0,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                f"BM25 reveal rate limit exceeded "
+                f"({settings.bm25_reveal_rate_limit_per_hour}/hour). "
+                f"Try again later."
+            ),
+        )
+
     row_result = await db.execute(select(Bm25IdfDriftLog).where(Bm25IdfDriftLog.id == row_id))
     row = row_result.scalar_one_or_none()
     if row is None:
@@ -458,49 +503,6 @@ async def reveal_drift_terms(
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Drift log {row_id} not found.",
-        )
-
-    try:
-        count = await increment_counter(f"rate:bm25_reveal:{user_sub}", ttl=3600)
-    except RedisError:
-        # Fail-closed: rate limit is part of the threat model for this admin
-        # endpoint, so treat Redis unavailability as a deny. Audit the
-        # attempt with outcome=rate_limit_unavailable so security teams can
-        # distinguish "user was rate-limited" from "rate-limit infra broke".
-        await _write_reveal_audit(
-            db,
-            admin,
-            user_sub,
-            row_id,
-            outcome="rate_limit_unavailable",
-            reason=body.reason,
-            context_id=str(row.context_id),
-            num_terms_resolved=0,
-            num_terms_total=0,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Rate limit service unavailable.",
-        ) from None
-    if count > settings.bm25_reveal_rate_limit_per_hour:
-        await _write_reveal_audit(
-            db,
-            admin,
-            user_sub,
-            row_id,
-            outcome="rate_limited",
-            reason=body.reason,
-            context_id=str(row.context_id),
-            num_terms_resolved=0,
-            num_terms_total=0,
-        )
-        raise HTTPException(
-            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
-            detail=(
-                f"BM25 reveal rate limit exceeded "
-                f"({settings.bm25_reveal_rate_limit_per_hour}/hour). "
-                f"Try again later."
-            ),
         )
 
     top_terms: list[dict[str, Any]] = row.top_divergent_terms or []

--- a/backend/src/api/routes/bm25_drift.py
+++ b/backend/src/api/routes/bm25_drift.py
@@ -1,9 +1,8 @@
 """BM25 IDF drift admin API.
 
 Issue #343: read-only list/detail of bm25_idf_drift_log rows + manual
-trigger for dev/staging. All endpoints are admin-only and tagged
-`(preview)` because the underlying cron is disabled in production until
-v0.14.0.
+trigger for dev/staging + plaintext term reveal endpoint (#377).
+All endpoints are admin-only.
 """
 
 from __future__ import annotations
@@ -15,23 +14,29 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from pydantic import BaseModel
+from pydantic import Field as PydanticField
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import require_admin
+from auth.dependencies import AdminUser, require_admin
+from config.settings import get_settings
 from db.base import get_db
+from db.qdrant import QDRANT_TOKEN_PAYLOAD_FIELDS, scroll_context_points
+from db.redis import increment_counter
 from models.api_base import TZAwareBaseModel
-from models.auth import Context
+from models.auth import AuditLog, Context
 from models.bm25_drift import Bm25IdfDriftLog
 from services.bm25_drift.orchestrator import Bm25DriftOrchestrator
 from services.bm25_drift.psi_calculator import PsiStatus
 from utils.logger import get_logger
+from utils.sparse_vector import hash_token
+from utils.tokenizer import tokenize_for_search
 
 logger = get_logger(__name__)
 
 router = APIRouter(
     prefix="/admin/bm25-drift",
-    tags=["bm25-drift (preview)"],
+    tags=["bm25-drift"],
 )
 
 
@@ -86,6 +91,34 @@ class Bm25DriftRunRequest(BaseModel):
 
 class Bm25DriftRunResponse(BaseModel):
     scheduled_context_count: int
+
+
+class Bm25DriftRevealRequest(BaseModel):
+    """Body for POST /admin/bm25-drift/{row_id}/reveal-terms."""
+
+    reason: str = PydanticField(
+        ...,
+        min_length=10,
+        description="Justification for viewing plaintext terms (audit-logged)",
+    )
+
+
+class ResolvedTermEntry(BaseModel):
+    """Single entry from top_divergent_terms with resolved token."""
+
+    index: int
+    df_memory: float
+    df_global: float
+    idf_memory: float
+    idf_global: float
+    delta: float
+    token: str | None = None
+
+
+class Bm25DriftRevealResponse(Bm25DriftDetail):
+    """Drift detail + resolved plaintext terms."""
+
+    resolved_terms: list[ResolvedTermEntry]
 
 
 # Single source of truth for the status enum: derive from the Literal in
@@ -179,25 +212,7 @@ async def get_drift_log_detail(
             detail=f"Drift log {row_id} not found.",
         )
 
-    ctx_result = await db.execute(
-        select(Context.id, Context.name, Context.display_name, Context.deleted_at).where(
-            Context.id == row.context_id
-        )
-    )
-    ctx_row = ctx_result.first()
-    context_deleted = False
-    if ctx_row is not None:
-        _cid, cname, cdisplay, cdeleted = ctx_row
-        if cdeleted is not None:
-            row.context_name = None
-            context_deleted = True
-        else:
-            row.context_name = cdisplay or cname
-    else:
-        row.context_name = None
-        context_deleted = True
-
-    row.context_deleted = context_deleted
+    await _apply_context_name(db, row)
 
     # Audit log — terms count only, never term content.
     logger.info(
@@ -291,3 +306,157 @@ async def _run_drift_job(context_id: UUID) -> None:
                 exc_info=True,
             )
         return
+
+
+async def _apply_context_name(db: AsyncSession, row: Bm25IdfDriftLog) -> None:
+    """Set synthetic row.context_name + row.context_deleted from the Context table.
+
+    These attributes are not mapped columns on Bm25IdfDriftLog — assigning
+    to them populates response shape without dirtying the SQLAlchemy session.
+    """
+    ctx_result = await db.execute(
+        select(Context.name, Context.display_name, Context.deleted_at).where(
+            Context.id == row.context_id
+        )
+    )
+    ctx_row = ctx_result.first()
+    if ctx_row is None:
+        row.context_name = None
+        row.context_deleted = True
+        return
+    cname, cdisplay, cdeleted = ctx_row
+    if cdeleted is not None:
+        row.context_name = None
+        row.context_deleted = True
+    else:
+        row.context_name = cdisplay or cname
+        row.context_deleted = False
+
+
+def _resolve_payload_tokens(points: list, needed: set[int]) -> dict[int, str]:
+    """Return {hash: token} for indices in `needed`, scanning payloads with early exit.
+
+    Reads pre-tokenized fields populated by memory_service. Falls back to
+    re-tokenizing summary text only for legacy points written before the
+    token payload fields existed. Stops as soon as every requested index
+    has been resolved — for a context with millions of unique tokens but
+    only ~20 needed, this caps work near the first few points.
+    """
+    found: dict[int, str] = {}
+
+    def _scan(tokens_str: str) -> bool:
+        for tok in tokens_str.split():
+            h = hash_token(tok)
+            if h in needed and h not in found:
+                found[h] = tok
+                if len(found) == len(needed):
+                    return True
+        return False
+
+    for point in points:
+        if len(found) == len(needed):
+            return found
+        payload = point.payload or {}
+        token_strs = [s for s in (payload.get(f) for f in QDRANT_TOKEN_PAYLOAD_FIELDS) if s]
+        if token_strs:
+            for s in token_strs:
+                if _scan(s):
+                    return found
+            continue
+        for text_field in ("summary", "context_summary"):
+            text = payload.get(text_field)
+            if text and _scan(tokenize_for_search(text)):
+                return found
+    return found
+
+
+@router.post("/{row_id}/reveal-terms", response_model=Bm25DriftRevealResponse)
+async def reveal_drift_terms(
+    row_id: int,
+    body: Bm25DriftRevealRequest,
+    admin: AdminUser,
+    db: AsyncSession = Depends(get_db),
+) -> Bm25DriftRevealResponse:
+    """Resolve mmh3-hashed term indices in top_divergent_terms to plaintext.
+
+    Reads pre-tokenized fields from the Qdrant payload (see
+    QDRANT_TOKEN_PAYLOAD_FIELDS) populated by memory_service, recomputes
+    mmh3 hashes via utils.sparse_vector.hash_token, and matches against
+    the stored indices. Falls back to re-tokenizing summary text only
+    for legacy points written before the token payload fields existed.
+    Rate-limited per user. Every call is audit-logged to both the DB
+    and structlog (term content is never logged).
+    """
+    settings = get_settings()
+
+    row_result = await db.execute(select(Bm25IdfDriftLog).where(Bm25IdfDriftLog.id == row_id))
+    row = row_result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Drift log {row_id} not found.",
+        )
+
+    user_sub = admin.get("sub") or admin.get("user_id")
+    if not user_sub:
+        # require_admin guarantees an authenticated dict; missing both keys
+        # is an upstream bug, not a routable identity.
+        raise HTTPException(status_code=500, detail="Admin identity missing sub/user_id.")
+    count = await increment_counter(f"rate:bm25_reveal:{user_sub}", ttl=3600)
+    if count > settings.bm25_reveal_rate_limit_per_hour:
+        raise HTTPException(
+            status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+            detail=(
+                f"BM25 reveal rate limit exceeded "
+                f"({settings.bm25_reveal_rate_limit_per_hour}/hour). "
+                f"Try again later."
+            ),
+        )
+
+    top_terms: list[dict[str, Any]] = row.top_divergent_terms or []
+    needed: set[int] = {entry["index"] for entry in top_terms}
+    if needed:
+        points = await scroll_context_points(
+            str(row.context_id),
+            with_payload=[*QDRANT_TOKEN_PAYLOAD_FIELDS, "summary", "context_summary"],
+        )
+        hash_to_token = _resolve_payload_tokens(points, needed)
+    else:
+        hash_to_token = {}
+
+    resolved_terms = [
+        ResolvedTermEntry(**entry, token=hash_to_token.get(entry["index"])) for entry in top_terms
+    ]
+    resolved_count = sum(1 for t in resolved_terms if t.token is not None)
+
+    await _apply_context_name(db, row)
+
+    audit = AuditLog(
+        user_email=admin.get("email", "unknown"),
+        user_id=user_sub,
+        action="bm25_drift_reveal_terms",
+        resource=f"bm25_drift_log:{row_id}",
+        user_metadata={
+            "context_id": str(row.context_id),
+            "reason": body.reason,
+            "num_terms_resolved": resolved_count,
+            "num_terms_total": len(top_terms),
+        },
+    )
+    db.add(audit)
+    await db.commit()
+
+    logger.info(
+        "bm25_drift_terms_revealed",
+        row_id=row_id,
+        context_id=str(row.context_id),
+        reason=body.reason,
+        num_terms_resolved=resolved_count,
+        num_terms_total=len(top_terms),
+    )
+
+    detail = Bm25DriftDetail.model_validate(row, from_attributes=True)
+    return Bm25DriftRevealResponse(
+        **detail.model_dump(),
+        resolved_terms=resolved_terms,
+    )

--- a/backend/src/api/routes/bm25_drift.py
+++ b/backend/src/api/routes/bm25_drift.py
@@ -28,6 +28,7 @@ from models.auth import AuditLog, Context
 from models.bm25_drift import Bm25IdfDriftLog
 from services.bm25_drift.orchestrator import Bm25DriftOrchestrator
 from services.bm25_drift.psi_calculator import PsiStatus
+from services.context_routing import resolve_collection_name
 from utils.exceptions import RedisError
 from utils.logger import get_logger
 from utils.sparse_vector import hash_token
@@ -506,9 +507,15 @@ async def reveal_drift_terms(
     needed: set[int] = {entry["index"] for entry in top_terms}
     hash_to_token: dict[int, str] = {}
     if needed:
+        # Resolve the per-context collection (matches what the drift writer
+        # uses in services/bm25_drift/orchestrator.py); contexts on
+        # non-default embedding configs live in `kagura_memories_<model>_<dim>`,
+        # so a default-collection scroll would find zero matching points.
+        collection_name = await resolve_collection_name(db, row.context_id)
         async for page in scroll_context_points(
             str(row.context_id),
             with_payload=[*QDRANT_TOKEN_PAYLOAD_FIELDS, "summary", "context_summary"],
+            collection_name=collection_name,
         ):
             _resolve_payload_tokens(page, needed, hash_to_token)
             if len(hash_to_token) == len(needed):

--- a/backend/src/api/routes/bm25_drift.py
+++ b/backend/src/api/routes/bm25_drift.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import AdminUser, require_admin
 from config.settings import get_settings
 from db.base import get_db
-from db.qdrant import QDRANT_TOKEN_PAYLOAD_FIELDS, scroll_context_points
+from db.qdrant import QDRANT_TOKEN_PAYLOAD_FIELDS, _admin_scroll_context_points
 from db.redis import increment_counter
 from models.api_base import TZAwareBaseModel
 from models.auth import AuditLog, Context
@@ -514,7 +514,7 @@ async def reveal_drift_terms(
         # non-default embedding configs live in `kagura_memories_<model>_<dim>`,
         # so a default-collection scroll would find zero matching points.
         collection_name = await resolve_collection_name(db, row.context_id)
-        async for page in scroll_context_points(
+        async for page in _admin_scroll_context_points(
             str(row.context_id),
             with_payload=[*QDRANT_TOKEN_PAYLOAD_FIELDS, "summary", "context_summary"],
             collection_name=collection_name,

--- a/backend/src/api/routes/bm25_drift.py
+++ b/backend/src/api/routes/bm25_drift.py
@@ -28,6 +28,7 @@ from models.auth import AuditLog, Context
 from models.bm25_drift import Bm25IdfDriftLog
 from services.bm25_drift.orchestrator import Bm25DriftOrchestrator
 from services.bm25_drift.psi_calculator import PsiStatus
+from utils.exceptions import RedisError
 from utils.logger import get_logger
 from utils.sparse_vector import hash_token
 from utils.tokenizer import tokenize_for_search
@@ -458,7 +459,28 @@ async def reveal_drift_terms(
             detail=f"Drift log {row_id} not found.",
         )
 
-    count = await increment_counter(f"rate:bm25_reveal:{user_sub}", ttl=3600)
+    try:
+        count = await increment_counter(f"rate:bm25_reveal:{user_sub}", ttl=3600)
+    except RedisError:
+        # Fail-closed: rate limit is part of the threat model for this admin
+        # endpoint, so treat Redis unavailability as a deny. Audit the
+        # attempt with outcome=rate_limit_unavailable so security teams can
+        # distinguish "user was rate-limited" from "rate-limit infra broke".
+        await _write_reveal_audit(
+            db,
+            admin,
+            user_sub,
+            row_id,
+            outcome="rate_limit_unavailable",
+            reason=body.reason,
+            context_id=str(row.context_id),
+            num_terms_resolved=0,
+            num_terms_total=0,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Rate limit service unavailable.",
+        ) from None
     if count > settings.bm25_reveal_rate_limit_per_hour:
         await _write_reveal_audit(
             db,

--- a/backend/src/api/routes/bm25_drift.py
+++ b/backend/src/api/routes/bm25_drift.py
@@ -333,16 +333,22 @@ async def _apply_context_name(db: AsyncSession, row: Bm25IdfDriftLog) -> None:
         row.context_deleted = False
 
 
-def _resolve_payload_tokens(points: list, needed: set[int]) -> dict[int, str]:
-    """Return {hash: token} for indices in `needed`, scanning payloads with early exit.
+def _resolve_payload_tokens(
+    points: list,
+    needed: set[int],
+    found: dict[int, str] | None = None,
+) -> dict[int, str]:
+    """Accumulate {hash: token} for indices in `needed`, scanning a single page with early exit.
 
     Reads pre-tokenized fields populated by memory_service. Falls back to
     re-tokenizing summary text only for legacy points written before the
     token payload fields existed. Stops as soon as every requested index
-    has been resolved — for a context with millions of unique tokens but
-    only ~20 needed, this caps work near the first few points.
+    has been resolved. The optional `found` argument lets the caller share
+    one accumulator across multiple scroll pages (the streaming-page path
+    in reveal_drift_terms relies on this so memory stays bounded).
     """
-    found: dict[int, str] = {}
+    if found is None:
+        found = {}
 
     def _scan(tokens_str: str) -> bool:
         for tok in tokens_str.split():
@@ -370,6 +376,42 @@ def _resolve_payload_tokens(points: list, needed: set[int]) -> dict[int, str]:
     return found
 
 
+async def _write_reveal_audit(
+    db: AsyncSession,
+    admin: dict,
+    user_sub: str,
+    row_id: int,
+    *,
+    outcome: str,
+    reason: str,
+    context_id: str | None,
+    num_terms_resolved: int,
+    num_terms_total: int,
+) -> None:
+    """Persist an AuditLog row for any reveal-terms attempt (success or denied).
+
+    Called from every terminal branch that has an authenticated identity so
+    security teams have a reconstructable access trail (success / row_not_found
+    / rate_limited). Term content is never logged.
+    """
+    db.add(
+        AuditLog(
+            user_email=admin.get("email", "unknown"),
+            user_id=user_sub,
+            action="bm25_drift_reveal_terms",
+            resource=f"bm25_drift_log:{row_id}",
+            user_metadata={
+                "outcome": outcome,
+                "context_id": context_id,
+                "reason": reason,
+                "num_terms_resolved": num_terms_resolved,
+                "num_terms_total": num_terms_total,
+            },
+        )
+    )
+    await db.commit()
+
+
 @router.post("/{row_id}/reveal-terms", response_model=Bm25DriftRevealResponse)
 async def reveal_drift_terms(
     row_id: int,
@@ -384,26 +426,51 @@ async def reveal_drift_terms(
     mmh3 hashes via utils.sparse_vector.hash_token, and matches against
     the stored indices. Falls back to re-tokenizing summary text only
     for legacy points written before the token payload fields existed.
-    Rate-limited per user. Every call is audit-logged to both the DB
-    and structlog (term content is never logged).
+    Streams Qdrant pages and breaks as soon as every requested hash is
+    resolved, so memory stays bounded for million-point contexts.
+    Rate-limited per user. Every terminal branch (success / 404 /
+    rate-limited) writes an AuditLog row; term content is never logged.
     """
     settings = get_settings()
-
-    row_result = await db.execute(select(Bm25IdfDriftLog).where(Bm25IdfDriftLog.id == row_id))
-    row = row_result.scalar_one_or_none()
-    if row is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Drift log {row_id} not found.",
-        )
 
     user_sub = admin.get("sub") or admin.get("user_id")
     if not user_sub:
         # require_admin guarantees an authenticated dict; missing both keys
         # is an upstream bug, not a routable identity.
         raise HTTPException(status_code=500, detail="Admin identity missing sub/user_id.")
+
+    row_result = await db.execute(select(Bm25IdfDriftLog).where(Bm25IdfDriftLog.id == row_id))
+    row = row_result.scalar_one_or_none()
+    if row is None:
+        await _write_reveal_audit(
+            db,
+            admin,
+            user_sub,
+            row_id,
+            outcome="row_not_found",
+            reason=body.reason,
+            context_id=None,
+            num_terms_resolved=0,
+            num_terms_total=0,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Drift log {row_id} not found.",
+        )
+
     count = await increment_counter(f"rate:bm25_reveal:{user_sub}", ttl=3600)
     if count > settings.bm25_reveal_rate_limit_per_hour:
+        await _write_reveal_audit(
+            db,
+            admin,
+            user_sub,
+            row_id,
+            outcome="rate_limited",
+            reason=body.reason,
+            context_id=str(row.context_id),
+            num_terms_resolved=0,
+            num_terms_total=0,
+        )
         raise HTTPException(
             status_code=status.HTTP_429_TOO_MANY_REQUESTS,
             detail=(
@@ -415,14 +482,15 @@ async def reveal_drift_terms(
 
     top_terms: list[dict[str, Any]] = row.top_divergent_terms or []
     needed: set[int] = {entry["index"] for entry in top_terms}
+    hash_to_token: dict[int, str] = {}
     if needed:
-        points = await scroll_context_points(
+        async for page in scroll_context_points(
             str(row.context_id),
             with_payload=[*QDRANT_TOKEN_PAYLOAD_FIELDS, "summary", "context_summary"],
-        )
-        hash_to_token = _resolve_payload_tokens(points, needed)
-    else:
-        hash_to_token = {}
+        ):
+            _resolve_payload_tokens(page, needed, hash_to_token)
+            if len(hash_to_token) == len(needed):
+                break
 
     resolved_terms = [
         ResolvedTermEntry(**entry, token=hash_to_token.get(entry["index"])) for entry in top_terms
@@ -431,20 +499,17 @@ async def reveal_drift_terms(
 
     await _apply_context_name(db, row)
 
-    audit = AuditLog(
-        user_email=admin.get("email", "unknown"),
-        user_id=user_sub,
-        action="bm25_drift_reveal_terms",
-        resource=f"bm25_drift_log:{row_id}",
-        user_metadata={
-            "context_id": str(row.context_id),
-            "reason": body.reason,
-            "num_terms_resolved": resolved_count,
-            "num_terms_total": len(top_terms),
-        },
+    await _write_reveal_audit(
+        db,
+        admin,
+        user_sub,
+        row_id,
+        outcome="success",
+        reason=body.reason,
+        context_id=str(row.context_id),
+        num_terms_resolved=resolved_count,
+        num_terms_total=len(top_terms),
     )
-    db.add(audit)
-    await db.commit()
 
     logger.info(
         "bm25_drift_terms_revealed",

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -260,6 +260,16 @@ class Settings(BaseSettings):
             s.strip().lower() for s in self.analysis_enabled_workspace_ids.split(",") if s.strip()
         ]
 
+    # BM25 IDF Drift (Issue #343, #378)
+    bm25_drift_cron_enabled: bool = Field(
+        default=False,
+        description="Enable BM25 IDF drift cron in production (Issue #378)",
+    )
+    bm25_reveal_rate_limit_per_hour: int = Field(
+        default=10,
+        description="Max BM25 reveal-terms calls per user per hour (Issue #377)",
+    )
+
     # Plan Tier Overrides (environment variable customization for OSS deployments)
     plan_free_max_contexts: int | None = Field(
         default=None, description="Override FREE plan max contexts per workspace"

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -1128,3 +1128,63 @@ async def delete_user_points(user_id: str) -> dict[str, int]:
             raise QdrantError(f"Failed to delete user points from {collection_name}: {e}") from e
 
     return deleted_per_collection
+
+
+# Payload field names that memory_service writes per point (issue #16),
+# read by the BM25 drift reveal-terms endpoint (#377). Source of truth so
+# writer (services/memory_service.py) and reader cannot drift apart.
+QDRANT_TOKEN_PAYLOAD_FIELDS: tuple[str, ...] = (
+    "summary_tokens",
+    "context_summary_tokens",
+    "content_tokens",
+    "summary_reading",
+)
+
+
+async def scroll_context_points(
+    context_id: str,
+    *,
+    with_vectors: bool = False,
+    with_payload: bool | list[str] = True,
+    collection_name: str = KAGURA_MEMORIES_COLLECTION,
+) -> list:
+    """Scroll all points for a context from Qdrant.
+
+    Admin-use only — deliberately skips workspace + user isolation so
+    every point in the context is returned regardless of ownership.
+    Used by the BM25 drift reveal-terms endpoint (#377) to rebuild the
+    token → mmh3-hash mapping for reverse lookup.
+
+    Args:
+        context_id: Context UUID string to filter on.
+        with_vectors: If True, include dense + sparse vectors in results.
+        with_payload: True for full payload, list[str] to fetch only
+            the named keys (recommended on hot paths to cut bandwidth).
+        collection_name: Qdrant collection name.
+
+    Returns:
+        List of qdrant_client.models.Record.
+    """
+    from qdrant_client.models import Record  # noqa: F811 - clarify return type intent
+
+    client = get_qdrant_client()
+    all_points: list[Record] = []
+    offset: str | int | None = None
+
+    while True:
+        points, next_offset = await client.scroll(
+            collection_name=collection_name,
+            scroll_filter=Filter(
+                must=[FieldCondition(key="context_id", match=MatchValue(value=context_id))]
+            ),
+            limit=200,
+            offset=offset,
+            with_payload=with_payload,
+            with_vectors=with_vectors,
+        )
+        all_points.extend(points)
+        if next_offset is None:
+            break
+        offset = next_offset
+
+    return all_points

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -9,6 +9,7 @@ Collection design (post Single Collection Migration, Issue #334):
 - Full-text index on summary + context_summary; keyword index on scope, type, context_id
 """
 
+from collections.abc import AsyncIterator
 from typing import Any
 from uuid import UUID
 
@@ -1147,13 +1148,18 @@ async def scroll_context_points(
     with_vectors: bool = False,
     with_payload: bool | list[str] = True,
     collection_name: str = KAGURA_MEMORIES_COLLECTION,
-) -> list:
-    """Scroll all points for a context from Qdrant.
+) -> AsyncIterator[list]:
+    """Yield Qdrant point pages for a context, one page at a time.
 
     Admin-use only — deliberately skips workspace + user isolation so
     every point in the context is returned regardless of ownership.
     Used by the BM25 drift reveal-terms endpoint (#377) to rebuild the
     token → mmh3-hash mapping for reverse lookup.
+
+    Yields pages (lists of Record) instead of materializing the full
+    point set so callers can break early once they have enough data —
+    a 100K-point context yields ~500 pages of 200, but the caller
+    typically needs only a handful of points to satisfy a reverse-lookup.
 
     Args:
         context_id: Context UUID string to filter on.
@@ -1162,13 +1168,10 @@ async def scroll_context_points(
             the named keys (recommended on hot paths to cut bandwidth).
         collection_name: Qdrant collection name.
 
-    Returns:
-        List of qdrant_client.models.Record.
+    Yields:
+        Successive lists of qdrant_client.models.Record, one per scroll page.
     """
-    from qdrant_client.models import Record  # noqa: F811 - clarify return type intent
-
     client = get_qdrant_client()
-    all_points: list[Record] = []
     offset: str | int | None = None
 
     while True:
@@ -1182,9 +1185,7 @@ async def scroll_context_points(
             with_payload=with_payload,
             with_vectors=with_vectors,
         )
-        all_points.extend(points)
+        yield points
         if next_offset is None:
             break
         offset = next_offset
-
-    return all_points

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -1142,17 +1142,21 @@ QDRANT_TOKEN_PAYLOAD_FIELDS: tuple[str, ...] = (
 )
 
 
-async def scroll_context_points(
+async def _admin_scroll_context_points(
     context_id: str,
     *,
     with_vectors: bool = False,
     with_payload: bool | list[str] = True,
     collection_name: str = KAGURA_MEMORIES_COLLECTION,
 ) -> AsyncIterator[list]:
-    """Yield Qdrant point pages for a context, one page at a time.
+    """Yield Qdrant point pages for a context, one page at a time. ADMIN-ONLY.
 
-    Admin-use only — deliberately skips workspace + user isolation so
-    every point in the context is returned regardless of ownership.
+    The leading underscore + `_admin_` prefix signal that this helper
+    deliberately skips workspace + user isolation so every point in the
+    context is returned regardless of ownership. New callers must opt
+    into the isolation bypass explicitly — do NOT use this from any
+    non-admin code path.
+
     Used by the BM25 drift reveal-terms endpoint (#377) to rebuild the
     token → mmh3-hash mapping for reverse lookup.
 

--- a/backend/src/tasks/bm25_drift_tasks.py
+++ b/backend/src/tasks/bm25_drift_tasks.py
@@ -4,7 +4,7 @@ Issue #343: scheduled job that walks every active context, computes the
 IDF distribution drift via Bm25DriftOrchestrator, and persists one
 bm25_idf_drift_log row per context per cycle.
 
-DISABLED IN PRODUCTION by default (BM25_DRIFT_CRON_ENABLED=false).
+Disabled by default (bm25_drift_cron_enabled=false).
 Mirrors the sleep_enabled precedent at neural/config.py:168.
 """
 
@@ -13,6 +13,7 @@ import os
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
+from config.settings import get_settings
 from db.base import get_db
 from utils.logger import get_logger
 
@@ -33,7 +34,8 @@ async def bm25_drift_maintenance_task() -> None:
     """
     logger.info("bm25_drift_task_started")
 
-    if os.getenv("BM25_DRIFT_CRON_ENABLED", "false").lower() != "true":
+    settings = get_settings()
+    if not settings.bm25_drift_cron_enabled:
         logger.info("bm25_drift_task_skipped", reason="bm25_drift_disabled")
         return
 
@@ -92,10 +94,8 @@ def schedule_bm25_drift_tasks(scheduler: AsyncIOScheduler) -> None:
     misconfigured environment cannot accidentally start emitting drift
     rows in production).
     """
-    # TODO(v0.14.0): enable BM25_DRIFT_CRON_ENABLED in production
-    # Blockers: #359 (Privacy Policy), #360 (right-to-erasure), and the
-    # follow-up "enable BM25_DRIFT_CRON_ENABLED" issue scoped to v0.14.0.
-    if os.getenv("BM25_DRIFT_CRON_ENABLED", "false").lower() != "true":
+    settings = get_settings()
+    if not settings.bm25_drift_cron_enabled:
         logger.info("bm25_drift_tasks_not_scheduled", reason="bm25_drift_disabled")
         return
 

--- a/backend/src/tasks/bm25_drift_tasks.py
+++ b/backend/src/tasks/bm25_drift_tasks.py
@@ -27,10 +27,11 @@ async def bm25_drift_maintenance_task() -> None:
     Bm25DriftOrchestrator per context with per-context commit/rollback —
     a failing context does not poison the rest of the cycle.
 
-    Only runs when BM25_DRIFT_CRON_ENABLED=true. The double-check inside
-    the task body (mirroring sleep_tasks.py) catches the case where the
-    scheduler somehow registered the job despite the registration-time
-    gate.
+    Only runs when settings.bm25_drift_cron_enabled is true (env var
+    BM25_DRIFT_CRON_ENABLED feeds the same setting via pydantic-settings).
+    The double-check inside the task body (mirroring sleep_tasks.py) catches
+    the case where the scheduler somehow registered the job despite the
+    registration-time gate.
     """
     logger.info("bm25_drift_task_started")
 

--- a/backend/src/tasks/bm25_drift_tasks.py
+++ b/backend/src/tasks/bm25_drift_tasks.py
@@ -90,10 +90,11 @@ async def bm25_drift_maintenance_task() -> None:
 def schedule_bm25_drift_tasks(scheduler: AsyncIOScheduler) -> None:
     """Schedule the BM25 IDF drift maintenance cron.
 
-    Only registers when BM25_DRIFT_CRON_ENABLED=true. The flag is read at
-    registration time AND inside the task body (defense in depth — a
-    misconfigured environment cannot accidentally start emitting drift
-    rows in production).
+    Only registers when settings.bm25_drift_cron_enabled is true (env var
+    BM25_DRIFT_CRON_ENABLED feeds the same setting via pydantic-settings).
+    The flag is read at registration time AND inside the task body (defense
+    in depth — a misconfigured environment cannot accidentally start
+    emitting drift rows in production).
     """
     settings = get_settings()
     if not settings.bm25_drift_cron_enabled:

--- a/backend/src/utils/sparse_vector.py
+++ b/backend/src/utils/sparse_vector.py
@@ -17,6 +17,16 @@ import mmh3
 from utils.tokenizer import tokenize_for_search
 
 
+def hash_token(token: str) -> int:
+    """Token-to-sparse-index hash used by the BM25 producer + drift consumer.
+
+    Centralized so the document writer (sparse vector builder) and the
+    drift-log reverse-lookup (reveal-terms endpoint) cannot diverge on
+    `signed=False` or hash seed.
+    """
+    return mmh3.hash(token, signed=False)
+
+
 def tokens_to_sparse_vector(
     tokens_str: str,
     weight: float = 1.0,
@@ -34,7 +44,7 @@ def tokens_to_sparse_vector(
         return {}
     tokens = tokens_str.split()
     counts = Counter(tokens)
-    return {mmh3.hash(token, signed=False): count * weight for token, count in counts.items()}
+    return {hash_token(token): count * weight for token, count in counts.items()}
 
 
 def build_document_sparse_vector(
@@ -124,6 +134,6 @@ def build_query_sparse_vector(query_tokens: str) -> tuple[list[int], list[float]
     if not query_tokens:
         return [], []
     unique_tokens = sorted(set(query_tokens.split()))
-    indices = [mmh3.hash(t, signed=False) for t in unique_tokens]
+    indices = [hash_token(t) for t in unique_tokens]
     values = [1.0] * len(indices)
     return indices, values

--- a/backend/tests/api/test_bm25_drift_admin.py
+++ b/backend/tests/api/test_bm25_drift_admin.py
@@ -198,7 +198,7 @@ class TestRevealTerms:
         async def _resolve(*_a, **_kw) -> str:
             return "kagura_memories_qwen3_1024"
 
-        monkeypatch.setattr(drift_route, "scroll_context_points", _scroll)
+        monkeypatch.setattr(drift_route, "_admin_scroll_context_points", _scroll)
         monkeypatch.setattr(drift_route, "increment_counter", _increment)
         monkeypatch.setattr(drift_route, "resolve_collection_name", _resolve)
         return scroll_calls, counter_calls
@@ -209,10 +209,12 @@ class TestRevealTerms:
         mock_db: MagicMock,
         patch_reveal_deps,
     ) -> None:
-        import mmh3
+        from utils.sparse_vector import hash_token
 
+        # Use the centralized helper so the test can't drift from the
+        # producer/consumer if the hash params (seed/signed) ever change.
         ctx_id = uuid4()
-        alpha_hash = mmh3.hash("alpha", signed=False)
+        alpha_hash = hash_token("alpha")
         row = _make_drift_row(context_id=ctx_id)
         row.top_divergent_terms = [
             {
@@ -314,7 +316,7 @@ class TestRevealTerms:
             # Default settings.bm25_reveal_rate_limit_per_hour = 10.
             return 11
 
-        monkeypatch.setattr(drift_route, "scroll_context_points", _scroll)
+        monkeypatch.setattr(drift_route, "_admin_scroll_context_points", _scroll)
         monkeypatch.setattr(drift_route, "increment_counter", _over_limit)
 
         resp = client.post(

--- a/backend/tests/api/test_bm25_drift_admin.py
+++ b/backend/tests/api/test_bm25_drift_admin.py
@@ -23,7 +23,12 @@ from db.base import get_db
 
 @pytest.fixture
 def admin_user() -> dict:
-    return {"email": "admin@example.com", "role": "admin"}
+    return {
+        "email": "admin@example.com",
+        "role": "admin",
+        "user_id": "admin-user-id",
+        "sub": "admin-sub",
+    }
 
 
 @pytest.fixture
@@ -127,7 +132,7 @@ class TestDetail:
         row_result = MagicMock()
         row_result.scalar_one_or_none.return_value = row
         ctx_result = MagicMock()
-        ctx_result.first.return_value = (ctx_id, "ctx-name", "Ctx Display", None)
+        ctx_result.first.return_value = ("ctx-name", "Ctx Display", None)
         mock_db.execute.side_effect = [row_result, ctx_result]
 
         resp = client.get("/api/v1/admin/bm25-drift/1")
@@ -153,7 +158,7 @@ class TestDetail:
         ctx_result = MagicMock()
         # deleted_at is non-null → context is treated as deleted.
         deleted_at = datetime(2026, 4, 1, tzinfo=UTC)
-        ctx_result.first.return_value = (ctx_id, "ctx", "Ctx", deleted_at)
+        ctx_result.first.return_value = ("ctx", "Ctx", deleted_at)
         mock_db.execute.side_effect = [row_result, ctx_result]
 
         resp = client.get("/api/v1/admin/bm25-drift/1")
@@ -161,6 +166,168 @@ class TestDetail:
         body = resp.json()
         assert body["row"]["context_deleted"] is True
         assert body["row"]["context_name"] is None
+
+
+class TestRevealTerms:
+    """Tests for POST /admin/bm25-drift/{row_id}/reveal-terms (#377)."""
+
+    @pytest.fixture
+    def patch_reveal_deps(self, monkeypatch: pytest.MonkeyPatch):
+        """Patch Qdrant scroll + Redis counter at the route module."""
+        from api.routes import bm25_drift as drift_route
+
+        scroll_calls: list[str] = []
+        counter_calls: list[tuple[str, int | None]] = []
+
+        async def _scroll(context_id: str, **_: object) -> list:
+            scroll_calls.append(context_id)
+            point = SimpleNamespace(
+                payload={
+                    "summary_tokens": "alpha beta gamma",
+                    "context_summary_tokens": "",
+                    "content_tokens": "",
+                    "summary_reading": "",
+                }
+            )
+            return [point]
+
+        async def _increment(key: str, ttl: int | None = None) -> int:
+            counter_calls.append((key, ttl))
+            return len(counter_calls)
+
+        monkeypatch.setattr(drift_route, "scroll_context_points", _scroll)
+        monkeypatch.setattr(drift_route, "increment_counter", _increment)
+        return scroll_calls, counter_calls
+
+    def test_returns_resolved_terms_on_success(
+        self,
+        client: TestClient,
+        mock_db: MagicMock,
+        patch_reveal_deps,
+    ) -> None:
+        import mmh3
+
+        ctx_id = uuid4()
+        alpha_hash = mmh3.hash("alpha", signed=False)
+        row = _make_drift_row(context_id=ctx_id)
+        row.top_divergent_terms = [
+            {
+                "index": alpha_hash,
+                "df_memory": 10,
+                "df_global": 50,
+                "idf_memory": 1.5,
+                "idf_global": 0.3,
+                "delta": 1.2,
+            },
+            {
+                "index": 99999999,  # unresolvable
+                "df_memory": 5,
+                "df_global": 25,
+                "idf_memory": 1.1,
+                "idf_global": 0.2,
+                "delta": 0.9,
+            },
+        ]
+        row_result = MagicMock()
+        row_result.scalar_one_or_none.return_value = row
+        ctx_result = MagicMock()
+        ctx_result.first.return_value = ("ctx", "Ctx", None)
+        mock_db.execute.side_effect = [row_result, ctx_result]
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        resp = client.post(
+            f"/api/v1/admin/bm25-drift/{row.id}/reveal-terms",
+            json={"reason": "Investigating drift alert PSI 0.31"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        terms = body["resolved_terms"]
+        assert len(terms) == 2
+        assert terms[0]["token"] == "alpha"
+        assert terms[1]["token"] is None
+        # Audit log was written and committed.
+        assert mock_db.add.call_count == 1
+        assert mock_db.commit.await_count == 1
+
+    def test_missing_row_returns_404(
+        self,
+        client: TestClient,
+        mock_db: MagicMock,
+        patch_reveal_deps,
+    ) -> None:
+        row_result = MagicMock()
+        row_result.scalar_one_or_none.return_value = None
+        mock_db.execute.side_effect = [row_result]
+
+        resp = client.post(
+            "/api/v1/admin/bm25-drift/9999/reveal-terms",
+            json={"reason": "Investigating drift alert PSI 0.31"},
+        )
+        assert resp.status_code == 404
+
+    def test_short_reason_returns_422(self, client: TestClient) -> None:
+        resp = client.post(
+            "/api/v1/admin/bm25-drift/1/reveal-terms",
+            json={"reason": "too short"},  # 9 chars, min is 10
+        )
+        assert resp.status_code == 422
+
+    def test_missing_reason_returns_422(self, client: TestClient) -> None:
+        resp = client.post("/api/v1/admin/bm25-drift/1/reveal-terms", json={})
+        assert resp.status_code == 422
+
+    def test_rate_limit_returns_429(
+        self,
+        client: TestClient,
+        mock_db: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from api.routes import bm25_drift as drift_route
+
+        ctx_id = uuid4()
+        row = _make_drift_row(context_id=ctx_id)
+        row_result = MagicMock()
+        row_result.scalar_one_or_none.return_value = row
+        mock_db.execute.side_effect = [row_result]
+
+        async def _scroll(*_a, **_kw):
+            return []
+
+        async def _over_limit(*_a, **_kw) -> int:
+            # Default settings.bm25_reveal_rate_limit_per_hour = 10.
+            return 11
+
+        monkeypatch.setattr(drift_route, "scroll_context_points", _scroll)
+        monkeypatch.setattr(drift_route, "increment_counter", _over_limit)
+
+        resp = client.post(
+            "/api/v1/admin/bm25-drift/1/reveal-terms",
+            json={"reason": "Investigating drift alert PSI 0.31"},
+        )
+        assert resp.status_code == 429
+
+    def test_non_admin_returns_403(self, mock_db: MagicMock) -> None:
+        """Non-admin role is rejected by require_admin (no override here)."""
+        from auth.dependencies import get_current_user
+
+        async def _non_admin():
+            return {"email": "user@example.com", "role": "user"}
+
+        async def _db():
+            yield mock_db
+
+        app.dependency_overrides[get_current_user] = _non_admin
+        app.dependency_overrides[get_db] = _db
+        try:
+            tc = TestClient(app, raise_server_exceptions=False)
+            resp = tc.post(
+                "/api/v1/admin/bm25-drift/1/reveal-terms",
+                json={"reason": "Investigating drift alert PSI 0.31"},
+            )
+            assert resp.status_code == 403
+        finally:
+            app.dependency_overrides.clear()
 
 
 class TestRunTrigger:

--- a/backend/tests/api/test_bm25_drift_admin.py
+++ b/backend/tests/api/test_bm25_drift_admin.py
@@ -173,14 +173,14 @@ class TestRevealTerms:
 
     @pytest.fixture
     def patch_reveal_deps(self, monkeypatch: pytest.MonkeyPatch):
-        """Patch Qdrant scroll + Redis counter at the route module."""
+        """Patch Qdrant scroll + Redis counter + collection routing at the route module."""
         from api.routes import bm25_drift as drift_route
 
-        scroll_calls: list[str] = []
+        scroll_calls: list[tuple[str, str | None]] = []
         counter_calls: list[tuple[str, int | None]] = []
 
-        async def _scroll(context_id: str, **_: object):
-            scroll_calls.append(context_id)
+        async def _scroll(context_id: str, **kw: object):
+            scroll_calls.append((context_id, kw.get("collection_name")))  # type: ignore[arg-type]
             point = SimpleNamespace(
                 payload={
                     "summary_tokens": "alpha beta gamma",
@@ -195,8 +195,12 @@ class TestRevealTerms:
             counter_calls.append((key, ttl))
             return len(counter_calls)
 
+        async def _resolve(*_a, **_kw) -> str:
+            return "kagura_memories_qwen3_1024"
+
         monkeypatch.setattr(drift_route, "scroll_context_points", _scroll)
         monkeypatch.setattr(drift_route, "increment_counter", _increment)
+        monkeypatch.setattr(drift_route, "resolve_collection_name", _resolve)
         return scroll_calls, counter_calls
 
     def test_returns_resolved_terms_on_success(
@@ -236,6 +240,7 @@ class TestRevealTerms:
         mock_db.add = MagicMock()
         mock_db.commit = AsyncMock()
 
+        scroll_calls, _ = patch_reveal_deps
         resp = client.post(
             f"/api/v1/admin/bm25-drift/{row.id}/reveal-terms",
             json={"reason": "Investigating drift alert PSI 0.31"},
@@ -249,6 +254,9 @@ class TestRevealTerms:
         # Audit log was written and committed.
         assert mock_db.add.call_count == 1
         assert mock_db.commit.await_count == 1
+        # Scroll was called with the per-context routed collection name.
+        assert len(scroll_calls) == 1
+        assert scroll_calls[0][1] == "kagura_memories_qwen3_1024"
 
     def test_missing_row_returns_404(
         self,

--- a/backend/tests/api/test_bm25_drift_admin.py
+++ b/backend/tests/api/test_bm25_drift_admin.py
@@ -318,6 +318,37 @@ class TestRevealTerms:
         assert mock_db.add.call_count == 1
         assert mock_db.commit.await_count == 1
 
+    def test_redis_error_returns_503_with_audit(
+        self,
+        client: TestClient,
+        mock_db: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Redis incident → fail-closed 503 + audit row with rate_limit_unavailable."""
+        from api.routes import bm25_drift as drift_route
+        from utils.exceptions import RedisError
+
+        ctx_id = uuid4()
+        row = _make_drift_row(context_id=ctx_id)
+        row_result = MagicMock()
+        row_result.scalar_one_or_none.return_value = row
+        mock_db.execute.side_effect = [row_result]
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        async def _redis_down(*_a, **_kw) -> int:
+            raise RedisError("connection refused")
+
+        monkeypatch.setattr(drift_route, "increment_counter", _redis_down)
+
+        resp = client.post(
+            "/api/v1/admin/bm25-drift/1/reveal-terms",
+            json={"reason": "Investigating drift alert PSI 0.31"},
+        )
+        assert resp.status_code == 503
+        assert mock_db.add.call_count == 1
+        assert mock_db.commit.await_count == 1
+
     def test_non_admin_returns_403(self, mock_db: MagicMock) -> None:
         """Non-admin role is rejected by require_admin (no override here)."""
         from auth.dependencies import get_current_user

--- a/backend/tests/api/test_bm25_drift_admin.py
+++ b/backend/tests/api/test_bm25_drift_admin.py
@@ -179,7 +179,7 @@ class TestRevealTerms:
         scroll_calls: list[str] = []
         counter_calls: list[tuple[str, int | None]] = []
 
-        async def _scroll(context_id: str, **_: object) -> list:
+        async def _scroll(context_id: str, **_: object):
             scroll_calls.append(context_id)
             point = SimpleNamespace(
                 payload={
@@ -189,7 +189,7 @@ class TestRevealTerms:
                     "summary_reading": "",
                 }
             )
-            return [point]
+            yield [point]
 
         async def _increment(key: str, ttl: int | None = None) -> int:
             counter_calls.append((key, ttl))
@@ -259,12 +259,17 @@ class TestRevealTerms:
         row_result = MagicMock()
         row_result.scalar_one_or_none.return_value = None
         mock_db.execute.side_effect = [row_result]
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
 
         resp = client.post(
             "/api/v1/admin/bm25-drift/9999/reveal-terms",
             json={"reason": "Investigating drift alert PSI 0.31"},
         )
         assert resp.status_code == 404
+        # 404 branch now writes a denied-attempt audit row.
+        assert mock_db.add.call_count == 1
+        assert mock_db.commit.await_count == 1
 
     def test_short_reason_returns_422(self, client: TestClient) -> None:
         resp = client.post(
@@ -290,9 +295,12 @@ class TestRevealTerms:
         row_result = MagicMock()
         row_result.scalar_one_or_none.return_value = row
         mock_db.execute.side_effect = [row_result]
+        mock_db.add = MagicMock()
+        mock_db.commit = AsyncMock()
 
         async def _scroll(*_a, **_kw):
-            return []
+            if False:
+                yield []  # pragma: no cover - never reached, still an async generator
 
         async def _over_limit(*_a, **_kw) -> int:
             # Default settings.bm25_reveal_rate_limit_per_hour = 10.
@@ -306,6 +314,9 @@ class TestRevealTerms:
             json={"reason": "Investigating drift alert PSI 0.31"},
         )
         assert resp.status_code == 429
+        # 429 branch now writes a denied-attempt audit row.
+        assert mock_db.add.call_count == 1
+        assert mock_db.commit.await_count == 1
 
     def test_non_admin_returns_403(self, mock_db: MagicMock) -> None:
         """Non-admin role is rejected by require_admin (no override here)."""

--- a/backend/tests/tasks/test_bm25_drift_tasks.py
+++ b/backend/tests/tasks/test_bm25_drift_tasks.py
@@ -14,10 +14,15 @@ from tasks.bm25_drift_tasks import (
 
 
 def _mock_settings(enabled: bool, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Replace get_settings with a controlled instance."""
+    """Replace get_settings with a controlled instance.
+
+    `_env_file=None` keeps the mock isolated — without it, Settings() reads
+    the repo's .env and runs unrelated validators (e.g. EMAIL_PROVIDER) that
+    can fail on environments missing those keys.
+    """
     monkeypatch.setattr(
         "tasks.bm25_drift_tasks.get_settings",
-        lambda: Settings(bm25_drift_cron_enabled=enabled),
+        lambda: Settings(_env_file=None, bm25_drift_cron_enabled=enabled),
     )
 
 

--- a/backend/tests/tasks/test_bm25_drift_tasks.py
+++ b/backend/tests/tasks/test_bm25_drift_tasks.py
@@ -6,29 +6,38 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from config.settings import Settings
 from tasks.bm25_drift_tasks import (
     bm25_drift_maintenance_task,
     schedule_bm25_drift_tasks,
 )
 
 
+def _mock_settings(enabled: bool, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace get_settings with a controlled instance."""
+    monkeypatch.setattr(
+        "tasks.bm25_drift_tasks.get_settings",
+        lambda: Settings(bm25_drift_cron_enabled=enabled),
+    )
+
+
 class TestSchedulerRegistration:
     """Sleeping-code discipline: cron must NOT register when env flag is unset."""
 
     def test_disabled_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("BM25_DRIFT_CRON_ENABLED", raising=False)
+        _mock_settings(False, monkeypatch)
         scheduler = MagicMock()
         schedule_bm25_drift_tasks(scheduler)
         scheduler.add_job.assert_not_called()
 
     def test_explicit_false_does_not_register(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("BM25_DRIFT_CRON_ENABLED", "false")
+        _mock_settings(False, monkeypatch)
         scheduler = MagicMock()
         schedule_bm25_drift_tasks(scheduler)
         scheduler.add_job.assert_not_called()
 
     def test_enabled_registers_cron_job(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("BM25_DRIFT_CRON_ENABLED", "true")
+        _mock_settings(True, monkeypatch)
         monkeypatch.setenv("BM25_DRIFT_CRON_HOUR", "5")
         monkeypatch.setenv("BM25_DRIFT_CRON_MINUTE", "30")
         scheduler = MagicMock()
@@ -44,15 +53,12 @@ class TestTaskBodyGate:
 
     @pytest.mark.asyncio
     async def test_task_skips_when_env_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("BM25_DRIFT_CRON_ENABLED", raising=False)
-        # No DB / orchestrator imports should happen — if they did, the
-        # absence of fixtures would raise. The fact that this returns
-        # without error is the assertion.
+        _mock_settings(False, monkeypatch)
         await bm25_drift_maintenance_task()
 
     @pytest.mark.asyncio
     async def test_task_skips_when_env_explicit_false(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        monkeypatch.setenv("BM25_DRIFT_CRON_ENABLED", "false")
+        _mock_settings(False, monkeypatch)
         await bm25_drift_maintenance_task()


### PR DESCRIPTION
Closes #377
Closes #378

## Summary
- **#377**: New admin endpoint `POST /admin/bm25-drift/{row_id}/reveal-terms` resolves mmh3-hashed term indices in `top_divergent_terms` to plaintext by reading Qdrant payload tokens (`summary_tokens` / `context_summary_tokens` / `content_tokens` / `summary_reading`). Includes `AdminUser` gate, per-user rate limit (default 10/h, configurable via `bm25_reveal_rate_limit_per_hour`), required `reason` field (>=10 chars), audit log on success (term content NEVER logged), early-exit token resolution capped at `len(top_divergent_terms)`, and a centralized `hash_token()` helper preventing writer/reader hash drift.
- **#378**: Migrate the BM25 drift cron gate from `os.getenv` to `settings.bm25_drift_cron_enabled`. Removes the `# TODO(v0.14.0)` marker and the `(preview)` OpenAPI tag. Production env flip (`BM25_DRIFT_CRON_ENABLED=true`) is an ops-side action — hard blockers #359 (Privacy Policy) and #360 (right-to-erasure) are CLOSED.
- Existing `get_drift_log_detail` endpoint refactored to use the new `_apply_context_name` helper (~15-line dedup, behavior-preserving).

## Implementation notes
- `utils/sparse_vector.hash_token()` becomes the single source of truth for `mmh3.hash(token, signed=False)`; existing call sites in `tokens_to_sparse_vector` and `build_query_sparse_vector` migrated.
- `db/qdrant.QDRANT_TOKEN_PAYLOAD_FIELDS` constant pins the payload field names read by the reveal endpoint. Writer-side adoption in `services/memory_service.py:2689-2701` is a follow-up.
- `db/qdrant.scroll_context_points` is admin-use-only — deliberately bypasses workspace + user isolation. Currently single-caller; a future rename to `_admin_scroll_context_points` is a recommended follow-up.
- `_resolve_payload_tokens` builds a `needed: set[int]` upfront and early-exits once every required hash has been resolved — caps work at the first few points for any context size.
- Tests: 13 admin route tests (incl. 6 new `TestRevealTerms` covering 200/403/404/422x2/429), 5 cron task tests, 22 sparse vector tests — all passing. Lint + type-check clean.

## Pre-PR review summary
- gate2 mode: advisor-only (binary gate not configured)
- audit: skipped (advisor-only mode default)
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (not escalated)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/377-batch-377-378.gate1.md
- ~/.claude/cache/gh-issue-driven/377-batch-377-378.gate2.md

🤖 Generated via /gh-issue-driven:ship
