### PR TITLE
chore(api,models,types): pyright tier-A re-enable + DDL drift cleanup (#599, #600)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -194,6 +194,10 @@ reportMissingTypeStubs = false
 #   D     reportOptionalMemberAccess          ?             deferred
 #   D     reportIndexIssue                    ?             deferred
 #   D     reportOptionalOperand               ?             deferred
+# Tier A — explicitly enabled (robust against future typeCheckingMode shifts):
+reportAssignmentType = true
+reportReturnType = true
+# Tiers B/C/D — explicitly disabled:
 reportArgumentType = false
 reportAttributeAccessIssue = false
 reportGeneralTypeIssues = false

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -178,40 +178,32 @@ pythonVersion = "3.11"
 typeCheckingMode = "basic"
 reportMissingImports = true
 reportMissingTypeStubs = false
-# Post-#596 (Mapped[T] migration epic #370 complete) pyright re-enablement
-# audit. Each rule was tested individually after Part 1 by flipping it to
-# `true`, running `pyright src/`, and counting residual errors. The
-# Column[T]-vs-T mismatches the original suppressions were hiding are now
-# gone (the migration removes them), but each rule still surfaces unrelated
-# caller-side type-narrowing issues that fall outside the model-layer scope
-# of #596. Per the #596 acceptance plan, rules with < 20 residual errors are
-# re-enable candidates, but for all 5 SA-related rules the residuals are
-# caller-side fixes that belong in a follow-up issue (model-layer typing is
-# the scope; narrowing in services/routes is not).
+# Post-#596 (Mapped[T] migration epic #370 complete) pyright re-enablement.
+# The Column[T]-vs-T mismatches the original suppressions were hiding are
+# now gone (the migration removes them); the residuals are unrelated
+# caller-side type-narrowing issues. #599 narrows them tier by tier:
 #
-# Audit results (one rule re-enabled at a time vs the all-disabled baseline
-# of 1 error in db/base.py unresolvable-import):
+#   Tier  Rule                         Residuals (pre-fix)  Status
+#   ----  --------                     -------------------  ------
+#   A     reportAssignmentType                4             re-enabled (#599)
+#   A     reportReturnType                    5             re-enabled (#599)
+#   B     reportCallIssue                    22             deferred
+#   B     reportAttributeAccessIssue         36             deferred
+#   C     reportArgumentType                163             deferred
+#   D     reportGeneralTypeIssues             ?             deferred
+#   D     reportOptionalMemberAccess          ?             deferred
+#   D     reportIndexIssue                    ?             deferred
+#   D     reportOptionalOperand               ?             deferred
 #
-#   reportArgumentType            163 errors  — caller-side: many
-#   reportAttributeAccessIssue     36 errors  — caller-side: many
-#   reportAssignmentType            4 errors  — caller-side: contexts.py x2,
-#                                              workspace_service.py x2 (None
-#                                              vs WorkspaceMember narrowing)
-#   reportReturnType                5 errors  — caller-side: roles.py missing-
-#                                              return-path, oauth2.py Google
-#                                              creds union, qdrant.py PointId
-#                                              narrowing
-#   reportCallIssue                22 errors  — caller-side
-#
-# Follow-up: #599 will narrow these one-by-one and re-enable the rules. The
-# Column[T]-related suppression rationale is no longer load-bearing on any
-# of them — the only thing keeping them disabled is the caller-side fix
-# backlog tracked in that issue.
+# Tier A re-enable (#599 + #600 cleanup pair) — caller-side fixes:
+#   - api/routes/contexts.py: dict value-type narrowing + label rename
+#   - services/workspace_service.py: explicit None-narrowing after get_member
+#   - auth/roles.py: missing return path on async-for fall-through
+#   - auth/oauth2.py: cast(Credentials, ...) on Flow.credentials
+#   - db/qdrant.py: switch offset to qdrant-client's PointId | None
 reportArgumentType = false
 reportAttributeAccessIssue = false
 reportGeneralTypeIssues = false
-reportReturnType = false
-reportAssignmentType = false
 reportCallIssue = false
 reportOptionalMemberAccess = false
 reportIndexIssue = false

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -194,13 +194,6 @@ reportMissingTypeStubs = false
 #   D     reportOptionalMemberAccess          ?             deferred
 #   D     reportIndexIssue                    ?             deferred
 #   D     reportOptionalOperand               ?             deferred
-#
-# Tier A re-enable (#599 + #600 cleanup pair) — caller-side fixes:
-#   - api/routes/contexts.py: dict value-type narrowing + label rename
-#   - services/workspace_service.py: explicit None-narrowing after get_member
-#   - auth/roles.py: missing return path on async-for fall-through
-#   - auth/oauth2.py: cast(Credentials, ...) on Flow.credentials
-#   - db/qdrant.py: switch offset to qdrant-client's PointId | None
 reportArgumentType = false
 reportAttributeAccessIssue = false
 reportGeneralTypeIssues = false

--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -305,7 +305,10 @@ async def list_contexts(
         stmt = select(User).where(User.user_id.in_(creator_ids))
         result = await db.execute(stmt)
         users = result.scalars().all()
-        creator_names: dict[str, str] = {u.user_id: u.name for u in users}
+        # User.name is nullable (str | None); the downstream consumer at
+        # `creator_names.get(context.created_by)` already handles the optional
+        # value, so the dict value type matches the underlying column.
+        creator_names: dict[str, str | None] = {u.user_id: u.name for u in users}
 
     # Issue #217: Get search configs for all contexts (single query)
     context_ids = [c.id for c in contexts_list]
@@ -356,7 +359,11 @@ async def list_contexts(
         stats_stmt = (
             select(
                 Memory.context_id,
-                func.count(Memory.id).label("count"),
+                # Label is "memory_count" (not "count") to avoid clashing with
+                # tuple.count, which pyright resolves first when the label is
+                # accessed as ``row.count`` and then complains the int() cast
+                # below has a method-typed argument.
+                func.count(Memory.id).label("memory_count"),
                 func.max(func.coalesce(Memory.updated_at, Memory.created_at)).label(
                     "last_activity"
                 ),
@@ -369,7 +376,7 @@ async def list_contexts(
         )
         stats_result = await db.execute(stats_stmt)
         memory_stats = {
-            row.context_id: (row.count, row.last_activity) for row in stats_result.all()
+            row.context_id: (int(row.memory_count), row.last_activity) for row in stats_result.all()
         }
 
     context_responses = []

--- a/backend/src/auth/oauth2.py
+++ b/backend/src/auth/oauth2.py
@@ -4,7 +4,7 @@ import json
 import logging
 import os
 from datetime import UTC
-from typing import Any
+from typing import Any, cast
 
 from cryptography.fernet import Fernet
 from google.auth.transport.requests import Request
@@ -366,7 +366,10 @@ class OAuth2Manager:
 
             flow.fetch_token(code=code)
             logger.info("Code exchange successful")
-            return flow.credentials
+            # Flow.credentials is typed as Credentials | OAuth2Token, but the
+            # web flow always populates Credentials after a successful
+            # fetch_token. Cast to satisfy the declared return type.
+            return cast(Credentials, flow.credentials)
 
         except Exception as e:
             logger.error(f"Code exchange failed: {e}")

--- a/backend/src/auth/roles.py
+++ b/backend/src/auth/roles.py
@@ -601,6 +601,10 @@ class RoleManager:
                     )
                     for u in db_users
                 ]
+            # async for over get_db() always yields at least one session
+            # in practice, but the type system can't see that — return [] so
+            # the function has an explicit list[UserRole] in every code path.
+            return []
         else:
             return []
 

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -1176,7 +1176,13 @@ async def _admin_scroll_context_points(
         Successive lists of qdrant_client.models.Record, one per scroll page.
     """
     client = get_qdrant_client()
-    offset: str | int | None = None
+    # Use qdrant-client's own PointId union for the cursor, matching scroll's
+    # declared parameter type. Importing locally (vs at module top) keeps the
+    # qdrant_client.conversions.common_types path scoped to this generator —
+    # no other call site in this file consumes the cursor.
+    from qdrant_client.conversions.common_types import PointId
+
+    offset: PointId | None = None
 
     while True:
         points, next_offset = await client.scroll(

--- a/backend/src/db/qdrant.py
+++ b/backend/src/db/qdrant.py
@@ -1176,10 +1176,8 @@ async def _admin_scroll_context_points(
         Successive lists of qdrant_client.models.Record, one per scroll page.
     """
     client = get_qdrant_client()
-    # Use qdrant-client's own PointId union for the cursor, matching scroll's
-    # declared parameter type. Importing locally (vs at module top) keeps the
-    # qdrant_client.conversions.common_types path scoped to this generator —
-    # no other call site in this file consumes the cursor.
+    # qdrant-client's PointId union (int | str | UUID) matches scroll's
+    # declared offset parameter and the next_offset return value.
     from qdrant_client.conversions.common_types import PointId
 
     offset: PointId | None = None

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -15,7 +15,6 @@ through the cost-grade plumbing introduced by #523.
 import uuid
 from datetime import datetime
 from typing import Any
-from uuid import uuid4
 
 from sqlalchemy import (
     BigInteger,
@@ -89,7 +88,7 @@ class MemoryAnalysis(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
-        default=uuid4,
+        default=uuid.uuid4,
         server_default=text("gen_random_uuid()"),
     )
     workspace_id: Mapped[uuid.UUID] = mapped_column(
@@ -200,7 +199,7 @@ class MemoryAnalysisCluster(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         primary_key=True,
-        default=uuid4,
+        default=uuid.uuid4,
         server_default=text("gen_random_uuid()"),
     )
     analysis_id: Mapped[uuid.UUID] = mapped_column(

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -10,10 +10,8 @@ Provides ORM models for:
 import uuid
 from datetime import datetime
 from typing import Any
-from uuid import uuid4
 
 from sqlalchemy import (
-    ARRAY,
     JSON,
     BigInteger,
     Boolean,
@@ -30,7 +28,7 @@ from sqlalchemy import (
     UniqueConstraint,
     func,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
@@ -77,7 +75,7 @@ class Memory(Base):
     __tablename__ = "memories"
 
     # 基本情報
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
 
     # Migration 063: 3-level isolation (workspace, context, user)
@@ -220,7 +218,7 @@ class Attachment(Base):
 
     __tablename__ = "attachments"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     memory_id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("memories.id", ondelete="CASCADE"),
@@ -232,7 +230,7 @@ class Attachment(Base):
     size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
     data: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, server_default=func.now(), nullable=False
+        DateTime, nullable=False, server_default=func.now()
     )
 
     __table_args__ = (

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -75,7 +75,12 @@ class SleepReport(Base):
 
     __tablename__ = "sleep_reports"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
     user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     workspace_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     context_id: Mapped[uuid.UUID | None] = mapped_column(

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -94,7 +94,7 @@ class SleepReport(Base):
         String(20),
         nullable=False,
         default="running",
-        server_default=text("'running'"),
+        server_default="running",
     )
 
     # Per-phase results (JSON)
@@ -111,13 +111,13 @@ class SleepReport(Base):
     # any reader that selects them directly (legacy dashboards, log analyzers,
     # MCP tools) continues to work without change.
     llm_calls_made: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
     llm_tokens_used: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
     embedding_calls_made: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
 
     # Embedding cost-grade columns (#471). Embedding is instance-global per
@@ -132,7 +132,7 @@ class SleepReport(Base):
     embedding_provider: Mapped[str | None] = mapped_column(String(50), nullable=True)
     embedding_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
     embedding_tokens: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
 
     # Cost-grade dimensions (#523). Both columns carry a Python-side
@@ -154,19 +154,19 @@ class SleepReport(Base):
 
     # Activity counters
     memories_processed: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
     edges_created: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
     memories_merged: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
     memories_promoted: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
     memories_flagged: Mapped[int] = mapped_column(
-        Integer, nullable=False, default=0, server_default=text("0")
+        Integer, nullable=False, default=0, server_default="0"
     )
 
     # Error tracking

--- a/backend/src/models/sleep.py
+++ b/backend/src/models/sleep.py
@@ -6,7 +6,6 @@ Issue #101: Sleep Maintenance Foundation — report tracking and audit log.
 import uuid
 from datetime import datetime
 from typing import Any, Literal
-from uuid import uuid4
 
 from sqlalchemy import (
     JSON,
@@ -76,7 +75,7 @@ class SleepReport(Base):
 
     __tablename__ = "sleep_reports"
 
-    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
     workspace_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
     context_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -91,7 +90,12 @@ class SleepReport(Base):
         DateTime, nullable=False, server_default=func.now()
     )
     completed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    status: Mapped[str] = mapped_column(String(20), nullable=False, default="running")
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="running",
+        server_default=text("'running'"),
+    )
 
     # Per-phase results (JSON)
     edge_discovery_result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
@@ -106,9 +110,15 @@ class SleepReport(Base):
     # remain populated by the reporter as a sum of child rows for back-compat:
     # any reader that selects them directly (legacy dashboards, log analyzers,
     # MCP tools) continues to work without change.
-    llm_calls_made: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    llm_tokens_used: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    embedding_calls_made: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    llm_calls_made: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    llm_tokens_used: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    embedding_calls_made: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
 
     # Embedding cost-grade columns (#471). Embedding is instance-global per
     # ``backend/src/config/settings.py`` (one EMBEDDING_PROVIDER /
@@ -121,7 +131,9 @@ class SleepReport(Base):
     # the embedding API but don't increment any counter; #475 closes that gap.
     embedding_provider: Mapped[str | None] = mapped_column(String(50), nullable=True)
     embedding_model: Mapped[str | None] = mapped_column(String(100), nullable=True)
-    embedding_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    embedding_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
 
     # Cost-grade dimensions (#523). Both columns carry a Python-side
     # ``default`` (in-memory ORM objects readable after flush without
@@ -141,11 +153,21 @@ class SleepReport(Base):
     )
 
     # Activity counters
-    memories_processed: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    edges_created: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    memories_merged: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    memories_promoted: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    memories_flagged: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    memories_processed: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    edges_created: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    memories_merged: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    memories_promoted: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    memories_flagged: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
 
     # Error tracking
     error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -274,11 +296,19 @@ class SleepReportLLMUsage(Base):
     provider: Mapped[str] = mapped_column(String(50), nullable=False)
     model: Mapped[str] = mapped_column(String(100), nullable=False)
 
-    input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    output_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    cached_input_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    cache_write_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    calls: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    input_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    output_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    cached_input_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    cache_write_tokens: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    calls: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default=text("0"))
     tokenizer_version: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -571,6 +571,10 @@ class WorkspaceService:
         self.validate_role(new_role)
 
         member = await self.get_member(workspace_id, user_id)
+        # get_member raises by default when not found, so this branch is
+        # defense-in-depth for any future call site that flips the default.
+        if member is None:
+            raise NotFoundException(f"Member not found: {user_id} in workspace {workspace_id}")
 
         # Validate single owner constraint (Issue #165)
         if new_role == "owner" and member.role != "owner":
@@ -634,6 +638,10 @@ class WorkspaceService:
             owner/admin roles always have full access (this setting is ignored).
         """
         member = await self.get_member(workspace_id, user_id)
+        # get_member raises by default when not found, so this branch is
+        # defense-in-depth for any future call site that flips the default.
+        if member is None:
+            raise NotFoundException(f"Member not found: {user_id} in workspace {workspace_id}")
 
         # Warn if setting on owner/admin (no effect)
         if member.role in ("owner", "admin") and allowed_context_ids is not None:

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -571,9 +571,9 @@ class WorkspaceService:
         self.validate_role(new_role)
 
         member = await self.get_member(workspace_id, user_id)
-        # get_member raises by default when not found, so this branch is
-        # defense-in-depth for any future call site that flips the default.
         if member is None:
+            # get_member raises by default; narrow for pyright + any future
+            # call site that passes raise_if_not_found=False.
             raise NotFoundException(f"Member not found: {user_id} in workspace {workspace_id}")
 
         # Validate single owner constraint (Issue #165)
@@ -638,9 +638,9 @@ class WorkspaceService:
             owner/admin roles always have full access (this setting is ignored).
         """
         member = await self.get_member(workspace_id, user_id)
-        # get_member raises by default when not found, so this branch is
-        # defense-in-depth for any future call site that flips the default.
         if member is None:
+            # get_member raises by default; narrow for pyright + any future
+            # call site that passes raise_if_not_found=False.
             raise NotFoundException(f"Member not found: {user_id} in workspace {workspace_id}")
 
         # Warn if setting on owner/admin (no effect)


### PR DESCRIPTION
Closes #599
Closes #600

## Summary

Two #596 (Mapped[T] migration epic #370) follow-up cleanup issues bundled as a mini-batch (file-area disjoint):

- **#599 Tier A only** — re-enable two pyright rules suppressed since #596 (`reportAssignmentType` + `reportReturnType`) by fixing 9 caller-side type narrowings. Tier B (~58 fixes), Tier C (~163 fixes), Tier D (4 broader rules) remain deferred.
- **#600** — fix DDL drift on `sleep.py` by adding `server_default` to 15 columns (matches alembic a91/c02/e01); apply 3 cosmetic consistency cleanups (B1 kwarg order, B2 `uuid.uuid4` qualified, B3 `ARRAY` dialect import).

## Implementation notes

**#599 Tier A — 9 caller-side fixes**:
- `api/routes/contexts.py` (×2): widen `creator_names` dict value to `str | None` to match nullable `User.name`; rename `label("count")` → `label("memory_count")` to avoid `tuple.count` collision in pyright; explicit `int(row.memory_count)` cast.
- `services/workspace_service.py` (×2): insert `if member is None: raise NotFoundException(...)` after `get_member` calls in `update_member_role` + `update_member_context_access`. `get_member` raises by default — this is forward-compat narrowing for any future call site that passes `raise_if_not_found=False`. Caller audit (`api/routes/workspaces.py`) confirmed no None-check dead branches to remove.
- `auth/roles.py`: add `return []` after `async for db in get_db():` loop in `list_users` for the no-iteration fall-through.
- `auth/oauth2.py`: `cast(Credentials, flow.credentials)` on web-flow code-exchange return; new `from typing import cast` import.
- `db/qdrant.py`: switch `_admin_scroll_context_points` offset variable to `qdrant_client.conversions.common_types.PointId | None` (function-local import).
- `pyproject.toml`: remove `reportAssignmentType = false` and `reportReturnType = false`. Audit comment rewritten as Tier A/B/C/D status table.

**#600 — DDL drift + cosmetic**:
- `models/sleep.py`: 15 columns gain `server_default=text("...")` matching alembic migrations (a91 SleepReport status + 9 counter cols, c02 SleepReportLLMUsage 4 counters + embedding_tokens, e01 cache_write_tokens). Symptom: `Base.metadata.create_all()` test fixtures previously produced schema without DDL DEFAULT clauses; raw INSERTs that bypass the ORM now succeed with documented defaults instead of failing NOT NULL.
- `models/memory.py`: B1 swap `Attachment.created_at` kwarg order; B2 drop `from uuid import uuid4` and qualify as `uuid.uuid4`; B3 move `ARRAY` import to `sqlalchemy.dialects.postgresql`.
- `models/sleep.py` and `models/analysis.py`: B2 only.

**Out of scope (deferred to follow-up issues)**:
- Tier B/C/D pyright re-enable
- Repo-wide `label("count")` rename (7 sister sites in workspace_service.py / workspaces.py / usage.py / workspace.py — same `tuple.count` collision pattern)
- Optional schema-drift test (`Base.metadata.create_all()` vs `alembic upgrade head`)
- `@overload` on `workspace_service.get_member` (would centralize narrowing for all callers but expands blast radius beyond Tier A charter)

## Verification

- `pyright src/`: 0 new errors (1 pre-existing `reportOperatorIssue` in `neural_tasks.py:263` unchanged — out of Tier A scope)
- `pytest tests/services tests/utils tests/auth tests/mcp_server`: 1130 passed (no regression)

## Pre-PR review summary

- gate2 mode: advisor-only (binary_gate=null)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens) — batch coherence review
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/599-batch-599-600.gate1.md
- ~/.claude/cache/gh-issue-driven/599-batch-599-600.gate2.md

🤖 Generated via /gh-issue-driven:ship
