### PR TITLE
fix(db): merge alembic e10 heads to unblock prod deploy

### DIFF
--- a/backend/alembic/versions/e11_merge_e10_heads.py
+++ b/backend/alembic/versions/e11_merge_e10_heads.py
@@ -1,0 +1,25 @@
+"""Merge e10 heads (kagura-cli client + apikey context binding).
+
+#624 (``e10_624_seed_kagura_cli_client``) and #626
+(``e10_626_apikey_bound_context_id``) both branched from
+``e09_608_dcr_default_narrow``. They were merged to ``main`` in sequence
+without rebasing the second migration's ``down_revision``, leaving the
+alembic chain with two heads. This empty merge revision converges them
+into a single head so ``alembic upgrade head`` succeeds in production.
+
+No schema changes here — both branches are independently safe and
+already applied in dev. This is purely a topology fix.
+"""
+
+revision = "e11_merge_e10_heads"
+down_revision = ("e10_624_seed_kagura_cli_client", "e10_626_apikey_bound_context_id")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

- #624 and #626 were merged sequentially without rebasing the second migration's `down_revision`, leaving alembic with two heads at `e09_608_dcr_default_narrow`.
- `deploy.sh` runs `alembic upgrade head` which fails with "Multiple head revisions are present" on multi-head DBs — this blocks v0.16.0 prod deploy.
- This empty merge revision (`e11_merge_e10_heads`) converges both into a single head. No schema changes.

## Verification

Local dev DB upgraded cleanly:
\`\`\`
e09_608_dcr_default_narrow -> e10_624_seed_kagura_cli_client
e10_624_seed_kagura_cli_client, e10_626_apikey_bound_context_id -> e11_merge_e10_heads (head)
\`\`\`

## Test plan

- [x] `alembic heads` shows single head `e11_merge_e10_heads`
- [x] `alembic upgrade head` succeeds on dev DB
- [ ] Prod deploy completes blue→green rotation without alembic error

🤖 Generated with [Claude Code](https://claude.com/claude-code)