### PR TITLE
refactor(test): consolidate _FakeBlobStorage copies (#578)

### DIFF
--- a/backend/tests/services/test_file_storage_migrate.py
+++ b/backend/tests/services/test_file_storage_migrate.py
@@ -14,28 +14,7 @@ from uuid import uuid4
 import pytest
 
 from services.file_storage_service import FileStorageService
-
-
-class _FakeBlobStorage:
-    def __init__(self) -> None:
-        self.objects: dict[str, tuple[bytes, str, str]] = {}
-
-    async def write_object(self, key, data, content_type, sha256):
-        self.objects[key] = (data, content_type, sha256)
-
-    async def head_object(self, key):
-        if key not in self.objects:
-            return None
-        return {"size_bytes": len(self.objects[key][0]), "etag": self.objects[key][2]}
-
-    async def delete_object(self, key):
-        self.objects.pop(key, None)
-
-    async def generate_presigned_put(self, key, content_type, size_bytes, ttl_seconds, sha256):
-        return f"put://{key}"
-
-    async def generate_presigned_get(self, key, filename, ttl_seconds):
-        return f"get://{key}"
+from tests.storage._fakes import FakeBlobStorage
 
 
 @pytest.fixture
@@ -50,7 +29,7 @@ def attachment_id():
 
 @pytest.fixture
 def fake_storage():
-    return _FakeBlobStorage()
+    return FakeBlobStorage()
 
 
 @pytest.fixture

--- a/backend/tests/services/test_file_storage_service.py
+++ b/backend/tests/services/test_file_storage_service.py
@@ -1,8 +1,8 @@
 """Unit tests for ``FileStorageService`` (Issue #485).
 
-Mocks the DB session and uses the in-memory ``BlobStorageProtocol``
-fake from ``tests.storage.test_protocol`` so this file does not depend
-on aioboto3 or a real Redis. SQL constraint behaviour (partial unique
+Mocks the DB session and uses the shared in-memory ``BlobStorageProtocol``
+fake from ``tests.storage._fakes`` so this file does not depend on
+aioboto3 or a real Redis. SQL constraint behaviour (partial unique
 violations, CHECK constraints, computed columns) is covered by the
 integration suite gated on ``make test-integration``.
 """
@@ -16,6 +16,7 @@ from uuid import UUID, uuid4
 import pytest
 
 from services.file_storage_service import FileStorageService, ReserveResult
+from tests.storage._fakes import FakeBlobStorage
 from utils.exceptions import (
     ConflictError,
     NotFoundException,
@@ -23,36 +24,6 @@ from utils.exceptions import (
     UnsupportedMediaTypeError,
     ValidationError,
 )
-
-
-# Reusable in-memory blob storage matching BlobStorageProtocol
-class _FakeBlobStorage:
-    def __init__(self) -> None:
-        self.objects: dict[str, tuple[bytes, str, str]] = {}
-        self.head_size_override: int | None = None
-
-    async def write_object(self, key, data, content_type, sha256):
-        self.objects[key] = (data, content_type, sha256)
-
-    async def head_object(self, key):
-        if key not in self.objects:
-            return None
-        size = self.head_size_override
-        if size is None:
-            size = len(self.objects[key][0])
-        return {"size_bytes": size, "etag": self.objects[key][2]}
-
-    async def delete_object(self, key):
-        self.objects.pop(key, None)
-
-    async def generate_presigned_put(self, key, content_type, size_bytes, ttl_seconds, sha256):
-        return (
-            f"https://test.local/put/{key}?size={size_bytes}&ttl={ttl_seconds}&sha256={sha256[:8]}"
-        )
-
-    async def generate_presigned_get(self, key, filename, ttl_seconds):
-        return f"https://test.local/get/{key}?file={filename}&ttl={ttl_seconds}"
-
 
 VALID_SHA = "a" * 64
 
@@ -97,7 +68,7 @@ def workspace_id():
 
 @pytest.fixture
 def fake_storage():
-    return _FakeBlobStorage()
+    return FakeBlobStorage()
 
 
 @pytest.fixture

--- a/backend/tests/storage/_fakes.py
+++ b/backend/tests/storage/_fakes.py
@@ -1,0 +1,53 @@
+"""Shared in-memory ``BlobStorageProtocol`` fake for service-layer tests.
+
+Note: ``tests/storage/test_protocol.py`` keeps its own ``_InMemoryStorage``
+on purpose — that file's job is to pin the Protocol contract via
+``isinstance(_, BlobStorageProtocol)``, and routing it through an import
+would dilute the pin (any contract drift would point at this module
+instead of the test file demonstrating the contract).
+"""
+
+from __future__ import annotations
+
+from storage.protocol import ObjectMetadata
+
+
+class FakeBlobStorage:
+    """In-memory fake conforming to ``BlobStorageProtocol``.
+
+    ``head_size_override`` is an opt-in test seam: when set to an int,
+    ``head_object`` reports that size instead of the actual byte length.
+    Used by truncation-refund tests to simulate a backend that reports a
+    different size than the bytes the client claims to have uploaded.
+    Default ``None`` means ``head_object`` returns the true size — i.e.
+    setting this attribute is the only way to deviate from truthful
+    behaviour, and tests that do not touch it cannot be silently affected.
+    """
+
+    def __init__(self) -> None:
+        self.objects: dict[str, tuple[bytes, str, str]] = {}
+        self.head_size_override: int | None = None
+
+    async def write_object(self, key: str, data: bytes, content_type: str, sha256: str) -> None:
+        self.objects[key] = (data, content_type, sha256)
+
+    async def head_object(self, key: str) -> ObjectMetadata | None:
+        if key not in self.objects:
+            return None
+        size = self.head_size_override
+        if size is None:
+            size = len(self.objects[key][0])
+        return {"size_bytes": size, "etag": self.objects[key][2]}
+
+    async def delete_object(self, key: str) -> None:
+        self.objects.pop(key, None)
+
+    async def generate_presigned_put(
+        self, key: str, content_type: str, size_bytes: int, ttl_seconds: int, sha256: str
+    ) -> str:
+        return (
+            f"https://test.local/put/{key}?size={size_bytes}&ttl={ttl_seconds}&sha256={sha256[:8]}"
+        )
+
+    async def generate_presigned_get(self, key: str, filename: str, ttl_seconds: int) -> str:
+        return f"https://test.local/get/{key}?file={filename}&ttl={ttl_seconds}"


### PR DESCRIPTION
Closes #578

## Summary
- Promote a shared `FakeBlobStorage` to `backend/tests/storage/_fakes.py` so the in-memory `BlobStorageProtocol` fake lives in one place — eliminates the 3-way maintenance burden surfaced by PR #574 (`generate_presigned_put` adding `sha256: str` had to be edited in 3 files).
- Replace the local `_FakeBlobStorage` copies in `tests/services/test_file_storage_service.py` and `tests/services/test_file_storage_migrate.py` with imports from the shared module.
- Keep `_InMemoryStorage` in `tests/storage/test_protocol.py` deliberately — that file's job is to pin the Protocol contract via `isinstance(_, BlobStorageProtocol)`, and routing it through an import would dilute the pin (any drift would point at `_fakes.py` instead of the test demonstrating the contract). Documented in the new module's docstring.

## Implementation notes
- The shared `FakeBlobStorage` carries full `BlobStorageProtocol`-conformant type signatures (`key: str`, `data: bytes`, `-> ObjectMetadata | None`, etc.) — strengthening drift detection beyond the original untyped local fakes.
- `head_size_override: int | None = None` is preserved as an opt-in test seam — only `test_file_storage_service.py`'s truncation-refund tests set it; the default `None` path returns the truthful size, so no test that doesn't touch it can be silently affected.
- URL format unified to `https://test.local/...` (was `put://`/`get://` in the migrate fake — those URLs are not asserted on, so behavior is preserved). The `test_file_storage_service.py:148` `startswith("https://test.local/put/")` assertion continues to hold.
- Acceptance scope adjusted: 2/3 copies consolidated, not 3/3. The third (`_InMemoryStorage` in `test_protocol.py`) is the issue's own "Out of scope" item and verification confirmed it serves a distinct contract-pin role.

## Test count (before / after)
| File | Before | After |
|---|---|---|
| `tests/storage/test_protocol.py` | 6 | 6 |
| `tests/services/test_file_storage_service.py` | 42 | 42 |
| `tests/services/test_file_storage_migrate.py` | 2 | 2 |
| **Total** | **50** | **50** |

Broader `tests/storage/*` + `tests/services/test_file_storage_*.py` suite: 67/67 pass.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (routed to QA Lead)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/578-feat-refactor-test-consolidate-3-fakeblobstor.gate1.md`
- `~/.claude/cache/gh-issue-driven/578-feat-refactor-test-consolidate-3-fakeblobstor.gate2.md`

🤖 Generated via /gh-issue-driven:ship
