### PR TITLE
feat(storage): platform-managed R2 object storage for file ingest BLOBs (#485)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -223,6 +223,38 @@ BILLING_ENABLED=false
 # BM25_DRIFT_CRON_MINUTE=0
 
 # -----------------------------------------------------------------------------
+# Object Storage / Cloudflare R2 (Issue #485 Phase 1)
+# -----------------------------------------------------------------------------
+# Platform-managed file storage for SDK File Ingestion BLOBs. Empty values
+# disable the file-storage feature entirely — the /api/v1/files routes and
+# MCP file tools return a clear error on first call until R2 is configured.
+#
+# Generate S3-compatible access keys in the Cloudflare R2 dashboard with
+# bucket-scoped permissions. One key per environment (dev/staging/prod).
+#
+# R2_ACCOUNT_ID=
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=
+# R2_BUCKET=kagura-memory-files-dev
+# R2_ENDPOINT_URL=https://<account_id>.r2.cloudflarestorage.com
+#
+# Per-file Phase 1 cap (MiB). Hard ceiling enforced server-side; clients
+# uploading more than this fail at upload-init.
+# FILE_OBJECT_MAX_SIZE_MB=100
+#
+# Presigned URL TTLs (seconds). PUT covers the time between upload-init
+# and the client's PUT completing; GET is the lifetime of a download
+# link. Both default to 5 minutes.
+# PRESIGN_PUT_TTL_SECONDS=300
+# PRESIGN_GET_TTL_SECONDS=300
+#
+# Per-tier storage caps (bytes; commented = uses defaults — see
+# config/plan_tiers.py: FREE 100 MiB / BASIC 1 GiB / PRO 10 GiB).
+# PLAN_FREE_STORAGE_LIMIT_BYTES=104857600    # 100 MiB
+# PLAN_BASIC_STORAGE_LIMIT_BYTES=1073741824  # 1 GiB
+# PLAN_PRO_STORAGE_LIMIT_BYTES=10737418240   # 10 GiB
+
+# -----------------------------------------------------------------------------
 # Production Deployment
 # -----------------------------------------------------------------------------
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -8,24 +8,25 @@ Database URL is read from DATABASE_URL environment variable
 import asyncio
 from logging.config import fileConfig
 
-from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
+import models.analysis  # noqa: F401  # Issue #494: Memory Broadlistening tables
+import models.auth  # noqa: F401
+import models.config  # noqa: F401
+import models.erasure  # noqa: F401
+import models.file_objects  # noqa: F401  # Issue #485: file storage tables
+import models.hub_tag  # noqa: F401
+import models.llm_pricing  # noqa: F401  # Issue #471: cost-grade pricing master
+import models.memory  # noqa: F401
+import models.neural  # noqa: F401
+import models.resource  # noqa: F401
+import models.sleep  # noqa: F401  # Issue #471: SleepReportLLMUsage child added
+from alembic import context
 from config.database import get_database_url
 
 # Import all models so autogenerate can detect them
 from db.base import Base  # noqa: F401
-import models.auth  # noqa: F401
-import models.memory  # noqa: F401
-import models.config  # noqa: F401
-import models.resource  # noqa: F401
-import models.neural  # noqa: F401
-import models.hub_tag  # noqa: F401
-import models.erasure  # noqa: F401
-import models.sleep  # noqa: F401  # Issue #471: SleepReportLLMUsage child added
-import models.llm_pricing  # noqa: F401  # Issue #471: cost-grade pricing master
-import models.analysis  # noqa: F401  # Issue #494: Memory Broadlistening tables
 
 # Alembic Config object
 config = context.config

--- a/backend/alembic/versions/e02_485_addon_storage_bonus_mb.py
+++ b/backend/alembic/versions/e02_485_addon_storage_bonus_mb.py
@@ -1,0 +1,50 @@
+"""Add addon_storage_bonus_mb column to workspaces (#485 prerequisite).
+
+Issue #485: Platform-managed R2 object storage. Phase 1 prerequisite —
+``AddonCalculatorService.recalculate_workspace_bonuses()`` already writes
+``workspace.addon_storage_bonus_mb``, but the column is missing from the
+``Workspace`` ORM model and the database. Any workspace with an
+``extra_storage`` addon row hits ``AttributeError`` on persist, blocking
+storage quota machinery.
+
+This migration adds the column with ``NOT NULL DEFAULT 0`` so existing
+rows are backfilled without table rewrite (PostgreSQL >= 11).
+
+The ``check_addon_type`` constraint on ``workspace_addons`` already
+accepts ``'extra_storage'`` (added in 2f53be30e6d6) so no constraint
+change is needed here.
+
+Revision ID: e02_485_addon_storage_mb
+Revises: e01_546_cache_write_pricing
+"""
+
+from alembic import op
+
+revision = "e02_485_addon_storage_mb"
+down_revision = "e01_546_cache_write_pricing"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add ``addon_storage_bonus_mb`` to ``workspaces`` (idempotent)."""
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'workspaces'
+                  AND column_name = 'addon_storage_bonus_mb'
+            ) THEN
+                ALTER TABLE workspaces
+                  ADD COLUMN addon_storage_bonus_mb INTEGER NOT NULL DEFAULT 0;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop ``addon_storage_bonus_mb`` from ``workspaces``."""
+    op.drop_column("workspaces", "addon_storage_bonus_mb")

--- a/backend/alembic/versions/e03_485_file_objects.py
+++ b/backend/alembic/versions/e03_485_file_objects.py
@@ -1,0 +1,151 @@
+"""Add file_objects + workspace_storage_usage + Memory.external_blob computed columns (#485).
+
+Issue #485 Phase 1 schema:
+
+- ``file_objects``: authoritative blob registry with the upload state
+  machine (``reserved | uploaded | failed``), partial-unique sha256
+  dedup per workspace, sweeper helper index on reserved expiries.
+- ``workspace_storage_usage``: denormalized per-workspace counter
+  updated atomically with ``file_objects`` insert/soft-delete to keep
+  quota reads off online ``SUM`` queries.
+- ``memories.external_blob_backend`` and ``memories.external_blob_ref``:
+  generated columns extracted from ``details->'external_blob'->>(...)``.
+  Mirrors the existing ``resource_id``/``resource_doc_id``/``resource_version``
+  Computed pattern. Partial btree on ``external_blob_ref`` (nullable
+  rows excluded) keeps the index size proportional to actual blob
+  usage rather than total memory rows.
+
+Revision ID: e03_485_file_objects
+Revises: e02_485_addon_storage_mb
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e03_485_file_objects"
+down_revision = "e02_485_addon_storage_mb"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Create file_objects + workspace_storage_usage + Memory generated cols."""
+
+    # ----- file_objects ---------------------------------------------------
+    op.create_table(
+        "file_objects",
+        sa.Column(
+            "id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("sha256", sa.String(64), nullable=False),
+        sa.Column("size_bytes", sa.BigInteger, nullable=False),
+        sa.Column("content_type", sa.String(255), nullable=False),
+        sa.Column("filename", sa.String(512), nullable=False),
+        sa.Column("storage_backend", sa.String(20), nullable=False, server_default="r2"),
+        sa.Column("storage_key", sa.String(1024), nullable=True),
+        sa.Column("inline_bytes", sa.dialects.postgresql.BYTEA(), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False, server_default="reserved"),
+        sa.Column("expires_at", sa.DateTime, nullable=True),
+        sa.Column("created_by", sa.String(255), nullable=False),
+        sa.Column("created_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.Column("uploaded_at", sa.DateTime, nullable=True),
+        sa.Column("deleted_at", sa.DateTime, nullable=True),
+        sa.CheckConstraint(
+            "storage_backend IN ('r2', 'pg_inline')",
+            name="valid_file_storage_backend",
+        ),
+        sa.CheckConstraint(
+            "status IN ('reserved', 'uploaded', 'failed')",
+            name="valid_file_status",
+        ),
+        sa.CheckConstraint(
+            "(status = 'reserved') "
+            "OR (storage_backend = 'r2' "
+            "    AND storage_key IS NOT NULL "
+            "    AND inline_bytes IS NULL) "
+            "OR (storage_backend = 'pg_inline' "
+            "    AND storage_key IS NULL "
+            "    AND inline_bytes IS NOT NULL)",
+            name="valid_file_storage_shape",
+        ),
+    )
+
+    op.create_index(
+        "ix_file_objects_workspace_id",
+        "file_objects",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "uq_file_objects_workspace_sha256_active",
+        "file_objects",
+        ["workspace_id", "sha256"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL AND status <> 'failed'"),
+    )
+    op.create_index(
+        "idx_file_objects_reserved_expires",
+        "file_objects",
+        ["expires_at"],
+        postgresql_where=sa.text("status = 'reserved'"),
+    )
+
+    # ----- workspace_storage_usage ---------------------------------------
+    op.create_table(
+        "workspace_storage_usage",
+        sa.Column(
+            "workspace_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("used_bytes", sa.BigInteger, nullable=False, server_default="0"),
+        sa.Column("file_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("updated_at", sa.DateTime, nullable=False, server_default=sa.func.now()),
+        sa.CheckConstraint("used_bytes >= 0", name="nonneg_used_bytes"),
+        sa.CheckConstraint("file_count >= 0", name="nonneg_file_count"),
+    )
+
+    # ----- Memory.external_blob computed columns -------------------------
+    op.execute(
+        """
+        ALTER TABLE memories
+        ADD COLUMN external_blob_backend VARCHAR(50)
+        GENERATED ALWAYS AS (details->'external_blob'->>'backend') STORED
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE memories
+        ADD COLUMN external_blob_ref VARCHAR(2048)
+        GENERATED ALWAYS AS (details->'external_blob'->>'ref') STORED
+        """
+    )
+
+    op.create_index(
+        "idx_memories_external_blob_ref",
+        "memories",
+        ["external_blob_ref"],
+        postgresql_where=sa.text("external_blob_ref IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Drop everything in reverse order."""
+    op.drop_index("idx_memories_external_blob_ref", table_name="memories")
+    op.drop_column("memories", "external_blob_ref")
+    op.drop_column("memories", "external_blob_backend")
+    op.drop_table("workspace_storage_usage")
+    op.drop_index("idx_file_objects_reserved_expires", table_name="file_objects")
+    op.drop_index("uq_file_objects_workspace_sha256_active", table_name="file_objects")
+    op.drop_index("ix_file_objects_workspace_id", table_name="file_objects")
+    op.drop_table("file_objects")

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -49,6 +49,9 @@ dependencies = [
     # HTTP Client
     "httpx>=0.27.0",
 
+    # Object Storage (Cloudflare R2 / S3-compatible) — Issue #485
+    "aioboto3>=13.0.0",
+
     # Billing (optional, for SaaS deployments with BILLING_ENABLED=true)
     "stripe>=11.0.0",
 

--- a/backend/scripts/migrate_attachments_to_r2.py
+++ b/backend/scripts/migrate_attachments_to_r2.py
@@ -123,6 +123,22 @@ async def run(*, dry_run: bool, batch_size: int) -> dict[str, int]:
                         attachment_id=str(att.id),
                         error=str(exc),
                     )
+                    # If the failure happened mid-transaction (e.g.
+                    # ``flush`` errored before ``commit``), the shared
+                    # ``db`` session is in a poisoned ``failed
+                    # transaction`` state and any subsequent
+                    # ``db.execute`` will raise ``InvalidStateError``,
+                    # aborting the rest of the run. Roll back so the
+                    # next iteration starts fresh (Copilot loop 4
+                    # finding on PR #551).
+                    try:
+                        await db.rollback()
+                    except Exception:  # noqa: BLE001 — best-effort
+                        # Even rollback can fail on a closed session;
+                        # log + continue, the next iteration's
+                        # ``db.execute`` will surface the underlying
+                        # state.
+                        pass
                 last_id = att.id
         break  # exit the get_db async-iterator loop after one session
 

--- a/backend/scripts/migrate_attachments_to_r2.py
+++ b/backend/scripts/migrate_attachments_to_r2.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""One-shot migration: copy legacy ``attachments`` BYTEA blobs to R2.
+
+Issue #485 Phase 1 (final commit): unify file storage onto the new
+``file_objects`` + R2 surface. The legacy ``Attachment`` table (BYTEA
+in PostgreSQL, 5MB cap) stays in place to keep the existing REST
+``/api/v1/attachments/*`` route functional during the transition.
+
+This script:
+
+1. Iterates non-orphan ``Attachment`` rows in pages.
+2. For each, joins to the parent ``Memory`` to resolve ``workspace_id``.
+3. Calls ``FileStorageService.migrate_attachment`` — idempotent,
+   matching by storage key shape ``{workspace_id}/legacy/{attachment_id}/{filename}``.
+4. Logs a per-row result and accumulates totals.
+
+Skips:
+- Attachments whose parent memory has ``workspace_id IS NULL``
+  (pre-#247 / pre-multi-tenant rows). Logged for ops follow-up.
+- Memory soft-deleted (``deleted_at IS NOT NULL``) — those rows are
+  scheduled for hard delete; their attachments will be GC'd alongside.
+
+Usage:
+    python backend/scripts/migrate_attachments_to_r2.py
+    python backend/scripts/migrate_attachments_to_r2.py --dry-run
+    python backend/scripts/migrate_attachments_to_r2.py --batch-size 100
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+
+# Add src to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_db
+from models.memory import Attachment, Memory
+from services.file_storage_service import FileStorageService
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def _migrate_one(
+    *,
+    db: AsyncSession,
+    attachment: Attachment,
+    memory: Memory,
+    dry_run: bool,
+) -> str:
+    """Migrate a single attachment. Returns ``"migrated" | "skipped" | "dry_run"``."""
+    if memory.workspace_id is None:
+        logger.warning(
+            "attachment_skip_no_workspace",
+            attachment_id=str(attachment.id),
+            memory_id=str(memory.id),
+        )
+        return "skipped"
+    if dry_run:
+        logger.info(
+            "attachment_migration_dry_run",
+            attachment_id=str(attachment.id),
+            memory_id=str(memory.id),
+            workspace_id=str(memory.workspace_id),
+            size_bytes=attachment.size_bytes,
+        )
+        return "dry_run"
+
+    service = FileStorageService(db)
+    await service.migrate_attachment(
+        workspace_id=memory.workspace_id,
+        attachment_id=attachment.id,
+        filename=attachment.filename,
+        content_type=attachment.content_type,
+        size_bytes=attachment.size_bytes,
+        data=attachment.data,
+        created_by=f"migration:attachment:{attachment.id}",
+    )
+    return "migrated"
+
+
+async def run(*, dry_run: bool, batch_size: int) -> dict[str, int]:
+    """Walk all attachments in pages of ``batch_size``."""
+    counts = {"migrated": 0, "skipped": 0, "dry_run": 0, "failed": 0}
+    last_id = None
+
+    async for db in get_db():
+        while True:
+            stmt = (
+                select(Attachment, Memory)
+                .join(Memory, Memory.id == Attachment.memory_id)
+                .where(Memory.deleted_at.is_(None))
+                .order_by(Attachment.id)
+                .limit(batch_size)
+            )
+            if last_id is not None:
+                stmt = stmt.where(Attachment.id > last_id)
+
+            result = await db.execute(stmt)
+            rows = list(result.all())
+            if not rows:
+                break
+
+            for att, mem in rows:
+                try:
+                    outcome = await _migrate_one(
+                        db=db,
+                        attachment=att,
+                        memory=mem,
+                        dry_run=dry_run,
+                    )
+                    counts[outcome] += 1
+                except Exception as exc:  # noqa: BLE001 — best-effort migration
+                    counts["failed"] += 1
+                    logger.error(
+                        "attachment_migration_failed",
+                        attachment_id=str(att.id),
+                        error=str(exc),
+                    )
+                last_id = att.id
+        break  # exit the get_db async-iterator loop after one session
+
+    logger.info("attachment_migration_complete", **counts)
+    return counts
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dry-run", action="store_true", help="Don't upload to R2")
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50,
+        help="Attachments per page (default: 50)",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    counts = asyncio.run(run(dry_run=args.dry_run, batch_size=args.batch_size))
+    if counts["failed"] > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -67,6 +67,7 @@ async def lifespan(app: FastAPI):
         schedule_credentials_tasks,
         schedule_embedding_tasks,
         schedule_erasure_tasks,
+        schedule_file_tasks,
         schedule_mcp_tasks,
         schedule_neural_tasks,
         schedule_resource_indexer_jobs,
@@ -83,6 +84,7 @@ async def lifespan(app: FastAPI):
     schedule_sleep_tasks(scheduler)
     schedule_bm25_drift_tasks(scheduler)
     schedule_erasure_tasks(scheduler)
+    schedule_file_tasks(scheduler)
     start_scheduler()
     logger.info("background_tasks_scheduled")
 

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -110,6 +110,12 @@ async def lifespan(app: FastAPI):
     shutdown_erasure_executor()
     logger.info("stripe_erasure_executor_stopped")
 
+    # Release blob storage (Issue #485)
+    from storage.factory import close_blob_storage
+
+    await close_blob_storage()
+    logger.info("blob_storage_closed")
+
     # Close database
     from db.base import close_db
 

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -152,6 +152,13 @@ openapi_tags = [
         "name": "attachments",
         "description": "File attachments for memories (upload, download, delete)",
     },
+    {
+        "name": "files",
+        "description": (
+            "Platform-managed file storage (Issue #485). Presigned upload to "
+            "Cloudflare R2, per-workspace quota."
+        ),
+    },
     {"name": "graph", "description": "Neural Memory graph operations"},
     # Integrations
     {"name": "api-keys", "description": "MCP API key management"},
@@ -371,6 +378,7 @@ from api.routes import (  # noqa: E402
     contexts,
     cost_aggregation,  # Issue #472: cost aggregation API (admin + workspace-scoped)
     external_keys,
+    files,  # Issue #485: platform-managed R2 file storage
     graph,
     invitations,
     mcp,
@@ -462,6 +470,9 @@ app.include_router(admin_signup_gate.router, prefix="/api/v1")
 
 # BM25 IDF Drift admin (Issue #343 - cron disabled by default until v0.14.0)
 app.include_router(bm25_drift.router, prefix="/api/v1")
+
+# File storage routes (Issue #485 - platform-managed R2)
+app.include_router(files.router, prefix="/api/v1")
 
 # External API Keys routes (Issue #45 - External keys management)
 app.include_router(external_keys.router, prefix="/api/v1")

--- a/backend/src/api/routes/files.py
+++ b/backend/src/api/routes/files.py
@@ -1,0 +1,211 @@
+"""REST routes for platform-managed file storage (Issue #485).
+
+Thin handlers that delegate to ``FileStorageService``. Exceptions
+(``NotFoundException`` / ``ValidationError`` / ``ConflictError`` /
+``QuotaExceededError``) are mapped to HTTP responses by the global
+``MemoryCloudException`` handler in ``api.main``.
+
+Auth: ``APIKeyOrSessionUser`` for all endpoints — the same dual-mode
+auth used by the rest of the workspace surface. ``workspace_id`` comes
+from the request body or query (and is verified by the service).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, Query
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import APIKeyOrSessionUser
+from db.base import get_db
+from models.api_base import TZAwareBaseModel
+from services.file_storage_service import FileStorageService
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/files", tags=["files"])
+
+# ---------------------------------------------------------------------------
+# Request / Response models
+# ---------------------------------------------------------------------------
+
+# Phase 1 100 MiB cap (Field constraint mirrors settings.file_object_max_size_mb;
+# the service re-validates against the runtime setting so an env-var override
+# does not get bypassed by stale schema validation).
+_MAX_PHASE1_SIZE_BYTES = 100 * 1024 * 1024
+
+
+class FileReserveRequest(BaseModel):
+    """Body for ``POST /api/v1/files/reserve``."""
+
+    workspace_id: UUID
+    filename: str = Field(min_length=1, max_length=512)
+    content_type: str = Field(min_length=1, max_length=255)
+    size_bytes: int = Field(gt=0, le=_MAX_PHASE1_SIZE_BYTES)
+    sha256: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+        description="Lower-case hex sha256 of the bytes the client will PUT",
+    )
+
+
+class FileReserveResponse(TZAwareBaseModel):
+    file_id: UUID
+    upload_url: str
+    expires_at: datetime
+
+
+class FileConfirmRequest(BaseModel):
+    """Body for ``POST /api/v1/files/{file_id}/confirm``."""
+
+    sha256: str = Field(
+        min_length=64,
+        max_length=64,
+        pattern=r"^[0-9a-fA-F]{64}$",
+    )
+
+
+class FileObjectOut(TZAwareBaseModel):
+    id: UUID
+    workspace_id: UUID
+    filename: str
+    content_type: str
+    size_bytes: int
+    sha256: str
+    status: str
+    created_at: datetime
+    uploaded_at: datetime | None = None
+
+
+class FileDownloadUrlOut(TZAwareBaseModel):
+    download_url: str
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _to_out(file) -> FileObjectOut:
+    """Convert a ``FileObject`` ORM row to the API response model."""
+    return FileObjectOut(
+        id=file.id,
+        workspace_id=file.workspace_id,
+        filename=file.filename,
+        content_type=file.content_type,
+        size_bytes=file.size_bytes,
+        sha256=file.sha256,
+        status=file.status,
+        created_at=file.created_at,
+        uploaded_at=file.uploaded_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.post("/reserve", response_model=FileReserveResponse, status_code=201)
+async def reserve_upload(
+    body: FileReserveRequest,
+    user: APIKeyOrSessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> FileReserveResponse:
+    """Reserve quota and return a presigned PUT URL for the upload.
+
+    The client computes the sha256 ahead of time so the server can dedup
+    against the active set on this workspace. Repeated calls with the
+    same sha256 from the same workspace return 409 with the existing
+    ``file_id`` (idempotent — the SDK can use the existing one).
+    """
+    service = FileStorageService(db)
+    result = await service.reserve_upload(
+        workspace_id=body.workspace_id,
+        created_by=str(user.get("user_id", "")),
+        filename=body.filename,
+        content_type=body.content_type,
+        size_bytes=body.size_bytes,
+        sha256=body.sha256.lower(),
+    )
+    return FileReserveResponse(
+        file_id=result.file_id,
+        upload_url=result.upload_url,
+        expires_at=result.expires_at,
+    )
+
+
+@router.post("/{file_id}/confirm", response_model=FileObjectOut)
+async def confirm_upload(
+    file_id: UUID,
+    body: FileConfirmRequest,
+    user: APIKeyOrSessionUser,
+    workspace_id: UUID = Query(..., description="Owning workspace"),
+    db: AsyncSession = Depends(get_db),
+) -> FileObjectOut:
+    """Verify the upload landed in R2 and finalize the row.
+
+    Idempotent: confirming an already-uploaded file with a matching
+    sha256 returns the existing row unchanged.
+    """
+    del user  # auth dep enforces membership; service uses workspace_id directly
+    service = FileStorageService(db)
+    file = await service.confirm_upload(
+        workspace_id=workspace_id,
+        file_id=file_id,
+        sha256=body.sha256.lower(),
+    )
+    return _to_out(file)
+
+
+@router.get("/{file_id}/download-url", response_model=FileDownloadUrlOut)
+async def get_download_url(
+    file_id: UUID,
+    user: APIKeyOrSessionUser,
+    workspace_id: UUID = Query(..., description="Owning workspace"),
+    db: AsyncSession = Depends(get_db),
+) -> FileDownloadUrlOut:
+    """Return a short-lived presigned GET URL."""
+    del user
+    service = FileStorageService(db)
+    url = await service.get_presigned_download(
+        workspace_id=workspace_id,
+        file_id=file_id,
+    )
+    return FileDownloadUrlOut(download_url=url)
+
+
+@router.delete("/{file_id}", status_code=204, response_model=None)
+async def delete_file(
+    file_id: UUID,
+    user: APIKeyOrSessionUser,
+    workspace_id: UUID = Query(..., description="Owning workspace"),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Soft-delete the file and immediately release the quota.
+
+    The R2 binary lingers for 7 days (sweeper handles deletion); the
+    workspace counter is decremented in the same transaction (R5).
+    """
+    del user
+    service = FileStorageService(db)
+    await service.delete_file(workspace_id=workspace_id, file_id=file_id)
+
+
+@router.get("", response_model=list[FileObjectOut])
+async def list_files(
+    user: APIKeyOrSessionUser,
+    workspace_id: UUID = Query(..., description="Owning workspace"),
+    limit: int = Query(50, ge=1, le=500),
+    db: AsyncSession = Depends(get_db),
+) -> list[FileObjectOut]:
+    """List uploaded, non-deleted files in the workspace, newest first."""
+    del user
+    service = FileStorageService(db)
+    files = await service.list_files(workspace_id=workspace_id, limit=limit)
+    return [_to_out(f) for f in files]

--- a/backend/src/api/routes/files.py
+++ b/backend/src/api/routes/files.py
@@ -23,6 +23,7 @@ from auth.dependencies import APIKeyOrSessionUser
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from services.file_storage_service import FileStorageService
+from services.permission_service import PermissionService
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -107,6 +108,32 @@ def _to_out(file) -> FileObjectOut:
 
 
 # ---------------------------------------------------------------------------
+# Auth helper — workspace boundary enforcement
+# ---------------------------------------------------------------------------
+
+
+async def _enforce_workspace_membership(
+    db: AsyncSession,
+    user: dict,
+    workspace_id: UUID,
+) -> None:
+    """Authorize ``user`` for ``workspace_id`` (member or higher).
+
+    ``APIKeyOrSessionUser`` proves identity, not workspace membership.
+    Without this gate an authenticated user from workspace A could
+    pass workspace B's id in the request body / query and access /
+    enumerate B's files. Mirrors the pattern at
+    ``api/routes/resource_ingest.py``.
+    """
+    permissions = PermissionService(db)
+    await permissions.check_workspace_access(
+        user_id=str(user.get("user_id", "")),
+        workspace_id=workspace_id,
+        required_role="member",
+    )
+
+
+# ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
 
@@ -124,6 +151,7 @@ async def reserve_upload(
     same sha256 from the same workspace return 409 with the existing
     ``file_id`` (idempotent — the SDK can use the existing one).
     """
+    await _enforce_workspace_membership(db, user, body.workspace_id)
     service = FileStorageService(db)
     result = await service.reserve_upload(
         workspace_id=body.workspace_id,
@@ -153,7 +181,7 @@ async def confirm_upload(
     Idempotent: confirming an already-uploaded file with a matching
     sha256 returns the existing row unchanged.
     """
-    del user  # auth dep enforces membership; service uses workspace_id directly
+    await _enforce_workspace_membership(db, user, workspace_id)
     service = FileStorageService(db)
     file = await service.confirm_upload(
         workspace_id=workspace_id,
@@ -171,7 +199,7 @@ async def get_download_url(
     db: AsyncSession = Depends(get_db),
 ) -> FileDownloadUrlOut:
     """Return a short-lived presigned GET URL."""
-    del user
+    await _enforce_workspace_membership(db, user, workspace_id)
     service = FileStorageService(db)
     url = await service.get_presigned_download(
         workspace_id=workspace_id,
@@ -192,7 +220,7 @@ async def delete_file(
     The R2 binary lingers for 7 days (sweeper handles deletion); the
     workspace counter is decremented in the same transaction (R5).
     """
-    del user
+    await _enforce_workspace_membership(db, user, workspace_id)
     service = FileStorageService(db)
     await service.delete_file(workspace_id=workspace_id, file_id=file_id)
 
@@ -205,7 +233,7 @@ async def list_files(
     db: AsyncSession = Depends(get_db),
 ) -> list[FileObjectOut]:
     """List uploaded, non-deleted files in the workspace, newest first."""
-    del user
+    await _enforce_workspace_membership(db, user, workspace_id)
     service = FileStorageService(db)
     files = await service.list_files(workspace_id=workspace_id, limit=limit)
     return [_to_out(f) for f in files]

--- a/backend/src/api/routes/files.py
+++ b/backend/src/api/routes/files.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser
@@ -72,6 +72,14 @@ class FileConfirmRequest(BaseModel):
 
 
 class FileObjectOut(TZAwareBaseModel):
+    """Subset of ``FileObject`` exposed to clients.
+
+    ``from_attributes=True`` lets us pass the ORM row directly to
+    ``model_validate`` — no per-field copy needed.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
     id: UUID
     workspace_id: UUID
     filename: str
@@ -85,26 +93,6 @@ class FileObjectOut(TZAwareBaseModel):
 
 class FileDownloadUrlOut(TZAwareBaseModel):
     download_url: str
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
-
-
-def _to_out(file) -> FileObjectOut:
-    """Convert a ``FileObject`` ORM row to the API response model."""
-    return FileObjectOut(
-        id=file.id,
-        workspace_id=file.workspace_id,
-        filename=file.filename,
-        content_type=file.content_type,
-        size_bytes=file.size_bytes,
-        sha256=file.sha256,
-        status=file.status,
-        created_at=file.created_at,
-        uploaded_at=file.uploaded_at,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +176,7 @@ async def confirm_upload(
         file_id=file_id,
         sha256=body.sha256.lower(),
     )
-    return _to_out(file)
+    return FileObjectOut.model_validate(file)
 
 
 @router.get("/{file_id}/download-url", response_model=FileDownloadUrlOut)
@@ -236,4 +224,4 @@ async def list_files(
     await _enforce_workspace_membership(db, user, workspace_id)
     service = FileStorageService(db)
     files = await service.list_files(workspace_id=workspace_id, limit=limit)
-    return [_to_out(f) for f in files]
+    return [FileObjectOut.model_validate(f) for f in files]

--- a/backend/src/api/routes/files.py
+++ b/backend/src/api/routes/files.py
@@ -35,9 +35,13 @@ router = APIRouter(prefix="/files", tags=["files"])
 # ---------------------------------------------------------------------------
 
 # Phase 1 100 MiB cap (Field constraint mirrors settings.file_object_max_size_mb;
-# the service re-validates against the runtime setting so an env-var override
-# does not get bypassed by stale schema validation).
-_MAX_PHASE1_SIZE_BYTES = 100 * 1024 * 1024
+# Pydantic only enforces ``gt=0`` here so an obvious bad input (zero or
+# negative bytes) is rejected at the boundary. The runtime per-file cap
+# comes from ``settings.file_object_max_size_mb`` and is enforced inside
+# ``FileStorageService.reserve_upload``. Encoding the cap here as a
+# ``le=...`` constant would silently diverge from MCP and from the live
+# config when an operator bumps ``FILE_OBJECT_MAX_SIZE_MB`` (Copilot
+# loop 5 finding on PR #551).
 
 
 class FileReserveRequest(BaseModel):
@@ -46,7 +50,7 @@ class FileReserveRequest(BaseModel):
     workspace_id: UUID
     filename: str = Field(min_length=1, max_length=512)
     content_type: str = Field(min_length=1, max_length=255)
-    size_bytes: int = Field(gt=0, le=_MAX_PHASE1_SIZE_BYTES)
+    size_bytes: int = Field(gt=0)
     sha256: str = Field(
         min_length=64,
         max_length=64,

--- a/backend/src/api/routes/files.py
+++ b/backend/src/api/routes/files.py
@@ -104,20 +104,28 @@ async def _enforce_workspace_membership(
     db: AsyncSession,
     user: dict,
     workspace_id: UUID,
+    *,
+    required_role: str = "member",
 ) -> None:
-    """Authorize ``user`` for ``workspace_id`` (member or higher).
+    """Authorize ``user`` for ``workspace_id`` at ``required_role`` or higher.
 
     ``APIKeyOrSessionUser`` proves identity, not workspace membership.
     Without this gate an authenticated user from workspace A could
     pass workspace B's id in the request body / query and access /
     enumerate B's files. Mirrors the pattern at
     ``api/routes/resource_ingest.py``.
+
+    ``required_role`` defaults to ``"member"`` for write paths
+    (reserve / confirm / delete). Read paths (download-url, list)
+    pass ``"viewer"`` so workspace viewers — who are intentionally
+    read-only members per the repo's role semantics — can read file
+    metadata and download URLs (Copilot loop 4 finding on PR #551).
     """
     permissions = PermissionService(db)
     await permissions.check_workspace_access(
         user_id=str(user.get("user_id", "")),
         workspace_id=workspace_id,
-        required_role="member",
+        required_role=required_role,
     )
 
 
@@ -187,7 +195,7 @@ async def get_download_url(
     db: AsyncSession = Depends(get_db),
 ) -> FileDownloadUrlOut:
     """Return a short-lived presigned GET URL."""
-    await _enforce_workspace_membership(db, user, workspace_id)
+    await _enforce_workspace_membership(db, user, workspace_id, required_role="viewer")
     service = FileStorageService(db)
     url = await service.get_presigned_download(
         workspace_id=workspace_id,
@@ -221,7 +229,7 @@ async def list_files(
     db: AsyncSession = Depends(get_db),
 ) -> list[FileObjectOut]:
     """List uploaded, non-deleted files in the workspace, newest first."""
-    await _enforce_workspace_membership(db, user, workspace_id)
+    await _enforce_workspace_membership(db, user, workspace_id, required_role="viewer")
     service = FileStorageService(db)
     files = await service.list_files(workspace_id=workspace_id, limit=limit)
     return [FileObjectOut.model_validate(f) for f in files]

--- a/backend/src/config/plan_tiers.py
+++ b/backend/src/config/plan_tiers.py
@@ -67,6 +67,7 @@ class PlanTier:
     public_calls_per_day: int = 0  # Issue #238: Public REST API quota
     public_calls_per_week: int = 0  # Issue #238: Public REST API quota
     analysis_runs_per_day: int = 0  # Issue #494: Memory Broadlistening analyses/day
+    storage_limit_bytes: int = 0  # Issue #485: File-storage hard cap per workspace
     allows_shared_contexts: bool = False  # Issue #271: Shared context feature (Pro only)
     features: frozenset[str] = field(default_factory=frozenset)
 
@@ -89,6 +90,7 @@ PLAN_FREE = PlanTier(
     rest_calls_per_week=0,
     public_calls_per_day=0,  # Free plan: no public contexts
     public_calls_per_week=0,
+    storage_limit_bytes=100 * 1024 * 1024,  # Issue #485: 100 MB
     allows_shared_contexts=False,  # Issue #271: Private contexts only
     features=frozenset({"api_keys", "oauth"}),  # Free plan includes OAuth (App Credentials)
 )
@@ -111,6 +113,7 @@ PLAN_BASIC = PlanTier(
     rest_calls_per_week=5000,
     public_calls_per_day=0,  # Basic plan: no public contexts (PRO only)
     public_calls_per_week=0,
+    storage_limit_bytes=1 * 1024 * 1024 * 1024,  # Issue #485: 1 GiB
     features=frozenset({"api_keys", "reranking", "oauth"}),  # Public contexts removed (PRO only)
 )
 
@@ -133,6 +136,7 @@ PLAN_PRO = PlanTier(
     public_calls_per_day=1000,
     public_calls_per_week=5000,
     analysis_runs_per_day=3,  # Issue #494: Memory Broadlistening (Pro only; FREE/BASIC=0)
+    storage_limit_bytes=10 * 1024 * 1024 * 1024,  # Issue #485: 10 GiB
     features=frozenset(
         {
             "api_keys",
@@ -185,18 +189,21 @@ def _apply_settings_overrides() -> None:
             "max_contexts_per_workspace": settings.plan_free_max_contexts,
             "memory_limit": settings.plan_free_memory_limit,
             "mcp_calls_per_day": settings.plan_free_mcp_calls_per_day,
+            "storage_limit_bytes": settings.plan_free_storage_limit_bytes,
             "display_name": settings.plan_free_display_name,
         },
         PlanName.BASIC: {
             "max_contexts_per_workspace": settings.plan_basic_max_contexts,
             "memory_limit": settings.plan_basic_memory_limit,
             "mcp_calls_per_day": settings.plan_basic_mcp_calls_per_day,
+            "storage_limit_bytes": settings.plan_basic_storage_limit_bytes,
             "display_name": settings.plan_basic_display_name,
         },
         PlanName.PRO: {
             "max_contexts_per_workspace": settings.plan_pro_max_contexts,
             "memory_limit": settings.plan_pro_memory_limit,
             "mcp_calls_per_day": settings.plan_pro_mcp_calls_per_day,
+            "storage_limit_bytes": settings.plan_pro_storage_limit_bytes,
             "display_name": settings.plan_pro_display_name,
         },
     }

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -298,6 +298,15 @@ class Settings(BaseSettings):
     plan_pro_mcp_calls_per_day: int | None = Field(
         default=None, description="Override PRO plan MCP calls/day"
     )
+    plan_free_storage_limit_bytes: int | None = Field(
+        default=None, description="Override FREE plan file-storage hard cap (bytes, Issue #485)"
+    )
+    plan_basic_storage_limit_bytes: int | None = Field(
+        default=None, description="Override BASIC plan file-storage hard cap (bytes, Issue #485)"
+    )
+    plan_pro_storage_limit_bytes: int | None = Field(
+        default=None, description="Override PRO plan file-storage hard cap (bytes, Issue #485)"
+    )
 
     # Plan Display Names (customizable for SaaS forks)
     plan_free_display_name: str | None = Field(
@@ -325,6 +334,25 @@ class Settings(BaseSettings):
     )
     usage_critical_threshold: float = Field(
         default=0.95, description="Usage critical threshold (0.0-1.0)"
+    )
+
+    # Object Storage / Cloudflare R2 (Issue #485)
+    r2_account_id: str = Field(default="", description="Cloudflare R2 account ID")
+    r2_access_key_id: str = Field(default="", description="R2 S3-compatible access key ID")
+    r2_secret_access_key: str = Field(default="", description="R2 S3-compatible secret access key")
+    r2_bucket: str = Field(default="", description="R2 bucket name (e.g. kagura-memory-files-dev)")
+    r2_endpoint_url: str = Field(
+        default="",
+        description="R2 S3-compatible endpoint (https://<account>.r2.cloudflarestorage.com)",
+    )
+    file_object_max_size_mb: int = Field(
+        default=100, description="Per-file size cap in MB (Issue #485 Phase 1 = 100)"
+    )
+    presign_put_ttl_seconds: int = Field(
+        default=300, description="Presigned PUT URL lifetime in seconds (Issue #485 R4)"
+    )
+    presign_get_ttl_seconds: int = Field(
+        default=300, description="Presigned GET URL lifetime in seconds"
     )
 
     @field_validator("resend_dpa_accepted_at", mode="before")

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -41,6 +41,11 @@ _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
         "list_resource_tokens",  # Uses resource_id, not context_id
         "get_analysis",  # Issue #496: uses run_id, not context_id
         "get_cluster",  # Issue #496: uses run_id, not context_id
+        "init_file_upload",  # Issue #485: uses workspace_id + sha256
+        "complete_file_upload",  # Issue #485: uses file_id
+        "get_file_download_url",  # Issue #485: uses file_id
+        "delete_file",  # Issue #485: uses file_id
+        "list_files",  # Issue #485: workspace-scoped listing
     }
 )
 
@@ -60,6 +65,8 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "list_analyses",  # Issue #496: read-only analysis list
         "get_active_analysis",  # Issue #496: read-only most-recent succeeded
         "get_cluster",  # Issue #496: read-only cluster drill-down
+        "get_file_download_url",  # Issue #485: read-only presigned GET
+        "list_files",  # Issue #485: read-only workspace listing
     }
 )
 
@@ -94,6 +101,13 @@ def _build_registry() -> dict[str, Any]:
         handle_delete_edge,
         handle_list_edges,
         handle_update_edge,
+    )
+    from mcp_server.tools.files import (
+        handle_complete_file_upload,
+        handle_delete_file,
+        handle_get_file_download_url,
+        handle_init_file_upload,
+        handle_list_files,
     )
     from mcp_server.tools.resource import (
         handle_get_resource_impact,
@@ -144,6 +158,13 @@ def _build_registry() -> dict[str, Any]:
         "list_analyses": handle_list_analyses,
         "get_active_analysis": handle_get_active_analysis,
         "get_cluster": handle_get_cluster,
+        # Issue #485: platform-managed file storage — 5 tools sharing
+        # FileStorageService with REST /api/v1/files routes.
+        "init_file_upload": handle_init_file_upload,
+        "complete_file_upload": handle_complete_file_upload,
+        "get_file_download_url": handle_get_file_download_url,
+        "delete_file": handle_delete_file,
+        "list_files": handle_list_files,
     }
 
 

--- a/backend/src/mcp_server/tools/_constants.py
+++ b/backend/src/mcp_server/tools/_constants.py
@@ -43,6 +43,12 @@ TOOL_TIMEOUTS: dict[str, float] = {
     "get_resource_impact": _get_timeout("get_resource_impact", 10.0),
     "get_resource_schema": _get_timeout("get_resource_schema", 10.0),
     "list_resource_tokens": _get_timeout("list_resource_tokens", 10.0),
+    # Issue #485: file storage tools
+    "init_file_upload": _get_timeout("init_file_upload", 20.0),
+    "complete_file_upload": _get_timeout("complete_file_upload", 20.0),
+    "get_file_download_url": _get_timeout("get_file_download_url", 10.0),
+    "delete_file": _get_timeout("delete_file", 15.0),
+    "list_files": _get_timeout("list_files", 10.0),
 }
 DEFAULT_TOOL_TIMEOUT = float(os.getenv("MCP_TIMEOUT_DEFAULT", 60.0))
 

--- a/backend/src/mcp_server/tools/_constants.py
+++ b/backend/src/mcp_server/tools/_constants.py
@@ -407,7 +407,7 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 
 ---
 
-## Available Tools (26 tools)
+## Available Tools (31 tools)
 
 | Tool | Purpose |
 |------|---------|
@@ -437,6 +437,11 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 | `get_resource_impact` | Get resource stats (tokens, memories, schema version) |
 | `get_resource_schema` | Get field definitions for a resource |
 | `list_resource_tokens` | List resource tokens for your workspace |
+| `init_file_upload` | Reserve quota + return presigned PUT URL (R2, ≤100 MiB) |
+| `complete_file_upload` | Finalize upload after PUT (idempotent on retry) |
+| `get_file_download_url` | Get short-lived presigned GET URL for a file |
+| `delete_file` | Soft-delete file + immediate quota release |
+| `list_files` | List uploaded files in the workspace, newest first |
 
 Most context-scoped tools take a single `context_id`. Exceptions:
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1397,6 +1397,147 @@ Requires action recording (reports created before this feature have no actions t
                 },
             },
         },
+        # ====================================================================
+        # Issue #485: Platform-managed file storage (Cloudflare R2)
+        # ====================================================================
+        {
+            "name": "init_file_upload",
+            "description": (
+                "Reserve quota and return a presigned PUT URL for a file upload "
+                "to platform-managed R2 storage. Phase 1 cap is 100 MiB per file; "
+                "the workspace's effective storage limit is enforced atomically "
+                "via Redis reservation.\n\n"
+                "Compute the sha256 ahead of time so the server can dedup against "
+                "the workspace's active set. Two calls with the same sha256 in "
+                "the same workspace return a 'conflict' error referencing the "
+                "existing file_id; clients should reuse it instead of re-uploading."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["filename", "content_type", "size_bytes", "sha256"],
+                "properties": {
+                    "filename": {
+                        "type": "string",
+                        "description": "Original filename (used for Content-Disposition on download).",
+                    },
+                    "content_type": {
+                        "type": "string",
+                        "description": "MIME type (e.g. 'application/pdf').",
+                    },
+                    "size_bytes": {
+                        "type": "integer",
+                        "description": "Total bytes the client will PUT. Phase 1 cap: 100 MiB.",
+                    },
+                    "sha256": {
+                        "type": "string",
+                        "description": "Lower-case hex sha256 of the bytes the client will PUT.",
+                    },
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Optional. Overrides the authenticated workspace_id.",
+                    },
+                },
+            },
+        },
+        {
+            "name": "complete_file_upload",
+            "description": (
+                "Finalize a file upload after the client has PUT bytes to the "
+                "presigned URL returned by init_file_upload. The server verifies "
+                "the object exists in R2 (head_object) and matches the declared "
+                "sha256 / size; on success the row transitions reserved → uploaded "
+                "and the workspace storage counter is updated atomically.\n\n"
+                "Idempotent: confirming an already-uploaded file with a matching "
+                "sha256 returns the existing row unchanged."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["file_id", "sha256"],
+                "properties": {
+                    "file_id": {
+                        "type": "string",
+                        "description": "UUID returned by init_file_upload.",
+                    },
+                    "sha256": {
+                        "type": "string",
+                        "description": "Lower-case hex sha256 of the bytes uploaded.",
+                    },
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Optional. Overrides the authenticated workspace_id.",
+                    },
+                },
+            },
+        },
+        {
+            "name": "get_file_download_url",
+            "description": (
+                "Return a short-lived presigned GET URL for a previously-uploaded "
+                "file. The URL sets Content-Disposition to the original filename "
+                "so browsers and curl preserve it on save."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["file_id"],
+                "properties": {
+                    "file_id": {
+                        "type": "string",
+                        "description": "MUST be a UUID from a prior init_file_upload + complete_file_upload pair.",
+                    },
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Optional. Overrides the authenticated workspace_id.",
+                    },
+                },
+            },
+            "readOnly": True,
+        },
+        {
+            "name": "delete_file",
+            "description": (
+                "Soft-delete a file. The workspace storage quota is released "
+                "immediately (R5 contract); the R2 binary lingers for 7 days "
+                "before the nightly sweeper removes it (no client-visible "
+                "behavior on the binary side)."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["file_id"],
+                "properties": {
+                    "file_id": {
+                        "type": "string",
+                        "description": "UUID of the file to soft-delete.",
+                    },
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Optional. Overrides the authenticated workspace_id.",
+                    },
+                },
+            },
+        },
+        {
+            "name": "list_files",
+            "description": (
+                "List uploaded, non-deleted files in the workspace, newest first. "
+                "Returns up to 50 by default (max 500). Each entry includes "
+                "id, filename, content_type, size_bytes, sha256, status, "
+                "created_at, uploaded_at."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Number of rows to return (1-500, default 50).",
+                    },
+                    "workspace_id": {
+                        "type": "string",
+                        "description": "Optional. Overrides the authenticated workspace_id.",
+                    },
+                },
+            },
+            "readOnly": True,
+        },
     ]
 
 

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -312,6 +312,52 @@ async def _get_workspace_member_role(
     return member.role if member else None
 
 
+async def _check_workspace_membership(
+    db: "AsyncSession",
+    user_id: str,
+    workspace_id: UUID | None,
+    operation: str,
+) -> list[TextContent] | None:
+    """Membership-only gate for READ-ONLY MCP tools.
+
+    Issue #485: read tools that accept an optional ``workspace_id``
+    arg (e.g. ``get_file_download_url``, ``list_files``) need to deny
+    callers who are NOT members of the target workspace, but MUST
+    allow callers whose role is ``viewer`` — viewers ARE members and
+    are entitled to read access by design.
+
+    ``_check_viewer_permission`` (below) explicitly rejects viewers
+    as part of write-tool fail-closed gating; using it on read tools
+    accidentally blocks viewer reads. This helper is the read-friendly
+    sibling: it short-circuits only when membership is missing.
+
+    Args:
+        db: Database session.
+        user_id: User ID.
+        workspace_id: Workspace ID (None = skip check).
+        operation: Operation description for error message.
+
+    Returns:
+        Error response if the caller is NOT a member of the
+        workspace, otherwise ``None``.
+    """
+    if not workspace_id:
+        return None
+    user_role = await _get_workspace_member_role(db, user_id, workspace_id)
+    if user_role is None:
+        return _error_response(
+            "permission_denied",
+            f"Cannot {operation}: workspace not accessible.",
+            your_role="not_a_member",
+            required_role="viewer",
+            help=(
+                "Verify the workspace is active and you are a member "
+                "(any role — viewer is sufficient for read access)."
+            ),
+        )
+    return None
+
+
 async def _check_viewer_permission(
     db: "AsyncSession",
     user_id: str,

--- a/backend/src/mcp_server/tools/files.py
+++ b/backend/src/mcp_server/tools/files.py
@@ -101,6 +101,15 @@ async def handle_init_file_upload(
     if missing:
         return _error_response("missing_fields", f"Missing required fields: {sorted(missing)}")
 
+    # Coerce size_bytes BEFORE entering the service — ``int(...)`` on a
+    # malformed input would otherwise leak as a generic 500 instead of
+    # the documented validation_error vocabulary (Copilot loop 5 finding
+    # on PR #551).
+    try:
+        size_bytes = int(args["size_bytes"])
+    except (ValueError, TypeError):
+        return _error_response("validation_error", "size_bytes must be a positive integer")
+
     ws, err = await _resolve_workspace(args.get("workspace_id"), workspace_id)
     if err is not None:
         return err
@@ -118,10 +127,16 @@ async def handle_init_file_upload(
                 created_by=user_id,
                 filename=str(args["filename"]),
                 content_type=str(args["content_type"]),
-                size_bytes=int(args["size_bytes"]),
+                size_bytes=size_bytes,
                 sha256=str(args["sha256"]).lower(),
             )
-        except (ValidationError, ConflictError, QuotaExceededError, NotFoundException) as exc:
+        except (
+            ValidationError,
+            ConflictError,
+            QuotaExceededError,
+            NotFoundException,
+            ExternalServiceError,
+        ) as exc:
             return _exc_to_error_response(exc)
     return _success_response(
         file_id=str(result.file_id),

--- a/backend/src/mcp_server/tools/files.py
+++ b/backend/src/mcp_server/tools/files.py
@@ -212,9 +212,15 @@ async def handle_get_file_download_url(
     from db.base import get_db
 
     async for db in get_db():
-        # Viewer can read; no permission gate beyond workspace membership
-        # (which the auth dep enforces upstream).
-        del user_id  # not currently used; reserve for future audit logging
+        # Workspace membership MUST be enforced before reading. The
+        # auth layer only proves identity, not membership of the
+        # ``workspace_id`` the caller supplied. Without this, an
+        # authenticated MCP caller could pass another workspace's UUID
+        # via the ``workspace_id`` arg and obtain download URLs for
+        # files they shouldn't be able to read.
+        viewer_err = await _check_viewer_permission(db, user_id, ws, "download files")
+        if viewer_err is not None:
+            return viewer_err
         service = FileStorageService(db)
         try:
             url = await service.get_presigned_download(
@@ -289,7 +295,13 @@ async def handle_list_files(
     from db.base import get_db
 
     async for db in get_db():
-        del user_id  # auth enforced upstream; viewer can list
+        # Membership gate (same reasoning as handle_get_file_download_url):
+        # without this an authenticated caller could enumerate another
+        # workspace's file metadata by supplying its UUID via the
+        # ``workspace_id`` arg.
+        viewer_err = await _check_viewer_permission(db, user_id, ws, "list files")
+        if viewer_err is not None:
+            return viewer_err
         service = FileStorageService(db)
         try:
             files = await service.list_files(workspace_id=ws, limit=limit)

--- a/backend/src/mcp_server/tools/files.py
+++ b/backend/src/mcp_server/tools/files.py
@@ -20,6 +20,7 @@ from mcp.types import TextContent
 
 from mcp_server.tools._helpers import (
     _check_viewer_permission,
+    _check_workspace_membership,
     _error_response,
     _success_response,
 )
@@ -218,9 +219,13 @@ async def handle_get_file_download_url(
         # authenticated MCP caller could pass another workspace's UUID
         # via the ``workspace_id`` arg and obtain download URLs for
         # files they shouldn't be able to read.
-        viewer_err = await _check_viewer_permission(db, user_id, ws, "download files")
-        if viewer_err is not None:
-            return viewer_err
+        #
+        # Use the membership-only variant — viewers ARE members and
+        # ``_check_viewer_permission`` would reject them on this
+        # read-only path (regression caught on PR #551 Copilot loop 3).
+        membership_err = await _check_workspace_membership(db, user_id, ws, "download files")
+        if membership_err is not None:
+            return membership_err
         service = FileStorageService(db)
         try:
             url = await service.get_presigned_download(
@@ -298,10 +303,11 @@ async def handle_list_files(
         # Membership gate (same reasoning as handle_get_file_download_url):
         # without this an authenticated caller could enumerate another
         # workspace's file metadata by supplying its UUID via the
-        # ``workspace_id`` arg.
-        viewer_err = await _check_viewer_permission(db, user_id, ws, "list files")
-        if viewer_err is not None:
-            return viewer_err
+        # ``workspace_id`` arg. Use the membership-only variant so
+        # viewers (read-only role) can list files.
+        membership_err = await _check_workspace_membership(db, user_id, ws, "list files")
+        if membership_err is not None:
+            return membership_err
         service = FileStorageService(db)
         try:
             files = await service.list_files(workspace_id=ws, limit=limit)

--- a/backend/src/mcp_server/tools/files.py
+++ b/backend/src/mcp_server/tools/files.py
@@ -24,6 +24,7 @@ from mcp_server.tools._helpers import (
     _success_response,
 )
 from services.file_storage_service import FileStorageService
+from utils.datetime import to_utc_iso
 from utils.exceptions import (
     ConflictError,
     NotFoundException,
@@ -117,7 +118,7 @@ async def handle_init_file_upload(
     return _success_response(
         file_id=str(result.file_id),
         upload_url=result.upload_url,
-        expires_at=result.expires_at.isoformat(),
+        expires_at=to_utc_iso(result.expires_at),
     )
 
 
@@ -291,8 +292,8 @@ async def handle_list_files(
                 "size_bytes": f.size_bytes,
                 "sha256": f.sha256,
                 "status": f.status,
-                "created_at": f.created_at.isoformat() if f.created_at else None,
-                "uploaded_at": f.uploaded_at.isoformat() if f.uploaded_at else None,
+                "created_at": to_utc_iso(f.created_at) if f.created_at else None,
+                "uploaded_at": to_utc_iso(f.uploaded_at) if f.uploaded_at else None,
             }
             for f in files
         ],

--- a/backend/src/mcp_server/tools/files.py
+++ b/backend/src/mcp_server/tools/files.py
@@ -27,6 +27,7 @@ from services.file_storage_service import FileStorageService
 from utils.datetime import to_utc_iso
 from utils.exceptions import (
     ConflictError,
+    ExternalServiceError,
     NotFoundException,
     QuotaExceededError,
     ValidationError,
@@ -50,6 +51,12 @@ def _exc_to_error_response(exc: Exception) -> list[TextContent]:
         return _error_response("conflict", str(exc))
     if isinstance(exc, QuotaExceededError):
         return _error_response("quota_exceeded", str(exc))
+    if isinstance(exc, ExternalServiceError):
+        # R2 5xx / AccessDenied / throttling — reachable from
+        # ``confirm_upload`` and ``get_presigned_download``. Surface as a
+        # named error so clients can retry with backoff rather than
+        # treating it as an opaque 500.
+        return _error_response("service_unavailable", str(exc))
     raise exc  # unexpected — let the dispatch layer log a 500
 
 
@@ -162,7 +169,12 @@ async def handle_complete_file_upload(
                 file_id=file_id,
                 sha256=str(args["sha256"]).lower(),
             )
-        except (ValidationError, ConflictError, NotFoundException) as exc:
+        except (
+            ValidationError,
+            ConflictError,
+            NotFoundException,
+            ExternalServiceError,
+        ) as exc:
             return _exc_to_error_response(exc)
     return _success_response(
         file_id=str(file.id),
@@ -209,7 +221,7 @@ async def handle_get_file_download_url(
                 workspace_id=ws,
                 file_id=file_id,
             )
-        except (ValidationError, NotFoundException) as exc:
+        except (ValidationError, NotFoundException, ExternalServiceError) as exc:
             return _exc_to_error_response(exc)
     return _success_response(download_url=url)
 

--- a/backend/src/mcp_server/tools/files.py
+++ b/backend/src/mcp_server/tools/files.py
@@ -1,0 +1,300 @@
+"""MCP tool handlers for platform-managed file storage (Issue #485).
+
+Five thin handlers that route through ``FileStorageService`` — the
+exact same service the REST routes use, so the #332 lesson (REST and
+MCP must funnel through one quota check) is enforced structurally.
+
+Tool names use the verb-first convention shared with the rest of the
+MCP surface (``init_file_upload`` / ``complete_file_upload`` /
+``get_file_download_url`` / ``list_files`` / ``delete_file``). All
+five operate on a workspace (no ``context_id``) so they live in
+``_TOOLS_WITHOUT_CONTEXT_ID``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from mcp.types import TextContent
+
+from mcp_server.tools._helpers import (
+    _check_viewer_permission,
+    _error_response,
+    _success_response,
+)
+from services.file_storage_service import FileStorageService
+from utils.exceptions import (
+    ConflictError,
+    NotFoundException,
+    QuotaExceededError,
+    ValidationError,
+)
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _exc_to_error_response(exc: Exception) -> list[TextContent]:
+    """Map a service-layer exception to an MCP error response.
+
+    Mirrors the global REST exception handler so MCP clients see the
+    same vocabulary as REST callers.
+    """
+    if isinstance(exc, ValidationError):
+        return _error_response("validation_error", str(exc))
+    if isinstance(exc, NotFoundException):
+        return _error_response("not_found", str(exc))
+    if isinstance(exc, ConflictError):
+        return _error_response("conflict", str(exc))
+    if isinstance(exc, QuotaExceededError):
+        return _error_response("quota_exceeded", str(exc))
+    raise exc  # unexpected — let the dispatch layer log a 500
+
+
+async def _resolve_workspace(
+    workspace_id_arg: Any,
+    fallback: UUID | None,
+) -> tuple[UUID | None, list[TextContent] | None]:
+    """Resolve the workspace_id from the tool args, falling back to the
+    authenticated workspace_id if not specified.
+
+    Returns ``(workspace_id, error)`` — exactly one is non-None.
+    """
+    if workspace_id_arg is None:
+        if fallback is None:
+            return None, _error_response("workspace_required", "No active workspace.")
+        return fallback, None
+    try:
+        return UUID(str(workspace_id_arg)), None
+    except (ValueError, TypeError):
+        return None, _error_response(
+            "validation_error",
+            f"workspace_id must be a UUID, got {workspace_id_arg!r}",
+        )
+
+
+# ---------------------------------------------------------------------------
+# init_file_upload
+# ---------------------------------------------------------------------------
+
+
+async def handle_init_file_upload(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Reserve quota and return a presigned PUT URL.
+
+    Required args: ``filename``, ``content_type``, ``size_bytes``, ``sha256``.
+    Optional: ``workspace_id`` (overrides the authenticated workspace).
+    """
+    required = {"filename", "content_type", "size_bytes", "sha256"}
+    missing = required - args.keys()
+    if missing:
+        return _error_response("missing_fields", f"Missing required fields: {sorted(missing)}")
+
+    ws, err = await _resolve_workspace(args.get("workspace_id"), workspace_id)
+    if err is not None:
+        return err
+
+    from db.base import get_db
+
+    async for db in get_db():
+        viewer_err = await _check_viewer_permission(db, user_id, ws, "upload files")
+        if viewer_err is not None:
+            return viewer_err
+        service = FileStorageService(db)
+        try:
+            result = await service.reserve_upload(
+                workspace_id=ws,
+                created_by=user_id,
+                filename=str(args["filename"]),
+                content_type=str(args["content_type"]),
+                size_bytes=int(args["size_bytes"]),
+                sha256=str(args["sha256"]).lower(),
+            )
+        except (ValidationError, ConflictError, QuotaExceededError, NotFoundException) as exc:
+            return _exc_to_error_response(exc)
+    return _success_response(
+        file_id=str(result.file_id),
+        upload_url=result.upload_url,
+        expires_at=result.expires_at.isoformat(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# complete_file_upload
+# ---------------------------------------------------------------------------
+
+
+async def handle_complete_file_upload(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Verify the upload landed and finalize the row.
+
+    Required args: ``file_id``, ``sha256``.
+    Optional: ``workspace_id``.
+    """
+    required = {"file_id", "sha256"}
+    missing = required - args.keys()
+    if missing:
+        return _error_response("missing_fields", f"Missing required fields: {sorted(missing)}")
+
+    ws, err = await _resolve_workspace(args.get("workspace_id"), workspace_id)
+    if err is not None:
+        return err
+
+    try:
+        file_id = UUID(str(args["file_id"]))
+    except (ValueError, TypeError):
+        return _error_response("validation_error", "file_id must be a UUID")
+
+    from db.base import get_db
+
+    async for db in get_db():
+        viewer_err = await _check_viewer_permission(db, user_id, ws, "confirm file uploads")
+        if viewer_err is not None:
+            return viewer_err
+        service = FileStorageService(db)
+        try:
+            file = await service.confirm_upload(
+                workspace_id=ws,
+                file_id=file_id,
+                sha256=str(args["sha256"]).lower(),
+            )
+        except (ValidationError, ConflictError, NotFoundException) as exc:
+            return _exc_to_error_response(exc)
+    return _success_response(
+        file_id=str(file.id),
+        status=file.status,
+        size_bytes=file.size_bytes,
+        sha256=file.sha256,
+    )
+
+
+# ---------------------------------------------------------------------------
+# get_file_download_url
+# ---------------------------------------------------------------------------
+
+
+async def handle_get_file_download_url(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Return a short-lived presigned GET URL.
+
+    Required args: ``file_id``.
+    Optional: ``workspace_id``.
+    """
+    if "file_id" not in args:
+        return _error_response("missing_fields", "Missing required field: file_id")
+
+    ws, err = await _resolve_workspace(args.get("workspace_id"), workspace_id)
+    if err is not None:
+        return err
+
+    try:
+        file_id = UUID(str(args["file_id"]))
+    except (ValueError, TypeError):
+        return _error_response("validation_error", "file_id must be a UUID")
+
+    from db.base import get_db
+
+    async for db in get_db():
+        # Viewer can read; no permission gate beyond workspace membership
+        # (which the auth dep enforces upstream).
+        del user_id  # not currently used; reserve for future audit logging
+        service = FileStorageService(db)
+        try:
+            url = await service.get_presigned_download(
+                workspace_id=ws,
+                file_id=file_id,
+            )
+        except (ValidationError, NotFoundException) as exc:
+            return _exc_to_error_response(exc)
+    return _success_response(download_url=url)
+
+
+# ---------------------------------------------------------------------------
+# delete_file
+# ---------------------------------------------------------------------------
+
+
+async def handle_delete_file(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Soft-delete a file and immediately release the quota.
+
+    Required args: ``file_id``.
+    Optional: ``workspace_id``.
+    """
+    if "file_id" not in args:
+        return _error_response("missing_fields", "Missing required field: file_id")
+
+    ws, err = await _resolve_workspace(args.get("workspace_id"), workspace_id)
+    if err is not None:
+        return err
+
+    try:
+        file_id = UUID(str(args["file_id"]))
+    except (ValueError, TypeError):
+        return _error_response("validation_error", "file_id must be a UUID")
+
+    from db.base import get_db
+
+    async for db in get_db():
+        viewer_err = await _check_viewer_permission(db, user_id, ws, "delete files")
+        if viewer_err is not None:
+            return viewer_err
+        service = FileStorageService(db)
+        try:
+            await service.delete_file(workspace_id=ws, file_id=file_id)
+        except NotFoundException as exc:
+            return _exc_to_error_response(exc)
+    return _success_response(file_id=str(file_id), deleted=True)
+
+
+# ---------------------------------------------------------------------------
+# list_files
+# ---------------------------------------------------------------------------
+
+
+async def handle_list_files(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """List uploaded, non-deleted files in the workspace, newest first.
+
+    Optional args: ``workspace_id``, ``limit`` (default 50).
+    """
+    ws, err = await _resolve_workspace(args.get("workspace_id"), workspace_id)
+    if err is not None:
+        return err
+
+    try:
+        limit = int(args.get("limit", 50))
+    except (ValueError, TypeError):
+        return _error_response("validation_error", "limit must be an integer")
+
+    from db.base import get_db
+
+    async for db in get_db():
+        del user_id  # auth enforced upstream; viewer can list
+        service = FileStorageService(db)
+        try:
+            files = await service.list_files(workspace_id=ws, limit=limit)
+        except ValidationError as exc:
+            return _exc_to_error_response(exc)
+    return _success_response(
+        files=[
+            {
+                "id": str(f.id),
+                "filename": f.filename,
+                "content_type": f.content_type,
+                "size_bytes": f.size_bytes,
+                "sha256": f.sha256,
+                "status": f.status,
+                "created_at": f.created_at.isoformat() if f.created_at else None,
+                "uploaded_at": f.uploaded_at.isoformat() if f.uploaded_at else None,
+            }
+            for f in files
+        ],
+        count=len(files),
+    )

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -9,9 +9,11 @@
 # ``backend/tests/conftest.py`` so production startup matches the
 # test environment's import graph (#531).
 import models.analysis  # noqa: F401
+import models.file_objects  # noqa: F401  # Issue #485: file storage
 import models.llm_pricing  # noqa: F401
 import models.sleep  # noqa: F401
 from models.config import ContextSearchConfig
+from models.file_objects import FileObject, WorkspaceStorageUsage
 from models.neural import NeuralConfig
 from models.resource import (
     IndexerState,
@@ -24,6 +26,8 @@ from models.resource import (
 __all__ = [
     "NeuralConfig",
     "ContextSearchConfig",
+    "FileObject",
+    "WorkspaceStorageUsage",
     "ResourceEvent",
     "ResourceSchema",
     "IndexerState",

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1284,6 +1284,18 @@ class Workspace(Base):
         """Memory Broadlistening analysis runs/day: plan tier base + addon (Issue #494)."""
         return self._plan_tier.analysis_runs_per_day + (self.addon_analysis_bonus or 0)
 
+    @property
+    def effective_storage_limit_bytes(self) -> int:
+        """File-storage hard cap (bytes): plan tier base + addon (Issue #485).
+
+        ``addon_storage_bonus_mb`` stores the bonus in MB to align with the
+        ``ADDON_UNIT_VALUES["extra_storage"]`` unit; the conversion to bytes
+        happens here so callers always see a single unit at the boundary.
+        """
+        return (
+            self._plan_tier.storage_limit_bytes + (self.addon_storage_bonus_mb or 0) * 1024 * 1024
+        )
+
     # Stripe billing (Issue #351)
     stripe_customer_id = Column(String(255), nullable=True)
     stripe_subscription_id = Column(String(255), nullable=True)

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1209,6 +1209,7 @@ class Workspace(Base):
     addon_member_bonus = Column(Integer, nullable=False, server_default="0")
     addon_context_bonus = Column(Integer, nullable=False, server_default="0")  # Issue #15
     addon_analysis_bonus = Column(Integer, nullable=False, server_default="0")  # Issue #494
+    addon_storage_bonus_mb = Column(Integer, nullable=False, server_default="0")  # Issue #485
 
     # Issue #494: per-workspace default + quality model selection for
     # Memory Broadlistening analyses. Both nullable — analysis is gated

--- a/backend/src/models/file_objects.py
+++ b/backend/src/models/file_objects.py
@@ -1,0 +1,163 @@
+"""SQLAlchemy models for platform-managed file storage (Issue #485).
+
+Two tables:
+
+- ``file_objects`` — authoritative blob registry. One row per uploaded
+  file. The ``status`` column carries the upload state machine
+  (``reserved → uploaded`` on success, ``→ failed`` on orphan sweep).
+- ``workspace_storage_usage`` — per-workspace denormalized counter.
+  Updated atomically with ``file_objects`` insert/soft-delete so quota
+  checks read a single hot row instead of online ``SUM()`` (same lesson
+  as #50 / #136 / #198 around effective quota centralization).
+
+Phase 1 only writes ``storage_backend='r2'`` rows. ``inline_bytes`` /
+``pg_inline`` is reserved Phase 1.5; the CHECK constraint already
+covers both shapes so no ALTER is needed when the inline path lands.
+
+Phase 2 BYO bucket support (``byo_s3`` / ``byo_gcs``) does NOT add rows
+here — those references live directly in ``Memory.details.external_blob``
+with ``backend='byo_*'`` and ``ref=<bucket URI>``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import BYTEA
+from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+
+from db.base import Base
+
+
+class FileObject(Base):
+    """One row per uploaded file (Issue #485).
+
+    The upload flow is:
+
+    1. ``upload-init`` inserts a row with ``status='reserved'`` and a
+       short-lived presigned PUT URL.
+    2. The client PUTs bytes directly to R2 using the presigned URL.
+    3. ``upload-complete`` verifies the object via ``head_object`` and
+       transitions ``reserved → uploaded``.
+    4. If the client never confirms, the orphan sweeper transitions
+       ``reserved → failed`` after the TTL grace and releases the
+       reserved quota bytes.
+    """
+
+    __tablename__ = "file_objects"
+
+    id: Column[UUID] = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4)
+    workspace_id: Column[UUID] = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    sha256 = Column(String(64), nullable=False)
+    size_bytes = Column(BigInteger, nullable=False)
+    content_type = Column(String(255), nullable=False)
+    filename = Column(String(512), nullable=False)
+
+    storage_backend = Column(
+        String(20),
+        nullable=False,
+        server_default="r2",
+        comment="'r2' (Phase 1), 'pg_inline' (reserved Phase 1.5)",
+    )
+    storage_key = Column(String(1024), nullable=True)
+    inline_bytes = Column(BYTEA, nullable=True)
+
+    status = Column(
+        String(20),
+        nullable=False,
+        server_default="reserved",
+        comment="'reserved' | 'uploaded' | 'failed'",
+    )
+    expires_at: Column[datetime] = Column(DateTime, nullable=True)
+    created_by = Column(String(255), nullable=False)
+
+    created_at: Column[datetime] = Column(DateTime, nullable=False, server_default=func.now())
+    uploaded_at: Column[datetime] = Column(DateTime, nullable=True)
+    deleted_at: Column[datetime] = Column(DateTime, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "storage_backend IN ('r2', 'pg_inline')",
+            name="valid_file_storage_backend",
+        ),
+        CheckConstraint(
+            "status IN ('reserved', 'uploaded', 'failed')",
+            name="valid_file_status",
+        ),
+        # Phase-coherent shape: r2 rows must have a key; pg_inline rows must
+        # have inline bytes; reserved rows are exempt because the client may
+        # not have completed the PUT yet (storage_key NULL is normal in flight).
+        CheckConstraint(
+            (
+                "(status = 'reserved') "
+                "OR (storage_backend = 'r2' "
+                "    AND storage_key IS NOT NULL "
+                "    AND inline_bytes IS NULL) "
+                "OR (storage_backend = 'pg_inline' "
+                "    AND storage_key IS NULL "
+                "    AND inline_bytes IS NOT NULL)"
+            ),
+            name="valid_file_storage_shape",
+        ),
+        # Active dedup: a workspace can hold one row per sha256 at a time;
+        # soft-deleted and failed rows are excluded so a redo upload
+        # of a previously-deleted file is allowed.
+        Index(
+            "uq_file_objects_workspace_sha256_active",
+            "workspace_id",
+            "sha256",
+            unique=True,
+            postgresql_where=("deleted_at IS NULL AND status <> 'failed'"),
+        ),
+        # Orphan sweep helper: only matters for in-flight reservations.
+        Index(
+            "idx_file_objects_reserved_expires",
+            "expires_at",
+            postgresql_where="status = 'reserved'",
+        ),
+    )
+
+
+class WorkspaceStorageUsage(Base):
+    """Denormalized per-workspace storage counter (Issue #485).
+
+    Maintained atomically with ``file_objects`` inserts/soft-deletes so
+    the quota path reads one row instead of an online ``SUM`` over
+    millions of rows. Identical pattern to ``addon_*_bonus`` columns on
+    ``Workspace`` — single source of truth for fast reads.
+    """
+
+    __tablename__ = "workspace_storage_usage"
+
+    workspace_id: Column[UUID] = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    used_bytes = Column(BigInteger, nullable=False, server_default="0")
+    file_count = Column(Integer, nullable=False, server_default="0")
+    updated_at: Column[datetime] = Column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        CheckConstraint("used_bytes >= 0", name="nonneg_used_bytes"),
+        CheckConstraint("file_count >= 0", name="nonneg_file_count"),
+    )

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -162,6 +162,20 @@ class Memory(Base):
         index=False,  # Index created in Migration 061
     )
 
+    # Issue #485: Polymorphic blob reference inside details.external_blob.
+    # Phase 1 only writes backend='platform_r2'; Phase 2 BYO adds
+    # 'byo_s3'/'byo_gcs' rows without altering this schema.
+    external_blob_backend = Column(
+        String(50),
+        Computed("details->'external_blob'->>'backend'", persisted=True),
+        index=False,  # Partial btree index created in migration e03_485
+    )
+    external_blob_ref = Column(
+        String(2048),
+        Computed("details->'external_blob'->>'ref'", persisted=True),
+        index=False,  # Partial btree index created in migration e03_485
+    )
+
     # Constraints
     __table_args__ = (
         CheckConstraint("importance BETWEEN 0 AND 1", name="valid_importance"),

--- a/backend/src/services/effective_quota_service.py
+++ b/backend/src/services/effective_quota_service.py
@@ -104,6 +104,7 @@ class EffectiveQuotaService:
             "max_members": workspace.effective_max_members,
             "max_contexts": workspace.effective_max_contexts,
             "analysis_runs_per_day": workspace.effective_analysis_runs_per_day,
+            "storage_bytes_limit": workspace.effective_storage_limit_bytes,
         }
 
         logger.debug(

--- a/backend/src/services/file_storage_service.py
+++ b/backend/src/services/file_storage_service.py
@@ -370,6 +370,91 @@ class FileStorageService:
         )
 
     # ------------------------------------------------------------------
+    # Legacy attachment migration (Commit 9 of #485)
+    # ------------------------------------------------------------------
+
+    async def migrate_attachment(
+        self,
+        *,
+        workspace_id: UUID,
+        attachment_id: UUID,
+        filename: str,
+        content_type: str,
+        size_bytes: int,
+        data: bytes,
+        created_by: str,
+    ) -> FileObject:
+        """Copy a legacy ``attachments`` BYTEA row to R2 + ``file_objects``.
+
+        Idempotent: if a ``file_objects`` row already exists for this
+        attachment (matched by the legacy ``storage_key`` shape) the
+        existing row is returned without re-uploading.
+
+        The legacy ``Attachment`` row stays untouched — the existing
+        REST attachments route continues to serve from BYTEA until a
+        follow-up PR migrates it. This commit's job is to land the
+        bytes in R2 and the metadata in ``file_objects`` so the
+        cutover is unblocked.
+        """
+        import hashlib
+
+        sha256 = hashlib.sha256(data).hexdigest()
+        # Distinct key shape so legacy migrations are visually
+        # distinguishable from new uploads (no sha256 sub-prefix here
+        # because the attachment_id is already unique-per-workspace).
+        storage_key = f"{workspace_id}/legacy/{attachment_id}/{filename}"
+
+        existing = await self.db.execute(
+            select(FileObject).where(FileObject.storage_key == storage_key)
+        )
+        existing_row = existing.scalar_one_or_none()
+        if existing_row is not None:
+            logger.info(
+                "attachment_migration_skipped_already_done",
+                attachment_id=str(attachment_id),
+                file_id=str(existing_row.id),
+            )
+            return existing_row
+
+        await self._storage.write_object(
+            key=storage_key,
+            data=data,
+            content_type=content_type,
+            sha256=sha256,
+        )
+
+        now = utcnow()
+        file = FileObject(
+            id=uuid4(),
+            workspace_id=workspace_id,
+            sha256=sha256,
+            size_bytes=size_bytes,
+            content_type=content_type,
+            filename=filename,
+            storage_backend="r2",
+            storage_key=storage_key,
+            inline_bytes=None,
+            status="uploaded",
+            expires_at=None,
+            created_by=created_by,
+            created_at=now,
+            uploaded_at=now,
+        )
+        self.db.add(file)
+        await self.db.flush()
+        await self._upsert_workspace_usage(workspace_id, delta_bytes=size_bytes, delta_files=1)
+        await self.db.commit()
+        await self.db.refresh(file)
+
+        logger.info(
+            "attachment_migrated_to_r2",
+            attachment_id=str(attachment_id),
+            file_id=str(file.id),
+            size_bytes=size_bytes,
+        )
+        return file
+
+    # ------------------------------------------------------------------
     # Delete (R5: immediate quota release)
     # ------------------------------------------------------------------
 

--- a/backend/src/services/file_storage_service.py
+++ b/backend/src/services/file_storage_service.py
@@ -102,10 +102,11 @@ class FileStorageService:
         Per-workspace prefix supports per-prefix lifecycle/ACL policies;
         sha256[:2] sub-prefix avoids R2 hot-partition on workloads that
         upload many files in quick succession.
+
+        Caller is the only public path (``reserve_upload``) and that
+        path validates ``len(sha256) == 64`` upstream — no defensive
+        re-check here.
         """
-        if len(sha256) != 64:
-            msg = f"sha256 must be 64 hex chars, got {len(sha256)}"
-            raise ValidationError(msg)
         return f"{workspace_id}/{sha256[:2]}/{sha256}"
 
     async def _load_workspace(self, workspace_id: UUID) -> Workspace:

--- a/backend/src/services/file_storage_service.py
+++ b/backend/src/services/file_storage_service.py
@@ -210,9 +210,22 @@ class FileStorageService:
             )
             self.db.add(file)
             await self.db.flush()
+            upload_url = await self._storage.generate_presigned_put(
+                key=storage_key,
+                content_type=content_type,
+                size_bytes=size_bytes,
+                ttl_seconds=settings.presign_put_ttl_seconds,
+            )
+            await self.db.commit()
         except Exception as exc:
-            # Roll the Redis reservation back — the DB insert never landed
-            # so we owe the workspace those bytes.
+            # Roll the Redis reservation back — neither the DB row nor the
+            # presigned URL are durable. Covers all three failure modes:
+            # flush() (partial-unique conflict), presign (R2 transient
+            # error), and commit() (DB consistency). Without this, the
+            # Redis counter would stay incremented until the 24h reseed
+            # — over-counting the workspace by ``size_bytes`` and
+            # potentially blocking later legitimate uploads on small
+            # plans.
             await storage_quota_service.release_storage_bytes(
                 workspace_id=workspace_id,
                 size_bytes=size_bytes,
@@ -224,15 +237,6 @@ class FileStorageService:
                 conflict = ConflictError(f"file with sha256={sha256} already exists in workspace")
                 raise conflict from exc
             raise
-
-        upload_url = await self._storage.generate_presigned_put(
-            key=storage_key,
-            content_type=content_type,
-            size_bytes=size_bytes,
-            ttl_seconds=settings.presign_put_ttl_seconds,
-        )
-
-        await self.db.commit()
 
         logger.info(
             "file_upload_reserved",
@@ -503,9 +507,33 @@ class FileStorageService:
         The R2 binary stays for 7 days (sweeper handles deletion).
         """
         file = await self._load_file(workspace_id, file_id)
+
+        # Reserved rows: ``reserve_upload`` already incremented the Redis
+        # counter, but no committed-bytes are tracked in
+        # ``workspace_storage_usage`` yet. Release the reservation here
+        # so a cancelled in-flight upload doesn't leave the workspace's
+        # quota stuck until the orphan sweeper runs (15 minutes later
+        # by default — long enough on the Free 100 MiB tier to block
+        # the next legitimate upload after a single cancelled big one).
+        if file.status == "reserved":
+            reserved_size = file.size_bytes
+            file.deleted_at = utcnow()
+            await self.db.commit()
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=reserved_size,
+            )
+            logger.info(
+                "file_reserved_cancelled",
+                workspace_id=str(workspace_id),
+                file_id=str(file_id),
+                size_bytes=reserved_size,
+            )
+            return
+
+        # Failed rows: orphan sweeper already released the Redis counter
+        # when the row transitioned reserved → failed. Just mark deleted.
         if file.status != "uploaded":
-            # Non-uploaded rows have no committed quota to release; just
-            # mark them deleted so retries see the latest state.
             file.deleted_at = utcnow()
             await self.db.commit()
             return

--- a/backend/src/services/file_storage_service.py
+++ b/backend/src/services/file_storage_service.py
@@ -1,0 +1,453 @@
+"""``FileStorageService`` — Phase 1 platform-managed file storage (Issue #485).
+
+Single shared service for both the REST router (``/api/v1/files/*``) and
+the MCP tool layer (``init_file_upload`` / ``complete_file_upload`` /
+``get_file_download_url`` / ``delete_file``). The #332 lesson is enforced
+structurally: there is exactly one place that calls
+``storage_quota_service.reserve_storage_bytes`` and one place that
+generates presigned R2 URLs — this class.
+
+Upload state machine (R3):
+
+    upload-init  ──INSERT(reserved)──▶  client PUTs to presigned URL
+                                              │
+                                              ▼
+                                   upload-complete (head_object OK)
+                                              │
+                                              ▼
+                                          uploaded
+                                              │
+                                              ▼
+                              soft-delete (R5: quota released here)
+                                              │
+                                              ▼
+                                   nightly GC (R2 binary deleted)
+
+Orphan path: ``status='reserved'`` rows past ``expires_at + 1h`` are
+swept by the orphan task (Commit 8) — the sweeper calls
+``release_storage_bytes`` and deletes any orphan R2 object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from uuid import UUID, uuid4
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.settings import get_settings
+from models.auth import Workspace
+from models.file_objects import FileObject, WorkspaceStorageUsage
+from services import storage_quota_service
+from storage.factory import get_blob_storage
+from storage.protocol import BlobStorageProtocol
+from utils.datetime import utcnow
+from utils.exceptions import (
+    ConflictError,
+    NotFoundException,
+    ValidationError,
+)
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class ReserveResult:
+    """Returned by ``reserve_upload`` — what the REST/MCP handler echoes
+    back to the client."""
+
+    file_id: UUID
+    upload_url: str
+    expires_at: datetime
+
+
+class FileStorageService:
+    """One row, one service. Both REST and MCP funnel through here.
+
+    The class is intentionally light: complex behaviour (Redis
+    reservation, presigned URL generation, blob backend selection)
+    lives in the dedicated modules
+    (``storage_quota_service``, ``storage.factory``, ``storage.r2``).
+    """
+
+    def __init__(
+        self,
+        db: AsyncSession,
+        *,
+        storage: BlobStorageProtocol | None = None,
+    ) -> None:
+        self.db = db
+        self._storage_override = storage
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def _storage(self) -> BlobStorageProtocol:
+        """Resolve the blob backend lazily so unit tests can inject a fake
+        without paying the ``get_blob_storage`` cost."""
+        if self._storage_override is not None:
+            return self._storage_override
+        return get_blob_storage()
+
+    @staticmethod
+    def _build_storage_key(workspace_id: UUID, sha256: str) -> str:
+        """Bucket key per issue spec: ``{workspace_id}/{sha256[:2]}/{sha256}``.
+
+        Per-workspace prefix supports per-prefix lifecycle/ACL policies;
+        sha256[:2] sub-prefix avoids R2 hot-partition on workloads that
+        upload many files in quick succession.
+        """
+        if len(sha256) != 64:
+            msg = f"sha256 must be 64 hex chars, got {len(sha256)}"
+            raise ValidationError(msg)
+        return f"{workspace_id}/{sha256[:2]}/{sha256}"
+
+    async def _load_workspace(self, workspace_id: UUID) -> Workspace:
+        result = await self.db.execute(select(Workspace).where(Workspace.id == workspace_id))
+        workspace = result.scalar_one_or_none()
+        if workspace is None:
+            msg = f"workspace {workspace_id} not found"
+            raise NotFoundException(msg)
+        return workspace
+
+    async def _load_file(
+        self,
+        workspace_id: UUID,
+        file_id: UUID,
+        *,
+        include_deleted: bool = False,
+    ) -> FileObject:
+        """Load a file_objects row, enforcing workspace boundary.
+
+        Cross-workspace access raises ``NotFoundException`` (not 403) so
+        the existence of a file in another workspace is not leaked.
+        """
+        result = await self.db.execute(
+            select(FileObject).where(
+                FileObject.id == file_id,
+                FileObject.workspace_id == workspace_id,
+            )
+        )
+        file = result.scalar_one_or_none()
+        if file is None:
+            msg = f"file {file_id} not found in workspace {workspace_id}"
+            raise NotFoundException(msg)
+        if not include_deleted and file.deleted_at is not None:
+            msg = f"file {file_id} not found in workspace {workspace_id}"
+            raise NotFoundException(msg)
+        return file
+
+    # ------------------------------------------------------------------
+    # Upload flow (R3)
+    # ------------------------------------------------------------------
+
+    async def reserve_upload(
+        self,
+        *,
+        workspace_id: UUID,
+        created_by: str,
+        filename: str,
+        content_type: str,
+        size_bytes: int,
+        sha256: str,
+    ) -> ReserveResult:
+        """Reserve quota + insert reserved row + return presigned PUT URL.
+
+        Raises:
+            ValidationError: invalid size or sha256.
+            QuotaExceededError: workspace storage cap would be exceeded.
+            ConflictError: same ``(workspace_id, sha256)`` already has an
+                active or in-flight row (partial unique violation).
+            NotFoundException: workspace missing.
+        """
+        settings = get_settings()
+        max_bytes = settings.file_object_max_size_mb * 1024 * 1024
+        if size_bytes <= 0 or size_bytes > max_bytes:
+            msg = f"size_bytes must be in (0, {max_bytes}], got {size_bytes}"
+            raise ValidationError(msg)
+        if len(sha256) != 64:
+            msg = f"sha256 must be 64 hex chars, got {len(sha256)}"
+            raise ValidationError(msg)
+
+        workspace = await self._load_workspace(workspace_id)
+
+        # R5/R3: reserve in Redis BEFORE inserting the row so a quota
+        # rejection short-circuits without touching the DB.
+        await storage_quota_service.reserve_storage_bytes(
+            workspace_id=workspace_id,
+            size_bytes=size_bytes,
+            quota_bytes=workspace.effective_storage_limit_bytes,
+            db=self.db,
+        )
+
+        try:
+            file_id = uuid4()
+            storage_key = self._build_storage_key(workspace_id, sha256)
+            now = utcnow()
+            expires_at = now + timedelta(seconds=settings.presign_put_ttl_seconds)
+
+            file = FileObject(
+                id=file_id,
+                workspace_id=workspace_id,
+                sha256=sha256,
+                size_bytes=size_bytes,
+                content_type=content_type,
+                filename=filename,
+                storage_backend="r2",
+                storage_key=storage_key,
+                inline_bytes=None,
+                status="reserved",
+                expires_at=expires_at,
+                created_by=created_by,
+                created_at=now,
+            )
+            self.db.add(file)
+            await self.db.flush()
+        except Exception as exc:
+            # Roll the Redis reservation back — the DB insert never landed
+            # so we owe the workspace those bytes.
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=size_bytes,
+            )
+            # Detect the partial unique violation without depending on a
+            # specific dialect class — the index name surfaces in the
+            # message.
+            if "uq_file_objects_workspace_sha256_active" in str(exc):
+                conflict = ConflictError(f"file with sha256={sha256} already exists in workspace")
+                raise conflict from exc
+            raise
+
+        upload_url = await self._storage.generate_presigned_put(
+            key=storage_key,
+            content_type=content_type,
+            size_bytes=size_bytes,
+            ttl_seconds=settings.presign_put_ttl_seconds,
+        )
+
+        await self.db.commit()
+
+        logger.info(
+            "file_upload_reserved",
+            workspace_id=str(workspace_id),
+            file_id=str(file_id),
+            sha256=sha256,
+            size_bytes=size_bytes,
+        )
+        return ReserveResult(
+            file_id=file_id,
+            upload_url=upload_url,
+            expires_at=expires_at,
+        )
+
+    async def confirm_upload(
+        self,
+        *,
+        workspace_id: UUID,
+        file_id: UUID,
+        sha256: str,
+    ) -> FileObject:
+        """Verify the upload landed in R2 and finalize the row.
+
+        Idempotent on retry: if the row is already ``status='uploaded'``
+        and the sha256 matches, return the existing row unchanged.
+
+        Raises:
+            NotFoundException: file or its workspace not found.
+            ValidationError: sha256 mismatch (tamper / wrong upload).
+            ConflictError: ``head_object`` says the binary is missing.
+        """
+        file = await self._load_file(workspace_id, file_id)
+
+        # Idempotent retry path
+        if file.status == "uploaded":
+            if file.sha256 != sha256:
+                msg = f"sha256 mismatch on retry: stored={file.sha256[:8]}…, caller={sha256[:8]}…"
+                raise ValidationError(msg)
+            return file
+
+        if file.status != "reserved":
+            msg = f"file {file_id} is in status={file.status!r}; cannot confirm"
+            raise ValidationError(msg)
+
+        if file.sha256 != sha256:
+            msg = (
+                f"sha256 mismatch: reservation declared {file.sha256[:8]}…, "
+                f"upload reports {sha256[:8]}…"
+            )
+            raise ValidationError(msg)
+
+        # R2 head_object verifies the client actually wrote bytes
+        meta = await self._storage.head_object(file.storage_key or "")
+        if meta is None:
+            msg = (
+                f"R2 object missing for file {file_id} (key={file.storage_key}); "
+                "presigned PUT may have expired or never happened"
+            )
+            raise ConflictError(msg)
+        if meta["size_bytes"] != file.size_bytes:
+            # Truncation refund: release the difference back to the quota
+            # so the workspace isn't charged for bytes it didn't write.
+            delta = file.size_bytes - meta["size_bytes"]
+            if delta > 0:
+                await storage_quota_service.release_storage_bytes(
+                    workspace_id=workspace_id,
+                    size_bytes=delta,
+                )
+            file.size_bytes = meta["size_bytes"]
+
+        file.status = "uploaded"
+        file.uploaded_at = utcnow()
+        file.expires_at = None  # uploaded rows are durable; expires_at is sweeper-only
+
+        await self._upsert_workspace_usage(workspace_id, delta_bytes=file.size_bytes, delta_files=1)
+
+        await self.db.commit()
+        await self.db.refresh(file)
+
+        logger.info(
+            "file_upload_confirmed",
+            workspace_id=str(workspace_id),
+            file_id=str(file_id),
+            size_bytes=file.size_bytes,
+        )
+        return file
+
+    # ------------------------------------------------------------------
+    # Read / download
+    # ------------------------------------------------------------------
+
+    async def list_files(
+        self,
+        *,
+        workspace_id: UUID,
+        limit: int = 50,
+    ) -> list[FileObject]:
+        """Return uploaded, non-deleted files for the workspace, newest first."""
+        if limit <= 0 or limit > 500:
+            msg = f"limit must be in (0, 500], got {limit}"
+            raise ValidationError(msg)
+
+        result = await self.db.execute(
+            select(FileObject)
+            .where(
+                FileObject.workspace_id == workspace_id,
+                FileObject.deleted_at.is_(None),
+                FileObject.status == "uploaded",
+            )
+            .order_by(FileObject.created_at.desc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def get_presigned_download(
+        self,
+        *,
+        workspace_id: UUID,
+        file_id: UUID,
+    ) -> str:
+        """Return a short-lived presigned GET URL for ``file_id``.
+
+        Raises ``NotFoundException`` for missing / deleted / not-yet-uploaded
+        files (cross-workspace identity is not leaked).
+        """
+        file = await self._load_file(workspace_id, file_id)
+        if file.status != "uploaded":
+            msg = f"file {file_id} not found in workspace {workspace_id}"
+            raise NotFoundException(msg)
+
+        settings = get_settings()
+        return await self._storage.generate_presigned_get(
+            key=file.storage_key or "",
+            filename=file.filename,
+            ttl_seconds=settings.presign_get_ttl_seconds,
+        )
+
+    # ------------------------------------------------------------------
+    # Delete (R5: immediate quota release)
+    # ------------------------------------------------------------------
+
+    async def delete_file(
+        self,
+        *,
+        workspace_id: UUID,
+        file_id: UUID,
+    ) -> None:
+        """Soft-delete and immediately release the quota.
+
+        R5 contract: ``deleted_at`` is set, ``workspace_storage_usage``
+        is decremented, and ``storage_quota_service.release_storage_bytes``
+        is called — all in the same DB transaction. The R2 binary stays
+        for 7 days (sweeper handles deletion in Commit 8).
+        """
+        file = await self._load_file(workspace_id, file_id)
+        if file.status != "uploaded":
+            # Non-uploaded rows have no committed quota to release; just
+            # mark them deleted so retries see the latest state.
+            file.deleted_at = utcnow()
+            await self.db.commit()
+            return
+
+        size = file.size_bytes
+        file.deleted_at = utcnow()
+        await self._upsert_workspace_usage(
+            workspace_id,
+            delta_bytes=-size,
+            delta_files=-1,
+        )
+        await storage_quota_service.release_storage_bytes(
+            workspace_id=workspace_id,
+            size_bytes=size,
+        )
+
+        await self.db.commit()
+        logger.info(
+            "file_soft_deleted",
+            workspace_id=str(workspace_id),
+            file_id=str(file_id),
+            size_bytes=size,
+        )
+
+    # ------------------------------------------------------------------
+    # Counter helper (UPSERT pattern)
+    # ------------------------------------------------------------------
+
+    async def _upsert_workspace_usage(
+        self,
+        workspace_id: UUID,
+        *,
+        delta_bytes: int,
+        delta_files: int,
+    ) -> None:
+        """Atomically adjust ``workspace_storage_usage`` for the given
+        workspace.
+
+        ON CONFLICT updates the existing row; otherwise inserts a fresh
+        row clamped to the non-negative regime (the CHECK constraint
+        also enforces this server-side).
+        """
+        now = utcnow()
+        stmt = (
+            pg_insert(WorkspaceStorageUsage)
+            .values(
+                workspace_id=workspace_id,
+                used_bytes=max(delta_bytes, 0),
+                file_count=max(delta_files, 0),
+                updated_at=now,
+            )
+            .on_conflict_do_update(
+                index_elements=[WorkspaceStorageUsage.workspace_id],
+                set_={
+                    "used_bytes": WorkspaceStorageUsage.used_bytes + delta_bytes,
+                    "file_count": WorkspaceStorageUsage.file_count + delta_files,
+                    "updated_at": now,
+                },
+            )
+        )
+        await self.db.execute(stmt)

--- a/backend/src/services/file_storage_service.py
+++ b/backend/src/services/file_storage_service.py
@@ -232,9 +232,28 @@ class FileStorageService:
             )
             # Detect the partial unique violation without depending on a
             # specific dialect class — the index name surfaces in the
-            # message.
+            # message. Look up the existing row and include its file_id
+            # in the error so SDK callers can switch to it directly
+            # instead of running a separate dedup query (the docstring
+            # of this method advertises this idempotent-retry path).
             if "uq_file_objects_workspace_sha256_active" in str(exc):
-                conflict = ConflictError(f"file with sha256={sha256} already exists in workspace")
+                existing_id = None
+                try:
+                    existing = await self.db.execute(
+                        select(FileObject.id).where(
+                            FileObject.workspace_id == workspace_id,
+                            FileObject.sha256 == sha256,
+                            FileObject.deleted_at.is_(None),
+                            FileObject.status != "failed",
+                        )
+                    )
+                    existing_id = existing.scalar_one_or_none()
+                except Exception:  # noqa: BLE001 — best-effort enrichment
+                    pass
+                msg = f"file with sha256={sha256} already exists in workspace"
+                if existing_id is not None:
+                    msg += f"; reuse file_id={existing_id}"
+                conflict = ConflictError(msg)
                 raise conflict from exc
             raise
 
@@ -262,6 +281,16 @@ class FileStorageService:
 
         Idempotent on retry: if the row is already ``status='uploaded'``
         and the sha256 matches, return the existing row unchanged.
+
+        Phase 1 limitation: this method verifies (a) the R2 object
+        exists, (b) its size matches the reservation, and (c) the
+        client's claimed sha256 matches the reservation's declared
+        sha256. It does NOT recompute the sha256 from the actual bytes
+        in R2 — a workspace member can declare sha256=X at upload-init
+        and PUT bytes with digest Y, and confirm_upload will accept
+        the upload as long as the size matches. Mitigation deferred
+        to Phase 1.5; rationale documented in
+        ``backend/src/storage/r2.py:generate_presigned_put`` SECURITY NOTE.
 
         Raises:
             NotFoundException: file or its workspace not found.
@@ -515,9 +544,16 @@ class FileStorageService:
         # quota stuck until the orphan sweeper runs (15 minutes later
         # by default — long enough on the Free 100 MiB tier to block
         # the next legitimate upload after a single cancelled big one).
+        #
+        # Critically, ALSO transition the row to ``status='failed'`` so
+        # the orphan sweeper's ``WHERE status='reserved'`` filter
+        # excludes it — without this, the sweeper would later call
+        # ``release_storage_bytes`` a second time on the same row and
+        # under-count the workspace's Redis counter.
         if file.status == "reserved":
             reserved_size = file.size_bytes
             file.deleted_at = utcnow()
+            file.status = "failed"
             await self.db.commit()
             await storage_quota_service.release_storage_bytes(
                 workspace_id=workspace_id,

--- a/backend/src/services/file_storage_service.py
+++ b/backend/src/services/file_storage_service.py
@@ -291,15 +291,25 @@ class FileStorageService:
                 "presigned PUT may have expired or never happened"
             )
             raise ConflictError(msg)
-        if meta["size_bytes"] != file.size_bytes:
-            # Truncation refund: release the difference back to the quota
-            # so the workspace isn't charged for bytes it didn't write.
-            delta = file.size_bytes - meta["size_bytes"]
-            if delta > 0:
-                await storage_quota_service.release_storage_bytes(
-                    workspace_id=workspace_id,
-                    size_bytes=delta,
-                )
+        if meta["size_bytes"] > file.size_bytes:
+            # R2 reports MORE bytes than the client declared at reservation
+            # time. This bypasses the per-file 100MB cap and over-charges
+            # quota — reject hard. Operator may need to delete the orphan
+            # R2 object manually.
+            msg = (
+                f"R2 object for file {file_id} is {meta['size_bytes']} bytes "
+                f"but reservation declared only {file.size_bytes}; rejecting "
+                "as malformed upload"
+            )
+            raise ConflictError(msg)
+
+        # Truncation refund — only the underflow case (R2 < reserved)
+        # gives bytes back to the workspace quota. ``release`` is
+        # deferred until AFTER ``db.commit`` succeeds (R5: Redis
+        # follows the durable-DB-state truth, not the other way around).
+        truncation_refund = 0
+        if meta["size_bytes"] < file.size_bytes:
+            truncation_refund = file.size_bytes - meta["size_bytes"]
             file.size_bytes = meta["size_bytes"]
 
         file.status = "uploaded"
@@ -310,6 +320,12 @@ class FileStorageService:
 
         await self.db.commit()
         await self.db.refresh(file)
+
+        if truncation_refund > 0:
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=truncation_refund,
+            )
 
         logger.info(
             "file_upload_confirmed",
@@ -446,6 +462,15 @@ class FileStorageService:
         await self.db.commit()
         await self.db.refresh(file)
 
+        # Bump the live Redis quota counter so concurrent ``reserve_upload``
+        # calls don't see a stale-low total until the 24h reseed expires.
+        # Wrapped in try/except — RedisError here is self-healing on next
+        # reseed and MUST NOT roll back the migrated row.
+        await storage_quota_service.bump_committed_storage_bytes(
+            workspace_id=workspace_id,
+            size_bytes=size_bytes,
+        )
+
         logger.info(
             "attachment_migrated_to_r2",
             attachment_id=str(attachment_id),
@@ -466,10 +491,15 @@ class FileStorageService:
     ) -> None:
         """Soft-delete and immediately release the quota.
 
-        R5 contract: ``deleted_at`` is set, ``workspace_storage_usage``
-        is decremented, and ``storage_quota_service.release_storage_bytes``
-        is called — all in the same DB transaction. The R2 binary stays
-        for 7 days (sweeper handles deletion in Commit 8).
+        R5 contract: ``deleted_at`` is set and ``workspace_storage_usage``
+        is decremented in one DB transaction. ``release_storage_bytes``
+        runs **after** that commit succeeds — Redis follows the durable
+        DB state, never leads it. If the commit fails, the row stays
+        ``uploaded`` and Redis is unchanged, preserving the invariant
+        that "Redis ≤ committed file_objects sum" (modulo in-flight
+        reservations) until the next reseed.
+
+        The R2 binary stays for 7 days (sweeper handles deletion).
         """
         file = await self._load_file(workspace_id, file_id)
         if file.status != "uploaded":
@@ -486,12 +516,12 @@ class FileStorageService:
             delta_bytes=-size,
             delta_files=-1,
         )
+        await self.db.commit()
+
         await storage_quota_service.release_storage_bytes(
             workspace_id=workspace_id,
             size_bytes=size,
         )
-
-        await self.db.commit()
         logger.info(
             "file_soft_deleted",
             workspace_id=str(workspace_id),

--- a/backend/src/services/storage_quota_service.py
+++ b/backend/src/services/storage_quota_service.py
@@ -106,6 +106,34 @@ async def reserve_storage_bytes(
         return
 
 
+async def bump_committed_storage_bytes(
+    workspace_id: UUID,
+    size_bytes: int,
+) -> None:
+    """Increment the workspace's Redis counter without a quota check.
+
+    Used by ``FileStorageService.migrate_attachment`` to keep the live
+    counter in sync after committing a migrated row directly into
+    ``status='uploaded'``. Unlike ``reserve_storage_bytes`` this does
+    not check or raise on cap exceedance — migrations restore data
+    that already exists; the cap was implicitly satisfied at original
+    upload time.
+
+    Fail-open on RedisError — next reseed self-corrects from DB.
+    """
+    if size_bytes <= 0:
+        return
+    key = _build_key(workspace_id)
+    try:
+        await incrby_counter(key, size_bytes)
+    except RedisError as exc:
+        logger.warning(
+            "storage_quota_bump_redis_failed",
+            workspace_id=str(workspace_id),
+            error=str(exc),
+        )
+
+
 async def release_storage_bytes(
     workspace_id: UUID,
     size_bytes: int,

--- a/backend/src/services/storage_quota_service.py
+++ b/backend/src/services/storage_quota_service.py
@@ -178,11 +178,42 @@ async def release_storage_bytes(
                 new_total=new_total,
             )
     except RedisError as exc:
+        # Redis is down at release time — we cannot DECRBY now and the
+        # caller will continue without retry (release is post-commit
+        # in delete_file / sweeper / truncation refund, all best-effort).
+        # Without further action the counter would remain
+        # over-counted until either the 24h reseed TTL expires OR an
+        # operator manually drops the key. Both are slow.
+        #
+        # Mitigation: best-effort EXPIRE the key to a short TTL so the
+        # next access reseeds from the DB aggregate (which is the
+        # source of truth — committed bytes are durable). If even
+        # that EXPIRE call fails, log loudly so ops can intervene
+        # (Copilot loop 5 finding on PR #551).
         logger.error(
             "storage_quota_release_redis_failed",
             workspace_id=str(workspace_id),
             error=str(exc),
         )
+        try:
+            from db.redis import get_redis_client
+
+            client = get_redis_client()
+            # 60s TTL so the next reservation reseeds from DB instead of
+            # carrying the stale over-counted value forward. Reseeding
+            # is the existing recovery path; this just triggers it.
+            await client.expire(_build_key(workspace_id), 60)
+            logger.info(
+                "storage_quota_release_forced_reseed",
+                workspace_id=str(workspace_id),
+                expire_ttl_seconds=60,
+            )
+        except Exception as expire_exc:  # noqa: BLE001 — last-resort
+            logger.error(
+                "storage_quota_release_force_reseed_failed",
+                workspace_id=str(workspace_id),
+                error=str(expire_exc),
+            )
 
 
 async def get_current_storage_usage(

--- a/backend/src/services/storage_quota_service.py
+++ b/backend/src/services/storage_quota_service.py
@@ -1,0 +1,224 @@
+"""Per-workspace file-storage quota — Redis-backed reservation (Issue #485).
+
+Issue #332 lesson: REST and MCP paths MUST share the same quota check.
+This module is the canonical shared service that ``FileStorageService``
+funnels both routes through. The CI grep gate (Commit 7+) verifies no
+handler calls these functions outside the service layer.
+
+Key format: ``storage:bytes:{workspace_id}``
+
+- Workspace-scoped (storage is workspace-level, not context-level).
+- **No TTL** — storage is a hard cap, not a rate limit. The counter is
+  durable; reseed from DB on key miss (cold-start / Redis flush).
+- ``release_storage_bytes`` reverses a reservation when an upload
+  fails (orphan sweeper) or a file is soft-deleted (R5: immediate
+  quota release in same txn).
+- Fail-open on ``RedisError`` (matches ``resource_quota_service`` —
+  Redis outage MUST NOT block uploads; reconcile via DB sweep later).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.redis import get_cache, incrby_counter, set_cache
+from utils.exceptions import QuotaExceededError, RedisError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+def _build_key(workspace_id: UUID) -> str:
+    return f"storage:bytes:{workspace_id}"
+
+
+async def reserve_storage_bytes(
+    workspace_id: UUID,
+    size_bytes: int,
+    quota_bytes: int,
+    db: AsyncSession,
+) -> None:
+    """Atomically reserve ``size_bytes`` against ``quota_bytes`` ceiling.
+
+    Reseeds from DB on Redis key miss — matches the durable-counter
+    semantics of file storage (vs the ephemeral hour-window of
+    ``resource_quota_service``).
+
+    Args:
+        workspace_id: Owning workspace.
+        size_bytes: Bytes to reserve. Caller passes the upload size from
+            ``upload-init``. Must be > 0.
+        quota_bytes: Maximum allowed bytes. ``Workspace.effective_storage_limit_bytes``.
+            Values <= 0 disable the check.
+        db: Async session, used for DB reseed on Redis cache miss.
+
+    Raises:
+        QuotaExceededError: HTTP 409. Reserving ``size_bytes`` would
+            push past ``quota_bytes``.
+        ValueError: ``size_bytes <= 0`` (defensive).
+
+    Fail-open: ``RedisError`` is logged and swallowed so uploads are
+    not blocked. The next Redis-healthy reservation reseeds from DB.
+    """
+    if quota_bytes <= 0:
+        return
+    if size_bytes <= 0:
+        msg = f"size_bytes must be > 0, got {size_bytes}"
+        raise ValueError(msg)
+
+    key = _build_key(workspace_id)
+
+    try:
+        current = await _get_or_seed_counter(workspace_id, db, key)
+
+        if current + size_bytes > quota_bytes:
+            logger.warning(
+                "storage_quota_exceeded",
+                workspace_id=str(workspace_id),
+                current_bytes=current,
+                quota_bytes=quota_bytes,
+                requested_bytes=size_bytes,
+            )
+            raise QuotaExceededError(
+                message=(f"Storage quota exceeded: {current + size_bytes} / {quota_bytes} bytes"),
+                quota_type="storage_bytes",
+                limit=quota_bytes,
+                current=current,
+                requested=size_bytes,
+            )
+
+        new_total = await incrby_counter(key, size_bytes)
+        logger.debug(
+            "storage_quota_reserved",
+            workspace_id=str(workspace_id),
+            previous_bytes=current,
+            reserved_bytes=size_bytes,
+            new_total=new_total,
+            quota_bytes=quota_bytes,
+        )
+    except QuotaExceededError:
+        raise
+    except RedisError as exc:
+        logger.error("storage_quota_redis_failed", workspace_id=str(workspace_id), error=str(exc))
+        return
+
+
+async def release_storage_bytes(
+    workspace_id: UUID,
+    size_bytes: int,
+) -> None:
+    """Reverse a previous reservation by ``size_bytes``.
+
+    Called by:
+
+    - Orphan sweeper when ``status='reserved'`` rows expire (R3).
+    - ``FileStorageService.delete_file`` immediately on soft-delete (R5).
+    - ``FileStorageService.confirm_upload`` if ``head_object`` reports a
+      smaller-than-reserved size (truncation refund).
+
+    Idempotency: a second release for the same bytes will floor the
+    counter at zero on next reseed; we don't try to detect double-release
+    here. Net effect is "slightly under-counted in Redis until next
+    reseed", which is the safer drift direction.
+
+    Fail-open on Redis errors — sweeper retries naturally on next tick.
+    """
+    if size_bytes <= 0:
+        return
+
+    key = _build_key(workspace_id)
+    try:
+        new_total = await incrby_counter(key, -size_bytes)
+        # Floor at zero — INCRBY with a negative can go below 0 if we
+        # released more than was reserved. Reseed-on-miss handles
+        # eventual consistency; here we just log so tests can see it.
+        if new_total < 0:
+            logger.warning(
+                "storage_quota_release_underflow",
+                workspace_id=str(workspace_id),
+                released_bytes=size_bytes,
+                new_total=new_total,
+            )
+        else:
+            logger.debug(
+                "storage_quota_released",
+                workspace_id=str(workspace_id),
+                released_bytes=size_bytes,
+                new_total=new_total,
+            )
+    except RedisError as exc:
+        logger.error(
+            "storage_quota_release_redis_failed",
+            workspace_id=str(workspace_id),
+            error=str(exc),
+        )
+
+
+async def get_current_storage_usage(
+    workspace_id: UUID,
+    db: AsyncSession,
+) -> int:
+    """Return current Redis counter, reseeding from DB on miss.
+
+    Used by dashboards / admin pages to display "X / Y MB used".
+    """
+    key = _build_key(workspace_id)
+    try:
+        return await _get_or_seed_counter(workspace_id, db, key)
+    except RedisError:
+        # Fall back to a fresh DB aggregate — slow but correct.
+        return await _aggregate_from_db(workspace_id, db)
+
+
+async def _get_or_seed_counter(
+    workspace_id: UUID,
+    db: AsyncSession,
+    key: str,
+) -> int:
+    """Read Redis counter, reseed from DB if missing.
+
+    The reseed window is racy — two concurrent reservations both miss
+    the key, both run the DB aggregate, both ``set_cache`` (last writer
+    wins). Net effect is at worst one reservation skipped against the
+    cap (the under-counted side); the next ``reserve_storage_bytes``
+    call self-corrects via the next reseed. Acceptable given the
+    fail-open posture.
+    """
+    cached = await get_cache(key)
+    if cached is not None:
+        return int(cached)
+
+    seeded = await _aggregate_from_db(workspace_id, db)
+    # Persist the seed for ~24h; INCRBY preserves the value, only EXPIRE
+    # resets it. ``set_cache`` is fine here because we're seeding, not
+    # incrementing.
+    await set_cache(key, str(seeded), ttl=86400)
+    logger.info(
+        "storage_quota_seeded_from_db",
+        workspace_id=str(workspace_id),
+        seeded_bytes=seeded,
+    )
+    return seeded
+
+
+async def _aggregate_from_db(workspace_id: UUID, db: AsyncSession) -> int:
+    """Sum committed (uploaded, not deleted) ``file_objects`` size_bytes
+    for ``workspace_id``.
+
+    Excludes ``status='reserved'`` rows because those are tracked in
+    Redis until ``confirm_upload`` flips them to ``uploaded``. Excludes
+    ``status='failed'`` and soft-deleted rows.
+    """
+    from models.file_objects import FileObject
+
+    result = await db.execute(
+        select(func.coalesce(func.sum(FileObject.size_bytes), 0)).where(
+            FileObject.workspace_id == workspace_id,
+            FileObject.status == "uploaded",
+            FileObject.deleted_at.is_(None),
+        )
+    )
+    return int(result.scalar_one())

--- a/backend/src/storage/__init__.py
+++ b/backend/src/storage/__init__.py
@@ -1,0 +1,18 @@
+"""Object storage abstraction layer (Issue #485).
+
+Phase 1 ships a single concrete backend (Cloudflare R2 via aioboto3),
+but the public surface is the ``BlobStorageProtocol`` contract so Phase
+2 BYO bucket support (`backend/byo_s3`, `backend/byo_gcs`) plugs in by
+adding new implementations without touching ``FileStorageService`` or
+the API/MCP route layer.
+"""
+
+from storage.factory import close_blob_storage, get_blob_storage
+from storage.protocol import BlobStorageProtocol, ObjectMetadata
+
+__all__ = [
+    "BlobStorageProtocol",
+    "ObjectMetadata",
+    "close_blob_storage",
+    "get_blob_storage",
+]

--- a/backend/src/storage/factory.py
+++ b/backend/src/storage/factory.py
@@ -27,30 +27,44 @@ _storage: BlobStorageProtocol | None = None
 def get_blob_storage() -> BlobStorageProtocol:
     """Return the process-wide ``BlobStorageProtocol`` instance.
 
-    Lazily constructed on first call. Raises ``RuntimeError`` if R2 is
-    not configured — the caller is expected to gate file-storage
-    features on ``settings.r2_endpoint_url`` non-empty before reaching
-    this code path.
+    Lazily constructed on first call. Raises ``ExternalServiceError``
+    (HTTP 502 via the global handler) if R2 is missing OR partially
+    configured — both unconfigured (``r2_endpoint_url`` empty) and
+    half-configured (some fields set, others empty) surface the same
+    "storage unavailable" shape so REST and MCP file handlers can
+    return a usable error message instead of an opaque 500.
+
+    Pre-fix: ``RuntimeError`` (unconfigured) and ``ValueError`` (partial)
+    leaked unchanged through the file handlers — Copilot finding on
+    PR #551 loop 2 (commit 53e8213d → loop 3 fix).
     """
+    from utils.exceptions import ExternalServiceError
+
     global _storage
     if _storage is None:
         settings = get_settings()
         if not settings.r2_endpoint_url:
-            raise RuntimeError(
-                "R2 storage is not configured. Set R2_ACCOUNT_ID, "
-                "R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET, "
-                "and R2_ENDPOINT_URL in the environment, or skip file "
-                "operations entirely (Issue #485)."
+            raise ExternalServiceError(
+                "R2",
+                "storage is not configured (R2_ENDPOINT_URL empty). "
+                "Set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, "
+                "R2_BUCKET, and R2_ENDPOINT_URL — see .env.example.",
             )
         from storage.r2 import R2Storage
 
-        _storage = R2Storage(
-            account_id=settings.r2_account_id,
-            access_key_id=settings.r2_access_key_id,
-            secret_access_key=settings.r2_secret_access_key,
-            bucket=settings.r2_bucket,
-            endpoint_url=settings.r2_endpoint_url,
-        )
+        try:
+            _storage = R2Storage(
+                account_id=settings.r2_account_id,
+                access_key_id=settings.r2_access_key_id,
+                secret_access_key=settings.r2_secret_access_key,
+                bucket=settings.r2_bucket,
+                endpoint_url=settings.r2_endpoint_url,
+            )
+        except ValueError as exc:
+            raise ExternalServiceError(
+                "R2",
+                f"storage construction failed (partial config?): {exc}",
+            ) from exc
         logger.info("blob_storage_initialized", backend="r2", bucket=settings.r2_bucket)
     return _storage
 

--- a/backend/src/storage/factory.py
+++ b/backend/src/storage/factory.py
@@ -1,0 +1,79 @@
+"""Factory + lifecycle for the in-process ``BlobStorageProtocol`` instance.
+
+Phase 1 dispatches on whether R2 settings are configured:
+
+- All five R2 settings populated → ``R2Storage`` instance.
+- Anything missing → raise on first ``get_blob_storage()`` call so dev
+  environments without R2 fail fast with a clear error instead of
+  reaching production with a half-wired upload path.
+
+Phase 2 BYO will dispatch on a new ``settings.storage_backend_type``
+discriminator. Adding it then will be a one-place change here.
+"""
+
+from __future__ import annotations
+
+import structlog
+
+from config.settings import get_settings
+from storage.protocol import BlobStorageProtocol
+
+logger = structlog.get_logger(__name__)
+
+
+_storage: BlobStorageProtocol | None = None
+
+
+def get_blob_storage() -> BlobStorageProtocol:
+    """Return the process-wide ``BlobStorageProtocol`` instance.
+
+    Lazily constructed on first call. Raises ``RuntimeError`` if R2 is
+    not configured — the caller is expected to gate file-storage
+    features on ``settings.r2_endpoint_url`` non-empty before reaching
+    this code path.
+    """
+    global _storage
+    if _storage is None:
+        settings = get_settings()
+        if not settings.r2_endpoint_url:
+            raise RuntimeError(
+                "R2 storage is not configured. Set R2_ACCOUNT_ID, "
+                "R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, R2_BUCKET, "
+                "and R2_ENDPOINT_URL in the environment, or skip file "
+                "operations entirely (Issue #485)."
+            )
+        from storage.r2 import R2Storage
+
+        _storage = R2Storage(
+            account_id=settings.r2_account_id,
+            access_key_id=settings.r2_access_key_id,
+            secret_access_key=settings.r2_secret_access_key,
+            bucket=settings.r2_bucket,
+            endpoint_url=settings.r2_endpoint_url,
+        )
+        logger.info("blob_storage_initialized", backend="r2", bucket=settings.r2_bucket)
+    return _storage
+
+
+async def close_blob_storage() -> None:
+    """Release the process-wide blob storage instance, if any.
+
+    Safe to call when ``get_blob_storage`` was never invoked.
+    """
+    global _storage
+    if _storage is not None:
+        close = getattr(_storage, "close", None)
+        if close is not None:
+            await close()
+        _storage = None
+        logger.info("blob_storage_closed")
+
+
+def _reset_for_tests() -> None:
+    """Drop the cached instance — test helpers ONLY.
+
+    Tests that swap ``Settings`` between cases need a way to force a
+    re-construction. Production code should never call this.
+    """
+    global _storage
+    _storage = None

--- a/backend/src/storage/protocol.py
+++ b/backend/src/storage/protocol.py
@@ -1,0 +1,91 @@
+"""Blob-storage Protocol for Issue #485 (#485 R1).
+
+Structural typing — implementations need only define the methods, no
+inheritance. Phase 1 ships ``R2Storage``; Phase 2 adds ``S3Storage`` and
+``GCSStorage`` (BYO bucket) without touching ``FileStorageService``.
+
+All operations are async because the dominant call sites
+(``upload-init``, ``upload-complete``, ``download``, soft-delete) are
+inside FastAPI request handlers. ``generate_presigned_*`` is technically
+synchronous in boto3 / aioboto3, but is exposed as async so callers
+need not branch on backend.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypedDict, runtime_checkable
+
+
+class ObjectMetadata(TypedDict):
+    """Subset of object metadata returned by ``head_object``.
+
+    R2 / S3-compatible backends return many more fields (etag, version
+    id, server-side encryption, etc.); only the ones used by the upload
+    confirmation flow are typed here. Implementations may include
+    additional keys.
+    """
+
+    size_bytes: int
+    etag: str
+
+
+@runtime_checkable
+class BlobStorageProtocol(Protocol):
+    """Contract for object-storage backends used by ``FileStorageService``."""
+
+    async def write_object(
+        self,
+        key: str,
+        data: bytes,
+        content_type: str,
+        sha256: str,
+    ) -> None:
+        """Upload ``data`` to ``key`` with ``content_type`` metadata.
+
+        Used by the legacy-attachment migration step (Commit 9). The
+        normal upload flow uses ``generate_presigned_put`` instead so
+        bytes never traverse the platform.
+        """
+        ...
+
+    async def head_object(self, key: str) -> ObjectMetadata | None:
+        """Return ``ObjectMetadata`` if the object exists, ``None`` otherwise.
+
+        Implementations MUST return ``None`` (not raise) for missing
+        objects — used by ``upload-complete`` to verify a presigned PUT
+        actually landed.
+        """
+        ...
+
+    async def delete_object(self, key: str) -> None:
+        """Delete ``key``. No-op if the object is already missing."""
+        ...
+
+    async def generate_presigned_put(
+        self,
+        key: str,
+        content_type: str,
+        size_bytes: int,
+        ttl_seconds: int,
+    ) -> str:
+        """Return a short-lived presigned PUT URL clients can upload to.
+
+        ``size_bytes`` is reflected as a `Content-Length` constraint
+        when the backend supports it; R2 currently does not enforce
+        this server-side, so the platform must validate via
+        ``head_object`` after the upload.
+        """
+        ...
+
+    async def generate_presigned_get(
+        self,
+        key: str,
+        filename: str,
+        ttl_seconds: int,
+    ) -> str:
+        """Return a short-lived presigned GET URL.
+
+        ``filename`` is set as the ``Content-Disposition`` so the
+        browser uses the original filename instead of the storage key.
+        """
+        ...

--- a/backend/src/storage/r2.py
+++ b/backend/src/storage/r2.py
@@ -12,8 +12,10 @@ from typing import Any
 
 import aioboto3
 import structlog
+from botocore.exceptions import ClientError
 
 from storage.protocol import ObjectMetadata
+from utils.exceptions import ExternalServiceError
 
 logger = structlog.get_logger(__name__)
 
@@ -78,10 +80,26 @@ class R2Storage:
         async with self._client() as client:
             try:
                 resp = await client.head_object(Bucket=self._bucket, Key=key)
-            except client.exceptions.ClientError as exc:
-                if exc.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+            except ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code")
+                # Both shapes appear in the wild — botocore translates
+                # HTTP 404 to ``"404"`` for HEAD; ``NoSuchKey`` is the
+                # GET shape, kept for safety in case R2 differs.
+                if code in ("404", "NoSuchKey"):
                     return None
-                raise
+                # Non-404 errors (5xx, AccessDenied, throttling, …) are
+                # surfaced as a domain exception so REST/MCP layers map
+                # them to a clear 502 instead of a raw boto traceback.
+                logger.warning(
+                    "r2_head_object_error",
+                    key=key,
+                    code=code,
+                    error=str(exc),
+                )
+                raise ExternalServiceError(
+                    "R2",
+                    f"head_object failed for key={key!r}: {code}",
+                ) from exc
             return ObjectMetadata(
                 size_bytes=int(resp["ContentLength"]),
                 etag=str(resp.get("ETag", "")).strip('"'),

--- a/backend/src/storage/r2.py
+++ b/backend/src/storage/r2.py
@@ -157,13 +157,24 @@ class R2Storage:
         filename: str,
         ttl_seconds: int,
     ) -> str:
+        # Sanitize the filename before embedding into the
+        # ``Content-Disposition`` header. Without this a filename
+        # containing a literal ``"`` could break out of the quoted
+        # parameter and enable filename-spoofing for downloads;
+        # CR/LF could (in principle) corrupt the header. Mirrors
+        # ``api/routes/attachments.py:_sanitize_filename`` to keep the
+        # legacy and new file paths consistent (CSO Gate2 finding F-1
+        # + Copilot loop 5 finding on PR #551).
+        safe_filename = (
+            filename.replace('"', "_").replace("\n", "_").replace("\r", "_").replace("\x00", "_")
+        )
         async with self._client() as client:
             url = await client.generate_presigned_url(
                 ClientMethod="get_object",
                 Params={
                     "Bucket": self._bucket,
                     "Key": key,
-                    "ResponseContentDisposition": f'attachment; filename="{filename}"',
+                    "ResponseContentDisposition": f'attachment; filename="{safe_filename}"',
                 },
                 ExpiresIn=ttl_seconds,
                 HttpMethod="GET",

--- a/backend/src/storage/r2.py
+++ b/backend/src/storage/r2.py
@@ -117,6 +117,26 @@ class R2Storage:
         size_bytes: int,
         ttl_seconds: int,
     ) -> str:
+        # SECURITY NOTE (Phase 1 limitation, tracked for Phase 1.5):
+        # The presigned PUT signs (Bucket, Key, ContentType, ContentLength)
+        # but does NOT bind the body's sha256. A malicious client can
+        # declare sha256=X at upload-init time, then PUT bytes whose
+        # actual digest is Y at the same key — the server's
+        # ``confirm_upload`` only verifies size via head_object, not
+        # the actual bytes. This breaks dedup (a later legit upload
+        # with sha256=X dedupes to the malicious bytes via the partial
+        # unique index) and lets a member poison the workspace's file
+        # cache.
+        #
+        # Mitigation Phase 1.5: switch to ``generate_presigned_post``
+        # with a POST policy that includes ``x-amz-content-sha256`` as
+        # a signed header (S3 SigV4 supports body-sha256 binding).
+        # Alternative: download bytes server-side post-PUT and compute
+        # sha256 — expensive on 100 MiB but correct. For Phase 1 the
+        # workspace-membership gate keeps the attack surface to
+        # workspace insiders, who would also be detected by the
+        # downstream BM25/embedding pipeline (different bytes → different
+        # vectors → different recall behavior, observable to ops).
         async with self._client() as client:
             url = await client.generate_presigned_url(
                 ClientMethod="put_object",

--- a/backend/src/storage/r2.py
+++ b/backend/src/storage/r2.py
@@ -1,0 +1,144 @@
+"""Cloudflare R2 implementation of ``BlobStorageProtocol`` (Issue #485).
+
+R2 exposes an S3-compatible API, so we use ``aioboto3`` against R2's
+endpoint. Single ``aioboto3.Session`` is reused; the per-call client
+context manager opens a connection from the underlying ``aiobotocore``
+pool, so there is no per-request socket setup cost.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aioboto3
+import structlog
+
+from storage.protocol import ObjectMetadata
+
+logger = structlog.get_logger(__name__)
+
+
+class R2Storage:
+    """``BlobStorageProtocol`` impl backed by Cloudflare R2.
+
+    The class deliberately does not inherit from ``BlobStorageProtocol``
+    — runtime structural typing (``@runtime_checkable``) is enough, and
+    keeping it separate avoids tight coupling for Phase 2 BYO impls.
+    """
+
+    def __init__(
+        self,
+        *,
+        account_id: str,
+        access_key_id: str,
+        secret_access_key: str,
+        bucket: str,
+        endpoint_url: str,
+    ) -> None:
+        if not (account_id and access_key_id and secret_access_key and bucket and endpoint_url):
+            raise ValueError(
+                "R2Storage requires non-empty account_id, access_key_id, "
+                "secret_access_key, bucket, and endpoint_url"
+            )
+        self._bucket = bucket
+        self._endpoint_url = endpoint_url
+        self._session = aioboto3.Session(
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            region_name="auto",  # R2 ignores region; "auto" is the canonical value
+        )
+
+    def _client(self) -> Any:
+        """Return a fresh aioboto3 S3 client context manager.
+
+        Callers MUST use it with ``async with`` so the underlying
+        connection is returned to the pool.
+        """
+        return self._session.client("s3", endpoint_url=self._endpoint_url)
+
+    async def write_object(
+        self,
+        key: str,
+        data: bytes,
+        content_type: str,
+        sha256: str,
+    ) -> None:
+        """Server-side upload (used by the attachments migration only)."""
+        async with self._client() as client:
+            await client.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=data,
+                ContentType=content_type,
+                Metadata={"sha256": sha256},
+            )
+            logger.info("r2_object_written", key=key, size_bytes=len(data))
+
+    async def head_object(self, key: str) -> ObjectMetadata | None:
+        async with self._client() as client:
+            try:
+                resp = await client.head_object(Bucket=self._bucket, Key=key)
+            except client.exceptions.ClientError as exc:
+                if exc.response.get("Error", {}).get("Code") in ("404", "NoSuchKey"):
+                    return None
+                raise
+            return ObjectMetadata(
+                size_bytes=int(resp["ContentLength"]),
+                etag=str(resp.get("ETag", "")).strip('"'),
+            )
+
+    async def delete_object(self, key: str) -> None:
+        async with self._client() as client:
+            await client.delete_object(Bucket=self._bucket, Key=key)
+            logger.info("r2_object_deleted", key=key)
+
+    async def generate_presigned_put(
+        self,
+        key: str,
+        content_type: str,
+        size_bytes: int,
+        ttl_seconds: int,
+    ) -> str:
+        async with self._client() as client:
+            url = await client.generate_presigned_url(
+                ClientMethod="put_object",
+                Params={
+                    "Bucket": self._bucket,
+                    "Key": key,
+                    "ContentType": content_type,
+                    "ContentLength": size_bytes,
+                },
+                ExpiresIn=ttl_seconds,
+                HttpMethod="PUT",
+            )
+            return str(url)
+
+    async def generate_presigned_get(
+        self,
+        key: str,
+        filename: str,
+        ttl_seconds: int,
+    ) -> str:
+        async with self._client() as client:
+            url = await client.generate_presigned_url(
+                ClientMethod="get_object",
+                Params={
+                    "Bucket": self._bucket,
+                    "Key": key,
+                    "ResponseContentDisposition": f'attachment; filename="{filename}"',
+                },
+                ExpiresIn=ttl_seconds,
+                HttpMethod="GET",
+            )
+            return str(url)
+
+    async def close(self) -> None:
+        """Release any pooled resources held by aiobotocore.
+
+        Currently a no-op — aioboto3 pools live inside the per-call
+        ``async with`` block and are released on context exit. Kept on
+        the API surface so the lifespan handler can call it
+        unconditionally and a future eager-init refactor stays
+        backwards compatible.
+        """
+        return None

--- a/backend/src/tasks/__init__.py
+++ b/backend/src/tasks/__init__.py
@@ -13,6 +13,7 @@ from .bm25_drift_tasks import schedule_bm25_drift_tasks
 from .credentials_tasks import schedule_credentials_tasks
 from .embedding_tasks import schedule_embedding_tasks
 from .erasure_tasks import schedule_erasure_tasks
+from .file_tasks import schedule_file_tasks
 from .mcp_tasks import schedule_mcp_tasks
 from .neural_tasks import schedule_neural_tasks
 from .resource_indexer_job import schedule_resource_indexer_jobs
@@ -31,4 +32,5 @@ __all__ = [
     "schedule_resource_indexer_jobs",
     "schedule_sleep_tasks",
     "schedule_bm25_drift_tasks",
+    "schedule_file_tasks",
 ]

--- a/backend/src/tasks/file_tasks.py
+++ b/backend/src/tasks/file_tasks.py
@@ -23,6 +23,8 @@ orphan UX impact under one quarter-hour worst case.
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.interval import IntervalTrigger
 from sqlalchemy import select
@@ -52,13 +54,16 @@ async def sweep_orphan_files() -> dict[str, int]:
     """
     counts = {"swept": 0, "released_bytes": 0, "r2_deleted": 0, "r2_failed": 0}
 
-    threshold = utcnow().timestamp() - _ORPHAN_GRACE_SECONDS
+    # Filter at SQL so the partial index ``idx_file_objects_reserved_expires``
+    # is used; otherwise every sweeper tick loads all in-flight rows.
+    threshold = utcnow() - timedelta(seconds=_ORPHAN_GRACE_SECONDS)
 
     async for db in get_db():
         result = await db.execute(
             select(FileObject).where(
                 FileObject.status == "reserved",
                 FileObject.expires_at.isnot(None),
+                FileObject.expires_at <= threshold,
             )
         )
         candidates = list(result.scalars().all())
@@ -77,13 +82,10 @@ async def sweep_orphan_files() -> dict[str, int]:
         # tick re-evaluates the same rows fresh — no double-release.
         pending_releases: list[tuple] = []  # list[(workspace_id, size_bytes, storage_key|None)]
         for file in candidates:
-            # Compute orphan-ness in Python so the timezone-naive DB
-            # column is compared against utcnow() directly without
-            # relying on driver-side conversion.
-            if file.expires_at is None:
-                continue
-            expiry_ts = file.expires_at.timestamp()
-            if expiry_ts > threshold:
+            # SQL-side filter already ensured ``expires_at <= threshold``,
+            # but a defensive Python re-check guards against unexpected
+            # mutations within the same transaction.
+            if file.expires_at is None or file.expires_at > threshold:
                 continue
 
             file.status = "failed"

--- a/backend/src/tasks/file_tasks.py
+++ b/backend/src/tasks/file_tasks.py
@@ -34,6 +34,7 @@ from models.file_objects import FileObject
 from services import storage_quota_service
 from storage.factory import get_blob_storage
 from utils.datetime import utcnow
+from utils.exceptions import ExternalServiceError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -73,7 +74,12 @@ async def sweep_orphan_files() -> dict[str, int]:
         # failed and release Redis quota.
         try:
             storage = get_blob_storage()
-        except RuntimeError:
+        except ExternalServiceError:
+            # R2 not configured in dev/test — sweep the DB rows but skip
+            # the binary cleanup. Same outcome as the legacy
+            # ``RuntimeError`` branch this used to catch (the factory
+            # now raises ``ExternalServiceError`` per the Copilot loop 3
+            # fix on PR #551 so REST/MCP handlers map cleanly to 502).
             storage = None
 
         # Two-phase: mark all rows ``failed`` first, then commit, then

--- a/backend/src/tasks/file_tasks.py
+++ b/backend/src/tasks/file_tasks.py
@@ -65,6 +65,16 @@ async def sweep_orphan_files() -> dict[str, int]:
                 FileObject.status == "reserved",
                 FileObject.expires_at.isnot(None),
                 FileObject.expires_at <= threshold,
+                # Defensive: ``delete_file`` on a reserved row already
+                # transitions ``status='failed'`` (loop 3 fix on PR #551),
+                # so under normal flow no soft-deleted reserved row
+                # reaches this query. Adding ``deleted_at IS NULL``
+                # as a SQL invariant pins down the contract — protects
+                # against future regressions where a path soft-deletes
+                # a reserved row without changing status, which would
+                # otherwise cause the sweeper to double-release Redis
+                # quota (Copilot loop 4 finding).
+                FileObject.deleted_at.is_(None),
             )
         )
         candidates = list(result.scalars().all())

--- a/backend/src/tasks/file_tasks.py
+++ b/backend/src/tasks/file_tasks.py
@@ -71,6 +71,11 @@ async def sweep_orphan_files() -> dict[str, int]:
         except RuntimeError:
             storage = None
 
+        # Two-phase: mark all rows ``failed`` first, then commit, then
+        # do the side-effects (Redis release + R2 delete). If the
+        # commit fails, no Redis release happens and the next sweeper
+        # tick re-evaluates the same rows fresh — no double-release.
+        pending_releases: list[tuple] = []  # list[(workspace_id, size_bytes, storage_key|None)]
         for file in candidates:
             # Compute orphan-ness in Python so the timezone-naive DB
             # column is compared against utcnow() directly without
@@ -84,26 +89,33 @@ async def sweep_orphan_files() -> dict[str, int]:
             file.status = "failed"
             counts["swept"] += 1
             counts["released_bytes"] += file.size_bytes
-
-            await storage_quota_service.release_storage_bytes(
-                workspace_id=file.workspace_id,
-                size_bytes=file.size_bytes,
+            pending_releases.append(
+                (file.workspace_id, file.size_bytes, file.storage_key, str(file.id))
             )
 
-            if storage is not None and file.storage_key:
+        await db.commit()
+
+        # Side effects (post-commit). A Redis or R2 failure at this
+        # point leaves the row durably ``failed`` so the partial-unique
+        # index frees the (workspace, sha256) slot — consistent with
+        # the operator's mental model of "sweeper marked these dead".
+        for workspace_id, size_bytes, storage_key, file_id in pending_releases:
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=size_bytes,
+            )
+            if storage is not None and storage_key:
                 try:
-                    await storage.delete_object(file.storage_key)
+                    await storage.delete_object(storage_key)
                     counts["r2_deleted"] += 1
                 except Exception as exc:  # noqa: BLE001 — best-effort
                     counts["r2_failed"] += 1
                     logger.warning(
                         "orphan_file_r2_delete_failed",
-                        file_id=str(file.id),
-                        storage_key=file.storage_key,
+                        file_id=file_id,
+                        storage_key=storage_key,
                         error=str(exc),
                     )
-
-        await db.commit()
 
     if counts["swept"] > 0:
         logger.info("orphan_files_swept", **counts)

--- a/backend/src/tasks/file_tasks.py
+++ b/backend/src/tasks/file_tasks.py
@@ -1,0 +1,122 @@
+"""Orphan file sweeper (Issue #485 R3).
+
+Reservation rows in ``file_objects`` that pass their ``expires_at + 1h``
+grace without a matching ``upload-complete`` are stale: the client
+either died mid-upload, the presigned PUT URL expired, or some other
+transport failure left the row dangling. The sweeper:
+
+1. Marks the row ``status='failed'`` so the partial-unique index
+   (``WHERE deleted_at IS NULL AND status <> 'failed'``) frees up
+   ``(workspace_id, sha256)`` for a redo.
+2. Releases the Redis storage reservation so the workspace doesn't
+   lose capacity.
+3. Best-effort deletes any orphan R2 object the client may have
+   PUT-ed inside the window. Swallows R2 errors — a failed delete
+   leaves the binary as garbage in R2 and is reconciled by the
+   bucket lifecycle rule (Phase 1.5 inventory job).
+
+Cadence: 15 minutes. Architect A's design rationale — Free-tier 100MB
+is the smallest cap and a single reserved orphan can otherwise block
+new uploads up to ~25h on a nightly sweep. 15min beat keeps reserved-
+orphan UX impact under one quarter-hour worst case.
+"""
+
+from __future__ import annotations
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from sqlalchemy import select
+
+from db.base import get_db
+from models.file_objects import FileObject
+from services import storage_quota_service
+from storage.factory import get_blob_storage
+from utils.datetime import utcnow
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# Grace window past expires_at before a reserved row is considered orphan.
+# Architect A's design specifies 1h to absorb cross-region clock skew and
+# transient client retry windows.
+_ORPHAN_GRACE_SECONDS = 3600
+
+
+async def sweep_orphan_files() -> dict[str, int]:
+    """Reap reserved-but-not-uploaded ``file_objects`` rows past grace.
+
+    Returns:
+        ``{"swept": N, "released_bytes": N, "r2_deleted": N, "r2_failed": N}``
+        — useful for the scheduler log and future ops dashboards.
+    """
+    counts = {"swept": 0, "released_bytes": 0, "r2_deleted": 0, "r2_failed": 0}
+
+    threshold = utcnow().timestamp() - _ORPHAN_GRACE_SECONDS
+
+    async for db in get_db():
+        result = await db.execute(
+            select(FileObject).where(
+                FileObject.status == "reserved",
+                FileObject.expires_at.isnot(None),
+            )
+        )
+        candidates = list(result.scalars().all())
+
+        # Try to load the storage backend once; if R2 is not configured
+        # (dev / test) we skip the binary cleanup but still mark rows
+        # failed and release Redis quota.
+        try:
+            storage = get_blob_storage()
+        except RuntimeError:
+            storage = None
+
+        for file in candidates:
+            # Compute orphan-ness in Python so the timezone-naive DB
+            # column is compared against utcnow() directly without
+            # relying on driver-side conversion.
+            if file.expires_at is None:
+                continue
+            expiry_ts = file.expires_at.timestamp()
+            if expiry_ts > threshold:
+                continue
+
+            file.status = "failed"
+            counts["swept"] += 1
+            counts["released_bytes"] += file.size_bytes
+
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=file.workspace_id,
+                size_bytes=file.size_bytes,
+            )
+
+            if storage is not None and file.storage_key:
+                try:
+                    await storage.delete_object(file.storage_key)
+                    counts["r2_deleted"] += 1
+                except Exception as exc:  # noqa: BLE001 — best-effort
+                    counts["r2_failed"] += 1
+                    logger.warning(
+                        "orphan_file_r2_delete_failed",
+                        file_id=str(file.id),
+                        storage_key=file.storage_key,
+                        error=str(exc),
+                    )
+
+        await db.commit()
+
+    if counts["swept"] > 0:
+        logger.info("orphan_files_swept", **counts)
+    return counts
+
+
+def schedule_file_tasks(scheduler: AsyncIOScheduler) -> None:
+    """Register the orphan file sweeper at 15-minute intervals."""
+    scheduler.add_job(
+        sweep_orphan_files,
+        trigger=IntervalTrigger(minutes=15),
+        id="orphan_file_sweeper",
+        name="Orphan File Sweeper (Issue #485)",
+        replace_existing=True,
+    )
+    logger.info("scheduled_orphan_file_sweeper", interval_minutes=15)

--- a/backend/tests/api/test_files.py
+++ b/backend/tests/api/test_files.py
@@ -31,6 +31,14 @@ def _mock_user() -> dict:
 
 @pytest.fixture
 def client():
+    """Test client with auth + DB + workspace-membership check stubbed.
+
+    ``_enforce_workspace_membership`` (and its internal
+    ``PermissionService.check_workspace_access``) is patched to a
+    no-op for normal tests; specific tests can override via
+    ``patch.object`` to verify the gate fires.
+    """
+
     async def fake_user():
         return _mock_user()
 
@@ -39,7 +47,11 @@ def client():
 
     app.dependency_overrides[get_user_from_api_key_or_session] = fake_user
     app.dependency_overrides[get_db] = fake_db
-    yield TestClient(app, raise_server_exceptions=False)
+    with patch(
+        "api.routes.files._enforce_workspace_membership",
+        AsyncMock(return_value=None),
+    ):
+        yield TestClient(app, raise_server_exceptions=False)
     app.dependency_overrides.clear()
 
 
@@ -232,3 +244,88 @@ class TestListFiles:
         ws = uuid4()
         r = client.get(f"/api/v1/files?workspace_id={ws}&limit=10000")
         assert r.status_code == 422
+
+
+class TestWorkspaceMembershipGate:
+    """B-7: every endpoint MUST run ``_enforce_workspace_membership``
+    before reaching the service. Otherwise an authenticated user from
+    workspace A can pass workspace B's id in the request body / query
+    and read or modify B's files.
+    """
+
+    def test_membership_check_called_for_all_endpoints(self):
+        """One test, five endpoints — each must call the gate exactly
+        once with the body/query workspace_id, before any service
+        method is invoked."""
+        from fastapi import HTTPException
+
+        from api.main import app
+        from auth.dependencies import get_user_from_api_key_or_session
+        from db.base import get_db
+
+        async def fake_user():
+            return _mock_user()
+
+        async def fake_db():
+            yield MagicMock()
+
+        app.dependency_overrides[get_user_from_api_key_or_session] = fake_user
+        app.dependency_overrides[get_db] = fake_db
+        try:
+            ws = uuid4()
+            file_id = uuid4()
+
+            # Make the gate raise — confirms it's the FIRST authorization
+            # check and that no service method is reached when it fails.
+            denial = HTTPException(status_code=403, detail="not a member")
+            with (
+                patch(
+                    "api.routes.files._enforce_workspace_membership",
+                    AsyncMock(side_effect=denial),
+                ) as gate,
+                patch(
+                    "api.routes.files.FileStorageService.reserve_upload",
+                    AsyncMock(),
+                ) as reserve_svc,
+                patch(
+                    "api.routes.files.FileStorageService.list_files",
+                    AsyncMock(),
+                ) as list_svc,
+            ):
+                tc = TestClient(app, raise_server_exceptions=False)
+
+                # POST /reserve
+                r = tc.post(
+                    "/api/v1/files/reserve",
+                    json={
+                        "workspace_id": str(ws),
+                        "filename": "x.bin",
+                        "content_type": "application/octet-stream",
+                        "size_bytes": 1024,
+                        "sha256": VALID_SHA,
+                    },
+                )
+                assert r.status_code == 403
+                # GET /
+                r = tc.get(f"/api/v1/files?workspace_id={ws}")
+                assert r.status_code == 403
+                # GET /{id}/download-url
+                r = tc.get(f"/api/v1/files/{file_id}/download-url?workspace_id={ws}")
+                assert r.status_code == 403
+                # POST /{id}/confirm
+                r = tc.post(
+                    f"/api/v1/files/{file_id}/confirm?workspace_id={ws}",
+                    json={"sha256": VALID_SHA},
+                )
+                assert r.status_code == 403
+                # DELETE /{id}
+                r = tc.delete(f"/api/v1/files/{file_id}?workspace_id={ws}")
+                assert r.status_code == 403
+
+                # Gate fired on every endpoint…
+                assert gate.await_count == 5
+                # …and no service method ran.
+                reserve_svc.assert_not_awaited()
+                list_svc.assert_not_awaited()
+        finally:
+            app.dependency_overrides.clear()

--- a/backend/tests/api/test_files.py
+++ b/backend/tests/api/test_files.py
@@ -1,0 +1,234 @@
+"""API tests for /api/v1/files routes (Issue #485).
+
+Service-layer behavior is covered by
+``backend/tests/services/test_file_storage_service.py``. These tests
+verify HTTP/serialization shape, Pydantic validation, dispatch into
+the service, and the global ``MemoryCloudException`` handler mapping
+(NotFound → 404, Validation → 400, Conflict → 409, QuotaExceeded → 429).
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from auth.dependencies import get_user_from_api_key_or_session
+from db.base import get_db
+from services.file_storage_service import ReserveResult
+
+VALID_SHA = "a" * 64
+OTHER_SHA = "b" * 64
+
+
+def _mock_user() -> dict:
+    return {"user_id": "u1", "email": "u@test", "role": "member"}
+
+
+@pytest.fixture
+def client():
+    async def fake_user():
+        return _mock_user()
+
+    async def fake_db():
+        yield MagicMock()
+
+    app.dependency_overrides[get_user_from_api_key_or_session] = fake_user
+    app.dependency_overrides[get_db] = fake_db
+    yield TestClient(app, raise_server_exceptions=False)
+    app.dependency_overrides.clear()
+
+
+def _file_object_mock(**overrides):
+    """Mock that survives Pydantic validation for FileObjectOut."""
+    file = MagicMock()
+    file.id = overrides.get("id", uuid4())
+    file.workspace_id = overrides.get("workspace_id", uuid4())
+    file.filename = overrides.get("filename", "test.bin")
+    file.content_type = overrides.get("content_type", "application/octet-stream")
+    file.size_bytes = overrides.get("size_bytes", 1024)
+    file.sha256 = overrides.get("sha256", VALID_SHA)
+    file.status = overrides.get("status", "uploaded")
+    file.created_at = overrides.get("created_at", datetime(2026, 5, 5, tzinfo=UTC))
+    file.uploaded_at = overrides.get("uploaded_at", datetime(2026, 5, 5, tzinfo=UTC))
+    return file
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/files/reserve
+# ---------------------------------------------------------------------------
+
+
+class TestReserveUpload:
+    def test_happy_path(self, client):
+        ws = uuid4()
+        file_id = uuid4()
+        expires = datetime.now(UTC) + timedelta(seconds=300)
+
+        with patch(
+            "api.routes.files.FileStorageService.reserve_upload",
+            AsyncMock(
+                return_value=ReserveResult(
+                    file_id=file_id,
+                    upload_url="https://r2.test/put/key?ttl=300",
+                    expires_at=expires,
+                )
+            ),
+        ) as svc:
+            r = client.post(
+                "/api/v1/files/reserve",
+                json={
+                    "workspace_id": str(ws),
+                    "filename": "x.pdf",
+                    "content_type": "application/pdf",
+                    "size_bytes": 1024,
+                    "sha256": VALID_SHA,
+                },
+            )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["file_id"] == str(file_id)
+        assert body["upload_url"].startswith("https://r2.test/put/")
+        svc.assert_awaited_once()
+
+    def test_oversize_rejected_by_pydantic(self, client):
+        r = client.post(
+            "/api/v1/files/reserve",
+            json={
+                "workspace_id": str(uuid4()),
+                "filename": "big.bin",
+                "content_type": "application/octet-stream",
+                "size_bytes": 200 * 1024 * 1024,  # > 100 MiB cap
+                "sha256": VALID_SHA,
+            },
+        )
+        assert r.status_code == 422
+
+    def test_invalid_sha256_rejected_by_pydantic(self, client):
+        r = client.post(
+            "/api/v1/files/reserve",
+            json={
+                "workspace_id": str(uuid4()),
+                "filename": "x.bin",
+                "content_type": "application/octet-stream",
+                "size_bytes": 1024,
+                "sha256": "not-hex",
+            },
+        )
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/files/{file_id}/confirm
+# ---------------------------------------------------------------------------
+
+
+class TestConfirmUpload:
+    def test_happy_path(self, client):
+        ws = uuid4()
+        file_id = uuid4()
+        with patch(
+            "api.routes.files.FileStorageService.confirm_upload",
+            AsyncMock(return_value=_file_object_mock(id=file_id, workspace_id=ws)),
+        ):
+            r = client.post(
+                f"/api/v1/files/{file_id}/confirm?workspace_id={ws}",
+                json={"sha256": VALID_SHA},
+            )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["id"] == str(file_id)
+        assert body["status"] == "uploaded"
+
+    def test_sha256_mismatch_validation_error_returns_422(self, client):
+        """``ValidationError`` is mapped to HTTP 422 by the global
+        ``MemoryCloudException`` handler — same status FastAPI uses for
+        Pydantic body validation, so client error handling is uniform."""
+        ws = uuid4()
+        file_id = uuid4()
+        from utils.exceptions import ValidationError
+
+        with patch(
+            "api.routes.files.FileStorageService.confirm_upload",
+            AsyncMock(side_effect=ValidationError("sha256 mismatch")),
+        ):
+            r = client.post(
+                f"/api/v1/files/{file_id}/confirm?workspace_id={ws}",
+                json={"sha256": OTHER_SHA},
+            )
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/files/{file_id}/download-url
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadUrl:
+    def test_happy_path(self, client):
+        ws = uuid4()
+        file_id = uuid4()
+        with patch(
+            "api.routes.files.FileStorageService.get_presigned_download",
+            AsyncMock(return_value="https://r2.test/get/key?ttl=300"),
+        ):
+            r = client.get(f"/api/v1/files/{file_id}/download-url?workspace_id={ws}")
+        assert r.status_code == 200, r.text
+        assert r.json()["download_url"].startswith("https://r2.test/get/")
+
+    def test_not_found_returns_404(self, client):
+        ws = uuid4()
+        file_id = uuid4()
+        from utils.exceptions import NotFoundException
+
+        with patch(
+            "api.routes.files.FileStorageService.get_presigned_download",
+            AsyncMock(side_effect=NotFoundException("missing")),
+        ):
+            r = client.get(f"/api/v1/files/{file_id}/download-url?workspace_id={ws}")
+        assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/v1/files/{file_id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteFile:
+    def test_returns_204(self, client):
+        ws = uuid4()
+        file_id = uuid4()
+        with patch(
+            "api.routes.files.FileStorageService.delete_file",
+            AsyncMock(return_value=None),
+        ) as svc:
+            r = client.delete(f"/api/v1/files/{file_id}?workspace_id={ws}")
+        assert r.status_code == 204
+        svc.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# GET /api/v1/files
+# ---------------------------------------------------------------------------
+
+
+class TestListFiles:
+    def test_happy_path(self, client):
+        ws = uuid4()
+        files = [_file_object_mock(workspace_id=ws), _file_object_mock(workspace_id=ws)]
+        with patch(
+            "api.routes.files.FileStorageService.list_files",
+            AsyncMock(return_value=files),
+        ):
+            r = client.get(f"/api/v1/files?workspace_id={ws}&limit=10")
+        assert r.status_code == 200
+        assert len(r.json()) == 2
+
+    def test_invalid_limit_rejected_by_pydantic(self, client):
+        ws = uuid4()
+        r = client.get(f"/api/v1/files?workspace_id={ws}&limit=10000")
+        assert r.status_code == 422

--- a/backend/tests/mcp_server/test_file_tools.py
+++ b/backend/tests/mcp_server/test_file_tools.py
@@ -54,10 +54,31 @@ def _patch_get_db():
 
 
 def _patch_viewer_check_pass():
-    return patch(
-        "mcp_server.tools.files._check_viewer_permission",
-        AsyncMock(return_value=None),
-    )
+    """Patch BOTH gates (write-tool _check_viewer_permission and
+    read-tool _check_workspace_membership) — tests use this helper as
+    a one-stop "auth passes" override regardless of which gate the
+    handler under test is using. Read tools (get_file_download_url,
+    list_files) switched to ``_check_workspace_membership`` in
+    Copilot loop 3 (PR #551) so viewers can read; without patching
+    that helper too, those tests would skip the gate via the
+    membership-only check returning a real error."""
+    from contextlib import contextmanager
+
+    @contextmanager
+    def _both():
+        with (
+            patch(
+                "mcp_server.tools.files._check_viewer_permission",
+                AsyncMock(return_value=None),
+            ),
+            patch(
+                "mcp_server.tools.files._check_workspace_membership",
+                AsyncMock(return_value=None),
+            ),
+        ):
+            yield
+
+    return _both()
 
 
 def _payload(text_list) -> dict:
@@ -309,7 +330,11 @@ class TestGetFileDownloadUrl:
         with (
             get_db_patch,
             patch(
-                "mcp_server.tools.files._check_viewer_permission",
+                # Loop 3: read tools use _check_workspace_membership
+                # (membership-only); write tools still use
+                # _check_viewer_permission. This test exercises the
+                # read tool path so it patches the membership variant.
+                "mcp_server.tools.files._check_workspace_membership",
                 AsyncMock(
                     return_value=[
                         MagicMock(

--- a/backend/tests/mcp_server/test_file_tools.py
+++ b/backend/tests/mcp_server/test_file_tools.py
@@ -263,6 +263,7 @@ class TestGetFileDownloadUrl:
         get_db_patch, _ = _patch_get_db()
         with (
             get_db_patch,
+            _patch_viewer_check_pass(),
             patch(
                 "mcp_server.tools.files.FileStorageService.get_presigned_download",
                 AsyncMock(return_value="https://r2.test/get/key"),
@@ -282,6 +283,7 @@ class TestGetFileDownloadUrl:
         get_db_patch, _ = _patch_get_db()
         with (
             get_db_patch,
+            _patch_viewer_check_pass(),
             patch(
                 "mcp_server.tools.files.FileStorageService.get_presigned_download",
                 AsyncMock(side_effect=NotFoundException("missing")),
@@ -294,6 +296,43 @@ class TestGetFileDownloadUrl:
             )
         body = _payload(out)
         assert body["error"] == "not_found"
+
+    @pytest.mark.asyncio
+    async def test_workspace_id_override_requires_membership(self):
+        """Copilot finding on PR #551: an authenticated MCP caller passing
+        a foreign ``workspace_id`` MUST be blocked at the membership gate
+        before reaching the service."""
+        from utils.exceptions import AuthorizationError
+
+        foreign_ws = uuid4()
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            patch(
+                "mcp_server.tools.files._check_viewer_permission",
+                AsyncMock(
+                    return_value=[
+                        MagicMock(
+                            text='{"status":"error","error":"forbidden","message":"not a member"}'
+                        )
+                    ]
+                ),
+            ),
+            patch(
+                "mcp_server.tools.files.FileStorageService.get_presigned_download",
+                AsyncMock(),
+            ) as svc,
+        ):
+            out = await handle_get_file_download_url(
+                {"file_id": str(uuid4()), "workspace_id": str(foreign_ws)},
+                user_id=USER_ID,
+                workspace_id=uuid4(),  # caller's home workspace, different
+            )
+        # Service NEVER reached — gate fired first.
+        svc.assert_not_awaited()
+        # The mocked viewer-check error response is returned verbatim.
+        assert "forbidden" in out[0].text
+        del AuthorizationError  # silence unused-import on the test-class
 
 
 # ---------------------------------------------------------------------------
@@ -358,6 +397,7 @@ class TestListFiles:
         get_db_patch, _ = _patch_get_db()
         with (
             get_db_patch,
+            _patch_viewer_check_pass(),
             patch(
                 "mcp_server.tools.files.FileStorageService.list_files",
                 AsyncMock(return_value=[f1, f2]),
@@ -378,6 +418,7 @@ class TestListFiles:
         get_db_patch, _ = _patch_get_db()
         with (
             get_db_patch,
+            _patch_viewer_check_pass(),
             patch(
                 "mcp_server.tools.files.FileStorageService.list_files",
                 AsyncMock(side_effect=ValidationError("limit out of range")),

--- a/backend/tests/mcp_server/test_file_tools.py
+++ b/backend/tests/mcp_server/test_file_tools.py
@@ -1,0 +1,438 @@
+"""Tests for MCP file storage tool handlers (Issue #485).
+
+Service-layer behaviour is covered by
+``tests/services/test_file_storage_service.py``. These tests verify
+the MCP-specific shape:
+
+- argument validation / missing-fields error vocabulary
+- workspace_id resolution (arg override vs auth fallback)
+- error-vocabulary mapping (MCP returns ``error: validation_error``,
+  ``not_found``, ``conflict``, ``quota_exceeded`` — same vocabulary
+  as the REST layer's HTTP status codes)
+- success response shape (file_id / upload_url / etc.)
+
+Patches FileStorageService at the class level (mirrors
+``test_resource_ingest_quota.py``'s pattern for MCP handler tests).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.files import (
+    handle_complete_file_upload,
+    handle_delete_file,
+    handle_get_file_download_url,
+    handle_init_file_upload,
+    handle_list_files,
+)
+from services.file_storage_service import ReserveResult
+from utils.exceptions import (
+    ConflictError,
+    NotFoundException,
+    QuotaExceededError,
+    ValidationError,
+)
+
+VALID_SHA = "a" * 64
+USER_ID = "u1"
+
+
+def _patch_get_db():
+    """Make ``async for db in get_db()`` yield a MagicMock once."""
+    db = MagicMock()
+
+    async def _aiter():
+        yield db
+
+    return patch("db.base.get_db", return_value=_aiter()), db
+
+
+def _patch_viewer_check_pass():
+    return patch(
+        "mcp_server.tools.files._check_viewer_permission",
+        AsyncMock(return_value=None),
+    )
+
+
+def _payload(text_list) -> dict:
+    """Decode the JSON payload of a TextContent response."""
+    assert len(text_list) == 1
+    return json.loads(text_list[0].text)
+
+
+# ---------------------------------------------------------------------------
+# init_file_upload
+# ---------------------------------------------------------------------------
+
+
+class TestInitFileUpload:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        ws = uuid4()
+        file_id = uuid4()
+        expires = datetime.now(UTC) + timedelta(seconds=300)
+
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            _patch_viewer_check_pass(),
+            patch(
+                "mcp_server.tools.files.FileStorageService.reserve_upload",
+                AsyncMock(
+                    return_value=ReserveResult(
+                        file_id=file_id,
+                        upload_url="https://r2.test/put/key",
+                        expires_at=expires,
+                    )
+                ),
+            ),
+        ):
+            out = await handle_init_file_upload(
+                {
+                    "filename": "x.pdf",
+                    "content_type": "application/pdf",
+                    "size_bytes": 1024,
+                    "sha256": VALID_SHA,
+                },
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+
+        body = _payload(out)
+        assert body["file_id"] == str(file_id)
+        assert body["upload_url"] == "https://r2.test/put/key"
+
+    @pytest.mark.asyncio
+    async def test_missing_field_returns_error(self):
+        out = await handle_init_file_upload(
+            {"filename": "x.pdf"},
+            user_id=USER_ID,
+            workspace_id=uuid4(),
+        )
+        body = _payload(out)
+        assert body["error"] == "missing_fields"
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_returns_error(self):
+        out = await handle_init_file_upload(
+            {
+                "filename": "x.pdf",
+                "content_type": "application/pdf",
+                "size_bytes": 1024,
+                "sha256": VALID_SHA,
+            },
+            user_id=USER_ID,
+            workspace_id=None,  # No fallback either
+        )
+        body = _payload(out)
+        assert body["error"] == "workspace_required"
+
+    @pytest.mark.asyncio
+    async def test_quota_exceeded_maps_to_quota_error(self):
+        ws = uuid4()
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            _patch_viewer_check_pass(),
+            patch(
+                "mcp_server.tools.files.FileStorageService.reserve_upload",
+                AsyncMock(side_effect=QuotaExceededError("over the limit")),
+            ),
+        ):
+            out = await handle_init_file_upload(
+                {
+                    "filename": "x.pdf",
+                    "content_type": "application/pdf",
+                    "size_bytes": 1024,
+                    "sha256": VALID_SHA,
+                },
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+        body = _payload(out)
+        assert body["error"] == "quota_exceeded"
+
+    @pytest.mark.asyncio
+    async def test_conflict_maps_to_conflict_error(self):
+        ws = uuid4()
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            _patch_viewer_check_pass(),
+            patch(
+                "mcp_server.tools.files.FileStorageService.reserve_upload",
+                AsyncMock(side_effect=ConflictError("duplicate sha256")),
+            ),
+        ):
+            out = await handle_init_file_upload(
+                {
+                    "filename": "x.pdf",
+                    "content_type": "application/pdf",
+                    "size_bytes": 1024,
+                    "sha256": VALID_SHA,
+                },
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+        body = _payload(out)
+        assert body["error"] == "conflict"
+
+
+# ---------------------------------------------------------------------------
+# complete_file_upload
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteFileUpload:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        ws = uuid4()
+        file_id = uuid4()
+
+        finalised = MagicMock()
+        finalised.id = file_id
+        finalised.status = "uploaded"
+        finalised.size_bytes = 1024
+        finalised.sha256 = VALID_SHA
+
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            _patch_viewer_check_pass(),
+            patch(
+                "mcp_server.tools.files.FileStorageService.confirm_upload",
+                AsyncMock(return_value=finalised),
+            ),
+        ):
+            out = await handle_complete_file_upload(
+                {"file_id": str(file_id), "sha256": VALID_SHA},
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+
+        body = _payload(out)
+        assert body["status"] == "uploaded"
+        assert body["file_id"] == str(file_id)
+
+    @pytest.mark.asyncio
+    async def test_invalid_file_id_returns_validation_error(self):
+        out = await handle_complete_file_upload(
+            {"file_id": "not-a-uuid", "sha256": VALID_SHA},
+            user_id=USER_ID,
+            workspace_id=uuid4(),
+        )
+        body = _payload(out)
+        assert body["error"] == "validation_error"
+
+    @pytest.mark.asyncio
+    async def test_sha256_mismatch_validation_error(self):
+        ws = uuid4()
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            _patch_viewer_check_pass(),
+            patch(
+                "mcp_server.tools.files.FileStorageService.confirm_upload",
+                AsyncMock(side_effect=ValidationError("sha256 mismatch")),
+            ),
+        ):
+            out = await handle_complete_file_upload(
+                {"file_id": str(uuid4()), "sha256": VALID_SHA},
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+        body = _payload(out)
+        assert body["error"] == "validation_error"
+
+
+# ---------------------------------------------------------------------------
+# get_file_download_url
+# ---------------------------------------------------------------------------
+
+
+class TestGetFileDownloadUrl:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        ws = uuid4()
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            patch(
+                "mcp_server.tools.files.FileStorageService.get_presigned_download",
+                AsyncMock(return_value="https://r2.test/get/key"),
+            ),
+        ):
+            out = await handle_get_file_download_url(
+                {"file_id": str(uuid4())},
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+        body = _payload(out)
+        assert body["download_url"] == "https://r2.test/get/key"
+
+    @pytest.mark.asyncio
+    async def test_not_found_maps_to_not_found(self):
+        ws = uuid4()
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            patch(
+                "mcp_server.tools.files.FileStorageService.get_presigned_download",
+                AsyncMock(side_effect=NotFoundException("missing")),
+            ),
+        ):
+            out = await handle_get_file_download_url(
+                {"file_id": str(uuid4())},
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+        body = _payload(out)
+        assert body["error"] == "not_found"
+
+
+# ---------------------------------------------------------------------------
+# delete_file
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteFile:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        ws = uuid4()
+        file_id = uuid4()
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            _patch_viewer_check_pass(),
+            patch(
+                "mcp_server.tools.files.FileStorageService.delete_file",
+                AsyncMock(return_value=None),
+            ) as svc,
+        ):
+            out = await handle_delete_file(
+                {"file_id": str(file_id)},
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+        body = _payload(out)
+        assert body["deleted"] is True
+        assert body["file_id"] == str(file_id)
+        svc.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# list_files
+# ---------------------------------------------------------------------------
+
+
+class TestListFiles:
+    @pytest.mark.asyncio
+    async def test_happy_path(self):
+        ws = uuid4()
+        f1 = MagicMock(
+            id=uuid4(),
+            filename="a.bin",
+            content_type="application/octet-stream",
+            size_bytes=100,
+            sha256=VALID_SHA,
+            status="uploaded",
+            created_at=datetime.now(UTC),
+            uploaded_at=datetime.now(UTC),
+        )
+        f2 = MagicMock(
+            id=uuid4(),
+            filename="b.bin",
+            content_type="application/octet-stream",
+            size_bytes=200,
+            sha256="b" * 64,
+            status="uploaded",
+            created_at=datetime.now(UTC),
+            uploaded_at=datetime.now(UTC),
+        )
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            patch(
+                "mcp_server.tools.files.FileStorageService.list_files",
+                AsyncMock(return_value=[f1, f2]),
+            ),
+        ):
+            out = await handle_list_files(
+                {"limit": 10},
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+        body = _payload(out)
+        assert body["count"] == 2
+        assert len(body["files"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_invalid_limit_validation_error(self):
+        ws = uuid4()
+        get_db_patch, _ = _patch_get_db()
+        with (
+            get_db_patch,
+            patch(
+                "mcp_server.tools.files.FileStorageService.list_files",
+                AsyncMock(side_effect=ValidationError("limit out of range")),
+            ),
+        ):
+            out = await handle_list_files(
+                {"limit": 9999},
+                user_id=USER_ID,
+                workspace_id=ws,
+            )
+        body = _payload(out)
+        assert body["error"] == "validation_error"
+
+
+# ---------------------------------------------------------------------------
+# Registry / TOOLS_WITHOUT_CONTEXT_ID
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryWiring:
+    def test_all_five_tools_in_no_context_set(self):
+        """Files don't have a context_id; the dispatch guard MUST not
+        reject them for missing context_id."""
+        from mcp_server.tools import _TOOLS_WITHOUT_CONTEXT_ID
+
+        for name in (
+            "init_file_upload",
+            "complete_file_upload",
+            "get_file_download_url",
+            "delete_file",
+            "list_files",
+        ):
+            assert name in _TOOLS_WITHOUT_CONTEXT_ID, (
+                f"{name} missing from _TOOLS_WITHOUT_CONTEXT_ID"
+            )
+
+    def test_registry_dispatches_file_handlers(self):
+        from mcp_server.tools import _build_registry
+
+        reg = _build_registry()
+        assert reg["init_file_upload"] is handle_init_file_upload
+        assert reg["complete_file_upload"] is handle_complete_file_upload
+        assert reg["get_file_download_url"] is handle_get_file_download_url
+        assert reg["delete_file"] is handle_delete_file
+        assert reg["list_files"] is handle_list_files
+
+    def test_definitions_include_all_five(self):
+        from mcp_server.tools._definitions import get_tool_definitions
+
+        names = {d["name"] for d in get_tool_definitions()}
+        for n in (
+            "init_file_upload",
+            "complete_file_upload",
+            "get_file_download_url",
+            "delete_file",
+            "list_files",
+        ):
+            assert n in names

--- a/backend/tests/models/test_file_objects.py
+++ b/backend/tests/models/test_file_objects.py
@@ -1,0 +1,111 @@
+"""Tests for ``file_objects`` + ``workspace_storage_usage`` ORM models (Issue #485).
+
+These are pure metadata-level checks — no DB connection — so they run
+in ``make test-local``. End-to-end constraint behaviour (CHECK
+violations, partial-unique conflicts, generated-column population) is
+covered by the integration suite under ``backend/tests/integration/``.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy.dialects.postgresql import BYTEA, UUID
+
+from models.file_objects import FileObject, WorkspaceStorageUsage
+
+
+class TestFileObjectModel:
+    def test_table_name(self):
+        assert FileObject.__tablename__ == "file_objects"
+
+    def test_required_columns_present(self):
+        cols = {c.name for c in FileObject.__table__.columns}
+        # Identity + workspace + content
+        assert {"id", "workspace_id", "sha256", "size_bytes", "filename", "content_type"} <= cols
+        # Storage routing (R1 / R2)
+        assert {"storage_backend", "storage_key", "inline_bytes"} <= cols
+        # Upload state machine (R3)
+        assert {"status", "expires_at", "uploaded_at", "deleted_at"} <= cols
+
+    def test_inline_bytes_column_is_bytea(self):
+        """Phase 1 reserves ``inline_bytes`` for Phase 1.5 use."""
+        col = FileObject.__table__.c.inline_bytes
+        assert isinstance(col.type, BYTEA)
+        assert col.nullable is True
+
+    def test_id_is_uuid(self):
+        col = FileObject.__table__.c.id
+        assert isinstance(col.type, UUID)
+        assert col.primary_key is True
+
+    def test_check_constraints_declared(self):
+        names = {c.name for c in FileObject.__table_args__ if hasattr(c, "name")}
+        assert "valid_file_storage_backend" in names
+        assert "valid_file_status" in names
+        assert "valid_file_storage_shape" in names
+
+    def test_partial_unique_index_declared(self):
+        """The (workspace_id, sha256) WHERE deleted_at IS NULL AND
+        status != 'failed' partial unique index is the dedup gate."""
+        for arg in FileObject.__table_args__:
+            if hasattr(arg, "name") and arg.name == "uq_file_objects_workspace_sha256_active":
+                # Index objects expose `unique` and `dialect_options`
+                assert arg.unique is True
+                # Partial WHERE clause stored as a dialect-specific option
+                where = arg.dialect_options.get("postgresql", {}).get("where")
+                assert where is not None
+                assert "deleted_at IS NULL" in str(where)
+                assert "status" in str(where)
+                return
+        msg = "uq_file_objects_workspace_sha256_active not found in __table_args__"
+        raise AssertionError(msg)
+
+
+class TestWorkspaceStorageUsageModel:
+    def test_table_name(self):
+        assert WorkspaceStorageUsage.__tablename__ == "workspace_storage_usage"
+
+    def test_workspace_id_is_pk(self):
+        col = WorkspaceStorageUsage.__table__.c.workspace_id
+        assert col.primary_key is True
+
+    def test_counter_columns_have_zero_default(self):
+        used = WorkspaceStorageUsage.__table__.c.used_bytes
+        count = WorkspaceStorageUsage.__table__.c.file_count
+        assert used.server_default is not None
+        assert count.server_default is not None
+        assert used.nullable is False
+        assert count.nullable is False
+
+    def test_nonneg_check_constraints_declared(self):
+        names = {c.name for c in WorkspaceStorageUsage.__table_args__ if hasattr(c, "name")}
+        assert "nonneg_used_bytes" in names
+        assert "nonneg_file_count" in names
+
+
+class TestMemoryExternalBlobComputedColumns:
+    """Issue #485 R1: ``Memory`` exposes the discriminated-union blob
+    reference via two persisted generated columns."""
+
+    def test_columns_declared(self):
+        from models.memory import Memory
+
+        cols = {c.name for c in Memory.__table__.columns}
+        assert "external_blob_backend" in cols
+        assert "external_blob_ref" in cols
+
+    def test_columns_are_computed_persisted(self):
+        from models.memory import Memory
+
+        for name in ("external_blob_backend", "external_blob_ref"):
+            col = Memory.__table__.c[name]
+            assert col.computed is not None, f"{name} must be a Computed column"
+            assert col.computed.persisted is True, f"{name} must be persisted=True"
+
+    def test_computed_expression_uses_nested_arrow(self):
+        """``details->'external_blob'->>'backend|ref'`` two-step extraction."""
+        from models.memory import Memory
+
+        backend_expr = str(Memory.__table__.c.external_blob_backend.computed.sqltext)
+        ref_expr = str(Memory.__table__.c.external_blob_ref.computed.sqltext)
+        assert "external_blob" in backend_expr and "backend" in backend_expr
+        assert "external_blob" in ref_expr and "ref" in ref_expr

--- a/backend/tests/services/test_addon_calculator_service.py
+++ b/backend/tests/services/test_addon_calculator_service.py
@@ -1,0 +1,124 @@
+"""Tests for AddonCalculatorService.
+
+Issue #485 prerequisite: ``recalculate_workspace_bonuses`` writes
+``workspace.addon_storage_bonus_mb`` (since the service was originally
+authored alongside the ``extra_storage`` addon type), but the column
+was never added to the ``Workspace`` model nor any prior migration.
+The first commit of #485 closes that gap; these tests guard against
+regression.
+"""
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.addon_calculator_service import (
+    ADDON_UNIT_VALUES,
+    AddonCalculatorService,
+)
+from utils.datetime import utcnow
+
+
+def _make_addon(addon_type: str, quantity: int):
+    """Build a minimal active WorkspaceAddon mock."""
+    addon = MagicMock()
+    addon.addon_type = addon_type
+    addon.quantity = quantity
+    addon.active_from = utcnow() - timedelta(days=1)
+    addon.active_until = None
+    return addon
+
+
+def _make_workspace(workspace_id):
+    """Build a Workspace mock with all addon_*_bonus columns settable."""
+    workspace = MagicMock()
+    workspace.id = workspace_id
+    workspace.addon_storage_bonus_mb = 0
+    workspace.addon_memory_bonus = 0
+    workspace.addon_mcp_quota_bonus = 0
+    workspace.addon_rest_quota_bonus = 0
+    workspace.addon_public_quota_bonus = 0
+    workspace.addon_member_bonus = 0
+    workspace.addon_context_bonus = 0
+    workspace.addon_analysis_bonus = 0
+    return workspace
+
+
+def _make_side_effects(addons, workspace):
+    """Return the 2-element side_effect list for db.execute.
+
+    Call order inside ``recalculate_workspace_bonuses``:
+      1. select(WorkspaceAddon) — active addons
+      2. select(Workspace)      — target workspace row
+    """
+    addon_result = MagicMock()
+    addon_result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=addons)))
+
+    workspace_result = MagicMock()
+    workspace_result.scalar_one_or_none = MagicMock(return_value=workspace)
+
+    return [addon_result, workspace_result]
+
+
+class TestAddonCalculatorStorageBonus:
+    """Persist ``addon_storage_bonus_mb`` without ``AttributeError`` (#485)."""
+
+    @pytest.fixture
+    def mock_db(self):
+        db = MagicMock()
+        db.execute = AsyncMock()
+        db.commit = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def service(self, mock_db):
+        return AddonCalculatorService(mock_db)
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.mark.asyncio
+    async def test_extra_storage_addon_bonus_is_persisted(self, service, mock_db, workspace_id):
+        """Single ``extra_storage`` addon (qty=3) → 300 MB bonus column."""
+        unit_mb = ADDON_UNIT_VALUES["extra_storage"]
+        assert unit_mb == 100, "Unit value drift — review pricing assumptions"
+
+        addons = [_make_addon("extra_storage", quantity=3)]
+        workspace = _make_workspace(workspace_id)
+        mock_db.execute.side_effect = _make_side_effects(addons, workspace)
+
+        bonuses = await service.recalculate_workspace_bonuses(workspace_id)
+
+        assert bonuses["addon_storage_bonus_mb"] == 300
+        assert workspace.addon_storage_bonus_mb == 300
+        mock_db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_addons_yields_zero_storage_bonus(self, service, mock_db, workspace_id):
+        """No active addons → zero bonus, no AttributeError on persist."""
+        workspace = _make_workspace(workspace_id)
+        mock_db.execute.side_effect = _make_side_effects([], workspace)
+
+        bonuses = await service.recalculate_workspace_bonuses(workspace_id)
+
+        assert bonuses["addon_storage_bonus_mb"] == 0
+        assert workspace.addon_storage_bonus_mb == 0
+
+    @pytest.mark.asyncio
+    async def test_mixed_addons_isolate_storage_bonus(self, service, mock_db, workspace_id):
+        """Storage + memory addons must not cross-pollinate bonus dimensions."""
+        addons = [
+            _make_addon("extra_storage", quantity=2),
+            _make_addon("extra_memory", quantity=5),
+        ]
+        workspace = _make_workspace(workspace_id)
+        mock_db.execute.side_effect = _make_side_effects(addons, workspace)
+
+        bonuses = await service.recalculate_workspace_bonuses(workspace_id)
+
+        assert bonuses["addon_storage_bonus_mb"] == 200  # 2 × 100 MB
+        assert workspace.addon_storage_bonus_mb == 200
+        assert bonuses["addon_memory_bonus"] == 5 * ADDON_UNIT_VALUES["extra_memory"]

--- a/backend/tests/services/test_effective_quota_service.py
+++ b/backend/tests/services/test_effective_quota_service.py
@@ -33,6 +33,7 @@ class TestEffectiveQuotaService:
         addon_public_quota_bonus=50,
         addon_member_bonus=3,
         addon_context_bonus=5,
+        addon_storage_bonus_mb=0,
     ):
         """Create a mock workspace with addon bonuses and effective properties."""
         ws = MagicMock()
@@ -45,6 +46,7 @@ class TestEffectiveQuotaService:
         ws.addon_public_quota_bonus = addon_public_quota_bonus
         ws.addon_member_bonus = addon_member_bonus
         ws.addon_context_bonus = addon_context_bonus
+        ws.addon_storage_bonus_mb = addon_storage_bonus_mb
         from config.plan_tiers import get_plan_tier
 
         tier = get_plan_tier(plan_name)
@@ -52,6 +54,9 @@ class TestEffectiveQuotaService:
         ws.effective_mcp_calls_per_day = tier.mcp_calls_per_day + addon_mcp_quota_bonus
         ws.effective_max_contexts = tier.max_contexts_per_workspace + addon_context_bonus
         ws.effective_max_members = tier.max_members_per_workspace + addon_member_bonus
+        ws.effective_storage_limit_bytes = (
+            tier.storage_limit_bytes + addon_storage_bonus_mb * 1024 * 1024
+        )
         return ws
 
     @pytest.mark.asyncio
@@ -140,6 +145,7 @@ class TestDashboardAddonReflection:
         ws.addon_member_bonus = 3
         ws.addon_context_bonus = 5
         ws.addon_analysis_bonus = 2  # Issue #494
+        ws.addon_storage_bonus_mb = 250  # Issue #485
         from config.plan_tiers import get_plan_tier
 
         tier = get_plan_tier("pro")
@@ -153,6 +159,7 @@ class TestDashboardAddonReflection:
         ws.effective_max_contexts = tier.max_contexts_per_workspace + 5
         ws.effective_max_members = tier.max_members_per_workspace + 3
         ws.effective_analysis_runs_per_day = tier.analysis_runs_per_day + 2
+        ws.effective_storage_limit_bytes = tier.storage_limit_bytes + 250 * 1024 * 1024
 
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = ws
@@ -170,3 +177,35 @@ class TestDashboardAddonReflection:
         assert quotas["public_calls_per_week"] == tier.public_calls_per_week + 50
         # Issue #494: broadlistening analysis runs/day surfaces here too.
         assert quotas["analysis_runs_per_day"] == tier.analysis_runs_per_day + 2
+        # Issue #485: storage byte limit surfaces here too.
+        assert quotas["storage_bytes_limit"] == tier.storage_limit_bytes + 250 * 1024 * 1024
+
+
+class TestStorageQuotaSurface:
+    """Issue #485: storage_bytes_limit travels through EffectiveQuotaService."""
+
+    def test_free_tier_default_is_100mb(self):
+        """FREE plan default storage cap is 100 MiB (per #485 Phase 1 spec)."""
+        from config.plan_tiers import get_plan_tier
+
+        tier = get_plan_tier("free")
+        assert tier.storage_limit_bytes == 100 * 1024 * 1024
+
+    def test_workspace_effective_storage_property(self):
+        """``Workspace.effective_storage_limit_bytes`` =
+        ``tier.storage_limit_bytes + addon_storage_bonus_mb * 1 MiB``.
+
+        Invoke the property's ``fget`` descriptor against a MagicMock so we
+        don't need a real Workspace row — that would force every NOT NULL
+        column to be supplied just to read one derived value.
+        """
+        from config.plan_tiers import get_plan_tier
+        from models.auth import Workspace
+
+        tier = get_plan_tier("pro")
+        ws = MagicMock()
+        ws._plan_tier = tier
+        ws.addon_storage_bonus_mb = 1024  # +1 GiB
+
+        result = Workspace.effective_storage_limit_bytes.fget(ws)
+        assert result == tier.storage_limit_bytes + 1024 * 1024 * 1024

--- a/backend/tests/services/test_file_storage_migrate.py
+++ b/backend/tests/services/test_file_storage_migrate.py
@@ -1,0 +1,156 @@
+"""Tests for ``FileStorageService.migrate_attachment`` (Issue #485 Commit 9).
+
+The migration logic copies legacy ``Attachment`` BYTEA blobs to R2 and
+inserts a corresponding ``file_objects`` row with ``status='uploaded'``.
+Idempotent: re-running on already-migrated rows is a no-op.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from services.file_storage_service import FileStorageService
+
+
+class _FakeBlobStorage:
+    def __init__(self) -> None:
+        self.objects: dict[str, tuple[bytes, str, str]] = {}
+
+    async def write_object(self, key, data, content_type, sha256):
+        self.objects[key] = (data, content_type, sha256)
+
+    async def head_object(self, key):
+        if key not in self.objects:
+            return None
+        return {"size_bytes": len(self.objects[key][0]), "etag": self.objects[key][2]}
+
+    async def delete_object(self, key):
+        self.objects.pop(key, None)
+
+    async def generate_presigned_put(self, key, content_type, size_bytes, ttl_seconds):
+        return f"put://{key}"
+
+    async def generate_presigned_get(self, key, filename, ttl_seconds):
+        return f"get://{key}"
+
+
+@pytest.fixture
+def workspace_id():
+    return uuid4()
+
+
+@pytest.fixture
+def attachment_id():
+    return uuid4()
+
+
+@pytest.fixture
+def fake_storage():
+    return _FakeBlobStorage()
+
+
+@pytest.fixture
+def db():
+    db = MagicMock()
+    db.execute = AsyncMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+@pytest.fixture
+def service(db, fake_storage):
+    return FileStorageService(db, storage=fake_storage)
+
+
+def _no_existing(db):
+    """Patch the existing-row lookup to return None (no prior migration)."""
+    miss = MagicMock()
+    miss.scalar_one_or_none = MagicMock(return_value=None)
+    db.execute.return_value = miss
+
+
+class TestMigrateAttachment:
+    @pytest.mark.asyncio
+    async def test_happy_path_writes_r2_and_inserts_file_object(
+        self, service, db, fake_storage, workspace_id, attachment_id
+    ):
+        _no_existing(db)
+        data = b"legacy-bytea-bytes"
+        expected_sha = hashlib.sha256(data).hexdigest()
+
+        with patch.object(FileStorageService, "_upsert_workspace_usage", AsyncMock()) as upsert:
+            file = await service.migrate_attachment(
+                workspace_id=workspace_id,
+                attachment_id=attachment_id,
+                filename="report.pdf",
+                content_type="application/pdf",
+                size_bytes=len(data),
+                data=data,
+                created_by="migration:test",
+            )
+
+        # R2 write happened with correct sha256
+        expected_key = f"{workspace_id}/legacy/{attachment_id}/report.pdf"
+        assert expected_key in fake_storage.objects
+        body, content_type, stored_sha = fake_storage.objects[expected_key]
+        assert body == data
+        assert content_type == "application/pdf"
+        assert stored_sha == expected_sha
+
+        # FileObject row inserted with status=uploaded
+        assert file.status == "uploaded"
+        assert file.uploaded_at is not None
+        assert file.sha256 == expected_sha
+        assert file.storage_backend == "r2"
+        assert file.storage_key == expected_key
+
+        # workspace_storage_usage incremented
+        upsert.assert_awaited_once()
+        kwargs = upsert.call_args.kwargs
+        assert kwargs["delta_bytes"] == len(data)
+        assert kwargs["delta_files"] == 1
+
+        # Atomic commit
+        db.flush.assert_awaited_once()
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_skip_when_already_migrated(
+        self, service, db, fake_storage, workspace_id, attachment_id
+    ):
+        """If a file_objects row with the same legacy key exists, the
+        migration is a no-op — bytes are not re-uploaded and no INSERT
+        happens. Re-running the script is safe."""
+        existing = MagicMock()
+        existing.id = uuid4()
+        existing.storage_key = f"{workspace_id}/legacy/{attachment_id}/x.bin"
+
+        hit = MagicMock()
+        hit.scalar_one_or_none = MagicMock(return_value=existing)
+        db.execute.return_value = hit
+
+        with patch.object(FileStorageService, "_upsert_workspace_usage", AsyncMock()) as upsert:
+            file = await service.migrate_attachment(
+                workspace_id=workspace_id,
+                attachment_id=attachment_id,
+                filename="x.bin",
+                content_type="application/octet-stream",
+                size_bytes=100,
+                data=b"x" * 100,
+                created_by="migration:test",
+            )
+
+        assert file is existing
+        # No R2 write, no DB insert, no quota touch
+        assert fake_storage.objects == {}
+        db.add.assert_not_called()
+        db.flush.assert_not_awaited()
+        db.commit.assert_not_awaited()
+        upsert.assert_not_awaited()

--- a/backend/tests/services/test_file_storage_service.py
+++ b/backend/tests/services/test_file_storage_service.py
@@ -325,7 +325,8 @@ class TestConfirmUpload:
         self, service, db, fake_storage, workspace_id
     ):
         """If R2 reports a smaller size than reserved, the diff must be
-        released back to the quota counter."""
+        released back to the quota counter — but only AFTER the DB
+        commit succeeds (Redis follows durable state)."""
         file = _make_file_object(workspace_id, status="reserved", size_bytes=2000)
         await fake_storage.write_object(
             file.storage_key, b"x" * 2000, file.content_type, file.sha256
@@ -345,6 +346,33 @@ class TestConfirmUpload:
         release.assert_awaited_once()
         kwargs = release.call_args.kwargs
         assert kwargs["size_bytes"] == 500
+
+    @pytest.mark.asyncio
+    async def test_oversize_upload_rejects_as_conflict(
+        self, service, db, fake_storage, workspace_id
+    ):
+        """Defence in depth: if R2 reports MORE bytes than declared,
+        reject with ConflictError. Otherwise the per-file 100 MiB cap
+        could be bypassed by PUTting a larger object than the
+        reservation accepted."""
+        file = _make_file_object(workspace_id, status="reserved", size_bytes=1000)
+        await fake_storage.write_object(
+            file.storage_key, b"x" * 1000, file.content_type, file.sha256
+        )
+        fake_storage.head_size_override = 5000  # reports more than declared
+
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+
+        with pytest.raises(ConflictError, match="malformed upload"):
+            await service.confirm_upload(
+                workspace_id=workspace_id, file_id=file.id, sha256=file.sha256
+            )
+        # The reservation is NOT released — operator should investigate
+        # the orphan R2 object explicitly. The row stays ``reserved``
+        # for the orphan sweeper to pick up.
+        assert file.status == "reserved"
 
 
 class TestDeleteFile:

--- a/backend/tests/services/test_file_storage_service.py
+++ b/backend/tests/services/test_file_storage_service.py
@@ -394,10 +394,30 @@ class TestDeleteFile:
         db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_reserved_file_skips_quota_release(self, service, db, workspace_id):
-        """A still-reserved row has no committed quota — release would
-        double-deduct via the orphan sweeper. So delete just marks it."""
+    async def test_reserved_file_releases_redis_reservation(self, service, db, workspace_id):
+        """Cancelling a reserved upload MUST release the Redis reservation
+        right away — otherwise the workspace stays over-counted until
+        the orphan sweeper runs (15 min later by default), which on the
+        Free 100 MiB tier blocks every subsequent upload (Copilot loop
+        finding on PR #551)."""
         file = _make_file_object(workspace_id, status="reserved", size_bytes=1024)
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+
+        with _patch_quota_release() as release:
+            await service.delete_file(workspace_id=workspace_id, file_id=file.id)
+
+        assert file.deleted_at is not None
+        release.assert_awaited_once()
+        kwargs = release.call_args.kwargs
+        assert kwargs["size_bytes"] == 1024
+
+    @pytest.mark.asyncio
+    async def test_failed_file_skips_quota_release(self, service, db, workspace_id):
+        """``status='failed'`` rows already had their Redis quota released
+        by the orphan sweeper — releasing again here would underflow."""
+        file = _make_file_object(workspace_id, status="failed", size_bytes=1024)
         load_result = MagicMock()
         load_result.scalar_one_or_none = MagicMock(return_value=file)
         db.execute.return_value = load_result

--- a/backend/tests/services/test_file_storage_service.py
+++ b/backend/tests/services/test_file_storage_service.py
@@ -1,0 +1,403 @@
+"""Unit tests for ``FileStorageService`` (Issue #485).
+
+Mocks the DB session and uses the in-memory ``BlobStorageProtocol``
+fake from ``tests.storage.test_protocol`` so this file does not depend
+on aioboto3 or a real Redis. SQL constraint behaviour (partial unique
+violations, CHECK constraints, computed columns) is covered by the
+integration suite gated on ``make test-integration``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from services.file_storage_service import FileStorageService, ReserveResult
+from utils.exceptions import (
+    ConflictError,
+    NotFoundException,
+    QuotaExceededError,
+    ValidationError,
+)
+
+
+# Reusable in-memory blob storage matching BlobStorageProtocol
+class _FakeBlobStorage:
+    def __init__(self) -> None:
+        self.objects: dict[str, tuple[bytes, str, str]] = {}
+        self.head_size_override: int | None = None
+
+    async def write_object(self, key, data, content_type, sha256):
+        self.objects[key] = (data, content_type, sha256)
+
+    async def head_object(self, key):
+        if key not in self.objects:
+            return None
+        size = self.head_size_override
+        if size is None:
+            size = len(self.objects[key][0])
+        return {"size_bytes": size, "etag": self.objects[key][2]}
+
+    async def delete_object(self, key):
+        self.objects.pop(key, None)
+
+    async def generate_presigned_put(self, key, content_type, size_bytes, ttl_seconds):
+        return f"https://test.local/put/{key}?size={size_bytes}&ttl={ttl_seconds}"
+
+    async def generate_presigned_get(self, key, filename, ttl_seconds):
+        return f"https://test.local/get/{key}?file={filename}&ttl={ttl_seconds}"
+
+
+VALID_SHA = "a" * 64
+
+
+def _make_workspace(workspace_id: UUID, *, storage_limit_bytes: int = 100 * 1024 * 1024):
+    """Mock Workspace exposing only the attributes FileStorageService reads."""
+    ws = MagicMock()
+    ws.id = workspace_id
+    ws.effective_storage_limit_bytes = storage_limit_bytes
+    return ws
+
+
+def _make_file_object(
+    workspace_id: UUID,
+    *,
+    file_id: UUID | None = None,
+    sha256: str = VALID_SHA,
+    size_bytes: int = 1024,
+    status: str = "reserved",
+    deleted_at: datetime | None = None,
+):
+    file = MagicMock()
+    file.id = file_id or uuid4()
+    file.workspace_id = workspace_id
+    file.sha256 = sha256
+    file.size_bytes = size_bytes
+    file.content_type = "application/octet-stream"
+    file.filename = "test.bin"
+    file.storage_backend = "r2"
+    file.storage_key = f"{workspace_id}/{sha256[:2]}/{sha256}"
+    file.status = status
+    file.deleted_at = deleted_at
+    file.expires_at = None
+    file.uploaded_at = None
+    return file
+
+
+@pytest.fixture
+def workspace_id():
+    return uuid4()
+
+
+@pytest.fixture
+def fake_storage():
+    return _FakeBlobStorage()
+
+
+@pytest.fixture
+def db():
+    db = MagicMock()
+    db.execute = AsyncMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    db.add = MagicMock()
+    return db
+
+
+@pytest.fixture
+def service(db, fake_storage):
+    return FileStorageService(db, storage=fake_storage)
+
+
+def _patch_quota_reserve(succeed: bool = True):
+    if succeed:
+        return patch(
+            "services.file_storage_service.storage_quota_service.reserve_storage_bytes",
+            AsyncMock(),
+        )
+    return patch(
+        "services.file_storage_service.storage_quota_service.reserve_storage_bytes",
+        AsyncMock(side_effect=QuotaExceededError("quota exceeded")),
+    )
+
+
+def _patch_quota_release():
+    return patch(
+        "services.file_storage_service.storage_quota_service.release_storage_bytes",
+        AsyncMock(),
+    )
+
+
+class TestReserveUpload:
+    @pytest.mark.asyncio
+    async def test_happy_path(self, service, db, workspace_id):
+        ws = _make_workspace(workspace_id)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=ws)
+        db.execute.return_value = result
+
+        with _patch_quota_reserve(succeed=True):
+            out = await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="user-1",
+                filename="test.bin",
+                content_type="application/octet-stream",
+                size_bytes=1024,
+                sha256=VALID_SHA,
+            )
+
+        assert isinstance(out, ReserveResult)
+        assert out.upload_url.startswith("https://test.local/put/")
+        db.add.assert_called_once()
+        db.flush.assert_awaited_once()
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_zero_size_raises_validation(self, service, workspace_id):
+        with pytest.raises(ValidationError, match="size_bytes"):
+            await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="x",
+                content_type="application/octet-stream",
+                size_bytes=0,
+                sha256=VALID_SHA,
+            )
+
+    @pytest.mark.asyncio
+    async def test_oversize_raises_validation(self, service, workspace_id):
+        too_big = 200 * 1024 * 1024  # > 100 MiB Phase 1 cap
+        with pytest.raises(ValidationError, match="size_bytes"):
+            await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="x",
+                content_type="application/octet-stream",
+                size_bytes=too_big,
+                sha256=VALID_SHA,
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_sha256_raises_validation(self, service, workspace_id):
+        with pytest.raises(ValidationError, match="sha256"):
+            await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="x",
+                content_type="application/octet-stream",
+                size_bytes=1024,
+                sha256="too-short",
+            )
+
+    @pytest.mark.asyncio
+    async def test_quota_exceeded_propagates(self, service, db, workspace_id):
+        ws = _make_workspace(workspace_id, storage_limit_bytes=100)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=ws)
+        db.execute.return_value = result
+
+        with _patch_quota_reserve(succeed=False):
+            with pytest.raises(QuotaExceededError):
+                await service.reserve_upload(
+                    workspace_id=workspace_id,
+                    created_by="u",
+                    filename="x",
+                    content_type="application/octet-stream",
+                    size_bytes=1024,
+                    sha256=VALID_SHA,
+                )
+        # No DB flush should have happened.
+        db.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_workspace_not_found_raises(self, service, db, workspace_id):
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)
+        db.execute.return_value = result
+
+        with pytest.raises(NotFoundException, match="workspace"):
+            await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="x",
+                content_type="application/octet-stream",
+                size_bytes=1024,
+                sha256=VALID_SHA,
+            )
+
+    @pytest.mark.asyncio
+    async def test_unique_constraint_violation_releases_reservation(
+        self, service, db, workspace_id
+    ):
+        """If the DB flush hits the partial-unique index, the Redis
+        reservation MUST be rolled back so the workspace doesn't lose
+        capacity."""
+        ws = _make_workspace(workspace_id)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=ws)
+        db.execute.return_value = result
+        db.flush.side_effect = Exception(
+            "duplicate key value violates unique constraint "
+            '"uq_file_objects_workspace_sha256_active"'
+        )
+
+        with _patch_quota_reserve(succeed=True), _patch_quota_release() as release:
+            with pytest.raises(ConflictError, match="already exists"):
+                await service.reserve_upload(
+                    workspace_id=workspace_id,
+                    created_by="u",
+                    filename="x",
+                    content_type="application/octet-stream",
+                    size_bytes=1024,
+                    sha256=VALID_SHA,
+                )
+            release.assert_awaited_once()
+
+
+class TestConfirmUpload:
+    @pytest.mark.asyncio
+    async def test_happy_path_transitions_to_uploaded(
+        self, service, db, fake_storage, workspace_id
+    ):
+        file = _make_file_object(workspace_id, status="reserved")
+        # Pre-populate the fake R2 object so head_object returns the right size
+        await fake_storage.write_object(
+            file.storage_key, b"x" * file.size_bytes, file.content_type, file.sha256
+        )
+
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+
+        out = await service.confirm_upload(
+            workspace_id=workspace_id, file_id=file.id, sha256=file.sha256
+        )
+
+        assert out.status == "uploaded"
+        assert out.uploaded_at is not None
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_retry_returns_existing(self, service, db, workspace_id):
+        """Already-uploaded row + matching sha256 → no-op return."""
+        file = _make_file_object(workspace_id, status="uploaded")
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+
+        out = await service.confirm_upload(
+            workspace_id=workspace_id, file_id=file.id, sha256=file.sha256
+        )
+        assert out is file
+        db.commit.assert_not_awaited()  # purely a read
+
+    @pytest.mark.asyncio
+    async def test_sha256_mismatch_raises(self, service, db, workspace_id):
+        file = _make_file_object(workspace_id, status="reserved", sha256=VALID_SHA)
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+
+        with pytest.raises(ValidationError, match="sha256 mismatch"):
+            await service.confirm_upload(
+                workspace_id=workspace_id, file_id=file.id, sha256="b" * 64
+            )
+
+    @pytest.mark.asyncio
+    async def test_r2_object_missing_raises_conflict(self, service, db, workspace_id):
+        file = _make_file_object(workspace_id, status="reserved")
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+        # fake_storage starts empty — head_object returns None
+
+        with pytest.raises(ConflictError, match="R2 object missing"):
+            await service.confirm_upload(
+                workspace_id=workspace_id, file_id=file.id, sha256=file.sha256
+            )
+
+    @pytest.mark.asyncio
+    async def test_truncated_upload_refunds_difference(
+        self, service, db, fake_storage, workspace_id
+    ):
+        """If R2 reports a smaller size than reserved, the diff must be
+        released back to the quota counter."""
+        file = _make_file_object(workspace_id, status="reserved", size_bytes=2000)
+        await fake_storage.write_object(
+            file.storage_key, b"x" * 2000, file.content_type, file.sha256
+        )
+        fake_storage.head_size_override = 1500  # truncated by 500
+
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+
+        with _patch_quota_release() as release:
+            out = await service.confirm_upload(
+                workspace_id=workspace_id, file_id=file.id, sha256=file.sha256
+            )
+
+        assert out.size_bytes == 1500
+        release.assert_awaited_once()
+        kwargs = release.call_args.kwargs
+        assert kwargs["size_bytes"] == 500
+
+
+class TestDeleteFile:
+    @pytest.mark.asyncio
+    async def test_uploaded_file_releases_quota_immediately(self, service, db, workspace_id):
+        """R5: soft-delete must call release_storage_bytes in the same txn."""
+        file = _make_file_object(workspace_id, status="uploaded", size_bytes=1024)
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+
+        with _patch_quota_release() as release:
+            await service.delete_file(workspace_id=workspace_id, file_id=file.id)
+
+        assert file.deleted_at is not None
+        release.assert_awaited_once()
+        kwargs = release.call_args.kwargs
+        assert kwargs["size_bytes"] == 1024
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_reserved_file_skips_quota_release(self, service, db, workspace_id):
+        """A still-reserved row has no committed quota — release would
+        double-deduct via the orphan sweeper. So delete just marks it."""
+        file = _make_file_object(workspace_id, status="reserved", size_bytes=1024)
+        load_result = MagicMock()
+        load_result.scalar_one_or_none = MagicMock(return_value=file)
+        db.execute.return_value = load_result
+
+        with _patch_quota_release() as release:
+            await service.delete_file(workspace_id=workspace_id, file_id=file.id)
+
+        assert file.deleted_at is not None
+        release.assert_not_awaited()
+
+
+class TestListFiles:
+    @pytest.mark.asyncio
+    async def test_invalid_limit_raises(self, service, workspace_id):
+        with pytest.raises(ValidationError, match="limit"):
+            await service.list_files(workspace_id=workspace_id, limit=0)
+        with pytest.raises(ValidationError, match="limit"):
+            await service.list_files(workspace_id=workspace_id, limit=10_000)
+
+    @pytest.mark.asyncio
+    async def test_returns_uploaded_rows(self, service, db, workspace_id):
+        files = [
+            _make_file_object(workspace_id, status="uploaded"),
+            _make_file_object(workspace_id, status="uploaded"),
+        ]
+        list_result = MagicMock()
+        list_result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=files)))
+        db.execute.return_value = list_result
+
+        out = await service.list_files(workspace_id=workspace_id, limit=10)
+        assert len(out) == 2

--- a/backend/tests/services/test_storage_quota_service.py
+++ b/backend/tests/services/test_storage_quota_service.py
@@ -1,0 +1,210 @@
+"""Tests for ``services.storage_quota_service`` (Issue #485).
+
+Mirrors the patterns in ``test_resource_ingest_quota.py`` (the canonical
+#332 shared-quota test). Patches ``db.redis.*`` calls because the
+service is the only thing we want to exercise — the Redis layer itself
+is tested elsewhere.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from services import storage_quota_service
+from utils.exceptions import QuotaExceededError, RedisError
+
+
+@pytest.fixture
+def workspace_id():
+    return uuid4()
+
+
+class TestReserveStorageBytes:
+    @pytest.mark.asyncio
+    async def test_within_quota_increments_counter(self, workspace_id):
+        """Reservation within ceiling → INCRBY by size_bytes, no exception."""
+        db = MagicMock()
+        with (
+            patch.object(storage_quota_service, "get_cache", AsyncMock(return_value="0")),
+            patch.object(
+                storage_quota_service, "incrby_counter", AsyncMock(return_value=1024)
+            ) as incrby,
+        ):
+            await storage_quota_service.reserve_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=1024,
+                quota_bytes=10_000,
+                db=db,
+            )
+            incrby.assert_awaited_once()
+            args, _ = incrby.call_args
+            assert args[1] == 1024
+
+    @pytest.mark.asyncio
+    async def test_at_ceiling_raises_quota_exceeded(self, workspace_id):
+        """current + size > quota_bytes → QuotaExceededError, no INCRBY."""
+        db = MagicMock()
+        with (
+            patch.object(storage_quota_service, "get_cache", AsyncMock(return_value="9500")),
+            patch.object(storage_quota_service, "incrby_counter", AsyncMock()) as incrby,
+        ):
+            with pytest.raises(QuotaExceededError, match="Storage quota exceeded"):
+                await storage_quota_service.reserve_storage_bytes(
+                    workspace_id=workspace_id,
+                    size_bytes=1000,
+                    quota_bytes=10_000,
+                    db=db,
+                )
+            incrby.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_quota_zero_disables_check(self, workspace_id):
+        """quota_bytes <= 0 → skip the Redis round-trip entirely."""
+        db = MagicMock()
+        with (
+            patch.object(storage_quota_service, "get_cache", AsyncMock()) as get_cache,
+            patch.object(storage_quota_service, "incrby_counter", AsyncMock()) as incrby,
+        ):
+            await storage_quota_service.reserve_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=1024,
+                quota_bytes=0,
+                db=db,
+            )
+            get_cache.assert_not_awaited()
+            incrby.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_negative_size_raises_value_error(self, workspace_id):
+        """Defensive: caller MUST pass a positive size."""
+        db = MagicMock()
+        with pytest.raises(ValueError, match="size_bytes must be > 0"):
+            await storage_quota_service.reserve_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=-1,
+                quota_bytes=10_000,
+                db=db,
+            )
+
+    @pytest.mark.asyncio
+    async def test_redis_error_is_swallowed_fail_open(self, workspace_id):
+        """RedisError on get_cache MUST NOT block the upload."""
+        db = MagicMock()
+        with (
+            patch.object(
+                storage_quota_service,
+                "get_cache",
+                AsyncMock(side_effect=RedisError("redis down")),
+            ),
+            patch.object(storage_quota_service, "incrby_counter", AsyncMock()) as incrby,
+        ):
+            # No exception should bubble up; reservation simply skipped.
+            await storage_quota_service.reserve_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=1024,
+                quota_bytes=10_000,
+                db=db,
+            )
+            incrby.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_cold_start_reseeds_from_db(self, workspace_id):
+        """Redis miss → DB aggregate → set_cache (with TTL) → INCRBY."""
+        db_session = MagicMock()
+        result = MagicMock()
+        result.scalar_one = MagicMock(return_value=2048)
+        db_session.execute = AsyncMock(return_value=result)
+
+        with (
+            patch.object(storage_quota_service, "get_cache", AsyncMock(return_value=None)),
+            patch.object(storage_quota_service, "set_cache", AsyncMock()) as set_cache,
+            patch.object(storage_quota_service, "incrby_counter", AsyncMock(return_value=3072)),
+        ):
+            await storage_quota_service.reserve_storage_bytes(
+                workspace_id=workspace_id,
+                size_bytes=1024,
+                quota_bytes=10_000,
+                db=db_session,
+            )
+            set_cache.assert_awaited_once()
+            args, kwargs = set_cache.call_args
+            assert args[1] == "2048"
+            assert kwargs.get("ttl") == 86400
+
+
+class TestReleaseStorageBytes:
+    @pytest.mark.asyncio
+    async def test_release_calls_negative_incrby(self, workspace_id):
+        with patch.object(
+            storage_quota_service, "incrby_counter", AsyncMock(return_value=512)
+        ) as incrby:
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=workspace_id, size_bytes=512
+            )
+            incrby.assert_awaited_once()
+            args, _ = incrby.call_args
+            assert args[1] == -512
+
+    @pytest.mark.asyncio
+    async def test_release_zero_is_noop(self, workspace_id):
+        with patch.object(storage_quota_service, "incrby_counter", AsyncMock()) as incrby:
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=workspace_id, size_bytes=0
+            )
+            incrby.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_release_redis_error_swallowed(self, workspace_id):
+        """Sweeper retries naturally; one failed release MUST NOT raise."""
+        with patch.object(
+            storage_quota_service,
+            "incrby_counter",
+            AsyncMock(side_effect=RedisError("down")),
+        ):
+            # Must not raise.
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=workspace_id, size_bytes=512
+            )
+
+    @pytest.mark.asyncio
+    async def test_release_underflow_does_not_raise(self, workspace_id):
+        """Negative INCRBY result is logged but does not raise — net
+        effect is "slightly under-counted", which is the safer drift
+        direction (matches docstring contract)."""
+        with patch.object(
+            storage_quota_service,
+            "incrby_counter",
+            AsyncMock(return_value=-100),
+        ):
+            # Must not raise.
+            await storage_quota_service.release_storage_bytes(
+                workspace_id=workspace_id, size_bytes=500
+            )
+
+
+class TestGetCurrentStorageUsage:
+    @pytest.mark.asyncio
+    async def test_uses_redis_when_present(self, workspace_id):
+        db = MagicMock()
+        with patch.object(storage_quota_service, "get_cache", AsyncMock(return_value="4096")):
+            assert await storage_quota_service.get_current_storage_usage(workspace_id, db) == 4096
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_db_on_redis_error(self, workspace_id):
+        db_session = MagicMock()
+        result = MagicMock()
+        result.scalar_one = MagicMock(return_value=8192)
+        db_session.execute = AsyncMock(return_value=result)
+
+        with patch.object(
+            storage_quota_service,
+            "get_cache",
+            AsyncMock(side_effect=RedisError("down")),
+        ):
+            assert (
+                await storage_quota_service.get_current_storage_usage(workspace_id, db_session)
+                == 8192
+            )

--- a/backend/tests/storage/test_factory.py
+++ b/backend/tests/storage/test_factory.py
@@ -50,11 +50,14 @@ def _settings_without_r2():
 
 class TestGetBlobStorage:
     def test_raises_when_r2_endpoint_url_missing(self):
-        """``get_blob_storage`` MUST raise (not silently no-op) when R2
-        is not configured — callers should gate on
-        ``settings.r2_endpoint_url`` upstream."""
+        """``get_blob_storage`` MUST raise ``ExternalServiceError``
+        (HTTP 502) — not RuntimeError — when R2 is not configured, so
+        REST and MCP file handlers map cleanly to 502/service_unavailable
+        instead of an opaque 500 (Copilot loop 3 fix on PR #551)."""
+        from utils.exceptions import ExternalServiceError
+
         with patch("storage.factory.get_settings", return_value=_settings_without_r2()):
-            with pytest.raises(RuntimeError, match="R2 storage is not configured"):
+            with pytest.raises(ExternalServiceError, match="R2"):
                 factory.get_blob_storage()
 
     def test_returns_r2_storage_when_configured(self):

--- a/backend/tests/storage/test_factory.py
+++ b/backend/tests/storage/test_factory.py
@@ -1,0 +1,90 @@
+"""Tests for ``storage.factory`` (Issue #485).
+
+The factory is a tiny indirection layer, but it is also the only place
+the dispatch from "is R2 configured?" → concrete impl lives. Bugs here
+surface as cryptic 500s in the upload path, so the contract is worth
+pinning down explicitly.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from storage import factory
+from storage.r2 import R2Storage
+
+
+@pytest.fixture(autouse=True)
+def _reset_factory():
+    """Drop the cached singleton between tests.
+
+    Without this, the first test seeds ``factory._storage`` and every
+    subsequent test sees the wrong instance. ``_reset_for_tests`` is
+    declared in factory.py exactly for this purpose.
+    """
+    factory._reset_for_tests()
+    yield
+    factory._reset_for_tests()
+
+
+def _settings_with_r2(**overrides):
+    """Build a Mock ``Settings`` object with R2 fields populated."""
+    from unittest.mock import MagicMock
+
+    s = MagicMock()
+    s.r2_account_id = "acct"
+    s.r2_access_key_id = "key"
+    s.r2_secret_access_key = "secret"
+    s.r2_bucket = "kagura-files-test"
+    s.r2_endpoint_url = "https://acct.r2.cloudflarestorage.com"
+    for k, v in overrides.items():
+        setattr(s, k, v)
+    return s
+
+
+def _settings_without_r2():
+    return _settings_with_r2(r2_endpoint_url="")
+
+
+class TestGetBlobStorage:
+    def test_raises_when_r2_endpoint_url_missing(self):
+        """``get_blob_storage`` MUST raise (not silently no-op) when R2
+        is not configured — callers should gate on
+        ``settings.r2_endpoint_url`` upstream."""
+        with patch("storage.factory.get_settings", return_value=_settings_without_r2()):
+            with pytest.raises(RuntimeError, match="R2 storage is not configured"):
+                factory.get_blob_storage()
+
+    def test_returns_r2_storage_when_configured(self):
+        with patch("storage.factory.get_settings", return_value=_settings_with_r2()):
+            storage = factory.get_blob_storage()
+            assert isinstance(storage, R2Storage)
+
+    def test_returns_same_instance_on_repeat_calls(self):
+        """Singleton: the second call returns the cached instance."""
+        with patch("storage.factory.get_settings", return_value=_settings_with_r2()):
+            first = factory.get_blob_storage()
+            second = factory.get_blob_storage()
+            assert first is second
+
+
+class TestCloseBlobStorage:
+    @pytest.mark.asyncio
+    async def test_close_when_uninitialized_is_noop(self):
+        """``close_blob_storage`` is safe to call when storage was never
+        constructed (lifespan shutdown on a server with R2 disabled)."""
+        await factory.close_blob_storage()  # must not raise
+        assert factory._storage is None
+
+    @pytest.mark.asyncio
+    async def test_close_releases_cached_instance(self):
+        """After close, the cached instance is dropped — a subsequent
+        ``get_blob_storage`` call constructs a fresh one."""
+        with patch("storage.factory.get_settings", return_value=_settings_with_r2()):
+            first = factory.get_blob_storage()
+            await factory.close_blob_storage()
+            assert factory._storage is None
+            second = factory.get_blob_storage()
+            assert first is not second

--- a/backend/tests/storage/test_protocol.py
+++ b/backend/tests/storage/test_protocol.py
@@ -1,0 +1,110 @@
+"""Tests for ``BlobStorageProtocol`` (Issue #485).
+
+Protocol-shape contract: any class that implements the five required
+methods passes ``isinstance`` against ``BlobStorageProtocol`` thanks to
+``@runtime_checkable``. This is what lets ``FileStorageService`` accept
+either the production ``R2Storage`` or a test fake without explicit
+inheritance, and what guards us against silently breaking the contract
+in Phase 2 when BYO impls land.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from storage.protocol import BlobStorageProtocol, ObjectMetadata
+
+
+class _InMemoryStorage:
+    """Minimal Protocol-conforming impl for tests.
+
+    Stores objects in a dict; presigned URLs return synthetic strings.
+    Mirrors the surface ``R2Storage`` exposes so tests at higher layers
+    can swap this in without touching aioboto3 / R2 at all.
+    """
+
+    def __init__(self) -> None:
+        self.objects: dict[str, tuple[bytes, str, str]] = {}
+
+    async def write_object(self, key: str, data: bytes, content_type: str, sha256: str) -> None:
+        self.objects[key] = (data, content_type, sha256)
+
+    async def head_object(self, key: str) -> ObjectMetadata | None:
+        if key not in self.objects:
+            return None
+        data, _, sha256 = self.objects[key]
+        return ObjectMetadata(size_bytes=len(data), etag=sha256)
+
+    async def delete_object(self, key: str) -> None:
+        self.objects.pop(key, None)
+
+    async def generate_presigned_put(
+        self, key: str, content_type: str, size_bytes: int, ttl_seconds: int
+    ) -> str:
+        return f"https://test.local/put/{key}?ttl={ttl_seconds}"
+
+    async def generate_presigned_get(self, key: str, filename: str, ttl_seconds: int) -> str:
+        return f"https://test.local/get/{key}?file={filename}&ttl={ttl_seconds}"
+
+
+class TestProtocolContract:
+    def test_in_memory_storage_satisfies_protocol(self):
+        """Any object exposing the 5 required async methods passes
+        isinstance against the runtime-checkable Protocol."""
+        storage = _InMemoryStorage()
+        assert isinstance(storage, BlobStorageProtocol)
+
+    def test_object_missing_method_does_not_satisfy_protocol(self):
+        """An impl missing one of the 5 required methods MUST fail
+        isinstance — this is what catches Protocol drift in Phase 2."""
+
+        class IncompleteStorage:
+            async def write_object(
+                self, key: str, data: bytes, content_type: str, sha256: str
+            ) -> None:
+                pass
+
+            # missing head_object, delete_object, generate_presigned_*
+
+        assert not isinstance(IncompleteStorage(), BlobStorageProtocol)
+
+
+class TestInMemoryStorageRoundtrip:
+    """Sanity checks on the in-memory fake itself (used as fixture in
+    higher-layer tests)."""
+
+    @pytest.mark.asyncio
+    async def test_write_then_head_returns_metadata(self):
+        storage = _InMemoryStorage()
+        await storage.write_object(
+            "ws/abc/file.bin", b"hello", "application/octet-stream", "0xdead"
+        )
+        meta = await storage.head_object("ws/abc/file.bin")
+        assert meta is not None
+        assert meta["size_bytes"] == 5
+        assert meta["etag"] == "0xdead"
+
+    @pytest.mark.asyncio
+    async def test_head_missing_returns_none(self):
+        storage = _InMemoryStorage()
+        assert await storage.head_object("ws/abc/missing") is None
+
+    @pytest.mark.asyncio
+    async def test_delete_is_idempotent(self):
+        storage = _InMemoryStorage()
+        await storage.write_object("ws/abc/x.bin", b"x", "text/plain", "0x1")
+        await storage.delete_object("ws/abc/x.bin")
+        await storage.delete_object("ws/abc/x.bin")  # second call: must not raise
+        assert await storage.head_object("ws/abc/x.bin") is None
+
+    @pytest.mark.asyncio
+    async def test_presigned_urls_include_key_and_ttl(self):
+        storage = _InMemoryStorage()
+        put_url = await storage.generate_presigned_put("ws/abc/y.pdf", "application/pdf", 1024, 300)
+        assert "ws/abc/y.pdf" in put_url
+        assert "ttl=300" in put_url
+
+        get_url = await storage.generate_presigned_get("ws/abc/y.pdf", "report.pdf", 60)
+        assert "ws/abc/y.pdf" in get_url
+        assert "file=report.pdf" in get_url
+        assert "ttl=60" in get_url

--- a/backend/tests/storage/test_r2.py
+++ b/backend/tests/storage/test_r2.py
@@ -1,0 +1,57 @@
+"""Tests for ``R2Storage`` construction (Issue #485).
+
+The class is a thin wrapper over ``aioboto3.Session`` — actual R2
+interactions are deferred to integration tests against a real bucket.
+This file pins the construction contract: required-field validation
+and Protocol conformance.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from storage.protocol import BlobStorageProtocol
+from storage.r2 import R2Storage
+
+
+def _kwargs(**overrides):
+    base = {
+        "account_id": "acct",
+        "access_key_id": "key",
+        "secret_access_key": "secret",
+        "bucket": "kagura-files-test",
+        "endpoint_url": "https://acct.r2.cloudflarestorage.com",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestR2StorageConstruction:
+    def test_construction_succeeds_with_valid_args(self):
+        storage = R2Storage(**_kwargs())
+        assert isinstance(storage, BlobStorageProtocol)
+
+    @pytest.mark.parametrize(
+        "missing_field",
+        [
+            "account_id",
+            "access_key_id",
+            "secret_access_key",
+            "bucket",
+            "endpoint_url",
+        ],
+    )
+    def test_empty_required_field_raises(self, missing_field):
+        """Empty string for any of the 5 required fields → ValueError.
+
+        Catches the half-configured-prod scenario where one env var is
+        missing and the deployment silently boots with broken uploads.
+        """
+        with pytest.raises(ValueError, match="non-empty"):
+            R2Storage(**_kwargs(**{missing_field: ""}))
+
+    @pytest.mark.asyncio
+    async def test_close_is_noop(self):
+        """``close`` is callable on a fresh instance and returns None."""
+        storage = R2Storage(**_kwargs())
+        assert await storage.close() is None

--- a/backend/tests/tasks/test_file_tasks.py
+++ b/backend/tests/tasks/test_file_tasks.py
@@ -1,0 +1,159 @@
+"""Tests for the orphan file sweeper (Issue #485 R3).
+
+The sweeper logic is async + DB + Redis + R2, so the test mocks all
+three boundaries: ``get_db`` is patched to yield a controlled
+``AsyncSession`` mock, ``storage_quota_service.release_storage_bytes``
+is patched, and ``get_blob_storage`` returns an in-memory fake. This
+keeps the test purely a unit test that exercises the sweeper's
+selection + per-row decision logic.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from tasks import file_tasks
+from utils.datetime import utcnow
+
+
+def _make_file(*, expires_at, status="reserved", size_bytes=1024, storage_key="ws/aa/key"):
+    file = MagicMock()
+    file.id = uuid4()
+    file.workspace_id = uuid4()
+    file.size_bytes = size_bytes
+    file.storage_key = storage_key
+    file.status = status
+    file.expires_at = expires_at
+    return file
+
+
+def _patch_get_db(rows):
+    """``async for db in get_db()`` yields one mock that returns ``rows``."""
+    db = MagicMock()
+    db.commit = AsyncMock()
+
+    list_result = MagicMock()
+    list_result.scalars = MagicMock(return_value=MagicMock(all=MagicMock(return_value=rows)))
+    db.execute = AsyncMock(return_value=list_result)
+
+    async def _aiter():
+        yield db
+
+    return patch("tasks.file_tasks.get_db", return_value=_aiter()), db
+
+
+def _patch_release():
+    return patch.object(file_tasks.storage_quota_service, "release_storage_bytes", AsyncMock())
+
+
+def _patch_storage(storage_or_none=None):
+    """Patch ``get_blob_storage`` to return ``storage_or_none``.
+
+    ``None`` means the storage layer is not configured (dev/test).
+    """
+    if storage_or_none is None:
+        return patch(
+            "tasks.file_tasks.get_blob_storage",
+            side_effect=RuntimeError("not configured"),
+        )
+    return patch("tasks.file_tasks.get_blob_storage", return_value=storage_or_none)
+
+
+class TestSweepOrphanFiles:
+    @pytest.mark.asyncio
+    async def test_no_orphans_is_noop(self):
+        rows: list = []
+        get_db_patch, db = _patch_get_db(rows)
+        with get_db_patch, _patch_release(), _patch_storage(None):
+            counts = await file_tasks.sweep_orphan_files()
+        assert counts == {"swept": 0, "released_bytes": 0, "r2_deleted": 0, "r2_failed": 0}
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_skips_rows_within_grace(self):
+        """A reservation that just expired should NOT be swept until the
+        1h grace has passed."""
+        recent = _make_file(expires_at=utcnow() - timedelta(seconds=30))
+        get_db_patch, _ = _patch_get_db([recent])
+        with get_db_patch, _patch_release() as release, _patch_storage(None):
+            counts = await file_tasks.sweep_orphan_files()
+        assert counts["swept"] == 0
+        release.assert_not_awaited()
+        assert recent.status == "reserved"  # untouched
+
+    @pytest.mark.asyncio
+    async def test_sweeps_orphan_past_grace(self):
+        old = _make_file(
+            expires_at=utcnow() - timedelta(hours=2),  # past 1h grace
+            size_bytes=4096,
+        )
+        get_db_patch, db = _patch_get_db([old])
+
+        fake_storage = MagicMock()
+        fake_storage.delete_object = AsyncMock()
+        with get_db_patch, _patch_release() as release, _patch_storage(fake_storage):
+            counts = await file_tasks.sweep_orphan_files()
+
+        assert counts["swept"] == 1
+        assert counts["released_bytes"] == 4096
+        assert counts["r2_deleted"] == 1
+        assert old.status == "failed"
+        release.assert_awaited_once()
+        fake_storage.delete_object.assert_awaited_once_with("ws/aa/key")
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_r2_delete_failure_is_swallowed(self):
+        """If R2 delete throws, the row is still marked failed and the
+        Redis quota is still released — the binary becomes garbage and
+        is reconciled later by lifecycle / inventory."""
+        old = _make_file(expires_at=utcnow() - timedelta(hours=2))
+        get_db_patch, _ = _patch_get_db([old])
+
+        bad_storage = MagicMock()
+        bad_storage.delete_object = AsyncMock(side_effect=Exception("R2 down"))
+        with get_db_patch, _patch_release() as release, _patch_storage(bad_storage):
+            counts = await file_tasks.sweep_orphan_files()
+
+        assert counts["swept"] == 1
+        assert counts["r2_deleted"] == 0
+        assert counts["r2_failed"] == 1
+        assert old.status == "failed"
+        release.assert_awaited_once()  # quota still released
+
+    @pytest.mark.asyncio
+    async def test_skips_storage_when_r2_unconfigured(self):
+        """In dev/test, R2 may be unconfigured. Sweep still marks rows
+        failed and releases quota, just no R2 delete attempt."""
+        old = _make_file(expires_at=utcnow() - timedelta(hours=2))
+        get_db_patch, _ = _patch_get_db([old])
+
+        with get_db_patch, _patch_release() as release, _patch_storage(None):
+            counts = await file_tasks.sweep_orphan_files()
+
+        assert counts["swept"] == 1
+        assert counts["r2_deleted"] == 0
+        assert counts["r2_failed"] == 0
+        assert old.status == "failed"
+        release.assert_awaited_once()
+
+
+class TestScheduling:
+    def test_schedule_registers_15min_interval_job(self):
+        scheduler = MagicMock()
+        scheduler.add_job = MagicMock()
+        file_tasks.schedule_file_tasks(scheduler)
+
+        scheduler.add_job.assert_called_once()
+        kwargs = scheduler.add_job.call_args.kwargs
+        assert kwargs["id"] == "orphan_file_sweeper"
+        # Trigger interval should be 15 minutes
+        trigger = kwargs["trigger"]
+        # IntervalTrigger keeps the interval as a timedelta on `.interval`.
+        from datetime import timedelta
+
+        assert trigger.interval == timedelta(minutes=15)

--- a/backend/tests/tasks/test_file_tasks.py
+++ b/backend/tests/tasks/test_file_tasks.py
@@ -54,11 +54,15 @@ def _patch_storage(storage_or_none=None):
     """Patch ``get_blob_storage`` to return ``storage_or_none``.
 
     ``None`` means the storage layer is not configured (dev/test).
+    Factory now raises ``ExternalServiceError`` (HTTP 502 surface)
+    instead of ``RuntimeError`` since Copilot loop 3 fix on PR #551.
     """
     if storage_or_none is None:
+        from utils.exceptions import ExternalServiceError
+
         return patch(
             "tasks.file_tasks.get_blob_storage",
-            side_effect=RuntimeError("not configured"),
+            side_effect=ExternalServiceError("R2", "not configured"),
         )
     return patch("tasks.file_tasks.get_blob_storage", return_value=storage_or_none)
 


### PR DESCRIPTION
Implements **#485** — Phase 1 platform-managed file storage on Cloudflare R2.

Most of the issue's acceptance criteria are delivered in this PR; the 7-day
soft-delete cleanup sub-item is deferred to a follow-up PR (the orphan
sweeper for `status='reserved'` rows IS shipped here). The PR therefore
references but does not auto-close #485 — JFK can close it manually after
the follow-up sweeper lands, or re-open if other gaps surface.

## Summary

- New `file_objects` + `workspace_storage_usage` tables with full upload state machine (`reserved → uploaded → failed`) and partial-unique sha256 dedup per workspace.
- `BlobStorageProtocol` (Phase 2 BYO bucket ready) + concrete `R2Storage` (aioboto3) + singleton factory.
- `FileStorageService` is the single SoT both REST (`/api/v1/files/*`, 5 endpoints) and MCP (5 tools: `init_file_upload` / `complete_file_upload` / `get_file_download_url` / `delete_file` / `list_files`) funnel through — the #332 lesson is enforced structurally.
- Redis-backed `storage_quota_service` mirrors `resource_quota_service.py` (reserve/release/bump/seed-on-miss). Per-workspace cap fed by `Workspace.effective_storage_limit_bytes` (PlanTier base + addon_storage_bonus_mb).
- Pre-existing `addon_calculator_service` bug (`workspace.addon_storage_bonus_mb` written to a column that didn't exist) fixed as commit-1 prerequisite.
- 15-minute orphan sweeper for `status='reserved'` rows past `expires_at + 1h` grace; per-workspace Redis quota release after DB commit.
- One-shot legacy migration script (`scripts/migrate_attachments_to_r2.py`) — idempotent, `--dry-run` supported.

## Implementation notes

Design contract is locked at gate1 (R1–R6 in the cached gate1.md). Highlights:

- **R1**: `Memory.details.external_blob` is a discriminated union (`backend = platform_r2 | byo_s3 | byo_gcs | pg_inline`), persisted via two computed columns (`external_blob_backend`, `external_blob_ref`) that mirror the existing `resource_id` pattern. Phase 2 BYO buckets land in this same JSONB shape with zero migration on the memory side.
- **R5**: soft-delete decrements `workspace_storage_usage` in the same DB txn AND releases the Redis counter — but Redis follows commit (post-review fix `51fdccf1`: B-2/B-5 ordering — Redis was originally before commit, which double-released on retry).
- **Per-file 100 MiB cap** triple-defended: Pydantic `le=100*1024*1024` + service runtime check against `settings.file_object_max_size_mb` + R2 over-size reject (`ConflictError` when `head_object` reports more bytes than the reservation declared — post-review fix B-1).
- **Workspace boundary**: every REST endpoint runs `_enforce_workspace_membership` (`PermissionService.check_workspace_access(member)`) BEFORE reaching the service (post-review fix B-7 — previously `APIKeyOrSessionUser` proved identity but not membership).
- **R2 errors**: `R2Storage.head_object` catches `botocore.exceptions.ClientError` and maps non-404 codes to `ExternalServiceError` (HTTP 502) so transient R2 issues don't surface as raw 500s. MCP tools also map to `error=service_unavailable` so clients can retry with backoff.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green (advisor — verified workspace boundaries, sha256 normalization, presigned URL IDOR, no R2 secret in logs, content-disposition has 1 low-severity hardening recommendation deferred)
- qa-lead: not run this session — operator requested PR creation before it returned
- cto: not run this session — operator requested PR creation before it returned
- gate1: green via /ask (CTO lens, 2 iterations: yellow → green after R1–R6 design refinement)
- review provider: copilot

3 reviewer agents (Phase 6 of /feature-dev) caught all critical/high issues before this PR; fixes landed in `51fdccf1` + `f73173ed`. /self-review found one additional [W] (`ExternalServiceError` not in MCP except map) + one [I] (`.env.example` missing R2 vars), both fixed in `470f8d6c`.

## Test results

- Unit: 106 cumulative pass + 1 pre-existing skip (`make test-local`, ruff + pyright clean)
- Integration: 147 pass — alembic upgrade/downgrade roundtrip incl. e02_485 + e03_485, `test_attachments.py` 3/3 (no legacy regression)
- `npm test` and `npm run build` reflect main HEAD state (no frontend diff in this PR)

## Follow-ups (Phase 1.5 / separate PRs)

- 7-day soft-delete + R2 binary cleanup (acceptance item `Nightly GC job for soft-deleted + dangling objects` — orphan part shipped, soft-delete part TBD)
- Filename → Content-Disposition sanitization (CSO low-severity finding F-1 — analogous to existing `attachments.py:_sanitize_filename`)
- content_type allow-list + virus scan (CSO low-severity finding F-2 — by design Phase 1.5 with ClamAV)
- TOCTOU hardening on `reserve_storage_bytes` (Lua `WATCH`/`MULTI` — gate1 review B-3 acknowledged fail-open posture)
- legacy `/api/v1/attachments/*` route deprecation: `410 Gone` + `Sunset` header after the migration script has been run in prod (separate PR)

Full gate1 + gate2 markdown lives in plugin cache:
- `~/.claude/cache/gh-issue-driven/485-feat-feat-storage-platform-managed-r2-object.gate1.md`
- `~/.claude/cache/gh-issue-driven/485-feat-feat-storage-platform-managed-r2-object.gate2.md`

🤖 Generated via /gh-issue-driven:ship
