### PR TITLE
feat(auth,api): public-bound API key attribution on /api/v1/public/* (#626)

### DIFF
--- a/backend/alembic/versions/e10_626_apikey_bound_context_id.py
+++ b/backend/alembic/versions/e10_626_apikey_bound_context_id.py
@@ -1,0 +1,104 @@
+"""Add ``bound_context_id`` to api_keys + ``api_key_id`` to usage_stats (#626).
+
+Extends the existing public read endpoint (``POST /api/v1/public/{ctx}/search``)
+with optional API-key attribution. A key whose ``bound_context_id`` is set
+restricts to that one ``is_public=true`` context; absence preserves the
+existing owner-scoped / workspace-scoped (#169) semantics.
+
+Schema changes:
+
+1. ``api_keys.bound_context_id`` — UUID, nullable, indexed. References
+   ``contexts.id`` with ``ON DELETE SET NULL`` so that deleting the bound
+   context disables the key without cascading the key's deletion (audit
+   trail of the lifecycle stays intact).
+2. ``api_keys.bound_context_id`` and ``api_keys.workspace_id`` are mutually
+   exclusive via a CHECK constraint. A key cannot simultaneously be
+   workspace-scoped (#169 — full access to all contexts in a workspace)
+   AND public-bound (single-context attribution); the two scopings have
+   contradictory semantics.
+3. ``usage_stats.api_key_id`` — Integer, nullable, indexed. NOT a foreign
+   key on purpose: we want attribution rows to survive key deletion so
+   billing/audit reports remain readable; the api_keys.id reference
+   becomes a soft dangling pointer post-delete (acceptable for analytics).
+
+The binding itself is immutable (no update endpoint at the route layer).
+To change which context a key is attributed to, the operator revokes the
+old key and creates a new one. This keeps the audit story simple.
+
+Revision ID: e10_626_apikey_bound_context_id
+Revises: e09_608_dcr_default_narrow
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision = "e10_626_apikey_bound_context_id"
+down_revision = "e09_608_dcr_default_narrow"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # api_keys.bound_context_id with FK to contexts.id and SET NULL on delete.
+    op.add_column(
+        "api_keys",
+        sa.Column(
+            "bound_context_id",
+            UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_api_keys_bound_context_id",
+        "api_keys",
+        "contexts",
+        ["bound_context_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index(
+        "idx_api_keys_bound_context_id",
+        "api_keys",
+        ["bound_context_id"],
+    )
+
+    # Mutual exclusion: a key cannot be both workspace-scoped (#169) and
+    # public-bound (#626). Either both NULL (global key) or exactly one
+    # non-NULL (workspace or public-bound) is permitted.
+    op.create_check_constraint(
+        "ck_api_keys_binding_workspace_exclusion",
+        "api_keys",
+        "bound_context_id IS NULL OR workspace_id IS NULL",
+    )
+
+    # usage_stats.api_key_id — soft reference (no FK) for attribution that
+    # survives key deletion.
+    op.add_column(
+        "usage_stats",
+        sa.Column("api_key_id", sa.Integer(), nullable=True),
+    )
+    op.create_index(
+        "idx_usage_stats_api_key_id",
+        "usage_stats",
+        ["api_key_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_usage_stats_api_key_id", table_name="usage_stats")
+    op.drop_column("usage_stats", "api_key_id")
+
+    op.drop_constraint(
+        "ck_api_keys_binding_workspace_exclusion",
+        "api_keys",
+        type_="check",
+    )
+    op.drop_index("idx_api_keys_bound_context_id", table_name="api_keys")
+    op.drop_constraint(
+        "fk_api_keys_bound_context_id",
+        "api_keys",
+        type_="foreignkey",
+    )
+    op.drop_column("api_keys", "bound_context_id")

--- a/backend/src/api/routes/api_keys.py
+++ b/backend/src/api/routes/api_keys.py
@@ -203,23 +203,11 @@ async def create_api_key(
         # Issue #246: current_context_id removed
         # current_context_id = user.get("current_context_id")
 
-        api_key = await manager.create_key(
+        api_key, created_key = await manager.create_key(
             name=data.name,
             user_id=user_id,
             expires_days=data.expires_days,
         )
-
-        # Retrieve metadata
-        keys = await manager.list_keys(
-            user_id=user_id,
-        )
-        created_key = next((k for k in keys if k.name == data.name), None)
-
-        if not created_key:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to retrieve created key",
-            )
 
         response_data = _format_key_response(created_key)
         return APIKeyCreateResponse(**response_data.model_dump(), api_key=api_key)
@@ -368,7 +356,6 @@ async def regenerate_api_key(
 
         # Store old key info
         key_name = old_key.name
-        key_context_id = old_key.context_id
         key_workspace_id = old_key.workspace_id
         key_expires_at = old_key.expires_at
 
@@ -384,25 +371,14 @@ async def regenerate_api_key(
         await db.flush()
 
         # Create new key with same name
-        new_api_key = await manager.create_key(
+        new_api_key, new_key = await manager.create_key(
             name=key_name,
             user_id=user_id,
             expires_days=expires_days,
-            context_id=key_context_id,
             workspace_id=key_workspace_id,
         )
 
         await db.commit()
-
-        # Retrieve new key metadata
-        keys = await manager.list_keys(user_id=user_id)
-        new_key = next((k for k in keys if k.name == key_name and k.revoked_at is None), None)
-
-        if not new_key:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to retrieve regenerated key",
-            )
 
         logger.info(f"api_key_regenerated: old_id={key_id}, new_id={new_key.id}, user={user_id}")
 

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -248,27 +248,12 @@ async def regenerate_api_key(
 
     # Create new key
     manager = APIKeyManager(db)
-    new_plaintext_key = await manager.create_key(
+    new_plaintext_key, new_key = await manager.create_key(
         name=old_key.name,
         user_id=user_id,
         workspace_id=workspace_id,
         auto_hide_minutes=10,
     )
-
-    # Get new key record (most recently created)
-    result = await db.execute(
-        select(APIKey)
-        .where(
-            and_(
-                APIKey.user_id == user_id,
-                APIKey.workspace_id == workspace_id,
-                APIKey.revoked_at.is_(None),
-            )
-        )
-        .order_by(APIKey.created_at.desc())
-        .limit(1)
-    )
-    new_key = result.scalar_one()
 
     await db.commit()
 
@@ -298,10 +283,17 @@ async def create_api_key(
 ) -> dict:
     """Create new API key (Owner only).
 
+    Issue #626: If ``data.bound_context_id`` is supplied, the key is stored
+    as a public-bound key (``api_keys.workspace_id`` is left NULL) and is
+    attributed to that one ``is_public=true`` context for the rate-limit /
+    audit / revoke surface on ``/api/v1/public/{ctx}/*``. The binding is
+    immutable — to change it, revoke this key and create a new one.
+
     Args:
-        workspace_id: Workspace ID
+        workspace_id: Workspace ID (from URL — used as permission scope; also
+            assigned to ``api_keys.workspace_id`` unless a bound context is set)
         user_id: Target user ID
-        data: API key creation data (name, auto_hide_minutes)
+        data: API key creation data (name, auto_hide_minutes, bound_context_id)
         user: Current user (from auth)
         db: Database session
 
@@ -309,45 +301,122 @@ async def create_api_key(
         Created API key with plaintext (shown once)
 
     Raises:
-        HTTPException: If not owner or name already exists
+        HTTPException: If not owner, name already exists, tier gate fails,
+            or the bound context is missing / not public / not in this workspace.
     """
     # Permission check: only owner can create their own keys
     if user["user_id"] != user_id:
         raise HTTPException(status_code=403, detail="Only owner can create API keys")
 
+    # Issue #626: Public-bound key creation gating + scope decision.
+    # When ``bound_context_id`` is supplied, the key is public-bound and the
+    # ``api_keys.workspace_id`` column is left NULL (mutually exclusive per
+    # the DB CHECK constraint). The URL ``workspace_id`` continues to scope
+    # permission (the workspace must own the context, the plan must include
+    # ``public_contexts``) but does NOT scope the key itself.
+    bound_context_uuid: UUID | None = None
+    key_scope_workspace_id: UUID | None = workspace_id
+    if data.bound_context_id is not None:
+        try:
+            bound_context_uuid = UUID(data.bound_context_id)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=400, detail="bound_context_id must be a valid UUID"
+            ) from exc
+
+        # Verify the context exists, is public, and belongs to this workspace.
+        from sqlalchemy import select as _select
+
+        from models.auth import Context
+
+        ctx_row = await db.execute(_select(Context).where(Context.id == bound_context_uuid))
+        ctx = ctx_row.scalar_one_or_none()
+        if ctx is None:
+            raise HTTPException(status_code=404, detail="bound_context_id: context not found")
+        if ctx.workspace_id != workspace_id:
+            raise HTTPException(
+                status_code=403,
+                detail="bound_context_id: context does not belong to this workspace",
+            )
+        if ctx.is_public is not True:
+            raise HTTPException(
+                status_code=422,
+                detail="bound_context_id: context is not public (set is_public=true first)",
+            )
+        # Ownership gate: only the context creator can mint a public-bound key
+        # against it. In a multi-member PRO workspace this prevents a non-admin
+        # member from minting per-key buckets (and an audit-trail footprint)
+        # against another member's public context. Workspace owner/admin gets
+        # this implicitly by creating their own context to bind.
+        if ctx.created_by is not None and ctx.created_by != user_id:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "bound_context_id: only the context creator can mint a "
+                    "public-bound key against this context"
+                ),
+            )
+
+        # Tier gate: workspace plan must include the ``public_contexts`` feature.
+        from sqlalchemy import select as _select_ws
+
+        from config.plan_tiers import has_feature
+        from models.auth import Workspace
+
+        ws_row = await db.execute(_select_ws(Workspace).where(Workspace.id == workspace_id))
+        ws = ws_row.scalar_one_or_none()
+        plan_name = ws.plan_name if ws is not None else "free"
+        if not has_feature(plan_name, "public_contexts"):
+            raise HTTPException(
+                status_code=403,
+                detail="Workspace plan does not include the public_contexts feature",
+            )
+
+        # Mutual exclusion with workspace scope (#169).
+        key_scope_workspace_id = None
+
     manager = APIKeyManager(db)
 
     try:
-        plaintext_key = await manager.create_key(
+        plaintext_key, new_key = await manager.create_key(
             name=data.name,
             user_id=user_id,
-            workspace_id=workspace_id,
+            workspace_id=key_scope_workspace_id,
+            bound_context_id=bound_context_uuid,
             auto_hide_minutes=data.auto_hide_minutes,
         )
 
-        # Get the created key
-        from sqlalchemy import and_, select
+        # Issue #626: audit log entry for public-bound key creation. Other
+        # key types are intentionally not audited here — the codebase does
+        # not write AuditLog for owner/workspace key creation today, and
+        # adding it for public-bound only matches the heightened scrutiny
+        # of credentials that grant public access.
+        if bound_context_uuid is not None:
+            from models.auth import AuditLog
 
-        from models.auth import APIKey
-
-        result = await db.execute(
-            select(APIKey)
-            .where(
-                and_(
-                    APIKey.user_id == user_id,
-                    APIKey.workspace_id == workspace_id,
-                    APIKey.name == data.name,
-                    APIKey.revoked_at.is_(None),
+            db.add(
+                AuditLog(
+                    user_email=user.get("email") or f"{user_id}@api",
+                    user_id=user_id,
+                    action="public_bound_api_key_created",
+                    resource=f"api_key:{new_key.id}",
+                    user_metadata={
+                        "bound_context_id": str(bound_context_uuid),
+                        "workspace_id": str(workspace_id),
+                        "key_name": data.name,
+                    },
                 )
             )
-            .order_by(APIKey.created_at.desc())
-            .limit(1)
-        )
-        new_key = result.scalar_one()
 
         await db.commit()
 
-        logger.info("api_key_created", key_id=new_key.id, user_id=user_id, name=data.name)
+        logger.info(
+            "api_key_created",
+            key_id=new_key.id,
+            user_id=user_id,
+            name=data.name,
+            bound_context_id=str(bound_context_uuid) if bound_context_uuid else None,
+        )
 
         # Return with plaintext (shown once)
         return {
@@ -359,6 +428,9 @@ async def create_api_key(
             "visibility_expires_at": to_utc_iso(new_key.visibility_expires_at),
             "created_at": to_utc_iso(new_key.created_at),
             "revoked_at": None,
+            "bound_context_id": (
+                str(new_key.bound_context_id) if new_key.bound_context_id else None
+            ),
         }
 
     except ValueError as e:
@@ -429,6 +501,116 @@ async def delete_api_key(
     logger.info("api_key_deleted", key_id=api_key.id, user_id=user_id)
 
     return {"status": "deleted", "key_id": api_key.id}
+
+
+@router.delete("/{user_id}/credentials/api-keys/{key_id}")
+async def delete_api_key_by_id(
+    workspace_id: UUID,
+    user_id: str,
+    key_id: int,
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Delete a specific API key by ID (owner only).
+
+    Issue #626: Required for revoking public-bound keys, which have
+    ``workspace_id IS NULL`` and so are invisible to the legacy singleton
+    DELETE endpoint above. This per-id endpoint accepts both regular
+    workspace-scoped keys and public-bound keys belonging to this user;
+    the ``workspace_id`` in the URL is the permission scope (the caller
+    must be the owner) and not a filter on ``api_keys.workspace_id``.
+
+    Args:
+        workspace_id: Workspace ID (permission scope, from URL)
+        user_id: Target user ID (must match the key's ``user_id``)
+        key_id: API key integer ID
+        user: Current user (from auth)
+        db: Database session
+
+    Returns:
+        Status message
+
+    Raises:
+        HTTPException: 403 if not owner, 404 if key not found.
+    """
+    if user["user_id"] != user_id:
+        raise HTTPException(status_code=403, detail="Only owner can delete API keys")
+
+    from sqlalchemy import and_, select
+
+    from models.auth import APIKey, Context
+
+    result = await db.execute(
+        select(APIKey).where(and_(APIKey.id == key_id, APIKey.user_id == user_id))
+    )
+    api_key = result.scalar_one_or_none()
+    if api_key is None:
+        raise HTTPException(status_code=404, detail="API key not found")
+
+    # Verify the URL ``workspace_id`` matches the key's real scope.
+    # Without this, an authenticated user could pass an arbitrary
+    # ``workspace_id`` in the path and the AuditLog row would record a
+    # workspace that has nothing to do with the deleted key. Owner-only
+    # enforcement above prevents privilege escalation, but auditing
+    # integrity matters: the workspace in the audit trail must reflect
+    # where the key was actually scoped.
+    if api_key.workspace_id is not None:
+        # Workspace-scoped key (#169) — URL workspace must match the column.
+        if api_key.workspace_id != workspace_id:
+            raise HTTPException(
+                status_code=403,
+                detail="API key does not belong to this workspace",
+            )
+    elif api_key.bound_context_id is not None:
+        # Public-bound key (#626) — the binding's workspace must match.
+        ctx_row = await db.execute(select(Context).where(Context.id == api_key.bound_context_id))
+        bound_ctx = ctx_row.scalar_one_or_none()
+        # If the bound context was deleted (SET NULL would have already
+        # nulled bound_context_id, but in-flight requests may race), the
+        # key has no anchoring workspace — fall through to delete without
+        # the workspace-match assertion.
+        if bound_ctx is not None and bound_ctx.workspace_id != workspace_id:
+            raise HTTPException(
+                status_code=403,
+                detail="API key is bound to a context in a different workspace",
+            )
+    # else: global / owner-scoped key (both columns NULL) — workspace_id in
+    # the URL is purely permission scope; the owner-only check above is
+    # the only gate that applies.
+
+    # Capture binding info before delete — the audit-log entry below
+    # needs the original ``bound_context_id`` and the row is about to go.
+    bound_ctx_id = api_key.bound_context_id
+
+    await db.delete(api_key)
+
+    # Issue #626: audit log entry for public-bound key revocation.
+    if bound_ctx_id is not None:
+        from models.auth import AuditLog
+
+        db.add(
+            AuditLog(
+                user_email=user.get("email") or f"{user_id}@api",
+                user_id=user_id,
+                action="public_bound_api_key_revoked",
+                resource=f"api_key:{key_id}",
+                user_metadata={
+                    "bound_context_id": str(bound_ctx_id),
+                    "workspace_id": str(workspace_id),
+                },
+            )
+        )
+
+    await db.commit()
+
+    logger.info(
+        "api_key_deleted",
+        key_id=key_id,
+        user_id=user_id,
+        bound_context_id=str(bound_ctx_id) if bound_ctx_id is not None else None,
+    )
+
+    return {"status": "deleted", "key_id": key_id}
 
 
 # ============================================================================

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -398,7 +398,7 @@ async def create_api_key(
                 AuditLog(
                     user_email=user.get("email") or f"{user_id}@api",
                     user_id=user_id,
-                    action="public_bound_api_key_created",
+                    action="public_bound_key_created",
                     resource=f"api_key:{new_key.id}",
                     user_metadata={
                         "bound_context_id": str(bound_context_uuid),
@@ -592,7 +592,7 @@ async def delete_api_key_by_id(
             AuditLog(
                 user_email=user.get("email") or f"{user_id}@api",
                 user_id=user_id,
-                action="public_bound_api_key_revoked",
+                action="public_bound_key_revoked",
                 resource=f"api_key:{key_id}",
                 user_metadata={
                     "bound_context_id": str(bound_ctx_id),

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -371,7 +371,10 @@ async def create_api_key(
 
         ws_row = await db.execute(_select_ws(Workspace).where(Workspace.id == workspace_id))
         ws = ws_row.scalar_one_or_none()
-        plan_name = ws.plan_name if ws is not None else "free"
+        # ``ws.plan_name`` itself is nullable for legacy rows that
+        # pre-date the plan_name backfill — coerce to "free" so
+        # ``has_feature`` / ``get_plan_tier`` don't see ``None`` and 500.
+        plan_name = (ws.plan_name if ws is not None else None) or "free"
         if not has_feature(plan_name, "public_contexts"):
             raise HTTPException(
                 status_code=403,

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -348,7 +348,15 @@ async def create_api_key(
         # member from minting per-key buckets (and an audit-trail footprint)
         # against another member's public context. Workspace owner/admin gets
         # this implicitly by creating their own context to bind.
-        if ctx.created_by is not None and ctx.created_by != user_id:
+        # Strict match: ``created_by == user_id`` only. Legacy contexts with
+        # ``created_by IS NULL`` (pre-#160 backfill survivors) are NOT
+        # eligible — there is no way to prove client-side OR server-side
+        # which workspace member should own a null-created context, so
+        # defaulting-to-permit would let any workspace member mint keys
+        # against it. The owner can resolve by updating the context's
+        # ``created_by`` (via a separate admin action) or by recreating
+        # the context.
+        if ctx.created_by != user_id:
             raise HTTPException(
                 status_code=403,
                 detail=(

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -357,10 +357,16 @@ async def create_api_key(
                 ),
             )
 
-        # Tier gate: workspace plan must include the ``public_contexts`` feature.
+        # Tier gate: workspace plan must include the ``public_contexts`` feature
+        # AND have a non-zero per-key minute quota. The two checks defend in
+        # depth: the feature-flag check is the primary intent (PRO+), but a
+        # custom plan / env override that left ``bound_public_calls_per_minute``
+        # at 0 would otherwise mint a key that 429s on every public-endpoint
+        # call. Refuse creation up-front so the operator sees the
+        # misconfiguration immediately, not after distributing a dead key.
         from sqlalchemy import select as _select_ws
 
-        from config.plan_tiers import has_feature
+        from config.plan_tiers import get_plan_tier, has_feature
         from models.auth import Workspace
 
         ws_row = await db.execute(_select_ws(Workspace).where(Workspace.id == workspace_id))
@@ -370,6 +376,14 @@ async def create_api_key(
             raise HTTPException(
                 status_code=403,
                 detail="Workspace plan does not include the public_contexts feature",
+            )
+        if get_plan_tier(plan_name).bound_public_calls_per_minute <= 0:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Workspace plan does not provision a per-key quota for "
+                    "public-bound API keys (bound_public_calls_per_minute=0)"
+                ),
             )
 
         # Mutual exclusion with workspace scope (#169).

--- a/backend/src/api/routes/public_search.py
+++ b/backend/src/api/routes/public_search.py
@@ -17,7 +17,7 @@ from auth.api_keys import APIKeyManager, VerifiedKey
 from auth.dependencies import get_api_key, get_current_user_optional
 from config.plan_tiers import get_plan_tier
 from db.base import get_db
-from db.redis import incrby_counter, increment_counter
+from db.redis import incrby_counter
 from models.auth import Context, Workspace
 from services.resource_lookup import get_latest_schema
 from services.search_service import SearchService
@@ -96,11 +96,16 @@ async def check_public_search_rate_limit(
         logger.debug("rate_limit_skipped_for_workspace_member", user_id=user_id)
         return
 
-    # Apply rate limit for anonymous/public token access
+    # Apply rate limit for anonymous/public token access. ``incrby_counter``
+    # post-checks the TTL via ``TTL`` and sets ``EXPIRE`` whenever absent —
+    # avoiding the race in the older ``increment_counter`` where two
+    # concurrent first-increments could leave the key with no TTL (counter
+    # grows forever, locking the bucket into permanent 429). Same primitive
+    # the new #626 bound-key bucket uses.
     redis_key = f"public_search:{context_id}:minute"
 
     try:
-        current_count = await increment_counter(redis_key, ttl=60)
+        current_count = await incrby_counter(redis_key, amount=1, ttl=60)
 
         if current_count > limit_per_minute:
             logger.warning(
@@ -534,7 +539,8 @@ async def get_public_context_info(
 
     Errors:
         - 401: API key supplied but invalid / expired
-        - 403: Context is not public, OR API key is bound to a different context
+        - 403: Context is not public, OR API key is not public-bound, OR
+               API key is bound to a different context (CWE-639 IDOR)
         - 404: Context not found
     """
     # Issue #626: IDOR guard runs before context lookup (symmetry with /search).

--- a/backend/src/api/routes/public_search.py
+++ b/backend/src/api/routes/public_search.py
@@ -490,9 +490,13 @@ async def public_search(
             context_id=context_id,
             error=str(e),
         )
+        # Do not leak the raw exception message to the (potentially
+        # anonymous) client — DB / provider / library errors can carry
+        # column names, connection strings, file paths, etc. The full
+        # message is in the logger.error above for operator triage.
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Search failed: {str(e)}",
+            detail="Internal search error",
         ) from e
 
 

--- a/backend/src/api/routes/public_search.py
+++ b/backend/src/api/routes/public_search.py
@@ -373,23 +373,37 @@ async def public_search(
                 detail="This public context belongs to a different workspace. Please switch workspaces or use anonymous access.",
             )
 
-    # 3. Resolve workspace (used for rate-limit tier AND for the search
-    # owner_user_id below). One fetch covers both.
-    workspace = await db.get(Workspace, context.workspace_id)
-    if workspace is None:
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Context workspace not found",
-        )
-
-    # 4. Rate limit dispatch by principal type.
+    # 3. Rate limit dispatch by principal type.
+    # The Workspace fetch is deferred to after this gate so a flood of
+    # 429-bound anonymous requests don't burn a DB lookup each. Bound-key
+    # path needs the plan tier (so it fetches workspace inline); other
+    # paths fetch lazily below, only on requests that survive the bucket.
+    workspace: Workspace | None = None
     if bound_key is not None:
+        workspace = await db.get(Workspace, context.workspace_id)
+        if workspace is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Context workspace not found",
+            )
         plan = get_plan_tier(workspace.plan_name or "free")
         await check_bound_key_rate_limit(bound_key.id, plan.bound_public_calls_per_minute)
     elif user is None:
         # Anonymous shared bucket — existing behavior preserved.
+        # Workspace lookup is deferred to step 4 below: under abuse, a
+        # 429 returns BEFORE any Workspace SELECT.
         await check_public_search_rate_limit(context_id, None)
     # else: workspace member session → no rate limit (existing behavior).
+
+    # 4. Resolve workspace lazily if not already fetched above. Required
+    # for the embedding-service caller user_id (search_user_id).
+    if workspace is None:
+        workspace = await db.get(Workspace, context.workspace_id)
+        if workspace is None:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Context workspace not found",
+            )
 
     # 5. Hoist usage-log attribution + caller id once so the success and
     # error paths below share one definition.

--- a/backend/src/api/routes/public_search.py
+++ b/backend/src/api/routes/public_search.py
@@ -196,6 +196,54 @@ async def check_bound_key_rate_limit(key_id: int, limit_per_minute: int) -> None
         logger.error("redis_bound_key_rate_limit_check_failed", error=str(e))
 
 
+async def check_pre_auth_rate_limit(context_id: UUID, limit_per_minute: int = 200) -> None:
+    """Pre-auth rate-limit bucket — protects against invalid-key DB DoS.
+
+    Without this gate, any caller can hammer the public endpoint with
+    ``Authorization: Bearer <random>`` headers: each request reaches
+    ``APIKeyManager.verify_key`` (a SELECT on the unique ``key_hash``
+    index) BEFORE the anonymous shared 50/min bucket is consulted —
+    turning the route into an unauthenticated DB-backed key-verification
+    oracle and amplifying the DB load per attacker-request.
+
+    Strategy: a cheap Redis check keyed on ``context_id`` runs BEFORE
+    ``verify_key``. The default 200/min/context is 4× the anonymous 50/
+    min cap, so legitimate bound-key callers (whose per-key quotas are
+    typically 100/min on PRO) are not the binding constraint — the
+    per-key bucket trips first. Invalid-key spammers, however, get
+    throttled at 200/min total per context regardless of how many
+    distinct keys they cycle through.
+
+    Args:
+        context_id: Target context UUID — bucket scope.
+        limit_per_minute: Pre-auth requests/minute cap (default 200).
+
+    Raises:
+        RateLimitError: If the per-minute bucket is exhausted. Redis
+            errors are logged and swallowed (fail-open).
+    """
+    redis_key = f"public_search_pre_auth:{context_id}:minute"
+    try:
+        current_count = await incrby_counter(redis_key, amount=1, ttl=60)
+        if current_count > limit_per_minute:
+            logger.warning(
+                "public_search_pre_auth_rate_limit_exceeded",
+                context_id=context_id,
+                current=current_count,
+                limit=limit_per_minute,
+            )
+            raise RateLimitError(
+                message=(
+                    f"Pre-auth rate limit exceeded: {current_count}/{limit_per_minute} per minute"
+                ),
+                retry_after=60,
+            )
+    except RateLimitError:
+        raise
+    except Exception as e:
+        logger.error("redis_pre_auth_rate_limit_check_failed", error=str(e))
+
+
 async def _resolve_public_attribution(
     api_key: str | None,
     context_id: UUID,
@@ -323,7 +371,17 @@ async def public_search(
     """
     start_time = utcnow()
 
-    # 1. Resolve optional API-key attribution BEFORE reading context data,
+    # 1a. Pre-auth rate limit when an Authorization header is supplied.
+    # Without this, an attacker could bypass the anonymous 50/min bucket
+    # by sending invalid-key Authorization headers — each request would
+    # reach ``verify_key`` (a DB SELECT) before any rate-limit check,
+    # turning the endpoint into a DB-DoS amplifier and a key-verification
+    # oracle. The cheap Redis check here runs BEFORE ``verify_key`` so
+    # invalid-key floods are bounded.
+    if api_key is not None:
+        await check_pre_auth_rate_limit(context_id)
+
+    # 1b. Resolve optional API-key attribution BEFORE reading context data,
     # so a key bound to a different context cannot leak existence of the
     # URL context via the response shape.
     bound_key = await _resolve_public_attribution(api_key, context_id, db)
@@ -557,7 +615,11 @@ async def get_public_context_info(
                API key is bound to a different context (CWE-639 IDOR)
         - 404: Context not found
     """
-    # Issue #626: IDOR guard runs before context lookup (symmetry with /search).
+    # Issue #626: pre-auth rate limit + IDOR guard run before context
+    # lookup, symmetry with /search. The pre-auth gate protects
+    # ``verify_key`` from invalid-key DB-DoS amplification.
+    if api_key is not None:
+        await check_pre_auth_rate_limit(context_id)
     await _resolve_public_attribution(api_key, context_id, db)
 
     # Get context

--- a/backend/src/api/routes/public_search.py
+++ b/backend/src/api/routes/public_search.py
@@ -13,10 +13,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from auth.dependencies import get_current_user_optional
+from auth.api_keys import APIKeyManager, VerifiedKey
+from auth.dependencies import get_api_key, get_current_user_optional
+from config.plan_tiers import get_plan_tier
 from db.base import get_db
-from db.redis import increment_counter
-from models.auth import Context
+from db.redis import incrby_counter, increment_counter
+from models.auth import Context, Workspace
 from services.resource_lookup import get_latest_schema
 from services.search_service import SearchService
 from utils.datetime import to_utc_iso, utcnow
@@ -126,6 +128,123 @@ async def check_public_search_rate_limit(
         logger.error("redis_rate_limit_check_failed", error=str(e))
 
 
+async def check_bound_key_rate_limit(key_id: int, limit_per_minute: int) -> None:
+    """Per-key rate-limit bucket for public-bound API key access (#626).
+
+    Uses a dedicated Redis bucket keyed on the API key id, so attributed
+    consumers do not share the anonymous ``public_search:{ctx}:minute``
+    bucket — and one bound key being scraped does not exhaust the quota
+    for anonymous users or for the owner's other bound keys.
+
+    Args:
+        key_id: ``api_keys.id`` of the public-bound key.
+        limit_per_minute: Per-key per-minute quota from the workspace plan
+            (``PlanTier.bound_public_calls_per_minute``). When 0, every
+            request is treated as quota-exceeded so the route returns 429
+            instead of silently allowing unlimited traffic — keys should
+            not have been mintable on such a plan in the first place
+            (tier gate at create time), but defensive enforcement here
+            keeps the contract honest.
+
+    Raises:
+        RateLimitError: If the per-minute bucket is exhausted. Redis
+            errors are logged and swallowed (fail-open), mirroring the
+            anonymous bucket's behavior.
+    """
+    if limit_per_minute <= 0:
+        raise RateLimitError(
+            message="Public-bound API key quota not provisioned for this plan",
+            retry_after=60,
+        )
+
+    redis_key = f"public_bound_key:{key_id}:minute"
+    # Use ``incrby_counter`` rather than ``increment_counter`` here: the
+    # older variant only sets TTL when ``count == 1``, so two concurrent
+    # first-increments leave the key with no expiration (counter grows
+    # forever). ``incrby_counter`` post-checks the TTL via ``TTL`` and
+    # sets it whenever absent — race-window stays advisory-bounded.
+    try:
+        current_count = await incrby_counter(redis_key, amount=1, ttl=60)
+        if current_count > limit_per_minute:
+            logger.warning(
+                "public_bound_key_rate_limit_exceeded",
+                key_id=key_id,
+                current=current_count,
+                limit=limit_per_minute,
+            )
+            raise RateLimitError(
+                message=(
+                    f"Public-bound API key rate limit exceeded: "
+                    f"{current_count}/{limit_per_minute} per minute"
+                ),
+                retry_after=60,
+            )
+        logger.debug(
+            "public_bound_key_rate_limit_checked",
+            key_id=key_id,
+            current=current_count,
+            limit=limit_per_minute,
+        )
+    except RateLimitError:
+        raise
+    except Exception as e:
+        logger.error("redis_bound_key_rate_limit_check_failed", error=str(e))
+
+
+async def _resolve_public_attribution(
+    api_key: str | None,
+    context_id: UUID,
+    db: AsyncSession,
+) -> VerifiedKey | None:
+    """Resolve an optional Bearer API key for public endpoint attribution.
+
+    Issue #626. Returns ``None`` for anonymous (no Authorization header) so
+    the caller falls through to the existing rate-limit bucket. Returns a
+    ``VerifiedKey`` for a valid public-bound key whose binding matches the
+    URL ``context_id``. Raises ``HTTPException`` directly for any failure
+    so the IDOR / authn / authz contract is enforced BEFORE the route
+    reads any context data.
+
+    Status codes (matches the route docstring's ``Errors:`` section):
+
+    - ``401`` for authentication failure (invalid / expired / revoked key).
+    - ``403`` for authorization failure (key authenticates but is owner /
+      workspace-scoped, or is bound to a different context).
+    """
+    if api_key is None:
+        return None
+
+    verified = await APIKeyManager(db).verify_key(api_key)
+    if verified is None:
+        # Authentication failure — invalid hash, revoked, or expired.
+        raise HTTPException(status_code=401, detail="Invalid or expired API key")
+
+    if verified.bound_context_id is None:
+        # Valid key (owner / workspace-scoped) without a public binding.
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "API key is not bound to a public context; "
+                "use a public-bound key or omit Authorization for anonymous access"
+            ),
+        )
+
+    if verified.bound_context_id != context_id:
+        # CWE-639 (IDOR) — key is bound to a different context than the URL
+        # asks for. 403 rather than 404 so we don't leak URL-context existence.
+        logger.warning(
+            "public_bound_key_scope_violation",
+            requested_context_id=str(context_id),
+            bound_context_id=str(verified.bound_context_id),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail="API key is bound to a different context (BOUND_SCOPE_VIOLATION)",
+        )
+
+    return verified
+
+
 # ============================================================================
 # Public Search Endpoint
 # ============================================================================
@@ -136,27 +255,34 @@ async def public_search(
     context_id: UUID,
     request: PublicSearchRequest,
     user: dict | None = Depends(get_current_user_optional),
+    api_key: str | None = Depends(get_api_key),
     db: AsyncSession = Depends(get_db),
 ):
     """Search public context with schema-aware response formatting.
 
     Issue #238: Public REST API for external systems (EC inventory, docs, etc.).
+    Issue #626: Optional API-key attribution via ``Authorization: Bearer
+    <kagura_…>``. A bound key gets a per-key rate-limit bucket and audit
+    attribution; an unbound key (owner / workspace-scoped) is rejected so
+    callers don't accidentally route their primary credentials through a
+    public path. Anonymous access continues to work without any header.
 
     Authentication:
         - Workspace member session (authenticated access, no rate limit)
-        - Anonymous access (rate limited to 50 req/min per context)
-
-    Note:
-        Public token-based authentication is planned for future implementation.
-        Currently, this endpoint supports both authenticated workspace member sessions
-        and anonymous access with rate limiting.
+        - Public-bound API key (#626) — per-key rate limit, audit-attributed
+        - Anonymous access (rate limited to 50 req/min per context, shared)
 
     Rate Limits:
-        - Anonymous access: 50 requests/minute per context
+        - Anonymous access: 50 requests/minute per context (shared bucket)
+        - Public-bound key: per-key bucket from workspace plan tier
+          (``bound_public_calls_per_minute``)
         - Workspace members: No limit (uses normal workspace quota)
 
     Request:
         POST /api/v1/public/{context_id}/search
+        Headers:
+            Authorization: Bearer kagura_…    (optional; required only for
+                                               attributed/bound-key access)
         Body:
         {
             "query": "商品名 価格",
@@ -184,11 +310,18 @@ async def public_search(
         }
 
     Errors:
-        - 403: Context is not public
+        - 401: API key supplied but invalid / expired
+        - 403: Context is not public, OR API key is not public-bound, OR
+               API key is bound to a different context (CWE-639 IDOR)
         - 404: Context not found
-        - 429: Rate limit exceeded (public access only)
+        - 429: Rate limit exceeded (anonymous or per-key bucket)
     """
     start_time = utcnow()
+
+    # 1. Resolve optional API-key attribution BEFORE reading context data,
+    # so a key bound to a different context cannot leak existence of the
+    # URL context via the response shape.
+    bound_key = await _resolve_public_attribution(api_key, context_id, db)
 
     logger.info(
         "public_search_request",
@@ -196,21 +329,30 @@ async def public_search(
         query=request.query,
         limit=request.limit,
         has_user=user is not None,
+        has_bound_key=bound_key is not None,
+        bound_key_id=bound_key.id if bound_key else None,
     )
 
-    # 1. Get context and verify it's public
+    # 2. Get context and verify it's public
     context = await db.get(Context, context_id)
     if not context:
         raise NotFoundException("Context", str(context_id))
 
     if context.is_public is not True:
+        # When the binding row points to a context that the owner has since
+        # flipped to is_public=false, we deny here exactly like anonymous —
+        # the binding row stays so the owner can re-enable, but access is
+        # blocked while the public flag is off.
         raise AuthorizationError("This context is not public")
 
     # SECURITY: For authenticated users, verify workspace boundary
     # Issue #268: Workspace boundary violation prevention
     # Authenticated users can only search public contexts in their own workspace
     # Anonymous users can search any public context (rate limited)
-    if user is not None:
+    # Public-bound keys (#626) are exempt — the binding itself IS the
+    # authorization, and the IDOR check above already ensured the key
+    # belongs to this exact context.
+    if user is not None and bound_key is None:
         current_workspace_id = user.get("current_workspace_id")
 
         # Authenticated user must have workspace selected
@@ -226,70 +368,79 @@ async def public_search(
                 detail="This public context belongs to a different workspace. Please switch workspaces or use anonymous access.",
             )
 
-    # 2. Check rate limit (skip for workspace members)
-    request_user_id: str | None = user.get("user_id") if user else None
-    await check_public_search_rate_limit(context_id, request_user_id)
+    # 3. Resolve workspace (used for rate-limit tier AND for the search
+    # owner_user_id below). One fetch covers both.
+    workspace = await db.get(Workspace, context.workspace_id)
+    if workspace is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Context workspace not found",
+        )
 
-    # 3. Perform search
+    # 4. Rate limit dispatch by principal type.
+    if bound_key is not None:
+        plan = get_plan_tier(workspace.plan_name or "free")
+        await check_bound_key_rate_limit(bound_key.id, plan.bound_public_calls_per_minute)
+    elif user is None:
+        # Anonymous shared bucket — existing behavior preserved.
+        await check_public_search_rate_limit(context_id, None)
+    # else: workspace member session → no rate limit (existing behavior).
+
+    # 5. Hoist usage-log attribution + caller id once so the success and
+    # error paths below share one definition.
+    log_user_id: str = (
+        str(bound_key.user_id)
+        if bound_key is not None
+        else str(user.get("user_id", "anonymous"))
+        if user
+        else "anonymous"
+    )
+    log_attribution = {
+        "context_id": str(context_id),
+        "workspace_id": str(context.workspace_id),
+        "api_key_id": bound_key.id if bound_key is not None else None,
+    }
+
     search_service = SearchService(db)
-
-    # For public search, use context owner's user_id for API key resolution
-    # Public contexts are searchable by anyone, but we need a user_id for embedding service
-    # Use context owner's user_id
     try:
-        # Get context owner's workspace
-        from models.auth import Workspace
-
-        workspace = await db.get(Workspace, context.workspace_id)
-        if not workspace:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Context workspace not found",
-            )
-
-        # Use workspace owner's user_id for search (for API key resolution)
+        # Workspace owner's user_id is used as the embedding-service caller so
+        # API-key resolution lands on the owner's keys, not the public caller.
         owner_id = workspace.owner_user_id
         search_user_id: str = str(owner_id) if owner_id is not None else "system"
 
-        # Single Collection Migration: Use workspace_id/context_id directly
-        # Perform hybrid search
+        # Reranking is permitted for workspace members (existing behavior) and
+        # for attributed bound-key callers (#626); anonymous traffic stays
+        # rerank-disabled to avoid exposing rerank cost to unbounded callers.
         results = await search_service.hybrid_search(
             query=request.query,
             user_id=search_user_id,
             workspace_id=str(context.workspace_id),
             context_id=str(context_id),
             k=request.limit,
-            use_rerank=request.use_rerank and user is not None,  # Rerank only for workspace members
+            use_rerank=request.use_rerank and (user is not None or bound_key is not None),
             search_mode=request.search_mode,
         )
 
-        # 4. Load schema for response formatting (if resource-backed).
         schema = (
             await get_latest_schema(db, context.workspace_id, context.resource_id)
             if context.resource_id is not None
             else None
         )
 
-        # 5. Format results with schema-aware metadata
-        formatted_results = []
-        for result in results:
-            payload = result.get("payload", {})
-            # Use summary as primary content, fallback to content field
-            content = payload.get("summary", payload.get("content", ""))
-
-            formatted_result = PublicSearchResult(
-                memory_id=str(result["id"]),  # Correct field name
-                content=content,
+        formatted_results = [
+            PublicSearchResult(
+                memory_id=str(result["id"]),
+                content=result.get("payload", {}).get(
+                    "summary", result.get("payload", {}).get("content", "")
+                ),
                 score=result["score"],
-                metadata=payload,  # Entire payload as metadata
+                metadata=result.get("payload", {}),
                 highlighted=None,  # TODO: Implement highlighting in future
             )
-            formatted_results.append(formatted_result)
+            for result in results
+        ]
 
-        # 6. Log usage
-        log_user_id: str = str(user.get("user_id", "anonymous")) if user else "anonymous"
         response_time_ms = int((utcnow() - start_time).total_seconds() * 1000)
-
         await log_usage(
             db=db,
             user_id=log_user_id,
@@ -297,6 +448,7 @@ async def public_search(
             method="POST",
             status_code=200,
             response_time_ms=response_time_ms,
+            **log_attribution,
         )
 
         logger.info(
@@ -322,17 +474,15 @@ async def public_search(
         )
 
     except Exception as e:
-        # Log failed usage
-        error_user_id: str = str(user.get("user_id", "anonymous")) if user else "anonymous"
         response_time_ms = int((utcnow() - start_time).total_seconds() * 1000)
-
         await log_usage(
             db=db,
-            user_id=error_user_id,
+            user_id=log_user_id,
             endpoint=f"/api/v1/public/{context_id}/search",
             method="POST",
             status_code=500,
             response_time_ms=response_time_ms,
+            **log_attribution,
         )
 
         logger.error(
@@ -354,6 +504,7 @@ async def public_search(
 @router.get("/{context_id}/info")
 async def get_public_context_info(
     context_id: UUID,
+    api_key: str | None = Depends(get_api_key),
     db: AsyncSession = Depends(get_db),
 ):
     """Get public context metadata and schema information.
@@ -363,17 +514,28 @@ async def get_public_context_info(
     - Resource schema (if resource-backed)
     - Statistics (memory count, last updated)
 
+    Issue #626: An optional ``Authorization: Bearer <api_key>`` is accepted
+    for symmetry with ``/search``. The same IDOR guard applies — a key
+    bound to a different context is rejected with 403 — but no rate limit
+    or audit attribution is applied here because ``/info`` returns only
+    static metadata (no memory contents).
+
     Args:
         context_id: Context UUID
+        api_key: Optional public-bound API key (Issue #626).
         db: Database session
 
     Returns:
         Public context metadata
 
     Errors:
-        - 403: Context is not public
+        - 401: API key supplied but invalid / expired
+        - 403: Context is not public, OR API key is bound to a different context
         - 404: Context not found
     """
+    # Issue #626: IDOR guard runs before context lookup (symmetry with /search).
+    await _resolve_public_attribution(api_key, context_id, db)
+
     # Get context
     context = await db.get(Context, context_id)
     if not context:

--- a/backend/src/auth/api_keys.py
+++ b/backend/src/auth/api_keys.py
@@ -158,7 +158,11 @@ class APIKeyManager:
         existing = result.scalar_one_or_none()
 
         if existing:
-            raise ValueError(f"API key with name '{name}' already exists in this workspace")
+            # The uniqueness query above scopes to workspace_id only when
+            # one is provided (#169 keys); for owner-scoped and public-bound
+            # keys it scopes to (user_id, active). Tail the message to match.
+            scope_phrase = "in this workspace" if workspace_id is not None else "for this user"
+            raise ValueError(f"API key with name '{name}' already exists {scope_phrase}")
 
         # Generate new key
         api_key = self._generate_key()

--- a/backend/src/auth/api_keys.py
+++ b/backend/src/auth/api_keys.py
@@ -31,9 +31,11 @@ class VerifiedKey(NamedTuple):
     Issue #626 — extended from a plain ``(user_id, workspace_id)`` 2-tuple
     so that public-bound keys (#626) and workspace-scoped keys (#169) can
     coexist without further breaking changes when more attribution shapes
-    appear. Adding a field is a non-breaking change for callers that read
-    by attribute name; positional unpacking remains backward-compatible
-    for the first two positions only.
+    appear. **Callers MUST use attribute access** (``result.user_id``,
+    ``result.workspace_id``) — positional unpacking like
+    ``user_id, workspace_id = verified`` will raise ``ValueError: too
+    many values to unpack`` against this 4-field tuple. All in-tree
+    callers were migrated to attribute access in this change.
 
     Attributes:
         id: ``api_keys.id`` integer primary key — surfaced here so the

--- a/backend/src/auth/api_keys.py
+++ b/backend/src/auth/api_keys.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 
 import secrets
 from datetime import timedelta
+from typing import NamedTuple
 from uuid import UUID
 
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.auth import APIKey
+from models.auth import APIKey, Context
 from utils.datetime import utcnow
 from utils.hashing import sha256_hex
 from utils.logger import get_logger
@@ -22,6 +23,33 @@ logger = get_logger(__name__)
 
 # API Key prefix for easy identification
 API_KEY_PREFIX = "kagura_"
+
+
+class VerifiedKey(NamedTuple):
+    """Result of a successful API key verification.
+
+    Issue #626 — extended from a plain ``(user_id, workspace_id)`` 2-tuple
+    so that public-bound keys (#626) and workspace-scoped keys (#169) can
+    coexist without further breaking changes when more attribution shapes
+    appear. Adding a field is a non-breaking change for callers that read
+    by attribute name; positional unpacking remains backward-compatible
+    for the first two positions only.
+
+    Attributes:
+        id: ``api_keys.id`` integer primary key — surfaced here so the
+            public endpoint can populate per-key rate-limit buckets and
+            ``usage_stats.api_key_id`` without a second SELECT.
+        user_id: Owner OAuth2 sub.
+        workspace_id: Workspace scope (Issue #169). None for global and
+            for public-bound keys (mutually exclusive with bound_context_id).
+        bound_context_id: Public-context attribution (Issue #626). None
+            unless the key was created with a binding.
+    """
+
+    id: int
+    user_id: str
+    workspace_id: UUID | None
+    bound_context_id: UUID | None
 
 
 class APIKeyManager:
@@ -59,11 +87,16 @@ class APIKeyManager:
         user_id: str,
         expires_days: int | None = None,
         workspace_id: UUID | None = None,
+        bound_context_id: UUID | None = None,
         auto_hide_minutes: int = 10,
-    ) -> str:
+    ) -> tuple[str, APIKey]:
         """Create a new API key.
 
         Issue #169: Workspace-scoped API keys (access all contexts in workspace).
+        Issue #626: Public-bound API keys (attributed to one is_public=true context).
+            Returning the freshly-flushed ``APIKey`` row alongside the plaintext
+            saves callers a second SELECT just to read back ``id`` / ``created_at``
+            for the one-time-reveal response.
         Migration 034: Added auto_hide for visibility control (Zero-knowledge model).
         Migration 034: Removed context_id parameter (deprecated).
 
@@ -71,15 +104,45 @@ class APIKeyManager:
             name: Friendly name for the key
             user_id: User ID that owns this key
             expires_days: Optional expiration in days
-            workspace_id: Optional workspace ID for workspace-scoped access (Issue #169)
+            workspace_id: Optional workspace ID for workspace-scoped access (Issue #169).
+                Mutually exclusive with ``bound_context_id``.
+            bound_context_id: Optional context ID for public-bound attribution
+                (Issue #626). The context must satisfy ``is_public=True`` at
+                creation time. Mutually exclusive with ``workspace_id``.
             auto_hide_minutes: Minutes until key is auto-hidden (default: 10)
 
         Returns:
-            Plaintext API key (only shown once)
+            ``(plaintext_key, new_api_key_row)`` — the plaintext is only ever
+            available in this return value (encrypted-at-rest beyond that);
+            the row carries the assigned ``id`` and ``created_at``.
 
         Raises:
-            ValueError: If name already exists for user
+            ValueError: If name already exists for user, if both scoping
+                params are supplied, or if the bound context is not public.
         """
+        if workspace_id is not None and bound_context_id is not None:
+            raise ValueError(
+                "workspace_id and bound_context_id are mutually exclusive — "
+                "a key cannot be both workspace-scoped and public-bound"
+            )
+
+        # Validate the bound context exists and is public at creation time.
+        # Subsequent flips of context.is_public are handled at request time
+        # by the public endpoint (the binding row stays; access is denied
+        # while is_public is false).
+        if bound_context_id is not None:
+            ctx_result = await self.db.execute(
+                select(Context).where(Context.id == bound_context_id)
+            )
+            ctx = ctx_result.scalar_one_or_none()
+            if ctx is None:
+                raise ValueError(f"Context {bound_context_id} not found")
+            if ctx.is_public is not True:
+                raise ValueError(
+                    "Cannot bind API key to a non-public context — "
+                    "set is_public=true on the context first"
+                )
+
         # Check if name already exists in current workspace (Issue #169)
         conditions = [
             APIKey.name == name,
@@ -120,6 +183,7 @@ class APIKeyManager:
             name=name,
             user_id=user_id,
             workspace_id=workspace_id,  # Issue #169
+            bound_context_id=bound_context_id,  # Issue #626
             expires_at=expires_at,
             visibility_expires_at=visibility_expires_at,  # Migration 034
             plaintext_encrypted=plaintext_encrypted,  # Migration 035
@@ -133,23 +197,29 @@ class APIKeyManager:
             name=name,
             user_id=user_id,
             workspace_id=str(workspace_id) if workspace_id else None,
+            bound_context_id=str(bound_context_id) if bound_context_id else None,
         )
 
-        return api_key
+        return api_key, new_key
 
-    async def verify_key(self, api_key: str) -> tuple[str, UUID | None] | None:
-        """Verify API key and return (user_id, workspace_id).
+    async def verify_key(self, api_key: str) -> VerifiedKey | None:
+        """Verify API key and return a ``VerifiedKey`` view.
 
         Issue #169: Returns workspace_id for workspace-scoped API keys.
+        Issue #626: Returns bound_context_id for public-bound API keys.
         Migration 034: Removed context_id (deprecated).
 
         Args:
             api_key: Plaintext API key to verify
 
         Returns:
-            (user_id, workspace_id) tuple if valid, None otherwise.
-            - For workspace-scoped keys: workspace_id=<UUID>
-            - For global keys: workspace_id=None
+            ``VerifiedKey`` if valid, None if not found / revoked / expired.
+
+            - Owner-scoped (global) keys: workspace_id=None, bound_context_id=None
+            - Workspace-scoped keys (#169): workspace_id=<UUID>, bound_context_id=None
+            - Public-bound keys (#626): workspace_id=None, bound_context_id=<UUID>
+
+            The two non-null scopings are mutually exclusive (DB CHECK constraint).
         """
         key_hash = self._hash_key(api_key)
 
@@ -172,7 +242,12 @@ class APIKeyManager:
         key_record.last_used_at = utcnow()
         await self.db.flush()
 
-        return (key_record.user_id, key_record.workspace_id)
+        return VerifiedKey(
+            id=key_record.id,
+            user_id=key_record.user_id,
+            workspace_id=key_record.workspace_id,
+            bound_context_id=key_record.bound_context_id,
+        )
 
     async def list_keys(
         self,

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -160,23 +160,38 @@ async def verify_api_key(api_key: str) -> VerifiedKey | None:
     """Verify API key and return a ``VerifiedKey`` view.
 
     Issue #169: ``workspace_id`` for workspace-scoped API keys.
-    Issue #626: ``bound_context_id`` for public-bound API keys.
+    Issue #626: ``bound_context_id`` for public-bound API keys (REJECTED
+    here — see below).
     Migration 034: Removed context_id (deprecated).
 
     Standalone function for MCP authentication (non-FastAPI context).
     This function does not use FastAPI dependencies, making it suitable
     for use in MCP server authentication flows.
 
+    **Public-bound key rejection (#626)**: A key with
+    ``bound_context_id != None`` is intended ONLY for the REST public
+    endpoint (`/api/v1/public/{ctx}/*` via ``_resolve_public_attribution``)
+    and MUST NOT authenticate any other surface. Returning ``None`` here
+    treats such a key as "not authenticated" for MCP and any other
+    consumer of this standalone function — preventing a public-bound
+    key from being repurposed as a full-account API key (which would be
+    a privilege escalation: the bound key carries the owner's
+    workspace_id implicitly via the row, and downstream principal
+    construction would otherwise grant it). The public endpoint reaches
+    ``APIKeyManager.verify_key`` directly (not through this wrapper)
+    and bypasses this guard.
+
     Args:
         api_key: API key to verify (e.g., "kagura_...")
 
     Returns:
-        ``VerifiedKey`` if valid, None if invalid/revoked/expired.
+        ``VerifiedKey`` if valid AND not public-bound; ``None`` if
+        invalid/revoked/expired OR if the key is public-bound (#626).
 
     Example:
         result = await verify_api_key("kagura_1234567890abcdef...")
         if result:
-            # API key is valid
+            # API key is valid and not public-bound
             user_id = result.user_id
             ...
     """
@@ -186,7 +201,19 @@ async def verify_api_key(api_key: str) -> VerifiedKey | None:
     try:
         async for db in get_db():
             manager = APIKeyManager(db)
-            return await manager.verify_key(api_key)
+            verified = await manager.verify_key(api_key)
+            if verified is None:
+                return None
+            if verified.bound_context_id is not None:
+                # Public-bound key (#626) — reject from non-public surfaces.
+                # The public endpoint calls APIKeyManager.verify_key directly
+                # (not this wrapper) and is unaffected.
+                logger.warning(
+                    "public_bound_key_rejected_outside_public_endpoint",
+                    bound_context_id=str(verified.bound_context_id),
+                )
+                return None
+            return verified
     except Exception:
         # Silent failure - return None on any error
         return None
@@ -197,20 +224,25 @@ async def _build_api_key_user_dict(
     user_id: str,
     api_key_workspace_id: UUID | None,
     db: AsyncSession,
-    bound_context_id: UUID | None = None,
 ) -> dict:
     """Build user info dict from verified API key data.
 
     Shared by verify_api_key_user and get_user_from_api_key_or_session.
 
+    Note (Issue #626): callers MUST reject public-bound keys
+    (``VerifiedKey.bound_context_id is not None``) BEFORE invoking this
+    helper. A public-bound key reaching this function would silently
+    inherit the owner's ``current_workspace_id`` via
+    ``_get_user_workspace_id``, granting the bound key full account
+    access — a privilege escalation. The dependency wrappers above
+    (``verify_api_key_user`` / ``get_user_from_api_key_or_session``)
+    enforce this gate; the standalone ``verify_api_key`` returns ``None``
+    for bound keys so MCP gets the same effective rejection.
+
     Args:
         user_id: Authenticated user ID
         api_key_workspace_id: Workspace UUID from API key scope (None for global keys)
         db: Database session
-        bound_context_id: Issue #626 — public-context attribution (None
-            unless the key was created with a binding). Surfaced in the
-            principal dict so the public read endpoint can enforce the
-            CWE-639 (IDOR) match without re-querying the api_keys table.
 
     Returns:
         User info dict compatible with get_current_user format
@@ -224,7 +256,6 @@ async def _build_api_key_user_dict(
         "api_key_authenticated",
         user_id=user_id,
         workspace_id=str(current_workspace_id) if current_workspace_id else None,
-        bound_context_id=str(bound_context_id) if bound_context_id else None,
     )
 
     return {
@@ -234,7 +265,6 @@ async def _build_api_key_user_dict(
         "current_context_id": None,  # Issue #246: always None, must be explicit
         "current_workspace_id": current_workspace_id,
         "api_key_workspace_id": api_key_workspace_id,
-        "bound_context_id": bound_context_id,  # Issue #626
     }
 
 
@@ -261,9 +291,24 @@ async def verify_api_key_user(
         logger.warning("invalid_api_key_attempt", key_prefix=api_key[:16] if api_key else None)
         raise HTTPException(status_code=401, detail="Invalid or expired API key")
 
-    return await _build_api_key_user_dict(
-        result.user_id, result.workspace_id, db, result.bound_context_id
-    )
+    # Issue #626: public-bound keys MUST NOT authenticate outside the
+    # /api/v1/public/* attribution flow. Without this gate, a bound key
+    # would inherit the owner's workspace_id via _build_api_key_user_dict
+    # and grant full account access — privilege escalation.
+    if result.bound_context_id is not None:
+        logger.warning(
+            "public_bound_key_rejected_outside_public_endpoint",
+            bound_context_id=str(result.bound_context_id),
+        )
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "Public-bound API keys cannot authenticate here; "
+                "they are only valid on /api/v1/public/{context_id}/* endpoints"
+            ),
+        )
+
+    return await _build_api_key_user_dict(result.user_id, result.workspace_id, db)
 
 
 async def require_session_auth(
@@ -361,9 +406,22 @@ async def get_user_from_api_key_or_session(
         result = await manager.verify_key(api_key)
 
         if result:
-            return await _build_api_key_user_dict(
-                result.user_id, result.workspace_id, db, result.bound_context_id
-            )
+            # Issue #626: reject public-bound keys here too — same rationale
+            # as verify_api_key_user above. The public endpoint reaches
+            # APIKeyManager.verify_key directly and bypasses this gate.
+            if result.bound_context_id is not None:
+                logger.warning(
+                    "public_bound_key_rejected_outside_public_endpoint",
+                    bound_context_id=str(result.bound_context_id),
+                )
+                raise HTTPException(
+                    status_code=403,
+                    detail=(
+                        "Public-bound API keys cannot authenticate here; "
+                        "they are only valid on /api/v1/public/{context_id}/* endpoints"
+                    ),
+                )
+            return await _build_api_key_user_dict(result.user_id, result.workspace_id, db)
 
         logger.warning("invalid_api_key_attempt", key_prefix=api_key[:16])
         raise HTTPException(status_code=401, detail="Invalid or expired API key")

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -11,6 +11,7 @@ from fastapi import Depends, Header, HTTPException, Request
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.api_keys import VerifiedKey
 from db.base import get_db
 from models.auth import User
 from utils.exceptions import AuthorizationError
@@ -155,10 +156,11 @@ async def get_api_key(authorization: str | None = Header(None)) -> str | None:
     return authorization[7:]  # Remove "Bearer " prefix
 
 
-async def verify_api_key(api_key: str) -> tuple[str, UUID | None] | None:
-    """Verify API key and return (user_id, workspace_id).
+async def verify_api_key(api_key: str) -> VerifiedKey | None:
+    """Verify API key and return a ``VerifiedKey`` view.
 
-    Issue #169: Returns workspace_id for workspace-scoped API keys.
+    Issue #169: ``workspace_id`` for workspace-scoped API keys.
+    Issue #626: ``bound_context_id`` for public-bound API keys.
     Migration 034: Removed context_id (deprecated).
 
     Standalone function for MCP authentication (non-FastAPI context).
@@ -169,15 +171,13 @@ async def verify_api_key(api_key: str) -> tuple[str, UUID | None] | None:
         api_key: API key to verify (e.g., "kagura_...")
 
     Returns:
-        (user_id, workspace_id) tuple if valid, None if invalid/revoked/expired.
-        - For workspace-scoped keys: workspace_id=<UUID>
-        - For global keys: workspace_id=None
+        ``VerifiedKey`` if valid, None if invalid/revoked/expired.
 
     Example:
         result = await verify_api_key("kagura_1234567890abcdef...")
         if result:
-            user_id, workspace_id = result
             # API key is valid
+            user_id = result.user_id
             ...
     """
     from auth.api_keys import APIKeyManager
@@ -186,17 +186,18 @@ async def verify_api_key(api_key: str) -> tuple[str, UUID | None] | None:
     try:
         async for db in get_db():
             manager = APIKeyManager(db)
-            result = await manager.verify_key(api_key)  # Returns 3-tuple
-            return result
+            return await manager.verify_key(api_key)
     except Exception:
         # Silent failure - return None on any error
         return None
+    return None
 
 
 async def _build_api_key_user_dict(
     user_id: str,
     api_key_workspace_id: UUID | None,
     db: AsyncSession,
+    bound_context_id: UUID | None = None,
 ) -> dict:
     """Build user info dict from verified API key data.
 
@@ -206,6 +207,10 @@ async def _build_api_key_user_dict(
         user_id: Authenticated user ID
         api_key_workspace_id: Workspace UUID from API key scope (None for global keys)
         db: Database session
+        bound_context_id: Issue #626 — public-context attribution (None
+            unless the key was created with a binding). Surfaced in the
+            principal dict so the public read endpoint can enforce the
+            CWE-639 (IDOR) match without re-querying the api_keys table.
 
     Returns:
         User info dict compatible with get_current_user format
@@ -218,7 +223,8 @@ async def _build_api_key_user_dict(
     logger.info(
         "api_key_authenticated",
         user_id=user_id,
-        workspace_id=str(current_workspace_id),
+        workspace_id=str(current_workspace_id) if current_workspace_id else None,
+        bound_context_id=str(bound_context_id) if bound_context_id else None,
     )
 
     return {
@@ -228,6 +234,7 @@ async def _build_api_key_user_dict(
         "current_context_id": None,  # Issue #246: always None, must be explicit
         "current_workspace_id": current_workspace_id,
         "api_key_workspace_id": api_key_workspace_id,
+        "bound_context_id": bound_context_id,  # Issue #626
     }
 
 
@@ -254,8 +261,9 @@ async def verify_api_key_user(
         logger.warning("invalid_api_key_attempt", key_prefix=api_key[:16] if api_key else None)
         raise HTTPException(status_code=401, detail="Invalid or expired API key")
 
-    user_id, api_key_workspace_id = result
-    return await _build_api_key_user_dict(user_id, api_key_workspace_id, db)
+    return await _build_api_key_user_dict(
+        result.user_id, result.workspace_id, db, result.bound_context_id
+    )
 
 
 async def require_session_auth(
@@ -353,8 +361,9 @@ async def get_user_from_api_key_or_session(
         result = await manager.verify_key(api_key)
 
         if result:
-            user_id, api_key_workspace_id = result
-            return await _build_api_key_user_dict(user_id, api_key_workspace_id, db)
+            return await _build_api_key_user_dict(
+                result.user_id, result.workspace_id, db, result.bound_context_id
+            )
 
         logger.warning("invalid_api_key_attempt", key_prefix=api_key[:16])
         raise HTTPException(status_code=401, detail="Invalid or expired API key")

--- a/backend/src/config/plan_tiers.py
+++ b/backend/src/config/plan_tiers.py
@@ -47,6 +47,11 @@ class PlanTier:
         rest_calls_per_week: REST API calls per week (Issue #238)
         public_calls_per_day: Public REST API calls per day (Issue #238)
         public_calls_per_week: Public REST API calls per week (Issue #238)
+        bound_public_calls_per_minute: Per-minute quota for each public-bound
+            API key (Issue #626). Anonymous public access keeps its existing
+            shared 50/min/context bucket; bound keys get their own per-key
+            bucket sized by this field. 0 disables bound-key creation for
+            the plan.
         allows_shared_contexts: Whether plan allows shared (non-private) contexts (Issue #271)
         features: Set of enabled features
     """
@@ -66,6 +71,7 @@ class PlanTier:
     rest_calls_per_week: int = 0  # Issue #238: REST API quota
     public_calls_per_day: int = 0  # Issue #238: Public REST API quota
     public_calls_per_week: int = 0  # Issue #238: Public REST API quota
+    bound_public_calls_per_minute: int = 0  # Issue #626: per-key bucket for bound public keys
     analysis_runs_per_day: int = 0  # Issue #494: Memory Broadlistening analyses/day
     storage_limit_bytes: int = 0  # Issue #485: File-storage hard cap per workspace
     sleep_enabled_contexts_limit: int = 0  # Issue #560: Sleep-mode contexts cap (PRO-only)
@@ -136,6 +142,7 @@ PLAN_PRO = PlanTier(
     rest_calls_per_week=25000,
     public_calls_per_day=1000,
     public_calls_per_week=5000,
+    bound_public_calls_per_minute=100,  # Issue #626: per-key bucket (PRO only)
     analysis_runs_per_day=3,  # Issue #494: Memory Broadlistening (Pro only; FREE/BASIC=0)
     storage_limit_bytes=10 * 1024 * 1024 * 1024,  # Issue #485: 10 GiB
     sleep_enabled_contexts_limit=3,  # Issue #560: Sleep mode (Pro only; FREE/BASIC=0)

--- a/backend/src/mcp_server/auth.py
+++ b/backend/src/mcp_server/auth.py
@@ -105,22 +105,28 @@ async def _verify_api_key(api_key: str) -> tuple[str, "UUID | None", "UUID | Non
     """Verify API key.
 
     Migration 034: verify_api_key() returned a 2-tuple of (user_id, workspace_id).
-    Issue #626: verify_api_key() now returns ``VerifiedKey`` — we read attributes
+    Issue #626: verify_api_key() now returns ``VerifiedKey``; we read attributes
     by name. The MCP auth surface remains a 3-tuple ``(user_id, context_id,
     workspace_id)`` for backward compatibility with MCP tool args (Issue #245).
-    ``bound_context_id`` is intentionally **ignored** in the MCP auth path: MCP
-    does not currently expose any public-bound-key-aware tools, so a request
-    that arrives with a #626 bound key reaches MCP as a generic owner-scoped
-    request (workspace_id from the row, context_id=None as required by Issue
-    #245). Public-bound key attribution lives entirely on the REST public
-    endpoint (`/api/v1/public/{ctx}/*`). Read-only MCP introspection of
-    bindings is tracked as a follow-up.
+
+    **Public-bound key rejection (#626)**: ``auth.dependencies.verify_api_key``
+    (the standalone wrapper called below) returns ``None`` for any key with
+    ``bound_context_id != None``. That treats a public-bound key as
+    "invalid" on the MCP surface — preventing the privilege escalation
+    where a key intended for one public context would otherwise inherit
+    the owner's workspace_id and grant full account access on MCP tools.
+    Bound keys are only honored on the REST public endpoint
+    (``/api/v1/public/{ctx}/*`` via
+    ``api.routes.public_search._resolve_public_attribution``, which
+    reaches ``APIKeyManager.verify_key`` directly and bypasses this
+    wrapper). MCP introspection of bindings is a separate follow-up.
 
     Args:
         api_key: API key value
 
     Returns:
-        (user_id, context_id, workspace_id) tuple if key is valid, None otherwise.
+        (user_id, context_id, workspace_id) tuple if key is valid AND not
+        public-bound; None otherwise (invalid / revoked / expired / bound).
         - context_id is always None (now required in tool arguments)
         - workspace_id is from the API key scope (workspace-scoped keys)
     """

--- a/backend/src/mcp_server/auth.py
+++ b/backend/src/mcp_server/auth.py
@@ -108,9 +108,13 @@ async def _verify_api_key(api_key: str) -> tuple[str, "UUID | None", "UUID | Non
     Issue #626: verify_api_key() now returns ``VerifiedKey`` — we read attributes
     by name. The MCP auth surface remains a 3-tuple ``(user_id, context_id,
     workspace_id)`` for backward compatibility with MCP tool args (Issue #245).
-    ``bound_context_id`` is **not** propagated into the MCP context_id slot:
-    MCP read tools enforce binding separately in ``list_my_bindings`` /
-    ``describe_binding`` rather than re-using the principal's MCP context_id.
+    ``bound_context_id`` is intentionally **ignored** in the MCP auth path: MCP
+    does not currently expose any public-bound-key-aware tools, so a request
+    that arrives with a #626 bound key reaches MCP as a generic owner-scoped
+    request (workspace_id from the row, context_id=None as required by Issue
+    #245). Public-bound key attribution lives entirely on the REST public
+    endpoint (`/api/v1/public/{ctx}/*`). Read-only MCP introspection of
+    bindings is tracked as a follow-up.
 
     Args:
         api_key: API key value

--- a/backend/src/mcp_server/auth.py
+++ b/backend/src/mcp_server/auth.py
@@ -104,8 +104,13 @@ async def authenticate_mcp_request(
 async def _verify_api_key(api_key: str) -> tuple[str, "UUID | None", "UUID | None"] | None:
     """Verify API key.
 
-    Migration 034: verify_api_key() returns (user_id, workspace_id) 2-tuple.
-    Issue #245: context_id is now required in tool args, not from auth.
+    Migration 034: verify_api_key() returned a 2-tuple of (user_id, workspace_id).
+    Issue #626: verify_api_key() now returns ``VerifiedKey`` — we read attributes
+    by name. The MCP auth surface remains a 3-tuple ``(user_id, context_id,
+    workspace_id)`` for backward compatibility with MCP tool args (Issue #245).
+    ``bound_context_id`` is **not** propagated into the MCP context_id slot:
+    MCP read tools enforce binding separately in ``list_my_bindings`` /
+    ``describe_binding`` rather than re-using the principal's MCP context_id.
 
     Args:
         api_key: API key value
@@ -121,7 +126,8 @@ async def _verify_api_key(api_key: str) -> tuple[str, "UUID | None", "UUID | Non
         result = await verify_api_key(api_key)
 
         if result:
-            user_id, workspace_id = result
+            user_id = result.user_id
+            workspace_id = result.workspace_id
             context_id = None  # Issue #245: context_id is now in tool args
             logger.debug(f"API key valid: user={user_id}, workspace={workspace_id}")
             return (user_id, context_id, workspace_id)

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -235,6 +235,15 @@ class APIKey(Base):
         index=True,
     )
 
+    # Issue #626: Public-bound API key — attribution to one is_public=true
+    # context for per-key rate-limit, audit, and revoke. Mutually exclusive
+    # with workspace_id (CHECK constraint at the DB level).
+    bound_context_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()
@@ -255,6 +264,11 @@ class APIKey(Base):
         Index("idx_user_name", "user_id", "name"),
         Index("idx_revoked", "revoked_at"),
         Index("idx_expires", "expires_at"),
+        Index("idx_api_keys_bound_context_id", "bound_context_id"),
+        CheckConstraint(
+            "bound_context_id IS NULL OR workspace_id IS NULL",
+            name="ck_api_keys_binding_workspace_exclusion",
+        ),
     )
 
     def __repr__(self) -> str:
@@ -1050,6 +1064,11 @@ class UsageStats(Base):
         UUID(as_uuid=True), nullable=True
     )  # Deprecated, kept for backward compatibility
 
+    # Issue #626: Soft reference to api_keys.id for per-key attribution on
+    # public endpoints. Not an FK — attribution rows must survive key
+    # deletion so billing/audit reports stay readable.
+    api_key_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     __table_args__ = (
         Index("idx_usage_stats_user_date", "user_id", "date"),
         Index("idx_usage_stats_user_endpoint", "user_id", "endpoint", "date"),
@@ -1057,6 +1076,7 @@ class UsageStats(Base):
         Index("idx_usage_stats_context_date", "context_id", "date"),
         Index("idx_usage_stats_workspace_date", "workspace_id", "date"),
         Index("idx_usage_stats_project_date", "project_id", "date"),
+        Index("idx_usage_stats_api_key_id", "api_key_id"),
     )
 
 

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -954,6 +954,7 @@ class MemberAPIKeyResponse(BaseModel):
     """Response for member's API key (Zero-knowledge model).
 
     Migration 034: Member-scoped credentials.
+    Issue #626: Optional public-context binding.
     """
 
     id: int
@@ -964,6 +965,7 @@ class MemberAPIKeyResponse(BaseModel):
     visibility_expires_at: str | None
     created_at: str
     revoked_at: str | None
+    bound_context_id: str | None = None  # Issue #626: public attribution
 
 
 class MemberOAuthAppResponse(BaseModel):
@@ -994,10 +996,18 @@ class MemberCredentialsResponse(BaseModel):
 
 
 class CreateAPIKeyRequest(BaseModel):
-    """Request for creating a new API key."""
+    """Request for creating a new API key.
+
+    Issue #626: ``bound_context_id`` makes this a public-bound key that is
+    attributed to one ``is_public=true`` context (immutable binding —
+    revoke and re-create to change). Mutually exclusive with the
+    workspace-scoping derived from the URL: when supplied, the key is
+    stored with ``workspace_id=NULL``.
+    """
 
     name: str
     auto_hide_minutes: int = 10  # Auto-hide after 10 minutes (default)
+    bound_context_id: str | None = None  # Issue #626
 
 
 class RegenerateAPIKeyResponse(BaseModel):

--- a/backend/src/services/member_credentials_service.py
+++ b/backend/src/services/member_credentials_service.py
@@ -11,7 +11,7 @@ Implements:
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import and_, delete, select, update
+from sqlalchemy import and_, delete, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import (
@@ -164,13 +164,27 @@ class MemberCredentialsService:
         # Permission check: Can view credentials?
         await self._check_can_view(requester_id, workspace_id, user_id)
 
-        # Get ALL api keys for user + workspace
+        # Get ALL api keys for user + workspace.
+        # Issue #626: public-bound keys have ``workspace_id=NULL`` (mutually
+        # exclusive with the #169 workspace scoping). To surface them in the
+        # credentials UI for the workspace where their bound context lives,
+        # OR in via the ``bound_context_id``'s workspace. Without this OR,
+        # public-bound keys are invisible to ``get_or_create_credentials``
+        # and the entire #626 frontend flow (binding badge, per-id revoke,
+        # one-time-reveal of plaintext) renders nothing.
+        from models.auth import Context as _Context
+
         result = await self.db.execute(
             select(APIKey)
             .where(
                 and_(
                     APIKey.user_id == user_id,
-                    APIKey.workspace_id == workspace_id,
+                    or_(
+                        APIKey.workspace_id == workspace_id,
+                        APIKey.bound_context_id.in_(
+                            select(_Context.id).where(_Context.workspace_id == workspace_id)
+                        ),
+                    ),
                     APIKey.revoked_at.is_(None),
                 )
             )

--- a/backend/src/services/member_credentials_service.py
+++ b/backend/src/services/member_credentials_service.py
@@ -658,4 +658,7 @@ class MemberCredentialsService:
             "visibility_expires_at": to_utc_iso(api_key.visibility_expires_at),
             "created_at": to_utc_iso(api_key.created_at),
             "revoked_at": to_utc_iso(api_key.revoked_at),
+            "bound_context_id": (
+                str(api_key.bound_context_id) if api_key.bound_context_id else None
+            ),
         }

--- a/backend/src/utils/usage_logger.py
+++ b/backend/src/utils/usage_logger.py
@@ -23,6 +23,7 @@ async def log_usage(
     response_time_ms: int | None = None,
     context_id: str | None = None,  # Bugfix: Add context_id for stats tracking
     workspace_id: str | None = None,  # Bugfix: Add workspace_id for stats tracking
+    api_key_id: int | None = None,  # Issue #626: per-key attribution
 ) -> None:
     """Log API or MCP tool usage to usage_stats table.
 
@@ -39,6 +40,9 @@ async def log_usage(
         response_time_ms: Response time in milliseconds (optional)
         context_id: Context UUID (optional, for context-specific stats)
         workspace_id: Workspace UUID (optional, for workspace-specific stats)
+        api_key_id: API key integer ID (Issue #626). Set on public endpoint
+            access attributed to a public-bound key. Soft reference — survives
+            key deletion.
 
     Example usage:
         # HTTP API (from middleware)
@@ -62,6 +66,7 @@ async def log_usage(
                 date=now.date(),
                 context_id=context_id,  # Bugfix: Add context_id
                 workspace_id=workspace_id,  # Bugfix: Add workspace_id
+                api_key_id=api_key_id,  # Issue #626
             )
         )
         await db.commit()

--- a/backend/tests/auth/test_api_key_binding.py
+++ b/backend/tests/auth/test_api_key_binding.py
@@ -1,0 +1,138 @@
+"""Unit tests for `APIKeyManager.create_key` public-bound validation (#626).
+
+Covers the validation gates added in #626:
+
+1. Mutual exclusion: ``workspace_id`` and ``bound_context_id`` together → ValueError.
+2. Non-existent context: ``bound_context_id`` referencing a missing context → ValueError.
+3. Non-public context: ``bound_context_id`` of an ``is_public=False`` context → ValueError.
+4. Happy path: valid public context produces ``VerifiedKey`` with ``bound_context_id`` set.
+
+These are unit tests with mocked ``AsyncSession`` — they exercise only the
+``APIKeyManager`` logic without touching a real database. The DB-level CHECK
+constraint is covered by ``tests/integration/test_e10_626_apikey_bound_context_id_migration.py``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from auth.api_keys import APIKeyManager
+
+
+def _execute_result(value: object | None = None):
+    """Build a MagicMock that mimics ``await db.execute(stmt)`` result.
+
+    ``.scalar_one_or_none()`` returns ``value``. This avoids depending on
+    MagicMock's auto-attribute behavior, which would silently return a
+    fresh MagicMock and could mask future refactors.
+    """
+    result = MagicMock()
+    result.scalar_one_or_none = MagicMock(return_value=value)
+    return result
+
+
+def _make_db_mock(execute_results: list[object | None]) -> AsyncMock:
+    """Build an AsyncMock DB that returns the given results in order."""
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[_execute_result(r) for r in execute_results])
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    return db
+
+
+def _public_context_row():
+    """Mock row for an ``is_public=True`` Context."""
+    ctx = MagicMock()
+    ctx.id = uuid.uuid4()
+    ctx.is_public = True
+    return ctx
+
+
+def _private_context_row():
+    """Mock row for an ``is_public=False`` Context."""
+    ctx = MagicMock()
+    ctx.id = uuid.uuid4()
+    ctx.is_public = False
+    return ctx
+
+
+class TestCreateKeyBoundContextValidation:
+    """Validation rules around ``create_key(..., bound_context_id=...)``."""
+
+    @pytest.mark.asyncio
+    async def test_workspace_id_and_bound_context_id_both_set_raises(self) -> None:
+        """Both scoping params at once → ValueError before any DB work."""
+        db = AsyncMock()  # No execute calls expected — validator runs first.
+        manager = APIKeyManager(db)
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await manager.create_key(
+                name="bad-key",
+                user_id="user-1",
+                workspace_id=uuid.uuid4(),
+                bound_context_id=uuid.uuid4(),
+            )
+
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bound_context_not_found_raises(self) -> None:
+        """``bound_context_id`` referencing missing context → ValueError."""
+        # The context lookup returns None (first execute call).
+        db = _make_db_mock(execute_results=[None])
+        manager = APIKeyManager(db)
+
+        with pytest.raises(ValueError, match="not found"):
+            await manager.create_key(
+                name="missing-ctx",
+                user_id="user-1",
+                bound_context_id=uuid.uuid4(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_bound_context_not_public_raises(self) -> None:
+        """``bound_context_id`` of a private context → ValueError, no key created."""
+        db = _make_db_mock(execute_results=[_private_context_row()])
+        manager = APIKeyManager(db)
+
+        with pytest.raises(ValueError, match="non-public"):
+            await manager.create_key(
+                name="priv-ctx",
+                user_id="user-1",
+                bound_context_id=uuid.uuid4(),
+            )
+
+        # Validator runs BEFORE the name-uniqueness query, so only one
+        # execute should have fired (the context lookup).
+        assert db.execute.call_count == 1
+        db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_bound_context_id_set_workspace_id_none_succeeds(self) -> None:
+        """Happy path: bound key with valid public context creates a row."""
+        ctx = _public_context_row()
+        # Execute sequence:
+        #   1. Context lookup → returns the public ctx row
+        #   2. Name-uniqueness check → returns None (no collision)
+        db = _make_db_mock(execute_results=[ctx, None])
+        manager = APIKeyManager(db)
+
+        plaintext, returned_key = await manager.create_key(
+            name="bound-ok",
+            user_id="user-1",
+            bound_context_id=ctx.id,
+        )
+
+        # Returns a (plaintext, APIKey) tuple — the plaintext is kagura_…
+        # and the row carries the binding.
+        assert isinstance(plaintext, str)
+        assert plaintext.startswith("kagura_")
+        assert returned_key.bound_context_id == ctx.id
+        assert returned_key.workspace_id is None
+        # ``returned_key`` is the same row that was added to the session.
+        db.add.assert_called_once()
+        added_key = db.add.call_args.args[0]
+        assert added_key is returned_key

--- a/backend/tests/auth/test_api_key_binding.py
+++ b/backend/tests/auth/test_api_key_binding.py
@@ -15,7 +15,7 @@ constraint is covered by ``tests/integration/test_e10_626_apikey_bound_context_i
 from __future__ import annotations
 
 import uuid
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -112,7 +112,15 @@ class TestCreateKeyBoundContextValidation:
 
     @pytest.mark.asyncio
     async def test_bound_context_id_set_workspace_id_none_succeeds(self) -> None:
-        """Happy path: bound key with valid public context creates a row."""
+        """Happy path: bound key with valid public context creates a row.
+
+        Patches ``utils.encryption.get_encryptor`` because ``create_key``
+        encrypts the plaintext-for-reveal at-rest via Fernet, and the
+        global encryptor reads ``API_KEY_SECRET`` from the environment.
+        Setting that env var in unit tests would leak production-shaped
+        config into CI; mocking the encryptor keeps this test a true
+        validation-layer unit test.
+        """
         ctx = _public_context_row()
         # Execute sequence:
         #   1. Context lookup → returns the public ctx row
@@ -120,11 +128,14 @@ class TestCreateKeyBoundContextValidation:
         db = _make_db_mock(execute_results=[ctx, None])
         manager = APIKeyManager(db)
 
-        plaintext, returned_key = await manager.create_key(
-            name="bound-ok",
-            user_id="user-1",
-            bound_context_id=ctx.id,
-        )
+        mock_encryptor = MagicMock()
+        mock_encryptor.encrypt = MagicMock(return_value="encrypted-blob")
+        with patch("utils.encryption.get_encryptor", return_value=mock_encryptor):
+            plaintext, returned_key = await manager.create_key(
+                name="bound-ok",
+                user_id="user-1",
+                bound_context_id=ctx.id,
+            )
 
         # Returns a (plaintext, APIKey) tuple — the plaintext is kagura_…
         # and the row carries the binding.

--- a/backend/tests/auth/test_api_key_binding.py
+++ b/backend/tests/auth/test_api_key_binding.py
@@ -111,6 +111,73 @@ class TestCreateKeyBoundContextValidation:
         db.add.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_verify_api_key_user_rejects_bound_keys(self) -> None:
+        """Privilege-escalation guard: ``verify_api_key_user`` MUST 403 a
+        public-bound key (#626) so it cannot authenticate any endpoint
+        other than ``/api/v1/public/{ctx}/*``.
+
+        Without this gate, the bound key would inherit the owner's
+        ``current_workspace_id`` via ``_build_api_key_user_dict`` and
+        grant full account access — exactly the escalation the bound
+        scoping is supposed to prevent.
+        """
+        from fastapi import HTTPException
+
+        from auth.api_keys import VerifiedKey
+        from auth.dependencies import verify_api_key_user
+
+        bound_result = VerifiedKey(
+            id=42,
+            user_id="user-1",
+            workspace_id=None,
+            bound_context_id=uuid.uuid4(),
+        )
+
+        with patch(
+            "auth.api_keys.APIKeyManager.verify_key",
+            new=AsyncMock(return_value=bound_result),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await verify_api_key_user(api_key="kagura_test", db=AsyncMock())
+
+        assert exc_info.value.status_code == 403
+        assert "public-bound" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_verify_api_key_standalone_rejects_bound_keys(self) -> None:
+        """``auth.dependencies.verify_api_key`` (used by MCP) MUST return
+        None for public-bound keys — same privilege-escalation guard,
+        different code path. MCP auth treats None as "invalid token",
+        which is the correct rejection shape on that surface.
+        """
+        from auth.api_keys import VerifiedKey
+        from auth.dependencies import verify_api_key
+
+        bound_result = VerifiedKey(
+            id=42,
+            user_id="user-1",
+            workspace_id=None,
+            bound_context_id=uuid.uuid4(),
+        )
+
+        # Patch the inner db generator + manager.verify_key. The standalone
+        # opens its own session via async for db in get_db(), so we patch
+        # the whole APIKeyManager.verify_key path.
+        async def _fake_get_db():
+            yield AsyncMock()
+
+        with (
+            patch("db.base.get_db", new=_fake_get_db),
+            patch(
+                "auth.api_keys.APIKeyManager.verify_key",
+                new=AsyncMock(return_value=bound_result),
+            ),
+        ):
+            result = await verify_api_key("kagura_test")
+
+        assert result is None  # bound key rejected, masquerades as "invalid"
+
+    @pytest.mark.asyncio
     async def test_bound_context_id_set_workspace_id_none_succeeds(self) -> None:
         """Happy path: bound key with valid public context creates a row.
 

--- a/backend/tests/integration/test_e10_626_apikey_bound_context_id_migration.py
+++ b/backend/tests/integration/test_e10_626_apikey_bound_context_id_migration.py
@@ -1,0 +1,249 @@
+"""Integration tests for migration ``e10_626_apikey_bound_context_id`` (#626).
+
+Covers:
+
+1. ``api_keys.bound_context_id`` is added (UUID, nullable, indexed).
+2. ``usage_stats.api_key_id`` is added (Integer, nullable, indexed).
+3. The CHECK constraint ``ck_api_keys_binding_workspace_exclusion`` rejects
+   rows where both ``bound_context_id`` and ``workspace_id`` are non-NULL
+   (the two scopings are mutually exclusive — workspace-scoped #169 keys
+   grant access to all contexts in a workspace, public-bound #626 keys
+   grant attribution for one is_public=true context only).
+4. FK ``fk_api_keys_bound_context_id`` is SET NULL on delete (deleting the
+   bound context disables the key without cascading the key's deletion).
+5. ``downgrade()`` drops both columns, the constraint, the FK, and both
+   indexes cleanly.
+
+The pre-revision is ``e09_608_dcr_default_narrow``.
+"""
+
+import uuid
+
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from alembic import command
+from tests.integration.test_alembic_migrations import (
+    _alembic_at_test_db,
+    _get_alembic_config,
+    _reset_alembic_state,
+    _sync_engine,
+)
+
+# Pin the pre-revision so this test stays correct as more migrations land on
+# top of e10_626. The downgrade tests assume a clean rewind to exactly this
+# revision.
+PRE_E10_REV = "e09_608_dcr_default_narrow"
+E10_REV = "e10_626_apikey_bound_context_id"
+
+
+def _seed_workspace(conn, plan_name: str = "pro", owner_user_id: str = "owner-626") -> str:
+    ws_id = str(uuid.uuid4())
+    conn.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_user_id, plan_name) "
+            "VALUES (:id, :name, :owner, :plan)"
+        ),
+        {"id": ws_id, "name": f"ws-{ws_id[:8]}", "owner": owner_user_id, "plan": plan_name},
+    )
+    return ws_id
+
+
+def _seed_context(conn, workspace_id: str, is_public: bool = True) -> str:
+    ctx_id = str(uuid.uuid4())
+    conn.execute(
+        text(
+            "INSERT INTO contexts (id, workspace_id, name, created_by, is_public) "
+            "VALUES (:id, :ws, :name, :owner, :is_pub)"
+        ),
+        {
+            "id": ctx_id,
+            "ws": workspace_id,
+            "name": f"ctx-{ctx_id[:8]}",
+            "owner": "owner-626",
+            "is_pub": is_public,
+        },
+    )
+    return ctx_id
+
+
+def _seed_api_key(
+    conn,
+    user_id: str = "owner-626",
+    workspace_id: str | None = None,
+    bound_context_id: str | None = None,
+    key_suffix: str = "test",
+) -> int:
+    """Insert an api_keys row and return its integer id.
+
+    Raises:
+        IntegrityError: When the row violates the new CHECK constraint
+            (``bound_context_id IS NULL OR workspace_id IS NULL``).
+    """
+    conn.execute(
+        text(
+            "INSERT INTO api_keys "
+            "(key_hash, key_prefix, name, user_id, workspace_id, bound_context_id) "
+            "VALUES (:hash, :prefix, :name, :uid, :ws, :bound)"
+        ),
+        {
+            # 64-char SHA256-shaped hash so the unique index is satisfied
+            # for each row (length must match ``String(64)``).
+            "hash": f"hash_{key_suffix}".ljust(64, "0"),
+            "prefix": f"kagura_{key_suffix[:8]}".ljust(16, "x")[:16],
+            "name": f"key-{key_suffix}",
+            "uid": user_id,
+            "ws": workspace_id,
+            "bound": bound_context_id,
+        },
+    )
+    return conn.execute(
+        text("SELECT id FROM api_keys WHERE name = :name"),
+        {"name": f"key-{key_suffix}"},
+    ).scalar_one()
+
+
+class TestE10ApiKeyBoundContextIdMigration:
+    """Data-shape and constraint checks for ``e10_626_apikey_bound_context_id``."""
+
+    def test_upgrade_adds_bound_context_id_column(self) -> None:
+        """``api_keys.bound_context_id`` exists with the expected shape."""
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), E10_REV)
+
+        engine = _sync_engine()
+        try:
+            inspector = inspect(engine)
+            cols = {c["name"]: c for c in inspector.get_columns("api_keys")}
+            assert "bound_context_id" in cols
+            assert cols["bound_context_id"]["nullable"] is True
+
+            indexes = {idx["name"] for idx in inspector.get_indexes("api_keys")}
+            assert "idx_api_keys_bound_context_id" in indexes
+        finally:
+            engine.dispose()
+
+    def test_upgrade_adds_api_key_id_to_usage_stats(self) -> None:
+        """``usage_stats.api_key_id`` exists, nullable, indexed."""
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), E10_REV)
+
+        engine = _sync_engine()
+        try:
+            inspector = inspect(engine)
+            cols = {c["name"]: c for c in inspector.get_columns("usage_stats")}
+            assert "api_key_id" in cols
+            assert cols["api_key_id"]["nullable"] is True
+
+            indexes = {idx["name"] for idx in inspector.get_indexes("usage_stats")}
+            assert "idx_usage_stats_api_key_id" in indexes
+        finally:
+            engine.dispose()
+
+    def test_mutual_exclusion_check_rejects_both_set(self) -> None:
+        """A key with both ``workspace_id`` and ``bound_context_id`` is rejected."""
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), E10_REV)
+
+        engine = _sync_engine()
+        try:
+            with engine.begin() as conn:
+                ws = _seed_workspace(conn)
+                ctx = _seed_context(conn, ws, is_public=True)
+                try:
+                    _seed_api_key(
+                        conn,
+                        workspace_id=ws,
+                        bound_context_id=ctx,
+                        key_suffix="conflict",
+                    )
+                    raise AssertionError(
+                        "Expected IntegrityError on both workspace_id and "
+                        "bound_context_id being set"
+                    )
+                except IntegrityError:
+                    pass
+        finally:
+            engine.dispose()
+
+    def test_either_one_or_neither_is_permitted(self) -> None:
+        """Rows with workspace_id-only, bound_context_id-only, or neither are valid."""
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), E10_REV)
+
+        engine = _sync_engine()
+        try:
+            with engine.begin() as conn:
+                ws = _seed_workspace(conn)
+                ctx = _seed_context(conn, ws, is_public=True)
+                # Owner-scoped (neither set): valid
+                _seed_api_key(conn, key_suffix="owner")
+                # Workspace-scoped (#169): valid
+                _seed_api_key(conn, workspace_id=ws, key_suffix="ws")
+                # Public-bound (#626): valid
+                _seed_api_key(conn, bound_context_id=ctx, key_suffix="bound")
+        finally:
+            engine.dispose()
+
+    def test_fk_set_null_on_context_delete(self) -> None:
+        """Deleting the bound context nulls ``api_keys.bound_context_id``."""
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), E10_REV)
+
+        engine = _sync_engine()
+        try:
+            with engine.begin() as conn:
+                ws = _seed_workspace(conn)
+                ctx = _seed_context(conn, ws, is_public=True)
+                key_id = _seed_api_key(
+                    conn,
+                    bound_context_id=ctx,
+                    key_suffix="setnull",
+                )
+                # Delete the bound context.
+                conn.execute(text("DELETE FROM contexts WHERE id = :id"), {"id": ctx})
+
+            with engine.begin() as conn:
+                bound = conn.execute(
+                    text("SELECT bound_context_id FROM api_keys WHERE id = :id"),
+                    {"id": key_id},
+                ).scalar_one()
+            assert bound is None
+        finally:
+            engine.dispose()
+
+    def test_downgrade_removes_column_and_constraint(self) -> None:
+        """Downgrade drops both new columns, the FK, the indexes, and the CHECK."""
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), E10_REV)
+            command.downgrade(_get_alembic_config(), PRE_E10_REV)
+
+        engine = _sync_engine()
+        try:
+            inspector = inspect(engine)
+
+            ak_cols = {c["name"] for c in inspector.get_columns("api_keys")}
+            assert "bound_context_id" not in ak_cols
+
+            us_cols = {c["name"] for c in inspector.get_columns("usage_stats")}
+            assert "api_key_id" not in us_cols
+
+            ak_indexes = {idx["name"] for idx in inspector.get_indexes("api_keys")}
+            assert "idx_api_keys_bound_context_id" not in ak_indexes
+            us_indexes = {idx["name"] for idx in inspector.get_indexes("usage_stats")}
+            assert "idx_usage_stats_api_key_id" not in us_indexes
+
+            # Confirm the CHECK constraint is gone too.
+            ak_constraints = {c["name"] for c in inspector.get_check_constraints("api_keys")}
+            assert "ck_api_keys_binding_workspace_exclusion" not in ak_constraints
+        finally:
+            # Convention: leave DB at head after each test.
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), "head")
+            engine.dispose()

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,6 +19,16 @@ curl -H "Authorization: Bearer kagura_xxxxxxxxxxxx" \
   http://localhost:8080/api/v1/memory/recall
 ```
 
+API keys come in three scoping shapes:
+
+| Scope | Created via | Access | Issue |
+|---|---|---|---|
+| Owner-scoped | `POST /api/v1/config/api-keys` | All of the owner's contexts (current workspace) | — |
+| Workspace-scoped | `POST /api/v1/workspaces/{wsid}/members/{uid}/credentials/api-keys` | All contexts in one workspace | #169 |
+| Public-bound | Same as workspace-scoped, with `bound_context_id` in the body | One `is_public=true` context only — for attributed access to `/api/v1/public/{ctx}/*` (per-key rate limit, audit, independent revocation) | #626 |
+
+Public-bound keys are immutable: to change which context a key attributes to, revoke the key and create a new one. They cannot also be workspace-scoped (DB CHECK constraint).
+
 ### 2. OAuth2 Access Token
 
 ```bash
@@ -551,6 +561,50 @@ Update a context. All fields are optional.
 Soft-delete a context. The context row is marked deleted (sets `deleted_at`) so it stops appearing in listings, but the record and its memories are retained for recovery / audit purposes.
 
 **Response:** `204 No Content` (no response body)
+
+---
+
+## Public Read API
+
+`POST /api/v1/public/{context_id}/search` and `GET /api/v1/public/{context_id}/info` expose `is_public=true` contexts to anonymous and attributed callers (Issue #238, extended by Issue #626).
+
+### Anonymous access (no Authorization header)
+
+```bash
+curl -X POST https://memory.kagura-ai.com/api/v1/public/CTX_UUID/search \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is Hebbian learning", "limit": 3}'
+```
+
+Rate-limited to **50 requests/minute per context**, shared across all anonymous callers. The bucket is `public_search:{ctx}:minute` in Redis. The shared quota means a single noisy client can saturate the bucket — that's the gap public-bound API keys fill.
+
+### Attributed access (with public-bound API key)
+
+```bash
+curl -X POST https://memory.kagura-ai.com/api/v1/public/CTX_UUID/search \
+  -H "Authorization: Bearer kagura_xxxxxxxxxxxx" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is Hebbian learning", "limit": 3}'
+```
+
+When the bound key matches the URL context (CWE-639 IDOR guard fires otherwise with `403`), the request gets:
+
+- **Per-key rate-limit bucket** (`public_bound_key:{key_id}:minute`) sized by the workspace plan's `bound_public_calls_per_minute` (PRO default: 100/min).
+- **Per-key audit attribution** in `usage_stats` (`api_key_id` populated alongside `context_id` and `workspace_id`).
+- **Independent revocation** — the key can be deleted without flipping `is_public=false` on the context.
+
+The bound key MUST be created with `bound_context_id` set (see API Keys Management); a regular owner-scoped or workspace-scoped key passed here is rejected with `403`.
+
+### Error matrix
+
+| Condition | Status |
+|---|---|
+| Context not found | `404` |
+| Context is not public | `403` |
+| API key supplied but invalid / expired | `401` |
+| API key is not public-bound | `403` |
+| API key is bound to a different context (CWE-639) | `403` |
+| Per-key / shared rate limit exhausted | `429` |
 
 ---
 

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -692,15 +692,14 @@ export function APIKeysTabPanel() {
                     {t("regenerate")}
                   </ActionButton>
 
-                  {/* Issue #626: hide the legacy per-card delete for
-                      public-bound keys — that flow routes through
-                      deleteWorkspaceMemberAPIKey which filters by
-                      workspace_id and would NOT delete a bound key
-                      (workspace_id IS NULL), or worse, would delete a
-                      different workspace-scoped key. Bound keys revoke
-                      via the dedicated trash icon next to the badge
-                      (see line ~555) which calls
-                      deleteWorkspaceMemberAPIKeyById. */}
+                  {/* Issue #626: bound keys use the dedicated trash icon
+                      next to the badge (see line ~555) so the confirmation
+                      copy can name the public-context revocation
+                      specifically. ``deleteWorkspaceMemberAPIKey`` is now
+                      a thin alias around the per-id endpoint (post-#626
+                      both delete paths use ``DELETE /credentials/api-keys/
+                      {keyId}``), so this filter is purely a UX split —
+                      not a safety gate. */}
                   {!apiKey.revoked_at && !apiKey.bound_context_id && (
                     <ActionButton
                       onClick={() => handleDeleteAPIKeyClick(apiKey.id)}

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -630,16 +630,25 @@ export function APIKeysTabPanel() {
                         className="flex-1"
                         data-testid={`api-key-field-${apiKey.id}`}
                       />
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleHideAPIKeyClick(apiKey.id)}
-                        title={t("hideSecretNow")}
-                        aria-label={t("hideSecretNow")}
-                      >
-                        <EyeOff className="w-4 h-4" />
-                      </Button>
+                      {/* Issue #626: Hide button targets the legacy
+                          singleton endpoint (filters by workspace_id,
+                          operates on "most recent" key) and cannot
+                          safely target public-bound keys. Suppressed
+                          for bound keys — they're meant to be shared
+                          as attribution, not zero-knowledge secrets,
+                          so manual-hide has no use case anyway. */}
+                      {!apiKey.bound_context_id && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleHideAPIKeyClick(apiKey.id)}
+                          title={t("hideSecretNow")}
+                          aria-label={t("hideSecretNow")}
+                        >
+                          <EyeOff className="w-4 h-4" />
+                        </Button>
+                      )}
                       {apiKey.visibility_expires_at &&
                         (() => {
                           const expiresAt = new Date(
@@ -688,23 +697,29 @@ export function APIKeysTabPanel() {
                   </div>
                 )}
 
-                {/* Action Buttons */}
+                {/* Action Buttons. Issue #626: ``regenerate`` and
+                    ``hide`` (above) both target legacy singleton
+                    endpoints that operate on "most recent active key
+                    for (user, workspace)" — workspace-scoped keys only.
+                    They cannot safely target public-bound keys
+                    (workspace_id IS NULL) and would either no-op or
+                    operate on a different key. Hide both buttons for
+                    bound keys; the bound-key lifecycle is intentionally
+                    simpler (revoke and create), so regenerate has no
+                    use case anyway. Plumbing per-id endpoints for
+                    hide/regenerate is deferred (no use case for bound
+                    keys, and workspace-scoped keys already have the
+                    existing UX). */}
                 <div className="flex gap-2">
-                  <ActionButton
-                    onClick={() => handleRegenerateAPIKeyClick(apiKey.id)}
-                    icon={<RefreshCw className="w-4 h-4" />}
-                  >
-                    {t("regenerate")}
-                  </ActionButton>
+                  {!apiKey.bound_context_id && (
+                    <ActionButton
+                      onClick={() => handleRegenerateAPIKeyClick(apiKey.id)}
+                      icon={<RefreshCw className="w-4 h-4" />}
+                    >
+                      {t("regenerate")}
+                    </ActionButton>
+                  )}
 
-                  {/* Issue #626: bound keys use the dedicated trash icon
-                      next to the badge (see line ~555) so the confirmation
-                      copy can name the public-context revocation
-                      specifically. ``deleteWorkspaceMemberAPIKey`` is now
-                      a thin alias around the per-id endpoint (post-#626
-                      both delete paths use ``DELETE /credentials/api-keys/
-                      {keyId}``), so this filter is purely a UX split —
-                      not a safety gate. */}
                   {!apiKey.revoked_at && !apiKey.bound_context_id && (
                     <ActionButton
                       onClick={() => handleDeleteAPIKeyClick(apiKey.id)}

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -21,9 +21,12 @@ import {
   hideAPIKey,
   regenerateAPIKey,
   deleteWorkspaceMemberAPIKey,
+  deleteWorkspaceMemberAPIKeyById,
   createAPIKey,
   MemberCredentials,
 } from "@/lib/api/member-credentials";
+import { getContexts } from "@/lib/api/contexts";
+import type { Context } from "@/lib/types/context";
 import {
   Copy,
   Check,
@@ -97,6 +100,13 @@ export function APIKeysTabPanel() {
   const [showCreateKeyDialog, setShowCreateKeyDialog] = useState(false);
   const [newKeyName, setNewKeyName] = useState("");
   const [createKeyError, setCreateKeyError] = useState<string | null>(null);
+  // Issue #626: public-context binding picker state. Both fields reset on
+  // dialog open/close so the operator never carries a stale selection into
+  // a fresh create flow.
+  const [bindToPublicContext, setBindToPublicContext] = useState(false);
+  const [boundContextId, setBoundContextId] = useState<string>("");
+  const [publicContexts, setPublicContexts] = useState<Context[]>([]);
+  const [loadingPublicContexts, setLoadingPublicContexts] = useState(false);
   const [showHideApiKeyDialog, setShowHideApiKeyDialog] = useState(false);
   const [showRegenerateApiKeyDialog, setShowRegenerateApiKeyDialog] =
     useState(false);
@@ -263,6 +273,38 @@ export function APIKeysTabPanel() {
     }
   };
 
+  // Issue #626: load is_public=true contexts for the binding picker when
+  // the operator toggles the "bind to public context" option. Fetched on
+  // demand rather than eagerly so the credentials page stays cheap when
+  // the operator only wants regular keys.
+  const loadPublicContexts = useCallback(async () => {
+    if (publicContexts.length > 0 || loadingPublicContexts) return;
+    setLoadingPublicContexts(true);
+    try {
+      const resp = await getContexts();
+      // Filter to public contexts only — the binding constraint requires
+      // is_public=true at create time on the backend, but surfacing only
+      // those in the picker avoids a confusing 422.
+      const publics = resp.contexts.filter((c) => c.is_public);
+      setPublicContexts(publics);
+    } catch {
+      // Picker silently empty on fetch failure; the dialog already has a
+      // gating message ("no public contexts available") that covers the
+      // empty-list case and the actual save attempt will surface any
+      // backend error via the inline message inside the dialog.
+    } finally {
+      setLoadingPublicContexts(false);
+    }
+  }, [publicContexts.length, loadingPublicContexts]);
+
+  const resetCreateDialog = () => {
+    setShowCreateKeyDialog(false);
+    setNewKeyName("");
+    setCreateKeyError(null);
+    setBindToPublicContext(false);
+    setBoundContextId("");
+  };
+
   const handleCreateAPIKey = async () => {
     if (!currentWorkspaceId || !userId) return;
 
@@ -274,10 +316,21 @@ export function APIKeysTabPanel() {
         return;
       }
 
-      await createAPIKey(currentWorkspaceId, userId, { name: newKeyName });
+      // Issue #626: when bind mode is on, the context selection is required
+      // — submitting with no selection is a form-level validation failure.
+      if (bindToPublicContext && !boundContextId) {
+        setCreateKeyError(t("publicBindContextRequired"));
+        return;
+      }
+
+      await createAPIKey(currentWorkspaceId, userId, {
+        name: newKeyName,
+        ...(bindToPublicContext && boundContextId
+          ? { bound_context_id: boundContextId }
+          : {}),
+      });
       await loadCredentials();
-      setShowCreateKeyDialog(false);
-      setNewKeyName("");
+      resetCreateDialog();
 
       toast({
         title: tCommon("success"),
@@ -295,6 +348,31 @@ export function APIKeysTabPanel() {
           ? err.message
           : t("errorCreateKey"),
       );
+    }
+  };
+
+  // Issue #626: per-id delete for bound keys. The legacy singleton DELETE
+  // endpoint filters on workspace_id and so cannot see bound keys (which
+  // have workspace_id IS NULL). Routes the delete through the new per-id
+  // endpoint when the key has a binding.
+  const handleConfirmDeleteBoundKey = async (keyId: number) => {
+    if (!currentWorkspaceId || !userId) return;
+    try {
+      setDeleting(true);
+      await deleteWorkspaceMemberAPIKeyById(currentWorkspaceId, userId, keyId);
+      await loadCredentials();
+      toast({
+        title: tCommon("success"),
+        description: t("deleteSuccess"),
+      });
+    } catch (err: unknown) {
+      toast({
+        title: tCommon("error"),
+        description: err instanceof Error ? err.message : String(err),
+        variant: "destructive",
+      });
+    } finally {
+      setDeleting(false);
     }
   };
 
@@ -450,14 +528,43 @@ export function APIKeysTabPanel() {
               >
                 {/* Key Name */}
                 <div className="flex items-center justify-between">
-                  <h4 className="font-semibold text-gray-900 dark:text-gray-100">
-                    {apiKey.name}
-                  </h4>
-                  {apiKey.revoked_at && (
-                    <span className="text-xs text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/20 px-2 py-1 rounded">
-                      {t("revoked")}
-                    </span>
-                  )}
+                  <div className="flex items-center gap-2">
+                    <h4 className="font-semibold text-gray-900 dark:text-gray-100">
+                      {apiKey.name}
+                    </h4>
+                    {/* Issue #626: badge for public-bound keys so the list
+                        view makes attribution visible at a glance. The badge
+                        is its own non-revocation status — keys can be active
+                        AND public-bound, or revoked AND public-bound. */}
+                    {apiKey.bound_context_id && (
+                      <span
+                        className="text-xs bg-amber-100 dark:bg-amber-900/30 text-amber-800 dark:text-amber-200 px-2 py-0.5 rounded border border-amber-200 dark:border-amber-800"
+                        title={t("publicBindBadgeTitle")}
+                      >
+                        {t("publicBindBadge")}
+                      </span>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    {apiKey.revoked_at && (
+                      <span className="text-xs text-red-600 dark:text-red-400 bg-red-100 dark:bg-red-900/20 px-2 py-1 rounded">
+                        {t("revoked")}
+                      </span>
+                    )}
+                    {apiKey.bound_context_id && !apiKey.revoked_at && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => handleConfirmDeleteBoundKey(apiKey.id)}
+                        disabled={deleting}
+                        title={t("publicBindRevoke")}
+                        aria-label={t("publicBindRevoke")}
+                      >
+                        <Trash2 className="w-4 h-4 text-red-600" />
+                      </Button>
+                    )}
+                  </div>
                 </div>
 
                 {/* Key Display */}
@@ -601,6 +708,71 @@ export function APIKeysTabPanel() {
                 placeholder={t("keyNamePlaceholder")}
               />
             </div>
+
+            {/* Issue #626: public-bound key creation. Toggle off by default
+                so the existing self-service flow is unchanged for users who
+                are just minting a regular workspace-scoped key. */}
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 text-sm font-medium cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={bindToPublicContext}
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    setBindToPublicContext(checked);
+                    setBoundContextId("");
+                    setCreateKeyError(null);
+                    if (checked) {
+                      void loadPublicContexts();
+                    }
+                  }}
+                  className="h-4 w-4"
+                />
+                <span>{t("publicBindToggleLabel")}</span>
+              </label>
+              {bindToPublicContext && (
+                <div className="space-y-2 pl-6">
+                  {loadingPublicContexts ? (
+                    <p className="text-xs text-muted-foreground">
+                      {tCommon("loading")}
+                    </p>
+                  ) : publicContexts.length === 0 ? (
+                    <div className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-2 text-xs text-amber-800 dark:text-amber-200">
+                      {t("publicBindNoContextsAvailable")}
+                    </div>
+                  ) : (
+                    <>
+                      <label
+                        htmlFor="create-api-key-bound-context"
+                        className="block text-xs font-medium"
+                      >
+                        {t("publicBindContextLabel")}
+                      </label>
+                      <select
+                        id="create-api-key-bound-context"
+                        className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                        value={boundContextId}
+                        onChange={(e) => setBoundContextId(e.target.value)}
+                      >
+                        <option value="">
+                          {t("publicBindContextPlaceholder")}
+                        </option>
+                        {publicContexts.map((c) => (
+                          <option key={c.id} value={c.id}>
+                            {(c.display_name || c.name) +
+                              (c.resource_id ? ` (${c.resource_id})` : "")}
+                          </option>
+                        ))}
+                      </select>
+                      <div className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-2 text-xs text-amber-800 dark:text-amber-200">
+                        {t("publicBindWarning")}
+                      </div>
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+
             {createKeyError && (
               <p className="text-sm text-red-600 dark:text-red-400">
                 {createKeyError}
@@ -611,13 +783,7 @@ export function APIKeysTabPanel() {
             </p>
           </div>
           <AlertDialogFooter>
-            <AlertDialogCancel
-              onClick={() => {
-                setShowCreateKeyDialog(false);
-                setNewKeyName("");
-                setCreateKeyError(null);
-              }}
-            >
+            <AlertDialogCancel onClick={resetCreateDialog}>
               {tCommon("cancel")}
             </AlertDialogCancel>
             <AlertDialogAction onClick={handleCreateAPIKey}>

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -282,10 +282,17 @@ export function APIKeysTabPanel() {
     setLoadingPublicContexts(true);
     try {
       const resp = await getContexts();
-      // Filter to public contexts only — the binding constraint requires
-      // is_public=true at create time on the backend, but surfacing only
-      // those in the picker avoids a confusing 422.
-      const publics = resp.contexts.filter((c) => c.is_public);
+      // Filter to public contexts the current user can actually bind:
+      // backend enforces is_public=true AND created_by==user_id at the
+      // route's ownership gate, so surfacing only those in the picker
+      // avoids a "selectable in UI, 403 on submit" confusion.
+      // Contexts with created_by===null (legacy data, pre-#160) are
+      // excluded — backend permits them, but the UI cannot prove
+      // ownership client-side; users with such contexts can still bind
+      // via the API directly.
+      const publics = resp.contexts.filter(
+        (c) => c.is_public && c.created_by === userId,
+      );
       setPublicContexts(publics);
     } catch {
       // Picker silently empty on fetch failure; the dialog already has a
@@ -295,7 +302,7 @@ export function APIKeysTabPanel() {
     } finally {
       setLoadingPublicContexts(false);
     }
-  }, [publicContexts.length, loadingPublicContexts]);
+  }, [publicContexts.length, loadingPublicContexts, userId]);
 
   const resetCreateDialog = () => {
     setShowCreateKeyDialog(false);
@@ -650,7 +657,16 @@ export function APIKeysTabPanel() {
                     {t("regenerate")}
                   </ActionButton>
 
-                  {!apiKey.revoked_at && (
+                  {/* Issue #626: hide the legacy per-card delete for
+                      public-bound keys — that flow routes through
+                      deleteWorkspaceMemberAPIKey which filters by
+                      workspace_id and would NOT delete a bound key
+                      (workspace_id IS NULL), or worse, would delete a
+                      different workspace-scoped key. Bound keys revoke
+                      via the dedicated trash icon next to the badge
+                      (see line ~555) which calls
+                      deleteWorkspaceMemberAPIKeyById. */}
+                  {!apiKey.revoked_at && !apiKey.bound_context_id && (
                     <ActionButton
                       onClick={() => handleDeleteAPIKeyClick(apiKey.id)}
                       variant="danger"

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -12,7 +12,10 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { useTranslations, useLocale } from "next-intl";
 import { Section } from "@/components/common/Section";
 import { ActionButton } from "@/components/common/ActionButton";
-import { TableLoadingState } from "@/components/common/LoadingState";
+import {
+  InlineSpinner,
+  TableLoadingState,
+} from "@/components/common/LoadingState";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -749,10 +752,15 @@ export function APIKeysTabPanel() {
               {bindToPublicContext && (
                 <div className="space-y-2 pl-6">
                   {loadingPublicContexts ? (
-                    <p className="text-xs text-muted-foreground">
+                    <p className="text-xs text-muted-foreground flex items-center gap-2">
+                      <InlineSpinner size="sm" />
                       {tCommon("loading")}
                     </p>
                   ) : publicContexts.length === 0 ? (
+                    // Informational gating notice (prerequisite hint), NOT an
+                    // empty-list "create your first" state — keep the amber
+                    // div per .claude/rules/frontend.md "Empty States" rule
+                    // for prerequisite-not-met cases.
                     <div className="rounded-md border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-2 text-xs text-amber-800 dark:text-amber-200">
                       {t("publicBindNoContextsAvailable")}
                     </div>

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -296,18 +296,23 @@ export function APIKeysTabPanel() {
   // the operator only wants regular keys.
   const loadPublicContexts = useCallback(async () => {
     if (publicContexts.length > 0 || loadingPublicContexts) return;
+    // Auth-loading race guard: ``userId`` is undefined during initial
+    // render. If the operator toggled the bind option before
+    // ``useAuth()`` resolved, filtering by ``created_by === undefined``
+    // would always match 0 contexts and cache an empty list, leaving
+    // the picker stuck in the "no public contexts available" state.
+    // Return early; the useEffect re-fire-on-toggle in the checkbox
+    // handler will retry once ``userId`` is populated.
+    if (!userId) return;
     setLoadingPublicContexts(true);
     setPublicContextsError(null);
     try {
       const resp = await getContexts();
       // Filter to public contexts the current user can actually bind:
       // backend enforces is_public=true AND created_by==user_id at the
-      // route's ownership gate, so surfacing only those in the picker
-      // avoids a "selectable in UI, 403 on submit" confusion.
-      // Contexts with created_by===null (legacy data, pre-#160) are
-      // excluded — backend permits them, but the UI cannot prove
-      // ownership client-side; users with such contexts can still bind
-      // via the API directly.
+      // route's ownership gate (strict — null-created_by is rejected
+      // post-loop-7), so surfacing only those in the picker avoids a
+      // "selectable in UI, 403 on submit" confusion.
       const publics = resp.contexts.filter(
         (c) => c.is_public && c.created_by === userId,
       );

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -58,6 +58,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   Collapsible,
   CollapsibleContent,
@@ -124,6 +125,12 @@ export function APIKeysTabPanel() {
   const [selectedKeyId, setSelectedKeyId] = useState<number | null>(null);
   const [regenerating, setRegenerating] = useState(false);
   const [deleting, setDeleting] = useState(false);
+  // Issue #626: dedicated confirmation flow for revoking a public-bound
+  // key. Separate from the legacy showDeleteApiKeyDialog so the bound-key
+  // path stays clearly distinguished (different copy, calls the per-id
+  // delete endpoint rather than the singleton).
+  const [showBoundRevokeDialog, setShowBoundRevokeDialog] = useState(false);
+  const [boundRevokeKeyId, setBoundRevokeKeyId] = useState<number | null>(null);
 
   // Track if component is mounted to prevent state updates after unmount
   // (used by the load handlers; copy feedback owns its own mount tracking).
@@ -378,13 +385,17 @@ export function APIKeysTabPanel() {
   // Issue #626: per-id delete for bound keys. The legacy singleton DELETE
   // endpoint filters on workspace_id and so cannot see bound keys (which
   // have workspace_id IS NULL). Routes the delete through the new per-id
-  // endpoint when the key has a binding.
-  const handleConfirmDeleteBoundKey = async (keyId: number) => {
-    if (!currentWorkspaceId || !userId) return;
+  // endpoint when the key has a binding. Invoked from the bound-revoke
+  // AlertDialog confirm handler — destructive ops never fire on raw click.
+  const handleConfirmDeleteBoundKey = async () => {
+    if (!currentWorkspaceId || !userId || boundRevokeKeyId === null) return;
+    const keyId = boundRevokeKeyId;
     try {
       setDeleting(true);
       await deleteWorkspaceMemberAPIKeyById(currentWorkspaceId, userId, keyId);
       await loadCredentials();
+      setShowBoundRevokeDialog(false);
+      setBoundRevokeKeyId(null);
       toast({
         title: tCommon("success"),
         description: t("deleteSuccess"),
@@ -580,7 +591,14 @@ export function APIKeysTabPanel() {
                         type="button"
                         variant="ghost"
                         size="sm"
-                        onClick={() => handleConfirmDeleteBoundKey(apiKey.id)}
+                        onClick={() => {
+                          // Issue #626: destructive op — route through the
+                          // existing AlertDialog confirmation flow rather than
+                          // firing immediately, matching the rest of this
+                          // screen's UX for destructive actions.
+                          setBoundRevokeKeyId(apiKey.id);
+                          setShowBoundRevokeDialog(true);
+                        }}
                         disabled={deleting}
                         title={t("publicBindRevoke")}
                         aria-label={t("publicBindRevoke")}
@@ -771,17 +789,16 @@ export function APIKeysTabPanel() {
                       {tCommon("loading")}
                     </p>
                   ) : publicContextsError ? (
-                    // Fetch failure (network / auth / 5xx). Rendered as a
-                    // destructive inline alert per .claude/rules/frontend.md
+                    // Fetch failure (network / auth / 5xx). Use the shared
+                    // Alert primitive per .claude/rules/frontend.md
                     // "Errors raised inside a Dialog body → <Alert variant=
                     // 'destructive'>". Distinct from the empty-list amber
                     // notice below so the operator sees the real cause.
-                    <div
-                      role="alert"
-                      className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-2 text-xs text-red-700 dark:text-red-300"
-                    >
-                      {publicContextsError}
-                    </div>
+                    <Alert variant="destructive">
+                      <AlertDescription className="text-xs">
+                        {publicContextsError}
+                      </AlertDescription>
+                    </Alert>
                   ) : publicContexts.length === 0 ? (
                     // Informational gating notice (prerequisite hint), NOT an
                     // empty-list "create your first" state — keep the amber
@@ -913,6 +930,40 @@ export function APIKeysTabPanel() {
               className="bg-red-600 hover:bg-red-700"
             >
               {deleting ? tCommon("saving") : tCommon("delete")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Issue #626: revoke confirmation for public-bound keys. Separate
+          from the legacy Delete dialog above so the copy can be specific
+          (the public surface this key was attributing to will lose its
+          per-key bucket) and the action routes through the per-id
+          endpoint rather than the singleton. */}
+      <AlertDialog
+        open={showBoundRevokeDialog}
+        onOpenChange={(open) => {
+          setShowBoundRevokeDialog(open);
+          if (!open) setBoundRevokeKeyId(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("publicBindRevoke")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("publicBindRevokeDesc")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={deleting}>
+              {tCommon("cancel")}
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmDeleteBoundKey}
+              disabled={deleting}
+              className="bg-red-600 hover:bg-red-700"
+            >
+              {deleting ? tCommon("saving") : t("publicBindRevoke")}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -110,6 +110,13 @@ export function APIKeysTabPanel() {
   const [boundContextId, setBoundContextId] = useState<string>("");
   const [publicContexts, setPublicContexts] = useState<Context[]>([]);
   const [loadingPublicContexts, setLoadingPublicContexts] = useState(false);
+  // Issue #626: distinguish "fetch failed" from "fetched, list is empty".
+  // Without this, a network/auth failure on getContexts() rendered the same
+  // "no public contexts available" notice as a successful-but-empty fetch,
+  // misleading the operator about the real cause.
+  const [publicContextsError, setPublicContextsError] = useState<string | null>(
+    null,
+  );
   const [showHideApiKeyDialog, setShowHideApiKeyDialog] = useState(false);
   const [showRegenerateApiKeyDialog, setShowRegenerateApiKeyDialog] =
     useState(false);
@@ -283,6 +290,7 @@ export function APIKeysTabPanel() {
   const loadPublicContexts = useCallback(async () => {
     if (publicContexts.length > 0 || loadingPublicContexts) return;
     setLoadingPublicContexts(true);
+    setPublicContextsError(null);
     try {
       const resp = await getContexts();
       // Filter to public contexts the current user can actually bind:
@@ -297,15 +305,20 @@ export function APIKeysTabPanel() {
         (c) => c.is_public && c.created_by === userId,
       );
       setPublicContexts(publics);
-    } catch {
-      // Picker silently empty on fetch failure; the dialog already has a
-      // gating message ("no public contexts available") that covers the
-      // empty-list case and the actual save attempt will surface any
-      // backend error via the inline message inside the dialog.
+    } catch (err) {
+      // Surface fetch failure distinctly from "fetched OK, list is empty".
+      // The dialog renders publicContextsError before the empty-list
+      // notice so the operator sees the real cause (network / auth
+      // failure) instead of a misleading "set is_public=true first" hint.
+      setPublicContextsError(
+        err instanceof Error && err.message.trim()
+          ? err.message
+          : t("publicBindLoadError"),
+      );
     } finally {
       setLoadingPublicContexts(false);
     }
-  }, [publicContexts.length, loadingPublicContexts, userId]);
+  }, [publicContexts.length, loadingPublicContexts, userId, t]);
 
   const resetCreateDialog = () => {
     setShowCreateKeyDialog(false);
@@ -313,6 +326,7 @@ export function APIKeysTabPanel() {
     setCreateKeyError(null);
     setBindToPublicContext(false);
     setBoundContextId("");
+    setPublicContextsError(null);
   };
 
   const handleCreateAPIKey = async () => {
@@ -756,6 +770,18 @@ export function APIKeysTabPanel() {
                       <InlineSpinner size="sm" />
                       {tCommon("loading")}
                     </p>
+                  ) : publicContextsError ? (
+                    // Fetch failure (network / auth / 5xx). Rendered as a
+                    // destructive inline alert per .claude/rules/frontend.md
+                    // "Errors raised inside a Dialog body → <Alert variant=
+                    // 'destructive'>". Distinct from the empty-list amber
+                    // notice below so the operator sees the real cause.
+                    <div
+                      role="alert"
+                      className="rounded-md border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 p-2 text-xs text-red-700 dark:text-red-300"
+                    >
+                      {publicContextsError}
+                    </div>
                   ) : publicContexts.length === 0 ? (
                     // Informational gating notice (prerequisite hint), NOT an
                     // empty-list "create your first" state — keep the amber

--- a/frontend/src/components/credentials/MCPConfigBlock.test.tsx
+++ b/frontend/src/components/credentials/MCPConfigBlock.test.tsx
@@ -83,6 +83,7 @@ const VISIBLE_KEY: MemberAPIKey = {
   visibility_expires_at: "2099-01-01T00:00:00Z",
   created_at: "2026-04-01T00:00:00Z",
   revoked_at: null,
+  bound_context_id: null,
 };
 
 const HIDDEN_KEY: MemberAPIKey = {

--- a/frontend/src/lib/api/member-credentials.ts
+++ b/frontend/src/lib/api/member-credentials.ts
@@ -175,48 +175,23 @@ export async function deleteWorkspaceMemberAPIKeyById(
 }
 
 /**
- * Delete member API key (Permission-based)
+ * Delete member API key by id (Permission-based).
  *
- * @deprecated Backend limitation: This function currently deletes the MOST RECENT API key
- * for the specified user, NOT the key identified by keyId parameter.
- *
- * The keyId parameter is accepted for API compatibility but is currently ignored by the backend.
- * Use with extreme caution - verify which key will be deleted before calling.
- *
- * @param workspaceId - Workspace ID
- * @param userId - Target user ID
- * @param keyId - API key ID (CURRENTLY IGNORED by backend)
- *
- * @todo Once backend implements DELETE /api/v1/workspaces/{workspaceId}/members/{userId}/credentials/api-keys/{keyId}
- * remove the @deprecated tag and update the endpoint URL.
- *
- * @see Issue #XXX - Multiple API Key deletion support
+ * Issue #626: rewritten on top of the per-id DELETE endpoint
+ * (`/credentials/api-keys/{keyId}`) — the legacy singleton DELETE this
+ * function previously wrapped IGNORED its `keyId` arg and deleted the
+ * most-recent active key, which was unsafe for callers that wanted a
+ * specific key. With the backend now exposing per-id deletion (added
+ * in #626), the function is now a thin alias around
+ * ``deleteWorkspaceMemberAPIKeyById`` so existing call sites get
+ * correct behavior without renaming. ``keyId`` is now required.
  */
 export async function deleteWorkspaceMemberAPIKey(
   workspaceId: string,
   userId: string,
-  keyId?: number, // CURRENTLY IGNORED - Backend deletes most recent key
+  keyId: number,
 ): Promise<void> {
-  // WARNING: Backend limitation - keyId is ignored, most recent key is deleted
-  // TODO: Update to /credentials/api-keys/${keyId} when backend supports it
-  const response = await fetch(
-    `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials/api-key`,
-    {
-      method: "DELETE",
-      credentials: "include",
-    },
-  );
-
-  if (!response.ok) {
-    throw new Error(`Failed to delete API key: ${response.statusText}`);
-  }
-
-  // TODO: Log warning in development if keyId is provided but ignored
-  if (process.env.NODE_ENV === "development" && keyId !== undefined) {
-    console.warn(
-      `deleteWorkspaceMemberAPIKey: keyId=${keyId} provided but ignored. Backend deletes most recent key.`,
-    );
-  }
+  return deleteWorkspaceMemberAPIKeyById(workspaceId, userId, keyId);
 }
 
 /**

--- a/frontend/src/lib/api/member-credentials.ts
+++ b/frontend/src/lib/api/member-credentials.ts
@@ -4,23 +4,28 @@
  * Migration 034: Member-scoped API Keys and OAuth Apps
  */
 
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
 export interface MemberAPIKey {
   id: number;
   name: string;
   key_prefix: string;
-  plaintext_key: string | null;  // Only if visible + owner
+  plaintext_key: string | null; // Only if visible + owner
   is_visible: boolean;
   visibility_expires_at: string | null;
   created_at: string;
   revoked_at: string | null;
+  // Issue #626: Public-context attribution. When non-null, this key is a
+  // public-bound key — attributed to one is_public=true context on the
+  // public REST endpoint (per-key rate-limit + audit + independent revoke).
+  // Binding is immutable; revoke and re-create to change.
+  bound_context_id: string | null;
 }
 
 export interface MemberOAuthApp {
   client_id: string;
   client_name: string;
-  plaintext_secret: string | null;  // Only if visible + owner
+  plaintext_secret: string | null; // Only if visible + owner
   is_visible: boolean;
   visibility_expires_at: string | null;
   created_at: string;
@@ -29,8 +34,8 @@ export interface MemberOAuthApp {
 }
 
 export interface MemberCredentials {
-  api_keys: MemberAPIKey[];  // Multiple API keys support
-  target_user_role: string;  // Target user's workspace role (for permission checks)
+  api_keys: MemberAPIKey[]; // Multiple API keys support
+  target_user_role: string; // Target user's workspace role (for permission checks)
 }
 
 /**
@@ -38,13 +43,13 @@ export interface MemberCredentials {
  */
 export async function getMemberCredentials(
   workspaceId: string,
-  userId: string
+  userId: string,
 ): Promise<MemberCredentials> {
   const response = await fetch(
     `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials`,
     {
-      credentials: 'include',
-    }
+      credentials: "include",
+    },
   );
 
   if (!response.ok) {
@@ -59,14 +64,14 @@ export async function getMemberCredentials(
  */
 export async function hideAPIKey(
   workspaceId: string,
-  userId: string
+  userId: string,
 ): Promise<void> {
   const response = await fetch(
     `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials/api-key/hide`,
     {
-      method: 'POST',
-      credentials: 'include',
-    }
+      method: "POST",
+      credentials: "include",
+    },
   );
 
   if (!response.ok) {
@@ -79,14 +84,14 @@ export async function hideAPIKey(
  */
 export async function regenerateAPIKey(
   workspaceId: string,
-  userId: string
+  userId: string,
 ): Promise<{ key: string; key_prefix: string; key_id: number }> {
   const response = await fetch(
     `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials/api-key/regenerate`,
     {
-      method: 'POST',
-      credentials: 'include',
-    }
+      method: "POST",
+      credentials: "include",
+    },
   );
 
   if (!response.ok) {
@@ -97,31 +102,76 @@ export async function regenerateAPIKey(
 }
 
 /**
- * Create new API key (Owner only)
+ * Create new API key (Owner only).
+ *
+ * Issue #626: When `bound_context_id` is supplied, the key is created as
+ * a public-bound key — attributed to one `is_public=true` context on the
+ * public REST endpoint. The binding is immutable; revoke and re-create to
+ * change.
  */
 export async function createAPIKey(
   workspaceId: string,
   userId: string,
-  data: { name: string; auto_hide_minutes?: number }
+  data: {
+    name: string;
+    auto_hide_minutes?: number;
+    bound_context_id?: string;
+  },
 ): Promise<MemberAPIKey> {
   const response = await fetch(
     `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials/api-keys`,
     {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
-      credentials: 'include',
+      credentials: "include",
       body: JSON.stringify(data),
-    }
+    },
   );
 
   if (!response.ok) {
-    const error = await response.json().catch(() => ({ detail: response.statusText }));
-    throw new Error(error.detail || `Failed to create API key: ${response.statusText}`);
+    const error = await response
+      .json()
+      .catch(() => ({ detail: response.statusText }));
+    throw new Error(
+      error.detail || `Failed to create API key: ${response.statusText}`,
+    );
   }
 
   return response.json();
+}
+
+/**
+ * Delete a specific API key by id (Owner only).
+ *
+ * Issue #626: Required for revoking public-bound keys, which have
+ * `workspace_id IS NULL` and so are invisible to the legacy singleton
+ * `deleteWorkspaceMemberAPIKey` endpoint. This per-id endpoint accepts
+ * both regular workspace-scoped keys and public-bound keys belonging to
+ * the user.
+ */
+export async function deleteWorkspaceMemberAPIKeyById(
+  workspaceId: string,
+  userId: string,
+  keyId: number,
+): Promise<void> {
+  const response = await fetch(
+    `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials/api-keys/${keyId}`,
+    {
+      method: "DELETE",
+      credentials: "include",
+    },
+  );
+
+  if (!response.ok) {
+    const error = await response
+      .json()
+      .catch(() => ({ detail: response.statusText }));
+    throw new Error(
+      error.detail || `Failed to delete API key: ${response.statusText}`,
+    );
+  }
 }
 
 /**
@@ -145,16 +195,16 @@ export async function createAPIKey(
 export async function deleteWorkspaceMemberAPIKey(
   workspaceId: string,
   userId: string,
-  keyId?: number  // CURRENTLY IGNORED - Backend deletes most recent key
+  keyId?: number, // CURRENTLY IGNORED - Backend deletes most recent key
 ): Promise<void> {
   // WARNING: Backend limitation - keyId is ignored, most recent key is deleted
   // TODO: Update to /credentials/api-keys/${keyId} when backend supports it
   const response = await fetch(
     `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials/api-key`,
     {
-      method: 'DELETE',
-      credentials: 'include',
-    }
+      method: "DELETE",
+      credentials: "include",
+    },
   );
 
   if (!response.ok) {
@@ -162,9 +212,9 @@ export async function deleteWorkspaceMemberAPIKey(
   }
 
   // TODO: Log warning in development if keyId is provided but ignored
-  if (process.env.NODE_ENV === 'development' && keyId !== undefined) {
+  if (process.env.NODE_ENV === "development" && keyId !== undefined) {
     console.warn(
-      `deleteWorkspaceMemberAPIKey: keyId=${keyId} provided but ignored. Backend deletes most recent key.`
+      `deleteWorkspaceMemberAPIKey: keyId=${keyId} provided but ignored. Backend deletes most recent key.`,
     );
   }
 }
@@ -173,17 +223,15 @@ export async function deleteWorkspaceMemberAPIKey(
  * Manually hide OAuth app secret (Owner only)
  * Note: Use OAuth clients API directly
  */
-export async function hideOAuthClientSecret(
-  clientId: string
-): Promise<void> {
-  const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+export async function hideOAuthClientSecret(clientId: string): Promise<void> {
+  const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8080";
 
   const response = await fetch(
     `${API_BASE}/api/v1/oauth/clients/${clientId}/hide`,
     {
-      method: 'POST',
-      credentials: 'include',
-    }
+      method: "POST",
+      credentials: "include",
+    },
   );
 
   if (!response.ok) {
@@ -196,18 +244,20 @@ export async function hideOAuthClientSecret(
  */
 export async function regenerateOAuthSecret(
   workspaceId: string,
-  userId: string
+  userId: string,
 ): Promise<{ client_secret: string; client_id: string }> {
   const response = await fetch(
     `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials/oauth/regenerate`,
     {
-      method: 'POST',
-      credentials: 'include',
-    }
+      method: "POST",
+      credentials: "include",
+    },
   );
 
   if (!response.ok) {
-    throw new Error(`Failed to regenerate OAuth secret: ${response.statusText}`);
+    throw new Error(
+      `Failed to regenerate OAuth secret: ${response.statusText}`,
+    );
   }
 
   return response.json();
@@ -218,14 +268,14 @@ export async function regenerateOAuthSecret(
  */
 export async function deleteOAuthApp(
   workspaceId: string,
-  userId: string
+  userId: string,
 ): Promise<void> {
   const response = await fetch(
     `${API_BASE}/api/v1/workspaces/${workspaceId}/members/${userId}/credentials/oauth`,
     {
-      method: 'DELETE',
-      credentials: 'include',
-    }
+      method: "DELETE",
+      credentials: "include",
+    },
   );
 
   if (!response.ok) {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1524,6 +1524,7 @@
     "publicBindContextPlaceholder": "Select a public context…",
     "publicBindContextRequired": "Please select a public context to bind this key to.",
     "publicBindNoContextsAvailable": "No public contexts available. Set is_public=true on a context first.",
+    "publicBindLoadError": "Could not load public contexts. Check your connection and try again.",
     "publicBindWarning": "Anyone with this key can read the bound context publicly. The binding is immutable — revoke and create a new key to change it.",
     "publicBindBadge": "Public-bound",
     "publicBindBadgeTitle": "This key is attributed to one is_public=true context (per-key rate limit + audit).",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1518,7 +1518,16 @@
     "createSuccess": "API key created successfully",
     "deleteSuccess": "API key deleted successfully",
     "regenerateSuccess": "API key regenerated successfully",
-    "errorCreateKey": "Failed to create API key. Please try again."
+    "errorCreateKey": "Failed to create API key. Please try again.",
+    "publicBindToggleLabel": "Bind this key to one public context (optional)",
+    "publicBindContextLabel": "Public context to attribute",
+    "publicBindContextPlaceholder": "Select a public context…",
+    "publicBindContextRequired": "Please select a public context to bind this key to.",
+    "publicBindNoContextsAvailable": "No public contexts available. Set is_public=true on a context first.",
+    "publicBindWarning": "Anyone with this key can read the bound context publicly. The binding is immutable — revoke and create a new key to change it.",
+    "publicBindBadge": "Public-bound",
+    "publicBindBadgeTitle": "This key is attributed to one is_public=true context (per-key rate limit + audit).",
+    "publicBindRevoke": "Revoke this public-bound key"
   },
   "customApps": {
     "title": "App Authentication",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1528,7 +1528,8 @@
     "publicBindWarning": "Anyone with this key can read the bound context publicly. The binding is immutable — revoke and create a new key to change it.",
     "publicBindBadge": "Public-bound",
     "publicBindBadgeTitle": "This key is attributed to one is_public=true context (per-key rate limit + audit).",
-    "publicBindRevoke": "Revoke this public-bound key"
+    "publicBindRevoke": "Revoke this public-bound key",
+    "publicBindRevokeDesc": "This will permanently revoke the key. Anyone using it will immediately lose access to the bound public context. The context itself stays public — only this key's attributed access is removed."
   },
   "customApps": {
     "title": "App Authentication",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1528,7 +1528,8 @@
     "publicBindWarning": "このキーを持つ誰でも、紐付けられたコンテキストを公開アクセスできます。紐付けは変更不可です。変更するには revoke して新しいキーを作成してください。",
     "publicBindBadge": "公開バインド",
     "publicBindBadgeTitle": "このキーは1つの is_public=true コンテキストに紐付けられています（キー単位のレート制限+監査）。",
-    "publicBindRevoke": "この公開バインドキーを revoke"
+    "publicBindRevoke": "この公開バインドキーを revoke",
+    "publicBindRevokeDesc": "このキーを永久に失効させます。使用中のクライアントは紐付けられた公開コンテキストへのアクセスを即座に失います。コンテキスト自体は公開のままで、このキーの属性付きアクセスのみが解除されます。"
   },
   "customApps": {
     "title": "アプリ認証",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1518,7 +1518,16 @@
     "createSuccess": "APIキーが正常に作成されました",
     "deleteSuccess": "APIキーが正常に削除されました",
     "regenerateSuccess": "APIキーが正常に再生成されました",
-    "errorCreateKey": "APIキーの作成に失敗しました。もう一度お試しください。"
+    "errorCreateKey": "APIキーの作成に失敗しました。もう一度お試しください。",
+    "publicBindToggleLabel": "このキーを1つの公開コンテキストに紐付ける（任意）",
+    "publicBindContextLabel": "紐付ける公開コンテキスト",
+    "publicBindContextPlaceholder": "公開コンテキストを選択…",
+    "publicBindContextRequired": "紐付ける公開コンテキストを選択してください。",
+    "publicBindNoContextsAvailable": "公開コンテキストがありません。先にコンテキストの is_public=true を設定してください。",
+    "publicBindWarning": "このキーを持つ誰でも、紐付けられたコンテキストを公開アクセスできます。紐付けは変更不可です。変更するには revoke して新しいキーを作成してください。",
+    "publicBindBadge": "公開バインド",
+    "publicBindBadgeTitle": "このキーは1つの is_public=true コンテキストに紐付けられています（キー単位のレート制限+監査）。",
+    "publicBindRevoke": "この公開バインドキーを revoke"
   },
   "customApps": {
     "title": "アプリ認証",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1524,6 +1524,7 @@
     "publicBindContextPlaceholder": "公開コンテキストを選択…",
     "publicBindContextRequired": "紐付ける公開コンテキストを選択してください。",
     "publicBindNoContextsAvailable": "公開コンテキストがありません。先にコンテキストの is_public=true を設定してください。",
+    "publicBindLoadError": "公開コンテキストを読み込めませんでした。ネットワークを確認してから再試行してください。",
     "publicBindWarning": "このキーを持つ誰でも、紐付けられたコンテキストを公開アクセスできます。紐付けは変更不可です。変更するには revoke して新しいキーを作成してください。",
     "publicBindBadge": "公開バインド",
     "publicBindBadgeTitle": "このキーは1つの is_public=true コンテキストに紐付けられています（キー単位のレート制限+監査）。",


### PR DESCRIPTION
Closes #626

## Summary

Add optional API-key attribution to the existing anonymous public read endpoint (`POST /api/v1/public/{ctx}/search` and `/info`). A context owner can now mint named keys, each bound to one `is_public=true` context, to get:

- **Per-key rate-limit bucket** (`public_bound_key:{id}:minute`) sized by the new `plan.bound_public_calls_per_minute` (PRO default 100/min) — escapes the shared 50/min/context anonymous bucket
- **Per-key audit attribution** — `usage_stats.api_key_id` populated alongside `context_id` and `workspace_id`; `AuditLog` rows for key create/revoke lifecycle
- **Per-key revocation** — DELETE per id, independent of `context.is_public` flips

Anonymous access stays unchanged (omit `Authorization` → existing shared bucket). The binding is immutable: revoke and create to change. Read-only scope; write mode is a future extension and stays additive (just `bound_mode` column + new write endpoints, no migration to current shape).

## Implementation notes

**Schema** (additive, instant ALTER on PG ≥ 11):
- `api_keys.bound_context_id` UUID, nullable, indexed, FK `contexts.id ON DELETE SET NULL`
- `api_keys` CHECK constraint `bound_context_id IS NULL OR workspace_id IS NULL` — mutual exclusion between #169 (workspace) and #626 (public-bound) scopings
- `usage_stats.api_key_id` Integer, nullable, indexed, soft reference (no FK) so attribution survives key deletion

**CWE-639 (IDOR) guard**: `_resolve_public_attribution` runs BEFORE `db.get(Context)` in the route — a key bound to context A receiving a request for context B returns 403 without leaking the URL context's existence.

**Validation cascade in `create_api_key`** (5 gates): UUID format → context exists → workspace match → `is_public=true` → `created_by == user_id` (ownership) → plan has `public_contexts` feature (tier gate). Ownership gate prevents a non-creator workspace member from minting per-key buckets against another member's public context.

**`VerifiedKey` NamedTuple** replaces the 2-tuple return of `APIKeyManager.verify_key` — adds `id` (saves a redundant SELECT in the public endpoint) and `bound_context_id`. `create_key` returns `(plaintext, APIKey)` so 3 callers drop their post-create re-SELECT.

**MCP boundary preserved**: credential mint/revoke is intentionally NOT exposed via MCP. Prompt-injection attack surface stays minimal. Read-only `list_my_bindings` / `describe_binding` are deferred to a follow-up issue.

**Drive-by**: removed a latent `AttributeError` in `api_keys.py:359` regenerate route (referenced `old_key.context_id` on a column dropped in Migration 034).

## Pre-PR review summary

- gate2 mode: advisor-only (gate2.binary_gate=null)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (no end-to-end integration test for public_search bound key flow — covered by APIKeyManager unit + DB migration tests; tracked as follow-up)
- cto: green
- gate1: green via /claude-c-suite:ask → CSO lens
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/626-feat-feat-auth-bind-one-public-context-per-ap.gate1.md`
- `~/.claude/cache/gh-issue-driven/626-feat-feat-auth-bind-one-public-context-per-ap.gate2.md`

## Deferred follow-ups (filed separately)

- MCP read-only `list_my_bindings` / `describe_binding`
- Integration test for `public_search` bound key end-to-end flow
- `WorkspaceService.get_plan_name()` extraction (7 callsites)
- `last_used_at` write-throttling on `verify_key`
- Server-side `?is_public=true` filter on `GET /contexts`
- Principal dict → TypedDict refactor

🤖 Generated via /gh-issue-driven:ship
