### PR TITLE
fix(oauth): scope mismatch across 3 metadata sources breaks Claude Code MCP DCR flow (#592)

### DIFF
--- a/backend/alembic/versions/e08_592_oauth_scope_canonicalize.py
+++ b/backend/alembic/versions/e08_592_oauth_scope_canonicalize.py
@@ -28,11 +28,17 @@ SDK's scope-drift cache eviction.
 
 Scope of the data fix:
 
-- Only rows whose ``scope`` exactly equals the pre-fix default are
-  updated. Manually-managed or workspace-scoped clients (whose scope
-  may legitimately be narrower than the canonical set) are NOT touched.
-- The new canonical default is written as a single space-separated
-  string matching ``auth.mcp_scopes.DCR_DEFAULT_SCOPE``.
+- Rows whose ``scope`` differs from the exact pre-fix default string are
+  left untouched. This preserves any explicitly-narrower client scope
+  (e.g. ``memory:read`` only).
+- Rows with the exact pre-fix default string are widened to canonical
+  regardless of how they were registered. This intentionally includes
+  admin-managed clients that were created without an explicit
+  ``scope=`` override (the admin Pydantic schema also defaulted to the
+  pre-fix narrow string before #592). Widening them is benign because
+  the added ``memory:admin`` scope is not enforced on any route yet.
+- The canonical default is a single space-separated string matching
+  ``auth.mcp_scopes.DCR_DEFAULT_SCOPE``.
 
 Downgrade restores the narrow scope on rows we widened. We can identify
 them precisely because the canonical and pre-fix strings differ.

--- a/backend/alembic/versions/e08_592_oauth_scope_canonicalize.py
+++ b/backend/alembic/versions/e08_592_oauth_scope_canonicalize.py
@@ -1,0 +1,80 @@
+"""Canonicalize oauth_clients.scope to match advertised metadata (#592).
+
+Issue #592 surfaced a 4-way drift between the OAuth metadata sources:
+
+- ``GET /.well-known/oauth-authorization-server`` advertised
+  ``{memory:read, memory:write, memory:admin, offline_access}``.
+- ``GET /.well-known/oauth-protected-resource`` advertised
+  ``{memory:read, memory:write, memory:delete, memory:admin}``
+  (with a fictional ``memory:delete`` that nothing enforced, and missing
+  ``offline_access``).
+- ``GET /.well-known/openid-configuration`` advertised
+  ``{openid, memory:read, memory:write, memory:admin, offline_access}``
+  (with a fictional ``openid`` — the server does not issue ``id_token``).
+- ``POST /api/v1/oauth/register`` (DCR) fell back to
+  ``{memory:read, memory:write, offline_access}`` when the client did
+  not specify a scope, silently omitting ``memory:admin``.
+
+The Claude Code MCP SDK's scope-drift check (``Invalidated credentials
+(scope: all)``) was tripping because the authorization URL combined the
+union of advertised scopes while the DCR-issued client only held a
+subset.
+
+The application-level fix consolidates all four sources behind
+``auth.mcp_scopes.ALL_ADVERTISED_SCOPES``. This migration normalises any
+existing DCR-registered ``oauth_clients`` rows that still carry the
+narrow pre-fix default so a refresh after deploy does not re-trip the
+SDK's scope-drift cache eviction.
+
+Scope of the data fix:
+
+- Only rows whose ``scope`` exactly equals the pre-fix default are
+  updated. Manually-managed or workspace-scoped clients (whose scope
+  may legitimately be narrower than the canonical set) are NOT touched.
+- The new canonical default is written as a single space-separated
+  string matching ``auth.mcp_scopes.DCR_DEFAULT_SCOPE``.
+
+Downgrade restores the narrow scope on rows we widened. We can identify
+them precisely because the canonical and pre-fix strings differ.
+
+Revision ID: e08_592_oauth_scope_canonicalize
+Revises: e07_556_sha256_lowercase_index
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e08_592_oauth_scope_canonicalize"
+down_revision = "e07_556_sha256_lowercase_index"
+branch_labels = None
+depends_on = None
+
+
+# Hard-coded here on purpose: an Alembic migration is a snapshot of intent at
+# revision time. Importing ``auth.mcp_scopes`` would couple the migration to
+# whatever the canonical set happens to be the day someone runs ``alembic
+# upgrade head`` years later, which is the opposite of what migrations are for.
+_PRE_FIX_DEFAULT = "memory:read memory:write offline_access"
+_CANONICAL_AT_E08 = "memory:read memory:write memory:admin offline_access"
+
+
+def upgrade() -> None:
+    # Widen DCR-issued clients that still hold the pre-#592 narrow default.
+    # Matching on the exact string keeps custom scopes (e.g. workspace-scoped
+    # admin clients with only ``memory:read``) untouched.
+    op.execute(
+        sa.text("UPDATE oauth_clients SET scope = :new_scope WHERE scope = :old_scope").bindparams(
+            new_scope=_CANONICAL_AT_E08, old_scope=_PRE_FIX_DEFAULT
+        )
+    )
+
+
+def downgrade() -> None:
+    # Restore the narrow scope on the rows we widened. Anything we did not
+    # touch in upgrade() stays put.
+    op.execute(
+        sa.text("UPDATE oauth_clients SET scope = :old_scope WHERE scope = :new_scope").bindparams(
+            old_scope=_PRE_FIX_DEFAULT, new_scope=_CANONICAL_AT_E08
+        )
+    )

--- a/backend/alembic/versions/e08_592_oauth_scope_canonicalize.py
+++ b/backend/alembic/versions/e08_592_oauth_scope_canonicalize.py
@@ -6,14 +6,13 @@ Issue #592 surfaced a 4-way drift between the OAuth metadata sources:
   ``{memory:read, memory:write, memory:admin, offline_access}``.
 - ``GET /.well-known/oauth-protected-resource`` advertised
   ``{memory:read, memory:write, memory:delete, memory:admin}``
-  (with a fictional ``memory:delete`` that nothing enforced, and missing
-  ``offline_access``).
+  (missing ``offline_access``).
 - ``GET /.well-known/openid-configuration`` advertised
-  ``{openid, memory:read, memory:write, memory:admin, offline_access}``
-  (with a fictional ``openid`` — the server does not issue ``id_token``).
+  ``{openid, memory:read, memory:write, memory:admin, offline_access}``.
 - ``POST /api/v1/oauth/register`` (DCR) fell back to
   ``{memory:read, memory:write, offline_access}`` when the client did
-  not specify a scope, silently omitting ``memory:admin``.
+  not specify a scope, silently omitting ``memory:admin`` and other
+  scopes advertised by the metadata.
 
 The Claude Code MCP SDK's scope-drift check (``Invalidated credentials
 (scope: all)``) was tripping because the authorization URL combined the
@@ -21,10 +20,12 @@ union of advertised scopes while the DCR-issued client only held a
 subset.
 
 The application-level fix consolidates all four sources behind
-``auth.mcp_scopes.ALL_ADVERTISED_SCOPES``. This migration normalises any
-existing DCR-registered ``oauth_clients`` rows that still carry the
-narrow pre-fix default so a refresh after deploy does not re-trip the
-SDK's scope-drift cache eviction.
+``auth.mcp_scopes.ALL_ADVERTISED_SCOPES`` — which is the UNION of every
+scope previously advertised by any source, so no external client sees a
+removed scope. This migration normalises any existing DCR-registered
+``oauth_clients`` rows that still carry the narrow pre-fix default so a
+refresh after deploy does not re-trip the SDK's scope-drift cache
+eviction.
 
 Scope of the data fix:
 
@@ -36,7 +37,9 @@ Scope of the data fix:
   admin-managed clients that were created without an explicit
   ``scope=`` override (the admin Pydantic schema also defaulted to the
   pre-fix narrow string before #592). Widening them is benign because
-  the added ``memory:admin`` scope is not enforced on any route yet.
+  the added scopes (``memory:admin``, ``memory:delete``, ``openid``) are
+  not enforced on any route yet — they are advertised solely to keep the
+  four metadata sources self-consistent. #608 tracks paired enforcement.
 - The canonical default is a single space-separated string matching
   ``auth.mcp_scopes.DCR_DEFAULT_SCOPE``.
 
@@ -62,7 +65,7 @@ depends_on = None
 # whatever the canonical set happens to be the day someone runs ``alembic
 # upgrade head`` years later, which is the opposite of what migrations are for.
 _PRE_FIX_DEFAULT = "memory:read memory:write offline_access"
-_CANONICAL_AT_E08 = "memory:read memory:write memory:admin offline_access"
+_CANONICAL_AT_E08 = "openid memory:read memory:write memory:admin memory:delete offline_access"
 
 
 def upgrade() -> None:

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -146,9 +146,6 @@ class OAuth2ClientCreateRequest(BaseModel):
     )
     response_types: list[str] = Field(default=["code"], description="Allowed response types")
     scope: str = Field(
-        # Canonical set lives in auth.mcp_scopes — #592 drift fix. Previously
-        # this default was "memory:read memory:write offline_access" which
-        # silently omitted memory:admin, causing scope drift vs metadata.
         default=DCR_DEFAULT_SCOPE,
         description="Space-separated scopes",
     )
@@ -729,10 +726,6 @@ async def dynamic_client_registration(
         plaintext_secret_encrypted = get_encryptor().encrypt(client_secret)
         visibility_expires_at = utcnow() + timedelta(minutes=10)
 
-        # For DCR: fall back to canonical advertised scope set if client did
-        # not request one. Defense in depth — the Pydantic default also points
-        # at DCR_DEFAULT_SCOPE, so this branch is only reachable if a future
-        # change widens the field type to Optional.
         scope = data.scope if data.scope else DCR_DEFAULT_SCOPE
 
         # Create OAuth2Client (DCR: owner_id=None, workspace_id=None, auth_method=none)

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import SessionUser, require_admin
+from auth.mcp_scopes import DCR_DEFAULT_SCOPE
 from auth.oauth2_server import _OAuthUser, create_authorization_server
 from config.settings import get_settings
 from db.base import get_db, get_sync_session
@@ -145,7 +146,10 @@ class OAuth2ClientCreateRequest(BaseModel):
     )
     response_types: list[str] = Field(default=["code"], description="Allowed response types")
     scope: str = Field(
-        default="memory:read memory:write offline_access",  # Issue #132: offline_access for refresh token
+        # Canonical set lives in auth.mcp_scopes — #592 drift fix. Previously
+        # this default was "memory:read memory:write offline_access" which
+        # silently omitted memory:admin, causing scope drift vs metadata.
+        default=DCR_DEFAULT_SCOPE,
         description="Space-separated scopes",
     )
     token_endpoint_auth_method: str = Field(
@@ -725,8 +729,11 @@ async def dynamic_client_registration(
         plaintext_secret_encrypted = get_encryptor().encrypt(client_secret)
         visibility_expires_at = utcnow() + timedelta(minutes=10)
 
-        # For DCR: auto-set scope if not provided
-        scope = data.scope if data.scope else "memory:read memory:write offline_access"
+        # For DCR: fall back to canonical advertised scope set if client did
+        # not request one. Defense in depth — the Pydantic default also points
+        # at DCR_DEFAULT_SCOPE, so this branch is only reachable if a future
+        # change widens the field type to Optional.
+        scope = data.scope if data.scope else DCR_DEFAULT_SCOPE
 
         # Create OAuth2Client (DCR: owner_id=None, workspace_id=None, auth_method=none)
         client = OAuth2Client(

--- a/backend/src/api/routes/well_known.py
+++ b/backend/src/api/routes/well_known.py
@@ -45,7 +45,6 @@ async def oauth_protected_resource():
     return {
         "resource": mcp_base,  # Must match MCP server URL exactly (RFC 9728)
         "authorization_servers": [base_url],
-        # Canonical set lives in auth.mcp_scopes — #592 drift fix
         "scopes_supported": list(ALL_ADVERTISED_SCOPES),
         "bearer_methods_supported": ["header"],
         "resource_signing_alg_values_supported": ["RS256", "HS256"],
@@ -94,11 +93,9 @@ async def openid_configuration(request: Request):
         "registration_endpoint": f"{base_url}/api/v1/oauth/register",  # DCR endpoint (RFC 7591)
         # PKCE required by MCP (CRITICAL - clients will refuse if absent)
         "code_challenge_methods_supported": ["S256"],
-        # Canonical set lives in auth.mcp_scopes — #592 drift fix.
-        # Note: "openid" was previously advertised here but the server does NOT
-        # issue id_token (no OIDC subject path). Removed to stop the dishonest
-        # OIDC claim; clients that strictly require OIDC compliance will fail
-        # discovery (intentional), but MCP clients only need PKCE + scopes.
+        # "openid" intentionally omitted: this server does not issue id_token
+        # (no OIDC subject path). Clients that strictly require OIDC
+        # compliance will fail discovery; MCP clients only need PKCE + scopes.
         "scopes_supported": list(ALL_ADVERTISED_SCOPES),
         # Response types
         "response_types_supported": ["code"],
@@ -149,7 +146,6 @@ async def oauth_authorization_server(request: Request):
         "revocation_endpoint": f"{base_url}/api/v1/oauth/revoke",
         "introspection_endpoint": f"{base_url}/api/v1/oauth/introspect",  # RFC 7662 (Issue #157)
         "registration_endpoint": f"{base_url}/api/v1/oauth/register",  # DCR endpoint (RFC 7591)
-        # Canonical set lives in auth.mcp_scopes — #592 drift fix
         "scopes_supported": list(ALL_ADVERTISED_SCOPES),
         "response_types_supported": ["code"],
         "grant_types_supported": [

--- a/backend/src/api/routes/well_known.py
+++ b/backend/src/api/routes/well_known.py
@@ -93,9 +93,6 @@ async def openid_configuration(request: Request):
         "registration_endpoint": f"{base_url}/api/v1/oauth/register",  # DCR endpoint (RFC 7591)
         # PKCE required by MCP (CRITICAL - clients will refuse if absent)
         "code_challenge_methods_supported": ["S256"],
-        # "openid" intentionally omitted: this server does not issue id_token
-        # (no OIDC subject path). Clients that strictly require OIDC
-        # compliance will fail discovery; MCP clients only need PKCE + scopes.
         "scopes_supported": list(ALL_ADVERTISED_SCOPES),
         # Response types
         "response_types_supported": ["code"],

--- a/backend/src/api/routes/well_known.py
+++ b/backend/src/api/routes/well_known.py
@@ -8,6 +8,8 @@ import os
 
 from fastapi import APIRouter, Request
 
+from auth.mcp_scopes import ALL_ADVERTISED_SCOPES
+
 router = APIRouter(tags=["well-known"])
 
 
@@ -43,12 +45,8 @@ async def oauth_protected_resource():
     return {
         "resource": mcp_base,  # Must match MCP server URL exactly (RFC 9728)
         "authorization_servers": [base_url],
-        "scopes_supported": [
-            "memory:read",
-            "memory:write",
-            "memory:delete",
-            "memory:admin",
-        ],
+        # Canonical set lives in auth.mcp_scopes — #592 drift fix
+        "scopes_supported": list(ALL_ADVERTISED_SCOPES),
         "bearer_methods_supported": ["header"],
         "resource_signing_alg_values_supported": ["RS256", "HS256"],
         "resource_documentation": f"{base_url}/redoc",
@@ -96,14 +94,12 @@ async def openid_configuration(request: Request):
         "registration_endpoint": f"{base_url}/api/v1/oauth/register",  # DCR endpoint (RFC 7591)
         # PKCE required by MCP (CRITICAL - clients will refuse if absent)
         "code_challenge_methods_supported": ["S256"],
-        # Scopes (OpenID Connect requires "openid" scope)
-        "scopes_supported": [
-            "openid",  # Required for OIDC compliance
-            "memory:read",
-            "memory:write",
-            "memory:admin",
-            "offline_access",  # For refresh token support
-        ],
+        # Canonical set lives in auth.mcp_scopes — #592 drift fix.
+        # Note: "openid" was previously advertised here but the server does NOT
+        # issue id_token (no OIDC subject path). Removed to stop the dishonest
+        # OIDC claim; clients that strictly require OIDC compliance will fail
+        # discovery (intentional), but MCP clients only need PKCE + scopes.
+        "scopes_supported": list(ALL_ADVERTISED_SCOPES),
         # Response types
         "response_types_supported": ["code"],
         # Grant types
@@ -153,12 +149,8 @@ async def oauth_authorization_server(request: Request):
         "revocation_endpoint": f"{base_url}/api/v1/oauth/revoke",
         "introspection_endpoint": f"{base_url}/api/v1/oauth/introspect",  # RFC 7662 (Issue #157)
         "registration_endpoint": f"{base_url}/api/v1/oauth/register",  # DCR endpoint (RFC 7591)
-        "scopes_supported": [
-            "memory:read",
-            "memory:write",
-            "memory:admin",
-            "offline_access",  # Issue #132: Required for refresh token support
-        ],
+        # Canonical set lives in auth.mcp_scopes — #592 drift fix
+        "scopes_supported": list(ALL_ADVERTISED_SCOPES),
         "response_types_supported": ["code"],
         "grant_types_supported": [
             "authorization_code",

--- a/backend/src/auth/mcp_scopes.py
+++ b/backend/src/auth/mcp_scopes.py
@@ -1,49 +1,26 @@
 """Canonical MCP OAuth 2.0 scope definitions (single source of truth).
 
-All ``scopes_supported`` advertisements (RFC 8414 authorization-server metadata,
-RFC 9728 protected-resource metadata, OIDC discovery) and the DCR (RFC 7591)
-fallback scope MUST derive from these constants. Issue #592 surfaced a 4-way
-drift between three metadata endpoints and the DCR handler that broke the
-Claude Code MCP OAuth flow; the drift-guard test in
-``tests/api/test_oauth_metadata_drift.py`` pins this contract.
+All ``scopes_supported`` advertisements (RFC 8414, RFC 9728, OIDC discovery)
+and the DCR (RFC 7591) fallback scope MUST derive from these constants.
 
-Authorization scopes are MCP-tier permission tokens (``memory:*``); they govern
-what an authorized client may do against the protected resource (``/mcp/*``).
-``offline_access`` is a meta-scope (RFC 6749 §1.3.5 / §6) that requests a
-refresh token; it is advertised alongside the MCP scopes so refresh-capable
-clients (Claude Code, ChatGPT) can request it without falling back to defaults.
+Policy notes:
 
-Notes:
-- ``memory:admin`` is advertised but not yet enforced in any route. The
-  follow-up issue tracks adding ``requires_scope`` enforcement so that
-  advertising this scope is not a fiction. Until then, treat its presence
-  here as a forward-compatibility commitment, NOT a permission gate.
-- ``memory:delete`` was previously advertised on the protected-resource
-  metadata endpoint only; it is NOT enforced and has been removed to avoid
-  another drift source. Reintroduce only with paired enforcement.
-- ``openid`` was previously advertised on the OIDC discovery endpoint only;
-  this server does not issue ``id_token`` (no OIDC subject claims path), so
-  the OIDC advertisement was dishonest and has been removed. The discovery
-  endpoint remains because MCP clients probe it first before
-  ``oauth-authorization-server``.
+- ``memory:admin`` is advertised as a forward-compatibility commitment, NOT a
+  permission gate. No route enforces it yet; advertising it lets DCR-issued
+  clients hold the scope ahead of enforcement landing.
+- ``memory:delete`` is intentionally NOT advertised — nothing enforces it.
+  Reintroduce only with paired enforcement to avoid a fictional-scope drift.
+- ``openid`` is intentionally NOT advertised on the OIDC discovery endpoint:
+  this server does not issue ``id_token``. The discovery endpoint remains
+  for MCP clients that probe it first.
+- ``offline_access`` (RFC 6749 §1.3.5 / §6) requests a refresh token.
 """
 
-MCP_SCOPES: list[str] = [
+ALL_ADVERTISED_SCOPES: list[str] = [
     "memory:read",
     "memory:write",
     "memory:admin",
+    "offline_access",
 ]
-"""MCP permission scopes (granted to authorized clients)."""
-
-MCP_REFRESH_SCOPE: str = "offline_access"
-"""RFC 6749 §1.3.5 meta-scope requesting a refresh token."""
-
-ALL_ADVERTISED_SCOPES: list[str] = [*MCP_SCOPES, MCP_REFRESH_SCOPE]
-"""Every scope a discovery/metadata endpoint may advertise. All four metadata
-sources (oauth-authorization-server, oauth-protected-resource,
-openid-configuration, DCR response) must advertise exactly this set."""
 
 DCR_DEFAULT_SCOPE: str = " ".join(ALL_ADVERTISED_SCOPES)
-"""Space-separated default scope returned by RFC 7591 DCR when the client
-does not request a specific scope. Matches ALL_ADVERTISED_SCOPES so a DCR
-client immediately holds every advertised scope."""

--- a/backend/src/auth/mcp_scopes.py
+++ b/backend/src/auth/mcp_scopes.py
@@ -5,21 +5,33 @@ and the DCR (RFC 7591) fallback scope MUST derive from these constants.
 
 Policy notes:
 
-- ``memory:admin`` is advertised as a forward-compatibility commitment, NOT a
-  permission gate. No route enforces it yet; advertising it lets DCR-issued
-  clients hold the scope ahead of enforcement landing.
-- ``memory:delete`` is intentionally NOT advertised — nothing enforces it.
-  Reintroduce only with paired enforcement to avoid a fictional-scope drift.
-- ``openid`` is intentionally NOT advertised on the OIDC discovery endpoint:
-  this server does not issue ``id_token``. The discovery endpoint remains
-  for MCP clients that probe it first.
+- The canonical set is the UNION of every scope previously advertised by
+  any of the four metadata sources at the time of #592. Keeping the union
+  avoids a backward-incompatible removal in the hotfix — strict OIDC
+  clients still get ``openid``, clients that whitelisted ``memory:delete``
+  still see it. Drift (every source advertising a DIFFERENT subset) was
+  the actual bug; advertising the union from one shared constant is the
+  fix.
+- ``memory:admin`` and ``memory:delete`` are advertised but not yet
+  enforced on any route. Advertising them is a forward-compatibility
+  commitment — DCR-issued clients hold the scope ahead of enforcement.
+  #608 tracks paired enforcement; until that lands, treat these as
+  unenforced fictional scopes (no permission gate, no implicit grant).
+- ``openid`` is advertised on every metadata source so the discovery
+  contract is consistent — but the server does NOT issue ``id_token``,
+  so a strict OIDC client that proceeds past discovery will fail at the
+  authorization step. The advertisement preserves discovery
+  compatibility; the OIDC dishonesty is a separate cleanup, NOT part of
+  the #592 drift fix.
 - ``offline_access`` (RFC 6749 §1.3.5 / §6) requests a refresh token.
 """
 
 ALL_ADVERTISED_SCOPES: list[str] = [
+    "openid",
     "memory:read",
     "memory:write",
     "memory:admin",
+    "memory:delete",
     "offline_access",
 ]
 

--- a/backend/src/auth/mcp_scopes.py
+++ b/backend/src/auth/mcp_scopes.py
@@ -1,0 +1,49 @@
+"""Canonical MCP OAuth 2.0 scope definitions (single source of truth).
+
+All ``scopes_supported`` advertisements (RFC 8414 authorization-server metadata,
+RFC 9728 protected-resource metadata, OIDC discovery) and the DCR (RFC 7591)
+fallback scope MUST derive from these constants. Issue #592 surfaced a 4-way
+drift between three metadata endpoints and the DCR handler that broke the
+Claude Code MCP OAuth flow; the drift-guard test in
+``tests/api/test_oauth_metadata_drift.py`` pins this contract.
+
+Authorization scopes are MCP-tier permission tokens (``memory:*``); they govern
+what an authorized client may do against the protected resource (``/mcp/*``).
+``offline_access`` is a meta-scope (RFC 6749 §1.3.5 / §6) that requests a
+refresh token; it is advertised alongside the MCP scopes so refresh-capable
+clients (Claude Code, ChatGPT) can request it without falling back to defaults.
+
+Notes:
+- ``memory:admin`` is advertised but not yet enforced in any route. The
+  follow-up issue tracks adding ``requires_scope`` enforcement so that
+  advertising this scope is not a fiction. Until then, treat its presence
+  here as a forward-compatibility commitment, NOT a permission gate.
+- ``memory:delete`` was previously advertised on the protected-resource
+  metadata endpoint only; it is NOT enforced and has been removed to avoid
+  another drift source. Reintroduce only with paired enforcement.
+- ``openid`` was previously advertised on the OIDC discovery endpoint only;
+  this server does not issue ``id_token`` (no OIDC subject claims path), so
+  the OIDC advertisement was dishonest and has been removed. The discovery
+  endpoint remains because MCP clients probe it first before
+  ``oauth-authorization-server``.
+"""
+
+MCP_SCOPES: list[str] = [
+    "memory:read",
+    "memory:write",
+    "memory:admin",
+]
+"""MCP permission scopes (granted to authorized clients)."""
+
+MCP_REFRESH_SCOPE: str = "offline_access"
+"""RFC 6749 §1.3.5 meta-scope requesting a refresh token."""
+
+ALL_ADVERTISED_SCOPES: list[str] = [*MCP_SCOPES, MCP_REFRESH_SCOPE]
+"""Every scope a discovery/metadata endpoint may advertise. All four metadata
+sources (oauth-authorization-server, oauth-protected-resource,
+openid-configuration, DCR response) must advertise exactly this set."""
+
+DCR_DEFAULT_SCOPE: str = " ".join(ALL_ADVERTISED_SCOPES)
+"""Space-separated default scope returned by RFC 7591 DCR when the client
+does not request a specific scope. Matches ALL_ADVERTISED_SCOPES so a DCR
+client immediately holds every advertised scope."""

--- a/backend/src/auth/mcp_scopes.py
+++ b/backend/src/auth/mcp_scopes.py
@@ -26,13 +26,13 @@ Policy notes:
 - ``offline_access`` (RFC 6749 §1.3.5 / §6) requests a refresh token.
 """
 
-ALL_ADVERTISED_SCOPES: list[str] = [
+ALL_ADVERTISED_SCOPES: tuple[str, ...] = (
     "openid",
     "memory:read",
     "memory:write",
     "memory:admin",
     "memory:delete",
     "offline_access",
-]
+)
 
 DCR_DEFAULT_SCOPE: str = " ".join(ALL_ADVERTISED_SCOPES)

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -7,6 +7,7 @@ Issue #248: SSE transport removed (deprecated in MCP spec 2025-03-26).
 import asyncio
 import json
 import logging
+import os
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -515,11 +516,20 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
             error_code = getattr(auth_error, "error_code", "invalid_token")
             error_description = getattr(auth_error, "error_description", str(auth_error))
 
-        # Build RFC 6750 compliant WWW-Authenticate header
+        # Build RFC 6750 + RFC 9728 compliant WWW-Authenticate header.
+        # The resource_metadata attribute (RFC 9728 §5.1) tells MCP clients
+        # where to fetch the protected-resource metadata document — before
+        # #592, clients had to guess the URL by convention, and any drift in
+        # the well-known endpoint location silently broke discovery. Anchored
+        # to FRONTEND_URL (same env the well-known endpoints use) so reverse-
+        # proxied deployments produce the correct absolute URL.
+        base_url = os.getenv("FRONTEND_URL", "http://localhost:3000").rstrip("/")
+        resource_metadata_url = f"{base_url}/.well-known/oauth-protected-resource"
         www_authenticate = (
             f'Bearer realm="Kagura Memory Cloud", '
             f'error="{error_code}", '
-            f'error_description="{error_description}"'
+            f'error_description="{error_description}", '
+            f'resource_metadata="{resource_metadata_url}"'
         )
 
         error_response = json.dumps(

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -24,6 +24,19 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _sanitize_challenge_attr_value(value: str) -> str:
+    """Sanitize a string before interpolating it into an RFC 6750
+    ``WWW-Authenticate: Bearer ...`` quoted-attribute value.
+
+    The ``error_description`` attribute can echo back malformed-token bytes,
+    and a stray ``"`` or CR/LF would close the quoted attribute early or
+    split the response (CWE-93 / response splitting). Strip the three
+    characters that would break the header — leaving the JSON body to carry
+    the unsanitized description for client logging.
+    """
+    return value.replace("\r", " ").replace("\n", " ").replace('"', "'")
+
+
 async def _get_user_workspace_id(user_id: str) -> "UUID | None":
     """Get user's current workspace ID.
 
@@ -516,13 +529,7 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
             error_code = getattr(auth_error, "error_code", "invalid_token")
             error_description = getattr(auth_error, "error_description", str(auth_error))
 
-        # Strip control characters and quotes from the description before it
-        # lands in the WWW-Authenticate header value. ``str(auth_error)`` and
-        # ``error_description`` attributes can echo back parts of the
-        # malformed token, and a ``"`` or CR/LF in the header would close the
-        # quoted attribute early or split the response. The JSON body still
-        # carries the original description for the client to log.
-        safe_description = error_description.replace("\r", " ").replace("\n", " ").replace('"', "'")
+        safe_description = _sanitize_challenge_attr_value(error_description)
 
         # RFC 6750 + RFC 9728 §5.1 challenge. resource_metadata is anchored
         # to frontend_url so a reverse-proxied deployment produces the same

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -7,7 +7,6 @@ Issue #248: SSE transport removed (deprecated in MCP spec 2025-03-26).
 import asyncio
 import json
 import logging
-import os
 from typing import TYPE_CHECKING
 from uuid import UUID
 
@@ -15,6 +14,7 @@ from starlette.responses import Response
 from starlette.types import Receive, Scope, Send
 
 from config.constants import APP_VERSION
+from config.settings import get_settings
 from mcp_server.auth import authenticate_mcp_request
 from mcp_server.session import get_session_manager
 
@@ -516,14 +516,10 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
             error_code = getattr(auth_error, "error_code", "invalid_token")
             error_description = getattr(auth_error, "error_description", str(auth_error))
 
-        # Build RFC 6750 + RFC 9728 compliant WWW-Authenticate header.
-        # The resource_metadata attribute (RFC 9728 §5.1) tells MCP clients
-        # where to fetch the protected-resource metadata document — before
-        # #592, clients had to guess the URL by convention, and any drift in
-        # the well-known endpoint location silently broke discovery. Anchored
-        # to FRONTEND_URL (same env the well-known endpoints use) so reverse-
-        # proxied deployments produce the correct absolute URL.
-        base_url = os.getenv("FRONTEND_URL", "http://localhost:3000").rstrip("/")
+        # RFC 6750 + RFC 9728 §5.1 challenge. resource_metadata is anchored
+        # to frontend_url so a reverse-proxied deployment produces the same
+        # absolute URL the well-known endpoints publish.
+        base_url = get_settings().frontend_url.rstrip("/")
         resource_metadata_url = f"{base_url}/.well-known/oauth-protected-resource"
         www_authenticate = (
             f'Bearer realm="Kagura Memory Cloud", '

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -516,6 +516,14 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
             error_code = getattr(auth_error, "error_code", "invalid_token")
             error_description = getattr(auth_error, "error_description", str(auth_error))
 
+        # Strip control characters and quotes from the description before it
+        # lands in the WWW-Authenticate header value. ``str(auth_error)`` and
+        # ``error_description`` attributes can echo back parts of the
+        # malformed token, and a ``"`` or CR/LF in the header would close the
+        # quoted attribute early or split the response. The JSON body still
+        # carries the original description for the client to log.
+        safe_description = error_description.replace("\r", " ").replace("\n", " ").replace('"', "'")
+
         # RFC 6750 + RFC 9728 §5.1 challenge. resource_metadata is anchored
         # to frontend_url so a reverse-proxied deployment produces the same
         # absolute URL the well-known endpoints publish.
@@ -524,7 +532,7 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
         www_authenticate = (
             f'Bearer realm="Kagura Memory Cloud", '
             f'error="{error_code}", '
-            f'error_description="{error_description}", '
+            f'error_description="{safe_description}", '
             f'resource_metadata="{resource_metadata_url}"'
         )
 

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -521,12 +521,17 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
         # Authentication failed - send 401 with RFC 6750 compliant headers
         logger.warning(f"MCP auth failed: {auth_error}")
 
-        # Determine error details for RFC 6750
+        # Map exception type to RFC 6750 §3.1 error code.
+        # RFC 6750 limits the error attribute to "invalid_request",
+        # "invalid_token", and "insufficient_scope" — internal error codes
+        # like AUTH-001/AUTH-003 must NOT leak into the challenge header.
+        # All token-related auth failures map to invalid_token; everything
+        # else (missing Bearer header, malformed request) is invalid_request.
         error_code = "invalid_request"
         error_description = str(auth_error)
 
         if isinstance(auth_error, (TokenExpiredError, TokenRevokedError, InvalidTokenError)):
-            error_code = getattr(auth_error, "error_code", "invalid_token")
+            error_code = "invalid_token"
             error_description = getattr(auth_error, "error_description", str(auth_error))
 
         # Sanitize every interpolated value, not just error_description.

--- a/backend/src/mcp_server/transport.py
+++ b/backend/src/mcp_server/transport.py
@@ -529,18 +529,25 @@ async def mcp_asgi_app(scope: Scope, receive: Receive, send: Send) -> None:
             error_code = getattr(auth_error, "error_code", "invalid_token")
             error_description = getattr(auth_error, "error_description", str(auth_error))
 
+        # Sanitize every interpolated value, not just error_description.
+        # Settings.frontend_url is server-side config but a typo or stale
+        # value with a stray quote / CR / LF would corrupt the header just
+        # as effectively as user-controlled token bytes. Defense in depth.
+        safe_code = _sanitize_challenge_attr_value(error_code)
         safe_description = _sanitize_challenge_attr_value(error_description)
 
         # RFC 6750 + RFC 9728 §5.1 challenge. resource_metadata is anchored
         # to frontend_url so a reverse-proxied deployment produces the same
         # absolute URL the well-known endpoints publish.
-        base_url = get_settings().frontend_url.rstrip("/")
-        resource_metadata_url = f"{base_url}/.well-known/oauth-protected-resource"
+        base_url = get_settings().frontend_url.strip().rstrip("/")
+        safe_resource_metadata_url = _sanitize_challenge_attr_value(
+            f"{base_url}/.well-known/oauth-protected-resource"
+        )
         www_authenticate = (
             f'Bearer realm="Kagura Memory Cloud", '
-            f'error="{error_code}", '
+            f'error="{safe_code}", '
             f'error_description="{safe_description}", '
-            f'resource_metadata="{resource_metadata_url}"'
+            f'resource_metadata="{safe_resource_metadata_url}"'
         )
 
         error_response = json.dumps(

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -445,11 +445,6 @@ class OAuth2Client(Base):
     scope: Mapped[str] = mapped_column(
         String(255),
         nullable=False,
-        # Canonical set lives in auth.mcp_scopes — #592 drift fix. Previously
-        # this default was "memory:read memory:write offline_access" which
-        # silently omitted memory:admin and drifted from the well-known
-        # metadata endpoints. Existing rows are migrated by Alembic
-        # e08_592_oauth_scope_canonicalize.
         default=DCR_DEFAULT_SCOPE,
     )
     token_endpoint_auth_method: Mapped[str] = mapped_column(

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -40,6 +40,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from auth.mcp_scopes import DCR_DEFAULT_SCOPE
 from db.base import Base
 from utils.datetime import utcnow
 from utils.redirect_uri import any_redirect_uri_matches
@@ -444,7 +445,12 @@ class OAuth2Client(Base):
     scope: Mapped[str] = mapped_column(
         String(255),
         nullable=False,
-        default="memory:read memory:write offline_access",  # Issue #132: offline_access for refresh token
+        # Canonical set lives in auth.mcp_scopes — #592 drift fix. Previously
+        # this default was "memory:read memory:write offline_access" which
+        # silently omitted memory:admin and drifted from the well-known
+        # metadata endpoints. Existing rows are migrated by Alembic
+        # e08_592_oauth_scope_canonicalize.
+        default=DCR_DEFAULT_SCOPE,
     )
     token_endpoint_auth_method: Mapped[str] = mapped_column(
         String(50), nullable=False, default="client_secret_post"

--- a/backend/tests/api/test_oauth_metadata_drift.py
+++ b/backend/tests/api/test_oauth_metadata_drift.py
@@ -126,12 +126,15 @@ class TestMcpAuthChallengeIncludesResourceMetadata:
 
     def test_mcp_401_includes_resource_metadata_attr(self, client: TestClient) -> None:
         response = client.get("/mcp/")
-        if response.status_code != 401:
-            pytest.skip(
-                "MCP route did not return 401 for unauthenticated GET in test "
-                f"client (got {response.status_code}); transport may short-circuit "
-                "before auth in TestClient. Manual verification covers this path."
-            )
+        # /mcp/ must require authentication and emit the RFC 6750 + RFC 9728
+        # challenge. If the transport ever stops returning 401 here (auth
+        # short-circuit, accidental public access), failing loud is what we
+        # want — silently skipping would defeat the purpose of pinning the
+        # challenge contract.
+        assert response.status_code == 401, (
+            f"expected 401 for unauthenticated GET /mcp/, got "
+            f"{response.status_code}: {response.text[:200]}"
+        )
         www_authenticate = response.headers.get("www-authenticate", "")
         assert "Bearer" in www_authenticate, (
             f"missing Bearer challenge in WWW-Authenticate: {www_authenticate!r}"

--- a/backend/tests/api/test_oauth_metadata_drift.py
+++ b/backend/tests/api/test_oauth_metadata_drift.py
@@ -1,0 +1,171 @@
+"""Drift guard for OAuth metadata scope advertisements (#592).
+
+Issue #592 surfaced a 4-way drift between OAuth metadata sources that broke
+the Claude Code MCP DCR flow: ``oauth-authorization-server``,
+``oauth-protected-resource``, ``openid-configuration``, and the DCR
+``POST /oauth/register`` fallback each advertised a different
+``scopes_supported`` set, and the SDK's scope-mismatch check correctly
+invalidated all credentials when the union didn't match what was issued.
+
+The fix consolidates the canonical set in :mod:`auth.mcp_scopes`. This test
+file is the property test that PINS that contract — if any of the four
+sources drift again, one of these tests fails before production does.
+
+The tests are intentionally narrow: they assert set equality on
+``scopes_supported`` only. Other metadata fields (issuer, endpoints,
+PKCE methods) are covered by ``tests/smoke/test_well_known.py``.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# Match the sys.path layout the rest of the backend tests use.
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from api.main import app  # noqa: E402
+from auth.mcp_scopes import ALL_ADVERTISED_SCOPES, DCR_DEFAULT_SCOPE  # noqa: E402
+
+
+@pytest.fixture
+def client():
+    """Test client without auth overrides — these endpoints must be public."""
+    with TestClient(app) as c:
+        yield c
+
+
+class TestMetadataScopesNoDrift:
+    """All three metadata endpoints advertise the canonical scope set.
+
+    Set equality (not list equality) — order is not part of the contract and
+    enforcing it would just create churn whenever the constant list is
+    reordered.
+    """
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "/.well-known/oauth-authorization-server",
+            "/.well-known/oauth-protected-resource",
+            "/.well-known/openid-configuration",
+        ],
+    )
+    def test_scopes_supported_matches_canonical(self, client: TestClient, endpoint: str) -> None:
+        response = client.get(endpoint)
+        assert response.status_code == 200, (
+            f"{endpoint} returned {response.status_code}: {response.text}"
+        )
+        body = response.json()
+        assert "scopes_supported" in body, f"{endpoint} response is missing scopes_supported"
+        assert set(body["scopes_supported"]) == set(ALL_ADVERTISED_SCOPES), (
+            f"{endpoint} advertises {sorted(body['scopes_supported'])}, "
+            f"expected {sorted(ALL_ADVERTISED_SCOPES)} — metadata drift "
+            "detected, re-anchor on auth.mcp_scopes.ALL_ADVERTISED_SCOPES."
+        )
+
+
+class TestDcrFallbackScopeNoDrift:
+    """DCR fallback scope (``POST /oauth/register`` with no ``scope``) matches
+    the canonical set, so a fresh DCR client holds every advertised scope.
+
+    Before #592, this fell back to ``memory:read memory:write offline_access``
+    while the well-known endpoints advertised ``memory:admin`` too — the
+    union/issued mismatch was what tripped the Claude Code SDK's scope check.
+    """
+
+    def _patched_dcr_session(self):
+        """Mock the DCR success path: rate-limit counter + sync DB session +
+        encryptor. Same shape as ``test_oauth_dcr._patch_dcr_dependencies``
+        but inlined to keep this file independent — drift guards should not
+        couple to other tests' fixtures.
+        """
+        rate_limit = AsyncMock(return_value=1)
+        fake_session = MagicMock()
+
+        def _refresh(c):
+            if c.id is None:
+                c.id = 99999
+
+        fake_session.refresh.side_effect = _refresh
+
+        fake_encryptor = MagicMock()
+        fake_encryptor.encrypt = MagicMock(return_value="encrypted-secret-blob-base64")
+        return rate_limit, fake_session, fake_encryptor
+
+    def test_dcr_default_scope_matches_canonical(self, client: TestClient) -> None:
+        rate_limit, fake_session, fake_encryptor = self._patched_dcr_session()
+        with (
+            patch("db.redis.increment_counter", rate_limit),
+            patch("api.routes.oauth.get_sync_session", return_value=fake_session),
+            patch("utils.encryption.get_encryptor", return_value=fake_encryptor),
+        ):
+            response = client.post(
+                "/api/v1/oauth/register",
+                json={
+                    "client_name": "Claude Code",
+                    "redirect_uris": ["http://localhost:8080/callback"],
+                    "token_endpoint_auth_method": "none",
+                    # NB: no "scope" key — exercise the fallback path
+                },
+            )
+
+        assert response.status_code == 201, (
+            f"DCR registration failed: {response.status_code} {response.text}"
+        )
+        body = response.json()
+        issued_scopes = set(body["scope"].split())
+        assert issued_scopes == set(ALL_ADVERTISED_SCOPES), (
+            f"DCR issued {sorted(issued_scopes)}, "
+            f"expected {sorted(ALL_ADVERTISED_SCOPES)} — fallback default "
+            "drifted from auth.mcp_scopes.DCR_DEFAULT_SCOPE."
+        )
+
+    def test_dcr_default_scope_constant_matches_advertised_set(self) -> None:
+        """Independent of any HTTP round-trip: the constant DCR_DEFAULT_SCOPE
+        is exactly the advertised set as a space-separated string. Pins both
+        the contents AND the encoding (space-separated, RFC 6749 §3.3).
+        """
+        assert set(DCR_DEFAULT_SCOPE.split()) == set(ALL_ADVERTISED_SCOPES)
+        # space-separated, no leading/trailing whitespace, no double spaces
+        assert DCR_DEFAULT_SCOPE == " ".join(ALL_ADVERTISED_SCOPES)
+
+
+class TestMcpAuthChallengeIncludesResourceMetadata:
+    """RFC 9728 §5.1: the ``WWW-Authenticate`` header on 401 responses from a
+    protected resource SHOULD include a ``resource_metadata`` attribute
+    pointing at the protected-resource metadata document. Before #592, the
+    Claude Code MCP SDK had to guess this URL by convention; making it
+    explicit closes the discovery hole.
+
+    This is a smoke test, not a full RFC 9728 audit — it asserts the header
+    is present and well-formed when MCP auth fails. End-to-end behavior with
+    a real Claude Code client is verified manually post-deploy.
+    """
+
+    def test_mcp_401_includes_resource_metadata_attr(self, client: TestClient) -> None:
+        # Unauthenticated GET to /mcp/ — auth should fail and emit RFC 6750 +
+        # RFC 9728 challenge.
+        response = client.get("/mcp/")
+        if response.status_code != 401:
+            pytest.skip(
+                "MCP route did not return 401 for unauthenticated GET in test "
+                f"client (got {response.status_code}); transport may short-circuit "
+                "before auth in TestClient. Manual verification covers this path."
+            )
+        www_authenticate = response.headers.get("www-authenticate", "")
+        assert "Bearer" in www_authenticate, (
+            f"missing Bearer challenge in WWW-Authenticate: {www_authenticate!r}"
+        )
+        assert "resource_metadata=" in www_authenticate, (
+            "WWW-Authenticate is missing the RFC 9728 resource_metadata "
+            f"attribute: {www_authenticate!r}"
+        )
+        assert "/.well-known/oauth-protected-resource" in www_authenticate, (
+            "resource_metadata URL does not point at the protected-resource "
+            f"metadata document: {www_authenticate!r}"
+        )

--- a/backend/tests/api/test_oauth_metadata_drift.py
+++ b/backend/tests/api/test_oauth_metadata_drift.py
@@ -1,19 +1,6 @@
-"""Drift guard for OAuth metadata scope advertisements (#592).
-
-Issue #592 surfaced a 4-way drift between OAuth metadata sources that broke
-the Claude Code MCP DCR flow: ``oauth-authorization-server``,
-``oauth-protected-resource``, ``openid-configuration``, and the DCR
-``POST /oauth/register`` fallback each advertised a different
-``scopes_supported`` set, and the SDK's scope-mismatch check correctly
-invalidated all credentials when the union didn't match what was issued.
-
-The fix consolidates the canonical set in :mod:`auth.mcp_scopes`. This test
-file is the property test that PINS that contract — if any of the four
-sources drift again, one of these tests fails before production does.
-
-The tests are intentionally narrow: they assert set equality on
-``scopes_supported`` only. Other metadata fields (issuer, endpoints,
-PKCE methods) are covered by ``tests/smoke/test_well_known.py``.
+"""Property test pinning the canonical OAuth scope set across all four
+sources (three metadata endpoints + DCR fallback). Set equality only —
+other metadata fields are covered by ``tests/smoke/test_well_known.py``.
 """
 
 import sys
@@ -72,17 +59,13 @@ class TestMetadataScopesNoDrift:
 class TestDcrFallbackScopeNoDrift:
     """DCR fallback scope (``POST /oauth/register`` with no ``scope``) matches
     the canonical set, so a fresh DCR client holds every advertised scope.
-
-    Before #592, this fell back to ``memory:read memory:write offline_access``
-    while the well-known endpoints advertised ``memory:admin`` too — the
-    union/issued mismatch was what tripped the Claude Code SDK's scope check.
     """
 
     def _patched_dcr_session(self):
-        """Mock the DCR success path: rate-limit counter + sync DB session +
-        encryptor. Same shape as ``test_oauth_dcr._patch_dcr_dependencies``
-        but inlined to keep this file independent — drift guards should not
-        couple to other tests' fixtures.
+        """Same shape as ``test_oauth_dcr._patch_dcr_dependencies``, inlined
+        intentionally — a drift guard must not couple to fixtures owned by
+        other test files, or its contract becomes hostage to unrelated test
+        churn.
         """
         rate_limit = AsyncMock(return_value=1)
         fake_session = MagicMock()
@@ -131,25 +114,17 @@ class TestDcrFallbackScopeNoDrift:
         the contents AND the encoding (space-separated, RFC 6749 §3.3).
         """
         assert set(DCR_DEFAULT_SCOPE.split()) == set(ALL_ADVERTISED_SCOPES)
-        # space-separated, no leading/trailing whitespace, no double spaces
         assert DCR_DEFAULT_SCOPE == " ".join(ALL_ADVERTISED_SCOPES)
 
 
 class TestMcpAuthChallengeIncludesResourceMetadata:
-    """RFC 9728 §5.1: the ``WWW-Authenticate`` header on 401 responses from a
-    protected resource SHOULD include a ``resource_metadata`` attribute
-    pointing at the protected-resource metadata document. Before #592, the
-    Claude Code MCP SDK had to guess this URL by convention; making it
-    explicit closes the discovery hole.
-
-    This is a smoke test, not a full RFC 9728 audit — it asserts the header
-    is present and well-formed when MCP auth fails. End-to-end behavior with
-    a real Claude Code client is verified manually post-deploy.
+    """RFC 9728 §5.1: ``WWW-Authenticate`` on a 401 from a protected resource
+    SHOULD include a ``resource_metadata`` attribute pointing at the
+    protected-resource metadata document. Smoke test only — end-to-end
+    behavior with a real Claude Code client is verified manually.
     """
 
     def test_mcp_401_includes_resource_metadata_attr(self, client: TestClient) -> None:
-        # Unauthenticated GET to /mcp/ — auth should fail and emit RFC 6750 +
-        # RFC 9728 challenge.
         response = client.get("/mcp/")
         if response.status_code != 401:
             pytest.skip(

--- a/backend/tests/mcp_server/test_transport_challenge.py
+++ b/backend/tests/mcp_server/test_transport_challenge.py
@@ -1,0 +1,53 @@
+"""Unit tests for ``_sanitize_challenge_attr_value`` in mcp_server.transport.
+
+Pins the header-value sanitizer added in #592. ``error_description`` lands
+in the RFC 6750 ``WWW-Authenticate: Bearer ...`` quoted-attribute value,
+and a stray ``"`` or CR/LF would close the attribute early or split the
+HTTP response (CWE-93). The sanitizer must neutralize all three.
+"""
+
+import sys
+from pathlib import Path
+
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+import pytest  # noqa: E402
+
+from mcp_server.transport import _sanitize_challenge_attr_value  # noqa: E402
+
+
+class TestSanitizeChallengeAttrValue:
+    """Three characters must always be stripped: ``\\r``, ``\\n``, ``"``."""
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ('Bad token: "', "Bad token: '"),
+            ("Bad token: \r\n", "Bad token:   "),
+            ('Bad: "x"\r\nfake-header: y', "Bad: 'x'  fake-header: y"),
+            ("plain message", "plain message"),
+            ("", ""),
+        ],
+    )
+    def test_strips_crlf_and_quotes(self, raw: str, expected: str) -> None:
+        result = _sanitize_challenge_attr_value(raw)
+        assert result == expected
+        assert "\r" not in result
+        assert "\n" not in result
+        assert '"' not in result
+
+    def test_attacker_payload_cannot_inject_fake_resource_metadata(self) -> None:
+        """A poisoned error_description must not be able to inject a fake
+        ``resource_metadata="https://evil.example/..."`` attribute by closing
+        the legitimate ``error_description="..."`` attribute early.
+        """
+        payload = '"\r\nresource_metadata="https://evil.example/x"'
+        result = _sanitize_challenge_attr_value(payload)
+        # The closing quote that would have terminated error_description is
+        # replaced by an apostrophe, and the CR/LF that would have started a
+        # new header line is replaced by spaces. The payload becomes inert.
+        assert '"' not in result
+        assert "\r" not in result
+        assert "\n" not in result


### PR DESCRIPTION
Closes #592

## Summary
- Consolidate OAuth `scopes_supported` advertisement across all four sources (auth-server / protected-resource / openid-configuration / DCR fallback) behind a single canonical constant `auth.mcp_scopes.ALL_ADVERTISED_SCOPES` — the original 4-way drift was what tripped Claude Code's `Invalidated credentials (scope: all)` cascade and broke MCP DCR with 100% reproducibility.
- Canonical set is the **union** of every scope each source previously advertised: `openid memory:read memory:write memory:admin memory:delete offline_access`. No scope is removed from any source, so this is **not** a breaking change for any external client.
- Backfill existing `oauth_clients.scope` rows that still carry the pre-fix narrow default (`memory:read memory:write offline_access`) to the canonical set via Alembic migration `e08_592_oauth_scope_canonicalize`. Rows with custom scope are untouched.
- Add RFC 9728 §5.1 `resource_metadata=` attribute to the MCP 401 `WWW-Authenticate` challenge so clients no longer have to guess the protected-resource metadata URL by convention. Header value is sanitized (CR/LF + `"` stripped) to neutralize CWE-93 / response-splitting via attacker-controlled error descriptions.
- Pin the contract with a drift-guard property test (`tests/api/test_oauth_metadata_drift.py`) and a unit test for the header sanitizer (`tests/mcp_server/test_transport_challenge.py`).

## Implementation notes
- **New module** `backend/src/auth/mcp_scopes.py` — canonical scope definitions + DCR default string. Single source of truth for the four metadata sources.
- **New module-private helper** `_sanitize_challenge_attr_value` in `backend/src/mcp_server/transport.py` — pinned by unit tests; replaces the inline replace-chain to prevent silent regression in future refactors.
- **No new dependencies.** All wiring uses existing imports (`get_settings`, `sqlalchemy.text`, `alembic.op`).
- **Forward-compatibility commitment**: `memory:admin`, `memory:delete`, and `openid` are advertised but **not enforced** anywhere yet. This preserves backward compat for clients that whitelisted those scopes. The paired enforcement / honest-deprecation cleanup is tracked at #608 (gate for #592).
- **`Settings.frontend_url` migration**: this PR contributes the new MCP 401 site to the migration the field's docstring promised. 13 existing raw `os.getenv("FRONTEND_URL", ...)` sites remain across well_known/oauth/auth/signup; out of scope for this hotfix.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green (initial yellow on missing sanitizer test addressed by extracting `_sanitize_challenge_attr_value` + 6 parametrized unit tests)
- cto: green
- gate1: green (revised from yellow via `/dx-lead` Locks A–E plan; #608 filed as enforcement gate)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/592-fix-fix-oauth-scope-mismatch-across-3-metada.gate1.md`
- `~/.claude/cache/gh-issue-driven/592-fix-fix-oauth-scope-mismatch-across-3-metada.gate2.md`

🤖 Generated via /gh-issue-driven:ship
