### PR TITLE
refactor(db,api): SQLAlchemy 2.0 — DeclarativeBase + small models (Mapped[T] PR-A of 3, #370) (#594)

### DIFF
--- a/backend/src/db/base.py
+++ b/backend/src/db/base.py
@@ -11,15 +11,18 @@ from collections.abc import AsyncGenerator
 
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import Session, declarative_base, sessionmaker
+from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
 from utils.logger import get_logger
 from utils.url_redact import redact_db_url
 
 logger = get_logger(__name__)
 
+
 # SQLAlchemy Base for models
-Base = declarative_base()
+class Base(DeclarativeBase):
+    pass
+
 
 # Lazy initialization (to avoid import-time errors)
 engine = None

--- a/backend/src/models/bm25_drift.py
+++ b/backend/src/models/bm25_drift.py
@@ -4,10 +4,14 @@ Issue #343: One row per context per cron cycle, capturing the PSI score
 between memory-only and collection-global IDF distributions.
 """
 
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
 from sqlalchemy import (
     BigInteger,
     CheckConstraint,
-    Column,
     DateTime,
     ForeignKey,
     Index,
@@ -18,6 +22,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
@@ -40,23 +45,23 @@ class Bm25IdfDriftLog(Base):
 
     __tablename__ = "bm25_idf_drift_log"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    context_id = Column(
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    context_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=False,
     )
-    measured_at = Column(
+    measured_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         server_default=func.now(),
     )
-    psi = Column(Numeric(10, 6), nullable=True)
-    psi_status = Column(String(30), nullable=False)
-    m_memory_points = Column(Integer, nullable=False)
-    r_resource_points = Column(Integer, nullable=False)
-    num_terms = Column(Integer, nullable=False)
-    top_divergent_terms = Column(JSONB, nullable=True)
+    psi: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    psi_status: Mapped[str] = mapped_column(String(30), nullable=False)
+    m_memory_points: Mapped[int] = mapped_column(Integer, nullable=False)
+    r_resource_points: Mapped[int] = mapped_column(Integer, nullable=False)
+    num_terms: Mapped[int] = mapped_column(Integer, nullable=False)
+    top_divergent_terms: Mapped[list[dict[str, Any]] | None] = mapped_column(JSONB, nullable=True)
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/src/models/config.py
+++ b/backend/src/models/config.py
@@ -5,18 +5,22 @@ Issue #160: Renamed from Project to Context
 Issue #363: Config value storage in database
 """
 
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
 from sqlalchemy import (
     DECIMAL,
     TIMESTAMP,
     Boolean,
     CheckConstraint,
-    Column,
     DateTime,
     ForeignKey,
     Integer,
     String,
 )
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
 from db.base import Base
@@ -31,11 +35,13 @@ class ConfigOverride(Base):
 
     __tablename__ = "config_overrides"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    key = Column(String(255), unique=True, nullable=False, index=True)
-    value = Column(String(2000), nullable=False)
-    updated_by = Column(String(255), nullable=True)
-    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now())
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    key: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
+    value: Mapped[str] = mapped_column(String(2000), nullable=False)
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, server_default=func.now(), onupdate=func.now()
+    )
 
 
 class ContextSearchConfig(Base):
@@ -65,8 +71,8 @@ class ContextSearchConfig(Base):
 
     __tablename__ = "context_search_configs"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    context_id = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    context_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         unique=True,
@@ -75,24 +81,28 @@ class ContextSearchConfig(Base):
     )
 
     # Hybrid Search weights
-    semantic_weight = Column(DECIMAL(3, 2), nullable=False, default=0.60)
-    bm25_weight = Column(DECIMAL(3, 2), nullable=False, default=0.40)
+    semantic_weight: Mapped[Decimal] = mapped_column(DECIMAL(3, 2), nullable=False, default=0.60)
+    bm25_weight: Mapped[Decimal] = mapped_column(DECIMAL(3, 2), nullable=False, default=0.40)
 
     # Fetch factor
-    fetch_factor = Column(Integer, nullable=False, default=3)
+    fetch_factor: Mapped[int] = mapped_column(Integer, nullable=False, default=3)
 
     # Reranker settings
-    use_rerank = Column(Boolean, nullable=False, default=False)
-    reranker_provider = Column(String(20), default="voyage")
-    reranker_model = Column(String(50), default="rerank-2")
+    use_rerank: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    reranker_provider: Mapped[str | None] = mapped_column(String(20), default="voyage")
+    reranker_model: Mapped[str | None] = mapped_column(String(50), default="rerank-2")
 
     # Embedding configuration (Issue #146: Immutable after context creation)
-    embedding_model = Column(String(100), nullable=False, default="text-embedding-3-small")
-    embedding_dimensions = Column(Integer, nullable=False, default=512)
+    embedding_model: Mapped[str] = mapped_column(
+        String(100), nullable=False, default="text-embedding-3-small"
+    )
+    embedding_dimensions: Mapped[int] = mapped_column(Integer, nullable=False, default=512)
 
     # Timestamps
-    created_at = Column(TIMESTAMP(timezone=True), server_default=func.now(), nullable=False)
-    updated_at = Column(
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), server_default=func.now(), onupdate=func.now(), nullable=False
     )
 

--- a/backend/src/models/erasure.py
+++ b/backend/src/models/erasure.py
@@ -12,10 +12,13 @@ service deletes the user row itself; readers must therefore not assume
 ``erasure_requests.user_id`` joins to a live ``users.user_id``.
 """
 
+import uuid
+from datetime import datetime
+from typing import Any
+
 from sqlalchemy import (
     Boolean,
     CheckConstraint,
-    Column,
     DateTime,
     Index,
     String,
@@ -24,6 +27,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
@@ -81,43 +85,47 @@ class ErasureRequest(Base):
 
     __tablename__ = "erasure_requests"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
 
     # Subject of the erasure (OAuth2 sub). Not a FK — repo convention.
     # Indexed via the explicit Index() entry in __table_args__ below so the
     # index has a deterministic name and matches the migration shape.
-    user_id = Column(String(255), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False)
 
     # SHA256 of the user's email at request time. Plaintext email never on disk.
-    user_email_hash = Column(String(64), nullable=False)
+    user_email_hash: Mapped[str] = mapped_column(String(64), nullable=False)
 
     # Self user_id (self-service) or admin user_id (admin force-erase).
-    initiated_by = Column(String(255), nullable=False)
+    initiated_by: Mapped[str] = mapped_column(String(255), nullable=False)
 
-    is_self_service = Column(Boolean, nullable=False, default=False)
+    is_self_service: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
-    reason_code = Column(String(50), nullable=False)
-    reason_detail = Column(Text, nullable=True)
+    reason_code: Mapped[str] = mapped_column(String(50), nullable=False)
+    reason_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    status = Column(String(20), nullable=False, default=STATUS_PENDING)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default=STATUS_PENDING)
 
     # SHA256 of the one-time token; raw token in Redis only. Size is
     # exact (SHA256 hex = 64 chars) so the column does not imply a
     # different hash encoding.
-    confirm_token_hash = Column(String(64), nullable=True)
+    confirm_token_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
 
-    requested_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    confirmed_at = Column(DateTime(timezone=True), nullable=True)
-    scheduled_for = Column(DateTime(timezone=True), nullable=True)
-    started_at = Column(DateTime(timezone=True), nullable=True)
-    completed_at = Column(DateTime(timezone=True), nullable=True)
-    cancelled_at = Column(DateTime(timezone=True), nullable=True)
+    requested_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    confirmed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    scheduled_for: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    cancelled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
-    failure_reason = Column(Text, nullable=True)
-    deleted_data_summary = Column(JSONB, nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    deleted_data_summary: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
 
-    ip_address = Column(String(45), nullable=True)
-    user_agent = Column(String(255), nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Source the CHECK constraints from VALID_STATUSES / VALID_REASON_CODES
     # so adding a new state value never requires editing two places. The

--- a/backend/src/models/file_objects.py
+++ b/backend/src/models/file_objects.py
@@ -21,8 +21,8 @@ with ``backend='byo_*'`` and ``ref=<bucket URI>``.
 
 from __future__ import annotations
 
+import uuid
 from datetime import datetime
-from uuid import UUID, uuid4
 
 from sqlalchemy import (
     BigInteger,
@@ -34,8 +34,7 @@ from sqlalchemy import (
     String,
     func,
 )
-from sqlalchemy.dialects.postgresql import BYTEA
-from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.dialects.postgresql import BYTEA, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
@@ -58,9 +57,9 @@ class FileObject(Base):
 
     __tablename__ = "file_objects"
 
-    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4)
-    workspace_id: Mapped[UUID] = mapped_column(
-        PG_UUID(as_uuid=True),
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
@@ -157,8 +156,8 @@ class WorkspaceStorageUsage(Base):
 
     __tablename__ = "workspace_storage_usage"
 
-    workspace_id: Mapped[UUID] = mapped_column(
-        PG_UUID(as_uuid=True),
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         primary_key=True,
     )

--- a/backend/src/models/file_objects.py
+++ b/backend/src/models/file_objects.py
@@ -27,7 +27,6 @@ from uuid import UUID, uuid4
 from sqlalchemy import (
     BigInteger,
     CheckConstraint,
-    Column,
     DateTime,
     ForeignKey,
     Index,
@@ -37,6 +36,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import BYTEA
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
@@ -58,39 +58,41 @@ class FileObject(Base):
 
     __tablename__ = "file_objects"
 
-    id: Column[UUID] = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4)
-    workspace_id: Column[UUID] = Column(
+    id: Mapped[UUID] = mapped_column(PG_UUID(as_uuid=True), primary_key=True, default=uuid4)
+    workspace_id: Mapped[UUID] = mapped_column(
         PG_UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    sha256 = Column(String(64), nullable=False)
-    size_bytes = Column(BigInteger, nullable=False)
-    content_type = Column(String(255), nullable=False)
-    filename = Column(String(512), nullable=False)
+    sha256: Mapped[str] = mapped_column(String(64), nullable=False)
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    content_type: Mapped[str] = mapped_column(String(255), nullable=False)
+    filename: Mapped[str] = mapped_column(String(512), nullable=False)
 
-    storage_backend = Column(
+    storage_backend: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         server_default="r2",
         comment="'r2' (Phase 1), 'pg_inline' (reserved Phase 1.5)",
     )
-    storage_key = Column(String(1024), nullable=True)
-    inline_bytes = Column(BYTEA, nullable=True)
+    storage_key: Mapped[str | None] = mapped_column(String(1024), nullable=True)
+    inline_bytes: Mapped[bytes | None] = mapped_column(BYTEA, nullable=True)
 
-    status = Column(
+    status: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         server_default="reserved",
         comment="'reserved' | 'uploaded' | 'failed'",
     )
-    expires_at: Column[datetime] = Column(DateTime, nullable=True)
-    created_by = Column(String(255), nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[str] = mapped_column(String(255), nullable=False)
 
-    created_at: Column[datetime] = Column(DateTime, nullable=False, server_default=func.now())
-    uploaded_at: Column[datetime] = Column(DateTime, nullable=True)
-    deleted_at: Column[datetime] = Column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    uploaded_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     __table_args__ = (
         CheckConstraint(
@@ -155,14 +157,14 @@ class WorkspaceStorageUsage(Base):
 
     __tablename__ = "workspace_storage_usage"
 
-    workspace_id: Column[UUID] = Column(
+    workspace_id: Mapped[UUID] = mapped_column(
         PG_UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    used_bytes = Column(BigInteger, nullable=False, server_default="0")
-    file_count = Column(Integer, nullable=False, server_default="0")
-    updated_at: Column[datetime] = Column(
+    used_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, server_default="0")
+    file_count: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    updated_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
     )
 

--- a/backend/src/models/hub_tag.py
+++ b/backend/src/models/hub_tag.py
@@ -15,10 +15,12 @@ Design:
       computed state.
 """
 
+import uuid
+from datetime import datetime
+
 from sqlalchemy import (
     BigInteger,
     CheckConstraint,
-    Column,
     DateTime,
     Float,
     ForeignKey,
@@ -29,6 +31,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
@@ -54,17 +57,19 @@ class HubTagCache(Base):
 
     __tablename__ = "hub_tag_cache"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    workspace_id = Column(UUID(as_uuid=True), nullable=False)
-    context_id = Column(
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
+    context_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=False,
     )
-    hub_tags = Column(JSONB, nullable=False, server_default=text("'[]'::jsonb"))
-    memory_count = Column(Integer, nullable=False)
-    threshold_used = Column(Float, nullable=False)
-    computed_at = Column(
+    hub_tags: Mapped[list[str]] = mapped_column(
+        JSONB, nullable=False, server_default=text("'[]'::jsonb")
+    )
+    memory_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    threshold_used: Mapped[float] = mapped_column(Float, nullable=False)
+    computed_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
         server_default=func.now(),

--- a/backend/src/models/llm_pricing.py
+++ b/backend/src/models/llm_pricing.py
@@ -45,10 +45,12 @@ PostgreSQL ENUM) — the rest of this codebase uses the same pattern
 PG ENUMs are painful to ALTER and don't play nicely with alembic.
 """
 
+from datetime import datetime
+from decimal import Decimal
+
 from sqlalchemy import (
     BigInteger,
     CheckConstraint,
-    Column,
     DateTime,
     Integer,
     Numeric,
@@ -56,6 +58,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
@@ -103,44 +106,46 @@ class LLMPricing(Base):
 
     __tablename__ = "llm_pricing"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    provider = Column(String(50), nullable=False)
-    model = Column(String(100), nullable=False)
-    unit_type = Column(String(30), nullable=False)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    unit_type: Mapped[str] = mapped_column(String(30), nullable=False)
     # Naive ``DateTime`` to match the codebase convention (everything stored
     # in UTC; see ``sleep_reports.started_at`` and the rest of
     # ``backend/src/models/``). Mixing tz-aware and tz-naive datetimes in
     # SQLAlchemy comparisons raises TypeError at the Python layer, so the
     # column type must agree with the join target. Callers pass naive UTC
     # datetimes (e.g. ``utils.datetime.utcnow()``).
-    effective_from = Column(DateTime, nullable=False)
+    effective_from: Mapped[datetime] = mapped_column(DateTime, nullable=False)
 
     # Tier breakpoint columns. ``context_min_tokens`` defaults to 0 (no
     # lower bound). ``context_max_tokens`` is nullable for "no upper bound";
     # most rows have NULL here. Gemini 2.5 Pro is the canonical multi-tier
     # case in the 2026-04-28 seed.
-    context_min_tokens = Column(Integer, nullable=False, default=0)
-    context_max_tokens = Column(Integer, nullable=True)
+    context_min_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    context_max_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # NUMERIC(14, 10) gives 4 digits before the decimal and 10 after — enough
     # for prices like 25.0000000000 (Claude Opus output, $25/1M) down to
     # 0.0000200000 (text-embedding-3-small, $0.02/1M) without rounding.
-    pricing_model = Column(
+    pricing_model: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         default="per_token",
         server_default="per_token",
     )
 
-    price_per_unit = Column(Numeric(14, 10), nullable=False)
-    currency = Column(String(3), nullable=False, default="USD")
+    price_per_unit: Mapped[Decimal] = mapped_column(Numeric(14, 10), nullable=False)
+    currency: Mapped[str] = mapped_column(String(3), nullable=False, default="USD")
 
     # Bridges per-1M-tokens (1_000_000) and per-1k-search-units (1_000)
     # so both fit the same row shape. Default 1_000_000 matches the
     # majority-case (token-based providers).
-    unit_denominator = Column(BigInteger, nullable=False, default=1_000_000)
+    unit_denominator: Mapped[int] = mapped_column(BigInteger, nullable=False, default=1_000_000)
 
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
 
     __table_args__ = (
         # Composite uniqueness — multiple rows for the same


### PR DESCRIPTION
Closes #594

## Summary

- Migrate `backend/src/db/base.py` from `declarative_base()` (1.x) to `class Base(DeclarativeBase)` (2.0), and 6 small model files (`config / hub_tag / bm25_drift / llm_pricing / erasure / file_objects`) from `Column(...)` to `Mapped[T] = mapped_column(...)`.
- First of 3 PRs in the #370 SQLAlchemy 2.0 migration epic — establishes the pattern (UUID alias convention, `Mapped[T | None]` nullable annotation, dual default preservation) for sibling PRs #595 (auth.py) and #596 (remaining models + CI guard).
- Pure annotation-only refactor: zero schema change, zero migration file, zero test regression vs `main`.

## Implementation notes

- **Per-file atomic commits** (7 commits, 1 file each). Pattern: `import uuid` + bare `UUID` SA dialect type + `Mapped[uuid.UUID]` annotation. Standardized in the final commit (`d34e473`) after `/simplify` flagged a pre-existing inconsistency in `file_objects.py`.
- **Nullable columns** (23 total) annotated as `Mapped[T | None]`. Explicit `nullable=True` kwargs preserved for readability vs implicit-from-annotation form.
- **JSONB shape annotations**: `bm25_drift.top_divergent_terms` -> `Mapped[list[dict[str, Any]] | None]`, `erasure.deleted_data_summary` -> `Mapped[dict[str, Any] | None]`. Advisory at the type level; JSONB doesn't enforce shape at the DB level.
- **Dual default pattern preserved** (memory c4e43074): `llm_pricing.pricing_model` keeps both `default="per_token"` (Python-side) and `server_default="per_token"` (SQL-side) on the `mapped_column()` call.
- **`server_default=func.gen_random_uuid()`** (erasure.id), `server_default=text("'[]'::jsonb")` (hub_tag.hub_tags), `server_default=func.now()` (various timestamps), all `__table_args__` (CheckConstraint, UniqueConstraint, Index, `postgresql_where`) preserved verbatim.
- **`from __future__ import annotations`** in `file_objects.py` (pre-existing) is safe with SA 2.0 `Mapped[T]`: SA uses `get_type_hints()` to resolve string annotations against module globals; all required types (`uuid`, `datetime`, `UUID`, `BYTEA`, `bytes`, `str`, `int`) are imported at module scope.

### Pyright impact (strict mode, 9 normally-suppressed rules temporarily re-enabled to forecast)

| State | errors | warnings |
|---|---:|---:|
| `main` HEAD (pre-#594) | 5 | **1,690** |
| post-#594 (this PR) | 5 | **1,603** |

**Delta: -87 warnings** (~5.2% reduction). 83 `Column(` definitions converted; project-wide total is ~548, so siblings #595 (215 from auth.py) and #596 (250 from 6 files) will produce the bulk of the remaining drop. Per-rule top movers: `reportArgumentType` -59, `reportGeneralTypeIssues` -27.

**Bonus finding**: `backend/pyproject.toml:181-190` disables 9 pyright rules to silence Column-vs-instance warnings (`reportArgumentType`, `reportAttributeAccessIssue`, `reportGeneralTypeIssues`, etc.). After #594 + #595 + #596 land, PR-C (#596) should re-enable these as part of acceptance. Recorded as a comment on epic #370.

### Test verification

- **Unit tests** (`docker exec kagura-api python -m pytest --continue-on-collection-errors --ignore=tests/e2e --ignore=tests/integration`): 1654 passed / 38 failed (all pre-existing, identical to main) / 128 skipped / 32 collection errors (pre-existing, optional deps `umap`/`aioboto3`/`ollama`/`botocore` not installed in test image)
- **Integration tests** (`docker exec kagura-api python -m pytest tests/integration/`): 10 passed / 26 failed (all pre-existing, identical to main) / 53 skipped
- **Regression vs main**: ZERO new failures (verified by `comm -23 <branch failures> <main failures>`)

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/594-feat-refactor-db-api-sqlalchemy-2-0-declarati.gate1.md`
- `~/.claude/cache/gh-issue-driven/594-feat-refactor-db-api-sqlalchemy-2-0-declarati.gate2.md`

🤖 Generated via /gh-issue-driven:ship
