### PR TITLE
fix(admin): preserve workspace admin role in accessible_contexts display (#699)

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -576,7 +576,7 @@ async def get_user_detail(
             # Determine user's role in this context
             ctx_role = "viewer"  # Default
             if workspace_role in ("owner", "admin"):
-                ctx_role = "owner"  # Workspace owner/admin have full access
+                ctx_role = workspace_role  # #699: preserve owner/admin distinction
             else:
                 # Check context_members for explicit role
                 ctx_member = ctx_members_by_context.get(ctx.id)

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -544,7 +544,6 @@ async def get_user_detail(
         # Critical Fix: Avoid O(N²) queries - collect all contexts first, then batch fetch ContextMembers
         all_contexts = []
         context_workspace_map = {}
-        workspace_role_map = {}
 
         for member, workspace in workspace_memberships:
             try:
@@ -552,7 +551,6 @@ async def get_user_detail(
                 for ctx in contexts:
                     all_contexts.append(ctx)
                     context_workspace_map[ctx.id] = (workspace, member.role)
-                    workspace_role_map[ctx.id] = member.role
             except (NotFoundException, AuthorizationError):
                 # Skip if no access
                 pass

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -788,7 +788,7 @@ class UserAccessibleContext(TZAwareBaseModel):
     context_name: str
     workspace_id: str
     workspace_name: str
-    role: str  # owner/editor/viewer
+    role: str  # owner/admin/editor/viewer  # #699: admin added for workspace_admin without ContextMember
     last_used_at: datetime | None
 
     class Config:

--- a/backend/tests/integration/_admin_helpers.py
+++ b/backend/tests/integration/_admin_helpers.py
@@ -1,0 +1,74 @@
+"""Shared helpers for admin integration tests.
+
+Used by:
+- test_admin_users_soft_delete_filter.py (#681)
+- test_admin_users_list_cap_column.py (#695)
+- test_admin_workspace_slot_bonus.py (#676)
+- test_admin_user_detail_context_role.py (#699)
+
+Each helper returns a fresh, unsaved SQLAlchemy instance with a unique
+auto-generated identifier (user_id / workspace UUID / context name) so
+fixtures composed from these helpers do not collide across tests.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from sqlalchemy import func
+
+from models.auth import Context, User, Workspace
+
+
+def mock_admin() -> dict:
+    """Mock auth dict matching ``require_admin``'s shape for direct handler invocation."""
+    return {"user_id": "admin_runner", "email": "admin@test.invalid", "role": "admin"}
+
+
+def make_workspace(
+    *,
+    owner_user_id: str,
+    soft_deleted: bool = False,
+    plan_name: str = "pro",
+) -> Workspace:
+    """Build a Workspace with required limits and a pre-assigned UUID."""
+    return Workspace(
+        id=uuid4(),
+        name=f"{'deleted' if soft_deleted else 'active'}-{uuid4().hex[:8]}",
+        plan_name=plan_name,
+        owner_user_id=owner_user_id,
+        memory_limit=1000,
+        daily_api_limit=500,
+        weekly_api_limit=2500,
+        deleted_at=(func.now() if soft_deleted else None),
+    )
+
+
+def make_user(
+    *,
+    role: str = "user",
+    workspace_slot_bonus: int = 0,
+    name: str = "Test User",
+) -> User:
+    """Build a User with a unique user_id and standard oauth provider fields."""
+    user_id = f"u_{uuid4().hex[:8]}"
+    return User(
+        email=f"{user_id}@test.invalid",
+        user_id=user_id,
+        name=name,
+        role=role,
+        is_initial_admin=False,
+        auth_method="oauth",
+        auth_provider="google",
+        workspace_slot_bonus=workspace_slot_bonus,
+    )
+
+
+def make_context(*, workspace_id, created_by: str, is_private: bool = False) -> Context:
+    """Build a non-private Context; the id is server-generated on flush."""
+    return Context(
+        workspace_id=workspace_id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=created_by,
+        is_private=is_private,
+    )

--- a/backend/tests/integration/test_admin_user_detail_context_role.py
+++ b/backend/tests/integration/test_admin_user_detail_context_role.py
@@ -11,68 +11,30 @@ lookup the handler performs.
 
 from __future__ import annotations
 
-from uuid import uuid4
-
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin import get_user_detail
-from models.auth import Context, ContextMember, User, Workspace, WorkspaceMember
+from models.auth import ContextMember, WorkspaceMember
 
-
-def _mock_admin() -> dict:
-    return {"user_id": "admin_runner", "email": "admin@test.invalid", "role": "admin"}
-
-
-def _new_user(role: str = "user") -> User:
-    user_id = f"u_{uuid4().hex[:8]}"
-    return User(
-        email=f"{user_id}@test.invalid",
-        user_id=user_id,
-        name="Test User",
-        role=role,
-        is_initial_admin=False,
-        auth_method="oauth",
-        auth_provider="google",
-    )
-
-
-def _new_workspace(owner_user_id: str) -> Workspace:
-    return Workspace(
-        id=uuid4(),
-        name=f"ws-{uuid4().hex[:8]}",
-        plan_name="pro",
-        owner_user_id=owner_user_id,
-        memory_limit=1000,
-        daily_api_limit=500,
-        weekly_api_limit=2500,
-    )
-
-
-def _new_context(workspace_id, created_by: str) -> Context:
-    return Context(
-        workspace_id=workspace_id,
-        name=f"ctx-{uuid4().hex[:8]}",
-        created_by=created_by,
-        is_private=False,
-    )
+from ._admin_helpers import make_context, make_user, make_workspace, mock_admin
 
 
 @pytest_asyncio.fixture
 async def workspace_owner_no_ctx_member(db_session: AsyncSession) -> dict:
     """User is the workspace owner with no ContextMember row (full access via workspace role)."""
-    user = _new_user()
+    user = make_user()
     db_session.add(user)
     await db_session.flush()
 
-    ws = _new_workspace(owner_user_id=user.user_id)
+    ws = make_workspace(owner_user_id=user.user_id)
     db_session.add(ws)
     await db_session.flush()
 
     db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role="owner"))
 
-    ctx = _new_context(workspace_id=ws.id, created_by=user.user_id)
+    ctx = make_context(workspace_id=ws.id, created_by=user.user_id)
     db_session.add(ctx)
     await db_session.commit()
 
@@ -85,12 +47,12 @@ async def workspace_admin_no_ctx_member(db_session: AsyncSession) -> dict:
 
     Regression pin for #699: previously displayed as ctx_role='owner'.
     """
-    owner_user = _new_user()
-    admin_user = _new_user()
+    owner_user = make_user()
+    admin_user = make_user()
     db_session.add_all([owner_user, admin_user])
     await db_session.flush()
 
-    ws = _new_workspace(owner_user_id=owner_user.user_id)
+    ws = make_workspace(owner_user_id=owner_user.user_id)
     db_session.add(ws)
     await db_session.flush()
 
@@ -101,7 +63,7 @@ async def workspace_admin_no_ctx_member(db_session: AsyncSession) -> dict:
         ]
     )
 
-    ctx = _new_context(workspace_id=ws.id, created_by=owner_user.user_id)
+    ctx = make_context(workspace_id=ws.id, created_by=owner_user.user_id)
     db_session.add(ctx)
     await db_session.commit()
     # NOTE: no ContextMember row for admin_user — that's the point of this fixture.
@@ -110,20 +72,57 @@ async def workspace_admin_no_ctx_member(db_session: AsyncSession) -> dict:
 
 
 @pytest_asyncio.fixture
+async def workspace_member_no_ctx_member(db_session: AsyncSession) -> dict:
+    """User is workspace member (allowed_context_ids whitelisted) with NO ContextMember row.
+
+    Exercises the default fallback in admin.py:577 — when workspace_role is not in
+    (owner, admin) and no ContextMember row exists, ctx_role stays at the "viewer" default.
+    """
+    owner_user = make_user()
+    member_user = make_user()
+    db_session.add_all([owner_user, member_user])
+    await db_session.flush()
+
+    ws = make_workspace(owner_user_id=owner_user.user_id)
+    db_session.add(ws)
+    await db_session.flush()
+
+    ctx = make_context(workspace_id=ws.id, created_by=owner_user.user_id)
+    db_session.add(ctx)
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            WorkspaceMember(workspace_id=ws.id, user_id=owner_user.user_id, role="owner"),
+            WorkspaceMember(
+                workspace_id=ws.id,
+                user_id=member_user.user_id,
+                role="member",
+                allowed_context_ids=[ctx.id],
+            ),
+        ]
+    )
+    await db_session.commit()
+    # NOTE: no ContextMember row — exercises the "viewer" default fallback.
+
+    return {"user_id": member_user.user_id, "context_id": str(ctx.id)}
+
+
+@pytest_asyncio.fixture
 async def workspace_member_with_ctx_member(db_session: AsyncSession) -> dict:
     """User is workspace member (allowed_context_ids whitelisted) with an explicit
     ContextMember(role='editor') row.
     """
-    owner_user = _new_user()
-    member_user = _new_user()
+    owner_user = make_user()
+    member_user = make_user()
     db_session.add_all([owner_user, member_user])
     await db_session.flush()
 
-    ws = _new_workspace(owner_user_id=owner_user.user_id)
+    ws = make_workspace(owner_user_id=owner_user.user_id)
     db_session.add(ws)
     await db_session.flush()
 
-    ctx = _new_context(workspace_id=ws.id, created_by=owner_user.user_id)
+    ctx = make_context(workspace_id=ws.id, created_by=owner_user.user_id)
     db_session.add(ctx)
     await db_session.flush()
 
@@ -160,7 +159,7 @@ class TestAccessibleContextRole:
     ) -> None:
         detail = await get_user_detail(
             user_id=workspace_owner_no_ctx_member["user_id"],
-            admin=_mock_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         ctx = _pick_context(detail, workspace_owner_no_ctx_member["context_id"])
@@ -175,7 +174,7 @@ class TestAccessibleContextRole:
     ) -> None:
         detail = await get_user_detail(
             user_id=workspace_admin_no_ctx_member["user_id"],
-            admin=_mock_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         ctx = _pick_context(detail, workspace_admin_no_ctx_member["context_id"])
@@ -186,6 +185,25 @@ class TestAccessibleContextRole:
         )
 
     @pytest.mark.asyncio
+    async def test_workspace_member_no_ctx_member_displays_viewer(
+        self,
+        db_session: AsyncSession,
+        workspace_member_no_ctx_member: dict,
+    ) -> None:
+        """workspace_member without ContextMember row falls through to the 'viewer' default."""
+        detail = await get_user_detail(
+            user_id=workspace_member_no_ctx_member["user_id"],
+            admin=mock_admin(),
+            db=db_session,
+        )
+        ctx = _pick_context(detail, workspace_member_no_ctx_member["context_id"])
+        assert ctx is not None, "test context must appear in accessible_contexts"
+        assert ctx.role == "viewer", (
+            "workspace member with no ContextMember row must fall through to the "
+            "'viewer' default (admin.py:577)"
+        )
+
+    @pytest.mark.asyncio
     async def test_workspace_member_with_ctx_member_displays_explicit_role(
         self,
         db_session: AsyncSession,
@@ -193,7 +211,7 @@ class TestAccessibleContextRole:
     ) -> None:
         detail = await get_user_detail(
             user_id=workspace_member_with_ctx_member["user_id"],
-            admin=_mock_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         ctx = _pick_context(detail, workspace_member_with_ctx_member["context_id"])

--- a/backend/tests/integration/test_admin_user_detail_context_role.py
+++ b/backend/tests/integration/test_admin_user_detail_context_role.py
@@ -1,0 +1,205 @@
+"""Regression tests for #699 — admin user detail accessible_contexts role display.
+
+Pins the role-derivation logic in ``admin.py:get_user_detail`` so workspace
+``admin`` is no longer collapsed to context role ``owner``.
+
+Hits a real Postgres test DB because the existing mock-DB tests in
+``tests/api/test_admin_*.py`` cannot exercise the
+``PermissionService.get_accessible_contexts`` + ``ContextMember`` batch
+lookup the handler performs.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin import get_user_detail
+from models.auth import Context, ContextMember, User, Workspace, WorkspaceMember
+
+
+def _mock_admin() -> dict:
+    return {"user_id": "admin_runner", "email": "admin@test.invalid", "role": "admin"}
+
+
+def _new_user(role: str = "user") -> User:
+    user_id = f"u_{uuid4().hex[:8]}"
+    return User(
+        email=f"{user_id}@test.invalid",
+        user_id=user_id,
+        name="Test User",
+        role=role,
+        is_initial_admin=False,
+        auth_method="oauth",
+        auth_provider="google",
+    )
+
+
+def _new_workspace(owner_user_id: str) -> Workspace:
+    return Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_user_id,
+        memory_limit=1000,
+        daily_api_limit=500,
+        weekly_api_limit=2500,
+    )
+
+
+def _new_context(workspace_id, created_by: str) -> Context:
+    return Context(
+        workspace_id=workspace_id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=created_by,
+        is_private=False,
+    )
+
+
+@pytest_asyncio.fixture
+async def workspace_owner_fixture(db_session: AsyncSession) -> dict:
+    """User is the workspace owner with no ContextMember row (full access via workspace role)."""
+    user = _new_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    ws = _new_workspace(owner_user_id=user.user_id)
+    db_session.add(ws)
+    await db_session.flush()
+
+    db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role="owner"))
+
+    ctx = _new_context(workspace_id=ws.id, created_by=user.user_id)
+    db_session.add(ctx)
+    await db_session.commit()
+
+    return {"user_id": user.user_id, "context_id": str(ctx.id)}
+
+
+@pytest_asyncio.fixture
+async def workspace_admin_no_ctx_member(db_session: AsyncSession) -> dict:
+    """User is workspace admin (NOT owner) with NO ContextMember row.
+
+    Regression pin for #699: previously displayed as ctx_role='owner'.
+    """
+    owner_user = _new_user()
+    admin_user = _new_user()
+    db_session.add_all([owner_user, admin_user])
+    await db_session.flush()
+
+    ws = _new_workspace(owner_user_id=owner_user.user_id)
+    db_session.add(ws)
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            WorkspaceMember(workspace_id=ws.id, user_id=owner_user.user_id, role="owner"),
+            WorkspaceMember(workspace_id=ws.id, user_id=admin_user.user_id, role="admin"),
+        ]
+    )
+
+    ctx = _new_context(workspace_id=ws.id, created_by=owner_user.user_id)
+    db_session.add(ctx)
+    await db_session.commit()
+    # NOTE: no ContextMember row for admin_user — that's the point of this fixture.
+
+    return {"user_id": admin_user.user_id, "context_id": str(ctx.id)}
+
+
+@pytest_asyncio.fixture
+async def workspace_member_with_ctx_member(db_session: AsyncSession) -> dict:
+    """User is workspace member (allowed_context_ids whitelisted) with an explicit
+    ContextMember(role='editor') row.
+    """
+    owner_user = _new_user()
+    member_user = _new_user()
+    db_session.add_all([owner_user, member_user])
+    await db_session.flush()
+
+    ws = _new_workspace(owner_user_id=owner_user.user_id)
+    db_session.add(ws)
+    await db_session.flush()
+
+    ctx = _new_context(workspace_id=ws.id, created_by=owner_user.user_id)
+    db_session.add(ctx)
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            WorkspaceMember(workspace_id=ws.id, user_id=owner_user.user_id, role="owner"),
+            WorkspaceMember(
+                workspace_id=ws.id,
+                user_id=member_user.user_id,
+                role="member",
+                allowed_context_ids=[ctx.id],
+            ),
+            ContextMember(context_id=ctx.id, user_id=member_user.user_id, role="editor"),
+        ]
+    )
+    await db_session.commit()
+
+    return {"user_id": member_user.user_id, "context_id": str(ctx.id)}
+
+
+def _pick_context(detail, context_id: str):
+    return next((c for c in detail.accessible_contexts if c.context_id == context_id), None)
+
+
+class TestAccessibleContextRole:
+    """#699 — ``UserAccessibleContext.role`` must reflect the user's actual access role,
+    not collapse workspace admin to 'owner'."""
+
+    @pytest.mark.asyncio
+    async def test_workspace_owner_displays_owner(
+        self,
+        db_session: AsyncSession,
+        workspace_owner_fixture: dict,
+    ) -> None:
+        detail = await get_user_detail(
+            user_id=workspace_owner_fixture["user_id"],
+            admin=_mock_admin(),
+            db=db_session,
+        )
+        ctx = _pick_context(detail, workspace_owner_fixture["context_id"])
+        assert ctx is not None, "test context must appear in accessible_contexts"
+        assert ctx.role == "owner"
+
+    @pytest.mark.asyncio
+    async def test_workspace_admin_no_ctx_member_displays_admin(
+        self,
+        db_session: AsyncSession,
+        workspace_admin_no_ctx_member: dict,
+    ) -> None:
+        """REGRESSION PIN for #699: previously displayed as 'owner'."""
+        detail = await get_user_detail(
+            user_id=workspace_admin_no_ctx_member["user_id"],
+            admin=_mock_admin(),
+            db=db_session,
+        )
+        ctx = _pick_context(detail, workspace_admin_no_ctx_member["context_id"])
+        assert ctx is not None, "test context must appear in accessible_contexts"
+        assert ctx.role == "admin", (
+            "workspace admin with no ContextMember row must display 'admin', "
+            "not 'owner' (#699 regression pin)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_workspace_member_with_ctx_member_displays_explicit_role(
+        self,
+        db_session: AsyncSession,
+        workspace_member_with_ctx_member: dict,
+    ) -> None:
+        detail = await get_user_detail(
+            user_id=workspace_member_with_ctx_member["user_id"],
+            admin=_mock_admin(),
+            db=db_session,
+        )
+        ctx = _pick_context(detail, workspace_member_with_ctx_member["context_id"])
+        assert ctx is not None, "test context must appear in accessible_contexts"
+        assert ctx.role == "editor", (
+            "workspace member with explicit ContextMember(role='editor') must "
+            "display the ContextMember role"
+        )

--- a/backend/tests/integration/test_admin_user_detail_context_role.py
+++ b/backend/tests/integration/test_admin_user_detail_context_role.py
@@ -60,7 +60,7 @@ def _new_context(workspace_id, created_by: str) -> Context:
 
 
 @pytest_asyncio.fixture
-async def workspace_owner_fixture(db_session: AsyncSession) -> dict:
+async def workspace_owner_no_ctx_member(db_session: AsyncSession) -> dict:
     """User is the workspace owner with no ContextMember row (full access via workspace role)."""
     user = _new_user()
     db_session.add(user)
@@ -156,14 +156,14 @@ class TestAccessibleContextRole:
     async def test_workspace_owner_displays_owner(
         self,
         db_session: AsyncSession,
-        workspace_owner_fixture: dict,
+        workspace_owner_no_ctx_member: dict,
     ) -> None:
         detail = await get_user_detail(
-            user_id=workspace_owner_fixture["user_id"],
+            user_id=workspace_owner_no_ctx_member["user_id"],
             admin=_mock_admin(),
             db=db_session,
         )
-        ctx = _pick_context(detail, workspace_owner_fixture["context_id"])
+        ctx = _pick_context(detail, workspace_owner_no_ctx_member["context_id"])
         assert ctx is not None, "test context must appear in accessible_contexts"
         assert ctx.role == "owner"
 
@@ -173,7 +173,6 @@ class TestAccessibleContextRole:
         db_session: AsyncSession,
         workspace_admin_no_ctx_member: dict,
     ) -> None:
-        """REGRESSION PIN for #699: previously displayed as 'owner'."""
         detail = await get_user_detail(
             user_id=workspace_admin_no_ctx_member["user_id"],
             admin=_mock_admin(),

--- a/backend/tests/integration/test_admin_users_list_cap_column.py
+++ b/backend/tests/integration/test_admin_users_list_cap_column.py
@@ -8,32 +8,15 @@ soft-deleted workspaces from ``owned_count`` (same #681 class as
 
 from __future__ import annotations
 
-from uuid import uuid4
-
 import pytest
 import pytest_asyncio
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin import list_users
-from models.auth import User, Workspace
+from models.auth import User
 
-
-def _mock_admin() -> dict:
-    return {"user_id": "admin_runner", "email": "admin@test.invalid", "role": "admin"}
-
-
-def _new_workspace(*, owner: str, soft_deleted: bool) -> Workspace:
-    return Workspace(
-        id=uuid4(),
-        name=f"{'deleted' if soft_deleted else 'active'}-{uuid4().hex[:8]}",
-        plan_name="pro",
-        owner_user_id=owner,
-        memory_limit=1000,
-        daily_api_limit=500,
-        weekly_api_limit=2500,
-        deleted_at=(func.now() if soft_deleted else None),
-    )
+from ._admin_helpers import make_user, make_workspace, mock_admin
 
 
 @pytest_asyncio.fixture
@@ -44,55 +27,27 @@ async def users_with_varied_cap(db_session: AsyncSession) -> dict:
     - bonus_grant:  bonus=2, owns 1 live + 1 soft-deleted    → 1 / 3 (not at cap)
     - zero_owned:   bonus=0, owns 0                          → 0 / 1
     """
-    uids = {key: f"u_{uuid4().hex[:8]}" for key in ("baseline", "bonus_grant", "zero_owned")}
-
-    db_session.add_all(
-        [
-            User(
-                email=f"{uids['baseline']}@test.invalid",
-                user_id=uids["baseline"],
-                name="Baseline User",
-                role="user",
-                is_initial_admin=False,
-                auth_method="oauth",
-                auth_provider="google",
-                workspace_slot_bonus=0,
-            ),
-            User(
-                email=f"{uids['bonus_grant']}@test.invalid",
-                user_id=uids["bonus_grant"],
-                name="Bonus User",
-                role="user",
-                is_initial_admin=False,
-                auth_method="oauth",
-                auth_provider="google",
-                workspace_slot_bonus=2,
-            ),
-            User(
-                email=f"{uids['zero_owned']}@test.invalid",
-                user_id=uids["zero_owned"],
-                name="Zero Owned User",
-                role="user",
-                is_initial_admin=False,
-                auth_method="oauth",
-                auth_provider="google",
-                workspace_slot_bonus=0,
-            ),
-        ]
-    )
+    baseline = make_user(workspace_slot_bonus=0, name="Baseline User")
+    bonus_grant = make_user(workspace_slot_bonus=2, name="Bonus User")
+    zero_owned = make_user(workspace_slot_bonus=0, name="Zero Owned User")
+    db_session.add_all([baseline, bonus_grant, zero_owned])
     await db_session.flush()
 
     db_session.add_all(
         [
-            _new_workspace(owner=uids["baseline"], soft_deleted=False),
-            _new_workspace(owner=uids["bonus_grant"], soft_deleted=False),
-            _new_workspace(owner=uids["bonus_grant"], soft_deleted=True),
+            make_workspace(owner_user_id=baseline.user_id, soft_deleted=False),
+            make_workspace(owner_user_id=bonus_grant.user_id, soft_deleted=False),
+            make_workspace(owner_user_id=bonus_grant.user_id, soft_deleted=True),
             # zero_owned: intentionally no workspaces
         ]
     )
     await db_session.commit()
 
-    return uids
+    return {
+        "baseline": baseline.user_id,
+        "bonus_grant": bonus_grant.user_id,
+        "zero_owned": zero_owned.user_id,
+    }
 
 
 _LIST_DEFAULTS = {
@@ -116,7 +71,7 @@ class TestListUsersCapColumn:
         db_session: AsyncSession,
         users_with_varied_cap: dict,
     ) -> None:
-        response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
+        response = await list_users(user=mock_admin(), db=db_session, **_LIST_DEFAULTS)
         target = next(
             (u for u in response.users if u.id == users_with_varied_cap["baseline"]),
             None,
@@ -132,7 +87,7 @@ class TestListUsersCapColumn:
         db_session: AsyncSession,
         users_with_varied_cap: dict,
     ) -> None:
-        response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
+        response = await list_users(user=mock_admin(), db=db_session, **_LIST_DEFAULTS)
         target = next(
             (u for u in response.users if u.id == users_with_varied_cap["bonus_grant"]),
             None,
@@ -149,7 +104,7 @@ class TestListUsersCapColumn:
         db_session: AsyncSession,
         users_with_varied_cap: dict,
     ) -> None:
-        response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
+        response = await list_users(user=mock_admin(), db=db_session, **_LIST_DEFAULTS)
         target = next(
             (u for u in response.users if u.id == users_with_varied_cap["zero_owned"]),
             None,
@@ -174,7 +129,7 @@ class TestListUsersCapColumn:
         duplicate user rows in ``response.users``. Asserting both no
         duplicates AND a lower-bound on ``total`` catches both failure modes.
         """
-        response = await list_users(user=_mock_admin(), db=db_session, **_LIST_DEFAULTS)
+        response = await list_users(user=mock_admin(), db=db_session, **_LIST_DEFAULTS)
         fixture_ids = set(users_with_varied_cap.values())
 
         # 1. Each fixture user appears EXACTLY once in the response page

--- a/backend/tests/integration/test_admin_users_soft_delete_filter.py
+++ b/backend/tests/integration/test_admin_users_soft_delete_filter.py
@@ -8,66 +8,38 @@ Hits a real Postgres test DB because the existing mock-DB tests in
 
 from __future__ import annotations
 
-from uuid import uuid4
-
 import pytest
 import pytest_asyncio
-from sqlalchemy import func
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin import get_user_detail, list_users
-from models.auth import User, Workspace, WorkspaceMember
+from models.auth import WorkspaceMember
 
-
-def _mock_admin() -> dict:
-    return {"user_id": "admin_runner", "email": "admin@test.invalid", "role": "admin"}
-
-
-def _new_workspace(*, owner: str, soft_deleted: bool) -> Workspace:
-    return Workspace(
-        id=uuid4(),
-        name=f"{'deleted' if soft_deleted else 'active'}-{uuid4().hex[:8]}",
-        plan_name="pro",
-        owner_user_id=owner,
-        memory_limit=1000,
-        daily_api_limit=500,
-        weekly_api_limit=2500,
-        deleted_at=(func.now() if soft_deleted else None),
-    )
+from ._admin_helpers import make_user, make_workspace, mock_admin
 
 
 @pytest_asyncio.fixture
 async def user_with_mixed_workspaces(db_session: AsyncSession) -> dict:
     """One user owning two ``pro`` workspaces — one active, one soft-deleted."""
-    user_id = f"u_{uuid4().hex[:8]}"
-    db_session.add(
-        User(
-            email=f"{user_id}@test.invalid",
-            user_id=user_id,
-            name="Test User",
-            role="user",
-            is_initial_admin=False,
-            auth_method="oauth",
-            auth_provider="google",
-        )
-    )
+    user = make_user()
+    db_session.add(user)
     await db_session.flush()
 
-    active = _new_workspace(owner=user_id, soft_deleted=False)
-    deleted = _new_workspace(owner=user_id, soft_deleted=True)
+    active = make_workspace(owner_user_id=user.user_id, soft_deleted=False)
+    deleted = make_workspace(owner_user_id=user.user_id, soft_deleted=True)
     db_session.add_all([active, deleted])
     await db_session.flush()
 
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=active.id, user_id=user_id, role="owner"),
-            WorkspaceMember(workspace_id=deleted.id, user_id=user_id, role="owner"),
+            WorkspaceMember(workspace_id=active.id, user_id=user.user_id, role="owner"),
+            WorkspaceMember(workspace_id=deleted.id, user_id=user.user_id, role="owner"),
         ]
     )
     await db_session.commit()
 
     return {
-        "user_id": user_id,
+        "user_id": user.user_id,
         "active_workspace_id": str(active.id),
         "deleted_workspace_id": str(deleted.id),
     }
@@ -97,7 +69,7 @@ class TestListUsersIncludeWorkspaces:
         user_with_mixed_workspaces: dict,
     ) -> None:
         response = await list_users(
-            user=_mock_admin(),
+            user=mock_admin(),
             db=db_session,
             **{**_LIST_DEFAULTS, "include_workspaces": True},
         )
@@ -126,7 +98,7 @@ class TestGetUserDetail:
     ) -> None:
         detail = await get_user_detail(
             user_id=user_with_mixed_workspaces["user_id"],
-            admin=_mock_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
 

--- a/backend/tests/integration/test_admin_workspace_slot_bonus.py
+++ b/backend/tests/integration/test_admin_workspace_slot_bonus.py
@@ -12,12 +12,10 @@ read-modify-write loops.
 
 from __future__ import annotations
 
-from uuid import uuid4
-
 import pytest
 import pytest_asyncio
 from fastapi import HTTPException
-from sqlalchemy import func, select
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin import (
@@ -25,26 +23,11 @@ from api.routes.admin import (
     list_users,
     update_workspace_slot_bonus,
 )
-from models.auth import AuditLog, User, Workspace, WorkspaceMember
+from models.auth import AuditLog, User, WorkspaceMember
 from models.schemas import UpdateWorkspaceSlotBonusRequest
 from utils.exceptions import BonusBelowZeroError, InsufficientReasonError
 
-
-def _admin() -> dict:
-    return {"user_id": "admin_runner", "email": "admin@test.invalid", "role": "admin"}
-
-
-def _new_workspace(*, owner: str, soft_deleted: bool = False, plan: str = "pro") -> Workspace:
-    return Workspace(
-        id=uuid4(),
-        name=f"{'deleted' if soft_deleted else 'active'}-{uuid4().hex[:8]}",
-        plan_name=plan,
-        owner_user_id=owner,
-        memory_limit=1000,
-        daily_api_limit=500,
-        weekly_api_limit=2500,
-        deleted_at=(func.now() if soft_deleted else None),
-    )
+from ._admin_helpers import make_user, make_workspace, mock_admin
 
 
 @pytest_asyncio.fixture
@@ -54,28 +37,17 @@ async def user_with_bonus(db_session: AsyncSession) -> dict:
     Non-destructive baseline: owned_count=1, cap=3 → admin can decrement
     bonus by 1 without hitting the destructive-op gate (new_cap=2 ≥ owned=1).
     """
-    user_id = f"u_{uuid4().hex[:8]}"
-    db_session.add(
-        User(
-            email=f"{user_id}@test.invalid",
-            user_id=user_id,
-            name="Bonus Test User",
-            role="user",
-            is_initial_admin=False,
-            auth_method="oauth",
-            auth_provider="google",
-            workspace_slot_bonus=2,
-        )
-    )
+    user = make_user(workspace_slot_bonus=2, name="Bonus Test User")
+    db_session.add(user)
     await db_session.flush()
 
-    ws = _new_workspace(owner=user_id)
+    ws = make_workspace(owner_user_id=user.user_id)
     db_session.add(ws)
     await db_session.flush()
-    db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user_id, role="owner"))
+    db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role="owner"))
     await db_session.commit()
 
-    return {"user_id": user_id, "email": f"{user_id}@test.invalid", "workspace_id": str(ws.id)}
+    return {"user_id": user.user_id, "email": user.email, "workspace_id": str(ws.id)}
 
 
 @pytest_asyncio.fixture
@@ -85,28 +57,17 @@ async def user_at_risk(db_session: AsyncSession) -> dict:
     Setting delta=-0 is non-mutating; decrementing bonus past zero is rejected
     by BONUS-002. Used to exercise the below-zero guard cleanly.
     """
-    user_id = f"u_{uuid4().hex[:8]}"
-    db_session.add(
-        User(
-            email=f"{user_id}@test.invalid",
-            user_id=user_id,
-            name="At-Risk Test User",
-            role="user",
-            is_initial_admin=False,
-            auth_method="oauth",
-            auth_provider="google",
-            workspace_slot_bonus=0,
-        )
-    )
+    user = make_user(workspace_slot_bonus=0, name="At-Risk Test User")
+    db_session.add(user)
     await db_session.flush()
 
-    ws = _new_workspace(owner=user_id, plan="free")
+    ws = make_workspace(owner_user_id=user.user_id, plan_name="free")
     db_session.add(ws)
     await db_session.flush()
-    db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user_id, role="owner"))
+    db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role="owner"))
     await db_session.commit()
 
-    return {"user_id": user_id, "email": f"{user_id}@test.invalid"}
+    return {"user_id": user.user_id, "email": user.email}
 
 
 @pytest_asyncio.fixture
@@ -116,30 +77,19 @@ async def user_destructive(db_session: AsyncSession) -> dict:
 
     new_cap (after -1) = 3 < owned_count (4) → destructive.
     """
-    user_id = f"u_{uuid4().hex[:8]}"
-    db_session.add(
-        User(
-            email=f"{user_id}@test.invalid",
-            user_id=user_id,
-            name="Destructive Test User",
-            role="user",
-            is_initial_admin=False,
-            auth_method="oauth",
-            auth_provider="google",
-            workspace_slot_bonus=3,
-        )
-    )
+    user = make_user(workspace_slot_bonus=3, name="Destructive Test User")
+    db_session.add(user)
     await db_session.flush()
 
-    workspaces = [_new_workspace(owner=user_id) for _ in range(4)]
+    workspaces = [make_workspace(owner_user_id=user.user_id) for _ in range(4)]
     db_session.add_all(workspaces)
     await db_session.flush()
     db_session.add_all(
-        [WorkspaceMember(workspace_id=w.id, user_id=user_id, role="owner") for w in workspaces]
+        [WorkspaceMember(workspace_id=w.id, user_id=user.user_id, role="owner") for w in workspaces]
     )
     await db_session.commit()
 
-    return {"user_id": user_id, "email": f"{user_id}@test.invalid"}
+    return {"user_id": user.user_id, "email": user.email}
 
 
 @pytest_asyncio.fixture
@@ -152,33 +102,23 @@ async def user_with_mixed_workspaces_plan_filter(db_session: AsyncSession) -> di
     row (i.e. the active row should be sufficient to qualify them; we only
     want the soft-deleted row to be invisible to the filter).
     """
-    user_id = f"u_{uuid4().hex[:8]}"
-    db_session.add(
-        User(
-            email=f"{user_id}@test.invalid",
-            user_id=user_id,
-            name="Plan Filter Test User",
-            role="user",
-            is_initial_admin=False,
-            auth_method="oauth",
-            auth_provider="google",
-        )
-    )
+    user = make_user(name="Plan Filter Test User")
+    db_session.add(user)
     await db_session.flush()
 
-    active = _new_workspace(owner=user_id, soft_deleted=False)
-    deleted = _new_workspace(owner=user_id, soft_deleted=True)
+    active = make_workspace(owner_user_id=user.user_id, soft_deleted=False)
+    deleted = make_workspace(owner_user_id=user.user_id, soft_deleted=True)
     db_session.add_all([active, deleted])
     await db_session.flush()
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=active.id, user_id=user_id, role="owner"),
-            WorkspaceMember(workspace_id=deleted.id, user_id=user_id, role="owner"),
+            WorkspaceMember(workspace_id=active.id, user_id=user.user_id, role="owner"),
+            WorkspaceMember(workspace_id=deleted.id, user_id=user.user_id, role="owner"),
         ]
     )
     await db_session.commit()
 
-    return {"user_id": user_id, "active_id": str(active.id), "deleted_id": str(deleted.id)}
+    return {"user_id": user.user_id, "active_id": str(active.id), "deleted_id": str(deleted.id)}
 
 
 _LIST_DEFAULTS = {
@@ -203,7 +143,7 @@ class TestUpdateWorkspaceSlotBonus:
         response = await update_workspace_slot_bonus(
             user_id=user_with_bonus["user_id"],
             request=UpdateWorkspaceSlotBonusRequest(delta=1, reason=None),
-            admin=_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         assert response.before_value == 2
@@ -222,7 +162,7 @@ class TestUpdateWorkspaceSlotBonus:
         response = await update_workspace_slot_bonus(
             user_id=user_with_bonus["user_id"],
             request=UpdateWorkspaceSlotBonusRequest(delta=-1, reason=None),
-            admin=_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         assert response.after_value == 1
@@ -236,7 +176,7 @@ class TestUpdateWorkspaceSlotBonus:
             await update_workspace_slot_bonus(
                 user_id=user_at_risk["user_id"],
                 request=UpdateWorkspaceSlotBonusRequest(delta=-1, reason=None),
-                admin=_admin(),
+                admin=mock_admin(),
                 db=db_session,
             )
         assert exc.value.error_code == "BONUS-002"
@@ -250,7 +190,7 @@ class TestUpdateWorkspaceSlotBonus:
             await update_workspace_slot_bonus(
                 user_id=user_destructive["user_id"],
                 request=UpdateWorkspaceSlotBonusRequest(delta=-1, reason=None),
-                admin=_admin(),
+                admin=mock_admin(),
                 db=db_session,
             )
         assert exc.value.error_code == "BONUS-001"
@@ -264,7 +204,7 @@ class TestUpdateWorkspaceSlotBonus:
             request=UpdateWorkspaceSlotBonusRequest(
                 delta=-1, reason="Reducing bonus per request from finance"
             ),
-            admin=_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         assert response.before_value == 3
@@ -300,7 +240,7 @@ class TestUpdateWorkspaceSlotBonus:
             await update_workspace_slot_bonus(
                 user_id=user_destructive["user_id"],
                 request=UpdateWorkspaceSlotBonusRequest(delta=-1, reason="   "),
-                admin=_admin(),
+                admin=mock_admin(),
                 db=db_session,
             )
 
@@ -310,7 +250,7 @@ class TestUpdateWorkspaceSlotBonus:
             await update_workspace_slot_bonus(
                 user_id="u_nonexistent_xyz",
                 request=UpdateWorkspaceSlotBonusRequest(delta=1, reason=None),
-                admin=_admin(),
+                admin=mock_admin(),
                 db=db_session,
             )
         assert exc.value.status_code == 404
@@ -325,7 +265,7 @@ class TestGetUserDetailWorkspaceSummary:
     ) -> None:
         detail = await get_user_detail(
             user_id=user_with_bonus["user_id"],
-            admin=_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         assert detail.workspace_summary is not None
@@ -346,7 +286,7 @@ class TestGetUserDetailWorkspaceSummary:
         """owned_workspaces must apply the soft-delete filter (no #681 regression)."""
         detail = await get_user_detail(
             user_id=user_with_mixed_workspaces_plan_filter["user_id"],
-            admin=_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         assert detail.workspace_summary is not None
@@ -363,33 +303,22 @@ async def user_with_two_pro_workspaces(db_session: AsyncSession) -> dict:
     ``.distinct()`` the user would appear twice in ``GET /admin/users?plan=pro``
     and ``total`` would count workspace matches rather than distinct users.
     """
-    user_id = f"u_{uuid4().hex[:8]}"
-    db_session.add(
-        User(
-            email=f"{user_id}@test.invalid",
-            user_id=user_id,
-            name="Two-Pro Test User",
-            role="user",
-            is_initial_admin=False,
-            auth_method="oauth",
-            auth_provider="google",
-            workspace_slot_bonus=1,  # cap = 2, can own 2 workspaces
-        )
-    )
+    user = make_user(workspace_slot_bonus=1, name="Two-Pro Test User")  # cap = 2
+    db_session.add(user)
     await db_session.flush()
 
-    ws_a = _new_workspace(owner=user_id)
-    ws_b = _new_workspace(owner=user_id)
+    ws_a = make_workspace(owner_user_id=user.user_id)
+    ws_b = make_workspace(owner_user_id=user.user_id)
     db_session.add_all([ws_a, ws_b])
     await db_session.flush()
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws_a.id, user_id=user_id, role="owner"),
-            WorkspaceMember(workspace_id=ws_b.id, user_id=user_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=user.user_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=user.user_id, role="owner"),
         ]
     )
     await db_session.commit()
-    return {"user_id": user_id}
+    return {"user_id": user.user_id}
 
 
 class TestListUsersPlanFilterSoftDelete:
@@ -416,7 +345,7 @@ class TestListUsersPlanFilterSoftDelete:
         once.
         """
         response = await list_users(
-            user=_admin(),
+            user=mock_admin(),
             db=db_session,
             **{**_LIST_DEFAULTS, "plan": "pro"},
         )
@@ -439,7 +368,7 @@ class TestListUsersPlanFilterSoftDelete:
         yield two User rows and inflate ``total``.
         """
         response = await list_users(
-            user=_admin(),
+            user=mock_admin(),
             db=db_session,
             **{**_LIST_DEFAULTS, "plan": "pro"},
         )
@@ -534,7 +463,7 @@ class TestInputBounds:
         response = await update_workspace_slot_bonus(
             user_id=user_with_bonus["user_id"],
             request=UpdateWorkspaceSlotBonusRequest(delta=1, reason=long_reason),
-            admin=_admin(),
+            admin=mock_admin(),
             db=db_session,
         )
         assert response.reason == long_reason


### PR DESCRIPTION
Closes #699

## Summary
- `admin.py:579` was collapsing both `owner` and `admin` workspace roles to `ctx_role="owner"`, causing admin UI to display workspace admins as context owners. Fix: use `workspace_role` directly to preserve the owner/admin distinction.
- Pre-existing dead code (`workspace_role_map`) in the same function was removed (surfaced by /simplify review).
- Added 4 integration tests covering all 4 branches of the role-derivation logic (owner / admin / member-with-CM / member-no-CM) against a real Postgres DB.
- Consolidated 4-way duplication of admin test helpers (`_mock_admin`, `_new_workspace`, inline `User()`) into a shared `tests/integration/_admin_helpers.py` module.

## Implementation notes
- The fix is a 1-line change at `backend/src/api/routes/admin.py:579`. The `permission_service.get_accessible_contexts` side is unchanged — workspace owner/admin still get full access (correct by design); only the display-time role label was wrong.
- `UserAccessibleContext.role` value set expands from `{owner, editor, viewer}` to `{owner, admin, editor, viewer}`. Backwards-compatible: schema type stays `str`, frontend displays the value passthrough in a `<Badge>` with no enum lookup or i18n key.
- Schema docstring at `models/schemas.py:791` updated to reflect the expanded value set.
- The new `_admin_helpers.py` module unifies the previously-divergent `_new_workspace` signatures across three sibling test files on the superset `(owner_user_id, soft_deleted=False, plan_name="pro")`. All 29 admin integration tests pass with no behavior change.
- Follow-up filed as #700 (v0.17.0): introduce `WorkspaceRole`/`ContextRole` StrEnum to eliminate repo-wide stringly-typed role literals.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (root cause confirmed in-session, effective green)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/699-fix-bug-admin-user-detail-accessible-context.gate1.md
- ~/.claude/cache/gh-issue-driven/699-fix-bug-admin-user-detail-accessible-context.gate2.md

🤖 Generated via /gh-issue-driven:ship
