### PR TITLE
fix(frontend): pin aria-query to 5.3.2 via npm overrides (#512)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -4946,17 +4946,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -7143,17 +7132,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/dequal": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
-      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -74,5 +74,8 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5",
     "vitest": "^4.1.2"
+  },
+  "overrides": {
+    "aria-query": "5.3.2"
   }
 }


### PR DESCRIPTION
## Summary

`npm ls aria-query` で 2 バージョン重複を確認:

\`\`\`
├─ @testing-library/jest-dom@6.9.1 → aria-query@5.3.2
└─ @testing-library/react@16.3.2 → @testing-library/dom@10.4.1 → aria-query@5.3.0
\`\`\`

`@testing-library/dom@10.4.1` だけが古い `5.3.0` を引き込み、parallel Vitest forks pool で別実体の `rolesMap.js` が二重 init されて `_nonIterableRest` destructure error が発火していた。`overrides` で `5.3.2` 単一化することで `MembersSection.test.tsx` の aria-query unhandled rejection を完全に解消。

## Verification

- `npm ls aria-query` → 全パスが `5.3.2 (overridden|deduped)` 単一に
- `npx vitest run src/components/contexts/MembersSection.test.tsx` → 10/10 passed isolated
- `npm test` 5 連続: aria-query 言及 **0/5**（修正前は deterministic 2 file fail）
- 完全クリーン率: **0/5 → 3/5**（残り 40% は別 root cause）

## Out of scope

vitest 4 forks pool の worker-termination flake（react-dom CJS `var` 再宣言 + "Timeout terminating forks worker"）が残存します。pool 切替・teardownTimeout・singleFork で改善せず別 root cause と判明。**#584 で別途追跡**。

## Test plan

- [x] `npm ls aria-query` で重複が消えていることを確認
- [x] `npm test` 単体実行で `MembersSection.test.tsx` 10/10 pass
- [x] `npm test` 5 連続実行で aria-query エラー言及ゼロ
- [ ] CI green

Partially addresses #512.