### PR TITLE
refactor(api): auth.py SQLAlchemy 2.0 migration (Mapped[T] PR-B of 3, #370) (#595)

### DIFF
--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1760,21 +1760,21 @@ class PlanChange(Base):
     workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False
     )
-    old_plan: Mapped[str | None] = mapped_column(String(20))
+    old_plan: Mapped[str | None] = mapped_column(String(20), nullable=True)
     new_plan: Mapped[str] = mapped_column(String(20), nullable=False)
     changed_by: Mapped[str] = mapped_column(String(255), nullable=False)
     changed_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
-    reason: Mapped[str | None] = mapped_column(Text)
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Old limits (for audit)
-    old_memory_limit: Mapped[int | None] = mapped_column(Integer)
-    old_daily_api_limit: Mapped[int | None] = mapped_column(Integer)
-    old_weekly_api_limit: Mapped[int | None] = mapped_column(Integer)
+    old_memory_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    old_daily_api_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    old_weekly_api_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # New limits (for audit)
-    new_memory_limit: Mapped[int | None] = mapped_column(Integer)
-    new_daily_api_limit: Mapped[int | None] = mapped_column(Integer)
-    new_weekly_api_limit: Mapped[int | None] = mapped_column(Integer)
+    new_memory_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    new_daily_api_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    new_weekly_api_limit: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     __table_args__ = (
         Index("idx_plan_changes_workspace", "workspace_id"),

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -17,6 +17,7 @@ Provides ORM models for:
 
 import secrets
 import uuid
+from datetime import date as date_type
 from datetime import datetime
 from functools import cached_property
 from typing import Any
@@ -26,7 +27,6 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     Date,
     DateTime,
     ForeignKey,
@@ -1031,21 +1031,21 @@ class UsageStats(Base):
 
     __tablename__ = "usage_stats"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(String(255), nullable=False, index=True)
-    endpoint = Column(String(255), nullable=False)
-    method = Column(String(10), nullable=False)
-    status_code = Column(Integer, nullable=False)
-    response_time_ms = Column(Integer, nullable=True)
-    created_at = Column(DateTime, nullable=False, default=func.now())
-    date = Column(Date, nullable=False, index=True)
-    context_id = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    endpoint: Mapped[str] = mapped_column(String(255), nullable=False)
+    method: Mapped[str] = mapped_column(String(10), nullable=False)
+    status_code: Mapped[int] = mapped_column(Integer, nullable=False)
+    response_time_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=func.now())
+    date: Mapped[date_type] = mapped_column(Date, nullable=False, index=True)
+    context_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("contexts.id", ondelete="SET NULL"), nullable=True
     )
-    workspace_id = Column(
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="SET NULL"), nullable=True
     )
-    project_id = Column(
+    project_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True), nullable=True
     )  # Deprecated, kept for backward compatibility
 
@@ -1077,13 +1077,15 @@ class UserPlan(Base):
 
     __tablename__ = "user_plans"
 
-    user_id = Column(String(255), primary_key=True)
-    plan_name = Column(String(50), nullable=False, default="free")
-    memory_limit = Column(Integer, nullable=False, default=1000)
-    daily_api_limit = Column(Integer, nullable=False, default=1000)
-    weekly_api_limit = Column(Integer, nullable=False, default=5000)
-    created_at = Column(DateTime, nullable=False, default=func.now())
-    updated_at = Column(DateTime, nullable=False, default=func.now(), onupdate=func.now())
+    user_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    plan_name: Mapped[str] = mapped_column(String(50), nullable=False, default="free")
+    memory_limit: Mapped[int] = mapped_column(Integer, nullable=False, default=1000)
+    daily_api_limit: Mapped[int] = mapped_column(Integer, nullable=False, default=1000)
+    weekly_api_limit: Mapped[int] = mapped_column(Integer, nullable=False, default=5000)
+    created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=func.now(), onupdate=func.now()
+    )
 
     __table_args__ = (Index("idx_user_plans_plan_name", "plan_name"),)
 
@@ -1754,25 +1756,25 @@ class PlanChange(Base):
 
     __tablename__ = "plan_changes"
 
-    id: int = Column(Integer, primary_key=True, autoincrement=True)
-    workspace_id: UUID = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False
     )
-    old_plan: str | None = Column(String(20))
-    new_plan: str = Column(String(20), nullable=False)
-    changed_by: str = Column(String(255), nullable=False)
-    changed_at: datetime = Column(DateTime, default=func.now(), nullable=False)
-    reason: str | None = Column(Text)
+    old_plan: Mapped[str | None] = mapped_column(String(20))
+    new_plan: Mapped[str] = mapped_column(String(20), nullable=False)
+    changed_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    changed_at: Mapped[datetime] = mapped_column(DateTime, default=func.now(), nullable=False)
+    reason: Mapped[str | None] = mapped_column(Text)
 
     # Old limits (for audit)
-    old_memory_limit: int | None = Column(Integer)
-    old_daily_api_limit: int | None = Column(Integer)
-    old_weekly_api_limit: int | None = Column(Integer)
+    old_memory_limit: Mapped[int | None] = mapped_column(Integer)
+    old_daily_api_limit: Mapped[int | None] = mapped_column(Integer)
+    old_weekly_api_limit: Mapped[int | None] = mapped_column(Integer)
 
     # New limits (for audit)
-    new_memory_limit: int | None = Column(Integer)
-    new_daily_api_limit: int | None = Column(Integer)
-    new_weekly_api_limit: int | None = Column(Integer)
+    new_memory_limit: Mapped[int | None] = mapped_column(Integer)
+    new_daily_api_limit: Mapped[int | None] = mapped_column(Integer)
+    new_weekly_api_limit: Mapped[int | None] = mapped_column(Integer)
 
     __table_args__ = (
         Index("idx_plan_changes_workspace", "workspace_id"),
@@ -1813,14 +1815,18 @@ class MCPToolDescription(Base):
 
     __tablename__ = "mcp_tool_descriptions"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    tool_name = Column(String(50), nullable=False, index=True)
-    locale = Column(String(10), nullable=False, server_default="en")
-    description = Column(Text, nullable=False)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    tool_name: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    locale: Mapped[str] = mapped_column(String(10), nullable=False, server_default="en")
+    description: Mapped[str] = mapped_column(Text, nullable=False)
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
 
     # Constraints
     __table_args__ = (

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -409,22 +409,24 @@ class OAuth2Client(Base):
 
     __tablename__ = "oauth_clients"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # Client Identity
-    client_id = Column(String(48), nullable=False, unique=True, index=True)
-    client_secret_hash = Column(String(64), nullable=False)  # SHA256 hash (always required)
-    client_name = Column(String(100), nullable=False)
+    client_id: Mapped[str] = mapped_column(String(48), nullable=False, unique=True, index=True)
+    client_secret_hash: Mapped[str] = mapped_column(
+        String(64), nullable=False
+    )  # SHA256 hash (always required)
+    client_name: Mapped[str] = mapped_column(String(100), nullable=False)
     # Issue #519 (#513 follow-up): DCR-registered clients (RFC 7591) have no
     # human owner — ``dynamic_client_registration`` creates them with
     # ``owner_id=None``. Admin-managed clients still record the creating
     # user's id. Migration revision ``d04_519_oauth_owner_nullable`` drops
     # the corresponding NOT NULL DB constraint.
-    owner_id = Column(String(255), nullable=True, index=True)
+    owner_id: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
 
     # Issue #169: Workspace-scoped OAuth clients (access all contexts in workspace)
     # Migration 034: context_id removed (deprecated)
-    workspace_id = Column(
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=True,
@@ -432,32 +434,44 @@ class OAuth2Client(Base):
     )
 
     # OAuth2 Configuration
-    redirect_uris = Column(JSON, nullable=False)  # ["https://example.com/callback"]
-    grant_types = Column(JSON, nullable=False, default=["authorization_code", "refresh_token"])
-    response_types = Column(JSON, nullable=False, default=["code"])
-    scope = Column(
+    redirect_uris: Mapped[list[str]] = mapped_column(
+        JSON, nullable=False
+    )  # ["https://example.com/callback"]
+    grant_types: Mapped[list[str]] = mapped_column(
+        JSON, nullable=False, default=["authorization_code", "refresh_token"]
+    )
+    response_types: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=["code"])
+    scope: Mapped[str] = mapped_column(
         String(255),
         nullable=False,
         default="memory:read memory:write offline_access",  # Issue #132: offline_access for refresh token
     )
-    token_endpoint_auth_method = Column(String(50), nullable=False, default="client_secret_post")
+    token_endpoint_auth_method: Mapped[str] = mapped_column(
+        String(50), nullable=False, default="client_secret_post"
+    )
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
 
     # Migration 034: Visibility control (Zero-knowledge model)
-    hidden_at = Column(DateTime, nullable=True)
-    visibility_expires_at = Column(DateTime, nullable=True)
+    hidden_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    visibility_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Migration 035: Encrypted plaintext secret for display until hidden
-    plaintext_secret_encrypted = Column(String, nullable=True)
+    plaintext_secret_encrypted: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Migration 036: Provider type (claude, chatgpt, custom)
-    provider = Column(String(50), nullable=False, server_default="custom")
+    provider: Mapped[str] = mapped_column(String(50), nullable=False, server_default="custom")
 
     # Relationships
-    tokens = relationship("OAuth2Token", back_populates="client", cascade="all, delete")
+    tokens: Mapped[list["OAuth2Token"]] = relationship(
+        "OAuth2Token", back_populates="client", cascade="all, delete"
+    )
 
     def __repr__(self) -> str:
         """String representation."""
@@ -636,27 +650,27 @@ class OAuth2AuthorizationCode(Base):
 
     __tablename__ = "oauth_authorization_codes"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # Authorization Code Data
-    code = Column(String(120), nullable=False, unique=True, index=True)
-    client_id = Column(String(48), nullable=False, index=True)
-    user_id = Column(String(255), nullable=False, index=True)
+    code: Mapped[str] = mapped_column(String(120), nullable=False, unique=True, index=True)
+    client_id: Mapped[str] = mapped_column(String(48), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # OAuth2 Flow Data
-    redirect_uri = Column(String(512), nullable=False)
-    scope = Column(String(255), nullable=True)
+    redirect_uri: Mapped[str] = mapped_column(String(512), nullable=False)
+    scope: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # PKCE Support (RFC 7636 - not enforced but kept for future)
-    code_challenge = Column(String(128), nullable=True)
-    code_challenge_method = Column(String(10), nullable=True)
+    code_challenge: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    code_challenge_method: Mapped[str | None] = mapped_column(String(10), nullable=True)
 
     # RFC 8707 Resource Indicators (Issue #157)
-    resource = Column(String(512), nullable=True)  # Audience for token
+    resource: Mapped[str | None] = mapped_column(String(512), nullable=True)  # Audience for token
 
     # Timestamps
-    auth_time = Column(DateTime, nullable=False, server_default=func.now())
-    expires_at = Column(DateTime, nullable=False, index=True)
+    auth_time: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, index=True)
 
     # Indexes
     __table_args__ = (
@@ -768,27 +782,29 @@ class OAuth2DeviceCode(Base):
 
     __tablename__ = "oauth_device_codes"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
-    device_code = Column(String(255), nullable=False, unique=True, index=True)
-    user_code = Column(String(8), nullable=False, unique=True, index=True)
-    client_id = Column(
+    device_code: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    user_code: Mapped[str] = mapped_column(String(8), nullable=False, unique=True, index=True)
+    client_id: Mapped[str] = mapped_column(
         String(48),
         ForeignKey("oauth_clients.client_id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    user_id = Column(String(255), nullable=True)
-    scope = Column(String(255), nullable=True)
+    user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    scope: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
-    expires_at = Column(DateTime, nullable=False, index=True)
-    last_polled_at = Column(DateTime, nullable=True)
-    denied_at = Column(DateTime, nullable=True)
-    authorized_at = Column(DateTime, nullable=True)
+    expires_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, index=True)
+    last_polled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    denied_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    authorized_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
 
-    client = relationship("OAuth2Client")
+    client: Mapped["OAuth2Client"] = relationship("OAuth2Client")
 
     def __repr__(self) -> str:
         return f"<OAuth2DeviceCode(device_code='{self.device_code[:8]}...', client='{self.client_id}')>"
@@ -842,39 +858,41 @@ class OAuth2Token(Base):
 
     __tablename__ = "oauth_tokens"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # Token Owner
-    client_id = Column(
+    client_id: Mapped[str] = mapped_column(
         String(48),
         ForeignKey("oauth_clients.client_id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    user_id = Column(String(255), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # Token Data
-    token_type = Column(String(20), nullable=False, default="Bearer")
-    access_token = Column(String(255), nullable=False, unique=True, index=True)
-    refresh_token = Column(String(255), nullable=True, unique=True, index=True)
-    scope = Column(String(255), nullable=True)
+    token_type: Mapped[str] = mapped_column(String(20), nullable=False, default="Bearer")
+    access_token: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    refresh_token: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, unique=True, index=True
+    )
+    scope: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Status
-    revoked = Column(Boolean, nullable=False, default=False, index=True)
+    revoked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, index=True)
 
     # Timestamps
-    issued_at = Column(DateTime, nullable=False, server_default=func.now())
-    access_token_revoked_at = Column(DateTime, nullable=True)
-    refresh_token_revoked_at = Column(DateTime, nullable=True)
+    issued_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
+    access_token_revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    refresh_token_revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Expiration
-    expires_in = Column(Integer, nullable=False, default=3600)  # 1 hour
+    expires_in: Mapped[int] = mapped_column(Integer, nullable=False, default=3600)  # 1 hour
 
     # RFC 8707 Resource Indicators (Issue #157)
-    resource = Column(String(512), nullable=True)  # Audience claim (aud)
+    resource: Mapped[str | None] = mapped_column(String(512), nullable=True)  # Audience claim (aud)
 
     # Relationships
-    client = relationship("OAuth2Client", back_populates="tokens")
+    client: Mapped["OAuth2Client"] = relationship("OAuth2Client", back_populates="tokens")
 
     # Indexes
     __table_args__ = (

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -16,8 +16,10 @@ Provides ORM models for:
 """
 
 import secrets
+import uuid
 from datetime import datetime
 from functools import cached_property
+from typing import Any
 
 from sqlalchemy import (
     JSON,
@@ -36,7 +38,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from db.base import Base
 from utils.datetime import utcnow
@@ -73,28 +75,30 @@ class User(Base):
 
     __tablename__ = "users"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # OAuth2 Identity
-    email = Column(String(255), nullable=False, unique=True, index=True)
-    user_id = Column(String(255), nullable=False, unique=True, index=True)
-    name = Column(String(255), nullable=True)
-    picture = Column(String(512), nullable=True)
+    email: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    picture: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
     # Issue #175: User Preferences
-    timezone = Column(String(50), nullable=False, default="UTC", index=True)
+    timezone: Mapped[str] = mapped_column(String(50), nullable=False, default="UTC", index=True)
 
     # Issue #221: i18n support
-    locale = Column(String(10), nullable=False, default="en", index=True)
+    locale: Mapped[str] = mapped_column(String(10), nullable=False, default="en", index=True)
 
     # Role & Permissions
-    role = Column(String(50), nullable=False, default="user", index=True)
+    role: Mapped[str] = mapped_column(String(50), nullable=False, default="user", index=True)
 
     # Issue #166: System Admin Protection
-    is_initial_admin = Column(Boolean, nullable=False, default=False, index=True)
+    is_initial_admin: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, index=True
+    )
 
     # Workspace (Issue #115 Phase B)
-    current_workspace_id = Column(
+    current_workspace_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="SET NULL"),
         nullable=True,
@@ -104,20 +108,32 @@ class User(Base):
     # Issue #246: current_context_id removed (context always explicit from Frontend/API)
 
     # Issue #51: Password + MFA authentication
-    login_id = Column(String(255), nullable=True, unique=True, index=True)
-    password_hash = Column(String(255), nullable=True)
-    auth_method = Column(String(20), nullable=False, default="oauth", index=True)
-    totp_secret = Column(String(255), nullable=True)  # Fernet-encrypted
-    totp_enabled = Column(Boolean, nullable=False, default=False)
+    login_id: Mapped[str | None] = mapped_column(
+        String(255), nullable=True, unique=True, index=True
+    )
+    password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    auth_method: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="oauth", index=True
+    )
+    totp_secret: Mapped[str | None] = mapped_column(String(255), nullable=True)  # Fernet-encrypted
+    totp_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
-    last_login_at = Column(DateTime, nullable=True)
-    auth_provider = Column(String(20), nullable=True)  # Issue #361: google, github
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
+    last_login_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    auth_provider: Mapped[str | None] = mapped_column(
+        String(20), nullable=True
+    )  # Issue #361: google, github
 
     # Relationships
-    current_workspace = relationship("Workspace", foreign_keys=[current_workspace_id])
+    current_workspace: Mapped["Workspace | None"] = relationship(
+        "Workspace", foreign_keys=[current_workspace_id]
+    )
 
     # Constraints
     __table_args__ = (
@@ -151,27 +167,29 @@ class AuditLog(Base):
 
     __tablename__ = "audit_logs"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # Who
-    user_email = Column(String(255), nullable=False, index=True)
-    user_id = Column(String(255), nullable=False)
+    user_email: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False)
 
     # What
-    action = Column(String(100), nullable=False, index=True)
-    resource = Column(String(255), nullable=False, index=True)
+    action: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    resource: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # Details (SHA256 hashes, NOT plaintext!)
-    old_value_hash = Column(String(64), nullable=True)
-    new_value_hash = Column(String(64), nullable=True)
-    user_metadata = Column(JSON, nullable=True)
+    old_value_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    new_value_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    user_metadata: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     # Context
-    ip_address = Column(String(45), nullable=True)
-    user_agent = Column(String, nullable=True)
+    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)
+    user_agent: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Timestamp
-    created_at = Column(DateTime, nullable=False, server_default=func.now(), index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), index=True
+    )
 
     def __repr__(self) -> str:
         return f"<AuditLog(action='{self.action}', resource='{self.resource}')>"
@@ -199,17 +217,17 @@ class APIKey(Base):
 
     __tablename__ = "api_keys"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # API Key Data
-    key_hash = Column(String(64), nullable=False, unique=True, index=True)
-    key_prefix = Column(String(16), nullable=False)
-    name = Column(String(100), nullable=False)
-    user_id = Column(String(255), nullable=False, index=True)
+    key_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    key_prefix: Mapped[str] = mapped_column(String(16), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # Issue #169: Workspace-scoped API keys (access all contexts in workspace)
     # Migration 034: context_id removed (deprecated)
-    workspace_id = Column(
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=True,
@@ -217,17 +235,19 @@ class APIKey(Base):
     )
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    last_used_at = Column(DateTime, nullable=True)
-    revoked_at = Column(DateTime, nullable=True)
-    expires_at = Column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Migration 034: Visibility control (Zero-knowledge model)
-    hidden_at = Column(DateTime, nullable=True)
-    visibility_expires_at = Column(DateTime, nullable=True)
+    hidden_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    visibility_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Migration 035: Encrypted plaintext for display until hidden
-    plaintext_encrypted = Column(String, nullable=True)
+    plaintext_encrypted: Mapped[str | None] = mapped_column(String, nullable=True)
 
     # Indexes
     __table_args__ = (
@@ -263,20 +283,20 @@ class ExternalAPIKey(Base):
 
     __tablename__ = "external_api_keys"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # API Key Identity
-    key_name = Column(String(100), nullable=False, index=True)
-    provider = Column(String(50), nullable=False, index=True)
+    key_name: Mapped[str] = mapped_column(String(100), nullable=False, index=True)
+    provider: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
 
     # Encrypted Value (Fernet)
-    encrypted_value = Column(String, nullable=False)
+    encrypted_value: Mapped[str] = mapped_column(String, nullable=False)
 
     # Owner
-    user_id = Column(String(255), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # Issue #82 → #160: Context-scoped external keys (renamed from project)
-    context_id = Column(
+    context_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=True,
@@ -284,7 +304,7 @@ class ExternalAPIKey(Base):
 
     # Issue #146: Workspace-scoped external keys
     # Issue #385: NOT NULL — every external API key belongs to exactly one workspace.
-    workspace_id = Column(
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
@@ -292,12 +312,18 @@ class ExternalAPIKey(Base):
     )
 
     # Issue #105: Enable/disable state
-    enabled = Column(Boolean, nullable=False, default=True, server_default="true")
+    enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=True, server_default="true"
+    )
 
     # Audit Trail
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
-    updated_by = Column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+    updated_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Indexes
     __table_args__ = (

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1156,49 +1156,63 @@ class Context(Base):
 
     __tablename__ = "contexts"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
-    workspace_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    name = Column(String(100), nullable=False)
-    display_name = Column(String(200), nullable=True)  # Human-readable display name
-    description = Column(Text, nullable=True)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    display_name: Mapped[str | None] = mapped_column(
+        String(200), nullable=True
+    )  # Human-readable display name
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Issue #160: LLM-oriented fields for get_context_info
-    summary = Column(Text, nullable=True)  # 200-500 chars context overview
-    usage_guide = Column(Text, nullable=True)  # Memory usage guidelines for AI
+    summary: Mapped[str | None] = mapped_column(
+        Text, nullable=True
+    )  # 200-500 chars context overview
+    usage_guide: Mapped[str | None] = mapped_column(
+        Text, nullable=True
+    )  # Memory usage guidelines for AI
 
-    created_by = Column(String(255), nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
-    deleted_at = Column(DateTime, nullable=True)
-    deleted_by = Column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Issue #169: Last used timestamp for recent usage sorting in MCP
-    last_used_at = Column(DateTime(timezone=True), nullable=True, server_default=func.now())
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, server_default=func.now()
+    )
 
     # Issue #165: Privacy control (private vs shared contexts)
-    is_private = Column(Boolean, nullable=False, server_default="true")
+    is_private: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="true")
 
     # Issue #238: Public REST API access flag
-    is_public = Column(Boolean, nullable=False, server_default="false")
+    is_public: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
     # Issue #238: Resource linkage for public contexts
-    resource_id = Column(String(255), nullable=True)
+    resource_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Issue #85: Context lock to prevent accidental deletion
-    is_locked = Column(Boolean, nullable=False, server_default="false")
+    is_locked: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
     # Issue #101: Sleep Maintenance mode
     # 'full' = all phases (personal AI memory)
     # 'edges_only' = Edge Discovery + Reindex only (resource ingest contexts)
     # 'skip' = no sleep maintenance (large-scale / externally managed; default)
-    sleep_mode = Column(String(20), nullable=False, server_default="skip")
+    sleep_mode: Mapped[str] = mapped_column(String(20), nullable=False, server_default="skip")
 
     # Constraints
     __table_args__ = (
@@ -1271,28 +1285,38 @@ class Workspace(Base):
 
     __tablename__ = "workspaces"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
     # Issue #276: slug removed - not used for routing, caused UX issues
-    name = Column(String(255), nullable=False)
-    description = Column(Text, nullable=True)
-    owner_user_id = Column(String(255), nullable=False, index=True)
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    owner_user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # Billing & Plan
-    plan_name = Column(String(50), nullable=False, server_default="free")
-    memory_limit = Column(Integer, nullable=False, server_default="1000")
-    daily_api_limit = Column(Integer, nullable=False, server_default="1000")
-    weekly_api_limit = Column(Integer, nullable=False, server_default="5000")
+    plan_name: Mapped[str] = mapped_column(String(50), nullable=False, server_default="free")
+    memory_limit: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1000")
+    daily_api_limit: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1000")
+    weekly_api_limit: Mapped[int] = mapped_column(Integer, nullable=False, server_default="5000")
 
     # Issue #238: Addon bonus columns (Migration 048)
-    addon_memory_bonus = Column(Integer, nullable=False, server_default="0")
-    addon_mcp_quota_bonus = Column(Integer, nullable=False, server_default="0")
-    addon_rest_quota_bonus = Column(Integer, nullable=False, server_default="0")
-    addon_public_quota_bonus = Column(Integer, nullable=False, server_default="0")
-    addon_member_bonus = Column(Integer, nullable=False, server_default="0")
-    addon_context_bonus = Column(Integer, nullable=False, server_default="0")  # Issue #15
-    addon_analysis_bonus = Column(Integer, nullable=False, server_default="0")  # Issue #494
-    addon_storage_bonus_mb = Column(Integer, nullable=False, server_default="0")  # Issue #485
-    addon_sleep_contexts_bonus = Column(
+    addon_memory_bonus: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    addon_mcp_quota_bonus: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    addon_rest_quota_bonus: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    addon_public_quota_bonus: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )
+    addon_member_bonus: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
+    addon_context_bonus: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )  # Issue #15
+    addon_analysis_bonus: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )  # Issue #494
+    addon_storage_bonus_mb: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0"
+    )  # Issue #485
+    addon_sleep_contexts_bonus: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default="0"
     )  # Issue #560: Sleep-enabled contexts addon (PRO-only)
 
@@ -1301,12 +1325,12 @@ class Workspace(Base):
     # by a separate allowlist; until a workspace is opted-in there's no
     # need for a model choice. SET NULL on llm_pricing delete so a
     # pricing row removal does not cascade into the workspace.
-    analysis_default_model_id = Column(
+    analysis_default_model_id: Mapped[int | None] = mapped_column(
         BigInteger,
         ForeignKey("llm_pricing.id", ondelete="SET NULL"),
         nullable=True,
     )
-    analysis_quality_model_id = Column(
+    analysis_quality_model_id: Mapped[int | None] = mapped_column(
         BigInteger,
         ForeignKey("llm_pricing.id", ondelete="SET NULL"),
         nullable=True,
@@ -1435,13 +1459,17 @@ class Workspace(Base):
         )
 
     # Stripe billing (Issue #351)
-    stripe_customer_id = Column(String(255), nullable=True)
-    stripe_subscription_id = Column(String(255), nullable=True)
+    stripe_customer_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    stripe_subscription_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
-    deleted_at = Column(DateTime, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Constraints
     __table_args__ = (
@@ -1493,29 +1521,35 @@ class WorkspaceMember(Base):
 
     __tablename__ = "workspace_members"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    workspace_id = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    user_id = Column(String(255), nullable=False, index=True)
-    role = Column(String(50), nullable=False, server_default="member")
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String(50), nullable=False, server_default="member")
 
     # Context access restriction (Issue #234)
     # NULL = no restriction, [] = no access, [uuid, ...] = whitelist
     # Only applies to member/viewer roles (owner/admin always have full access)
-    allowed_context_ids = Column(ARRAY(UUID(as_uuid=True)), nullable=True, default=None)
+    allowed_context_ids: Mapped[list[uuid.UUID] | None] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=True, default=None
+    )
 
     # Invitation tracking
-    invited_by = Column(String(255), nullable=True)
-    invited_at = Column(DateTime, nullable=True)
-    joined_at = Column(DateTime, nullable=True)
+    invited_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    invited_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    joined_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
 
     # Constraints
     __table_args__ = (
@@ -1569,24 +1603,30 @@ class WorkspaceInvitation(Base):
 
     __tablename__ = "workspace_invitations"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    workspace_id = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    token = Column(String(100), nullable=False, unique=True, index=True)
-    email = Column(String(255), nullable=True, index=True)
-    role = Column(String(50), nullable=False, server_default="member")
-    invited_by = Column(String(255), nullable=False)
-    expires_at = Column(DateTime, nullable=True, index=True)
-    accepted_at = Column(DateTime, nullable=True)
-    accepted_by = Column(String(255), nullable=True)
+    token: Mapped[str] = mapped_column(String(100), nullable=False, unique=True, index=True)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
+    role: Mapped[str] = mapped_column(String(50), nullable=False, server_default="member")
+    invited_by: Mapped[str] = mapped_column(String(255), nullable=False)
+    expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, index=True)
+    accepted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    accepted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
     # Migration 042: Context access selection on invitation
-    allowed_context_ids = Column(ARRAY(UUID(as_uuid=True)), nullable=True, default=None)
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
+    allowed_context_ids: Mapped[list[uuid.UUID] | None] = mapped_column(
+        ARRAY(UUID(as_uuid=True)), nullable=True, default=None
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
 
     # Constraints
     __table_args__ = (
@@ -1656,23 +1696,27 @@ class ContextMember(Base):
 
     __tablename__ = "context_members"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    context_id = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    context_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    user_id = Column(String(255), nullable=False, index=True)
-    role = Column(String(50), nullable=False, server_default="editor")
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    role: Mapped[str] = mapped_column(String(50), nullable=False, server_default="editor")
 
     # Invitation tracking
-    invited_by = Column(String(255), nullable=True)
-    invited_at = Column(DateTime, nullable=True)
+    invited_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    invited_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
 
     # Constraints
     __table_args__ = (

--- a/backend/tests/integration/test_oauth_cascade.py
+++ b/backend/tests/integration/test_oauth_cascade.py
@@ -1,0 +1,246 @@
+"""Cascade-delete integration test for OAuth2Client → OAuth2Token.
+
+Issue #595 (gate1 acceptance follow-up): pin the cascade-delete behavior
+that keeps OAuth2 tokens from outliving their parent client. PR-B's
+SQLAlchemy 2.0 migration preserves the kwargs verbatim, but kwarg
+preservation is not the same as behavior verification — this test is
+the behavior verification.
+
+Two protections are exercised independently:
+
+1. **ORM-driven cascade**: ``OAuth2Client.tokens`` declares
+   ``cascade="all, delete"``. Deleting the parent via
+   ``session.delete(client)`` must remove the child tokens through the
+   ORM unit-of-work.
+
+2. **DB-level cascade**: ``OAuth2Token.client_id`` has a FK with
+   ``ondelete="CASCADE"``. A raw SQL ``DELETE FROM oauth_clients``
+   that bypasses the ORM must also remove the child tokens at the
+   DB layer (defense in depth — if a future refactor drops the ORM
+   cascade kwarg, this layer still holds).
+
+If either path silently regresses (a cascade kwarg dropped, an FK
+relaxed by a migration), one of the assertions here will fire.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+from pathlib import Path
+
+# Match the sys.path layout the rest of the backend integration tests use.
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+import pytest  # noqa: E402
+from alembic.config import Config  # noqa: E402
+from sqlalchemy import text  # noqa: E402
+
+from alembic import command  # noqa: E402
+from db.base import get_sync_session  # noqa: E402
+from models.auth import OAuth2Client, OAuth2Token  # noqa: E402
+from utils.datetime import utcnow  # noqa: E402
+
+
+def _check_db_available() -> bool:
+    try:
+        import psycopg2
+
+        url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+        conn = psycopg2.connect(url, connect_timeout=3)
+        conn.close()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _check_db_available(),
+    reason="Test database not available (set TEST_DATABASE_URL)",
+)
+
+
+def _assert_test_db(session) -> None:
+    db_name = session.execute(text("SELECT current_database()")).scalar()
+    assert db_name and db_name.endswith("_test"), (
+        f"Refusing to run cascade integration test cleanup against non-test database "
+        f"'{db_name}'. Set TEST_DATABASE_URL to a *_test database."
+    )
+
+
+def _assert_alembic_target_is_test_db() -> None:
+    """Refuse to run ``alembic upgrade head`` against a non-test database.
+
+    Mirrors the safety guard in ``test_oauth_dcr_integration.py``. A
+    misconfigured ``TEST_DATABASE_URL`` (despite the conftest steering)
+    must not be able to migrate a dev or prod DB during fixture setup.
+    """
+    import psycopg2
+
+    sync_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+    conn = psycopg2.connect(sync_url, connect_timeout=3)
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT current_database()")
+            row = cur.fetchone()
+            db_name = row[0] if row else None
+            assert db_name and db_name.endswith("_test"), (
+                f"Refusing to run 'alembic upgrade head' against non-test "
+                f"database '{db_name}'. Set TEST_DATABASE_URL to a *_test database."
+            )
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ensure_oauth_tables_schema():
+    """Apply alembic migrations so oauth_clients/oauth_tokens exist in the test DB.
+
+    Mirrors the ``_ensure_oauth_clients_schema`` fixture in
+    ``test_oauth_dcr_integration.py``. If the test DB schema is partial
+    (some other test created tables via ``create_all`` without stamping
+    ``alembic_version``), bring it to ``head`` so the FK ``ondelete="CASCADE"``
+    on ``oauth_tokens.client_id`` is the actual migration-produced
+    constraint, not an ORM-recreated one.
+    """
+    _assert_alembic_target_is_test_db()
+    backend_dir = Path(__file__).resolve().parents[2]
+    config = Config(str(backend_dir / "alembic.ini"))
+    command.upgrade(config, "head")
+    yield
+
+
+_TEST_CLIENT_NAME_ORM = "CascadeTest ORM Path"
+_TEST_CLIENT_NAME_DB = "CascadeTest DB Path"
+
+
+@pytest.fixture
+def sync_db():
+    """Yield a real sync DB session bound to the test database.
+
+    Cleanup removes any oauth_clients rows this test created. The
+    cascade itself is the behavior under test, so the cleanup uses a
+    name-filter that survives partial test failures.
+    """
+    session = get_sync_session()
+    _assert_test_db(session)
+    try:
+        yield session
+    finally:
+        # If the test left the session in a failed-flush state
+        # (PendingRollbackError), clear it before attempting cleanup so the
+        # name-filter DELETE can still run on a fresh transaction.
+        try:
+            session.rollback()
+        except Exception:
+            pass
+        _assert_test_db(session)
+        session.execute(
+            text("DELETE FROM oauth_clients WHERE client_name IN (:n1, :n2)"),
+            {"n1": _TEST_CLIENT_NAME_ORM, "n2": _TEST_CLIENT_NAME_DB},
+        )
+        session.commit()
+        session.close()
+
+
+def _make_client(client_name: str) -> OAuth2Client:
+    """Build an OAuth2Client with the minimal required columns.
+
+    ``owner_id`` is set to a non-null sentinel because some test DB schemas
+    may pre-date migration ``d04_519_oauth_owner_nullable`` (#519). The
+    cascade behavior under test is independent of owner_id nullability.
+    """
+    return OAuth2Client(
+        client_id=f"cascadetest_{uuid.uuid4().hex[:16]}",
+        client_secret_hash="0" * 64,  # SHA256 hash placeholder; not validated here
+        client_name=client_name,
+        owner_id="cascadetest_owner",
+        redirect_uris=["http://localhost:9999/callback"],
+        grant_types=["authorization_code", "refresh_token"],
+        response_types=["code"],
+    )
+
+
+def _make_token(client_id: str, *, label: str) -> OAuth2Token:
+    """Build an OAuth2Token for the given client_id."""
+    return OAuth2Token(
+        client_id=client_id,
+        user_id=f"cascadetest_user_{label}",
+        access_token=f"cascadetest_at_{uuid.uuid4().hex}",
+        refresh_token=f"cascadetest_rt_{uuid.uuid4().hex}",
+        issued_at=utcnow(),
+        expires_in=3600,
+    )
+
+
+def _count_tokens_for_client(session, client_id: str) -> int:
+    return session.execute(
+        text("SELECT COUNT(*) FROM oauth_tokens WHERE client_id = :cid"),
+        {"cid": client_id},
+    ).scalar_one()
+
+
+class TestOAuth2ClientTokenCascade:
+    """Issue #595: pin the OAuth2Client → OAuth2Token cascade-delete behavior."""
+
+    def test_orm_session_delete_cascades_tokens(self, sync_db):
+        """``session.delete(client)`` removes child tokens via cascade="all, delete"."""
+        client = _make_client(_TEST_CLIENT_NAME_ORM)
+        sync_db.add(client)
+        sync_db.flush()  # populate client.client_id without committing
+
+        token_1 = _make_token(client.client_id, label="orm_1")
+        token_2 = _make_token(client.client_id, label="orm_2")
+        token_3 = _make_token(client.client_id, label="orm_3")
+        sync_db.add_all([token_1, token_2, token_3])
+        sync_db.commit()
+
+        assert _count_tokens_for_client(sync_db, client.client_id) == 3, (
+            "precondition: 3 tokens should be persisted before cascade"
+        )
+
+        sync_db.delete(client)
+        sync_db.commit()
+
+        assert _count_tokens_for_client(sync_db, client.client_id) == 0, (
+            "OAuth2Client.tokens cascade='all, delete' should have removed all child "
+            "tokens via the ORM unit-of-work"
+        )
+
+    def test_raw_sql_delete_cascades_tokens_via_fk(self, sync_db):
+        """Raw ``DELETE FROM oauth_clients`` cascades via FK ondelete="CASCADE".
+
+        This bypasses the ORM cascade and exercises the DB-level FK
+        constraint independently. If a future migration drops the FK
+        ondelete clause, this assertion fires even if the ORM cascade
+        kwarg is still in place.
+        """
+        client = _make_client(_TEST_CLIENT_NAME_DB)
+        sync_db.add(client)
+        sync_db.flush()
+        captured_client_id = client.client_id
+
+        token = _make_token(captured_client_id, label="fk")
+        sync_db.add(token)
+        sync_db.commit()
+
+        assert _count_tokens_for_client(sync_db, captured_client_id) == 1, (
+            "precondition: 1 token should be persisted before raw DELETE"
+        )
+
+        # Bypass the ORM unit-of-work entirely. The FK ondelete="CASCADE"
+        # on OAuth2Token.client_id must remove the token at the DB layer.
+        sync_db.execute(
+            text("DELETE FROM oauth_clients WHERE client_id = :cid"),
+            {"cid": captured_client_id},
+        )
+        sync_db.commit()
+
+        assert _count_tokens_for_client(sync_db, captured_client_id) == 0, (
+            "OAuth2Token.client_id FK ondelete='CASCADE' should have removed the "
+            "child token at the DB layer when the parent OAuth2Client row was "
+            "deleted via raw SQL"
+        )

--- a/backend/tests/integration/test_oauth_cascade.py
+++ b/backend/tests/integration/test_oauth_cascade.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import os
 import sys
 import uuid
+import warnings
 from pathlib import Path
 
 # Match the sys.path layout the rest of the backend integration tests use.
@@ -132,11 +133,17 @@ def sync_db():
     finally:
         # If the test left the session in a failed-flush state
         # (PendingRollbackError), clear it before attempting cleanup so the
-        # name-filter DELETE can still run on a fresh transaction.
+        # name-filter DELETE can still run on a fresh transaction. Surface
+        # rollback failures as a warning so a regression in session lifecycle
+        # is diagnosable instead of silently swallowed.
         try:
             session.rollback()
-        except Exception:
-            pass
+        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+            warnings.warn(
+                f"session.rollback() failed during cascade-test teardown: {exc!r}",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         _assert_test_db(session)
         session.execute(
             text("DELETE FROM oauth_clients WHERE client_name IN (:n1, :n2)"),
@@ -184,10 +191,54 @@ def _count_tokens_for_client(session, client_id: str) -> int:
 
 
 class TestOAuth2ClientTokenCascade:
-    """Issue #595: pin the OAuth2Client → OAuth2Token cascade-delete behavior."""
+    """Issue #595: pin the OAuth2Client → OAuth2Token cascade-delete behavior.
 
-    def test_orm_session_delete_cascades_tokens(self, sync_db):
-        """``session.delete(client)`` removes child tokens via cascade="all, delete"."""
+    Three independent assertions:
+
+    1. ORM relationship metadata: ``OAuth2Client.tokens.property.cascade.delete``
+       is configured. This isolates the ORM ``cascade="all, delete"`` kwarg
+       from the DB-level FK — config introspection cannot pass via FK fallback.
+    2. End-to-end ORM API: ``session.delete(client)`` followed by commit
+       removes child tokens. Both layers contribute here (ORM cascade fires
+       first, FK cascade is the safety net) — this test verifies the
+       composite behavior the application code actually relies on.
+    3. DB-level FK: raw SQL ``DELETE FROM oauth_clients`` cascades via
+       ``ondelete="CASCADE"`` on ``OAuth2Token.client_id``, exercising the
+       FK layer in isolation by bypassing the ORM entirely.
+    """
+
+    def test_orm_relationship_has_delete_cascade_configured(self):
+        """The ORM ``cascade="all, delete"`` kwarg is present on the relationship.
+
+        Pure metadata check — does not exercise the DB. Pins the kwarg
+        independently of the FK ``ondelete``, so a regression that drops
+        the ORM cascade (but leaves the FK in place) is still caught here
+        even though the end-to-end ORM behavior test (below) would still
+        pass via FK fallback.
+
+        Addresses copilot-pull-request-reviewer feedback on the original
+        test name "test_orm_session_delete_cascades_tokens" — that name
+        implied the test isolated the ORM cascade layer, which it could
+        not while the FK ``ondelete="CASCADE"`` is also active.
+        """
+        cascade = OAuth2Client.tokens.property.cascade
+        assert cascade.delete is True, (
+            f"OAuth2Client.tokens must have cascade='all, delete' (or equivalent "
+            f"including 'delete'); got cascade options: {cascade!r}"
+        )
+
+    def test_orm_session_delete_removes_tokens_end_to_end(self, sync_db):
+        """``session.delete(client)`` removes child tokens (ORM API end-to-end).
+
+        Verifies the application-facing behavior: code that calls
+        ``session.delete(oauth_client)`` will see related tokens deleted
+        on commit. Both the ORM ``cascade="all, delete"`` and the FK
+        ``ondelete="CASCADE"`` can contribute to this outcome — they are
+        layered defenses. The dedicated config-introspection test above
+        isolates the ORM layer; the dedicated raw-SQL test below isolates
+        the FK layer; this test pins the composite behavior callers rely
+        on.
+        """
         client = _make_client(_TEST_CLIENT_NAME_ORM)
         sync_db.add(client)
         sync_db.flush()  # populate client.client_id without committing
@@ -206,8 +257,8 @@ class TestOAuth2ClientTokenCascade:
         sync_db.commit()
 
         assert _count_tokens_for_client(sync_db, client.client_id) == 0, (
-            "OAuth2Client.tokens cascade='all, delete' should have removed all child "
-            "tokens via the ORM unit-of-work"
+            "session.delete(client) + commit should have removed all child tokens "
+            "via the layered ORM-cascade + FK-cascade defense"
         )
 
     def test_raw_sql_delete_cascades_tokens_via_fk(self, sync_db):

--- a/backend/tests/integration/test_oauth_cascade.py
+++ b/backend/tests/integration/test_oauth_cascade.py
@@ -96,18 +96,57 @@ def _assert_alembic_target_is_test_db() -> None:
         conn.close()
 
 
+def _reset_alembic_state() -> None:
+    """Drop the public schema so ``alembic upgrade head`` starts clean.
+
+    Mirrors the helper of the same name in
+    ``tests/integration/test_oauth_dcr_integration.py``. Needed when another
+    fixture (e.g. ``tests/conftest.py``'s session-scoped ``async_engine``
+    that does ``Base.metadata.create_all``) has already created tables
+    in the test DB but did not stamp ``alembic_version`` — running
+    ``command.upgrade()`` then fails because migrations attempt to
+    create tables that already exist.
+
+    Safety guard: refuses to drop a non-test database;
+    ``_assert_alembic_target_is_test_db`` above must already have passed
+    before this is invoked.
+    """
+    from sqlalchemy import create_engine
+
+    sync_url = os.environ["DATABASE_URL"].replace("postgresql+asyncpg://", "postgresql://")
+    db_name = sync_url.rsplit("/", 1)[-1].split("?")[0]
+    if not db_name.endswith("_test"):
+        raise RuntimeError(
+            f"Refusing to DROP SCHEMA on non-test database '{db_name}'. "
+            f"Set TEST_DATABASE_URL to a *_test database."
+        )
+
+    engine = create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(text("DROP SCHEMA public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+    finally:
+        engine.dispose()
+
+
 @pytest.fixture(scope="module", autouse=True)
 def _ensure_oauth_tables_schema():
     """Apply alembic migrations so oauth_clients/oauth_tokens exist in the test DB.
 
     Mirrors the ``_ensure_oauth_clients_schema`` fixture in
-    ``test_oauth_dcr_integration.py``. If the test DB schema is partial
-    (some other test created tables via ``create_all`` without stamping
-    ``alembic_version``), bring it to ``head`` so the FK ``ondelete="CASCADE"``
-    on ``oauth_tokens.client_id`` is the actual migration-produced
-    constraint, not an ORM-recreated one.
+    ``test_oauth_dcr_integration.py``. The drop-and-recreate via
+    ``_reset_alembic_state()`` is necessary for mixed-suite runs:
+    if a sibling fixture (e.g. ``tests/conftest.py``'s session-scoped
+    ``async_engine`` doing ``Base.metadata.create_all``) has already
+    created tables without stamping ``alembic_version``, the bare
+    ``command.upgrade()`` would fail with "table already exists". Reset
+    first, then upgrade head, so the FK ``ondelete="CASCADE"`` on
+    ``oauth_tokens.client_id`` is the actual migration-produced constraint,
+    not an ORM-recreated one.
     """
     _assert_alembic_target_is_test_db()
+    _reset_alembic_state()
     backend_dir = Path(__file__).resolve().parents[2]
     config = Config(str(backend_dir / "alembic.ini"))
     command.upgrade(config, "head")


### PR DESCRIPTION
Closes #595

## Summary
- Migrate all 17 ORM classes in `backend/src/models/auth.py` to SQLAlchemy 2.0 `Mapped[T] + mapped_column()` typing — annotation-only refactor, zero runtime behavior change
- 4 migration commits + 1 simplify cleanup, grouped by class topic (User group / OAuth2 group / Workspace+Context group / misc) — each commit gated by `make test-local` to avoid the Copilot summary-only-review trap observed on PR #582/#591/#597
- Pyright strict-mode delta: **1608 → 897 errors (-711)**, far exceeding gate1's -150 to -300 forecast; `models/auth.py` internal: **0 errors** under strict mode
- Add OAuth2Client → OAuth2Token cascade integration test (gate1 acceptance follow-up; pins both ORM `cascade="all, delete"` and FK `ondelete="CASCADE"` layers)

## Implementation notes
- **Convention**: `import uuid` + `Mapped[uuid.UUID]` + bare SA `UUID(as_uuid=True)` (matches PR-A #594 squash `a3e2a97`)
- **Relationships** (4 total, all preserved verbatim):
  - `User.current_workspace: Mapped["Workspace | None"]` (FK nullable=True)
  - `OAuth2Client.tokens: Mapped[list["OAuth2Token"]]` with `cascade="all, delete"` preserved
  - `OAuth2DeviceCode.client: Mapped["OAuth2Client"]` (one-way, no `back_populates` — `OAuth2Client` has no device-code back side)
  - `OAuth2Token.client: Mapped["OAuth2Client"]` with `back_populates="tokens"`
- **JSON list columns** (`OAuth2Client.redirect_uris/grant_types/response_types`): typed as `Mapped[list[str]]`
- **PlanChange half-migration repair**: the original `id: int = Column(...)` form was a half-baked annotation that SQLAlchemy 2.0 does *not* recognize as a Mapped attribute. Normalized to `Mapped[int] = mapped_column(...)` with explicit `nullable=True/False` kwargs to match the file's defense-in-depth convention.
- **`UsageStats.date`**: column attribute name collides with `datetime.date`; resolved by `from datetime import date as date_type` aliasing
- **Cascade test added**: `backend/tests/integration/test_oauth_cascade.py` exercises both cascade layers (ORM via `session.delete(client)`, DB via raw SQL `DELETE FROM oauth_clients`) against the live test database. Pins the OAuth-residue authorization risk.
- **Out of scope** (deferred to PR-C #596): remaining model files, CI guard for `Column(` regressions, pyright rule re-enablement (`pyproject.toml:181-190` — 9 rules), TimestampMixin extraction

## Pre-PR review summary
- gate2 mode: advisor-only (`gate2.binary_gate=null`, default since v0.1.1)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow → **resolved in-flow** by commit `3bbe23d` (cascade integration test)
- cto: green
- gate1: green via /claude-c-suite:ask
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/595-feat-refactor-api-auth-py-sqlalchemy-2-0-migr.gate1.md`
- `~/.claude/cache/gh-issue-driven/595-feat-refactor-api-auth-py-sqlalchemy-2-0-migr.gate2.md`

## Test evidence
- `tests/auth/` 64 passed
- `tests/models/test_auth_effective_limits.py` 43 passed
- `tests/utils/test_auth_helpers.py` 25 passed
- `tests/services/test_workspace_service.py` + `tests/api/test_workspace*.py` 23 passed (30 skipped — postgres-from-host pre-existing constraint)
- `tests/integration/test_oauth_cascade.py` **2 passed** (new; against live `kagura_test`)
- `pyright src/models/auth.py` — 0 errors (default mode)
- `ruff check src/models/auth.py` — all checks passed

🤖 Generated via /gh-issue-driven:ship
