### PR TITLE
fix(api): drop graph_service.stats() from neural background tasks (#651)

### DIFF
--- a/backend/src/tasks/neural_tasks.py
+++ b/backend/src/tasks/neural_tasks.py
@@ -17,7 +17,7 @@ from neural.decay import DecayManager
 from repositories.graph import GraphRepository
 from repositories.memory import MemoryRepository
 from services.graph_service import GraphService
-from utils.datetime import utcnow
+from utils.datetime import to_utc_iso, utcnow
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -254,7 +254,7 @@ async def cleanup_deleted_memories_task():
                 logger.info(
                     "old_deleted_memory_purged",
                     memory_id=str(memory.id),
-                    deleted_at=memory.deleted_at,
+                    deleted_at=to_utc_iso(memory.deleted_at),
                     age_days=(utcnow() - memory.deleted_at).days,
                 )
 
@@ -263,7 +263,7 @@ async def cleanup_deleted_memories_task():
             logger.info(
                 "cleanup_deleted_memories_task_completed",
                 purged=total_deleted,
-                cutoff=cutoff,
+                cutoff=to_utc_iso(cutoff),
             )
             return
 

--- a/backend/src/tasks/neural_tasks.py
+++ b/backend/src/tasks/neural_tasks.py
@@ -5,7 +5,6 @@ Implements:
 - Memory consolidation (daily)
 """
 
-import logging
 import os
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
@@ -19,8 +18,9 @@ from repositories.graph import GraphRepository
 from repositories.memory import MemoryRepository
 from services.graph_service import GraphService
 from utils.datetime import utcnow
+from utils.logger import get_logger
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 async def weight_decay_task():
@@ -32,12 +32,12 @@ async def weight_decay_task():
 
     # Check if Neural Memory is enabled
     if os.getenv("ENABLE_NEURAL_MEMORY", "false").lower() != "true":
-        logger.info("weight_decay_task_skipped")
+        logger.info("weight_decay_task_skipped", reason="neural_memory_disabled")
         return
 
     # Check if decay is enabled
     if os.getenv("ENABLE_DECAY", "true").lower() != "true":
-        logger.info("weight_decay_task_skipped")
+        logger.info("weight_decay_task_skipped", reason="decay_disabled")
         return
 
     try:
@@ -61,32 +61,40 @@ async def weight_decay_task():
                 edges_decayed = decay_result.get("edges_decayed", 0)
 
                 if edges_decayed > 0:
-                    stats = await graph_service.stats()
-
-                    graph_model.total_nodes = stats["total_nodes"]
-                    graph_model.total_edges = stats["total_edges"]
-                    graph_model.avg_edge_weight = stats["avg_edge_weight"]
-                    graph_model.max_edge_weight = stats["max_edge_weight"]
-                    graph_model.last_decay_at = utcnow()
-                    graph_model.updated_at = utcnow()
+                    # Issue #651: previously called graph_service.stats() here to
+                    # refresh graph_memory.total_*/avg/max cache columns. That call
+                    # violates the 3-level isolation invariant from #273 H-2 / #383
+                    # (workspace_id/context_id are unavailable in this global
+                    # cross-tenant task, and the validator on get_stats rejects
+                    # None pairs to prevent cross-tenant aggregation). The cache
+                    # columns are write-only — no consumer reads them — so
+                    # dropping the refresh has no functional impact. Removal of
+                    # the dead columns themselves is tracked as a follow-up
+                    # issue (TBD — to be filed when this PR lands).
+                    now = utcnow()
+                    graph_model.last_decay_at = now
+                    graph_model.updated_at = now
 
                     total_updated += 1
 
                     logger.info(
-                        f"graph_decay_applied: user={user_id}, "
-                        f"edges_decayed={edges_decayed}, total_edges={stats['total_edges']}"
+                        "graph_decay_applied",
+                        user_id=user_id,
+                        edges_decayed=edges_decayed,
+                        edges_pruned=decay_result.get("edges_pruned", 0),
                     )
 
             await db.commit()
 
             logger.info(
-                f"weight_decay_task_completed: total_graphs={len(graphs)}, "
-                f"updated_graphs={total_updated}"
+                "weight_decay_task_completed",
+                total_graphs=len(graphs),
+                updated_graphs=total_updated,
             )
             return
 
     except Exception as e:
-        logger.error(f"weight_decay_task_failed: {e}", exc_info=True)
+        logger.error("weight_decay_task_failed", error=str(e), exc_info=True)
 
 
 async def consolidation_task():
@@ -94,6 +102,25 @@ async def consolidation_task():
 
     Runs daily at 3 AM UTC to promote frequently used working memories
     and delete old unused ones.
+
+    Issue #651: removed the Neural Memory metrics integration (the Issue #44
+    enhancement). graph_service.stats() and graph_service.get_node_metrics()
+    both require workspace_id and context_id, which are not available in this
+    global cross-tenant task, and the get_stats validator rejects None pairs
+    to prevent cross-tenant aggregation (#273 H-2 / #383). Additionally, the
+    get_node_metrics call in main lacked an ``await``, so the entire neural-
+    enhanced branch was already raising TypeError and being swallowed by the
+    bare ``except`` — the integration was non-functional in practice. Promotion
+    and deletion now use only the original Issue #1 criteria (access patterns,
+    importance, age). The deletion guard's former ``is_isolated`` check is
+    therefore not restored here (it never executed in prod). Re-introducing
+    neural metrics under the 3-level isolation model — including a properly
+    awaited isolation-aware ``is_isolated`` deletion guard — is tracked as a
+    follow-up issue (TBD — to be filed when this PR lands).
+
+    Note: this task only runs when ``SLEEP_ENABLED=false``. With sleep
+    enabled (the production setting), ``services/sleep/consolidation.py``
+    handles consolidation and retains its own neural metrics path.
     """
     logger.info("consolidation_task_started")
 
@@ -109,17 +136,7 @@ async def consolidation_task():
             total_promoted = 0
             total_deleted = 0
 
-            # Get environment variable thresholds (Issue #44)
-            neural_centrality_threshold = float(os.getenv("NEURAL_CENTRALITY_THRESHOLD", "0.7"))
-            neural_hub_threshold = int(os.getenv("NEURAL_HUB_NODE_THRESHOLD", "5"))
-            neural_weight_threshold = float(os.getenv("NEURAL_EDGE_WEIGHT_THRESHOLD", "0.8"))
-
             for user_id in user_ids:
-                # Load graph for Neural Memory metrics (Issue #44)
-                graph_service = GraphService(user_id, db)
-                graph_stats = await graph_service.stats()
-                has_graph = graph_stats["total_edges"] > 0
-
                 # Get working memories
                 working_memories = await memory_repo.list(
                     filters={"user_id": user_id, "scope": "working"}
@@ -128,14 +145,8 @@ async def consolidation_task():
                 for memory in working_memories:
                     age_days = (utcnow() - memory.created_at).days
 
-                    # Get Neural Memory metrics (Issue #44)
-                    neural_metrics = None
-                    if has_graph:
-                        neural_metrics = graph_service.get_node_metrics(str(memory.id))
-
-                    # Enhanced promotion criteria (Issue #44)
+                    # Promotion criteria (Issue #1)
                     should_promote = (
-                        # Existing criteria (from Issue #1)
                         # Pattern 1: Frequently used + Important
                         (memory.access_count >= 3 and memory.importance >= 0.5)
                         # Pattern 2: Very frequently used
@@ -144,16 +155,6 @@ async def consolidation_task():
                         or (memory.importance >= 0.8 and age_days >= 3)
                         # Pattern 4: Old + used at least once
                         or (age_days >= 30 and memory.access_count >= 1)
-                        # NEW: Neural Memory criteria (Issue #44)
-                        or (
-                            neural_metrics
-                            and neural_metrics["centrality"] >= neural_centrality_threshold
-                        )
-                        or (neural_metrics and neural_metrics["edge_count"] >= neural_hub_threshold)
-                        or (
-                            neural_metrics
-                            and neural_metrics["avg_edge_weight"] >= neural_weight_threshold
-                        )
                     )
 
                     if should_promote:
@@ -161,28 +162,17 @@ async def consolidation_task():
                         await memory_repo.promote_to_persistent(memory.id)
                         total_promoted += 1
 
-                        promotion_reason = "standard"
-                        if neural_metrics:
-                            if neural_metrics["centrality"] >= neural_centrality_threshold:
-                                promotion_reason = "neural_centrality"
-                            elif neural_metrics["edge_count"] >= neural_hub_threshold:
-                                promotion_reason = "neural_hub"
-                            elif neural_metrics["avg_edge_weight"] >= neural_weight_threshold:
-                                promotion_reason = "neural_weight"
-
                         logger.info(
-                            f"memory_promoted: memory_id={memory.id}, user={user_id}, "
-                            f"access_count={memory.access_count}, age_days={age_days}, "
-                            f"importance={memory.importance}, reason={promotion_reason}, "
-                            f"neural_metrics={neural_metrics}"
+                            "memory_promoted",
+                            memory_id=str(memory.id),
+                            user_id=user_id,
+                            access_count=memory.access_count,
+                            age_days=age_days,
+                            importance=memory.importance,
                         )
 
-                    # Enhanced deletion criteria (Issue #44)
-                    elif (
-                        age_days >= 30
-                        and memory.access_count == 0
-                        and (not neural_metrics or neural_metrics["is_isolated"])
-                    ):
+                    # Deletion criteria
+                    elif age_days >= 30 and memory.access_count == 0:
                         # ================================================================
                         # BUG FIX #83-10: Delete from Qdrant to prevent orphan vectors
                         # ================================================================
@@ -208,21 +198,24 @@ async def consolidation_task():
                         total_deleted += 1
 
                         logger.info(
-                            f"old_memory_deleted: memory_id={memory.id}, "
-                            f"user={user_id}, age_days={age_days}, "
-                            f"isolated={neural_metrics['is_isolated'] if neural_metrics else True}"
+                            "old_memory_deleted",
+                            memory_id=str(memory.id),
+                            user_id=user_id,
+                            age_days=age_days,
                         )
 
             await db.commit()
 
             logger.info(
-                f"consolidation_task_completed: users={len(user_ids)}, "
-                f"promoted={total_promoted}, deleted={total_deleted}"
+                "consolidation_task_completed",
+                users=len(user_ids),
+                promoted=total_promoted,
+                deleted=total_deleted,
             )
             return
 
     except Exception as e:
-        logger.error(f"consolidation_task_failed: {e}", exc_info=True)
+        logger.error("consolidation_task_failed", error=str(e), exc_info=True)
 
 
 async def cleanup_deleted_memories_task():
@@ -259,19 +252,23 @@ async def cleanup_deleted_memories_task():
                 await memory_repo.delete(memory.id)
                 total_deleted += 1
                 logger.info(
-                    f"old_deleted_memory_purged: memory_id={memory.id}, "
-                    f"deleted_at={memory.deleted_at}, age_days={(utcnow() - memory.deleted_at).days}"
+                    "old_deleted_memory_purged",
+                    memory_id=str(memory.id),
+                    deleted_at=memory.deleted_at,
+                    age_days=(utcnow() - memory.deleted_at).days,
                 )
 
             await db.commit()
 
             logger.info(
-                f"cleanup_deleted_memories_task_completed: purged={total_deleted}, cutoff={cutoff}"
+                "cleanup_deleted_memories_task_completed",
+                purged=total_deleted,
+                cutoff=cutoff,
             )
             return
 
     except Exception as e:
-        logger.error(f"cleanup_deleted_memories_task_failed: {e}", exc_info=True)
+        logger.error("cleanup_deleted_memories_task_failed", error=str(e), exc_info=True)
 
 
 def schedule_neural_tasks(scheduler: AsyncIOScheduler) -> None:
@@ -301,9 +298,9 @@ def schedule_neural_tasks(scheduler: AsyncIOScheduler) -> None:
             name="Memory Consolidation",
             replace_existing=True,
         )
-        logger.info("scheduled_consolidation_task (legacy)")
+        logger.info("scheduled_consolidation_task", mode="legacy")
     else:
-        logger.info("consolidation_task_skipped (sleep_maintenance_handles_this)")
+        logger.info("consolidation_task_skipped", reason="sleep_maintenance_handles_this")
 
     # Cleanup Deleted Memories: Daily at 4 AM UTC
     scheduler.add_job(

--- a/backend/tests/services/sleep/test_consolidation.py
+++ b/backend/tests/services/sleep/test_consolidation.py
@@ -79,8 +79,12 @@ class TestConsolidationPhase:
 class TestRuleBasedPromotion:
     """Test that rule-based promotion matches legacy consolidation_task.
 
-    These rules must be identical to neural_tasks.py:137-157 for
-    backward compatibility when sleep_enabled=true.
+    Patterns 1-4 (memory access / importance / age) must stay identical to
+    the rules in tasks/neural_tasks.py::consolidation_task for backward
+    compatibility when sleep_enabled=true. The Issue #44 neural metrics
+    criteria were dropped from neural_tasks.py in Issue #651 (they live on
+    in services/sleep/consolidation.py only), so this parity covers Issue
+    #1 patterns only.
     """
 
     def test_pattern1_frequent_and_important(self):

--- a/backend/tests/tasks/conftest.py
+++ b/backend/tests/tasks/conftest.py
@@ -1,0 +1,17 @@
+"""Shared fixtures and helpers for backend/tests/tasks/ test files."""
+
+from __future__ import annotations
+
+
+def mock_get_db_factory(mock_db):
+    """Build an async generator that yields ``mock_db`` once.
+
+    Used to patch ``tasks.<task_module>.get_db`` in task tests so the
+    ``async for db in get_db():`` pattern receives a controlled mock
+    session without touching a real database.
+    """
+
+    async def get_db():
+        yield mock_db
+
+    return get_db

--- a/backend/tests/tasks/test_embedding_tasks.py
+++ b/backend/tests/tasks/test_embedding_tasks.py
@@ -12,15 +12,7 @@ from uuid import uuid4
 import pytest
 
 from tasks.embedding_tasks import schedule_embedding_tasks, sweep_pending_embeddings
-
-
-def _mock_get_db(mock_db):
-    """Return an async generator that yields mock_db once."""
-
-    async def get_db():
-        yield mock_db
-
-    return get_db
+from tests.tasks.conftest import mock_get_db_factory
 
 
 class TestScheduleEmbeddingTasks:
@@ -47,7 +39,7 @@ class TestSweepPendingEmbeddings:
         mock_result.all.return_value = []
         mock_db.execute = AsyncMock(return_value=mock_result)
 
-        with patch("db.base.get_db", _mock_get_db(mock_db)):
+        with patch("db.base.get_db", mock_get_db_factory(mock_db)):
             await sweep_pending_embeddings()
 
         mock_db.execute.assert_called_once()
@@ -62,7 +54,7 @@ class TestSweepPendingEmbeddings:
         mock_db.execute = AsyncMock(return_value=mock_result)
 
         with (
-            patch("db.base.get_db", _mock_get_db(mock_db)),
+            patch("db.base.get_db", mock_get_db_factory(mock_db)),
             patch(
                 "services.memory_service.process_pending_embedding", new=AsyncMock()
             ) as mock_process,
@@ -90,7 +82,7 @@ class TestSweepPendingEmbeddings:
 
         mock_db.execute.side_effect = capture_execute
 
-        with patch("db.base.get_db", _mock_get_db(mock_db)):
+        with patch("db.base.get_db", mock_get_db_factory(mock_db)):
             await sweep_pending_embeddings()
 
         assert captured_stmt is not None
@@ -104,7 +96,7 @@ class TestSweepPendingEmbeddings:
         mock_db = MagicMock()
         mock_db.execute = AsyncMock(side_effect=RuntimeError("DB exploded"))
 
-        with patch("db.base.get_db", _mock_get_db(mock_db)):
+        with patch("db.base.get_db", mock_get_db_factory(mock_db)):
             # Should not raise despite DB error
             await sweep_pending_embeddings()
 
@@ -135,7 +127,7 @@ class TestSweepPendingEmbeddings:
         flaky_process.side_effect = flaky_side_effect
 
         with (
-            patch("db.base.get_db", _mock_get_db(mock_db)),
+            patch("db.base.get_db", mock_get_db_factory(mock_db)),
             patch("services.memory_service.process_pending_embedding", flaky_process),
         ):
             await sweep_pending_embeddings()

--- a/backend/tests/tasks/test_neural_tasks.py
+++ b/backend/tests/tasks/test_neural_tasks.py
@@ -1,0 +1,300 @@
+"""Tests for tasks/neural_tasks.py.
+
+Covers weight_decay_task and consolidation_task. Heavy dependencies (DB,
+GraphService, MemoryRepository, DecayManager, Qdrant) are patched so tests
+run without Docker.
+
+Issue #651 regression guards: weight_decay_task and consolidation_task must
+NOT call graph_service.stats() or graph_service.get_node_metrics() — those
+methods require workspace_id/context_id which are unavailable in these
+global cross-tenant tasks, and the get_stats validator (#273 H-2 / #383)
+rejects None pairs to prevent cross-tenant aggregation.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from tasks.neural_tasks import consolidation_task, weight_decay_task
+from tests.tasks.conftest import mock_get_db_factory
+from utils.datetime import utcnow
+
+
+def _make_graph(user_id: str = "user-1"):
+    """Build a minimal graph_memory row mock with the timestamp fields the task updates."""
+    graph = MagicMock()
+    graph.user_id = user_id
+    graph.last_decay_at = None
+    graph.updated_at = None
+    # Pre-existing cache columns — we assert these are NOT touched by the task.
+    graph.total_nodes = 0
+    graph.total_edges = 0
+    graph.avg_edge_weight = 0.0
+    graph.max_edge_weight = 0.0
+    return graph
+
+
+def _make_memory(
+    user_id: str = "user-1",
+    access_count: int = 0,
+    importance: float = 0.0,
+    age_days: int = 0,
+):
+    """Build a minimal Memory row mock with the fields consolidation_task reads."""
+    mem = MagicMock()
+    mem.id = uuid4()
+    mem.user_id = user_id
+    mem.access_count = access_count
+    mem.importance = importance
+    mem.created_at = utcnow() - timedelta(days=age_days)
+    return mem
+
+
+class TestWeightDecayTask:
+    @pytest.mark.asyncio
+    async def test_skips_when_neural_memory_disabled(self, monkeypatch):
+        """ENABLE_NEURAL_MEMORY=false → early return, no DB access.
+
+        Patch ``tasks.neural_tasks.get_db`` (the bound name in the module under
+        test) rather than ``db.base.get_db``: the module does
+        ``from db.base import get_db`` at import time, copying the reference
+        into its own namespace. Patching the source attribute after import
+        has no effect on the already-bound name.
+        """
+        monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "false")
+
+        with patch("tasks.neural_tasks.get_db") as mock_get_db:
+            await weight_decay_task()
+
+        mock_get_db.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_when_decay_disabled(self, monkeypatch):
+        """ENABLE_DECAY=false → early return."""
+        monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+        monkeypatch.setenv("ENABLE_DECAY", "false")
+
+        with patch("tasks.neural_tasks.get_db") as mock_get_db:
+            await weight_decay_task()
+
+        mock_get_db.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_does_not_call_graph_service_stats(self, monkeypatch):
+        """Issue #651 regression guard: weight_decay_task must NOT call
+        graph_service.stats() — that call violates 3-level isolation."""
+        monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+        monkeypatch.setenv("ENABLE_DECAY", "true")
+
+        mock_db = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        graph = _make_graph()
+        mock_graph_repo = MagicMock()
+        mock_graph_repo.list = AsyncMock(return_value=[graph])
+
+        mock_graph_service = MagicMock()
+        # stats() should NEVER be called; if the regression returns we'll see it here.
+        mock_graph_service.stats = AsyncMock(return_value={"total_nodes": 999})
+
+        mock_decay_manager = MagicMock()
+        mock_decay_manager.apply_decay = AsyncMock(
+            return_value={"edges_decayed": 5, "edges_pruned": 2}
+        )
+
+        with (
+            patch("tasks.neural_tasks.get_db", mock_get_db_factory(mock_db)),
+            patch("tasks.neural_tasks.GraphRepository", return_value=mock_graph_repo),
+            patch(
+                "tasks.neural_tasks.NeuralMemoryConfig.from_db", AsyncMock(return_value=MagicMock())
+            ),
+            patch("tasks.neural_tasks.GraphService", return_value=mock_graph_service),
+            patch("tasks.neural_tasks.DecayManager", return_value=mock_decay_manager),
+        ):
+            await weight_decay_task()
+
+        mock_graph_service.stats.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_updates_timestamps_when_edges_decayed(self, monkeypatch):
+        """When edges_decayed > 0, the task updates last_decay_at and updated_at
+        (operational telemetry) but does NOT update the dead total_*/avg/max cache."""
+        monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+        monkeypatch.setenv("ENABLE_DECAY", "true")
+
+        mock_db = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        graph = _make_graph()
+        mock_graph_repo = MagicMock()
+        mock_graph_repo.list = AsyncMock(return_value=[graph])
+
+        mock_decay_manager = MagicMock()
+        mock_decay_manager.apply_decay = AsyncMock(
+            return_value={"edges_decayed": 3, "edges_pruned": 1}
+        )
+
+        with (
+            patch("tasks.neural_tasks.get_db", mock_get_db_factory(mock_db)),
+            patch("tasks.neural_tasks.GraphRepository", return_value=mock_graph_repo),
+            patch(
+                "tasks.neural_tasks.NeuralMemoryConfig.from_db", AsyncMock(return_value=MagicMock())
+            ),
+            patch("tasks.neural_tasks.GraphService", return_value=MagicMock()),
+            patch("tasks.neural_tasks.DecayManager", return_value=mock_decay_manager),
+        ):
+            await weight_decay_task()
+
+        # Telemetry was refreshed.
+        assert graph.last_decay_at is not None
+        assert graph.updated_at is not None
+        # Dead cache columns were left untouched.
+        assert graph.total_nodes == 0
+        assert graph.total_edges == 0
+        assert graph.avg_edge_weight == 0.0
+        assert graph.max_edge_weight == 0.0
+
+    @pytest.mark.asyncio
+    async def test_skips_timestamp_update_when_no_edges_decayed(self, monkeypatch):
+        """When edges_decayed == 0, last_decay_at is not refreshed."""
+        monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+        monkeypatch.setenv("ENABLE_DECAY", "true")
+
+        mock_db = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        graph = _make_graph()
+        mock_graph_repo = MagicMock()
+        mock_graph_repo.list = AsyncMock(return_value=[graph])
+
+        mock_decay_manager = MagicMock()
+        mock_decay_manager.apply_decay = AsyncMock(
+            return_value={"edges_decayed": 0, "edges_pruned": 0}
+        )
+
+        with (
+            patch("tasks.neural_tasks.get_db", mock_get_db_factory(mock_db)),
+            patch("tasks.neural_tasks.GraphRepository", return_value=mock_graph_repo),
+            patch(
+                "tasks.neural_tasks.NeuralMemoryConfig.from_db", AsyncMock(return_value=MagicMock())
+            ),
+            patch("tasks.neural_tasks.GraphService", return_value=MagicMock()),
+            patch("tasks.neural_tasks.DecayManager", return_value=mock_decay_manager),
+        ):
+            await weight_decay_task()
+
+        assert graph.last_decay_at is None
+        assert graph.updated_at is None
+
+
+class TestConsolidationTask:
+    @pytest.mark.asyncio
+    async def test_does_not_construct_graph_service(self):
+        """Issue #651 regression guard: consolidation_task must not instantiate
+        GraphService at all. Since GraphService is unconstructable in this
+        task's context (no workspace_id/context_id), instantiation would be
+        the first step toward re-introducing the broken stats() / get_node_metrics()
+        calls. Asserting non-instantiation is strictly stronger than asserting
+        the methods are not called."""
+        mock_db = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        mock_graph_repo = MagicMock()
+        mock_graph_repo.list = AsyncMock(return_value=[_make_graph()])
+        mock_memory_repo = MagicMock()
+        mock_memory_repo.list = AsyncMock(return_value=[])
+
+        with (
+            patch("tasks.neural_tasks.get_db", mock_get_db_factory(mock_db)),
+            patch("tasks.neural_tasks.GraphRepository", return_value=mock_graph_repo),
+            patch("tasks.neural_tasks.MemoryRepository", return_value=mock_memory_repo),
+            patch("tasks.neural_tasks.GraphService") as mock_graph_service_cls,
+        ):
+            await consolidation_task()
+
+        mock_graph_service_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_promotes_frequently_used_memory(self):
+        """Promotion criteria still fire on memory-only signals (Issue #1 patterns)."""
+        mock_db = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        graph = _make_graph()
+        mock_graph_repo = MagicMock()
+        mock_graph_repo.list = AsyncMock(return_value=[graph])
+
+        # access_count=5 satisfies Pattern 2 (Very frequently used).
+        frequent_memory = _make_memory(access_count=5, importance=0.1, age_days=1)
+        mock_memory_repo = MagicMock()
+        mock_memory_repo.list = AsyncMock(return_value=[frequent_memory])
+        mock_memory_repo.promote_to_persistent = AsyncMock()
+        mock_memory_repo.delete = AsyncMock()
+
+        with (
+            patch("tasks.neural_tasks.get_db", mock_get_db_factory(mock_db)),
+            patch("tasks.neural_tasks.GraphRepository", return_value=mock_graph_repo),
+            patch("tasks.neural_tasks.MemoryRepository", return_value=mock_memory_repo),
+        ):
+            await consolidation_task()
+
+        mock_memory_repo.promote_to_persistent.assert_called_once_with(frequent_memory.id)
+        mock_memory_repo.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_deletes_old_unused_memory(self):
+        """Deletion criteria still fire on memory-only signals (age>=30 + access_count==0)."""
+        mock_db = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        graph = _make_graph()
+        mock_graph_repo = MagicMock()
+        mock_graph_repo.list = AsyncMock(return_value=[graph])
+
+        old_memory = _make_memory(access_count=0, importance=0.0, age_days=45)
+        mock_memory_repo = MagicMock()
+        mock_memory_repo.list = AsyncMock(return_value=[old_memory])
+        mock_memory_repo.promote_to_persistent = AsyncMock()
+        mock_memory_repo.delete = AsyncMock()
+
+        with (
+            patch("tasks.neural_tasks.get_db", mock_get_db_factory(mock_db)),
+            patch("tasks.neural_tasks.GraphRepository", return_value=mock_graph_repo),
+            patch("tasks.neural_tasks.MemoryRepository", return_value=mock_memory_repo),
+            patch("db.qdrant.delete_memory_from_qdrant", new=AsyncMock()) as mock_qdrant_delete,
+        ):
+            await consolidation_task()
+
+        mock_qdrant_delete.assert_called_once_with(old_memory.user_id, old_memory.id)
+        mock_memory_repo.delete.assert_called_once_with(old_memory.id)
+        mock_memory_repo.promote_to_persistent.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_leaves_recent_unused_memory_alone(self):
+        """A young, unused, unimportant memory is neither promoted nor deleted."""
+        mock_db = MagicMock()
+        mock_db.commit = AsyncMock()
+
+        graph = _make_graph()
+        mock_graph_repo = MagicMock()
+        mock_graph_repo.list = AsyncMock(return_value=[graph])
+
+        idle_memory = _make_memory(access_count=0, importance=0.0, age_days=1)
+        mock_memory_repo = MagicMock()
+        mock_memory_repo.list = AsyncMock(return_value=[idle_memory])
+        mock_memory_repo.promote_to_persistent = AsyncMock()
+        mock_memory_repo.delete = AsyncMock()
+
+        with (
+            patch("tasks.neural_tasks.get_db", mock_get_db_factory(mock_db)),
+            patch("tasks.neural_tasks.GraphRepository", return_value=mock_graph_repo),
+            patch("tasks.neural_tasks.MemoryRepository", return_value=mock_memory_repo),
+        ):
+            await consolidation_task()
+
+        mock_memory_repo.promote_to_persistent.assert_not_called()
+        mock_memory_repo.delete.assert_not_called()


### PR DESCRIPTION
Closes #651

## Summary

- `weight_decay_task` and `consolidation_task` in `tasks/neural_tasks.py` called `graph_service.stats()` without workspace_id/context_id, hitting the 3-level isolation validator from #273 H-2 / #383 and silently failing every scheduled run.
- Resolution drops the broken codepaths entirely (Option A). The `graph_memory.total_*` cache columns those calls populated are **write-only — no consumer reads them anywhere** (verified via grep), so the refresh adds no value. In `consolidation_task`, the broader Issue #44 Neural Memory metrics enhancement was discovered to be **non-functional on `main`** because `get_node_metrics(...)` lacked an `await` — the entire neural-enhanced branch was raising `TypeError` and being swallowed by the broad `except`, so this PR removes dead code rather than restore it.
- `_validate_isolation_params` and the `get_stats` invariant from PR #394 are **fully preserved** — the original Option 1 (aggregate path on the service with a None-ids bypass) was discarded because `get_stats:771-777` and `get_top_connected_nodes:898-900` explicitly forbid that access pattern.

## Implementation notes

- Production change is small: `weight_decay_task` keeps the timestamp telemetry (`last_decay_at`, `updated_at`) and drops the broken `stats()`/cache block; `consolidation_task` drops the entire neural-metrics codepath (env-var reads, GraphService construction, `get_node_metrics` call, neural promotion criteria, `is_isolated` deletion guard).
- Collateral cleanup from `/simplify` review: stdlib `logging` -> `utils.logger.get_logger` (structlog) per backend rule, all f-string log calls converted to event+kwargs form, `utcnow()` cached once in `weight_decay_task` to avoid microsecond drift between `last_decay_at` and `updated_at`, and `_mock_get_db` helper hoisted from `test_embedding_tasks.py` to a shared `tests/tasks/conftest.py` as `mock_get_db_factory`.
- New `tests/tasks/test_neural_tasks.py` adds **9 regression guards** (the file previously had zero coverage). `test_does_not_construct_graph_service` for `consolidation_task` is intentionally constructor-level — strictly stronger than asserting `.stats()` is not called.
- During `/self-review`, the busy-path tests had a real bug (`patch("db.base.get_db", ...)` is ineffective because `neural_tasks.py` does `from db.base import get_db` at module top — patching the source attribute doesn't intercept the importer's already-bound name). All 13 patch sites in the new test file now correctly target `tasks.neural_tasks.*`. `test_embedding_tasks.py` keeps `db.base.get_db` patches because that file uses a deferred `from` import inside the function body — verified that pattern is correct.

## Behavior changes to flag

- **`consolidation_task` deletion criteria** (legacy-only codepath, gated by `SLEEP_ENABLED=false`): previously `age_days >= 30 AND access_count == 0 AND (not neural_metrics OR neural_metrics["is_isolated"])`. Now `age_days >= 30 AND access_count == 0`. **Production behavior is unchanged** because the `is_isolated` term was non-functional on `main` (the missing-`await` bug above made the whole expression raise `TypeError` and be swallowed). In `SLEEP_ENABLED=true` (production setting), `services/sleep/consolidation.py` handles consolidation and retains its own neural-metrics path. The behavior change only affects test/dev with `SLEEP_ENABLED=false`. Restoring an isolation-aware `is_isolated` guard is part of the Issue #44 follow-up.
- **Log line format**: `tasks/neural_tasks.py` now emits structured key/value events (`logger.info("graph_decay_applied", user_id=..., edges_decayed=..., edges_pruned=...)`) instead of pre-formatted f-strings. Event names are unchanged; any downstream log consumer that grep'd the old f-string format will need updating.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow
- cto: green
- gate1: yellow via /ask (CTO lens, escalation not triggered)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/651-fix-weight-decay-task-fails-hourly-graph-ser.gate1.md`
- `~/.claude/cache/gh-issue-driven/651-fix-weight-decay-task-fails-hourly-graph-ser.gate2.md`

## Follow-ups (to file when this PR lands)

1. Drop the dead `graph_memory.total_nodes / total_edges / avg_edge_weight / max_edge_weight` columns via Alembic migration. Suggested scope: pre-1.0 surface freeze (#622).
2. Re-introduce the Issue #44 Neural Memory metrics integration under the 3-level isolation model, including a properly-awaited isolation-aware `is_isolated` deletion guard. When implemented, add `test_does_not_delete_connected_memory` (qa-lead caveat) and `is_isolated` restoration tests (cso caveat).

## Test plan

- [x] `make test-local` scope tests pass (296 tests across `tests/tasks/`, `tests/services/sleep/`, `tests/neural/`, 0 regressions)
- [x] `ruff check` clean on `src/tasks/neural_tasks.py` and `tests/tasks/`
- [x] 9 new regression guards in `tests/tasks/test_neural_tasks.py` all pass
- [x] `make test-integration` (DB-touching) — N/A, no schema changes in this PR
- [ ] Verify after merge: production logs no longer emit `weight_decay_task_failed: 2-level isolation requires workspace_id and context_id` at `:53` UTC

🤖 Generated via /gh-issue-driven:ship
