### PR TITLE
feat(mcp,api): list_tags tool for tag discovery per context (#614)

### DIFF
--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -22,8 +22,9 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import APIKeyOrSessionUser, SessionUser, get_current_user
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
+from models.schemas import RelatedTagItem
 from models.sleep import SleepMode
-from services.context_service import ContextService
+from services.context_service import ContextService, TagSortMode
 from utils.datetime import to_utc_iso
 from utils.exceptions import NotFoundException, ValidationError
 from utils.logger import get_logger
@@ -256,6 +257,21 @@ class ContextStatsResponse(BaseModel):
     context_name: str = Field(..., description="Context name")
     memory_count: int = Field(..., description="Number of memories in context")
     status: str = Field(..., description="Context status")
+
+
+class ContextTagsResponse(BaseModel):
+    """Response model for ``GET /contexts/{context_id}/tags`` (Issue #614).
+
+    Envelope wrapper consistent with ``ContextListResponse``. ``RelatedTagItem``
+    inherits ``TZAwareBaseModel`` so the per-item ``last_used_at`` datetime
+    serializes with an explicit UTC ``Z`` suffix when populated.
+    """
+
+    context_id: UUID = Field(..., description="Context UUID")
+    tags: list[RelatedTagItem] = Field(
+        ..., description="Aggregated tag info, sorted per the `sort` parameter."
+    )
+    total: int = Field(..., description="Number of tags returned (post-filter, post-limit).")
 
 
 # ============================================================================
@@ -678,6 +694,82 @@ async def get_context_stats(
 
     except NotFoundException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.get("/{context_id}/tags", response_model=ContextTagsResponse)
+async def list_context_tags(
+    context_id: UUID,
+    user: APIKeyOrSessionUser,
+    service: ContextService = Depends(get_context_service),
+    limit: int = Query(50, ge=1, le=500, description="Maximum tags to return."),
+    min_count: int = Query(
+        1,
+        ge=1,
+        le=10_000,
+        description=(
+            "Minimum memory count per tag. Default 1 surfaces one-off tags so "
+            "drift typos are visible; raise to hide low-frequency noise."
+        ),
+    ),
+    sort: TagSortMode = Query(
+        "count",
+        description="Sort: count (default), recent, or alpha (lower-case).",
+    ),
+    prefix: str = Query(
+        "",
+        max_length=200,
+        description=(
+            "Case-insensitive prefix filter for autocomplete. `%` / `_` are "
+            "escaped to literal characters — the parameter cannot be used as "
+            "a wildcard probe."
+        ),
+    ),
+) -> ContextTagsResponse:
+    """List existing tag vocabulary in a context (Issue #614).
+
+    Surfaces aggregated tags with usage counts and last-used timestamps so
+    LLM clients can discover existing tag spellings before calling
+    ``remember()`` (avoid drift: ``troubleshoot`` vs ``troubleshooting``) or
+    build accurate ``recall(filters={"tags": [...]})`` filters. Empty
+    contexts return ``200`` with ``tags=[]`` (no 404). Soft-deleted memories
+    are excluded, and the workspace boundary is honored for shared contexts.
+
+    Args:
+        context_id: Target context UUID.
+        limit: Max tags returned (1-500).
+        min_count: Minimum memory count per tag (default 1).
+        sort: Sort mode (``count`` | ``recent`` | ``alpha``).
+        prefix: Case-insensitive literal prefix filter.
+
+    Raises:
+        404: Context not found or caller has no access.
+        422: Invalid ``sort`` or ``min_count`` (FastAPI bound checks).
+    """
+    user_id = user.get("user_id")
+
+    try:
+        result = await service.aggregate_tags(
+            user_id,
+            context_id,
+            limit=limit,
+            min_count=min_count,
+            sort=sort,
+            prefix=prefix,
+        )
+    except NotFoundException as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except ValidationError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
+
+    tags = [
+        RelatedTagItem(
+            tag=row["tag"],
+            count=row["count"],
+            last_used_at=row["last_used_at"],
+        )
+        for row in result["rows"]
+    ]
+    return ContextTagsResponse(context_id=context_id, tags=tags, total=len(tags))
 
 
 @router.put("/{context_id}", response_model=ContextResponse)

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -67,6 +67,7 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "get_cluster",  # Issue #496: read-only cluster drill-down
         "get_file_download_url",  # Issue #485: read-only presigned GET
         "list_files",  # Issue #485: read-only workspace listing
+        "list_tags",  # Issue #614: read-only tag discovery
     }
 )
 
@@ -93,6 +94,7 @@ def _build_registry() -> dict[str, Any]:
         handle_delete_context,
         handle_get_context_info,
         handle_list_contexts,
+        handle_list_tags,
         handle_merge_contexts,
         handle_update_context,
     )
@@ -137,6 +139,7 @@ def _build_registry() -> dict[str, Any]:
         "delete_context": handle_delete_context,
         "merge_contexts": handle_merge_contexts,
         "list_contexts": handle_list_contexts,
+        "list_tags": handle_list_tags,  # Issue #614
         "update_search_config": handle_update_search_config,
         "list_edges": handle_list_edges,
         "create_edge": handle_create_edge,

--- a/backend/src/mcp_server/tools/_constants.py
+++ b/backend/src/mcp_server/tools/_constants.py
@@ -25,6 +25,7 @@ TOOL_TIMEOUTS: dict[str, float] = {
     "explore": _get_timeout("explore", 45.0),
     "get_context_info": _get_timeout("get_context_info", 15.0),
     "list_contexts": _get_timeout("list_contexts", 10.0),
+    "list_tags": _get_timeout("list_tags", 10.0),  # Issue #614
     "create_context": _get_timeout("create_context", 15.0),
     "update_context": _get_timeout("update_context", 15.0),
     "update_search_config": _get_timeout("update_search_config", 10.0),
@@ -407,7 +408,7 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 
 ---
 
-## Available Tools (31 tools)
+## Available Tools (32 tools)
 
 | Tool | Purpose |
 |------|---------|
@@ -417,6 +418,7 @@ update_context(context_id, summary="Project X knowledge base", usage_guide="Tag 
 | `forget` | Delete memories (soft delete, recoverable) |
 | `reference` | Get full memory details (Layer 3) by ID |
 | `explore` | Discover related memories via Neural Memory graph |
+| `list_tags` | List tag vocabulary in a context (call before remember/recall) |
 | `list_edges` | List edges connected to a memory |
 | `create_edge` | Create an edge between two memories |
 | `update_edge` | Update edge weight or type |

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -663,6 +663,81 @@ Response includes:
                 },
             },
         },
+        # =================================================================
+        # Issue #614: list_tags — tag-discovery for tag-drift mitigation
+        # =================================================================
+        {
+            "name": "list_tags",
+            "readOnly": True,
+            "description": """List existing tag vocabulary in a context with usage counts and recency.
+
+Use this to discover what tags already exist before calling remember() or recall(),
+so you reuse existing spellings instead of inventing new ones. This is the primary
+mitigation for tag drift, where semantically identical tags appear under different
+spellings (e.g. `troubleshoot` / `troubleshooting` / `trouble-shoot`) and silently
+degrade the precision of `recall(filters={"tags": [...]})` over time.
+
+**Call this BEFORE remember()** to pick existing tag spellings.
+**Call this BEFORE recall(filters={"tags": [...]})** to build accurate tag filters
+that actually match what is stored in this context.
+
+Examples:
+  list_tags(context_id="...")                       # top 50 tags by usage count
+  list_tags(context_id="...", min_count=5)          # only frequently-used tags
+  list_tags(context_id="...", prefix="auth")        # autocomplete style: tags starting with "auth"
+  list_tags(context_id="...", sort="recent")        # most recently used tags first
+  list_tags(context_id="...", sort="alpha")         # alphabetical (lower-case fold)
+
+Response shape:
+  {
+    "status": "success",
+    "context_id": "...",
+    "context_name": "...",
+    "tags": [{"tag": "...", "count": N, "last_used_at": "...Z"}, ...],
+    "total": N
+  }
+
+Empty context returns the same shape with tags=[] and total=0 — there is no 404.
+Soft-deleted memories are excluded; workspace boundary is honored for shared contexts.""",
+            "inputSchema": {
+                "type": "object",
+                "required": ["context_id"],
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target context UUID. MUST be a valid UUID from list_contexts().",
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum tags to return (1-500, default 50).",
+                    },
+                    "min_count": {
+                        "type": "integer",
+                        "description": (
+                            "Minimum memory count per tag (default 1 — show one-off tags "
+                            "so drift typos are visible; raise to hide low-frequency noise)."
+                        ),
+                    },
+                    "sort": {
+                        "type": "string",
+                        "enum": ["count", "recent", "alpha"],
+                        "description": (
+                            "Sort order: 'count' (most-used first, default), "
+                            "'recent' (most-recently used first), or 'alpha' (alphabetical)."
+                        ),
+                    },
+                    "prefix": {
+                        "type": "string",
+                        "description": (
+                            "Case-insensitive prefix filter for autocomplete. The characters "
+                            "% and _ are escaped to literal characters — this parameter "
+                            "cannot be used as a wildcard probe."
+                        ),
+                    },
+                },
+            },
+        },
         # Issue #240: switch_context removed - use context_id argument in each tool
         {
             "name": "create_context",

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -828,11 +828,12 @@ async def handle_list_tags(
     except ValueError as e:
         return _error_response("invalid_context_id_format", str(e))
 
-    # Bound checks for limits the service doesn't validate. ``sort`` is
-    # validated by the service itself (single source of truth); a bad value
-    # surfaces here via ``ValidationError`` below.
+    # ``type(x) is T`` (not ``isinstance``) so bool — which subclasses int — is
+    # rejected here. Service validates the same bounds defensively; the handler
+    # check stays so the MCP error code is ``invalid_argument`` rather than
+    # the generic 422-equivalent path. ``sort`` is service-validated.
     limit = args.get("limit", 50)
-    if not isinstance(limit, int) or limit < 1 or limit > 500:
+    if type(limit) is not int or limit < 1 or limit > 500:
         return _error_response(
             "invalid_argument",
             "limit must be an integer between 1 and 500.",
@@ -840,16 +841,19 @@ async def handle_list_tags(
         )
 
     min_count = args.get("min_count", 1)
-    if not isinstance(min_count, int) or min_count < 1 or min_count > 10_000:
+    if type(min_count) is not int or min_count < 1 or min_count > 10_000:
         return _error_response(
             "invalid_argument",
             "min_count must be an integer between 1 and 10000.",
             received=min_count,
         )
 
-    # Treat missing / None / "" identically; non-strings are caught by the isinstance guard below.
-    prefix = args.get("prefix") or ""
-    if not isinstance(prefix, str) or len(prefix) > 200:
+    # Treat absent / None as empty; reject any non-string up-front (without the
+    # ``or ""`` shorthand, which would silently coerce 0 / False to "").
+    prefix = args.get("prefix")
+    if prefix is None:
+        prefix = ""
+    if type(prefix) is not str or len(prefix) > 200:
         return _error_response(
             "invalid_argument",
             "prefix must be a string up to 200 characters.",

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -797,3 +797,159 @@ async def handle_merge_contexts(
             return _error_response("merge_contexts_error", str(e))
 
     return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_list_tags(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """List tag vocabulary in a context (Issue #614).
+
+    Read-only tag-discovery tool that helps callers reuse existing tag
+    spellings before remember()/recall(), mitigating tag drift. Access is
+    gated inside ``ContextService.aggregate_tags`` via ``get_context``,
+    which raises ``NotFoundException`` for not-found / private-non-creator /
+    non-member / whitelist-miss — all caught here and reshaped into the
+    uniform ``context_not_found`` MCP error (CWE-639).
+    """
+    from db.base import get_db
+    from utils.datetime import to_utc_iso
+    from utils.exceptions import NotFoundException, ValidationError
+
+    start_time = time.time()
+
+    if "context_id" not in args:
+        return _error_response(
+            "context_id_required",
+            "list_tags requires context_id.",
+            help="Use list_contexts() to discover available context IDs.",
+        )
+    try:
+        context_id = _resolve_context_id(args["context_id"])
+    except ValueError as e:
+        return _error_response("invalid_context_id_format", str(e))
+
+    # Bound checks for limits the service doesn't validate. ``sort`` is
+    # validated by the service itself (single source of truth); a bad value
+    # surfaces here via ``ValidationError`` below.
+    limit = args.get("limit", 50)
+    if not isinstance(limit, int) or limit < 1 or limit > 500:
+        return _error_response(
+            "invalid_argument",
+            "limit must be an integer between 1 and 500.",
+            received=limit,
+        )
+
+    min_count = args.get("min_count", 1)
+    if not isinstance(min_count, int) or min_count < 1 or min_count > 10_000:
+        return _error_response(
+            "invalid_argument",
+            "min_count must be an integer between 1 and 10000.",
+            received=min_count,
+        )
+
+    # Treat missing / None / "" identically; non-strings are caught by the isinstance guard below.
+    prefix = args.get("prefix") or ""
+    if not isinstance(prefix, str) or len(prefix) > 200:
+        return _error_response(
+            "invalid_argument",
+            "prefix must be a string up to 200 characters.",
+        )
+
+    sort = args.get("sort", "count")
+
+    async for db in get_db():
+        try:
+            from services.context_service import ContextService
+
+            service = ContextService(db)
+            result = await execute_with_timeout(
+                service.aggregate_tags(
+                    user_id,
+                    context_id,
+                    limit=limit,
+                    min_count=min_count,
+                    sort=sort,
+                    prefix=prefix,
+                ),
+                operation_name="list_tags",
+            )
+
+            tags_payload = [
+                {
+                    "tag": row["tag"],
+                    "count": row["count"],
+                    "last_used_at": to_utc_iso(row["last_used_at"]),
+                }
+                for row in result["rows"]
+            ]
+
+            await _log_tool_usage(
+                db,
+                user_id,
+                "list_tags",
+                start_time,
+                200,
+                context_id,
+                workspace_id,
+            )
+
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "status": "success",
+                            "context_id": str(context_id),
+                            "context_name": result["context_name"],
+                            "tags": tags_payload,
+                            "total": len(tags_payload),
+                        }
+                    ),
+                )
+            ]
+        except NotFoundException:
+            # CWE-639: never leak the deny reason. Surface shape matches
+            # `_ContextNotFoundError.to_response()` used by sibling handlers.
+            await db.rollback()
+            await _log_tool_usage(
+                db,
+                user_id,
+                "list_tags",
+                start_time,
+                404,
+                context_id,
+                workspace_id,
+            )
+            return _error_response(
+                "context_not_found",
+                "Context not found or you don't have access to it.",
+                context_id=str(context_id),
+                help="Use list_contexts() to see contexts you have access to.",
+            )
+        except ValidationError as e:
+            await db.rollback()
+            await _log_tool_usage(
+                db,
+                user_id,
+                "list_tags",
+                start_time,
+                422,
+                context_id,
+                workspace_id,
+            )
+            return _error_response("invalid_argument", str(e))
+        except Exception as e:
+            await db.rollback()
+            await _log_tool_usage(
+                db,
+                user_id,
+                "list_tags",
+                start_time,
+                500,
+                context_id,
+                workspace_id,
+            )
+            logger.error(f"list_tags_failed: {e}", exc_info=True)
+            return _error_response("list_tags_error", str(e))
+
+    return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -185,12 +185,20 @@ class MemoryResponse(TZAwareBaseModel):
         from_attributes = True
 
 
-class RelatedTagItem(BaseModel):
-    """Related tag with count and sample summary."""
+class RelatedTagItem(TZAwareBaseModel):
+    """Related tag with count, sample summary, and last-used timestamp.
+
+    Used by ``recall.related_tags`` (Issue #104 — populates ``sample_summary``)
+    and ``list_tags`` (Issue #614 — populates ``last_used_at``). The shared
+    schema means clients can unify their "tag info" type across both surfaces.
+    Inherits ``TZAwareBaseModel`` so the optional ``last_used_at`` serializes
+    with an explicit UTC ``Z`` suffix when populated.
+    """
 
     tag: str
     count: int
     sample_summary: str | None = None
+    last_used_at: datetime | None = None
 
 
 class ExploreHint(BaseModel):

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -9,7 +9,7 @@ Contexts are owned by workspaces, not individual users.
 """
 
 import re
-from typing import Literal
+from typing import Literal, get_args
 from uuid import UUID
 
 from sqlalchemy import and_, delete, func, select
@@ -1081,7 +1081,9 @@ class ContextService:
             )
             raise
 
-    _LIST_TAGS_SORT_MODES = ("count", "recent", "alpha")
+    # Single source of truth — derived from TagSortMode so adding a new mode
+    # requires only updating the Literal type.
+    _LIST_TAGS_SORT_MODES = get_args(TagSortMode)
 
     async def aggregate_tags(
         self,
@@ -1107,11 +1109,11 @@ class ContextService:
         Args:
             user_id: Caller's user ID for access check.
             context_id: Target context UUID.
-            limit: Maximum tags to return (1-500). REST Query enforces bounds;
-                callers passing through trust those bounds.
+            limit: Maximum tags to return (1-500). Validated here so future
+                internal callers can't slip through unbounded values.
             min_count: Minimum memory count per tag (default 1, i.e. include
                 one-off tags so tag-drift typos are visible by default — see
-                Issue #614 DX review).
+                Issue #614 DX review). Range 1-10000.
             sort: One of ``"count"`` / ``"recent"`` / ``"alpha"``.
             prefix: Case-insensitive prefix filter for autocomplete. ``%`` /
                 ``_`` / ``#`` are escaped to literal characters via
@@ -1138,6 +1140,10 @@ class ContextService:
                 f"Invalid sort mode '{sort}'. Must be one of: "
                 f"{', '.join(self._LIST_TAGS_SORT_MODES)}."
             )
+        if type(limit) is not int or not (1 <= limit <= 500):
+            raise ValidationError(f"limit must be an integer in [1, 500]; got {limit!r}.")
+        if type(min_count) is not int or not (1 <= min_count <= 10_000):
+            raise ValidationError(f"min_count must be an integer in [1, 10000]; got {min_count!r}.")
 
         # Uniform 404 disclosure: not-found and access-denied are indistinguishable
         # (CWE-639) — get_context conflates both into NotFoundException by design.

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -9,6 +9,7 @@ Contexts are owned by workspaces, not individual users.
 """
 
 import re
+from typing import Literal
 from uuid import UUID
 
 from sqlalchemy import and_, delete, func, select
@@ -29,10 +30,13 @@ from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
-# Constants
 DEFAULT_CONTEXT_NAME = "default"
 DEFAULT_CONTEXT_DESCRIPTION = "Default context (auto-created)"
 CONTEXT_NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+
+# Issue #614: list_tags sort modes — single source of truth shared by REST
+# Query type and MCP handler validation.
+TagSortMode = Literal["count", "recent", "alpha"]
 
 
 class ContextService:
@@ -1076,6 +1080,138 @@ class ContextService:
                 error=str(e),
             )
             raise
+
+    _LIST_TAGS_SORT_MODES = ("count", "recent", "alpha")
+
+    async def aggregate_tags(
+        self,
+        user_id: str,
+        context_id: UUID,
+        *,
+        limit: int = 50,
+        min_count: int = 1,
+        sort: TagSortMode = "count",
+        prefix: str = "",
+    ) -> dict:
+        """Aggregate tags across non-deleted memories in a context (Issue #614).
+
+        Mirrors the canonical aggregation pattern from
+        ``tasks.sleep_tasks._refresh_hub_tag_cache``: the inner
+        ``SELECT DISTINCT id, unnest(tags)::text`` collapses intra-memory
+        duplicate tags so a memory with ``tags=["python","python"]`` counts
+        as 1 for ``python``, not 2 (Copilot loop 2 lesson from #223). The
+        ``deleted_at IS NULL`` filter excludes soft-deleted memories, and the
+        ``workspace_id`` filter (in addition to ``context_id``) preserves the
+        workspace boundary for shared contexts.
+
+        Args:
+            user_id: Caller's user ID for access check.
+            context_id: Target context UUID.
+            limit: Maximum tags to return (1-500). REST Query enforces bounds;
+                callers passing through trust those bounds.
+            min_count: Minimum memory count per tag (default 1, i.e. include
+                one-off tags so tag-drift typos are visible by default — see
+                Issue #614 DX review).
+            sort: One of ``"count"`` / ``"recent"`` / ``"alpha"``.
+            prefix: Case-insensitive prefix filter for autocomplete. ``%`` /
+                ``_`` / ``#`` are escaped to literal characters via
+                ``ILIKE ... ESCAPE '#'`` so the parameter cannot be used as a
+                wildcard probe.
+
+        Returns:
+            ``{"context_name": str, "rows": list[dict]}`` where each row is
+            ``{"tag": str, "count": int, "last_used_at": datetime | None}``.
+            ``context_name`` is carried back so MCP callers can include it
+            in the response envelope without re-resolving the context.
+            ``last_used_at`` is the naive UTC
+            ``GREATEST(created_at, updated_at)`` of the most recent memory
+            carrying the tag.
+
+        Raises:
+            NotFoundException: Context not found or caller lacks access.
+            ValidationError: Invalid ``sort`` mode.
+        """
+        from sqlalchemy import text
+
+        if sort not in self._LIST_TAGS_SORT_MODES:
+            raise ValidationError(
+                f"Invalid sort mode '{sort}'. Must be one of: "
+                f"{', '.join(self._LIST_TAGS_SORT_MODES)}."
+            )
+
+        # Uniform 404 disclosure: not-found and access-denied are indistinguishable
+        # (CWE-639) — get_context conflates both into NotFoundException by design.
+        context = await self.get_context(user_id, context_id)
+
+        if prefix:
+            escaped = prefix.replace("#", "##").replace("%", "#%").replace("_", "#_")
+            prefix_pattern = f"{escaped}%"
+        else:
+            prefix_pattern = ""
+
+        # sort is allow-list validated above; safe to interpolate.
+        sort_clause = {
+            "count": "ORDER BY cnt DESC, tag ASC",
+            "recent": "ORDER BY last_used_at DESC NULLS LAST, tag ASC",
+            "alpha": "ORDER BY lower(tag) ASC, tag ASC",
+        }[sort]
+
+        sql = text(
+            f"""
+            WITH scope AS (
+                SELECT id,
+                       tags,
+                       GREATEST(created_at, updated_at) AS last_at
+                FROM memories
+                WHERE workspace_id = CAST(:workspace_id AS uuid)
+                  AND context_id = CAST(:context_id AS uuid)
+                  AND deleted_at IS NULL
+                  AND tags IS NOT NULL
+                  AND cardinality(tags) > 0
+            ),
+            tag_rows AS (
+                -- DISTINCT id, tag collapses intra-array duplicates so a
+                -- memory with ['python','python'] counts once. last_at is
+                -- functionally determined by id, so including it does not
+                -- change distinctness.
+                SELECT DISTINCT id, unnest(tags)::text AS tag, last_at
+                FROM scope
+            ),
+            tag_counts AS (
+                SELECT
+                    tag,
+                    COUNT(*) AS cnt,
+                    MAX(last_at) AS last_used_at
+                FROM tag_rows
+                WHERE (:prefix_pattern = '' OR tag ILIKE :prefix_pattern ESCAPE '#')
+                GROUP BY tag
+                HAVING COUNT(*) >= :min_count
+            )
+            SELECT tag, cnt, last_used_at
+            FROM tag_counts
+            {sort_clause}
+            LIMIT :limit
+            """
+        )
+        result = await self.db.execute(
+            sql,
+            {
+                "workspace_id": str(context.workspace_id),
+                "context_id": str(context_id),
+                "prefix_pattern": prefix_pattern,
+                "min_count": min_count,
+                "limit": limit,
+            },
+        )
+        rows = [
+            {
+                "tag": row.tag,
+                "count": int(row.cnt),
+                "last_used_at": row.last_used_at,
+            }
+            for row in result
+        ]
+        return {"context_name": context.name, "rows": rows}
 
     async def get_context_stats(
         self,

--- a/backend/tests/api/test_context_tags.py
+++ b/backend/tests/api/test_context_tags.py
@@ -1,0 +1,150 @@
+"""Tests for GET /contexts/{context_id}/tags.
+
+Locks down the REST surface for ``list_context_tags``: response envelope shape,
+empty-context behavior (200 + ``tags=[]``), and ``NotFoundException`` → 404
+contract. The aggregation correctness itself is exercised at the integration
+level — these tests pin the route wiring around a mocked service.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.contexts import list_context_tags
+from utils.exceptions import NotFoundException, ValidationError
+
+MOCK_USER = {"user_id": "test_user"}
+
+
+class TestListContextTagsRoute:
+    """REST route surface for list_context_tags."""
+
+    @pytest.fixture
+    def context_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def mock_service(self):
+        return MagicMock(aggregate_tags=AsyncMock())
+
+    @pytest.mark.asyncio
+    async def test_returns_envelope_with_tags(self, mock_service, context_id):
+        """Populated context returns envelope with RelatedTagItem entries."""
+        last_used = datetime(2026, 5, 12, 3, 39, 39)
+        mock_service.aggregate_tags.return_value = {
+            "context_name": "kagura-dev",
+            "rows": [
+                {"tag": "python", "count": 5, "last_used_at": last_used},
+                {"tag": "fastapi", "count": 3, "last_used_at": None},
+            ],
+        }
+
+        response = await list_context_tags(
+            context_id=context_id,
+            user=MOCK_USER,
+            service=mock_service,
+            limit=50,
+            min_count=1,
+            sort="count",
+            prefix="",
+        )
+
+        assert response.context_id == context_id
+        assert response.total == 2
+        assert [t.tag for t in response.tags] == ["python", "fastapi"]
+        assert response.tags[0].count == 5
+        assert response.tags[0].last_used_at == last_used
+        assert response.tags[1].last_used_at is None
+
+    @pytest.mark.asyncio
+    async def test_empty_context_returns_200_with_empty_list(self, mock_service, context_id):
+        """Empty / untagged context returns 200 + tags=[], NOT 404 (DX contract)."""
+        mock_service.aggregate_tags.return_value = {
+            "context_name": "empty-ctx",
+            "rows": [],
+        }
+
+        response = await list_context_tags(
+            context_id=context_id,
+            user=MOCK_USER,
+            service=mock_service,
+            limit=50,
+            min_count=1,
+            sort="count",
+            prefix="",
+        )
+
+        assert response.total == 0
+        assert response.tags == []
+        assert response.context_id == context_id
+
+    @pytest.mark.asyncio
+    async def test_not_found_maps_to_404(self, mock_service, context_id):
+        """NotFoundException → HTTP 404 (uniform disclosure for not-found/no-access)."""
+        mock_service.aggregate_tags.side_effect = NotFoundException(
+            f"Context {context_id} not found"
+        )
+
+        with pytest.raises(HTTPException) as exc:
+            await list_context_tags(
+                context_id=context_id,
+                user=MOCK_USER,
+                service=mock_service,
+                limit=50,
+                min_count=1,
+                sort="count",
+                prefix="",
+            )
+
+        assert exc.value.status_code == 404
+        assert "not found" in str(exc.value.detail).lower()
+
+    @pytest.mark.asyncio
+    async def test_validation_error_maps_to_422(self, mock_service, context_id):
+        """ValidationError from service (bad sort etc.) → HTTP 422."""
+        mock_service.aggregate_tags.side_effect = ValidationError("Invalid sort mode 'bogus'.")
+
+        with pytest.raises(HTTPException) as exc:
+            await list_context_tags(
+                context_id=context_id,
+                user=MOCK_USER,
+                service=mock_service,
+                limit=50,
+                min_count=1,
+                sort="count",  # FastAPI pattern would already reject 'bogus' upstream
+                prefix="",
+            )
+
+        assert exc.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_passes_through_query_params(self, mock_service, context_id):
+        """Route forwards query params verbatim to the service layer."""
+        mock_service.aggregate_tags.return_value = {
+            "context_name": "ctx",
+            "rows": [],
+        }
+
+        await list_context_tags(
+            context_id=context_id,
+            user=MOCK_USER,
+            service=mock_service,
+            limit=100,
+            min_count=3,
+            sort="recent",
+            prefix="auth",
+        )
+
+        mock_service.aggregate_tags.assert_awaited_once_with(
+            "test_user",
+            context_id,
+            limit=100,
+            min_count=3,
+            sort="recent",
+            prefix="auth",
+        )

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -1,0 +1,404 @@
+"""Integration tests for ``ContextService.aggregate_tags``.
+
+Exercise the raw-SQL CTE against a real Postgres so the load-bearing
+correctness properties are pinned:
+
+1. Intra-array duplicates (``tags=["python","python"]``) collapse to 1 count.
+2. Soft-deleted memories (``deleted_at IS NOT NULL``) are excluded.
+3. Cross-workspace memories with the same ``context_id`` do NOT leak in.
+4. Empty / untagged context returns ``[]`` (200-equivalent).
+5. ``min_count`` filter (HAVING clause).
+6. ``prefix`` filter treats ``%`` / ``_`` as literal characters.
+7. Sort modes: ``count`` / ``recent`` / ``alpha``.
+8. ``last_used_at`` reflects ``MAX(GREATEST(created_at, updated_at))``
+   across distinct memories carrying the tag.
+
+The mock-only unit tests at ``tests/api/test_context_tags.py`` and
+``tests/mcp_server/test_list_tags.py`` cover the route / handler wiring;
+this file covers the SQL itself.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import Context, Workspace, WorkspaceMember
+from models.memory import Memory
+from services.context_service import ContextService
+
+
+@pytest.fixture
+def now() -> datetime:
+    """Anchor for deterministic timestamps."""
+    return datetime(2026, 5, 12, 3, 0, 0)
+
+
+async def _agg_rows(db, user_id, ctx_id, **kwargs):
+    """Call aggregate_tags and unwrap the ``rows`` list for assertion convenience."""
+    result = await ContextService(db).aggregate_tags(user_id, ctx_id, **kwargs)
+    return result["rows"]
+
+
+async def _seed_workspace_context(
+    db: AsyncSession,
+    *,
+    user_id: str,
+    is_private: bool = False,
+) -> tuple[Workspace, Context]:
+    """Mint a workspace + workspace_member + context owned by ``user_id``.
+
+    All UUIDs are random so each test run is isolated within the shared
+    session-scoped ``db_session`` fixture.
+    """
+    ws = Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=user_id,
+        memory_limit=100_000,
+        daily_api_limit=50_000,
+        weekly_api_limit=250_000,
+    )
+    member = WorkspaceMember(
+        workspace_id=ws.id,
+        user_id=user_id,
+        role="owner",
+    )
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=user_id,
+        is_private=is_private,
+    )
+    db.add_all([ws, member, ctx])
+    await db.flush()
+    return ws, ctx
+
+
+def _memory(
+    *,
+    ws_id,
+    ctx_id,
+    user_id: str,
+    tags: list[str] | None,
+    created_at: datetime,
+    updated_at: datetime | None = None,
+    deleted_at: datetime | None = None,
+) -> Memory:
+    return Memory(
+        id=uuid4(),
+        user_id=user_id,
+        workspace_id=ws_id,
+        context_id=ctx_id,
+        summary=f"mem-{uuid4().hex[:6]}",
+        content="x",
+        type="note",
+        client="test",
+        tags=tags,
+        created_at=created_at,
+        updated_at=updated_at or created_at,
+        deleted_at=deleted_at,
+    )
+
+
+@pytest.mark.asyncio
+class TestAggregateTagsCTE:
+    async def test_empty_context_returns_empty_list(self, db_session, now):
+        user_id = f"u_empty_{uuid4().hex[:6]}"
+        _, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+
+        rows = await _agg_rows(db_session, user_id, ctx.id)
+
+        assert rows == []
+
+    async def test_intra_array_duplicates_count_once(self, db_session, now):
+        """`tags=['python','python','backend']` → python:1, backend:1 (not 2:1)."""
+        user_id = f"u_dup_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        db_session.add(
+            _memory(
+                ws_id=ws.id,
+                ctx_id=ctx.id,
+                user_id=user_id,
+                tags=["python", "python", "backend"],
+                created_at=now,
+            )
+        )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx.id)
+
+        counts = {r["tag"]: r["count"] for r in rows}
+        assert counts == {"python": 1, "backend": 1}
+
+    async def test_soft_deleted_memory_excluded(self, db_session, now):
+        user_id = f"u_softdel_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        db_session.add_all(
+            [
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["live"],
+                    created_at=now,
+                ),
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["ghost"],
+                    created_at=now - timedelta(days=1),
+                    deleted_at=now,
+                ),
+            ]
+        )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx.id)
+
+        tags = {r["tag"] for r in rows}
+        assert tags == {"live"}
+
+    async def test_cross_workspace_does_not_leak(self, db_session, now):
+        """Two workspaces, same caller in workspace A — only ws A's tags appear."""
+        user_id = f"u_xws_{uuid4().hex[:6]}"
+        other_user = f"u_other_{uuid4().hex[:6]}"
+        ws_a, ctx_a = await _seed_workspace_context(db_session, user_id=user_id)
+        ws_b, ctx_b = await _seed_workspace_context(db_session, user_id=other_user)
+
+        # Same fake context_id reuse is impossible (uuid4), but we still
+        # cross-check that workspace_id filter holds. Seed each with distinct
+        # tags so leakage would be obvious.
+        db_session.add_all(
+            [
+                _memory(
+                    ws_id=ws_a.id,
+                    ctx_id=ctx_a.id,
+                    user_id=user_id,
+                    tags=["alpha"],
+                    created_at=now,
+                ),
+                _memory(
+                    ws_id=ws_b.id,
+                    ctx_id=ctx_b.id,
+                    user_id=other_user,
+                    tags=["beta"],
+                    created_at=now,
+                ),
+            ]
+        )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx_a.id)
+
+        tags = {r["tag"] for r in rows}
+        assert tags == {"alpha"}
+
+    async def test_min_count_filter(self, db_session, now):
+        user_id = f"u_minc_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        for _ in range(3):
+            db_session.add(
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["popular"],
+                    created_at=now,
+                )
+            )
+        db_session.add(
+            _memory(
+                ws_id=ws.id,
+                ctx_id=ctx.id,
+                user_id=user_id,
+                tags=["once"],
+                created_at=now,
+            )
+        )
+        await db_session.flush()
+
+        rows_default = await _agg_rows(db_session, user_id, ctx.id, min_count=1)
+        rows_filtered = await _agg_rows(db_session, user_id, ctx.id, min_count=3)
+
+        assert {r["tag"] for r in rows_default} == {"popular", "once"}
+        assert {r["tag"] for r in rows_filtered} == {"popular"}
+
+    async def test_prefix_filter_treats_wildcards_as_literals(self, db_session, now):
+        """`prefix='100_'` matches the literal '100_', not the '100<any>' glob."""
+        user_id = f"u_pfx_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        db_session.add_all(
+            [
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["100_percent"],
+                    created_at=now,
+                ),
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["100xpercent"],  # would match '100_' if _ were a glob
+                    created_at=now,
+                ),
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["alphabet"],
+                    created_at=now,
+                ),
+            ]
+        )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx.id, prefix="100_")
+
+        tags = {r["tag"] for r in rows}
+        # '100_' is treated literally: only '100_percent' matches, NOT '100xpercent'.
+        assert tags == {"100_percent"}
+
+    async def test_sort_count_descending_then_alpha(self, db_session, now):
+        user_id = f"u_sortc_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        for tag, n in [("zeta", 2), ("alpha", 2), ("beta", 5)]:
+            for _ in range(n):
+                db_session.add(
+                    _memory(
+                        ws_id=ws.id,
+                        ctx_id=ctx.id,
+                        user_id=user_id,
+                        tags=[tag],
+                        created_at=now,
+                    )
+                )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx.id, sort="count")
+
+        ordered = [r["tag"] for r in rows]
+        # beta (5) first, then alpha and zeta tied at 2 → ascending alpha tiebreak.
+        assert ordered == ["beta", "alpha", "zeta"]
+
+    async def test_sort_recent_uses_greatest_created_updated(self, db_session, now):
+        """`recent` ordering uses MAX(GREATEST(created_at, updated_at))."""
+        user_id = f"u_sortr_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        # "old": created earlier, never updated.
+        db_session.add(
+            _memory(
+                ws_id=ws.id,
+                ctx_id=ctx.id,
+                user_id=user_id,
+                tags=["old"],
+                created_at=now - timedelta(days=10),
+            )
+        )
+        # "tagged_late": created early but tags-only update brings it to "now".
+        db_session.add(
+            _memory(
+                ws_id=ws.id,
+                ctx_id=ctx.id,
+                user_id=user_id,
+                tags=["tagged_late"],
+                created_at=now - timedelta(days=20),
+                updated_at=now,
+            )
+        )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx.id, sort="recent")
+
+        ordered = [r["tag"] for r in rows]
+        # tagged_late wins because updated_at=now > old.created_at=now-10d.
+        assert ordered == ["tagged_late", "old"]
+
+    async def test_sort_alpha_case_insensitive(self, db_session, now):
+        user_id = f"u_sorta_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        for tag in ["Banana", "apple", "Cherry"]:
+            db_session.add(
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=[tag],
+                    created_at=now,
+                )
+            )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx.id, sort="alpha")
+
+        ordered = [r["tag"] for r in rows]
+        assert ordered == ["apple", "Banana", "Cherry"]
+
+    async def test_limit_cap(self, db_session, now):
+        user_id = f"u_lim_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        for i in range(7):
+            db_session.add(
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=[f"tag-{i:02d}"],
+                    created_at=now,
+                )
+            )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx.id, limit=3)
+
+        assert len(rows) == 3
+
+    async def test_last_used_at_takes_max_across_memories(self, db_session, now):
+        """For a tag spanning multiple memories, last_used_at is the MAX."""
+        user_id = f"u_lua_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        early = now - timedelta(days=5)
+        late = now
+        db_session.add_all(
+            [
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["shared"],
+                    created_at=early,
+                ),
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["shared"],
+                    created_at=late,
+                ),
+            ]
+        )
+        await db_session.flush()
+
+        rows = await _agg_rows(db_session, user_id, ctx.id)
+
+        assert len(rows) == 1
+        assert rows[0]["tag"] == "shared"
+        assert rows[0]["count"] == 2
+        assert rows[0]["last_used_at"] == late
+
+    async def test_invalid_sort_raises_validation_error(self, db_session):
+        from utils.exceptions import ValidationError
+
+        user_id = f"u_badsort_{uuid4().hex[:6]}"
+        _, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+
+        with pytest.raises(ValidationError):
+            await _agg_rows(db_session, user_id, ctx.id, sort="bogus")

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -165,40 +165,62 @@ class TestAggregateTagsCTE:
         tags = {r["tag"] for r in rows}
         assert tags == {"live"}
 
-    async def test_cross_workspace_does_not_leak(self, db_session, now):
-        """Two workspaces, same caller in workspace A — only ws A's tags appear."""
-        user_id = f"u_xws_{uuid4().hex[:6]}"
-        other_user = f"u_other_{uuid4().hex[:6]}"
-        ws_a, ctx_a = await _seed_workspace_context(db_session, user_id=user_id)
-        ws_b, ctx_b = await _seed_workspace_context(db_session, user_id=other_user)
+    async def test_workspace_id_filter_blocks_cross_workspace_leak(self, db_session, now):
+        """The ``workspace_id`` predicate must reject a memory rooted in another
+        workspace, even when its ``context_id`` matches the caller's context.
 
-        # Same fake context_id reuse is impossible (uuid4), but we still
-        # cross-check that workspace_id filter holds. Seed each with distinct
-        # tags so leakage would be obvious.
+        ``memories`` has no compound FK tying ``workspace_id`` to
+        ``contexts.workspace_id`` — a row with mismatched (ws, ctx) is
+        representable at the schema level. The CTE's
+        ``WHERE workspace_id = :workspace_id`` is what prevents leakage.
+
+        Setup: caller in ws_a queries ctx_a. We seed:
+          (1) a legitimate memory in (ws_a, ctx_a) tagged 'legit'
+          (2) a "leaked" memory in (ws_b, ctx_a) tagged 'leaked'
+          (3) an unrelated memory in (ws_b, ctx_b) tagged 'unrelated'
+        Only 'legit' should be returned.
+        """
+        user_a = f"u_wsfilt_a_{uuid4().hex[:6]}"
+        user_b = f"u_wsfilt_b_{uuid4().hex[:6]}"
+        ws_a, ctx_a = await _seed_workspace_context(db_session, user_id=user_a)
+        ws_b, ctx_b = await _seed_workspace_context(db_session, user_id=user_b)
+
         db_session.add_all(
             [
                 _memory(
                     ws_id=ws_a.id,
                     ctx_id=ctx_a.id,
-                    user_id=user_id,
-                    tags=["alpha"],
+                    user_id=user_a,
+                    tags=["legit"],
+                    created_at=now,
+                ),
+                # Cross-rooted: ws_b but context_id=ctx_a.id. The schema's FK only
+                # requires ``contexts.id`` to exist; (ws, ctx) consistency is a
+                # runtime invariant, not a DB constraint.
+                _memory(
+                    ws_id=ws_b.id,
+                    ctx_id=ctx_a.id,
+                    user_id=user_b,
+                    tags=["leaked"],
                     created_at=now,
                 ),
                 _memory(
                     ws_id=ws_b.id,
                     ctx_id=ctx_b.id,
-                    user_id=other_user,
-                    tags=["beta"],
+                    user_id=user_b,
+                    tags=["unrelated"],
                     created_at=now,
                 ),
             ]
         )
         await db_session.flush()
 
-        rows = await _agg_rows(db_session, user_id, ctx_a.id)
+        rows = await _agg_rows(db_session, user_a, ctx_a.id)
 
         tags = {r["tag"] for r in rows}
-        assert tags == {"alpha"}
+        assert tags == {"legit"}, (
+            "workspace_id filter failed — 'leaked' or 'unrelated' appeared in caller's view"
+        )
 
     async def test_min_count_filter(self, db_session, now):
         user_id = f"u_minc_{uuid4().hex[:6]}"

--- a/backend/tests/mcp_server/test_list_tags.py
+++ b/backend/tests/mcp_server/test_list_tags.py
@@ -1,0 +1,243 @@
+"""Tests for MCP ``handle_list_tags`` tool.
+
+Pins:
+- Happy path response shape (status / context_id / context_name / tags / total).
+- Empty-context returns ``tags=[]`` and ``total=0`` (no ``context_not_found``).
+- ``NotFoundException`` from the service → uniform ``context_not_found`` surface.
+- Arg validation: bad ``limit`` / ``min_count`` / oversized ``prefix`` / invalid UUID
+  return ``invalid_argument`` / ``invalid_context_id_format`` without touching the DB.
+- ``last_used_at`` datetime is rendered with a ``Z`` suffix.
+
+Aggregation correctness (SQL CTE) is exercised at the integration level
+(``tests/integration/test_list_tags_aggregation.py``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.context import handle_list_tags
+from utils.exceptions import NotFoundException
+
+
+@pytest.fixture
+def user_id():
+    return "test_user"
+
+
+@pytest.fixture
+def workspace_id():
+    return uuid4()
+
+
+@pytest.fixture
+def context_id():
+    return uuid4()
+
+
+def _mock_db_context():
+    """Return a (mock_db, async_get_db) pair that yields the mock once."""
+    mock_db = AsyncMock()
+    mock_db.rollback = AsyncMock()
+    mock_db.commit = AsyncMock()
+
+    async def mock_get_db():
+        yield mock_db
+
+    return mock_db, mock_get_db
+
+
+class TestHandleListTagsHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_success_envelope(self, user_id, workspace_id, context_id):
+        """Populated context returns ``status=success`` with tag array."""
+        _, mock_get_db = _mock_db_context()
+        last_used = datetime(2026, 5, 12, 3, 39, 39)
+        mock_service = MagicMock(
+            aggregate_tags=AsyncMock(
+                return_value={
+                    "context_name": "kagura-dev",
+                    "rows": [
+                        {"tag": "python", "count": 5, "last_used_at": last_used},
+                        {"tag": "fastapi", "count": 3, "last_used_at": None},
+                    ],
+                }
+            )
+        )
+
+        with (
+            patch("db.base.get_db", mock_get_db),
+            patch("services.context_service.ContextService", return_value=mock_service),
+            patch("mcp_server.tools.context._log_tool_usage", AsyncMock()),
+        ):
+            result = await handle_list_tags({"context_id": str(context_id)}, user_id, workspace_id)
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "success"
+        assert payload["context_id"] == str(context_id)
+        assert payload["context_name"] == "kagura-dev"
+        assert payload["total"] == 2
+        assert payload["tags"][0] == {
+            "tag": "python",
+            "count": 5,
+            "last_used_at": "2026-05-12T03:39:39Z",
+        }
+        assert payload["tags"][1]["last_used_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_empty_context_returns_empty_array(self, user_id, workspace_id, context_id):
+        """Empty context returns ``tags=[]`` and ``total=0`` (no context_not_found)."""
+        _, mock_get_db = _mock_db_context()
+        mock_service = MagicMock(
+            aggregate_tags=AsyncMock(return_value={"context_name": "empty-ctx", "rows": []})
+        )
+
+        with (
+            patch("db.base.get_db", mock_get_db),
+            patch("services.context_service.ContextService", return_value=mock_service),
+            patch("mcp_server.tools.context._log_tool_usage", AsyncMock()),
+        ):
+            result = await handle_list_tags({"context_id": str(context_id)}, user_id, workspace_id)
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "success"
+        assert payload["tags"] == []
+        assert payload["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_forwards_optional_args_to_service(self, user_id, workspace_id, context_id):
+        """All optional args (limit/min_count/sort/prefix) reach the service."""
+        _, mock_get_db = _mock_db_context()
+        mock_service = MagicMock(
+            aggregate_tags=AsyncMock(return_value={"context_name": "ctx", "rows": []})
+        )
+
+        with (
+            patch("db.base.get_db", mock_get_db),
+            patch("services.context_service.ContextService", return_value=mock_service),
+            patch("mcp_server.tools.context._log_tool_usage", AsyncMock()),
+        ):
+            await handle_list_tags(
+                {
+                    "context_id": str(context_id),
+                    "limit": 100,
+                    "min_count": 3,
+                    "sort": "recent",
+                    "prefix": "auth",
+                },
+                user_id,
+                workspace_id,
+            )
+
+        mock_service.aggregate_tags.assert_awaited_once_with(
+            user_id,
+            context_id,
+            limit=100,
+            min_count=3,
+            sort="recent",
+            prefix="auth",
+        )
+
+
+class TestHandleListTagsErrorSurface:
+    @pytest.mark.asyncio
+    async def test_not_found_returns_uniform_surface(self, user_id, workspace_id, context_id):
+        """NotFoundException from the service → context_not_found error response."""
+        _, mock_get_db = _mock_db_context()
+        mock_service = MagicMock(
+            aggregate_tags=AsyncMock(
+                side_effect=NotFoundException(f"Context not found: {context_id}")
+            )
+        )
+
+        with (
+            patch("db.base.get_db", mock_get_db),
+            patch("services.context_service.ContextService", return_value=mock_service),
+            patch("mcp_server.tools.context._log_tool_usage", AsyncMock()),
+        ):
+            result = await handle_list_tags({"context_id": str(context_id)}, user_id, workspace_id)
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "context_not_found"
+        assert payload["context_id"] == str(context_id)
+
+    @pytest.mark.asyncio
+    async def test_invalid_sort_from_service_returns_invalid_argument(
+        self, user_id, workspace_id, context_id
+    ):
+        """Service-raised ValidationError (e.g. bad sort) → invalid_argument."""
+        from utils.exceptions import ValidationError
+
+        _, mock_get_db = _mock_db_context()
+        mock_service = MagicMock(
+            aggregate_tags=AsyncMock(side_effect=ValidationError("Invalid sort mode 'bogus'."))
+        )
+
+        with (
+            patch("db.base.get_db", mock_get_db),
+            patch("services.context_service.ContextService", return_value=mock_service),
+            patch("mcp_server.tools.context._log_tool_usage", AsyncMock()),
+        ):
+            result = await handle_list_tags(
+                {"context_id": str(context_id), "sort": "bogus"},
+                user_id,
+                workspace_id,
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "invalid_argument"
+
+    @pytest.mark.asyncio
+    async def test_missing_context_id_returns_required(self, user_id, workspace_id):
+        """Missing context_id short-circuits before touching the DB."""
+        # No DB patch — if the handler touches get_db it raises.
+        result = await handle_list_tags({}, user_id, workspace_id)
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "context_id_required"
+
+    @pytest.mark.asyncio
+    async def test_invalid_uuid_returns_format_error_without_db(self, user_id, workspace_id):
+        """Bad context_id UUID short-circuits before touching the DB."""
+        # No DB patch — if the handler touches get_db it raises.
+        result = await handle_list_tags({"context_id": "not-a-uuid"}, user_id, workspace_id)
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "invalid_context_id_format"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "bad_args",
+        [
+            {"limit": 0},
+            {"limit": 501},
+            {"limit": "fifty"},
+            {"min_count": 0},
+            {"min_count": -1},
+            {"min_count": 10_001},
+            {"prefix": "x" * 201},
+        ],
+    )
+    async def test_bad_args_short_circuit_without_db(
+        self, user_id, workspace_id, context_id, bad_args
+    ):
+        """Each handler-bounded invalid arg returns invalid_argument pre-DB.
+
+        ``sort`` is validated by the service (single source of truth), so a
+        bad ``sort`` is covered by ``test_invalid_sort_from_service_*``.
+        """
+        args = {"context_id": str(context_id), **bad_args}
+        result = await handle_list_tags(args, user_id, workspace_id)
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "invalid_argument"

--- a/backend/tests/mcp_server/test_list_tags.py
+++ b/backend/tests/mcp_server/test_list_tags.py
@@ -221,10 +221,14 @@ class TestHandleListTagsErrorSurface:
             {"limit": 0},
             {"limit": 501},
             {"limit": "fifty"},
+            {"limit": True},  # bool subclasses int but type(x) is int rejects it
             {"min_count": 0},
             {"min_count": -1},
             {"min_count": 10_001},
+            {"min_count": False},  # bool — must be rejected by type() check
             {"prefix": "x" * 201},
+            {"prefix": 0},  # falsy non-string; `or ""` shorthand would coerce silently
+            {"prefix": False},  # ditto
         ],
     )
     async def test_bad_args_short_circuit_without_db(


### PR DESCRIPTION
Closes #614

## Summary
- Adds a read-only `list_tags` MCP tool + REST endpoint so LLM clients can discover existing tag spellings before `remember()` / `recall()`, mitigating tag drift (`troubleshoot` vs `troubleshooting` silently degrading filter precision).
- Service `ContextService.aggregate_tags()` mirrors the canonical CTE pattern in `sleep_tasks._refresh_hub_tag_cache` — DISTINCT-per-memory dedup, soft-delete and workspace boundary filters.
- `RelatedTagItem` schema extended with optional `last_used_at` so `recall.related_tags` and `list_tags` share one client-side type.

## Implementation notes
- **Service** (`backend/src/services/context_service.py`): new `aggregate_tags(user_id, context_id, *, limit, min_count, sort, prefix)` returning `{"context_name": str, "rows": [...]}`. Module-level `TagSortMode = Literal["count","recent","alpha"]` is the single source of truth shared with the REST `Query(...)` and service signature (same pattern as `SleepMode`, `SearchMode`). Access check runs once via `self.get_context()`; the MCP handler and REST route both delegate without pre-resolving.
- **REST route** (`backend/src/api/routes/contexts.py`): `GET /contexts/{context_id}/tags` mirrors `get_context_stats`; `APIKeyOrSessionUser` auth matches the `get_memory_usage_stats` analytics precedent. Bounded query params (`limit` 1–500, `min_count` 1–10000, `prefix` max 200 chars).
- **MCP tool** (`backend/src/mcp_server/tools/context.py`): `handle_list_tags` mirrors `handle_get_context_info` structurally. Added to `_RATE_LIMIT_EXEMPT_TOOLS` (read-only), `TOOL_TIMEOUTS` (10s), `_definitions.py` (with `readOnly: True` + "Call this BEFORE remember/recall" guidance), and the registry. Uniform `context_not_found` on `NotFoundException` (CWE-639 — never leak deny reason); `db.rollback()` on every error path.
- **Schema** (`backend/src/models/schemas.py`): `RelatedTagItem` switched `BaseModel → TZAwareBaseModel` (UTC-Z serialization for the new optional `last_used_at`); existing `recall.related_tags` callers unaffected (additive, defaults `None`).
- **SQL**: `WITH scope AS (… WHERE workspace_id=… AND context_id=… AND deleted_at IS NULL AND cardinality(tags)>0) → SELECT DISTINCT id, unnest(tags)::text AS tag, last_at → GROUP BY tag with MAX(last_at) → ORDER BY <sort_clause> LIMIT`. `sort` allow-list validated before f-string interpolation; `prefix` `%`/`_`/`#` escaped (`ESCAPE '#'`) before binding as `:prefix_pattern`.
- **Pagination decision recorded**: limit-only (cap 500), no cursor — discovery use case doesn't warrant the API-contract surface.
- **`min_count` default = 1**: chosen over issue body's `2` so drift typos are visible by default (DX pit of success).

## Pre-PR review summary
- gate2 mode: advisor-only (no binary gate configured)
- audit: skipped
- binary_gate: (none)
- /claude-c-suite:cso: green
- /claude-c-suite:qa-lead: green
- /claude-c-suite:cto: green
- gate1: yellow via /ask (CIO lens) → DX Lead consult → all yellow concerns addressed pre-implementation
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/614-feat-feat-mcp-api-list-tags-tool-for-tag-disc.gate1.md`
- `~/.claude/cache/gh-issue-driven/614-feat-feat-mcp-api-list-tags-tool-for-tag-disc.gate2.md`

## Test plan
- [x] 19 unit tests (REST 5 + MCP 14): happy / empty / 404 / 422 / args forwarding / 7 bound-violation cases
- [x] 12 integration tests (PG-required): DISTINCT-per-memory dedup, soft-delete exclusion, cross-workspace boundary, `min_count`, `prefix`-as-literal, 3 sort modes, `last_used_at`-MAX
- [x] ruff clean, pyright clean
- [x] 157 surrounding tests pass (no regressions)
- [ ] CI integration lane runs the 12 PG tests
- [ ] Manual smoke: `list_tags` via Claude Code MCP after deploy

## Out of scope (separate follow-ups)
- SDK `client.list_tags(...)` in `kagura-memory-python-sdk`
- Frontend tag-cloud / autocomplete UI on context detail page
- Compound `(workspace_id, context_id)` index — defer until profiling shows need

🤖 Generated via /gh-issue-driven:ship
