### PR TITLE
feat(auth): Phase 2 pre-OAuth Google allowlist (#655 follow-up)

### DIFF
--- a/backend/src/api/routes/admin_signup_gate.py
+++ b/backend/src/api/routes/admin_signup_gate.py
@@ -238,25 +238,52 @@ async def add_to_allowlist(
             )
         else:  # provider == "google"
             assert payload.email is not None  # validator guarantee
-            sub, canonical_email = await resolve_google_sub_by_email(payload.email, db)
-            entry = await svc.add_to_allowlist_entry(
-                provider="google",
-                subject_id=sub,
-                subject_label=canonical_email,
-                added_by_user_id=user["user_id"],
-            )
+            try:
+                sub, canonical_email = await resolve_google_sub_by_email(payload.email, db)
+            except GoogleUserNotFound:
+                # Phase 2 (#655 follow-up): the target user hasn't OAuth'd
+                # yet, so we can't resolve their OIDC ``sub``. Create a
+                # **pending** allowlist row with a sentinel ``subject_id``
+                # that the OAuth callback gate will promote to the real
+                # ``sub`` on first sign-in
+                # (see ``SignupGateService._promote_pending_google_entry``).
+                #
+                # The sentinel format is ``pending:<email-lower>``:
+                # - Distinct from a real OIDC ``sub`` (Google subs are
+                #   numeric strings, no colons), so the unique constraint
+                #   ``(provider, subject_id, source)`` cannot collide
+                #   between a pending row and a real-sub row.
+                # - Two admins trying to pre-allowlist the same email
+                #   collide on the same constraint via the lower-cased
+                #   email, which is the desired behaviour
+                #   (raises ValueError → 409 below).
+                #
+                # Email-change attack: the IdP can change the email
+                # between admin-add and user-OAuth, in which case the
+                # promotion lookup will miss and the row stays pending
+                # (eventually rejected by the gate). The window is
+                # operator-controlled, so this is documented as an
+                # accepted risk for Phase 2 v1; the long-term mitigation
+                # is the OIDC ``sub`` claim, which we resolve at promotion
+                # time.
+                canonical_email = payload.email.lower()
+                entry = await svc.add_to_allowlist_entry(
+                    provider="google",
+                    subject_id=f"pending:{canonical_email}",
+                    subject_label=canonical_email,
+                    added_by_user_id=user["user_id"],
+                )
+            else:
+                entry = await svc.add_to_allowlist_entry(
+                    provider="google",
+                    subject_id=sub,
+                    subject_label=canonical_email,
+                    added_by_user_id=user["user_id"],
+                )
     except GitHubUserNotFound as exc:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"GitHub user '{payload.github_username}' not found",
-        ) from exc
-    except GoogleUserNotFound as exc:
-        # Distinct from the GitHub 404: the user simply hasn't OAuth'd yet
-        # against this app, so we can't resolve their sub. Surface the
-        # bootstrap UX hint from the exception message verbatim.
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=str(exc),
         ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc

--- a/backend/src/api/routes/admin_signup_gate.py
+++ b/backend/src/api/routes/admin_signup_gate.py
@@ -121,7 +121,17 @@ class AllowlistAddRequest(BaseModel):
     )
     email: str | None = Field(
         default=None,
-        max_length=255,
+        # Capped at 247 (= 255 − len("pending:")) so the Phase 2 sentinel
+        # ``subject_id=f"pending:{email-lower}"`` always fits the
+        # ``signup_allowlist.subject_id VARCHAR(255)`` column. Without
+        # this cap a valid 248–255-char email would fail at COMMIT with
+        # a DB error instead of returning a controlled 422 here. The
+        # ``subject_id`` column IS the matching key used by the OAuth
+        # callback gate's promotion lookup, so column-side truncation
+        # would corrupt uniqueness — schema-side cap is the safe fix.
+        # 247 still exceeds the RFC 3696 practical email limit (~254
+        # octets; real-world addresses are typically <100 chars).
+        max_length=247,
         # Same shape as the InvitationCreateRequest email field
         # (models/schemas.py:830) — kept identical so admin/invitation
         # flows share one validation surface.

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -165,6 +165,19 @@ class SignupGateService:
         if effective_mode == "manual":
             if await self._is_allowlisted(provider, oauth_sub, effective_mode):
                 return None
+            # Phase 2 (#655 follow-up): Google admins can pre-allowlist a
+            # target by email before the user has OAuth'd. Such rows carry
+            # a sentinel ``subject_id='pending:<email>'`` (set by the admin
+            # POST handler). On first OAuth callback for that email we
+            # rewrite ``subject_id`` to the real OIDC ``sub`` so subsequent
+            # logins match the regular ``(provider, subject_id)`` path
+            # above. GitHub has no email-only fallback because
+            # ``resolve_github_user_id`` resolves to a numeric ID at
+            # add-time, so the pending state only exists for Google.
+            if provider == "google" and await self._promote_pending_google_entry(
+                email=email, oauth_sub=oauth_sub
+            ):
+                return None
             await self._record_blocked_signup(
                 provider=provider,
                 oauth_sub=oauth_sub,
@@ -416,6 +429,78 @@ class SignupGateService:
     async def _is_first_user(self) -> bool:
         result = await self.db.execute(select(func.count()).select_from(User))
         return (result.scalar() or 0) == 0
+
+    async def _promote_pending_google_entry(self, *, email: str, oauth_sub: str) -> bool:
+        """Promote a pending Google allowlist row to the real OIDC sub.
+
+        Phase 2 (#655 follow-up): admin pre-allowlists a Google user
+        by email before they have OAuth'd. The row carries a sentinel
+        ``subject_id='pending:<email-lower>'``; on the user's first
+        OAuth callback, this method looks up the pending row, rewrites
+        ``subject_id`` to the real sub, and updates the legacy column
+        ``github_user_id`` (still NOT NULL during the #655 migration
+        window) to ``google:<sub>``. ``subject_label`` (the email) is
+        left unchanged — it was a snapshot at add-time and the email
+        may legitimately differ from the IdP's current email by the
+        time the user OAuths.
+
+        Email match is case-insensitive (IdP convention).
+
+        Args:
+            email: Email from the OAuth ``userinfo`` payload.
+            oauth_sub: OIDC ``sub`` claim, the immutable per-IdP ID.
+
+        Returns:
+            True if a pending row was found and promoted; False
+            otherwise. The caller treats False as "no pending row —
+            apply the normal block".
+        """
+        pending_subject_id = f"pending:{email.lower()}"
+        result = await self.db.execute(
+            select(SignupAllowlistEntry)
+            .where(
+                SignupAllowlistEntry.provider == "google",
+                SignupAllowlistEntry.subject_id == pending_subject_id,
+                SignupAllowlistEntry.state == "active",
+                SignupAllowlistEntry.source == "manual",
+            )
+            .limit(1)
+        )
+        pending = result.scalar_one_or_none()
+        if pending is None:
+            return False
+
+        pending.subject_id = oauth_sub
+        # Keep the deprecated NOT-NULL column populated with the
+        # ``<provider>:<subject_id>`` sentinel format used by other
+        # google rows (see ``add_to_allowlist_entry``). The label
+        # column is left as the email, which is the snapshot the
+        # admin wrote at add-time.
+        pending.github_user_id = f"google:{oauth_sub}"
+
+        try:
+            await self.db.commit()
+        except IntegrityError:
+            # Defensive: a real-sub row for the same OIDC sub already
+            # exists (admin double-allowlisted via two paths). Roll back
+            # the in-flight promotion and report "not promoted" — the
+            # caller's ``_is_allowlisted`` check earlier already would
+            # have hit the real row, so reaching here means a race that
+            # is fine to fall through.
+            await self.db.rollback()
+            logger.warning(
+                "signup_allowlist_pending_promote_race",
+                email_hmac=hmac_sha256_hex(email, get_settings().audit_hmac_key),
+                pending_id=str(pending.id),
+            )
+            return False
+
+        logger.info(
+            "signup_allowlist_pending_promoted",
+            email_hmac=hmac_sha256_hex(email, get_settings().audit_hmac_key),
+            pending_id=str(pending.id),
+        )
+        return True
 
     async def _is_allowlisted(
         self,

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -480,6 +480,15 @@ class SignupGateService:
         if pending is None:
             return False
 
+        # Snapshot the PK before mutating + committing so the rollback /
+        # success-log paths can reference the ID without re-reading the
+        # ORM instance. After ``db.rollback()`` the async session expires
+        # attached instances; accessing ``pending.id`` afterwards can
+        # trigger an implicit lazy load in async context and raise
+        # ``MissingGreenlet``, masking the intended recovery path
+        # (PR #673 Copilot review #3).
+        pending_id = pending.id
+
         pending.subject_id = oauth_sub
         # Keep the deprecated NOT-NULL column populated with the
         # ``<provider>:<subject_id>`` sentinel format used by other
@@ -494,24 +503,46 @@ class SignupGateService:
         try:
             await self.db.commit()
         except IntegrityError:
-            # Defensive: a real-sub row for the same OIDC sub already
-            # exists (admin double-allowlisted via two paths). Roll back
-            # the in-flight promotion and report "not promoted" — the
-            # caller's ``_is_allowlisted`` check earlier already would
-            # have hit the real row, so reaching here means a race that
-            # is fine to fall through.
+            # The commit collided on the unique
+            # ``(provider, subject_id, source)`` constraint. Two
+            # realistic causes:
+            #   1. A concurrent admin add or another promotion just
+            #      inserted a ``(google, oauth_sub, manual)`` row →
+            #      the user IS now allowlisted; returning False would
+            #      send them through the blocked-signup redirect
+            #      despite a winning entry being present
+            #      (PR #673 Copilot review #3 finding E).
+            #   2. A stale/inconsistent real-sub row for the same sub
+            #      exists outside the active+manual scope (different
+            #      source / state). The re-check below will not see
+            #      it, so we return False and fall through to block
+            #      — the original defensive intent of the handler.
+            # After rollback the in-flight UPDATE is discarded; the
+            # pending sentinel row remains for a future retry.
             await self.db.rollback()
+            race_result = await self.db.execute(
+                select(SignupAllowlistEntry.id)
+                .where(
+                    SignupAllowlistEntry.provider == "google",
+                    SignupAllowlistEntry.subject_id == oauth_sub,
+                    SignupAllowlistEntry.state == "active",
+                    SignupAllowlistEntry.source == "manual",
+                )
+                .limit(1)
+            )
+            race_winner_present = race_result.first() is not None
             logger.warning(
                 "signup_allowlist_pending_promote_race",
                 email_hmac=hmac_sha256_hex(email, get_settings().audit_hmac_key),
-                pending_id=str(pending.id),
+                pending_id=str(pending_id),
+                race_winner_present=race_winner_present,
             )
-            return False
+            return race_winner_present
 
         logger.info(
             "signup_allowlist_pending_promoted",
             email_hmac=hmac_sha256_hex(email, get_settings().audit_hmac_key),
-            pending_id=str(pending.id),
+            pending_id=str(pending_id),
         )
         return True
 

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -309,7 +309,17 @@ class SignupGateService:
             legacy_user_id = github_user_id
             legacy_username = github_username
         else:
-            legacy_user_id = f"{provider}:{subject_id}"
+            # ``signup_allowlist.github_user_id`` is ``String(64)`` (legacy
+            # GitHub numeric IDs fit easily). For Google rows the sentinel
+            # is ``google:<subject_id>`` — fine for a real OIDC sub
+            # (numeric, ~21 chars), but a Phase 2 pending sentinel
+            # ``google:pending:<email>`` can exceed 64 when the email is
+            # long (RFC 5321 caps the local part at 64 + domain up to 255).
+            # Truncate to the column limit; the column is deprecated and
+            # not used as a matching key (``subject_id`` carries the full
+            # value for matching), so a truncated legacy value cannot
+            # cause data loss for any feature.
+            legacy_user_id = f"{provider}:{subject_id}"[:64]
             legacy_username = subject_label
 
         existing = await self.db.execute(
@@ -473,10 +483,13 @@ class SignupGateService:
         pending.subject_id = oauth_sub
         # Keep the deprecated NOT-NULL column populated with the
         # ``<provider>:<subject_id>`` sentinel format used by other
-        # google rows (see ``add_to_allowlist_entry``). The label
-        # column is left as the email, which is the snapshot the
-        # admin wrote at add-time.
-        pending.github_user_id = f"google:{oauth_sub}"
+        # google rows (see ``add_to_allowlist_entry``). The column is
+        # ``String(64)``; an OIDC sub is ~21 chars so the full sentinel
+        # fits comfortably, but the slice keeps this code defensive
+        # against any future IdP whose sub format pushes past the
+        # limit. The label column is left as the email, which is the
+        # snapshot the admin wrote at add-time.
+        pending.github_user_id = f"google:{oauth_sub}"[:64]
 
         try:
             await self.db.commit()

--- a/backend/src/services/signup_gate_service.py
+++ b/backend/src/services/signup_gate_service.py
@@ -16,6 +16,7 @@ provider-uniformly. Both providers match on the immutable IdP identity
 email-change attacks closed.
 """
 
+import hashlib
 import os
 from typing import Literal, cast
 from urllib.parse import urlencode
@@ -39,6 +40,43 @@ logger = get_logger(__name__)
 
 SignupGateMode = Literal["manual", "github_sponsors", "both"]
 SignupGateProvider = Literal["github", "google"]
+
+# ``signup_allowlist.github_user_id`` is a deprecated ``String(64)``
+# kept NOT NULL during the #655 migration window. For non-github
+# providers we synthesize a ``<provider>:<subject_id>`` value. The
+# current schema's unique key is ``(provider, subject_id, source)``,
+# so a truncated legacy column value is normally harmless — BUT the
+# downgrade migration in ``e14_655_signup_allowlist_provider`` restores
+# the old unique constraint on ``(github_user_id, source)``. Two
+# distinct ``subject_id`` values whose first 64 chars of
+# ``<provider>:<subject_id>`` are equal (e.g. Phase 2 pending sentinels
+# for two emails sharing a 49+ char prefix) would then collide and
+# break downgrade. Use a hash-based sentinel when the readable form
+# would exceed the column limit so each distinct ``subject_id`` maps
+# to a distinct legacy value (PR #673 Copilot review #4 finding F).
+_LEGACY_USER_ID_COLUMN_LEN = 64
+
+
+def _legacy_user_id_for_non_github(provider: str, subject_id: str) -> str:
+    """Build a downgrade-safe ``github_user_id`` value for a non-github row.
+
+    - Returns the readable ``f"{provider}:{subject_id}"`` when it fits
+      the 64-char column (the common case: a real OIDC sub is ~21 chars).
+    - Falls back to ``f"{provider}:<sha256(subject_id) hex prefix>"``
+      truncated to fit when the readable form would overflow. The hash
+      input is the full ``subject_id``, so distinct subject_ids never
+      collide regardless of shared prefixes.
+
+    The column is deprecated and slated for removal in a #655 follow-up;
+    this helper is the temporary write-side safety until that drop lands.
+    """
+    readable = f"{provider}:{subject_id}"
+    if len(readable) <= _LEGACY_USER_ID_COLUMN_LEN:
+        return readable
+    prefix = f"{provider}:"
+    digest_budget = _LEGACY_USER_ID_COLUMN_LEN - len(prefix)
+    digest = hashlib.sha256(subject_id.encode("utf-8")).hexdigest()
+    return f"{prefix}{digest[:digest_budget]}"
 
 
 async def check_signup_access(
@@ -309,17 +347,12 @@ class SignupGateService:
             legacy_user_id = github_user_id
             legacy_username = github_username
         else:
-            # ``signup_allowlist.github_user_id`` is ``String(64)`` (legacy
-            # GitHub numeric IDs fit easily). For Google rows the sentinel
-            # is ``google:<subject_id>`` — fine for a real OIDC sub
-            # (numeric, ~21 chars), but a Phase 2 pending sentinel
-            # ``google:pending:<email>`` can exceed 64 when the email is
-            # long (RFC 5321 caps the local part at 64 + domain up to 255).
-            # Truncate to the column limit; the column is deprecated and
-            # not used as a matching key (``subject_id`` carries the full
-            # value for matching), so a truncated legacy value cannot
-            # cause data loss for any feature.
-            legacy_user_id = f"{provider}:{subject_id}"[:64]
+            # See ``_legacy_user_id_for_non_github`` for the column-fit +
+            # downgrade-safe construction. Real OIDC subs (~21 chars)
+            # land in the readable branch; Phase 2 pending sentinels
+            # with long emails take the hash branch so distinct
+            # subject_ids never collide on the legacy column.
+            legacy_user_id = _legacy_user_id_for_non_github(provider, subject_id)
             legacy_username = subject_label
 
         existing = await self.db.execute(
@@ -492,13 +525,14 @@ class SignupGateService:
         pending.subject_id = oauth_sub
         # Keep the deprecated NOT-NULL column populated with the
         # ``<provider>:<subject_id>`` sentinel format used by other
-        # google rows (see ``add_to_allowlist_entry``). The column is
-        # ``String(64)``; an OIDC sub is ~21 chars so the full sentinel
-        # fits comfortably, but the slice keeps this code defensive
-        # against any future IdP whose sub format pushes past the
-        # limit. The label column is left as the email, which is the
-        # snapshot the admin wrote at add-time.
-        pending.github_user_id = f"google:{oauth_sub}"[:64]
+        # google rows. ``_legacy_user_id_for_non_github`` keeps the
+        # value ≤64 chars and collision-resistant under the downgrade
+        # migration's restored unique on ``(github_user_id, source)``.
+        # An OIDC sub is ~21 chars so the readable branch wins here;
+        # the helper makes that explicit instead of hand-truncating.
+        # The label column is left as the email, which is the snapshot
+        # the admin wrote at add-time.
+        pending.github_user_id = _legacy_user_id_for_non_github("google", oauth_sub)
 
         try:
             await self.db.commit()

--- a/backend/tests/api/test_admin_signup_gate.py
+++ b/backend/tests/api/test_admin_signup_gate.py
@@ -289,23 +289,48 @@ class TestAddToAllowlist:
         assert body["subject_id"] == google_sub
         assert body["subject_label"] == "alice@example.com"
 
-    def test_google_404_when_user_not_in_users_table(self, client, monkeypatch):
-        """Bootstrap UX gap: a Google user must OAuth once before they can
-        be added — return 404 with the actionable hint baked into the
-        helper's exception message."""
+    def test_google_pending_row_when_user_not_in_users_table(self, client, monkeypatch):
+        """Phase 2 (#655 follow-up): admin can pre-allowlist a Google user
+        by email before they've OAuth'd. The handler creates a pending row
+        with a sentinel ``subject_id='pending:<email>'`` that the OAuth
+        callback gate promotes to the real OIDC sub on first sign-in.
+        """
         from utils.google_user import GoogleUserNotFound
 
         monkeypatch.setattr(
             "api.routes.admin_signup_gate.resolve_google_sub_by_email",
             AsyncMock(side_effect=GoogleUserNotFound("user must OAuth first")),
         )
+        add_mock = AsyncMock(
+            return_value=_mock_entry(
+                provider="google",
+                subject_id="pending:stranger@example.com",
+                subject_label="stranger@example.com",
+            )
+        )
+        monkeypatch.setattr(
+            "services.signup_gate_service.SignupGateService.add_to_allowlist_entry",
+            add_mock,
+        )
+
         resp = client.post(
             "/api/v1/admin/signup-gate/allowlist",
-            json={"provider": "google", "email": "stranger@example.com"},
+            json={"provider": "google", "email": "Stranger@Example.com"},
         )
-        assert resp.status_code == 404
-        # The bootstrap-UX hint comes through verbatim.
-        assert "OAuth" in resp.json()["detail"]
+        assert resp.status_code == 201
+
+        # Route normalized the email to lower-case and built the sentinel
+        # subject_id format the OAuth callback gate looks for.
+        add_mock.assert_awaited_once()
+        kwargs = add_mock.await_args.kwargs
+        assert kwargs["provider"] == "google"
+        assert kwargs["subject_id"] == "pending:stranger@example.com"
+        assert kwargs["subject_label"] == "stranger@example.com"
+
+        body = resp.json()
+        assert body["provider"] == "google"
+        assert body["subject_id"] == "pending:stranger@example.com"
+        assert body["subject_label"] == "stranger@example.com"
 
     def test_google_422_when_email_missing(self, client):
         """provider='google' requires the email field."""

--- a/backend/tests/api/test_admin_signup_gate.py
+++ b/backend/tests/api/test_admin_signup_gate.py
@@ -400,6 +400,43 @@ class TestAddToAllowlist:
         )
         assert resp.status_code == 422
 
+    def test_google_422_when_email_exceeds_pending_sentinel_budget(self, client):
+        """PR #673 Copilot review #2: ``AllowlistAddRequest.email`` is capped
+        at 247 (= 255 − len("pending:")) so the Phase 2 pending sentinel
+        ``f"pending:{email}"`` always fits ``subject_id VARCHAR(255)``.
+
+        A 248-char email would have produced a 256-char sentinel and
+        failed at DB commit with a controlled-error-skipping
+        ``StringDataRightTruncationError``. The schema-side cap turns
+        that DB error into a 422 here.
+        """
+        # local part 235 chars + "@example.com" (12 chars) = 247 OK
+        ok_email = ("a" * 235) + "@example.com"
+        assert len(ok_email) == 247
+        # local part 236 chars + "@example.com" = 248 over the cap
+        too_long = ("a" * 236) + "@example.com"
+        assert len(too_long) == 248
+
+        # 248 chars → 422 from Pydantic max_length, no DB call
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "google", "email": too_long},
+        )
+        assert resp.status_code == 422
+
+        # 247 chars passes parse (handler then takes its normal path —
+        # we don't drive the full pending-row creation here; the
+        # boundary check is the contract under test).
+        resp = client.post(
+            "/api/v1/admin/signup-gate/allowlist",
+            json={"provider": "google", "email": ok_email},
+        )
+        # 422 would mean the schema rejected the 247-char input — that's
+        # the regression we're guarding against. Any other status is
+        # produced downstream (the real google-sub resolver runs and
+        # 500s because no DB; we only care that parse passed).
+        assert resp.status_code != 422
+
     def test_409_on_duplicate_google_entry(self, client, monkeypatch):
         """Duplicate Google entry surfaces the standard 409 conflict."""
         monkeypatch.setattr(

--- a/backend/tests/services/test_signup_gate_service.py
+++ b/backend/tests/services/test_signup_gate_service.py
@@ -13,7 +13,10 @@ from uuid import uuid4
 import pytest
 from fastapi.responses import RedirectResponse
 
-from services.signup_gate_service import SignupGateService
+from services.signup_gate_service import (
+    SignupGateService,
+    _legacy_user_id_for_non_github,
+)
 from utils.github_user import GitHubUserNotFound
 
 
@@ -876,6 +879,93 @@ class TestAddToAllowlistEntry:
                 subject_label="octocat",
                 added_by_user_id="admin1",
             )
+
+    @pytest.mark.asyncio
+    async def test_long_pending_sentinel_uses_hashed_legacy_value(self):
+        """PR #673 Copilot review #4 finding F: a long pending sentinel
+        for the Phase 2 path
+        (``subject_id='pending:<email>'`` with an email near the 247-char
+        cap) would overflow the legacy ``github_user_id String(64)``.
+        Hash-based fallback keeps the value ≤64 chars AND
+        collision-resistant under the downgrade migration's restored
+        unique on ``(github_user_id, source)``.
+        """
+        svc = _svc()
+        scalar_result = MagicMock()
+        scalar_result.scalar_one_or_none = MagicMock(return_value=None)
+        svc.db.execute = AsyncMock(return_value=scalar_result)
+        svc.db.add = MagicMock()
+        svc.db.commit = AsyncMock()
+        svc.db.refresh = AsyncMock()
+
+        # Email at the 247-char cap → sentinel is "pending:" + 247 = 255.
+        long_email = ("a" * 235) + "@example.com"
+        assert len(long_email) == 247
+        long_sentinel = f"pending:{long_email}"
+
+        entry = await svc.add_to_allowlist_entry(
+            provider="google",
+            subject_id=long_sentinel,
+            subject_label=long_email,
+            added_by_user_id="admin1",
+        )
+
+        assert entry.subject_id == long_sentinel  # full sentinel preserved
+        # Legacy column fits the 64-char limit AND keeps the provider
+        # prefix readable so spot-queries during the migration window
+        # still identify the row's origin.
+        assert len(entry.github_user_id) <= 64
+        assert entry.github_user_id.startswith("google:")
+        # Raw truncation would have produced this colliding value:
+        raw_truncated = f"google:{long_sentinel}"[:64]
+        assert entry.github_user_id != raw_truncated
+
+
+class TestLegacyUserIdForNonGithub:
+    """PR #673 Copilot review #4 finding F: legacy ``github_user_id`` write
+    must be downgrade-safe. The helper switches from readable
+    ``<provider>:<subject_id>`` to a sha256-based sentinel when the
+    readable form would overflow ``String(64)``, so two distinct
+    subject_ids never collide on the legacy column (which the e14
+    downgrade migration re-uniques on)."""
+
+    def test_short_subject_returns_readable_form(self):
+        # Real OIDC sub (~21 chars) + "google:" = 28 chars — fits 64.
+        result = _legacy_user_id_for_non_github("google", "108276939729829363")
+        assert result == "google:108276939729829363"
+
+    def test_long_subject_returns_hashed_form_fitting_column(self):
+        long_subject = "pending:" + ("a" * 235) + "@example.com"
+        result = _legacy_user_id_for_non_github("google", long_subject)
+        assert len(result) == 64  # exactly the column width
+        assert result.startswith("google:")
+        # Hash budget = 64 - len("google:") = 57 hex chars.
+        digest_part = result[len("google:") :]
+        assert len(digest_part) == 57
+        assert all(c in "0123456789abcdef" for c in digest_part)
+
+    def test_long_subject_helper_is_deterministic(self):
+        """Same subject_id → same legacy value (idempotent across
+        re-writes; e.g. _promote_pending_google_entry retries)."""
+        s = "pending:" + ("a" * 235) + "@example.com"
+        assert _legacy_user_id_for_non_github("google", s) == _legacy_user_id_for_non_github(
+            "google", s
+        )
+
+    def test_long_subject_helper_collision_resistant_on_shared_prefix(self):
+        """Two distinct long subject_ids that share a 49+ char prefix
+        (raw truncation would collide) must map to distinct legacy
+        values via the hash branch — this is the corner case the
+        downgrade migration's unique constraint relies on.
+        """
+        s1 = "pending:" + ("a" * 235) + "@example.com"
+        s2 = "pending:" + ("a" * 235) + "@example.org"
+        v1 = _legacy_user_id_for_non_github("google", s1)
+        v2 = _legacy_user_id_for_non_github("google", s2)
+        # Pre-fix raw truncation would have collided here:
+        assert f"google:{s1}"[:64] == f"google:{s2}"[:64]
+        # Hashed form does not:
+        assert v1 != v2
 
 
 class TestRecordBlockedSignup:

--- a/backend/tests/services/test_signup_gate_service.py
+++ b/backend/tests/services/test_signup_gate_service.py
@@ -185,10 +185,15 @@ class TestCheckAccess:
         svc.db.commit.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_promote_pending_google_entry_integrity_error_rolls_back(self):
-        """If commit raises IntegrityError (race: a real-sub row for the
-        same OIDC sub already exists), the method rolls back the in-flight
-        promotion and returns False so the caller falls through cleanly.
+    async def test_promote_pending_google_entry_integrity_error_no_race_winner_returns_false(self):
+        """IntegrityError + post-rollback re-check finds no
+        ``(google, oauth_sub, active, manual)`` row → method returns
+        False so the caller falls through to the regular block path.
+
+        Covers the stale/inconsistent case: a duplicate-key error came
+        from a row outside the active+manual scope (e.g. a soft-deleted
+        or sponsor-source row), so the user is NOT effectively
+        allowlisted under the manual gate.
         """
         from sqlalchemy.exc import IntegrityError
 
@@ -196,12 +201,107 @@ class TestCheckAccess:
         pending = MagicMock()
         pending.id = uuid4()
         pending.subject_id = "pending:racy@example.com"
-        execute_result = MagicMock()
-        execute_result.scalar_one_or_none = MagicMock(return_value=pending)
-        svc.db.execute = AsyncMock(return_value=execute_result)
+
+        # First execute() = initial SELECT returns pending. Second
+        # execute() = post-rollback re-check returns no row.
+        initial_result = MagicMock()
+        initial_result.scalar_one_or_none = MagicMock(return_value=pending)
+        recheck_result = MagicMock()
+        recheck_result.first = MagicMock(return_value=None)
+        svc.db.execute = AsyncMock(side_effect=[initial_result, recheck_result])
         svc.db.commit = AsyncMock(side_effect=IntegrityError("INSERT", {}, BaseException("dup")))
         svc.db.rollback = AsyncMock()
 
+        result = await svc._promote_pending_google_entry(
+            email="racy@example.com", oauth_sub="2222222222"
+        )
+
+        assert result is False
+        svc.db.rollback.assert_awaited_once()
+        # Two execute() calls = initial SELECT + post-rollback re-check.
+        assert svc.db.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_promote_pending_google_entry_integrity_error_with_race_winner_returns_true(self):
+        """IntegrityError caused by a concurrent admin add (or another
+        promotion) that just inserted ``(google, oauth_sub, manual)`` —
+        re-check finds the winning row → method returns True so the
+        gate treats the user as allowlisted rather than blocking them
+        despite the row actually being present (PR #673 Copilot
+        review #3 finding E).
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        svc = _svc()
+        pending = MagicMock()
+        pending.id = uuid4()
+        pending.subject_id = "pending:racy@example.com"
+
+        # First execute() = initial SELECT returns pending. Second
+        # execute() = post-rollback re-check finds the race-winning row.
+        initial_result = MagicMock()
+        initial_result.scalar_one_or_none = MagicMock(return_value=pending)
+        recheck_result = MagicMock()
+        # ``first()`` returning anything non-None signals "row present".
+        recheck_result.first = MagicMock(return_value=(uuid4(),))
+        svc.db.execute = AsyncMock(side_effect=[initial_result, recheck_result])
+        svc.db.commit = AsyncMock(side_effect=IntegrityError("INSERT", {}, BaseException("dup")))
+        svc.db.rollback = AsyncMock()
+
+        result = await svc._promote_pending_google_entry(
+            email="racy@example.com", oauth_sub="2222222222"
+        )
+
+        assert result is True
+        svc.db.rollback.assert_awaited_once()
+        assert svc.db.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_promote_pending_google_entry_rollback_does_not_touch_orm_instance(self):
+        """The rollback / success-log paths must reference a pre-commit
+        ID snapshot, not ``pending.id`` on an instance that may have
+        been expired by ``db.rollback()`` (which in async sessions
+        triggers an implicit lazy load → ``MissingGreenlet``).
+
+        Simulate the failure mode by making ``pending.id`` raise on
+        access after rollback, and verify the method still completes
+        without hitting that attribute (PR #673 Copilot review #3
+        finding D).
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        svc = _svc()
+
+        # Use a class with a property that raises after a flag is set,
+        # so the snapshot at the top of the method captures a usable
+        # ID but any post-commit/post-rollback access blows up.
+        class _ExpiringInstance:
+            def __init__(self):
+                self._id = uuid4()
+                self._expired = False
+                self.subject_id = "pending:racy@example.com"
+                self.github_user_id = "google:pending:racy@example.com"
+
+            @property
+            def id(self):
+                if self._expired:
+                    raise RuntimeError("MissingGreenlet-like lazy load on expired instance")
+                return self._id
+
+        pending = _ExpiringInstance()
+        initial_result = MagicMock()
+        initial_result.scalar_one_or_none = MagicMock(return_value=pending)
+        recheck_result = MagicMock()
+        recheck_result.first = MagicMock(return_value=None)
+        svc.db.execute = AsyncMock(side_effect=[initial_result, recheck_result])
+
+        async def _rollback_then_expire():
+            pending._expired = True
+
+        svc.db.commit = AsyncMock(side_effect=IntegrityError("INSERT", {}, BaseException("dup")))
+        svc.db.rollback = AsyncMock(side_effect=_rollback_then_expire)
+
+        # Must NOT raise — the method captured pending_id before commit.
         result = await svc._promote_pending_google_entry(
             email="racy@example.com", oauth_sub="2222222222"
         )

--- a/backend/tests/services/test_signup_gate_service.py
+++ b/backend/tests/services/test_signup_gate_service.py
@@ -92,6 +92,11 @@ class TestCheckAccess:
         svc._is_existing_user = AsyncMock(return_value=False)
         svc._is_first_user = AsyncMock(return_value=False)
         svc._is_allowlisted = AsyncMock(return_value=False)
+        # Phase 2 (#655 follow-up): check_access now also consults
+        # _promote_pending_google_entry before falling through to block.
+        # Stub it to "not promoted" so this test still covers the block
+        # path; the promotion path has its own coverage below.
+        svc._promote_pending_google_entry = AsyncMock(return_value=False)
         # Stub the audit-write so the test doesn't try to talk to a real
         # session — _record_blocked_signup is exercised on its own below.
         svc._record_blocked_signup = AsyncMock()
@@ -118,6 +123,66 @@ class TestCheckAccess:
         assert kwargs["email"] == "stranger@example.com"
         assert kwargs["ip_address"] == "203.0.113.7"
         assert kwargs["user_agent"] == "Mozilla/5.0"
+
+    @pytest.mark.asyncio
+    async def test_google_pending_entry_promoted_on_first_oauth(self):
+        """Phase 2 (#655 follow-up): a pending pre-OAuth row is promoted
+        to the real OIDC sub on first sign-in, and the gate returns None
+        (signup allowed) without writing a blocked-signup audit row.
+        """
+        svc = _svc()
+        svc._load_config = AsyncMock(return_value=_config(enabled=True, mode="manual"))
+        svc._is_existing_user = AsyncMock(return_value=False)
+        svc._is_first_user = AsyncMock(return_value=False)
+        # Regular allowlist check misses (no real-sub row yet).
+        svc._is_allowlisted = AsyncMock(return_value=False)
+        # Promotion succeeds for this email.
+        svc._promote_pending_google_entry = AsyncMock(return_value=True)
+        svc._record_blocked_signup = AsyncMock()
+
+        result = await svc.check_access(
+            provider="google",
+            oauth_sub="108276939729829363",
+            email="newcomer@example.com",
+            username="newcomer@example.com",
+        )
+
+        assert result is None
+        svc._promote_pending_google_entry.assert_awaited_once_with(
+            email="newcomer@example.com",
+            oauth_sub="108276939729829363",
+        )
+        # Promotion path must not write a blocked-signup audit row — the
+        # signup is actually being ALLOWED via the pending → real-sub flip.
+        svc._record_blocked_signup.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_github_does_not_attempt_pending_promotion(self):
+        """Phase 2 (#655 follow-up): the pending-promotion path is
+        Google-only. GitHub usernames are resolvable to a numeric ID via
+        the GitHub API at add-time, so a "pending sub" state cannot
+        exist; the check_access path must NOT invoke the promotion
+        helper when provider=github (it would otherwise scan for sentinel
+        rows that can't be created via the github path).
+        """
+        svc = _svc()
+        svc._load_config = AsyncMock(return_value=_config(enabled=True, mode="manual"))
+        svc._is_existing_user = AsyncMock(return_value=False)
+        svc._is_first_user = AsyncMock(return_value=False)
+        svc._is_allowlisted = AsyncMock(return_value=False)
+        # If this were called, the assertion below would fail.
+        svc._promote_pending_google_entry = AsyncMock(return_value=False)
+        svc._record_blocked_signup = AsyncMock()
+
+        result = await svc.check_access(
+            provider="github",
+            oauth_sub="1234",
+            email="stranger@example.com",
+            username="stranger",
+        )
+
+        assert isinstance(result, RedirectResponse)
+        svc._promote_pending_google_entry.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_existing_user_always_allowed(self):

--- a/backend/tests/services/test_signup_gate_service.py
+++ b/backend/tests/services/test_signup_gate_service.py
@@ -125,6 +125,91 @@ class TestCheckAccess:
         assert kwargs["user_agent"] == "Mozilla/5.0"
 
     @pytest.mark.asyncio
+    async def test_promote_pending_google_entry_updates_row_and_returns_true(self):
+        """Direct unit cover for ``_promote_pending_google_entry`` — the
+        method that the broader ``test_google_pending_entry_promoted_on_first_oauth``
+        only exercises through a mock. This test pins the actual
+        query / mutation / commit path so a refactor that breaks the
+        sentinel lookup or the legacy-column rewrite surfaces here
+        before reaching production.
+        """
+        svc = _svc()
+        # Mock a SignupAllowlistEntry instance the query returns.
+        pending = MagicMock()
+        pending.id = uuid4()
+        pending.subject_id = "pending:newcomer@example.com"
+        pending.github_user_id = "google:pending:newcomer@example.com"
+        pending.provider = "google"
+        pending.state = "active"
+        pending.source = "manual"
+
+        # First db.execute call (the SELECT inside the method) returns a
+        # result whose scalar_one_or_none yields the pending row.
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none = MagicMock(return_value=pending)
+        svc.db.execute = AsyncMock(return_value=execute_result)
+        svc.db.commit = AsyncMock()
+        svc.db.rollback = AsyncMock()
+
+        result = await svc._promote_pending_google_entry(
+            email="Newcomer@Example.com",  # mixed case — method lower-cases
+            oauth_sub="108276939729829363",
+        )
+
+        assert result is True
+        # subject_id rewritten to the real sub.
+        assert pending.subject_id == "108276939729829363"
+        # Legacy column also updated, with provider prefix.
+        assert pending.github_user_id == "google:108276939729829363"
+        svc.db.commit.assert_awaited_once()
+        svc.db.rollback.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_promote_pending_google_entry_missing_returns_false(self):
+        """No pending row → return False without committing.
+
+        Ensures the gate falls through to the regular block path instead
+        of silently committing on every Google sign-in attempt.
+        """
+        svc = _svc()
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none = MagicMock(return_value=None)
+        svc.db.execute = AsyncMock(return_value=execute_result)
+        svc.db.commit = AsyncMock()
+
+        result = await svc._promote_pending_google_entry(
+            email="absent@example.com", oauth_sub="999999999999999"
+        )
+
+        assert result is False
+        svc.db.commit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_promote_pending_google_entry_integrity_error_rolls_back(self):
+        """If commit raises IntegrityError (race: a real-sub row for the
+        same OIDC sub already exists), the method rolls back the in-flight
+        promotion and returns False so the caller falls through cleanly.
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        svc = _svc()
+        pending = MagicMock()
+        pending.id = uuid4()
+        pending.subject_id = "pending:racy@example.com"
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none = MagicMock(return_value=pending)
+        svc.db.execute = AsyncMock(return_value=execute_result)
+        svc.db.commit = AsyncMock(side_effect=IntegrityError("INSERT", {}, BaseException("dup")))
+        svc.db.rollback = AsyncMock()
+
+        result = await svc._promote_pending_google_entry(
+            email="racy@example.com", oauth_sub="2222222222"
+        )
+
+        assert result is False
+        svc.db.rollback.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_google_pending_entry_promoted_on_first_oauth(self):
         """Phase 2 (#655 follow-up): a pending pre-OAuth row is promoted
         to the real OIDC sub on first sign-in, and the gate returns None


### PR DESCRIPTION
Resolves the bootstrap circularity in the Phase 1 (#655) Google signup-gate flow: admin can now pre-allowlist a Google email **before** the user has OAuth'd, by creating a **pending** allowlist row that the OAuth callback gate promotes to the real OIDC sub on first sign-in.

## Problem (post v0.16.1 deploy)

Operator hit a circular bug while trying to allowlist `fumikazu.kiyota@democracy-x.org`:

1. Admin POSTs `{provider: google, email: ...}` → backend tries to resolve email → OIDC sub via the local `users` table → 404 "user must OAuth first"
2. Operator disables signup gate → target attempts Google sign-in → `_check_registration_allowed` (legacy) blocks because `ALLOW_REGISTRATION=false` and no pending invitation → no User row created
3. Re-enable gate → still no User row → email→sub still unresolvable → can't allowlist

The `#655` issue body explicitly listed this as out-of-scope ("Pre-OAuth invitation (email-only allowlist entry, sub filled at first callback). Phase 2."). This PR ships Phase 2.

## Approach

- Admin POST handler: on `GoogleUserNotFound`, create a row with `subject_id='pending:<email-lower>'` instead of 404
- OAuth callback gate (`SignupGateService.check_access`, google + manual): after the regular `(provider, subject_id=oauth_sub)` miss, consult new `_promote_pending_google_entry` which finds the pending row by email and rewrites `subject_id` to the actual OIDC sub
- GitHub branch untouched (no pending state needed — GitHub username resolves to ID at add-time via public API)

## Tests

- Service: pending-entry-promoted path + github-no-promotion guard + existing-blocked-test updated to mock the new helper
- Route: pending-row-on-create replaces the old 404-on-no-user test
- 67 tests pass across the two impacted files
- TypeScript / frontend: unchanged

## Trade-offs

- Email-change attack window: if the IdP changes the user's email between admin-add and user-OAuth, the promotion lookup misses (user re-blocked, admin re-adds with new email). Operator-controlled window, accepted risk for Phase 2 v1.
- Pending rows live under the same `state='active'` / `source='manual'` as real rows; the sentinel `subject_id` is the distinguishing marker. Existing list/remove endpoints work unchanged.

🤖 Filed against #655 follow-up