### PR TITLE
fix(admin): exclude soft-deleted workspaces from admin users list/detail (#681)

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -232,7 +232,10 @@ async def list_users(
             workspace_memberships_result = await db.execute(
                 select(WorkspaceMember, Workspace)
                 .join(Workspace, Workspace.id == WorkspaceMember.workspace_id)
-                .where(WorkspaceMember.user_id.in_(user_ids))
+                .where(
+                    WorkspaceMember.user_id.in_(user_ids),
+                    Workspace.deleted_at.is_(None),  # #681: exclude soft-deleted
+                )
                 .order_by(WorkspaceMember.role.desc())
             )
             workspace_memberships = workspace_memberships_result.all()
@@ -396,7 +399,10 @@ async def get_user_detail(
         workspace_memberships_result = await db.execute(
             select(WorkspaceMember, Workspace)
             .join(Workspace, Workspace.id == WorkspaceMember.workspace_id)
-            .where(WorkspaceMember.user_id == user_id)
+            .where(
+                WorkspaceMember.user_id == user_id,
+                Workspace.deleted_at.is_(None),  # #681: exclude soft-deleted
+            )
             .order_by(WorkspaceMember.role.desc())
         )
         workspace_memberships = workspace_memberships_result.all()

--- a/backend/tests/integration/test_admin_users_soft_delete_filter.py
+++ b/backend/tests/integration/test_admin_users_soft_delete_filter.py
@@ -75,16 +75,16 @@ async def user_with_mixed_workspaces(db_session: AsyncSession) -> dict:
 
 # Route-function defaults that mirror the FastAPI Query(...) defaults so we can
 # invoke the handlers directly without the dependency-injection machinery.
-_LIST_DEFAULTS = dict(
-    limit=100,
-    offset=0,
-    include_workspaces=False,
-    search=None,
-    workspace_id=None,
-    role=None,
-    plan=None,
-    sort="created_at",
-)
+_LIST_DEFAULTS = {
+    "limit": 100,
+    "offset": 0,
+    "include_workspaces": False,
+    "search": None,
+    "workspace_id": None,
+    "role": None,
+    "plan": None,
+    "sort": "created_at",
+}
 
 
 class TestListUsersIncludeWorkspaces:

--- a/backend/tests/integration/test_admin_users_soft_delete_filter.py
+++ b/backend/tests/integration/test_admin_users_soft_delete_filter.py
@@ -1,0 +1,137 @@
+"""Regression tests for #681 — admin user routes must exclude soft-deleted workspaces.
+
+Same pattern class as #660 / #665 (soft-delete filter omission).
+
+Hits a real Postgres test DB because the existing mock-DB tests in
+``tests/api/test_admin_*.py`` cannot detect SQL ``WHERE`` clause omissions.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin import get_user_detail, list_users
+from models.auth import User, Workspace, WorkspaceMember
+
+
+def _mock_admin() -> dict:
+    return {"user_id": "admin_runner", "email": "admin@test.invalid", "role": "admin"}
+
+
+def _new_workspace(*, owner: str, soft_deleted: bool) -> Workspace:
+    return Workspace(
+        id=uuid4(),
+        name=f"{'deleted' if soft_deleted else 'active'}-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner,
+        memory_limit=1000,
+        daily_api_limit=500,
+        weekly_api_limit=2500,
+        deleted_at=(func.now() if soft_deleted else None),
+    )
+
+
+@pytest_asyncio.fixture
+async def user_with_mixed_workspaces(db_session: AsyncSession) -> dict:
+    """One user owning two ``pro`` workspaces — one active, one soft-deleted."""
+    user_id = f"u_{uuid4().hex[:8]}"
+    db_session.add(
+        User(
+            email=f"{user_id}@test.invalid",
+            user_id=user_id,
+            name="Test User",
+            role="user",
+            is_initial_admin=False,
+            auth_method="oauth",
+            auth_provider="google",
+        )
+    )
+    await db_session.flush()
+
+    active = _new_workspace(owner=user_id, soft_deleted=False)
+    deleted = _new_workspace(owner=user_id, soft_deleted=True)
+    db_session.add_all([active, deleted])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            WorkspaceMember(workspace_id=active.id, user_id=user_id, role="owner"),
+            WorkspaceMember(workspace_id=deleted.id, user_id=user_id, role="owner"),
+        ]
+    )
+    await db_session.commit()
+
+    return {
+        "user_id": user_id,
+        "active_workspace_id": str(active.id),
+        "deleted_workspace_id": str(deleted.id),
+    }
+
+
+# Route-function defaults that mirror the FastAPI Query(...) defaults so we can
+# invoke the handlers directly without the dependency-injection machinery.
+_LIST_DEFAULTS = dict(
+    limit=100,
+    offset=0,
+    include_workspaces=False,
+    search=None,
+    workspace_id=None,
+    role=None,
+    plan=None,
+    sort="created_at",
+)
+
+
+class TestListUsersIncludeWorkspaces:
+    """``GET /admin/users?include_workspaces=true`` filters soft-deleted (L233-238)."""
+
+    @pytest.mark.asyncio
+    async def test_workspaces_array_excludes_soft_deleted(
+        self,
+        db_session: AsyncSession,
+        user_with_mixed_workspaces: dict,
+    ) -> None:
+        response = await list_users(
+            user=_mock_admin(),
+            db=db_session,
+            **{**_LIST_DEFAULTS, "include_workspaces": True},
+        )
+
+        target = next(
+            (u for u in response.users if u.id == user_with_mixed_workspaces["user_id"]),
+            None,
+        )
+        assert target is not None, "test user not present in admin listing"
+
+        workspace_ids = {ws["workspace_id"] for ws in target.workspaces}
+        assert user_with_mixed_workspaces["active_workspace_id"] in workspace_ids
+        assert user_with_mixed_workspaces["deleted_workspace_id"] not in workspace_ids, (
+            "soft-deleted workspace must NOT appear in admin user listing (#681)"
+        )
+
+
+class TestGetUserDetail:
+    """``GET /admin/users/{user_id}`` ``workspaces`` excludes soft-deleted (L398-404)."""
+
+    @pytest.mark.asyncio
+    async def test_workspaces_array_excludes_soft_deleted(
+        self,
+        db_session: AsyncSession,
+        user_with_mixed_workspaces: dict,
+    ) -> None:
+        detail = await get_user_detail(
+            user_id=user_with_mixed_workspaces["user_id"],
+            admin=_mock_admin(),
+            db=db_session,
+        )
+
+        workspace_ids = {ws.workspace_id for ws in detail.workspaces}
+        assert user_with_mixed_workspaces["active_workspace_id"] in workspace_ids
+        assert user_with_mixed_workspaces["deleted_workspace_id"] not in workspace_ids, (
+            "soft-deleted workspace must NOT appear in admin user detail (#681)"
+        )


### PR DESCRIPTION
Closes #681

## Summary

- `GET /admin/users` (with `include_workspaces=true`) and `GET /admin/users/{user_id}` joined `WorkspaceMember` → `Workspace` without filtering `Workspace.deleted_at IS NULL`, leaking soft-deleted workspaces into admin views (same pattern class as #660 / #665).
- Fix adds `Workspace.deleted_at.is_(None)` to both `WHERE` clauses (`backend/src/api/routes/admin.py:235, :402`). Reference correct pattern: `backend/src/api/routes/admin_plans.py:156`.
- Adds 2 integration regression tests against a real Postgres test DB; mock-DB tests in `tests/api/test_admin_*.py` cannot detect SQL `WHERE`-clause omissions, which is why the bug went unnoticed.

## Implementation notes

- Admin-only endpoints (`Depends(require_admin)`) — not a cross-tenant data leak (CWE-639), an admin-UI integrity bug.
- Test fixture uses `deleted_at=func.now()` direct assignment rather than `workspace_service.delete_workspace()` — keeps the test focused on the SQL filter and avoids mocking Qdrant / ExternalAPIKey side-effects. The soft-delete mechanism itself is covered elsewhere (`test_account_erasure_integration.py`).
- New test file lives in `tests/integration/` (real Postgres) because the existing `tests/api/test_admin_*.py` tests mock the DB and cannot catch SQL WHERE omissions.

## Out-of-scope findings (for follow-up issues)

- **Pre-existing brokenness at `admin.py:152-156` (plan filter)**: discovered during integration testing — `stmt.join(WorkspaceMember)` raises `sqlalchemy.exc.InvalidRequestError: Don't know how to join to WorkspaceMember` because `User.user_id` is a plain `String(255)` with no FK / relationship to `WorkspaceMember.user_id`. The path returns HTTP 500 for any `GET /admin/users?plan=…` in production. My initial speculative `Workspace.deleted_at` addition there was reverted (dead code path violates the project rule against "designing for hypothetical future requirements"). Will be filed as a separate follow-up issue.
- **Pattern-class detector**: #660 / #665 / #681 are the 3rd recurrence of "soft-delete filter omission". A runtime assertion (e.g. `sqlalchemy.event.listen('do_orm_execute')` in dev/test envs) or AST lint rule would catch the 4th occurrence before it ships. Recommended as a separate issue.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CIO lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/681-fix-fix-admin-admin-users-list-detail-surfac.gate1.md`
- `~/.claude/cache/gh-issue-driven/681-fix-fix-admin-admin-users-list-detail-surfac.gate2.md`

## Test plan

- [x] `pytest tests/integration/test_admin_users_soft_delete_filter.py` — 2/2 passing against real Postgres
- [x] Regression: services / utils / billing tests pass (1049/1050; 1 unrelated pre-existing `resend` module missing in local env)
- [ ] Manual smoke: load admin user detail page after soft-deleting a workspace — confirm it disappears from the Workspaces list

🤖 Generated via /gh-issue-driven:ship
