### PR TITLE
feat(db): add llm_call_log event store + writer skeleton (#474 partial)

### DIFF
--- a/backend/alembic/versions/e12_474_llm_call_log.py
+++ b/backend/alembic/versions/e12_474_llm_call_log.py
@@ -38,9 +38,10 @@ Out of scope (deferred to follow-ups):
 Revision ID: e12_474_llm_call_log
 Revises: e11_merge_e10_heads
 
-NOTE: Revision ID is 20 chars (alembic_version.version_num is VARCHAR(32),
-asyncpg raises StringDataRightTruncationError above 25 — see c02_471
-header for the canonical note).
+NOTE: Revision ID is 20 chars, well within the VARCHAR(32) limit on
+``alembic_version.version_num``. Revision IDs above 32 chars trigger
+``asyncpg.exceptions.StringDataRightTruncationError`` at upgrade time —
+see ``c02_471`` header for the canonical note describing the limit.
 """
 
 from collections.abc import Sequence

--- a/backend/alembic/versions/e12_474_llm_call_log.py
+++ b/backend/alembic/versions/e12_474_llm_call_log.py
@@ -1,0 +1,144 @@
+"""Add llm_call_log: append-only event log for non-Sleep LLM/embedding/rerank calls (#474).
+
+Issue #474: Companion to ``sleep_reports`` (run-shaped) — captures
+per-call cost events from recall reranking, recall embedding (wired up
+in #475 PR-3), future ``ask()`` synthesis, and one-off admin actions.
+Cost aggregation in #472 UNION ALLs ``sleep_reports`` and ``llm_call_log``
+on ``(workspace_id, occurred_at)`` and groups by ``caller`` for the
+dashboard breakdown.
+
+This revision adds schema only. Pricing seed rows for Voyage rerank-2 /
+Voyage rerank-2-lite / Cohere rerank-3.5 / Cohere embed-multilingual-v3
+land in the next revision (``e13_474_pricing_seeds``) so schema and
+data fixes have independent rollback units.
+
+Design notes (mirror module docstring of ``models/llm_call_log.py``):
+
+- ``cost_usd`` is computed at write time from ``llm_pricing`` and stored
+  as a snapshot (NOT NULL DEFAULT 0). Pricing misses store 0 + a flag in
+  ``call_metadata``.
+- ``call_metadata`` is JSONB with a 4 KB CHECK constraint defending
+  against accidental storage of prompt bodies. This is the codebase's
+  first schema-level JSONB size cap.
+- ``paid_by`` mirrors ``sleep_reports.paid_by`` so the #472 UNION ALL
+  groups both legs on the same axis.
+- ``caller`` CHECK includes 'sleep' for forward-compat (future migration
+  may unify) but the writer service refuses to emit it today — Sleep
+  cost stays in ``sleep_reports`` + ``sleep_report_llm_usage``.
+- Two indexes: ``(occurred_at)`` for the admin-wide query,
+  ``(workspace_id, occurred_at)`` for per-tenant aggregation. Mirrors
+  ``idx_sleep_reports_workspace_source_started`` so the UNION ALL has
+  matching index support on both legs.
+
+Out of scope (deferred to follow-ups):
+- Partitioning / retention (escalation trigger: 100M rows).
+- Recall path instrumentation itself (#475 PR-3).
+- Aggregation API extension (#472).
+
+Revision ID: e12_474_llm_call_log
+Revises: e11_merge_e10_heads
+
+NOTE: Revision ID is 20 chars (alembic_version.version_num is VARCHAR(32),
+asyncpg raises StringDataRightTruncationError above 25 — see c02_471
+header for the canonical note).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e12_474_llm_call_log"
+down_revision: str | Sequence[str] | None = "e11_merge_e10_heads"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create llm_call_log with CHECK constraints + 2 indexes."""
+    op.create_table(
+        "llm_call_log",
+        sa.Column("id", sa.BigInteger, primary_key=True, autoincrement=True),
+        # Naive DateTime to match ``sleep_reports.started_at`` and
+        # ``llm_pricing.effective_from`` (the cost-snapshot join target).
+        sa.Column("occurred_at", sa.DateTime, nullable=False),
+        sa.Column("user_id", sa.String(255), nullable=True),
+        sa.Column("workspace_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("context_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("caller", sa.String(20), nullable=False),
+        sa.Column("call_type", sa.String(20), nullable=False),
+        sa.Column("provider", sa.String(50), nullable=False),
+        sa.Column("model", sa.String(100), nullable=False),
+        # Per-call usage columns. Any subset may be NULL per ``call_type``;
+        # the writer service enforces the correct field is set.
+        sa.Column("input_tokens", sa.Integer, nullable=True),
+        sa.Column("output_tokens", sa.Integer, nullable=True),
+        sa.Column("cached_input_tokens", sa.Integer, nullable=True),
+        sa.Column("cache_write_tokens", sa.Integer, nullable=True),
+        sa.Column("embedding_tokens", sa.Integer, nullable=True),
+        sa.Column("rerank_tokens", sa.Integer, nullable=True),
+        sa.Column("rerank_search_units", sa.Integer, nullable=True),
+        # Write-time cost snapshot. NOT NULL DEFAULT 0 so aggregation
+        # queries don't need COALESCE; pricing misses store 0 + a flag
+        # in ``call_metadata``.
+        sa.Column(
+            "cost_usd",
+            sa.Numeric(12, 6),
+            nullable=False,
+            server_default=sa.text("0"),
+        ),
+        sa.Column(
+            "paid_by",
+            sa.String(20),
+            nullable=False,
+            server_default=sa.text("'platform'"),
+        ),
+        # Free-form audit JSON. 4 KB cap enforced by CHECK below.
+        sa.Column("call_metadata", JSONB, nullable=True),
+        sa.CheckConstraint(
+            "caller IN ('sleep', 'recall', 'rerank', 'ask', 'admin')",
+            name="valid_llm_call_log_caller",
+        ),
+        sa.CheckConstraint(
+            "call_type IN ('completion', 'embedding', 'rerank')",
+            name="valid_llm_call_log_call_type",
+        ),
+        sa.CheckConstraint(
+            "paid_by IN ('platform', 'byok')",
+            name="valid_llm_call_log_paid_by",
+        ),
+        sa.CheckConstraint(
+            "cost_usd >= 0",
+            name="valid_llm_call_log_cost_nonneg",
+        ),
+        # First-of-its-kind in this codebase: 4 KB schema-level cap on a
+        # JSONB column to defend against prompt-body storage.
+        # ``octet_length(jsonb::text)`` gives a stable upper bound — the
+        # text serialization is the most verbose form, always >= the
+        # on-disk JSONB size. 4096 bytes fits ~40-50 short audit fields;
+        # a typical prompt body (2-10 KB) hits the wall.
+        sa.CheckConstraint(
+            "call_metadata IS NULL OR octet_length(call_metadata::text) <= 4096",
+            name="valid_llm_call_log_metadata_size",
+        ),
+    )
+    op.create_index(
+        "idx_llm_call_log_occurred_at",
+        "llm_call_log",
+        ["occurred_at"],
+    )
+    op.create_index(
+        "idx_llm_call_log_workspace_period",
+        "llm_call_log",
+        ["workspace_id", "occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    """Drop llm_call_log + indexes in reverse order."""
+    op.drop_index("idx_llm_call_log_workspace_period", table_name="llm_call_log")
+    op.drop_index("idx_llm_call_log_occurred_at", table_name="llm_call_log")
+    op.drop_table("llm_call_log")

--- a/backend/alembic/versions/e12_474_llm_call_log.py
+++ b/backend/alembic/versions/e12_474_llm_call_log.py
@@ -81,12 +81,18 @@ def upgrade() -> None:
         sa.Column("embedding_tokens", sa.Integer, nullable=True),
         sa.Column("rerank_tokens", sa.Integer, nullable=True),
         sa.Column("rerank_search_units", sa.Integer, nullable=True),
-        # Write-time cost snapshot. NOT NULL DEFAULT 0 so aggregation
-        # queries don't need COALESCE; pricing misses store 0 + a flag
-        # in ``call_metadata``.
+        # Write-time cost snapshot. NUMERIC(14, 10) mirrors
+        # ``llm_pricing.price_per_unit`` precision so sub-microcent
+        # per-call costs (e.g., 20 embedding tokens at $0.02/1M =
+        # $0.0000004) don't round to 0 and silently undercount when
+        # SUMmed across many rows (Copilot loop 2 #1). 4 digits before
+        # the decimal cap per-call cost at ~$9,999.99 — orders of
+        # magnitude above any plausible single API call. NOT NULL
+        # DEFAULT 0 so aggregation queries don't need COALESCE; pricing
+        # misses store 0 + a flag in ``call_metadata``.
         sa.Column(
             "cost_usd",
-            sa.Numeric(12, 6),
+            sa.Numeric(14, 10),
             nullable=False,
             server_default=sa.text("0"),
         ),

--- a/backend/alembic/versions/e13_474_pricing_seeds.py
+++ b/backend/alembic/versions/e13_474_pricing_seeds.py
@@ -1,0 +1,164 @@
+"""Seed llm_pricing rows for Voyage rerank + Cohere rerank/embed (#474).
+
+Issue #474: ``llm_pricing`` was seeded by ``c03_471_seed_pricing`` with
+Sleep-relevant LLM and embedding rates only — rerank pricing was
+intentionally deferred (see that file's header). This migration closes
+that gap by adding the four provider/model rows recall reranking
+(#475 PR-3) and any future non-Sleep recall instrumentation will look
+up:
+
+- ``voyage`` × ``rerank-2`` × ``rerank_tokens`` — $0.05 / 1M tokens
+- ``voyage`` × ``rerank-2-lite`` × ``rerank_tokens`` — $0.02 / 1M tokens
+- ``cohere`` × ``rerank-3.5`` × ``rerank_search_units`` — $2.00 / 1k SU
+  (Cohere splits docs > 500 tokens into multiple SUs — captured by the
+  reranker_service from ``response.meta.billed_units.search_units``
+  when #475 PR-3 wires up the writer)
+- ``cohere`` × ``embed-multilingual-v3`` × ``embedding_tokens`` —
+  $0.10 / 1M tokens
+
+All effective_from = 2026-04-28 to align with c03 seeds (the canonical
+snapshot date). The append-only contract means a price change inserts
+a new row with a later ``effective_from`` — these seed rows are never
+mutated.
+
+Schema-vs-data split rationale: ``e12_474_llm_call_log`` adds the
+event-log table itself; this revision is data-fixup. Splitting them
+keeps the rollback unit clean — a price correction needing a re-seed
+doesn't have to drop the table.
+
+NOTE: Rates above are the public 2026-04-28 snapshot. Corrections land
+as new INSERT rows with later ``effective_from``; downgrade here only
+removes rows with this exact ``effective_from`` so corrections survive
+a partial rollback.
+
+Revision ID: e13_474_pricing_seeds
+Revises: e12_474_llm_call_log
+
+NOTE: Revision ID is 21 chars (under the 25-char asyncpg-safe limit).
+"""
+
+from collections.abc import Sequence
+from datetime import datetime
+from decimal import Decimal
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e13_474_pricing_seeds"
+down_revision: str | Sequence[str] | None = "e12_474_llm_call_log"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Aligned with c03_471_seed_pricing's snapshot date so both seed sets
+# share a single canonical ``effective_from`` — recall path lookups
+# don't have to compose two different snapshots.
+_SEED_EFFECTIVE_FROM = datetime(2026, 4, 28, 0, 0, 0)
+
+
+# Parameterized INSERT supporting both unit_denominator values
+# (1_000_000 for per-1M-token rates, 1_000 for per-1k-SU Cohere rates).
+# Mirrors c03 style: bound params per `.claude/rules/security.md`
+# (no f-string SQL even with hardcoded literals).
+_INSERT_PRICING_SQL = sa.text("""
+    INSERT INTO llm_pricing (
+        provider, model, unit_type, effective_from,
+        context_min_tokens, context_max_tokens,
+        price_per_unit, currency, unit_denominator
+    ) VALUES (
+        :provider, :model, :unit_type, :effective_from,
+        0, NULL,
+        :price_per_unit, 'USD', :unit_denominator
+    )
+""")
+
+
+def _insert_pricing_row(
+    *,
+    provider: str,
+    model: str,
+    unit_type: str,
+    price_per_unit: str,
+    unit_denominator: int,
+) -> None:
+    """Emit one parameterized INSERT against llm_pricing.
+
+    ``price_per_unit`` is taken as a string for literal-precision
+    ergonomics, converted to ``Decimal`` before binding so asyncpg
+    infers ``NUMERIC`` (a VARCHAR bind would force PostgreSQL into a
+    coercion failure against ``NUMERIC(14, 10)``). ``unit_denominator``
+    is exposed so Cohere's per-1k-SU rows fit the same code path as
+    Voyage's per-1M-token rows.
+    """
+    op.execute(
+        _INSERT_PRICING_SQL.bindparams(
+            provider=provider,
+            model=model,
+            unit_type=unit_type,
+            effective_from=_SEED_EFFECTIVE_FROM,
+            price_per_unit=Decimal(price_per_unit),
+            unit_denominator=unit_denominator,
+        )
+    )
+
+
+def upgrade() -> None:
+    """Seed Voyage rerank + Cohere rerank/embed rows for 2026-04-28."""
+    # Voyage rerank — token-based, per 1M tokens.
+    _insert_pricing_row(
+        provider="voyage",
+        model="rerank-2",
+        unit_type="rerank_tokens",
+        price_per_unit="0.05",
+        unit_denominator=1_000_000,
+    )
+    _insert_pricing_row(
+        provider="voyage",
+        model="rerank-2-lite",
+        unit_type="rerank_tokens",
+        price_per_unit="0.02",
+        unit_denominator=1_000_000,
+    )
+
+    # Cohere rerank — billed per "search unit" at $2.00 per 1k SU.
+    # unit_denominator=1000 puts it on the same row shape as the
+    # token-based rows; the cost formula uses unit_denominator as the
+    # divisor uniformly.
+    _insert_pricing_row(
+        provider="cohere",
+        model="rerank-3.5",
+        unit_type="rerank_search_units",
+        price_per_unit="2.00",
+        unit_denominator=1_000,
+    )
+
+    # Cohere embedding — token-based, per 1M tokens. Aligns with the
+    # OpenAI embedding rows c03 seeded ($0.02-0.13 / 1M).
+    _insert_pricing_row(
+        provider="cohere",
+        model="embed-multilingual-v3",
+        unit_type="embedding_tokens",
+        price_per_unit="0.10",
+        unit_denominator=1_000_000,
+    )
+
+
+def downgrade() -> None:
+    """Remove only the seed rows added by this migration.
+
+    Targets ``(effective_from, provider)`` so a future price correction
+    INSERTed with a later ``effective_from`` survives a partial rollback,
+    and so the c03 seeds (same effective_from, different providers) are
+    not collateral damage.
+    """
+    op.execute(
+        sa.text(
+            "DELETE FROM llm_pricing "
+            "WHERE effective_from = :effective_from "
+            "AND provider IN ('voyage', 'cohere')"
+        ).bindparams(
+            effective_from=_SEED_EFFECTIVE_FROM,
+        )
+    )

--- a/backend/alembic/versions/e13_474_pricing_seeds.py
+++ b/backend/alembic/versions/e13_474_pricing_seeds.py
@@ -34,7 +34,9 @@ a partial rollback.
 Revision ID: e13_474_pricing_seeds
 Revises: e12_474_llm_call_log
 
-NOTE: Revision ID is 21 chars (under the 25-char asyncpg-safe limit).
+NOTE: Revision ID is 21 chars, well within the VARCHAR(32) limit on
+``alembic_version.version_num`` (see ``c02_471`` for the canonical
+note on the asyncpg truncation error path).
 """
 
 from collections.abc import Sequence

--- a/backend/alembic/versions/e13_474_pricing_seeds.py
+++ b/backend/alembic/versions/e13_474_pricing_seeds.py
@@ -105,60 +105,69 @@ def _insert_pricing_row(
 
 
 def upgrade() -> None:
-    """Seed Voyage rerank + Cohere rerank/embed rows for 2026-04-28."""
-    # Voyage rerank — token-based, per 1M tokens.
-    _insert_pricing_row(
-        provider="voyage",
-        model="rerank-2",
-        unit_type="rerank_tokens",
-        price_per_unit="0.05",
-        unit_denominator=1_000_000,
-    )
-    _insert_pricing_row(
-        provider="voyage",
-        model="rerank-2-lite",
-        unit_type="rerank_tokens",
-        price_per_unit="0.02",
-        unit_denominator=1_000_000,
-    )
+    """Seed Voyage rerank + Cohere rerank/embed rows for 2026-04-28.
 
-    # Cohere rerank — billed per "search unit" at $2.00 per 1k SU.
-    # unit_denominator=1000 puts it on the same row shape as the
-    # token-based rows; the cost formula uses unit_denominator as the
-    # divisor uniformly.
-    _insert_pricing_row(
-        provider="cohere",
-        model="rerank-3.5",
-        unit_type="rerank_search_units",
-        price_per_unit="2.00",
-        unit_denominator=1_000,
-    )
+    Iterates ``_SEED_ROWS`` so the upgrade and downgrade stay locked to
+    the same authoritative list. Rate semantics:
 
-    # Cohere embedding — token-based, per 1M tokens. Aligns with the
-    # OpenAI embedding rows c03 seeded ($0.02-0.13 / 1M).
-    _insert_pricing_row(
-        provider="cohere",
-        model="embed-multilingual-v3",
-        unit_type="embedding_tokens",
-        price_per_unit="0.10",
-        unit_denominator=1_000_000,
-    )
+    - Voyage rerank-2 / rerank-2-lite: token-based, per 1M tokens.
+    - Cohere rerank-3.5: per "search unit", $2.00 per 1k SU
+      (``unit_denominator=1_000`` puts it on the same row shape as the
+      token-based rows; the cost formula uses ``unit_denominator`` as
+      the divisor uniformly).
+    - Cohere embed-multilingual-v3: token-based, per 1M tokens (aligns
+      with the OpenAI embedding rows c03 seeded).
+    """
+    for provider, model, unit_type, price_per_unit, unit_denominator in _SEED_ROWS:
+        _insert_pricing_row(
+            provider=provider,
+            model=model,
+            unit_type=unit_type,
+            price_per_unit=price_per_unit,
+            unit_denominator=unit_denominator,
+        )
+
+
+_DELETE_PRICING_SQL = sa.text("""
+    DELETE FROM llm_pricing
+    WHERE provider = :provider
+      AND model = :model
+      AND unit_type = :unit_type
+      AND effective_from = :effective_from
+""")
+
+
+# Authoritative list of the exact (provider, model, unit_type) tuples
+# this migration inserts. ``upgrade()`` and ``downgrade()`` both iterate
+# this so the two stay locked together — a future contributor who adds
+# a fifth seed row only edits one place.
+_SEED_ROWS: tuple[tuple[str, str, str, str, int], ...] = (
+    # (provider, model, unit_type, price_per_unit, unit_denominator)
+    ("voyage", "rerank-2", "rerank_tokens", "0.05", 1_000_000),
+    ("voyage", "rerank-2-lite", "rerank_tokens", "0.02", 1_000_000),
+    ("cohere", "rerank-3.5", "rerank_search_units", "2.00", 1_000),
+    ("cohere", "embed-multilingual-v3", "embedding_tokens", "0.10", 1_000_000),
+)
 
 
 def downgrade() -> None:
-    """Remove only the seed rows added by this migration.
+    """Remove only the seed rows this migration inserted.
 
-    Targets ``(effective_from, provider)`` so a future price correction
-    INSERTed with a later ``effective_from`` survives a partial rollback,
-    and so the c03 seeds (same effective_from, different providers) are
-    not collateral damage.
+    Targets each row by its exact ``(provider, model, unit_type,
+    effective_from)`` tuple, so a future price correction INSERTed with
+    a later ``effective_from`` AND any unrelated row added by a future
+    migration at the same ``effective_from`` (e.g., a new Voyage / Cohere
+    model rate that shares 2026-04-28 as its snapshot) survives a partial
+    rollback. The previous "WHERE provider IN ('voyage', 'cohere') AND
+    effective_from = ..." form was wider than the migration's actual
+    insertions.
     """
-    op.execute(
-        sa.text(
-            "DELETE FROM llm_pricing "
-            "WHERE effective_from = :effective_from "
-            "AND provider IN ('voyage', 'cohere')"
-        ).bindparams(
-            effective_from=_SEED_EFFECTIVE_FROM,
+    for provider, model, unit_type, _price, _denom in _SEED_ROWS:
+        op.execute(
+            _DELETE_PRICING_SQL.bindparams(
+                provider=provider,
+                model=model,
+                unit_type=unit_type,
+                effective_from=_SEED_EFFECTIVE_FROM,
+            )
         )
-    )

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -10,6 +10,7 @@
 # test environment's import graph (#531).
 import models.analysis  # noqa: F401
 import models.file_objects  # noqa: F401  # Issue #485: file storage
+import models.llm_call_log  # noqa: F401  # Issue #474: comprehensive call ledger
 import models.llm_pricing  # noqa: F401
 import models.sleep  # noqa: F401
 from models.config import ContextSearchConfig

--- a/backend/src/models/llm_call_log.py
+++ b/backend/src/models/llm_call_log.py
@@ -201,11 +201,16 @@ class LLMCallLog(Base):
     rerank_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
     rerank_search_units: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
-    # Write-time cost snapshot. NUMERIC(12, 6) handles a single call up
-    # to $999,999.999999 — orders of magnitude beyond any plausible
-    # per-call cost. NOT NULL with default 0 so aggregation queries
-    # don't need COALESCE; pricing misses store 0 + a flag in
-    # ``call_metadata``.
+    # Write-time cost snapshot. NUMERIC(14, 10) mirrors
+    # ``llm_pricing.price_per_unit`` precision: 4 digits before the
+    # decimal (per-call cap of ~$9,999.99 — orders of magnitude beyond
+    # any plausible single API call) and **10 digits after the decimal**
+    # so sub-microcent costs survive the row. A low-volume embedding
+    # call like 20 tokens at $0.02 / 1M = $0.0000004 stores faithfully;
+    # NUMERIC(12, 6) would have rounded this to 0 and made
+    # SUM-over-many-rows materially under-count (Copilot loop 2 #1).
+    # NOT NULL with default 0 so aggregation queries don't need COALESCE;
+    # pricing misses store 0 + a flag in ``call_metadata``.
     # Both ``default=`` and ``server_default=`` declared so the value is
     # populated on ORM-constructed rows (Python-side) and the schema
     # carries a DDL DEFAULT clause matching the migration (catches drift
@@ -214,7 +219,7 @@ class LLMCallLog(Base):
     # in this codebase (see ``SleepReport.source`` / ``SleepReport.paid_by``)
     # so the rendered DDL byte-for-byte matches the alembic migration.
     cost_usd: Mapped[Decimal] = mapped_column(
-        Numeric(12, 6),
+        Numeric(14, 10),
         nullable=False,
         default=Decimal("0"),
         server_default=text("0"),

--- a/backend/src/models/llm_call_log.py
+++ b/backend/src/models/llm_call_log.py
@@ -1,0 +1,286 @@
+"""SQLAlchemy model for the comprehensive LLM call ledger (#474).
+
+Issue #474: Append-only event log capturing every LLM, embedding, and
+rerank API call across the application. The companion to ``sleep_reports``
+(run-shaped, one row per sleep run) — this table is event-shaped, one row
+per provider call, used by call sites that don't fit the run shape:
+
+- **Recall reranking** (Voyage / Cohere) — ``reranker_service`` is called
+  from the recall path, not the sleep path. Cohere bills per "search
+  unit" ($2 / 1k SU) which has no place in ``sleep_reports``.
+- **Recall path embedding** — every recall/semantic search call embeds the
+  query. Today this is uninstrumented (#475 PR-3 will switch the recall
+  path to ``embed_with_usage()`` once this table lands).
+- **Future ``ask()`` synthesis** and **/ceo-style multi-lens** — both
+  call LLMs outside Sleep.
+- **One-off admin actions** (backfill, manual recalibration) that call
+  LLMs.
+
+Cost aggregation in #472 UNION ALLs ``sleep_reports`` (run-shaped, source
+of truth for Sleep cost) and ``llm_call_log`` (event-shaped, source of
+truth for non-Sleep cost) and groups by ``caller`` for the dashboard
+breakdown. ``llm_call_log`` rows are NEVER written by Sleep Maintenance —
+Sleep is a run-shaped emitter and its cost lives in ``sleep_reports`` +
+``sleep_report_llm_usage``. Writing Sleep cost twice would force a
+reconciliation contract that delivers no value (gate1 yellow #3,
+2026-05-14 decision; see memory ``9db43e36`` for the canonical pattern).
+
+## Design notes
+
+**``cost_usd`` is write-time snapshot.** The writer joins ``llm_pricing``
+at insert time with ``effective_from <= occurred_at`` and stores the
+computed value as a snapshot. Lazy/read-time computation would tie cost
+reports to the pricing table's current state, breaking historical
+reproducibility across price changes (gate1 yellow #1, 2026-05-14). A
+pricing-table miss writes ``cost_usd = 0`` and sets
+``call_metadata['pricing_miss'] = true`` so the row stays queryable and
+the gap surfaces in the dashboard as "cost unknown" without an
+``IntegrityError`` on the hot path.
+
+**``call_metadata`` size is capped at 4 KB via CHECK constraint.** The
+field is free-form JSONB intended for opaque audit fields (request IDs,
+latency, retry counts). Capping it at the schema layer defends against
+accidentally storing prompt bodies — a privacy/PII concern that is
+explicitly out of scope for this issue (the codebase's first ``JSONB``
+size CHECK, well-documented in this docstring as the canonical pattern
+for future PII-sensitive JSONB columns). Application-layer writers should
+never serialize raw prompts into this column.
+
+**``paid_by`` mirrors ``sleep_reports.paid_by``** ('platform' vs 'byok')
+so the #472 UNION ALL aggregation can group both tables on the same axis
+without coalescing NULLs. ``platform`` covers the standard kagura-managed
+billing path; ``byok`` covers users routing through their own API keys.
+
+**``caller`` nullability matrix.** A defense-in-depth Python assertion in
+``services/llm_call_log_writer.py`` enforces these contracts on the
+writer side too:
+
+| caller    | user_id | workspace_id | context_id |
+|-----------|---------|--------------|------------|
+| recall    | NOT NULL| NOT NULL     | NOT NULL   |
+| rerank    | NOT NULL| NOT NULL     | NOT NULL   |
+| ask       | NOT NULL| NOT NULL     | NOT NULL   |
+| admin     | nullable| nullable     | nullable   |
+| sleep     | (never written, see above)                |
+
+The 'sleep' value in the CHECK constraint exists for forward-compat
+(future migration that might unify sleep ledger here) but the writer
+refuses to emit it today. Adding it to the CHECK now is cheap; adding it
+later would force a CHECK-constraint migration.
+
+## Out of scope for this issue
+
+- **Partitioning / retention strategy.** v1 ships with no partitioning
+  and unlimited retention. The 100M-row growth threshold is the
+  escalation trigger to file a follow-up issue. ``occurred_at`` index
+  + ``(workspace_id, occurred_at)`` index are sized for low-tens-of-
+  millions of rows.
+- **Aggregation API** that UNIONs this table with ``sleep_reports`` —
+  that lives in #472 (extension / sibling endpoint), not this issue.
+- **Recall path instrumentation** itself — this issue only lands the
+  table + a writer service stub. The recall path embed/rerank call
+  sites switch to the writer in #475 PR-3.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID as PyUUID
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    DateTime,
+    Index,
+    Integer,
+    Numeric,
+    String,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base
+
+# Public list of allowed ``caller`` values. Imported by the writer
+# service for input validation (defense in depth — the DB CHECK is the
+# source of truth). Keep in sync with the ``valid_llm_call_log_caller``
+# CHECK constraint string below AND the matching string in the alembic
+# migration (op.create_table form, see ``e12_474_llm_call_log``).
+LLM_CALL_LOG_CALLERS: tuple[str, ...] = (
+    "sleep",
+    "recall",
+    "rerank",
+    "ask",
+    "admin",
+)
+
+# Public list of allowed ``call_type`` values. The codebase consistently
+# uses ``unit_type`` / ``pricing_model`` / ``call_type``-style names
+# (snake_case + ``_type`` suffix) — see ``llm_pricing.unit_type``. The
+# issue body draft used ``call_kind`` but that doesn't match this
+# convention.
+LLM_CALL_LOG_CALL_TYPES: tuple[str, ...] = (
+    "completion",
+    "embedding",
+    "rerank",
+)
+
+# Mirrors ``models.sleep.SLEEP_REPORT_PAID_BY_VALUES``. Kept local rather
+# than imported across modules so ``models/__init__.py`` doesn't take an
+# implicit dependency on Sleep models being import-ordered first.
+LLM_CALL_LOG_PAID_BY_VALUES: tuple[str, ...] = ("platform", "byok")
+
+# 4 KB cap on the ``call_metadata`` JSONB field. Defends against
+# accidental storage of full prompt bodies. The check uses
+# ``octet_length(call_metadata::text)`` because PostgreSQL doesn't expose
+# a native JSONB-byte-size function — converting through text gives a
+# stable upper bound (always >= the on-disk JSONB size since text is the
+# verbose form).
+LLM_CALL_LOG_METADATA_MAX_BYTES: int = 4096
+
+
+class LLMCallLog(Base):
+    """Append-only event log for one LLM/embedding/rerank API call (#474).
+
+    See module docstring for the design rationale (write-time cost
+    snapshot, ``call_metadata`` size cap, nullability contracts per
+    ``caller``, Sleep stays in ``sleep_reports``).
+
+    Usage cost per call (computed at write time from ``llm_pricing``):
+
+        cost_usd = SUM_over_unit_type(
+            tokens_for_unit_type * price_per_unit / unit_denominator
+        )
+
+    A pricing miss writes ``cost_usd = 0`` and surfaces in the dashboard
+    via ``call_metadata.pricing_miss = true`` — never raise on the hot
+    path (``services/llm_call_log_writer.py`` enforces this).
+    """
+
+    __tablename__ = "llm_call_log"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+
+    # Naive UTC by convention (matches ``sleep_reports.started_at`` and
+    # ``llm_pricing.effective_from``). Joining against ``llm_pricing``
+    # for the write-time price snapshot requires both sides agree.
+    occurred_at: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+
+    # Identity columns. Nullability semantics depend on ``caller`` —
+    # the per-caller matrix lives in the module docstring; the writer
+    # service Python-asserts it. The DB columns themselves are all
+    # nullable so the ``admin`` path (which may write rows with no user
+    # context, e.g. backfill jobs) can land without a CHECK constraint
+    # carve-out per caller.
+    user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    workspace_id: Mapped[PyUUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+    context_id: Mapped[PyUUID | None] = mapped_column(UUID(as_uuid=True), nullable=True)
+
+    caller: Mapped[str] = mapped_column(String(20), nullable=False)
+    call_type: Mapped[str] = mapped_column(String(20), nullable=False)
+
+    # ``provider`` / ``model`` widths match ``llm_pricing`` columns so
+    # the cost-grade join doesn't need a cast / length coercion.
+    provider: Mapped[str] = mapped_column(String(50), nullable=False)
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    # Per-call usage. Any subset may be NULL depending on ``call_type``:
+    # ``completion`` populates input/output (+ cached_input / cache_write
+    # when the provider supports cache pricing — Anthropic, OpenAI),
+    # ``embedding`` populates ``embedding_tokens``, ``rerank`` populates
+    # exactly one of (``rerank_tokens`` for Voyage, ``rerank_search_units``
+    # for Cohere). The writer Python-asserts the right field is set;
+    # the DB columns stay loose so future ``call_type`` values
+    # (multi-modal, audio, …) can land without ALTER TABLE per kind.
+    input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    output_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cached_input_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cache_write_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    embedding_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rerank_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    rerank_search_units: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # Write-time cost snapshot. NUMERIC(12, 6) handles a single call up
+    # to $999,999.999999 — orders of magnitude beyond any plausible
+    # per-call cost. NOT NULL with default 0 so aggregation queries
+    # don't need COALESCE; pricing misses store 0 + a flag in
+    # ``call_metadata``.
+    # Both ``default=`` and ``server_default=`` declared so the value is
+    # populated on ORM-constructed rows (Python-side) and the schema
+    # carries a DDL DEFAULT clause matching the migration (catches drift
+    # between model and migration in ``test_schema_drift.py``).
+    cost_usd: Mapped[Decimal] = mapped_column(
+        Numeric(12, 6),
+        nullable=False,
+        default=Decimal("0"),
+        server_default="0",
+    )
+
+    # 'platform' = kagura-managed billing path. 'byok' = user-supplied
+    # API key (no kagura billing on this row, but still useful for
+    # operational cost telemetry). Mirrors ``sleep_reports.paid_by``.
+    paid_by: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default="platform",
+        server_default="platform",
+    )
+
+    # Free-form audit JSON. Allowed keys (writer convention, not
+    # schema-enforced): ``request_id``, ``latency_ms``, ``retry_count``,
+    # ``pricing_miss`` (sentinel for ``cost_usd=0`` rows). Schema-level
+    # 4 KB cap defends against prompt bodies. The Python attribute is
+    # named ``call_metadata`` (not ``metadata``) because ``metadata``
+    # is reserved by the SQLAlchemy Declarative API; the SQL column
+    # name follows the attribute name (which is the goal — the
+    # migration creates a column literally called ``call_metadata``).
+    call_metadata: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+
+    __table_args__ = (
+        CheckConstraint(
+            "caller IN ('sleep', 'recall', 'rerank', 'ask', 'admin')",
+            name="valid_llm_call_log_caller",
+        ),
+        CheckConstraint(
+            "call_type IN ('completion', 'embedding', 'rerank')",
+            name="valid_llm_call_log_call_type",
+        ),
+        CheckConstraint(
+            "paid_by IN ('platform', 'byok')",
+            name="valid_llm_call_log_paid_by",
+        ),
+        CheckConstraint(
+            "cost_usd >= 0",
+            name="valid_llm_call_log_cost_nonneg",
+        ),
+        # First-of-its-kind in this codebase: schema-level cap on a
+        # JSONB column's serialized size. octet_length on JSONB::text
+        # gives a stable upper bound (text form is the most verbose,
+        # always >= the on-disk JSONB size). The 4 KB threshold is
+        # large enough for ~40-50 short audit fields and small enough
+        # that a full prompt body (typically 2-10 KB) hits the wall.
+        CheckConstraint(
+            f"call_metadata IS NULL OR "
+            f"octet_length(call_metadata::text) <= {LLM_CALL_LOG_METADATA_MAX_BYTES}",
+            name="valid_llm_call_log_metadata_size",
+        ),
+        # Single-column index on occurred_at supports the "all-tenant
+        # cost over a date range" admin query.
+        Index("idx_llm_call_log_occurred_at", "occurred_at"),
+        # Composite index matching the per-tenant aggregation shape
+        # (workspace_id, occurred_at) — mirrors
+        # ``idx_sleep_reports_workspace_source_started`` on sleep_reports
+        # so the #472 UNION ALL has matching index support on both legs.
+        Index(
+            "idx_llm_call_log_workspace_period",
+            "workspace_id",
+            "occurred_at",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<LLMCallLog(id={self.id} caller={self.caller} "
+            f"call_type={self.call_type} {self.provider}/{self.model} "
+            f"cost={self.cost_usd} at={self.occurred_at})>"
+        )

--- a/backend/src/models/llm_call_log.py
+++ b/backend/src/models/llm_call_log.py
@@ -95,6 +95,7 @@ from sqlalchemy import (
     Integer,
     Numeric,
     String,
+    text,
 )
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -208,22 +209,26 @@ class LLMCallLog(Base):
     # Both ``default=`` and ``server_default=`` declared so the value is
     # populated on ORM-constructed rows (Python-side) and the schema
     # carries a DDL DEFAULT clause matching the migration (catches drift
-    # between model and migration in ``test_schema_drift.py``).
+    # between model and migration in ``test_schema_drift.py``). The
+    # ``text(...)`` form is the canonical pattern for ``server_default``
+    # in this codebase (see ``SleepReport.source`` / ``SleepReport.paid_by``)
+    # so the rendered DDL byte-for-byte matches the alembic migration.
     cost_usd: Mapped[Decimal] = mapped_column(
         Numeric(12, 6),
         nullable=False,
         default=Decimal("0"),
-        server_default="0",
+        server_default=text("0"),
     )
 
     # 'platform' = kagura-managed billing path. 'byok' = user-supplied
     # API key (no kagura billing on this row, but still useful for
-    # operational cost telemetry). Mirrors ``sleep_reports.paid_by``.
+    # operational cost telemetry). Mirrors ``sleep_reports.paid_by``
+    # including the ``text("'platform'")`` server_default form.
     paid_by: Mapped[str] = mapped_column(
         String(20),
         nullable=False,
         default="platform",
-        server_default="platform",
+        server_default=text("'platform'"),
     )
 
     # Free-form audit JSON. Allowed keys (writer convention, not

--- a/backend/src/services/llm_call_log_writer.py
+++ b/backend/src/services/llm_call_log_writer.py
@@ -1,0 +1,341 @@
+"""Writer service for the comprehensive LLM call ledger (#474).
+
+Issue #474: Inserts one ``llm_call_log`` row per LLM/embedding/rerank
+API call from non-Sleep paths (recall reranking, recall embedding via
+#475 PR-3, future ``ask()``, admin actions). Sleep Maintenance never
+emits here — Sleep cost stays in ``sleep_reports`` + ``sleep_report_llm_usage``
+(canonical pattern, memory ``9db43e36`` / 2026-05-14 gate1 decision).
+
+Design contract (mirrors ``services/sleep/reporter.py:SleepReporter``):
+
+- ``__init__(db: AsyncSession)`` — caller injects the session, writer
+  uses it directly. No internal session acquisition / commit / rollback.
+- ``record()`` performs ``self.db.add(row)`` + ``await self.db.flush()``
+  so the caller can read back ``row.id`` immediately. ``commit()`` is
+  the orchestrator's responsibility.
+- Errors propagate to the caller (no swallow). The recall-path call
+  site decides whether a writer failure should degrade silently — the
+  writer never makes that policy call.
+
+Cost computation is **write-time snapshot**: for each non-None positive
+usage column, ``LLMPricingService.compute_cost_usd`` is called with
+``occurred_at`` as the ``started_at`` and the result is summed into
+``cost_usd``. A lookup miss on any axis stores ``cost_usd = 0`` and
+sets ``call_metadata.pricing_miss = true`` so the row stays queryable
+and the dashboard surfaces the gap. Lazy/read-time computation was
+rejected at gate1 yellow #1 — it ties historical reports to the
+current ``llm_pricing`` state and breaks reproducibility across price
+changes.
+
+The ``caller`` value ``'sleep'`` is permitted by the table CHECK
+(forward-compat) but the writer refuses it — emitting Sleep cost twice
+would force a reconciliation contract this PR explicitly avoids.
+
+The nullability matrix per ``caller`` is asserted Python-side as
+defense-in-depth on top of the schema. See ``models/llm_call_log.py``
+module docstring for the canonical table.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.llm_call_log import (
+    LLM_CALL_LOG_CALL_TYPES,
+    LLM_CALL_LOG_CALLERS,
+    LLM_CALL_LOG_PAID_BY_VALUES,
+    LLMCallLog,
+)
+from services.llm_pricing_service import LLMPricingService
+from utils.datetime import utcnow
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# Caller values the writer refuses to emit. Sleep is included for the
+# canonical-store reason; future "forbidden" callers can be added here
+# without touching the CHECK constraint (the CHECK is a superset).
+_FORBIDDEN_CALLERS: frozenset[str] = frozenset({"sleep"})
+
+# Callers that require full (user_id, workspace_id, context_id) identity.
+# ``admin`` is intentionally excluded — backfill / recalibration jobs
+# may run without a user binding. The table CHECK is permissive (all
+# three columns nullable); this Python-side assert enforces the
+# operational contract.
+_FULL_IDENTITY_CALLERS: frozenset[str] = frozenset({"recall", "rerank", "ask"})
+
+# Column-name → llm_pricing.unit_type axis. ``cached_input_tokens`` maps
+# to the ``cache_read_tokens`` pricing axis — naming differs because
+# providers (Anthropic) return ``cached_input_tokens`` in their usage
+# payload but pricing tables consistently use ``cache_read_tokens`` for
+# the dimension. Same convention as ``sleep_report_llm_usage``.
+_USAGE_TO_UNIT_TYPE: dict[str, str] = {
+    "input_tokens": "input_tokens",
+    "output_tokens": "output_tokens",
+    "cached_input_tokens": "cache_read_tokens",
+    "cache_write_tokens": "cache_write_tokens",
+    "embedding_tokens": "embedding_tokens",
+    "rerank_tokens": "rerank_tokens",
+    "rerank_search_units": "rerank_search_units",
+}
+
+# Import-time guard: if anyone renames a usage column on ``LLMCallLog``
+# (e.g., ``cached_input_tokens`` → ``cache_read_input_tokens`` to match
+# the pricing axis), this assertion turns the silent miss into a hard
+# AssertionError at module load — the writer would otherwise drop the
+# axis silently because the ``_USAGE_TO_UNIT_TYPE`` key would no longer
+# match any column and the loop in ``record()`` iterates the same
+# hardcoded keys.
+_LLM_CALL_LOG_COLUMN_KEYS: frozenset[str] = frozenset(LLMCallLog.__table__.columns.keys())
+assert set(_USAGE_TO_UNIT_TYPE.keys()) <= _LLM_CALL_LOG_COLUMN_KEYS, (
+    "_USAGE_TO_UNIT_TYPE keys must all be columns on LLMCallLog; "
+    f"missing: {set(_USAGE_TO_UNIT_TYPE.keys()) - _LLM_CALL_LOG_COLUMN_KEYS}"
+)
+
+
+def _coerce_uuid(value: UUID | str | None) -> UUID | None:
+    """Accept either ``UUID`` or ``str`` from callers; return ``UUID | None``.
+
+    Recall/rerank call sites already hold ``UUID`` objects (from auth
+    dependencies), but admin / MCP entry points may pass strings. Keep
+    the writer's surface loose so callers don't have to coerce.
+    """
+    if value is None:
+        return None
+    if isinstance(value, UUID):
+        return value
+    return UUID(value)
+
+
+class LlmCallLogWriter:
+    """Inserts one ``llm_call_log`` row per provider call.
+
+    Stateless from the caller's perspective; the only mutable state is
+    the injected ``AsyncSession``. Reuse one instance per request /
+    operation context — each ``record()`` call performs at most
+    (1 + number_of_priced_unit_types) DB round trips: one or more
+    ``llm_pricing`` SELECTs followed by a single INSERT via ``flush()``.
+    """
+
+    def __init__(self, db: AsyncSession, pricing: LLMPricingService | None = None) -> None:
+        """Initialize the writer.
+
+        Args:
+            db: Async SQLAlchemy session. Same session pattern as every
+                other service in this layer (compare ``SleepReporter``,
+                ``LLMPricingService``).
+            pricing: Optional pre-built pricing service — useful for
+                tests that mock pricing without mocking the DB. When
+                omitted, the writer constructs one from ``db``.
+        """
+        self.db = db
+        self.pricing = pricing or LLMPricingService(db)
+
+    async def record(
+        self,
+        *,
+        caller: str,
+        call_type: str,
+        provider: str,
+        model: str,
+        occurred_at: datetime | None = None,
+        user_id: str | None = None,
+        workspace_id: UUID | str | None = None,
+        context_id: UUID | str | None = None,
+        input_tokens: int | None = None,
+        output_tokens: int | None = None,
+        cached_input_tokens: int | None = None,
+        cache_write_tokens: int | None = None,
+        embedding_tokens: int | None = None,
+        rerank_tokens: int | None = None,
+        rerank_search_units: int | None = None,
+        paid_by: str = "platform",
+        call_metadata: dict[str, Any] | None = None,
+    ) -> LLMCallLog:
+        """Insert one llm_call_log row with a write-time cost snapshot.
+
+        Returns the inserted ``LLMCallLog`` (post-flush, so ``id`` is
+        populated). The caller is responsible for the surrounding
+        transaction lifecycle.
+
+        Raises:
+            ValueError: ``caller`` / ``call_type`` / ``paid_by`` is
+                outside its allowed set, OR ``caller`` is in
+                ``_FORBIDDEN_CALLERS`` (today: 'sleep'), OR the
+                nullability matrix is violated for the chosen caller.
+        """
+        self._validate_inputs(
+            caller=caller,
+            call_type=call_type,
+            paid_by=paid_by,
+            user_id=user_id,
+            workspace_id=workspace_id,
+            context_id=context_id,
+        )
+
+        resolved_occurred_at: datetime = occurred_at if occurred_at is not None else utcnow()
+
+        # Per-axis usage list (only positive counts contribute to cost;
+        # zeros and Nones are skipped — saves a pricing round trip per
+        # unused column). Negative values are an error: silent drop
+        # would let bad data into the row with cost_usd=0, which would
+        # under-count cost without any signal at the writer boundary.
+        usage_pairs: list[tuple[str, int]] = []
+        for column_name, value in (
+            ("input_tokens", input_tokens),
+            ("output_tokens", output_tokens),
+            ("cached_input_tokens", cached_input_tokens),
+            ("cache_write_tokens", cache_write_tokens),
+            ("embedding_tokens", embedding_tokens),
+            ("rerank_tokens", rerank_tokens),
+            ("rerank_search_units", rerank_search_units),
+        ):
+            if value is None:
+                continue
+            if value < 0:
+                raise ValueError(f"{column_name}={value} must be >= 0")
+            if value > 0:
+                usage_pairs.append((column_name, value))
+
+        cost_usd, pricing_miss = await self._compute_cost_usd(
+            provider=provider,
+            model=model,
+            occurred_at=resolved_occurred_at,
+            usage_pairs=usage_pairs,
+        )
+
+        final_metadata: dict[str, Any] | None = dict(call_metadata) if call_metadata else None
+        if pricing_miss:
+            final_metadata = final_metadata or {}
+            final_metadata["pricing_miss"] = True
+            logger.warning(
+                "llm_call_log_pricing_miss",
+                caller=caller,
+                provider=provider,
+                model=model,
+                call_type=call_type,
+            )
+
+        row = LLMCallLog(
+            occurred_at=resolved_occurred_at,
+            user_id=user_id,
+            workspace_id=_coerce_uuid(workspace_id),
+            context_id=_coerce_uuid(context_id),
+            caller=caller,
+            call_type=call_type,
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_input_tokens=cached_input_tokens,
+            cache_write_tokens=cache_write_tokens,
+            embedding_tokens=embedding_tokens,
+            rerank_tokens=rerank_tokens,
+            rerank_search_units=rerank_search_units,
+            cost_usd=cost_usd,
+            paid_by=paid_by,
+            call_metadata=final_metadata,
+        )
+        self.db.add(row)
+        await self.db.flush()
+        return row
+
+    @staticmethod
+    def _validate_inputs(
+        *,
+        caller: str,
+        call_type: str,
+        paid_by: str,
+        user_id: str | None,
+        workspace_id: UUID | str | None,
+        context_id: UUID | str | None,
+    ) -> None:
+        """Defense-in-depth enum + nullability checks before the DB sees them.
+
+        Each constraint is mirrored by a CHECK constraint on the table;
+        the Python-side validation just turns a future bug into a clear
+        ``ValueError`` at the writer boundary instead of an
+        ``IntegrityError`` from the COMMIT path.
+        """
+        if caller not in LLM_CALL_LOG_CALLERS:
+            raise ValueError(f"invalid caller {caller!r}; must be one of {LLM_CALL_LOG_CALLERS}")
+        if caller in _FORBIDDEN_CALLERS:
+            raise ValueError(
+                f"caller {caller!r} is not allowed in llm_call_log — "
+                "Sleep Maintenance writes to sleep_reports + "
+                "sleep_report_llm_usage; #472 UNION ALLs both tables"
+            )
+        if call_type not in LLM_CALL_LOG_CALL_TYPES:
+            raise ValueError(
+                f"invalid call_type {call_type!r}; must be one of {LLM_CALL_LOG_CALL_TYPES}"
+            )
+        if paid_by not in LLM_CALL_LOG_PAID_BY_VALUES:
+            raise ValueError(
+                f"invalid paid_by {paid_by!r}; must be one of {LLM_CALL_LOG_PAID_BY_VALUES}"
+            )
+        if caller in _FULL_IDENTITY_CALLERS:
+            missing: list[str] = []
+            if user_id is None:
+                missing.append("user_id")
+            if workspace_id is None:
+                missing.append("workspace_id")
+            if context_id is None:
+                missing.append("context_id")
+            if missing:
+                raise ValueError(
+                    f"caller {caller!r} requires all of "
+                    f"(user_id, workspace_id, context_id); missing: {missing}"
+                )
+
+    async def _compute_cost_usd(
+        self,
+        *,
+        provider: str,
+        model: str,
+        occurred_at: datetime,
+        usage_pairs: list[tuple[str, int]],
+    ) -> tuple[Decimal, bool]:
+        """Sum cost across all priced unit_types for this call.
+
+        Returns ``(cost_usd, pricing_miss)``. ``pricing_miss`` is True
+        iff at least one ``compute_cost_usd`` lookup returned ``None``
+        (caller writes ``cost_usd = 0`` and sets the metadata flag).
+        An empty ``usage_pairs`` list returns ``(Decimal(0), False)`` —
+        a row with no priced units is valid (e.g., a degenerate
+        completion with input_tokens=0).
+        """
+        if not usage_pairs:
+            return Decimal("0"), False
+
+        total = Decimal("0")
+        miss = False
+        for column_name, units in usage_pairs:
+            unit_type = _USAGE_TO_UNIT_TYPE[column_name]
+            partial = await self.pricing.compute_cost_usd(
+                provider=provider,
+                model=model,
+                unit_type=unit_type,
+                started_at=occurred_at,
+                units=units,
+            )
+            if partial is None:
+                miss = True
+                continue
+            # ``compute_cost_usd`` returns float — convert via str to
+            # preserve precision the float repr would otherwise mangle
+            # (e.g. 0.05 → 0.05000000000000000277...) when crossing the
+            # Decimal boundary.
+            total += Decimal(str(partial))
+
+        if miss:
+            # Miss on any axis collapses the whole cost to 0; the
+            # metadata flag carries the signal. Don't return a partial
+            # sum — that would understate cost without being marked.
+            return Decimal("0"), True
+        return total, False

--- a/backend/src/services/llm_call_log_writer.py
+++ b/backend/src/services/llm_call_log_writer.py
@@ -85,6 +85,21 @@ _USAGE_TO_UNIT_TYPE: dict[str, str] = {
     "rerank_search_units": "rerank_search_units",
 }
 
+# Per ``call_type``, which usage axes are semantically allowed. The
+# model docstring (``models/llm_call_log.py:187-194``) declares this
+# contract — the writer enforces it here so a caller cannot mix
+# axes across call_types (e.g., completion + embedding_tokens) and
+# silently produce an under-counted row with ``cost_usd=0`` and no
+# ``pricing_miss`` signal. Empty / all-zero rows are still allowed
+# (a degenerate call that returned no usage is a valid audit row).
+_CALL_TYPE_ALLOWED_USAGE: dict[str, frozenset[str]] = {
+    "completion": frozenset(
+        {"input_tokens", "output_tokens", "cached_input_tokens", "cache_write_tokens"}
+    ),
+    "embedding": frozenset({"embedding_tokens"}),
+    "rerank": frozenset({"rerank_tokens", "rerank_search_units"}),
+}
+
 # Import-time guard: if anyone renames a usage column on ``LLMCallLog``
 # (e.g., ``cached_input_tokens`` → ``cache_read_input_tokens`` to match
 # the pricing axis), this assertion turns the silent miss into a hard
@@ -186,7 +201,12 @@ class LlmCallLogWriter:
         # unused column). Negative values are an error: silent drop
         # would let bad data into the row with cost_usd=0, which would
         # under-count cost without any signal at the writer boundary.
+        # The ``call_type``-allowed-axes contract from
+        # ``_CALL_TYPE_ALLOWED_USAGE`` is enforced inside the loop so a
+        # caller cannot silently mix axes across call_types.
+        allowed_axes = _CALL_TYPE_ALLOWED_USAGE[call_type]
         usage_pairs: list[tuple[str, int]] = []
+        rerank_axes_populated: list[str] = []
         for column_name, value in (
             ("input_tokens", input_tokens),
             ("output_tokens", output_tokens),
@@ -201,7 +221,27 @@ class LlmCallLogWriter:
             if value < 0:
                 raise ValueError(f"{column_name}={value} must be >= 0")
             if value > 0:
+                if column_name not in allowed_axes:
+                    raise ValueError(
+                        f"call_type={call_type!r} does not allow {column_name}; "
+                        f"allowed axes: {sorted(allowed_axes)}"
+                    )
                 usage_pairs.append((column_name, value))
+                if call_type == "rerank" and column_name in (
+                    "rerank_tokens",
+                    "rerank_search_units",
+                ):
+                    rerank_axes_populated.append(column_name)
+
+        # Rerank semantics: Voyage uses ``rerank_tokens``, Cohere uses
+        # ``rerank_search_units`` — exactly one provider, so exactly one
+        # axis. Both populated indicates a writer-side bug.
+        if len(rerank_axes_populated) > 1:
+            raise ValueError(
+                f"call_type='rerank' must populate exactly one of "
+                f"(rerank_tokens, rerank_search_units); got both: "
+                f"{rerank_axes_populated}"
+            )
 
         cost_usd, pricing_miss = await self._compute_cost_usd(
             provider=provider,

--- a/backend/src/services/llm_call_log_writer.py
+++ b/backend/src/services/llm_call_log_writer.py
@@ -264,7 +264,14 @@ class LLMCallLogWriter:
         if pricing_miss:
             final_metadata = final_metadata or {}
             final_metadata["pricing_miss"] = True
-            logger.warning(
+            # Pricing misses are expected (newly-deployed model before
+            # its seed row lands; exotic provider). The signal is
+            # already carried on the row via ``call_metadata.pricing_miss``
+            # and surfaced in dashboards; logging at debug matches
+            # ``LLMPricingService.lookup()`` (the lower-level "no row"
+            # path) and avoids alert fatigue on a recall hot path
+            # (Copilot loop 4 #2).
+            logger.debug(
                 "llm_call_log_pricing_miss",
                 caller=caller,
                 provider=provider,
@@ -364,7 +371,6 @@ class LLMCallLogWriter:
             return Decimal("0"), False
 
         total = Decimal("0")
-        miss = False
         for column_name, units in usage_pairs:
             unit_type = _USAGE_TO_UNIT_TYPE[column_name]
             partial = await self.pricing.compute_cost_usd(
@@ -375,17 +381,17 @@ class LLMCallLogWriter:
                 units=units,
             )
             if partial is None:
-                miss = True
-                continue
+                # First miss collapses the whole cost to 0 — short-circuit
+                # remaining lookups to save DB round-trips on the recall
+                # hot path. The "new model not yet seeded" case is the
+                # common cause and hitting all 4 axes adds no signal:
+                # ``call_metadata.pricing_miss=true`` carries the gap to
+                # the dashboard (Copilot loop 4 #1).
+                return Decimal("0"), True
             # ``compute_cost_usd`` returns float — convert via str to
             # preserve precision the float repr would otherwise mangle
             # (e.g. 0.05 → 0.05000000000000000277...) when crossing the
             # Decimal boundary.
             total += Decimal(str(partial))
 
-        if miss:
-            # Miss on any axis collapses the whole cost to 0; the
-            # metadata flag carries the signal. Don't return a partial
-            # sum — that would understate cost without being marked.
-            return Decimal("0"), True
         return total, False

--- a/backend/src/services/llm_call_log_writer.py
+++ b/backend/src/services/llm_call_log_writer.py
@@ -128,7 +128,7 @@ def _coerce_uuid(value: UUID | str | None) -> UUID | None:
     return UUID(value)
 
 
-class LlmCallLogWriter:
+class LLMCallLogWriter:
     """Inserts one ``llm_call_log`` row per provider call.
 
     Stateless from the caller's perspective; the only mutable state is
@@ -230,13 +230,18 @@ class LlmCallLogWriter:
                     f"call_type={call_type!r} does not allow {column_name}; "
                     f"allowed axes: {sorted(allowed_axes)}"
                 )
+            # Track rerank axes on **any** non-None value (including 0) —
+            # downstream queries treat ``IS NOT NULL`` as "this axis was
+            # relevant for the call", so the exclusivity check has to
+            # operate on the same signal that the schema produces, not
+            # just positive values (Copilot loop 3 #1).
+            if call_type == "rerank" and column_name in (
+                "rerank_tokens",
+                "rerank_search_units",
+            ):
+                rerank_axes_populated.append(column_name)
             if value > 0:
                 usage_pairs.append((column_name, value))
-                if call_type == "rerank" and column_name in (
-                    "rerank_tokens",
-                    "rerank_search_units",
-                ):
-                    rerank_axes_populated.append(column_name)
 
         # Rerank semantics: Voyage uses ``rerank_tokens``, Cohere uses
         # ``rerank_search_units`` — exactly one provider, so exactly one

--- a/backend/src/services/llm_call_log_writer.py
+++ b/backend/src/services/llm_call_log_writer.py
@@ -244,13 +244,19 @@ class LLMCallLogWriter:
                 usage_pairs.append((column_name, value))
 
         # Rerank semantics: Voyage uses ``rerank_tokens``, Cohere uses
-        # ``rerank_search_units`` — exactly one provider, so exactly one
-        # axis. Both populated indicates a writer-side bug.
-        if len(rerank_axes_populated) > 1:
+        # ``rerank_search_units`` — exactly one provider per call, so
+        # exactly one axis. The check rejects both-populated AND
+        # neither-populated: the caller (``reranker_service``) always
+        # has a usage figure from the provider, so a zero-axis rerank
+        # row is a caller-side bug rather than a degenerate audit case.
+        # An axis with value=0 still counts as "populated" via the
+        # non-None tracking above (matches the schema's ``IS NOT NULL``
+        # signal). (Copilot loop 5 #1.)
+        if call_type == "rerank" and len(rerank_axes_populated) != 1:
+            populated_repr = rerank_axes_populated or "neither"
             raise ValueError(
                 f"call_type='rerank' must populate exactly one of "
-                f"(rerank_tokens, rerank_search_units); got both: "
-                f"{rerank_axes_populated}"
+                f"(rerank_tokens, rerank_search_units); got {populated_repr}"
             )
 
         cost_usd, pricing_miss = await self._compute_cost_usd(

--- a/backend/src/services/llm_call_log_writer.py
+++ b/backend/src/services/llm_call_log_writer.py
@@ -220,12 +220,17 @@ class LlmCallLogWriter:
                 continue
             if value < 0:
                 raise ValueError(f"{column_name}={value} must be >= 0")
+            # Reject any non-None value on a disallowed axis — including
+            # 0. Downstream queries may treat ``IS NOT NULL`` as "this
+            # axis was relevant for this call_type"; permitting
+            # ``embedding_tokens=0`` on a completion row would write
+            # dirty data through that filter (Copilot loop 2 #3).
+            if column_name not in allowed_axes:
+                raise ValueError(
+                    f"call_type={call_type!r} does not allow {column_name}; "
+                    f"allowed axes: {sorted(allowed_axes)}"
+                )
             if value > 0:
-                if column_name not in allowed_axes:
-                    raise ValueError(
-                        f"call_type={call_type!r} does not allow {column_name}; "
-                        f"allowed axes: {sorted(allowed_axes)}"
-                    )
                 usage_pairs.append((column_name, value))
                 if call_type == "rerank" and column_name in (
                     "rerank_tokens",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -17,6 +17,7 @@ from models.memory import Base as MemoryBase
 # transitively via service imports today; importing explicitly here
 # keeps the test setup robust to future import-graph changes.
 import models.llm_pricing  # noqa: F401  isort: skip
+import models.llm_call_log  # noqa: F401  isort: skip  # Issue #474: comprehensive LLM call ledger
 import models.sleep  # noqa: F401  isort: skip
 import models.analysis  # noqa: F401  isort: skip  # Issue #494: Memory Broadlistening tables
 

--- a/backend/tests/integration/test_llm_call_log_schema.py
+++ b/backend/tests/integration/test_llm_call_log_schema.py
@@ -1,0 +1,237 @@
+"""Integration tests for the llm_call_log schema (#474).
+
+Covers:
+
+- CHECK constraint on ``caller`` rejects values outside the allowed tuple.
+- CHECK constraint on ``call_type`` rejects values outside the allowed tuple.
+- CHECK constraint on ``paid_by`` rejects values outside ``('platform', 'byok')``.
+- CHECK constraint on ``cost_usd >= 0`` rejects negative values.
+- CHECK constraint on ``octet_length(call_metadata::text) <= 4096`` rejects
+  oversized JSONB payloads — the codebase's first JSONB size cap, so the
+  test is the contract for future similar columns.
+- ``information_schema`` DDL audit: column types + nullability + indexes
+  are what the model declared. Catches drift between the migration and
+  the model (mirrors ``test_sleep_report_schema.py`` and PR #610's
+  ``server_default`` parity rule).
+- ORM defaults: ``cost_usd`` defaults to 0, ``paid_by`` defaults to
+  'platform' on a row built without those columns.
+- BYOK round-trip: ``paid_by='byok'`` persists and reads back unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+
+from models.llm_call_log import LLMCallLog
+
+
+def _make_call_log(**overrides: Any) -> LLMCallLog:
+    """Minimal LLMCallLog constructor; callers override columns under test.
+
+    Defaults pick the most permissive caller ('admin') so identity columns
+    can stay None unless a test wants to exercise the nullability matrix.
+    """
+    defaults: dict[str, Any] = {
+        "occurred_at": datetime(2026, 5, 14, 0, 0, 0),
+        "caller": "admin",
+        "call_type": "completion",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-6",
+        "input_tokens": 100,
+        "output_tokens": 50,
+    }
+    defaults.update(overrides)
+    return LLMCallLog(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_invalid_caller(db_session):
+    """caller outside the allowed tuple must raise IntegrityError."""
+    db_session.add(_make_call_log(caller="bogus"))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_invalid_call_type(db_session):
+    """call_type outside ('completion', 'embedding', 'rerank') must raise."""
+    db_session.add(_make_call_log(call_type="audio"))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_invalid_paid_by(db_session):
+    """paid_by outside ('platform', 'byok') must raise."""
+    db_session.add(_make_call_log(paid_by="user"))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_negative_cost(db_session):
+    """cost_usd must be >= 0."""
+    db_session.add(_make_call_log(cost_usd=Decimal("-0.01")))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_check_rejects_oversized_metadata(db_session):
+    """call_metadata over 4 KB (octet_length on text form) must raise.
+
+    Defends against accidental storage of prompt bodies. The threshold
+    is the source of truth for the codebase's first JSONB size cap;
+    future PII-sensitive JSONB columns should mirror this pattern.
+    """
+    # Build a payload whose JSON text serialization is well over 4096
+    # bytes. A single 5000-char string is ~5004 bytes once quoted.
+    oversized = {"prompt": "x" * 5000}
+    db_session.add(_make_call_log(call_metadata=oversized))
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_metadata_under_limit_accepted(db_session):
+    """call_metadata at ~1 KB (well under the 4 KB cap) round-trips."""
+    payload = {
+        "request_id": "req_abc123",
+        "latency_ms": 248,
+        "retry_count": 0,
+    }
+    row = _make_call_log(call_metadata=payload)
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+
+    assert row.call_metadata == payload
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_orm_defaults_populate_after_flush(db_session):
+    """cost_usd defaults to 0 and paid_by defaults to 'platform' without explicit set.
+
+    The Python-side ``default=`` fires at flush. Server-default presence
+    is exercised separately by ``test_server_default_clause_present_in_schema``.
+    """
+    row = _make_call_log()  # no cost_usd, no paid_by
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+
+    assert row.cost_usd == Decimal("0")
+    assert row.paid_by == "platform"
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_byok_round_trips(db_session):
+    """paid_by='byok' persists and reads back unchanged (recall BYOK path)."""
+    row = _make_call_log(paid_by="byok")
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+
+    assert row.paid_by == "byok"
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_server_default_clause_present_in_schema(db_session):
+    """server_default is declared in the catalog for cost_usd and paid_by.
+
+    Reads ``information_schema.columns.column_default`` directly to catch
+    drift between ORM-declared defaults and the migration. The Python-side
+    ``default=`` tests above would silently pass if the migration omitted
+    the ``server_default``.
+    """
+    rows = (
+        await db_session.execute(
+            sa.text(
+                "SELECT column_name, column_default "
+                "FROM information_schema.columns "
+                "WHERE table_name = 'llm_call_log' "
+                "AND column_name IN ('cost_usd', 'paid_by') "
+                "ORDER BY column_name"
+            )
+        )
+    ).all()
+
+    defaults = {r.column_name: r.column_default for r in rows}
+    assert defaults["cost_usd"] is not None and "0" in defaults["cost_usd"]
+    assert (
+        defaults["paid_by"] is not None and "'platform'::character varying" in defaults["paid_by"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_required_indexes_exist(db_session):
+    """Both query-shape indexes are declared in the catalog.
+
+    The (occurred_at) single-column index supports the admin-wide query;
+    the (workspace_id, occurred_at) composite supports per-tenant
+    aggregation and matches the #472 UNION ALL leg against sleep_reports.
+    """
+    rows = (
+        await db_session.execute(
+            sa.text(
+                "SELECT indexname FROM pg_indexes "
+                "WHERE tablename = 'llm_call_log' "
+                "ORDER BY indexname"
+            )
+        )
+    ).all()
+
+    index_names = {r.indexname for r in rows}
+    assert "idx_llm_call_log_occurred_at" in index_names
+    assert "idx_llm_call_log_workspace_period" in index_names
+
+
+@pytest.mark.asyncio
+async def test_full_happy_path_round_trip(db_session):
+    """A recall-shaped row with all identity + usage fields round-trips."""
+    import uuid
+
+    workspace_id = uuid.uuid4()
+    context_id = uuid.uuid4()
+    row = _make_call_log(
+        caller="recall",
+        call_type="embedding",
+        provider="openai",
+        model="text-embedding-3-small",
+        user_id="user_42",
+        workspace_id=workspace_id,
+        context_id=context_id,
+        input_tokens=None,
+        output_tokens=None,
+        embedding_tokens=512,
+        cost_usd=Decimal("0.000010"),
+        paid_by="platform",
+        call_metadata={"request_id": "req_xyz"},
+    )
+    db_session.add(row)
+    await db_session.flush()
+    await db_session.refresh(row)
+
+    assert row.id is not None
+    assert row.caller == "recall"
+    assert row.call_type == "embedding"
+    assert row.workspace_id == workspace_id
+    assert row.context_id == context_id
+    assert row.embedding_tokens == 512
+    assert row.cost_usd == Decimal("0.000010")
+    assert row.call_metadata == {"request_id": "req_xyz"}
+    await db_session.rollback()

--- a/backend/tests/services/test_llm_call_log_writer.py
+++ b/backend/tests/services/test_llm_call_log_writer.py
@@ -1,0 +1,378 @@
+"""Unit tests for LlmCallLogWriter (#474).
+
+Mocked-DB tests — match ``test_reporter_cost_grade.py`` style so the
+suite runs without a Docker container. Database-level CHECK constraints
+and DDL audit live in ``tests/integration/test_llm_call_log_schema.py``.
+
+Coverage:
+
+- Input validation (caller / call_type / paid_by enums, forbidden 'sleep',
+  nullability matrix per caller).
+- Cost computation happy path (single axis, multi axis).
+- Pricing-miss propagation: any unit_type miss → ``cost_usd = 0`` +
+  ``call_metadata.pricing_miss = true``.
+- Row construction: identity columns, usage columns, and metadata land
+  on the inserted ``LLMCallLog`` instance via ``db.add(...)``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from models.llm_call_log import LLMCallLog
+from services.llm_call_log_writer import LlmCallLogWriter
+
+
+@pytest.fixture
+def mock_db():
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def mock_pricing():
+    """Pricing service mock — tests configure ``compute_cost_usd`` per case."""
+    pricing = MagicMock()
+    pricing.compute_cost_usd = AsyncMock()
+    return pricing
+
+
+@pytest.fixture
+def writer(mock_db, mock_pricing):
+    return LlmCallLogWriter(db=mock_db, pricing=mock_pricing)
+
+
+def _added_row(mock_db) -> LLMCallLog:
+    """Return the LLMCallLog instance passed to ``db.add()`` (exactly one)."""
+    rows = [
+        call.args[0] for call in mock_db.add.call_args_list if isinstance(call.args[0], LLMCallLog)
+    ]
+    assert len(rows) == 1, f"expected 1 LLMCallLog row, got {len(rows)}"
+    return rows[0]
+
+
+class TestInputValidation:
+    """Defense-in-depth enum + nullability checks at the writer boundary."""
+
+    @pytest.mark.asyncio
+    async def test_invalid_caller_raises(self, writer):
+        with pytest.raises(ValueError, match="invalid caller"):
+            await writer.record(
+                caller="bogus",
+                call_type="completion",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+            )
+
+    @pytest.mark.asyncio
+    async def test_forbidden_sleep_caller_raises(self, writer):
+        """Sleep cost belongs in sleep_reports, not llm_call_log."""
+        with pytest.raises(ValueError, match="caller 'sleep' is not allowed"):
+            await writer.record(
+                caller="sleep",
+                call_type="completion",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                user_id="u",
+                workspace_id=uuid4(),
+                context_id=uuid4(),
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_call_type_raises(self, writer):
+        with pytest.raises(ValueError, match="invalid call_type"):
+            await writer.record(
+                caller="admin",
+                call_type="audio",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_paid_by_raises(self, writer):
+        with pytest.raises(ValueError, match="invalid paid_by"):
+            await writer.record(
+                caller="admin",
+                call_type="completion",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                paid_by="user",
+            )
+
+    @pytest.mark.asyncio
+    async def test_recall_caller_requires_full_identity(self, writer):
+        """recall / rerank / ask must carry (user_id, workspace_id, context_id)."""
+        with pytest.raises(ValueError, match="missing.*user_id"):
+            await writer.record(
+                caller="recall",
+                call_type="embedding",
+                provider="openai",
+                model="text-embedding-3-small",
+                # no user_id, no workspace_id, no context_id
+            )
+
+    @pytest.mark.asyncio
+    async def test_admin_caller_allows_null_identity(self, writer, mock_pricing):
+        """admin caller may legitimately run without user/workspace/context."""
+        mock_pricing.compute_cost_usd.return_value = 0.0
+        await writer.record(
+            caller="admin",
+            call_type="completion",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+        )
+        # No exception → identity-optional contract honored.
+
+    @pytest.mark.asyncio
+    async def test_negative_usage_value_rejected(self, writer):
+        """Negative usage counts raise ValueError, not silent drop.
+
+        Defends against a bad caller passing a negative token count: the
+        row would otherwise INSERT with cost_usd=0 (the filter excludes
+        the axis from cost computation) and no signal would surface.
+        """
+        with pytest.raises(ValueError, match="input_tokens=-1 must be >= 0"):
+            await writer.record(
+                caller="admin",
+                call_type="completion",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=-1,
+            )
+
+
+class TestCostComputation:
+    """Write-time cost snapshot, single and multi-axis."""
+
+    @pytest.mark.asyncio
+    async def test_single_axis_cost(self, writer, mock_pricing, mock_db):
+        """embedding call → one pricing lookup + cost on the inserted row."""
+        mock_pricing.compute_cost_usd.return_value = 0.0001
+
+        await writer.record(
+            caller="recall",
+            call_type="embedding",
+            provider="openai",
+            model="text-embedding-3-small",
+            user_id="u",
+            workspace_id=uuid4(),
+            context_id=uuid4(),
+            embedding_tokens=512,
+        )
+
+        # Only one priced axis (embedding_tokens), so only one lookup.
+        assert mock_pricing.compute_cost_usd.call_count == 1
+        kwargs = mock_pricing.compute_cost_usd.call_args.kwargs
+        assert kwargs["unit_type"] == "embedding_tokens"
+        assert kwargs["units"] == 512
+
+        row = _added_row(mock_db)
+        assert row.cost_usd == Decimal("0.0001")
+        # Without a pricing miss the metadata flag is absent.
+        assert row.call_metadata is None or "pricing_miss" not in row.call_metadata
+
+    @pytest.mark.asyncio
+    async def test_multi_axis_cost_sum(self, writer, mock_pricing, mock_db):
+        """completion call sums input + output + cached_input pricings."""
+
+        # Return distinct values per axis so the test can verify ordering
+        # and that all three were summed.
+        async def fake_compute_cost_usd(**kwargs):
+            return {
+                "input_tokens": 0.5,
+                "output_tokens": 1.5,
+                "cache_read_tokens": 0.05,
+            }[kwargs["unit_type"]]
+
+        mock_pricing.compute_cost_usd.side_effect = fake_compute_cost_usd
+
+        await writer.record(
+            caller="ask",
+            call_type="completion",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            user_id="u",
+            workspace_id=uuid4(),
+            context_id=uuid4(),
+            input_tokens=100,
+            output_tokens=50,
+            cached_input_tokens=10,
+        )
+
+        # Three priced axes → three lookups.
+        assert mock_pricing.compute_cost_usd.call_count == 3
+
+        row = _added_row(mock_db)
+        # 0.5 + 1.5 + 0.05 = 2.05
+        assert row.cost_usd == Decimal("2.05")
+
+    @pytest.mark.asyncio
+    async def test_zero_and_none_axes_are_skipped(self, writer, mock_pricing):
+        """Only positive non-None counts trigger a pricing lookup."""
+        mock_pricing.compute_cost_usd.return_value = 0.1
+
+        await writer.record(
+            caller="admin",
+            call_type="completion",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            input_tokens=100,  # priced
+            output_tokens=0,  # skipped (zero)
+            cached_input_tokens=None,  # skipped (None)
+        )
+
+        # Only input_tokens → one lookup.
+        assert mock_pricing.compute_cost_usd.call_count == 1
+        assert mock_pricing.compute_cost_usd.call_args.kwargs["unit_type"] == "input_tokens"
+
+    @pytest.mark.asyncio
+    async def test_pricing_miss_collapses_cost_to_zero_with_flag(
+        self, writer, mock_pricing, mock_db
+    ):
+        """Any miss → cost_usd=0 AND call_metadata.pricing_miss=true.
+
+        A partial-sum return path would understate cost silently; the
+        flag carries the signal instead.
+        """
+
+        # Two axes priced; the second returns None (lookup miss).
+        async def partial_miss(**kwargs):
+            return 0.5 if kwargs["unit_type"] == "input_tokens" else None
+
+        mock_pricing.compute_cost_usd.side_effect = partial_miss
+
+        await writer.record(
+            caller="admin",
+            call_type="completion",
+            provider="anthropic",
+            model="newly-released-model",
+            input_tokens=100,
+            output_tokens=50,
+        )
+
+        row = _added_row(mock_db)
+        assert row.cost_usd == Decimal("0")
+        assert row.call_metadata == {"pricing_miss": True}
+
+    @pytest.mark.asyncio
+    async def test_pricing_miss_preserves_existing_metadata(self, writer, mock_pricing, mock_db):
+        """pricing_miss flag merges with caller-supplied metadata; doesn't replace."""
+        mock_pricing.compute_cost_usd.return_value = None
+
+        await writer.record(
+            caller="admin",
+            call_type="embedding",
+            provider="cohere",
+            model="embed-experimental",
+            embedding_tokens=100,
+            call_metadata={"request_id": "req_abc"},
+        )
+
+        row = _added_row(mock_db)
+        assert row.call_metadata == {"request_id": "req_abc", "pricing_miss": True}
+
+    @pytest.mark.asyncio
+    async def test_no_priced_axes_writes_zero_cost(self, writer, mock_pricing, mock_db):
+        """A degenerate call with no usage counts writes a 0-cost row (no miss flag).
+
+        This is the documented contract — a writer call with no token
+        counts at all (e.g. a completion that returned an empty result)
+        is valid and stores cost=0 without setting pricing_miss.
+        """
+        await writer.record(
+            caller="admin",
+            call_type="completion",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+        )
+
+        assert mock_pricing.compute_cost_usd.call_count == 0
+        row = _added_row(mock_db)
+        assert row.cost_usd == Decimal("0")
+        assert row.call_metadata is None
+
+
+class TestRowConstruction:
+    """Identity + usage columns land on the inserted LLMCallLog instance."""
+
+    @pytest.mark.asyncio
+    async def test_uuid_string_coerced_to_uuid(self, writer, mock_pricing, mock_db):
+        """workspace_id / context_id accept str AND UUID; both end up as UUID."""
+        mock_pricing.compute_cost_usd.return_value = 0.0
+
+        ws_uuid = uuid4()
+        ctx_uuid = uuid4()
+        await writer.record(
+            caller="recall",
+            call_type="embedding",
+            provider="openai",
+            model="text-embedding-3-small",
+            user_id="u",
+            workspace_id=str(ws_uuid),  # passed as str
+            context_id=ctx_uuid,  # passed as UUID
+            embedding_tokens=10,
+        )
+
+        row = _added_row(mock_db)
+        assert row.workspace_id == ws_uuid
+        assert row.context_id == ctx_uuid
+
+    @pytest.mark.asyncio
+    async def test_occurred_at_defaults_to_now(self, writer, mock_pricing, mock_db):
+        """No occurred_at → writer fills in current UTC."""
+        mock_pricing.compute_cost_usd.return_value = 0.0
+
+        await writer.record(
+            caller="admin",
+            call_type="completion",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            input_tokens=10,
+        )
+
+        row = _added_row(mock_db)
+        # ``utcnow()`` returns a naive datetime, not None.
+        assert row.occurred_at is not None
+        assert row.occurred_at.tzinfo is None
+
+    @pytest.mark.asyncio
+    async def test_explicit_occurred_at_passed_to_pricing_and_row(
+        self, writer, mock_pricing, mock_db
+    ):
+        """Caller-supplied occurred_at is used for both pricing lookup and row."""
+        mock_pricing.compute_cost_usd.return_value = 0.5
+        ts = datetime(2026, 1, 1, 12, 0, 0)
+
+        await writer.record(
+            caller="admin",
+            call_type="completion",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+            input_tokens=100,
+            occurred_at=ts,
+        )
+
+        row = _added_row(mock_db)
+        assert row.occurred_at == ts
+        # Pricing was looked up at the same timestamp (snapshot semantics).
+        assert mock_pricing.compute_cost_usd.call_args.kwargs["started_at"] == ts
+
+    @pytest.mark.asyncio
+    async def test_flush_called_so_caller_can_read_id(self, writer, mock_pricing, mock_db):
+        """db.flush() is awaited so the caller can access row.id."""
+        mock_pricing.compute_cost_usd.return_value = 0.0
+        await writer.record(
+            caller="admin",
+            call_type="embedding",
+            provider="openai",
+            model="text-embedding-3-small",
+            embedding_tokens=1,
+        )
+        mock_db.flush.assert_awaited_once()

--- a/backend/tests/services/test_llm_call_log_writer.py
+++ b/backend/tests/services/test_llm_call_log_writer.py
@@ -147,6 +147,87 @@ class TestInputValidation:
                 input_tokens=-1,
             )
 
+    @pytest.mark.asyncio
+    async def test_completion_rejects_embedding_tokens(self, writer):
+        """call_type='completion' must not populate embedding_tokens.
+
+        Without this guard a caller could write a completion row with
+        only embedding_tokens populated, resulting in cost_usd=0 (the
+        pricing lookup uses unit_type='embedding_tokens' which has no
+        rows for the completion model). The row would land silently
+        under-counted and undetectable in dashboards.
+        """
+        with pytest.raises(
+            ValueError, match=r"call_type='completion' does not allow embedding_tokens"
+        ):
+            await writer.record(
+                caller="admin",
+                call_type="completion",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                embedding_tokens=100,
+            )
+
+    @pytest.mark.asyncio
+    async def test_embedding_rejects_input_tokens(self, writer):
+        """call_type='embedding' must not populate input_tokens."""
+        with pytest.raises(ValueError, match=r"call_type='embedding' does not allow input_tokens"):
+            await writer.record(
+                caller="admin",
+                call_type="embedding",
+                provider="openai",
+                model="text-embedding-3-small",
+                input_tokens=100,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rerank_rejects_both_token_axes(self, writer):
+        """call_type='rerank' must populate exactly one of rerank_tokens / rerank_search_units.
+
+        Voyage uses rerank_tokens, Cohere uses rerank_search_units. Both
+        populated indicates a writer-side bug — the caller can't be both
+        providers at once.
+        """
+        with pytest.raises(ValueError, match=r"call_type='rerank' must populate exactly one"):
+            await writer.record(
+                caller="admin",
+                call_type="rerank",
+                provider="voyage",
+                model="rerank-2",
+                rerank_tokens=100,
+                rerank_search_units=10,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rerank_accepts_voyage_tokens(self, writer, mock_pricing, mock_db):
+        """rerank with rerank_tokens only (Voyage) is allowed."""
+        mock_pricing.compute_cost_usd.return_value = 0.000005
+        await writer.record(
+            caller="admin",
+            call_type="rerank",
+            provider="voyage",
+            model="rerank-2",
+            rerank_tokens=100,
+        )
+        row = _added_row(mock_db)
+        assert row.rerank_tokens == 100
+        assert row.rerank_search_units is None
+
+    @pytest.mark.asyncio
+    async def test_rerank_accepts_cohere_search_units(self, writer, mock_pricing, mock_db):
+        """rerank with rerank_search_units only (Cohere) is allowed."""
+        mock_pricing.compute_cost_usd.return_value = 0.002
+        await writer.record(
+            caller="admin",
+            call_type="rerank",
+            provider="cohere",
+            model="rerank-3.5",
+            rerank_search_units=1,
+        )
+        row = _added_row(mock_db)
+        assert row.rerank_search_units == 1
+        assert row.rerank_tokens is None
+
 
 class TestCostComputation:
     """Write-time cost snapshot, single and multi-axis."""

--- a/backend/tests/services/test_llm_call_log_writer.py
+++ b/backend/tests/services/test_llm_call_log_writer.py
@@ -1,4 +1,4 @@
-"""Unit tests for LlmCallLogWriter (#474).
+"""Unit tests for LLMCallLogWriter (#474).
 
 Mocked-DB tests — match ``test_reporter_cost_grade.py`` style so the
 suite runs without a Docker container. Database-level CHECK constraints
@@ -25,7 +25,7 @@ from uuid import uuid4
 import pytest
 
 from models.llm_call_log import LLMCallLog
-from services.llm_call_log_writer import LlmCallLogWriter
+from services.llm_call_log_writer import LLMCallLogWriter
 
 
 @pytest.fixture
@@ -46,7 +46,7 @@ def mock_pricing():
 
 @pytest.fixture
 def writer(mock_db, mock_pricing):
-    return LlmCallLogWriter(db=mock_db, pricing=mock_pricing)
+    return LLMCallLogWriter(db=mock_db, pricing=mock_pricing)
 
 
 def _added_row(mock_db) -> LLMCallLog:
@@ -216,6 +216,25 @@ class TestInputValidation:
                 provider="voyage",
                 model="rerank-2",
                 rerank_tokens=100,
+                rerank_search_units=10,
+            )
+
+    @pytest.mark.asyncio
+    async def test_rerank_rejects_both_axes_with_zero_value(self, writer):
+        """Exclusivity check fires even when one axis is 0 (non-None).
+
+        Loop-2 fix only tracked rerank axes inside ``if value > 0:``,
+        so ``rerank_tokens=0`` + ``rerank_search_units=10`` would bypass
+        the check and store both columns as non-NULL — ambiguous for
+        downstream queries that key off ``IS NOT NULL`` (Copilot loop 3 #1).
+        """
+        with pytest.raises(ValueError, match=r"call_type='rerank' must populate exactly one"):
+            await writer.record(
+                caller="admin",
+                call_type="rerank",
+                provider="voyage",
+                model="rerank-2",
+                rerank_tokens=0,
                 rerank_search_units=10,
             )
 

--- a/backend/tests/services/test_llm_call_log_writer.py
+++ b/backend/tests/services/test_llm_call_log_writer.py
@@ -169,6 +169,27 @@ class TestInputValidation:
             )
 
     @pytest.mark.asyncio
+    async def test_completion_rejects_zero_value_on_disallowed_axis(self, writer):
+        """Disallowed axis with value=0 (non-None) also raises.
+
+        Downstream queries may treat ``IS NOT NULL`` as "this axis was
+        relevant for this row"; permitting ``embedding_tokens=0`` on a
+        completion row would write dirty data through that filter
+        (Copilot loop 2 #3 — loop-1 fix only guarded value > 0).
+        """
+        with pytest.raises(
+            ValueError, match=r"call_type='completion' does not allow embedding_tokens"
+        ):
+            await writer.record(
+                caller="admin",
+                call_type="completion",
+                provider="anthropic",
+                model="claude-sonnet-4-6",
+                input_tokens=100,
+                embedding_tokens=0,
+            )
+
+    @pytest.mark.asyncio
     async def test_embedding_rejects_input_tokens(self, writer):
         """call_type='embedding' must not populate input_tokens."""
         with pytest.raises(ValueError, match=r"call_type='embedding' does not allow input_tokens"):

--- a/backend/tests/services/test_llm_call_log_writer.py
+++ b/backend/tests/services/test_llm_call_log_writer.py
@@ -220,6 +220,25 @@ class TestInputValidation:
             )
 
     @pytest.mark.asyncio
+    async def test_rerank_rejects_no_axis_populated(self, writer):
+        """rerank with neither axis populated raises ValueError.
+
+        Voyage / Cohere always return a usage figure from a successful
+        rerank call, so a zero-axis rerank row is a caller-side bug,
+        not a degenerate audit case (Copilot loop 5 #1). The "exactly
+        one" contract enforces both rejection paths: both populated
+        AND neither populated.
+        """
+        with pytest.raises(ValueError, match=r"call_type='rerank' must populate exactly one"):
+            await writer.record(
+                caller="admin",
+                call_type="rerank",
+                provider="voyage",
+                model="rerank-2",
+                # Neither rerank_tokens nor rerank_search_units set.
+            )
+
+    @pytest.mark.asyncio
     async def test_rerank_rejects_both_axes_with_zero_value(self, writer):
         """Exclusivity check fires even when one axis is 0 (non-None).
 


### PR DESCRIPTION
Partially addresses #474

## Summary

- Adds `llm_call_log` append-only event store for non-Sleep LLM/embedding/rerank API calls — companion to `sleep_reports` (run-shaped). #472 cost aggregation UNION ALLs both tables and groups by `caller`.
- `LlmCallLogWriter` service skeleton mirroring `SleepReporter` pattern (session-injected, `db.add` + `flush`, no commit, raise on error).
- Pricing seed rows for Voyage `rerank-2`/`rerank-2-lite` + Cohere `rerank-3.5` + Cohere `embed-multilingual-v3` (separate alembic revision for rollback granularity).
- Pilot call sites (`reranker_service` / `embedding_service` / recall path) **deferred to #475 PR-3** per the 3-PR split decision.

## 3-PR split (memory `45d4b9fe`)

| PR | Scope | Status |
|----|-------|--------|
| PR-1 | #475 Sleep Phase 1/2 embedding tracking | MERGED (#647, `1ba90db4`) |
| **PR-2** | **#474 schema-design** | **this PR** |
| PR-3 | #475 Task 4 recall path instrumentation | deferred (gated on this PR) |

## Implementation notes

### Schema (`backend/src/models/llm_call_log.py` + `e12_474_llm_call_log`)

- BigInt PK, append-only, no FK on `workspace_id`/`context_id` (audit preservation across entity deletion).
- 5 CHECK constraints: `caller` / `call_type` / `paid_by` / `cost_usd >= 0` / **`call_metadata` 4 KB octet_length** (first JSONB size cap in this codebase, defends against prompt-body storage).
- 2 indexes: `(occurred_at)` (admin all-tenant date range) + `(workspace_id, occurred_at)` (per-tenant aggregation; mirrors `idx_sleep_reports_workspace_source_started`).
- `paid_by` mirrors `sleep_reports.paid_by` for the #472 UNION ALL leg.

### Writer (`backend/src/services/llm_call_log_writer.py`)

- `_FORBIDDEN_CALLERS = {"sleep"}` — Sleep cost stays in `sleep_reports` + `sleep_report_llm_usage` (memory `9db43e36` canonical pattern). CHECK is a superset for forward-compat.
- `_FULL_IDENTITY_CALLERS = {"recall", "rerank", "ask"}` — Python-side nullability matrix enforcement (DB columns stay nullable to support `admin` backfill jobs).
- `cost_usd` = **write-time snapshot** from `LLMPricingService.compute_cost_usd`; pricing miss → `cost_usd=0` + `call_metadata.pricing_miss=true` (never raises on hot path).
- Negative usage values rejected with `ValueError` (defense against silent under-count).
- Import-time assert: `_USAGE_TO_UNIT_TYPE` keys ⊆ `LLMCallLog.__table__.columns` (catches future column rename).

### Alembic split

- `e12_474_llm_call_log` — schema only.
- `e13_474_pricing_seeds` — 4 seed rows at `effective_from=2026-04-28`. Targeted downgrade by `(effective_from, provider)` so c03 seeds (same date, different providers) survive partial rollback.

## Gate1 yellow points → Acceptance (CIO lens, 2026-05-14)

| # | Point | Resolution |
|---|---|---|
| 1 | `cost_usd` write-time vs lazy compute | write-time snapshot; pricing miss flag in `call_metadata` |
| 2 | partition/retention deferral | 100M-row threshold documented as escalation trigger |
| 3 | Sleep dual-write decision | v1: Sleep → `sleep_reports` only; #472 UNION ALL aggregates |
| 4 | caller nullability matrix | docstring table + writer Python asserts |
| 5 | `call_metadata` PII defense | 4 KB CHECK constraint (first JSONB size cap) |
| 6 | seed-row alembic split | e12 (schema) + e13 (seeds) separate revisions |
| 7 | UNION query shape index match | `(workspace_id, occurred_at)` mirrors sleep_reports leg |

## Out of scope (deferred)

- Pilot hooks on `reranker_service` / `embedding_service` → **#475 PR-3** (recall path embedding/rerank instrumentation, gated on this PR's schema)
- `#472` aggregation API extension → separate PR
- Partitioning / retention implementation → follow-up issue at 100M-row threshold

## Test coverage

- 11 schema integration tests (CHECK reject paths, DDL audit, server defaults, indexes, round-trip)
- 17 writer unit tests (validation, cost computation, pricing miss propagation, negative-value rejection, UUID coercion)
- 78 schema_drift tests pass (auto-detects new model)
- 4 alembic forward/rollback tests pass
- ruff: clean

## Follow-ups (non-blocking)

- e13 seed-row presence verification test (`SELECT count(*)` against the 4 rows landed) — gap shared with `c03_471_seed_pricing`
- `call_metadata` 4 KB CHECK boundary tests (exactly-4096, multibyte unicode, empty-dict) — pin recall-path #475 PR-3 Japanese-content behavior
- Application-layer allowed-key whitelist for `call_metadata` → ship in #475 PR-3 when call sites materialize
- Doc nit: extend the 4 KB CHECK comment with "apply only when JSONB is PII-sensitive AND has no application-layer key whitelist" so the pattern doesn't proliferate

## Pre-PR review summary

- gate2 mode: advisor-only (no binary gate configured)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (CIO lens, 7 yellow points addressed at design time)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/474-feat-feat-observability-comprehensive-llm-cos.gate1.md`
- `~/.claude/cache/gh-issue-driven/474-feat-feat-observability-comprehensive-llm-cos.gate2.md`

🤖 Generated via /gh-issue-driven:ship
