### PR TITLE
feat(api): embedding token tracking in recall path (#475 PR-3)

### DIFF
--- a/backend/src/services/llm_call_log_writer.py
+++ b/backend/src/services/llm_call_log_writer.py
@@ -13,9 +13,14 @@ Design contract (mirrors ``services/sleep/reporter.py:SleepReporter``):
 - ``record()`` performs ``self.db.add(row)`` + ``await self.db.flush()``
   so the caller can read back ``row.id`` immediately. ``commit()`` is
   the orchestrator's responsibility.
-- Errors propagate to the caller (no swallow). The recall-path call
-  site decides whether a writer failure should degrade silently — the
-  writer never makes that policy call.
+- Errors propagate to the caller by default. Read-path call sites pass
+  ``fail_on_error=False`` to opt into fail-open semantics: pricing /
+  flush failures are caught, a structured ``llm_call_log_write_failed``
+  warning is emitted, and ``record()`` returns ``None`` instead of
+  raising. Validation errors (invalid caller / call_type / identity
+  matrix) still raise unconditionally — those signal a caller-side
+  programming bug and must surface, not be swallowed (#475 PR-3
+  operator-pinned decision, 2026-05-14).
 
 Cost computation is **write-time snapshot**: for each non-None positive
 usage column, ``LLMPricingService.compute_cost_usd`` is called with
@@ -172,18 +177,40 @@ class LLMCallLogWriter:
         rerank_search_units: int | None = None,
         paid_by: str = "platform",
         call_metadata: dict[str, Any] | None = None,
-    ) -> LLMCallLog:
+        fail_on_error: bool = True,
+    ) -> LLMCallLog | None:
         """Insert one llm_call_log row with a write-time cost snapshot.
 
         Returns the inserted ``LLMCallLog`` (post-flush, so ``id`` is
         populated). The caller is responsible for the surrounding
-        transaction lifecycle.
+        transaction lifecycle. When ``fail_on_error=False``, returns
+        ``None`` instead of raising if the pricing lookup or DB flush
+        fails — used by read-path callers (recall) where cost-tracking
+        loss must not break the user-facing request.
+
+        Args:
+            fail_on_error: When ``True`` (default), pricing / flush
+                exceptions propagate — used by write-path callers
+                (Sleep emitters, admin actions) where a missed ledger
+                row is itself a failure. When ``False``, those
+                exceptions are caught, a structured
+                ``llm_call_log_write_failed`` warning is emitted with
+                ``caller`` / ``call_type`` / ``provider`` / ``model``
+                / ``error_type`` (never ``str(exc)`` — credential leak
+                guard), and the method returns ``None``. Validation
+                errors (bad enum, missing identity columns for the
+                caller) always raise regardless: they signal a
+                programming bug in the caller and would mask future
+                regressions if swallowed (#475 PR-3, 2026-05-14).
 
         Raises:
             ValueError: ``caller`` / ``call_type`` / ``paid_by`` is
                 outside its allowed set, OR ``caller`` is in
                 ``_FORBIDDEN_CALLERS`` (today: 'sleep'), OR the
-                nullability matrix is violated for the chosen caller.
+                nullability matrix is violated for the chosen caller,
+                OR a usage axis is populated outside its ``call_type``
+                allowlist, OR a usage value is negative. Always raised
+                regardless of ``fail_on_error`` — see Args.
         """
         self._validate_inputs(
             caller=caller,
@@ -259,55 +286,78 @@ class LLMCallLogWriter:
                 f"(rerank_tokens, rerank_search_units); got {populated_repr}"
             )
 
-        cost_usd, pricing_miss = await self._compute_cost_usd(
-            provider=provider,
-            model=model,
-            occurred_at=resolved_occurred_at,
-            usage_pairs=usage_pairs,
-        )
-
-        final_metadata: dict[str, Any] | None = dict(call_metadata) if call_metadata else None
-        if pricing_miss:
-            final_metadata = final_metadata or {}
-            final_metadata["pricing_miss"] = True
-            # Pricing misses are expected (newly-deployed model before
-            # its seed row lands; exotic provider). The signal is
-            # already carried on the row via ``call_metadata.pricing_miss``
-            # and surfaced in dashboards; logging at debug matches
-            # ``LLMPricingService.lookup()`` (the lower-level "no row"
-            # path) and avoids alert fatigue on a recall hot path
-            # (Copilot loop 4 #2).
-            logger.debug(
-                "llm_call_log_pricing_miss",
-                caller=caller,
+        # Pricing lookup + flush are the only async / IO-touching parts
+        # below validation. Read-path callers (recall) pass
+        # ``fail_on_error=False`` so a DB flake or ``llm_pricing`` outage
+        # never propagates into the user-facing recall response —
+        # observability loss is preferable to a recall 500. Validation
+        # above always raises; ``CancelledError`` is a ``BaseException``
+        # subclass so ``except Exception`` deliberately lets it through.
+        try:
+            cost_usd, pricing_miss = await self._compute_cost_usd(
                 provider=provider,
                 model=model,
-                call_type=call_type,
+                occurred_at=resolved_occurred_at,
+                usage_pairs=usage_pairs,
             )
 
-        row = LLMCallLog(
-            occurred_at=resolved_occurred_at,
-            user_id=user_id,
-            workspace_id=_coerce_uuid(workspace_id),
-            context_id=_coerce_uuid(context_id),
-            caller=caller,
-            call_type=call_type,
-            provider=provider,
-            model=model,
-            input_tokens=input_tokens,
-            output_tokens=output_tokens,
-            cached_input_tokens=cached_input_tokens,
-            cache_write_tokens=cache_write_tokens,
-            embedding_tokens=embedding_tokens,
-            rerank_tokens=rerank_tokens,
-            rerank_search_units=rerank_search_units,
-            cost_usd=cost_usd,
-            paid_by=paid_by,
-            call_metadata=final_metadata,
-        )
-        self.db.add(row)
-        await self.db.flush()
-        return row
+            final_metadata: dict[str, Any] | None = dict(call_metadata) if call_metadata else None
+            if pricing_miss:
+                final_metadata = final_metadata or {}
+                final_metadata["pricing_miss"] = True
+                # Pricing misses are expected (newly-deployed model before
+                # its seed row lands; exotic provider). The signal is
+                # already carried on the row via ``call_metadata.pricing_miss``
+                # and surfaced in dashboards; logging at debug matches
+                # ``LLMPricingService.lookup()`` (the lower-level "no row"
+                # path) and avoids alert fatigue on a recall hot path
+                # (Copilot loop 4 #2).
+                logger.debug(
+                    "llm_call_log_pricing_miss",
+                    caller=caller,
+                    provider=provider,
+                    model=model,
+                    call_type=call_type,
+                )
+
+            row = LLMCallLog(
+                occurred_at=resolved_occurred_at,
+                user_id=user_id,
+                workspace_id=_coerce_uuid(workspace_id),
+                context_id=_coerce_uuid(context_id),
+                caller=caller,
+                call_type=call_type,
+                provider=provider,
+                model=model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cached_input_tokens=cached_input_tokens,
+                cache_write_tokens=cache_write_tokens,
+                embedding_tokens=embedding_tokens,
+                rerank_tokens=rerank_tokens,
+                rerank_search_units=rerank_search_units,
+                cost_usd=cost_usd,
+                paid_by=paid_by,
+                call_metadata=final_metadata,
+            )
+            self.db.add(row)
+            await self.db.flush()
+            return row
+        except Exception as exc:
+            if fail_on_error:
+                raise
+            # Structured-only — ``str(exc)`` can echo request bodies /
+            # credentials from upstream SDKs and is forbidden in this
+            # codebase's logging convention (memory ``d5d09cd9``).
+            logger.warning(
+                "llm_call_log_write_failed",
+                caller=caller,
+                call_type=call_type,
+                provider=provider,
+                model=model,
+                error_type=type(exc).__name__,
+            )
+            return None
 
     @staticmethod
     def _validate_inputs(

--- a/backend/src/services/search_service.py
+++ b/backend/src/services/search_service.py
@@ -14,15 +14,35 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.qdrant import search_memories_fulltext, search_memories_qdrant
+from models.llm_call_log import (
+    LLM_CALL_LOG_CALL_TYPES,
+    LLM_CALL_LOG_CALLERS,
+    LLM_CALL_LOG_PAID_BY_VALUES,
+)
 from repositories.config_repository import ContextSearchConfigRepository
 from services.context_routing import resolve_routing_from_config
 from services.embedding_service import EmbeddingService
+from services.llm_call_log_writer import LLMCallLogWriter
 from services.reranker_service import RerankerService
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
 SearchMode = Literal["hybrid", "semantic", "keyword"]
+
+# #475 PR-3: pinned literal values for the llm_call_log row this module emits.
+# Module-level singletons with import-time tuple-membership assertions match
+# the pattern in ``services/analysis/orchestrator.py:121-129`` — a future
+# rename in the model's enum tuples turns into an ImportError here instead of
+# a runtime ``ValueError`` on the first recall after deploy. Cheaper than
+# indexing into the tuple (fragile to reorder) or repeating the literal at
+# every future call site (lets the looser convention ossify).
+_RECALL_CALLER = "recall"
+_EMBEDDING_CALL_TYPE = "embedding"
+_PAID_BY_PLATFORM = "platform"
+assert _RECALL_CALLER in LLM_CALL_LOG_CALLERS
+assert _EMBEDDING_CALL_TYPE in LLM_CALL_LOG_CALL_TYPES
+assert _PAID_BY_PLATFORM in LLM_CALL_LOG_PAID_BY_VALUES
 
 
 class SearchService:
@@ -161,9 +181,33 @@ class SearchService:
             logger.debug(
                 "semantic_search_starting", query=normalized_query[:50], fetch_size=fetch_size
             )
-            query_vector = await embed_svc.embed(
+            # #475 PR-3: capture token usage so we can attribute embedding
+            # cost via llm_call_log. ``embed_svc`` may be a context-specific
+            # service returned by ``resolve_routing_from_config`` above
+            # (different model than ``self.embedding_service``) — read
+            # provider/model from it directly so multi-tenant pricing
+            # routes correctly.
+            query_vector, embedding_tokens = await embed_svc.embed_with_usage(
                 normalized_query, user_id, context_id=primary_context_id, workspace_id=workspace_id
             )
+            if embedding_tokens > 0:
+                # Cache hits return 0 tokens and intentionally produce no
+                # llm_call_log row (B1 pin) — the table is "API was
+                # called" event log, not cache analytics. fail_on_error
+                # is False so a writer flake never breaks recall.
+                writer = LLMCallLogWriter(self.db)
+                await writer.record(
+                    caller=_RECALL_CALLER,
+                    call_type=_EMBEDDING_CALL_TYPE,
+                    provider=embed_svc.provider,
+                    model=embed_svc.model,
+                    user_id=user_id,
+                    workspace_id=workspace_id,
+                    context_id=primary_context_id,
+                    embedding_tokens=embedding_tokens,
+                    paid_by=_PAID_BY_PLATFORM,
+                    fail_on_error=False,
+                )
             semantic_results = await search_memories_qdrant(
                 user_id=user_id,
                 query_vector=query_vector,

--- a/backend/tests/services/test_llm_call_log_writer.py
+++ b/backend/tests/services/test_llm_call_log_writer.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
+from structlog.testing import capture_logs
 
 from models.llm_call_log import LLMCallLog
 from services.llm_call_log_writer import LLMCallLogWriter
@@ -515,4 +516,153 @@ class TestRowConstruction:
             model="text-embedding-3-small",
             embedding_tokens=1,
         )
+        mock_db.flush.assert_awaited_once()
+
+
+class TestFailOnErrorSemantics:
+    """#475 PR-3 fail_on_error contract for read-path callers (recall).
+
+    Sleep / admin write-path callers keep the default ``fail_on_error=True``
+    so a missed ledger row surfaces as an exception. Recall pages a writer
+    flake or ``llm_pricing`` outage into a structured warning and a
+    ``None`` return so the user-facing recall response never 500s on
+    observability infrastructure.
+
+    Validation errors (bad enum, missing identity) always raise — see
+    ``test_fail_on_error_false_does_not_suppress_validation`` — because
+    they signal caller-side programming bugs that should not silently
+    hide behind a warning log.
+    """
+
+    @pytest.mark.asyncio
+    async def test_fail_on_error_true_is_default_and_raises_on_flush(
+        self, writer, mock_pricing, mock_db
+    ):
+        """Default behavior unchanged: flush exceptions propagate."""
+        mock_pricing.compute_cost_usd.return_value = 0.0001
+        mock_db.flush.side_effect = RuntimeError("connection reset")
+
+        with pytest.raises(RuntimeError, match="connection reset"):
+            await writer.record(
+                caller="recall",
+                call_type="embedding",
+                provider="openai",
+                model="text-embedding-3-small",
+                user_id="u",
+                workspace_id=uuid4(),
+                context_id=uuid4(),
+                embedding_tokens=100,
+                # fail_on_error not passed — uses True default
+            )
+
+    @pytest.mark.asyncio
+    async def test_fail_on_error_false_swallows_flush_and_returns_none(
+        self, writer, mock_pricing, mock_db
+    ):
+        """Read-path opt-in: flush failure → warn log + None return."""
+        mock_pricing.compute_cost_usd.return_value = 0.0001
+        mock_db.flush.side_effect = RuntimeError("connection reset")
+
+        with capture_logs() as captured:
+            result = await writer.record(
+                caller="recall",
+                call_type="embedding",
+                provider="openai",
+                model="text-embedding-3-small",
+                user_id="u",
+                workspace_id=uuid4(),
+                context_id=uuid4(),
+                embedding_tokens=100,
+                fail_on_error=False,
+            )
+
+        assert result is None
+        warn_events = [e for e in captured if e.get("event") == "llm_call_log_write_failed"]
+        assert len(warn_events) == 1
+        ev = warn_events[0]
+        assert ev["caller"] == "recall"
+        assert ev["call_type"] == "embedding"
+        assert ev["provider"] == "openai"
+        assert ev["model"] == "text-embedding-3-small"
+        assert ev["error_type"] == "RuntimeError"
+        # Credential-handling rule: str(exc) must never leak into the log
+        # event (memory d5d09cd9). Verify no field carries the message.
+        assert all("connection reset" not in str(v) for v in ev.values())
+
+    @pytest.mark.asyncio
+    async def test_fail_on_error_false_swallows_pricing_exception(
+        self, writer, mock_pricing, mock_db
+    ):
+        """Pricing-service DB flake (not a clean miss) → warn + None."""
+        mock_pricing.compute_cost_usd.side_effect = RuntimeError("pricing db timeout")
+
+        with capture_logs() as captured:
+            result = await writer.record(
+                caller="recall",
+                call_type="embedding",
+                provider="openai",
+                model="text-embedding-3-small",
+                user_id="u",
+                workspace_id=uuid4(),
+                context_id=uuid4(),
+                embedding_tokens=100,
+                fail_on_error=False,
+            )
+
+        assert result is None
+        # The flush never happens because pricing raised first.
+        mock_db.flush.assert_not_awaited()
+        warn_events = [e for e in captured if e.get("event") == "llm_call_log_write_failed"]
+        assert len(warn_events) == 1
+        assert warn_events[0]["error_type"] == "RuntimeError"
+
+    @pytest.mark.asyncio
+    async def test_fail_on_error_false_does_not_suppress_validation(self, writer):
+        """ValueError from validation always raises — it's a caller bug.
+
+        The fail-open contract only catches infrastructure failures
+        (pricing DB lookups, flush). Hiding an invalid ``caller`` /
+        ``call_type`` / identity mismatch behind a warning log would
+        let a deploy-time wiring bug rot in production undetected.
+        """
+        # Missing user_id for caller='recall' (full-identity required).
+        with pytest.raises(ValueError, match="missing.*user_id"):
+            await writer.record(
+                caller="recall",
+                call_type="embedding",
+                provider="openai",
+                model="text-embedding-3-small",
+                # no user_id / workspace_id / context_id
+                embedding_tokens=100,
+                fail_on_error=False,  # still raises
+            )
+
+    @pytest.mark.asyncio
+    async def test_fail_on_error_false_happy_path_returns_row_no_warning(
+        self, writer, mock_pricing, mock_db
+    ):
+        """Successful write under fail_on_error=False behaves identically.
+
+        No warning, returns the row (not None), pricing/flush still ran.
+        """
+        mock_pricing.compute_cost_usd.return_value = 0.0001
+
+        with capture_logs() as captured:
+            result = await writer.record(
+                caller="recall",
+                call_type="embedding",
+                provider="openai",
+                model="text-embedding-3-small",
+                user_id="u",
+                workspace_id=uuid4(),
+                context_id=uuid4(),
+                embedding_tokens=512,
+                fail_on_error=False,
+            )
+
+        assert result is not None
+        assert isinstance(result, LLMCallLog)
+        assert result.embedding_tokens == 512
+        warn_events = [e for e in captured if e.get("event") == "llm_call_log_write_failed"]
+        assert warn_events == []
         mock_db.flush.assert_awaited_once()

--- a/backend/tests/services/test_recall_llm_instrumentation.py
+++ b/backend/tests/services/test_recall_llm_instrumentation.py
@@ -1,0 +1,251 @@
+"""#475 PR-3: recall path embedding cost instrumentation.
+
+These tests assert the wiring between ``SearchService.hybrid_search`` and
+``LLMCallLogWriter``: every embedding call on the recall path that
+actually hits the provider (cache miss) emits exactly one
+``llm_call_log`` row, while cache hits (tokens=0) and keyword-only
+searches emit zero rows. Writer-level semantics (``fail_on_error=False``
+swallowing flush / pricing exceptions, validation errors still raising)
+are tested in ``test_llm_call_log_writer.py:TestFailOnErrorSemantics``
+— here we only confirm the call site passes the right kwargs.
+
+The 5th acceptance test for #475 PR-3 — the inventory regression guard
+that asserts ``hybrid_search`` never calls ``.embed()`` directly again
+— is ``test_hybrid_search_uses_embed_with_usage_not_embed``. Without
+this guard a future refactor could silently re-introduce the cost gap
+that PR-3 closes.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+# Shared helpers ---------------------------------------------------------
+
+
+def _fake_config() -> SimpleNamespace:
+    """Minimal ContextSearchConfig-shaped object for hybrid_search.
+
+    Carries only the attributes the function reads. ``context_id`` is
+    present so ``hasattr(config, "context_id")`` resolves True and
+    ``resolve_routing_from_config`` receives a routing-eligible config
+    object — exercises the same code path production hits.
+    """
+    return SimpleNamespace(
+        context_id=uuid4(),
+        fetch_factor=2,
+        use_rerank=False,
+        semantic_weight=0.6,
+        bm25_weight=0.4,
+    )
+
+
+def _fake_embed_svc(tokens_used: int) -> MagicMock:
+    """An EmbeddingService-shaped mock for the recall-side embedding call.
+
+    Provider/model are read from the *returned* ``embed_svc`` (not from
+    ``SearchService.embedding_service`` directly) so a context-specific
+    routing override is correctly priced — the writer call site copies
+    these attributes off ``embed_svc``, so the test mock must carry them.
+    """
+    svc = MagicMock()
+    svc.provider = "openai"
+    svc.model = "text-embedding-3-small"
+    svc.embed_with_usage = AsyncMock(return_value=([0.1] * 8, tokens_used))
+    return svc
+
+
+async def _run_hybrid_search(
+    *,
+    embed_tokens: int,
+    search_mode: str = "semantic",
+    writer_cls_target: str = "services.search_service.LLMCallLogWriter",
+):
+    """Invoke ``SearchService.hybrid_search`` with everything around the
+    embedding call mocked out. Returns ``(mock_writer_cls, mock_writer_instance)``
+    so assertions can target either the constructor call or the
+    ``record()`` invocation.
+
+    ``search_mode='semantic'`` exercises the embedding branch without
+    paying the BM25 path's mocking cost. ``search_mode='keyword'``
+    exercises the no-embed branch.
+    """
+    # Import inside the helper so test collection doesn't trigger module
+    # import errors on environments where the path isn't wired up yet
+    # (mirrors the pattern in test_llm_call_log_writer.py — imports stay
+    # near the consumers).
+    from services.search_service import SearchService
+
+    user_id = "u-test"
+    workspace_id = str(uuid4())
+    context_id = str(uuid4())
+
+    embed_svc = _fake_embed_svc(embed_tokens)
+    cfg = _fake_config()
+
+    mock_writer = MagicMock()
+    mock_writer.record = AsyncMock(return_value=None)
+    mock_writer_cls = MagicMock(return_value=mock_writer)
+
+    # Patch every IO boundary hybrid_search crosses on the embedding path.
+    # ``ContextService`` is imported inside the function body, so we patch
+    # the source module rather than the search_service namespace.
+    with (
+        patch(writer_cls_target, mock_writer_cls),
+        patch(
+            "services.search_service.resolve_routing_from_config",
+            return_value=("default", embed_svc),
+        ),
+        patch(
+            "services.search_service.search_memories_qdrant",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "services.search_service.search_memories_fulltext",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "services.context_service.ContextService.is_context_shared",
+            new=AsyncMock(return_value=False),
+        ),
+    ):
+        service = SearchService(db=AsyncMock())
+        # _get_search_config is async; replace with our pre-built config.
+        service._get_search_config = AsyncMock(return_value=cfg)
+
+        await service.hybrid_search(
+            query="test query",
+            user_id=user_id,
+            workspace_id=workspace_id,
+            context_id=context_id,
+            k=5,
+            use_rerank=False,
+            filters=None,
+            search_mode=search_mode,
+        )
+
+    return mock_writer_cls, mock_writer, embed_svc, user_id, workspace_id, context_id
+
+
+# Tests ------------------------------------------------------------------
+
+
+class TestRecallEmbeddingInstrumentation:
+    """SearchService.hybrid_search → LLMCallLogWriter wiring (#475 PR-3)."""
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_does_not_invoke_writer(self):
+        """Cache hit returns tokens=0 → writer never constructed (B1 pin).
+
+        The ``llm_call_log`` ledger is "API was called" event log, not
+        cache analytics. Emitting a zero-token row on a cache hit would
+        let the table be misread as a hit-rate metric (operator pin B1,
+        2026-05-14). The gate is co-located with the embed call site so
+        the writer never opens an unnecessary DB connection on the
+        recall hot path.
+        """
+        writer_cls, writer, *_ = await _run_hybrid_search(embed_tokens=0)
+        writer_cls.assert_not_called()
+        writer.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_records_one_row_with_recall_caller(self):
+        """tokens > 0 → exactly one writer.record() call with the right kwargs.
+
+        Verifies the full kwarg surface the writer's nullability matrix
+        requires for ``caller='recall'`` (user_id + workspace_id +
+        context_id all populated) and the operator-pinned A1 contract
+        (``fail_on_error=False`` so a writer flake never breaks the
+        user-facing recall response).
+        """
+        writer_cls, writer, embed_svc, uid, wid, cid = await _run_hybrid_search(embed_tokens=150)
+
+        writer_cls.assert_called_once()
+        writer.record.assert_awaited_once()
+        kwargs = writer.record.await_args.kwargs
+
+        assert kwargs["caller"] == "recall"
+        assert kwargs["call_type"] == "embedding"
+        assert kwargs["provider"] == embed_svc.provider
+        assert kwargs["model"] == embed_svc.model
+        assert kwargs["user_id"] == uid
+        assert kwargs["workspace_id"] == wid
+        assert kwargs["context_id"] == cid
+        assert kwargs["embedding_tokens"] == 150
+        assert kwargs["paid_by"] == "platform"
+        assert kwargs["fail_on_error"] is False  # A1 pin
+
+    @pytest.mark.asyncio
+    async def test_keyword_only_search_skips_embedding_and_writer(self):
+        """search_mode='keyword' never embeds → never logs.
+
+        The current implementation gates the writer on ``embedding_tokens > 0``
+        *inside* the ``("hybrid", "semantic")`` branch. A future refactor
+        that lifts the writer call out of that branch would emit a
+        spurious zero-token row for every keyword-only search; this test
+        guards against that regression. Hiragana-heavy queries route
+        through this mode at scale (#163 context), so the noise floor
+        would be non-trivial without the gate.
+        """
+        writer_cls, writer, embed_svc, *_ = await _run_hybrid_search(
+            embed_tokens=999,  # irrelevant — embed_with_usage shouldn't run
+            search_mode="keyword",
+        )
+        embed_svc.embed_with_usage.assert_not_called()
+        writer_cls.assert_not_called()
+        writer.record.assert_not_called()
+
+
+class TestRecallEmbeddingInventory:
+    """Regression guard: ``hybrid_search`` must never re-introduce ``.embed()``.
+
+    The cost-discarding ``EmbeddingService.embed()`` wrapper exists
+    intentionally for callers that don't track cost (``resource_indexer``,
+    etc.). On the recall path it is a silent cost leak — every call site
+    must use ``embed_with_usage`` so the writer can attribute tokens via
+    ``llm_call_log``. Pure-AST check rather than a behavior assertion so
+    a refactor that *swaps* embed implementations (without breaking the
+    behavior tests) still fails fast.
+    """
+
+    def test_hybrid_search_uses_embed_with_usage_not_embed(self):
+        """No bare ``.embed(`` call inside ``hybrid_search``'s body.
+
+        AST walk instead of substring grep so ``.embed_with_usage(`` /
+        ``.embed_v2(`` don't false-positive against ``.embed(``.
+        ``inspect.getsource`` instead of a path-based read survives test
+        file moves and matches the single-function inspection convention
+        at ``tests/cli/test_create_admin_mcp_json.py:138``.
+        """
+        from services.search_service import SearchService
+
+        # ``inspect.getsource`` returns the method body with its class-
+        # level indentation; ``ast.parse`` rejects that with
+        # IndentationError, so dedent before parsing.
+        src = textwrap.dedent(inspect.getsource(SearchService.hybrid_search))
+        tree = ast.parse(src)
+
+        bare_embed_calls: list[ast.Call] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Attribute):
+                continue
+            # Exact attribute-name match: ``embed`` not ``embed_with_usage``.
+            if node.func.attr == "embed":
+                bare_embed_calls.append(node)
+
+        assert bare_embed_calls == [], (
+            f"Found {len(bare_embed_calls)} bare .embed() call(s) inside "
+            "SearchService.hybrid_search — recall path must use "
+            ".embed_with_usage() so embedding tokens can be attributed to "
+            "llm_call_log (#475 PR-3). Update the call site to "
+            "``embed_with_usage`` and emit a writer row when tokens > 0."
+        )

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -7,20 +7,40 @@ import pytest
 from services.search_service import SearchService
 
 
+@pytest.fixture
+def _patch_routing():
+    """Patch ``resolve_routing_from_config`` so tests don't hit DB.
+
+    #475 PR-3: production code calls ``embed_with_usage`` on the routed
+    ``embed_svc`` (returns a ``(vector, tokens)`` tuple). ``tokens=0``
+    exercises the cache-hit branch — the writer is never constructed,
+    so these tests stay focused on search behavior without needing
+    ``LLMCallLogWriter`` mocks.
+
+    Module-level so both ``TestSearchService`` and ``TestSearchMode`` share
+    a single source of truth — a signature drift here previously required
+    editing two identical copies.
+    """
+    with patch(
+        "services.search_service.resolve_routing_from_config",
+        return_value=(
+            "kagura_memories",
+            MagicMock(
+                embed_with_usage=AsyncMock(return_value=([0.1] * 512, 0)),
+                provider="openai",
+                model="text-embedding-3-small",
+            ),
+        ),
+    ):
+        yield
+
+
 class TestSearchService:
     """Test SearchService for Hybrid Search (Semantic + BM25)."""
 
     @pytest.fixture(autouse=True)
-    def _patch_routing(self):
-        """Patch resolve_routing_from_config so tests don't hit DB."""
-        with patch(
-            "services.search_service.resolve_routing_from_config",
-            return_value=(
-                "kagura_memories",
-                MagicMock(embed=AsyncMock(return_value=[0.1] * 512)),
-            ),
-        ):
-            yield
+    def _routing(self, _patch_routing):
+        """Activate the module-level routing patch for every test in this class."""
 
     @pytest.fixture
     def mock_db(self):
@@ -66,7 +86,6 @@ class TestSearchService:
             {"id": "mem3", "score": 0.6, "payload": {"summary": "Test 3"}},
         ]
 
-        service.embedding_service.embed = AsyncMock(return_value=[0.1] * 512)
         service._get_search_config = AsyncMock(return_value=default_search_config)
 
         mock_ctx_svc = MagicMock()
@@ -100,7 +119,6 @@ class TestSearchService:
     @pytest.mark.asyncio
     async def test_hybrid_search_no_results(self, service, default_search_config):
         """Test hybrid search with no results."""
-        service.embedding_service.embed = AsyncMock(return_value=[0.1] * 512)
         service._get_search_config = AsyncMock(return_value=default_search_config)
 
         mock_ctx_svc = MagicMock()
@@ -135,16 +153,8 @@ class TestSearchMode:
     """Test search_mode parameter (Issue #17)."""
 
     @pytest.fixture(autouse=True)
-    def _patch_routing(self):
-        """Patch resolve_routing_from_config so tests don't hit DB."""
-        with patch(
-            "services.search_service.resolve_routing_from_config",
-            return_value=(
-                "kagura_memories",
-                MagicMock(embed=AsyncMock(return_value=[0.1] * 512)),
-            ),
-        ):
-            yield
+    def _routing(self, _patch_routing):
+        """Activate the module-level routing patch for every test in this class."""
 
     @pytest.fixture
     def mock_db(self):
@@ -171,7 +181,6 @@ class TestSearchMode:
 
     def _setup_mocks(self, service, default_search_config):
         """Common mock setup for search mode tests."""
-        service.embedding_service.embed = AsyncMock(return_value=[0.1] * 512)
         service._get_search_config = AsyncMock(return_value=default_search_config)
 
         mock_ctx_svc = MagicMock()
@@ -180,7 +189,14 @@ class TestSearchMode:
 
     @pytest.mark.asyncio
     async def test_keyword_mode_skips_embedding(self, service, default_search_config):
-        """keyword mode should not call embed() or search_memories_qdrant."""
+        """keyword mode skips Qdrant (no embedding call needed).
+
+        The "no embedding call" half of the contract is asserted at the
+        routed-service level in ``test_recall_llm_instrumentation.py``
+        (``test_keyword_only_search_skips_embedding_and_writer``) — that
+        is where the production code actually obtains its embedding
+        service, and where the assertion remains meaningful post-#475 PR-3.
+        """
         mock_ctx_svc = self._setup_mocks(service, default_search_config)
         fulltext_results = [{"id": "mem1", "score": 10.0, "payload": {"summary": "Test"}}]
 
@@ -202,7 +218,6 @@ class TestSearchMode:
             )
             mock_qdrant.assert_not_called()
             mock_fulltext.assert_called_once()
-            service.embedding_service.embed.assert_not_called()
             assert len(results) == 1
             assert results[0]["id"] == "mem1"
 


### PR DESCRIPTION
Partially addresses #475 (PR-3 of the 3-PR split per kagura memory 45d4b9fe).
The other two PRs are already merged: PR-1 sleep phases in 1ba90db4 (PR #647)
and PR-2 writer schema skeleton in cf72b570 (PR #648, #474 partial).

## Summary
- Wire `LLMCallLogWriter` into the recall path so every cache-miss embedding
  API call produces a `llm_call_log` row attributable via the #472 cost
  aggregation. Sleep emission and writer schema are untouched.
- 5 writer-level `fail_on_error` tests + 4 recall-path instrumentation tests
  (cache hit, cache miss, keyword skip, AST inventory regression guard).
- Closes the 3-PR atomic-split sequence for #475.

## Implementation notes
- Add `fail_on_error: bool = True` parameter to `LLMCallLogWriter.record()`.
  When `False`, pricing/flush exceptions caught, structured
  `llm_call_log_write_failed` warning emitted (no `str(exc)` — credential
  leak guard, kagura memory `d5d09cd9`), returns `None`. Validation errors
  still raise unconditionally because they signal caller-side programming
  bugs that must not be silently swallowed.
- `search_service.py:hybrid_search()` switches from `embed_svc.embed()` to
  `embed_svc.embed_with_usage()`; when `tokens > 0`, inline-constructs
  `LLMCallLogWriter(self.db)` and emits a row with `caller='recall'`,
  `call_type='embedding'`, `paid_by='platform'`, `fail_on_error=False`.
- Module-level pinned literal constants `_RECALL_CALLER`,
  `_EMBEDDING_CALL_TYPE`, `_PAID_BY_PLATFORM` with import-time
  `assert ... in LLM_CALL_LOG_<TUPLE>` from `models/llm_call_log.py`.
  Matches `services/analysis/orchestrator.py:121-129` precedent so an
  enum-tuple rename surfaces as `ImportError` at deploy time instead of
  a runtime `ValueError` on the first recall.
- AST inventory regression test uses
  `inspect.getsource(SearchService.hybrid_search) + textwrap.dedent` so it
  survives test-file moves (precedent: `tests/cli/test_create_admin_mcp_json.py:138`).
  Asserts no bare `.embed(` call inside the method body — guard against
  future refactors silently dropping back to the cost-discarding wrapper.
- `test_search_service.py`: moved `_patch_routing` to a module-level
  fixture (DRY across two test classes); removed dead
  `service.embedding_service.embed = AsyncMock(...)` assignments now that
  production embeds via the routed `embed_svc`, not `self.embedding_service`.

## Pinned design decisions (gate1 yellow → operator HITL pin, 2026-05-14)
- **A1**: fail-open on recall path via `fail_on_error=False`. Sleep call sites
  keep the default `True` (a missed Sleep ledger row is itself a failure).
- **B1**: cache hit (`tokens=0`) emits no `llm_call_log` row. The table is
  "API was called" event log, not cache analytics.
- **C1**: rerank instrumentation is out of scope. Follow-up not filed —
  revisit when actual cost analysis need emerges (operator decision).

## Out of scope (follow-up candidates, not blocking)
- Rerank instrumentation (C1 pin).
- End-to-end integration test with a real DB recall → `llm_call_log` row
  (PR-2 already covers writer-in-DB via `test_llm_call_log_schema.py`).
- `asyncio.CancelledError` explicit pass-through test (Python semantics
  already guarantee `except Exception` does not catch it).
- AST inventory test module-level widen (defer until first helper-extraction
  refactor; method-level scope is sufficient today).
- Pre-existing flaky `test_single_collection_isolation` (test-order
  dependent, passes in isolation; verified unrelated to this PR — file as
  separate v0.17.x triage issue).

## Pre-PR review summary
- gate2 mode: advisor-only (gate2.binary_gate=null)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /claude-c-suite:ask (3 operator-pinned design decisions,
  see "Pinned design decisions" above)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/475-feat-feat-observability-full-pipeline-embedd.gate1.md
- ~/.claude/cache/gh-issue-driven/475-feat-feat-observability-full-pipeline-embedd.gate2.md

🤖 Generated via /gh-issue-driven:ship
