### PR TITLE
refactor(api,ci): remaining models + CI guard (Mapped[T] PR-C, #370)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
       - name: Format check
         run: cd backend && ruff format --check src/ tests/
 
+      # #596 / epic #370 — guard against drift back to legacy SQLAlchemy 1.x
+      # Column() in model files. Catches both `name = Column(...)` and the
+      # annotated half-migration form `id: int = Column(...)` (pyright-OK,
+      # SA-2.0-broken). The Makefile target lives at repo root.
+      - name: Models no-Column guard
+        run: make lint-models-no-column
+
   backend-unit:
     runs-on: ubuntu-latest
     services:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,6 @@ jobs:
       - name: Format check
         run: cd backend && ruff format --check src/ tests/
 
-      # #596 / epic #370 — guard against drift back to legacy SQLAlchemy 1.x
-      # Column() in model files. Catches both `name = Column(...)` and the
-      # annotated half-migration form `id: int = Column(...)` (pyright-OK,
-      # SA-2.0-broken). The Makefile target lives at repo root.
       - name: Models no-Column guard
         run: make lint-models-no-column
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -219,6 +219,12 @@ jobs:
           ruff format --check src/
         continue-on-error: true  # Allow existing formatting issues
 
+      # 8b. Models no-Column guard (#596 / epic #370)
+      - name: Models no-Column guard
+        if: steps.check.outputs.authorized == 'true'
+        id: no_column_guard
+        run: make lint-models-no-column
+
       # 9. Type check
       - name: Type Check (pyright)
         if: steps.check.outputs.authorized == 'true'

--- a/Makefile
+++ b/Makefile
@@ -211,8 +211,20 @@ lint: lint-models-no-column
 # Negative-case smoke test lives at backend/tests/test_models_no_column_guard.py.
 .PHONY: lint-models-no-column
 lint-models-no-column:
-	@! grep -rnE '^[[:space:]]+[[:alnum:]_]+(:[[:space:]]*[^=]+)?[[:space:]]*=[[:space:]]*Column\(' $(BACKEND_DIR)/src/models/ \
-	  || (echo "ERROR: legacy 'Column(...)' usage detected in $(BACKEND_DIR)/src/models/. Use 'Mapped[T] = mapped_column(...)' instead. The annotated half-migration form 'id: int = Column(...)' is also rejected because SQLAlchemy 2.0 does not recognize it as a Mapped attribute (it silently fails type-resolution)."; exit 1)
+	@if grep -rnE '^[[:space:]]+[[:alnum:]_]+(:[[:space:]]*[^=]+)?[[:space:]]*=[[:space:]]*Column\(' $(BACKEND_DIR)/src/models/; then \
+	  echo ""; \
+	  echo "ERROR: legacy 'Column(...)' usage detected in $(BACKEND_DIR)/src/models/."; \
+	  echo "Use 'Mapped[T] = mapped_column(...)' instead. The annotated half-migration"; \
+	  echo "form 'id: int = Column(...)' is also rejected because SQLAlchemy 2.0 does"; \
+	  echo "not recognize it as a Mapped attribute (it silently fails type-resolution)."; \
+	  exit 1; \
+	else \
+	  EC=$$?; \
+	  if [ "$$EC" -ne 1 ]; then \
+	    echo "ERROR: grep failed with exit $$EC scanning $(BACKEND_DIR)/src/models/ (likely missing directory, permission issue, or grep not installed)." >&2; \
+	    exit 1; \
+	  fi; \
+	fi
 
 .PHONY: format
 format:

--- a/Makefile
+++ b/Makefile
@@ -203,10 +203,15 @@ lint: lint-models-no-column
 #   - annotated:   `id: int = Column(...)`  ← pyright accepts but SA 2.0 does
 #                                              NOT recognize as a Mapped attr
 #
+# POSIX character classes ([[:space:]] / [[:alnum:]_]) are used instead of
+# the GNU \s / \w shorthand so the guard is portable across GNU grep
+# (Linux CI) and BSD grep (macOS dev). The shorthand would be treated as
+# literal `s` / `w` on BSD and silently let regressions through.
+#
 # Negative-case smoke test lives at backend/tests/test_models_no_column_guard.py.
 .PHONY: lint-models-no-column
 lint-models-no-column:
-	@! grep -rnE '^\s+\w+(:\s*[^=]+)?\s*=\s*Column\(' $(BACKEND_DIR)/src/models/ \
+	@! grep -rnE '^[[:space:]]+[[:alnum:]_]+(:[[:space:]]*[^=]+)?[[:space:]]*=[[:space:]]*Column\(' $(BACKEND_DIR)/src/models/ \
 	  || (echo "ERROR: legacy 'Column(...)' usage detected in $(BACKEND_DIR)/src/models/. Use 'Mapped[T] = mapped_column(...)' instead. The annotated half-migration form 'id: int = Column(...)' is also rejected because SQLAlchemy 2.0 does not recognize it as a Mapped attribute (it silently fails type-resolution)."; exit 1)
 
 .PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -190,10 +190,24 @@ test-watch:
 	cd $(BACKEND_DIR) && pytest-watch
 
 .PHONY: lint
-lint:
+lint: lint-models-no-column
 	@echo "Running linter..."
 	cd $(BACKEND_DIR) && ruff check src/ tests/
 	@echo "Lint complete."
+
+# Guard against drift back to the legacy SQLAlchemy 1.x Column() pattern in
+# model files (#596 / epic #370). The regex accepts both forms the half-
+# migration trap produces:
+#
+#   - bare:        `name = Column(...)`
+#   - annotated:   `id: int = Column(...)`  ← pyright accepts but SA 2.0 does
+#                                              NOT recognize as a Mapped attr
+#
+# Negative-case smoke test lives at backend/tests/test_models_no_column_guard.py.
+.PHONY: lint-models-no-column
+lint-models-no-column:
+	@! grep -rnE '^\s+\w+(:\s*[^=]+)?\s*=\s*Column\(' $(BACKEND_DIR)/src/models/ \
+	  || (echo "ERROR: legacy 'Column(...)' usage detected in $(BACKEND_DIR)/src/models/. Use 'Mapped[T] = mapped_column(...)' instead. The annotated half-migration form 'id: int = Column(...)' is also rejected because SQLAlchemy 2.0 does not recognize it as a Mapped attribute (it silently fails type-resolution). See PR #596 / epic #370."; exit 1)
 
 .PHONY: format
 format:

--- a/Makefile
+++ b/Makefile
@@ -207,7 +207,7 @@ lint: lint-models-no-column
 .PHONY: lint-models-no-column
 lint-models-no-column:
 	@! grep -rnE '^\s+\w+(:\s*[^=]+)?\s*=\s*Column\(' $(BACKEND_DIR)/src/models/ \
-	  || (echo "ERROR: legacy 'Column(...)' usage detected in $(BACKEND_DIR)/src/models/. Use 'Mapped[T] = mapped_column(...)' instead. The annotated half-migration form 'id: int = Column(...)' is also rejected because SQLAlchemy 2.0 does not recognize it as a Mapped attribute (it silently fails type-resolution). See PR #596 / epic #370."; exit 1)
+	  || (echo "ERROR: legacy 'Column(...)' usage detected in $(BACKEND_DIR)/src/models/. Use 'Mapped[T] = mapped_column(...)' instead. The annotated half-migration form 'id: int = Column(...)' is also rejected because SQLAlchemy 2.0 does not recognize it as a Mapped attribute (it silently fails type-resolution)."; exit 1)
 
 .PHONY: format
 format:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -178,7 +178,35 @@ pythonVersion = "3.11"
 typeCheckingMode = "basic"
 reportMissingImports = true
 reportMissingTypeStubs = false
-# SQLAlchemy Column type issues (Column[str] vs str) — not real bugs
+# Post-#596 (Mapped[T] migration epic #370 complete) pyright re-enablement
+# audit. Each rule was tested individually after Part 1 by flipping it to
+# `true`, running `pyright src/`, and counting residual errors. The
+# Column[T]-vs-T mismatches the original suppressions were hiding are now
+# gone (the migration removes them), but each rule still surfaces unrelated
+# caller-side type-narrowing issues that fall outside the model-layer scope
+# of #596. Per the #596 acceptance plan, rules with < 20 residual errors are
+# re-enable candidates, but for all 5 SA-related rules the residuals are
+# caller-side fixes that belong in a follow-up issue (model-layer typing is
+# the scope; narrowing in services/routes is not).
+#
+# Audit results (one rule re-enabled at a time vs the all-disabled baseline
+# of 1 error in db/base.py unresolvable-import):
+#
+#   reportArgumentType            163 errors  — caller-side: many
+#   reportAttributeAccessIssue     36 errors  — caller-side: many
+#   reportAssignmentType            4 errors  — caller-side: contexts.py x2,
+#                                              workspace_service.py x2 (None
+#                                              vs WorkspaceMember narrowing)
+#   reportReturnType                5 errors  — caller-side: roles.py missing-
+#                                              return-path, oauth2.py Google
+#                                              creds union, qdrant.py PointId
+#                                              narrowing
+#   reportCallIssue                22 errors  — caller-side
+#
+# Follow-up: #599 will narrow these one-by-one and re-enable the rules. The
+# Column[T]-related suppression rationale is no longer load-bearing on any
+# of them — the only thing keeping them disabled is the caller-side fix
+# backlog tracked in that issue.
 reportArgumentType = false
 reportAttributeAccessIssue = false
 reportGeneralTypeIssues = false

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -12,12 +12,14 @@ Cost rows are NOT in this module — analysis runs emit a
 through the cost-grade plumbing introduced by #523.
 """
 
+import uuid
+from datetime import datetime
+from typing import Any
 from uuid import uuid4
 
 from sqlalchemy import (
     BigInteger,
     CheckConstraint,
-    Column,
     DateTime,
     Float,
     ForeignKey,
@@ -29,6 +31,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
@@ -83,64 +86,66 @@ class MemoryAnalysis(Base):
 
     __tablename__ = "memory_analyses"
 
-    id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
-    workspace_id = Column(
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
     )
-    context_id = Column(
+    context_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=False,
     )
 
-    started_at = Column(DateTime, nullable=False, server_default=func.now())
-    finished_at = Column(DateTime, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    finished_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     # Dual default (Python + server) so flush() reads ``running`` without
     # a refresh AND raw INSERT paths satisfy NOT NULL.
-    status = Column(
+    status: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         default="running",
         server_default=text("'running'"),
     )
-    triggered_by = Column(String(255), nullable=False)
+    triggered_by: Mapped[str] = mapped_column(String(255), nullable=False)
 
-    model_id = Column(
+    model_id: Mapped[int] = mapped_column(
         BigInteger,
         ForeignKey("llm_pricing.id", ondelete="RESTRICT"),
         nullable=False,
     )
-    model_snapshot = Column(JSONB, nullable=False)
-    embedding_model = Column(String(100), nullable=False)
-    params = Column(JSONB, nullable=False)
-    input_count = Column(Integer, nullable=False)
+    model_snapshot: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    embedding_model: Mapped[str] = mapped_column(String(100), nullable=False)
+    params: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    input_count: Mapped[int] = mapped_column(Integer, nullable=False)
 
-    cost_estimated_cents = Column(Integer, nullable=True)
-    cost_actual_cents = Column(Integer, nullable=True)
+    cost_estimated_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_actual_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # ``platform`` reserved for v2 platform-paid mode; all v1 runs are BYOK.
-    paid_by = Column(
+    paid_by: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         default="byok",
         server_default=text("'byok'"),
     )
 
-    quality = Column(JSONB, nullable=True)
-    overview = Column(Text, nullable=True)
-    error = Column(Text, nullable=True)
+    quality: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    overview: Mapped[str | None] = mapped_column(Text, nullable=True)
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Issue #496: human-readable cancellation reason when status='cancelled'.
     # NULL for non-cancelled runs. Distinct from `error` so a future
     # taxonomy can branch on (status='cancelled', reason='timeout' / 'admin'
     # / 'cost_cap' / 'user') without overloading the failure column.
-    cancellation_reason = Column(Text, nullable=True)
+    cancellation_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     __table_args__ = (
         CheckConstraint(
@@ -192,37 +197,37 @@ class MemoryAnalysisCluster(Base):
 
     __tablename__ = "memory_analysis_clusters"
 
-    id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         default=uuid4,
         server_default=text("gen_random_uuid()"),
     )
-    analysis_id = Column(
+    analysis_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("memory_analyses.id", ondelete="CASCADE"),
         nullable=False,
     )
-    parent_id = Column(
+    parent_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("memory_analysis_clusters.id", ondelete="CASCADE"),
         nullable=True,
     )
-    cluster_index = Column(Integer, nullable=False)
-    label = Column(Text, nullable=False)
-    description = Column(Text, nullable=True)
-    count = Column(Integer, nullable=False)
-    centroid_2d = Column(ARRAY(Float), nullable=False)
+    cluster_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    label: Mapped[str] = mapped_column(Text, nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    count: Mapped[int] = mapped_column(Integer, nullable=False)
+    centroid_2d: Mapped[list[float]] = mapped_column(ARRAY(Float), nullable=False)
     # NOTE: PostgreSQL cannot enforce FK on array elements, so a memory
     # deleted after a run lands here as a stale UUID. Read paths
     # (#496 API / #497 frontend) MUST LEFT JOIN against ``memories`` and
     # filter out NULLs rather than trusting every ID resolves.
-    representative_memory_ids = Column(
+    representative_memory_ids: Mapped[list[uuid.UUID]] = mapped_column(
         ARRAY(UUID(as_uuid=True)),
         nullable=False,
     )
-    property_stats = Column(JSONB, nullable=False)
-    label_confidence = Column(Float, nullable=False)
+    property_stats: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    label_confidence: Mapped[float] = mapped_column(Float, nullable=False)
 
     __table_args__ = (
         CheckConstraint(
@@ -258,23 +263,23 @@ class MemoryAnalysisAssignment(Base):
 
     __tablename__ = "memory_analysis_assignments"
 
-    analysis_id = Column(
+    analysis_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("memory_analyses.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    memory_id = Column(
+    memory_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("memories.id", ondelete="CASCADE"),
         primary_key=True,
     )
-    cluster_id = Column(
+    cluster_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("memory_analysis_clusters.id", ondelete="CASCADE"),
         nullable=False,
     )
-    x = Column(Float, nullable=False)
-    y = Column(Float, nullable=False)
+    x: Mapped[float] = mapped_column(Float, nullable=False)
+    y: Mapped[float] = mapped_column(Float, nullable=False)
 
     __table_args__ = (
         Index(

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -7,6 +7,9 @@ Provides ORM models for:
 - graph_memory table (NetworkX graph JSON storage)
 """
 
+import uuid
+from datetime import datetime
+from typing import Any
 from uuid import uuid4
 
 from sqlalchemy import (
@@ -15,7 +18,6 @@ from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     Computed,  # Migration 061: For generated columns
     DateTime,
     Float,
@@ -29,6 +31,7 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
@@ -74,12 +77,14 @@ class Memory(Base):
     __tablename__ = "memories"
 
     # 基本情報
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    user_id = Column(String(255), nullable=False, index=True)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # Migration 063: 3-level isolation (workspace, context, user)
-    workspace_id = Column(UUID(as_uuid=True), nullable=True, index=True)
-    context_id = Column(
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True
+    )
+    context_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=True,
@@ -87,73 +92,80 @@ class Memory(Base):
     )
 
     # Layer 1: 検索用サマリー
-    summary = Column(Text, nullable=False)
-    summary_embedding_id = Column(UUID(as_uuid=True), nullable=True)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    summary_embedding_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True
+    )
 
     # Issue #122: Embedding status tracking for transaction integrity
     # Values: 'pending', 'success', 'failed'
-    embedding_status = Column(String(20), nullable=False, default="pending")
-    embedding_error = Column(Text, nullable=True)
+    embedding_status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
+    embedding_error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Layer 2: 文脈説明
-    context_summary = Column(Text, nullable=True)
+    context_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Layer 3: 完全詳細
-    content = Column(Text, nullable=False)
-    details = Column(JSON, nullable=True)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    details: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     # メタデータ（LLM判断）
-    type = Column(String(50), nullable=False, index=True)
-    importance = Column(Float, nullable=False, default=0.5)
-    confidence = Column(Float, nullable=False, default=1.0)
-    tags = Column(ARRAY(String), nullable=True)
-    context = Column(JSON, nullable=True)
+    type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    importance: Mapped[float] = mapped_column(Float, nullable=False, default=0.5)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
+    tags: Mapped[list[str] | None] = mapped_column(ARRAY(String), nullable=True)
+    context: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     # Working/Persistent メモリ
-    scope = Column(String(20), nullable=False, default="working", index=True)
-    long_term = Column(Boolean, nullable=False, default=False)
-    promoted_at = Column(DateTime, nullable=True)
+    scope: Mapped[str] = mapped_column(String(20), nullable=False, default="working", index=True)
+    long_term: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    promoted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # 利用統計（Consolidation判定用）
-    use_count = Column(Integer, nullable=False, default=0)
-    last_used_at = Column(DateTime, nullable=True)
-    accessed_by_clients = Column(ARRAY(String), nullable=True)
-    access_count = Column(Integer, nullable=False, default=0)
+    use_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    accessed_by_clients: Mapped[list[str] | None] = mapped_column(ARRAY(String), nullable=True)
+    access_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     # システム情報
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=True, onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True, onupdate=func.now()
+    )
 
     # Logical Delete (Issue #46 Phase 4)
-    deleted_at = Column(DateTime, nullable=True)
-    deleted_by = Column(String(255), nullable=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    deleted_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # クライアント情報
-    client = Column(String(100), nullable=False)
-    client_version = Column(String(50), nullable=True)
+    client: Mapped[str] = mapped_column(String(100), nullable=False)
+    client_version: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
     # Issue #262: Track memory creation source
     # P2-7: Remove index=True (index created in migration 057)
-    source = Column(String(50), nullable=False, default="mcp_remember")
+    source: Mapped[str] = mapped_column(String(50), nullable=False, default="mcp_remember")
 
     # Issue #213: Origin URI for external integration (Obsidian, code ingestion, web clipping)
     # Partial index idx_memories_source_uri created in migration a95
-    source_uri = Column(String(2048), nullable=True)
-    source_type = Column(String(20), nullable=True)  # file, url, vault, api, manual
+    source_uri: Mapped[str | None] = mapped_column(String(2048), nullable=True)
+    source_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    # source_type: file, url, vault, api, manual
 
     # Migration 061: Generated columns for efficient resource memory lookups
     # These columns are automatically computed from details JSONB field
-    resource_id = Column(
+    resource_id: Mapped[str | None] = mapped_column(
         String(255),
         Computed("details->>'resource_id'", persisted=True),
         index=False,  # Index created in Migration 061
     )
-    resource_doc_id = Column(
+    resource_doc_id: Mapped[str | None] = mapped_column(
         String(255),
         Computed("details->>'doc_id'", persisted=True),
         index=False,  # Index created in Migration 061
     )
-    resource_version = Column(
+    resource_version: Mapped[int | None] = mapped_column(
         Integer,
         Computed(
             "CASE WHEN details->>'version' ~ '^[0-9]+$' THEN (details->>'version')::INTEGER ELSE NULL END",
@@ -165,12 +177,12 @@ class Memory(Base):
     # Issue #485: Polymorphic blob reference inside details.external_blob.
     # Phase 1 only writes backend='platform_r2'; Phase 2 BYO adds
     # 'byo_s3'/'byo_gcs' rows without altering this schema.
-    external_blob_backend = Column(
+    external_blob_backend: Mapped[str | None] = mapped_column(
         String(50),
         Computed("details->'external_blob'->>'backend'", persisted=True),
         index=False,  # Partial btree index created in migration e03_485
     )
-    external_blob_ref = Column(
+    external_blob_ref: Mapped[str | None] = mapped_column(
         String(2048),
         Computed("details->'external_blob'->>'ref'", persisted=True),
         index=False,  # Partial btree index created in migration e03_485
@@ -208,18 +220,20 @@ class Attachment(Base):
 
     __tablename__ = "attachments"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    memory_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    memory_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("memories.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    filename = Column(String(255), nullable=False)
-    content_type = Column(String(100), nullable=False)
-    size_bytes = Column(Integer, nullable=False)
-    data = Column(LargeBinary, nullable=False)
-    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    content_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    data: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )
 
     __table_args__ = (
         CheckConstraint("size_bytes > 0 AND size_bytes <= 5242880", name="attachment_size_limit"),
@@ -253,25 +267,29 @@ class GraphMemory(Base):
 
     __tablename__ = "graph_memory"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    user_id = Column(String(255), nullable=False, unique=True, index=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
 
     # NetworkX グラフ全体（node_link_data形式）
-    graph_data = Column(JSON, nullable=False)
+    graph_data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
 
     # 統計情報（キャッシュ・監視用）
-    total_nodes = Column(Integer, nullable=False, default=0)
-    total_edges = Column(Integer, nullable=False, default=0)
-    avg_edge_weight = Column(Float, nullable=False, default=0.0)
-    max_edge_weight = Column(Float, nullable=False, default=0.0)
+    total_nodes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    total_edges: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    avg_edge_weight: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    max_edge_weight: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
 
     # タイムスタンプ
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
 
     # パフォーマンス監視
-    last_decay_at = Column(DateTime, nullable=True)
-    last_consolidation_at = Column(DateTime, nullable=True)
+    last_decay_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    last_consolidation_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     def __repr__(self) -> str:
         return f"<GraphMemory(user='{self.user_id}', nodes={self.total_nodes}, edges={self.total_edges})>"
@@ -323,19 +341,19 @@ class NeuralMemoryEdge(Base):
     __tablename__ = "neural_memory_edges"
 
     # Primary key
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
 
     # Graph structure
-    user_id = Column(String(255), nullable=False, index=True)
-    src_id = Column(UUID(as_uuid=True), nullable=False, index=True)
-    dst_id = Column(UUID(as_uuid=True), nullable=False, index=True)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    src_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    dst_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
 
     # Migration 062 added these as nullable; b03_396 backfilled NULL rows
     # from endpoint memories and enforced NOT NULL via CHECK constraint +
     # SET NOT NULL so the context_id FK's ON DELETE CASCADE cannot be
     # bypassed (prior NULL rows were a GDPR right-to-erasure death zone).
-    workspace_id = Column(UUID(as_uuid=True), nullable=False, index=True)
-    context_id = Column(
+    workspace_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    context_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=False,
@@ -343,17 +361,23 @@ class NeuralMemoryEdge(Base):
     )
 
     # Edge properties
-    edge_type = Column(String(50), nullable=False, default=EDGE_TYPE_NEURAL_ASSOCIATION)
-    weight = Column(Float, nullable=False, default=0.0)
-    confidence = Column(Float, nullable=False, default=1.0)
+    edge_type: Mapped[str] = mapped_column(
+        String(50), nullable=False, default=EDGE_TYPE_NEURAL_ASSOCIATION
+    )
+    weight: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
 
     # Metadata (flexible JSONB for future extensions)
     # Note: 'metadata' is reserved in SQLAlchemy, use edge_metadata
-    edge_metadata = Column("metadata", JSON, nullable=True)
+    edge_metadata: Mapped[dict[str, Any] | None] = mapped_column("metadata", JSON, nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    last_updated = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    last_updated: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
 
     # Table constraints
     __table_args__ = (

--- a/backend/src/models/neural.py
+++ b/backend/src/models/neural.py
@@ -4,11 +4,11 @@ Issue #107: Move neural config from env vars to database
 Issue #406: Add EmbeddingCalibration for knn_seed percentile calibration
 """
 
+import uuid
 from datetime import UTC, datetime
 
 from sqlalchemy import (
     CheckConstraint,
-    Column,
     DateTime,
     Float,
     ForeignKey,
@@ -19,6 +19,7 @@ from sqlalchemy import (
     func,
 )
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import expression
 
 from db.base import Base
@@ -45,22 +46,26 @@ class NeuralConfig(Base):
 
     __tablename__ = "neural_config"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
     # Configuration key-value
-    key = Column(String(64), nullable=False, unique=True, index=True)
-    value = Column(String(255), nullable=False)
-    value_type = Column(String(16), nullable=False, default="float")
-    category = Column(String(32), nullable=False, default="general", index=True)
+    key: Mapped[str] = mapped_column(String(64), nullable=False, unique=True, index=True)
+    value: Mapped[str] = mapped_column(String(255), nullable=False)
+    value_type: Mapped[str] = mapped_column(String(16), nullable=False, default="float")
+    category: Mapped[str] = mapped_column(String(32), nullable=False, default="general", index=True)
 
     # Metadata
-    description = Column(Text, nullable=True)  # TEXT to match migration
-    min_value = Column(Float, nullable=True)
-    max_value = Column(Float, nullable=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)  # TEXT to match migration
+    min_value: Mapped[float | None] = mapped_column(Float, nullable=True)
+    max_value: Mapped[float | None] = mapped_column(Float, nullable=True)
 
     # Timestamps
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
 
     def __repr__(self) -> str:
         return f"<NeuralConfig(key='{self.key}', value='{self.value}')>"
@@ -147,32 +152,34 @@ class EmbeddingCalibration(Base):
 
     __tablename__ = "embedding_calibrations"
 
-    id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         server_default=expression.text("gen_random_uuid()"),
     )
-    model_name = Column(String(100), nullable=False)
-    dimensions = Column(Integer, nullable=False)
+    model_name: Mapped[str] = mapped_column(String(100), nullable=False)
+    dimensions: Mapped[int] = mapped_column(Integer, nullable=False)
     # FK to contexts.id with ON DELETE CASCADE so per-context calibration
     # rows (v2) get cleaned up automatically when a context is deleted.
     # Nullable because model-global rows use NULL here (v1 runtime path).
-    context_id = Column(
+    context_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=True,
     )
 
-    p25 = Column(Float, nullable=False)
-    p50 = Column(Float, nullable=False)
-    p75 = Column(Float, nullable=False)
-    p90 = Column(Float, nullable=False)
-    p95 = Column(Float, nullable=False)
-    p99 = Column(Float, nullable=False)
+    p25: Mapped[float] = mapped_column(Float, nullable=False)
+    p50: Mapped[float] = mapped_column(Float, nullable=False)
+    p75: Mapped[float] = mapped_column(Float, nullable=False)
+    p90: Mapped[float] = mapped_column(Float, nullable=False)
+    p95: Mapped[float] = mapped_column(Float, nullable=False)
+    p99: Mapped[float] = mapped_column(Float, nullable=False)
 
-    sample_size = Column(Integer, nullable=False)
-    sampled_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
-    valid_until = Column(DateTime(timezone=True), nullable=False)
+    sample_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    sampled_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    valid_until: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -39,11 +39,14 @@ Phase C+ cleanup once all external API contracts have migrated to
 UUID-based identifiers.
 """
 
+import uuid
+from datetime import datetime
+from typing import Any
+
 from sqlalchemy import (
     BigInteger,
     Boolean,
     CheckConstraint,
-    Column,
     DateTime,
     Float,  # Issue #262: For importance column
     ForeignKey,
@@ -58,6 +61,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 from db.constraint_names import RESOURCE_EVENTS_UPSERT_UNIQUE
@@ -87,21 +91,23 @@ class Resource(Base):
 
     __tablename__ = "resources"
 
-    id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         server_default=func.gen_random_uuid(),
     )
-    workspace_id = Column(
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    resource_id = Column(String(255), nullable=False, index=True)
-    name = Column(Text, nullable=True)
-    created_by = Column(String(255), nullable=True)
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    resource_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
 
     __table_args__ = (
         UniqueConstraint(
@@ -135,24 +141,34 @@ class ResourceEvent(Base):
 
     __tablename__ = "resource_events"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    resource_pk = Column(
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    resource_pk: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("resources.id", ondelete="CASCADE"),
         nullable=True,  # Phase 1 shadow column — tightened in #325
         index=True,
     )
-    resource_id = Column(String(255), nullable=False, index=True)
-    op = Column(String(10), nullable=False)  # 'upsert' or 'delete'
-    doc_id = Column(String(255), nullable=False)
-    version = Column(Integer, nullable=True)  # Issue #262: NULL = delete all versions
-    payload = Column(JSONB, nullable=True)  # NULL for delete operations
-    idempotency_key = Column(String(255), unique=True, nullable=True)
-    created_at = Column(DateTime, nullable=False, server_default=func.now(), index=True)
-    event_metadata = Column(JSONB, default={}, server_default="{}")
+    resource_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    op: Mapped[str] = mapped_column(String(10), nullable=False)  # 'upsert' or 'delete'
+    doc_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    version: Mapped[int | None] = mapped_column(
+        Integer, nullable=True
+    )  # Issue #262: NULL = delete all versions
+    payload: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, nullable=True
+    )  # NULL for delete operations
+    idempotency_key: Mapped[str | None] = mapped_column(String(255), unique=True, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), index=True
+    )
+    event_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, default={}, server_default="{}", nullable=True
+    )
     # Issue #262: Importance for Memory creation
     # P2-8: NOT NULL with DEFAULT 0.6 (Migration 059)
-    importance = Column(Float, nullable=False, default=0.6, server_default="0.6")
+    importance: Mapped[float] = mapped_column(
+        Float, nullable=False, default=0.6, server_default="0.6"
+    )
 
     __table_args__ = (
         CheckConstraint("op IN ('upsert', 'delete')", name="check_op_type"),
@@ -191,18 +207,22 @@ class ResourceSchema(Base):
 
     __tablename__ = "resource_schemas"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    resource_pk = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    resource_pk: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("resources.id", ondelete="CASCADE"),
         nullable=True,  # Phase 1 shadow column — tightened in #325
         index=True,
     )
-    resource_id = Column(String(255), nullable=False, index=True)
-    schema_version = Column(Integer, nullable=False, default=1)
-    field_definitions = Column(JSONB, nullable=False)
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    resource_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    schema_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    field_definitions: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
 
     __table_args__ = (
         # Issue #323: partial UNIQUE(resource_pk, schema_version) created
@@ -243,28 +263,34 @@ class IndexerState(Base):
 
     __tablename__ = "indexer_state"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    resource_pk = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    resource_pk: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("resources.id", ondelete="CASCADE"),
         nullable=True,  # Phase 1 shadow column — tightened in #325
         index=True,
     )
-    resource_id = Column(String(255), nullable=False, index=True)
-    context_id = Column(
+    resource_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    context_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    last_offset = Column(BigInteger, nullable=False, default=0)
-    last_run_at = Column(DateTime, nullable=True)
-    next_run_at = Column(DateTime, nullable=True, index=True)
-    active_version = Column(Integer, nullable=False, default=1)
-    job_status = Column(String(20), nullable=False, default="idle")
-    metrics = Column(JSONB, default={}, server_default="{}")
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    last_offset: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
+    last_run_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    next_run_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, index=True)
+    active_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    job_status: Mapped[str] = mapped_column(String(20), nullable=False, default="idle")
+    metrics: Mapped[dict[str, Any] | None] = mapped_column(
+        JSONB, default={}, server_default="{}", nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
 
     __table_args__ = (
         CheckConstraint(
@@ -312,27 +338,29 @@ class ResourceToken(Base):
 
     __tablename__ = "resource_tokens"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    resource_pk = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    resource_pk: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("resources.id", ondelete="CASCADE"),
         nullable=True,  # Phase 1 shadow column — tightened in #325
         index=True,
     )
-    resource_id = Column(String(255), nullable=False, index=True)
-    workspace_id = Column(
+    resource_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=True,  # Phase 1 shadow column — tightened in #325
         index=True,
     )
-    token_hash = Column(String(255), nullable=False, unique=True)
-    description = Column(Text, nullable=True)
-    quota_events_per_hour = Column(Integer, nullable=False, default=1000)
-    created_by = Column(String(255), nullable=True)
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    last_used_at = Column(DateTime, nullable=True)
-    is_active = Column(Boolean, nullable=False, default=True)
+    token_hash: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    quota_events_per_hour: Mapped[int] = mapped_column(Integer, nullable=False, default=1000)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
 
 
 class WorkspaceAddon(Base):
@@ -355,21 +383,27 @@ class WorkspaceAddon(Base):
 
     __tablename__ = "workspace_addons"
 
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    workspace_id = Column(
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("workspaces.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
-    addon_type = Column(String(50), nullable=False)
-    quantity = Column(Integer, nullable=False, default=1)
-    purchase_price_cents = Column(Integer, nullable=True)
-    stripe_product_id = Column(String(100), nullable=True)
-    active_from = Column(DateTime, nullable=False, server_default=func.now())
-    active_until = Column(DateTime, nullable=True)  # NULL = permanent/subscription
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    created_by = Column(String(255), nullable=False)
+    addon_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    purchase_price_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    stripe_product_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    active_from: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    active_until: Mapped[datetime | None] = mapped_column(
+        DateTime, nullable=True
+    )  # NULL = permanent/subscription
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    created_by: Mapped[str] = mapped_column(String(255), nullable=False)
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -162,7 +162,7 @@ class ResourceEvent(Base):
         DateTime, nullable=False, server_default=func.now(), index=True
     )
     event_metadata: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, default={}, server_default="{}", nullable=True
+        JSONB, default=dict, server_default="{}", nullable=True
     )
     # Issue #262: Importance for Memory creation
     # P2-8: NOT NULL with DEFAULT 0.6 (Migration 059)
@@ -283,7 +283,7 @@ class IndexerState(Base):
     active_version: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     job_status: Mapped[str] = mapped_column(String(20), nullable=False, default="idle")
     metrics: Mapped[dict[str, Any] | None] = mapped_column(
-        JSONB, default={}, server_default="{}", nullable=True
+        JSONB, default=dict, server_default="{}", nullable=True
     )
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()

--- a/backend/src/models/signup_gate.py
+++ b/backend/src/models/signup_gate.py
@@ -9,10 +9,12 @@ Sponsors-related columns on ``SignupGateConfig`` are reserved in Phase 1 and
 populated by Phase 2's GraphQL sync + webhook flow.
 """
 
+import uuid
+from datetime import datetime
+
 from sqlalchemy import (
     Boolean,
     CheckConstraint,
-    Column,
     DateTime,
     Integer,
     String,
@@ -20,6 +22,7 @@ from sqlalchemy import (
     UniqueConstraint,
 )
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
 from db.base import Base
@@ -35,20 +38,28 @@ class SignupGateConfig(Base):
 
     __tablename__ = "signup_gate_config"
 
-    id = Column(Integer, primary_key=True)
-    enabled = Column(Boolean, nullable=False, server_default="false")
-    mode = Column(String(20), nullable=False, server_default="manual")
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
+    mode: Mapped[str] = mapped_column(String(20), nullable=False, server_default="manual")
 
     # --- Phase 2 (reserved — unused in Phase 1) ---
-    github_sponsors_account = Column(String(255), nullable=True)
-    github_sponsors_token_encrypted = Column(Text, nullable=True)
-    github_sponsors_webhook_secret_encrypted = Column(Text, nullable=True)
-    github_sponsors_min_tier_cents = Column(Integer, nullable=True)
-    github_sponsors_grace_period_days = Column(Integer, nullable=False, server_default="30")
-    last_sync_at = Column(DateTime, nullable=True)
+    github_sponsors_account: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    github_sponsors_token_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    github_sponsors_webhook_secret_encrypted: Mapped[str | None] = mapped_column(
+        Text, nullable=True
+    )
+    github_sponsors_min_tier_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    github_sponsors_grace_period_days: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="30"
+    )
+    last_sync_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
 
     __table_args__ = (
         CheckConstraint(
@@ -69,24 +80,28 @@ class SignupAllowlistEntry(Base):
 
     __tablename__ = "signup_allowlist"
 
-    id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
         server_default=func.gen_random_uuid(),
     )
-    github_user_id = Column(String(64), nullable=False, index=True)
-    github_username = Column(String(255), nullable=False)
-    source = Column(String(32), nullable=False, server_default="manual")
-    state = Column(String(16), nullable=False, server_default="active")
-    added_by_user_id = Column(String(255), nullable=True)
+    github_user_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    github_username: Mapped[str] = mapped_column(String(255), nullable=False)
+    source: Mapped[str] = mapped_column(String(32), nullable=False, server_default="manual")
+    state: Mapped[str] = mapped_column(String(16), nullable=False, server_default="active")
+    added_by_user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # --- Phase 2 (reserved — populated by Sponsors sync later) ---
-    sponsor_tier_cents = Column(Integer, nullable=True)
-    revoked_at = Column(DateTime, nullable=True)
-    grace_until = Column(DateTime, nullable=True)
+    sponsor_tier_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    revoked_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    grace_until: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
-    updated_at = Column(DateTime, nullable=False, server_default=func.now(), onupdate=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
 
     __table_args__ = (
         CheckConstraint(

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -3,14 +3,15 @@
 Issue #101: Sleep Maintenance Foundation — report tracking and audit log.
 """
 
-from typing import Literal
+import uuid
+from datetime import datetime
+from typing import Any, Literal
 from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
     BigInteger,
     CheckConstraint,
-    Column,
     DateTime,
     ForeignKey,
     Index,
@@ -21,6 +22,7 @@ from sqlalchemy import (
     text,
 )
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
@@ -74,10 +76,10 @@ class SleepReport(Base):
 
     __tablename__ = "sleep_reports"
 
-    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
-    user_id = Column(String(255), nullable=False, index=True)
-    workspace_id = Column(UUID(as_uuid=True), nullable=True)
-    context_id = Column(
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    workspace_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    context_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=True,
@@ -85,16 +87,18 @@ class SleepReport(Base):
     )
 
     # Execution timing
-    started_at = Column(DateTime, nullable=False, server_default=func.now())
-    completed_at = Column(DateTime, nullable=True)
-    status = Column(String(20), nullable=False, default="running")
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False, default="running")
 
     # Per-phase results (JSON)
-    edge_discovery_result = Column(JSON, nullable=True)
-    dedup_result = Column(JSON, nullable=True)
-    importance_result = Column(JSON, nullable=True)
-    consolidation_result = Column(JSON, nullable=True)
-    reindex_result = Column(JSON, nullable=True)
+    edge_discovery_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    dedup_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    importance_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    consolidation_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    reindex_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
     # Cost tracking — legacy roll-up totals (#101).
     # Issue #471 split per-(phase, provider, model) LLM usage into the
@@ -102,9 +106,9 @@ class SleepReport(Base):
     # remain populated by the reporter as a sum of child rows for back-compat:
     # any reader that selects them directly (legacy dashboards, log analyzers,
     # MCP tools) continues to work without change.
-    llm_calls_made = Column(Integer, nullable=False, default=0)
-    llm_tokens_used = Column(Integer, nullable=False, default=0)
-    embedding_calls_made = Column(Integer, nullable=False, default=0)
+    llm_calls_made: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    llm_tokens_used: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    embedding_calls_made: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     # Embedding cost-grade columns (#471). Embedding is instance-global per
     # ``backend/src/config/settings.py`` (one EMBEDDING_PROVIDER /
@@ -115,21 +119,21 @@ class SleepReport(Base):
     # API calls today, mirroring the existing ``embedding_calls_made``
     # behavior. Sleep phases 1 (edge_discovery) and 2 (dedup_merge) also call
     # the embedding API but don't increment any counter; #475 closes that gap.
-    embedding_provider = Column(String(50), nullable=True)
-    embedding_model = Column(String(100), nullable=True)
-    embedding_tokens = Column(Integer, nullable=False, default=0)
+    embedding_provider: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    embedding_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    embedding_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     # Cost-grade dimensions (#523). Both columns carry a Python-side
     # ``default`` (in-memory ORM objects readable after flush without
     # refresh) AND a ``server_default`` (raw INSERT paths that bypass the
     # ORM still satisfy NOT NULL). #472 aggregates by these axes.
-    source = Column(
+    source: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         default="sleep",
         server_default=text("'sleep'"),
     )
-    paid_by = Column(
+    paid_by: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         default="platform",
@@ -137,14 +141,14 @@ class SleepReport(Base):
     )
 
     # Activity counters
-    memories_processed = Column(Integer, nullable=False, default=0)
-    edges_created = Column(Integer, nullable=False, default=0)
-    memories_merged = Column(Integer, nullable=False, default=0)
-    memories_promoted = Column(Integer, nullable=False, default=0)
-    memories_flagged = Column(Integer, nullable=False, default=0)
+    memories_processed: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    edges_created: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    memories_merged: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    memories_promoted: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    memories_flagged: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
 
     # Error tracking
-    error_message = Column(Text, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     __table_args__ = (
         CheckConstraint(
@@ -199,21 +203,23 @@ class SleepAction(Base):
 
     __tablename__ = "sleep_actions"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
-    report_id = Column(
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    report_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("sleep_reports.id", ondelete="CASCADE"),
         nullable=False,
         index=True,
     )
 
-    phase = Column(String(30), nullable=False)
-    action_type = Column(String(30), nullable=False)
-    memory_id = Column(UUID(as_uuid=True), nullable=True)
-    target_id = Column(UUID(as_uuid=True), nullable=True)
-    details = Column(JSON, nullable=True)
+    phase: Mapped[str] = mapped_column(String(30), nullable=False)
+    action_type: Mapped[str] = mapped_column(String(30), nullable=False)
+    memory_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    target_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    details: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
 
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
 
     __table_args__ = (Index("idx_sleep_actions_report_phase", "report_id", "phase"),)
 
@@ -251,31 +257,33 @@ class SleepReportLLMUsage(Base):
 
     __tablename__ = "sleep_report_llm_usage"
 
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
     # report_id has an explicit ``Index`` in __table_args__ below to match
     # the migration's ``idx_sleep_report_llm_usage_report_id`` name.
     # ``index=True`` here would create an auto-named index
     # (``ix_sleep_report_llm_usage_report_id``) and cause schema-drift
     # noise on alembic autogenerate or duplicate indexes when
     # Base.metadata.create_all is used in tests.
-    report_id = Column(
+    report_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("sleep_reports.id", ondelete="CASCADE"),
         nullable=False,
     )
 
-    phase = Column(String(30), nullable=False)
-    provider = Column(String(50), nullable=False)
-    model = Column(String(100), nullable=False)
+    phase: Mapped[str] = mapped_column(String(30), nullable=False)
+    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
 
-    input_tokens = Column(Integer, nullable=False, default=0)
-    output_tokens = Column(Integer, nullable=False, default=0)
-    cached_input_tokens = Column(Integer, nullable=False, default=0)
-    cache_write_tokens = Column(Integer, nullable=False, default=0)
-    calls = Column(Integer, nullable=False, default=0)
-    tokenizer_version = Column(String(50), nullable=True)
+    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cached_input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    cache_write_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    calls: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    tokenizer_version: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
-    created_at = Column(DateTime, nullable=False, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
 
     __table_args__ = (
         # Single-column index on report_id (FK join key). PostgreSQL does

--- a/backend/tests/test_models_no_column_guard.py
+++ b/backend/tests/test_models_no_column_guard.py
@@ -1,0 +1,193 @@
+"""Negative-case smoke test for the `lint-models-no-column` CI guard (#596).
+
+The guard's purpose is to prevent regression to the legacy SQLAlchemy 1.x
+``Column()`` pattern after the #370 migration to ``Mapped[T] = mapped_column()``
+completes. There are two forms the regex must catch:
+
+1. **Bare**: ``name = Column(...)`` — the pre-PR-A style.
+2. **Annotated half-migration**: ``id: int = Column(...)`` — type-annotated
+   but still using ``Column()``. pyright accepts this (no type-checker
+   warning) but SQLAlchemy 2.0 does NOT recognize it as a ``Mapped`` attribute,
+   so it silently fails ORM behavior (no instrumentation, no relationship
+   resolution, etc.). See memory ``fcc7cf87`` for the original discovery.
+
+Without explicit coverage for the annotated form, a reviewer would assume
+"pyright is green, must be fine" and miss the latent bug. These tests run as
+part of the normal unit suite so the contract is verified on every CI run,
+not only when someone manually invokes ``make lint-models-no-column``.
+
+The guard itself is a single ``grep -rnE`` invocation in the repo-root
+``Makefile``. We run it via ``subprocess`` against synthetic content in
+a tmpdir, so the test is hermetic: it does not depend on the actual model
+files (which may evolve over time), and it does not require GNU grep
+extensions beyond what ``grep -E`` provides on every CI runner.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# The exact regex used by ``make lint-models-no-column`` in the repo-root
+# Makefile. Keep this constant in sync with the Makefile target — duplicating
+# the source-of-truth is intentional: a stale Makefile + a stale test is
+# noisier than a silent regex divergence.
+GUARD_REGEX = r"^\s+\w+(:\s*[^=]+)?\s*=\s*Column\("
+
+
+def _grep_returncode(content: str, tmp_path: Path) -> int:
+    """Run the guard regex against ``content`` in a tmpdir and return the
+    ``grep`` exit code.
+
+    grep exits 0 if any match is found (= guard would fail in CI),
+    exits 1 if no match is found (= guard passes).
+    """
+    models_dir = tmp_path / "models"
+    models_dir.mkdir()
+    (models_dir / "fake_model.py").write_text(content)
+    # ``grep -rnE`` is what the Makefile target invokes. We use the same
+    # flags for parity, even though for a single file ``-r`` is redundant.
+    result = subprocess.run(
+        ["grep", "-rnE", GUARD_REGEX, str(models_dir) + "/"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode
+
+
+@pytest.fixture(scope="module")
+def grep_available() -> None:
+    """Skip the suite cleanly if ``grep`` is not on PATH (unlikely on any
+    Linux CI runner; defensive against future Windows runners)."""
+    if shutil.which("grep") is None:
+        pytest.skip("grep not available on PATH")
+
+
+# ---------------------------------------------------------------------------
+# Positive cases — the guard MUST flag these
+# ---------------------------------------------------------------------------
+
+
+def test_bare_column_form_is_caught(tmp_path: Path, grep_available: None) -> None:
+    """The original pre-migration form ``name = Column(...)`` must trigger."""
+    content = textwrap.dedent(
+        """\
+        from sqlalchemy import Column, String
+
+        class FakeModel:
+            __tablename__ = "fake"
+            name = Column(String(255), nullable=False)
+        """
+    )
+    assert _grep_returncode(content, tmp_path) == 0, (
+        "Guard regex did not match the bare 'name = Column(...)' form. "
+        "This is the primary case the guard exists to catch."
+    )
+
+
+def test_annotated_half_migration_form_is_caught(tmp_path: Path, grep_available: None) -> None:
+    """The annotated half-migration form ``id: int = Column(...)`` must
+    trigger.
+
+    This is the memory ``fcc7cf87`` latent bug: pyright sees the ``int``
+    annotation and reports no error, but SA 2.0 does not recognize the
+    attribute as a ``Mapped`` column. The guard's main value-add over a
+    naive ``= Column(`` regex is catching this form.
+    """
+    content = textwrap.dedent(
+        """\
+        from sqlalchemy import Column, Integer
+
+        class FakeModel:
+            __tablename__ = "fake"
+            id: int = Column(Integer, primary_key=True)
+        """
+    )
+    assert _grep_returncode(content, tmp_path) == 0, (
+        "Guard regex did not match the annotated 'id: int = Column(...)' "
+        "half-migration form. This is the latent bug pattern (memory "
+        "fcc7cf87) the guard exists to catch — the regex must be wide "
+        "enough that pyright-clean half-migrations cannot slip through."
+    )
+
+
+def test_annotated_with_optional_type_is_caught(tmp_path: Path, grep_available: None) -> None:
+    """Variant with a complex type annotation: ``user_id: str | None = Column(...)``.
+
+    Ensures the ``(:\\s*[^=]+)?`` group accepts arbitrary type expressions
+    between the name and the ``=``, not just simple identifiers.
+    """
+    content = textwrap.dedent(
+        """\
+        from sqlalchemy import Column, String
+
+        class FakeModel:
+            __tablename__ = "fake"
+            user_id: str | None = Column(String(255), nullable=True)
+        """
+    )
+    assert _grep_returncode(content, tmp_path) == 0, (
+        "Guard regex did not match the union-typed half-migration form. "
+        "The type-annotation group must accept '|' (PEP 604 unions) — "
+        "matching only simple identifiers would let half-migrations slip "
+        "through any time the column type is nullable."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative cases — the guard must NOT flag these
+# ---------------------------------------------------------------------------
+
+
+def test_modern_mapped_column_form_is_not_caught(tmp_path: Path, grep_available: None) -> None:
+    """The target ``Mapped[T] = mapped_column(...)`` form must pass cleanly.
+
+    Without this counter-test, a regression in the regex (e.g. dropping
+    the ``Column\\(`` literal) would still pass the positive cases but
+    start false-positiving on every model file in the repo.
+    """
+    content = textwrap.dedent(
+        """\
+        from sqlalchemy import Integer, String
+        from sqlalchemy.orm import Mapped, mapped_column
+
+        class FakeModel:
+            __tablename__ = "fake"
+            id: Mapped[int] = mapped_column(Integer, primary_key=True)
+            name: Mapped[str] = mapped_column(String(255), nullable=False)
+        """
+    )
+    assert _grep_returncode(content, tmp_path) == 1, (
+        "Guard regex false-positived on the target 'mapped_column(...)' "
+        "form. A passing positive case is not enough — the regex must "
+        "also be precise enough that every migrated model in the repo "
+        "lints clean."
+    )
+
+
+def test_column_import_alone_is_not_caught(tmp_path: Path, grep_available: None) -> None:
+    """``from sqlalchemy import Column`` (import only, no usage) must pass.
+
+    Some modules import ``Column`` for non-column purposes (e.g. inside
+    ``CheckConstraint`` SQL strings, or for type-only references). The
+    regex anchors on indented ``\\s+\\w+\\s*=\\s*Column\\(`` so a bare
+    import line cannot trigger it.
+    """
+    content = textwrap.dedent(
+        """\
+        from sqlalchemy import Column  # noqa: F401  unused — used in CheckConstraint below
+
+        # ... no column assignment ...
+        """
+    )
+    assert _grep_returncode(content, tmp_path) == 1, (
+        "Guard regex false-positived on a bare 'from sqlalchemy import "
+        "Column' line. The regex must require an indented '<name> = "
+        "Column(...)' assignment, not just the word 'Column' anywhere "
+        "in the file."
+    )

--- a/backend/tests/test_models_no_column_guard.py
+++ b/backend/tests/test_models_no_column_guard.py
@@ -15,12 +15,6 @@ Without explicit coverage for the annotated form, a reviewer would assume
 "pyright is green, must be fine" and miss the latent bug. These tests run as
 part of the normal unit suite so the contract is verified on every CI run,
 not only when someone manually invokes ``make lint-models-no-column``.
-
-The guard itself is a single ``grep -rnE`` invocation in the repo-root
-``Makefile``. We run it via ``subprocess`` against synthetic content in
-a tmpdir, so the test is hermetic: it does not depend on the actual model
-files (which may evolve over time), and it does not require GNU grep
-extensions beyond what ``grep -E`` provides on every CI runner.
 """
 
 from __future__ import annotations
@@ -32,10 +26,7 @@ from pathlib import Path
 
 import pytest
 
-# The exact regex used by ``make lint-models-no-column`` in the repo-root
-# Makefile. Keep this constant in sync with the Makefile target — duplicating
-# the source-of-truth is intentional: a stale Makefile + a stale test is
-# noisier than a silent regex divergence.
+# Must match the regex in the Makefile lint-models-no-column target exactly.
 GUARD_REGEX = r"^\s+\w+(:\s*[^=]+)?\s*=\s*Column\("
 
 
@@ -110,9 +101,8 @@ def test_annotated_half_migration_form_is_caught(tmp_path: Path, grep_available:
     )
     assert _grep_returncode(content, tmp_path) == 0, (
         "Guard regex did not match the annotated 'id: int = Column(...)' "
-        "half-migration form. This is the latent bug pattern (memory "
-        "fcc7cf87) the guard exists to catch — the regex must be wide "
-        "enough that pyright-clean half-migrations cannot slip through."
+        "half-migration form. The regex must be wide enough that "
+        "pyright-clean half-migrations cannot slip through."
     )
 
 

--- a/backend/tests/test_models_no_column_guard.py
+++ b/backend/tests/test_models_no_column_guard.py
@@ -1,4 +1,7 @@
-"""Negative-case smoke test for the `lint-models-no-column` CI guard (#596).
+"""Smoke tests for the `lint-models-no-column` CI guard (#596).
+
+Covers both positive cases (forms the guard must catch) and negative cases
+(forms it must NOT trigger on).
 
 The guard's purpose is to prevent regression to the legacy SQLAlchemy 1.x
 ``Column()`` pattern after the #370 migration to ``Mapped[T] = mapped_column()``
@@ -41,7 +44,7 @@ def _grep_returncode(content: str, tmp_path: Path) -> int:
     """
     models_dir = tmp_path / "models"
     models_dir.mkdir()
-    (models_dir / "fake_model.py").write_text(content)
+    (models_dir / "fake_model.py").write_text(content, encoding="utf-8")
     # ``grep -rnE`` is what the Makefile target invokes. We use the same
     # flags for parity, even though for a single file ``-r`` is redundant.
     result = subprocess.run(

--- a/backend/tests/test_models_no_column_guard.py
+++ b/backend/tests/test_models_no_column_guard.py
@@ -27,7 +27,9 @@ from pathlib import Path
 import pytest
 
 # Must match the regex in the Makefile lint-models-no-column target exactly.
-GUARD_REGEX = r"^\s+\w+(:\s*[^=]+)?\s*=\s*Column\("
+# POSIX character classes ([[:space:]] / [[:alnum:]_]) are used instead of
+# GNU shorthand (\s / \w) so the guard is portable to BSD grep (macOS dev).
+GUARD_REGEX = r"^[[:space:]]+[[:alnum:]_]+(:[[:space:]]*[^=]+)?[[:space:]]*=[[:space:]]*Column\("
 
 
 def _grep_returncode(content: str, tmp_path: Path) -> int:


### PR DESCRIPTION
Closes #596

## Summary

PR-C of 3, **final**, in the SQLAlchemy 2.0 `Mapped[T]` migration epic (#370).
After merge, every model file in `backend/src/models/*.py` uses
`Mapped[T] = mapped_column(...)` — total 548 sites across 16 files, zero
legacy `Column(...)`.

- **Part 1** — migrate the 6 remaining model files (250 `Column` sites):
  memory.py, resource.py, sleep.py, analysis.py, neural.py, signup_gate.py
- **Part 2** — add a CI grep guard against drift back to legacy `Column(...)`,
  including the annotated half-migration form `id: int = Column(...)`
  (memory `fcc7cf87` — pyright-OK but SA-2.0-broken). Wired into the
  repo-root `Makefile`'s `lint:` dependency chain and added as a step in
  both `ci.yml` and `pr-review.yml`. 5 hermetic subprocess smoke tests
  verify the regex catches both forms.
- **Part 3** — audit the 9 pyright suppressions in `backend/pyproject.toml`,
  document residual error counts per rule, and file follow-up #599 for the
  caller-side narrowing fixes that would unblock re-enable.

## Implementation notes

### Migration recipe (followed PR-B auth.py @ `d780b548`)

- 36 distinct column patterns catalogued before implementation
- `Mapped[T]` annotation matches SQL type Python semantics
  (`Mapped[uuid.UUID | None]` for nullable UUID, `Mapped[list[float]]` for
  `ARRAY(Float)`, `Mapped[dict[str, Any]]` for non-null JSONB, etc.)
- `nullable=True`/`False` explicit on every non-PK column (PR-B convention)
- `default=` vs `server_default=` semantics preserved exactly — never swapped
- `JSON` vs `JSONB` preserved per column (not normalized)
- `ARRAY` element type matches `Mapped[list[X]]`
- Computed columns omit `nullable=` per SA 2.0 rule
- `text("'...'::jsonb")` preserved for JSONB defaults
- `DateTime(timezone=True)` preserved where present
- Column-name aliases preserved as first positional arg
  (`NeuralMemoryEdge.edge_metadata = mapped_column("metadata", JSON, ...)`)
- Composite PK on `MemoryAnalysisAssignment` (two `primary_key=True` columns)
- Self-referential FK on `MemoryAnalysisCluster.parent_id` (string ref)
- `expression.text(...)` preserved verbatim in `neural.py` per
  operator-confirmed "out-of-scope rewrite" rule

### Per-file verification

| File | `Column` (pre) | `mapped_column` (post) | Tests passed |
|---|---|---|---|
| memory.py | 67 | 67 | 159 |
| resource.py | 57 | 57 | 122 |
| sleep.py | 46 | 46 | 221 |
| analysis.py | 35 | 35 | 56 |
| neural.py | 23 | 23 | 147 |
| signup_gate.py | 22 | 22 | 50 |
| **Total** | **250** | **250** | **~755** + 5 new smoke tests |

### Part 2 — CI guard

Makefile target:

```makefile
.PHONY: lint-models-no-column
lint-models-no-column:
	@! grep -rnE '^\s+\w+(:\s*[^=]+)?\s*=\s*Column\(' $(BACKEND_DIR)/src/models/ \
	  || (echo "ERROR: ..."; exit 1)
```

The optional `(:\s*[^=]+)?` group is what makes the annotated half-migration form trip the guard. Smoke tests at `backend/tests/test_models_no_column_guard.py` verify:

- bare `name = Column(...)` → caught
- annotated `id: int = Column(...)` → caught
- PEP 604 union `user_id: str | None = Column(...)` → caught
- migrated `Mapped[T] = mapped_column(...)` → NOT caught
- bare `from sqlalchemy import Column` import → NOT caught

### Part 3 — pyright audit results

Per-rule residual error counts after Part 1 (measured by flipping each rule to `true`, one at a time, vs the all-disabled baseline of 1 error):

| Rule | Residual | Tier in #599 |
|---|---|---|
| `reportArgumentType` | 163 | C (large sweep) |
| `reportAttributeAccessIssue` | 36 | B (medium) |
| `reportAssignmentType` | 4 | **A** (easy: 4 caller-side narrowing) |
| `reportReturnType` | 5 | **A** (easy: incl. `auth/roles.py:576`) |
| `reportCallIssue` | 22 | B |

All 5 SA-related suppressions stay `false` in this PR. Per operator HITL judgment, all residuals are caller-side narrowing (services, routes, auth) — outside the model-layer scope of #596. `#599` tracks the tiered re-enable backlog.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (CTO lens) — resolved in-flight via issue body patch (Part 2 regex extension, Makefile path correction, Part 3 acceptance added)
- review provider: copilot

3-lens green consensus with shared next-step pointer: prioritise #599 Tier A (`reportAssignmentType` + `reportReturnType`, 9 caller-side narrowing fixes including `auth/roles.py:576` which is security-relevant).

Full reviews are saved in the plugin cache:

- `~/.claude/cache/gh-issue-driven/596-feat-refactor-api-ci-remaining-models-ci-guar.gate1.md`
- `~/.claude/cache/gh-issue-driven/596-feat-refactor-api-ci-remaining-models-ci-guar.gate2.md`

## Follow-up issues

- **#599** — re-enable the 5 SA-related pyright rules (Tier A → C) and the 4 broader rules (Tier D), one rule at a time, each with the caller-side narrowing fixes the rule surfaces.
- **#600** — fix the pre-existing model-vs-migration DDL drift on `sleep.py:SleepReport.status` (and `SleepReportLLMUsage` counters) and clean up 3 cosmetic consistency nits (kwarg order, `uuid4` import shape, `ARRAY` import source) that were preserved verbatim by this migration but are inconsistent with the PR-A/PR-B reference style.

🤖 Generated via /gh-issue-driven:ship
