### PR TITLE
refactor(api): make get_current_usage pure-read (#586)

### DIFF
--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -402,21 +402,16 @@ async def get_current_usage(
 
         settings = get_settings()
 
-        # Get user plan (or default to free)
+        # The default UserPlan row is created at user-creation time in
+        # auth.roles.RoleManager._ensure_user_postgres (#586). The fallback
+        # below covers (a) the race window between user creation and the
+        # first /usage/current call and (b) test fixtures that bypass the
+        # signup flow.
         result = await db.execute(select(UserPlan).where(UserPlan.user_id == user_id))
         plan = result.scalar_one_or_none()
 
         if not plan:
-            # Create default free plan from environment variables
-            plan = UserPlan(
-                user_id=user_id,
-                plan_name="free",
-                memory_limit=settings.default_plan_memory_limit,
-                daily_api_limit=settings.default_plan_daily_api_limit,
-                weekly_api_limit=settings.default_plan_weekly_api_limit,
-            )
-            db.add(plan)
-            await db.commit()
+            plan = UserPlan.default_for_user(user_id, settings)
 
         # Get current memory count.
         # Issue #198 (Bug D): exclude soft-deleted rows so this matches the

--- a/backend/src/auth/roles.py
+++ b/backend/src/auth/roles.py
@@ -326,9 +326,23 @@ class RoleManager:
                 last_login_at=utcnow(),
                 auth_provider=auth_provider,
             )
+            # Pre-check for an orphan UserPlan row before adding a fresh
+            # one in the same tx. The orphan case (UserPlan exists for
+            # this user_id without its User row, e.g. from a prior
+            # partial account_erasure failure) is rare but otherwise
+            # surfaces as a 500 that permanently blocks first-login,
+            # because the IntegrityError handler below only recognizes
+            # users.user_id races and users.email collisions — a
+            # user_plans.user_id PK violation falls through and re-raises.
+            # Doing the SELECT before db.add(new_user) avoids any
+            # autoflush surprise (Issue #586, Copilot review).
+            existing_plan_id = (
+                await db.execute(select(UserPlan.user_id).where(UserPlan.user_id == user_id))
+            ).scalar_one_or_none()
             db.add(new_user)
             # Default UserPlan in the same tx — keeps GET /usage/current pure-read (#586).
-            db.add(UserPlan.default_for_user(user_id, get_settings()))
+            if existing_plan_id is None:
+                db.add(UserPlan.default_for_user(user_id, get_settings()))
             try:
                 await db.commit()
                 return role

--- a/backend/src/auth/roles.py
+++ b/backend/src/auth/roles.py
@@ -292,7 +292,7 @@ class RoleManager:
         from sqlalchemy.exc import IntegrityError
 
         from db.base import get_db
-        from models.auth import User
+        from models.auth import User, UserPlan
 
         async for db in get_db():
             # Lookup key: user_id (oauth_sub), not email — email is mutable.
@@ -327,6 +327,8 @@ class RoleManager:
                 auth_provider=auth_provider,
             )
             db.add(new_user)
+            # Default UserPlan in the same tx — keeps GET /usage/current pure-read (#586).
+            db.add(UserPlan.default_for_user(user_id, get_settings()))
             try:
                 await db.commit()
                 return role

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1043,6 +1043,25 @@ class UserPlan(Base):
 
     __table_args__ = (Index("idx_user_plans_plan_name", "plan_name"),)
 
+    @classmethod
+    def default_for_user(cls, user_id: str, settings) -> "UserPlan":
+        """Construct the default 'free' plan from settings defaults.
+
+        Shared between two callers so a future column add can't drift
+        them apart (Issue #586):
+        - ``auth.roles.RoleManager._ensure_user_postgres`` writes this
+          row on user creation.
+        - ``api.routes.usage.get_current_usage`` builds an in-memory
+          instance on the fallback path (no persistence).
+        """
+        return cls(
+            user_id=user_id,
+            plan_name="free",
+            memory_limit=settings.default_plan_memory_limit,
+            daily_api_limit=settings.default_plan_daily_api_limit,
+            weekly_api_limit=settings.default_plan_weekly_api_limit,
+        )
+
 
 # ============================================================================
 # Context-based Multi-Collection (Issue #82 → #160: renamed from Project)

--- a/backend/tests/api/test_usage_pure_read.py
+++ b/backend/tests/api/test_usage_pure_read.py
@@ -1,0 +1,149 @@
+"""Pure-read contract for `GET /api/v1/usage/current` (Issue #586).
+
+PR #588 made ``EffectiveQuotaService.get_effective_quotas`` pure-read at the
+service layer. The route layer carried a sister antipattern: when the
+caller had no ``UserPlan`` row, ``get_current_usage`` lazy-created one and
+COMMITted from the GET path. This file pins the new pure-read contract
+with the **four-pillar** mock pattern:
+
+1. ``commit.assert_not_awaited()`` — no explicit commit reaches the DB.
+2. ``add.assert_not_called()`` — and no ``db.add`` either, because the
+   ``get_db()`` dependency runs ``await session.commit()`` on normal exit
+   (``backend/src/db/base.py:142``). An ``add`` without an explicit commit
+   would still persist the row through that auto-commit, masking the bug.
+   Pillar 4 is the explicit defense against that.
+3. ``execute.await_count`` — read-side calls still happen (we are not
+   regressing into a degenerate no-op endpoint).
+4. Functional value check — the response uses ``settings.default_*``
+   values when the plan row is missing.
+
+The default ``UserPlan`` row is now created in
+``auth.roles.RoleManager._ensure_user_postgres`` (same transaction as the
+``User`` INSERT). Existing users without a row fall through to the
+in-memory fallback this file pins.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.routes.usage import get_current_usage
+
+
+@pytest.fixture
+def session_user():
+    """Session user dict with no current workspace.
+
+    Setting ``current_workspace_id=None`` short-circuits
+    ``_build_analysis_usage`` / ``_build_sleep_contexts_usage`` (both return
+    ``None`` early when no workspace is selected) and skips the
+    ``EffectiveQuotaService`` block. That keeps the unit test focused on
+    the UserPlan fetch + the per-day / per-week ``UsageStats`` counts.
+    """
+    return {"user_id": "u-pure-read", "current_workspace_id": None}
+
+
+def _mock_db_with_plan_lookup_returning(plan):
+    """Build a MagicMock AsyncSession whose first execute() returns ``plan``
+    (the UserPlan lookup) and every subsequent execute() returns a row with
+    ``scalar() == 0`` (the count queries).
+
+    SQLAlchemy patterns used by the handler:
+    - ``result.scalar_one_or_none()`` for the UserPlan SELECT.
+    - ``result.scalar()`` for ``count(...)`` queries.
+
+    The same Result-shaped mock satisfies both because both methods are
+    stubbed to return the values the handler expects.
+    """
+    db = MagicMock()
+
+    plan_result = MagicMock()
+    plan_result.scalar_one_or_none.return_value = plan
+    plan_result.scalar.return_value = 0
+
+    count_result = MagicMock()
+    count_result.scalar_one_or_none.return_value = None
+    count_result.scalar.return_value = 0
+
+    # First call returns the plan lookup; the headroom of 32 zero-count
+    # results absorbs the 9-10 count queries the handler currently issues
+    # plus future additions, so a query added in an unrelated PR doesn't
+    # break this test for the wrong reason.
+    db.execute = AsyncMock(side_effect=[plan_result] + [count_result] * 32)
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
+    return db
+
+
+class TestGetCurrentUsagePureReadContract:
+    """Pin the four-pillar pure-read contract for `GET /usage/current`."""
+
+    @pytest.mark.asyncio
+    async def test_no_commit_no_add_when_plan_missing(self, session_user):
+        """Pillars 1 + 2: missing-plan branch emits no commit and no add."""
+        db = _mock_db_with_plan_lookup_returning(None)
+
+        await get_current_usage(user=session_user, db=db)
+
+        db.commit.assert_not_awaited()
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_executes_read_queries(self, session_user):
+        """Pillar 3: read-side queries still happen (lower-bound 10)."""
+        db = _mock_db_with_plan_lookup_returning(None)
+
+        await get_current_usage(user=session_user, db=db)
+
+        assert db.execute.await_count >= 10
+
+    @pytest.mark.asyncio
+    async def test_response_uses_settings_defaults_when_plan_missing(
+        self, session_user, monkeypatch
+    ):
+        """Pillar 4: missing-plan branch propagates ``settings.default_*``."""
+        from api.routes import usage as usage_module
+
+        # Sentinel ints proxy through the missing-plan branch into the response.
+        # Floats for the warning/critical thresholds prevent MagicMock leaking
+        # into ``calculate_usage_status``'s percentage comparison.
+        sentinel = MagicMock()
+        sentinel.default_plan_memory_limit = 4242
+        sentinel.default_plan_daily_api_limit = 1234
+        sentinel.default_plan_weekly_api_limit = 5678
+        sentinel.usage_warning_threshold = 0.8
+        sentinel.usage_critical_threshold = 0.95
+        monkeypatch.setattr(usage_module, "get_settings", lambda: sentinel)
+
+        db = _mock_db_with_plan_lookup_returning(None)
+        response = await get_current_usage(user=session_user, db=db)
+
+        assert response.plan.plan_name == "free"
+        assert response.plan.memory_limit == 4242
+        assert response.plan.daily_total_limit == 1234
+        assert response.plan.weekly_total_limit == 5678
+
+    @pytest.mark.asyncio
+    async def test_no_commit_no_add_when_plan_exists(self, session_user):
+        """Sanity twin: existing-plan branch must also stay pure-read.
+
+        Guards against a future edit that adds a write side-effect to the
+        existing-plan branch (e.g. ``last_seen_at`` update) from quietly
+        regressing the contract.
+        """
+        existing_plan = MagicMock()
+        existing_plan.plan_name = "pro"
+        existing_plan.memory_limit = 9999
+        existing_plan.daily_api_limit = 9999
+        existing_plan.weekly_api_limit = 99999
+
+        db = _mock_db_with_plan_lookup_returning(existing_plan)
+
+        await get_current_usage(user=session_user, db=db)
+
+        db.commit.assert_not_awaited()
+        db.add.assert_not_called()

--- a/backend/tests/auth/test_role_manager_postgres.py
+++ b/backend/tests/auth/test_role_manager_postgres.py
@@ -331,8 +331,9 @@ class TestUpdateCollision:
 class TestCreatePath:
     @pytest.mark.asyncio
     async def test_first_user_gets_admin(self, role_manager):
-        # Sequence: lookup miss → count=0 → commit succeeds
-        db = _make_db_mock(_execute_returns(None, {"scalar": 0}))
+        # Sequence: User lookup miss → count=0 → UserPlan pre-check miss
+        # (Issue #586) → commit succeeds
+        db = _make_db_mock(_execute_returns(None, {"scalar": 0}, None))
 
         with _patch_get_db(db):
             role = await role_manager.ensure_user(
@@ -348,7 +349,8 @@ class TestCreatePath:
 
     @pytest.mark.asyncio
     async def test_second_user_gets_user(self, role_manager):
-        db = _make_db_mock(_execute_returns(None, {"scalar": 1}))
+        # Sequence: User lookup miss → count=1 → UserPlan pre-check miss (Issue #586)
+        db = _make_db_mock(_execute_returns(None, {"scalar": 1}, None))
 
         with _patch_get_db(db):
             role = await role_manager.ensure_user(
@@ -372,11 +374,12 @@ class TestCreatePath:
         # Existing row was just inserted by another concurrent request with a
         # stale email — the racing caller's IdP payload has the fresher value.
         race_existing = _user_row(email="alice@old.com", name="Alice Old", role="admin")
-        # Sequence: lookup miss → count=0 → commit raises (user_id race —
-        # constraint_name ix_users_user_id, NOT email, so we precisely model
-        # the user_id-collision shape rather than reusing the email helper)
-        # → re-lookup hits → sync_existing_user commits the update
-        db = _make_db_mock(_execute_returns(None, {"scalar": 0}, race_existing))
+        # Sequence: User lookup miss → count=0 → UserPlan pre-check miss
+        # (Issue #586) → commit raises (user_id race — constraint_name
+        # ix_users_user_id, NOT email, so we precisely model the user_id-
+        # collision shape rather than reusing the email helper) → re-lookup
+        # hits → sync_existing_user commits the update
+        db = _make_db_mock(_execute_returns(None, {"scalar": 0}, None, race_existing))
         db.commit = AsyncMock(side_effect=[_user_id_unique_violation(), None])
 
         with _patch_get_db(db):
@@ -400,8 +403,9 @@ class TestCreatePath:
 
     @pytest.mark.asyncio
     async def test_email_collision_on_create_raises_conflict(self, role_manager):
-        # Sequence: lookup miss → count → commit raises → re-lookup also miss
-        db = _make_db_mock(_execute_returns(None, {"scalar": 5}, None))
+        # Sequence: User lookup miss → count=5 → UserPlan pre-check miss
+        # (Issue #586) → commit raises → re-lookup also miss
+        db = _make_db_mock(_execute_returns(None, {"scalar": 5}, None, None))
         db.commit = AsyncMock(side_effect=_email_unique_violation())
 
         with _patch_get_db(db), structlog.testing.capture_logs() as logs:

--- a/backend/tests/auth/test_roles_user_plan.py
+++ b/backend/tests/auth/test_roles_user_plan.py
@@ -30,29 +30,30 @@ from auth.roles import RoleManager
 from models.auth import User, UserPlan
 
 
-@pytest.fixture
-def patched_get_db(monkeypatch):
-    """Patch ``auth.roles.get_db`` (referenced via local import) so
-    ``_ensure_user_postgres`` yields a single MagicMock session under
-    test control.
+def _build_patched_get_db(monkeypatch, *, orphan_plan_user_id: str | None = None):
+    """Patch ``db.base.get_db`` to yield a controlled MagicMock session.
 
-    The local-import shape inside ``_ensure_user_postgres`` means we
-    need to patch ``db.base.get_db`` (the canonical name) rather than a
-    re-export, because the function does
-    ``from db.base import get_db`` at call time.
+    The new-user path issues three SELECTs in order:
+    1. User lookup by user_id.
+    2. User row count (to decide ADMIN vs USER).
+    3. UserPlan pre-check for orphan rows (Issue #586, Copilot review).
+
+    ``orphan_plan_user_id`` toggles the third SELECT's return value:
+    - ``None`` (default): no orphan row → handler will add a fresh UserPlan.
+    - ``"<user_id>"``: orphan row exists → handler must skip the UserPlan add.
     """
     from db import base as db_base
 
     captured_db = MagicMock()
 
-    # First execute() call: User lookup → no existing user.
-    # Second execute() call: User count → 1 (so the new user is USER, not ADMIN).
     user_lookup = MagicMock()
     user_lookup.scalar_one_or_none.return_value = None
     count_result = MagicMock()
     count_result.scalar.return_value = 1
+    plan_precheck = MagicMock()
+    plan_precheck.scalar_one_or_none.return_value = orphan_plan_user_id
 
-    captured_db.execute = AsyncMock(side_effect=[user_lookup, count_result])
+    captured_db.execute = AsyncMock(side_effect=[user_lookup, count_result, plan_precheck])
     captured_db.add = MagicMock()
     captured_db.commit = AsyncMock()
     captured_db.rollback = AsyncMock()
@@ -63,6 +64,12 @@ def patched_get_db(monkeypatch):
 
     monkeypatch.setattr(db_base, "get_db", _fake_get_db)
     return captured_db
+
+
+@pytest.fixture
+def patched_get_db(monkeypatch):
+    """Default scenario: no orphan UserPlan row exists for the new user."""
+    return _build_patched_get_db(monkeypatch, orphan_plan_user_id=None)
 
 
 class TestEnsureUserCreatesDefaultPlan:
@@ -94,6 +101,45 @@ class TestEnsureUserCreatesDefaultPlan:
         assert user_plans[0].user_id == "oauth-sub-new"
         # Both adds must precede the commit (atomic transaction).
         patched_get_db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orphan_user_plan_row_skipped_to_avoid_pk_violation(self, monkeypatch):
+        """Orphan UserPlan path: a pre-existing UserPlan row without its
+        User row (e.g. from a partial account_erasure failure) must NOT
+        cause first-login to bubble a 500.
+
+        Without the pre-check in `_ensure_user_postgres`, the UserPlan
+        INSERT would PK-violate at commit time and the IntegrityError
+        handler would re-raise (it only recognizes users.user_id races
+        and users.email collisions). Copilot review on PR #589 flagged
+        this; the fix is to SELECT for an existing UserPlan row first
+        and skip the add when it exists.
+        """
+        captured_db = _build_patched_get_db(monkeypatch, orphan_plan_user_id="oauth-sub-orphan")
+
+        rm = RoleManager(use_postgres=True)
+        await rm._ensure_user_postgres(
+            email="orphan@example.com",
+            user_id="oauth-sub-orphan",
+            name=None,
+            auth_provider="google",
+            email_verified=True,
+            ip_address=None,
+            user_agent=None,
+        )
+
+        added = [call.args[0] for call in captured_db.add.call_args_list]
+        users = [obj for obj in added if isinstance(obj, User)]
+        user_plans = [obj for obj in added if isinstance(obj, UserPlan)]
+
+        # User row IS added (this is still a fresh user creation).
+        assert len(users) == 1
+        # UserPlan add is SKIPPED — the orphan row already occupies the PK.
+        assert user_plans == [], (
+            f"expected zero UserPlan adds when an orphan row exists, got {len(user_plans)}"
+        )
+        # Commit still runs so the User row is persisted, reusing the orphan plan.
+        captured_db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_user_plan_uses_settings_defaults(self, patched_get_db, monkeypatch):

--- a/backend/tests/auth/test_roles_user_plan.py
+++ b/backend/tests/auth/test_roles_user_plan.py
@@ -1,0 +1,129 @@
+"""UserPlan creation in `RoleManager._ensure_user_postgres` (Issue #586).
+
+Pre-#586: the default ``UserPlan`` row was lazy-created on the GET path
+of ``/usage/current`` (route layer). #586 moves that creation to the
+write path — specifically into the ``User`` INSERT transaction in
+``RoleManager._ensure_user_postgres`` — so the GET handler can be
+pure-read.
+
+These tests pin two contracts on the new-user path:
+
+1. ``db.add`` is called with both a ``User`` and a ``UserPlan`` instance
+   in the same transaction (atomic), and they share the same ``user_id``.
+2. The ``UserPlan`` is constructed from ``settings.default_plan_*``
+   values, matching the legacy lazy-create branch this replaces.
+
+The existing-user path (``_sync_existing_user``) intentionally does NOT
+add a ``UserPlan`` row. Existing users predate this change and are
+covered by the lazy fallback in ``api/routes/usage.py``; backfilling
+their plan rows is explicitly out-of-scope (Issue #586 ``## Out of
+scope``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auth.roles import RoleManager
+from models.auth import User, UserPlan
+
+
+@pytest.fixture
+def patched_get_db(monkeypatch):
+    """Patch ``auth.roles.get_db`` (referenced via local import) so
+    ``_ensure_user_postgres`` yields a single MagicMock session under
+    test control.
+
+    The local-import shape inside ``_ensure_user_postgres`` means we
+    need to patch ``db.base.get_db`` (the canonical name) rather than a
+    re-export, because the function does
+    ``from db.base import get_db`` at call time.
+    """
+    from db import base as db_base
+
+    captured_db = MagicMock()
+
+    # First execute() call: User lookup → no existing user.
+    # Second execute() call: User count → 1 (so the new user is USER, not ADMIN).
+    user_lookup = MagicMock()
+    user_lookup.scalar_one_or_none.return_value = None
+    count_result = MagicMock()
+    count_result.scalar.return_value = 1
+
+    captured_db.execute = AsyncMock(side_effect=[user_lookup, count_result])
+    captured_db.add = MagicMock()
+    captured_db.commit = AsyncMock()
+    captured_db.rollback = AsyncMock()
+    captured_db.flush = AsyncMock()
+
+    async def _fake_get_db():
+        yield captured_db
+
+    monkeypatch.setattr(db_base, "get_db", _fake_get_db)
+    return captured_db
+
+
+class TestEnsureUserCreatesDefaultPlan:
+    """`_ensure_user_postgres` must create the default UserPlan in the
+    same transaction as the User row (Issue #586)."""
+
+    @pytest.mark.asyncio
+    async def test_user_and_user_plan_added_atomically(self, patched_get_db):
+        """Pillar 1: User + UserPlan are added once each, both before commit."""
+        rm = RoleManager(use_postgres=True)
+
+        await rm._ensure_user_postgres(
+            email="new@example.com",
+            user_id="oauth-sub-new",
+            name="New User",
+            auth_provider="google",
+            email_verified=True,
+            ip_address=None,
+            user_agent=None,
+        )
+
+        added = [call.args[0] for call in patched_get_db.add.call_args_list]
+        users = [obj for obj in added if isinstance(obj, User)]
+        user_plans = [obj for obj in added if isinstance(obj, UserPlan)]
+
+        assert len(users) == 1, f"expected one User add, got {len(users)}"
+        assert len(user_plans) == 1, f"expected one UserPlan add, got {len(user_plans)}"
+        assert users[0].user_id == "oauth-sub-new"
+        assert user_plans[0].user_id == "oauth-sub-new"
+        # Both adds must precede the commit (atomic transaction).
+        patched_get_db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_user_plan_uses_settings_defaults(self, patched_get_db, monkeypatch):
+        """Pillar 2: the UserPlan row uses settings.default_plan_* values."""
+        sentinel = MagicMock()
+        sentinel.default_plan_memory_limit = 7777
+        sentinel.default_plan_daily_api_limit = 333
+        sentinel.default_plan_weekly_api_limit = 1111
+        sentinel.audit_hmac_key = "test-hmac-key"
+        from auth import roles as roles_module
+
+        monkeypatch.setattr(roles_module, "get_settings", lambda: sentinel)
+
+        rm = RoleManager(use_postgres=True)
+
+        await rm._ensure_user_postgres(
+            email="defaults@example.com",
+            user_id="oauth-sub-defaults",
+            name=None,
+            auth_provider="github",
+            email_verified=True,
+            ip_address=None,
+            user_agent=None,
+        )
+
+        added = [call.args[0] for call in patched_get_db.add.call_args_list]
+        user_plans = [obj for obj in added if isinstance(obj, UserPlan)]
+        assert len(user_plans) == 1
+        plan = user_plans[0]
+        assert plan.plan_name == "free"
+        assert plan.memory_limit == 7777
+        assert plan.daily_api_limit == 333
+        assert plan.weekly_api_limit == 1111


### PR DESCRIPTION
## Summary

Sister bug of #570 (PR #588) at the route layer. `GET /api/v1/usage/current` lazy-created a `UserPlan` row and `await db.commit()`-ed from the read path. This PR moves that write to `RoleManager._ensure_user_postgres` (same transaction as the `User` INSERT) so the GET handler stays pure-read.

- New `UserPlan.default_for_user(user_id, settings)` classmethod — shared by the write trigger and the route-layer in-memory fallback so the construction can't drift on a future column add.
- The route's missing-plan branch now builds an in-memory `UserPlan` with no `db.add` and no `db.commit`. Covers (a) the race window between user creation and the first `/usage/current` call and (b) test fixtures that bypass the signup flow. Production traffic should normally not hit this branch.
- Default `UserPlan` is created at user creation in the same transaction as the `User` INSERT — atomic, no concurrency reshuffling.

## Acceptance (#586)

- [x] `get_current_usage` no longer calls `db.commit()` in any code path.
- [x] Default `UserPlan` is created at a deterministic write trigger (NOT on read).
- [x] Existing users without a `UserPlan` row are reconciled via the lazy fallback to settings defaults at read time. Backfill remains explicitly out-of-scope (verified there is exactly one `UserPlan` reader in the codebase: `usage.py:410`).
- [x] Test pin: GET `/api/v1/usage/current` invocations do not COMMIT — extended to a **four-pillar pattern** to close the gap `/dx-lead` horizontal scan flagged.

## The four-pillar test pin

`/dx-lead` horizontal scan revealed that `get_db()`'s unit-of-work pattern in `db/base.py:142` runs `await session.commit()` on normal exit. So removing only the explicit `commit()` from a GET handler leaves the bug latent: a stray `db.add()` would still persist via the dependency-cleanup auto-commit. PR #588's three-pillar pattern (`commit.assert_not_awaited` + `execute.await_count` + spot-check value) is therefore extended with a fourth pillar:

- `db.commit.assert_not_awaited()` — no explicit commit.
- `db.add.assert_not_called()` — defends against `get_db()` auto-commit silent persist.
- `db.execute.await_count >= 10` — read-side queries still happen.
- Functional value check — response uses `settings.default_*` when row is missing.

## Notes from self-review

- **Orphan `UserPlan` edge case**: an existing `UserPlan` row without a `User` row (e.g. from a partial `account_erasure` failure) would surface as 500 on the next first-login because the `_is_email_unique_violation` filter doesn't recognize a `user_plans.user_id` PK violation. This is a column-set widening of the existing IntegrityError fallback class, not a regression — pre-#586 the same orphan would have surfaced via a different path. Worth investigating if it ever fires; not worth silencing here.
- **Factory `settings` parameter is untyped** — pyright won't catch attribute typos at the call site. Acceptable given the factory is exercised by 100% of tests; could be tightened to `Settings` or a Protocol in a future cleanup.
- **`/cto` YAGNI ruling**: the deeper architectural question — "should `get_db()` itself drop auto-commit or split into read/write deps?" — is rejected for blast radius (40+ route files). A CI lint that statically rejects `db.add` / `db.commit` in `@router.get` bodies is a cheaper preventive measure and a candidate for v0.16.x.

## Test plan

- [x] `make lint` (ruff) — clean
- [x] `make type-check` (pyright) — 0 errors
- [x] `pytest tests/api/test_usage_pure_read.py tests/auth/test_roles_user_plan.py -v` — 6/6 pass
- [x] `pytest tests/auth/test_roles.py tests/services/test_effective_quota_service.py tests/api/test_workspace_quota_display.py -v` — 19/19 pass (no regression in adjacent areas)
- [x] Broader sweep `pytest tests/api/ tests/auth/ -k "usage or role or auth or workspace_quota"` — 230 passed, 0 failed (18 pre-existing local-env ERRORS on integration fixtures unrelated to this change)
- [ ] Manual smoke after merge: hit `GET /api/v1/usage/current` for a fresh user, confirm response shape unchanged and no new write to `user_plans` from the GET path

🤖 Generated with [Claude Code](https://claude.com/claude-code)