### PR TITLE
fix(auth,db): narrow DCR_DEFAULT_SCOPE to exclude memory:admin (#608)

### DIFF
--- a/backend/alembic/versions/e09_608_dcr_default_narrow.py
+++ b/backend/alembic/versions/e09_608_dcr_default_narrow.py
@@ -13,28 +13,47 @@ FIRST, then enforce on routes.
 
 Scope of the data fix (R1 policy from gate1 review):
 
-- Rows whose ``scope`` is exactly the post-#592 canonical string get
-  ``memory:admin`` stripped. This is the "got admin by default" cohort
-  — clients that did not explicitly opt into admin and would have
-  received it merely because the DCR fallback included it.
+- Only DCR-registered clients are touched. The WHERE clause includes
+  ``owner_id IS NULL`` — DCR clients have ``owner_id=NULL`` per
+  ``d04_519_oauth_owner_nullable``; admin-managed clients have a
+  non-null ``owner_id`` and are never touched by this migration even
+  if their scope string happens to match the canonical.
+- Among DCR clients, rows whose ``scope`` is exactly the post-#592
+  canonical string get ``memory:admin`` stripped. This is the "got
+  admin by default" cohort — clients that did not explicitly opt
+  into admin and would have received it merely because the DCR
+  fallback included it.
 - Rows whose ``scope`` differs from the exact post-#592 canonical
-  string are left untouched. This preserves any client that
-  EXPLICITLY requested ``memory:admin`` (their stored scope is a
-  custom subset / superset that does not match the full default), as
-  well as any other custom-scoped client.
+  string are left untouched. This preserves any DCR client that
+  registered with a custom scope set (subset, superset, or any
+  ordering that doesn't match the canonical exactly).
 
-This guarantees that no client that explicitly requested admin loses
-it. Clients that got admin by accident lose it, which is the intended
-behaviour — they never needed admin to begin with.
+Residual limitation (Copilot review on PR #615): the migration cannot
+distinguish a DCR client that EXPLICITLY requested the full canonical
+string (``scope="openid memory:read memory:write memory:admin
+memory:delete offline_access"`` in this exact ordering) from a client
+that received the same string via the fallback default. Such a client
+would have ``memory:admin`` stripped despite having explicitly
+requested it. In practice this collision is rare — it requires the
+client to type out all six scopes in the server's canonical ordering,
+which only matches clients that derived their scope list from the
+server's discovery endpoint. Affected clients can recover by
+re-registering with a distinguishing custom scope ordering, or by
+operator-driven re-grant.
 
 ``memory:delete`` is intentionally NOT narrowed in this migration. The
 distinct-vs-implied policy for ``memory:delete`` lands in #608 (D4) in
 a separate migration; coarsening admin first, then handling delete as
 its own least-privilege decision keeps the two concerns independent.
 
-Downgrade restores ``memory:admin`` on the exact rows we touched. We
-can identify them precisely because the pre-narrow and post-narrow
-canonical strings differ.
+Downgrade applies the inverse: re-adds ``memory:admin`` on DCR clients
+whose scope matches the post-narrow canonical. Same DCR-only filter
+(``owner_id IS NULL``) and the same canonical-string residual
+limitation apply in reverse — a DCR client that registered AFTER this
+migration with the exact post-narrow canonical string would have
+``memory:admin`` ADDED on downgrade (symmetric privilege escalation).
+Operators running the downgrade should re-issue narrower scopes to
+affected clients via the OAuth admin endpoints if this matters.
 
 Rollback (operator runbook): if Claude Code MCP DCR breaks post-deploy
 because a pre-SEP-835 SDK invalidates the narrowed token (the
@@ -81,21 +100,31 @@ _POST_NARROW_CANONICAL = "openid memory:read memory:write memory:delete offline_
 
 
 def upgrade() -> None:
-    # Strip memory:admin from rows that match the pre-narrow default
-    # exactly. Anything that doesn't match (custom-scoped clients,
-    # explicit-admin requests with extra scopes, etc.) is left alone.
+    # Strip memory:admin from DCR clients whose scope matches the
+    # pre-narrow canonical exactly. ``owner_id IS NULL`` restricts to
+    # DCR-registered clients (admin-managed clients have non-null
+    # owner_id per d04_519_oauth_owner_nullable) — any custom-scoped
+    # DCR client whose scope string differs from the canonical is also
+    # untouched. See module docstring for the residual exact-match
+    # canonical-ordering corner case.
     op.execute(
-        sa.text("UPDATE oauth_clients SET scope = :new_scope WHERE scope = :old_scope").bindparams(
-            new_scope=_POST_NARROW_CANONICAL, old_scope=_PRE_NARROW_CANONICAL
-        )
+        sa.text(
+            "UPDATE oauth_clients SET scope = :new_scope "
+            "WHERE scope = :old_scope AND owner_id IS NULL"
+        ).bindparams(new_scope=_POST_NARROW_CANONICAL, old_scope=_PRE_NARROW_CANONICAL)
     )
 
 
 def downgrade() -> None:
-    # Restore memory:admin on the exact rows we narrowed. Anything we
-    # did not touch in upgrade() stays put.
+    # Restore memory:admin on DCR clients whose scope matches the
+    # post-narrow canonical. Symmetric ``owner_id IS NULL`` filter
+    # excludes admin-managed clients. See module docstring for the
+    # symmetric privilege-escalation note on the rare exact-match
+    # corner case (DCR client registered post-upgrade with exact
+    # post-narrow canonical string).
     op.execute(
-        sa.text("UPDATE oauth_clients SET scope = :old_scope WHERE scope = :new_scope").bindparams(
-            old_scope=_PRE_NARROW_CANONICAL, new_scope=_POST_NARROW_CANONICAL
-        )
+        sa.text(
+            "UPDATE oauth_clients SET scope = :old_scope "
+            "WHERE scope = :new_scope AND owner_id IS NULL"
+        ).bindparams(old_scope=_PRE_NARROW_CANONICAL, new_scope=_POST_NARROW_CANONICAL)
     )

--- a/backend/alembic/versions/e09_608_dcr_default_narrow.py
+++ b/backend/alembic/versions/e09_608_dcr_default_narrow.py
@@ -1,0 +1,101 @@
+"""Narrow DCR default scope by stripping ``memory:admin`` (#608 D1).
+
+#608 (D1) closes the "advertise-without-enforcement" gap left open by
+#592 (v0.15.4). The hotfix kept the UNION of every previously-advertised
+scope — including ``memory:admin`` — in ``DCR_DEFAULT_SCOPE`` to avoid a
+backward-incompatible removal. That preserved compatibility but also
+auto-granted ``memory:admin`` to every newly-registered DCR client. When
+a future sub-PR adds ``require_scope("memory:admin")`` to admin routes,
+every already-issued DCR token would silently gain admin against those
+routes — a backward-compat privilege escalation. The narrowing-first
+ordering closes this window: drop ``memory:admin`` from the DCR default
+FIRST, then enforce on routes.
+
+Scope of the data fix (R1 policy from gate1 review):
+
+- Rows whose ``scope`` is exactly the post-#592 canonical string get
+  ``memory:admin`` stripped. This is the "got admin by default" cohort
+  — clients that did not explicitly opt into admin and would have
+  received it merely because the DCR fallback included it.
+- Rows whose ``scope`` differs from the exact post-#592 canonical
+  string are left untouched. This preserves any client that
+  EXPLICITLY requested ``memory:admin`` (their stored scope is a
+  custom subset / superset that does not match the full default), as
+  well as any other custom-scoped client.
+
+This guarantees that no client that explicitly requested admin loses
+it. Clients that got admin by accident lose it, which is the intended
+behaviour — they never needed admin to begin with.
+
+``memory:delete`` is intentionally NOT narrowed in this migration. The
+distinct-vs-implied policy for ``memory:delete`` lands in #608 (D4) in
+a separate migration; coarsening admin first, then handling delete as
+its own least-privilege decision keeps the two concerns independent.
+
+Downgrade restores ``memory:admin`` on the exact rows we touched. We
+can identify them precisely because the pre-narrow and post-narrow
+canonical strings differ.
+
+Rollback (operator runbook): if Claude Code MCP DCR breaks post-deploy
+because a pre-SEP-835 SDK invalidates the narrowed token (the
+``Invalidated credentials (scope: all)`` symptom that #592 originally
+fixed), recovery is:
+
+  1. ``alembic downgrade e08_592_oauth_scope_canonicalize`` — restores
+     ``memory:admin`` on rows narrowed by this migration.
+  2. Revert the ``DCR_DEFAULT_SCOPES`` narrowing in
+     ``backend/src/auth/mcp_scopes.py`` (set ``DCR_DEFAULT_SCOPE = " ".join(
+     ALL_ADVERTISED_SCOPES)`` again).
+  3. Re-deploy. New DCR clients again receive the full union and the SDK
+     drift check passes.
+
+Standard Alembic ordering applies: deploy the application code BEFORE
+running this migration (or atomically). A DCR registration that lands
+between migration and deploy uses the old app's default and is not
+touched by ``upgrade()``.
+
+Revision ID: e09_608_dcr_default_narrow
+Revises: e08_592_oauth_scope_canonicalize
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "e09_608_dcr_default_narrow"
+down_revision = "e08_592_oauth_scope_canonicalize"
+branch_labels = None
+depends_on = None
+
+
+# Hard-coded on purpose: an Alembic migration is a snapshot of intent at
+# revision time. Importing ``auth.mcp_scopes`` would couple the migration
+# to whatever the canonical set happens to be the day someone runs
+# ``alembic upgrade head`` years later, which is the opposite of what
+# migrations are for. The string below must match
+# ``auth.mcp_scopes.DCR_DEFAULT_SCOPE`` as it was AT THIS REVISION — if
+# the runtime constant changes again, write a new migration; do not edit
+# this file.
+_PRE_NARROW_CANONICAL = "openid memory:read memory:write memory:admin memory:delete offline_access"
+_POST_NARROW_CANONICAL = "openid memory:read memory:write memory:delete offline_access"
+
+
+def upgrade() -> None:
+    # Strip memory:admin from rows that match the pre-narrow default
+    # exactly. Anything that doesn't match (custom-scoped clients,
+    # explicit-admin requests with extra scopes, etc.) is left alone.
+    op.execute(
+        sa.text("UPDATE oauth_clients SET scope = :new_scope WHERE scope = :old_scope").bindparams(
+            new_scope=_POST_NARROW_CANONICAL, old_scope=_PRE_NARROW_CANONICAL
+        )
+    )
+
+
+def downgrade() -> None:
+    # Restore memory:admin on the exact rows we narrowed. Anything we
+    # did not touch in upgrade() stays put.
+    op.execute(
+        sa.text("UPDATE oauth_clients SET scope = :old_scope WHERE scope = :new_scope").bindparams(
+            old_scope=_PRE_NARROW_CANONICAL, new_scope=_POST_NARROW_CANONICAL
+        )
+    )

--- a/backend/src/auth/mcp_scopes.py
+++ b/backend/src/auth/mcp_scopes.py
@@ -1,28 +1,44 @@
 """Canonical MCP OAuth 2.0 scope definitions (single source of truth).
 
 All ``scopes_supported`` advertisements (RFC 8414, RFC 9728, OIDC discovery)
-and the DCR (RFC 7591) fallback scope MUST derive from these constants.
+derive from ``ALL_ADVERTISED_SCOPES``. The DCR (RFC 7591) fallback default
+derives from ``DCR_DEFAULT_SCOPES``, which is intentionally narrower than
+``ALL_ADVERTISED_SCOPES`` — see the policy notes below.
 
 Policy notes:
 
-- The canonical set is the UNION of every scope previously advertised by
-  any of the four metadata sources at the time of #592. Keeping the union
-  avoids a backward-incompatible removal in the hotfix — strict OIDC
-  clients still get ``openid``, clients that whitelisted ``memory:delete``
-  still see it. Drift (every source advertising a DIFFERENT subset) was
-  the actual bug; advertising the union from one shared constant is the
-  fix.
-- ``memory:admin`` and ``memory:delete`` are advertised but not yet
-  enforced on any route. Advertising them is a forward-compatibility
-  commitment — DCR-issued clients hold the scope ahead of enforcement.
-  #608 tracks paired enforcement; until that lands, treat these as
-  unenforced fictional scopes (no permission gate, no implicit grant).
+- ``ALL_ADVERTISED_SCOPES`` is the UNION of every scope previously
+  advertised by any of the four metadata sources at the time of #592.
+  Keeping the union avoids a backward-incompatible removal in that
+  hotfix — strict OIDC clients still see ``openid``, clients that
+  whitelisted ``memory:delete`` still see it. Drift (every source
+  advertising a DIFFERENT subset) was the actual bug; advertising the
+  union from one shared constant is the fix.
+- ``DCR_DEFAULT_SCOPES`` is the advertised set MINUS ``memory:admin``.
+  ``memory:admin`` remains explicitly requestable via the DCR ``scope``
+  parameter and is still advertised in ``scopes_supported``, but a
+  client that omits ``scope`` no longer receives admin privileges by
+  default. This is the narrowing-first ordering required by #608 (D1):
+  every newly-issued DCR token is admin-less by default, so when a
+  later sub-PR adds ``require_scope("memory:admin")`` to admin routes,
+  no already-issued DCR client silently gains admin against the newly-
+  protected routes. ``memory:delete`` stays in the default for now and
+  is addressed separately in #608 (D4).
+
+  SEP-835 (MCP authorization spec evolution) endorses this asymmetry:
+  authorization servers MAY issue tokens with narrower scopes than
+  requested, and clients SHOULD recover via 403 + ``WWW-Authenticate:
+  insufficient_scope`` upgrade flows. A pre-SEP-835 strict-drift SDK may
+  invalidate credentials when issued ⊂ requested; the rollback path if
+  Claude Code MCP DCR breaks post-deploy is ``alembic downgrade
+  e08_592_oauth_scope_canonicalize`` plus reverting this file's
+  narrowing edit.
 - ``openid`` is advertised on every metadata source so the discovery
   contract is consistent — but the server does NOT issue ``id_token``,
   so a strict OIDC client that proceeds past discovery will fail at the
   authorization step. The advertisement preserves discovery
-  compatibility; the OIDC dishonesty is a separate cleanup, NOT part of
-  the #592 drift fix.
+  compatibility; the OIDC dishonesty is addressed separately in #608
+  (D5), not part of this narrowing.
 - ``offline_access`` (RFC 6749 §1.3.5 / §6) requests a refresh token.
 """
 
@@ -35,4 +51,8 @@ ALL_ADVERTISED_SCOPES: tuple[str, ...] = (
     "offline_access",
 )
 
-DCR_DEFAULT_SCOPE: str = " ".join(ALL_ADVERTISED_SCOPES)
+# DCR fallback default — advertised set minus ``memory:admin``. See module
+# docstring (#608 D1) for the narrowing-first ordering rationale.
+DCR_DEFAULT_SCOPES: tuple[str, ...] = tuple(s for s in ALL_ADVERTISED_SCOPES if s != "memory:admin")
+
+DCR_DEFAULT_SCOPE: str = " ".join(DCR_DEFAULT_SCOPES)

--- a/backend/tests/api/test_oauth_metadata_drift.py
+++ b/backend/tests/api/test_oauth_metadata_drift.py
@@ -142,7 +142,7 @@ class TestDcrFallbackScopeNoDrift:
             response = client.post(
                 "/api/v1/oauth/register",
                 json={
-                    "client_name": "Admin Worker",
+                    "client_name": "Claude Code",
                     "redirect_uris": ["http://localhost:8080/callback"],
                     "token_endpoint_auth_method": "none",
                     "scope": "memory:read memory:write memory:admin",

--- a/backend/tests/api/test_oauth_metadata_drift.py
+++ b/backend/tests/api/test_oauth_metadata_drift.py
@@ -16,7 +16,11 @@ import pytest  # noqa: E402
 from fastapi.testclient import TestClient  # noqa: E402
 
 from api.main import app  # noqa: E402
-from auth.mcp_scopes import ALL_ADVERTISED_SCOPES, DCR_DEFAULT_SCOPE  # noqa: E402
+from auth.mcp_scopes import (  # noqa: E402
+    ALL_ADVERTISED_SCOPES,
+    DCR_DEFAULT_SCOPE,
+    DCR_DEFAULT_SCOPES,
+)
 
 
 @pytest.fixture
@@ -58,7 +62,12 @@ class TestMetadataScopesNoDrift:
 
 class TestDcrFallbackScopeNoDrift:
     """DCR fallback scope (``POST /oauth/register`` with no ``scope``) matches
-    the canonical set, so a fresh DCR client holds every advertised scope.
+    ``DCR_DEFAULT_SCOPES`` — the advertised set minus ``memory:admin``.
+
+    #608 (D1) narrows the DCR fallback so a client that omits ``scope`` no
+    longer receives ``memory:admin`` by default. ``memory:admin`` remains
+    advertised in ``scopes_supported`` and explicitly requestable via the
+    ``scope`` parameter; only the silent auto-grant is removed.
     """
 
     def _patched_dcr_session(self):
@@ -102,19 +111,146 @@ class TestDcrFallbackScopeNoDrift:
         )
         body = response.json()
         issued_scopes = set(body["scope"].split())
-        assert issued_scopes == set(ALL_ADVERTISED_SCOPES), (
+        assert issued_scopes == set(DCR_DEFAULT_SCOPES), (
             f"DCR issued {sorted(issued_scopes)}, "
-            f"expected {sorted(ALL_ADVERTISED_SCOPES)} — fallback default "
-            "drifted from auth.mcp_scopes.DCR_DEFAULT_SCOPE."
+            f"expected {sorted(DCR_DEFAULT_SCOPES)} — fallback default "
+            "drifted from auth.mcp_scopes.DCR_DEFAULT_SCOPES."
+        )
+        assert "memory:admin" not in issued_scopes, (
+            "DCR fallback re-introduced memory:admin into the default — "
+            "this breaks the narrowing-first ordering required by #608 D1 "
+            "(a later require_scope deployment would silently grant admin "
+            "to every already-issued DCR token)."
         )
 
-    def test_dcr_default_scope_constant_matches_advertised_set(self) -> None:
+    def test_dcr_explicit_admin_request_preserves_admin(self, client: TestClient) -> None:
+        """When a client explicitly requests ``memory:admin`` at DCR
+        registration, the issued client retains admin in its registered
+        scope. The narrowing in #608 (D1) is to the FALLBACK default only,
+        not to the explicit-grant path.
+
+        This pins the R1 policy from gate1 review: admin remains an
+        opt-in capability, not a removed one. The e09 migration mirrors
+        this on the data side (custom-scope rows are preserved).
+        """
+        rate_limit, fake_session, fake_encryptor = self._patched_dcr_session()
+        with (
+            patch("db.redis.increment_counter", rate_limit),
+            patch("api.routes.oauth.get_sync_session", return_value=fake_session),
+            patch("utils.encryption.get_encryptor", return_value=fake_encryptor),
+        ):
+            response = client.post(
+                "/api/v1/oauth/register",
+                json={
+                    "client_name": "Admin Worker",
+                    "redirect_uris": ["http://localhost:8080/callback"],
+                    "token_endpoint_auth_method": "none",
+                    "scope": "memory:read memory:write memory:admin",
+                },
+            )
+
+        assert response.status_code == 201, (
+            f"DCR registration with explicit admin failed: {response.status_code} {response.text}"
+        )
+        body = response.json()
+        issued_scopes = set(body["scope"].split())
+        assert "memory:admin" in issued_scopes, (
+            f"DCR dropped explicitly-requested memory:admin from scope "
+            f"{sorted(issued_scopes)} — the narrowing in #608 D1 should "
+            "apply ONLY to the fallback default, not to explicit grants."
+        )
+
+    def test_dcr_default_scopes_excludes_only_memory_admin(self) -> None:
+        """Pin the narrowing contract: ``DCR_DEFAULT_SCOPES`` is exactly
+        ``ALL_ADVERTISED_SCOPES`` minus ``memory:admin``. No other scope is
+        dropped from the default. If a future change accidentally narrows
+        the default further (e.g. removes ``memory:delete`` here instead of
+        in the #608 D4 migration), this test fails loud.
+        """
+        assert set(DCR_DEFAULT_SCOPES) == set(ALL_ADVERTISED_SCOPES) - {"memory:admin"}
+
+    def test_dcr_default_scope_constant_matches_dcr_set(self) -> None:
         """Independent of any HTTP round-trip: the constant DCR_DEFAULT_SCOPE
-        is exactly the advertised set as a space-separated string. Pins both
+        is exactly DCR_DEFAULT_SCOPES as a space-separated string. Pins both
         the contents AND the encoding (space-separated, RFC 6749 §3.3).
         """
-        assert set(DCR_DEFAULT_SCOPE.split()) == set(ALL_ADVERTISED_SCOPES)
-        assert DCR_DEFAULT_SCOPE == " ".join(ALL_ADVERTISED_SCOPES)
+        assert set(DCR_DEFAULT_SCOPE.split()) == set(DCR_DEFAULT_SCOPES)
+        assert DCR_DEFAULT_SCOPE == " ".join(DCR_DEFAULT_SCOPES)
+
+
+class TestNarrowedClientScopeRequestRespectsIntersection:
+    """Server-side authorization behavior when a DCR-narrowed client requests
+    ``memory:admin``.
+
+    A DCR client registered under the narrowed default (post-#608 D1) holds
+    ``DCR_DEFAULT_SCOPES`` — no admin. If that client later requests
+    ``memory:admin`` at the authorization step (which a legacy SDK may do
+    if it builds the authz URL from ``scopes_supported`` instead of the
+    DCR-registered scope), the server-side ``OAuth2Client.get_allowed_scope``
+    method returns the intersection of requested-and-registered, so the
+    issued token gets the narrowed scope. The MCP authorization spec
+    (SEP-835) explicitly endorses this narrowing as least-privilege
+    behavior: "Authorization Servers MAY issue access tokens with narrower
+    scopes."
+
+    This test pins that contract at the model layer. An SEP-835-compliant
+    SDK will accept the narrowed token. A pre-SEP-835 strict-drift SDK may
+    invalidate the token; the rollback path is ``alembic downgrade
+    e08_592_oauth_scope_canonicalize`` plus reverting `mcp_scopes.py`.
+    """
+
+    def test_narrowed_client_requesting_admin_gets_intersection(self) -> None:
+        from models.auth import OAuth2Client  # noqa: PLC0415
+
+        narrowed_client = OAuth2Client(
+            client_id="test-narrowed-client",
+            client_secret_hash="dummy",
+            client_name="Test Client (DCR default)",
+            redirect_uris=["http://localhost:8080/callback"],
+            grant_types=["authorization_code"],
+            response_types=["code"],
+            scope=DCR_DEFAULT_SCOPE,
+            token_endpoint_auth_method="none",
+        )
+
+        granted = set(
+            narrowed_client.get_allowed_scope(
+                "memory:read memory:write memory:admin offline_access"
+            ).split()
+        )
+
+        assert granted == {"memory:read", "memory:write", "offline_access"}, (
+            f"Expected intersection to exclude memory:admin, got {sorted(granted)}. "
+            "OAuth2Client.get_allowed_scope must return requested ∩ registered — "
+            "a DCR-narrowed client (no admin in registered scope) requesting "
+            "admin must receive a token without admin (SEP-835 least-privilege)."
+        )
+        assert "memory:admin" not in granted
+
+    def test_explicit_admin_client_requesting_admin_gets_admin(self) -> None:
+        """Counterpart to the narrowed case: a client whose registered scope
+        includes ``memory:admin`` (explicit-grant via R1 policy) DOES receive
+        admin when requesting it. Confirms the intersection logic is
+        symmetric — narrowing applies only when the client wasn't granted
+        admin in the first place.
+        """
+        from models.auth import OAuth2Client  # noqa: PLC0415
+
+        explicit_admin_client = OAuth2Client(
+            client_id="test-explicit-admin",
+            client_secret_hash="dummy",
+            client_name="Admin Worker",
+            redirect_uris=["http://localhost:8080/callback"],
+            grant_types=["authorization_code"],
+            response_types=["code"],
+            scope="memory:read memory:write memory:admin",
+            token_endpoint_auth_method="none",
+        )
+
+        granted = set(explicit_admin_client.get_allowed_scope("memory:read memory:admin").split())
+
+        assert granted == {"memory:read", "memory:admin"}
+        assert "memory:admin" in granted
 
 
 class TestMcpAuthChallengeIncludesResourceMetadata:

--- a/backend/tests/test_e09_608_dcr_default_narrow_migration.py
+++ b/backend/tests/test_e09_608_dcr_default_narrow_migration.py
@@ -103,3 +103,34 @@ class TestE09DcrDefaultNarrowMigrationPins:
         """
         assert e09.revision == "e09_608_dcr_default_narrow"
         assert e09.down_revision == "e08_592_oauth_scope_canonicalize"
+
+    def test_where_clause_restricts_to_dcr_clients(self) -> None:
+        """The UPDATE WHERE clause MUST include ``owner_id IS NULL`` so the
+        migration only touches DCR-registered clients (admin-managed clients
+        have non-null ``owner_id`` per d04_519_oauth_owner_nullable).
+
+        Copilot review on PR #615 surfaced this: without the filter, an
+        admin-managed client that happens to have the exact canonical scope
+        string would also be touched, which the R1 policy explicitly forbids.
+        Verified by inspecting the migration source for the literal SQL
+        fragment, which is the cheapest way to pin a SQL invariant without
+        spinning up a real DB connection.
+        """
+        import inspect  # noqa: PLC0415
+
+        source = inspect.getsource(e09)
+        upgrade_src = inspect.getsource(e09.upgrade)
+        downgrade_src = inspect.getsource(e09.downgrade)
+
+        assert "owner_id IS NULL" in upgrade_src, (
+            "e09.upgrade() WHERE clause must include 'owner_id IS NULL' to "
+            "exclude admin-managed clients (Copilot finding on PR #615)."
+        )
+        assert "owner_id IS NULL" in downgrade_src, (
+            "e09.downgrade() WHERE clause must include 'owner_id IS NULL' to "
+            "exclude admin-managed clients symmetrically."
+        )
+        # Belt-and-suspenders: also assert the canonical full migration
+        # source contains the literal substring, in case a refactor moves the
+        # UPDATE into a module-level constant.
+        assert source.count("owner_id IS NULL") >= 2

--- a/backend/tests/test_e09_608_dcr_default_narrow_migration.py
+++ b/backend/tests/test_e09_608_dcr_default_narrow_migration.py
@@ -1,0 +1,105 @@
+"""Pin the e09_608 migration to the runtime DCR scope contract.
+
+The e09_608 migration narrows ``DCR_DEFAULT_SCOPE`` by stripping
+``memory:admin`` from rows that match the post-#592 canonical default. It
+uses string-equal matching (``WHERE scope = :old_scope``) — anything that
+does not match the exact pre-narrow default is left untouched, which
+preserves clients that explicitly requested narrower or wider custom
+scope sets (R1 policy from #608 gate1 review).
+
+This test pins three invariants that, if regressed, would either over-
+strip legitimate clients or fail to strip the silent auto-grant cohort:
+
+1. The migration's ``_PRE_NARROW_CANONICAL`` exactly matches the
+   string that the post-#592 (``e08_592_oauth_scope_canonicalize``)
+   migration wrote into the DB. If a future change edits one but not
+   the other, ``WHERE scope = :old_scope`` matches zero rows on
+   real-world clients.
+2. The migration's ``_POST_NARROW_CANONICAL`` exactly matches the
+   current runtime ``DCR_DEFAULT_SCOPE`` (the string the application
+   issues today). If the runtime value drifts from the migration, new
+   rows get the runtime default while the migration still rewrites
+   pre-narrow rows to the stale value — the two paths diverge.
+3. ``memory:admin`` is the ONLY scope removed. If the migration is
+   accidentally edited to also strip ``memory:delete`` (D4) or
+   ``openid`` (D5) in this revision, those follow-up issues lose their
+   separate migration story and we lose the audit trail.
+
+These are deliberately string-level checks; we are NOT exercising the
+migration against a live DB here (that is covered by the integration
+suite when ``alembic upgrade head`` runs end-to-end). The string pins
+are cheap, fast, and catch the realistic regression: someone editing
+the migration constants without realising they are bound to runtime
+contracts.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+_BACKEND_SRC = Path(__file__).resolve().parents[1] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+_ALEMBIC_VERSIONS = Path(__file__).resolve().parents[1] / "alembic" / "versions"
+if str(_ALEMBIC_VERSIONS) not in sys.path:
+    sys.path.insert(0, str(_ALEMBIC_VERSIONS))
+
+from auth.mcp_scopes import (  # noqa: E402
+    ALL_ADVERTISED_SCOPES,
+    DCR_DEFAULT_SCOPE,
+)
+
+e08 = importlib.import_module("e08_592_oauth_scope_canonicalize")
+e09 = importlib.import_module("e09_608_dcr_default_narrow")
+
+
+class TestE09DcrDefaultNarrowMigrationPins:
+    def test_pre_narrow_string_matches_e08_post_canonical(self) -> None:
+        """e09's pre-narrow string is exactly what e08 wrote into the DB.
+
+        If e08's ``_CANONICAL_AT_E08`` is ever edited, e09 must follow — or
+        ``UPDATE ... WHERE scope = :old_scope`` matches zero real rows.
+        """
+        assert e09._PRE_NARROW_CANONICAL == e08._CANONICAL_AT_E08
+
+    def test_post_narrow_string_matches_runtime_default(self) -> None:
+        """e09's post-narrow string is exactly what the application issues today.
+
+        If the runtime ``DCR_DEFAULT_SCOPE`` is changed (e.g. another scope
+        added or reordered), e09 must follow — otherwise newly-issued rows
+        get the runtime default while the migration still rewrites pre-narrow
+        rows to the stale post-narrow value, diverging the two paths.
+        """
+        assert e09._POST_NARROW_CANONICAL == DCR_DEFAULT_SCOPE
+
+    def test_only_memory_admin_is_removed(self) -> None:
+        """The set difference between pre-narrow and post-narrow is exactly
+        ``{memory:admin}``. Stripping anything else in this revision steals
+        scope from a future #608 sub-PR.
+        """
+        pre = set(e09._PRE_NARROW_CANONICAL.split())
+        post = set(e09._POST_NARROW_CANONICAL.split())
+        removed = pre - post
+        added = post - pre
+        assert removed == {"memory:admin"}, (
+            f"e09 removes {sorted(removed)}, expected only memory:admin. "
+            "memory:delete is owned by #608 D4; openid is owned by #608 D5; "
+            "do not strip them in this revision."
+        )
+        assert added == set(), f"e09 unexpectedly adds {sorted(added)}"
+
+    def test_pre_narrow_string_is_full_advertised_union(self) -> None:
+        """The pre-narrow string is exactly ``ALL_ADVERTISED_SCOPES`` as a
+        space-separated string — i.e. the union that #592 established as
+        the post-fix canonical default. Pins the chain of reasoning end to
+        end: e08 wrote the union into the DB, e09 narrows by one scope.
+        """
+        assert set(e09._PRE_NARROW_CANONICAL.split()) == set(ALL_ADVERTISED_SCOPES)
+
+    def test_down_revision_chain(self) -> None:
+        """e09 revises e08. Re-ordering the migration chain by editing
+        ``down_revision`` would break the linear apply order, so pin it.
+        """
+        assert e09.revision == "e09_608_dcr_default_narrow"
+        assert e09.down_revision == "e08_592_oauth_scope_canonicalize"


### PR DESCRIPTION
Closes #608

## Summary
- Narrows the DCR fallback default scope to exclude `memory:admin`, closing the silent auto-grant of admin to newly-registered DCR clients (the "advertise-without-enforcement" gap left open by #592).
- `ALL_ADVERTISED_SCOPES` is unchanged — `memory:admin` remains discovery-advertised and explicitly requestable via the DCR `scope` parameter. Only the silent auto-grant in the fallback default is removed.
- Alembic e09 backfills `oauth_clients.scope` on the exact pre-narrow canonical string only; rows with custom scope sets (explicit grants, custom subsets) are preserved (R1 policy from gate1 review).
- This is sub-PR D1 of #608's enforcement gate. Subsequent sub-PRs land `require_scope` infrastructure (D2) and apply it to workspace-admin routes (D3); `memory:admin` enforcement is NOT in this PR.

## Implementation notes
- `backend/src/auth/mcp_scopes.py`: new `DCR_DEFAULT_SCOPES: tuple[str, ...]` derived as `ALL_ADVERTISED_SCOPES` minus `memory:admin`; `DCR_DEFAULT_SCOPE` is space-joined from it. Module docstring expanded with SEP-835 alignment and rollback note.
- `backend/alembic/versions/e09_608_dcr_default_narrow.py`: new migration revising e08. Uses `op.execute(sa.text(...).bindparams(...))` with hardcoded pre/post canonical strings (migration-snapshot discipline, matches e08 convention). Operator rollback runbook embedded in docstring (3 steps if Claude Code MCP DCR breaks post-deploy).
- `backend/tests/api/test_oauth_metadata_drift.py`: 3 new tests pinning the narrowing contract — DCR fallback excludes admin, explicit `scope=memory:admin` request preserves admin, server-side `get_allowed_scope` returns `requested ∩ registered` (SEP-835 least-privilege).
- `backend/tests/test_e09_608_dcr_default_narrow_migration.py`: new file with 5 string-level pin tests linking migration constants to e08's canonical string and runtime `DCR_DEFAULT_SCOPE`. Pins "only memory:admin removed" to prevent silent scope leakage into the D4/D5 PRs.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO lens, re-run after body refinement)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/608-feat-feat-auth-enforce-memory-admin-memory-de.gate1.md
- ~/.claude/cache/gh-issue-driven/608-feat-feat-auth-enforce-memory-admin-memory-de.gate2.md

Operator note (from gate1 review):
- Deploy app code BEFORE running this migration (or atomic deploy). A DCR registration that lands in the window between migration and deploy uses the old app's union default and is not touched by `upgrade()`.

🤖 Generated via /gh-issue-driven:ship
