### PR TITLE
test(api): regression guard for _run_oauth_sync exception logging (#637)

### DIFF
--- a/backend/tests/api/test_oauth_sync_exception_logging.py
+++ b/backend/tests/api/test_oauth_sync_exception_logging.py
@@ -1,0 +1,47 @@
+"""Regression guard for Issue #637 / PR #636 — exception logging in ``_run_oauth_sync``.
+
+WHY: existing oauth tests only mock-patch ``_run_oauth_sync`` itself, so the real
+``except Exception:`` block is never exercised. PR #636's ``logger.exception(...)``
+line could be silently deleted in a future refactor with no test failing.
+
+This pins three contracts at once for both action values
+(``create_token_response`` and ``create_authorization_response``):
+
+* the exception still propagates (re-raise intact),
+* exactly one ``oauth_sync_failed`` structlog event is emitted with the
+  expected ``action`` kwarg, and
+* the synchronous DB session is rolled back AND closed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from structlog.testing import capture_logs
+
+from api.routes.oauth import _run_oauth_sync
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["create_token_response", "create_authorization_response"],
+)
+def test_run_oauth_sync_logs_exception_before_reraise(action: str) -> None:
+    fake_server = MagicMock()
+    getattr(fake_server, action).side_effect = RuntimeError("simulated authlib failure")
+    fake_session = MagicMock()
+
+    with (
+        patch("api.routes.oauth.create_authorization_server", return_value=fake_server),
+        patch("api.routes.oauth.get_sync_session", return_value=fake_session),
+        capture_logs() as captured,
+    ):
+        with pytest.raises(RuntimeError, match="simulated authlib failure"):
+            _run_oauth_sync(action, request=MagicMock())
+
+    log_events = [r for r in captured if r.get("event") == "oauth_sync_failed"]
+    assert len(log_events) == 1
+    assert log_events[0]["action"] == action
+    fake_session.rollback.assert_called_once()
+    fake_session.close.assert_called_once()


### PR DESCRIPTION
Closes #637

## Summary
- Add `backend/tests/api/test_oauth_sync_exception_logging.py` to pin the regression guard for PR #636's `logger.exception("oauth_sync_failed", action=action)` in `_run_oauth_sync` (`backend/src/api/routes/oauth.py:1610`).
- Parametrized over both action values (`create_token_response`, `create_authorization_response`) — covers the dynamic `getattr(server, action)` dispatch path.
- Pins three contracts at once: exception re-raise, structlog event emission with the correct kwarg, DB session rollback + close.
- Mutation-checked in-session: commenting out the `logger.exception` line at `oauth.py:1610` fails both parametrized cases on `len(log_events) == 1`.

## Implementation notes
- Uses `structlog.testing.capture_logs()` (precedent: `test_byok_resolver.py:36`, `test_role_manager_postgres.py:310`).
- Skips the inline `sys.path` bootstrap stanza that 5 other `test_oauth_*.py` files carry — pytest's `pyproject.toml` `pythonpath = ["src"]` makes it a no-op. The 5 existing files can be cleaned up in a follow-up PR.
- Module docstring is WHY-only (14 lines) — refactor-resilience rationale, no narration.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (routed to QA Lead lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/637-feat-test-api-regression-guard-for-run-oauth.gate1.md`
- `~/.claude/cache/gh-issue-driven/637-feat-test-api-regression-guard-for-run-oauth.gate2.md`

🤖 Generated via /gh-issue-driven:ship
