### PR TITLE
fix(oauth): DeviceAuthorizationGrant generate_token override + RFC 6749 server_error shaping (#638)

### DIFF
--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -1744,8 +1744,23 @@ async def oauth_token(request: Request):
     # Debug: log form data
     logger.info("token_request_form", form=request.state.form_data)
 
-    # Run Authlib operations in thread pool to avoid blocking event loop
-    authlib_resp = await asyncio.to_thread(_run_oauth_sync, "create_token_response", request)
+    # Run Authlib operations in thread pool to avoid blocking event loop.
+    # Defense-in-depth (Issue #638): wrap with try/except so any unhandled exception
+    # in the Authlib stack (e.g. a Grant subclass missing a required override) returns
+    # an RFC 6749 server_error JSON instead of Starlette's plain-text 500. The
+    # underlying traceback is already captured by _run_oauth_sync's logger.exception
+    # call (Issue #635 / PR #636), so this handler only shapes the response.
+    try:
+        authlib_resp = await asyncio.to_thread(_run_oauth_sync, "create_token_response", request)
+    except Exception:
+        return JSONResponse(
+            content={
+                "error": "server_error",
+                "error_description": "internal authorization server error",
+            },
+            status_code=500,
+            headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
+        )
 
     # Extract status, body, headers from Authlib response
     if isinstance(authlib_resp, tuple) and len(authlib_resp) == 3:

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -1745,21 +1745,16 @@ async def oauth_token(request: Request):
     logger.info("token_request_form", form=request.state.form_data)
 
     # Run Authlib operations in thread pool to avoid blocking event loop.
-    # Defense-in-depth (Issue #638): wrap with try/except so any unhandled exception
-    # in the Authlib stack (e.g. a Grant subclass missing a required override) returns
-    # an RFC 6749 server_error JSON instead of Starlette's plain-text 500. The
-    # underlying traceback is already captured by _run_oauth_sync's logger.exception
-    # call (Issue #635 / PR #636), so this handler only shapes the response.
+    # Traceback is captured inside _run_oauth_sync; this wrapper only shapes
+    # the response so an unhandled exception in the Authlib stack returns an
+    # RFC 6749 server_error JSON instead of Starlette's plain-text 500.
     try:
         authlib_resp = await asyncio.to_thread(_run_oauth_sync, "create_token_response", request)
     except Exception:
-        return JSONResponse(
-            content={
-                "error": "server_error",
-                "error_description": "internal authorization server error",
-            },
+        return rfc6749_error_response(
+            error="server_error",
+            description="internal authorization server error",
             status_code=500,
-            headers={"Cache-Control": "no-store", "Pragma": "no-cache"},
         )
 
     # Extract status, body, headers from Authlib response

--- a/backend/src/auth/oauth2_server.py
+++ b/backend/src/auth/oauth2_server.py
@@ -510,6 +510,33 @@ class DeviceAuthorizationGrant(_DeviceCodeGrant):
     """
 
     TOKEN_ENDPOINT_AUTH_METHODS = _TOKEN_ENDPOINT_AUTH_METHODS
+    TOKEN_EXPIRES_IN = 3600
+
+    def generate_token(
+        self,
+        user=None,
+        scope=None,
+        grant_type=None,
+        expires_in=None,
+        include_refresh_token=True,
+    ) -> dict[str, Any]:
+        """Generate OAuth2 token for the device_code grant (Issue #638).
+
+        Mirrors ``AuthorizationCodeGrant.generate_token`` and
+        ``RefreshTokenGrant.generate_token``. Without this override
+        Authlib's ``BaseGrant.generate_token`` falls back to
+        ``server.generate_token``, which is intentionally unset per the
+        server bootstrap comment ("Grant methods take precedence"), and
+        raises ``RuntimeError("No configured token generator")`` on every
+        approved device_code poll. See Issue #635 for the prod traceback
+        captured via the observability fix in PR #636.
+        """
+        client = self.request.client
+        if expires_in is None:
+            expires_in = self.TOKEN_EXPIRES_IN
+        if grant_type is None:
+            grant_type = self.GRANT_TYPE
+        return _generate_token_with_expiry(grant_type, client, expires_in, scope)
 
     def query_device_credential(self, device_code: str) -> OAuth2DeviceCode | None:
         return (

--- a/backend/src/auth/oauth2_server.py
+++ b/backend/src/auth/oauth2_server.py
@@ -520,17 +520,9 @@ class DeviceAuthorizationGrant(_DeviceCodeGrant):
         expires_in=None,
         include_refresh_token=True,
     ) -> dict[str, Any]:
-        """Generate OAuth2 token for the device_code grant (Issue #638).
-
-        Mirrors ``AuthorizationCodeGrant.generate_token`` and
-        ``RefreshTokenGrant.generate_token``. Without this override
-        Authlib's ``BaseGrant.generate_token`` falls back to
-        ``server.generate_token``, which is intentionally unset per the
-        server bootstrap comment ("Grant methods take precedence"), and
-        raises ``RuntimeError("No configured token generator")`` on every
-        approved device_code poll. See Issue #635 for the prod traceback
-        captured via the observability fix in PR #636.
-        """
+        # Override required: Authlib's BaseGrant.generate_token delegates to
+        # server.generate_token, which is intentionally unset on the wrapper
+        # (see _register_grants — "Grant methods take precedence").
         client = self.request.client
         if expires_in is None:
             expires_in = self.TOKEN_EXPIRES_IN

--- a/backend/tests/api/test_device_code_endpoints.py
+++ b/backend/tests/api/test_device_code_endpoints.py
@@ -353,3 +353,47 @@ class TestDeviceConfirmEndpoint:
                 )
 
         assert resp.status_code == 409
+
+
+class TestTokenEndpointDefenseInDepth:
+    """Regression guard for Issue #638 defense-in-depth: unhandled exceptions
+    in ``_run_oauth_sync`` are shaped as RFC 6749 ``server_error`` JSON instead
+    of Starlette's default plain-text 500.
+
+    Pre-fix the bug from Issue #635 surfaced as ``Content-Type: text/plain``
+    body ``Internal Server Error`` (21 bytes). RFC 6749 §5.2 mandates JSON
+    error responses on the token endpoint, so even genuine 500s should carry
+    structured ``{error, error_description}`` for client tooling.
+    """
+
+    def test_unhandled_exception_returns_rfc6749_server_error_json(self):
+        with patch(
+            "api.routes.oauth._run_oauth_sync",
+            side_effect=RuntimeError("simulated authlib failure"),
+        ):
+            client = TestClient(app)
+            resp = client.post(
+                "/api/v1/oauth/token/",
+                data={
+                    "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+                    "device_code": "any-device-code-since-we-mocked-the-runner",
+                    "client_id": "kagura-cli",
+                },
+            )
+
+        # Regression: pre-fix this returned 500 text/plain "Internal Server Error".
+        assert resp.status_code == 500
+        content_type = resp.headers.get("content-type", "")
+        assert content_type.startswith("application/json"), (
+            f"expected JSON content-type, got {content_type!r}"
+        )
+
+        body = resp.json()
+        assert body == {
+            "error": "server_error",
+            "error_description": "internal authorization server error",
+        }
+
+        # RFC 6749 §5.1 cache directives on token error responses
+        assert resp.headers.get("cache-control") == "no-store"
+        assert resp.headers.get("pragma") == "no-cache"

--- a/backend/tests/auth/test_device_code_grant.py
+++ b/backend/tests/auth/test_device_code_grant.py
@@ -42,6 +42,15 @@ def _make_grant():
     return grant
 
 
+def _make_grant_with_request(client_id="kagura-cli"):
+    """Grant with a mock request/client/GRANT_TYPE attached — for generate_token tests."""
+    grant = _make_grant()
+    grant.request = MagicMock()
+    grant.request.client.client_id = client_id
+    grant.GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+    return grant
+
+
 class TestDeviceAuthorizationGrant:
     def test_query_device_credential_found(self):
         grant = _make_grant()
@@ -136,23 +145,14 @@ class TestDeviceGrantRegistration:
 
 
 class TestDeviceAuthorizationGrantTokenGeneration:
-    """Regression guard for Issue #638: DeviceAuthorizationGrant.generate_token override.
-
-    Without this method Authlib's BaseGrant.generate_token falls through to
-    server.generate_token (intentionally unset) and raises
-    RuntimeError("No configured token generator") on every approved
+    """Without ``generate_token`` Authlib's ``BaseGrant.generate_token`` falls
+    through to ``server.generate_token`` (intentionally unset) and raises
+    ``RuntimeError("No configured token generator")`` on every approved
     device_code poll.
     """
 
-    def _make_grant_with_request(self, client_id="kagura-cli"):
-        grant = _make_grant()
-        grant.request = MagicMock()
-        grant.request.client.client_id = client_id
-        grant.GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
-        return grant
-
     def test_generate_token_returns_oauth2_token_dict(self):
-        grant = self._make_grant_with_request()
+        grant = _make_grant_with_request()
         token = grant.generate_token(scope="memory:read")
 
         assert token["token_type"] == "Bearer"
@@ -161,21 +161,20 @@ class TestDeviceAuthorizationGrantTokenGeneration:
         assert token["scope"] == "memory:read"
 
     def test_generate_token_uses_class_token_expires_in_when_none(self):
-        grant = self._make_grant_with_request()
+        grant = _make_grant_with_request()
         token = grant.generate_token(scope="memory:read", expires_in=None)
         assert token["expires_in"] == DeviceAuthorizationGrant.TOKEN_EXPIRES_IN
         assert token["expires_in"] == 3600
 
     def test_generate_token_respects_explicit_expires_in(self):
-        grant = self._make_grant_with_request()
+        grant = _make_grant_with_request()
         token = grant.generate_token(scope="memory:read", expires_in=42)
         assert token["expires_in"] == 42
 
     def test_generate_token_uses_class_grant_type_when_none(self):
-        grant = self._make_grant_with_request()
+        # GRANT_TYPE fallback path: no exception means _generate_token_with_expiry
+        # accepted the device_code grant_type from the class attribute.
+        grant = _make_grant_with_request()
         token = grant.generate_token(scope="memory:read")
-        # Token dict itself doesn't echo grant_type, but the helper logs it.
-        # Confirm the call succeeded with the device_code GRANT_TYPE — no exception means
-        # _generate_token_with_expiry accepted the grant_type fallback path.
         assert token is not None
         assert "access_token" in token

--- a/backend/tests/auth/test_device_code_grant.py
+++ b/backend/tests/auth/test_device_code_grant.py
@@ -133,3 +133,49 @@ class TestDeviceGrantRegistration:
 
         registered_classes = [call.args[0] for call in wrapper.server.register_grant.call_args_list]
         assert DeviceAuthorizationGrant in registered_classes
+
+
+class TestDeviceAuthorizationGrantTokenGeneration:
+    """Regression guard for Issue #638: DeviceAuthorizationGrant.generate_token override.
+
+    Without this method Authlib's BaseGrant.generate_token falls through to
+    server.generate_token (intentionally unset) and raises
+    RuntimeError("No configured token generator") on every approved
+    device_code poll.
+    """
+
+    def _make_grant_with_request(self, client_id="kagura-cli"):
+        grant = _make_grant()
+        grant.request = MagicMock()
+        grant.request.client.client_id = client_id
+        grant.GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
+        return grant
+
+    def test_generate_token_returns_oauth2_token_dict(self):
+        grant = self._make_grant_with_request()
+        token = grant.generate_token(scope="memory:read")
+
+        assert token["token_type"] == "Bearer"
+        assert "access_token" in token and len(token["access_token"]) > 0
+        assert "refresh_token" in token and len(token["refresh_token"]) > 0
+        assert token["scope"] == "memory:read"
+
+    def test_generate_token_uses_class_token_expires_in_when_none(self):
+        grant = self._make_grant_with_request()
+        token = grant.generate_token(scope="memory:read", expires_in=None)
+        assert token["expires_in"] == DeviceAuthorizationGrant.TOKEN_EXPIRES_IN
+        assert token["expires_in"] == 3600
+
+    def test_generate_token_respects_explicit_expires_in(self):
+        grant = self._make_grant_with_request()
+        token = grant.generate_token(scope="memory:read", expires_in=42)
+        assert token["expires_in"] == 42
+
+    def test_generate_token_uses_class_grant_type_when_none(self):
+        grant = self._make_grant_with_request()
+        token = grant.generate_token(scope="memory:read")
+        # Token dict itself doesn't echo grant_type, but the helper logs it.
+        # Confirm the call succeeded with the device_code GRANT_TYPE — no exception means
+        # _generate_token_with_expiry accepted the grant_type fallback path.
+        assert token is not None
+        assert "access_token" in token


### PR DESCRIPTION
Closes #638

Refs #635 (parent observability + investigation issue). Once this PR lands and prod deploy verifies no further `oauth_sync_failed` events in api stdout, #635's remaining acceptance bullets are met and the parent can be closed manually.

## Summary

- **Primary fix**: add `generate_token` override to `DeviceAuthorizationGrant` (`backend/src/auth/oauth2_server.py:512`) so Authlib's RFC 8628 device-code flow stops raising `RuntimeError("No configured token generator")` on every approved device_code poll.
- **Defense-in-depth**: wrap `_run_oauth_sync` call in `oauth_token` (`backend/src/api/routes/oauth.py:1748`) with try/except → `rfc6749_error_response("server_error", ..., status_code=500)` so any future unhandled Authlib exception returns RFC 6749 §5.2 conformant JSON instead of Starlette's plain-text 500.
- **Tests**: 4 unit tests + 1 integration test (defense-in-depth path). All 28 device-code-area + 117 oauth-area tests pass.

## Root cause (captured via #635 observability)

PR #636 (squash 597e3b9d) landed `logger.exception("oauth_sync_failed", action=action)` in `_run_oauth_sync`. The first 500 captured in api-green stdout on 2026-05-13T10:02:34Z (immediately after deploy, during `kagura-cli auth login` dogfooding) terminated at:

```
File ".../authlib/oauth2/rfc6749/authorization_server.py", line 71, in generate_token
    raise RuntimeError("No configured token generator")
```

`AuthorizationCodeGrant` (line 213) and `RefreshTokenGrant` (line 421) each override `generate_token` per the `_register_grants` "Grant methods take precedence" contract. `DeviceAuthorizationGrant` (added in #536) did not — so Authlib's `BaseGrant.generate_token` delegated to `server.generate_token` (intentionally unset on the wrapper) and raised. The "1-in-30" rate from #635 was dilution: most polls return 400 `authorization_pending` from `validate_token_request` and never reach `generate_token`; once validation passes, the 500 fires 100% of the time.

## Implementation notes

- `_generate_token_with_expiry` helper at oauth2_server.py:150 is reused — same call shape as the two sibling grants.
- `TOKEN_EXPIRES_IN = 3600` class attr matches sibling grants — no token-lifetime policy change.
- `oauth_authorize` already returns RFC 6749 error via `RedirectResponse` (line 1693), per RFC 6749 §4.1.2.1 (authorize endpoint uses redirect; token endpoint uses JSON). No parity work needed there.
- `/simplify` pass folded an inline `JSONResponse(...)` into the existing `rfc6749_error_response` helper (oauth.py:682, 702 precedent), dropped task-narrative docstring on `generate_token` (matches the zero-docstring pattern on sibling grants), and moved `_make_grant_with_request()` test helper to module scope alongside `_make_grant()`.

### Wire-shape change (please note)

Token endpoint 500 responses change from `Content-Type: text/plain` body `"Internal Server Error"` (21 bytes) to `Content-Type: application/json` body `{"error": "server_error", "error_description": "internal authorization server error"}`. This is RFC 6749 §5.2 conformance — OAuth-aware clients (kagura-cli, Anthropic SDK) parse the structured form natively. Clients doing strict text-match on `"Internal Server Error"` were already broken on any well-formed 4xx response from this endpoint.

### Out-of-scope, follow-up issues recommended (v0.16.x maintenance)

- `refactor(auth): extract _ExpiryAwareGenerateTokenMixin for grant classes` — collapse the 3-copy duplication (low priority)
- `refactor(auth): assert generate_token override on every registered grant at bootstrap` — boot-time defensive assertion to catch the next "missing override" trap deterministically (medium priority)
- `chore(auth): redact device_code/refresh_token/code in token_request_form log` — `logger.info("token_request_form", form=request.state.form_data)` at oauth.py:1745 (pre-existing, unchanged) leaks short-lived bearer tokens to stdout (medium priority)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/638-fix-fix-oauth-deviceauthorizationgrant-missi.gate1.md
- ~/.claude/cache/gh-issue-driven/638-fix-fix-oauth-deviceauthorizationgrant-missi.gate2.md

🤖 Generated via /gh-issue-driven:ship
