### PR TITLE
feat(quota): advisory lock + enforce_workspace_cap flip + runbook (#674 sub-C)

### DIFF
--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -9,6 +9,7 @@ Responsibilities:
 - Provide quota status and warnings
 """
 
+import time
 from typing import Any
 from uuid import UUID
 
@@ -245,16 +246,19 @@ class QuotaService:
 
         # Issue #677 (sub-C): acquire a per-user advisory lock so the
         # subsequent count/cap read and the caller's workspace insert
-        # serialize per user_id. Hybrid fail policy applied on errors:
-        # deny when enforced (cap is the safety invariant), allow+log
-        # when not enforced (log-only must not produce false denials).
-        lock_wait_ms: int | None = None
+        # serialize per user_id. On lock_timeout / DB error the
+        # transaction is in error state and MUST be rolled back before
+        # any further statement — Postgres rejects everything until then.
+        # Hybrid fail policy: deny when enforced (cap is the safety
+        # invariant), allow when not enforced (log-only must not
+        # produce false denials).
+        lock_wait_ms: float | None = None
         try:
             lock_wait_ms = await self._acquire_workspace_create_lock(user_id)
         except OperationalError as exc:
             # SQLSTATE 55P03 = lock_not_available (SET LOCAL lock_timeout
-            # fired). Other DB errors get the same policy treatment but
-            # are logged with a distinct reason for triage.
+            # fired). asyncpg surfaces it as ``sqlstate``; psycopg2 as
+            # ``pgcode`` — both forms appear on different driver versions.
             sqlstate = getattr(exc.orig, "sqlstate", None) or getattr(exc.orig, "pgcode", None)
             reason = "lock_timeout" if sqlstate == "55P03" else "lock_error"
             logger.warning(
@@ -264,13 +268,17 @@ class QuotaService:
                 sqlstate=sqlstate,
                 enforced=settings.enforce_workspace_cap,
             )
+            # The session is poisoned until rollback — issue it before
+            # we either deny or fall back to allow.
+            await self.db.rollback()
             if settings.enforce_workspace_cap:
                 error = "Workspace creation temporarily unavailable. Please retry in a moment."
                 if raise_on_denied:
                     raise QuotaExceededError(error) from exc
                 return False, error
-            # enforce=False: fall through to the cap read — log-only
-            # mode must not generate false denials on lock errors.
+            # enforce=False: log-only mode must not generate false
+            # denials on infrastructure errors — allow the create.
+            return True, None
 
         # Issue #675 (epic #674 sub-A): cap = 1 (base) + users.workspace_slot_bonus.
         # The plan_resolver helper returns both numbers in a single SELECT
@@ -305,7 +313,7 @@ class QuotaService:
 
         return True, None
 
-    async def _acquire_workspace_create_lock(self, user_id: str) -> int:
+    async def _acquire_workspace_create_lock(self, user_id: str) -> float:
         """Acquire a per-user advisory lock for workspace-creation cap gating.
 
         Issue #677 (sub-C): serializes concurrent create paths for the
@@ -314,11 +322,6 @@ class QuotaService:
         it on commit/rollback, so the calling transaction must hold both
         the cap check and the insert for the lock to fully serialize the
         read-then-write.
-
-        ``hashtext()`` collisions across user_ids are theoretical and
-        only cause two unrelated users' create paths to briefly
-        serialize; the cap safety property holds regardless because
-        each user's cap is read under its own ``SELECT``.
 
         ``SET LOCAL lock_timeout = '5s'`` keeps a pathologically long
         peer transaction from stalling our worker indefinitely. On
@@ -330,10 +333,11 @@ class QuotaService:
             user_id: User ID (OAuth ``sub`` claim).
 
         Returns:
-            Elapsed wait time in milliseconds.
+            Elapsed wait time in milliseconds (float — sub-millisecond
+            precision matters when distinguishing "fast path, no
+            contention" from "lock granted immediately after queue
+            drain").
         """
-        import time
-
         lock_key = f"workspace_create:{user_id}"
         start = time.monotonic()
 
@@ -344,7 +348,7 @@ class QuotaService:
             text("SELECT pg_advisory_xact_lock(hashtext(:key))").bindparams(key=lock_key)
         )
 
-        return int((time.monotonic() - start) * 1000)
+        return (time.monotonic() - start) * 1000
 
     async def check_context_creation_allowed(
         self,

--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -14,7 +14,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import func, or_, select, text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config.plan_tiers import PLAN_TIERS, get_plan_tier, has_feature
@@ -255,10 +255,13 @@ class QuotaService:
         lock_wait_ms: float | None = None
         try:
             lock_wait_ms = await self._acquire_workspace_create_lock(user_id)
-        except OperationalError as exc:
-            # SQLSTATE 55P03 = lock_not_available (SET LOCAL lock_timeout
-            # fired). asyncpg surfaces it as ``sqlstate``; psycopg2 as
-            # ``pgcode`` — both forms appear on different driver versions.
+        except DBAPIError as exc:
+            # Catch the broader SQLAlchemy DBAPI wrapper so we cover every
+            # driver mapping for SQLSTATE 55P03 — asyncpg has historically
+            # mapped lock-cancellation to several exception subclasses, so
+            # narrowing to OperationalError would let real lock_timeouts
+            # bypass this branch (PR #686 Copilot review). asyncpg surfaces
+            # the SQLSTATE as ``sqlstate``; psycopg2 as ``pgcode``.
             sqlstate = getattr(exc.orig, "sqlstate", None) or getattr(exc.orig, "pgcode", None)
             reason = "lock_timeout" if sqlstate == "55P03" else "lock_error"
             logger.warning(
@@ -344,17 +347,33 @@ class QuotaService:
         """
         lock_key = f"workspace_create:{user_id}"
 
-        # SET LOCAL reverts on commit/rollback so this does not bleed
-        # into other operations on the same connection after the gate.
-        # Excluded from the timing measurement below so lock_wait_ms
-        # reflects only the advisory-lock acquire (PR #686 review).
+        # SET LOCAL applies to the rest of the current transaction, not
+        # just to the immediately-following statement. The caller's
+        # transaction continues past this helper into the workspace
+        # INSERT (and any other statements WorkspaceService.create_workspace
+        # issues), which must NOT inherit a 5s lock_timeout — without the
+        # reset below they would unexpectedly time out on any lock wait
+        # (PR #686 Copilot review). The acquire is bracketed by SET to
+        # 5s on entry and reset to '0' (no timeout, session default) on
+        # exit so the remainder of the caller's transaction is unaffected.
         await self.db.execute(text("SET LOCAL lock_timeout = '5s'"))
 
         start = time.monotonic()
-        await self.db.execute(
-            text("SELECT pg_advisory_xact_lock(hashtext(:key))").bindparams(key=lock_key)
-        )
-        return (time.monotonic() - start) * 1000
+        try:
+            await self.db.execute(
+                text("SELECT pg_advisory_xact_lock(hashtext(:key))").bindparams(key=lock_key)
+            )
+        finally:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            # On DBAPIError the tx is already in error state and any
+            # further execute would raise InFailedSqlTransaction — the
+            # caller's except branch is responsible for rolling back,
+            # which clears the lock_timeout along with the tx.
+            try:
+                await self.db.execute(text("SET LOCAL lock_timeout = '0'"))
+            except DBAPIError:
+                pass
+        return elapsed_ms
 
     async def check_context_creation_allowed(
         self,

--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -359,20 +359,23 @@ class QuotaService:
         await self.db.execute(text("SET LOCAL lock_timeout = '5s'"))
 
         start = time.monotonic()
+        acquired = False
         try:
             await self.db.execute(
                 text("SELECT pg_advisory_xact_lock(hashtext(:key))").bindparams(key=lock_key)
             )
+            acquired = True
         finally:
             elapsed_ms = (time.monotonic() - start) * 1000
-            # On DBAPIError the tx is already in error state and any
-            # further execute would raise InFailedSqlTransaction — the
-            # caller's except branch is responsible for rolling back,
-            # which clears the lock_timeout along with the tx.
-            try:
-                await self.db.execute(text("SET LOCAL lock_timeout = '0'"))
-            except DBAPIError:
-                pass
+
+        # Reset is OUTSIDE the try/finally: we only run it on success, and
+        # we let any reset error bubble up so the caller sees the poisoned
+        # session and applies the lock-error policy (PR #686 loop 3 review).
+        # When ``acquired`` is False, the tx is in error state from the
+        # acquire failure — the caller's except branch will rollback and
+        # clear the lock_timeout setting along with it.
+        if acquired:
+            await self.db.execute(text("SET LOCAL lock_timeout = '0'"))
         return elapsed_ms
 
     async def check_context_creation_allowed(

--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -12,7 +12,8 @@ Responsibilities:
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, or_, select
+from sqlalchemy import func, or_, select, text
+from sqlalchemy.exc import OperationalError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from config.plan_tiers import PLAN_TIERS, get_plan_tier, has_feature
@@ -203,20 +204,28 @@ class QuotaService:
     ) -> tuple[bool, str | None]:
         """Check if user can create another workspace.
 
-        Issue #276 (updated by Issue #661): owned-workspace cap is per
-        plan tier. Joined workspaces (via invite) do not count toward
-        this limit — they consume the inviting workspace's seat quota,
-        which the inviter pays for.
+        Issue #276 (updated by Issue #661, refined by #674/#675): the
+        owned-workspace cap is ``1 (base) + users.workspace_slot_bonus``.
+        Joined workspaces (via invite) do not count toward this limit —
+        they consume the inviting workspace's seat quota, which the
+        inviter pays for.
 
-        The user's effective tier is the highest tier among their owned
-        (``deleted_at IS NULL``) workspaces; users with zero owned
-        workspaces default to FREE.
+        Issue #677 (sub-C): a per-user ``pg_advisory_xact_lock`` is
+        acquired before the count/cap read to close the TOCTOU race
+        where two concurrent create paths could each observe
+        ``count < cap`` and both insert. The lock is xact-scoped, so
+        the caller must wrap the cap check and the workspace insert in
+        the same transaction for the serialization to extend across
+        the insert.
 
-        Rollout (Issue #661): when ``settings.enforce_workspace_cap`` is
-        False (default), this method emits a structured warn log when a
-        user would be over their tier's cap, but still returns OK. This
-        surfaces affected accounts via telemetry before the flag is
-        flipped to True.
+        Rollout (Issue #661, refined by #677): when
+        ``settings.enforce_workspace_cap`` is False (default), the
+        method logs over-cap creates but still returns OK so affected
+        accounts surface via telemetry. Lock-acquire failures
+        (``lock_timeout`` or unexpected DB errors) follow a hybrid fail
+        policy: deny when ``enforce=True`` (cap is the safety
+        invariant), allow + log when ``enforce=False`` (log-only mode
+        must not generate false denials).
 
         Args:
             user_id: User ID
@@ -234,18 +243,39 @@ class QuotaService:
 
         settings = get_settings()
 
+        # Issue #677 (sub-C): acquire a per-user advisory lock so the
+        # subsequent count/cap read and the caller's workspace insert
+        # serialize per user_id. Hybrid fail policy applied on errors:
+        # deny when enforced (cap is the safety invariant), allow+log
+        # when not enforced (log-only must not produce false denials).
+        lock_wait_ms: int | None = None
+        try:
+            lock_wait_ms = await self._acquire_workspace_create_lock(user_id)
+        except OperationalError as exc:
+            # SQLSTATE 55P03 = lock_not_available (SET LOCAL lock_timeout
+            # fired). Other DB errors get the same policy treatment but
+            # are logged with a distinct reason for triage.
+            sqlstate = getattr(exc.orig, "sqlstate", None) or getattr(exc.orig, "pgcode", None)
+            reason = "lock_timeout" if sqlstate == "55P03" else "lock_error"
+            logger.warning(
+                "workspace_create_lock_failed",
+                user_id=user_id,
+                reason=reason,
+                sqlstate=sqlstate,
+                enforced=settings.enforce_workspace_cap,
+            )
+            if settings.enforce_workspace_cap:
+                error = "Workspace creation temporarily unavailable. Please retry in a moment."
+                if raise_on_denied:
+                    raise QuotaExceededError(error) from exc
+                return False, error
+            # enforce=False: fall through to the cap read — log-only
+            # mode must not generate false denials on lock errors.
+
         # Issue #675 (epic #674 sub-A): cap = 1 (base) + users.workspace_slot_bonus.
         # The plan_resolver helper returns both numbers in a single SELECT
         # (JOIN of users + workspaces) so the gate and the dashboard read
         # consistent state.
-        #
-        # TOCTOU note: this read happens without ``WITH FOR UPDATE`` /
-        # row-level locking. Two concurrent ``POST /workspaces`` requests
-        # can both see ``count < cap`` and both succeed, briefly exceeding
-        # the cap. Mitigation (``pg_advisory_xact_lock`` on a per-user key
-        # plus the ``enforce_workspace_cap=True`` flip) is tracked in
-        # #674 sub-C (#677). Until then the gate is log-only (see flag
-        # handling below) so the race has no user-visible effect.
         workspace_count, cap = await get_user_workspace_cap_summary(self.db, user_id)
 
         if workspace_count >= cap:
@@ -261,6 +291,8 @@ class QuotaService:
                 current_owned_workspaces=workspace_count,
                 max_owned_workspaces=cap,
                 enforced=settings.enforce_workspace_cap,
+                lock_wait_ms=lock_wait_ms,
+                reason="over_cap",
             )
 
             # Issue #661 rollout gate: when the flag is off, log but allow.
@@ -272,6 +304,47 @@ class QuotaService:
             return False, error
 
         return True, None
+
+    async def _acquire_workspace_create_lock(self, user_id: str) -> int:
+        """Acquire a per-user advisory lock for workspace-creation cap gating.
+
+        Issue #677 (sub-C): serializes concurrent create paths for the
+        same user so the cap check and the caller's insert behave as
+        one critical section. The lock is xact-scoped — Postgres releases
+        it on commit/rollback, so the calling transaction must hold both
+        the cap check and the insert for the lock to fully serialize the
+        read-then-write.
+
+        ``hashtext()`` collisions across user_ids are theoretical and
+        only cause two unrelated users' create paths to briefly
+        serialize; the cap safety property holds regardless because
+        each user's cap is read under its own ``SELECT``.
+
+        ``SET LOCAL lock_timeout = '5s'`` keeps a pathologically long
+        peer transaction from stalling our worker indefinitely. On
+        timeout Postgres raises SQLSTATE 55P03 (``lock_not_available``);
+        the caller maps that to fail-closed vs fail-open via
+        ``settings.enforce_workspace_cap``.
+
+        Args:
+            user_id: User ID (OAuth ``sub`` claim).
+
+        Returns:
+            Elapsed wait time in milliseconds.
+        """
+        import time
+
+        lock_key = f"workspace_create:{user_id}"
+        start = time.monotonic()
+
+        # SET LOCAL reverts on commit/rollback so this does not bleed
+        # into other operations on the same connection after the gate.
+        await self.db.execute(text("SET LOCAL lock_timeout = '5s'"))
+        await self.db.execute(
+            text("SELECT pg_advisory_xact_lock(hashtext(:key))").bindparams(key=lock_key)
+        )
+
+        return int((time.monotonic() - start) * 1000)
 
     async def check_context_creation_allowed(
         self,

--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -336,18 +336,24 @@ class QuotaService:
             Elapsed wait time in milliseconds (float — sub-millisecond
             precision matters when distinguishing "fast path, no
             contention" from "lock granted immediately after queue
-            drain").
+            drain"). Measurement scope is the advisory-lock acquire
+            statement only — the preceding ``SET LOCAL`` round-trip is
+            excluded, so the value reflects time spent waiting for the
+            lock plus the single SELECT round-trip (typically <2 ms
+            without contention).
         """
         lock_key = f"workspace_create:{user_id}"
-        start = time.monotonic()
 
         # SET LOCAL reverts on commit/rollback so this does not bleed
         # into other operations on the same connection after the gate.
+        # Excluded from the timing measurement below so lock_wait_ms
+        # reflects only the advisory-lock acquire (PR #686 review).
         await self.db.execute(text("SET LOCAL lock_timeout = '5s'"))
+
+        start = time.monotonic()
         await self.db.execute(
             text("SELECT pg_advisory_xact_lock(hashtext(:key))").bindparams(key=lock_key)
         )
-
         return (time.monotonic() - start) * 1000
 
     async def check_context_creation_allowed(

--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -314,6 +314,18 @@ class QuotaService:
                 raise QuotaExceededError(error)
             return False, error
 
+        # Info-level success log so the 7-day observation window can
+        # measure lock_wait_ms p99 across normal (under-cap) creates,
+        # not just denials — without this, contention is invisible
+        # until users hit the cap (PR #686 loop 4 review).
+        logger.info(
+            "workspace_create_gate_passed",
+            user_id=user_id,
+            current_owned_workspaces=workspace_count,
+            max_owned_workspaces=cap,
+            lock_wait_ms=lock_wait_ms,
+            enforced=settings.enforce_workspace_cap,
+        )
         return True, None
 
     async def _acquire_workspace_create_lock(self, user_id: str) -> float:
@@ -331,6 +343,23 @@ class QuotaService:
         timeout Postgres raises SQLSTATE 55P03 (``lock_not_available``);
         the caller maps that to fail-closed vs fail-open via
         ``settings.enforce_workspace_cap``.
+
+        ``hashtextextended(:key, 0)`` returns a 64-bit hash matching
+        the bigint signature of single-key ``pg_advisory_xact_lock``.
+        At 64 bits the birthday-paradox collision probability is
+        negligible (~2^32 users for 50%) — vs ``hashtext`` which is
+        32-bit and would collide at ~65k users, potentially causing
+        unrelated users to block each other under load (PR #686
+        loop 4 review).
+
+        Coverage note: this helper only serializes callers of
+        ``check_workspace_creation_allowed``. The auto-create paths
+        ``WorkspaceService.ensure_personal_workspace`` and
+        ``ContextService._ensure_personal_workspace`` insert personal
+        workspaces directly without going through this gate. Closing
+        the cap on those paths is tracked separately (out of scope
+        for #677, which is the user-initiated ``POST /workspaces``
+        gate).
 
         Args:
             user_id: User ID (OAuth ``sub`` claim).
@@ -362,7 +391,9 @@ class QuotaService:
         acquired = False
         try:
             await self.db.execute(
-                text("SELECT pg_advisory_xact_lock(hashtext(:key))").bindparams(key=lock_key)
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))").bindparams(
+                    key=lock_key
+                )
             )
             acquired = True
         finally:

--- a/backend/tests/integration/test_quota_service_advisory_lock.py
+++ b/backend/tests/integration/test_quota_service_advisory_lock.py
@@ -1,0 +1,271 @@
+"""Integration tests for the workspace-creation advisory lock (#674 sub-C / #677).
+
+These tests exercise the real Postgres ``pg_advisory_xact_lock`` primitive
+that ``QuotaService.check_workspace_creation_allowed`` acquires. Mocked
+unit tests in ``tests/services/test_quota_service.py`` cannot reproduce
+the TOCTOU race because they bypass transaction-level concurrency — the
+very thing we are guarding against.
+
+Three test layers:
+
+1. **Deterministic race** — N >> cap parallel creates must yield exactly
+   ``cap`` workspaces, never more. Positive proof the lock serializes
+   read-then-write under contention.
+
+2. **Negative control** — with the advisory lock monkeypatched to a
+   no-op, the same parallel pattern reproduces ``count > cap``. Catches
+   the regression where the lock implementation breaks but the positive
+   test still passes by lucky scheduling: the negative control proves
+   the test setup is genuinely racy when the safeguard is removed.
+
+3. **Metric / log-field assertion** — under contention, at least one
+   non-first session records ``lock_wait_ms > 0`` on the
+   ``workspace_creation_denied`` log event. Confirms the lock actually
+   contended; if every recorded wait is 0, the lock isn't really being
+   acquired or every caller bypasses the wait.
+
+The fixture grants ``workspace_slot_bonus = 2`` (cap = 3) and dispatches
+20 parallel attempts on independent ``AsyncSession`` instances. Each
+attempt runs ``check_workspace_creation_allowed`` + ``INSERT`` inside one
+``session.begin()`` block — production callers must do the same for the
+xact-scoped lock to extend across both, and the test mirrors that
+contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+import services.quota_service as quota_service_module
+from models.auth import User, Workspace
+from services.quota_service import QuotaService
+
+_BONUS = 2
+_CAP = 1 + _BONUS  # 3
+_PARALLEL_ATTEMPTS = 20
+
+
+def _new_workspace(owner: str) -> Workspace:
+    """Build an active (non-soft-deleted) workspace owned by ``owner``."""
+    return Workspace(
+        id=uuid4(),
+        name=f"toctou-{uuid4().hex[:8]}",
+        plan_name="free",
+        owner_user_id=owner,
+        memory_limit=1000,
+        daily_api_limit=500,
+        weekly_api_limit=2500,
+        deleted_at=None,
+    )
+
+
+async def _count_owned(session: AsyncSession, user_id: str) -> int:
+    result = await session.execute(
+        select(func.count(Workspace.id)).where(
+            Workspace.owner_user_id == user_id,
+            Workspace.deleted_at.is_(None),
+        )
+    )
+    return int(result.scalar() or 0)
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def user_with_cap_3(db_session: AsyncSession):
+    """Create a user with ``workspace_slot_bonus = 2`` (cap = 3) and no workspaces.
+
+    Cleans up workspaces and the user after the test so repeated runs of
+    the suite do not accumulate rows that would skew subsequent fixtures.
+    """
+    user_id = f"u_{uuid4().hex[:8]}"
+    db_session.add(
+        User(
+            email=f"{user_id}@toctou.invalid",
+            user_id=user_id,
+            name="TOCTOU Test User",
+            role="user",
+            is_initial_admin=False,
+            auth_method="oauth",
+            auth_provider="google",
+            workspace_slot_bonus=_BONUS,
+        )
+    )
+    await db_session.commit()
+
+    yield user_id
+
+    # Best-effort teardown — delete workspaces first to satisfy FKs.
+    await db_session.execute(Workspace.__table__.delete().where(Workspace.owner_user_id == user_id))
+    await db_session.execute(User.__table__.delete().where(User.user_id == user_id))
+    await db_session.commit()
+
+
+@pytest.fixture
+def enforce_cap_on(monkeypatch):
+    """Force ``settings.enforce_workspace_cap = True`` for the test scope.
+
+    ``get_settings()`` returns a module-level singleton, so mutating its
+    attribute is process-wide. monkeypatch restores the original value
+    when the test exits, including on failure.
+    """
+    from config.settings import get_settings
+
+    settings = get_settings()
+    monkeypatch.setattr(settings, "enforce_workspace_cap", True)
+    return settings
+
+
+async def _attempt_one_create(
+    session_maker: async_sessionmaker[AsyncSession],
+    user_id: str,
+) -> bool:
+    """Try to create one workspace; return True iff the insert committed.
+
+    The cap check and the insert run inside a single ``session.begin()``
+    block so the xact-scoped advisory lock holds across both. That is
+    the contract production callers must honor for the lock to fully
+    serialize the read-then-write — this test mirrors that contract.
+    """
+    async with session_maker() as session:
+        async with session.begin():
+            quota = QuotaService(session)
+            can, _ = await quota.check_workspace_creation_allowed(user_id)
+            if can:
+                session.add(_new_workspace(user_id))
+                return True
+            return False
+
+
+class TestAdvisoryLockSerializesAtCap:
+    """The lock must hold ``count <= cap`` under any level of concurrency."""
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_n_parallel_attempts_produce_exactly_cap(
+        self, async_engine, user_with_cap_3, enforce_cap_on
+    ):
+        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+        results = await asyncio.gather(
+            *[
+                _attempt_one_create(session_maker, user_with_cap_3)
+                for _ in range(_PARALLEL_ATTEMPTS)
+            ],
+            return_exceptions=True,
+        )
+
+        # Bool successes only; surface unexpected exceptions in the
+        # assertion message rather than silently treating them as
+        # successes or failures.
+        unexpected = [r for r in results if not isinstance(r, bool)]
+        assert not unexpected, f"unexpected exceptions from attempts: {unexpected!r}"
+
+        successes = sum(1 for r in results if r is True)
+        assert successes == _CAP, (
+            f"expected exactly {_CAP} successful creates, got {successes} (results: {results!r})"
+        )
+
+        async with session_maker() as session:
+            count = await _count_owned(session, user_with_cap_3)
+        assert count == _CAP, f"final owned-workspace count is {count}, must equal cap={_CAP}"
+
+
+class TestAdvisoryLockNegativeControl:
+    """Without the lock, the same parallel pattern MUST reproduce ``count > cap``.
+
+    Regression safeguard for the positive test above: if the production
+    advisory lock silently breaks, the positive test could still pass
+    by lucky scheduling. This negative control confirms our test setup
+    is genuinely racy when the lock is removed.
+    """
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_exceeds_cap_when_lock_is_noop(
+        self, async_engine, user_with_cap_3, enforce_cap_on, monkeypatch
+    ):
+        async def _noop(self_, user_id: str) -> int:
+            return 0
+
+        monkeypatch.setattr(
+            QuotaService,
+            "_acquire_workspace_create_lock",
+            _noop,
+            raising=True,
+        )
+
+        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+        await asyncio.gather(
+            *[
+                _attempt_one_create(session_maker, user_with_cap_3)
+                for _ in range(_PARALLEL_ATTEMPTS)
+            ],
+            return_exceptions=True,
+        )
+
+        async with session_maker() as session:
+            count = await _count_owned(session, user_with_cap_3)
+
+        assert count > _CAP, (
+            f"with lock disabled, expected count > cap={_CAP}; got {count}. "
+            f"Either the parallel test setup is not actually concurrent, "
+            f"or production code has a second serialization path besides "
+            f"the advisory lock that this test does not reach."
+        )
+
+
+class TestLockWaitMsRecorded:
+    """Under contention, ``workspace_creation_denied`` must carry ``lock_wait_ms > 0``.
+
+    Without contention, ``lock_wait_ms`` is approximately 0 for every
+    caller because ``pg_advisory_xact_lock`` is a fast path when no peer
+    holds the lock. With contention, peers queue and wait > 0 ms. The
+    test fails if every recorded ``lock_wait_ms`` is 0 — that would
+    indicate the lock isn't actually being acquired or every caller is
+    bypassing the wait.
+    """
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_at_least_one_session_waits_under_parallel_load(
+        self, async_engine, user_with_cap_3, enforce_cap_on, monkeypatch
+    ):
+        # quota_service uses structlog routed to PrintLoggerFactory, so
+        # pytest ``caplog`` does not see the events. Intercept the
+        # module logger's warning() directly to capture call kwargs.
+        warning_mock = MagicMock()
+        monkeypatch.setattr(quota_service_module.logger, "warning", warning_mock)
+
+        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+        await asyncio.gather(
+            *[
+                _attempt_one_create(session_maker, user_with_cap_3)
+                for _ in range(_PARALLEL_ATTEMPTS)
+            ],
+            return_exceptions=True,
+        )
+
+        denied_events = [
+            call.kwargs
+            for call in warning_mock.call_args_list
+            if call.args and call.args[0] == "workspace_creation_denied"
+        ]
+        assert denied_events, (
+            f"expected at least one workspace_creation_denied event under "
+            f"{_PARALLEL_ATTEMPTS}-way parallel load, got 0 "
+            f"(all calls: {warning_mock.call_args_list!r})"
+        )
+
+        wait_ms_values = [kwargs.get("lock_wait_ms") for kwargs in denied_events]
+        positive_waits = [v for v in wait_ms_values if isinstance(v, int) and v > 0]
+        assert positive_waits, (
+            f"expected at least one denied event with lock_wait_ms > 0 under "
+            f"{_PARALLEL_ATTEMPTS}-way parallel load. "
+            f"Got {len(denied_events)} denied events, lock_wait_ms values: "
+            f"{wait_ms_values}"
+        )

--- a/backend/tests/integration/test_quota_service_advisory_lock.py
+++ b/backend/tests/integration/test_quota_service_advisory_lock.py
@@ -201,11 +201,29 @@ class TestAdvisoryLockNegativeControl:
 
         session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
 
+        # Without an explicit barrier between the cap-check SELECT and the
+        # INSERT, asyncio's cooperative scheduler can interleave each task
+        # check + insert serially (later tasks observing prior commits)
+        # and the race never materializes. The barrier forces all N
+        # workers to complete the cap read BEFORE any of them inserts,
+        # which deterministically reproduces the TOCTOU when the lock
+        # is disabled (PR #686 Copilot review).
+        all_read = asyncio.Barrier(_PARALLEL_ATTEMPTS)
+
+        async def attempt_with_barrier() -> bool:
+            async with session_maker() as session:
+                async with session.begin():
+                    quota = QuotaService(session)
+                    can, _ = await quota.check_workspace_creation_allowed(user_with_cap_3)
+                    # All workers must have read before any of us inserts.
+                    await all_read.wait()
+                    if can:
+                        session.add(_new_workspace(user_with_cap_3))
+                        return True
+                    return False
+
         await asyncio.gather(
-            *[
-                _attempt_one_create(session_maker, user_with_cap_3)
-                for _ in range(_PARALLEL_ATTEMPTS)
-            ],
+            *[attempt_with_barrier() for _ in range(_PARALLEL_ATTEMPTS)],
             return_exceptions=True,
         )
 
@@ -214,9 +232,10 @@ class TestAdvisoryLockNegativeControl:
 
         assert count > _CAP, (
             f"with lock disabled, expected count > cap={_CAP}; got {count}. "
-            f"Either the parallel test setup is not actually concurrent, "
-            f"or production code has a second serialization path besides "
-            f"the advisory lock that this test does not reach."
+            f"Either the barrier did not synchronize all workers before "
+            f"the INSERT phase, or production code has a second "
+            f"serialization path besides the advisory lock that this "
+            f"test does not reach."
         )
 
 

--- a/backend/tests/integration/test_quota_service_advisory_lock.py
+++ b/backend/tests/integration/test_quota_service_advisory_lock.py
@@ -41,7 +41,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 import services.quota_service as quota_service_module
@@ -220,35 +220,63 @@ class TestAdvisoryLockNegativeControl:
         )
 
 
-class TestLockWaitMsRecorded:
-    """Under contention, ``workspace_creation_denied`` must carry ``lock_wait_ms > 0``.
+class TestLockWaitMsReflectsContention:
+    """Under a deterministic holder/blocker, ``lock_wait_ms`` reflects the wait.
 
-    Without contention, ``lock_wait_ms`` is approximately 0 for every
-    caller because ``pg_advisory_xact_lock`` is a fast path when no peer
-    holds the lock. With contention, peers queue and wait > 0 ms. The
-    test fails if every recorded ``lock_wait_ms`` is 0 — that would
-    indicate the lock isn't actually being acquired or every caller is
-    bypassing the wait.
+    A naive "any positive wait_ms proves contention" assertion fails
+    silently because the SELECT round-trip itself contributes a small
+    positive duration even when the lock is granted instantly (PR #686
+    Copilot review). This test instead sets up a holder transaction
+    that sleeps for ``HOLD_SEC``, then asserts the waiter's recorded
+    wait is at least ``MIN_EXPECTED_WAIT_MS`` (well above any
+    round-trip noise).
+
+    The helper now measures only the advisory-lock acquire (SET LOCAL
+    is excluded), so without contention the floor is the single SELECT
+    round-trip (typically <2 ms) and the assertion of >= 200 ms is a
+    clean signal that the test actually waited on the lock.
     """
 
     @pytest.mark.asyncio(loop_scope="session")
-    async def test_at_least_one_session_waits_under_parallel_load(
+    async def test_wait_ms_at_least_hold_duration(
         self, async_engine, user_with_cap_3, enforce_cap_on, monkeypatch
     ):
-        # quota_service uses structlog routed to PrintLoggerFactory, so
-        # pytest ``caplog`` does not see the events. Intercept the
-        # module logger's warning() directly to capture call kwargs.
         warning_mock = MagicMock()
         monkeypatch.setattr(quota_service_module.logger, "warning", warning_mock)
 
-        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+        HOLD_SEC = 0.3
+        MIN_EXPECTED_WAIT_MS = 200
 
-        await asyncio.gather(
-            *[
-                _attempt_one_create(session_maker, user_with_cap_3)
-                for _ in range(_PARALLEL_ATTEMPTS)
-            ],
-            return_exceptions=True,
+        # Pre-fill to cap so the waiter takes the denial path (which is
+        # the path that logs lock_wait_ms via workspace_creation_denied).
+        async with async_sessionmaker(async_engine, expire_on_commit=False)() as pre:
+            async with pre.begin():
+                for _ in range(_CAP):
+                    pre.add(_new_workspace(user_with_cap_3))
+
+        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+        lock_key = f"workspace_create:{user_with_cap_3}"
+        holder_acquired = asyncio.Event()
+
+        async def hold_lock() -> None:
+            async with session_maker() as holder:
+                async with holder.begin():
+                    await holder.execute(
+                        text("SELECT pg_advisory_xact_lock(hashtext(:k))").bindparams(k=lock_key)
+                    )
+                    holder_acquired.set()
+                    await asyncio.sleep(HOLD_SEC)
+                # commit on block exit releases the lock
+
+        async def waiter_attempt_create() -> bool:
+            await holder_acquired.wait()
+            return await _attempt_one_create(session_maker, user_with_cap_3)
+
+        results = await asyncio.gather(hold_lock(), waiter_attempt_create())
+        waiter_succeeded = results[1]
+
+        assert waiter_succeeded is False, (
+            "waiter should have been denied (cap pre-filled) but reported success"
         )
 
         denied_events = [
@@ -256,20 +284,16 @@ class TestLockWaitMsRecorded:
             for call in warning_mock.call_args_list
             if call.args and call.args[0] == "workspace_creation_denied"
         ]
-        assert denied_events, (
-            f"expected at least one workspace_creation_denied event under "
-            f"{_PARALLEL_ATTEMPTS}-way parallel load, got 0 "
-            f"(all calls: {warning_mock.call_args_list!r})"
+        assert len(denied_events) == 1, (
+            f"expected exactly one workspace_creation_denied event from the waiter, "
+            f"got {len(denied_events)} (all calls: {warning_mock.call_args_list!r})"
         )
 
-        # ``lock_wait_ms`` is now a float to preserve sub-millisecond precision —
-        # the int form would have truncated fast lock acquires to 0 even when
-        # the lock genuinely contended for fractions of a millisecond.
-        wait_ms_values = [kwargs.get("lock_wait_ms") for kwargs in denied_events]
-        positive_waits = [v for v in wait_ms_values if isinstance(v, (int, float)) and v > 0]
-        assert positive_waits, (
-            f"expected at least one denied event with lock_wait_ms > 0 under "
-            f"{_PARALLEL_ATTEMPTS}-way parallel load. "
-            f"Got {len(denied_events)} denied events, lock_wait_ms values: "
-            f"{wait_ms_values}"
+        wait_ms = denied_events[0].get("lock_wait_ms")
+        assert isinstance(wait_ms, (int, float)), f"lock_wait_ms must be numeric; got {wait_ms!r}"
+        assert wait_ms >= MIN_EXPECTED_WAIT_MS, (
+            f"lock_wait_ms={wait_ms:.1f}ms should be >= {MIN_EXPECTED_WAIT_MS}ms "
+            f"(holder held the lock for {HOLD_SEC * 1000:.0f}ms). A value below "
+            f"the floor means the helper either bypassed the lock or measured "
+            f"the wrong interval."
         )

--- a/backend/tests/integration/test_quota_service_advisory_lock.py
+++ b/backend/tests/integration/test_quota_service_advisory_lock.py
@@ -35,6 +35,7 @@ contract.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -77,7 +78,7 @@ async def _count_owned(session: AsyncSession, user_id: str) -> int:
 
 
 @pytest_asyncio.fixture(loop_scope="session")
-async def user_with_cap_3(db_session: AsyncSession):
+async def user_with_cap_3(db_session: AsyncSession) -> AsyncIterator[str]:
     """Create a user with ``workspace_slot_bonus = 2`` (cap = 3) and no workspaces.
 
     Cleans up workspaces and the user after the test so repeated runs of
@@ -188,8 +189,8 @@ class TestAdvisoryLockNegativeControl:
     async def test_count_exceeds_cap_when_lock_is_noop(
         self, async_engine, user_with_cap_3, enforce_cap_on, monkeypatch
     ):
-        async def _noop(self_, user_id: str) -> int:
-            return 0
+        async def _noop(self_, user_id: str) -> float:
+            return 0.0
 
         monkeypatch.setattr(
             QuotaService,
@@ -261,8 +262,11 @@ class TestLockWaitMsRecorded:
             f"(all calls: {warning_mock.call_args_list!r})"
         )
 
+        # ``lock_wait_ms`` is now a float to preserve sub-millisecond precision —
+        # the int form would have truncated fast lock acquires to 0 even when
+        # the lock genuinely contended for fractions of a millisecond.
         wait_ms_values = [kwargs.get("lock_wait_ms") for kwargs in denied_events]
-        positive_waits = [v for v in wait_ms_values if isinstance(v, int) and v > 0]
+        positive_waits = [v for v in wait_ms_values if isinstance(v, (int, float)) and v > 0]
         assert positive_waits, (
             f"expected at least one denied event with lock_wait_ms > 0 under "
             f"{_PARALLEL_ATTEMPTS}-way parallel load. "

--- a/backend/tests/integration/test_quota_service_advisory_lock.py
+++ b/backend/tests/integration/test_quota_service_advisory_lock.py
@@ -293,8 +293,12 @@ class TestLockWaitMsReflectsContention:
         async def hold_lock() -> None:
             async with session_maker() as holder:
                 async with holder.begin():
+                    # Mirror the production helper's hash function so the
+                    # holder and waiter contend on the SAME advisory key.
                     await holder.execute(
-                        text("SELECT pg_advisory_xact_lock(hashtext(:k))").bindparams(k=lock_key)
+                        text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))").bindparams(
+                            k=lock_key
+                        )
                     )
                     holder_acquired.set()
                     await asyncio.sleep(HOLD_SEC)

--- a/backend/tests/integration/test_quota_service_advisory_lock.py
+++ b/backend/tests/integration/test_quota_service_advisory_lock.py
@@ -211,16 +211,29 @@ class TestAdvisoryLockNegativeControl:
         all_read = asyncio.Barrier(_PARALLEL_ATTEMPTS)
 
         async def attempt_with_barrier() -> bool:
-            async with session_maker() as session:
-                async with session.begin():
-                    quota = QuotaService(session)
-                    can, _ = await quota.check_workspace_creation_allowed(user_with_cap_3)
-                    # All workers must have read before any of us inserts.
-                    await all_read.wait()
-                    if can:
-                        session.add(_new_workspace(user_with_cap_3))
-                        return True
-                    return False
+            try:
+                async with session_maker() as session:
+                    async with session.begin():
+                        quota = QuotaService(session)
+                        can, _ = await quota.check_workspace_creation_allowed(user_with_cap_3)
+                        # All workers must have read before any of us inserts.
+                        # If a peer failed pre-barrier and aborted, our
+                        # wait() raises BrokenBarrierError so the test fails
+                        # fast instead of hanging (PR #686 loop 3 review).
+                        await all_read.wait()
+                        if can:
+                            session.add(_new_workspace(user_with_cap_3))
+                            return True
+                        return False
+            except Exception:
+                # Any pre-barrier failure (DB error, validation, etc.) must
+                # release peer waiters so asyncio.gather does not deadlock.
+                # ``abort()`` is idempotent on an already-broken barrier.
+                try:
+                    await all_read.abort()
+                except Exception:
+                    pass
+                raise
 
         await asyncio.gather(
             *[attempt_with_barrier() for _ in range(_PARALLEL_ATTEMPTS)],

--- a/backend/tests/services/test_quota_service.py
+++ b/backend/tests/services/test_quota_service.py
@@ -362,3 +362,129 @@ class TestQuotaServiceWorkspaceCreationCap:
             )
         assert can_create is True
         assert error is None
+
+    # ------------------------------------------------------------------
+    # Lock-error policy (#677 sub-C, PR #686 review follow-up)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_lock_error(sqlstate: str) -> Exception:
+        """Build a SQLAlchemy DBAPIError carrying a ``sqlstate`` attribute.
+
+        The production code reads ``exc.orig.sqlstate`` / ``exc.orig.pgcode``
+        — both forms appear on different asyncpg/psycopg2 versions — to
+        identify SQLSTATE 55P03 (``lock_not_available``). A minimal
+        ``MagicMock`` orig with ``sqlstate`` set satisfies the read.
+        """
+        from sqlalchemy.exc import DBAPIError
+
+        orig = MagicMock()
+        orig.sqlstate = sqlstate
+        orig.pgcode = sqlstate
+        return DBAPIError("stmt", {}, orig)
+
+    @pytest.mark.asyncio
+    async def test_lock_timeout_enforce_true_denies(self, service, mock_db, monkeypatch):
+        """SQLSTATE 55P03 + enforce=True → fail-closed (deny + rollback)."""
+        from services import quota_service as qs
+
+        async def _raise_lock_timeout(self_, user_id):
+            raise self._make_lock_error("55P03")
+
+        monkeypatch.setattr(qs.QuotaService, "_acquire_workspace_create_lock", _raise_lock_timeout)
+        mock_db.rollback = AsyncMock()
+        warning_mock = MagicMock()
+        monkeypatch.setattr(qs.logger, "warning", warning_mock)
+
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+
+        assert can_create is False
+        assert error is not None
+        assert "temporarily unavailable" in error.lower()
+        mock_db.rollback.assert_awaited_once()
+        event_calls = [
+            c
+            for c in warning_mock.call_args_list
+            if c.args and c.args[0] == "workspace_create_lock_failed"
+        ]
+        assert len(event_calls) == 1
+        assert event_calls[0].kwargs.get("reason") == "lock_timeout"
+        assert event_calls[0].kwargs.get("sqlstate") == "55P03"
+        assert event_calls[0].kwargs.get("enforced") is True
+
+    @pytest.mark.asyncio
+    async def test_lock_timeout_enforce_false_allows(self, service, mock_db, monkeypatch):
+        """SQLSTATE 55P03 + enforce=False → fail-open (allow + log, no cap read)."""
+        from services import quota_service as qs
+
+        async def _raise_lock_timeout(self_, user_id):
+            raise self._make_lock_error("55P03")
+
+        monkeypatch.setattr(qs.QuotaService, "_acquire_workspace_create_lock", _raise_lock_timeout)
+        mock_db.rollback = AsyncMock()
+        warning_mock = MagicMock()
+        monkeypatch.setattr(qs.logger, "warning", warning_mock)
+
+        with self._patch_settings(enforce=False):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+
+        assert can_create is True
+        assert error is None
+        mock_db.rollback.assert_awaited_once()
+        event_calls = [
+            c
+            for c in warning_mock.call_args_list
+            if c.args and c.args[0] == "workspace_create_lock_failed"
+        ]
+        assert len(event_calls) == 1
+        assert event_calls[0].kwargs.get("reason") == "lock_timeout"
+        assert event_calls[0].kwargs.get("enforced") is False
+
+    @pytest.mark.asyncio
+    async def test_non_timeout_dbapi_error_reason_is_lock_error(
+        self, service, mock_db, monkeypatch
+    ):
+        """Non-55P03 DBAPIError → ``reason='lock_error'`` (distinct from lock_timeout)."""
+        from services import quota_service as qs
+
+        async def _raise_other(self_, user_id):
+            raise self._make_lock_error("08006")  # connection_failure
+
+        monkeypatch.setattr(qs.QuotaService, "_acquire_workspace_create_lock", _raise_other)
+        mock_db.rollback = AsyncMock()
+        warning_mock = MagicMock()
+        monkeypatch.setattr(qs.logger, "warning", warning_mock)
+
+        with self._patch_settings(enforce=True):
+            can_create, error = await service.check_workspace_creation_allowed("user-1")
+
+        assert can_create is False
+        event_calls = [
+            c
+            for c in warning_mock.call_args_list
+            if c.args and c.args[0] == "workspace_create_lock_failed"
+        ]
+        assert len(event_calls) == 1
+        assert event_calls[0].kwargs.get("reason") == "lock_error"
+        assert event_calls[0].kwargs.get("sqlstate") == "08006"
+
+    @pytest.mark.asyncio
+    async def test_lock_error_raise_on_denied_chains_cause(self, service, mock_db, monkeypatch):
+        """raise_on_denied=True + enforce=True + lock error → QuotaExceededError chained from DBAPIError."""
+        from services import quota_service as qs
+
+        original = self._make_lock_error("55P03")
+
+        async def _raise_lock_timeout(self_, user_id):
+            raise original
+
+        monkeypatch.setattr(qs.QuotaService, "_acquire_workspace_create_lock", _raise_lock_timeout)
+        mock_db.rollback = AsyncMock()
+
+        with self._patch_settings(enforce=True):
+            with pytest.raises(QuotaExceededError) as exc_info:
+                await service.check_workspace_creation_allowed("user-1", raise_on_denied=True)
+
+        assert "temporarily unavailable" in str(exc_info.value).lower()
+        assert exc_info.value.__cause__ is original

--- a/docs/ops/workspace-cap-rollback.md
+++ b/docs/ops/workspace-cap-rollback.md
@@ -185,17 +185,26 @@ UPDATE users
 psql で実行する場合の具体例（`<user_id> = u_abc12345`, `<N> = 3` のケース）:
 
 ```bash
-# 文字列補間ではなく psql の :'var' / :var 記法で渡す（SQL injection 経路を作らない）
-psql "$PROD_DSN_READWRITE" \
-  --variable=uid="u_abc12345" \
-  --variable=n=3 \
-  -c "UPDATE users SET workspace_slot_bonus = :n
-        WHERE user_id = :'uid' AND workspace_slot_bonus < :n;"
+# psql の `:var` / `:'var'` 変数置換は **stdin/heredoc または -f file** モード
+# でのみ動作する。`-c "..."` だと literal `:` がサーバ送信されて syntax error
+# になる (PR #686 loop 5 review) — heredoc + \set で安全に渡す。
+psql "$PROD_DSN_READWRITE" <<'SQL'
+\set uid 'u_abc12345'
+\set n 3
+SELECT current_database() AS db, current_user AS who;  -- 環境取り違え防止チェック
+UPDATE users
+   SET workspace_slot_bonus = :n
+ WHERE user_id = :'uid'
+   AND workspace_slot_bonus < :n;
+SELECT user_id, workspace_slot_bonus FROM users WHERE user_id = :'uid';
+SQL
 ```
 
 > 🛡️ **条件付き UPDATE を使う理由**: 単純な `SET workspace_slot_bonus = N` だと、誰かが既に高い値を入れていた場合に **意図せず下げてしまう**。`workspace_slot_bonus < N` の WHERE 句で「下げない」を保証する。降格が必要な場面は本 runbook の対象外（別 admin 操作）。
 
-> ⚠️ **DSN の取り違え**: `$PROD_DSN_READWRITE` は production 本番用。stage / dev と読み違えると別環境の user に bonus 付与してしまう。`SELECT current_database();` を先頭に置いて目視確認を必須にする運用が望ましい。
+> ⚠️ **DSN の取り違え**: `$PROD_DSN_READWRITE` は production 本番用。stage / dev と読み違えると別環境の user に bonus 付与してしまう。上記 heredoc の冒頭で `SELECT current_database();` を実行し、結果を目視確認してから次回の oncall に進む運用が望ましい。
+
+> 🔐 **`<<'SQL'` の quote**: heredoc delimiter を `'SQL'` で quote しているのは **shell 展開を抑制する** ため。`$uid` のような shell 変数を埋め込みたくなった時に、quote 無しだと shell が先に展開して psql の `:var` 機構を bypass する事故の原因になる。psql 側の変数で完結させる。
 
 ### Step 4.4. 検証
 

--- a/docs/ops/workspace-cap-rollback.md
+++ b/docs/ops/workspace-cap-rollback.md
@@ -39,20 +39,30 @@ flip 後に false-positive denial が出る代表的シナリオ:
 
 ## 3. Procedure / 即時 rollback
 
-### Step 1. フラグを `false` に戻す（deploy 不要）
+### Step 1. フラグを `false` に戻す（deploy 不要、container 再作成のみ）
 
-memory.kagura-ai.com など single-server 構成では:
+memory.kagura-ai.com の single-server 構成（systemd unit `kagura-memory.service` が docker compose stack を保持、blue/green container 名は `kagura-api-blue` / `kagura-api-green`、active 色は `/opt/kagura-memory/active-color` に記録）:
 
 ```bash
+# 0. active 色 / 環境ファイル / project dir を確認
+ACTIVE=$(cat /opt/kagura-memory/active-color)
+PROJECT_DIR=/opt/kagura-memory/src/terraform/single-server
+ENV_FILE="$PROJECT_DIR/.env.prod"
+echo "active=$ACTIVE  env_file=$ENV_FILE"
+
 # 1. .env.prod を編集
-sudo -e /opt/kagura-memory/.env.prod
+sudo -e "$ENV_FILE"
 #    ENFORCE_WORKSPACE_CAP=true  →  ENFORCE_WORKSPACE_CAP=false
 
-# 2. uvicorn worker を reload
-sudo systemctl reload kagura-api-green   # active container (blue-green の active 側)
+# 2. active container を環境変数再注入で recreate
+#    --force-recreate + --no-deps で active のみ作り直す
+#    docker compose restart では env-file 再読込が走らないので NG
+cd "$PROJECT_DIR"
+sudo docker compose -f docker-compose.prod.yml --env-file "$ENV_FILE" \
+  up -d --no-deps --force-recreate "api-${ACTIVE}"
 ```
 
-> ⚠️ **重要**: `get_settings()` は `_settings` module-level singleton をキャッシュする (`backend/src/config/settings.py:502-519`)。`uvicorn reload` で **worker process が再起動して `_settings` が再初期化される必要がある**。`systemctl reload` が SIGHUP で workers を replace するか確認。replace されない場合は `systemctl restart`。
+> ⚠️ **重要**: `get_settings()` は `_settings` module-level singleton をキャッシュする (`backend/src/config/settings.py:502-519`)。container を **recreate** することで FastAPI worker process が新しく起動し `_settings` が再初期化される。`docker compose restart` や `docker restart kagura-api-${ACTIVE}` は env-file を再読込しないため使ってはいけない。
 
 ### Step 2. `/health` 200 確認
 
@@ -71,18 +81,23 @@ curl -fsS -H "Authorization: Bearer $ADMIN_TOKEN" \
   https://memory.kagura-ai.com/admin/config 2>/dev/null | jq '.enforce_workspace_cap'
 # false
 
-# 無ければログから確認: 新規 workspace_creation_denied が出ても deny されないこと
-# 直後の workspace_creation_denied 行が enforced=false を含むはず
-journalctl -u kagura-api-green --since '1 minute ago' | grep workspace_creation_denied | tail -3
+# 無ければログから確認 (docker のログ — JSONRenderer 想定)
+# 直後の workspace_creation_denied 行が "enforced": false を含むはず
+sudo docker logs "kagura-api-${ACTIVE}" --since 1m 2>&1 \
+  | grep workspace_creation_denied | tail -3
 ```
 
 ### Step 4. false-positive denial の沈静化を観測
 
-reload 後 5 分間、`workspace_creation_denied enforced=true` の発生レートが減衰することを確認:
+reload 後 5 分間、`workspace_creation_denied` の `enforced=true` イベント発生レートが減衰することを確認。**structlog のレンダラに応じて表記が変わるので 2 パターンを OR で grep**:
+
+- JSONRenderer (production の `LOG_COLORIZE=false`): `"enforced": true`
+- ConsoleRenderer (development): `enforced=True` (Python bool repr)
 
 ```bash
-journalctl -u kagura-api-green --since '5 minutes ago' \
-  | grep -c 'workspace_creation_denied.*enforced=true'
+sudo docker logs "kagura-api-${ACTIVE}" --since 5m 2>&1 \
+  | grep workspace_creation_denied \
+  | grep -cE '"enforced":\s*true|enforced=True'
 # 期待: reload 前のレートと比べて急減（reload 直後にバッファに残った分のみ）
 ```
 
@@ -96,12 +111,24 @@ sub-B (#676 admin UI) が未 merge / 未 deploy の段階で、影響を受け�
 
 ### Step 4.1. 影響 user の特定
 
-log から `workspace_creation_denied enforced=true` を抽出して `user_id` を取り出す:
+log から `workspace_creation_denied` の `enforced=true` イベントを抽出して `user_id` を取り出す。**structlog のレンダラに合わせて 2 パターンを併記** (production = JSON、dev = console):
 
 ```bash
-journalctl -u kagura-api-green --since '15 minutes ago' \
-  | grep 'workspace_creation_denied' \
-  | grep 'enforced=true' \
+ACTIVE=$(cat /opt/kagura-memory/active-color)
+
+# JSON renderer (production の LOG_COLORIZE=false): "enforced": true, "user_id": "..."
+sudo docker logs "kagura-api-${ACTIVE}" --since 15m 2>&1 \
+  | grep workspace_creation_denied \
+  | grep -E '"enforced":\s*true' \
+  | grep -oE '"user_id":\s*"[^"]+"' \
+  | sed -E 's/"user_id":\s*"([^"]+)"/\1/' \
+  | sort -u
+
+# Console renderer (dev / LOG_COLORIZE=true): enforced=True user_id=...
+# 同じコマンドで pattern を切り替え
+sudo docker logs "kagura-api-${ACTIVE}" --since 15m 2>&1 \
+  | grep workspace_creation_denied \
+  | grep -E 'enforced=True' \
   | grep -oE 'user_id=[a-zA-Z0-9_-]+' \
   | sort -u
 # user_id=u_abc12345
@@ -126,11 +153,21 @@ SELECT
  GROUP BY u.id, u.email, u.workspace_slot_bonus;
 ```
 
-期待する `workspace_slot_bonus` は `MAX(0, owned_active - 1)`（grandfather migration の式と同じ）。実際の値と乖離していれば調整対象。
+### Step 4.2.1. 期待値 `<N>` の計算
+
+`<N>` の選び方は **意図** に依存する。cap 判定は `workspace_count >= cap` で deny するので、bonus = `owned_active - 1` だと cap = `owned_active` となり **既存の数を保持するだけで新規作成は依然不可**（PR #686 Copilot review）。新規作成を許可したいかどうかで使い分ける:
+
+| 意図 | `<N>` | 結果として cap = `1 + N` |
+|---|---|---|
+| **既存 workspace 数を維持するだけ**（grandfather 状態を復元、新規作成は依然不可） | `MAX(0, owned_active - 1)` | `owned_active`（cap == 現在数、`>=` で deny） |
+| **既存を維持しつつ新規 1 つ作成を許可**（false-positive denial の典型） | `owned_active` | `owned_active + 1` |
+| **追加 K slot を grant**（特例対応） | `owned_active - 1 + K` | `owned_active + K` |
+
+false-positive denial の rollback 用途（本 runbook の主要ケース）は **2 番目** を選ぶ。Step 4.4 の検証で「新規作成成功」を確認する以上、cap に 1 slot 余裕が必要。
 
 ### Step 4.3. 条件付き UPDATE で bonus を増やす
 
-`<user_id>` と期待値 `<N>` は Step 4.1/4.2 で確定したリテラル値に置き換える。`psql --variable` で安全に変数渡しする例も併記。**シェル文字列補間（`"... = $BONUS ..."`）は絶対に使わない** — placeholder と SQL injection 経路を混同しないため。
+`<user_id>` と期待値 `<N>` は Step 4.1/4.2.1 で確定したリテラル値に置き換える。`psql --variable` で安全に変数渡しする例も併記。**シェル文字列補間（`"... = $BONUS ..."`）は絶対に使わない** — placeholder と SQL injection 経路を混同しないため。
 
 ```sql
 -- 期待値 N を確定したうえで、現在値が N 未満の場合のみ更新

--- a/docs/ops/workspace-cap-rollback.md
+++ b/docs/ops/workspace-cap-rollback.md
@@ -130,25 +130,41 @@ SELECT
 
 ### Step 4.3. 条件付き UPDATE で bonus を増やす
 
+`<user_id>` と期待値 `<N>` は Step 4.1/4.2 で確定したリテラル値に置き換える。`psql --variable` で安全に変数渡しする例も併記。**シェル文字列補間（`"... = $BONUS ..."`）は絶対に使わない** — placeholder と SQL injection 経路を混同しないため。
+
 ```sql
 -- 期待値 N を確定したうえで、現在値が N 未満の場合のみ更新
+-- <user_id>, <N> はリテラルに置換すること
 UPDATE users
-   SET workspace_slot_bonus = :expected_bonus
+   SET workspace_slot_bonus = <N>
  WHERE user_id = '<user_id>'
-   AND workspace_slot_bonus < :expected_bonus;
+   AND workspace_slot_bonus < <N>;
 
 -- 更新行数の確認
 -- 1 row affected: 適用済み
 -- 0 rows affected: 既に >= 期待値（追加調整不要、Step 4.2 を再確認）
 ```
 
+psql で実行する場合の具体例（`<user_id> = u_abc12345`, `<N> = 3` のケース）:
+
+```bash
+# 文字列補間ではなく psql の :'var' / :var 記法で渡す（SQL injection 経路を作らない）
+psql "$PROD_DSN_READWRITE" \
+  --variable=uid="u_abc12345" \
+  --variable=n=3 \
+  -c "UPDATE users SET workspace_slot_bonus = :n
+        WHERE user_id = :'uid' AND workspace_slot_bonus < :n;"
+```
+
 > 🛡️ **条件付き UPDATE を使う理由**: 単純な `SET workspace_slot_bonus = N` だと、誰かが既に高い値を入れていた場合に **意図せず下げてしまう**。`workspace_slot_bonus < N` の WHERE 句で「下げない」を保証する。降格が必要な場面は本 runbook の対象外（別 admin 操作）。
+
+> ⚠️ **DSN の取り違え**: `$PROD_DSN_READWRITE` は production 本番用。stage / dev と読み違えると別環境の user に bonus 付与してしまう。`SELECT current_database();` を先頭に置いて目視確認を必須にする運用が望ましい。
 
 ### Step 4.4. 検証
 
 ```sql
 SELECT user_id, workspace_slot_bonus FROM users WHERE user_id = '<user_id>';
--- 期待: workspace_slot_bonus = :expected_bonus
+-- 期待: workspace_slot_bonus = <N>
 ```
 
 ユーザ側で workspace 作成が成功することも併せて確認。

--- a/docs/ops/workspace-cap-rollback.md
+++ b/docs/ops/workspace-cap-rollback.md
@@ -1,0 +1,179 @@
+# Workspace Cap Enforcement — Rollback Runbook
+
+`ENFORCE_WORKSPACE_CAP=true` の本番反映後、正当な workspace 作成が `Workspace limit reached` で reject される事象（false-positive denial）が発生した場合の **即時 rollback + 原因調査 + bonus 調整** 手順 (Issue #674 Phase 1 sub-C / #677)。
+
+このフラグは workspace 作成の **owned-cap** を gate する。flip 前の log-only mode（`enforce=False`）では cap 超過を warn log のみで通すので false-positive denial は発生しない。flip 後は cap が hard gate になり、誤った `workspace_slot_bonus` 設定や grandfather migration 漏れで正当ユーザが reject されるリスクが現れる。本 runbook はその時の即応手順。
+
+---
+
+## 1. このフラグは何か / なぜ rollback が必要か
+
+`backend/src/services/quota_service.py` の `check_workspace_creation_allowed` は **`cap = 1 + users.workspace_slot_bonus`** を gate する。フラグは:
+
+- **目的**: TOCTOU race を `pg_advisory_xact_lock` で塞いだ上で（#677）、cap 超過を実際に deny する切替（#674 sub-C の最終段）。
+- **動作**: `False` のとき warn log のみで通す、`True` のとき deny + 5xx ではなく `QuotaExceededError` で 4xx 応答。
+- **default**: `False`（`backend/src/config/settings.py:enforce_workspace_cap`）。本番 flip は別 ops issue で 7-day log-only window 完走後に実施。
+
+flip 後に false-positive denial が出る代表的シナリオ:
+
+| シナリオ | 兆候 |
+|---|---|
+| Grandfather migration 漏れ user | `current_owned_workspaces >= max_owned_workspaces` でも本人は何も増やしていない |
+| Admin がうっかり bonus を下げた | 直近の admin audit log に `workspace_slot_bonus -= N` 操作 |
+| Stripe webhook (Phase 2) の double decrement | Phase 1 中は無関係。Phase 2 以降のみ |
+| advisory lock の lock_timeout 連発 | `workspace_create_lock_failed` warn が大量、`reason=lock_timeout` |
+
+---
+
+## 2. Pre-condition / 前提
+
+| 項目 | 想定値 |
+|---|---|
+| Backend release | #677 merge 済み (`QuotaService._acquire_workspace_create_lock` 存在) |
+| Migration head | `e15_675_workspace_slot_bonus` 以降 |
+| `ENFORCE_WORKSPACE_CAP` | `true`（本 runbook はこの状態で正当ユーザの denial が起きた時に使う） |
+| Sub-B (#676 admin UI) | `workspace_slot_bonus` inc/dec の admin UI が merge 済みなら §4 は admin UI 経由、未 merge なら §4 の SQL fallback を使用 |
+| 本番 DB アクセス | 既存 ops 手順（`psql` 経由）が available |
+
+---
+
+## 3. Procedure / 即時 rollback
+
+### Step 1. フラグを `false` に戻す（deploy 不要）
+
+memory.kagura-ai.com など single-server 構成では:
+
+```bash
+# 1. .env.prod を編集
+sudo -e /opt/kagura-memory/.env.prod
+#    ENFORCE_WORKSPACE_CAP=true  →  ENFORCE_WORKSPACE_CAP=false
+
+# 2. uvicorn worker を reload
+sudo systemctl reload kagura-api-green   # active container (blue-green の active 側)
+```
+
+> ⚠️ **重要**: `get_settings()` は `_settings` module-level singleton をキャッシュする (`backend/src/config/settings.py:502-519`)。`uvicorn reload` で **worker process が再起動して `_settings` が再初期化される必要がある**。`systemctl reload` が SIGHUP で workers を replace するか確認。replace されない場合は `systemctl restart`。
+
+### Step 2. `/health` 200 確認
+
+```bash
+curl -fsS https://memory.kagura-ai.com/health
+# {"status":"ok",...}
+```
+
+### Step 3. 設定値の実効確認
+
+worker process 内で `enforce_workspace_cap` が `False` になったことを確認:
+
+```bash
+# admin endpoint がある場合
+curl -fsS -H "Authorization: Bearer $ADMIN_TOKEN" \
+  https://memory.kagura-ai.com/admin/config 2>/dev/null | jq '.enforce_workspace_cap'
+# false
+
+# 無ければログから確認: 新規 workspace_creation_denied が出ても deny されないこと
+# 直後の workspace_creation_denied 行が enforced=false を含むはず
+journalctl -u kagura-api-green --since '1 minute ago' | grep workspace_creation_denied | tail -3
+```
+
+### Step 4. false-positive denial の沈静化を観測
+
+reload 後 5 分間、`workspace_creation_denied enforced=true` の発生レートが減衰することを確認:
+
+```bash
+journalctl -u kagura-api-green --since '5 minutes ago' \
+  | grep -c 'workspace_creation_denied.*enforced=true'
+# 期待: reload 前のレートと比べて急減（reload 直後にバッファに残った分のみ）
+```
+
+---
+
+## 4. Bonus 調整 / SQL fallback
+
+> 📝 **TODO (sub-B #676 merge 後)**: このセクションは admin UI 手順に置き換える。`/admin/users/{user_id}` の `workspace_slot_bonus` inc/dec ボタンが UI で expose され、audit log も自動で記録されるようになるため、SQL を直接打つ運用は廃止。
+
+sub-B (#676 admin UI) が未 merge / 未 deploy の段階で、影響を受けた user の bonus を手動で増やす手順。**oncall が深夜に対応する想定** で、誤適用を防ぐ条件付き SQL を載せる。
+
+### Step 4.1. 影響 user の特定
+
+log から `workspace_creation_denied enforced=true` を抽出して `user_id` を取り出す:
+
+```bash
+journalctl -u kagura-api-green --since '15 minutes ago' \
+  | grep 'workspace_creation_denied' \
+  | grep 'enforced=true' \
+  | grep -oE 'user_id=[a-zA-Z0-9_-]+' \
+  | sort -u
+# user_id=u_abc12345
+# user_id=u_def67890
+```
+
+ユーザに連絡を取り、**意図的に over-cap になっているのか、grandfather 漏れなのか** を確認する。意図的ならそのまま deny を維持（Step 1 の rollback は不要だった可能性、再確認）。漏れなら Step 4.2 へ。
+
+### Step 4.2. 現在の bonus 値を確認
+
+```sql
+-- 影響 user の現在の slot 情報
+SELECT
+    u.id,
+    u.email,
+    u.workspace_slot_bonus,
+    COUNT(w.id) FILTER (WHERE w.deleted_at IS NULL) AS owned_active,
+    COUNT(w.id) FILTER (WHERE w.deleted_at IS NOT NULL) AS owned_soft_deleted
+  FROM users u
+  LEFT JOIN workspaces w ON w.owner_user_id = u.user_id
+ WHERE u.user_id = '<user_id>'
+ GROUP BY u.id, u.email, u.workspace_slot_bonus;
+```
+
+期待する `workspace_slot_bonus` は `MAX(0, owned_active - 1)`（grandfather migration の式と同じ）。実際の値と乖離していれば調整対象。
+
+### Step 4.3. 条件付き UPDATE で bonus を増やす
+
+```sql
+-- 期待値 N を確定したうえで、現在値が N 未満の場合のみ更新
+UPDATE users
+   SET workspace_slot_bonus = :expected_bonus
+ WHERE user_id = '<user_id>'
+   AND workspace_slot_bonus < :expected_bonus;
+
+-- 更新行数の確認
+-- 1 row affected: 適用済み
+-- 0 rows affected: 既に >= 期待値（追加調整不要、Step 4.2 を再確認）
+```
+
+> 🛡️ **条件付き UPDATE を使う理由**: 単純な `SET workspace_slot_bonus = N` だと、誰かが既に高い値を入れていた場合に **意図せず下げてしまう**。`workspace_slot_bonus < N` の WHERE 句で「下げない」を保証する。降格が必要な場面は本 runbook の対象外（別 admin 操作）。
+
+### Step 4.4. 検証
+
+```sql
+SELECT user_id, workspace_slot_bonus FROM users WHERE user_id = '<user_id>';
+-- 期待: workspace_slot_bonus = :expected_bonus
+```
+
+ユーザ側で workspace 作成が成功することも併せて確認。
+
+---
+
+## 5. Re-enable criteria / フラグを再度 `true` に戻す条件
+
+Step 1 で `false` に戻した後、根本原因が解消されたと判断できるまで `true` への再 flip は **しない**。再 flip の必要条件:
+
+- 直近 1 時間以内に `workspace_creation_denied{enforced=true}` の false-positive が 0 件
+- 影響 user 全員に通知済み、bonus 調整が完了
+- 同種の根本原因（migration 漏れ / admin 誤操作 / lock_timeout）が再発しないと判断できる説明が記録されている
+- ops issue（`ops(quota): enforce_workspace_cap log-only window + prod flip (#674 sub-C follow)` 系）で再 flip 計画が separately tracked されている
+
+判断が即時困難な場合は `false` のまま log-only mode を継続するのが安全側。log-only mode は cap 超過を warn log で可視化するだけで実害ゼロ。
+
+---
+
+## 6. References
+
+- Issue #677 (sub-C): advisory lock + enforce_workspace_cap flip + runbook (本 runbook の起点)
+- Issue #674 (epic): slot-based workspace cap pivot
+- Issue #676 (sub-B): admin UI for `workspace_slot_bonus` inc/dec — merge 後に §4 を admin UI 手順に置換
+- Code: `backend/src/services/quota_service.py:_acquire_workspace_create_lock`, `check_workspace_creation_allowed`
+- Migration: `backend/alembic/versions/e15_675_workspace_slot_bonus.py` (grandfather backfill)
+- Helper: `backend/src/utils/plan_resolver.py:get_user_workspace_cap_summary`
+- Sibling runbook for tone reference: `docs/ops/r2-checksum-binding-rollout.md`


### PR DESCRIPTION
Closes #677

## Summary
- Adds per-user `pg_advisory_xact_lock` (transaction-scoped) around the workspace-creation cap check in `QuotaService.check_workspace_creation_allowed`, closing the TOCTOU race identified in #674 sub-C.
- Hybrid fail policy on lock errors: deny when `enforce_workspace_cap=true` (cap is the safety invariant), allow + log when `false` (log-only mode must not produce false denials). Session is rolled back before either branch.
- Adds a 3-layer integration test (`backend/tests/integration/test_quota_service_advisory_lock.py`) proving the race is closed and would reproduce without the lock (negative control).
- Adds a rollback runbook (`docs/ops/workspace-cap-rollback.md`) with a conditional-SQL fallback for `workspace_slot_bonus` adjustment until sub-B (#676 admin UI) lands.

## Implementation notes
- `_acquire_workspace_create_lock(user_id) -> float` is a private method on `QuotaService`. Runs `SET LOCAL lock_timeout = '5s'` then `SELECT pg_advisory_xact_lock(hashtext(:key))` with `lock_key = f"workspace_create:{user_id}"` passed via `bindparams` (no f-string SQL).
- `lock_wait_ms` is float (sub-millisecond precision) — added to the existing `workspace_creation_denied` log event alongside a new `reason="over_cap"` field. A separate `workspace_create_lock_failed` event covers `reason="lock_timeout"` (SQLSTATE 55P03) and `reason="lock_error"`.
- Driver-agnostic SQLSTATE detection: `getattr(exc.orig, "sqlstate", None) or getattr(exc.orig, "pgcode", None)` handles both asyncpg and psycopg2.
- The caller (`POST /workspaces` route, `backend/src/api/routes/workspaces.py:321-353`) relies on `get_db()`'s commit-at-end pattern, which keeps the cap check and the workspace insert inside one transaction so the xact-scoped lock extends across both. Documented in the helper docstring.
- Soft-delete filter consistency verified: `backend/alembic/versions/e15_675_workspace_slot_bonus.py:151` and `backend/src/utils/plan_resolver.py:61` both filter `deleted_at IS NULL`.
- `time.monotonic()` hoisted to module-level import (consistency with file convention).

## Out of scope (deliberate per gate1)
- prod `ENFORCE_WORKSPACE_CAP=true` flip + 7-day log-only window observation — separate ops issue
- Datadog dashboard / alert configuration — separate ops issue (the repo has no metrics layer today, only structured logs)
- sub-B (#676 admin UI for `workspace_slot_bonus`) — separate parallel PR

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask, routed to COO lens
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/677-feat-feat-quota-advisory-lock-enforce-workspa.gate1.md
- ~/.claude/cache/gh-issue-driven/677-feat-feat-quota-advisory-lock-enforce-workspa.gate2.md

🤖 Generated via /gh-issue-driven:ship
