### PR TITLE
refactor(api): replace HTTPException with domain exceptions in PermissionService (#401)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from config.constants import APP_VERSION
 from config.settings import get_settings
-from utils.exceptions import DatabaseConnectionError, MemoryCloudException
+from utils.exceptions import AuthorizationError, DatabaseConnectionError, MemoryCloudException
 from utils.logger import get_logger, setup_logger
 
 # Setup logger first
@@ -289,12 +289,20 @@ async def memory_cloud_exception_handler(
         path=request.url.path,
     )
 
+    # CWE-639 defense in depth: AuthorizationError is designed with a uniform
+    # client-facing message. Any forensics payload that leaks into ``details``
+    # (e.g. a future contributor adding `**details` kwargs) would re-introduce
+    # the workspace-enumeration vector. Strip ``details`` to ``{}`` for this
+    # type — the structured ``reason`` lives on ``exc.reason`` (private) for
+    # log/observability use only, never serialized to the response body.
+    details = {} if isinstance(exc, AuthorizationError) else exc.details
+
     return JSONResponse(
         status_code=exc.status_code,
         content={
             "error": exc.error_code,
             "message": exc.message,
-            "details": exc.details,
+            "details": details,
         },
     )
 

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -27,6 +27,7 @@ from models.auth import (
 from models.memory import Memory
 from utils import db_transaction, get_user_id
 from utils.datetime import to_utc_iso
+from utils.exceptions import AuthorizationError, NotFoundException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -430,7 +431,7 @@ async def get_user_detail(
                     all_contexts.append(ctx)
                     context_workspace_map[ctx.id] = (workspace, member.role)
                     workspace_role_map[ctx.id] = member.role
-            except HTTPException:
+            except (NotFoundException, AuthorizationError):
                 # Skip if no access
                 pass
 

--- a/backend/src/api/routes/context_search_config.py
+++ b/backend/src/api/routes/context_search_config.py
@@ -14,6 +14,7 @@ from db.base import get_db
 from models.schemas import ContextSearchConfigResponse, ContextSearchConfigUpdate
 from repositories.config_repository import ContextSearchConfigRepository
 from services.permission_service import PermissionService
+from utils.exceptions import MemoryCloudException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -130,7 +131,7 @@ async def update_context_search_config(
 
         return ContextSearchConfigResponse.model_validate(config)
 
-    except HTTPException:
+    except (HTTPException, MemoryCloudException):
         raise
     except ValueError as e:
         logger.error(

--- a/backend/src/api/routes/context_search_config.py
+++ b/backend/src/api/routes/context_search_config.py
@@ -64,6 +64,8 @@ async def get_context_search_config(
 
         return ContextSearchConfigResponse.model_validate(config)
 
+    except (HTTPException, MemoryCloudException):
+        raise
     except Exception as e:
         logger.error(
             "get_search_config_failed",
@@ -73,7 +75,7 @@ async def get_context_search_config(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to retrieve search configuration: {str(e)}",
+            detail="Failed to retrieve search configuration",
         ) from e
 
 
@@ -150,7 +152,7 @@ async def update_context_search_config(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to update search configuration: {str(e)}",
+            detail="Failed to update search configuration",
         ) from e
 
 
@@ -196,6 +198,8 @@ async def reset_context_search_config(
 
         return ContextSearchConfigResponse.model_validate(config)
 
+    except (HTTPException, MemoryCloudException):
+        raise
     except ValueError as e:
         logger.error(
             "reset_search_config_not_found",
@@ -213,5 +217,5 @@ async def reset_context_search_config(
         )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Failed to reset search configuration: {str(e)}",
+            detail="Failed to reset search configuration",
         ) from e

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -220,10 +220,6 @@ async def get_graph_stats(
         )
 
     except (HTTPException, MemoryCloudException):
-        # Propagate structured errors (HTTPException raised by this route or
-        # downstream FastAPI deps, MemoryCloudException raised by services
-        # like PermissionService.resolve_context_for_workspace_read). Anything
-        # else falls through to the 500 path below.
         raise
     except Exception as e:
         logger.error("graph_stats_failed", error=str(e))
@@ -414,7 +410,6 @@ async def get_graph_data(
         )
 
     except (HTTPException, MemoryCloudException):
-        # Same propagation contract as get_graph_stats above.
         raise
     except Exception as e:
         logger.error("graph_data_failed", error=str(e), user_id=user.get("user_id"))

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -17,6 +17,7 @@ from models.memory import Memory
 from services.graph_service import GraphService
 from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso, utcnow
+from utils.exceptions import MemoryCloudException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -218,7 +219,11 @@ async def get_graph_stats(
             last_updated=to_utc_iso(utcnow()) or "",
         )
 
-    except HTTPException:
+    except (HTTPException, MemoryCloudException):
+        # Propagate structured errors (HTTPException raised by this route or
+        # downstream FastAPI deps, MemoryCloudException raised by services
+        # like PermissionService.resolve_context_for_workspace_read). Anything
+        # else falls through to the 500 path below.
         raise
     except Exception as e:
         logger.error("graph_stats_failed", error=str(e))
@@ -408,7 +413,8 @@ async def get_graph_data(
             stats=stats,
         )
 
-    except HTTPException:
+    except (HTTPException, MemoryCloudException):
+        # Same propagation contract as get_graph_stats above.
         raise
     except Exception as e:
         logger.error("graph_data_failed", error=str(e), user_id=user.get("user_id"))

--- a/backend/src/api/routes/graph.py
+++ b/backend/src/api/routes/graph.py
@@ -6,7 +6,7 @@ Issue #46 Phase 5 - Rich Memory Overview
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, status
+from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,7 +17,7 @@ from models.memory import Memory
 from services.graph_service import GraphService
 from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso, utcnow
-from utils.exceptions import MemoryCloudException
+from utils.exceptions import InternalError, MemoryCloudException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -223,10 +223,7 @@ async def get_graph_stats(
         raise
     except Exception as e:
         logger.error("graph_stats_failed", error=str(e))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve graph statistics",
-        ) from e
+        raise InternalError("Failed to retrieve graph statistics") from e
 
 
 @router.get("/data", response_model=GraphDataResponse)
@@ -413,7 +410,4 @@ async def get_graph_data(
         raise
     except Exception as e:
         logger.error("graph_data_failed", error=str(e), user_id=user.get("user_id"))
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Failed to retrieve graph data",
-        ) from e
+        raise InternalError("Failed to retrieve graph data") from e

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -637,10 +637,6 @@ async def list_memories(
         return MemoryListResponse(memories=memory_items, total=total, has_more=has_more)
 
     except (HTTPException, MemoryCloudException):
-        # Propagate structured errors (HTTPException from route body /
-        # FastAPI deps, MemoryCloudException from PermissionService's
-        # resolve_context_for_workspace_read 404 / ContextService 404 etc.)
-        # to the global handler. Anything else falls through to the 500 path.
         raise
     except Exception as e:
         logger.error("list_memories_failed", error=str(e))

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -33,6 +33,7 @@ from services.context_service import ContextService
 from services.memory_service import MemoryService
 from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso, utcnow
+from utils.exceptions import MemoryCloudException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -635,7 +636,11 @@ async def list_memories(
 
         return MemoryListResponse(memories=memory_items, total=total, has_more=has_more)
 
-    except HTTPException:
+    except (HTTPException, MemoryCloudException):
+        # Propagate structured errors (HTTPException from route body /
+        # FastAPI deps, MemoryCloudException from PermissionService's
+        # resolve_context_for_workspace_read 404 / ContextService 404 etc.)
+        # to the global handler. Anything else falls through to the 500 path.
         raise
     except Exception as e:
         logger.error("list_memories_failed", error=str(e))

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -194,7 +194,7 @@ async def _enforce_workspace_membership(
             target_workspace_id=str(context.workspace_id),
             token_creator=token_record.created_by,
             client_ip=request.client.host if request.client else None,
-            reason=auth_error.details.get("reason", "workspace_access_denied"),
+            reason=auth_error.reason or "workspace_access_denied",
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -33,7 +33,7 @@ from services.permission_service import PermissionService
 from services.resource_lookup import resolve_resource_pk
 from services.resource_quota_service import check_event_quota
 from utils.datetime import utcnow
-from utils.exceptions import ConflictError, ValidationError
+from utils.exceptions import AuthorizationError, ConflictError, NotFoundException, ValidationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -186,10 +186,12 @@ async def _enforce_workspace_membership(
             workspace_id=context.workspace_id,
             required_role="member",
         )
-    except HTTPException as auth_error:
+    except (NotFoundException, AuthorizationError) as auth_error:
         # `reason` captures the underlying cause (workspace deleted /
         # non-member / role-too-low) for forensics without re-leaking the
-        # detail to the caller.
+        # detail to the caller. AuthorizationError carries the classification
+        # in details["reason"]; fall back to the message string for any other
+        # domain exception type.
         logger.warning(
             "cross_tenant_ingest_attempt",
             resource_id=context.resource_id,
@@ -197,7 +199,7 @@ async def _enforce_workspace_membership(
             target_workspace_id=str(context.workspace_id),
             token_creator=token_record.created_by,
             client_ip=request.client.host if request.client else None,
-            reason=auth_error.detail,
+            reason=auth_error.details.get("reason") or auth_error.message,
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -33,7 +33,7 @@ from services.permission_service import PermissionService
 from services.resource_lookup import resolve_resource_pk
 from services.resource_quota_service import check_event_quota
 from utils.datetime import utcnow
-from utils.exceptions import AuthorizationError, ConflictError, NotFoundException, ValidationError
+from utils.exceptions import AuthorizationError, ConflictError, ValidationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -186,12 +186,7 @@ async def _enforce_workspace_membership(
             workspace_id=context.workspace_id,
             required_role="member",
         )
-    except (NotFoundException, AuthorizationError) as auth_error:
-        # `reason` captures the underlying cause (workspace deleted /
-        # non-member / role-too-low) for forensics without re-leaking the
-        # detail to the caller. The "not_found" sentinel is the defensive
-        # fallback — NotFoundException is in the catch tuple for future-proofing
-        # but check_workspace_access only raises AuthorizationError today.
+    except AuthorizationError as auth_error:
         logger.warning(
             "cross_tenant_ingest_attempt",
             resource_id=context.resource_id,
@@ -199,7 +194,7 @@ async def _enforce_workspace_membership(
             target_workspace_id=str(context.workspace_id),
             token_creator=token_record.created_by,
             client_ip=request.client.host if request.client else None,
-            reason=auth_error.details.get("reason") or "not_found",
+            reason=auth_error.details.get("reason", "workspace_access_denied"),
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/src/api/routes/resource_ingest.py
+++ b/backend/src/api/routes/resource_ingest.py
@@ -189,9 +189,9 @@ async def _enforce_workspace_membership(
     except (NotFoundException, AuthorizationError) as auth_error:
         # `reason` captures the underlying cause (workspace deleted /
         # non-member / role-too-low) for forensics without re-leaking the
-        # detail to the caller. AuthorizationError carries the classification
-        # in details["reason"]; fall back to the message string for any other
-        # domain exception type.
+        # detail to the caller. The "not_found" sentinel is the defensive
+        # fallback — NotFoundException is in the catch tuple for future-proofing
+        # but check_workspace_access only raises AuthorizationError today.
         logger.warning(
             "cross_tenant_ingest_attempt",
             resource_id=context.resource_id,
@@ -199,7 +199,7 @@ async def _enforce_workspace_membership(
             target_workspace_id=str(context.workspace_id),
             token_creator=token_record.created_by,
             client_ip=request.client.host if request.client else None,
-            reason=auth_error.details.get("reason") or auth_error.message,
+            reason=auth_error.details.get("reason") or "not_found",
         )
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -66,7 +66,6 @@ from utils.exceptions import (
     AuthorizationError,
     ConfigurationError,
     FeatureNotAvailableError,
-    NotFoundException,
     QuotaExceededError,
 )
 from utils.logger import get_logger
@@ -235,7 +234,7 @@ async def require_memory_analysis_access(
     perm = PermissionService(db)
     try:
         await perm.check_workspace_owner(user_id, workspace_id)
-    except (NotFoundException, AuthorizationError) as exc:
+    except AuthorizationError as exc:
         logger.warning(
             "memory_analysis_owner_denied",
             user_id=user_id,
@@ -304,7 +303,7 @@ async def require_memory_analysis_read(
     perm = PermissionService(db)
     try:
         await perm.check_workspace_owner(user_id, workspace_id)
-    except (NotFoundException, AuthorizationError) as exc:
+    except AuthorizationError as exc:
         logger.warning(
             "memory_analysis_read_denied",
             user_id=user_id,
@@ -348,9 +347,9 @@ async def check_memory_analysis_access_mcp(
 
     Returns the caller's ``user_timezone`` for downstream formatting.
 
-    Raises ``AuthorizationError`` / ``NotFoundException`` /
-    ``FeatureNotAvailableError`` / ``QuotaExceededError`` so the caller
-    can map to the MCP error envelope at one place.
+    Raises ``AuthorizationError`` / ``FeatureNotAvailableError`` /
+    ``QuotaExceededError`` so the caller can map to the MCP error envelope
+    at one place.
     """
     from services.permission_service import PermissionService
 

--- a/backend/src/auth/analysis_gates.py
+++ b/backend/src/auth/analysis_gates.py
@@ -62,7 +62,13 @@ from auth.dependencies import get_user_from_api_key_or_session
 from db.base import get_db
 from models.auth import User
 from services.analysis.query_service import day_window_utc
-from utils.exceptions import ConfigurationError, FeatureNotAvailableError, QuotaExceededError
+from utils.exceptions import (
+    AuthorizationError,
+    ConfigurationError,
+    FeatureNotAvailableError,
+    NotFoundException,
+    QuotaExceededError,
+)
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -229,7 +235,7 @@ async def require_memory_analysis_access(
     perm = PermissionService(db)
     try:
         await perm.check_workspace_owner(user_id, workspace_id)
-    except HTTPException as exc:
+    except (NotFoundException, AuthorizationError) as exc:
         logger.warning(
             "memory_analysis_owner_denied",
             user_id=user_id,
@@ -298,7 +304,7 @@ async def require_memory_analysis_read(
     perm = PermissionService(db)
     try:
         await perm.check_workspace_owner(user_id, workspace_id)
-    except HTTPException as exc:
+    except (NotFoundException, AuthorizationError) as exc:
         logger.warning(
             "memory_analysis_read_denied",
             user_id=user_id,
@@ -342,9 +348,9 @@ async def check_memory_analysis_access_mcp(
 
     Returns the caller's ``user_timezone`` for downstream formatting.
 
-    Raises ``HTTPException`` / ``FeatureNotAvailableError`` /
-    ``QuotaExceededError`` so the caller can map to the MCP
-    error envelope at one place.
+    Raises ``AuthorizationError`` / ``NotFoundException`` /
+    ``FeatureNotAvailableError`` / ``QuotaExceededError`` so the caller
+    can map to the MCP error envelope at one place.
     """
     from services.permission_service import PermissionService
 

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -423,7 +423,7 @@ async def require_workspace_owner(
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            reason=exc.details.get("reason"),
+            reason=exc.reason,
         )
         raise
 
@@ -475,7 +475,7 @@ async def require_workspace_admin_session(
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            reason=exc.details.get("reason"),
+            reason=exc.reason,
         )
         raise
 
@@ -530,7 +530,7 @@ async def require_workspace_admin(
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            reason=exc.details.get("reason"),
+            reason=exc.reason,
         )
         raise
 

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_db
 from models.auth import User
+from utils.exceptions import AuthorizationError, NotFoundException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -411,10 +412,10 @@ async def require_workspace_owner(
     perm_service = PermissionService(db)
     try:
         await perm_service.check_workspace_owner(user_id, workspace_id)
-    except HTTPException as exc:
+    except (NotFoundException, AuthorizationError) as exc:
         # WARN on deny so audit pipelines can surface workspace-owner violations
         # (audit / incident-response concern flagged by #389 gate1 review).
-        # status_code + sanitized detail let downstream consumers distinguish
+        # status_code + sanitized message let downstream consumers distinguish
         # a pure role violation (403) from other deny paths (e.g. 404 if the
         # workspace was deleted mid-session), reducing false positives.
         logger.warning(
@@ -422,7 +423,7 @@ async def require_workspace_owner(
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            detail=exc.detail if isinstance(exc.detail, str) else None,
+            detail=exc.message,
         )
         raise
 
@@ -468,13 +469,13 @@ async def require_workspace_admin_session(
     perm_service = PermissionService(db)
     try:
         await perm_service.check_workspace_admin(user_id, workspace_id)
-    except HTTPException as exc:
+    except (NotFoundException, AuthorizationError) as exc:
         logger.warning(
             "workspace_admin_session_denied",
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            detail=exc.detail if isinstance(exc.detail, str) else None,
+            detail=exc.message,
         )
         raise
 
@@ -521,7 +522,7 @@ async def require_workspace_admin(
     perm_service = PermissionService(db)
     try:
         await perm_service.check_workspace_admin(user_id, workspace_id)
-    except HTTPException as exc:
+    except (NotFoundException, AuthorizationError) as exc:
         # WARN on deny so audit pipelines can surface workspace-admin violations
         # (same audit-log pattern as require_workspace_owner — Issue #389 gate1).
         logger.warning(
@@ -529,7 +530,7 @@ async def require_workspace_admin(
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            detail=exc.detail if isinstance(exc.detail, str) else None,
+            detail=exc.message,
         )
         raise
 

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -13,7 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_db
 from models.auth import User
-from utils.exceptions import AuthorizationError, NotFoundException
+from utils.exceptions import AuthorizationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -412,7 +412,7 @@ async def require_workspace_owner(
     perm_service = PermissionService(db)
     try:
         await perm_service.check_workspace_owner(user_id, workspace_id)
-    except (NotFoundException, AuthorizationError) as exc:
+    except AuthorizationError as exc:
         # WARN on deny so audit pipelines can surface workspace-owner violations
         # (#389 gate1 review). The structured ``reason`` (workspace_deleted /
         # not_a_member / role_too_low) is the actionable classification —
@@ -469,7 +469,7 @@ async def require_workspace_admin_session(
     perm_service = PermissionService(db)
     try:
         await perm_service.check_workspace_admin(user_id, workspace_id)
-    except (NotFoundException, AuthorizationError) as exc:
+    except AuthorizationError as exc:
         logger.warning(
             "workspace_admin_session_denied",
             user_id=user_id,
@@ -522,7 +522,7 @@ async def require_workspace_admin(
     perm_service = PermissionService(db)
     try:
         await perm_service.check_workspace_admin(user_id, workspace_id)
-    except (NotFoundException, AuthorizationError) as exc:
+    except AuthorizationError as exc:
         # WARN on deny so audit pipelines can surface workspace-admin violations
         # (same audit-log pattern as require_workspace_owner — Issue #389 gate1).
         logger.warning(

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -414,16 +414,16 @@ async def require_workspace_owner(
         await perm_service.check_workspace_owner(user_id, workspace_id)
     except (NotFoundException, AuthorizationError) as exc:
         # WARN on deny so audit pipelines can surface workspace-owner violations
-        # (audit / incident-response concern flagged by #389 gate1 review).
-        # status_code + sanitized message let downstream consumers distinguish
-        # a pure role violation (403) from other deny paths (e.g. 404 if the
-        # workspace was deleted mid-session), reducing false positives.
+        # (#389 gate1 review). The structured ``reason`` (workspace_deleted /
+        # not_a_member / role_too_low) is the actionable classification —
+        # exc.message is the uniform "Insufficient permissions" string by
+        # CWE-639 design, so logging it adds no signal.
         logger.warning(
             "workspace_owner_denied",
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            detail=exc.message,
+            reason=exc.details.get("reason"),
         )
         raise
 
@@ -475,7 +475,7 @@ async def require_workspace_admin_session(
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            detail=exc.message,
+            reason=exc.details.get("reason"),
         )
         raise
 
@@ -530,7 +530,7 @@ async def require_workspace_admin(
             user_id=user_id,
             workspace_id=str(workspace_id),
             status_code=exc.status_code,
-            detail=exc.message,
+            reason=exc.details.get("reason"),
         )
         raise
 

--- a/backend/src/mcp_server/tools/_helpers.py
+++ b/backend/src/mcp_server/tools/_helpers.py
@@ -188,33 +188,28 @@ async def _resolve_context_for_read(
     """Resolve a context_id to a Context the caller can read, MCP-flavored.
 
     Thin wrapper around ``PermissionService.resolve_context_for_workspace_read``
-    that translates the HTTP-flavored ``HTTPException(404)`` into the MCP-native
-    ``_ContextNotFoundError`` so every MCP read tool surfaces the same uniform
-    context_not_found shape (CWE-639 / OWASP A01 uniform disclosure) regardless
-    of the underlying deny reason (not found, private non-creator, not a
-    workspace member, member-suspended, whitelist miss).
+    that translates the domain-flavored ``NotFoundException`` into the
+    MCP-native ``_ContextNotFoundError`` so every MCP read tool surfaces the
+    same uniform context_not_found shape (CWE-639 / OWASP A01 uniform
+    disclosure) regardless of the underlying deny reason (not found, private
+    non-creator, not a workspace member, member-suspended, whitelist miss).
 
     The ``required_role="viewer"`` default matches the HTTP ``/graph/*`` and
     ``/memory/stats`` reference implementations — writers should pass ``admin``
     or ``owner``.
     """
-    # Local fastapi import keeps the HTTP layer leak contained to this helper;
-    # callers only need to catch _ContextNotFoundError. See the parent docstring.
-    from fastapi import HTTPException
-
     from services.permission_service import PermissionService
+    from utils.exceptions import NotFoundException
 
     try:
         return await PermissionService(db).resolve_context_for_workspace_read(
             user_id=user_id, context_id=context_id, required_role=required_role
         )
-    except HTTPException as exc:
-        if exc.status_code == 404:
-            raise _ContextNotFoundError(
-                context_id,
-                "Context not found or you don't have access to it.",
-            ) from exc
-        raise
+    except NotFoundException as exc:
+        raise _ContextNotFoundError(
+            context_id,
+            "Context not found or you don't have access to it.",
+        ) from exc
 
 
 def _resolve_context_id(arg_context_id: str) -> UUID:

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -137,21 +137,12 @@ def _gate_error_response(exc: Exception) -> list[TextContent]:
     is the MCP equivalent.
     """
     if isinstance(exc, (AuthorizationError, NotFoundException)):
-        # 403/404 from PermissionService.check_workspace_owner (and other
-        # PermissionService methods composed by analysis_gates). The uniform
-        # ``"Insufficient permissions"`` / ``"<resource> not found"`` messages
-        # come straight from the domain exception; the per-deny-path
-        # classification (workspace_deleted / role_too_low / etc.) lives in
-        # AuthorizationError.details["reason"] for structured logs, not for
-        # MCP clients.
         return _error_response(
             "permission_denied",
             exc.message,
             status_code=exc.status_code,
         )
     if isinstance(exc, HTTPException):
-        # Defensive fall-through for any non-PermissionService HTTPException
-        # that might propagate from FastAPI deps in this composition.
         return _error_response(
             "permission_denied",
             str(exc.detail) if exc.detail else "Access denied.",

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -39,8 +39,10 @@ from mcp_server.tools._helpers import (
     _success_response,
 )
 from utils.exceptions import (
+    AuthorizationError,
     ConflictError,
     FeatureNotAvailableError,
+    NotFoundException,
     QuotaExceededError,
     ValidationError,
 )
@@ -134,8 +136,22 @@ def _gate_error_response(exc: Exception) -> list[TextContent]:
     FastAPI's global ``MemoryCloudException`` handler — this function
     is the MCP equivalent.
     """
+    if isinstance(exc, (AuthorizationError, NotFoundException)):
+        # 403/404 from PermissionService.check_workspace_owner (and other
+        # PermissionService methods composed by analysis_gates). The uniform
+        # ``"Insufficient permissions"`` / ``"<resource> not found"`` messages
+        # come straight from the domain exception; the per-deny-path
+        # classification (workspace_deleted / role_too_low / etc.) lives in
+        # AuthorizationError.details["reason"] for structured logs, not for
+        # MCP clients.
+        return _error_response(
+            "permission_denied",
+            exc.message,
+            status_code=exc.status_code,
+        )
     if isinstance(exc, HTTPException):
-        # 403 from PermissionService.check_workspace_owner
+        # Defensive fall-through for any non-PermissionService HTTPException
+        # that might propagate from FastAPI deps in this composition.
         return _error_response(
             "permission_denied",
             str(exc.detail) if exc.detail else "Access denied.",

--- a/backend/src/services/member_credentials_service.py
+++ b/backend/src/services/member_credentials_service.py
@@ -11,7 +11,6 @@ Implements:
 from typing import Any
 from uuid import UUID
 
-from fastapi import HTTPException
 from sqlalchemy import and_, delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -25,7 +24,7 @@ from models.auth import (
     WorkspaceMember,
 )
 from utils.datetime import to_utc_iso, utcnow
-from utils.exceptions import ValidationError
+from utils.exceptions import AuthorizationError, ValidationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -160,7 +159,7 @@ class MemberCredentialsService:
             }
 
         Raises:
-            HTTPException: If requester doesn't have permission
+            AuthorizationError: If requester doesn't have permission (403)
         """
         # Permission check: Can view credentials?
         await self._check_can_view(requester_id, workspace_id, user_id)
@@ -250,7 +249,7 @@ class MemberCredentialsService:
             target_user_id: Target user ID
 
         Raises:
-            HTTPException: If not allowed
+            AuthorizationError: If not allowed (403)
         """
         # Self: always allowed
         if requester_id == target_user_id:
@@ -260,10 +259,7 @@ class MemberCredentialsService:
         requester_role = await self.get_workspace_role(requester_id, workspace_id)
 
         if requester_role not in ["owner", "admin"]:
-            raise HTTPException(
-                status_code=403,
-                detail="Only workspace owner/admin can view other members' credentials",
-            )
+            raise AuthorizationError("Insufficient permissions")
 
     async def get_workspace_role(self, user_id: str, workspace_id: UUID) -> str | None:
         """Get user's role in workspace.

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -8,12 +8,12 @@ Manages access control at workspace and context levels.
 from typing import NewType
 from uuid import UUID
 
-from fastapi import HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import Context, ContextMember, WorkspaceMember
 from services.workspace_service import WorkspaceService
+from utils.exceptions import AuthorizationError, NotFoundException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -88,7 +88,13 @@ class PermissionService:
             Workspace membership
 
         Raises:
-            HTTPException: 403 if user doesn't have required access or workspace is deleted
+            AuthorizationError: 403 if user doesn't have required access or
+                workspace is deleted. The fixed ``"Insufficient permissions"``
+                message uniformly hides which sub-reason fired (CWE-639
+                workspace enumeration defense). ``exc.details["reason"]``
+                carries one of ``"workspace_deleted"`` / ``"not_a_member"`` /
+                ``"role_too_low"`` for structured-log classification — never
+                surface this to clients.
         """
         # Issue #276: Verify workspace exists and is not deleted
         from sqlalchemy import select
@@ -104,9 +110,9 @@ class PermissionService:
         workspace = workspace_result.scalar_one_or_none()
 
         if not workspace:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Workspace {workspace_id} not found or has been deleted",
+            raise AuthorizationError(
+                "Insufficient permissions",
+                reason="workspace_deleted",
             )
 
         # Get membership
@@ -117,9 +123,9 @@ class PermissionService:
         )
 
         if not member:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Not a member of workspace {workspace_id}",
+            raise AuthorizationError(
+                "Insufficient permissions",
+                reason="not_a_member",
             )
 
         # Check role hierarchy
@@ -127,9 +133,9 @@ class PermissionService:
         required_weight = ORG_ROLE_WEIGHTS.get(required_role, 0)
 
         if user_weight < required_weight:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Requires '{required_role}' role or higher",
+            raise AuthorizationError(
+                "Insufficient permissions",
+                reason="role_too_low",
             )
 
         return member
@@ -184,8 +190,10 @@ class PermissionService:
             has access to.
 
         Raises:
-            HTTPException(404): slug does not exist, or exists only in
-                workspaces the caller cannot access.
+            NotFoundException: slug does not exist, or exists only in
+                workspaces the caller cannot access. The message is the
+                uniform ``"Resource not found"`` to keep the surface
+                indistinguishable from a completely unknown slug.
         """
         candidates = (
             (
@@ -208,13 +216,13 @@ class PermissionService:
                     required_role=required_role,
                 )
                 return ctx
-            except HTTPException:
+            except (AuthorizationError, NotFoundException):
                 # Not this one — keep looking. Under a96's global UNIQUE there
                 # will be at most one live candidate, but we loop defensively
                 # in case the index is ever dropped for an operational reason.
                 continue
 
-        raise HTTPException(status_code=404, detail="Resource not found")
+        raise NotFoundException("Resource")
 
     async def resolve_context_for_workspace_read(
         self,
@@ -252,8 +260,10 @@ class PermissionService:
             required workspace role.
 
         Raises:
-            HTTPException(404): context does not exist, or the caller is not
+            NotFoundException: context does not exist, or the caller is not
                 a member of its owning workspace with the required role.
+                The uniform 404 hides whether the context exists in another
+                workspace (CWE-639 / OWASP A01).
         """
         context_result = await self.db.execute(
             select(Context).where(
@@ -269,7 +279,7 @@ class PermissionService:
                 context_id=str(context_id),
                 user_id=user_id,
             )
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+            raise NotFoundException("Context", str(context_id))
 
         # Private context: creator-only. Enforce here so graph / other
         # UUID-addressed read endpoints match ``can_access_memory`` semantics
@@ -284,7 +294,7 @@ class PermissionService:
                 context_workspace_id=str(context.workspace_id),
                 user_id=user_id,
             )
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+            raise NotFoundException("Context", str(context_id))
 
         try:
             workspace_member = await self.check_workspace_access(
@@ -292,20 +302,13 @@ class PermissionService:
                 workspace_id=context.workspace_id,
                 required_role=required_role,
             )
-        except HTTPException as exc:
-            # Classify the deny reason by the detail string so observability
-            # distinguishes cross-tenant probes (enumeration signal worth
-            # alerting on) from routine role-too-low / workspace-deleted paths.
-            # External 404 stays uniform regardless (CWE-639 / OWASP A01).
-            detail = str(exc.detail or "")
-            if "deleted" in detail:
-                reason = "workspace_deleted"
-            elif detail.startswith("Not a member"):
-                reason = "not_a_member"
-            elif "role" in detail.lower():
-                reason = "role_too_low"
-            else:
-                reason = "workspace_access_denied"
+        except AuthorizationError as exc:
+            # Classify the deny reason via the structured ``reason`` carried
+            # in ``AuthorizationError.details`` so observability distinguishes
+            # cross-tenant probes (enumeration signal worth alerting on) from
+            # routine role-too-low / workspace-deleted paths. External 404
+            # stays uniform regardless (CWE-639 / OWASP A01).
+            reason = exc.details.get("reason", "workspace_access_denied")
             logger.warning(
                 "context_read_denied",
                 reason=reason,
@@ -313,7 +316,7 @@ class PermissionService:
                 context_workspace_id=str(context.workspace_id),
                 user_id=user_id,
             )
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found") from None
+            raise NotFoundException("Context", str(context_id)) from None
 
         # Apply the same allowed_context_ids semantics that get_accessible_contexts
         # and check_context_access enforce for the lower-privilege roles. Without
@@ -334,7 +337,7 @@ class PermissionService:
                 context_workspace_id=str(context.workspace_id),
                 user_id=user_id,
             )
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+            raise NotFoundException("Context", str(context_id))
 
         if (
             workspace_member.role in ("member", "viewer")
@@ -348,7 +351,7 @@ class PermissionService:
                 context_workspace_id=str(context.workspace_id),
                 user_id=user_id,
             )
-            raise HTTPException(status_code=404, detail=f"Context {context_id} not found")
+            raise NotFoundException("Context", str(context_id))
 
         return context
 
@@ -363,7 +366,8 @@ class PermissionService:
             Workspace membership
 
         Raises:
-            HTTPException: 403 if not owner
+            AuthorizationError: 403 if not owner (see ``check_workspace_access``
+                for the structured ``details["reason"]`` payload).
         """
         return await self.check_workspace_access(user_id, workspace_id, required_role="owner")
 
@@ -378,7 +382,9 @@ class PermissionService:
             Workspace membership
 
         Raises:
-            HTTPException: 403 if not admin/owner
+            AuthorizationError: 403 if not admin/owner (see
+                ``check_workspace_access`` for the structured
+                ``details["reason"]`` payload).
         """
         return await self.check_workspace_access(user_id, workspace_id, required_role="admin")
 
@@ -425,7 +431,12 @@ class PermissionService:
             Tuple of (Context, effective_role)
 
         Raises:
-            HTTPException: 403 if user doesn't have required access
+            NotFoundException: 404 if the context does not exist.
+            AuthorizationError: 403 if user doesn't have required access.
+                Message is the uniform ``"Insufficient permissions"`` —
+                per-deny-path messages were intentionally stripped to remove
+                a CWE-639 enumeration vector. Use structured logs / sentry
+                breadcrumbs for the deny reason.
         """
         from sqlalchemy import select
 
@@ -438,7 +449,7 @@ class PermissionService:
         context = result.scalar_one_or_none()
 
         if not context:
-            raise HTTPException(status_code=404, detail="Context not found")
+            raise NotFoundException("Context")
 
         # Issue #165: Private context check (creator-only access)
         if context.is_private:
@@ -447,10 +458,7 @@ class PermissionService:
                 return context, "owner"
             else:
                 # Others cannot access private contexts
-                raise HTTPException(
-                    status_code=403,
-                    detail="This is a private context (creator only)",
-                )
+                raise AuthorizationError("Insufficient permissions")
 
         # Shared context: Check workspace membership
         workspace_member = await self.workspace_service.get_member(
@@ -460,10 +468,7 @@ class PermissionService:
         )
 
         if not workspace_member:
-            raise HTTPException(
-                status_code=403,
-                detail="Not a member of context's workspace",
-            )
+            raise AuthorizationError("Insufficient permissions")
 
         # Workspace owner/admin → bypass context checks (full access)
         # Note: allowed_context_ids is ignored for owner/admin
@@ -474,19 +479,13 @@ class PermissionService:
         # Issue #234: Check allowed_context_ids whitelist for member/viewer
         if workspace_member.allowed_context_ids is not None:
             if context_id not in workspace_member.allowed_context_ids:
-                raise HTTPException(
-                    status_code=403,
-                    detail="Access to this context is not permitted",
-                )
+                raise AuthorizationError("Insufficient permissions")
 
         # Workspace viewer → read-only access (bypass context checks)
         if workspace_member.role == "viewer":
             # Check if viewer role meets requirement
             if required_role != "viewer":
-                raise HTTPException(
-                    status_code=403,
-                    detail="Workspace viewers have read-only access",
-                )
+                raise AuthorizationError("Insufficient permissions")
             return context, "viewer"
 
         # Workspace member → requires explicit context membership
@@ -498,20 +497,14 @@ class PermissionService:
         context_member = result.scalar_one_or_none()
 
         if not context_member:
-            raise HTTPException(
-                status_code=403,
-                detail="Not a member of this context",
-            )
+            raise AuthorizationError("Insufficient permissions")
 
         # Check context role hierarchy
         user_weight = CONTEXT_ROLE_WEIGHTS.get(context_member.role, 0)
         required_weight = CONTEXT_ROLE_WEIGHTS.get(required_role, 0)
 
         if user_weight < required_weight:
-            raise HTTPException(
-                status_code=403,
-                detail=f"Requires '{required_role}' context role or higher",
-            )
+            raise AuthorizationError("Insufficient permissions")
 
         return context, context_member.role
 
@@ -526,7 +519,8 @@ class PermissionService:
             Context
 
         Raises:
-            HTTPException: 403 if no write access
+            NotFoundException: 404 if the context does not exist.
+            AuthorizationError: 403 if no write access.
         """
         context, role = await self.check_context_access(
             user_id,
@@ -546,7 +540,8 @@ class PermissionService:
             Context
 
         Raises:
-            HTTPException: 403 if not context owner
+            NotFoundException: 404 if the context does not exist.
+            AuthorizationError: 403 if not context owner.
         """
         context, role = await self.check_context_access(
             user_id,
@@ -711,7 +706,7 @@ class PermissionService:
         try:
             await self.check_context_owner(user_id, context_id)
             return True
-        except HTTPException:
+        except (AuthorizationError, NotFoundException):
             return False
 
     async def can_write_context(self, user_id: str, context_id: UUID) -> bool:
@@ -727,7 +722,7 @@ class PermissionService:
         try:
             await self.check_context_write(user_id, context_id)
             return True
-        except HTTPException:
+        except (AuthorizationError, NotFoundException):
             return False
 
     # ========================================================================

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -91,10 +91,10 @@ class PermissionService:
             AuthorizationError: 403 if user doesn't have required access or
                 workspace is deleted. The fixed ``"Insufficient permissions"``
                 message uniformly hides which sub-reason fired (CWE-639
-                workspace enumeration defense). ``exc.details["reason"]``
-                carries one of ``"workspace_deleted"`` / ``"not_a_member"`` /
-                ``"role_too_low"`` for structured-log classification — never
-                surface this to clients.
+                workspace enumeration defense). ``exc.reason`` (private
+                attribute, never serialized to clients) carries one of
+                ``"workspace_deleted"`` / ``"not_a_member"`` / ``"role_too_low"``
+                for structured-log classification.
         """
         # Issue #276: Verify workspace exists and is not deleted
         from sqlalchemy import select

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -303,11 +303,6 @@ class PermissionService:
                 required_role=required_role,
             )
         except AuthorizationError as exc:
-            # Classify the deny reason via the structured ``reason`` carried
-            # in ``AuthorizationError.details`` so observability distinguishes
-            # cross-tenant probes (enumeration signal worth alerting on) from
-            # routine role-too-low / workspace-deleted paths. External 404
-            # stays uniform regardless (CWE-639 / OWASP A01).
             reason = exc.details.get("reason", "workspace_access_denied")
             logger.warning(
                 "context_read_denied",
@@ -366,8 +361,7 @@ class PermissionService:
             Workspace membership
 
         Raises:
-            AuthorizationError: 403 if not owner (see ``check_workspace_access``
-                for the structured ``details["reason"]`` payload).
+            AuthorizationError: 403 if not owner
         """
         return await self.check_workspace_access(user_id, workspace_id, required_role="owner")
 
@@ -382,9 +376,7 @@ class PermissionService:
             Workspace membership
 
         Raises:
-            AuthorizationError: 403 if not admin/owner (see
-                ``check_workspace_access`` for the structured
-                ``details["reason"]`` payload).
+            AuthorizationError: 403 if not admin/owner
         """
         return await self.check_workspace_access(user_id, workspace_id, required_role="admin")
 

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -5,7 +5,7 @@ Issue #115 Phase B-2: Workspace-level Multi-tenancy
 Manages access control at workspace and context levels.
 """
 
-from typing import NewType
+from typing import Literal, NewType
 from uuid import UUID
 
 from sqlalchemy import select
@@ -23,6 +23,19 @@ logger = get_logger(__name__)
 # Mint at authz function boundaries; do not leak these into repository layers.
 CallerId = NewType("CallerId", str)
 MemoryAuthorId = NewType("MemoryAuthorId", str)
+
+# Structured deny-reason payload for ``AuthorizationError.details["reason"]``
+# raised by ``check_workspace_access``. Consumed by
+# ``resolve_context_for_workspace_read`` and ``resource_ingest`` for
+# enumeration-alert classification (CWE-639 observability — never surfaced
+# to clients). The fallback ``"workspace_access_denied"`` covers future
+# code paths that raise ``AuthorizationError`` without a structured reason.
+DenyReason = Literal[
+    "workspace_deleted",
+    "not_a_member",
+    "role_too_low",
+    "workspace_access_denied",
+]
 
 # Role hierarchy weights (higher = more privilege)
 ORG_ROLE_WEIGHTS = {

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -5,7 +5,7 @@ Issue #115 Phase B-2: Workspace-level Multi-tenancy
 Manages access control at workspace and context levels.
 """
 
-from typing import Literal, NewType
+from typing import NewType
 from uuid import UUID
 
 from sqlalchemy import select
@@ -23,19 +23,6 @@ logger = get_logger(__name__)
 # Mint at authz function boundaries; do not leak these into repository layers.
 CallerId = NewType("CallerId", str)
 MemoryAuthorId = NewType("MemoryAuthorId", str)
-
-# Structured deny-reason payload for ``AuthorizationError.details["reason"]``
-# raised by ``check_workspace_access``. Consumed by
-# ``resolve_context_for_workspace_read`` and ``resource_ingest`` for
-# enumeration-alert classification (CWE-639 observability — never surfaced
-# to clients). The fallback ``"workspace_access_denied"`` covers future
-# code paths that raise ``AuthorizationError`` without a structured reason.
-DenyReason = Literal[
-    "workspace_deleted",
-    "not_a_member",
-    "role_too_low",
-    "workspace_access_denied",
-]
 
 # Role hierarchy weights (higher = more privilege)
 ORG_ROLE_WEIGHTS = {

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -303,7 +303,7 @@ class PermissionService:
                 required_role=required_role,
             )
         except AuthorizationError as exc:
-            reason = exc.details.get("reason", "workspace_access_denied")
+            reason = exc.reason or "workspace_access_denied"
             logger.warning(
                 "context_read_denied",
                 reason=reason,

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -72,10 +72,25 @@ class TokenExpiredError(AuthenticationError):
 
 
 class AuthorizationError(MemoryCloudException):
-    """Authorization failed - insufficient permissions (403)."""
+    """Authorization failed - insufficient permissions (403).
 
-    def __init__(self, message: str = "Insufficient permissions", **details: Any):
+    ``reason`` is a private classification for structured logging — never
+    serialized to clients. By CWE-639 design the response carries a uniform
+    ``"Insufficient permissions"`` message; exposing the deny sub-reason
+    (workspace_deleted / not_a_member / role_too_low / ...) would
+    re-introduce the workspace-enumeration vector that this exception type
+    is meant to close (#401 gate2 CSO finding).
+    """
+
+    def __init__(
+        self,
+        message: str = "Insufficient permissions",
+        *,
+        reason: str | None = None,
+        **details: Any,
+    ) -> None:
         super().__init__(message, status_code=403, error_code="AUTH-101", **details)
+        self.reason = reason
 
 
 class APIKeyError(MemoryCloudException):

--- a/backend/tests/api/test_analyses_quota_precedence.py
+++ b/backend/tests/api/test_analyses_quota_precedence.py
@@ -3,7 +3,7 @@
 The 4-stage gate chain in ``auth.analysis_gates.require_memory_analysis_access``
 must fail fast at the FIRST applicable gate, in this order:
 
-    Gate 2 (workspace owner)          → 403 (HTTPException)
+    Gate 2 (workspace owner)          → 403 (AuthorizationError)
     Gate 3 (Pro tier feature flag)    → 403 (FeatureNotAvailableError)
     Gate 4 (daily quota)              → 429 (QuotaExceededError)
     Gate 5 (allowlist kill switch)    → 403 (FeatureNotAvailableError)
@@ -29,7 +29,11 @@ import pytest
 from fastapi import HTTPException
 
 from auth.analysis_gates import require_memory_analysis_access
-from utils.exceptions import FeatureNotAvailableError, QuotaExceededError
+from utils.exceptions import (
+    AuthorizationError,
+    FeatureNotAvailableError,
+    QuotaExceededError,
+)
 
 
 def _user_dict(workspace_id: UUID) -> dict:
@@ -38,14 +42,14 @@ def _user_dict(workspace_id: UUID) -> dict:
 
 @pytest.mark.asyncio
 async def test_gate2_owner_failure_short_circuits():
-    """Owner check fails → HTTPException 403, gates 3-5 never run."""
+    """Owner check fails → AuthorizationError 403, gates 3-5 never run."""
     workspace_id = uuid4()
     user = _user_dict(workspace_id)
     db = AsyncMock()
 
     perm_mock = MagicMock()
     perm_mock.check_workspace_owner = AsyncMock(
-        side_effect=HTTPException(status_code=403, detail="not owner")
+        side_effect=AuthorizationError("Insufficient permissions")
     )
 
     quota_check_mock = AsyncMock()
@@ -65,7 +69,7 @@ async def test_gate2_owner_failure_short_circuits():
         ),
     ):
         quota_cls.return_value.check_feature_access = quota_check_mock
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(AuthorizationError) as exc:
             await require_memory_analysis_access(user=user, db=db)
         assert exc.value.status_code == 403
 

--- a/backend/tests/api/test_context_members_rbac.py
+++ b/backend/tests/api/test_context_members_rbac.py
@@ -18,10 +18,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from api.main import app
+from utils.exceptions import AuthorizationError
 
 WORKSPACE_ID = uuid4()
 CONTEXT_ID = uuid4()
@@ -66,7 +66,7 @@ def _owner_denies():
     """PermissionService.check_context_owner stub that raises 403."""
 
     async def _raise(*args, **kwargs):
-        raise HTTPException(status_code=403, detail="Not context owner")
+        raise AuthorizationError("Insufficient permissions")
 
     return _raise
 
@@ -397,7 +397,7 @@ class TestMutationEndpointsRequireContextOwner:
 class TestListRequiresViewerAccess:
     def test_non_member_gets_403(self, client):
         async def _raise(*args, **kwargs):
-            raise HTTPException(status_code=403, detail="Not a member")
+            raise AuthorizationError("Insufficient permissions")
 
         with (
             patch(

--- a/backend/tests/api/test_context_sleep_mode.py
+++ b/backend/tests/api/test_context_sleep_mode.py
@@ -13,7 +13,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -21,6 +20,7 @@ from api.routes.contexts import ContextResponse, ContextUpdate, get_context_serv
 from auth.dependencies import require_session_auth
 from db.base import get_db
 from services.context_service import ContextService
+from utils.exceptions import AuthorizationError
 
 # ============================================================================
 # 1. Enum Validation
@@ -185,7 +185,7 @@ class TestContextSleepModePermission:
         workspace_id = uuid4()
 
         async def _deny_owner(*args, **kwargs):
-            raise HTTPException(status_code=403, detail="Not context owner")
+            raise AuthorizationError("Insufficient permissions")
 
         app.dependency_overrides[require_session_auth] = lambda: {
             "user_id": "editor_user",

--- a/backend/tests/api/test_cost_aggregation_routes.py
+++ b/backend/tests/api/test_cost_aggregation_routes.py
@@ -22,7 +22,6 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -34,6 +33,7 @@ from services.cost_aggregation_service import (
     CostBreakdownBySource,
 )
 from services.permission_service import PermissionService
+from utils.exceptions import AuthorizationError
 
 _WORKSPACE_ID = uuid4()
 
@@ -118,7 +118,7 @@ def _install_workspace_overrides(
     canned_rows: list[CostAggregationRow],
     *,
     user: dict,
-    permission_raises: HTTPException | None = None,
+    permission_raises: AuthorizationError | None = None,
 ) -> AsyncMock:
     """Wire mocks for the workspace route.
 
@@ -301,10 +301,7 @@ class TestWorkspaceRoute:
             client,
             [],
             user=_regular_user(),
-            permission_raises=HTTPException(
-                status_code=403,
-                detail="Requires 'admin' role or higher",
-            ),
+            permission_raises=AuthorizationError("Insufficient permissions"),
         )
         response = client.get(
             f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
@@ -321,10 +318,7 @@ class TestWorkspaceRoute:
             client,
             [_make_canned_row()],  # would leak if route ran the query
             user=_regular_user(),
-            permission_raises=HTTPException(
-                status_code=403,
-                detail="Not a member of workspace",
-            ),
+            permission_raises=AuthorizationError("Insufficient permissions"),
         )
         other_workspace_id = uuid4()
         response = client.get(

--- a/backend/tests/api/test_exception_handler.py
+++ b/backend/tests/api/test_exception_handler.py
@@ -1,0 +1,100 @@
+"""Tests for the global memory_cloud_exception_handler in api/main.py.
+
+Locks down two contracts critical to the #401 CWE-639 fix:
+
+1. ``AuthorizationError`` MUST emit ``details: {}`` regardless of what the
+   exception carries internally — defense in depth against a future
+   contributor accidentally passing forensics kwargs as ``**details``.
+2. Other ``MemoryCloudException`` subclasses (NotFoundException, RateLimitError,
+   etc.) MUST preserve their ``details`` payload — clients depend on these
+   fields (e.g. ``retry_after``, ``feature``, ``resource_id``).
+
+These tests run at the handler level without a TestClient — no Redis, no DB,
+no FastAPI app required.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import Request
+
+from api.main import memory_cloud_exception_handler
+from utils.exceptions import (
+    AuthorizationError,
+    NotFoundException,
+    RateLimitError,
+)
+
+
+def _request_mock(path: str = "/test") -> Request:
+    """Minimal Request stub — the handler only reads ``request.url.path``."""
+    req = MagicMock(spec=Request)
+    req.url.path = path
+    return req
+
+
+class TestAuthorizationErrorFilter:
+    """CWE-639 defense in depth — AuthorizationError NEVER leaks details."""
+
+    @pytest.mark.asyncio
+    async def test_strips_smuggled_details_keys(self):
+        """A future contributor accidentally adding ``**details`` to an
+        AuthorizationError raise (e.g. ``raise AuthorizationError("msg",
+        forensic_marker="smuggled")``) must NOT see those keys in the
+        response body. The handler enforces this by overriding ``details``
+        to ``{}`` for any AuthorizationError instance.
+        """
+        exc = AuthorizationError("Insufficient permissions", smuggled_key="leak_me")
+        # Verify the kwarg reached the exception (this is the "if step 1 fails"
+        # scenario — the test_exceptions.py contract prevents this in practice,
+        # but the handler is the SECOND line of defense).
+        assert exc.details == {"smuggled_key": "leak_me"}
+
+        response = await memory_cloud_exception_handler(_request_mock(), exc)
+        body = json.loads(response.body)
+        assert body["details"] == {}, (
+            "AuthorizationError MUST emit details={} regardless of what the "
+            "exception carries. CWE-639: leaking the deny sub-reason re-introduces "
+            "the workspace-enumeration vector that the uniform message hides."
+        )
+        # Other fields should still be set correctly.
+        assert body["error"] == "AUTH-101"
+        assert body["message"] == "Insufficient permissions"
+        assert response.status_code == 403
+
+
+class TestOtherExceptionDetailsPreserved:
+    """Negative test — the AuthorizationError filter MUST NOT over-fire and
+    strip ``details`` from sibling MemoryCloudException subclasses that legitimately
+    expose structured fields to clients (NotFoundException's resource_id,
+    RateLimitError's retry_after, etc.)."""
+
+    @pytest.mark.asyncio
+    async def test_not_found_exception_preserves_details(self):
+        """NotFoundException currently sets no kwargs in details, but if a
+        future change does (e.g. via ``**details``), the handler must NOT
+        strip them — clients may rely on structured 404 info.
+        """
+        exc = NotFoundException("Context", "ctx-uuid-123")
+        response = await memory_cloud_exception_handler(_request_mock(), exc)
+        body = json.loads(response.body)
+        # NotFoundException's __init__ does not pass any **details today, so
+        # body["details"] is {} here. The test asserts that the handler does
+        # NOT actively erase what the exception had (filter is targeted to
+        # AuthorizationError, not blanket-applied).
+        assert body["details"] == exc.details
+        assert body["error"] == "RES-001"
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_preserves_retry_after(self):
+        """RateLimitError carries ``retry_after`` in details — clients depend
+        on this to back off properly. The handler MUST pass it through."""
+        exc = RateLimitError("Rate limit exceeded", retry_after=42)
+        response = await memory_cloud_exception_handler(_request_mock(), exc)
+        body = json.loads(response.body)
+        assert body["details"] == {"retry_after": 42}
+        assert response.status_code == 429

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -4,7 +4,7 @@ Covers the new ``context_id`` query-param filter:
   - Omitted: legacy behavior, no PermissionService call.
   - Provided: PermissionService.resolve_context_for_workspace_read enforces
     access and ``Memory.context_id`` is added to both data and count queries.
-  - Provided but context denied / not found: HTTPException 404 propagates.
+  - Provided but context denied / not found: NotFoundException 404 propagates.
 """
 
 from datetime import datetime
@@ -12,9 +12,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 
 from api.routes.memory import list_memories
+from utils.exceptions import NotFoundException
 
 MOCK_USER = {"user_id": "test_user_123"}
 
@@ -241,17 +241,17 @@ class TestListMemoriesContextFilter:
 
     @pytest.mark.asyncio
     async def test_context_id_denied_propagates_404(self):
-        """PermissionService 404 on forbidden/missing context propagates as HTTPException."""
+        """PermissionService 404 on forbidden/missing context propagates as NotFoundException."""
         mock_db = AsyncMock()  # must not reach .execute()
         context_id = uuid4()
 
         mock_perm_instance = MagicMock()
         mock_perm_instance.resolve_context_for_workspace_read = AsyncMock(
-            side_effect=HTTPException(status_code=404, detail=f"Context {context_id} not found")
+            side_effect=NotFoundException("Context", str(context_id))
         )
 
         with patch("api.routes.memory.PermissionService", return_value=mock_perm_instance):
-            with pytest.raises(HTTPException) as exc:
+            with pytest.raises(NotFoundException) as exc:
                 await list_memories(
                     user=MOCK_USER,
                     db=mock_db,

--- a/backend/tests/api/test_resource_ingest.py
+++ b/backend/tests/api/test_resource_ingest.py
@@ -26,7 +26,7 @@ from db.constraint_names import (
 from models.auth import Context
 from models.resource import ResourceEvent, ResourceToken
 from models.schemas import ResourceEventRequest
-from utils.exceptions import ConflictError
+from utils.exceptions import AuthorizationError, ConflictError
 
 
 def _make_integrity_error(
@@ -408,13 +408,10 @@ class TestResourceIngestWorkspaceBoundary:
         self, mock_request, mock_token, mock_context
     ):
         """Attacker token (non-member) must be rejected with audit warning.
-        The log's `reason` kwarg carries the underlying auth failure detail
-        for forensics."""
+        The log's `reason` kwarg carries the AuthorizationError deny
+        classification (private exc.reason) for forensics."""
         db = MagicMock()
-        auth_error = HTTPException(
-            status_code=403,
-            detail="Not a member of workspace " + str(mock_context.workspace_id),
-        )
+        auth_error = AuthorizationError("Insufficient permissions", reason="not_a_member")
         with (
             patch(
                 "services.permission_service.PermissionService.check_workspace_access",
@@ -433,7 +430,7 @@ class TestResourceIngestWorkspaceBoundary:
                 target_workspace_id=str(mock_context.workspace_id),
                 token_creator=mock_token.created_by,
                 client_ip="203.0.113.7",
-                reason=auth_error.detail,
+                reason="not_a_member",
             )
 
     @pytest.mark.asyncio
@@ -441,11 +438,11 @@ class TestResourceIngestWorkspaceBoundary:
         self, mock_request, mock_token, mock_context
     ):
         """Soft-deleted workspace must deny ingest — the prior is_workspace_member
-        check silently allowed this. `check_workspace_access` now catches it."""
+        check silently allowed this. `check_workspace_access` now catches it
+        and raises AuthorizationError(reason="workspace_deleted")."""
         db = MagicMock()
-        soft_deleted_error = HTTPException(
-            status_code=403,
-            detail=f"Workspace {mock_context.workspace_id} not found or has been deleted",
+        soft_deleted_error = AuthorizationError(
+            "Insufficient permissions", reason="workspace_deleted"
         )
         with (
             patch(
@@ -459,7 +456,7 @@ class TestResourceIngestWorkspaceBoundary:
 
             assert exc.value.status_code == 403
             call_kwargs = mock_logger.warning.call_args.kwargs
-            assert "deleted" in call_kwargs["reason"]
+            assert call_kwargs["reason"] == "workspace_deleted"
 
     @pytest.mark.asyncio
     async def test_membership_denied_without_request_client(self, mock_token, mock_context):
@@ -467,7 +464,7 @@ class TestResourceIngestWorkspaceBoundary:
         req = MagicMock()
         req.client = None
         db = MagicMock()
-        auth_error = HTTPException(status_code=403, detail="Not a member")
+        auth_error = AuthorizationError("Insufficient permissions", reason="not_a_member")
         with (
             patch(
                 "services.permission_service.PermissionService.check_workspace_access",

--- a/backend/tests/api/test_sleep_reports_workspace.py
+++ b/backend/tests/api/test_sleep_reports_workspace.py
@@ -14,13 +14,13 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from api.main import app
 from auth.dependencies import get_current_user
 from db.base import get_db
 from services.permission_service import PermissionService
+from utils.exceptions import AuthorizationError
 
 _WORKSPACE_ID = uuid4()
 _OTHER_WORKSPACE_ID = uuid4()
@@ -99,7 +99,7 @@ def _install_workspace_overrides(
     *,
     user: dict,
     db_mock=None,
-    permission_raises: HTTPException | None = None,
+    permission_raises: AuthorizationError | None = None,
 ):
     """Wire mocks for the workspace route."""
 
@@ -168,10 +168,7 @@ class TestWorkspaceListSleepReports:
         _install_workspace_overrides(
             client,
             user=_regular_user(),
-            permission_raises=HTTPException(
-                status_code=403,
-                detail="Requires 'admin' role or higher",
-            ),
+            permission_raises=AuthorizationError("Insufficient permissions"),
         )
 
         response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/sleep-reports")
@@ -182,10 +179,7 @@ class TestWorkspaceListSleepReports:
         _install_workspace_overrides(
             client,
             user=_regular_user(),
-            permission_raises=HTTPException(
-                status_code=403,
-                detail="Not a member of workspace",
-            ),
+            permission_raises=AuthorizationError("Insufficient permissions"),
         )
 
         response = client.get(f"/api/v1/workspaces/{_OTHER_WORKSPACE_ID}/sleep-reports")
@@ -299,10 +293,7 @@ class TestWorkspaceGetSleepReportDetail:
         _install_workspace_overrides(
             client,
             user=_regular_user(),
-            permission_raises=HTTPException(
-                status_code=403,
-                detail="Requires 'admin' role or higher",
-            ),
+            permission_raises=AuthorizationError("Insufficient permissions"),
         )
 
         response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/sleep-reports/{uuid4()}")

--- a/backend/tests/mcp_server/test_context_tools.py
+++ b/backend/tests/mcp_server/test_context_tools.py
@@ -1,0 +1,128 @@
+"""Tests for MCP context tool handlers (Issue #401).
+
+Locks down the AuthorizationError / NotFoundException response surface for
+``handle_delete_context``. The branches at ``mcp_server/tools/context.py``
+lines 691 (NotFoundException → ``context_not_found``) and 697-700
+(AuthorizationError → ``permission_denied``) were dead code before #401:
+``PermissionService.check_context_owner`` raised ``HTTPException``, which
+matched neither domain-exception branch and fell into the generic 500
+``delete_context_error`` path.
+
+After #401 the service raises domain exceptions and these branches are live
+— this test pins that contract so a future refactor of the MCP error
+surface can't silently revert it.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.context import handle_delete_context
+from utils.exceptions import AuthorizationError, NotFoundException
+
+
+class TestHandleDeleteContextErrorSurface:
+    @pytest.fixture
+    def user_id(self):
+        return "test_user_401"
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def context_id(self):
+        return uuid4()
+
+    @pytest.mark.asyncio
+    async def test_authorization_error_returns_permission_denied(
+        self, user_id, workspace_id, context_id
+    ):
+        """check_context_owner AuthorizationError → MCP ``permission_denied``.
+
+        Issue #401: this branch became live when PermissionService swapped
+        to domain exceptions. Before the refactor it was dead — the
+        HTTPException(403) raised by check_context_owner fell into the
+        generic Exception 500 path instead.
+        """
+        mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        mock_perm = MagicMock()
+        mock_perm.check_context_owner = AsyncMock(
+            side_effect=AuthorizationError("Insufficient permissions")
+        )
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "services.permission_service.PermissionService",
+                return_value=mock_perm,
+            ),
+            patch(
+                "mcp_server.tools.context._log_tool_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await handle_delete_context(
+                args={"context_id": str(context_id)},
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        assert len(result) == 1
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "permission_denied"
+        mock_db.rollback.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_not_found_exception_returns_context_not_found(
+        self, user_id, workspace_id, context_id
+    ):
+        """check_context_owner NotFoundException → MCP ``context_not_found``.
+
+        Same uniform-disclosure contract as test_graph_visibility's 404
+        cases: regardless of whether the context truly doesn't exist or
+        the caller can't see it, the MCP surface emits ``context_not_found``.
+        """
+        mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        mock_perm = MagicMock()
+        mock_perm.check_context_owner = AsyncMock(
+            side_effect=NotFoundException("Context", str(context_id))
+        )
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "services.permission_service.PermissionService",
+                return_value=mock_perm,
+            ),
+            patch(
+                "mcp_server.tools.context._log_tool_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await handle_delete_context(
+                args={"context_id": str(context_id)},
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        assert len(result) == 1
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "context_not_found"
+        mock_db.rollback.assert_awaited()

--- a/backend/tests/services/test_permission_service.py
+++ b/backend/tests/services/test_permission_service.py
@@ -69,7 +69,7 @@ class TestWorkspaceAccess:
         with pytest.raises(AuthorizationError) as exc_info:
             await service.check_workspace_access("user1", ws_id, required_role="admin")
         assert exc_info.value.status_code == 403
-        assert exc_info.value.details.get("reason") == "role_too_low"
+        assert exc_info.value.reason == "role_too_low"
 
     @pytest.mark.asyncio
     async def test_check_workspace_access_not_member(self, service):
@@ -80,7 +80,7 @@ class TestWorkspaceAccess:
         with pytest.raises(AuthorizationError) as exc_info:
             await service.check_workspace_access("user1", ws_id)
         assert exc_info.value.status_code == 403
-        assert exc_info.value.details.get("reason") == "not_a_member"
+        assert exc_info.value.reason == "not_a_member"
 
     @pytest.mark.asyncio
     async def test_check_workspace_access_deleted_workspace(self, service, mock_db):
@@ -92,7 +92,7 @@ class TestWorkspaceAccess:
         with pytest.raises(AuthorizationError) as exc_info:
             await service.check_workspace_access("user1", uuid4())
         assert exc_info.value.status_code == 403
-        assert exc_info.value.details.get("reason") == "workspace_deleted"
+        assert exc_info.value.reason == "workspace_deleted"
 
     @pytest.mark.asyncio
     async def test_is_workspace_member_true(self, service):

--- a/backend/tests/services/test_permission_service.py
+++ b/backend/tests/services/test_permission_service.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
 
 from services.permission_service import (
     CONTEXT_ROLE_WEIGHTS,
@@ -13,6 +12,7 @@ from services.permission_service import (
     MemoryAuthorId,
     PermissionService,
 )
+from utils.exceptions import AuthorizationError, NotFoundException
 
 
 class TestRoleWeights:
@@ -66,9 +66,10 @@ class TestWorkspaceAccess:
         mock_member = MagicMock(role="viewer")
         service.workspace_service.get_member = AsyncMock(return_value=mock_member)
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(AuthorizationError) as exc_info:
             await service.check_workspace_access("user1", ws_id, required_role="admin")
         assert exc_info.value.status_code == 403
+        assert exc_info.value.details.get("reason") == "role_too_low"
 
     @pytest.mark.asyncio
     async def test_check_workspace_access_not_member(self, service):
@@ -76,9 +77,10 @@ class TestWorkspaceAccess:
         ws_id = uuid4()
         service.workspace_service.get_member = AsyncMock(return_value=None)
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(AuthorizationError) as exc_info:
             await service.check_workspace_access("user1", ws_id)
         assert exc_info.value.status_code == 403
+        assert exc_info.value.details.get("reason") == "not_a_member"
 
     @pytest.mark.asyncio
     async def test_check_workspace_access_deleted_workspace(self, service, mock_db):
@@ -87,9 +89,10 @@ class TestWorkspaceAccess:
         mock_result.scalar_one_or_none.return_value = None  # workspace deleted
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(AuthorizationError) as exc_info:
             await service.check_workspace_access("user1", uuid4())
         assert exc_info.value.status_code == 403
+        assert exc_info.value.details.get("reason") == "workspace_deleted"
 
     @pytest.mark.asyncio
     async def test_is_workspace_member_true(self, service):
@@ -163,7 +166,7 @@ class TestContextAccess:
         mock_result.scalar_one_or_none.return_value = mock_ctx
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(AuthorizationError) as exc_info:
             await service.check_context_access("user1", ctx_id)
         assert exc_info.value.status_code == 403
 
@@ -174,7 +177,7 @@ class TestContextAccess:
         mock_result.scalar_one_or_none.return_value = None
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundException) as exc_info:
             await service.check_context_access("user1", uuid4())
         assert exc_info.value.status_code == 404
 
@@ -322,7 +325,7 @@ class TestGetAccessibleContextsForViewer:
         result = await service_with_viewer.get_accessible_contexts("viewer-user", uuid4())
         assert result == ["ctx-a", "ctx-b"], (
             "viewer should reach the per-role branch and receive shared "
-            "contexts; receiving an empty list (or HTTPException) means "
+            "contexts; receiving an empty list (or AuthorizationError) means "
             "the membership gate rejected viewer before the branch ran"
         )
 
@@ -377,7 +380,7 @@ class TestResolveContextWhitelistEnforcement:
         member.allowed_context_ids = [uuid4()]  # whitelist excludes ctx_id
         service = self._service_with_member(member, ctx)
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundException) as exc_info:
             await service.resolve_context_for_workspace_read("user1", ctx_id)
         assert exc_info.value.status_code == 404
 
@@ -390,7 +393,7 @@ class TestResolveContextWhitelistEnforcement:
         viewer.allowed_context_ids = []  # explicit empty whitelist
         service = self._service_with_member(viewer, ctx)
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundException) as exc_info:
             await service.resolve_context_for_workspace_read("user1", ctx_id)
         assert exc_info.value.status_code == 404
 
@@ -433,7 +436,7 @@ class TestResolveContextWhitelistEnforcement:
         suspended_member.allowed_context_ids = None  # suspended
         service = self._service_with_member(suspended_member, ctx)
 
-        with pytest.raises(HTTPException) as exc_info:
+        with pytest.raises(NotFoundException) as exc_info:
             await service.resolve_context_for_workspace_read("user1", ctx_id)
         assert exc_info.value.status_code == 404
 

--- a/backend/tests/utils/test_exceptions.py
+++ b/backend/tests/utils/test_exceptions.py
@@ -76,6 +76,25 @@ class TestAuthErrors:
         exc = AuthorizationError("Access denied")
         assert exc.status_code == 403
 
+    def test_authorization_error_reason_is_private(self):
+        """CWE-639: ``reason`` lives on ``exc.reason`` (private), not in
+        ``exc.details`` — the global handler serializes ``details`` to the
+        response body, so leaking ``reason`` would re-introduce the
+        workspace-enumeration vector that the uniform "Insufficient
+        permissions" message is designed to close. See #401 gate2 CSO.
+        """
+        exc = AuthorizationError("Insufficient permissions", reason="workspace_deleted")
+        assert exc.reason == "workspace_deleted"
+        assert "reason" not in exc.details
+        assert exc.details == {}
+
+    def test_authorization_error_default_reason_none(self):
+        """``reason`` defaults to ``None`` when not provided, so existing
+        AuthorizationError raises without a reason kwarg are unaffected."""
+        exc = AuthorizationError("Insufficient permissions")
+        assert exc.reason is None
+        assert exc.details == {}
+
     def test_api_key_error(self):
         exc = APIKeyError()
         assert exc.status_code == 401


### PR DESCRIPTION
Closes #401

## Summary

- Refactor `backend/src/services/permission_service.py` to raise domain exceptions (`NotFoundException`, `AuthorizationError`) instead of `fastapi.HTTPException`. Translation happens at the HTTP boundary via the already-registered `@app.exception_handler(MemoryCloudException)` at `api/main.py:279` — no new handler needed.
- **CWE-639 hardening**: 403 messages collapse to the uniform `"Insufficient permissions"`. Pre-refactor f-string details (`"Workspace X not found"`, `"Not a member of X"`, `"Requires admin role"`) leaked workspace existence — these are removed. The structured deny-reason classification is preserved via a private `AuthorizationError.reason` attribute that is NEVER serialized to clients (defense-in-depth filter in the global handler enforces this).
- **Forward-proofing for non-HTTP callers**: MCP `_helpers.py::_resolve_context_for_read` no longer imports `fastapi`; it catches `NotFoundException` directly. Future CLI tools / background jobs can do the same.
- **Sibling cleanup**: `member_credentials_service.py` (1 raise) also drops `fastapi` import. `system_admin_service.py` is intentionally **out of scope** — its 400 state preconditions and 403 business protections have no clean `MemoryCloudException` mapping today and require new exception class design (filed as follow-up candidate, see commit `93c5fd47`).

## Implementation notes

- 16 raise sites in `permission_service.py` migrated. 4 internal `except HTTPException` blocks updated to catch the new domain types.
- 7 caller-side files updated to catch `(NotFoundException, AuthorizationError)` and read `exc.reason` instead of `exc.detail`: `auth/dependencies.py`, `auth/analysis_gates.py`, `api/routes/{graph,memory,context_search_config,resource_ingest,admin}.py`, `mcp_server/tools/{_helpers,analysis}.py`.
- 9 test files updated. 2 new test files added: `test_context_tools.py` (2 tests covering MCP branches that were dead code pre-refactor and went live post-refactor), `test_exception_handler.py` (3 tests pinning the defense-in-depth filter contract).
- Pre-existing 500 paths in `graph.py` unified under `InternalError` (`utils/exceptions.py`) for response-shape consistency.
- `context_search_config.py` had a pre-existing bug where GET/POST handlers caught `Exception → 500` without an `MemoryCloudException` pass-through guard. Fixed as part of this PR (would have silently translated 403/404 to 500 with the UUID in the response detail).
- 12 commits on branch with atomic scope per logical step. Squash-merge collapses them; branch-internal `DenyReason` add-then-remove (e0a192d6 → 82df3ff9) is the result of the simplify-review path identifying the alias as dead documentation.

### Frontend / SDK impact

Pre-checked: `grep -rn 'response\.detail\|\["detail"\]' frontend/ kagura-memory-python-sdk/` returns 2 frontend hits, both consume `apiError.details["detail"]` (the `MemoryCloudException` shape) — they are unaffected because the response shape they read is the post-refactor uniform shape. SDK is not local; no observable breakage.

### Test status

- 111 unit tests pass (29 permission_service + 33 utils/exceptions + 6 memory_list + 3 exception_handler + 2 mcp/context + 38 others)
- Integration tests (test_graph_visibility.py 18 tests + test_context_sleep_mode + test_context_members_rbac) require Redis/Docker — confirmed clean in CI environment is the operator's pre-merge action.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green (initial red on CWE-639 details.reason leak — addressed in commit b98933fe + handler test 9a542dad)
- qa-lead: green (initial yellow on missing handler-filter unit test — addressed in commit 9a542dad)
- cto: green
- gate1: green via /ask → CTO route, with /cso cross-reference reinforcement
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/401-feat-refactor-services-replace-httpexception.gate1.md
- ~/.claude/cache/gh-issue-driven/401-feat-refactor-services-replace-httpexception.gate2.md

🤖 Generated via /gh-issue-driven:ship
