### PR TITLE
fix(auth): apply signup gate to Google OAuth (#655)

### DIFF
--- a/backend/alembic/versions/e14_655_signup_allowlist_provider.py
+++ b/backend/alembic/versions/e14_655_signup_allowlist_provider.py
@@ -76,34 +76,30 @@ def upgrade() -> None:
     # the end of Step 2 (DROP DEFAULT) so post-migration INSERTs from new
     # code must supply real values — the columns having a permanent default
     # is exactly what we are NOT trying to bake in.
-    op.add_column(
-        "signup_allowlist",
-        sa.Column(
-            "provider",
-            sa.String(20),
-            nullable=True,
-            server_default=sa.text("'github'"),
-        ),
+    #
+    # Each ADD COLUMN goes through raw SQL with ``IF NOT EXISTS`` so a
+    # partial-rerun under autocommit mode self-heals (PR #657 Copilot loop
+    # 4 finding #3). PG 9.6+ has native ``ADD COLUMN IF NOT EXISTS`` so this
+    # is one statement, not a DO block.
+    op.execute(
+        sa.text(
+            "ALTER TABLE signup_allowlist "
+            "ADD COLUMN IF NOT EXISTS provider VARCHAR(20) DEFAULT 'github'"
+        )
     )
-    op.add_column(
-        "signup_allowlist",
-        sa.Column(
-            "subject_id",
-            sa.String(255),
-            nullable=True,
+    op.execute(
+        sa.text(
+            "ALTER TABLE signup_allowlist "
             # Empty-string sentinel. Step 2's backfill overwrites both
             # legacy NULL rows and any '' rows from the deploy window.
-            server_default=sa.text("''"),
-        ),
+            "ADD COLUMN IF NOT EXISTS subject_id VARCHAR(255) DEFAULT ''"
+        )
     )
-    op.add_column(
-        "signup_allowlist",
-        sa.Column(
-            "subject_label",
-            sa.String(255),
-            nullable=True,
-            server_default=sa.text("''"),
-        ),
+    op.execute(
+        sa.text(
+            "ALTER TABLE signup_allowlist "
+            "ADD COLUMN IF NOT EXISTS subject_label VARCHAR(255) DEFAULT ''"
+        )
     )
 
     # Step 2: backfill from existing GitHub-only columns.
@@ -136,26 +132,36 @@ def upgrade() -> None:
     op.alter_column("signup_allowlist", "subject_label", server_default=None)
 
     # Step 3: drop old UNIQUE + INDEX before tightening to NOT NULL, so the
-    # new constraints can sit on the new columns. ``type_="unique"`` on
-    # drop_constraint matches the codebase convention from a99 / b03.
-    op.drop_constraint(
-        "uq_allowlist_user_source",
-        "signup_allowlist",
-        type_="unique",
+    # new constraints can sit on the new columns. Raw SQL with ``IF EXISTS``
+    # guards (PR #657 Copilot loop 4 finding #3): self-heals if a prior run
+    # already dropped these and was interrupted before reaching the version
+    # bump, OR if an operator runs the migration manually with
+    # ``transaction_per_migration=False`` and the alembic_version row
+    # wasn't updated. Under the default transactional mode the guards are
+    # idempotency insurance; under autocommit mode they're actually load-
+    # bearing.
+    op.execute(
+        sa.text("ALTER TABLE signup_allowlist DROP CONSTRAINT IF EXISTS uq_allowlist_user_source")
     )
-    op.drop_index(
-        "ix_signup_allowlist_github_user_id",
-        table_name="signup_allowlist",
-    )
+    op.execute(sa.text("DROP INDEX IF EXISTS ix_signup_allowlist_github_user_id"))
 
     # Step 4: add CHECK constraint on provider. For this small table we
     # don't need the NOT VALID + VALIDATE dance from b03 (which is for
     # large tables where the scan would block writes); a direct ADD
     # CONSTRAINT is fine.
-    op.create_check_constraint(
-        "valid_signup_allowlist_provider",
-        "signup_allowlist",
-        "provider IN ('github', 'google')",
+    #
+    # Wrapped in a DO block that catches ``duplicate_object`` so a partial-
+    # rerun under autocommit mode self-heals. PG has no native
+    # ``ADD CONSTRAINT IF NOT EXISTS`` for CHECK constraints.
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN "
+            "  ALTER TABLE signup_allowlist "
+            "    ADD CONSTRAINT valid_signup_allowlist_provider "
+            "    CHECK (provider IN ('github', 'google')); "
+            "EXCEPTION WHEN duplicate_object THEN NULL; "
+            "END $$"
+        )
     )
 
     # Step 4.5: belt-and-suspenders re-backfill. Step 2 caught the rows
@@ -206,15 +212,27 @@ def upgrade() -> None:
     # includes ``source`` for the same reason the old one did — a single
     # subject can legitimately have one ``manual`` row and one
     # ``github_sponsors`` row simultaneously.
-    op.create_unique_constraint(
-        "uq_allowlist_provider_subject_source",
-        "signup_allowlist",
-        ["provider", "subject_id", "source"],
+    #
+    # Both wrapped for idempotency (PR #657 Copilot loop 4 finding #3):
+    # UNIQUE goes through a ``DO $$ ... EXCEPTION WHEN duplicate_table``
+    # block because PG has no native ``ADD CONSTRAINT IF NOT EXISTS``
+    # for unique constraints. INDEX uses native ``CREATE INDEX IF NOT
+    # EXISTS`` which is the cleaner path.
+    op.execute(
+        sa.text(
+            "DO $$ BEGIN "
+            "  ALTER TABLE signup_allowlist "
+            "    ADD CONSTRAINT uq_allowlist_provider_subject_source "
+            "    UNIQUE (provider, subject_id, source); "
+            "EXCEPTION WHEN duplicate_table THEN NULL; "
+            "END $$"
+        )
     )
-    op.create_index(
-        "ix_signup_allowlist_provider_subject",
-        "signup_allowlist",
-        ["provider", "subject_id"],
+    op.execute(
+        sa.text(
+            "CREATE INDEX IF NOT EXISTS ix_signup_allowlist_provider_subject "
+            "ON signup_allowlist (provider, subject_id)"
+        )
     )
 
 

--- a/backend/alembic/versions/e14_655_signup_allowlist_provider.py
+++ b/backend/alembic/versions/e14_655_signup_allowlist_provider.py
@@ -154,18 +154,27 @@ def upgrade() -> None:
 
     # Step 4.5: belt-and-suspenders re-backfill. Step 2 caught the rows
     # that existed when the migration started; this catches any row that
-    # may have slipped in between Step 2 and now via the server_default
-    # path (e.g. a stray INSERT during a non-quiesced deploy window).
-    # Without this pass, a row inserted between Step 2 and Step 5 would
-    # land with subject_id='' from the now-dropped server_default,
-    # survive the NOT NULL check, and become a "ghost" row that the
-    # gate's (provider, subject_id) lookup can never match.
+    # may have slipped in via two paths:
+    #
+    # 1. Between Step 2 and Step 2.5: a stray INSERT during the deploy
+    #    window picked up the server_default sentinel ('') from Step 1.
+    # 2. **Between Step 2.5 and now**: after Step 2.5 drops the
+    #    server_default, an old-code INSERT that doesn't know about the
+    #    new columns lands them as NULL (column is still nullable until
+    #    Step 5). Without the NULL branch here, such a row would fail
+    #    Step 5's NOT NULL ALTER and abort the migration. (PR #657
+    #    Copilot loop 2 finding #3 — caught a real correctness bug in
+    #    the zero-downtime-deploy edge case.)
+    #
+    # Mirror Step 2's predicate exactly: ``subject_id IS NULL OR
+    # subject_id = ''`` (and same for subject_label) covers both shapes.
     conn.execute(
         sa.text(
             "UPDATE signup_allowlist "
             "SET subject_id = github_user_id, "
             "    subject_label = github_username "
-            "WHERE subject_id = '' OR subject_label = ''"
+            "WHERE subject_id IS NULL OR subject_id = '' "
+            "   OR subject_label IS NULL OR subject_label = ''"
         )
     )
 

--- a/backend/alembic/versions/e14_655_signup_allowlist_provider.py
+++ b/backend/alembic/versions/e14_655_signup_allowlist_provider.py
@@ -1,0 +1,244 @@
+"""Extend signup_allowlist to support Google OAuth (Issue #655).
+
+Phase 1 of the admin-configurable signup gate (#358) assumed Google's OAuth
+Consent Screen would gate signups via the test-users list. That assumption
+holds only for sensitive scopes — for ``openid``/``email``/``profile`` (what
+this app requests) Google in "Testing" status merely shows the "unverified
+app" warning and lets users click through. The 2026-05-15 production audit
+confirmed Google accounts outside the test-user list had completed OAuth.
+
+This migration extends the GitHub-only ``signup_allowlist`` schema with a
+provider dimension so the gate can match Google entries on the immutable
+OIDC ``sub`` claim. GitHub rows backfill cleanly (``provider='github'``,
+``subject_id=github_user_id``, ``subject_label=github_username``).
+
+The ``github_user_id``/``github_username`` columns stay NOT NULL during the
+migration window — physical drop is deferred to a future issue once all
+admin tooling has switched to the provider-aware columns.
+
+Backfilled data is NOT reversed on downgrade. The provider/subject_id/
+subject_label values remain populated if rows are re-created via downgrade
++ re-upgrade (DDL reverses; data is a one-way migration, matching the
+codebase convention from b03_396).
+
+**Deployment assumption**: this migration assumes the project's single-server
+deploy model (one ``kagura-api-green`` container per
+``.claude/rules/dev-environment.md``) where the API is briefly stopped while
+migrations apply. The transitional ``server_default`` on the three new
+columns plus the belt-and-suspenders re-UPDATE immediately before the Step 5
+NOT NULL tighten handle the case of a stray INSERT mid-migration (e.g. a
+manual restore-from-backup that left a transaction open, or a future
+zero-downtime deploy). In a true rolling deploy where new and old code
+serve INSERTs concurrently for an extended window, do NOT rely on this
+migration alone — coordinate by quiescing the admin allowlist API first.
+
+Revision ID: e14_655_signup_allowlist_provider
+Revises: e13_474_pricing_seeds
+
+NOTE: Revision IDs are capped at 32 chars because ``alembic_version.version_num``
+is VARCHAR(32) in this database (32 chars exact).
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e14_655_signup_allowlist_provider"
+down_revision = "e13_474_pricing_seeds"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add provider/subject_id/subject_label columns to signup_allowlist.
+
+    Phase 1 of #655. Existing rows are backfilled to ``provider='github'``,
+    ``subject_id`` from ``github_user_id``, ``subject_label`` from
+    ``github_username``. The new ``(provider, subject_id, source)`` UNIQUE
+    + ``(provider, subject_id)`` INDEX replace the GitHub-only versions.
+    """
+    conn = op.get_bind()
+
+    # Step 1: add all three columns NULLable with transitional server_defaults
+    # so any concurrent INSERT during the migration window (e.g. an old-code
+    # admin pod still serving the legacy GitHub allowlist API while a rolling
+    # deploy is in flight) lands with non-NULL values for the new columns
+    # and survives the Step 5 NOT NULL tightening.
+    #
+    # The transitional sentinels for subject_id/subject_label are dropped at
+    # the end of Step 2 (DROP DEFAULT) so post-migration INSERTs from new
+    # code must supply real values — the columns having a permanent default
+    # is exactly what we are NOT trying to bake in.
+    op.add_column(
+        "signup_allowlist",
+        sa.Column(
+            "provider",
+            sa.String(20),
+            nullable=True,
+            server_default=sa.text("'github'"),
+        ),
+    )
+    op.add_column(
+        "signup_allowlist",
+        sa.Column(
+            "subject_id",
+            sa.String(255),
+            nullable=True,
+            # Empty-string sentinel. Step 2's backfill overwrites both
+            # legacy NULL rows and any '' rows from the deploy window.
+            server_default=sa.text("''"),
+        ),
+    )
+    op.add_column(
+        "signup_allowlist",
+        sa.Column(
+            "subject_label",
+            sa.String(255),
+            nullable=True,
+            server_default=sa.text("''"),
+        ),
+    )
+
+    # Step 2: backfill from existing GitHub-only columns.
+    #
+    # Match on ``subject_id IS NULL OR subject_id = ''`` rather than the
+    # previous ``provider IS NULL`` — under the new server_default scheme,
+    # legacy rows have subject_id IS NULL while deploy-window inserts have
+    # subject_id = '' (and ALSO provider='github' from the server_default
+    # above). Both shapes need their subject_id / subject_label copied
+    # from the legacy github_user_id / github_username so Step 5's
+    # NOT NULL succeeds.
+    #
+    # signup_allowlist is admin-curated and small (single-digit to low-
+    # thousand rows in any realistic deployment); a single UPDATE inside
+    # the alembic transaction is the right shape — no chunking needed.
+    conn.execute(
+        sa.text(
+            "UPDATE signup_allowlist "
+            "SET provider = COALESCE(NULLIF(provider, ''), 'github'), "
+            "    subject_id = github_user_id, "
+            "    subject_label = github_username "
+            "WHERE subject_id IS NULL OR subject_id = ''"
+        )
+    )
+
+    # Step 2.5: drop the transitional server_defaults on subject_id /
+    # subject_label. From here on, INSERTs MUST supply real values — the
+    # empty-string sentinel was a deploy-window safety net only.
+    op.alter_column("signup_allowlist", "subject_id", server_default=None)
+    op.alter_column("signup_allowlist", "subject_label", server_default=None)
+
+    # Step 3: drop old UNIQUE + INDEX before tightening to NOT NULL, so the
+    # new constraints can sit on the new columns. ``type_="unique"`` on
+    # drop_constraint matches the codebase convention from a99 / b03.
+    op.drop_constraint(
+        "uq_allowlist_user_source",
+        "signup_allowlist",
+        type_="unique",
+    )
+    op.drop_index(
+        "ix_signup_allowlist_github_user_id",
+        table_name="signup_allowlist",
+    )
+
+    # Step 4: add CHECK constraint on provider. For this small table we
+    # don't need the NOT VALID + VALIDATE dance from b03 (which is for
+    # large tables where the scan would block writes); a direct ADD
+    # CONSTRAINT is fine.
+    op.create_check_constraint(
+        "valid_signup_allowlist_provider",
+        "signup_allowlist",
+        "provider IN ('github', 'google')",
+    )
+
+    # Step 4.5: belt-and-suspenders re-backfill. Step 2 caught the rows
+    # that existed when the migration started; this catches any row that
+    # may have slipped in between Step 2 and now via the server_default
+    # path (e.g. a stray INSERT during a non-quiesced deploy window).
+    # Without this pass, a row inserted between Step 2 and Step 5 would
+    # land with subject_id='' from the now-dropped server_default,
+    # survive the NOT NULL check, and become a "ghost" row that the
+    # gate's (provider, subject_id) lookup can never match.
+    conn.execute(
+        sa.text(
+            "UPDATE signup_allowlist "
+            "SET subject_id = github_user_id, "
+            "    subject_label = github_username "
+            "WHERE subject_id = '' OR subject_label = ''"
+        )
+    )
+
+    # Step 5: tighten the three new columns to NOT NULL. Safe now that
+    # backfill (Step 2 + Step 4.5) has populated every existing row.
+    op.alter_column("signup_allowlist", "provider", nullable=False)
+    op.alter_column("signup_allowlist", "subject_id", nullable=False)
+    op.alter_column("signup_allowlist", "subject_label", nullable=False)
+
+    # Step 6: new UNIQUE + INDEX on the provider-aware columns. The UNIQUE
+    # includes ``source`` for the same reason the old one did — a single
+    # subject can legitimately have one ``manual`` row and one
+    # ``github_sponsors`` row simultaneously.
+    op.create_unique_constraint(
+        "uq_allowlist_provider_subject_source",
+        "signup_allowlist",
+        ["provider", "subject_id", "source"],
+    )
+    op.create_index(
+        "ix_signup_allowlist_provider_subject",
+        "signup_allowlist",
+        ["provider", "subject_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop provider/subject_id/subject_label columns + restore old constraints.
+
+    The backfilled data (provider='github', subject_id, subject_label) is
+    NOT reversed — the columns themselves are dropped, so the values
+    vanish with them. This matches the codebase convention from b03_396
+    where DDL reverses but data backfill is treated as one-way.
+    """
+    # Reverse Step 6
+    op.drop_index(
+        "ix_signup_allowlist_provider_subject",
+        table_name="signup_allowlist",
+    )
+    op.drop_constraint(
+        "uq_allowlist_provider_subject_source",
+        "signup_allowlist",
+        type_="unique",
+    )
+
+    # Reverse Step 4 (CHECK on provider). ``IF EXISTS`` guards make the
+    # downgrade idempotent in case an earlier rollback already dropped it.
+    op.execute(
+        sa.text(
+            "ALTER TABLE signup_allowlist DROP CONSTRAINT IF EXISTS valid_signup_allowlist_provider"
+        )
+    )
+
+    # Reverse Step 5 (NOT NULL → nullable) before dropping columns. Some
+    # PG/SQLAlchemy combinations are picky about DROP COLUMN order with
+    # constraints attached, so loosen first.
+    op.alter_column("signup_allowlist", "subject_label", nullable=True)
+    op.alter_column("signup_allowlist", "subject_id", nullable=True)
+    op.alter_column("signup_allowlist", "provider", nullable=True)
+
+    # Reverse Step 3 (old UNIQUE + INDEX restored)
+    op.create_unique_constraint(
+        "uq_allowlist_user_source",
+        "signup_allowlist",
+        ["github_user_id", "source"],
+    )
+    op.create_index(
+        "ix_signup_allowlist_github_user_id",
+        "signup_allowlist",
+        ["github_user_id"],
+    )
+
+    # Reverse Step 1 (drop the three new columns; backfilled data NOT
+    # reversed — columns and their values are dropped together)
+    op.drop_column("signup_allowlist", "subject_label")
+    op.drop_column("signup_allowlist", "subject_id")
+    op.drop_column("signup_allowlist", "provider")

--- a/backend/alembic/versions/e14_655_signup_allowlist_provider.py
+++ b/backend/alembic/versions/e14_655_signup_allowlist_provider.py
@@ -32,11 +32,17 @@ zero-downtime deploy). In a true rolling deploy where new and old code
 serve INSERTs concurrently for an extended window, do NOT rely on this
 migration alone — coordinate by quiescing the admin allowlist API first.
 
-Revision ID: e14_655_signup_allowlist_provider
+Revision ID: e14_655_allowlist_provider
 Revises: e13_474_pricing_seeds
 
 NOTE: Revision IDs are capped at 32 chars because ``alembic_version.version_num``
-is VARCHAR(32) in this database (32 chars exact).
+is VARCHAR(32) in this database. The originally-drafted ID
+``e14_655_signup_allowlist_provider`` was 33 chars and would have failed the
+INSERT into ``alembic_version`` on ``alembic upgrade`` (asyncpg raises
+``StringDataRightTruncationError``; some backends silently truncate, which
+is worse — it leaves the DB in an unknown revision state). Shortened to
+``e14_655_allowlist_provider`` (26 chars). Caught by Copilot review loop
+on PR #657.
 """
 
 import sqlalchemy as sa
@@ -44,7 +50,7 @@ import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
-revision = "e14_655_signup_allowlist_provider"
+revision = "e14_655_allowlist_provider"
 down_revision = "e13_474_pricing_seeds"
 branch_labels = None
 depends_on = None
@@ -168,6 +174,18 @@ def upgrade() -> None:
     #
     # Mirror Step 2's predicate exactly: ``subject_id IS NULL OR
     # subject_id = ''`` (and same for subject_label) covers both shapes.
+    #
+    # ``provider`` is intentionally NOT in this WHERE clause. Unlike
+    # subject_id/subject_label whose server_default is dropped at Step
+    # 2.5, the server_default on ``provider`` ('github') persists through
+    # to the schema's permanent state — so any concurrent INSERT during
+    # the entire migration window picks up provider='github' from the
+    # default. The only path to provider IS NULL would be an explicit
+    # ``INSERT ... (provider) VALUES (NULL)``, which requires the writer
+    # to know about the new column — and any writer that does also
+    # supplies subject_id/subject_label explicitly (see
+    # ``add_to_allowlist_entry``). Old-code writers never name provider
+    # so the default fires unconditionally.
     conn.execute(
         sa.text(
             "UPDATE signup_allowlist "

--- a/backend/src/api/routes/admin_signup_gate.py
+++ b/backend/src/api/routes/admin_signup_gate.py
@@ -14,7 +14,7 @@ from uuid import UUID
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, status
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import AdminUser
@@ -127,6 +127,32 @@ class AllowlistAddRequest(BaseModel):
         # flows share one validation surface.
         pattern=r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$",
     )
+
+    @model_validator(mode="after")
+    def _enforce_provider_field_match(self) -> AllowlistAddRequest:
+        """Reject payloads where the supplied field doesn't match the provider.
+
+        Without this, an admin could pass ``{provider: "github", email: ...}``
+        and have the extra field silently ignored — an "add with extra data
+        success" surface that hides typos. We want the request to fail
+        explicitly with a 422 so the admin sees the mismatch (PR #657
+        Copilot review #3).
+        """
+        if self.provider == "github":
+            if self.email is not None:
+                raise ValueError(
+                    "email must not be set when provider='github'; use github_username instead"
+                )
+            if self.github_username is None:
+                raise ValueError("github_username is required when provider='github'")
+        else:  # provider == "google"
+            if self.github_username is not None:
+                raise ValueError(
+                    "github_username must not be set when provider='google'; use email instead"
+                )
+            if self.email is None:
+                raise ValueError("email is required when provider='google'")
+        return self
 
 
 # ============================================================================

--- a/backend/src/api/routes/admin_signup_gate.py
+++ b/backend/src/api/routes/admin_signup_gate.py
@@ -22,6 +22,7 @@ from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from services.signup_gate_service import SignupGateService
 from utils.github_user import GitHubUserNotFound
+from utils.google_user import GoogleUserNotFound, resolve_google_sub_by_email
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -59,7 +60,22 @@ class SignupGateConfigUpdate(BaseModel):
 
 
 class AllowlistEntryResponse(TZAwareBaseModel):
+    """Allowlist entry read-model.
+
+    #655 added ``provider`` / ``subject_id`` / ``subject_label`` as the
+    canonical fields. The legacy ``github_user_id`` / ``github_username``
+    fields are retained on the response for backward compatibility with
+    pre-#655 admin tooling — for ``provider='google'`` rows these carry
+    the sentinel values written by ``add_to_allowlist_entry``
+    (``"google:<sub>"`` / email), which existing GitHub-only consumers
+    can ignore via the new ``provider`` field.
+    """
+
     id: UUID
+    provider: str
+    subject_id: str
+    subject_label: str
+    # Legacy fields (deprecated #655, drop in a future migration).
     github_user_id: str
     github_username: str
     source: str
@@ -71,13 +87,45 @@ class AllowlistEntryResponse(TZAwareBaseModel):
 
 
 class AllowlistAddRequest(BaseModel):
-    # GitHub usernames are 1–39 chars, alphanumeric with hyphens, never at
-    # start/end. Enforce length + shape here so malformed payloads don't spend
-    # a GitHub API request (rate-limited to 60/hr unauthenticated).
-    github_username: str = Field(
+    """Allowlist add payload (provider-aware since #655).
+
+    Three accepted shapes:
+
+    * GitHub legacy (pre-#655): ``{github_username}`` — preserved verbatim
+      so existing admin tooling keeps working without a flag day.
+    * GitHub canonical: ``{provider: "github", github_username}`` — same
+      semantics, but with the discriminator explicit.
+    * Google: ``{provider: "google", email}`` — resolves the user's
+      OIDC ``sub`` by looking up an existing ``users`` row with
+      ``auth_provider='google'`` and matching email (v1 bootstrap UX —
+      pre-OAuth invitation lands in Phase 2).
+
+    Pydantic validates ``github_username`` shape when present (1–39 chars,
+    alphanumeric + hyphens, no leading/trailing hyphen) so malformed
+    payloads don't spend a GitHub API request (rate-limited to 60/hr
+    unauthenticated). The ``email`` field uses the same regex pattern
+    that the rest of the codebase uses for email-string validation
+    (see ``models/schemas.py:830``); switching to ``pydantic.EmailStr``
+    would require pulling in ``email-validator`` as a new dependency,
+    which is not warranted for a single field.
+    """
+
+    # Default provider keeps the pre-#655 ``{github_username}`` payload
+    # shape working (the discriminator was absent in v1).
+    provider: Literal["github", "google"] = "github"
+    github_username: str | None = Field(
+        default=None,
         min_length=1,
         max_length=39,
         pattern=r"^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$",
+    )
+    email: str | None = Field(
+        default=None,
+        max_length=255,
+        # Same shape as the InvitationCreateRequest email field
+        # (models/schemas.py:830) — kept identical so admin/invitation
+        # flows share one validation surface.
+        pattern=r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$",
     )
 
 
@@ -135,16 +183,53 @@ async def add_to_allowlist(
     user: AdminUser,
     db: AsyncSession = Depends(get_db),
 ) -> AllowlistEntryResponse:
+    """Add a GitHub or Google user to the manual allowlist (#655).
+
+    Provider is set explicitly via ``payload.provider`` (defaulting to
+    ``"github"`` for pre-#655 callers). The required field per provider:
+
+    * ``provider="github"`` → ``github_username`` (resolved to numeric ID
+      via the GitHub API).
+    * ``provider="google"`` → ``email`` (resolved to OIDC ``sub`` via the
+      local ``users`` table; the user must have OAuth'd at least once).
+    """
     svc = SignupGateService(db)
     try:
-        entry = await svc.add_to_allowlist(
-            github_username=payload.github_username,
-            added_by_user_id=user["user_id"],
-        )
+        if payload.provider == "github":
+            if not payload.github_username:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="github_username is required when provider='github'",
+                )
+            entry = await svc.add_to_allowlist(
+                github_username=payload.github_username,
+                added_by_user_id=user["user_id"],
+            )
+        else:  # provider == "google"
+            if not payload.email:
+                raise HTTPException(
+                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                    detail="email is required when provider='google'",
+                )
+            sub, canonical_email = await resolve_google_sub_by_email(payload.email, db)
+            entry = await svc.add_to_allowlist_entry(
+                provider="google",
+                subject_id=sub,
+                subject_label=canonical_email,
+                added_by_user_id=user["user_id"],
+            )
     except GitHubUserNotFound as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"GitHub user '{payload.github_username}' not found",
+        ) from exc
+    except GoogleUserNotFound as exc:
+        # Distinct from the GitHub 404: the user simply hasn't OAuth'd yet
+        # against this app, so we can't resolve their sub. Surface the
+        # bootstrap UX hint from the exception message verbatim.
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(exc),
         ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/backend/src/api/routes/admin_signup_gate.py
+++ b/backend/src/api/routes/admin_signup_gate.py
@@ -220,23 +220,24 @@ async def add_to_allowlist(
       local ``users`` table; the user must have OAuth'd at least once).
     """
     svc = SignupGateService(db)
+    # By the time the request reaches this handler, ``AllowlistAddRequest``'s
+    # ``_enforce_provider_field_match`` validator (defined in the schema
+    # above) has already rejected payloads missing the provider-specific
+    # required field with a 422 — so ``payload.github_username`` is
+    # guaranteed non-None when ``provider == "github"``, and ``payload.email``
+    # is guaranteed non-None when ``provider == "google"``. Asserts below
+    # narrow the types for the type checker without adding runtime cost
+    # (PR #657 Copilot loop 2 finding #4: keep validation centralized in
+    # the Pydantic validator, not duplicated as dead-code HTTPExceptions).
     try:
         if payload.provider == "github":
-            if not payload.github_username:
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail="github_username is required when provider='github'",
-                )
+            assert payload.github_username is not None  # validator guarantee
             entry = await svc.add_to_allowlist(
                 github_username=payload.github_username,
                 added_by_user_id=user["user_id"],
             )
         else:  # provider == "google"
-            if not payload.email:
-                raise HTTPException(
-                    status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-                    detail="email is required when provider='google'",
-                )
+            assert payload.email is not None  # validator guarantee
             sub, canonical_email = await resolve_google_sub_by_email(payload.email, db)
             entry = await svc.add_to_allowlist_entry(
                 provider="google",

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -472,16 +472,24 @@ async def google_callback(
         # 3. Get user info from Google
         user_info = _oauth2_manager.get_user_info_web(credentials)
 
-        # 3.5. Registration gate. Google's own OAuth + workspace configuration
-        # decides who can sign up via Google, so the backend gate passes
-        # through for provider="google" when admin-configurable mode is on;
-        # when off, delegates to _check_registration_allowed (Issue #349) just
-        # like the GitHub path. This keeps a single gate abstraction without
-        # layering a redundant backend allowlist on top of Google's own.
+        # 3.5. Registration gate. #655 removed the Google pass-through that
+        # #358 Phase 1 had — Google's "Testing" status does not enforce the
+        # test-users list for non-sensitive scopes (openid/email/profile),
+        # so the backend now gates Google uniformly with GitHub. Match is on
+        # the immutable OIDC `sub` claim; ip_address/user_agent are plumbed
+        # in so the audit_log row written on a blocked attempt has triage
+        # context (CSO gate1 D2).
         blocked = await check_signup_access(
             provider="google",
             oauth_sub=user_info["sub"],
             email=user_info["email"],
+            # Google has no GitHub-style "login" handle, so use the email
+            # as the display label. This is logged in audit_log
+            # user_metadata.subject_label and structlog only — never used
+            # for the allowlist match.
+            username=user_info["email"],
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("user-agent"),
         )
         if blocked:
             return blocked
@@ -915,11 +923,15 @@ async def github_callback(
 
         # 3.5. Registration gate: admin-configurable (Issue #358) with legacy
         # _check_registration_allowed delegation when disabled (Issue #349).
+        # #655 added ip_address/user_agent plumbing so the audit_log row
+        # written on a blocked attempt has triage context.
         blocked = await check_signup_access(
             provider="github",
             oauth_sub=user_info["sub"],
             email=user_info["email"],
             username=user_info.get("login"),
+            ip_address=request.client.host if request.client else None,
+            user_agent=request.headers.get("user-agent"),
         )
         if blocked:
             return blocked

--- a/backend/src/models/signup_gate.py
+++ b/backend/src/models/signup_gate.py
@@ -1,12 +1,19 @@
-"""Signup gate SQLAlchemy models (Issue #358).
+"""Signup gate SQLAlchemy models (Issue #358, extended in #655).
 
 Phase 1 of admin-configurable signup gate. The single-row
 ``signup_gate_config`` holds the runtime switch + mode; ``signup_allowlist``
-keys each allowed registrant on the immutable numeric ``github_user_id``
-(renames don't break the match).
+keys each allowed registrant on a stable, provider-specific immutable
+identifier (GitHub numeric ID, Google OIDC ``sub`` claim — neither changes
+when the user renames/changes email at the IdP).
 
 Sponsors-related columns on ``SignupGateConfig`` are reserved in Phase 1 and
 populated by Phase 2's GraphQL sync + webhook flow.
+
+#655 extended the allowlist to support Google entries via a ``provider`` /
+``subject_id`` / ``subject_label`` triplet that replaces the GitHub-only
+``github_user_id``/``github_username`` matching keys. The old columns are
+kept NOT NULL during the migration window (deprecated comment) — physical
+drop is deferred to a future issue.
 """
 
 import uuid
@@ -16,10 +23,12 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     DateTime,
+    Index,
     Integer,
     String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -73,9 +82,17 @@ class SignupGateConfig(Base):
 class SignupAllowlistEntry(Base):
     """A single entry on the signup allowlist.
 
-    Match is on ``github_user_id`` (immutable numeric ID), never on
-    ``github_username`` — GitHub usernames can be renamed and the rename
-    leaves an existing allowlist row pointing at the same person.
+    Matching key is the ``(provider, subject_id)`` pair. ``subject_id`` is
+    the immutable IdP-side identifier (GitHub numeric ID, Google OIDC ``sub``
+    claim) — never the username/email, which can change at the IdP without
+    breaking the match. ``subject_label`` is a display-only snapshot taken
+    at allowlist-add time; it is NEVER used for matching.
+
+    Migration window note (#655): ``github_user_id``/``github_username`` are
+    kept NOT NULL alongside the new provider-aware columns so the existing
+    GitHub admin-API path (``add_to_allowlist(github_username=...)``) can
+    continue to populate them without DDL churn. Physical drop is deferred
+    to a future issue once all admin tooling has switched to ``subject_id``.
     """
 
     __tablename__ = "signup_allowlist"
@@ -85,8 +102,32 @@ class SignupAllowlistEntry(Base):
         primary_key=True,
         server_default=func.gen_random_uuid(),
     )
-    github_user_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
+    # --- Provider-aware matching keys (#655) ---
+    # ``provider`` widens the natural key from (github_user_id, source) to
+    # (provider, subject_id, source). server_default lets existing GitHub
+    # admin tooling INSERT without specifying provider explicitly.
+    provider: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        server_default=text("'github'"),
+    )
+    # ``subject_id`` holds the immutable IdP identity: numeric GitHub user
+    # ID for github rows, OIDC ``sub`` claim for google rows. Sized 255 to
+    # accommodate either (GitHub IDs are <10 digits, Google subs are ~21
+    # digits, plus headroom for any future provider quirks).
+    subject_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    # ``subject_label`` is display-only: GitHub login for github rows,
+    # email for google rows. NEVER used for the allowlist match — matching
+    # on a mutable IdP field would re-open the email-change attack the
+    # provider-aware design was added to close.
+    subject_label: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # --- Legacy GitHub-only columns (deprecated #655, retained NOT NULL
+    # during the migration window so existing admin paths still write them
+    # alongside the new provider-aware columns; physical drop deferred) ---
+    github_user_id: Mapped[str] = mapped_column(String(64), nullable=False)
     github_username: Mapped[str] = mapped_column(String(255), nullable=False)
+
     source: Mapped[str] = mapped_column(String(32), nullable=False, server_default="manual")
     state: Mapped[str] = mapped_column(String(16), nullable=False, server_default="active")
     added_by_user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -105,6 +146,10 @@ class SignupAllowlistEntry(Base):
 
     __table_args__ = (
         CheckConstraint(
+            "provider IN ('github', 'google')",
+            name="valid_signup_allowlist_provider",
+        ),
+        CheckConstraint(
             "source IN ('manual', 'github_sponsors')",
             name="valid_signup_allowlist_source",
         ),
@@ -112,8 +157,19 @@ class SignupAllowlistEntry(Base):
             "state IN ('active', 'grace', 'revoked')",
             name="valid_signup_allowlist_state",
         ),
-        # Same GitHub user can legitimately sit in both `manual` and
-        # `github_sponsors` sources simultaneously (admin whitelisted them AND
-        # they later became a sponsor). (github_user_id, source) is the key.
-        UniqueConstraint("github_user_id", "source", name="uq_allowlist_user_source"),
+        # A single subject can legitimately sit in both ``manual`` and
+        # ``github_sponsors`` sources simultaneously (admin whitelisted them
+        # AND they later became a sponsor). (provider, subject_id, source)
+        # is the natural key in the post-#655 model.
+        UniqueConstraint(
+            "provider",
+            "subject_id",
+            "source",
+            name="uq_allowlist_provider_subject_source",
+        ),
+        Index(
+            "ix_signup_allowlist_provider_subject",
+            "provider",
+            "subject_id",
+        ),
     )

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -518,6 +518,18 @@ class SignupGateService:
         decision; an audit-write failure should never escalate into a
         callback 500 for the user being blocked. The structlog warn line
         below preserves observability of audit-write failures.
+
+        Session commit invariant (PR #657 Copilot loop 2 finding #7): this
+        method calls ``await self.db.commit()`` on the session that
+        ``check_signup_access`` borrowed from ``get_db()``. The gate runs
+        as step 3.5 of the OAuth callback — BEFORE any other DB mutation
+        (``ensure_user`` and downstream writes happen at step 4, only when
+        the gate passes). So at gate-time the session has no other pending
+        writes and the early commit can only flush the AuditLog row we
+        just added. **If a future refactor moves DB work in front of the
+        gate, switch this to ``async with self.db.begin_nested():`` to
+        scope the audit write to a SAVEPOINT** rather than committing the
+        outer transaction.
         """
         logger.info(
             "signup_blocked",

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -274,11 +274,19 @@ class SignupGateService:
         """
         # Sentinel values for the deprecated legacy columns when the row is
         # for a non-GitHub provider. The legacy columns stay NOT NULL during
-        # the migration window (#655), so we MUST write something. Using a
-        # prefixed/echoed sentinel keeps the deprecated columns unique per
-        # row (no spurious unique-index collisions on the old constraint
-        # *if* a future revert reintroduces it) and makes the source of the
-        # value obvious to anyone querying the table mid-migration.
+        # the migration window (#655), so we MUST write something. The
+        # ``<provider>:<subject_id>`` format is chosen deliberately:
+        #
+        # - GitHub real values are pure numeric strings (no colons), so the
+        #   prefixed sentinel cannot accidentally collide with a real GitHub
+        #   numeric ID. Even if the e14 downgrade-then-upgrade cycle restored
+        #   the old (github_user_id, source) UNIQUE constraint, two rows for
+        #   the same (provider="google", sub) would still collide via the
+        #   sentinel — which is the SAME failure mode as the new (provider,
+        #   subject_id, source) UNIQUE, so the legacy constraint enforcing
+        #   uniqueness on the sentinel is a feature, not a bug.
+        # - The colon prefix makes the value's origin obvious to anyone
+        #   spot-querying the table during the migration window.
         if provider == "github":
             if github_user_id is None or github_username is None:
                 raise ValueError(

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -1,4 +1,4 @@
-"""Admin-configurable signup gate service (Issue #358 Phase 1).
+"""Admin-configurable signup gate service (Issue #358 Phase 1, extended #655).
 
 Sits in front of the OAuth callback's user-creation step. When the gate is
 disabled (default OSS behavior), delegates to the existing env-based
@@ -6,10 +6,18 @@ disabled (default OSS behavior), delegates to the existing env-based
 don't need allowlists. When enabled, applies the configured mode — Phase 1
 implements ``manual`` only; ``github_sponsors`` / ``both`` raise
 NotImplementedError and are covered by the Phase 2 follow-up issue.
+
+#655 removed the Google pass-through that #358 Phase 1 had as a temporary
+trust-Google's-test-users-list contract; Google's "Testing" status does not
+enforce that list for non-sensitive scopes, so the gate now applies
+provider-uniformly. Both providers match on the immutable IdP identity
+(``provider`` + ``subject_id``) — GitHub numeric ID for github rows, OIDC
+``sub`` claim for google rows. Email is never used for matching to keep
+email-change attacks closed.
 """
 
 import os
-from typing import Literal
+from typing import Literal, cast
 from uuid import UUID
 
 from fastapi.responses import RedirectResponse
@@ -17,23 +25,29 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.roles import _OAUTH_CALLBACK_ACTOR
+from config.settings import get_settings
 from db.base import get_db
-from models.auth import User
+from models.auth import AuditLog, User
 from models.signup_gate import SignupAllowlistEntry, SignupGateConfig
 from utils.github_user import resolve_github_user_id
+from utils.hashing import hmac_sha256_hex
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
 SignupGateMode = Literal["manual", "github_sponsors", "both"]
+SignupGateProvider = Literal["github", "google"]
 
 
 async def check_signup_access(
     *,
-    provider: Literal["github", "google"],
+    provider: SignupGateProvider,
     oauth_sub: str,
     email: str,
     username: str | None = None,
+    ip_address: str | None = None,
+    user_agent: str | None = None,
 ) -> RedirectResponse | None:
     """Run the signup gate for an OAuth callback.
 
@@ -42,7 +56,23 @@ async def check_signup_access(
     the ``async for db in get_db()`` boilerplate and the inline service
     import (which exists to break a circular dependency with auth.py).
 
-    Returns None when signup is allowed, a RedirectResponse when blocked.
+    Args:
+        provider: OAuth provider (``"github"`` or ``"google"``).
+        oauth_sub: Immutable IdP identity — GitHub numeric ID (as string)
+            for github, OIDC ``sub`` claim for google. Matched verbatim
+            against ``signup_allowlist.subject_id``.
+        email: Candidate signup email. Used only for the existing-user /
+            legacy-gate paths; never for allowlist matching.
+        username: Display label (GitHub login for github, email for google).
+            Stored in ``audit_logs.user_metadata`` and structlog only; not
+            a matching key.
+        ip_address: Caller IP, passed into the audit row for blocked-signup
+            events (#655). Optional — None when called from a non-HTTP
+            context.
+        user_agent: Caller User-Agent header, same role as ``ip_address``.
+
+    Returns:
+        None when signup is allowed, a RedirectResponse when blocked.
     """
     async for db in get_db():
         gate = SignupGateService(db)
@@ -51,6 +81,8 @@ async def check_signup_access(
             oauth_sub=oauth_sub,
             email=email,
             username=username,
+            ip_address=ip_address,
+            user_agent=user_agent,
         )
     return None
 
@@ -68,36 +100,37 @@ class SignupGateService:
     async def check_access(
         self,
         *,
-        provider: Literal["github", "google"],
+        provider: SignupGateProvider,
         oauth_sub: str,
         email: str,
         username: str | None,
+        ip_address: str | None = None,
+        user_agent: str | None = None,
     ) -> RedirectResponse | None:
         """Return None when signup is allowed, RedirectResponse when blocked.
 
-        Phase 1 rules (top-down):
+        Rules (top-down, applied uniformly across both providers since #655):
         1. ``enabled=false`` → delegate to legacy env-based gate (OSS path).
-        2. ``provider == "google"`` → pass through (Google-side controls signup;
-           backend is a no-op for Google in Phase 1).
-        3. Existing user (users row matching this email or user_id/sub) → allowed
+        2. Existing user (users row matching this email or user_id/sub) → allowed
            (login not signup; user_id match handles email-change-at-IdP case).
-        4. First user (users table empty) → allowed (initial admin bootstrap).
-        5. ``mode == "manual"`` → allowed iff ``github_user_id`` is on the
-           allowlist with ``state='active'``.
-        6. ``mode in ("github_sponsors", "both")`` → NotImplementedError
-           (Phase 2).
+        3. First user (users table empty) → allowed (initial admin bootstrap).
+        4. ``mode == "manual"`` → allowed iff ``(provider, subject_id=oauth_sub)``
+           is on the allowlist with ``state='active'``.
+        5. ``mode in ("github_sponsors", "both")`` → NotImplementedError when
+           provider is ``"github"`` (Phase 2 work). When provider is
+           ``"google"`` these modes fall back to manual semantics (sponsorship
+           is GitHub-specific; #655 docs this).
         """
         config = await self._load_config()
 
         if not config.enabled:
             return await self._legacy_check(email, oauth_sub)
 
-        # Google's own OAuth + workspace configuration decides who can sign up
-        # on that side — having two places (backend allowlist + Google console)
-        # gate the same flow would just confuse admins. Backend stays neutral
-        # for provider=google in Phase 1.
-        if provider == "google":
-            return None
+        # #655: the historical Google pass-through is removed. Google's
+        # "Testing" status does NOT enforce the test-users list for
+        # non-sensitive scopes — the warning screen is click-through. The
+        # gate now applies uniformly to both providers, matching on the
+        # immutable IdP identity (subject_id).
 
         if await self._is_existing_user(email, oauth_sub):
             return None
@@ -105,26 +138,53 @@ class SignupGateService:
         if await self._is_first_user():
             return None
 
-        if config.mode == "manual":
-            if await self._is_allowlisted(oauth_sub, config.mode):
+        # Validate the mode against the Literal allow-list before narrowing.
+        # The DB has a CHECK constraint that pins ``mode`` to the same set,
+        # but admins with DB access can disable CHECK constraints, and a
+        # corrupted row would otherwise fall through to the NotImplementedError
+        # at the bottom of this function with a misleading "reserved for
+        # Phase 2" message. Raising here surfaces the actual problem.
+        if config.mode not in ("manual", "github_sponsors", "both"):
+            raise ValueError(
+                f"unknown signup_gate_config.mode value: {config.mode!r} "
+                f"(expected one of: manual, github_sponsors, both)"
+            )
+        # Pyright can't narrow ``Mapped[str]`` through the ``in`` check
+        # above, but the runtime guard means the cast is safe here.
+        effective_mode: SignupGateMode = cast(SignupGateMode, config.mode)
+
+        # #655: sponsors-style modes only apply to GitHub; for Google fall
+        # back to manual semantics (a Google user is never a "GitHub
+        # Sponsor"). Document the fallback explicitly so a future admin
+        # reading the gate logic isn't surprised by why mode='github_sponsors'
+        # only checks the manual allowlist for Google.
+        if provider == "google" and effective_mode in ("github_sponsors", "both"):
+            effective_mode = "manual"
+
+        if effective_mode == "manual":
+            if await self._is_allowlisted(provider, oauth_sub, effective_mode):
                 return None
-            logger.info(
-                "signup_blocked",
+            await self._record_blocked_signup(
                 provider=provider,
-                github_user_id=oauth_sub,
+                oauth_sub=oauth_sub,
+                email=email,
                 username=username,
+                ip_address=ip_address,
+                user_agent=user_agent,
             )
-            return self._blocked_response()
+            return self._blocked_response(provider=provider, oauth_sub=oauth_sub)
 
-        if config.mode in ("github_sponsors", "both"):
-            raise NotImplementedError(
-                f"Signup gate mode '{config.mode}' is reserved for Phase 2 "
-                "(Issue #358 follow-up). In Phase 1 the admin UI disables "
-                "selecting these modes; reaching this branch indicates a "
-                "direct DB edit."
-            )
-
-        return self._blocked_response()
+        # Reached only for provider="github" + mode in ("github_sponsors",
+        # "both") since the Google fallback above coerced those modes to
+        # "manual", and "manual" itself returned in the block above. With
+        # SignupGateMode being a 3-value Literal, this branch is the
+        # exhaustive remainder — there is no trailing-fallback return.
+        raise NotImplementedError(
+            f"Signup gate mode '{effective_mode}' is reserved for Phase 2 "
+            "(Issue #358 follow-up). In Phase 1 the admin UI disables "
+            "selecting these modes; reaching this branch indicates a "
+            "direct DB edit."
+        )
 
     # ------------------------------------------------------------------
     # Admin: config
@@ -154,26 +214,100 @@ class SignupGateService:
     async def add_to_allowlist(
         self, *, github_username: str, added_by_user_id: str
     ) -> SignupAllowlistEntry:
-        """Resolve username to canonical ID via GitHub API and insert.
+        """Resolve a GitHub username to canonical ID via GitHub API and insert.
+
+        Legacy single-provider entry point kept for backward compatibility
+        with the existing admin HTTP API. New callers should prefer
+        :meth:`add_to_allowlist_entry` which is provider-aware.
 
         Raises:
             GitHubUserNotFound: The username does not exist on GitHub.
-            ValueError: The (github_user_id, source='manual') pair already exists.
+            ValueError: The (provider='github', subject_id, source='manual')
+                triple already exists.
         """
         user_id, canonical_login = await resolve_github_user_id(github_username)
+        return await self.add_to_allowlist_entry(
+            provider="github",
+            subject_id=user_id,
+            subject_label=canonical_login,
+            added_by_user_id=added_by_user_id,
+            # Backward-compat: legacy column writes too. These shadow the
+            # provider/subject_id pair for the GitHub case so the
+            # deprecated columns remain populated for existing tooling
+            # until they get physically dropped.
+            github_user_id=user_id,
+            github_username=canonical_login,
+        )
+
+    async def add_to_allowlist_entry(
+        self,
+        *,
+        provider: SignupGateProvider,
+        subject_id: str,
+        subject_label: str,
+        added_by_user_id: str,
+        github_user_id: str | None = None,
+        github_username: str | None = None,
+    ) -> SignupAllowlistEntry:
+        """Insert a provider-aware allowlist entry.
+
+        Args:
+            provider: ``"github"`` or ``"google"``.
+            subject_id: Immutable IdP identity (GitHub numeric ID or Google
+                OIDC ``sub``). Stored in ``signup_allowlist.subject_id``
+                and used as the matching key.
+            subject_label: Display label (GitHub login or email). Snapshot
+                taken at add time; NOT used for matching.
+            added_by_user_id: Admin user_id (auth subject) doing the add.
+            github_user_id / github_username: Legacy column writes for the
+                GitHub case. When ``provider == "github"``, both MUST be
+                provided (the legacy columns are still NOT NULL during the
+                migration window). When ``provider == "google"``, both
+                are populated with sentinel values (``"google:<sub>"`` /
+                ``"<email>"``) since the columns remain NOT NULL until a
+                future migration drops them.
+
+        Raises:
+            ValueError: The (provider, subject_id, source='manual') triple
+                already exists.
+        """
+        # Sentinel values for the deprecated legacy columns when the row is
+        # for a non-GitHub provider. The legacy columns stay NOT NULL during
+        # the migration window (#655), so we MUST write something. Using a
+        # prefixed/echoed sentinel keeps the deprecated columns unique per
+        # row (no spurious unique-index collisions on the old constraint
+        # *if* a future revert reintroduces it) and makes the source of the
+        # value obvious to anyone querying the table mid-migration.
+        if provider == "github":
+            if github_user_id is None or github_username is None:
+                raise ValueError(
+                    "github_user_id and github_username are required when "
+                    "provider='github' (legacy columns are still NOT NULL)"
+                )
+            legacy_user_id = github_user_id
+            legacy_username = github_username
+        else:
+            legacy_user_id = f"{provider}:{subject_id}"
+            legacy_username = subject_label
 
         existing = await self.db.execute(
             select(SignupAllowlistEntry).where(
-                SignupAllowlistEntry.github_user_id == user_id,
+                SignupAllowlistEntry.provider == provider,
+                SignupAllowlistEntry.subject_id == subject_id,
                 SignupAllowlistEntry.source == "manual",
             )
         )
         if existing.scalar_one_or_none() is not None:
-            raise ValueError(f"User '{canonical_login}' is already on the manual allowlist")
+            raise ValueError(
+                f"{provider} subject '{subject_label}' is already on the manual allowlist"
+            )
 
         entry = SignupAllowlistEntry(
-            github_user_id=user_id,
-            github_username=canonical_login,
+            provider=provider,
+            subject_id=subject_id,
+            subject_label=subject_label,
+            github_user_id=legacy_user_id,
+            github_username=legacy_username,
             source="manual",
             state="active",
             added_by_user_id=added_by_user_id,
@@ -188,13 +322,14 @@ class SignupGateService:
             # consistent "duplicate" signal instead of a 500.
             await self.db.rollback()
             raise ValueError(
-                f"User '{canonical_login}' is already on the manual allowlist"
+                f"{provider} subject '{subject_label}' is already on the manual allowlist"
             ) from exc
         await self.db.refresh(entry)
         logger.info(
             "signup_allowlist_added",
-            github_username=canonical_login,
-            github_user_id=user_id,
+            provider=provider,
+            subject_id=subject_id,
+            subject_label=subject_label,
             added_by=added_by_user_id,
         )
         return entry
@@ -203,10 +338,20 @@ class SignupGateService:
         entry = await self.db.get(SignupAllowlistEntry, entry_id)
         if entry is None:
             raise ValueError(f"Allowlist entry {entry_id} not found")
-        username = entry.github_username
+        # Snapshot provider-aware fields before deletion so the log line
+        # survives the cascade. ``subject_label`` is the user-facing
+        # identifier post-#655 (GitHub login or email).
+        provider = entry.provider
+        subject_id = entry.subject_id
+        subject_label = entry.subject_label
         await self.db.delete(entry)
         await self.db.commit()
-        logger.info("signup_allowlist_removed", github_username=username)
+        logger.info(
+            "signup_allowlist_removed",
+            provider=provider,
+            subject_id=subject_id,
+            subject_label=subject_label,
+        )
 
     # ------------------------------------------------------------------
     # Internals
@@ -263,13 +408,20 @@ class SignupGateService:
         result = await self.db.execute(select(func.count()).select_from(User))
         return (result.scalar() or 0) == 0
 
-    async def _is_allowlisted(self, github_user_id: str, mode: SignupGateMode) -> bool:
+    async def _is_allowlisted(
+        self,
+        provider: SignupGateProvider,
+        subject_id: str,
+        mode: SignupGateMode,
+    ) -> bool:
         # Filter by source so mode='manual' doesn't silently accept a
         # sponsor-only row in Phase 2, and mode='github_sponsors' doesn't
         # silently accept a manually-added row — i.e. keep 'manual' and 'both'
         # semantically distinct. mode='both' omits the source filter by design.
+        # #655: match key is (provider, subject_id), not github_user_id alone.
         filters = [
-            SignupAllowlistEntry.github_user_id == github_user_id,
+            SignupAllowlistEntry.provider == provider,
+            SignupAllowlistEntry.subject_id == subject_id,
             SignupAllowlistEntry.state == "active",
         ]
         if mode == "manual":
@@ -278,9 +430,10 @@ class SignupGateService:
             filters.append(SignupAllowlistEntry.source == "github_sponsors")
         # mode == "both" → no source filter
 
-        # A GitHub user can have multiple rows (one per source), so
-        # scalar_one_or_none would raise MultipleResultsFound when mode='both'
-        # matches two rows. first() returns whichever active row hits first.
+        # A single (provider, subject_id) can have multiple rows (one per
+        # source), so scalar_one_or_none would raise MultipleResultsFound
+        # when mode='both' matches two rows. first() returns whichever
+        # active row hits first.
         result = await self.db.execute(select(SignupAllowlistEntry.id).where(*filters).limit(1))
         return result.first() is not None
 
@@ -296,6 +449,95 @@ class SignupGateService:
 
         return await _check_registration_allowed(email, self.db, user_id=user_id)
 
-    def _blocked_response(self) -> RedirectResponse:
+    def _blocked_response(
+        self,
+        *,
+        provider: SignupGateProvider | None = None,
+        oauth_sub: str | None = None,
+    ) -> RedirectResponse:
+        """Build the blocked-signup redirect.
+
+        #655: query params carry provider + first 8 chars of the OIDC sub
+        so the frontend ``/signup-blocked`` page can surface "show this to
+        the admin and they'll grant access" guidance without leaking the
+        full immutable identity. ``oauth_sub`` is sliced to 8 chars (cf.
+        Git short-SHA convention) — enough for an admin to disambiguate
+        between blocked attempts when correlating with the audit_log row
+        they share a request with, but short enough to be uncomfortable as
+        a leaked tracking handle on its own.
+
+        ``provider`` / ``oauth_sub`` are intentionally optional so the
+        function can still be called without context (e.g. a defensive
+        terminal-branch in :meth:`check_access`).
+        """
         frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
-        return RedirectResponse(f"{frontend_url}/signup-blocked", status_code=303)
+        params: list[str] = []
+        if provider is not None:
+            params.append(f"provider={provider}")
+        if oauth_sub:
+            params.append(f"sub={oauth_sub[:8]}")
+        suffix = ("?" + "&".join(params)) if params else ""
+        return RedirectResponse(f"{frontend_url}/signup-blocked{suffix}", status_code=303)
+
+    async def _record_blocked_signup(
+        self,
+        *,
+        provider: SignupGateProvider,
+        oauth_sub: str,
+        email: str,
+        username: str | None,
+        ip_address: str | None,
+        user_agent: str | None,
+    ) -> None:
+        """Record a blocked signup attempt to structlog AND audit_logs.
+
+        #655 (CSO gate1 D2): without a durable trail in ``audit_logs``,
+        admins cannot triage who tried to sign up after the fact — only
+        live structlog tails can. The audit row keeps the email HMAC'd
+        (never plaintext, matching the convention from
+        ``RoleManager._sync_existing_user``) and pins the IdP identity by
+        ``user_id`` so a future cleanup workflow can correlate the
+        blocked attempt with the eventual allowlist add.
+
+        Failures inside this method are swallowed deliberately. The
+        gate's primary responsibility is correctness of the block
+        decision; an audit-write failure should never escalate into a
+        callback 500 for the user being blocked.
+        """
+        logger.info(
+            "signup_blocked",
+            provider=provider,
+            subject_id=oauth_sub,
+            username=username,
+        )
+
+        try:
+            hmac_key = get_settings().audit_hmac_key
+            audit = AuditLog(
+                user_email=_OAUTH_CALLBACK_ACTOR,
+                user_id=oauth_sub,
+                action="signup_blocked",
+                resource=f"signup_gate:{provider}",
+                new_value_hash=hmac_sha256_hex(email, hmac_key),
+                user_metadata={
+                    "provider": provider,
+                    "subject_label": username,
+                },
+                ip_address=ip_address,
+                user_agent=user_agent,
+            )
+            self.db.add(audit)
+            await self.db.commit()
+        except Exception as exc:  # pragma: no cover — defensive; logged below
+            # Roll the failed audit out of the session so a later commit
+            # on this session doesn't trip over it.
+            try:
+                await self.db.rollback()
+            except Exception:
+                pass
+            logger.warning(
+                "signup_blocked_audit_failed",
+                provider=provider,
+                subject_id=oauth_sub,
+                error=str(exc),
+            )

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -18,6 +18,7 @@ email-change attacks closed.
 
 import os
 from typing import Literal, cast
+from urllib.parse import urlencode
 from uuid import UUID
 
 from fastapi.responses import RedirectResponse
@@ -470,13 +471,18 @@ class SignupGateService:
         function can still be called without context (e.g. a defensive
         terminal-branch in :meth:`check_access`).
         """
+        # Use urllib.parse.urlencode for correctness-by-default. Today both
+        # ``provider`` (Literal) and the GitHub/Google ``oauth_sub`` prefix
+        # are URL-safe, but a future provider whose ``sub`` could include
+        # ``&`` / ``#`` / ``+`` / non-ASCII would silently corrupt the URL
+        # if we hand-concatenated (Copilot review #5 on PR #657).
         frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
-        params: list[str] = []
+        params: dict[str, str] = {}
         if provider is not None:
-            params.append(f"provider={provider}")
+            params["provider"] = provider
         if oauth_sub:
-            params.append(f"sub={oauth_sub[:8]}")
-        suffix = ("?" + "&".join(params)) if params else ""
+            params["sub"] = oauth_sub[:8]
+        suffix = ("?" + urlencode(params)) if params else ""
         return RedirectResponse(f"{frontend_url}/signup-blocked{suffix}", status_code=303)
 
     async def _record_blocked_signup(
@@ -499,10 +505,19 @@ class SignupGateService:
         ``user_id`` so a future cleanup workflow can correlate the
         blocked attempt with the eventual allowlist add.
 
+        ``user_metadata`` deliberately stores only the provider type — never
+        the email or any other PII. The HMAC in ``new_value_hash`` is the
+        canonical email reference for an audit reader; storing the plaintext
+        email in metadata too would defeat that design intent and contradict
+        the ``auth/roles.py`` precedent (PR #657 CSO finding #1). For admin
+        triage, correlate ``user_id`` (immutable OIDC sub) + ``created_at``
+        + ``new_value_hash`` against the live OAuth flow.
+
         Failures inside this method are swallowed deliberately. The
         gate's primary responsibility is correctness of the block
         decision; an audit-write failure should never escalate into a
-        callback 500 for the user being blocked.
+        callback 500 for the user being blocked. The structlog warn line
+        below preserves observability of audit-write failures.
         """
         logger.info(
             "signup_blocked",
@@ -519,22 +534,29 @@ class SignupGateService:
                 action="signup_blocked",
                 resource=f"signup_gate:{provider}",
                 new_value_hash=hmac_sha256_hex(email, hmac_key),
-                user_metadata={
-                    "provider": provider,
-                    "subject_label": username,
-                },
+                # Provider type only — see docstring on PII rationale.
+                user_metadata={"provider": provider},
                 ip_address=ip_address,
                 user_agent=user_agent,
             )
             self.db.add(audit)
             await self.db.commit()
-        except Exception as exc:  # pragma: no cover — defensive; logged below
+        except Exception as exc:
             # Roll the failed audit out of the session so a later commit
-            # on this session doesn't trip over it.
+            # on this session doesn't trip over it. The rollback itself
+            # may fail (e.g. connection already torn down by the same
+            # error that broke commit) — that's expected and not
+            # actionable here; debug-log it so the rare case is still
+            # observable without bloating production logs.
             try:
                 await self.db.rollback()
-            except Exception:
-                pass
+            except Exception as rollback_exc:
+                logger.debug(
+                    "signup_blocked_rollback_failed",
+                    provider=provider,
+                    subject_id=oauth_sub,
+                    error=str(rollback_exc),
+                )
             logger.warning(
                 "signup_blocked_audit_failed",
                 provider=provider,

--- a/backend/src/utils/google_user.py
+++ b/backend/src/utils/google_user.py
@@ -1,0 +1,74 @@
+"""Google user resolution helpers (Issue #655).
+
+Companion to :mod:`utils.github_user`. Where GitHub's helper hits the
+public GitHub API to map ``username → numeric ID``, Google has no
+equivalent: the OIDC ``sub`` claim is opaque and there is no public
+``email → sub`` lookup endpoint that doesn't require admin SDK access to
+a Google Workspace.
+
+For v1 of the Google signup-gate work we resolve subs by querying our own
+``users`` table — i.e. an admin can only add a Google user to the
+allowlist *after* that user has OAuth'd at least once, because the
+allowlist needs the immutable ``sub`` for matching. That's an accepted
+bootstrap UX gap (issue #655 Out of Scope: "Pre-OAuth invitation (email-
+only allowlist entry, sub filled at first callback). Phase 2.").
+
+Why not match on email in the allowlist itself? Because email is mutable
+at the IdP — a match-on-email allowlist re-opens the email-change attack
+that the provider-aware ``subject_id`` design was added to close.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import User
+
+
+class GoogleUserNotFound(Exception):
+    """Raised when an email has no matching Google-authenticated user.
+
+    Mirrors :class:`utils.github_user.GitHubUserNotFound` so admin API
+    handlers can map both to a 404 response uniformly.
+    """
+
+
+async def resolve_google_sub_by_email(email: str, db: AsyncSession) -> tuple[str, str]:
+    """Find the Google OIDC ``sub`` for an email already present in ``users``.
+
+    Args:
+        email: Candidate email. Case-insensitive match against
+            ``users.email`` (which is stored case-sensitively but treated
+            as canonical lowercase by the OAuth callback flow).
+        db: Active async DB session.
+
+    Returns:
+        ``(sub, email)`` tuple. ``sub`` is the immutable OIDC identifier
+        suitable for ``signup_allowlist.subject_id``; ``email`` is the
+        canonical row email (in case the caller wants to mirror the
+        ``users``-side casing).
+
+    Raises:
+        GoogleUserNotFound: No ``users`` row matches ``email`` AND
+            ``auth_provider='google'``.
+    """
+    # Case-insensitive match — emails landing via Google OIDC are
+    # lowercase per Google's userinfo response, but the canonical
+    # storage isn't enforced, so the match needs to forgive case drift.
+    result = await db.execute(
+        select(User.user_id, User.email)
+        .where(User.auth_provider == "google")
+        .where(User.email.ilike(email))
+        .limit(1)
+    )
+    row = result.first()
+    if row is None:
+        raise GoogleUserNotFound(
+            f"No Google-authenticated user found with email '{email}'. "
+            "The user must complete Google OAuth at least once before they "
+            "can be added to the allowlist (Phase 2 will add pre-OAuth "
+            "invitation by email)."
+        )
+    sub, canonical_email = row
+    return sub, canonical_email

--- a/backend/src/utils/google_user.py
+++ b/backend/src/utils/google_user.py
@@ -20,7 +20,7 @@ that the provider-aware ``subject_id`` design was added to close.
 
 from __future__ import annotations
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import User
@@ -56,10 +56,17 @@ async def resolve_google_sub_by_email(email: str, db: AsyncSession) -> tuple[str
     # Case-insensitive match — emails landing via Google OIDC are
     # lowercase per Google's userinfo response, but the canonical
     # storage isn't enforced, so the match needs to forgive case drift.
+    #
+    # Use ``func.lower(...) == lower(email)`` rather than ``email.ilike(...)``
+    # so that ``%`` and ``_`` in an admin-supplied email (RFC 5321 permits
+    # both in the local part) are treated as literal characters, not as SQL
+    # LIKE wildcards. PR #657 Copilot review / CSO finding #2: with `ilike`,
+    # ``a%@example.com`` would over-match any Google user matching the
+    # surrounding pattern and silently allowlist the wrong account.
     result = await db.execute(
         select(User.user_id, User.email)
         .where(User.auth_provider == "google")
-        .where(User.email.ilike(email))
+        .where(func.lower(User.email) == email.lower())
         .limit(1)
     )
     row = result.first()

--- a/backend/tests/api/test_admin_signup_gate.py
+++ b/backend/tests/api/test_admin_signup_gate.py
@@ -364,7 +364,11 @@ class TestAddToAllowlist:
         assert "github_username must not be set" in str(resp.json())
 
     def test_422_on_malformed_google_email(self, client):
-        """EmailStr rejects non-RFC strings before we hit the DB."""
+        """The email regex pattern (Field(pattern=...)) rejects non-RFC strings
+        before we hit the DB. We deliberately use a regex rather than
+        pydantic.EmailStr to avoid pulling in email-validator as a new
+        dependency — see the AllowlistAddRequest.email comment in
+        admin_signup_gate.py."""
         resp = client.post(
             "/api/v1/admin/signup-gate/allowlist",
             json={"provider": "google", "email": "not-an-email"},

--- a/backend/tests/api/test_admin_signup_gate.py
+++ b/backend/tests/api/test_admin_signup_gate.py
@@ -331,6 +331,38 @@ class TestAddToAllowlist:
         )
         assert resp.status_code == 422
 
+    def test_422_when_github_payload_has_email(self, client):
+        """PR #657 review #3: provider=github MUST NOT accept an email field.
+
+        Without the model_validator, the extra field would be silently
+        ignored and the request would succeed with confusing data — admins
+        would not see their typo. The validator rejects with 422 so the
+        mismatch is explicit.
+        """
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={
+                "provider": "github",
+                "github_username": "octocat",
+                "email": "alice@example.com",
+            },
+        )
+        assert resp.status_code == 422
+        assert "email must not be set" in str(resp.json())
+
+    def test_422_when_google_payload_has_github_username(self, client):
+        """Symmetric: provider=google MUST NOT accept github_username."""
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={
+                "provider": "google",
+                "email": "alice@example.com",
+                "github_username": "octocat",
+            },
+        )
+        assert resp.status_code == 422
+        assert "github_username must not be set" in str(resp.json())
+
     def test_422_on_malformed_google_email(self, client):
         """EmailStr rejects non-RFC strings before we hit the DB."""
         resp = client.post(

--- a/backend/tests/api/test_admin_signup_gate.py
+++ b/backend/tests/api/test_admin_signup_gate.py
@@ -47,11 +47,38 @@ def _mock_config(enabled: bool = False, mode: str = "manual") -> Any:
     )
 
 
-def _mock_entry(username: str = "octocat", user_id: str = "583231") -> Any:
+def _mock_entry(
+    username: str = "octocat",
+    user_id: str = "583231",
+    *,
+    provider: str = "github",
+    subject_id: str | None = None,
+    subject_label: str | None = None,
+) -> Any:
+    """Build a provider-aware MagicMock entry (#655).
+
+    Defaults mimic a pre-#655 GitHub row so existing tests need no
+    changes. Pass ``provider="google"`` + ``subject_id``/``subject_label``
+    to mock a Google row.
+    """
+    if provider == "github":
+        resolved_sub = subject_id or user_id
+        resolved_label = subject_label or username
+        legacy_uid = user_id
+        legacy_username = username
+    else:
+        assert subject_id is not None, "google mock requires subject_id"
+        resolved_sub = subject_id
+        resolved_label = subject_label or username
+        legacy_uid = f"{provider}:{subject_id}"
+        legacy_username = resolved_label
     return MagicMock(
         id=uuid4(),
-        github_user_id=user_id,
-        github_username=username,
+        provider=provider,
+        subject_id=resolved_sub,
+        subject_label=resolved_label,
+        github_user_id=legacy_uid,
+        github_username=legacy_username,
         source="manual",
         state="active",
         added_by_user_id="admin_user_1",
@@ -212,6 +239,121 @@ class TestAddToAllowlist:
             json={"github_username": bad_username},
         )
         assert resp.status_code == 422
+
+    # ---- #655: provider-aware add ---------------------------------------
+
+    def test_legacy_payload_still_works(self, client, monkeypatch):
+        """Pre-#655 payload ``{github_username}`` (no provider field) still
+        routes to the GitHub path (provider defaults to 'github')."""
+        monkeypatch.setattr(
+            "services.signup_gate_service.SignupGateService.add_to_allowlist",
+            AsyncMock(return_value=_mock_entry("octocat")),
+        )
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"github_username": "octocat"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        # Response shape now includes the provider-aware fields too.
+        assert body["provider"] == "github"
+        assert body["subject_id"] == "583231"
+        assert body["subject_label"] == "octocat"
+        assert body["github_username"] == "octocat"
+
+    def test_201_on_google_success(self, client, monkeypatch):
+        """provider='google' resolves sub via the local users table and
+        creates an entry with the OIDC sub as subject_id."""
+        google_sub = "108276939729829363"
+        monkeypatch.setattr(
+            "api.routes.admin_signup_gate.resolve_google_sub_by_email",
+            AsyncMock(return_value=(google_sub, "alice@example.com")),
+        )
+        monkeypatch.setattr(
+            "services.signup_gate_service.SignupGateService.add_to_allowlist_entry",
+            AsyncMock(
+                return_value=_mock_entry(
+                    provider="google",
+                    subject_id=google_sub,
+                    subject_label="alice@example.com",
+                )
+            ),
+        )
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "google", "email": "alice@example.com"},
+        )
+        assert resp.status_code == 201
+        body = resp.json()
+        assert body["provider"] == "google"
+        assert body["subject_id"] == google_sub
+        assert body["subject_label"] == "alice@example.com"
+
+    def test_google_404_when_user_not_in_users_table(self, client, monkeypatch):
+        """Bootstrap UX gap: a Google user must OAuth once before they can
+        be added — return 404 with the actionable hint baked into the
+        helper's exception message."""
+        from utils.google_user import GoogleUserNotFound
+
+        monkeypatch.setattr(
+            "api.routes.admin_signup_gate.resolve_google_sub_by_email",
+            AsyncMock(side_effect=GoogleUserNotFound("user must OAuth first")),
+        )
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "google", "email": "stranger@example.com"},
+        )
+        assert resp.status_code == 404
+        # The bootstrap-UX hint comes through verbatim.
+        assert "OAuth" in resp.json()["detail"]
+
+    def test_google_422_when_email_missing(self, client):
+        """provider='google' requires the email field."""
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "google"},
+        )
+        assert resp.status_code == 422
+
+    def test_github_422_when_username_missing(self, client):
+        """Explicit provider='github' still needs github_username."""
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "github"},
+        )
+        assert resp.status_code == 422
+
+    def test_422_on_unknown_provider(self, client):
+        """provider values outside the Literal allow-list reject at parse time."""
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "microsoft", "email": "alice@example.com"},
+        )
+        assert resp.status_code == 422
+
+    def test_422_on_malformed_google_email(self, client):
+        """EmailStr rejects non-RFC strings before we hit the DB."""
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "google", "email": "not-an-email"},
+        )
+        assert resp.status_code == 422
+
+    def test_409_on_duplicate_google_entry(self, client, monkeypatch):
+        """Duplicate Google entry surfaces the standard 409 conflict."""
+        monkeypatch.setattr(
+            "api.routes.admin_signup_gate.resolve_google_sub_by_email",
+            AsyncMock(return_value=("9999", "dup@b.com")),
+        )
+        monkeypatch.setattr(
+            "services.signup_gate_service.SignupGateService.add_to_allowlist_entry",
+            AsyncMock(side_effect=ValueError("already on the manual allowlist")),
+        )
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "google", "email": "dup@b.com"},
+        )
+        assert resp.status_code == 409
 
 
 class TestRemoveFromAllowlist:

--- a/backend/tests/integration/test_signup_allowlist_provider_migration.py
+++ b/backend/tests/integration/test_signup_allowlist_provider_migration.py
@@ -1,0 +1,169 @@
+"""Migration data-shape check for e14_655_signup_allowlist_provider.
+
+The general round-trip (upgrade-then-downgrade-then-upgrade) is already
+covered by ``TestAlembicMigrations`` in the sibling
+``test_alembic_migrations`` module. These tests add the data-specific
+checks for #655:
+
+- Existing rows backfill cleanly (``provider='github'``,
+  ``subject_id=github_user_id``, ``subject_label=github_username``).
+- The new ``(provider, subject_id, source)`` UNIQUE constraint fires on
+  duplicates.
+- Downgrade drops the new columns (data loss expected — DDL-only revert,
+  matching the b03_396 convention this codebase has standardized on).
+"""
+
+from sqlalchemy import inspect, text
+
+from alembic import command
+from tests.integration.test_alembic_migrations import (
+    _alembic_at_test_db,
+    _get_alembic_config,
+    _reset_alembic_state,
+    _sync_engine,
+)
+
+
+class TestSignupAllowlistProviderMigration:
+    """Data-shape checks for e14_655_signup_allowlist_provider."""
+
+    def test_upgrade_adds_columns_and_backfills_existing_rows(self):
+        """Seed a pre-#655 row, upgrade, verify backfill + constraints."""
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            # Step 1: upgrade only to b04 (table creator). Tests in the
+            # sibling module pin head-revision behavior; here we want a
+            # known seedable state immediately BEFORE the e14 migration.
+            command.upgrade(_get_alembic_config(), "e13_474_pricing_seeds")
+
+            engine = _sync_engine()
+            try:
+                # Seed: one pre-#655 row mirroring what an admin add via
+                # the legacy GitHub-only path produces.
+                with engine.begin() as conn:
+                    conn.execute(
+                        text(
+                            "INSERT INTO signup_allowlist "
+                            "(github_user_id, github_username, source, state) "
+                            "VALUES ('583231', 'octocat', 'manual', 'active')"
+                        )
+                    )
+
+                # Step 2: apply the new migration.
+                command.upgrade(_get_alembic_config(), "e14_655_signup_allowlist_provider")
+
+                # Step 3: verify the seeded row now has all three new fields
+                # populated from the backfill.
+                with engine.begin() as conn:
+                    row = conn.execute(
+                        text(
+                            "SELECT provider, subject_id, subject_label, "
+                            "       github_user_id, github_username "
+                            "FROM signup_allowlist "
+                            "WHERE github_user_id = '583231'"
+                        )
+                    ).fetchone()
+                assert row is not None
+                provider, subject_id, subject_label, gh_uid, gh_uname = row
+                assert provider == "github"
+                assert subject_id == "583231"
+                assert subject_label == "octocat"
+                # Legacy columns left intact during the migration window.
+                assert gh_uid == "583231"
+                assert gh_uname == "octocat"
+            finally:
+                engine.dispose()
+
+    def test_upgrade_replaces_unique_constraint(self):
+        """The new (provider, subject_id, source) UNIQUE replaces the
+        GitHub-only (github_user_id, source) one."""
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), "head")
+
+        engine = _sync_engine()
+        try:
+            inspector = inspect(engine)
+            uniques = {uc["name"] for uc in inspector.get_unique_constraints("signup_allowlist")}
+            assert "uq_allowlist_provider_subject_source" in uniques
+            assert "uq_allowlist_user_source" not in uniques
+
+            # The new index on (provider, subject_id) is present.
+            index_names = {ix["name"] for ix in inspector.get_indexes("signup_allowlist")}
+            assert "ix_signup_allowlist_provider_subject" in index_names
+            assert "ix_signup_allowlist_github_user_id" not in index_names
+        finally:
+            engine.dispose()
+
+    def test_upgrade_enforces_new_unique_constraint(self):
+        """The same (provider, subject_id, source) triple cannot be inserted twice."""
+        from sqlalchemy.exc import IntegrityError
+
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), "head")
+
+        engine = _sync_engine()
+        try:
+            with engine.begin() as conn:
+                # First insert — should succeed.
+                conn.execute(
+                    text(
+                        "INSERT INTO signup_allowlist "
+                        "(provider, subject_id, subject_label, "
+                        " github_user_id, github_username, source, state) "
+                        "VALUES ('google', '108276939729829363', 'a@b.com', "
+                        "        'google:108276939729829363', 'a@b.com', "
+                        "        'manual', 'active')"
+                    )
+                )
+
+            # Second insert with the same (provider, subject_id, source)
+            # but a different legacy github_user_id MUST violate the new
+            # composite UNIQUE — proving the constraint is on the new
+            # columns, not just inherited from the old one.
+            failed = False
+            try:
+                with engine.begin() as conn:
+                    conn.execute(
+                        text(
+                            "INSERT INTO signup_allowlist "
+                            "(provider, subject_id, subject_label, "
+                            " github_user_id, github_username, source, state) "
+                            "VALUES ('google', '108276939729829363', 'a@b.com', "
+                            "        'google:duplicate-attempt', 'a@b.com', "
+                            "        'manual', 'active')"
+                        )
+                    )
+            except IntegrityError:
+                failed = True
+            assert failed, "duplicate (provider, subject_id, source) should violate UNIQUE"
+        finally:
+            engine.dispose()
+
+    def test_downgrade_drops_new_columns(self):
+        _reset_alembic_state()
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), "head")
+            command.downgrade(_get_alembic_config(), "e13_474_pricing_seeds")
+
+        engine = _sync_engine()
+        try:
+            inspector = inspect(engine)
+            columns = {col["name"] for col in inspector.get_columns("signup_allowlist")}
+            assert "provider" not in columns
+            assert "subject_id" not in columns
+            assert "subject_label" not in columns
+            # Old constraint + index restored on rollback.
+            uniques = {uc["name"] for uc in inspector.get_unique_constraints("signup_allowlist")}
+            assert "uq_allowlist_user_source" in uniques
+            index_names = {ix["name"] for ix in inspector.get_indexes("signup_allowlist")}
+            assert "ix_signup_allowlist_github_user_id" in index_names
+        finally:
+            engine.dispose()
+
+        # Leave the DB at head so the rest of the integration suite sees a
+        # clean, fully-migrated schema (same convention as the sibling
+        # ``TestSignupGateMigration``).
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), "head")

--- a/backend/tests/integration/test_signup_allowlist_provider_migration.py
+++ b/backend/tests/integration/test_signup_allowlist_provider_migration.py
@@ -1,4 +1,4 @@
-"""Migration data-shape check for e14_655_signup_allowlist_provider.
+"""Migration data-shape check for e14_655_allowlist_provider.
 
 The general round-trip (upgrade-then-downgrade-then-upgrade) is already
 covered by ``TestAlembicMigrations`` in the sibling
@@ -25,7 +25,7 @@ from tests.integration.test_alembic_migrations import (
 
 
 class TestSignupAllowlistProviderMigration:
-    """Data-shape checks for e14_655_signup_allowlist_provider."""
+    """Data-shape checks for e14_655_allowlist_provider."""
 
     def test_upgrade_adds_columns_and_backfills_existing_rows(self):
         """Seed a pre-#655 row, upgrade, verify backfill + constraints."""
@@ -50,7 +50,7 @@ class TestSignupAllowlistProviderMigration:
                     )
 
                 # Step 2: apply the new migration.
-                command.upgrade(_get_alembic_config(), "e14_655_signup_allowlist_provider")
+                command.upgrade(_get_alembic_config(), "e14_655_allowlist_provider")
 
                 # Step 3: verify the seeded row now has all three new fields
                 # populated from the backfill.

--- a/backend/tests/services/test_signup_gate_service.py
+++ b/backend/tests/services/test_signup_gate_service.py
@@ -665,11 +665,15 @@ class TestRecordBlockedSignup:
         # IP / UA are captured for triage.
         assert audit.ip_address == "203.0.113.7"
         assert audit.user_agent == "Mozilla/5.0"
-        # subject_label preserved in metadata for admin readability.
-        assert audit.user_metadata == {
-            "provider": "google",
-            "subject_label": "stranger@example.com",
-        }
+        # Metadata stores provider type only — never the email or any
+        # other PII. The HMAC in new_value_hash is the canonical email
+        # reference (matches the auth/roles.py precedent; PR #657 Copilot
+        # review / CSO finding #1).
+        assert audit.user_metadata == {"provider": "google"}
+        # Defense in depth: the plaintext email MUST NOT appear anywhere
+        # on the row (not in user_metadata, not in any other column).
+        assert "stranger@example.com" not in str(audit.user_metadata)
+        assert audit.user_email == "oauth-callback"  # the actor sentinel, not the subject
         svc.db.commit.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/backend/tests/services/test_signup_gate_service.py
+++ b/backend/tests/services/test_signup_gate_service.py
@@ -57,20 +57,67 @@ class TestCheckAccess:
         assert result is legacy_redirect
 
     @pytest.mark.asyncio
-    async def test_enabled_google_passes_through(self):
-        """provider=google never invokes the allowlist (Google-side controls signup)."""
+    async def test_enabled_google_now_gated(self):
+        """#655: Google no longer passes through; the allowlist is consulted.
+
+        Before #655 the gate trusted Google's Consent Screen test-user list
+        to filter signups. That assumption only holds for sensitive scopes —
+        for openid/email/profile the test-user list is advisory. The gate
+        now applies uniformly to both providers; Google goes through the
+        same existing-user / first-user / allowlist branches.
+        """
         svc = _svc()
         svc._load_config = AsyncMock(return_value=_config(enabled=True, mode="manual"))
-        svc._is_existing_user = AsyncMock()
-        svc._is_allowlisted = AsyncMock()
+        svc._is_existing_user = AsyncMock(return_value=False)
+        svc._is_first_user = AsyncMock(return_value=False)
+        svc._is_allowlisted = AsyncMock(return_value=True)
 
         result = await svc.check_access(
-            provider="google", oauth_sub="5678", email="a@b.com", username=None
+            provider="google",
+            oauth_sub="108276939729829363",
+            email="a@b.com",
+            username="a@b.com",
         )
 
         assert result is None
-        svc._is_existing_user.assert_not_awaited()
-        svc._is_allowlisted.assert_not_awaited()
+        # Allowlist IS consulted for Google now (with provider="google"
+        # and subject_id=oauth_sub as the match key).
+        svc._is_allowlisted.assert_awaited_once_with("google", "108276939729829363", "manual")
+
+    @pytest.mark.asyncio
+    async def test_enabled_google_blocked_when_not_allowlisted(self):
+        """#655: a Google user outside the allowlist is blocked and logged."""
+        svc = _svc()
+        svc._load_config = AsyncMock(return_value=_config(enabled=True, mode="manual"))
+        svc._is_existing_user = AsyncMock(return_value=False)
+        svc._is_first_user = AsyncMock(return_value=False)
+        svc._is_allowlisted = AsyncMock(return_value=False)
+        # Stub the audit-write so the test doesn't try to talk to a real
+        # session — _record_blocked_signup is exercised on its own below.
+        svc._record_blocked_signup = AsyncMock()
+
+        result = await svc.check_access(
+            provider="google",
+            oauth_sub="108276939729829363",
+            email="stranger@example.com",
+            username="stranger@example.com",
+            ip_address="203.0.113.7",
+            user_agent="Mozilla/5.0",
+        )
+
+        assert isinstance(result, RedirectResponse)
+        assert "/signup-blocked" in result.headers["location"]
+        # Reason hints surfaced via query params (provider + first 8 chars
+        # of the sub) so the frontend can render an admin-contact prompt.
+        assert "provider=google" in result.headers["location"]
+        assert "sub=10827693" in result.headers["location"]
+        svc._record_blocked_signup.assert_awaited_once()
+        kwargs = svc._record_blocked_signup.await_args.kwargs
+        assert kwargs["provider"] == "google"
+        assert kwargs["oauth_sub"] == "108276939729829363"
+        assert kwargs["email"] == "stranger@example.com"
+        assert kwargs["ip_address"] == "203.0.113.7"
+        assert kwargs["user_agent"] == "Mozilla/5.0"
 
     @pytest.mark.asyncio
     async def test_existing_user_always_allowed(self):
@@ -148,6 +195,10 @@ class TestCheckAccess:
         svc._is_existing_user = AsyncMock(return_value=False)
         svc._is_first_user = AsyncMock(return_value=False)
         svc._is_allowlisted = AsyncMock(return_value=False)
+        # #655: blocked-signup also writes an audit_logs row; stub the
+        # helper so the test stays pure (the audit-write itself is
+        # exercised in TestRecordBlockedSignup).
+        svc._record_blocked_signup = AsyncMock()
 
         result = await svc.check_access(
             provider="github", oauth_sub="1234", email="a@b.com", username="octocat"
@@ -155,7 +206,10 @@ class TestCheckAccess:
 
         assert isinstance(result, RedirectResponse)
         assert "/signup-blocked" in result.headers["location"]
+        assert "provider=github" in result.headers["location"]
+        assert "sub=1234" in result.headers["location"]
         assert result.status_code == 303
+        svc._record_blocked_signup.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_sponsors_mode_raises_not_implemented_in_phase1(self):
@@ -171,6 +225,34 @@ class TestCheckAccess:
                 email="a@b.com",
                 username="octocat",
             )
+
+    @pytest.mark.asyncio
+    async def test_google_sponsors_mode_falls_back_to_manual(self):
+        """#655: provider=google + sponsors mode → manual semantics.
+
+        Sponsorship is GitHub-specific (no equivalent Google concept), so
+        when an admin has the gate set to ``github_sponsors`` or ``both``
+        the Google path falls back to the manual allowlist rather than
+        raising NotImplementedError. Avoids surfacing a 500 for Google
+        users when the GitHub Sponsors integration is in flight.
+        """
+        svc = _svc()
+        svc._load_config = AsyncMock(return_value=_config(enabled=True, mode="github_sponsors"))
+        svc._is_existing_user = AsyncMock(return_value=False)
+        svc._is_first_user = AsyncMock(return_value=False)
+        svc._is_allowlisted = AsyncMock(return_value=True)
+
+        result = await svc.check_access(
+            provider="google",
+            oauth_sub="9999",
+            email="a@b.com",
+            username="a@b.com",
+        )
+
+        assert result is None
+        # The fallback evaluates ``manual`` semantics, NOT github_sponsors —
+        # _is_allowlisted is called with mode='manual'.
+        svc._is_allowlisted.assert_awaited_once_with("google", "9999", "manual")
 
     @pytest.mark.asyncio
     async def test_both_mode_raises_not_implemented_in_phase1(self):
@@ -369,7 +451,8 @@ class TestIsAllowlistedSourceFiltering:
 
         svc.db.execute = fake_execute
 
-        allowed = await svc._is_allowlisted("1234", mode)
+        # #655: _is_allowlisted now takes (provider, subject_id, mode).
+        allowed = await svc._is_allowlisted("github", "1234", mode)
         assert allowed is False  # no matching row → not allowlisted
 
         # SQL contains "source = " clause iff mode != 'both'
@@ -378,6 +461,9 @@ class TestIsAllowlistedSourceFiltering:
             assert not has_source_filter, f"mode=both must not filter by source: {captured['sql']}"
         else:
             assert has_source_filter, f"mode={mode} must filter by source: {captured['sql']}"
+        # All modes must include the provider + subject_id filters.
+        assert "signup_allowlist.provider" in captured["sql"]
+        assert "signup_allowlist.subject_id" in captured["sql"]
 
 
 class TestIsExistingUser:
@@ -470,3 +556,168 @@ class TestLegacyCheckPassesUserIdThrough:
         )
 
         svc._legacy_check.assert_awaited_once_with("user@example.com", "gh-sub-99")
+
+
+class TestAddToAllowlistEntry:
+    """#655: provider-aware add. Covers both the Google path (no GitHub API
+    call) and the GitHub legacy-column write side-effect."""
+
+    @pytest.mark.asyncio
+    async def test_adds_google_entry_with_sentinel_legacy_columns(self):
+        """Google entries must populate the deprecated github_user_id / github_username
+        columns with sentinel values since both stay NOT NULL during the migration."""
+        svc = _svc()
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=None)
+        svc.db.execute = AsyncMock(return_value=scalar_result)
+        svc.db.add = MagicMock()
+        svc.db.commit = AsyncMock()
+        svc.db.refresh = AsyncMock()
+
+        entry = await svc.add_to_allowlist_entry(
+            provider="google",
+            subject_id="108276939729829363",
+            subject_label="a@b.com",
+            added_by_user_id="admin1",
+        )
+
+        assert entry.provider == "google"
+        assert entry.subject_id == "108276939729829363"
+        assert entry.subject_label == "a@b.com"
+        # Sentinel writes to the deprecated columns (the migration window
+        # constraint requires NOT NULL on these until a future drop).
+        assert entry.github_user_id == "google:108276939729829363"
+        assert entry.github_username == "a@b.com"
+        assert entry.source == "manual"
+        assert entry.state == "active"
+        svc.db.add.assert_called_once()
+        svc.db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_rejects_duplicate_google_entry(self):
+        svc = _svc()
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=MagicMock())
+        svc.db.execute = AsyncMock(return_value=scalar_result)
+        svc.db.add = MagicMock()
+        svc.db.commit = AsyncMock()
+
+        with pytest.raises(ValueError, match="already on the manual allowlist"):
+            await svc.add_to_allowlist_entry(
+                provider="google",
+                subject_id="9999",
+                subject_label="dup@b.com",
+                added_by_user_id="admin1",
+            )
+
+        svc.db.add.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_github_path_requires_legacy_columns(self):
+        """provider='github' callers MUST supply the legacy github_user_id /
+        github_username — the entry-point is the migration-window contract."""
+        svc = _svc()
+        svc.db.execute = AsyncMock()
+
+        with pytest.raises(ValueError, match="legacy columns are still NOT NULL"):
+            await svc.add_to_allowlist_entry(
+                provider="github",
+                subject_id="583231",
+                subject_label="octocat",
+                added_by_user_id="admin1",
+            )
+
+
+class TestRecordBlockedSignup:
+    """#655: blocked signups now write an audit_logs row in addition to
+    the structlog event (CSO gate1 D2)."""
+
+    @pytest.mark.asyncio
+    async def test_writes_audit_log_with_hmac_email(self):
+        """The audit row must HMAC the email — never log plaintext PII."""
+        svc = _svc()
+        svc.db.add = MagicMock()
+        svc.db.commit = AsyncMock()
+
+        with patch(
+            "services.signup_gate_service.get_settings",
+            return_value=SimpleNamespace(audit_hmac_key="test-key"),
+        ):
+            await svc._record_blocked_signup(
+                provider="google",
+                oauth_sub="108276939729829363",
+                email="stranger@example.com",
+                username="stranger@example.com",
+                ip_address="203.0.113.7",
+                user_agent="Mozilla/5.0",
+            )
+
+        svc.db.add.assert_called_once()
+        audit = svc.db.add.call_args.args[0]
+        assert audit.action == "signup_blocked"
+        assert audit.resource == "signup_gate:google"
+        assert audit.user_id == "108276939729829363"
+        # Plaintext email must not leak into the row.
+        assert audit.new_value_hash is not None
+        assert audit.new_value_hash != "stranger@example.com"
+        # 64-char hex (SHA256 hex) shape.
+        assert len(audit.new_value_hash) == 64
+        # IP / UA are captured for triage.
+        assert audit.ip_address == "203.0.113.7"
+        assert audit.user_agent == "Mozilla/5.0"
+        # subject_label preserved in metadata for admin readability.
+        assert audit.user_metadata == {
+            "provider": "google",
+            "subject_label": "stranger@example.com",
+        }
+        svc.db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_audit_failure_is_swallowed(self):
+        """A DB hiccup during the audit-write must NOT escalate into a
+        callback 500 for the user being blocked."""
+        svc = _svc()
+        svc.db.add = MagicMock()
+        svc.db.commit = AsyncMock(side_effect=RuntimeError("db down"))
+        svc.db.rollback = AsyncMock()
+
+        with patch(
+            "services.signup_gate_service.get_settings",
+            return_value=SimpleNamespace(audit_hmac_key="test-key"),
+        ):
+            # Must NOT raise.
+            await svc._record_blocked_signup(
+                provider="github",
+                oauth_sub="1234",
+                email="a@b.com",
+                username="octocat",
+                ip_address=None,
+                user_agent=None,
+            )
+
+        svc.db.rollback.assert_awaited_once()
+
+
+class TestBlockedResponse:
+    """The blocked redirect must include reason hints (#655 D1)."""
+
+    def test_includes_provider_and_sub_head8(self):
+        svc = _svc()
+        response = svc._blocked_response(provider="google", oauth_sub="108276939729829363")
+
+        location = response.headers["location"]
+        assert "/signup-blocked" in location
+        assert "provider=google" in location
+        # First 8 chars only (Git short-SHA convention); the rest must
+        # not leak into the URL.
+        assert "sub=10827693" in location
+        assert "108276939729829363" not in location
+
+    def test_no_params_when_context_absent(self):
+        """Defensive call without context should still produce a valid URL."""
+        svc = _svc()
+        response = svc._blocked_response()
+
+        location = response.headers["location"]
+        assert "/signup-blocked" in location
+        assert "?" not in location

--- a/backend/tests/utils/test_google_user.py
+++ b/backend/tests/utils/test_google_user.py
@@ -77,9 +77,12 @@ class TestResolveGoogleSubByEmail:
         # WHERE clause includes the provider scope.
         sql = captured["sql"]
         assert "auth_provider" in sql
-        # Case-insensitive email match. SQLAlchemy compiles ``.ilike(...)``
-        # to either ``ILIKE`` (PostgreSQL dialect) or ``LOWER(...) LIKE
-        # LOWER(...)`` (default dialect — what the in-memory mock sees).
-        # Both produce the same runtime semantics, so accept either shape.
+        # Case-insensitive email match emits ``LOWER(users.email) = LOWER(:email_1)``
+        # from ``func.lower(User.email) == email.lower()`` (PR #657 Copilot loop 1
+        # finding #2 — switched from ``.ilike(...)`` to avoid SQL LIKE wildcard
+        # injection via admin-supplied ``%`` / ``_``). The assertion below tolerates
+        # both ``LOWER`` and the legacy ``ILIKE`` form so a future refactor that goes
+        # back to ``.ilike(...)`` with proper escaping wouldn't immediately break the
+        # test, but the production path is the LOWER one.
         upper = sql.upper()
-        assert "ILIKE" in upper or "LOWER" in upper
+        assert "LOWER" in upper or "ILIKE" in upper

--- a/backend/tests/utils/test_google_user.py
+++ b/backend/tests/utils/test_google_user.py
@@ -1,0 +1,85 @@
+"""Unit tests for utils.google_user (Issue #655).
+
+Mirrors the structure of ``test_github_user.py``. ``resolve_google_sub_by_email``
+hits only the local ``users`` table (unlike GitHub's helper, which calls the
+public GitHub API), so the tests use an in-memory result mock rather than an
+HTTP-layer mock.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from utils.google_user import GoogleUserNotFound, resolve_google_sub_by_email
+
+
+def _db_with_first(row):
+    """Helper: build an AsyncSession mock that returns ``row`` from .first()."""
+    result = MagicMock()
+    result.first = MagicMock(return_value=row)
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=result)
+    return db
+
+
+class TestResolveGoogleSubByEmail:
+    @pytest.mark.asyncio
+    async def test_returns_sub_for_existing_google_user(self):
+        db = _db_with_first(("108276939729829363", "alice@example.com"))
+
+        sub, email = await resolve_google_sub_by_email("alice@example.com", db)
+
+        assert sub == "108276939729829363"
+        assert email == "alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_email_match(self):
+        """Google's userinfo sometimes capitalizes locally; the lookup must
+        not be defeated by a single character of case drift."""
+        db = _db_with_first(("108276939729829363", "Alice@example.com"))
+
+        sub, email = await resolve_google_sub_by_email("alice@example.com", db)
+
+        assert sub == "108276939729829363"
+        # The canonical email from the users row (preserves stored case).
+        assert email == "Alice@example.com"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_no_google_user_with_this_email(self):
+        db = _db_with_first(None)
+
+        with pytest.raises(GoogleUserNotFound) as exc_info:
+            await resolve_google_sub_by_email("ghost@example.com", db)
+
+        # The exception message carries the bootstrap-UX hint admins need
+        # ("the user must OAuth once before they can be allowlisted").
+        assert "OAuth" in str(exc_info.value)
+        assert "ghost@example.com" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_filters_to_google_auth_provider(self):
+        """The query MUST scope to auth_provider='google' so a GitHub user
+        with the same email doesn't accidentally satisfy the lookup."""
+        captured = {}
+
+        async def fake_execute(stmt):
+            captured["sql"] = str(stmt.compile())
+            result = MagicMock()
+            result.first = MagicMock(return_value=None)
+            return result
+
+        db = MagicMock()
+        db.execute = fake_execute
+
+        with pytest.raises(GoogleUserNotFound):
+            await resolve_google_sub_by_email("a@b.com", db)
+
+        # WHERE clause includes the provider scope.
+        sql = captured["sql"]
+        assert "auth_provider" in sql
+        # Case-insensitive email match. SQLAlchemy compiles ``.ilike(...)``
+        # to either ``ILIKE`` (PostgreSQL dialect) or ``LOWER(...) LIKE
+        # LOWER(...)`` (default dialect — what the in-memory mock sees).
+        # Both produce the same runtime semantics, so accept either shape.
+        upper = sql.upper()
+        assert "ILIKE" in upper or "LOWER" in upper

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -280,6 +280,20 @@ All checks funnel through `PermissionService` in `backend/src/services/permissio
 - **JWT Tokens**: HS256 signing (1 hour expiration)
 - **OAuth2 Secrets**: SHA256 hash storage
 
+### Signup Gate
+
+The admin-configurable signup gate (`backend/src/services/signup_gate_service.py`) sits in front of the OAuth callback's user-creation step. It applies **uniformly to both GitHub and Google** (since #655 — the original #358 Phase 1 design trusted Google's Consent Screen test-user list, but that list is only strictly enforced for sensitive scopes and is click-through for basic profile scopes).
+
+**Match key**: `(provider, subject_id)` in `signup_allowlist`. `subject_id` is the immutable IdP identity (GitHub numeric ID for github rows, OIDC `sub` claim for google rows). Email is never used for matching — that would re-open email-change attacks at the IdP.
+
+**Modes** (singleton `signup_gate_config.mode`):
+- `manual`: signup allowed iff `(provider, subject_id)` is on the allowlist with `state='active'`.
+- `github_sponsors` / `both`: Phase 2 (NotImplemented for GitHub today; for Google, falls back to `manual` since sponsorship is GitHub-specific).
+
+**Blocked signup observability**: every blocked attempt writes to `audit_logs` (action=`signup_blocked`) with the email HMAC'd (never plaintext), plus IP / User-Agent for triage. The blocked redirect to `/signup-blocked?provider=<p>&sub=<first8>` lets the frontend render an admin-contact prompt without leaking the full identity.
+
+**Admin API**: `POST /api/v1/admin/signup-gate/allowlist` accepts either `{github_username}` (legacy GitHub shape) or `{provider: "google", email}`. Google adds resolve the OIDC `sub` from a pre-existing `users` row — the invitee must complete Google OAuth at least once before they can be allowlisted (pre-OAuth invitation by email is a Phase 2 follow-up).
+
 ## Scalability Considerations
 
 ### Horizontal Scaling


### PR DESCRIPTION
Closes #655

## Summary
- Removes the Google pass-through in `signup_gate_service.py` and gates Google OAuth uniformly with GitHub (the prior #358 Phase 1 design trusted Google's Consent Screen test-user list, which is advisory for non-sensitive scopes)
- Widens `signup_allowlist` from a GitHub-only key to `(provider, subject_id)` so Google rows match on the immutable OIDC `sub` claim (never email, to keep email-change attacks closed)
- Writes an `audit_logs` row on every blocked signup attempt — email HMAC'd via `hmac_sha256_hex`, plus IP/UA captured for admin triage
- Extends `POST /api/v1/admin/signup-gate/allowlist` to accept `{provider: "google", email}` alongside the legacy `{github_username}` shape (backward-compat, no flag day)

## Implementation notes
- **Migration `e14_655`**: adds `provider`/`subject_id`/`subject_label` with transitional `server_default`s, backfills GitHub rows (`subject_id=github_user_id`, `subject_label=github_username`), drops the server_defaults, swaps UNIQUE/INDEX onto the new key, then tightens to NOT NULL. Step 4.5 belt-and-suspenders re-UPDATE catches any stragglers from the deploy window. Legacy `github_user_id`/`github_username` columns stay NOT NULL during the migration window — physical drop deferred to a follow-up issue.
- **`utils/google_user.py`** (new): `resolve_google_sub_by_email` looks up an existing `users` row with `auth_provider='google'` to get the immutable `sub`. The invitee must complete Google OAuth at least once before they can be allowlisted (pre-OAuth invitation by email is a Phase 2 follow-up).
- **`mode=github_sponsors`/`both` + Google → manual fallback**: sponsorship is GitHub-specific, so Google falls back to manual allowlist semantics rather than raising NotImplementedError.
- **Existing users unchanged**: `_is_existing_user` branch still passes through; the gate only affects NEW signups. Removing already-admitted out-of-scope users is a separate operator decision and a separate follow-up.
- GitHub side intentionally untouched.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped (binary_gate = null)
- binary_gate: (none)
- cso: yellow — 2 findings, see below
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (PM lens)
- review provider: copilot

### CSO yellow findings (address in this PR or as follow-ups)

1. **`audit_logs.user_metadata.subject_label` stores plaintext email for Google rows** — defeats the HMAC design intent of `new_value_hash`. The codebase precedent (`backend/src/auth/roles.py:439-446`) HMACs the email and keeps `user_metadata` to provider-type only. Suggested fix: drop `subject_label` from `user_metadata` in `_record_blocked_signup` (2-line change).
2. **`User.email.ilike(email)` allows wildcard overmatch** when admin-supplied email contains `%` (RFC 5321 permits it in the local part). Admin-only path so bounded blast radius, but a correctness bug. Suggested fix: escape `%`/`_` before passing to `ilike`, or switch to `func.lower(...) == email.lower()` (1-line change).

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/655-fix-google-signup-gate.gate2.md

## Test plan
- [x] `make lint` (passes locally)
- [x] `pytest tests/services/test_signup_gate_service.py tests/utils/test_google_user.py` — 39/39 pass
- [ ] `make test-integration` (Docker — runs in CI): admin API + migration round-trip
- [ ] Verify migration upgrade + downgrade idempotency in CI
- [ ] Address CSO yellow findings (or accept as follow-up)
- [ ] Smoke test: Google user not in allowlist → blocked redirect with `?provider=google&sub=<first8>`
- [ ] Smoke test: Existing Google user (in `users` table) still logs in normally

🤖 Generated via /gh-issue-driven:ship
