### PR TITLE
feat(auth): support OAuth Bearer tokens on REST /api/v1/* endpoints (#649)

### DIFF
--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -12,10 +12,47 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.api_keys import VerifiedKey
+from auth.oauth2_bearer import is_oauth_bearer_token, verify_oauth_bearer_token
 from db.base import get_db
 from models.auth import User
 from utils.exceptions import AuthorizationError
 from utils.logger import get_logger
+
+# HTTP method → required OAuth scope. GET/HEAD/OPTIONS → memory:read;
+# mutating verbs → memory:write. Routes that need finer enforcement
+# (admin-only, etc.) layer their own scope check on top.
+_METHOD_REQUIRED_SCOPE: dict[str, str] = {
+    "GET": "memory:read",
+    "HEAD": "memory:read",
+    "OPTIONS": "memory:read",
+    "POST": "memory:write",
+    "PUT": "memory:write",
+    "PATCH": "memory:write",
+    "DELETE": "memory:write",
+}
+
+
+def _required_scope_for_method(method: str) -> str:
+    """Return the OAuth scope required for an HTTP method.
+
+    Unknown methods fail closed to ``memory:write`` so a future verb
+    cannot accidentally bypass enforcement.
+    """
+    return _METHOD_REQUIRED_SCOPE.get(method.upper(), "memory:write")
+
+
+def _scope_granted(granted: str | None, required: str) -> bool:
+    """Check whether ``required`` is present in a space-separated scope string.
+
+    RFC 6749 §3.3: scope is a space-delimited list of case-sensitive
+    strings. Membership test only — there is no hierarchy (``memory:admin``
+    does NOT imply ``memory:write``); routes that want admin-level access
+    must require ``memory:admin`` explicitly.
+    """
+    if not granted:
+        return False
+    return required in granted.split()
+
 
 logger = get_logger(__name__)
 
@@ -268,6 +305,41 @@ async def _build_api_key_user_dict(
     }
 
 
+async def _build_oauth_user_dict(
+    user_id: str,
+    granted_scope: str | None,
+    db: AsyncSession,
+) -> dict:
+    """Build user info dict from a verified OAuth Bearer token.
+
+    Mirrors the session-auth shape rather than the API-key shape: OAuth
+    tokens are NOT workspace-bound (``OAuth2Token`` has no workspace_id
+    column, and the workspace_id in the device-flow token response is
+    point-in-time and explicitly not security-bearing per the comment
+    in ``auth.oauth2_server``). Workspace gating is delegated downstream
+    to ``PermissionService.check_workspace_access``, same as session
+    auth. ``oauth_scope`` is attached so routes that want extra
+    introspection (e.g. require ``memory:admin``) can layer it.
+    """
+    current_workspace_id = await _get_user_workspace_id(user_id, db)
+
+    logger.info(
+        "oauth_bearer_authenticated",
+        user_id=user_id,
+        workspace_id=str(current_workspace_id) if current_workspace_id else None,
+        scope=granted_scope,
+    )
+
+    return {
+        "user_id": user_id,
+        "email": f"{user_id}@oauth",
+        "role": "user",
+        "current_context_id": None,
+        "current_workspace_id": current_workspace_id,
+        "oauth_scope": granted_scope,
+    }
+
+
 async def verify_api_key_user(
     api_key: str | None = Depends(get_api_key),
     db: AsyncSession = Depends(get_db),
@@ -342,16 +414,25 @@ async def require_session_auth(
             # Only accessible via browser session
             ...
     """
-    # Reject API key authentication for Web UI endpoints
+    # Web UI endpoints reject every Bearer credential — both ``kagura_*``
+    # API keys and OAuth device-flow tokens carry programmatic / CLI
+    # semantics, and UI-only flows (billing checkout, MFA) must require
+    # a real browser session. The event key stays ``api_key_rejected_for_web_ui``
+    # for dashboard continuity since #252; OAuth-vs-API-key is surfaced
+    # via the ``token_kind`` field instead of a new event name.
     if api_key:
         logger.warning(
             "api_key_rejected_for_web_ui",
             path=request.url.path,
-            key_prefix=api_key[:16] if api_key else None,
+            token_kind="oauth" if is_oauth_bearer_token(api_key) else "api_key",
+            token_prefix=api_key[:8],
         )
         raise HTTPException(
             status_code=403,
-            detail="API keys are not allowed for Web UI endpoints. Use browser session authentication.",
+            detail=(
+                "Bearer tokens (API keys or OAuth) are not allowed for Web UI endpoints. "
+                "Use browser session authentication."
+            ),
         )
 
     # Require session authentication
@@ -398,6 +479,40 @@ async def get_user_from_api_key_or_session(
             context_id = user.get("current_context_id")
             return await save_memory(user["user_id"], context_id, ...)
     """
+    # Priority 0: OAuth Bearer. The prefix check skips the OAuth DB
+    # lookup for ``kagura_*`` API keys (and vice versa), so each Bearer
+    # request hits only one of the two stores.
+    if api_key and is_oauth_bearer_token(api_key):
+        result = await verify_oauth_bearer_token(api_key, db)
+        if result is None:
+            logger.warning("invalid_oauth_bearer_attempt", token_prefix=api_key[:8])
+            raise HTTPException(status_code=401, detail="Invalid or expired Bearer token")
+
+        user_id, granted_scope = result
+
+        # Scope enforcement (RFC 6750 §3): map HTTP method → required scope,
+        # 403 with ``WWW-Authenticate: Bearer error="insufficient_scope"``
+        # on miss so SDK clients can recover via the upgrade flow.
+        required = _required_scope_for_method(request.method)
+        if not _scope_granted(granted_scope, required):
+            logger.warning(
+                "oauth_bearer_insufficient_scope",
+                user_id=user_id,
+                required=required,
+                granted=granted_scope,
+                method=request.method,
+                path=request.url.path,
+            )
+            raise HTTPException(
+                status_code=403,
+                detail=f"Insufficient scope: '{required}' required",
+                headers={
+                    "WWW-Authenticate": f'Bearer error="insufficient_scope", scope="{required}"'
+                },
+            )
+
+        return await _build_oauth_user_dict(user_id, granted_scope, db)
+
     # Priority 1: API Key authentication
     if api_key:
         from auth.api_keys import APIKeyManager

--- a/backend/src/auth/oauth2_bearer.py
+++ b/backend/src/auth/oauth2_bearer.py
@@ -1,0 +1,74 @@
+"""OAuth 2.0 Bearer access token verification (RFC 6749 §1.4, RFC 6750).
+
+Shared verifier used by both REST ``/api/v1/*`` (via
+``auth.dependencies.get_user_from_api_key_or_session``) and MCP ``/mcp``
+(via ``mcp_server.auth.authenticate_mcp_request``). A single
+implementation gates both transports so their validation contracts
+cannot drift.
+
+Distinct from ``auth.oauth2`` (``OAuth2Manager``), which is the Google
+OAuth client manager for the Web login flow.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.api_keys import API_KEY_PREFIX
+from models.auth import OAuth2Token
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def verify_oauth_bearer_token(
+    access_token: str,
+    db: AsyncSession,
+) -> tuple[str, str | None] | None:
+    """Verify an OAuth 2.0 Bearer access token issued by the device flow.
+
+    Looks up the token row in ``oauth_tokens``, checks expiry and
+    revocation, and returns ``(user_id, scope)`` — ``scope`` is a
+    space-separated RFC 6749 §3.3 string and may be ``None`` for tokens
+    issued without scope (legacy / non-CLI clients). Returns ``None`` if
+    the token is unknown, expired, revoked, or if the lookup itself
+    fails (matches ``verify_api_key``'s silent-failure contract so a
+    transient DB error surfaces as 401 to the client, not 500).
+
+    The async query uses the caller's request-scoped session so this
+    function does not contend with the smaller sync pool that Authlib's
+    grant endpoints depend on, and avoids the per-request thread hop
+    that an ``asyncio.to_thread`` wrapper would incur on every
+    authenticated REST request.
+    """
+    try:
+        stmt = select(OAuth2Token).where(OAuth2Token.access_token == access_token)
+        result = await db.execute(stmt)
+        token = result.scalar_one_or_none()
+    except SQLAlchemyError as exc:
+        logger.error("oauth_bearer_token_lookup_failed", error=str(exc))
+        return None
+
+    if token is None:
+        logger.debug("oauth_bearer_token_not_found")
+        return None
+    if token.is_revoked():
+        logger.debug("oauth_bearer_token_revoked", token_id=token.id)
+        return None
+    if token.is_expired():
+        logger.debug("oauth_bearer_token_expired", token_id=token.id)
+        return None
+    return (token.user_id, token.scope)
+
+
+def is_oauth_bearer_token(token: str) -> bool:
+    """Distinguish OAuth Bearer tokens from kagura API keys by prefix.
+
+    Cheap prefix check used to skip the API-key DB lookup for OAuth
+    tokens. Kagura API keys start with ``"kagura_"``; OAuth tokens
+    issued by ``oauth2_server`` are 43-char ``secrets.token_urlsafe(32)``
+    strings, which never collide with that prefix.
+    """
+    return bool(token) and not token.startswith(API_KEY_PREFIX)

--- a/backend/src/mcp_server/auth.py
+++ b/backend/src/mcp_server/auth.py
@@ -151,59 +151,25 @@ async def _verify_api_key(api_key: str) -> tuple[str, "UUID | None", "UUID | Non
 
 
 async def _verify_oauth2_token(access_token: str) -> str | None:
-    """Verify OAuth2 access token.
+    """Verify OAuth2 access token and return user_id.
 
-    Args:
-        access_token: OAuth2 access token value
-
-    Returns:
-        user_id if token is valid
-
-    Raises:
-        TokenExpiredError: Token has expired
-        TokenRevokedError: Token has been revoked
-        InvalidTokenError: Token is invalid or not found
+    Scope is discarded here because MCP enforces scopes at the tool
+    layer (``auth.mcp_scopes``), not at the transport gate. MCP's
+    transport entry point has no FastAPI-injected session, so this
+    shim opens its own short-lived async session — symmetric with
+    ``_verify_api_key`` above, which also calls a session-managing
+    wrapper.
     """
-    import asyncio
+    from auth.oauth2_bearer import verify_oauth_bearer_token
+    from db.base import get_db
 
-    from db.base import get_sync_session
-    from models.auth import OAuth2Token
-    from utils.exceptions import InvalidTokenError, TokenExpiredError, TokenRevokedError
-
-    # Issue #102: Wrap sync DB call in thread to avoid blocking event loop
-    def _verify_sync():
-        db_session = get_sync_session()
-        try:
-            token = db_session.query(OAuth2Token).filter_by(access_token=access_token).first()
-
-            if not token:
-                logger.debug("OAuth2 token not found")
-                raise InvalidTokenError("Token not found in database")
-
-            # Check if token is revoked
-            if token.is_revoked():
-                logger.debug(f"OAuth2 token revoked: token_id={token.id}")
-                raise TokenRevokedError()
-
-            # Check if token is expired
-            if token.is_expired():
-                logger.debug(f"OAuth2 token expired: token_id={token.id}")
-                raise TokenExpiredError()
-
-            logger.debug(f"OAuth2 token valid: user={token.user_id}")
-            return token.user_id
-
-        except (TokenExpiredError, TokenRevokedError, InvalidTokenError):
-            # Re-raise specific token errors
-            raise
-        except Exception as e:
-            logger.error(f"OAuth2 token verification error: {e}")
-            raise InvalidTokenError(f"Token verification failed: {e}") from e
-        finally:
-            db_session.close()
-
-    # Run in thread pool to avoid blocking event loop
-    return await asyncio.to_thread(_verify_sync)
+    async for db in get_db():
+        result = await verify_oauth_bearer_token(access_token, db)
+        if result is None:
+            return None
+        user_id, _scope = result
+        return user_id
+    return None
 
 
 async def _verify_session_cookie(cookie_header: bytes) -> str | None:

--- a/backend/tests/auth/test_oauth_bearer_rest.py
+++ b/backend/tests/auth/test_oauth_bearer_rest.py
@@ -1,0 +1,329 @@
+"""Tests for OAuth Bearer support on REST /api/v1/* endpoints (Issue #649).
+
+Covers the dependency-layer behavior the issue locks down:
+
+- ``verify_oauth_bearer_token`` + ``is_oauth_bearer_token`` helpers in
+  ``auth.oauth2_bearer``.
+- Method → scope mapping (``_required_scope_for_method``) and membership
+  test (``_scope_granted``) in ``auth.dependencies``.
+- ``get_user_from_api_key_or_session`` priority-0 OAuth branch:
+  insufficient-scope 403 with RFC 6750 ``WWW-Authenticate`` header,
+  invalid-token 401, ``kagura_*`` API-key fallthrough unchanged.
+- ``require_session_auth`` rejecting OAuth Bearer with 403 (carrying
+  the same #252 intent forward to OAuth).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+_BACKEND_SRC = Path(__file__).resolve().parents[2] / "src"
+if str(_BACKEND_SRC) not in sys.path:
+    sys.path.insert(0, str(_BACKEND_SRC))
+
+from auth.dependencies import (  # noqa: E402
+    _required_scope_for_method,
+    _scope_granted,
+    get_user_from_api_key_or_session,
+    require_session_auth,
+)
+from auth.oauth2_bearer import is_oauth_bearer_token  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Pure helpers — no DB, no FastAPI
+# ---------------------------------------------------------------------------
+
+
+class TestIsOAuthBearerToken:
+    def test_kagura_prefix_is_not_oauth(self):
+        assert is_oauth_bearer_token("kagura_abc123") is False
+
+    def test_random_token_is_oauth(self):
+        assert is_oauth_bearer_token("A" * 43) is True
+
+    def test_empty_string_is_not_oauth(self):
+        assert is_oauth_bearer_token("") is False
+
+
+class TestRequiredScopeForMethod:
+    @pytest.mark.parametrize("method", ["GET", "HEAD", "OPTIONS"])
+    def test_read_methods_map_to_memory_read(self, method):
+        assert _required_scope_for_method(method) == "memory:read"
+
+    @pytest.mark.parametrize("method", ["POST", "PUT", "PATCH", "DELETE"])
+    def test_write_methods_map_to_memory_write(self, method):
+        assert _required_scope_for_method(method) == "memory:write"
+
+    def test_lowercase_method_is_normalized(self):
+        assert _required_scope_for_method("get") == "memory:read"
+        assert _required_scope_for_method("post") == "memory:write"
+
+    def test_unknown_method_defaults_to_memory_write(self):
+        # Fail-closed: an unrecognized verb gets the stricter scope so a
+        # future HTTP method (TRACE / CONNECT / custom) cannot accidentally
+        # bypass enforcement.
+        assert _required_scope_for_method("EXTEND") == "memory:write"
+
+
+class TestScopeGranted:
+    def test_required_scope_present(self):
+        assert _scope_granted("memory:read memory:write", "memory:read") is True
+
+    def test_required_scope_absent(self):
+        assert _scope_granted("memory:read", "memory:write") is False
+
+    def test_none_granted_is_false(self):
+        assert _scope_granted(None, "memory:read") is False
+
+    def test_empty_granted_is_false(self):
+        assert _scope_granted("", "memory:read") is False
+
+    def test_no_substring_partial_match(self):
+        # Membership is per-token, not substring — ``memory:writeable``
+        # must NOT satisfy ``memory:write``.
+        assert _scope_granted("memory:writeable", "memory:write") is False
+
+
+# ---------------------------------------------------------------------------
+# get_user_from_api_key_or_session — OAuth priority-0 branch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_oauth_route():
+    """Mount a single test route protected by ``get_user_from_api_key_or_session``."""
+    app = FastAPI()
+
+    from fastapi import Depends
+
+    @app.get("/_t/read")
+    async def read_route(user: dict = Depends(get_user_from_api_key_or_session)):
+        return {"user_id": user["user_id"], "oauth_scope": user.get("oauth_scope")}
+
+    @app.post("/_t/write")
+    async def write_route(user: dict = Depends(get_user_from_api_key_or_session)):
+        return {"user_id": user["user_id"], "oauth_scope": user.get("oauth_scope")}
+
+    @app.delete("/_t/delete")
+    async def delete_route(user: dict = Depends(get_user_from_api_key_or_session)):
+        return {"user_id": user["user_id"], "oauth_scope": user.get("oauth_scope")}
+
+    return app
+
+
+class TestOAuthBranchInDependency:
+    def test_valid_oauth_with_read_scope_passes_get(self, app_with_oauth_route):
+        with (
+            patch(
+                "auth.dependencies.verify_oauth_bearer_token",
+                new=AsyncMock(return_value=("user-oauth-123", "memory:read memory:write")),
+            ),
+            patch(
+                "auth.dependencies._get_user_workspace_id",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            client = TestClient(app_with_oauth_route)
+            resp = client.get("/_t/read", headers={"Authorization": "Bearer randomtok"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["user_id"] == "user-oauth-123"
+            assert body["oauth_scope"] == "memory:read memory:write"
+
+    def test_valid_oauth_with_write_scope_passes_post(self, app_with_oauth_route):
+        with (
+            patch(
+                "auth.dependencies.verify_oauth_bearer_token",
+                new=AsyncMock(return_value=("user-oauth-123", "memory:write")),
+            ),
+            patch(
+                "auth.dependencies._get_user_workspace_id",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            client = TestClient(app_with_oauth_route)
+            resp = client.post("/_t/write", headers={"Authorization": "Bearer randomtok"})
+            assert resp.status_code == 200
+
+    def test_read_only_token_on_post_returns_403_with_www_authenticate(self, app_with_oauth_route):
+        with patch(
+            "auth.dependencies.verify_oauth_bearer_token",
+            new=AsyncMock(return_value=("user-oauth-123", "memory:read")),
+        ):
+            client = TestClient(app_with_oauth_route)
+            resp = client.post("/_t/write", headers={"Authorization": "Bearer randomtok"})
+            assert resp.status_code == 403
+            assert "insufficient_scope" in resp.headers.get("www-authenticate", "")
+            assert 'scope="memory:write"' in resp.headers.get("www-authenticate", "")
+
+    def test_read_only_token_on_delete_returns_403(self, app_with_oauth_route):
+        with patch(
+            "auth.dependencies.verify_oauth_bearer_token",
+            new=AsyncMock(return_value=("user-oauth-123", "memory:read")),
+        ):
+            client = TestClient(app_with_oauth_route)
+            resp = client.delete("/_t/delete", headers={"Authorization": "Bearer randomtok"})
+            assert resp.status_code == 403
+            assert "insufficient_scope" in resp.headers.get("www-authenticate", "")
+
+    def test_invalid_or_expired_oauth_returns_401(self, app_with_oauth_route):
+        with patch(
+            "auth.dependencies.verify_oauth_bearer_token",
+            new=AsyncMock(return_value=None),
+        ):
+            client = TestClient(app_with_oauth_route)
+            resp = client.get("/_t/read", headers={"Authorization": "Bearer randomtok"})
+            assert resp.status_code == 401
+
+    def test_kagura_prefix_bypasses_oauth_path(self, app_with_oauth_route):
+        """Tokens starting with ``kagura_`` MUST NOT trigger the OAuth verifier.
+
+        Verified via the verifier's mock: if the OAuth path is wrongly
+        taken, the mock is invoked. We assert it is NOT called even
+        when the API-key path itself rejects the token below. The
+        ``APIKeyManager.verify_key`` patch short-circuits the DB lookup
+        so the test does not require a live postgres.
+        """
+        oauth_mock = AsyncMock(return_value=None)
+        api_key_manager_mock = AsyncMock(return_value=None)
+        with (
+            patch("auth.dependencies.verify_oauth_bearer_token", new=oauth_mock),
+            patch("auth.api_keys.APIKeyManager.verify_key", new=api_key_manager_mock),
+        ):
+            client = TestClient(app_with_oauth_route)
+            resp = client.get("/_t/read", headers={"Authorization": "Bearer kagura_doesnotexist"})
+            # API-key path will 401 because the mock returns None, but
+            # the contract we're verifying is that the OAuth verifier
+            # is never reached.
+            assert resp.status_code == 401
+            oauth_mock.assert_not_called()
+            api_key_manager_mock.assert_called_once()
+
+    def test_no_scope_token_cannot_read(self, app_with_oauth_route):
+        """A token with NULL ``scope`` (legacy / non-CLI issuance) fails closed."""
+        with patch(
+            "auth.dependencies.verify_oauth_bearer_token",
+            new=AsyncMock(return_value=("user-oauth-123", None)),
+        ):
+            client = TestClient(app_with_oauth_route)
+            resp = client.get("/_t/read", headers={"Authorization": "Bearer randomtok"})
+            assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# require_session_auth — Web UI-only routes reject OAuth Bearer
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def app_with_session_only_route():
+    app = FastAPI()
+    from fastapi import Depends
+
+    @app.get("/_t/web_ui")
+    async def web_ui_route(user: dict = Depends(require_session_auth)):
+        return {"user_id": user["user_id"]}
+
+    return app
+
+
+class TestRequireSessionAuthRejectsOAuth:
+    def test_oauth_bearer_rejected_with_403(self, app_with_session_only_route):
+        client = TestClient(app_with_session_only_route)
+        resp = client.get(
+            "/_t/web_ui",
+            headers={"Authorization": "Bearer randomoauth"},
+        )
+        assert resp.status_code == 403
+        # Message must mention both kinds so SDK error surfaces don't
+        # mislead users into thinking only API keys are blocked.
+        assert "OAuth" in resp.json()["detail"] or "Bearer" in resp.json()["detail"]
+
+    def test_kagura_api_key_still_rejected_with_403(self, app_with_session_only_route):
+        client = TestClient(app_with_session_only_route)
+        resp = client.get(
+            "/_t/web_ui",
+            headers={"Authorization": "Bearer kagura_anykey"},
+        )
+        assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# MCP verify_oauth2_token shim — relocation regression guard
+# ---------------------------------------------------------------------------
+
+
+class TestMCPOAuth2TokenShim:
+    """Ensure ``mcp_server.auth._verify_oauth2_token`` still returns just
+    ``user_id`` after the verifier was relocated to
+    ``auth.oauth2_bearer.verify_oauth_bearer_token`` (Issue #649).
+
+    MCP scope enforcement happens at the tool layer
+    (``auth.mcp_scopes``), not the transport gate, so the MCP shim
+    intentionally discards scope here. This test pins that contract.
+    """
+
+    @pytest.mark.asyncio
+    async def test_shim_returns_user_id_only(self):
+        from mcp_server.auth import _verify_oauth2_token
+
+        with patch(
+            "auth.oauth2_bearer.verify_oauth_bearer_token",
+            new=AsyncMock(return_value=("user-mcp-xyz", "memory:read")),
+        ):
+            result = await _verify_oauth2_token("randomtok")
+            assert result == "user-mcp-xyz"
+
+    @pytest.mark.asyncio
+    async def test_shim_returns_none_on_invalid(self):
+        from mcp_server.auth import _verify_oauth2_token
+
+        with patch(
+            "auth.oauth2_bearer.verify_oauth_bearer_token",
+            new=AsyncMock(return_value=None),
+        ):
+            result = await _verify_oauth2_token("randomtok")
+            assert result is None
+
+
+# ---------------------------------------------------------------------------
+# DB failure → 401 (silent-failure contract matches verify_api_key)
+# ---------------------------------------------------------------------------
+
+
+class TestOAuthVerifyDBFailure:
+    """``verify_oauth_bearer_token`` swallows SQLAlchemy errors and
+    returns ``None`` so that a transient DB failure during the OAuth
+    lookup surfaces as 401 to the client, not 500 — matching
+    ``verify_api_key``'s contract (``auth.dependencies:225-227``).
+    """
+
+    @pytest.mark.asyncio
+    async def test_sqlalchemy_error_returns_none(self):
+        from sqlalchemy.exc import OperationalError
+
+        from auth.oauth2_bearer import verify_oauth_bearer_token
+
+        failing_db = AsyncMock()
+        failing_db.execute = AsyncMock(
+            side_effect=OperationalError("statement", {}, Exception("pool exhausted"))
+        )
+
+        result = await verify_oauth_bearer_token("randomtok", failing_db)
+        assert result is None
+
+    def test_db_failure_in_dependency_returns_401(self, app_with_oauth_route):
+        """End-to-end: DB error in the verifier results in 401, not 500."""
+        with patch(
+            "auth.dependencies.verify_oauth_bearer_token",
+            new=AsyncMock(return_value=None),  # simulate "lookup failed → None"
+        ):
+            client = TestClient(app_with_oauth_route)
+            resp = client.get("/_t/read", headers={"Authorization": "Bearer randomtok"})
+            assert resp.status_code == 401


### PR DESCRIPTION
Closes #649

## Summary
- Adds a priority-0 OAuth Bearer branch to `get_user_from_api_key_or_session` so REST `/api/v1/*` accepts device-flow access tokens — previously only `/mcp` validated OAuth.
- Extracts `_verify_oauth2_token` into a shared `auth/oauth2_bearer.py` module that REST and MCP both use, eliminating drift risk and the previous sync-pool / thread-hop overhead.
- Enforces RFC 6750 scope mapping (GET → memory:read; mutating verbs → memory:write) with `WWW-Authenticate: insufficient_scope` on 403 so SDK clients can recover via the upgrade flow.
- Web UI-only dependencies (`require_session_auth`, `require_workspace_admin_session`) reject OAuth Bearer with 403, carrying #252's intent forward.

## Implementation notes
- **No migration** — `OAuth2Token` has no `workspace_id` column and the device-flow token response's workspace_id is documented as "point-in-time, NOT security-bearing" (`oauth2_server.py:540-545`). OAuth tokens use session semantics: user_id from token, workspace resolved at request time via `User.current_workspace_id` + downstream `PermissionService.check_workspace_access`.
- **DB failure contract** — `verify_oauth_bearer_token` catches `SQLAlchemyError` and returns `None`, matching `verify_api_key`'s silent-failure contract. Transient DB errors surface as 401 to the client (not 500).
- **Audit log continuity** — event name `api_key_rejected_for_web_ui` preserved from #252 to keep existing dashboards firing; `token_kind` field distinguishes oauth vs api_key.
- **MCP scope enforcement** stays at the tool layer (`auth.mcp_scopes`), so the MCP shim returns user_id only — scope is discarded in that path.
- The existing `kagura_*` API key code path is untouched; OAuth check is added as priority 0 and prefix-discriminated so no wasted DB lookups on either side.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask → CSO (operator-overridden after clarification comment #issuecomment-4457185488)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/649-feat-feat-auth-support-oauth-bearer-tokens-on.gate1.md
- ~/.claude/cache/gh-issue-driven/649-feat-feat-auth-support-oauth-bearer-tokens-on.gate2.md

## Test plan
- [x] 30 new tests in `tests/auth/test_oauth_bearer_rest.py` covering all 9 acceptance criteria
- [x] 20 existing OAuth tests preserved after `_verify_oauth2_token` relocation (`test_device_code_grant.py`, `test_oauth_sync_exception_logging.py`)
- [x] Full `backend/tests/auth/` module: 86/86 pass
- [x] ruff check clean

🤖 Generated via /gh-issue-driven:ship
