### PR TITLE
fix(oauth): device-flow /api/v1/oauth/token response missing user_email / workspace_id / workspace_name (#640)

### DIFF
--- a/backend/src/auth/oauth2_server.py
+++ b/backend/src/auth/oauth2_server.py
@@ -552,9 +552,15 @@ class DeviceAuthorizationGrant(_DeviceCodeGrant):
             if user_row:
                 token["user_email"] = user_row.email
                 if user_row.current_workspace_id:
+                    # Filter out soft-deleted workspaces. Matches the project
+                    # convention (services/workspace_service.py and others).
+                    # The FK ondelete=SET NULL only covers hard deletes; soft
+                    # deletes via Workspace.deleted_at would otherwise leak a
+                    # stale workspace_id/name into the token response.
                     workspace = (
                         self.server.db_session.query(Workspace)
                         .filter_by(id=user_row.current_workspace_id)
+                        .filter(Workspace.deleted_at.is_(None))
                         .first()
                     )
                     if workspace:

--- a/backend/src/auth/oauth2_server.py
+++ b/backend/src/auth/oauth2_server.py
@@ -40,7 +40,14 @@ from authlib.oauth2.rfc8628 import DeviceCodeGrant as _DeviceCodeGrant
 from sqlalchemy.orm import Session
 
 from config.settings import get_settings
-from models.auth import OAuth2AuthorizationCode, OAuth2Client, OAuth2DeviceCode, OAuth2Token
+from models.auth import (
+    OAuth2AuthorizationCode,
+    OAuth2Client,
+    OAuth2DeviceCode,
+    OAuth2Token,
+    User,
+    Workspace,
+)
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -528,7 +535,33 @@ class DeviceAuthorizationGrant(_DeviceCodeGrant):
             expires_in = self.TOKEN_EXPIRES_IN
         if grant_type is None:
             grant_type = self.GRANT_TYPE
-        return _generate_token_with_expiry(grant_type, client, expires_in, scope)
+        token = _generate_token_with_expiry(grant_type, client, expires_in, scope)
+
+        # Attach identity (email + workspace) to the response body for SDK
+        # display. Lawful basis: /device consent (RFC 8628 §3.3, APPI 第27条,
+        # GDPR Art.6(1)(a)); recipient disclosure: Privacy Policy thirdParty
+        # section. NOT security-bearing — do not use for authorization.
+        # Workspace is User.current_workspace_id at grant time (point-in-time,
+        # not consent-bound — OAuth2DeviceCode lacks a workspace column).
+        # ``getattr`` default guards the contract verified by
+        # tests/auth/test_device_code_grant.py: callers may pass ``user=None``
+        # to assert the base token-shape; identity injection is skipped then.
+        user_id = getattr(user, "user_id", None)
+        if user_id:
+            user_row = self.server.db_session.query(User).filter_by(user_id=user_id).first()
+            if user_row:
+                token["user_email"] = user_row.email
+                if user_row.current_workspace_id:
+                    workspace = (
+                        self.server.db_session.query(Workspace)
+                        .filter_by(id=user_row.current_workspace_id)
+                        .first()
+                    )
+                    if workspace:
+                        token["workspace_id"] = str(workspace.id)
+                        token["workspace_name"] = workspace.name
+
+        return token
 
     def query_device_credential(self, device_code: str) -> OAuth2DeviceCode | None:
         return (

--- a/backend/tests/auth/test_device_code_grant.py
+++ b/backend/tests/auth/test_device_code_grant.py
@@ -178,3 +178,78 @@ class TestDeviceAuthorizationGrantTokenGeneration:
         token = grant.generate_token(scope="memory:read")
         assert token is not None
         assert "access_token" in token
+
+    # ----- Identity injection (#640) -----
+    # The next three tests pin the response-body identity contract that the SDK
+    # (kagura-memory-python-sdk device_flow.py:382-385) reads. They are the
+    # mirror of the user=None tests above for the user-populated branch.
+
+    @staticmethod
+    def _stub_identity_lookups(grant, user_row, workspace):
+        """Wire ``server.db_session.query(...)`` to return distinct chains for
+        ``User`` and ``Workspace`` lookups. ``Workspace`` uses a longer chain
+        (``filter_by(...).filter(...).first()``) because the production code
+        filters soft-deleted workspaces — keep this mirrored against
+        ``oauth2_server.py`` if that chain ever changes shape.
+        """
+        from models.auth import User
+
+        user_chain = MagicMock()
+        user_chain.filter_by.return_value.first.return_value = user_row
+        ws_chain = MagicMock()
+        ws_chain.filter_by.return_value.filter.return_value.first.return_value = workspace
+        grant.server.db_session.query.side_effect = lambda model: (
+            user_chain if model is User else ws_chain
+        )
+
+    def test_generate_token_injects_identity_when_user_and_workspace_present(self):
+        from uuid import uuid4
+
+        grant = _make_grant_with_request()
+        workspace_uuid = uuid4()
+        user_row = MagicMock(email="alice@example.com", current_workspace_id=workspace_uuid)
+        # ``MagicMock(name=...)`` sets the mock's repr name, not an attribute —
+        # assign workspace.name after construction so production reads it as data.
+        workspace = MagicMock(id=workspace_uuid)
+        workspace.name = "alice-workspace"
+        self._stub_identity_lookups(grant, user_row, workspace)
+
+        user = MagicMock(user_id="oauth-sub-alice")
+        token = grant.generate_token(user=user, scope="memory:read")
+
+        assert token["user_email"] == "alice@example.com"
+        assert token["workspace_id"] == str(workspace_uuid)
+        assert token["workspace_name"] == "alice-workspace"
+
+    def test_generate_token_skips_soft_deleted_workspace(self):
+        # Regression guard for the soft-delete filter (added after Copilot
+        # review loop 1). When the Workspace query returns None — which is
+        # what the ``.filter(Workspace.deleted_at.is_(None))`` clause produces
+        # for a soft-deleted row — the token must NOT carry stale identity.
+        from uuid import uuid4
+
+        grant = _make_grant_with_request()
+        user_row = MagicMock(email="bob@example.com", current_workspace_id=uuid4())
+        # workspace=None simulates the soft-delete filter excluding the row.
+        self._stub_identity_lookups(grant, user_row, None)
+
+        user = MagicMock(user_id="oauth-sub-bob")
+        token = grant.generate_token(user=user, scope="memory:read")
+
+        assert token["user_email"] == "bob@example.com"
+        assert "workspace_id" not in token
+        assert "workspace_name" not in token
+
+    def test_generate_token_skips_workspace_when_user_has_no_current_workspace(self):
+        grant = _make_grant_with_request()
+        user_row = MagicMock(email="carol@example.com", current_workspace_id=None)
+        # workspace stub is unused because user_row.current_workspace_id is
+        # falsy and the production code short-circuits before querying.
+        self._stub_identity_lookups(grant, user_row, workspace=None)
+
+        user = MagicMock(user_id="oauth-sub-carol")
+        token = grant.generate_token(user=user, scope="memory:read")
+
+        assert token["user_email"] == "carol@example.com"
+        assert "workspace_id" not in token
+        assert "workspace_name" not in token

--- a/frontend/src/app/device/page.test.tsx
+++ b/frontend/src/app/device/page.test.tsx
@@ -260,6 +260,28 @@ describe("DevicePage", () => {
     });
   });
 
+  it("discloses identity fields shared with the client on consent screen (#640)", async () => {
+    mockVerifyDeviceCode.mockResolvedValue({
+      user_code: "ABCD1234",
+      client_name: "Test CLI",
+      scope: "memory:read memory:write",
+      expires_at: "2026-01-01T00:00:00Z",
+      is_authorized: false,
+      is_expired: false,
+    });
+    render(<DevicePage />);
+
+    const input = screen.getByLabelText("device.codeLabel");
+    fireEvent.change(input, { target: { value: "ABCD1234" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(screen.getByText("device.identityShareLabel")).toBeDefined();
+      expect(screen.getByText("device.identityEmail")).toBeDefined();
+      expect(screen.getByText("device.identityWorkspace")).toBeDefined();
+    });
+  });
+
   it("transitions to denied on 409 already-denied during confirm", async () => {
     mockVerifyDeviceCode.mockResolvedValue({
       user_code: "ABCD1234",

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -260,7 +260,24 @@ function DevicePageInner() {
                 {deviceInfo.client_name}
               </p>
 
-              {renderScopeBadges(deviceInfo.scope)}
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                  {t("device.permissionsLabel")}
+                </p>
+                {renderScopeBadges(deviceInfo.scope)}
+              </div>
+
+              <div className="space-y-2">
+                <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                  {t("device.identityShareLabel")}
+                </p>
+                <div className="flex flex-wrap gap-2 justify-center">
+                  <Badge variant="secondary">{t("device.identityEmail")}</Badge>
+                  <Badge variant="secondary">
+                    {t("device.identityWorkspace")}
+                  </Badge>
+                </div>
+              </div>
 
               <div className="flex gap-3 justify-center pt-2">
                 <Button

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -614,6 +614,7 @@
         "authentication": "**Authentication**: Google OAuth2 (for login)",
         "infrastructure": "**Infrastructure**: Google Cloud Platform (hosting), Qdrant Cloud (vector database)",
         "aiApis": "**AI APIs**: OpenAI (embeddings), Voyage AI / Cohere (reranking) - only when explicitly enabled by you.",
+        "oauthOutgoing": "**Identity disclosure to OAuth clients**: When you authorize a third-party application (kagura-memory-python-sdk, Claude Code, Cursor, and other MCP clients) at the /device consent screen, those applications receive your email address, workspace identifier, and workspace name alongside the access token. This is required so the application can display account status. You can revoke this authorization at any time via Settings → OAuth Apps (GDPR Art. 13(1)(e), Japan APPI Art. 27).",
         "conclusion": "These services have their own privacy policies and we carefully vet all providers for compliance."
       },
       "subProcessors": {
@@ -3318,6 +3319,10 @@
     "scopeAdmin": "Manage workspace",
     "scopeOffline": "Offline access",
     "unknownScope": "Unknown permission: {scope}",
+    "permissionsLabel": "Permissions",
+    "identityShareLabel": "Identity shared",
+    "identityEmail": "Email address",
+    "identityWorkspace": "Workspace",
     "approve": "Approve",
     "approving": "Approving...",
     "deny": "Deny",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -614,6 +614,7 @@
         "authentication": "**認証**: Google OAuth2（ログイン用）",
         "infrastructure": "**インフラストラクチャ**: Google Cloud Platform（ホスティング）、Qdrant Cloud（ベクターデータベース）",
         "aiApis": "**AI API**: OpenAI（埋め込み）、Voyage AI / Cohere（リランキング）- あなたが明示的に有効にした場合のみ。",
+        "oauthOutgoing": "**OAuth クライアントへの identity 提供**: あなたが /device 同意画面で third-party アプリケーション（kagura-memory-python-sdk、Claude Code、Cursor 等の MCP client）を承認した場合、それらのアプリケーションには access token と共にあなたのメールアドレス・workspace 識別子・workspace 名が提供されます。これはアプリケーション側でアカウント状態を表示するために必要です。承認の取り消しは Settings → OAuth Apps から行えます（GDPR 第13条第1項(e)、個人情報保護法 第27条）。",
         "conclusion": "これらのサービスには独自のプライバシーポリシーがあり、準拠性についてすべてのプロバイダーを慎重に審査しています。"
       },
       "subProcessors": {
@@ -3318,6 +3319,10 @@
     "scopeAdmin": "ワークスペースの管理",
     "scopeOffline": "オフラインアクセス",
     "unknownScope": "不明な権限: {scope}",
+    "permissionsLabel": "アクセス権限",
+    "identityShareLabel": "共有される情報",
+    "identityEmail": "メールアドレス",
+    "identityWorkspace": "ワークスペース",
     "approve": "認証する",
     "approving": "認証中...",
     "deny": "拒否する",


### PR DESCRIPTION
Closes #640

## Summary
- Add `user_email` / `workspace_id` / `workspace_name` to the device-flow `/api/v1/oauth/token` response body so `kagura auth status` shows the User: and Workspace: lines instead of falling back to "Logged in as <unknown user>". The 3 fields were always read by the SDK (`kagura-memory-python-sdk` `device_flow.py:382-385`) but never populated by the server.
- Implementation chosen (Option B per gate1 design review): override `DeviceAuthorizationGrant.generate_token` only — no shared helper extraction, no schema migration, no API contract change (additive only).
- Workspace identity sourced from `User.current_workspace_id` (Issue #115 Phase B) at token-grant time. Documented in code comment as point-in-time, not consent-bound.
- Closes the informed-consent gap by adding a Privacy Policy paragraph (outgoing OAuth identity disclosure) and a `/device` consent UI "Identity shared" Badge section so users see what gets disclosed at the moment of consent.

## Implementation notes
- `backend/src/auth/oauth2_server.py` (+35/-2): `DeviceAuthorizationGrant.generate_token` looks up `User` (by `user_id`) and `Workspace` (by `current_workspace_id`), injects the 3 fields. Defensive `if` guards make every failure mode fail-graceful (deleted user / no workspace / deleted workspace → silent skip, SDK falls back to empty-string default). 8-line WHY-only comment block anchors the lawful basis (RFC 8628 §3.3, APPI 第27条, GDPR Art.6(1)(a)) and notes the workspace_id semantic weakness. `getattr(user, "user_id", None)` default preserves the `user=None` test contract in `tests/auth/test_device_code_grant.py`.
- `frontend/src/app/device/page.tsx` (+18/-1): two parallel labeled Badge sections (Permissions / Identity shared) replace the bare scope-badge render. Uses existing `Badge variant="secondary"` and existing scope-badge layout pattern — no new abstractions.
- `frontend/src/messages/{ja,en}.json` (+5 each): 4 new device i18n keys (permissionsLabel, identityShareLabel, identityEmail, identityWorkspace) + 1 PP paragraph (`privacy.sections.thirdParty.oauthOutgoing`).
- `frontend/src/app/device/page.test.tsx` (+22): isolated regression test `discloses identity fields shared with the client on consent screen (#640)`. Mutation-checked in-session: removing the disclosure section from `page.tsx` fails exactly 1 test (the new one); 10 existing tests stay green.
- 28 device + 74 broader auth backend tests pass. 11 frontend device tests pass. Ruff clean.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (CTO lens) → resolved via CxO chain (cso/clo/cdo/qa-lead) and operator HITL choosing 1-PR-with-5-artifacts
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/640-fix-fix-oauth-device-flow-api-v1-oauth-token.gate1.md`
- `~/.claude/cache/gh-issue-driven/640-fix-fix-oauth-device-flow-api-v1-oauth-token.gate2.md`

🤖 Generated via /gh-issue-driven:ship
