### PR TITLE
refactor(api): make get_effective_quotas pure-read (#570)

### DIFF
--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -253,11 +253,10 @@ async def _build_analysis_usage(
         effective_quotas: Pre-computed effective quotas dict (from
             ``EffectiveQuotaService.get_effective_quotas``) if the caller
             already has it. Passing it through avoids a duplicate
-            EffectiveQuotaService call AND avoids the second potential
-            ``AddonCalculatorService.recalculate_workspace_bonuses``
-            self-heal COMMIT (which would otherwise fire twice from a GET
-            request when both ``_build_analysis_usage`` and
-            ``_build_sleep_contexts_usage`` are called back-to-back).
+            EffectiveQuotaService call from the same request. Issue #570
+            removed the GET-time self-heal COMMIT, so the kwarg is now
+            purely a DB-roundtrip optimization rather than a correctness
+            requirement.
     """
     if not workspace_id:
         return None
@@ -324,12 +323,11 @@ async def _build_sleep_contexts_usage(
             ``EffectiveQuotaService.get_effective_quotas`` if the caller
             already has it (e.g. ``workspace.py:get_workspace_usage_current``
             calls the service for other fields). Passing the dict avoids a
-            duplicate DB roundtrip AND, more importantly, avoids re-triggering
-            ``AddonCalculatorService.recalculate_workspace_bonuses`` (which
-            ``EffectiveQuotaService`` may run as a self-heal — that helper
-            ``COMMIT`` s, so calling it twice from a GET request is a
-            request-side commit on a read endpoint). When ``None``, the
-            helper fetches fresh.
+            duplicate DB roundtrip from the same request. Issue #570 removed
+            the GET-time self-heal COMMIT in EffectiveQuotaService, so the
+            kwarg is now a DB-roundtrip optimization rather than a
+            correctness requirement. When ``None``, the helper fetches
+            fresh.
     """
     if not workspace_id:
         return None
@@ -508,10 +506,11 @@ async def get_current_usage(
         )
         rest_calls_week = rest_week_result.scalar() or 0
 
-        # Issue #560 follow-up: fetch effective quotas ONCE and pass into both
-        # helpers so we don't trigger ``EffectiveQuotaService`` twice — the
-        # service may invoke ``AddonCalculatorService.recalculate_workspace_bonuses``
-        # which COMMITS, and a GET endpoint should not commit twice.
+        # Fetch effective quotas ONCE and pass into both helpers so we don't
+        # trigger ``EffectiveQuotaService`` twice. Issue #570 removed the
+        # GET-time self-heal COMMIT, so this is now a DB-roundtrip optimization
+        # rather than a correctness requirement; the kwarg plumbing is kept
+        # because both helpers still need the same dict.
         #
         # On ``ValueError`` (workspace not found), pass an EMPTY dict (not
         # ``None``) into the helpers. ``None`` would make the helpers fall

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -37,7 +37,27 @@ ADDON_UNIT_VALUES = {
 
 
 class AddonCalculatorService:
-    """Service for calculating workspace addon bonuses."""
+    """Service for calculating workspace addon bonuses.
+
+    Cache-invalidation contract (Issue #570):
+        ``Workspace.addon_*_bonus`` columns cache the SUM of active
+        ``WorkspaceAddon`` rows. They are read by
+        ``EffectiveQuotaService.get_effective_quotas`` on every quota
+        check and exposed via ``Workspace.effective_*`` properties.
+
+        Any code that mutates ``WorkspaceAddon`` rows
+        (INSERT / UPDATE active_until / DELETE / future Stripe webhook
+        handlers / admin scripts) **MUST** call
+        ``recalculate_workspace_bonuses(workspace_id)`` post-mutation
+        and commit. Skipping the call leaves the cache stale and
+        every downstream quota check returns wrong numbers until
+        something else triggers a recalc.
+
+        ``recalculate_workspace_bonuses`` is idempotent: it computes
+        each bonus column as a SUM-from-source aggregate and writes
+        the absolute value, so concurrent recalcs converge on the
+        same final state regardless of ordering.
+    """
 
     def __init__(self, db: AsyncSession):
         """Initialize addon calculator service.

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -48,10 +48,21 @@ class AddonCalculatorService:
         Any code that mutates ``WorkspaceAddon`` rows
         (INSERT / UPDATE active_until / DELETE / future Stripe webhook
         handlers / admin scripts) **MUST** call
-        ``recalculate_workspace_bonuses(workspace_id)`` post-mutation
-        and commit. Skipping the call leaves the cache stale and
-        every downstream quota check returns wrong numbers until
-        something else triggers a recalc.
+        ``recalculate_workspace_bonuses(workspace_id)`` after staging
+        the mutation in the session (``db.add(...)`` / ``db.delete(...)``).
+        Skipping the call leaves the cache stale and every downstream
+        quota check returns wrong numbers until something else
+        triggers a recalc.
+
+        Commit semantics: ``recalculate_workspace_bonuses`` calls
+        ``db.commit()`` internally, which flushes BOTH the caller's
+        staged ``WorkspaceAddon`` mutation AND the recomputed
+        ``addon_*_bonus`` columns in a single transaction. **Callers
+        must not commit separately** — staging via ``db.add`` /
+        ``db.delete`` is enough; the recalc method finalizes the
+        transaction. This atomic pairing is the safety basis for
+        replacing the old GET-time self-heal with explicit
+        write-path invalidation.
 
         ``recalculate_workspace_bonuses`` is idempotent: it computes
         each bonus column as a SUM-from-source aggregate and writes

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -57,12 +57,18 @@ class AddonCalculatorService:
         Commit semantics: ``recalculate_workspace_bonuses`` calls
         ``db.commit()`` internally, which flushes BOTH the caller's
         staged ``WorkspaceAddon`` mutation AND the recomputed
-        ``addon_*_bonus`` columns in a single transaction. **Callers
-        must not commit separately** — staging via ``db.add`` /
-        ``db.delete`` is enough; the recalc method finalizes the
-        transaction. This atomic pairing is the safety basis for
-        replacing the old GET-time self-heal with explicit
-        write-path invalidation.
+        ``addon_*_bonus`` columns in a single transaction. After
+        the method returns, the session has no pending writes — so
+        any subsequent commit, whether explicit or implicit (e.g.
+        FastAPI's ``get_db`` dependency commits at request-end,
+        ``db/base.py``), is a harmless no-op. The constraint this
+        places on callers is composability: do not call this method
+        from inside a larger explicit transaction you intend to
+        commit or roll back as a unit, because the internal commit
+        will finalize the addon write before the outer block has
+        a chance to roll back. This atomic-on-recalc pairing is the
+        safety basis for replacing the old GET-time self-heal with
+        explicit write-path invalidation.
 
         ``recalculate_workspace_bonuses`` is idempotent: it computes
         each bonus column as a SUM-from-source aggregate and writes

--- a/backend/src/services/effective_quota_service.py
+++ b/backend/src/services/effective_quota_service.py
@@ -64,33 +64,17 @@ class EffectiveQuotaService:
         Raises:
             ValueError: If workspace not found
         """
-        # Get workspace with addon bonuses
+        # Pure read: SELECT the workspace and compute effective quotas from
+        # cached `addon_*_bonus` columns. Issue #570: removed the lazy
+        # self-heal recalc that COMMITted from this GET path. Any code that
+        # mutates `WorkspaceAddon` rows must call
+        # `AddonCalculatorService.recalculate_workspace_bonuses(workspace_id)`
+        # post-mutation to keep the cache consistent.
         result = await self.db.execute(select(Workspace).where(Workspace.id == workspace_id))
         workspace = result.scalar_one_or_none()
 
         if not workspace:
             raise ValueError(f"Workspace {workspace_id} not found")
-
-        # Check if addon bonuses need to be calculated
-        # If all bonuses are 0, recalculate from active addons
-        if (
-            workspace.addon_memory_bonus == 0
-            and workspace.addon_mcp_quota_bonus == 0
-            and workspace.addon_rest_quota_bonus == 0
-            and workspace.addon_public_quota_bonus == 0
-            and workspace.addon_member_bonus == 0
-            and workspace.addon_context_bonus == 0
-            and workspace.addon_analysis_bonus == 0
-        ):
-            # Import here to avoid circular dependency
-            from services.addon_calculator_service import AddonCalculatorService
-
-            calculator = AddonCalculatorService(self.db)
-            await calculator.recalculate_workspace_bonuses(workspace_id)
-
-            # Re-fetch workspace with updated bonuses
-            result = await self.db.execute(select(Workspace).where(Workspace.id == workspace_id))
-            workspace = result.scalar_one_or_none()
 
         # Calculate effective quotas via model properties
         # Issue #198 (Bug C): include weekly fields so callers don't need to fall

--- a/backend/tests/services/test_addon_calculator_service.py
+++ b/backend/tests/services/test_addon_calculator_service.py
@@ -122,3 +122,43 @@ class TestAddonCalculatorStorageBonus:
         assert bonuses["addon_storage_bonus_mb"] == 200  # 2 × 100 MB
         assert workspace.addon_storage_bonus_mb == 200
         assert bonuses["addon_memory_bonus"] == 5 * ADDON_UNIT_VALUES["extra_memory"]
+
+    @pytest.mark.asyncio
+    async def test_recalculate_is_idempotent(self, service, mock_db, workspace_id):
+        """Issue #570 invariant: ``recalculate_workspace_bonuses`` is idempotent.
+
+        Calling the method twice with the same active-addon snapshot must
+        produce the same bonus dict and the same persisted column values
+        (no accumulation, no drift). This pins the SUM-from-source aggregate
+        contract documented on ``AddonCalculatorService``'s class docstring,
+        which is the safety basis for replacing the GET-time self-heal with
+        explicit write-path invalidation. Concurrent recalcs (same source
+        snapshot, different orderings) converge on the same final state.
+        """
+        addons = [
+            _make_addon("extra_storage", quantity=4),
+            _make_addon("extra_memory", quantity=2),
+            _make_addon("extra_sleep_contexts", quantity=3),
+        ]
+        # Each call performs 2 execute()s (addons + workspace), so wire up
+        # 4 results for two consecutive calls. The same workspace mock is
+        # returned on the second pass — that's the shared cache row whose
+        # idempotency we're proving.
+        workspace = _make_workspace(workspace_id)
+        mock_db.execute.side_effect = _make_side_effects(addons, workspace) + _make_side_effects(
+            addons, workspace
+        )
+
+        first = await service.recalculate_workspace_bonuses(workspace_id)
+        second = await service.recalculate_workspace_bonuses(workspace_id)
+
+        assert first == second, "Bonus dict drifted between identical recalcs"
+        assert workspace.addon_storage_bonus_mb == first["addon_storage_bonus_mb"]
+        assert workspace.addon_memory_bonus == first["addon_memory_bonus"]
+        assert workspace.addon_sleep_contexts_bonus == first["addon_sleep_contexts_bonus"]
+        # SUM-from-source means the value equals the per-addon contribution
+        # exactly — not a multiple of it from accidental accumulation.
+        assert first["addon_storage_bonus_mb"] == 4 * ADDON_UNIT_VALUES["extra_storage"]
+        assert first["addon_memory_bonus"] == 2 * ADDON_UNIT_VALUES["extra_memory"]
+        assert first["addon_sleep_contexts_bonus"] == 3 * ADDON_UNIT_VALUES["extra_sleep_contexts"]
+        assert mock_db.commit.await_count == 2

--- a/backend/tests/services/test_effective_quota_service.py
+++ b/backend/tests/services/test_effective_quota_service.py
@@ -81,10 +81,42 @@ class TestEffectiveQuotaService:
         quotas = await service.get_effective_quotas(uuid4())
         assert quotas["mcp_calls_per_day"] > 200  # base + 200
 
-    @pytest.mark.skip(reason="Zero-bonus path triggers AddonCalculatorService which needs real DB")
     @pytest.mark.asyncio
-    async def test_no_addons_returns_base(self, service, mock_db):
-        """With zero addon bonuses, recalculation is triggered (needs integration test)."""
+    async def test_no_addons_returns_base_no_recalc(self, service, mock_db):
+        """Issue #570: with all bonus columns at 0, the service is pure-read.
+
+        Pre-#570 the zero-bonus path triggered ``AddonCalculatorService.recalculate_workspace_bonuses``
+        which COMMITted from this GET path. The refactor makes the service trust the cached
+        column values; ``recalculate_workspace_bonuses`` is now caller responsibility on the
+        write path. This test pins the new contract.
+        """
+        ws = self._mock_workspace(
+            addon_memory_bonus=0,
+            addon_mcp_quota_bonus=0,
+            addon_rest_quota_bonus=0,
+            addon_public_quota_bonus=0,
+            addon_member_bonus=0,
+            addon_context_bonus=0,
+            addon_storage_bonus_mb=0,
+        )
+        ws.addon_analysis_bonus = 0
+        ws.addon_sleep_contexts_bonus = 0
+        mock_result = MagicMock()
+        mock_result.scalar_one_or_none.return_value = ws
+        mock_db.execute = AsyncMock(return_value=mock_result)
+        # Catch a stray COMMIT — the service must not write on read.
+        mock_db.commit = AsyncMock()
+        mock_db.flush = AsyncMock()
+
+        quotas = await service.get_effective_quotas(uuid4())
+
+        # Pure read: exactly one SELECT, no COMMIT, no FLUSH.
+        assert mock_db.execute.await_count == 1
+        mock_db.commit.assert_not_awaited()
+        mock_db.flush.assert_not_awaited()
+        # Effective quotas equal tier base (since all addon bonuses are 0).
+        assert quotas["memory_limit"] == ws.effective_memory_limit
+        assert quotas["mcp_calls_per_day"] == ws.effective_mcp_calls_per_day
 
     @pytest.mark.asyncio
     async def test_workspace_not_found(self, service, mock_db):

--- a/backend/tests/services/test_effective_quota_service.py
+++ b/backend/tests/services/test_effective_quota_service.py
@@ -77,7 +77,7 @@ class TestEffectiveQuotaService:
             tier.storage_limit_bytes + addon_storage_bonus_mb * 1024 * 1024
         )
         ws.effective_sleep_enabled_contexts_limit = (
-            getattr(tier, "sleep_enabled_contexts_per_workspace", 0) + addon_sleep_contexts_bonus
+            tier.sleep_enabled_contexts_limit + addon_sleep_contexts_bonus
         )
         return ws
 
@@ -159,12 +159,16 @@ class TestEffectiveQuotaService:
         assert set(quotas.keys()) == expected_keys
         for key, value in quotas.items():
             assert isinstance(value, int), f"{key}={value!r} is not int"
-        # Spot-check three independent dimensions to ensure mock wiring
+        # Spot-check four independent dimensions to ensure mock wiring
         # actually returns tier-base values (not stray MagicMocks that pass
-        # the int instance check via __index__-able sentinels).
+        # the int instance check via __index__-able sentinels). The
+        # sleep_enabled_contexts_limit assertion specifically catches the
+        # PRO=3 base value and would have caught the typo Copilot's
+        # second-loop review flagged in _mock_workspace.
         assert quotas["memory_limit"] == ws.effective_memory_limit
         assert quotas["mcp_calls_per_day"] == ws.effective_mcp_calls_per_day
         assert quotas["storage_bytes_limit"] == ws.effective_storage_limit_bytes
+        assert quotas["sleep_enabled_contexts_limit"] == ws.effective_sleep_enabled_contexts_limit
 
     @pytest.mark.asyncio
     async def test_workspace_not_found(self, service, mock_db):

--- a/backend/tests/services/test_effective_quota_service.py
+++ b/backend/tests/services/test_effective_quota_service.py
@@ -34,8 +34,19 @@ class TestEffectiveQuotaService:
         addon_member_bonus=3,
         addon_context_bonus=5,
         addon_storage_bonus_mb=0,
+        addon_analysis_bonus=0,
+        addon_sleep_contexts_bonus=0,
     ):
-        """Create a mock workspace with addon bonuses and effective properties."""
+        """Create a mock workspace with addon bonuses and effective properties.
+
+        All 12 ``effective_*`` properties read by
+        ``EffectiveQuotaService.get_effective_quotas`` are set to concrete int
+        values. Without explicit assignment, MagicMock attribute access
+        produces nested MagicMocks — which silently pass equality checks but
+        return non-int values and let drift between the service's returned
+        keys and the mock's populated keys go undetected (Copilot review on
+        PR #588 flagged this gap).
+        """
         ws = MagicMock()
         ws.plan_name = plan_name
         ws.memory_limit = memory_limit
@@ -47,15 +58,26 @@ class TestEffectiveQuotaService:
         ws.addon_member_bonus = addon_member_bonus
         ws.addon_context_bonus = addon_context_bonus
         ws.addon_storage_bonus_mb = addon_storage_bonus_mb
+        ws.addon_analysis_bonus = addon_analysis_bonus
+        ws.addon_sleep_contexts_bonus = addon_sleep_contexts_bonus
         from config.plan_tiers import get_plan_tier
 
         tier = get_plan_tier(plan_name)
         ws.effective_memory_limit = memory_limit + addon_memory_bonus
         ws.effective_mcp_calls_per_day = tier.mcp_calls_per_day + addon_mcp_quota_bonus
+        ws.effective_mcp_calls_per_week = tier.mcp_calls_per_week + addon_mcp_quota_bonus
+        ws.effective_rest_calls_per_day = tier.rest_calls_per_day + addon_rest_quota_bonus
+        ws.effective_rest_calls_per_week = tier.rest_calls_per_week + addon_rest_quota_bonus
+        ws.effective_public_calls_per_day = tier.public_calls_per_day + addon_public_quota_bonus
+        ws.effective_public_calls_per_week = tier.public_calls_per_week + addon_public_quota_bonus
         ws.effective_max_contexts = tier.max_contexts_per_workspace + addon_context_bonus
         ws.effective_max_members = tier.max_members_per_workspace + addon_member_bonus
+        ws.effective_analysis_runs_per_day = tier.analysis_runs_per_day + addon_analysis_bonus
         ws.effective_storage_limit_bytes = (
             tier.storage_limit_bytes + addon_storage_bonus_mb * 1024 * 1024
+        )
+        ws.effective_sleep_enabled_contexts_limit = (
+            getattr(tier, "sleep_enabled_contexts_per_workspace", 0) + addon_sleep_contexts_bonus
         )
         return ws
 
@@ -98,9 +120,9 @@ class TestEffectiveQuotaService:
             addon_member_bonus=0,
             addon_context_bonus=0,
             addon_storage_bonus_mb=0,
+            addon_analysis_bonus=0,
+            addon_sleep_contexts_bonus=0,
         )
-        ws.addon_analysis_bonus = 0
-        ws.addon_sleep_contexts_bonus = 0
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = ws
         mock_db.execute = AsyncMock(return_value=mock_result)
@@ -114,9 +136,35 @@ class TestEffectiveQuotaService:
         assert mock_db.execute.await_count == 1
         mock_db.commit.assert_not_awaited()
         mock_db.flush.assert_not_awaited()
-        # Effective quotas equal tier base (since all addon bonuses are 0).
+
+        # Drift guard: the service returns 12 keys, all int-typed and matching
+        # the tier base when bonuses are 0. Without this whole-dict check, a
+        # MagicMock fixture would silently produce non-int (MagicMock-typed)
+        # values for any future field the service starts reading, and the test
+        # would still pass — Copilot flagged this gap on PR #588.
+        expected_keys = {
+            "memory_limit",
+            "mcp_calls_per_day",
+            "mcp_calls_per_week",
+            "rest_calls_per_day",
+            "rest_calls_per_week",
+            "public_calls_per_day",
+            "public_calls_per_week",
+            "max_members",
+            "max_contexts",
+            "analysis_runs_per_day",
+            "storage_bytes_limit",
+            "sleep_enabled_contexts_limit",
+        }
+        assert set(quotas.keys()) == expected_keys
+        for key, value in quotas.items():
+            assert isinstance(value, int), f"{key}={value!r} is not int"
+        # Spot-check three independent dimensions to ensure mock wiring
+        # actually returns tier-base values (not stray MagicMocks that pass
+        # the int instance check via __index__-able sentinels).
         assert quotas["memory_limit"] == ws.effective_memory_limit
         assert quotas["mcp_calls_per_day"] == ws.effective_mcp_calls_per_day
+        assert quotas["storage_bytes_limit"] == ws.effective_storage_limit_bytes
 
     @pytest.mark.asyncio
     async def test_workspace_not_found(self, service, mock_db):

--- a/backend/tests/services/test_quota_service.py
+++ b/backend/tests/services/test_quota_service.py
@@ -35,18 +35,19 @@ class TestQuotaServiceMemberQuota:
     def _make_workspace(self, workspace_id, plan_name, **kwargs):
         """Build a workspace mock with addon bonuses pre-set.
 
-        addon_memory_bonus is set to 1 by default so that
-        EffectiveQuotaService skips the addon-recalc branch
-        (which fires only when ALL bonus columns are 0), keeping the
-        total db.execute call count at exactly 4 per check_member_quota
-        invocation.  addon_member_bonus stays 0 so the plan's native
-        max_members limit is used unchanged.
+        Issue #570 made ``EffectiveQuotaService.get_effective_quotas`` pure-read,
+        so the historical "skip the addon-recalc branch by setting one bonus
+        non-zero" trick is no longer load-bearing — the branch is gone.
+        ``addon_member_bonus`` stays 0 so the plan's native ``max_members`` limit
+        is used unchanged. The 4-execute call count for ``check_member_quota``
+        below is still correct because there is no recalc-driven extra SELECT
+        either before or after #570.
         """
         workspace = MagicMock()
         workspace.id = workspace_id
         workspace.plan_name = plan_name
         workspace.memory_limit = kwargs.get("memory_limit", 1000)
-        workspace.addon_memory_bonus = 1  # non-zero: skips recalc branch
+        workspace.addon_memory_bonus = 1
         workspace.addon_mcp_quota_bonus = 0
         workspace.addon_rest_quota_bonus = 0
         workspace.addon_public_quota_bonus = 0


### PR DESCRIPTION
Closes #570

## Summary

- Remove the lazy self-heal block in `EffectiveQuotaService.get_effective_quotas()` (L74-91 pre-refactor) that called `AddonCalculatorService.recalculate_workspace_bonuses()` — which COMMITs — when all 7 hardcoded addon-bonus columns were 0. The trigger never included `addon_storage_bonus_mb` (#485) or `addon_sleep_contexts_bonus` (#560), so workspaces that acquired those addons would carry stale-zero values forever.
- Make the service a pure read: SELECT the workspace, compute effective quotas via `Workspace.effective_*` properties from the cached `addon_*_bonus` columns, return. No COMMIT, no recalc, no second SELECT.
- Document the new cache-invalidation contract on `AddonCalculatorService`'s class docstring: writers of `WorkspaceAddon` rows MUST call `recalculate_workspace_bonuses(workspace_id)` post-mutation. Add `test_recalculate_is_idempotent` to pin the SUM-from-source aggregate invariant that backs the safety reasoning.

## Implementation notes

### Why the issue's "wire write-path callers" acceptance was replaced with a docstring contract

A grep across `backend/src/` confirmed **zero production write paths for `WorkspaceAddon`** today:
- `backend/src/services/stripe_service.py:205 handle_webhook_event` does not touch `WorkspaceAddon`
- No admin scripts reference the model
- Only `backend/src/services/addon_calculator_service.py:63-69` reads from it

Stripe SKU rollout for addon products is a separate future scope. Wiring "explicit invalidation callers" into write paths that don't exist would be cargo-cult coding. The contract is documented on the class docstring instead, so the next implementer (likely the Stripe SKU rollout PR) sees it during code review. The one-time `recalculate_all_workspaces()` migration script is unnecessary because no source-of-truth rows exist to reconcile.

### Why the `_build_*_usage` kwarg plumbing was kept (Acceptance #4)

`_build_analysis_usage` and `_build_sleep_contexts_usage` in `backend/src/api/routes/usage.py` accept a pre-computed `effective_quotas` dict to avoid double-fetch. Pre-#570 this was load-bearing for correctness (avoiding double-COMMIT). Post-#570 it is a DB-roundtrip optimization within the same request. Comments updated to reflect this; the kwarg signature is unchanged.

### Test changes

- `test_no_addons_returns_base_no_recalc` (was `@pytest.mark.skip` pre-refactor): pins the new contract — all-zero bonuses must NOT trigger COMMIT or a second SELECT. Asserts `mock_db.execute.await_count == 1`, `mock_db.commit.assert_not_awaited()`, `mock_db.flush.assert_not_awaited()`.
- `test_recalculate_is_idempotent` (NEW, gate2 QA Lead recommendation): two consecutive recalcs against the same active-addon snapshot produce identical bonus dicts and identical persisted column values. Pins SUM-from-source aggregate (no accumulation, no drift).
- `test_quota_service::_make_workspace`: docstring updated; the `addon_memory_bonus = 1` "skip self-heal branch" trick is no longer load-bearing post-#570 (4-execute call count is still correct).

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/570-feat-refactor-api-effectivequotaservice-api.gate1.md`
- `~/.claude/cache/gh-issue-driven/570-feat-refactor-api-effectivequotaservice-api.gate2.md`

## Acceptance criteria — adjustments from issue body

| # | Criterion | Status |
|---|---|---|
| 1 | `get_effective_quotas` no longer calls `recalculate_workspace_bonuses` | ✅ done |
| 2 | Stripe webhook / admin paths invoke recalc post-mutation | ⚠️ replaced with class docstring contract — no production write paths exist today (verified by grep); pair with writer tests when Stripe SKU rollout lands |
| 3 | One-time `recalculate_all_workspaces()` migration script | ⚠️ skipped — no source-of-truth rows exist to reconcile (tied to #2 finding) |
| 4 | `_build_*_usage` kwarg pass-through preserved | ✅ done |
| 5 | CI lint for migration CHECK constraint vs ORM `__table_args__` drift | ❌ deferred — filed as #587 |

## Follow-ups

- #586 — `api/routes/usage.py:386 get_current_usage` lazy `UserPlan` create + COMMIT in GET handler (sister antipattern, route-layer twin)
- #587 — CI lint for `WorkspaceAddon.__table_args__` CHECK vs migration drift (Acceptance #5 deferred from this PR)

🤖 Generated via /gh-issue-driven:ship
