### PR TITLE
fix(frontend): silent in-session refetch in AuthContext (#678)

### DIFF
--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -164,7 +164,8 @@ describe("AuthContext silent refresh (issue #678)", () => {
       expect(screen.getByTestId("user").textContent).toBe(USER_A.email);
     });
 
-    // getCurrentUser swallows 401 and returns null (auth.ts:92-94).
+    // getCurrentUser swallows 401 and returns null — see its public-contract
+    // docblock in lib/auth/auth.ts.
     mockGetCurrentUser.mockResolvedValueOnce(null);
 
     await act(async () => {

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -19,7 +19,10 @@ vi.mock("next/navigation", () => ({
 
 const mockGetCurrentUser = vi.fn();
 const mockLogout = vi.fn();
-vi.mock("@/lib/auth/auth", () => ({
+vi.mock("@/lib/auth/auth", async () => ({
+  ...(await vi.importActual<typeof import("@/lib/auth/auth")>(
+    "@/lib/auth/auth",
+  )),
   getCurrentUser: () => mockGetCurrentUser(),
   logout: () => mockLogout(),
 }));

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -7,6 +7,7 @@
  * WorkspaceProvider state mid-flow.
  */
 
+import { useEffect } from "react";
 import { render, screen, act, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -43,10 +44,19 @@ const USER_B: User = {
   role: "admin",
 };
 
-/** Probe component: surfaces auth state into the DOM and exposes refetchUser. */
+/**
+ * Probe component: surfaces auth state into the DOM and exposes refetchUser.
+ *
+ * `isLoading` is recorded via `useEffect` so the log only reflects COMMITTED
+ * UI states — not render-phase side effects (which StrictMode double-renders
+ * and concurrent rendering can cancel). Recording during render would make
+ * the log non-deterministic and could mask real regressions.
+ */
 function Probe({ loadingLog }: { loadingLog: Array<boolean> }) {
   const { user, isLoading, refetchUser } = useAuth();
-  loadingLog.push(isLoading);
+  useEffect(() => {
+    loadingLog.push(isLoading);
+  }, [isLoading, loadingLog]);
   return (
     <>
       <div data-testid="user">{user ? user.email : "null"}</div>
@@ -106,12 +116,25 @@ describe("AuthContext silent refresh (issue #678)", () => {
     // Reset the log AFTER mount settles. We only care about post-mount behavior.
     log.length = 0;
 
-    // Second call returns a different user — refetchUser should swap the user
-    // without ever flipping isLoading to true.
-    mockGetCurrentUser.mockResolvedValueOnce(USER_B);
+    // Use a deferred promise so the user-update commits in a separate cycle
+    // from the click handler. Without this gap, React's automatic batching
+    // could coalesce a hypothetical setIsLoading(true) -> setIsLoading(false)
+    // into a single commit, hiding a real regression behind the batcher.
+    let resolveSecondFetch: (value: User | null) => void = () => {};
+    const deferredFetch = new Promise<User | null>((resolve) => {
+      resolveSecondFetch = resolve;
+    });
+    mockGetCurrentUser.mockReturnValueOnce(deferredFetch);
 
     await act(async () => {
       screen.getByTestId("refetch").click();
+    });
+
+    // Now resolve on a separate macrotask so the post-await `setUser` commits
+    // in its own React cycle.
+    await act(async () => {
+      resolveSecondFetch(USER_B);
+      await deferredFetch;
     });
 
     await waitFor(() => {

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tests for AuthContext silent-refresh discipline (issue #678).
+ *
+ * Regression guard for the "Context tree-killer" pattern: `refetchUser` MUST
+ * NOT flip `isLoading`, otherwise the authenticated subtree under
+ * DashboardContent's spinner gate (layout.tsx) unmounts and destroys
+ * WorkspaceProvider state mid-flow.
+ */
+
+import { render, screen, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { AuthProvider, useAuth } from "./AuthContext";
+import type { User } from "@/lib/auth/auth";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+const mockGetCurrentUser = vi.fn();
+const mockLogout = vi.fn();
+vi.mock("@/lib/auth/auth", () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+  logout: () => mockLogout(),
+}));
+
+const USER_A: User = {
+  id: "user-a",
+  email: "a@example.com",
+  name: "User A",
+  picture: "",
+  role: "user",
+};
+
+const USER_B: User = {
+  id: "user-b",
+  email: "b@example.com",
+  name: "User B",
+  picture: "",
+  role: "admin",
+};
+
+/** Probe component: surfaces auth state into the DOM and exposes refetchUser. */
+function Probe({ loadingLog }: { loadingLog: Array<boolean> }) {
+  const { user, isLoading, refetchUser } = useAuth();
+  loadingLog.push(isLoading);
+  return (
+    <>
+      <div data-testid="user">{user ? user.email : "null"}</div>
+      <div data-testid="loading">{isLoading ? "true" : "false"}</div>
+      <button
+        data-testid="refetch"
+        onClick={() => {
+          void refetchUser();
+        }}
+      >
+        refetch
+      </button>
+    </>
+  );
+}
+
+describe("AuthContext silent refresh (issue #678)", () => {
+  beforeEach(() => {
+    mockGetCurrentUser.mockReset();
+    mockLogout.mockReset();
+  });
+
+  it("initial mount flips isLoading true -> false (mount-time gate preserved)", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce(USER_A);
+    const log: boolean[] = [];
+
+    render(
+      <AuthProvider>
+        <Probe loadingLog={log} />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    // The very first render saw isLoading=true (mount-time gate).
+    expect(log[0]).toBe(true);
+    expect(log[log.length - 1]).toBe(false);
+    expect(screen.getByTestId("user").textContent).toBe(USER_A.email);
+  });
+
+  it("refetchUser does NOT flip isLoading (silent refresh — regression guard)", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce(USER_A);
+    const log: boolean[] = [];
+
+    render(
+      <AuthProvider>
+        <Probe loadingLog={log} />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading").textContent).toBe("false");
+    });
+
+    // Reset the log AFTER mount settles. We only care about post-mount behavior.
+    log.length = 0;
+
+    // Second call returns a different user — refetchUser should swap the user
+    // without ever flipping isLoading to true.
+    mockGetCurrentUser.mockResolvedValueOnce(USER_B);
+
+    await act(async () => {
+      screen.getByTestId("refetch").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe(USER_B.email);
+    });
+
+    // CORE ASSERTION: isLoading was never true during refetch.
+    expect(log.every((v) => v === false)).toBe(true);
+  });
+
+  it("refetchUser transient error preserves user (does NOT setUser(null))", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce(USER_A);
+
+    render(
+      <AuthProvider>
+        <Probe loadingLog={[]} />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe(USER_A.email);
+    });
+
+    // Simulate a transient network / 5xx error.
+    mockGetCurrentUser.mockRejectedValueOnce(new Error("network blip"));
+
+    await act(async () => {
+      screen.getByTestId("refetch").click();
+    });
+
+    // Give the rejected promise a tick to settle.
+    await waitFor(() => {
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(2);
+    });
+
+    // User remains USER_A — transient errors must not log the user out.
+    expect(screen.getByTestId("user").textContent).toBe(USER_A.email);
+  });
+
+  it("refetchUser observing 401 (getCurrentUser returns null) clears user", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce(USER_A);
+
+    render(
+      <AuthProvider>
+        <Probe loadingLog={[]} />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe(USER_A.email);
+    });
+
+    // getCurrentUser swallows 401 and returns null (auth.ts:92-94).
+    mockGetCurrentUser.mockResolvedValueOnce(null);
+
+    await act(async () => {
+      screen.getByTestId("refetch").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe("null");
+    });
+  });
+});

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -89,8 +89,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   };
 
+  /**
+   * In-session silent refresh.
+   *
+   * MUST NOT flip `isLoading` — toggling it would unmount the authenticated
+   * subtree via DashboardContent's spinner gate (layout.tsx), destroying the
+   * state of inner Contexts (WorkspaceProvider, MemoryContextProvider)
+   * mid-flow. See issue #678 for the tree-killer pattern.
+   *
+   * Transient refetch errors do NOT log the user out — a network blip should
+   * not eject a logged-in session. Real 401s still set `user` to null because
+   * `getCurrentUser` already returns null in that case (auth.ts:92-94), which
+   * triggers the normal redirect-to-login path through DashboardContent.
+   */
   const refetchUser = async () => {
-    await fetchUser();
+    try {
+      const currentUser = await getCurrentUser();
+      setUser(currentUser);
+    } catch (error) {
+      console.error("Failed to refetch user (silent):", error);
+      // Intentionally do not setUser(null) here — see the docblock above.
+    }
   };
 
   const value: AuthContextType = {

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -99,10 +99,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    *
    * Transient refetch errors do NOT log the user out — a network blip should
    * not eject a logged-in session. Real 401s still set `user` to null because
-   * `getCurrentUser` already returns null in that case (auth.ts:92-94), which
-   * triggers the normal redirect-to-login path through DashboardContent.
+   * `getCurrentUser` returns null in that case (see its public-contract
+   * docblock in `lib/auth/auth.ts`), which triggers the normal
+   * redirect-to-login path through DashboardContent.
+   *
+   * In dev mock-auth mode (`useMockAuth`), refetch is a no-op — the mock
+   * identity is static and the real `getCurrentUser` would 401 against the
+   * dev backend, clearing the mock user.
    */
   const refetchUser = async () => {
+    if (useMockAuth) {
+      return;
+    }
     try {
       const currentUser = await getCurrentUser();
       setUser(currentUser);

--- a/frontend/src/lib/auth/auth.ts
+++ b/frontend/src/lib/auth/auth.ts
@@ -81,14 +81,23 @@ export async function handleAuthCallback(
 }
 
 /**
- * Get current authenticated user information
+ * Get current authenticated user information.
+ *
+ * Public contract (depended on by `AuthContext.refetchUser`, issue #678):
+ * - 200 → returns the User
+ * - 401 → returns null (caller treats null as "session ended, go to /login")
+ * - other errors (5xx, network) → throws (caller preserves current user state)
+ *
+ * Changing the 401-returns-null branch to throw will silently break the
+ * in-session logout path in `AuthContext.refetchUser` — the catch there
+ * intentionally preserves the user on errors, so a 401 thrown instead of
+ * returned-as-null would leave a logged-out session displayed as logged-in.
  */
 export async function getCurrentUser(): Promise<User | null> {
   try {
     const response = await apiClient.get<{ user: User }>("/api/v1/auth/me");
     return response.user;
   } catch (error) {
-    // If 401 Unauthorized, user is not authenticated
     if ((error as { status?: number }).status === 401) {
       return null;
     }


### PR DESCRIPTION
Closes #678

## Summary

- Split `AuthContext.refetchUser` out of `fetchUser` so that in-session refresh no longer flips `isLoading` and unmounts the authenticated subtree via DashboardContent's spinner gate (the "Context tree-killer" pattern that was bouncing users back to `?create=true` after creating a workspace).
- Drop `setUser(null)` from `refetchUser`'s error path — transient 5xx / network errors now preserve the logged-in session. Real 401s still log the user out because `getCurrentUser` returns null in that case (auth.ts:86-98).
- Add 4 regression tests in `AuthContext.test.tsx` including the core guard that asserts `refetchUser` never toggles `isLoading`.
- Gate2 hardening: switch test mock to `vi.importActual` spread to catch contract drift between mock and prod; document the 401-returns-null contract at the `getCurrentUser` source of truth.

## Implementation notes

- `AuthContext.tsx`: `refetchUser` is now independent of `fetchUser`. `fetchUser` stays mount-time-only (still called by the `useEffect`). Docblock explains the tree-killer rationale.
- `AuthContext.test.tsx` (new, 4 tests): probe component records `isLoading` across renders; the core test resets the log after mount settles and asserts every post-mount tick stayed false. Other tests cover mount-time gate, transient error, and 401-clears-user.
- `auth.ts`: docblock on `getCurrentUser` now declares its public contract (200 returns User, 401 returns null, other errors throw) and warns that changing the 401 branch will silently break `AuthContext.refetchUser`.
- Mocks use `vi.importActual` spread so contract drift in `@/lib/auth/auth` surfaces at compile time instead of producing silently green tests.

Out of scope (filed as follow-ups):
- #682 — chore(frontend): use or remove `WorkspaceContext.setCreatedWorkspace` (defined-but-unused)
- #683 — fix(auth): distinguish 401 from transient errors in refetchUser silent-refresh (close the implicit coupling explicitly)

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: yellow → both High items applied in commit 2 (vi.importActual spread + auth.ts contract docblock)
- qa-lead: yellow → vi.importActual applied; mount-count guard + E2E coverage deferred per QA's own framing
- cto: green
- gate1: green via /claude-c-suite:ask (CTO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/678-fix-fix-frontend-workspaceprovider-state-los.gate1.md
- ~/.claude/cache/gh-issue-driven/678-fix-fix-frontend-workspaceprovider-state-los.gate2.md

## Test plan

- [x] `npx vitest run src/contexts/AuthContext.test.tsx` — 4 PASS
- [x] `npx vitest run` (full frontend suite) — 384 PASS / 0 FAIL (was 380 before)
- [x] `npx tsc --noEmit` — clean
- [ ] Manual browser repro: dev server → create workspace → click sidebar `Settings > Workspace` → verify URL stays `/workspace/settings/general` (no `?create=true`)
- [ ] Smoke check other `refetchUser` callers (profile page, workspace switch) — should be unaffected since signature is unchanged

🤖 Generated via /gh-issue-driven:ship
