### PR TITLE
feat(quota): plan-based owned-workspace cap (#661)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -277,6 +277,21 @@ BILLING_ENABLED=false
 # PLAN_BASIC_SLEEP_ENABLED_CONTEXTS_LIMIT=0
 # PLAN_PRO_SLEEP_ENABLED_CONTEXTS_LIMIT=3
 
+# Issue #661: Per-tier owned-workspace cap (commented = uses defaults — see
+# config/plan_tiers.py: FREE 1 / BASIC 3 / PRO 10). Caps the workspaces a
+# user can OWN; joining workspaces via invitation remains uncapped (the
+# inviting workspace's owner pays for the seat).
+# PLAN_FREE_MAX_OWNED_WORKSPACES=1
+# PLAN_BASIC_MAX_OWNED_WORKSPACES=3
+# PLAN_PRO_MAX_OWNED_WORKSPACES=10
+
+# Issue #661 rollout gate. When false (default), workspace creation is
+# allowed unconditionally but a structured warn log is emitted whenever a
+# user is over their tier's max_owned_workspaces — used to surface affected
+# accounts before enforcement. Flip to true after the email-outreach
+# cleanup window.
+# ENFORCE_WORKSPACE_CAP=false
+
 # -----------------------------------------------------------------------------
 # Production Deployment
 # -----------------------------------------------------------------------------

--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import SessionUser
 from config.settings import get_settings
 from db.base import get_db
-from models.auth import UsageStats, UserPlan, Workspace
+from models.auth import UsageStats, UserPlan
 from models.memory import Memory
 from utils.datetime import utcnow
 from utils.logger import get_logger
@@ -128,6 +128,12 @@ class WorkspacesUsage(BaseModel):
     populated regardless of which workspace the caller currently has
     selected — it is the user's own quota across all their owned
     workspaces.
+
+    No ``addon_bonus`` field as of Issue #661 because there is no
+    per-user addon SKU. If ``addon_workspace_bonus`` (or equivalent)
+    is introduced — see the Out-of-scope section of #661 — add
+    ``addon_bonus`` here to match ``SleepContextsUsage`` /
+    ``AnalysisUsage`` shape.
     """
 
     used: int = Field(0, description="Owned workspaces (deleted_at IS NULL)")
@@ -161,11 +167,11 @@ class CurrentUsage(BaseModel):
             "NULL when the caller has no current workspace selected."
         ),
     )
-    workspaces: WorkspacesUsage | None = Field(
-        None,
+    workspaces: WorkspacesUsage = Field(
+        ...,
         description=(
             "Owned-workspace cap usage for the caller (Issue #661). "
-            "User-level — populated independently of current workspace."
+            "User-level — always populated, independently of current workspace."
         ),
     )
 
@@ -408,26 +414,19 @@ async def _build_sleep_contexts_usage(
 async def _build_workspaces_usage(db: AsyncSession, user_id: str) -> "WorkspacesUsage":
     """Build the ``workspaces`` field of /usage/current (Issue #661).
 
-    User-level cap: counts the user's owned (``deleted_at IS NULL``)
-    workspaces and resolves the cap from their effective plan tier
-    (highest tier across owned workspaces; FREE when none owned).
+    User-level cap: ``get_user_workspace_summary`` returns the owned
+    count and the user's effective plan tier (highest tier across
+    owned workspaces; FREE when none owned) in a single SELECT. The
+    same helper is used by ``QuotaService.check_workspace_creation_allowed``
+    so the gate and the dashboard read consistent state.
 
     Always returns a populated ``WorkspacesUsage`` — the cap is
     user-scoped so there is no "no current workspace" null case here.
     """
     from config.plan_tiers import get_plan_tier
-    from utils.plan_resolver import get_user_effective_plan
+    from utils.plan_resolver import get_user_workspace_summary
 
-    owned_count = (
-        await db.execute(
-            select(func.count(Workspace.id)).where(
-                Workspace.owner_user_id == user_id,
-                Workspace.deleted_at.is_(None),
-            )
-        )
-    ).scalar() or 0
-
-    user_plan = await get_user_effective_plan(db, user_id)
+    owned_count, user_plan = await get_user_workspace_summary(db, user_id)
     plan_tier = get_plan_tier(user_plan)
     limit = plan_tier.max_owned_workspaces
 

--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -15,7 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import SessionUser
 from config.settings import get_settings
 from db.base import get_db
-from models.auth import UsageStats, UserPlan
+from models.auth import UsageStats, UserPlan, Workspace
 from models.memory import Memory
 from utils.datetime import utcnow
 from utils.logger import get_logger
@@ -117,6 +117,24 @@ class SleepContextsUsage(BaseModel):
     remaining: int = Field(0, description="max(0, limit - used)")
 
 
+class WorkspacesUsage(BaseModel):
+    """Owned-workspace cap usage (Issue #661).
+
+    User-level — the cap is per-user, not per-workspace. The dashboard
+    surfaces this so users can see "X / N workspaces owned" before
+    hitting the cap on workspace creation.
+
+    Unlike ``AnalysisUsage`` / ``SleepContextsUsage``, this field is
+    populated regardless of which workspace the caller currently has
+    selected — it is the user's own quota across all their owned
+    workspaces.
+    """
+
+    used: int = Field(0, description="Owned workspaces (deleted_at IS NULL)")
+    limit: int = Field(0, description="Plan tier's max_owned_workspaces")
+    remaining: int = Field(0, description="max(0, limit - used)")
+
+
 class CurrentUsage(BaseModel):
     """Current usage statistics."""
 
@@ -141,6 +159,13 @@ class CurrentUsage(BaseModel):
         description=(
             "Sleep-enabled contexts quota stats (Issue #560). "
             "NULL when the caller has no current workspace selected."
+        ),
+    )
+    workspaces: WorkspacesUsage | None = Field(
+        None,
+        description=(
+            "Owned-workspace cap usage for the caller (Issue #661). "
+            "User-level — populated independently of current workspace."
         ),
     )
 
@@ -380,6 +405,39 @@ async def _build_sleep_contexts_usage(
     )
 
 
+async def _build_workspaces_usage(db: AsyncSession, user_id: str) -> "WorkspacesUsage":
+    """Build the ``workspaces`` field of /usage/current (Issue #661).
+
+    User-level cap: counts the user's owned (``deleted_at IS NULL``)
+    workspaces and resolves the cap from their effective plan tier
+    (highest tier across owned workspaces; FREE when none owned).
+
+    Always returns a populated ``WorkspacesUsage`` — the cap is
+    user-scoped so there is no "no current workspace" null case here.
+    """
+    from config.plan_tiers import get_plan_tier
+    from utils.plan_resolver import get_user_effective_plan
+
+    owned_count = (
+        await db.execute(
+            select(func.count(Workspace.id)).where(
+                Workspace.owner_user_id == user_id,
+                Workspace.deleted_at.is_(None),
+            )
+        )
+    ).scalar() or 0
+
+    user_plan = await get_user_effective_plan(db, user_id)
+    plan_tier = get_plan_tier(user_plan)
+    limit = plan_tier.max_owned_workspaces
+
+    return WorkspacesUsage(
+        used=owned_count,
+        limit=limit,
+        remaining=max(0, limit - owned_count),
+    )
+
+
 @router.get("/current", response_model=UsageCurrentResponse)
 async def get_current_usage(
     user: SessionUser,
@@ -531,6 +589,8 @@ async def get_current_usage(
         sleep_contexts_usage = await _build_sleep_contexts_usage(
             db, current_workspace_id, effective_quotas=effective_quotas_dict
         )
+        # Issue #661: user-level owned-workspace cap (independent of current_workspace_id).
+        workspaces_usage = await _build_workspaces_usage(db, user_id)
 
         # Build response
         response = UsageCurrentResponse(
@@ -552,6 +612,7 @@ async def get_current_usage(
                 public_calls_this_week=public_calls_week,
                 analysis=analysis_usage,
                 sleep_contexts=sleep_contexts_usage,
+                workspaces=workspaces_usage,
             ),
             memory_usage=calculate_usage_status(memory_count, plan.memory_limit),
             daily_api_usage=calculate_usage_status(api_calls_today, plan.daily_api_limit),

--- a/backend/src/api/routes/workspace.py
+++ b/backend/src/api/routes/workspace.py
@@ -27,6 +27,7 @@ from api.routes.usage import (
     UsageCurrentResponse,
     UsageHistoryResponse,
     _build_sleep_contexts_usage,
+    _build_workspaces_usage,
     calculate_usage_status,
 )
 from auth.dependencies import get_user_from_api_key_or_session
@@ -415,6 +416,10 @@ async def get_workspace_usage_current(
                 sleep_contexts=await _build_sleep_contexts_usage(
                     db, workspace_id, effective_quotas=effective_quotas
                 ),
+                # Issue #661: user-level owned-workspace cap. The /workspace/usage/current
+                # endpoint is workspace-scoped overall but ``workspaces`` is required on
+                # ``CurrentUsage`` (always populated, user-scoped). Use the caller's user_id.
+                workspaces=await _build_workspaces_usage(db, user["user_id"]),
             ),
             memory_usage=calculate_usage_status(memory_count, effective_memory_limit),
             daily_api_usage=calculate_usage_status(api_calls_today, effective_daily_api_limit),

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -81,14 +81,6 @@ DB_POOL_SIZE = 20
 DB_MAX_OVERFLOW = 10
 
 # ============================================================================
-# Quota & Limits (Plan-based)
-# ============================================================================
-
-# Maximum owned workspaces per user (all plans)
-# Issue #276: Users can own max 10 workspaces but can be members of unlimited workspaces via invites.
-MAX_OWNED_WORKSPACES_PER_USER = 10
-
-# ============================================================================
 # Migration & Validation
 # ============================================================================
 

--- a/backend/src/config/plan_tiers.py
+++ b/backend/src/config/plan_tiers.py
@@ -28,8 +28,9 @@ class PlanName(StrEnum):
 class PlanTier:
     """Plan tier configuration.
 
-    Issue #276: All users can own max 10 workspaces (regardless of plan tier).
-    Users can be members of additional workspaces via invites.
+    Issue #276 (updated by Issue #661): User-owned workspaces are capped per
+    plan tier via ``max_owned_workspaces``. Joining workspaces via invite is
+    uncapped — only ownership counts toward this limit.
 
     Attributes:
         name: Plan tier name ('free', 'basic', 'pro')
@@ -38,6 +39,8 @@ class PlanTier:
         max_contexts_per_workspace: Maximum contexts per workspace
         max_members_per_workspace: Maximum members per workspace (Issue #229)
         max_resource_tokens: Maximum active resource tokens (Issue #242)
+        max_owned_workspaces: Maximum workspaces a user can own (Issue #661;
+            joined workspaces via invite are uncapped)
         memory_limit: Maximum memories per workspace
         daily_api_limit: Maximum API calls per day (legacy, kept for backward compatibility)
         weekly_api_limit: Maximum API calls per week (legacy, kept for backward compatibility)
@@ -75,6 +78,9 @@ class PlanTier:
     analysis_runs_per_day: int = 0  # Issue #494: Memory Broadlistening analyses/day
     storage_limit_bytes: int = 0  # Issue #485: File-storage hard cap per workspace
     sleep_enabled_contexts_limit: int = 0  # Issue #560: Sleep-mode contexts cap (PRO-only)
+    max_owned_workspaces: int = (
+        10  # Issue #661: Owned-workspace cap per user (default 10 for backward compat)
+    )
     allows_shared_contexts: bool = False  # Issue #271: Shared context feature (Pro only)
     features: frozenset[str] = field(default_factory=frozenset)
 
@@ -98,6 +104,7 @@ PLAN_FREE = PlanTier(
     public_calls_per_day=0,  # Free plan: no public contexts
     public_calls_per_week=0,
     storage_limit_bytes=100 * 1024 * 1024,  # Issue #485: 100 MB
+    max_owned_workspaces=1,  # Issue #661
     allows_shared_contexts=False,  # Issue #271: Private contexts only
     features=frozenset({"api_keys", "oauth"}),  # Free plan includes OAuth (App Credentials)
 )
@@ -121,6 +128,7 @@ PLAN_BASIC = PlanTier(
     public_calls_per_day=0,  # Basic plan: no public contexts (PRO only)
     public_calls_per_week=0,
     storage_limit_bytes=1 * 1024 * 1024 * 1024,  # Issue #485: 1 GiB
+    max_owned_workspaces=3,  # Issue #661
     features=frozenset({"api_keys", "reranking", "oauth"}),  # Public contexts removed (PRO only)
 )
 
@@ -146,6 +154,7 @@ PLAN_PRO = PlanTier(
     analysis_runs_per_day=3,  # Issue #494: Memory Broadlistening (Pro only; FREE/BASIC=0)
     storage_limit_bytes=10 * 1024 * 1024 * 1024,  # Issue #485: 10 GiB
     sleep_enabled_contexts_limit=3,  # Issue #560: Sleep mode (Pro only; FREE/BASIC=0)
+    max_owned_workspaces=10,  # Issue #661 (default; matches pre-#661 plan-independent cap)
     features=frozenset(
         {
             "api_keys",
@@ -200,6 +209,7 @@ def _apply_settings_overrides() -> None:
             "mcp_calls_per_day": settings.plan_free_mcp_calls_per_day,
             "storage_limit_bytes": settings.plan_free_storage_limit_bytes,
             "sleep_enabled_contexts_limit": settings.plan_free_sleep_enabled_contexts_limit,
+            "max_owned_workspaces": settings.plan_free_max_owned_workspaces,
             "display_name": settings.plan_free_display_name,
         },
         PlanName.BASIC: {
@@ -208,6 +218,7 @@ def _apply_settings_overrides() -> None:
             "mcp_calls_per_day": settings.plan_basic_mcp_calls_per_day,
             "storage_limit_bytes": settings.plan_basic_storage_limit_bytes,
             "sleep_enabled_contexts_limit": settings.plan_basic_sleep_enabled_contexts_limit,
+            "max_owned_workspaces": settings.plan_basic_max_owned_workspaces,
             "display_name": settings.plan_basic_display_name,
         },
         PlanName.PRO: {
@@ -216,6 +227,7 @@ def _apply_settings_overrides() -> None:
             "mcp_calls_per_day": settings.plan_pro_mcp_calls_per_day,
             "storage_limit_bytes": settings.plan_pro_storage_limit_bytes,
             "sleep_enabled_contexts_limit": settings.plan_pro_sleep_enabled_contexts_limit,
+            "max_owned_workspaces": settings.plan_pro_max_owned_workspaces,
             "display_name": settings.plan_pro_display_name,
         },
     }

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -321,6 +321,28 @@ class Settings(BaseSettings):
         default=None,
         description="Override PRO plan sleep-enabled contexts cap (Issue #560; default 3)",
     )
+    plan_free_max_owned_workspaces: int | None = Field(
+        default=None,
+        description="Override FREE plan owned-workspace cap (Issue #661; default 1)",
+    )
+    plan_basic_max_owned_workspaces: int | None = Field(
+        default=None,
+        description="Override BASIC plan owned-workspace cap (Issue #661; default 3)",
+    )
+    plan_pro_max_owned_workspaces: int | None = Field(
+        default=None,
+        description="Override PRO plan owned-workspace cap (Issue #661; default 10)",
+    )
+    enforce_workspace_cap: bool = Field(
+        default=False,
+        description=(
+            "Issue #661 rollout gate. When False (default), workspace creation "
+            "is allowed unconditionally but a structured warn log is emitted "
+            "whenever a user is over their tier's max_owned_workspaces — used "
+            "to surface affected accounts before enforcement. Flip to True "
+            "after the email-outreach cleanup window."
+        ),
+    )
 
     # Plan Display Names (customizable for SaaS forks)
     plan_free_display_name: str | None = Field(

--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -230,21 +230,26 @@ class QuotaService:
                 reached, AND ``settings.enforce_workspace_cap`` is True.
         """
         from config.settings import get_settings
-        from utils.plan_resolver import get_user_effective_plan
+        from utils.plan_resolver import get_user_workspace_summary
 
         settings = get_settings()
 
-        # Count user's owned workspaces (where user is owner, not soft-deleted).
-        workspace_count_result = await self.db.execute(
-            select(func.count(Workspace.id)).where(
-                Workspace.owner_user_id == user_id,
-                Workspace.deleted_at.is_(None),
-            )
-        )
-        workspace_count = workspace_count_result.scalar() or 0
-
-        # Issue #661: resolve user's effective plan tier and cap.
-        user_plan = await get_user_effective_plan(self.db, user_id)
+        # Issue #661: fold "owned count" + "effective plan" into one SELECT.
+        # Sharing this helper with ``_build_workspaces_usage`` keeps the
+        # gate and the dashboard reading from the same source.
+        #
+        # TOCTOU note: this read happens without ``WITH FOR UPDATE`` /
+        # row-level locking. The same race existed for the pre-#661
+        # plan-independent constant cap (Issue #276), but the new tighter
+        # Free=1 cap makes it more exploitable: two concurrent
+        # ``POST /workspaces`` requests can both see ``count=0 < cap=1``
+        # and both succeed. A follow-up should add a SELECT FOR UPDATE on
+        # a per-user sentinel row or a partial unique constraint on
+        # ``(owner_user_id) WHERE deleted_at IS NULL`` before flipping
+        # ``enforce_workspace_cap=True`` in production. Until then the
+        # gate is log-only (see flag handling below) so the race has no
+        # user-visible effect.
+        workspace_count, user_plan = await get_user_workspace_summary(self.db, user_id)
         plan_tier = get_plan_tier(user_plan)
         max_owned = plan_tier.max_owned_workspaces
 

--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -203,8 +203,20 @@ class QuotaService:
     ) -> tuple[bool, str | None]:
         """Check if user can create another workspace.
 
-        Issue #276: All users can own max 10 workspaces.
-        Users can be members of additional workspaces via invites.
+        Issue #276 (updated by Issue #661): owned-workspace cap is per
+        plan tier. Joined workspaces (via invite) do not count toward
+        this limit — they consume the inviting workspace's seat quota,
+        which the inviter pays for.
+
+        The user's effective tier is the highest tier among their owned
+        (``deleted_at IS NULL``) workspaces; users with zero owned
+        workspaces default to FREE.
+
+        Rollout (Issue #661): when ``settings.enforce_workspace_cap`` is
+        False (default), this method emits a structured warn log when a
+        user would be over their tier's cap, but still returns OK. This
+        surfaces affected accounts via telemetry before the flag is
+        flipped to True.
 
         Args:
             user_id: User ID
@@ -214,11 +226,15 @@ class QuotaService:
             Tuple of (can_create, error_message)
 
         Raises:
-            QuotaExceededError: If raise_on_denied=True and limit reached
+            QuotaExceededError: If raise_on_denied=True, the limit is
+                reached, AND ``settings.enforce_workspace_cap`` is True.
         """
-        from config.constants import MAX_OWNED_WORKSPACES_PER_USER
+        from config.settings import get_settings
+        from utils.plan_resolver import get_user_effective_plan
 
-        # Count user's owned workspaces (where user is owner)
+        settings = get_settings()
+
+        # Count user's owned workspaces (where user is owner, not soft-deleted).
         workspace_count_result = await self.db.execute(
             select(func.count(Workspace.id)).where(
                 Workspace.owner_user_id == user_id,
@@ -227,21 +243,29 @@ class QuotaService:
         )
         workspace_count = workspace_count_result.scalar() or 0
 
-        # Issue #276: Use centralized constant
-        MAX_OWNED_WORKSPACES = MAX_OWNED_WORKSPACES_PER_USER
+        # Issue #661: resolve user's effective plan tier and cap.
+        user_plan = await get_user_effective_plan(self.db, user_id)
+        plan_tier = get_plan_tier(user_plan)
+        max_owned = plan_tier.max_owned_workspaces
 
-        if workspace_count >= MAX_OWNED_WORKSPACES:
+        if workspace_count >= max_owned:
             error = (
                 f"Workspace limit reached. "
-                f"You can own maximum {MAX_OWNED_WORKSPACES} workspaces. "
-                f"You can join other workspaces as a member via invite."
+                f"Your {plan_tier.display_name} tier allows owning {max_owned} "
+                f"workspace(s). You can still join other workspaces as a member via invite."
             )
             logger.warning(
                 "workspace_creation_denied",
                 user_id=user_id,
                 current_owned_workspaces=workspace_count,
-                max_owned_workspaces=MAX_OWNED_WORKSPACES,
+                max_owned_workspaces=max_owned,
+                user_plan=user_plan,
+                enforced=settings.enforce_workspace_cap,
             )
+
+            # Issue #661 rollout gate: when the flag is off, log but allow.
+            if not settings.enforce_workspace_cap:
+                return True, None
 
             if raise_on_denied:
                 raise QuotaExceededError(error)

--- a/backend/src/utils/plan_resolver.py
+++ b/backend/src/utils/plan_resolver.py
@@ -1,0 +1,65 @@
+"""User-level plan resolution from owned workspaces.
+
+Issue #661: Determines a user's effective plan tier by inspecting their
+owned (deleted_at IS NULL) workspaces and returning the highest-tier
+plan_name. Used for cross-workspace quotas like ``max_owned_workspaces``
+where the tier must be derived from the user's holdings rather than a
+single workspace.
+
+Why "highest tier among owned" and not ``UserPlan.plan_name``:
+    ``UserPlan`` (models/auth.py) defaults to ``free`` and is not
+    currently updated by Stripe billing — only ``Workspace.plan_name``
+    is (see ``services/stripe_service._apply_plan_change``). So the
+    workspace-level plan column is the canonical billing source of
+    truth, and the user's effective tier is the highest one across
+    their owned workspaces.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.plan_tiers import PlanName
+from models.auth import Workspace
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# Tier ranking — higher wins. Aligned with PlanName values.
+# Unknown plan_name values rank below FREE (-1) so degenerate data
+# cannot accidentally elevate a user's effective tier.
+_TIER_RANK: dict[str, int] = {
+    PlanName.FREE: 0,
+    PlanName.BASIC: 1,
+    PlanName.PRO: 2,
+}
+
+
+async def get_user_effective_plan(db: AsyncSession, user_id: str) -> str:
+    """Return the user's effective plan_name based on owned workspaces.
+
+    Algorithm:
+        1. Query all ``Workspace.plan_name`` rows where the user is the
+           owner and the workspace is not soft-deleted.
+        2. Return the highest-tier plan_name per ``_TIER_RANK``.
+        3. Return ``PlanName.FREE`` when the user owns zero workspaces.
+
+    Args:
+        db: Async database session.
+        user_id: User ID to resolve.
+
+    Returns:
+        Plan name string (one of ``PlanName`` values). Defaults to
+        ``PlanName.FREE`` when the user has no owned workspaces.
+    """
+    result = await db.execute(
+        select(Workspace.plan_name).where(
+            Workspace.owner_user_id == user_id,
+            Workspace.deleted_at.is_(None),
+        )
+    )
+    plan_names = list(result.scalars().all())
+
+    if not plan_names:
+        return PlanName.FREE
+
+    return max(plan_names, key=lambda p: _TIER_RANK.get(p, -1))

--- a/backend/src/utils/plan_resolver.py
+++ b/backend/src/utils/plan_resolver.py
@@ -2,9 +2,9 @@
 
 Issue #661: Determines a user's effective plan tier by inspecting their
 owned (deleted_at IS NULL) workspaces and returning the highest-tier
-plan_name. Used for cross-workspace quotas like ``max_owned_workspaces``
-where the tier must be derived from the user's holdings rather than a
-single workspace.
+plan_name plus the count of owned rows. Used for cross-workspace quotas
+like ``max_owned_workspaces`` where the tier must be derived from the
+user's holdings rather than a single workspace.
 
 Why "highest tier among owned" and not ``UserPlan.plan_name``:
     ``UserPlan`` (models/auth.py) defaults to ``free`` and is not
@@ -13,6 +13,13 @@ Why "highest tier among owned" and not ``UserPlan.plan_name``:
     workspace-level plan column is the canonical billing source of
     truth, and the user's effective tier is the highest one across
     their owned workspaces.
+
+Single-query design (Issue #661 review):
+    ``get_user_workspace_summary`` returns both the owned count and
+    the resolved plan in one SELECT. Both ``QuotaService`` (gate)
+    and ``/usage/current`` (dashboard) need both values; folding them
+    into one helper avoids duplicate queries and the small race
+    window that two sequential SELECTs would expose.
 """
 
 from sqlalchemy import select
@@ -26,7 +33,8 @@ logger = get_logger(__name__)
 
 # Tier ranking — higher wins. Aligned with PlanName values.
 # Unknown plan_name values rank below FREE (-1) so degenerate data
-# cannot accidentally elevate a user's effective tier.
+# cannot accidentally elevate a user's effective tier during the
+# ``max()`` selection inside ``get_user_workspace_summary``.
 _TIER_RANK: dict[str, int] = {
     PlanName.FREE: 0,
     PlanName.BASIC: 1,
@@ -34,22 +42,32 @@ _TIER_RANK: dict[str, int] = {
 }
 
 
-async def get_user_effective_plan(db: AsyncSession, user_id: str) -> str:
-    """Return the user's effective plan_name based on owned workspaces.
+async def get_user_workspace_summary(db: AsyncSession, user_id: str) -> tuple[int, str]:
+    """Return ``(owned_count, effective_plan_name)`` for the user.
 
     Algorithm:
-        1. Query all ``Workspace.plan_name`` rows where the user is the
-           owner and the workspace is not soft-deleted.
-        2. Return the highest-tier plan_name per ``_TIER_RANK``.
-        3. Return ``PlanName.FREE`` when the user owns zero workspaces.
+        1. Single SELECT of all ``Workspace.plan_name`` rows where the
+           user is the owner and the workspace is not soft-deleted.
+        2. Count = number of returned rows.
+        3. Effective plan = highest-tier plan_name per ``_TIER_RANK``.
+        4. Empty result → ``(0, PlanName.FREE)``.
+
+    Corruption guard:
+        If the resolved plan_name is not a known ``PlanName`` member
+        (e.g. legacy ``"enterprise"`` from the older UserPlan model
+        leaking in, or a manual DB edit), this falls back to
+        ``PlanName.FREE`` and emits a ``plan_resolver_unknown_plan_names``
+        warning so the corruption surfaces in ops monitoring rather
+        than crashing the user's dashboard or workspace-creation
+        flow with ``ValueError`` from a downstream ``get_plan_tier``
+        lookup.
 
     Args:
         db: Async database session.
         user_id: User ID to resolve.
 
     Returns:
-        Plan name string (one of ``PlanName`` values). Defaults to
-        ``PlanName.FREE`` when the user has no owned workspaces.
+        Tuple of (owned workspace count, plan_name string).
     """
     result = await db.execute(
         select(Workspace.plan_name).where(
@@ -58,8 +76,20 @@ async def get_user_effective_plan(db: AsyncSession, user_id: str) -> str:
         )
     )
     plan_names = list(result.scalars().all())
+    count = len(plan_names)
 
     if not plan_names:
-        return PlanName.FREE
+        return (0, PlanName.FREE)
 
-    return max(plan_names, key=lambda p: _TIER_RANK.get(p, -1))
+    effective = max(plan_names, key=lambda p: _TIER_RANK.get(p, -1))
+
+    if effective not in _TIER_RANK:
+        logger.warning(
+            "plan_resolver_unknown_plan_names",
+            user_id=user_id,
+            plan_names=plan_names,
+            falling_back_to=PlanName.FREE,
+        )
+        return (count, PlanName.FREE)
+
+    return (count, effective)

--- a/backend/tests/api/test_usage_workspaces.py
+++ b/backend/tests/api/test_usage_workspaces.py
@@ -1,0 +1,107 @@
+"""Tests for the user-level workspace cap field in /api/v1/usage/current (Issue #661).
+
+Focused unit tests for ``_build_workspaces_usage`` (the helper that
+populates ``CurrentUsage.workspaces``). The helper takes an async db
+session and a user_id, and returns a ``WorkspacesUsage`` with
+``used`` (owned count), ``limit`` (tier cap), and ``remaining``.
+
+These tests mock the two DB calls the helper issues:
+  1. SELECT count(Workspace.id) WHERE owner_user_id = X AND deleted_at IS NULL
+  2. plan_resolver's SELECT Workspace.plan_name (same WHERE)
+
+Tier→cap mapping (Free=1 / Basic=3 / Pro=10) is exercised through the
+real ``PLAN_TIERS`` so this file also pins that mapping for the
+user-facing /usage/current response.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.routes.usage import _build_workspaces_usage
+from config.plan_tiers import PlanName
+
+
+def _mock_db(owned_count: int, plan_names: list[str]):
+    """Mock AsyncSession whose two execute() calls return:
+    1) a count result with .scalar() == owned_count
+    2) a plan_resolver result with .scalars().all() == plan_names
+    """
+    db = MagicMock()
+    db.execute = AsyncMock()
+
+    count_result = MagicMock()
+    count_result.scalar = MagicMock(return_value=owned_count)
+
+    plan_scalars = MagicMock()
+    plan_scalars.all = MagicMock(return_value=plan_names)
+    plan_result = MagicMock()
+    plan_result.scalars = MagicMock(return_value=plan_scalars)
+
+    db.execute.side_effect = [count_result, plan_result]
+    return db
+
+
+@pytest.mark.asyncio
+async def test_free_user_zero_owned():
+    """Free default, 0 owned → used=0, limit=1, remaining=1."""
+    db = _mock_db(owned_count=0, plan_names=[])
+    result = await _build_workspaces_usage(db, "user-1")
+    assert result.used == 0
+    assert result.limit == 1
+    assert result.remaining == 1
+
+
+@pytest.mark.asyncio
+async def test_free_user_at_cap():
+    """Free with 1 owned → used=1, limit=1, remaining=0."""
+    db = _mock_db(owned_count=1, plan_names=[PlanName.FREE])
+    result = await _build_workspaces_usage(db, "user-1")
+    assert result.used == 1
+    assert result.limit == 1
+    assert result.remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_basic_user_partial():
+    """Basic with 2 owned → used=2, limit=3, remaining=1."""
+    db = _mock_db(owned_count=2, plan_names=[PlanName.BASIC, PlanName.BASIC])
+    result = await _build_workspaces_usage(db, "user-1")
+    assert result.used == 2
+    assert result.limit == 3
+    assert result.remaining == 1
+
+
+@pytest.mark.asyncio
+async def test_pro_user_at_cap():
+    """Pro with 10 owned → used=10, limit=10, remaining=0."""
+    db = _mock_db(owned_count=10, plan_names=[PlanName.PRO] * 10)
+    result = await _build_workspaces_usage(db, "user-1")
+    assert result.used == 10
+    assert result.limit == 10
+    assert result.remaining == 0
+
+
+@pytest.mark.asyncio
+async def test_mixed_tier_uses_highest():
+    """User with 1 Basic + 1 Pro owned → cap is 10 (Pro)."""
+    db = _mock_db(owned_count=2, plan_names=[PlanName.BASIC, PlanName.PRO])
+    result = await _build_workspaces_usage(db, "user-1")
+    assert result.used == 2
+    assert result.limit == 10
+    assert result.remaining == 8
+
+
+@pytest.mark.asyncio
+async def test_remaining_never_negative():
+    """Pathological over-cap state (e.g. legacy data) → remaining clamped to 0.
+
+    Documents what the dashboard surfaces if an existing Free user
+    happens to be at 3 owned workspaces when the cap was lowered to 1
+    (the pre-enforcement migration scenario Issue #661 plans for).
+    """
+    db = _mock_db(owned_count=3, plan_names=[PlanName.FREE])
+    result = await _build_workspaces_usage(db, "user-1")
+    assert result.used == 3
+    assert result.limit == 1
+    assert result.remaining == 0  # clamped via max(0, ...)

--- a/backend/tests/api/test_usage_workspaces.py
+++ b/backend/tests/api/test_usage_workspaces.py
@@ -5,9 +5,10 @@ populates ``CurrentUsage.workspaces``). The helper takes an async db
 session and a user_id, and returns a ``WorkspacesUsage`` with
 ``used`` (owned count), ``limit`` (tier cap), and ``remaining``.
 
-These tests mock the two DB calls the helper issues:
-  1. SELECT count(Workspace.id) WHERE owner_user_id = X AND deleted_at IS NULL
-  2. plan_resolver's SELECT Workspace.plan_name (same WHERE)
+After the post-review refactor, the helper issues a single SELECT
+via ``get_user_workspace_summary`` which returns
+``(owned_count, plan_name)``. Tests mock exactly one ``execute()``
+call; ``owned_count`` is derived from ``len(plan_names)``.
 
 Tier→cap mapping (Free=1 / Basic=3 / Pro=10) is exercised through the
 real ``PLAN_TIERS`` so this file also pins that mapping for the
@@ -22,30 +23,28 @@ from api.routes.usage import _build_workspaces_usage
 from config.plan_tiers import PlanName
 
 
-def _mock_db(owned_count: int, plan_names: list[str]):
-    """Mock AsyncSession whose two execute() calls return:
-    1) a count result with .scalar() == owned_count
-    2) a plan_resolver result with .scalars().all() == plan_names
+def _mock_db(plan_names: list[str]):
+    """Mock AsyncSession whose execute() returns the plan-name rows.
+
+    ``.scalars().all()`` returns ``plan_names``; the resolver derives
+    ``owned_count = len(plan_names)``.
     """
     db = MagicMock()
     db.execute = AsyncMock()
-
-    count_result = MagicMock()
-    count_result.scalar = MagicMock(return_value=owned_count)
 
     plan_scalars = MagicMock()
     plan_scalars.all = MagicMock(return_value=plan_names)
     plan_result = MagicMock()
     plan_result.scalars = MagicMock(return_value=plan_scalars)
 
-    db.execute.side_effect = [count_result, plan_result]
+    db.execute.return_value = plan_result
     return db
 
 
 @pytest.mark.asyncio
 async def test_free_user_zero_owned():
     """Free default, 0 owned → used=0, limit=1, remaining=1."""
-    db = _mock_db(owned_count=0, plan_names=[])
+    db = _mock_db(plan_names=[])
     result = await _build_workspaces_usage(db, "user-1")
     assert result.used == 0
     assert result.limit == 1
@@ -55,7 +54,7 @@ async def test_free_user_zero_owned():
 @pytest.mark.asyncio
 async def test_free_user_at_cap():
     """Free with 1 owned → used=1, limit=1, remaining=0."""
-    db = _mock_db(owned_count=1, plan_names=[PlanName.FREE])
+    db = _mock_db(plan_names=[PlanName.FREE])
     result = await _build_workspaces_usage(db, "user-1")
     assert result.used == 1
     assert result.limit == 1
@@ -65,7 +64,7 @@ async def test_free_user_at_cap():
 @pytest.mark.asyncio
 async def test_basic_user_partial():
     """Basic with 2 owned → used=2, limit=3, remaining=1."""
-    db = _mock_db(owned_count=2, plan_names=[PlanName.BASIC, PlanName.BASIC])
+    db = _mock_db(plan_names=[PlanName.BASIC, PlanName.BASIC])
     result = await _build_workspaces_usage(db, "user-1")
     assert result.used == 2
     assert result.limit == 3
@@ -75,7 +74,7 @@ async def test_basic_user_partial():
 @pytest.mark.asyncio
 async def test_pro_user_at_cap():
     """Pro with 10 owned → used=10, limit=10, remaining=0."""
-    db = _mock_db(owned_count=10, plan_names=[PlanName.PRO] * 10)
+    db = _mock_db(plan_names=[PlanName.PRO] * 10)
     result = await _build_workspaces_usage(db, "user-1")
     assert result.used == 10
     assert result.limit == 10
@@ -85,7 +84,7 @@ async def test_pro_user_at_cap():
 @pytest.mark.asyncio
 async def test_mixed_tier_uses_highest():
     """User with 1 Basic + 1 Pro owned → cap is 10 (Pro)."""
-    db = _mock_db(owned_count=2, plan_names=[PlanName.BASIC, PlanName.PRO])
+    db = _mock_db(plan_names=[PlanName.BASIC, PlanName.PRO])
     result = await _build_workspaces_usage(db, "user-1")
     assert result.used == 2
     assert result.limit == 10
@@ -100,8 +99,21 @@ async def test_remaining_never_negative():
     happens to be at 3 owned workspaces when the cap was lowered to 1
     (the pre-enforcement migration scenario Issue #661 plans for).
     """
-    db = _mock_db(owned_count=3, plan_names=[PlanName.FREE])
+    db = _mock_db(plan_names=[PlanName.FREE, PlanName.FREE, PlanName.FREE])
     result = await _build_workspaces_usage(db, "user-1")
     assert result.used == 3
     assert result.limit == 1
     assert result.remaining == 0  # clamped via max(0, ...)
+
+
+@pytest.mark.asyncio
+async def test_corrupted_plan_names_fallback_to_free():
+    """Reviewer 2 [C1]: unknown plan_name corruption must NOT crash
+    the dashboard with 500. The resolver falls back to FREE so the
+    user sees a coherent (if degraded) usage card.
+    """
+    db = _mock_db(plan_names=["enterprise-legacy", "growth-bogus"])
+    result = await _build_workspaces_usage(db, "user-1")
+    assert result.used == 2  # real row count is preserved
+    assert result.limit == 1  # FREE fallback cap
+    assert result.remaining == 0  # 2 > 1 → clamped

--- a/backend/tests/api/test_workspace.py
+++ b/backend/tests/api/test_workspace.py
@@ -487,8 +487,10 @@ class TestWorkspaceUsageCurrent:
         # Issue #65 baseline: 3 queries (workspace, memory count, usage aggregation —
         # the IN-list member_ids query is eliminated, that's the optimization).
         # Issue #560 adds 2 more queries via _build_sleep_contexts_usage (addon select +
-        # contexts count). Total 5; the Issue #65 invariant on the IN-list still holds.
-        assert call_count == 5
+        # contexts count). Issue #661 adds 1 more via _build_workspaces_usage
+        # (single-SELECT plan_names lookup in get_user_workspace_summary).
+        # Total 6; the Issue #65 invariant on the IN-list still holds.
+        assert call_count == 6
 
     @staticmethod
     def _make_effective_quotas():
@@ -523,8 +525,10 @@ class TestWorkspaceUsageCurrent:
         dict into the helper so EffectiveQuotaService is NOT re-invoked from inside the
         helper — important because that service may COMMIT via AddonCalculatorService's
         self-heal path (a request-side COMMIT on a GET endpoint).
+        Issue #661 added 1 query via _build_workspaces_usage (single-SELECT
+        plan_names lookup in get_user_workspace_summary).
 
-        Total: 5 queries. The Issue #65 invariant ("no member_ids IN-list, no
+        Total: 6 queries. The Issue #65 invariant ("no member_ids IN-list, no
         per-endpoint usage queries") still holds.
         """
         # Query 1: workspace fetch
@@ -551,4 +555,18 @@ class TestWorkspaceUsageCurrent:
         # Query 5: count contexts with sleep_mode != 'skip' (Issue #560)
         count_result = MagicMock(scalar_one=MagicMock(return_value=0))
 
-        return [workspace_result, memory_result, usage_result, addon_result, count_result]
+        # Query 6: Workspace.plan_name rows for the caller's owned workspaces
+        # (Issue #661 — plan_resolver.get_user_workspace_summary). Returning
+        # ["pro"] resolves to (count=1, plan=PRO) → cap 10, remaining 9.
+        plan_scalars = MagicMock()
+        plan_scalars.all = MagicMock(return_value=["pro"])
+        plan_resolver_result = MagicMock(scalars=MagicMock(return_value=plan_scalars))
+
+        return [
+            workspace_result,
+            memory_result,
+            usage_result,
+            addon_result,
+            count_result,
+            plan_resolver_result,
+        ]

--- a/backend/tests/services/test_quota_service.py
+++ b/backend/tests/services/test_quota_service.py
@@ -210,14 +210,17 @@ class TestQuotaServiceMemberQuota:
 class TestQuotaServiceWorkspaceCreationCap:
     """Test QuotaService.check_workspace_creation_allowed() — Issue #661.
 
-    Mocks two execute() calls per check:
-      1. SELECT count(Workspace.id) WHERE owner_user_id = X AND deleted_at IS NULL
-      2. plan_resolver's SELECT Workspace.plan_name WHERE owner_user_id = X AND deleted_at IS NULL
+    After the post-review refactor, ``check_workspace_creation_allowed``
+    issues a single SELECT via ``get_user_workspace_summary`` which
+    returns ``(owned_count, plan_name)``. The mock arms exactly one
+    ``execute()`` call whose ``.scalars().all()`` returns the supplied
+    plan_names list — owned_count is derived from ``len(plan_names)``.
 
-    Settings are patched so each test controls ``enforce_workspace_cap``
-    explicitly. Tier resolution is exercised through the real
-    ``get_user_effective_plan`` and real ``PLAN_TIERS`` so the test
-    locks the actual tier→cap mapping (Free=1 / Basic=3 / Pro=10).
+    Settings are patched at ``services.quota_service.get_settings``
+    (the binding the method's lazy import resolves to) so each test
+    controls ``enforce_workspace_cap`` explicitly. Tier resolution is
+    exercised through the real ``PLAN_TIERS`` so the test locks the
+    actual tier→cap mapping (Free=1 / Basic=3 / Pro=10).
     """
 
     @pytest.fixture
@@ -233,27 +236,34 @@ class TestQuotaServiceWorkspaceCreationCap:
     def _patch_settings(self, enforce: bool):
         """Return a context manager that patches get_settings to return
         a settings object whose ``enforce_workspace_cap`` is ``enforce``.
+
+        Patches at the definition site (``config.settings.get_settings``)
+        rather than ``services.quota_service.get_settings`` because the
+        method uses a *local* (function-scope) ``from config.settings
+        import get_settings``. Local imports look the name up on the
+        source module at call time, so patching the source module is
+        what intercepts the lookup. Patching at
+        ``services.quota_service.get_settings`` would fail with
+        ``AttributeError`` because there is no module-level binding of
+        that name in ``services.quota_service``.
         """
         mock_settings = MagicMock()
         mock_settings.enforce_workspace_cap = enforce
         return patch("config.settings.get_settings", return_value=mock_settings)
 
-    def _arm_db(self, mock_db, owned_count: int, plan_names: list[str]):
-        """Configure mock_db.execute side_effect for the two SELECTs.
+    def _arm_db(self, mock_db, plan_names: list[str]):
+        """Configure mock_db.execute for the single SELECT inside
+        ``get_user_workspace_summary``.
 
-        Order matches check_workspace_creation_allowed:
-          1. count query → ``.scalar()``
-          2. plan_resolver query → ``.scalars().all()``
+        ``.scalars().all()`` returns ``plan_names``; the resolver
+        derives ``owned_count = len(plan_names)``.
         """
-        count_result = MagicMock()
-        count_result.scalar = MagicMock(return_value=owned_count)
-
         plan_scalars = MagicMock()
         plan_scalars.all = MagicMock(return_value=plan_names)
         plan_result = MagicMock()
         plan_result.scalars = MagicMock(return_value=plan_scalars)
 
-        mock_db.execute.side_effect = [count_result, plan_result]
+        mock_db.execute.return_value = plan_result
 
     # ------------------------------------------------------------------
     # Free tier (cap = 1)
@@ -262,7 +272,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_free_user_zero_owned_can_create(self, service, mock_db):
         """Free user with 0 owned workspaces can create (count=0 < cap=1)."""
-        self._arm_db(mock_db, owned_count=0, plan_names=[])
+        self._arm_db(mock_db, plan_names=[])
         with self._patch_settings(enforce=True):
             can_create, error = await service.check_workspace_creation_allowed("user-1")
         assert can_create is True
@@ -271,7 +281,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_free_user_one_owned_denied_when_enforced(self, service, mock_db):
         """Free user with 1 owned workspace denied when flag=True."""
-        self._arm_db(mock_db, owned_count=1, plan_names=[PlanName.FREE])
+        self._arm_db(mock_db, plan_names=[PlanName.FREE])
         with self._patch_settings(enforce=True):
             can_create, error = await service.check_workspace_creation_allowed("user-1")
         assert can_create is False
@@ -282,7 +292,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_free_user_one_owned_allowed_when_flag_off(self, service, mock_db):
         """Free user with 1 owned workspace passes when flag=False (rollout gate)."""
-        self._arm_db(mock_db, owned_count=1, plan_names=[PlanName.FREE])
+        self._arm_db(mock_db, plan_names=[PlanName.FREE])
         with self._patch_settings(enforce=False):
             can_create, error = await service.check_workspace_creation_allowed("user-1")
         # Flag off: still returns OK so the cap is observable via log only.
@@ -296,7 +306,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_basic_user_two_owned_can_create(self, service, mock_db):
         """Basic user with 2 owned workspaces can create (count=2 < cap=3)."""
-        self._arm_db(mock_db, owned_count=2, plan_names=[PlanName.BASIC, PlanName.BASIC])
+        self._arm_db(mock_db, plan_names=[PlanName.BASIC, PlanName.BASIC])
         with self._patch_settings(enforce=True):
             can_create, error = await service.check_workspace_creation_allowed("user-1")
         assert can_create is True
@@ -307,7 +317,6 @@ class TestQuotaServiceWorkspaceCreationCap:
         """Basic user with 3 owned workspaces denied at cap."""
         self._arm_db(
             mock_db,
-            owned_count=3,
             plan_names=[PlanName.BASIC, PlanName.BASIC, PlanName.BASIC],
         )
         with self._patch_settings(enforce=True):
@@ -323,7 +332,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_pro_user_nine_owned_can_create(self, service, mock_db):
         """Pro user with 9 owned workspaces can create (count=9 < cap=10)."""
-        self._arm_db(mock_db, owned_count=9, plan_names=[PlanName.PRO] * 9)
+        self._arm_db(mock_db, plan_names=[PlanName.PRO] * 9)
         with self._patch_settings(enforce=True):
             can_create, error = await service.check_workspace_creation_allowed("user-1")
         assert can_create is True
@@ -332,7 +341,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_pro_user_ten_owned_denied(self, service, mock_db):
         """Pro user with 10 owned workspaces denied at cap."""
-        self._arm_db(mock_db, owned_count=10, plan_names=[PlanName.PRO] * 10)
+        self._arm_db(mock_db, plan_names=[PlanName.PRO] * 10)
         with self._patch_settings(enforce=True):
             can_create, error = await service.check_workspace_creation_allowed("user-1")
         assert can_create is False
@@ -345,7 +354,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_mixed_free_and_basic_uses_basic_cap(self, service, mock_db):
         """User owning 1 Free + 1 Basic gets Basic cap (3). With 2 owned → allowed."""
-        self._arm_db(mock_db, owned_count=2, plan_names=[PlanName.FREE, PlanName.BASIC])
+        self._arm_db(mock_db, plan_names=[PlanName.FREE, PlanName.BASIC])
         with self._patch_settings(enforce=True):
             can_create, error = await service.check_workspace_creation_allowed("user-1")
         assert can_create is True
@@ -356,7 +365,6 @@ class TestQuotaServiceWorkspaceCreationCap:
         """User owning Basic + Pro gets Pro cap (10). With 5 owned → allowed."""
         self._arm_db(
             mock_db,
-            owned_count=5,
             plan_names=[PlanName.BASIC, PlanName.PRO, PlanName.PRO, PlanName.PRO, PlanName.PRO],
         )
         with self._patch_settings(enforce=True):
@@ -371,7 +379,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_raises_on_denied_when_enforced(self, service, mock_db):
         """raise_on_denied=True raises QuotaExceededError when flag=True and over cap."""
-        self._arm_db(mock_db, owned_count=1, plan_names=[PlanName.FREE])
+        self._arm_db(mock_db, plan_names=[PlanName.FREE])
         with self._patch_settings(enforce=True):
             with pytest.raises(QuotaExceededError) as exc_info:
                 await service.check_workspace_creation_allowed("user-1", raise_on_denied=True)
@@ -380,7 +388,7 @@ class TestQuotaServiceWorkspaceCreationCap:
     @pytest.mark.asyncio
     async def test_does_not_raise_when_flag_off(self, service, mock_db):
         """raise_on_denied=True does NOT raise when flag=False — log-only mode."""
-        self._arm_db(mock_db, owned_count=1, plan_names=[PlanName.FREE])
+        self._arm_db(mock_db, plan_names=[PlanName.FREE])
         with self._patch_settings(enforce=False):
             # Should silently allow, not raise.
             can_create, error = await service.check_workspace_creation_allowed(

--- a/backend/tests/services/test_quota_service.py
+++ b/backend/tests/services/test_quota_service.py
@@ -1,13 +1,15 @@
 """Tests for QuotaService.
 
 Issue #229: Team member limit (10 members max for Pro plan)
+Issue #661: Plan-based owned-workspace cap
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 
+from config.plan_tiers import PlanName
 from services.quota_service import QuotaService
 from utils.exceptions import QuotaExceededError
 
@@ -202,4 +204,187 @@ class TestQuotaServiceMemberQuota:
         can_invite, error = await service.check_member_quota(workspace_id)
 
         assert can_invite is True
+        assert error is None
+
+
+class TestQuotaServiceWorkspaceCreationCap:
+    """Test QuotaService.check_workspace_creation_allowed() — Issue #661.
+
+    Mocks two execute() calls per check:
+      1. SELECT count(Workspace.id) WHERE owner_user_id = X AND deleted_at IS NULL
+      2. plan_resolver's SELECT Workspace.plan_name WHERE owner_user_id = X AND deleted_at IS NULL
+
+    Settings are patched so each test controls ``enforce_workspace_cap``
+    explicitly. Tier resolution is exercised through the real
+    ``get_user_effective_plan`` and real ``PLAN_TIERS`` so the test
+    locks the actual tier→cap mapping (Free=1 / Basic=3 / Pro=10).
+    """
+
+    @pytest.fixture
+    def mock_db(self):
+        db = MagicMock()
+        db.execute = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def service(self, mock_db):
+        return QuotaService(mock_db)
+
+    def _patch_settings(self, enforce: bool):
+        """Return a context manager that patches get_settings to return
+        a settings object whose ``enforce_workspace_cap`` is ``enforce``.
+        """
+        mock_settings = MagicMock()
+        mock_settings.enforce_workspace_cap = enforce
+        return patch("config.settings.get_settings", return_value=mock_settings)
+
+    def _arm_db(self, mock_db, owned_count: int, plan_names: list[str]):
+        """Configure mock_db.execute side_effect for the two SELECTs.
+
+        Order matches check_workspace_creation_allowed:
+          1. count query → ``.scalar()``
+          2. plan_resolver query → ``.scalars().all()``
+        """
+        count_result = MagicMock()
+        count_result.scalar = MagicMock(return_value=owned_count)
+
+        plan_scalars = MagicMock()
+        plan_scalars.all = MagicMock(return_value=plan_names)
+        plan_result = MagicMock()
+        plan_result.scalars = MagicMock(return_value=plan_scalars)
+
+        mock_db.execute.side_effect = [count_result, plan_result]
+
+    # ------------------------------------------------------------------
+    # Free tier (cap = 1)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_free_user_zero_owned_can_create(self, service, mock_db):
+        """Free user with 0 owned workspaces can create (count=0 < cap=1)."""
+        self._arm_db(mock_db, owned_count=0, plan_names=[])
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        assert can_create is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_free_user_one_owned_denied_when_enforced(self, service, mock_db):
+        """Free user with 1 owned workspace denied when flag=True."""
+        self._arm_db(mock_db, owned_count=1, plan_names=[PlanName.FREE])
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        assert can_create is False
+        assert error is not None
+        assert "Workspace limit reached" in error
+        assert "1 workspace" in error  # tier cap surfaced in message
+
+    @pytest.mark.asyncio
+    async def test_free_user_one_owned_allowed_when_flag_off(self, service, mock_db):
+        """Free user with 1 owned workspace passes when flag=False (rollout gate)."""
+        self._arm_db(mock_db, owned_count=1, plan_names=[PlanName.FREE])
+        with self._patch_settings(enforce=False):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        # Flag off: still returns OK so the cap is observable via log only.
+        assert can_create is True
+        assert error is None
+
+    # ------------------------------------------------------------------
+    # Basic tier (cap = 3)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_basic_user_two_owned_can_create(self, service, mock_db):
+        """Basic user with 2 owned workspaces can create (count=2 < cap=3)."""
+        self._arm_db(mock_db, owned_count=2, plan_names=[PlanName.BASIC, PlanName.BASIC])
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        assert can_create is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_basic_user_three_owned_denied(self, service, mock_db):
+        """Basic user with 3 owned workspaces denied at cap."""
+        self._arm_db(
+            mock_db,
+            owned_count=3,
+            plan_names=[PlanName.BASIC, PlanName.BASIC, PlanName.BASIC],
+        )
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        assert can_create is False
+        assert error is not None
+        assert "3 workspace" in error
+
+    # ------------------------------------------------------------------
+    # Pro tier (cap = 10)
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_pro_user_nine_owned_can_create(self, service, mock_db):
+        """Pro user with 9 owned workspaces can create (count=9 < cap=10)."""
+        self._arm_db(mock_db, owned_count=9, plan_names=[PlanName.PRO] * 9)
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        assert can_create is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_pro_user_ten_owned_denied(self, service, mock_db):
+        """Pro user with 10 owned workspaces denied at cap."""
+        self._arm_db(mock_db, owned_count=10, plan_names=[PlanName.PRO] * 10)
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        assert can_create is False
+        assert "10 workspace" in error
+
+    # ------------------------------------------------------------------
+    # Mixed-tier ownership: highest tier wins
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_mixed_free_and_basic_uses_basic_cap(self, service, mock_db):
+        """User owning 1 Free + 1 Basic gets Basic cap (3). With 2 owned → allowed."""
+        self._arm_db(mock_db, owned_count=2, plan_names=[PlanName.FREE, PlanName.BASIC])
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        assert can_create is True
+        assert error is None
+
+    @pytest.mark.asyncio
+    async def test_mixed_basic_and_pro_uses_pro_cap(self, service, mock_db):
+        """User owning Basic + Pro gets Pro cap (10). With 5 owned → allowed."""
+        self._arm_db(
+            mock_db,
+            owned_count=5,
+            plan_names=[PlanName.BASIC, PlanName.PRO, PlanName.PRO, PlanName.PRO, PlanName.PRO],
+        )
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+        assert can_create is True
+        assert error is None
+
+    # ------------------------------------------------------------------
+    # raise_on_denied behaviour
+    # ------------------------------------------------------------------
+
+    @pytest.mark.asyncio
+    async def test_raises_on_denied_when_enforced(self, service, mock_db):
+        """raise_on_denied=True raises QuotaExceededError when flag=True and over cap."""
+        self._arm_db(mock_db, owned_count=1, plan_names=[PlanName.FREE])
+        with self._patch_settings(enforce=True):
+            with pytest.raises(QuotaExceededError) as exc_info:
+                await service.check_workspace_creation_allowed("user-1", raise_on_denied=True)
+        assert "Workspace limit reached" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_does_not_raise_when_flag_off(self, service, mock_db):
+        """raise_on_denied=True does NOT raise when flag=False — log-only mode."""
+        self._arm_db(mock_db, owned_count=1, plan_names=[PlanName.FREE])
+        with self._patch_settings(enforce=False):
+            # Should silently allow, not raise.
+            can_create, error = await service.check_workspace_creation_allowed(
+                "user-1", raise_on_denied=True
+            )
+        assert can_create is True
         assert error is None

--- a/backend/tests/utils/test_plan_resolver.py
+++ b/backend/tests/utils/test_plan_resolver.py
@@ -1,0 +1,99 @@
+"""Tests for utils.plan_resolver (Issue #661)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from config.plan_tiers import PlanName
+from utils.plan_resolver import get_user_effective_plan
+
+
+def _mock_db(plan_names: list[str]):
+    """Build a mock AsyncSession whose .execute().scalars().all() returns plan_names."""
+    db = MagicMock()
+    db.execute = AsyncMock()
+
+    scalars_result = MagicMock()
+    scalars_result.all = MagicMock(return_value=plan_names)
+
+    execute_result = MagicMock()
+    execute_result.scalars = MagicMock(return_value=scalars_result)
+
+    db.execute.return_value = execute_result
+    return db
+
+
+@pytest.mark.asyncio
+async def test_zero_workspaces_returns_free():
+    """User with no owned workspaces defaults to FREE."""
+    db = _mock_db([])
+    plan = await get_user_effective_plan(db, "user-1")
+    assert plan == PlanName.FREE
+
+
+@pytest.mark.asyncio
+async def test_single_free_workspace_returns_free():
+    """Single Free owned workspace → FREE."""
+    db = _mock_db([PlanName.FREE])
+    plan = await get_user_effective_plan(db, "user-1")
+    assert plan == PlanName.FREE
+
+
+@pytest.mark.asyncio
+async def test_single_pro_workspace_returns_pro():
+    """Single Pro owned workspace → PRO."""
+    db = _mock_db([PlanName.PRO])
+    plan = await get_user_effective_plan(db, "user-1")
+    assert plan == PlanName.PRO
+
+
+@pytest.mark.asyncio
+async def test_mixed_free_and_basic_returns_basic():
+    """Free + Basic owned → BASIC (highest)."""
+    db = _mock_db([PlanName.FREE, PlanName.BASIC])
+    plan = await get_user_effective_plan(db, "user-1")
+    assert plan == PlanName.BASIC
+
+
+@pytest.mark.asyncio
+async def test_mixed_basic_and_pro_returns_pro():
+    """Basic + Pro owned → PRO."""
+    db = _mock_db([PlanName.BASIC, PlanName.PRO])
+    plan = await get_user_effective_plan(db, "user-1")
+    assert plan == PlanName.PRO
+
+
+@pytest.mark.asyncio
+async def test_all_three_tiers_returns_pro():
+    """Free + Basic + Pro owned → PRO."""
+    db = _mock_db([PlanName.FREE, PlanName.BASIC, PlanName.PRO])
+    plan = await get_user_effective_plan(db, "user-1")
+    assert plan == PlanName.PRO
+
+
+@pytest.mark.asyncio
+async def test_unknown_plan_name_ranks_below_free():
+    """Unknown plan_name values cannot silently win against FREE.
+
+    Defensive case: if a row has a corrupted/unknown plan_name (e.g. a
+    legacy ``enterprise`` from the older UserPlan model leaking in, or
+    a manual DB edit), it must NOT outrank a valid FREE workspace.
+    """
+    db = _mock_db(["enterprise", PlanName.FREE])
+    plan = await get_user_effective_plan(db, "user-1")
+    assert plan == PlanName.FREE
+
+
+@pytest.mark.asyncio
+async def test_only_unknown_plan_name_is_returned_as_is():
+    """If all owned workspaces have unknown plan_names, the function
+    returns one of them rather than masking the data with FREE.
+
+    This surfaces corrupted data to callers rather than silently
+    treating it as Free; the caller's ``get_plan_tier`` lookup will
+    then raise, making the corruption visible instead of degrading
+    quietly to Free permissions.
+    """
+    db = _mock_db(["mystery-tier"])
+    plan = await get_user_effective_plan(db, "user-1")
+    assert plan == "mystery-tier"

--- a/backend/tests/utils/test_plan_resolver.py
+++ b/backend/tests/utils/test_plan_resolver.py
@@ -1,15 +1,20 @@
-"""Tests for utils.plan_resolver (Issue #661)."""
+"""Tests for utils.plan_resolver (Issue #661).
+
+Pure unit tests — no DB, no live settings. The single ``execute()``
+call inside ``get_user_workspace_summary`` is mocked so each test
+fully owns the (owned_count, plan_name) input/output.
+"""
 
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from config.plan_tiers import PlanName
-from utils.plan_resolver import get_user_effective_plan
+from utils.plan_resolver import get_user_workspace_summary
 
 
 def _mock_db(plan_names: list[str]):
-    """Build a mock AsyncSession whose .execute().scalars().all() returns plan_names."""
+    """Mock AsyncSession whose execute().scalars().all() returns plan_names."""
     db = MagicMock()
     db.execute = AsyncMock()
 
@@ -24,76 +29,101 @@ def _mock_db(plan_names: list[str]):
 
 
 @pytest.mark.asyncio
-async def test_zero_workspaces_returns_free():
-    """User with no owned workspaces defaults to FREE."""
+async def test_zero_workspaces_returns_count_zero_and_free():
+    """User with no owned workspaces → (0, FREE)."""
     db = _mock_db([])
-    plan = await get_user_effective_plan(db, "user-1")
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 0
     assert plan == PlanName.FREE
 
 
 @pytest.mark.asyncio
-async def test_single_free_workspace_returns_free():
-    """Single Free owned workspace → FREE."""
+async def test_single_free_workspace():
+    """Single Free owned workspace → (1, FREE)."""
     db = _mock_db([PlanName.FREE])
-    plan = await get_user_effective_plan(db, "user-1")
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 1
     assert plan == PlanName.FREE
 
 
 @pytest.mark.asyncio
-async def test_single_pro_workspace_returns_pro():
-    """Single Pro owned workspace → PRO."""
+async def test_single_pro_workspace():
+    """Single Pro owned workspace → (1, PRO)."""
     db = _mock_db([PlanName.PRO])
-    plan = await get_user_effective_plan(db, "user-1")
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 1
     assert plan == PlanName.PRO
 
 
 @pytest.mark.asyncio
 async def test_mixed_free_and_basic_returns_basic():
-    """Free + Basic owned → BASIC (highest)."""
+    """Free + Basic owned → (2, BASIC)."""
     db = _mock_db([PlanName.FREE, PlanName.BASIC])
-    plan = await get_user_effective_plan(db, "user-1")
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 2
     assert plan == PlanName.BASIC
 
 
 @pytest.mark.asyncio
 async def test_mixed_basic_and_pro_returns_pro():
-    """Basic + Pro owned → PRO."""
+    """Basic + Pro owned → (2, PRO)."""
     db = _mock_db([PlanName.BASIC, PlanName.PRO])
-    plan = await get_user_effective_plan(db, "user-1")
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 2
     assert plan == PlanName.PRO
 
 
 @pytest.mark.asyncio
 async def test_all_three_tiers_returns_pro():
-    """Free + Basic + Pro owned → PRO."""
+    """Free + Basic + Pro owned → (3, PRO)."""
     db = _mock_db([PlanName.FREE, PlanName.BASIC, PlanName.PRO])
-    plan = await get_user_effective_plan(db, "user-1")
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 3
     assert plan == PlanName.PRO
 
 
 @pytest.mark.asyncio
-async def test_unknown_plan_name_ranks_below_free():
-    """Unknown plan_name values cannot silently win against FREE.
+async def test_unknown_plan_name_does_not_outrank_free():
+    """Unknown plan_name cannot silently win against FREE.
 
-    Defensive case: if a row has a corrupted/unknown plan_name (e.g. a
-    legacy ``enterprise`` from the older UserPlan model leaking in, or
-    a manual DB edit), it must NOT outrank a valid FREE workspace.
+    Defensive case: a corrupted/unknown plan_name (e.g. legacy
+    ``"enterprise"`` from the older UserPlan model, or a manual DB
+    edit) must NOT outrank a valid FREE workspace. The known FREE
+    still wins.
     """
     db = _mock_db(["enterprise", PlanName.FREE])
-    plan = await get_user_effective_plan(db, "user-1")
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 2
     assert plan == PlanName.FREE
 
 
 @pytest.mark.asyncio
-async def test_only_unknown_plan_name_is_returned_as_is():
-    """If all owned workspaces have unknown plan_names, the function
-    returns one of them rather than masking the data with FREE.
+async def test_only_unknown_plan_names_fallback_to_free():
+    """If ALL owned workspaces have unknown plan_names, the resolver
+    falls back to FREE rather than returning the unknown string.
 
-    This surfaces corrupted data to callers rather than silently
-    treating it as Free; the caller's ``get_plan_tier`` lookup will
-    then raise, making the corruption visible instead of degrading
-    quietly to Free permissions.
+    The unknown string would otherwise crash ``get_plan_tier`` in
+    downstream callers (Issue #661 Reviewer 2 finding [C1]). The
+    fallback also emits a structured warn log (see resolver source);
+    we exercise the return-value path here because structlog's
+    pytest-capture behaviour depends on the global logger setup and
+    pinning on log content makes this test brittle.
     """
     db = _mock_db(["mystery-tier"])
-    plan = await get_user_effective_plan(db, "user-1")
-    assert plan == "mystery-tier"
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 1
+    assert plan == PlanName.FREE
+
+
+@pytest.mark.asyncio
+async def test_only_unknown_plan_names_count_reflects_real_rows():
+    """Fallback path still returns the actual owned-row count, not 0.
+
+    Important for the dashboard: a user with 3 corrupted-tier rows
+    must see ``used=3`` so they know workspaces exist, even though
+    the resolved tier degrades to FREE.
+    """
+    db = _mock_db(["mystery-1", "mystery-2", "mystery-3"])
+    count, plan = await get_user_workspace_summary(db, "user-1")
+    assert count == 3
+    assert plan == PlanName.FREE

--- a/frontend/src/components/dashboard/UsageStats.tsx
+++ b/frontend/src/components/dashboard/UsageStats.tsx
@@ -63,7 +63,7 @@ interface CurrentUsage {
   public_calls_today: number; // Issue #238
   public_calls_this_week: number; // Issue #238
   sleep_contexts: SleepContextsUsage | null; // Issue #560
-  workspaces: WorkspacesUsage | null; // Issue #661
+  workspaces: WorkspacesUsage; // Issue #661 — always populated
 }
 
 interface UsageStatus {
@@ -399,41 +399,38 @@ export const UsageStats = forwardRef<UsageStatsRef, UsageStatsProps>(
             )}
 
             {/* Owned Workspaces (Issue #661) — user-level cap, unlike
-                sleep_contexts which is workspace-scoped. Always present
-                in the response (backend populates it independently of
-                current_workspace_id), so no null gate. */}
-            {currentUsage.usage.workspaces && (
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-sm font-medium flex items-center gap-2">
-                    <Briefcase className="h-4 w-4" />
-                    {t("ownedWorkspaces")}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <div className="text-2xl font-bold mb-2">
-                    {currentUsage.usage.workspaces.used} /{" "}
-                    {currentUsage.usage.workspaces.limit}
-                  </div>
-                  <Progress
-                    value={
-                      currentUsage.usage.workspaces.limit > 0
-                        ? Math.min(
-                            (currentUsage.usage.workspaces.used /
-                              currentUsage.usage.workspaces.limit) *
-                              100,
+                sleep_contexts which is workspace-scoped. Always populated
+                by the backend so this card renders unconditionally. */}
+            <Card>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <Briefcase className="h-4 w-4" />
+                  {t("ownedWorkspaces")}
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="text-2xl font-bold mb-2">
+                  {currentUsage.usage.workspaces.used} /{" "}
+                  {currentUsage.usage.workspaces.limit}
+                </div>
+                <Progress
+                  value={
+                    currentUsage.usage.workspaces.limit > 0
+                      ? Math.min(
+                          (currentUsage.usage.workspaces.used /
+                            currentUsage.usage.workspaces.limit) *
                             100,
-                          )
-                        : 0
-                    }
-                    className="h-2"
-                  />
-                  <p className="text-xs text-muted-foreground mt-2">
-                    {t("ownedWorkspacesTier")}
-                  </p>
-                </CardContent>
-              </Card>
-            )}
+                          100,
+                        )
+                      : 0
+                  }
+                  className="h-2"
+                />
+                <p className="text-xs text-muted-foreground mt-2">
+                  {t("ownedWorkspacesTier")}
+                </p>
+              </CardContent>
+            </Card>
           </div>
 
           {/* API Breakdown - Issue #238: MCP/REST/Public separation,

--- a/frontend/src/components/dashboard/UsageStats.tsx
+++ b/frontend/src/components/dashboard/UsageStats.tsx
@@ -34,9 +34,13 @@ import {
   YAxis,
   CartesianGrid,
 } from "recharts";
-import { Brain, Zap, TrendingUp, XCircle, Moon } from "lucide-react";
+import { Brain, Zap, TrendingUp, XCircle, Moon, Briefcase } from "lucide-react";
 import { apiClient } from "@/lib/api";
-import type { PlanLimits, SleepContextsUsage } from "@/lib/api/usage";
+import type {
+  PlanLimits,
+  SleepContextsUsage,
+  WorkspacesUsage,
+} from "@/lib/api/usage";
 import {
   getWorkspaceUsageCurrent,
   getWorkspaceUsageHistory,
@@ -59,6 +63,7 @@ interface CurrentUsage {
   public_calls_today: number; // Issue #238
   public_calls_this_week: number; // Issue #238
   sleep_contexts: SleepContextsUsage | null; // Issue #560
+  workspaces: WorkspacesUsage | null; // Issue #661
 }
 
 interface UsageStatus {
@@ -388,6 +393,43 @@ export const UsageStats = forwardRef<UsageStatsRef, UsageStatsProps>(
                           addon: currentUsage.usage.sleep_contexts.addon_bonus,
                         })
                       : t("sleepContextsTier")}
+                  </p>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Owned Workspaces (Issue #661) — user-level cap, unlike
+                sleep_contexts which is workspace-scoped. Always present
+                in the response (backend populates it independently of
+                current_workspace_id), so no null gate. */}
+            {currentUsage.usage.workspaces && (
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-sm font-medium flex items-center gap-2">
+                    <Briefcase className="h-4 w-4" />
+                    {t("ownedWorkspaces")}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="text-2xl font-bold mb-2">
+                    {currentUsage.usage.workspaces.used} /{" "}
+                    {currentUsage.usage.workspaces.limit}
+                  </div>
+                  <Progress
+                    value={
+                      currentUsage.usage.workspaces.limit > 0
+                        ? Math.min(
+                            (currentUsage.usage.workspaces.used /
+                              currentUsage.usage.workspaces.limit) *
+                              100,
+                            100,
+                          )
+                        : 0
+                    }
+                    className="h-2"
+                  />
+                  <p className="text-xs text-muted-foreground mt-2">
+                    {t("ownedWorkspacesTier")}
                   </p>
                 </CardContent>
               </Card>

--- a/frontend/src/lib/api/usage.ts
+++ b/frontend/src/lib/api/usage.ts
@@ -38,6 +38,20 @@ export interface SleepContextsUsage {
   remaining: number;
 }
 
+/**
+ * Owned-workspace cap usage (Issue #661).
+ *
+ * User-level: counts the caller's owned (`deleted_at IS NULL`) workspaces
+ * against `PlanTier.max_owned_workspaces`. Populated unconditionally —
+ * unlike `analysis` / `sleep_contexts`, this does not depend on the
+ * caller's current workspace selection.
+ */
+export interface WorkspacesUsage {
+  used: number;
+  limit: number;
+  remaining: number;
+}
+
 export interface CurrentUsage {
   memory_count: number;
   api_calls_today: number;
@@ -49,6 +63,7 @@ export interface CurrentUsage {
   public_calls_today: number; // Issue #238: Public quota separation
   public_calls_this_week: number;
   sleep_contexts: SleepContextsUsage | null; // Issue #560
+  workspaces: WorkspacesUsage | null; // Issue #661
 }
 
 export interface UsageStatus {

--- a/frontend/src/lib/api/usage.ts
+++ b/frontend/src/lib/api/usage.ts
@@ -63,7 +63,9 @@ export interface CurrentUsage {
   public_calls_today: number; // Issue #238: Public quota separation
   public_calls_this_week: number;
   sleep_contexts: SleepContextsUsage | null; // Issue #560
-  workspaces: WorkspacesUsage | null; // Issue #661
+  // Issue #661 — always populated (user-level cap), unlike sleep_contexts
+  // which is workspace-scoped. See backend WorkspacesUsage docstring.
+  workspaces: WorkspacesUsage;
 }
 
 export interface UsageStatus {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1751,7 +1751,9 @@
     "otherEndpointsLabel": "Other ({count})",
     "sleepEnabledContexts": "Sleep-enabled Contexts",
     "sleepContextsWithAddon": "Includes +{addon} from extra_sleep_contexts addon",
-    "sleepContextsTier": "Plan-tier limit (PRO required to enable Sleep Maintenance)"
+    "sleepContextsTier": "Plan-tier limit (PRO required to enable Sleep Maintenance)",
+    "ownedWorkspaces": "Owned Workspaces",
+    "ownedWorkspacesTier": "Plan-tier owned-workspace cap (joined workspaces are uncapped)"
   },
   "memoryOverview": {
     "failedToLoad": "Failed to load memory overview",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1751,7 +1751,9 @@
     "otherEndpointsLabel": "その他 ({count})",
     "sleepEnabledContexts": "Sleep 有効コンテキスト",
     "sleepContextsWithAddon": "extra_sleep_contexts アドオンによる +{addon} を含む",
-    "sleepContextsTier": "プラン基本上限 (Sleep メンテナンスは PRO 専用機能)"
+    "sleepContextsTier": "プラン基本上限 (Sleep メンテナンスは PRO 専用機能)",
+    "ownedWorkspaces": "所有 Workspace",
+    "ownedWorkspacesTier": "プラン別の所有 Workspace 上限 (招待 join は無制限)"
   },
   "memoryOverview": {
     "failedToLoad": "メモリー概要の読み込みに失敗しました",


### PR DESCRIPTION
Closes #661

## Summary

- Per-tier `PlanTier.max_owned_workspaces` cap (Free=1 / Basic=3 / Pro=10), enforced at workspace creation only — `accept_invitation` deliberately unmodified (per-seat billing model: Pro owner pays for member seats).
- Tier resolution via new `utils/plan_resolver.get_user_workspace_summary(db, user_id) → (count, plan_name)` — single SELECT shared by gate (`QuotaService.check_workspace_creation_allowed`) and dashboard (`/usage/current`).
- `settings.enforce_workspace_cap` feature flag (default `False`) — log-only mode surfaces over-cap accounts via `workspace_creation_denied` warn log before enforcement is flipped.
- `/api/v1/usage/current` response surfaces user-level usage via new `WorkspacesUsage` Pydantic model + frontend "Owned Workspaces" card.

## Implementation notes

**Design pivoted from symmetric counting to owned-only** during gate1 review (see Design history section in #661 body). Per-seat billing model invalidates the original "invitation accumulation gap" rationale: joining a workspace consumes only the inviting workspace's `member_count_per_workspace` quota (owner-paid), not any joiner-side resource. The Qdrant collection bypass rationale is fully closed by the owned-only cap alone (Free=1 owned ⇒ max 1 collection).

**Reference impl reused from Issue #485** (`storage_limit_bytes` 3-layer template): `PlanTier` field + `Settings` env overrides + `_apply_settings_overrides` map. `addon_workspace_bonus` is deferred (documented in `WorkspacesUsage` docstring as the future hook).

**Corruption guard in plan_resolver**: unknown `plan_name` values rank below FREE during `max()` selection AND fall back to `PlanName.FREE` with a structured `plan_resolver_unknown_plan_names` warn log, so legacy `"enterprise"` rows or manual DB edits cannot crash the gate or the dashboard with a downstream `get_plan_tier(unknown)` `ValueError`.

**Tier resolution**: highest tier among owned (`deleted_at IS NULL`) workspaces; `owned=0` defaults to FREE so first-workspace creation works. Per-user plan column is NOT added — `Workspace.plan_name` (Stripe-updated) remains the canonical billing source.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (flag flip runbook gap — addressed via Next steps below)
- cto: green
- gate1: yellow → effective green after owned-only design pivot
- review provider: copilot

Full reviews saved in plugin cache:
- `~/.claude/cache/gh-issue-driven/661-feat-feat-quota-plan-based-owned-workspace-ca.gate1.md`
- `~/.claude/cache/gh-issue-driven/661-feat-feat-quota-plan-based-owned-workspace-ca.gate2.md`

## Acceptance criteria

- [x] Free user with 1 owned workspace cannot create another workspace (when flag on)
- [x] Free user with 1 owned workspace can still accept invitations to any number of other workspaces (uncapped by design)
- [x] Pro user at 10 cap cannot create further owned workspaces
- [x] Per-plan Settings env overrides (`plan_*_max_owned_workspaces`) take effect
- [x] `EffectiveQuotaService` exposes `max_owned_workspaces` — surfaced via `/api/v1/usage/current.usage.workspaces` (clean separation from workspace-scoped `EffectiveQuotaService`, per gate1 Q2)
- [x] `/api/v1/usage/current` OpenAPI schema includes `workspaces: WorkspacesUsage`
- [x] Frontend dashboard shows "X / N workspaces owned" (Briefcase card)
- [x] Tests cover `create_workspace` enforcement at each tier boundary

## Tests

- `backend/tests/utils/test_plan_resolver.py` (NEW): 9 tests
- `backend/tests/services/test_quota_service.py`: +12 tests (workspace creation cap)
- `backend/tests/api/test_usage_workspaces.py` (NEW): 7 tests
- `backend/tests/api/test_usage_pure_read.py`: 4 pre-existing tests pass unchanged
- **Total: 40 passing**

## Next steps (post-merge follow-ups)

Before flipping `enforce_workspace_cap=True` in production:

1. **File follow-up issue: TOCTOU hardening for `check_workspace_creation_allowed`** — add `SELECT FOR UPDATE` on a per-user sentinel row OR a partial unique constraint on `(owner_user_id) WHERE deleted_at IS NULL`. Pre-existing race (documented in `backend/src/services/quota_service.py:240-256`), but the new Free=1 cap makes it more exploitable.
2. **File follow-up issue: `enforce_workspace_cap` flag flip runbook** — staging validation steps: (a) query users with `owned > new tier cap`, (b) send email outreach with resolution path (delete/upgrade), (c) cleanup window (~7 days), (d) flag flip in staging + 24h smoke test, (e) production flag flip. Without this runbook the flip risks user-visible failures at workspace creation for affected accounts.
3. **(Optional) File epic: consolidate `UserPlan` ↔ `Workspace.plan_name` dual-plan-system** — pre-existing tech debt from #48 vs #149. Not in #661 scope; plan_resolver docstring explicitly references the choice and why.
4. **(Optional) File follow-up issue: `addon_workspace_bonus`** — future Stripe SKU + Workspace column when per-user expansion is needed. Reference impl: #485 storage addon pattern.

## Deploy ordering

Frontend `workspaces` field is now non-optional in TypeScript (per Phase 6 review). **Backend must deploy before frontend** to avoid a brief rolling-deploy window where frontend hits a stale backend pod without the field and throws `TypeError`. Follows existing project pattern.

🤖 Generated via /gh-issue-driven:ship
