### PR TITLE
refactor(api): replace HTTPException with domain exceptions in SystemAdminService (#603)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -18,7 +18,12 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from config.constants import APP_VERSION
 from config.settings import get_settings
-from utils.exceptions import AuthorizationError, DatabaseConnectionError, MemoryCloudException
+from utils.exceptions import (
+    AdminProtectionError,
+    AuthorizationError,
+    DatabaseConnectionError,
+    MemoryCloudException,
+)
 from utils.logger import get_logger, setup_logger
 
 # Setup logger first
@@ -289,13 +294,11 @@ async def memory_cloud_exception_handler(
         path=request.url.path,
     )
 
-    # CWE-639 defense in depth: AuthorizationError is designed with a uniform
-    # client-facing message. Any forensics payload that leaks into ``details``
-    # (e.g. a future contributor adding `**details` kwargs) would re-introduce
-    # the workspace-enumeration vector. Strip ``details`` to ``{}`` for this
-    # type — the structured ``reason`` lives on ``exc.reason`` (private) for
-    # log/observability use only, never serialized to the response body.
-    details = {} if isinstance(exc, AuthorizationError) else exc.details
+    # CWE-639 defense in depth: deny-class exceptions carry log-only
+    # ``reason`` on a private attribute and must never leak forensics
+    # through ``details``. Strip uniformly so future ``**details`` drift
+    # on either type cannot reopen the workspace-enumeration vector.
+    details = {} if isinstance(exc, (AuthorizationError, AdminProtectionError)) else exc.details
 
     return JSONResponse(
         status_code=exc.status_code,

--- a/backend/src/services/system_admin_service.py
+++ b/backend/src/services/system_admin_service.py
@@ -13,11 +13,11 @@ Protection Rules:
 - Cannot delete/demote if last remaining admin
 """
 
-from fastapi import HTTPException
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import AuditLog, User
+from utils.exceptions import AdminProtectionError, BadRequestError, NotFoundException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -81,7 +81,8 @@ class SystemAdminService:
             Updated user object
 
         Raises:
-            HTTPException: 404 if user not found, 400 if already admin
+            NotFoundException: 404 if user not found.
+            BadRequestError: 400 (``ADMIN-101``) if user is already a system admin.
 
         Example:
             >>> user = await service.promote_to_system_admin(
@@ -99,13 +100,16 @@ class SystemAdminService:
             logger.warning(
                 "promote_to_system_admin_failed", user_id=user_id, reason="user_not_found"
             )
-            raise HTTPException(status_code=404, detail="User not found")
+            raise NotFoundException("User")
 
         if user.role == "admin":
             logger.warning(
                 "promote_to_system_admin_failed", user_email=user.email, reason="already_admin"
             )
-            raise HTTPException(status_code=400, detail="User is already a system admin")
+            raise BadRequestError(
+                "User is already a system admin",
+                error_code="ADMIN-101",
+            )
 
         # Update role
         old_role = user.role
@@ -152,7 +156,10 @@ class SystemAdminService:
             Updated user object
 
         Raises:
-            HTTPException: 404 if not found, 403 if protected
+            NotFoundException: 404 if user not found.
+            BadRequestError: 400 (``ADMIN-102``) if user is not a system admin.
+            AdminProtectionError: 403 if the target is the initial admin or
+                the last remaining admin.
 
         Example:
             >>> user = await service.demote_system_admin(
@@ -168,11 +175,14 @@ class SystemAdminService:
 
         if not user:
             logger.warning("demote_system_admin_failed", user_id=user_id, reason="user_not_found")
-            raise HTTPException(status_code=404, detail="User not found")
+            raise NotFoundException("User")
 
         if user.role != "admin":
             logger.warning("demote_system_admin_failed", user_email=user.email, reason="not_admin")
-            raise HTTPException(status_code=400, detail="User is not a system admin")
+            raise BadRequestError(
+                "User is not a system admin",
+                error_code="ADMIN-102",
+            )
 
         # Protection 1: Cannot demote initial admin
         if user.is_initial_admin:
@@ -181,9 +191,9 @@ class SystemAdminService:
                 user_email=user.email,
                 reason="initial_admin_protected",
             )
-            raise HTTPException(
-                status_code=403,
-                detail="Cannot demote the initial system administrator. This is a protected account.",
+            raise AdminProtectionError(
+                "Cannot demote the initial system administrator. This is a protected account.",
+                reason="initial_admin",
             )
 
         # Protection 2: Cannot demote last remaining admin
@@ -198,9 +208,9 @@ class SystemAdminService:
                 reason="last_admin_protected",
                 admin_count=admin_count,
             )
-            raise HTTPException(
-                status_code=403,
-                detail="Cannot demote the last remaining system administrator. At least one admin must exist.",
+            raise AdminProtectionError(
+                "Cannot demote the last remaining system administrator. At least one admin must exist.",
+                reason="last_admin",
             )
 
         # Demote to user

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -93,6 +93,31 @@ class AuthorizationError(MemoryCloudException):
         self.reason = reason
 
 
+class AdminProtectionError(MemoryCloudException):
+    """System-admin invariant blocks this operation (403).
+
+    Distinct from ``AuthorizationError``: the caller IS authorized to
+    perform admin actions in general — the request is blocked by a
+    per-invariant protection rule (initial-admin sanctity, last-admin
+    existence) that exists to prevent the platform from being left
+    without any administrator. Surfaces 403 because the caller cannot
+    retry their way through it; the block is structural, not credential.
+
+    Mirroring ``AuthorizationError``'s CWE-639 pattern, ``reason`` is a
+    private classification (``"initial_admin"`` / ``"last_admin"``) for
+    structured-log breadcrumbs only — kept off the response body so
+    future ``**details`` kwargs cannot quietly create a leak path. The
+    user-facing ``message`` already names the specific protection
+    (admin governance is documented platform behavior), so the
+    workspace-enumeration concern that motivated AuthorizationError's
+    uniform message does not apply here.
+    """
+
+    def __init__(self, message: str, *, reason: str | None = None) -> None:
+        super().__init__(message, status_code=403, error_code="ADMIN-001")
+        self.reason = reason
+
+
 class APIKeyError(MemoryCloudException):
     """API key related error (401)."""
 
@@ -168,6 +193,31 @@ class ValidationError(MemoryCloudException):
 
     def __init__(self, message: str, field: str | None = None, **details: Any):
         super().__init__(message, status_code=422, error_code="VAL-001", field=field, **details)
+
+
+class BadRequestError(MemoryCloudException):
+    """Request violates a state precondition (400).
+
+    Generic 400 for service-layer state-precondition failures (e.g.
+    "user is already an admin", "user is not an admin"). Each call site
+    supplies a use-case-specific message and overrides ``error_code`` so
+    SDK consumers can route on a stable identifier rather than parsing
+    the free-form message.
+
+    Distinct from ``ValidationError`` (422): this is a state mismatch
+    against the *current* server-side state, not a shape/format failure
+    in the request body. The request is well-formed; the world is not in
+    the state the caller assumed.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        error_code: str = "REQ-001",
+        **details: Any,
+    ) -> None:
+        super().__init__(message, status_code=400, error_code=error_code, **details)
 
 
 class UnsupportedMediaTypeError(MemoryCloudException):

--- a/backend/tests/api/test_exception_handler.py
+++ b/backend/tests/api/test_exception_handler.py
@@ -23,6 +23,7 @@ from fastapi import Request
 
 from api.main import memory_cloud_exception_handler
 from utils.exceptions import (
+    AdminProtectionError,
     AuthorizationError,
     NotFoundException,
     RateLimitError,
@@ -64,6 +65,50 @@ class TestAuthorizationErrorFilter:
         assert body["error"] == "AUTH-101"
         assert body["message"] == "Insufficient permissions"
         assert response.status_code == 403
+
+
+class TestAdminProtectionErrorFilter:
+    """CWE-639 defense in depth — AdminProtectionError NEVER leaks details.
+
+    Mirrors the AuthorizationError contract one tier down: the exception
+    type is constructed with no ``**details`` passthrough today, but the
+    handler still strips ``details`` so a future contributor cannot quietly
+    add a forensics field by routing through ``exc.details`` directly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_strips_smuggled_details_keys(self):
+        exc = AdminProtectionError(
+            "Cannot demote the initial system administrator.",
+            reason="initial_admin",
+        )
+        # Simulate a future contributor poking at ``details`` directly
+        # (bypassing the constructor's keyword-only signature).
+        exc.details["smuggled_key"] = "leak_me"
+        assert exc.details == {"smuggled_key": "leak_me"}
+
+        response = await memory_cloud_exception_handler(_request_mock(), exc)
+        body = json.loads(response.body)
+        assert body["details"] == {}, (
+            "AdminProtectionError MUST emit details={} regardless of what the "
+            "exception carries. Defense in depth against future kwarg drift."
+        )
+        assert body["error"] == "ADMIN-001"
+        assert body["message"] == "Cannot demote the initial system administrator."
+        assert response.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_reason_never_serialized(self):
+        """``exc.reason`` is structured-log nomenclature only — confirm it
+        never appears in the response body even when set."""
+        exc = AdminProtectionError(
+            "Cannot demote the last remaining system administrator.",
+            reason="last_admin",
+        )
+        response = await memory_cloud_exception_handler(_request_mock(), exc)
+        body = json.loads(response.body)
+        assert "reason" not in body
+        assert "reason" not in body.get("details", {})
 
 
 class TestOtherExceptionDetailsPreserved:

--- a/backend/tests/services/test_system_admin_service.py
+++ b/backend/tests/services/test_system_admin_service.py
@@ -10,11 +10,11 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
-from fastapi import HTTPException
 from sqlalchemy import select, text
 
 from models.auth import AuditLog, User
 from services.system_admin_service import SystemAdminService
+from utils.exceptions import AdminProtectionError, BadRequestError, NotFoundException
 
 
 @pytest_asyncio.fixture(autouse=True)
@@ -162,18 +162,20 @@ class TestPromoteToSystemAdmin:
     @pytest.mark.asyncio
     async def test_promote_user_not_found_raises_404(self, db_session):
         service = SystemAdminService(db_session)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(NotFoundException) as exc:
             await service.promote_to_system_admin("nonexistent", "promoter@example.com")
         assert exc.value.status_code == 404
-        assert "User not found" in exc.value.detail
+        assert exc.value.error_code == "RES-001"
+        assert "User not found" in exc.value.message
 
     @pytest.mark.asyncio
     async def test_promote_already_admin_raises_400(self, db_session, fixture_admin):
         service = SystemAdminService(db_session)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(BadRequestError) as exc:
             await service.promote_to_system_admin(fixture_admin.user_id, "promoter@example.com")
         assert exc.value.status_code == 400
-        assert "already a system admin" in exc.value.detail
+        assert exc.value.error_code == "ADMIN-101"
+        assert "already a system admin" in exc.value.message
 
 
 class TestDemoteSystemAdmin:
@@ -206,25 +208,29 @@ class TestDemoteSystemAdmin:
     @pytest.mark.asyncio
     async def test_demote_user_not_found_raises_404(self, db_session):
         service = SystemAdminService(db_session)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(NotFoundException) as exc:
             await service.demote_system_admin("nonexistent", "demoter@example.com")
         assert exc.value.status_code == 404
+        assert exc.value.error_code == "RES-001"
 
     @pytest.mark.asyncio
     async def test_demote_not_admin_raises_400(self, db_session, fixture_regular):
         service = SystemAdminService(db_session)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(BadRequestError) as exc:
             await service.demote_system_admin(fixture_regular.user_id, "demoter@example.com")
         assert exc.value.status_code == 400
-        assert "not a system admin" in exc.value.detail
+        assert exc.value.error_code == "ADMIN-102"
+        assert "not a system admin" in exc.value.message
 
     @pytest.mark.asyncio
     async def test_demote_initial_admin_raises_403(self, db_session, fixture_admin):
         service = SystemAdminService(db_session)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(AdminProtectionError) as exc:
             await service.demote_system_admin(fixture_admin.user_id, "demoter@example.com")
         assert exc.value.status_code == 403
-        assert "initial" in exc.value.detail.lower()
+        assert exc.value.error_code == "ADMIN-001"
+        assert exc.value.reason == "initial_admin"
+        assert "initial" in exc.value.message.lower()
 
     @pytest.mark.asyncio
     async def test_demote_last_admin_raises_403(self, db_session):
@@ -240,10 +246,12 @@ class TestDemoteSystemAdmin:
         await db_session.flush()
 
         service = SystemAdminService(db_session)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(AdminProtectionError) as exc:
             await service.demote_system_admin(lone_admin.user_id, "demoter@example.com")
         assert exc.value.status_code == 403
-        assert "last" in exc.value.detail.lower()
+        assert exc.value.error_code == "ADMIN-001"
+        assert exc.value.reason == "last_admin"
+        assert "last" in exc.value.message.lower()
 
 
 class TestCanDeleteAdmin:

--- a/backend/tests/utils/test_exceptions.py
+++ b/backend/tests/utils/test_exceptions.py
@@ -1,11 +1,15 @@
 """Tests for custom exceptions."""
 
+import pytest
+
 from utils.exceptions import (
+    AdminProtectionError,
     APIKeyError,
     APIKeyExpiredError,
     APIKeyRevokedError,
     AuthenticationError,
     AuthorizationError,
+    BadRequestError,
     CohereError,
     ConfigurationError,
     ConflictError,
@@ -95,6 +99,37 @@ class TestAuthErrors:
         assert exc.reason is None
         assert exc.details == {}
 
+    def test_admin_protection_error_defaults(self):
+        exc = AdminProtectionError("Cannot demote the initial system administrator.")
+        assert exc.status_code == 403
+        assert exc.error_code == "ADMIN-001"
+        assert exc.reason is None
+        assert exc.details == {}
+
+    def test_admin_protection_error_carries_reason_privately(self):
+        """Mirrors AuthorizationError: ``reason`` lives on ``exc.reason``
+        (private), never in ``exc.details``. The handler additionally
+        strips ``details`` for AdminProtectionError so any future
+        ``**details`` smuggling cannot leak into the response body."""
+        exc = AdminProtectionError(
+            "Cannot demote the initial system administrator.",
+            reason="initial_admin",
+        )
+        assert exc.reason == "initial_admin"
+        assert "reason" not in exc.details
+        assert exc.details == {}
+
+    def test_admin_protection_error_rejects_unknown_kwargs(self):
+        """Constructor signature is keyword-only on ``reason`` with no
+        ``**details`` passthrough — a contributor adding a forensics kwarg
+        like ``user_email="..."`` gets a TypeError at construction time
+        instead of silently leaking into the response body."""
+        with pytest.raises(TypeError):
+            AdminProtectionError(  # type: ignore[call-arg]
+                "msg",
+                user_email="leak@example.com",
+            )
+
     def test_api_key_error(self):
         exc = APIKeyError()
         assert exc.status_code == 401
@@ -141,6 +176,26 @@ class TestResourceErrors:
         exc = ValidationError("Bad input", field="email")
         assert exc.status_code == 422
         assert exc.details["field"] == "email"
+
+    def test_bad_request_error_default_code(self):
+        exc = BadRequestError("User is already a system admin")
+        assert exc.status_code == 400
+        assert exc.error_code == "REQ-001"
+        assert exc.message == "User is already a system admin"
+
+    def test_bad_request_error_custom_code(self):
+        """Call sites override ``error_code`` so SDKs can route on a stable
+        identifier without parsing the free-form message."""
+        exc = BadRequestError("User is already a system admin", error_code="ADMIN-101")
+        assert exc.status_code == 400
+        assert exc.error_code == "ADMIN-101"
+
+    def test_bad_request_error_details_passthrough(self):
+        """Unlike AdminProtectionError, BadRequestError forwards ``**details``
+        because 400 state-precondition errors do not carry the CWE-639
+        enumeration risk that motivated the deny-class strip."""
+        exc = BadRequestError("bad state", error_code="X-001", field="role")
+        assert exc.details == {"field": "role"}
 
 
 class TestRateLimitErrors:


### PR DESCRIPTION
## Summary

Follow-up to #401 / PR #602 (PermissionService refactor). Migrates the 6 `HTTPException` raises in `SystemAdminService` to `MemoryCloudException` subclasses so the service no longer imports `fastapi`.

Closes #603.

### New exception classes

- **`BadRequestError`** (400, default code `REQ-001`) — generic 400 for state-precondition failures, with overridable `error_code` per call site so SDK consumers can route on a stable identifier (parallels `ConflictError` / `DatabaseError`).
- **`AdminProtectionError`** (403, `ADMIN-001`) — distinct from `AuthorizationError`. The caller IS authorized for admin actions in general but is blocked by a per-invariant protection (initial-admin sanctity, last-admin existence). Constructor refuses `**details` by design; `reason` (`initial_admin` / `last_admin`) is a private log-only attribute, never serialized.

### Service migrations

| Was | Now |
|---|---|
| `HTTPException(404, "User not found")` ×4 | `NotFoundException("User")` |
| `HTTPException(400, "User is already a system admin")` | `BadRequestError(error_code="ADMIN-101")` |
| `HTTPException(400, "User is not a system admin")` | `BadRequestError(error_code="ADMIN-102")` |
| `HTTPException(403, "Cannot demote the initial...")` | `AdminProtectionError(reason="initial_admin")` |
| `HTTPException(403, "Cannot demote the last remaining...")` | `AdminProtectionError(reason="last_admin")` |

`fastapi` import dropped from `system_admin_service.py`.

### CWE-639 defense in depth

`memory_cloud_exception_handler` now strips `details` → `{}` for both `AuthorizationError` and `AdminProtectionError` so future `**details` drift on either deny class cannot reopen the leak vector. Pinned by `TestAdminProtectionErrorFilter` (mutates `exc.details` directly and verifies the handler still produces `details={}` in the response body).

### Response shape

Changes from `{"detail": "..."}` to `{"error", "message", "details"}` for these 3 routes — intentional, consistent with #602. Frontend `lib/api/base.ts:79-81` already reads `errorDetails.message || errorDetails.detail`, so the admin UI is unaffected.

## Test plan

- [x] `tests/utils/test_exceptions.py` — new tests for both exception classes (defaults, private-reason, rejects-unknown-kwargs, details passthrough)
- [x] `tests/api/test_exception_handler.py` — handler strips smuggled `details` for `AdminProtectionError`; `reason` never serialized
- [x] `tests/services/test_system_admin_service.py` — migrated to domain exceptions (asserts on `status_code` + `error_code` + `reason` + `message`)
- [x] Adjacent test sweep: `test_account_erasure_service`, `test_api_routes_coverage`, `test_auth_required` — 31 passed
- [x] Full unit suite (`tests/services tests/api tests/utils tests/auth`, excluding integration) — 766 passed
- [x] Frontend contract verified: `frontend/src/lib/api/base.ts` reads both `message` and `detail` keys

## Acceptance criteria (from #603)

- [x] Design + add 2 new exception classes with tests
- [x] Migrate 6 raises in `system_admin_service.py`
- [x] Update `test_system_admin_service.py` (`exc.value.detail` → `exc.value.message`)
- [x] Drop `fastapi` import from `system_admin_service.py`
- [x] CWE-639 / response-shape contracts preserved (keyword-only kwargs + private attrs + handler defense-in-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)