### PR TITLE
fix(oauth): log exception in _run_oauth_sync to capture intermittent 500s (#635)

### DIFF
--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -1592,6 +1592,12 @@ def _run_oauth_sync(action: str, request, **kwargs):
 
     Shared helper for ``_handle_authorize_sync`` and ``_handle_token_sync``.
     Creates/closes the session internally so callers don't manage lifecycle.
+
+    Any exception propagates to FastAPI's default handler which returns a
+    plain-text 500 (``Internal Server Error``) — but without a logged
+    traceback we can't see WHERE the failure originated. Log with
+    ``logger.exception(...)`` here so the next intermittent failure leaves
+    a stack trace in api-blue stdout for post-mortem (Issue #635).
     """
     db_session = get_sync_session()
     try:
@@ -1601,6 +1607,7 @@ def _run_oauth_sync(action: str, request, **kwargs):
         return result
     except Exception:
         db_session.rollback()
+        logger.exception("oauth_sync_failed", action=action)
         raise
     finally:
         db_session.close()


### PR DESCRIPTION
Closes #635 (after a follow-up commit lands the root-cause fix once the traceback surfaces).

## Summary

`POST /api/v1/oauth/token/` (and `/oauth/authorize`) intermittently returns HTTP 500 with `Content-Type: text/plain` body \"Internal Server Error\" — the fingerprint of Starlette's `ServerErrorMiddleware` catching an unhandled exception escaping `_run_oauth_sync`. See #635 for the full investigation against \`memory.kagura-ai.com\` Caddy logs.

Today the exception is re-raised without being logged, so the traceback never lands in \`api-blue\` stdout. With blue-green deploys recycling containers we lose any in-memory hint about the failure site.

This adds one line — \`logger.exception(\"oauth_sync_failed\", action=action)\` — inside the existing \`except Exception:\` branch in \`_run_oauth_sync\` (\`backend/src/api/routes/oauth.py:1590\`).

## Why this is safe

- Behavior unchanged: the exception still propagates after logging, the session is still rolled back and closed, the route handler still returns the same 500.
- Same logger instance already used throughout the module; no new imports.
- \`action\` is one of the literal strings passed by callers (\`\"create_token_response\"\`, \`\"create_authorization_response\"\`) — no secret material or PII reaches the log.
- The structured kwarg form matches the project's existing \`structlog\` usage (e.g. \`logger.info(\"oauth2_handle_response\", status_code=status_code)\` on the surrounding lines).

## Test plan

- [ ] Locally: trigger a synthetic exception inside \`server.create_token_response()\` and confirm \`docker compose logs api\` contains the full Python traceback with \`event=oauth_sync_failed action=create_token_response\`.
- [ ] After deploy: leave the change in place; next occurrence of the intermittent 500 will leave a traceback that pinpoints the failure site. Follow-up PR converts that into a targeted fix (likely either an Authlib race condition in \`OAuth2DeviceCode\` row update, or a transient DB error from a deadlock retry).

## Diff

\`\`\`python
def _run_oauth_sync(action: str, request, **kwargs):
    db_session = get_sync_session()
    try:
        server = create_authorization_server(db_session)
        result = getattr(server, action)(request, **kwargs)
        db_session.commit()
        return result
    except Exception:
        db_session.rollback()
+       logger.exception(\"oauth_sync_failed\", action=action)
        raise
    finally:
        db_session.close()
\`\`\`

## Related

- kagura-ai/memory-cloud#635 — root issue (investigation, repro, server-side log fingerprint)
- kagura-ai/kagura-memory-python-sdk#100 / #102 — \`kagura auth\` CLI that surfaced this 500 during smoke test
- kagura-ai/kagura-memory-python-sdk#104 — SDK path fix that uncovered the intermittent behavior

🤖 Generated via end-to-end smoke test investigation