### PR TITLE
fix(test,frontend): vitest pool=vmForks to resolve worker-termination flake (#584)

### DIFF
--- a/frontend/vitest.config.mts
+++ b/frontend/vitest.config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.test.{ts,tsx}'],
+    pool: 'vmForks',
     coverage: {
       provider: 'v8',
       reporter: ['text', 'html'],


### PR DESCRIPTION
## Summary

Switches vitest pool from default `forks` to `vmForks` to resolve the v0.16.0
test-infrastructure flake tracked in #584. One-line config change.

`pool: 'vmForks'` creates a fresh V8 isolate per test file, eliminating the
cross-file module-state reuse that was causing react-dom v19's CJS module
to hit `Identifier 'currentHookNameInDev' cannot be declared with 'var'`
on worker reuse — the smoking gun documented in the #584 body.

See #584 for the full root-cause analysis and the 5-direction hypothesis space.

## Verification

10/10 consecutive `npm test` runs clean post-fix (issue AC met):

| Metric | Pre-fix | Post-fix |
|---|---|---|
| Per-run failure rate | ~40% | 0% (10/10 runs clean) |
| Test Files | 39 passed (39) (when clean) | 39 passed (39) every run |
| Tests | 378 passed (378) (when clean) | 378 passed (378) every run |
| `Unhandled Errors` block | Frequent | None |
| Duration | ~25s | 14-20s |

No speed regression observed; on most runs vmForks is actually faster than
the pre-fix `forks` pool, likely because the fresh-isolate path avoids the
reuse-cleanup overhead.

## Directions NOT pursued (vmForks alone sufficed)

The issue body listed 5 hypothesis directions. Per gate1 design review
(`/claude-c-suite:ask`, yellow with tactical refinements), operator chose
to attempt only the cheapest direction first. Result: it worked. The
remaining 4 directions stay documented in #584 as fallback candidates
should the flake resurface on CI hardware:

- happy-dom downgrade
- react-dom downgrade
- vitest 3.x pin
- jsdom environment switch

## CI scope note

CI (`.github/workflows/ci.yml:71-91`) does not currently run `npm test`
for frontend (only `tsc --noEmit` + `npm run build`). The flake's impact
was strictly on local dev experience. This PR makes that experience
clean again. Wiring frontend tests into CI is a separate v0.16.1+
candidate, out of scope here.

## Test plan

- [x] `npm test` × 10 consecutive runs locally — all clean (39/378 every run)
- [ ] CI green (tsc + build)
- [ ] Reviewer can `npm test` locally and confirm no flake

## Refs

- Closes #584
- Related: #512 (aria-query dedup, parent flake symptom)
- Related: #237 (audit umbrella; this is the last open scope of v0.16.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)