### PR TITLE
feat(sleep): track embedding token usage in phase 1/2 (#475 partial)

### DIFF
--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -229,8 +229,11 @@ class EmbeddingService:
 
         Thin wrapper around ``embed_with_usage()`` that discards the
         token count — kept for callers that don't need cost attribution
-        (recall, search). Issue #475 will migrate the remaining callers
-        to ``embed_with_usage()`` directly.
+        (recall path, ``resource_indexer``). Sleep phases 1/2/reindex
+        all use ``embed_with_usage`` directly post-#475 PR-1; the recall
+        path is the next migration target (#475 PR-3, gated on the #474
+        event-store schema). ``resource_indexer.py``'s migration is a
+        separate concern tracked outside #475.
 
         Args:
             text: Text to embed (summary)
@@ -269,9 +272,11 @@ class EmbeddingService:
 
         This is an additive companion to ``embed()`` rather than a
         breaking signature change — ``embed()`` keeps working for callers
-        that don't track cost (recall path, search service). #475 will
-        migrate the remaining callers as part of the
-        full-pipeline embedding-cost rollout.
+        that don't track cost (recall path, ``resource_indexer``). All
+        three sleep phases (edge_discovery, dedup_merge, reindex) use
+        ``embed_with_usage`` directly post-#475 PR-1. The recall path
+        migration is deferred to #475 PR-3 (blocked on the event-store
+        schema in #474).
 
         Args:
             text: Text to embed.

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -110,10 +110,8 @@ class DedupMergePhase:
         self.edge_repo = NeuralEdgeRepository(db)
         self.embedding_service = EmbeddingService(db, model=embedding_model)
         self.collection_name = collection_name
-        # #475: init here (matches edge_discovery convention) so
-        # ``_find_similar_pairs`` can be called in isolation from unit
-        # tests without ``AttributeError``. Reset in ``execute()`` for
-        # consecutive sleep cycles.
+        # #475: embedding cost-grade accumulators (init here so
+        # ``_find_similar_pairs`` can be unit-tested without execute()).
         self._embedding_calls_used: int = 0
         self._embedding_tokens_used: int = 0
 
@@ -146,8 +144,6 @@ class DedupMergePhase:
         # #471: per-(provider, model) accumulator (lazy-init).
         self._llm_breakdown: LLMCallBreakdown | None = None
         # #475: reset embedding accumulators between sleep cycles.
-        # Initialized in __init__ so direct ``_find_similar_pairs`` calls
-        # (e.g., unit tests) don't ``AttributeError`` before execute().
         self._embedding_calls_used = 0
         self._embedding_tokens_used = 0
 
@@ -258,9 +254,8 @@ class DedupMergePhase:
         # #471: attach per-(provider, model) breakdown for child-row write.
         if self._llm_breakdown is not None:
             result.llm_breakdown = [self._llm_breakdown]
-        # #475: surface embedding usage for cost-grade roll-up. Provider /
-        # model are set only when phase 2 actually performed at least one
-        # embed call (no-memories early-returns leave them None).
+        # #475: surface embedding usage; skip identity when no calls
+        # happened so no-memory early-returns don't fabricate it.
         result.embedding_calls_used = self._embedding_calls_used
         result.embedding_tokens = self._embedding_tokens_used
         if self._embedding_calls_used > 0:
@@ -320,12 +315,6 @@ class DedupMergePhase:
 
         for memory in memories:
             try:
-                # #475: capture embedding token usage via ``embed_with_usage``
-                # so phase 2 contributes to the cost-grade roll-up on
-                # ``sleep_reports`` (previously reindex-only). Mirror of the
-                # ``reindex.py`` accumulation pattern. Increment happens
-                # only after the await succeeds — failed embed calls do
-                # not count toward usage.
                 vector, tokens = await self.embedding_service.embed_with_usage(
                     memory.summary,
                     user_id=user_id,

--- a/backend/src/services/sleep/dedup_merge.py
+++ b/backend/src/services/sleep/dedup_merge.py
@@ -110,6 +110,12 @@ class DedupMergePhase:
         self.edge_repo = NeuralEdgeRepository(db)
         self.embedding_service = EmbeddingService(db, model=embedding_model)
         self.collection_name = collection_name
+        # #475: init here (matches edge_discovery convention) so
+        # ``_find_similar_pairs`` can be called in isolation from unit
+        # tests without ``AttributeError``. Reset in ``execute()`` for
+        # consecutive sleep cycles.
+        self._embedding_calls_used: int = 0
+        self._embedding_tokens_used: int = 0
 
     async def execute(
         self,
@@ -139,6 +145,11 @@ class DedupMergePhase:
         self._tokens_used = 0
         # #471: per-(provider, model) accumulator (lazy-init).
         self._llm_breakdown: LLMCallBreakdown | None = None
+        # #475: reset embedding accumulators between sleep cycles.
+        # Initialized in __init__ so direct ``_find_similar_pairs`` calls
+        # (e.g., unit tests) don't ``AttributeError`` before execute().
+        self._embedding_calls_used = 0
+        self._embedding_tokens_used = 0
 
         if not config.sleep_dedup_enabled:
             result.skipped = True
@@ -247,6 +258,14 @@ class DedupMergePhase:
         # #471: attach per-(provider, model) breakdown for child-row write.
         if self._llm_breakdown is not None:
             result.llm_breakdown = [self._llm_breakdown]
+        # #475: surface embedding usage for cost-grade roll-up. Provider /
+        # model are set only when phase 2 actually performed at least one
+        # embed call (no-memories early-returns leave them None).
+        result.embedding_calls_used = self._embedding_calls_used
+        result.embedding_tokens = self._embedding_tokens_used
+        if self._embedding_calls_used > 0:
+            result.embedding_provider = self.embedding_service.provider
+            result.embedding_model = self.embedding_service.model
 
         logger.info(
             "dedup_merge_phase_completed",
@@ -301,13 +320,20 @@ class DedupMergePhase:
 
         for memory in memories:
             try:
-                # Get embedding for this memory's summary
-                vector = await self.embedding_service.embed(
+                # #475: capture embedding token usage via ``embed_with_usage``
+                # so phase 2 contributes to the cost-grade roll-up on
+                # ``sleep_reports`` (previously reindex-only). Mirror of the
+                # ``reindex.py`` accumulation pattern. Increment happens
+                # only after the await succeeds — failed embed calls do
+                # not count toward usage.
+                vector, tokens = await self.embedding_service.embed_with_usage(
                     memory.summary,
                     user_id=user_id,
                     context_id=context_id,
                     workspace_id=workspace_id,
                 )
+                self._embedding_calls_used += 1
+                self._embedding_tokens_used += tokens
 
                 results = await search_memories_qdrant(
                     user_id=user_id,

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -363,11 +363,8 @@ class EdgeDiscoveryPhase:
         # initialized on the first LLM call so we don't fabricate empty
         # rows for runs that early-return before any LLM use.
         self._llm_breakdown: LLMCallBreakdown | None = None
-        # #475: embedding cost-grade accumulators. Mirror of the
-        # ``reindex.py`` per-call instrumentation pattern; calls increments
-        # +1 per ``embed_with_usage`` invocation (cache hit counts as a
-        # call), tokens accumulates the API-billed token count (cache hits
-        # contribute 0 — see ``EmbeddingService.embed_with_usage`` docstring).
+        # #475: embedding cost-grade accumulators (cache hits count as
+        # a call, tokens=0 — see ``embed_with_usage`` docstring).
         self._embedding_calls_used: int = 0
         self._embedding_tokens_used: int = 0
 
@@ -530,11 +527,8 @@ class EdgeDiscoveryPhase:
         # #471: attach per-(provider, model) breakdown for child-row write.
         if self._llm_breakdown is not None:
             result.llm_breakdown = [self._llm_breakdown]
-        # #475: surface embedding usage for cost-grade roll-up. Provider /
-        # model are instance-global (per ``EmbeddingService`` config) — only
-        # set them when phase 1 actually performed at least one call, so
-        # phases that early-return on no-memories don't fabricate identity
-        # for a service that was never invoked.
+        # #475: surface embedding usage; skip identity when no calls
+        # happened so no-memory early-returns don't fabricate it.
         result.embedding_calls_used = self._embedding_calls_used
         result.embedding_tokens = self._embedding_tokens_used
         if self._embedding_calls_used > 0:
@@ -624,12 +618,6 @@ class EdgeDiscoveryPhase:
 
         for memory in memories:
             try:
-                # #475: capture embedding token usage via ``embed_with_usage``
-                # so phase 1 contributes to the cost-grade roll-up on
-                # ``sleep_reports`` (previously reindex-only). Mirror of the
-                # ``reindex.py`` accumulation pattern. Increment happens
-                # only after the await succeeds — failed embed calls do
-                # not count toward usage.
                 vector, tokens = await self.embedding_service.embed_with_usage(
                     memory.summary,
                     user_id=user_id,

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -363,6 +363,13 @@ class EdgeDiscoveryPhase:
         # initialized on the first LLM call so we don't fabricate empty
         # rows for runs that early-return before any LLM use.
         self._llm_breakdown: LLMCallBreakdown | None = None
+        # #475: embedding cost-grade accumulators. Mirror of the
+        # ``reindex.py`` per-call instrumentation pattern; calls increments
+        # +1 per ``embed_with_usage`` invocation (cache hit counts as a
+        # call), tokens accumulates the API-billed token count (cache hits
+        # contribute 0 — see ``EmbeddingService.embed_with_usage`` docstring).
+        self._embedding_calls_used: int = 0
+        self._embedding_tokens_used: int = 0
 
     async def execute(
         self,
@@ -380,6 +387,8 @@ class EdgeDiscoveryPhase:
         llm_calls_before = budget.llm_calls_used
         self._tokens_used = 0
         self._llm_breakdown = None
+        self._embedding_calls_used = 0
+        self._embedding_tokens_used = 0
 
         if not config.sleep_edge_discovery_enabled:
             result.skipped = True
@@ -521,6 +530,16 @@ class EdgeDiscoveryPhase:
         # #471: attach per-(provider, model) breakdown for child-row write.
         if self._llm_breakdown is not None:
             result.llm_breakdown = [self._llm_breakdown]
+        # #475: surface embedding usage for cost-grade roll-up. Provider /
+        # model are instance-global (per ``EmbeddingService`` config) — only
+        # set them when phase 1 actually performed at least one call, so
+        # phases that early-return on no-memories don't fabricate identity
+        # for a service that was never invoked.
+        result.embedding_calls_used = self._embedding_calls_used
+        result.embedding_tokens = self._embedding_tokens_used
+        if self._embedding_calls_used > 0:
+            result.embedding_provider = self.embedding_service.provider
+            result.embedding_model = self.embedding_service.model
         result.details = {
             "sampled": len(sampled),
             "candidates": len(candidates),
@@ -605,12 +624,20 @@ class EdgeDiscoveryPhase:
 
         for memory in memories:
             try:
-                vector = await self.embedding_service.embed(
+                # #475: capture embedding token usage via ``embed_with_usage``
+                # so phase 1 contributes to the cost-grade roll-up on
+                # ``sleep_reports`` (previously reindex-only). Mirror of the
+                # ``reindex.py`` accumulation pattern. Increment happens
+                # only after the await succeeds — failed embed calls do
+                # not count toward usage.
+                vector, tokens = await self.embedding_service.embed_with_usage(
                     memory.summary,
                     user_id=user_id,
                     context_id=context_id,
                     workspace_id=workspace_id,
                 )
+                self._embedding_calls_used += 1
+                self._embedding_tokens_used += tokens
 
                 results = await search_memories_qdrant(
                     user_id=user_id,

--- a/backend/src/services/sleep/reporter.py
+++ b/backend/src/services/sleep/reporter.py
@@ -356,6 +356,14 @@ class SleepReporter:
                     }
                     for b in result.llm_breakdown
                 ],
+                # #475: per-phase embedding usage. Surfaces in the
+                # JSONB column for the phase (``edge_discovery_result`` /
+                # ``dedup_result`` / ``reindex_result``) so the per-phase
+                # breakdown is auditable without adding a child row to
+                # ``sleep_report_llm_usage`` (that schema decision is
+                # deferred to #472 co-decision).
+                "embedding_calls": result.embedding_calls_used,
+                "embedding_tokens": result.embedding_tokens,
             }
 
             if result.phase_name == "edge_discovery":

--- a/backend/src/services/sleep/reporter.py
+++ b/backend/src/services/sleep/reporter.py
@@ -356,12 +356,8 @@ class SleepReporter:
                     }
                     for b in result.llm_breakdown
                 ],
-                # #475: per-phase embedding usage. Surfaces in the
-                # JSONB column for the phase (``edge_discovery_result`` /
-                # ``dedup_result`` / ``reindex_result``) so the per-phase
-                # breakdown is auditable without adding a child row to
-                # ``sleep_report_llm_usage`` (that schema decision is
-                # deferred to #472 co-decision).
+                # #475: per-phase embedding usage (audit trail in JSONB
+                # blob, no sleep_report_llm_usage schema change).
                 "embedding_calls": result.embedding_calls_used,
                 "embedding_tokens": result.embedding_tokens,
             }

--- a/backend/tests/services/sleep/test_dedup_merge.py
+++ b/backend/tests/services/sleep/test_dedup_merge.py
@@ -279,3 +279,58 @@ class TestClusterSizeCap:
     def test_auto_merge_threshold_constant(self):
         """Verify the auto-merge threshold."""
         assert AUTO_MERGE_THRESHOLD == 0.98
+
+
+# ============================================================================
+# #475: Embedding cost-grade instrumentation tests
+# ============================================================================
+
+
+class TestDedupMergeEmbeddingInstrumentation:
+    """Phase 2 ``_find_similar_pairs`` accumulates embedding usage via
+    ``embed_with_usage`` (#475 PR-1). Mirrors ``reindex.py`` semantics:
+    calls increments +1 per invocation (cache hit included), tokens
+    accumulates the API-billed count (cache hits contribute 0).
+    """
+
+    @pytest.mark.asyncio
+    async def test_find_similar_pairs_accumulates_tokens(self, dedup_phase):
+        """Happy path: embed_with_usage returns positive tokens; both
+        counters move."""
+        dedup_phase.embedding_service.embed_with_usage = AsyncMock(return_value=([0.1] * 768, 75))
+        dedup_phase.embedding_service.provider = "openai"
+        dedup_phase.embedding_service.model = "text-embedding-3-small"
+
+        memories = [_make_memory(summary="alpha"), _make_memory(summary="beta")]
+
+        with patch(
+            "services.sleep.dedup_merge.search_memories_qdrant",
+            AsyncMock(return_value=[]),
+        ):
+            await dedup_phase._find_similar_pairs(
+                memories, "user-1", "ws-1", "ctx-1", threshold=0.92
+            )
+
+        assert dedup_phase._embedding_calls_used == 2
+        assert dedup_phase._embedding_tokens_used == 150  # 75 + 75
+
+    @pytest.mark.asyncio
+    async def test_find_similar_pairs_cache_hit_counts_call_not_tokens(self, dedup_phase):
+        """Cache-hit semantic: tokens=0 is correctly attributed (no API
+        bill), but the call still counts (+1) for parity with reindex.py."""
+        dedup_phase.embedding_service.embed_with_usage = AsyncMock(return_value=([0.1] * 768, 0))
+        dedup_phase.embedding_service.provider = "openai"
+        dedup_phase.embedding_service.model = "text-embedding-3-small"
+
+        memories = [_make_memory(summary="cached")]
+
+        with patch(
+            "services.sleep.dedup_merge.search_memories_qdrant",
+            AsyncMock(return_value=[]),
+        ):
+            await dedup_phase._find_similar_pairs(
+                memories, "user-1", "ws-1", "ctx-1", threshold=0.92
+            )
+
+        assert dedup_phase._embedding_calls_used == 1
+        assert dedup_phase._embedding_tokens_used == 0

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -1360,3 +1360,54 @@ class TestConfidenceHistogram:
             "0.7-0.85": 2,  # 0.7, 0.8
             "0.85-1.0": 3,  # 0.85, 0.9, 1.0
         }
+
+
+# ============================================================================
+# #475: Embedding cost-grade instrumentation tests
+# ============================================================================
+
+
+class TestEdgeDiscoveryEmbeddingInstrumentation:
+    """Phase 1 ``_find_candidates`` accumulates embedding usage via
+    ``embed_with_usage`` (#475 PR-1). Mirrors ``reindex.py`` semantics:
+    calls increments +1 per invocation (cache hit included), tokens
+    accumulates the API-billed count (cache hits contribute 0).
+    """
+
+    @pytest.mark.asyncio
+    async def test_find_candidates_accumulates_tokens(self, edge_phase):
+        """Happy path: embed_with_usage returns positive tokens; both
+        counters move."""
+        edge_phase.embedding_service.embed_with_usage = AsyncMock(return_value=([0.1] * 768, 50))
+        edge_phase.embedding_service.provider = "openai"
+        edge_phase.embedding_service.model = "text-embedding-3-small"
+
+        memories = [_make_memory(summary="alpha"), _make_memory(summary="beta")]
+
+        with patch(
+            "services.sleep.edge_discovery.search_memories_qdrant",
+            AsyncMock(return_value=[]),
+        ):
+            await edge_phase._find_candidates(memories, "user-1", "ws-1", "ctx-1")
+
+        assert edge_phase._embedding_calls_used == 2
+        assert edge_phase._embedding_tokens_used == 100  # 50 + 50
+
+    @pytest.mark.asyncio
+    async def test_find_candidates_cache_hit_counts_call_not_tokens(self, edge_phase):
+        """Cache-hit semantic: tokens=0 is correctly attributed (no API
+        bill), but the call still counts (+1) for parity with reindex.py."""
+        edge_phase.embedding_service.embed_with_usage = AsyncMock(return_value=([0.1] * 768, 0))
+        edge_phase.embedding_service.provider = "openai"
+        edge_phase.embedding_service.model = "text-embedding-3-small"
+
+        memories = [_make_memory(summary="cached")]
+
+        with patch(
+            "services.sleep.edge_discovery.search_memories_qdrant",
+            AsyncMock(return_value=[]),
+        ):
+            await edge_phase._find_candidates(memories, "user-1", "ws-1", "ctx-1")
+
+        assert edge_phase._embedding_calls_used == 1
+        assert edge_phase._embedding_tokens_used == 0

--- a/backend/tests/services/sleep/test_reporter_cost_grade.py
+++ b/backend/tests/services/sleep/test_reporter_cost_grade.py
@@ -183,3 +183,66 @@ class TestReporterCostGradeChildRows:
         # Legacy roll-up still populated (back-compat path).
         assert report.llm_calls_made == 5
         assert report.llm_tokens_used == 500
+
+    @pytest.mark.asyncio
+    async def test_complete_report_aggregates_phase_1_2_embedding(self, reporter):
+        """#475 PR-1: phases 1 and 2 now contribute embedding usage to
+        the cost-grade roll-up. Prior to PR-1 only reindex populated
+        ``result.embedding_*`` and the roll-up was reindex-only by
+        accident; this test pins the post-PR-1 contract that the
+        reporter correctly sums across all phases that report embedding
+        usage and that the per-phase JSONB blob carries the breakdown
+        (Option C audit trail).
+        """
+        report = MagicMock()
+        report.id = uuid4()
+        report.embedding_provider = None
+        report.embedding_model = None
+        report.edge_discovery_result = None
+        report.dedup_result = None
+        report.reindex_result = None
+
+        results = [
+            PhaseResult(
+                phase_name="edge_discovery",
+                memories_processed=20,
+                embedding_calls_used=20,
+                embedding_tokens=2000,
+                embedding_provider="openai",
+                embedding_model="text-embedding-3-small",
+            ),
+            PhaseResult(
+                phase_name="dedup_merge",
+                memories_processed=10,
+                embedding_calls_used=10,
+                embedding_tokens=1000,
+                embedding_provider="openai",
+                embedding_model="text-embedding-3-small",
+            ),
+            PhaseResult(
+                phase_name="reindex",
+                memories_processed=8,
+                embedding_calls_used=8,
+                embedding_tokens=4096,
+                embedding_provider="openai",
+                embedding_model="text-embedding-3-small",
+            ),
+        ]
+
+        await reporter.complete_report(report, results)
+
+        # Embedding scalar columns aggregate across all three phases.
+        assert report.embedding_calls_made == 38  # 20 + 10 + 8
+        assert report.embedding_tokens == 7096  # 2000 + 1000 + 4096
+        # Provider / model captured from the first phase with non-empty
+        # pair (edge_discovery, which runs first in phase order).
+        assert report.embedding_provider == "openai"
+        assert report.embedding_model == "text-embedding-3-small"
+
+        # Per-phase JSONB blobs carry the embedding breakdown (Option C).
+        assert report.edge_discovery_result["embedding_calls"] == 20
+        assert report.edge_discovery_result["embedding_tokens"] == 2000
+        assert report.dedup_result["embedding_calls"] == 10
+        assert report.dedup_result["embedding_tokens"] == 1000
+        assert report.reindex_result["embedding_calls"] == 8
+        assert report.reindex_result["embedding_tokens"] == 4096


### PR DESCRIPTION
Partially addresses #475 (PR-1 of 3-PR split).

## Summary

- Switch Sleep Phase 1 (`edge_discovery._find_candidates`) and Phase 2 (`dedup_merge._find_similar_pairs`) from `embedding_service.embed()` to `embed_with_usage()`, capturing token counts via the canonical `reindex.py:92-107` accumulation pattern.
- Surface per-phase embedding usage on `PhaseResult` (`embedding_calls_used` / `embedding_tokens` / `embedding_provider` / `embedding_model`); the existing `SleepReporter.complete_report()` roll-up then aggregates phase 1+2+reindex into `sleep_reports.embedding_calls_made` / `embedding_tokens` (previously reindex-only by accident).
- Add `embedding_calls` and `embedding_tokens` keys to each per-phase JSONB blob (`edge_discovery_result`, `dedup_result`, `reindex_result`) so the per-phase breakdown is auditable without a schema change on `sleep_report_llm_usage`.

## Implementation notes

### Scope clarification (issue body is stale)

Per the gate1 CTO review, several items in the issue body's "Tasks" section are **already implemented in #471**:

- **Task 1** (`embed_with_usage()` method): already exists at `backend/src/services/embedding_service.py:255+`; `embed()` is now a thin wrapper.
- **Task 3a** (`PhaseResult.embedding_tokens` / `embedding_provider` / `embedding_model` fields): already exist at `backend/src/services/sleep/reporter.py:138-141`.
- **Task 3b** (scalar roll-up in `complete_report()`): already implemented at `backend/src/services/sleep/reporter.py:288-375`.

The actual remaining work for this PR is **Task 2** (Phase 1/2 instrumentation) plus a deferred **Task 3c** alternative.

**In scope (this PR)**:
- Task 2 — Phase 1/2 `_find_*` migration to `embed_with_usage()` + per-call accumulation
- Task 3 (Option C) — `phase_data` JSONB blob receives `embedding_calls` / `embedding_tokens` keys; no schema change

**Out of scope (deferred)**:
- **Task 3c** (per-phase child rows in `sleep_report_llm_usage`) — would require a schema migration (`call_kind` column or new table). Deferred to #472 aggregation API PR for co-decision.
- **Task 4** (recall path → `llm_call_log`) — depends on #474 (not yet started). Deferred to PR-3.

### Code review history
- **gate1 (CTO lens)**: yellow → green (operator override). Issue body is stale; PR body clarifies scope above. Caveats persisted to plugin cache `gate1.md`.
- **feature-dev Phase 6**: 3 reviewers found 1 HIGH-confidence bug — `DedupMergePhase.__init__` missing init for new `_embedding_*` accumulators (would `AttributeError` if `_find_similar_pairs` called outside `execute()`). Fixed in this PR (init now mirrors `edge_discovery` pattern).
- **/simplify**: applied comment trim findings (-27 lines of redundant comment). Deferred one finding (`apply_embedding_usage` helper extraction) — recommended as a PR-3 co-decision follow-up so the helper signature can serve both phase + non-phase callers.

### Pre-flight signals
- 135 sleep tests pass (`pytest tests/services/sleep/`).
- Lint clean (`ruff check src/ tests/`).
- Pyright: my code clean (1 pre-existing unrelated error in `backend/src/tasks/neural_tasks.py:263`, unmodified).

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (5 tests defensible; failure-path + lazy-capture-no-call tests deferred to follow-up)
- cto: green
- gate1: green via /ask (CTO lens, operator override from yellow)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/475-feat-feat-observability-full-pipeline-embeddi.gate1.md`
- `~/.claude/cache/gh-issue-driven/475-feat-feat-observability-full-pipeline-embeddi.gate2.md`

## Follow-ups to file post-merge

- `_find_*` failure-path test (verify counters NOT incremented when `embed_with_usage` raises mid-loop)
- No-call phase provider/model identity unset test
- `apply_embedding_usage` helper extraction (co-decide with PR-3 caller shape)
- Optional: `gh issue edit 475` to annotate Tasks 1/3a/3b as "(implemented in #471)"

🤖 Generated via /gh-issue-driven:ship
