### PR TITLE
refactor(api,mcp,test): handle_update_context error envelope + member_credentials_service test (#604, #605)

### DIFF
--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -383,14 +383,8 @@ async def handle_update_context(
                     "No fields to update. Provide at least one of: summary, usage_guide, display_name, description, resource_id, is_public, is_locked.",
                 )
 
-            # Permission check using PermissionService (same as REST API).
-            # Mirrors handle_delete_context: NotFoundException → uniform 404
-            # envelope (CWE-639 — don't disclose whether the context exists in
-            # another workspace), AuthorizationError → permission_denied with
-            # exc.message (the AuthorizationError class enforces the uniform
-            # "Insufficient permissions" message — passing exc.message instead
-            # of str(exc) keeps the response body aligned with the
-            # global memory_cloud_exception_handler contract).
+            # Mirrors handle_delete_context. Uses exc.message (not str(exc))
+            # so AuthorizationError's CWE-639 uniform-message contract holds.
             try:
                 if requested_fields & owner_fields:
                     # Owner-only fields → require context owner

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -357,6 +357,7 @@ async def handle_update_context(
             from uuid import UUID as _UUID
 
             from services.permission_service import PermissionService
+            from utils.exceptions import AuthorizationError, NotFoundException
 
             ctx_uuid = _UUID(args["context_id"])
 
@@ -382,7 +383,14 @@ async def handle_update_context(
                     "No fields to update. Provide at least one of: summary, usage_guide, display_name, description, resource_id, is_public, is_locked.",
                 )
 
-            # Permission check using PermissionService (same as REST API)
+            # Permission check using PermissionService (same as REST API).
+            # Mirrors handle_delete_context: NotFoundException → uniform 404
+            # envelope (CWE-639 — don't disclose whether the context exists in
+            # another workspace), AuthorizationError → permission_denied with
+            # exc.message (the AuthorizationError class enforces the uniform
+            # "Insufficient permissions" message — passing exc.message instead
+            # of str(exc) keeps the response body aligned with the
+            # global memory_cloud_exception_handler contract).
             try:
                 if requested_fields & owner_fields:
                     # Owner-only fields → require context owner
@@ -392,10 +400,15 @@ async def handle_update_context(
                     context, _ = await perm_service.check_context_access(
                         user_id, ctx_uuid, required_role="editor"
                     )
-            except Exception as perm_err:
+            except NotFoundException:
+                return _error_response(
+                    "context_not_found",
+                    f"Context {ctx_uuid} not found or access denied.",
+                )
+            except AuthorizationError as perm_err:
                 return _error_response(
                     "permission_denied",
-                    str(perm_err),
+                    perm_err.message,
                     help="You need owner access for summary/usage_guide/resource_id/is_public/is_locked, or editor access for display_name/description.",
                 )
 

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -395,11 +395,13 @@ async def handle_update_context(
                         user_id, ctx_uuid, required_role="editor"
                     )
             except NotFoundException:
+                await db.rollback()
                 return _error_response(
                     "context_not_found",
                     f"Context {ctx_uuid} not found or access denied.",
                 )
             except AuthorizationError as perm_err:
+                await db.rollback()
                 return _error_response(
                     "permission_denied",
                     perm_err.message,

--- a/backend/tests/mcp_server/test_context_tools.py
+++ b/backend/tests/mcp_server/test_context_tools.py
@@ -129,16 +129,10 @@ class TestHandleDeleteContextErrorSurface:
 
 
 class TestHandleUpdateContextErrorSurface:
-    """Pins the same domain-exception envelope contract for
-    ``handle_update_context`` (Issue #604, follow-up to #401 / PR #602).
-
-    Pre-#604 the handler caught all permission failures via a generic
-    ``except Exception as perm_err`` and collapsed both 404-class (context
-    doesn't exist or access denied) and 403-class (caller lacks permission)
-    into a single ``permission_denied`` envelope. After #604 the catch is
-    split to mirror ``handle_delete_context`` — and the message field uses
-    ``exc.message`` instead of ``str(exc)`` so the CWE-639 uniform-disclosure
-    contract enforced by ``AuthorizationError`` is honored verbatim.
+    """Pins the domain-exception envelope contract for handle_update_context
+    (mirror of handle_delete_context). AuthorizationError → permission_denied
+    with exc.message (CWE-639 uniform string). NotFoundException →
+    context_not_found.
     """
 
     @pytest.fixture

--- a/backend/tests/mcp_server/test_context_tools.py
+++ b/backend/tests/mcp_server/test_context_tools.py
@@ -21,7 +21,7 @@ from uuid import uuid4
 
 import pytest
 
-from mcp_server.tools.context import handle_delete_context
+from mcp_server.tools.context import handle_delete_context, handle_update_context
 from utils.exceptions import AuthorizationError, NotFoundException
 
 
@@ -126,3 +126,106 @@ class TestHandleDeleteContextErrorSurface:
         assert payload["status"] == "error"
         assert payload["error"] == "context_not_found"
         mock_db.rollback.assert_awaited()
+
+
+class TestHandleUpdateContextErrorSurface:
+    """Pins the same domain-exception envelope contract for
+    ``handle_update_context`` (Issue #604, follow-up to #401 / PR #602).
+
+    Pre-#604 the handler caught all permission failures via a generic
+    ``except Exception as perm_err`` and collapsed both 404-class (context
+    doesn't exist or access denied) and 403-class (caller lacks permission)
+    into a single ``permission_denied`` envelope. After #604 the catch is
+    split to mirror ``handle_delete_context`` — and the message field uses
+    ``exc.message`` instead of ``str(exc)`` so the CWE-639 uniform-disclosure
+    contract enforced by ``AuthorizationError`` is honored verbatim.
+    """
+
+    @pytest.fixture
+    def user_id(self):
+        return "test_user_604"
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def context_id(self):
+        return uuid4()
+
+    @pytest.mark.asyncio
+    async def test_authorization_error_returns_permission_denied(
+        self, user_id, workspace_id, context_id
+    ):
+        """check_context_owner AuthorizationError → MCP ``permission_denied``.
+
+        The response message must come from ``exc.message`` (the
+        AuthorizationError-enforced uniform ``"Insufficient permissions"``),
+        not ``str(exc)`` which could vary across str-coercion edge cases.
+        """
+        mock_db = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        mock_perm = MagicMock()
+        mock_perm.check_context_owner = AsyncMock(
+            side_effect=AuthorizationError("Insufficient permissions")
+        )
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "services.permission_service.PermissionService",
+                return_value=mock_perm,
+            ),
+        ):
+            result = await handle_update_context(
+                args={"context_id": str(context_id), "summary": "new summary"},
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        assert len(result) == 1
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "permission_denied"
+        assert payload["message"] == "Insufficient permissions"
+
+    @pytest.mark.asyncio
+    async def test_not_found_exception_returns_context_not_found(
+        self, user_id, workspace_id, context_id
+    ):
+        """check_context_owner NotFoundException → MCP ``context_not_found``.
+
+        Same uniform-disclosure contract as the delete-path test: regardless
+        of whether the context truly doesn't exist or the caller can't see
+        it, the MCP surface emits ``context_not_found``.
+        """
+        mock_db = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        mock_perm = MagicMock()
+        mock_perm.check_context_owner = AsyncMock(
+            side_effect=NotFoundException("Context", str(context_id))
+        )
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "services.permission_service.PermissionService",
+                return_value=mock_perm,
+            ),
+        ):
+            result = await handle_update_context(
+                args={"context_id": str(context_id), "summary": "new summary"},
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        assert len(result) == 1
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "context_not_found"

--- a/backend/tests/mcp_server/test_context_tools.py
+++ b/backend/tests/mcp_server/test_context_tools.py
@@ -158,6 +158,7 @@ class TestHandleUpdateContextErrorSurface:
         not ``str(exc)`` which could vary across str-coercion edge cases.
         """
         mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
 
         async def mock_get_db():
             yield mock_db
@@ -185,6 +186,7 @@ class TestHandleUpdateContextErrorSurface:
         assert payload["status"] == "error"
         assert payload["error"] == "permission_denied"
         assert payload["message"] == "Insufficient permissions"
+        mock_db.rollback.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_not_found_exception_returns_context_not_found(
@@ -197,6 +199,7 @@ class TestHandleUpdateContextErrorSurface:
         it, the MCP surface emits ``context_not_found``.
         """
         mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
 
         async def mock_get_db():
             yield mock_db
@@ -223,3 +226,4 @@ class TestHandleUpdateContextErrorSurface:
         payload = json.loads(result[0].text)
         assert payload["status"] == "error"
         assert payload["error"] == "context_not_found"
+        mock_db.rollback.assert_awaited()

--- a/backend/tests/services/test_member_credentials_service.py
+++ b/backend/tests/services/test_member_credentials_service.py
@@ -1,0 +1,90 @@
+"""Tests for MemberCredentialsService._check_can_view (Issue #605).
+
+Follow-up to #401 / PR #602 — commit 93c5fd47 swapped ``_check_can_view``
+to raise ``AuthorizationError`` instead of ``fastapi.HTTPException`` but
+no service-layer unit tests existed. These tests pin the post-refactor
+contract:
+
+- self-access bypass (no role lookup)
+- owner / admin allow paths
+- member / viewer deny paths
+- non-member (None role) deny path
+- status_code == 403, message == "Insufficient permissions", reason is None
+  (single-bit decision — not multi-path like PermissionService.check_workspace_access)
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from services.member_credentials_service import MemberCredentialsService
+from utils.exceptions import AuthorizationError
+
+
+class TestCheckCanView:
+    @pytest.fixture
+    def mock_db(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def service(self, mock_db):
+        return MemberCredentialsService(mock_db)
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.mark.asyncio
+    async def test_self_access_allowed(self, service, workspace_id):
+        """Self-access short-circuits before any role lookup runs."""
+        await service._check_can_view("user1", workspace_id, "user1")
+
+    @pytest.mark.asyncio
+    async def test_self_access_does_not_query_role(self, service, workspace_id):
+        """Self-access must NOT call get_workspace_role — if it did, a future
+        regression that adds DB-bound side effects to the role lookup would
+        silently break self-only callers."""
+        service.get_workspace_role = AsyncMock(return_value=None)
+        await service._check_can_view("user1", workspace_id, "user1")
+        service.get_workspace_role.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_workspace_owner_allowed_to_view_other(self, service, workspace_id):
+        service.get_workspace_role = AsyncMock(return_value="owner")
+        await service._check_can_view("owner_user", workspace_id, "target_user")
+
+    @pytest.mark.asyncio
+    async def test_workspace_admin_allowed_to_view_other(self, service, workspace_id):
+        service.get_workspace_role = AsyncMock(return_value="admin")
+        await service._check_can_view("admin_user", workspace_id, "target_user")
+
+    @pytest.mark.asyncio
+    async def test_workspace_member_denied(self, service, workspace_id):
+        service.get_workspace_role = AsyncMock(return_value="member")
+        with pytest.raises(AuthorizationError) as exc_info:
+            await service._check_can_view("member_user", workspace_id, "target_user")
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.message == "Insufficient permissions"
+        # Single-bit decision (owner/admin vs everyone else) — no multi-path
+        # classification, unlike PermissionService.check_workspace_access which
+        # carries reason ∈ {workspace_deleted, not_a_member, role_too_low}.
+        assert exc_info.value.reason is None
+
+    @pytest.mark.asyncio
+    async def test_workspace_viewer_denied(self, service, workspace_id):
+        service.get_workspace_role = AsyncMock(return_value="viewer")
+        with pytest.raises(AuthorizationError) as exc_info:
+            await service._check_can_view("viewer_user", workspace_id, "target_user")
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.message == "Insufficient permissions"
+        assert exc_info.value.reason is None
+
+    @pytest.mark.asyncio
+    async def test_non_member_denied(self, service, workspace_id):
+        """get_workspace_role returns None for a user with no workspace
+        membership — must fall through to deny."""
+        service.get_workspace_role = AsyncMock(return_value=None)
+        with pytest.raises(AuthorizationError) as exc_info:
+            await service._check_can_view("outsider", workspace_id, "target_user")
+        assert exc_info.value.status_code == 403

--- a/backend/tests/services/test_member_credentials_service.py
+++ b/backend/tests/services/test_member_credentials_service.py
@@ -88,3 +88,5 @@ class TestCheckCanView:
         with pytest.raises(AuthorizationError) as exc_info:
             await service._check_can_view("outsider", workspace_id, "target_user")
         assert exc_info.value.status_code == 403
+        assert exc_info.value.message == "Insufficient permissions"
+        assert exc_info.value.reason is None


### PR DESCRIPTION
Closes #604
Closes #605

## Summary

Two follow-ups from PR #602 (#401 PermissionService → domain exceptions refactor):

- **#604**: `handle_update_context` MCP error path now mirrors `handle_delete_context` — `NotFoundException` → `context_not_found` envelope, `AuthorizationError` → `permission_denied` envelope with `exc.message` (CWE-639 uniform string). Replaces the previous generic `except Exception as perm_err` that collapsed 404-class and 403-class failures into a single envelope.
- **#605**: New unit test file `test_member_credentials_service.py` covering `_check_can_view` (PR #602 commit 93c5fd47 had refactored this service to raise `AuthorizationError` but no service-layer tests existed). 7 cases: self / owner / admin / member / viewer / non-member / self-no-role-query.

## Implementation notes

**`handle_update_context` catch swap** (`backend/src/mcp_server/tools/context.py`):
- 3-arm `except NotFoundException / except AuthorizationError / outer-Exception` (cleaner than `handle_delete_context`'s legacy nested isinstance pattern — flagged for future alignment)
- Uses `exc.message` not `str(exc)` so the `AuthorizationError`-enforced uniform message contract is honored at the contract level, not via `__str__` indirection
- `ValidationError` deliberately not caught — the permission call path doesn't raise it; outer `Exception` handles any unexpected case as 500

**`test_member_credentials_service.py`** (new file):
- Mirrors `test_permission_service.py` fixture structure
- `test_self_access_does_not_query_role` adds `get_workspace_role.assert_not_awaited()` to pin the self-access short-circuit against future regressions
- Verifies `exc.reason is None` to lock down that `_check_can_view` is a single-bit decision (no multi-path classification, unlike `PermissionService.check_workspace_access`)

**Verification**:
- `tests/mcp_server/test_context_tools.py` — 4 passed (2 existing + 2 new)
- `tests/services/test_member_credentials_service.py` — 7 passed
- Broader sweep `tests/services tests/mcp_server tests/utils` — 1138 passed (no regressions)

## Pre-PR review summary

- gate2 mode: advisor-only (binary_gate=null)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (QA Lead lens) — batch coherence review
- review provider: copilot

Follow-up issues recommended by gate2 advisors (out of scope for this PR):
- refactor(mcp): align handle_delete_context to 3-arm exception catch pattern
- chore(mcp): audit handle_* functions for legacy generic catch

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/604-batch-604-605.gate1.md
- ~/.claude/cache/gh-issue-driven/604-batch-604-605.gate2.md

🤖 Generated via /gh-issue-driven:ship
