### PR TITLE
fix(memory): bump access_count / last_used_at on explore() (#644)

### DIFF
--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1749,6 +1749,9 @@ class MemoryService:
                 score=None,
             )
 
+            await self.memory_repo.update_access_stats(seed_memory.id, client="api")
+            await self.db.commit()
+
             return ExploreResponse(
                 seed_memory=seed_response,
                 related_memories=[],
@@ -1801,6 +1804,9 @@ class MemoryService:
                 context=seed_memory.context,
                 score=None,
             )
+
+            await self.memory_repo.update_access_stats(seed_memory.id, client="api")
+            await self.db.commit()
 
             return ExploreResponse(
                 seed_memory=seed_response,
@@ -1872,6 +1878,11 @@ class MemoryService:
             context=seed_memory.context,
             score=None,
         )
+
+        await self.memory_repo.update_access_stats(seed_memory.id, client="api")
+        for related in related_memories:
+            await self.memory_repo.update_access_stats(related.memory_id, client="api")
+        await self.db.commit()
 
         logger.info(
             "explore_completed",

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1092,3 +1092,69 @@ class TestExploreHints:
         # Recall succeeded despite hint failure
         assert response.results is not None
         assert len(response.results) == 1
+
+
+class TestExploreAccessStats:
+    """Issue #644: explore() bumps access_count / last_used_at on returned memories
+    consistent with recall() and reference()."""
+
+    @pytest.fixture
+    def service(self):
+        return MemoryService(MagicMock())
+
+    @pytest.mark.asyncio
+    async def test_explore_bumps_seed_when_seed_not_in_graph(self, service):
+        """Path A: has_node() returns False → only seed is bumped, then return."""
+        from models.schemas import ExploreRequest
+
+        seed_id = uuid4()
+        workspace_id = uuid4()
+        context_id = uuid4()
+
+        mock_seed = MagicMock(
+            id=seed_id,
+            user_id="test_user",
+            summary="Seed",
+            context_summary=None,
+            type="note",
+            importance=0.5,
+            scope="working",
+            created_at=datetime.utcnow(),
+            client="api",
+            tags=[],
+            context=None,
+            workspace_id=workspace_id,
+            context_id=context_id,
+        )
+        service.memory_repo.get = AsyncMock(return_value=mock_seed)
+        service.memory_repo.update_access_stats = AsyncMock()
+        service.db.commit = AsyncMock()
+
+        with (
+            patch("services.permission_service.PermissionService") as mock_perm_cls,
+            patch("repositories.graph.GraphRepository") as mock_graph_repo_cls,
+            patch("services.graph_service.GraphService") as mock_graph_service_cls,
+        ):
+            mock_perm = MagicMock()
+            mock_perm.can_access_memory = AsyncMock(return_value=True)
+            mock_perm_cls.return_value = mock_perm
+
+            mock_graph_repo = MagicMock()
+            mock_graph_repo.get_or_create = AsyncMock()
+            mock_graph_repo_cls.return_value = mock_graph_repo
+
+            mock_graph_service = MagicMock()
+            mock_graph_service.has_node = AsyncMock(return_value=False)
+            mock_graph_service_cls.return_value = mock_graph_service
+
+            response = await service.explore(
+                request=ExploreRequest(memory_id=seed_id, depth=2),
+                user_id="test_user",
+            )
+
+        assert response.metadata.get("reason") == "seed_not_in_graph"
+        assert response.related_memories == []
+
+        # Only one update_access_stats call: for the seed, with client="api".
+        service.memory_repo.update_access_stats.assert_awaited_once_with(seed_id, client="api")
+        service.db.commit.assert_awaited()

--- a/backend/tests/test_single_collection_isolation.py
+++ b/backend/tests/test_single_collection_isolation.py
@@ -154,6 +154,30 @@ async def test_context_ws2(db_session, test_workspace2):
     return context
 
 
+@pytest_asyncio.fixture(autouse=True)
+async def pending_embedding_tasks(monkeypatch):
+    """Patch asyncio.create_task to track embedding tasks so tests can await them.
+
+    Tests that fire embedding-triggering calls (e.g., service.remember()) must await
+    all pending tasks before recall() — otherwise the Qdrant points are not yet
+    written and recall() returns empty. Tests that need that wait request this
+    fixture as a parameter and await it via asyncio.gather(*pending_embedding_tasks).
+    """
+    import asyncio
+
+    original_create_task = asyncio.create_task
+    pending_tasks: list = []
+
+    def tracking_create_task(coro, **kwargs):
+        task = original_create_task(coro, **kwargs)
+        pending_tasks.append(task)
+        return task
+
+    monkeypatch.setattr(asyncio, "create_task", tracking_create_task)
+    yield pending_tasks
+    monkeypatch.setattr(asyncio, "create_task", original_create_task)
+
+
 @pytest.mark.asyncio
 class TestSingleCollectionIsolation:
     """Test 3-level isolation (workspace, context, user) in single collection design.
@@ -162,36 +186,14 @@ class TestSingleCollectionIsolation:
     because process_pending_embedding creates its own DB session via get_db().
     """
 
-    @pytest_asyncio.fixture(autouse=True)
-    async def patch_create_task(self, monkeypatch):
-        """Patch asyncio.create_task to track embedding tasks so tests can await them.
-
-        In test environment, asyncio.create_task fires a background coroutine (embedding).
-        Tests must await all pending embedding tasks before calling recall(), otherwise
-        the Qdrant points won't exist yet and recall() returns empty results.
-
-        This fixture replaces create_task with a version that collects tasks so that
-        tests can call await asyncio.gather(*pending_tasks) after remember().
-        """
-        import asyncio
-
-        original_create_task = asyncio.create_task
-        pending_tasks: list = []
-
-        def tracking_create_task(coro, **kwargs):
-            task = original_create_task(coro, **kwargs)
-            pending_tasks.append(task)
-            return task
-
-        monkeypatch.setattr(asyncio, "create_task", tracking_create_task)
-
-        # Expose pending_tasks via a helper stored on the fixture return value
-        self._pending_embedding_tasks = pending_tasks
-        yield
-        monkeypatch.setattr(asyncio, "create_task", original_create_task)
-
     async def test_cross_workspace_isolation(
-        self, db_session, test_workspace1, test_workspace2, test_context1, test_context_ws2
+        self,
+        db_session,
+        test_workspace1,
+        test_workspace2,
+        test_context1,
+        test_context_ws2,
+        pending_embedding_tasks,
     ):
         """Test that workspace1 cannot see workspace2's memories.
 
@@ -233,7 +235,7 @@ class TestSingleCollectionIsolation:
         # Wait for all background embedding tasks to complete before recall
         import asyncio
 
-        await asyncio.gather(*self._pending_embedding_tasks, return_exceptions=True)
+        await asyncio.gather(*pending_embedding_tasks, return_exceptions=True)
 
         # Test: Workspace1 recalls - should NOT see workspace2's memory
         recall_request = RecallRequest(query="secret data", k=10)
@@ -261,7 +263,12 @@ class TestSingleCollectionIsolation:
         )
 
     async def test_cross_context_isolation_within_same_workspace(
-        self, db_session, test_workspace1, test_context1, test_context2
+        self,
+        db_session,
+        test_workspace1,
+        test_context1,
+        test_context2,
+        pending_embedding_tasks,
     ):
         """Test that context1 cannot see context2's memories (same workspace).
 
@@ -302,7 +309,7 @@ class TestSingleCollectionIsolation:
         # Wait for all background embedding tasks to complete before recall
         import asyncio
 
-        await asyncio.gather(*self._pending_embedding_tasks, return_exceptions=True)
+        await asyncio.gather(*pending_embedding_tasks, return_exceptions=True)
 
         # Test: Recall from context1 - should NOT see context2's memory
         recall_request = RecallRequest(query="data", k=10)
@@ -321,7 +328,7 @@ class TestSingleCollectionIsolation:
         )
 
     async def test_shared_context_members_see_all_memories(
-        self, db_session, test_workspace1, test_context1
+        self, db_session, test_workspace1, test_context1, pending_embedding_tasks
     ):
         """Test that in shared contexts, all members see all memories.
 
@@ -362,7 +369,7 @@ class TestSingleCollectionIsolation:
         # Wait for all background embedding tasks to complete before recall
         import asyncio
 
-        await asyncio.gather(*self._pending_embedding_tasks, return_exceptions=True)
+        await asyncio.gather(*pending_embedding_tasks, return_exceptions=True)
 
         # Test: User1 recalls in shared context — should see both memories
         recall_request = RecallRequest(query="shared note", k=10)
@@ -381,7 +388,12 @@ class TestSingleCollectionIsolation:
         )
 
     async def test_context_deletion_only_deletes_own_points(
-        self, db_session, test_workspace1, test_context1, test_context2
+        self,
+        db_session,
+        test_workspace1,
+        test_context1,
+        test_context2,
+        pending_embedding_tasks,
     ):
         """Test that deleting context1 doesn't affect context2's points.
 
@@ -413,7 +425,7 @@ class TestSingleCollectionIsolation:
         # Wait for all background embedding tasks to complete before deletion/recall
         import asyncio
 
-        await asyncio.gather(*self._pending_embedding_tasks, return_exceptions=True)
+        await asyncio.gather(*pending_embedding_tasks, return_exceptions=True)
 
         # Delete context1's points
         from db.qdrant import delete_context_points
@@ -541,3 +553,274 @@ class TestSingleCollectionIsolation:
                 workspace_id="workspace1",
                 context_id="ctx1",
             )
+
+
+async def _insert_memory(db_session, *, workspace_id, context_id, user_id="user1", summary):
+    """Insert a Memory row directly via the ORM and return its UUID.
+
+    Used by explore() tests that don't need Qdrant — explore() reads from PostgreSQL
+    only (graph + Memory table), so skipping service.remember() avoids the OpenAI
+    embedding round-trip while still satisfying explore()'s data requirements.
+
+    Returns the UUID rather than the ORM object so the caller never accesses a
+    SQLAlchemy attribute on an object whose state may later be expired by a
+    commit inside explore() — that would trigger a synchronous lazy-load and
+    fail with MissingGreenlet in an async context.
+    """
+    memory = Memory(
+        user_id=user_id,
+        summary=summary,
+        content=summary,
+        type="note",
+        client="test",
+        workspace_id=workspace_id,
+        context_id=context_id,
+    )
+    db_session.add(memory)
+    await db_session.flush()
+    memory_id = memory.id
+    return memory_id
+
+
+@pytest.mark.asyncio
+class TestExploreAccessStats:
+    """Test that explore() bumps access_count / last_used_at / accessed_by_clients
+    on returned memories, matching the behavior of recall() and reference()
+    (Issue #644).
+
+    Real-DB integration tests — assertions read back the Memory rows post-call.
+    """
+
+    async def test_explore_bumps_seed_and_related_on_normal_path(
+        self, db_session, test_workspace1, test_context1
+    ):
+        """Path C (normal success): seed + each related memory get bumped once."""
+        service = MemoryService(db_session)
+
+        seed_id = await _insert_memory(
+            db_session,
+            workspace_id=test_workspace1.id,
+            context_id=test_context1.id,
+            summary="Seed node for access stat test",
+        )
+        related_id = await _insert_memory(
+            db_session,
+            workspace_id=test_workspace1.id,
+            context_id=test_context1.id,
+            summary="Related node for access stat test",
+        )
+
+        from services.graph_service import GraphService
+
+        graph_service = GraphService(
+            user_id="user1",
+            db=db_session,
+            workspace_id=str(test_workspace1.id),
+            context_id=str(test_context1.id),
+        )
+        await graph_service.add_edge(
+            src_id=str(seed_id),
+            dst_id=str(related_id),
+            rel_type="related_to",
+            weight=0.8,
+        )
+        await db_session.commit()
+
+        # Baseline: fresh memories have access_count=0, last_used_at IS NULL.
+        seed_row_before = (
+            await db_session.execute(select(Memory).where(Memory.id == seed_id))
+        ).scalar_one()
+        assert seed_row_before.access_count == 0
+        assert seed_row_before.last_used_at is None
+
+        explore_result = await service.explore(
+            ExploreRequest(memory_id=seed_id, depth=2),
+            user_id="user1",
+            current_context_id=test_context1.id,
+            current_workspace_id=test_workspace1.id,
+        )
+
+        # Sanity check: this exercises Path C (related memories present).
+        related_ids = [str(r.memory_id) for r in explore_result.related_memories]
+        assert str(related_id) in related_ids
+
+        # Re-fetch from DB and assert both rows were bumped.
+        db_session.expire_all()
+        seed_row = (
+            await db_session.execute(select(Memory).where(Memory.id == seed_id))
+        ).scalar_one()
+        related_row = (
+            await db_session.execute(select(Memory).where(Memory.id == related_id))
+        ).scalar_one()
+
+        assert seed_row.access_count == 1
+        assert seed_row.last_used_at is not None
+        assert seed_row.accessed_by_clients == ["api"]
+
+        assert related_row.access_count == 1
+        assert related_row.last_used_at is not None
+        assert related_row.accessed_by_clients == ["api"]
+
+    async def test_explore_bumps_seed_only_when_seed_not_in_graph(
+        self, db_session, test_workspace1, test_context1
+    ):
+        """Path A (seed_not_in_graph): only seed gets bumped, no related memories.
+
+        Skips service.remember() entirely — explore() reads from PostgreSQL only
+        and has_node() returns False for a memory with no graph entry, so direct
+        Memory insertion is sufficient.
+        """
+        service = MemoryService(db_session)
+
+        seed_id = await _insert_memory(
+            db_session,
+            workspace_id=test_workspace1.id,
+            context_id=test_context1.id,
+            summary="Lonely seed not in graph",
+        )
+        await db_session.commit()
+
+        explore_result = await service.explore(
+            ExploreRequest(memory_id=seed_id, depth=2),
+            user_id="user1",
+            current_context_id=test_context1.id,
+            current_workspace_id=test_workspace1.id,
+        )
+
+        # Sanity check: this exercises Path A.
+        assert explore_result.metadata.get("reason") == "seed_not_in_graph"
+        assert explore_result.related_memories == []
+
+        db_session.expire_all()
+        seed_row = (
+            await db_session.execute(select(Memory).where(Memory.id == seed_id))
+        ).scalar_one()
+        assert seed_row.access_count == 1
+        assert seed_row.last_used_at is not None
+        assert seed_row.accessed_by_clients == ["api"]
+
+    async def test_explore_bumps_seed_only_when_traversal_yields_empty(
+        self, db_session, test_workspace1, test_context1
+    ):
+        """Path B (empty_traversal): seed in graph, but min_weight filters out everything.
+
+        Skips service.remember() — direct Memory insert plus add_edge gives both
+        the seed graph node (so has_node() returns True) and a related node that
+        will be filtered out by min_weight.
+        """
+        service = MemoryService(db_session)
+
+        seed_id = await _insert_memory(
+            db_session,
+            workspace_id=test_workspace1.id,
+            context_id=test_context1.id,
+            summary="Seed B for empty traversal path",
+        )
+        related_id = await _insert_memory(
+            db_session,
+            workspace_id=test_workspace1.id,
+            context_id=test_context1.id,
+            summary="Related B for empty traversal path",
+        )
+
+        from services.graph_service import GraphService
+
+        graph_service = GraphService(
+            user_id="user1",
+            db=db_session,
+            workspace_id=str(test_workspace1.id),
+            context_id=str(test_context1.id),
+        )
+        # add_edge creates both nodes implicitly, so the seed IS in the graph
+        # (has_node returns True). min_weight=2.0 then filters everything out.
+        await graph_service.add_edge(
+            src_id=str(seed_id),
+            dst_id=str(related_id),
+            rel_type="related_to",
+            weight=0.05,
+        )
+        await db_session.commit()
+
+        explore_result = await service.explore(
+            ExploreRequest(memory_id=seed_id, depth=2, min_weight=2.0),
+            user_id="user1",
+            current_context_id=test_context1.id,
+            current_workspace_id=test_workspace1.id,
+        )
+
+        # Sanity check: this exercises Path B (related filtered out, but seed was in graph).
+        assert explore_result.related_memories == []
+        assert "suggestion" in explore_result.metadata
+
+        db_session.expire_all()
+        seed_row = (
+            await db_session.execute(select(Memory).where(Memory.id == seed_id))
+        ).scalar_one()
+        related_row = (
+            await db_session.execute(select(Memory).where(Memory.id == related_id))
+        ).scalar_one()
+
+        assert seed_row.access_count == 1
+        assert seed_row.last_used_at is not None
+        assert seed_row.accessed_by_clients == ["api"]
+        # Related was NOT in the returned response → must NOT be bumped.
+        assert related_row.access_count == 0
+        assert related_row.last_used_at is None
+
+    async def test_explore_repeated_calls_increment_count(
+        self, db_session, test_workspace1, test_context1
+    ):
+        """Two explore() calls on the same seed (with an edge → Path C) bump both seed and
+        related to access_count=2 and keep accessed_by_clients deduped to ["api"]."""
+        service = MemoryService(db_session)
+
+        seed_id = await _insert_memory(
+            db_session,
+            workspace_id=test_workspace1.id,
+            context_id=test_context1.id,
+            summary="Repeated seed for dedupe test",
+        )
+        related_id = await _insert_memory(
+            db_session,
+            workspace_id=test_workspace1.id,
+            context_id=test_context1.id,
+            summary="Related node for repeated dedupe test",
+        )
+
+        from services.graph_service import GraphService
+
+        graph_service = GraphService(
+            user_id="user1",
+            db=db_session,
+            workspace_id=str(test_workspace1.id),
+            context_id=str(test_context1.id),
+        )
+        await graph_service.add_edge(
+            src_id=str(seed_id),
+            dst_id=str(related_id),
+            rel_type="related_to",
+            weight=0.8,
+        )
+        await db_session.commit()
+
+        for _ in range(2):
+            await service.explore(
+                ExploreRequest(memory_id=seed_id, depth=2),
+                user_id="user1",
+                current_context_id=test_context1.id,
+                current_workspace_id=test_workspace1.id,
+            )
+
+        db_session.expire_all()
+        seed_row = (
+            await db_session.execute(select(Memory).where(Memory.id == seed_id))
+        ).scalar_one()
+        related_row = (
+            await db_session.execute(select(Memory).where(Memory.id == related_id))
+        ).scalar_one()
+
+        assert seed_row.access_count == 2
+        assert seed_row.accessed_by_clients == ["api"]
+        # Related is also bumped via Path C and dedupes the client too.
+        assert related_row.access_count == 2
+        assert related_row.accessed_by_clients == ["api"]


### PR DESCRIPTION
Closes #644

## Summary
- `explore()` was the only read operation in `MemoryService` that did not call `update_access_stats()`. As a result, memories reachable solely via graph traversal had permanently stale `access_count=0` and `last_used_at=NULL`, breaking any cleanup/scoring heuristic based on those columns.
- This PR adds `update_access_stats(memory_id, client="api")` + `db.commit()` to all 3 return paths of `explore()` (seed_not_in_graph / empty_traversal / normal_success), matching the precedent established by `reference()` (`memory_service.py:845-846`).
- In Path C (normal_success), both the seed and each related memory in the response are bumped — consistent with the operator-confirmed design choice that the seed counts as accessed even when explore is the entry method.
- A precondition for the planned `last_used_at` NULL backfill (separate follow-up) is now in place: future writes stay consistent with whatever backfill strategy ships next.

## Implementation notes
- Approach A (inline at each return path) was chosen over a helper extraction in gate1 review. The 6 lines of duplicated `seed_memory.id` bump are an accepted trade-off vs a structural refactor outside this PR's scope.
- `client="api"` is hardcoded (matching `reference()`). `ExploreRequest` has no `filters` field for now, so the more flexible `recall()`-style `request.filters.get("client", "api")` is not applicable.
- Behavior change: `explore()` was previously read-only; all 3 paths now write + commit. The outer FastAPI transaction handles this the same way it does for `reference()`.
- Test refactor (approved during /simplify): `patch_create_task` lifted to module-level `pending_embedding_tasks` autouse fixture, eliminating per-class duplication between `TestSingleCollectionIsolation` and the new `TestExploreAccessStats`. 4 pre-existing test signatures gained the fixture parameter.
- New `_insert_memory()` test helper bypasses `service.remember()` to skip the OpenAI embedding round-trip — `explore()` reads PostgreSQL only (graph + Memory table), not Qdrant, so direct ORM insertion satisfies all data requirements. The helper returns the UUID (not the Memory ORM object) to avoid `MissingGreenlet` errors from lazy attribute loads after `expire_all()`.

## Test coverage
- 4 real-DB integration tests in `TestExploreAccessStats` covering Path A, Path B, Path C, and repeated-call dedupe of `accessed_by_clients`.
- 1 unit test for Path A with PermissionService / GraphRepository / GraphService mocked.
- All 10 tests in `test_single_collection_isolation.py` pass against real Postgres (6 pre-existing + 4 new).
- `make lint` clean.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green — no new attack surface, audit trail integrity improved (positive on OWASP A09)
- qa-lead: green — all 3 paths + dedupe property covered, strong assertion quality
- cto: green — surgical fix, symmetric with `reference()`, test debt reduced via fixture lift
- gate1: green via /ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/644-fix-fix-memory-bump-access-count-last-used-a.gate1.md
- ~/.claude/cache/gh-issue-driven/644-fix-fix-memory-bump-access-count-last-used-a.gate2.md

Related follow-ups (not in this PR, candidate issues):
- `last_used_at` NULL backfill via `COALESCE(last_used_at, created_at)` — referenced in #644 body
- `accessed_by_clients` array append atomicity (pre-existing race in recall/reference/explore)
- `seed_response = MemoryResponse(...)` triple construction in `explore()` (pre-existing duplication, refactor candidate)

🤖 Generated via /gh-issue-driven:ship
