### PR TITLE
fix(admin): add cap column to /admin/users list + Actions i18n (#695)

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -57,9 +57,11 @@ class UserInfo(TZAwareBaseModel):
 
     Issue #164: Extended with workspaces field.
     Issue #175: Added timezone field for user preferences.
-    Issue #695: Added owned_count / workspace_slot_bonus / effective_cap so the
-    /admin/users list can surface each user's owned-workspace usage against
-    their cap without a follow-up per-user detail fetch. Defaults keep the
+    Issue #695: Added owned_count / workspace_slot_bonus / base_cap / cap so
+    the /admin/users list can surface each user's owned-workspace usage
+    against their cap without a follow-up per-user detail fetch. Field names
+    intentionally mirror ``WorkspaceSummary`` (the detail endpoint's payload)
+    so client code and mental models stay consistent. Defaults keep the
     schema additive — older consumers that ignore these fields still work.
     """
 
@@ -77,14 +79,17 @@ class UserInfo(TZAwareBaseModel):
     workspaces: list[dict] = []  # Issue #164: Workspace memberships
 
     # Issue #695: owned-workspace cap summary (mirrors WorkspaceSummary fields
-    # used in /admin/users/{id} detail). Always populated for active users so
-    # the list UI can render `owned_count / effective_cap` and an at-cap flag.
-    # ``effective_cap`` defaults to ``BASE_CAP`` (not a literal ``1``) so the
-    # schema stays in sync if ``BASE_CAP`` ever changes — recomputed per-user
-    # in the handler from ``BASE_CAP + workspace_slot_bonus``.
+    # used in /admin/users/{id} detail — same field names ``base_cap`` /
+    # ``cap`` so client code and mental models stay consistent across
+    # closely-related admin endpoints). Always populated for active users so
+    # the list UI can render `owned_count / cap` and an at-cap flag.
+    # ``cap`` defaults to ``BASE_CAP`` (not a literal ``1``) so the schema
+    # stays in sync if ``BASE_CAP`` ever changes — recomputed per-user in
+    # the handler from ``BASE_CAP + workspace_slot_bonus``.
     owned_count: int = 0
     workspace_slot_bonus: int = 0
-    effective_cap: int = BASE_CAP
+    base_cap: int = BASE_CAP
+    cap: int = BASE_CAP
 
     # Issue #246: current_context_id removed
     # current_context_id: str | None = None
@@ -283,7 +288,8 @@ async def list_users(
                 cap_stats_dict[row.user_id] = {
                     "owned_count": int(row.owned_count or 0),
                     "workspace_slot_bonus": bonus,
-                    "effective_cap": BASE_CAP + bonus,
+                    "base_cap": BASE_CAP,
+                    "cap": BASE_CAP + bonus,
                 }
 
         # Issue #246: current_context_id removed - skip context lookup
@@ -304,7 +310,8 @@ async def list_users(
                 {
                     "owned_count": 0,
                     "workspace_slot_bonus": int(u.workspace_slot_bonus or 0),
-                    "effective_cap": BASE_CAP + int(u.workspace_slot_bonus or 0),
+                    "base_cap": BASE_CAP,
+                    "cap": BASE_CAP + int(u.workspace_slot_bonus or 0),
                 },
             )
             # Issue #246: current_context_id removed
@@ -326,7 +333,8 @@ async def list_users(
                     workspaces=[],  # Will be populated below if include_workspaces=True
                     owned_count=cap["owned_count"],  # Issue #695
                     workspace_slot_bonus=cap["workspace_slot_bonus"],  # Issue #695
-                    effective_cap=cap["effective_cap"],  # Issue #695
+                    base_cap=cap["base_cap"],  # Issue #695
+                    cap=cap["cap"],  # Issue #695
                     # Issue #246: current_context_id removed
                     # current_context_id=context_info.get('context_id'),
                     # current_context_name=context_info.get('context_name'),

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -79,9 +79,12 @@ class UserInfo(TZAwareBaseModel):
     # Issue #695: owned-workspace cap summary (mirrors WorkspaceSummary fields
     # used in /admin/users/{id} detail). Always populated for active users so
     # the list UI can render `owned_count / effective_cap` and an at-cap flag.
+    # ``effective_cap`` defaults to ``BASE_CAP`` (not a literal ``1``) so the
+    # schema stays in sync if ``BASE_CAP`` ever changes — recomputed per-user
+    # in the handler from ``BASE_CAP + workspace_slot_bonus``.
     owned_count: int = 0
     workspace_slot_bonus: int = 0
-    effective_cap: int = 1  # BASE_CAP default; recomputed per-user in handler
+    effective_cap: int = BASE_CAP
 
     # Issue #246: current_context_id removed
     # current_context_id: str | None = None

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -57,6 +57,10 @@ class UserInfo(TZAwareBaseModel):
 
     Issue #164: Extended with workspaces field.
     Issue #175: Added timezone field for user preferences.
+    Issue #695: Added owned_count / workspace_slot_bonus / effective_cap so the
+    /admin/users list can surface each user's owned-workspace usage against
+    their cap without a follow-up per-user detail fetch. Defaults keep the
+    schema additive — older consumers that ignore these fields still work.
     """
 
     id: str
@@ -71,6 +75,13 @@ class UserInfo(TZAwareBaseModel):
     timezone: str = "UTC"  # Issue #175: User timezone preference
     auth_provider: str | None = None  # Issue #361: Registration provider
     workspaces: list[dict] = []  # Issue #164: Workspace memberships
+
+    # Issue #695: owned-workspace cap summary (mirrors WorkspaceSummary fields
+    # used in /admin/users/{id} detail). Always populated for active users so
+    # the list UI can render `owned_count / effective_cap` and an at-cap flag.
+    owned_count: int = 0
+    workspace_slot_bonus: int = 0
+    effective_cap: int = 1  # BASE_CAP default; recomputed per-user in handler
 
     # Issue #246: current_context_id removed
     # current_context_id: str | None = None
@@ -238,6 +249,40 @@ async def list_users(
                     "memory_count": row.memory_count or 0,
                 }
 
+        # Issue #695: Bulk-fetch (owned_count, workspace_slot_bonus) per user.
+        # Mirrors the per-user logic in ``plan_resolver.get_user_workspace_cap_summary``
+        # but joined for all listed users in one query — calling the per-user
+        # helper in the loop would re-introduce the N+1 pattern fixed for
+        # memory_stats above. LEFT OUTER JOIN so users with zero owned
+        # workspaces still surface (count = 0), and the join predicate
+        # excludes soft-deleted workspaces (#681 pattern: cap math counts
+        # only live workspaces).
+        cap_stats_dict: dict[str, dict[str, int]] = {}
+        if user_ids:
+            cap_stats_result = await db.execute(
+                select(
+                    User.user_id,
+                    User.workspace_slot_bonus,
+                    func.count(Workspace.id).label("owned_count"),
+                )
+                .outerjoin(
+                    Workspace,
+                    and_(
+                        Workspace.owner_user_id == User.user_id,
+                        Workspace.deleted_at.is_(None),
+                    ),
+                )
+                .where(User.user_id.in_(user_ids))
+                .group_by(User.id, User.user_id, User.workspace_slot_bonus)
+            )
+            for row in cap_stats_result.all():
+                bonus = int(row.workspace_slot_bonus or 0)
+                cap_stats_dict[row.user_id] = {
+                    "owned_count": int(row.owned_count or 0),
+                    "workspace_slot_bonus": bonus,
+                    "effective_cap": BASE_CAP + bonus,
+                }
+
         # Issue #246: current_context_id removed - skip context lookup
         # from models.auth import Context
         # context_map = {}
@@ -247,6 +292,18 @@ async def list_users(
         user_infos = []
         for u in users_list:
             stats = memory_stats_dict.get(u.user_id, {"memory_count": 0})
+            # Issue #695: cap_stats falls back to (0, 0, BASE_CAP) for users
+            # that returned no row (extremely unlikely — only if the user was
+            # deleted between the listing query and the cap query). Same
+            # shape as the User column default so the UI always has values.
+            cap = cap_stats_dict.get(
+                u.user_id,
+                {
+                    "owned_count": 0,
+                    "workspace_slot_bonus": int(u.workspace_slot_bonus or 0),
+                    "effective_cap": BASE_CAP + int(u.workspace_slot_bonus or 0),
+                },
+            )
             # Issue #246: current_context_id removed
             # context_info = context_map.get(u.user_id, {})
 
@@ -264,6 +321,9 @@ async def list_users(
                     timezone=u.timezone or "UTC",  # Issue #175: User timezone preference
                     auth_provider=u.auth_provider,  # Issue #361
                     workspaces=[],  # Will be populated below if include_workspaces=True
+                    owned_count=cap["owned_count"],  # Issue #695
+                    workspace_slot_bonus=cap["workspace_slot_bonus"],  # Issue #695
+                    effective_cap=cap["effective_cap"],  # Issue #695
                     # Issue #246: current_context_id removed
                     # current_context_id=context_info.get('context_id'),
                     # current_context_name=context_info.get('context_name'),

--- a/backend/tests/integration/test_admin_users_list_cap_column.py
+++ b/backend/tests/integration/test_admin_users_list_cap_column.py
@@ -191,15 +191,12 @@ class TestListUsersCapColumn:
         # 2. ``total`` counts distinct users only — it must be at least the
         #    3 fixture users (test DB may have other users from sibling
         #    fixtures, so we cannot pin equality). If the cap join had
-        #    multiplied rows, ``total`` would jump to >= 4 just from the
-        #    bonus_grant user's 2 workspace rows leaking in.
+        #    multiplied rows, ``total`` would jump to >= len(fixture_ids)+1
+        #    just from the bonus_grant user's 2 workspace rows leaking in.
+        #    Combined with assertion (1) above (per_user_count==1 for every
+        #    fixture user), this lower bound is sufficient to catch JOIN
+        #    multiplication — no need for an upper bound (``total`` is the
+        #    pre-pagination match count and can legitimately exceed ``limit``).
         assert response.total >= len(fixture_ids), (
             f"total must include at least the {len(fixture_ids)} fixture users, got {response.total}"
-        )
-        # Total reflects distinct users (no per-user duplication). The
-        # fixture adds exactly 3 distinct users beyond whatever the test DB
-        # already contained, so the delta should never exceed the user count
-        # in the response page.
-        assert response.total <= len(response.users), (
-            f"total ({response.total}) must not exceed distinct users in response ({len(response.users)})"
         )

--- a/backend/tests/integration/test_admin_users_list_cap_column.py
+++ b/backend/tests/integration/test_admin_users_list_cap_column.py
@@ -1,0 +1,174 @@
+"""Regression tests for #695 — admin users list surfaces per-user cap summary.
+
+Verifies ``GET /admin/users`` returns ``owned_count`` / ``workspace_slot_bonus``
+/ ``effective_cap`` for each user, computed in bulk (no N+1) and excluding
+soft-deleted workspaces from ``owned_count`` (same #681 class as
+``test_admin_users_soft_delete_filter``).
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin import list_users
+from models.auth import User, Workspace
+
+
+def _mock_admin() -> dict:
+    return {"user_id": "admin_runner", "email": "admin@test.invalid", "role": "admin"}
+
+
+def _new_workspace(*, owner: str, soft_deleted: bool) -> Workspace:
+    return Workspace(
+        id=uuid4(),
+        name=f"{'deleted' if soft_deleted else 'active'}-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner,
+        memory_limit=1000,
+        daily_api_limit=500,
+        weekly_api_limit=2500,
+        deleted_at=(func.now() if soft_deleted else None),
+    )
+
+
+@pytest_asyncio.fixture
+async def users_with_varied_cap(db_session: AsyncSession) -> dict:
+    """Three users with distinct cap shapes:
+
+    - baseline:     bonus=0, owns 1 live workspace            → 1 / 1 (at cap)
+    - bonus_grant:  bonus=2, owns 1 live + 1 soft-deleted    → 1 / 3 (not at cap)
+    - zero_owned:   bonus=0, owns 0                          → 0 / 1
+    """
+    uids = {key: f"u_{uuid4().hex[:8]}" for key in ("baseline", "bonus_grant", "zero_owned")}
+
+    db_session.add_all(
+        [
+            User(
+                email=f"{uids['baseline']}@test.invalid",
+                user_id=uids["baseline"],
+                name="Baseline User",
+                role="user",
+                is_initial_admin=False,
+                auth_method="oauth",
+                auth_provider="google",
+                workspace_slot_bonus=0,
+            ),
+            User(
+                email=f"{uids['bonus_grant']}@test.invalid",
+                user_id=uids["bonus_grant"],
+                name="Bonus User",
+                role="user",
+                is_initial_admin=False,
+                auth_method="oauth",
+                auth_provider="google",
+                workspace_slot_bonus=2,
+            ),
+            User(
+                email=f"{uids['zero_owned']}@test.invalid",
+                user_id=uids["zero_owned"],
+                name="Zero Owned User",
+                role="user",
+                is_initial_admin=False,
+                auth_method="oauth",
+                auth_provider="google",
+                workspace_slot_bonus=0,
+            ),
+        ]
+    )
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            _new_workspace(owner=uids["baseline"], soft_deleted=False),
+            _new_workspace(owner=uids["bonus_grant"], soft_deleted=False),
+            _new_workspace(owner=uids["bonus_grant"], soft_deleted=True),
+            # zero_owned: intentionally no workspaces
+        ]
+    )
+    await db_session.commit()
+
+    return uids
+
+
+_LIST_DEFAULTS = {
+    "limit": 500,
+    "offset": 0,
+    "include_workspaces": False,
+    "search": None,
+    "workspace_id": None,
+    "role": None,
+    "plan": None,
+    "sort": "created_at",
+}
+
+
+class TestListUsersCapColumn:
+    """``GET /admin/users`` surfaces per-user owned_count / bonus / effective_cap (#695)."""
+
+    @pytest.mark.asyncio
+    async def test_baseline_user_at_cap(
+        self,
+        db_session: AsyncSession,
+        users_with_varied_cap: dict,
+    ) -> None:
+        response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
+        target = next(
+            (u for u in response.users if u.id == users_with_varied_cap["baseline"]),
+            None,
+        )
+        assert target is not None
+        assert target.owned_count == 1
+        assert target.workspace_slot_bonus == 0
+        assert target.effective_cap == 1
+
+    @pytest.mark.asyncio
+    async def test_bonus_user_below_cap_and_soft_deleted_excluded(
+        self,
+        db_session: AsyncSession,
+        users_with_varied_cap: dict,
+    ) -> None:
+        response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
+        target = next(
+            (u for u in response.users if u.id == users_with_varied_cap["bonus_grant"]),
+            None,
+        )
+        assert target is not None
+        # Soft-deleted workspace MUST NOT count toward owned_count (#681 class).
+        assert target.owned_count == 1
+        assert target.workspace_slot_bonus == 2
+        assert target.effective_cap == 3
+
+    @pytest.mark.asyncio
+    async def test_zero_owned_user(
+        self,
+        db_session: AsyncSession,
+        users_with_varied_cap: dict,
+    ) -> None:
+        response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
+        target = next(
+            (u for u in response.users if u.id == users_with_varied_cap["zero_owned"]),
+            None,
+        )
+        assert target is not None
+        # LEFT OUTER JOIN must surface users with zero owned workspaces.
+        assert target.owned_count == 0
+        assert target.workspace_slot_bonus == 0
+        assert target.effective_cap == 1
+
+    @pytest.mark.asyncio
+    async def test_pagination_total_unchanged_by_cap_join(
+        self,
+        db_session: AsyncSession,
+        users_with_varied_cap: dict,
+    ) -> None:
+        """The cap join is in a separate query, so ``total`` must not double-count."""
+        response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
+        # The 3 fixture users are present in response.users (plus any others).
+        fixture_ids = set(users_with_varied_cap.values())
+        present = {u.id for u in response.users} & fixture_ids
+        assert present == fixture_ids, "all three fixture users must appear once each"

--- a/backend/tests/integration/test_admin_users_list_cap_column.py
+++ b/backend/tests/integration/test_admin_users_list_cap_column.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 import pytest
 import pytest_asyncio
-from sqlalchemy import func
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin import list_users
@@ -188,15 +188,18 @@ class TestListUsersCapColumn:
             f"each fixture user must appear exactly once, got {per_user_count}"
         )
 
-        # 2. ``total`` counts distinct users only — it must be at least the
-        #    3 fixture users (test DB may have other users from sibling
-        #    fixtures, so we cannot pin equality). If the cap join had
-        #    multiplied rows, ``total`` would jump to >= len(fixture_ids)+1
-        #    just from the bonus_grant user's 2 workspace rows leaking in.
-        #    Combined with assertion (1) above (per_user_count==1 for every
-        #    fixture user), this lower bound is sufficient to catch JOIN
-        #    multiplication — no need for an upper bound (``total`` is the
-        #    pre-pagination match count and can legitimately exceed ``limit``).
-        assert response.total >= len(fixture_ids), (
-            f"total must include at least the {len(fixture_ids)} fixture users, got {response.total}"
+        # 2. ``total`` equals the **direct** distinct-user count in the DB.
+        #    A bare ``total >= len(fixture_ids)`` lower bound would silently
+        #    pass even if JOIN multiplication inflated ``total`` (an
+        #    inflated total still satisfies the lower bound). Comparing
+        #    against an independent ``SELECT COUNT(*) FROM users`` is the
+        #    only check that actually fails when ``list_users``'s count
+        #    starts double-counting bonus_grant (1 live + 1 soft-deleted
+        #    workspace = 2 join rows if the cap join leaks into the base
+        #    query). The direct count uses no joins so it cannot share the
+        #    same defect — it is the ground truth.
+        direct_count = (await db_session.execute(select(func.count(User.id)))).scalar() or 0
+        assert response.total == direct_count, (
+            f"response.total ({response.total}) must match the direct distinct user count "
+            f"({direct_count}) — a mismatch means the cap join inflated the count via row multiplication"
         )

--- a/backend/tests/integration/test_admin_users_list_cap_column.py
+++ b/backend/tests/integration/test_admin_users_list_cap_column.py
@@ -1,7 +1,7 @@
 """Regression tests for #695 — admin users list surfaces per-user cap summary.
 
 Verifies ``GET /admin/users`` returns ``owned_count`` / ``workspace_slot_bonus``
-/ ``effective_cap`` for each user, computed in bulk (no N+1) and excluding
+/ ``cap`` for each user, computed in bulk (no N+1) and excluding
 soft-deleted workspaces from ``owned_count`` (same #681 class as
 ``test_admin_users_soft_delete_filter``).
 """
@@ -108,7 +108,7 @@ _LIST_DEFAULTS = {
 
 
 class TestListUsersCapColumn:
-    """``GET /admin/users`` surfaces per-user owned_count / bonus / effective_cap (#695)."""
+    """``GET /admin/users`` surfaces per-user owned_count / bonus / cap (#695)."""
 
     @pytest.mark.asyncio
     async def test_baseline_user_at_cap(
@@ -124,7 +124,7 @@ class TestListUsersCapColumn:
         assert target is not None
         assert target.owned_count == 1
         assert target.workspace_slot_bonus == 0
-        assert target.effective_cap == 1
+        assert target.cap == 1
 
     @pytest.mark.asyncio
     async def test_bonus_user_below_cap_and_soft_deleted_excluded(
@@ -141,7 +141,7 @@ class TestListUsersCapColumn:
         # Soft-deleted workspace MUST NOT count toward owned_count (#681 class).
         assert target.owned_count == 1
         assert target.workspace_slot_bonus == 2
-        assert target.effective_cap == 3
+        assert target.cap == 3
 
     @pytest.mark.asyncio
     async def test_zero_owned_user(
@@ -158,7 +158,7 @@ class TestListUsersCapColumn:
         # LEFT OUTER JOIN must surface users with zero owned workspaces.
         assert target.owned_count == 0
         assert target.workspace_slot_bonus == 0
-        assert target.effective_cap == 1
+        assert target.cap == 1
 
     @pytest.mark.asyncio
     async def test_pagination_total_unchanged_by_cap_join(
@@ -166,9 +166,40 @@ class TestListUsersCapColumn:
         db_session: AsyncSession,
         users_with_varied_cap: dict,
     ) -> None:
-        """The cap join is in a separate query, so ``total`` must not double-count."""
+        """The cap join is in a separate query, so ``total`` must not double-count.
+
+        Regression guard: if the cap join were applied to the base list query
+        instead of being a separate bulk fetch, ``bonus_grant`` (owns 1 live
+        + 1 soft-deleted = 2 join rows) would inflate ``total`` and produce
+        duplicate user rows in ``response.users``. Asserting both no
+        duplicates AND a lower-bound on ``total`` catches both failure modes.
+        """
         response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
-        # The 3 fixture users are present in response.users (plus any others).
         fixture_ids = set(users_with_varied_cap.values())
-        present = {u.id for u in response.users} & fixture_ids
-        assert present == fixture_ids, "all three fixture users must appear once each"
+
+        # 1. Each fixture user appears EXACTLY once in the response page
+        #    (no JOIN row multiplication leaking into the user list).
+        per_user_count = dict.fromkeys(fixture_ids, 0)
+        for u in response.users:
+            if u.id in per_user_count:
+                per_user_count[u.id] += 1
+        expected_counts = dict.fromkeys(fixture_ids, 1)
+        assert per_user_count == expected_counts, (
+            f"each fixture user must appear exactly once, got {per_user_count}"
+        )
+
+        # 2. ``total`` counts distinct users only — it must be at least the
+        #    3 fixture users (test DB may have other users from sibling
+        #    fixtures, so we cannot pin equality). If the cap join had
+        #    multiplied rows, ``total`` would jump to >= 4 just from the
+        #    bonus_grant user's 2 workspace rows leaking in.
+        assert response.total >= len(fixture_ids), (
+            f"total must include at least the {len(fixture_ids)} fixture users, got {response.total}"
+        )
+        # Total reflects distinct users (no per-user duplication). The
+        # fixture adds exactly 3 distinct users beyond whatever the test DB
+        # already contained, so the delta should never exceed the user count
+        # in the response page.
+        assert response.total <= len(response.users), (
+            f"total ({response.total}) must not exceed distinct users in response ({len(response.users)})"
+        )

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -71,6 +71,13 @@ interface User {
   auth_provider?: string | null; // Issue #361: Registration provider
   workspaces?: WorkspaceMembership[]; // Issue #165: Workspace badges
 
+  // Issue #695: owned-workspace cap summary surfaced on the list page.
+  // Default values (0, 0, 1) are applied if backend response omits them
+  // so the cell still renders during a deploy gap.
+  owned_count?: number;
+  workspace_slot_bonus?: number;
+  effective_cap?: number;
+
   // Current context info
   current_context_id?: string | null;
   current_context_name?: string | null;
@@ -270,9 +277,12 @@ export default function AdminUsersPage() {
                 <TableHead>{t("table.user")}</TableHead>
                 <TableHead>{t("table.role")}</TableHead>
                 <TableHead>{t("table.workspaces")}</TableHead>
+                <TableHead>{t("table.cap")}</TableHead>
                 <TableHead>{t("table.memories")}</TableHead>
                 <TableHead>{t("table.lastLogin")}</TableHead>
-                <TableHead className="text-right">Actions</TableHead>
+                <TableHead className="text-right">
+                  {t("table.actions")}
+                </TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -370,6 +380,30 @@ export default function AdminUsersPage() {
                         None
                       </span>
                     )}
+                  </TableCell>
+                  <TableCell>
+                    {/* Issue #695: owned / cap with at-cap emphasis */}
+                    {(() => {
+                      const owned = user.owned_count ?? 0;
+                      const cap = user.effective_cap ?? 1;
+                      const atCap = owned >= cap;
+                      return (
+                        <span
+                          className={
+                            atCap
+                              ? "text-amber-700 dark:text-amber-400 font-medium tabular-nums"
+                              : "tabular-nums text-sm text-gray-700 dark:text-gray-300"
+                          }
+                          title={t("table.capTooltip", {
+                            owned,
+                            cap,
+                            bonus: user.workspace_slot_bonus ?? 0,
+                          })}
+                        >
+                          {owned} / {cap}
+                        </span>
+                      );
+                    })()}
                   </TableCell>
                   <TableCell>{user.memory_count}</TableCell>
                   <TableCell className="text-sm text-gray-500">

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -72,11 +72,16 @@ interface User {
   workspaces?: WorkspaceMembership[]; // Issue #165: Workspace badges
 
   // Issue #695: owned-workspace cap summary surfaced on the list page.
-  // Default values (0, 0, 1) are applied if backend response omits them
-  // so the cell still renders during a deploy gap.
+  // Field names mirror the detail endpoint's WorkspaceSummary (cap /
+  // base_cap) so the same mental model carries across admin endpoints.
+  // All three are optional so the cell can still render during a deploy
+  // gap; the render path derives a safe fallback from base_cap + bonus
+  // rather than a literal 1, so a user with a nonzero bonus shown in the
+  // tooltip never gets a denominator that contradicts it.
   owned_count?: number;
   workspace_slot_bonus?: number;
-  effective_cap?: number;
+  base_cap?: number;
+  cap?: number;
 
   // Current context info
   current_context_id?: string | null;
@@ -382,10 +387,17 @@ export default function AdminUsersPage() {
                     )}
                   </TableCell>
                   <TableCell>
-                    {/* Issue #695: owned / cap with at-cap emphasis */}
+                    {/* Issue #695: owned / cap with at-cap emphasis.
+                        Fallback derives cap as base_cap + bonus rather
+                        than a literal 1 — during a mixed-version deploy
+                        (frontend ahead of backend) a user with bonus > 0
+                        would otherwise see "owned / 1" in the denominator
+                        even though the tooltip shows a nonzero bonus. */}
                     {(() => {
                       const owned = user.owned_count ?? 0;
-                      const cap = user.effective_cap ?? 1;
+                      const bonus = user.workspace_slot_bonus ?? 0;
+                      const baseCap = user.base_cap ?? 1;
+                      const cap = user.cap ?? baseCap + bonus;
                       const atCap = owned >= cap;
                       return (
                         <span
@@ -397,7 +409,7 @@ export default function AdminUsersPage() {
                           title={t("table.capTooltip", {
                             owned,
                             cap,
-                            bonus: user.workspace_slot_bonus ?? 0,
+                            bonus,
                           })}
                         >
                           {owned} / {cap}

--- a/frontend/src/app/(authenticated)/admin/users/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/page.tsx
@@ -377,7 +377,7 @@ export default function AdminUsersPage() {
                       </div>
                     ) : (
                       <span className="text-xs text-gray-400 dark:text-gray-500">
-                        None
+                        {t("table.none")}
                       </span>
                     )}
                   </TableCell>

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2202,6 +2202,8 @@
         "user": "User",
         "role": "Role",
         "workspaces": "Workspaces",
+        "cap": "Cap",
+        "capTooltip": "Owns {owned} of {cap} workspaces (bonus: +{bonus})",
         "memories": "Memories",
         "storage": "Storage",
         "currentContext": "Current Context",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2202,6 +2202,8 @@
         "user": "ユーザー",
         "role": "ロール",
         "workspaces": "ワークスペース",
+        "cap": "上限",
+        "capTooltip": "ワークスペース {owned} / {cap} 所有 (ボーナス: +{bonus})",
         "memories": "メモリー",
         "storage": "ストレージ",
         "currentContext": "現在のコンテキスト",


### PR DESCRIPTION
## Summary

Surfaces each user's **owned-workspace / effective-cap** on the admin users list page so operators can spot at-cap users without drilling into the detail page. Also fixes the hardcoded `"Actions"` table header that bypassed the existing `admin.users.table` i18n namespace.

This emerged during #674 epic close-out — after flipping `ENFORCE_WORKSPACE_CAP=true` in prod and confirming the cap rejection actually fires (real user hit the limit), the operator needed list-level visibility of cap usage.

## Changes

### Backend (`backend/src/api/routes/admin.py`)
- `UserInfo` schema gains `owned_count`, `workspace_slot_bonus`, `effective_cap`. **Additive** — defaults keep older list consumers working.
- `list_users` bulk-fetches `(owned_count, workspace_slot_bonus)` in one LEFT OUTER JOIN keyed on `user_ids`, mirroring `plan_resolver.get_user_workspace_cap_summary`. Avoids N+1 — same fix-pattern as the existing memory_stats bulk query.
- Soft-deleted workspaces excluded from `owned_count` (#681 pattern: cap math counts only live workspaces).

### Frontend (`frontend/src/app/(authenticated)/admin/users/page.tsx`)
- New **"Cap"** column renders `owned / effective_cap` with at-cap emphasis (amber, font-medium) and a tooltip including the bonus value.
- `Actions` header switched from hardcoded `"Actions"` to `{t("table.actions")}` — i18n key already existed in `admin.users.table.actions`.

### i18n (`frontend/src/messages/{en,ja}.json`)
- `admin.users.table.cap` = `"Cap"` / `"上限"`
- `admin.users.table.capTooltip` = `"Owns {owned} of {cap} workspaces (bonus: +{bonus})"` / `"ワークスペース {owned} / {cap} 所有 (ボーナス: +{bonus})"`

### Tests (`backend/tests/integration/test_admin_users_list_cap_column.py`, new)
- `test_baseline_user_at_cap` — bonus=0, owns 1 → 1/1 (at cap)
- `test_bonus_user_below_cap_and_soft_deleted_excluded` — bonus=2, owns 1 live + 1 soft-deleted → 1/3
- `test_zero_owned_user` — LEFT JOIN must surface count=0
- `test_pagination_total_unchanged_by_cap_join` — cap join is separate query, total stays correct

## Verification

- `make lint` → all checks passed
- `npx tsc --noEmit` → No errors found
- `make test-frontend` → 312/312 passed (pre-existing #584 vitest worker flake unrelated)
- Backend test file collects 4 tests cleanly; will run in CI integration suite

## Deploy plan (after merge)

This PR's merge unblocks a bundled deploy that includes 3 commits currently merged-but-not-deployed:
- `0225658b` PR #690 (#676 sub-B admin slot bonus UI — backend endpoint + detail page)
- `bb15034b` PR #694 (#664 admin /plans tiers tab dynamic values)
- This PR (#695)

VM sequence: `git pull` → `docker compose build api-green web` → blue-green switch (`api-blue` → `api-green`) → web recreate → verify `/health` + UI smoke.

## Refs

- #674 epic (slot-based cap, shipped, prod `ENFORCE_WORKSPACE_CAP=true` flipped 2026-05-17)
- #676 sub-B (slot bonus UI on detail page)
- #680 (i18n error details — separate follow-up for the cap-rejection error message)

## Test plan

- [ ] After deploy, `/admin/users` shows new "Cap" column with `owned / cap` per user
- [ ] At-cap user (owned == cap) rendered with amber/font-medium emphasis
- [ ] Hovering the cap value shows the tooltip with bonus
- [ ] Action column header shows "操作" in `ja` locale (was "Actions")
- [ ] Existing list filters/search/sort regressionless

Closes #695

🤖 Generated with [Claude Code](https://claude.com/claude-code)