### PR TITLE
fix(api): apply zero-base-tier defense-in-depth to all effective_*_limit (#569)

### DIFF
--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1176,6 +1176,25 @@ class Context(Base):
         return self.name == "default"
 
 
+def _zero_floor(base: int, addon: int | None) -> int:
+    """Defense-in-depth quota helper (#569).
+
+    A plan-tier ``base`` of 0 means the feature is excluded from the tier —
+    no addon row can raise the effective limit above 0. Encoded in the data
+    (``base == 0``) rather than by plan name so a future paid tier with
+    ``base > 0`` automatically gets addon stacking (mirrors the rule from
+    PR #568 / #560 for ``sleep_enabled_contexts_limit``).
+
+    Callers that scale the addon to a different unit before stacking
+    (e.g. ``effective_storage_limit_bytes`` converts MB→bytes) must pass
+    the **scaled** value as ``addon`` so the zero-floor check happens on
+    the final unit.
+    """
+    if base == 0:
+        return 0
+    return base + (addon or 0)
+
+
 class Workspace(Base):
     """Workspace model for multi-user team management.
 
@@ -1334,11 +1353,14 @@ class Workspace(Base):
         addons" is encoded in the data (``sleep_enabled_contexts_limit == 0``)
         rather than by hard-coding plan names so a future paid tier with
         ``sleep_enabled_contexts_limit > 0`` automatically gets addon stacking.
+
+        Now routed through ``_zero_floor`` to share the rule with every other
+        ``effective_*_limit`` property (#569).
         """
-        base = self._plan_tier.sleep_enabled_contexts_limit
-        if base == 0:
-            return 0
-        return base + (self.addon_sleep_contexts_bonus or 0)
+        return _zero_floor(
+            self._plan_tier.sleep_enabled_contexts_limit,
+            self.addon_sleep_contexts_bonus,
+        )
 
     # Stripe billing (Issue #351)
     stripe_customer_id = Column(String(255), nullable=True)

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1309,10 +1309,15 @@ class Workspace(Base):
     def effective_public_calls_per_day(self) -> int:
         """Public REST API calls/day: plan tier base + addon (Issue #238).
 
-        FREE and BASIC have ``public_calls_per_day == 0``. Access is also
-        gated by the ``public_contexts`` feature flag (``plan_tiers.py``
-        ``FEATURE_MIN_PLANS``); the zero-base guard here is defense-in-depth
-        in case the feature gate is ever bypassed (#569).
+        FREE and BASIC have ``public_calls_per_day == 0``. There is **no other
+        runtime tier gate** on the public REST routes — ``api/routes/public_search.py``
+        rejects non-public contexts via ``context.is_public``, but does not check
+        the owner's plan tier. The ``public_contexts`` entry in
+        ``plan_tiers.py:FEATURE_MIN_PLANS`` is declared but never consumed at
+        runtime (``check_feature_access`` is only called for ``memory_analysis``
+        and ``reranking`` today), so the zero-base guard here is the **primary**
+        protection against a stray ``WorkspaceAddon`` row granting public-API
+        access to a tier that excludes it (#569).
         """
         return _zero_floor(self._plan_tier.public_calls_per_day, self.addon_public_quota_bonus)
 

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1278,52 +1278,70 @@ class Workspace(Base):
     @property
     def effective_memory_limit(self) -> int:
         """Memory limit including addon bonus."""
-        return self._plan_tier.memory_limit + (self.addon_memory_bonus or 0)
+        return _zero_floor(self._plan_tier.memory_limit, self.addon_memory_bonus)
 
     @property
     def effective_mcp_calls_per_day(self) -> int:
-        """MCP API calls/day: plan tier base + addon."""
-        return self._plan_tier.mcp_calls_per_day + (self.addon_mcp_quota_bonus or 0)
+        """MCP API calls/day: plan tier base + addon (Issue #238)."""
+        return _zero_floor(self._plan_tier.mcp_calls_per_day, self.addon_mcp_quota_bonus)
 
     @property
     def effective_mcp_calls_per_week(self) -> int:
-        """Weekly MCP API call limit: plan tier base + addon."""
-        return self._plan_tier.mcp_calls_per_week + (self.addon_mcp_quota_bonus or 0)
+        """Weekly MCP API call limit: plan tier base + addon (Issue #238)."""
+        return _zero_floor(self._plan_tier.mcp_calls_per_week, self.addon_mcp_quota_bonus)
 
     @property
     def effective_rest_calls_per_day(self) -> int:
-        """REST API calls/day: plan tier base + addon."""
-        return self._plan_tier.rest_calls_per_day + (self.addon_rest_quota_bonus or 0)
+        """REST API calls/day: plan tier base + addon (Issue #238).
+
+        FREE has ``rest_calls_per_day == 0`` — the zero-base guard in
+        ``_zero_floor`` ensures a manual addon row cannot grant REST access
+        to a tier that excludes it (#569).
+        """
+        return _zero_floor(self._plan_tier.rest_calls_per_day, self.addon_rest_quota_bonus)
 
     @property
     def effective_rest_calls_per_week(self) -> int:
-        """Weekly REST API call limit: plan tier base + addon."""
-        return self._plan_tier.rest_calls_per_week + (self.addon_rest_quota_bonus or 0)
+        """Weekly REST API call limit: plan tier base + addon (Issue #238)."""
+        return _zero_floor(self._plan_tier.rest_calls_per_week, self.addon_rest_quota_bonus)
 
     @property
     def effective_public_calls_per_day(self) -> int:
-        """Public REST API calls/day: plan tier base + addon."""
-        return self._plan_tier.public_calls_per_day + (self.addon_public_quota_bonus or 0)
+        """Public REST API calls/day: plan tier base + addon (Issue #238).
+
+        FREE and BASIC have ``public_calls_per_day == 0``. Access is also
+        gated by the ``public_contexts`` feature flag (``plan_tiers.py``
+        ``FEATURE_MIN_PLANS``); the zero-base guard here is defense-in-depth
+        in case the feature gate is ever bypassed (#569).
+        """
+        return _zero_floor(self._plan_tier.public_calls_per_day, self.addon_public_quota_bonus)
 
     @property
     def effective_public_calls_per_week(self) -> int:
-        """Weekly Public REST API call limit: plan tier base + addon."""
-        return self._plan_tier.public_calls_per_week + (self.addon_public_quota_bonus or 0)
+        """Weekly Public REST API call limit: plan tier base + addon (Issue #238)."""
+        return _zero_floor(self._plan_tier.public_calls_per_week, self.addon_public_quota_bonus)
 
     @property
     def effective_max_contexts(self) -> int:
         """Max contexts: plan tier base + addon."""
-        return self._plan_tier.max_contexts_per_workspace + (self.addon_context_bonus or 0)
+        return _zero_floor(self._plan_tier.max_contexts_per_workspace, self.addon_context_bonus)
 
     @property
     def effective_max_members(self) -> int:
-        """Max members: plan tier base + addon."""
-        return self._plan_tier.max_members_per_workspace + (self.addon_member_bonus or 0)
+        """Max members: plan tier base + addon (Issue #229)."""
+        return _zero_floor(self._plan_tier.max_members_per_workspace, self.addon_member_bonus)
 
     @property
     def effective_analysis_runs_per_day(self) -> int:
-        """Memory Broadlistening analysis runs/day: plan tier base + addon (Issue #494)."""
-        return self._plan_tier.analysis_runs_per_day + (self.addon_analysis_bonus or 0)
+        """Memory Broadlistening analysis runs/day: plan tier base + addon (Issue #494).
+
+        FREE and BASIC have ``analysis_runs_per_day == 0``. Access is also
+        gated by ``auth.analysis_gates.require_pro_tier`` which checks the
+        ``memory_analysis`` feature flag (``plan_tiers.py`` ``FEATURE_MIN_PLANS``);
+        the zero-base guard here is defense-in-depth in case that feature
+        gate is ever bypassed (#569).
+        """
+        return _zero_floor(self._plan_tier.analysis_runs_per_day, self.addon_analysis_bonus)
 
     @property
     def effective_storage_limit_bytes(self) -> int:
@@ -1332,10 +1350,15 @@ class Workspace(Base):
         ``addon_storage_bonus_mb`` stores the bonus in MB to align with the
         ``ADDON_UNIT_VALUES["extra_storage"]`` unit; the conversion to bytes
         happens here so callers always see a single unit at the boundary.
+
+        Defense-in-depth: addon bytes are computed first, then passed through
+        ``_zero_floor`` (#569). If a future tier sets ``storage_limit_bytes == 0``
+        — and ``api/routes/files.py:reserve_upload`` does not currently have a
+        tier-feature gate ahead of the limit check — the zero-floor here is
+        what stops a stray ``WorkspaceAddon`` row from granting storage access.
         """
-        return (
-            self._plan_tier.storage_limit_bytes + (self.addon_storage_bonus_mb or 0) * 1024 * 1024
-        )
+        addon_bytes = (self.addon_storage_bonus_mb or 0) * 1024 * 1024
+        return _zero_floor(self._plan_tier.storage_limit_bytes, addon_bytes)
 
     @property
     def effective_sleep_enabled_contexts_limit(self) -> int:

--- a/backend/tests/models/test_auth_effective_limits.py
+++ b/backend/tests/models/test_auth_effective_limits.py
@@ -1,0 +1,122 @@
+"""Defense-in-depth tests for ``effective_*_limit`` properties (Issue #569).
+
+Verifies the ``_zero_floor`` rule: when a plan tier's base value is 0,
+no addon bonus can raise the effective limit above 0. This closes a
+bypass where a misconfigured Stripe SKU or a manual ``WorkspaceAddon``
+SQL insert on a zero-base tier would otherwise grant access to a
+feature the tier explicitly excludes.
+
+The rule was established for ``sleep_enabled_contexts_limit`` in #560 /
+PR #568 and is now applied uniformly to all 12 ``effective_*_limit``
+properties via ``models.auth._zero_floor``. These tests are
+ORM-mock-only (no DB) so they run in ``make test-local``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from models.auth import Workspace, _zero_floor
+
+
+class TestZeroFloorHelper:
+    """Direct unit tests for the shared helper."""
+
+    @pytest.mark.parametrize(
+        ("base", "addon", "expected"),
+        [
+            (0, 0, 0),
+            (0, 100, 0),  # bypass attempt — addon must be ignored
+            (0, None, 0),
+            (1, 0, 1),
+            (1, None, 1),
+            (10, 5, 15),
+            (100, None, 100),  # None addon must be treated as 0
+        ],
+    )
+    def test_zero_floor(self, base, addon, expected):
+        assert _zero_floor(base, addon) == expected
+
+
+# (property, tier_attr, addon_attr, addon_scale)
+# ``addon_scale`` is the multiplier applied to the addon column before
+# stacking; 1 for plain counts, (1024 * 1024) for storage (MB→bytes).
+EFFECTIVE_PROPERTIES = [
+    ("effective_memory_limit", "memory_limit", "addon_memory_bonus", 1),
+    ("effective_mcp_calls_per_day", "mcp_calls_per_day", "addon_mcp_quota_bonus", 1),
+    ("effective_mcp_calls_per_week", "mcp_calls_per_week", "addon_mcp_quota_bonus", 1),
+    ("effective_rest_calls_per_day", "rest_calls_per_day", "addon_rest_quota_bonus", 1),
+    ("effective_rest_calls_per_week", "rest_calls_per_week", "addon_rest_quota_bonus", 1),
+    ("effective_public_calls_per_day", "public_calls_per_day", "addon_public_quota_bonus", 1),
+    ("effective_public_calls_per_week", "public_calls_per_week", "addon_public_quota_bonus", 1),
+    ("effective_max_contexts", "max_contexts_per_workspace", "addon_context_bonus", 1),
+    ("effective_max_members", "max_members_per_workspace", "addon_member_bonus", 1),
+    ("effective_analysis_runs_per_day", "analysis_runs_per_day", "addon_analysis_bonus", 1),
+    (
+        "effective_storage_limit_bytes",
+        "storage_limit_bytes",
+        "addon_storage_bonus_mb",
+        1024 * 1024,
+    ),
+    (
+        "effective_sleep_enabled_contexts_limit",
+        "sleep_enabled_contexts_limit",
+        "addon_sleep_contexts_bonus",
+        1,
+    ),
+]
+
+
+class TestZeroBaseBypassClosed:
+    """For every ``effective_*_limit``, a synthetic tier with base=0 and
+    a positive addon must still report effective=0. This is the core
+    anti-bypass invariant of #569.
+
+    Properties are invoked via the descriptor ``fget`` so we avoid
+    constructing a real ``Workspace`` row (which would require every
+    NOT NULL column to be populated just to read one derived value).
+    """
+
+    @pytest.mark.parametrize(
+        ("prop_name", "tier_attr", "addon_attr", "addon_scale"),
+        EFFECTIVE_PROPERTIES,
+        ids=[p[0] for p in EFFECTIVE_PROPERTIES],
+    )
+    def test_zero_base_with_addon_returns_zero(self, prop_name, tier_attr, addon_attr, addon_scale):
+        tier = MagicMock()
+        setattr(tier, tier_attr, 0)
+        ws = MagicMock()
+        ws._plan_tier = tier
+        setattr(ws, addon_attr, 5)  # any positive addon must be ignored
+        assert getattr(Workspace, prop_name).fget(ws) == 0
+
+    @pytest.mark.parametrize(
+        ("prop_name", "tier_attr", "addon_attr", "addon_scale"),
+        EFFECTIVE_PROPERTIES,
+        ids=[p[0] for p in EFFECTIVE_PROPERTIES],
+    )
+    def test_nonzero_base_stacks_addon(self, prop_name, tier_attr, addon_attr, addon_scale):
+        tier = MagicMock()
+        setattr(tier, tier_attr, 100)
+        ws = MagicMock()
+        ws._plan_tier = tier
+        setattr(ws, addon_attr, 5)
+        assert getattr(Workspace, prop_name).fget(ws) == 100 + 5 * addon_scale
+
+    @pytest.mark.parametrize(
+        ("prop_name", "tier_attr", "addon_attr", "addon_scale"),
+        EFFECTIVE_PROPERTIES,
+        ids=[p[0] for p in EFFECTIVE_PROPERTIES],
+    )
+    def test_none_addon_treated_as_zero(self, prop_name, tier_attr, addon_attr, addon_scale):
+        """Fresh ``WorkspaceAddon``-less workspaces have ``NULL`` bonus
+        columns. Must not raise ``TypeError`` on ``None + int``.
+        """
+        tier = MagicMock()
+        setattr(tier, tier_attr, 100)
+        ws = MagicMock()
+        ws._plan_tier = tier
+        setattr(ws, addon_attr, None)
+        assert getattr(Workspace, prop_name).fget(ws) == 100

--- a/backend/tests/models/test_auth_effective_limits.py
+++ b/backend/tests/models/test_auth_effective_limits.py
@@ -111,8 +111,12 @@ class TestZeroBaseBypassClosed:
         ids=[p[0] for p in EFFECTIVE_PROPERTIES],
     )
     def test_none_addon_treated_as_zero(self, prop_name, tier_attr, addon_attr, addon_scale):
-        """Fresh ``WorkspaceAddon``-less workspaces have ``NULL`` bonus
-        columns. Must not raise ``TypeError`` on ``None + int``.
+        """The ``addon_*_bonus`` columns are ``nullable=False`` with
+        ``server_default="0"`` so the DB never serves ``None``. This case
+        covers transient ORM objects (unflushed instances where the
+        attribute is still unset) and the defensive ``or 0`` coalescing
+        in ``_zero_floor`` — the helper must not raise ``TypeError`` if
+        it ever sees ``None``.
         """
         tier = MagicMock()
         setattr(tier, tier_attr, 100)


### PR DESCRIPTION
Closes #569

## Summary
- Extract the inline zero-base-tier guard from `effective_sleep_enabled_contexts_limit` (introduced in #560 / PR #568) into a module-private helper `_zero_floor(base, addon)` in `models/auth.py`.
- Apply the helper to all 12 `effective_*_limit` properties on `Workspace` so a `WorkspaceAddon` row cannot raise an effective limit above 0 when the plan-tier base is 0.
- Closes a real bypass on `effective_rest_calls_per_day/week`, `effective_public_calls_per_day/week`, and `effective_analysis_runs_per_day` for the FREE/BASIC tiers; future-proofs the other 6 properties for any tier that adds a `base=0` field.

## Implementation notes
- Helper lives at the top of `models/auth.py` as a module-private function (not in `utils/quota_helpers.py` or `services/`). Rationale: zero callers outside this module today, and the dependency direction (`services → models`) rules out placing it in `services`.
- `effective_storage_limit_bytes` computes `addon_bytes = (self.addon_storage_bonus_mb or 0) * 1024 * 1024` **before** calling the helper so the zero-floor check operates on the final bytes value — addons cannot bypass via the MB→bytes unit boundary.
- Per-property docstrings now record which tiers carry `base=0` today and which other gates (`FEATURE_MIN_PLANS`, `auth.analysis_gates.require_pro_tier`) provide partial protection. This makes the defense-in-depth structure readable from the property itself.
- Property signatures unchanged (`-> int`); all callers (`services/effective_quota_service.py`, `services/file_storage_service.py:248`, `services/context_service.py:570`, REST/MCP/Public quota services) keep working.

### Contract change
Setting any `PlanTier.*_limit = 0` now means **"this feature is excluded from the tier and addons cannot raise it"** — encoded in the data, not by hard-coding plan names. A future paid tier with `base > 0` automatically gets addon stacking.

### Out of scope (follow-up issue candidate)
`services/quota_service.py:286` computes `max_contexts = plan.max_contexts_per_workspace + (workspace.addon_context_bonus or 0)` directly instead of reading `workspace.effective_max_contexts`. No active impact (every tier has `max_contexts_per_workspace > 0`) but it bypasses the new single-source-of-truth pattern. Will be tracked separately.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO lens, plus a /cto follow-up on helper placement)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/569-feat-fix-api-apply-zero-base-tier-defense-in.gate1.md
- ~/.claude/cache/gh-issue-driven/569-feat-fix-api-apply-zero-base-tier-defense-in.gate2.md

## Test plan
- [x] 43 new parametrized cases in `backend/tests/models/test_auth_effective_limits.py` (helper unit + 12 properties × 3 scenarios)
- [x] Existing tests pass: `tests/services/test_context_service_sleep_quota.py`, `tests/services/test_effective_quota_service.py`, `tests/services/test_file_storage_service.py`, `tests/api/test_workspace_quota_display.py` (111 total)
- [x] `make lint` clean for changed files
- [x] `make type-check` clean for `models/auth.py` (pre-existing external-dep noise unchanged)

🤖 Generated via /gh-issue-driven:ship
