### PR TITLE
chore(api,services): rename func.count(...).label("count") repo-wide (#611)

### DIFF
--- a/backend/src/api/routes/usage.py
+++ b/backend/src/api/routes/usage.py
@@ -660,7 +660,7 @@ async def get_usage_history(
         result = await db.execute(
             select(
                 UsageStats.date,
-                func.count(UsageStats.id).label("count"),
+                func.count(UsageStats.id).label("event_count"),
             )
             .where(
                 usage_filter,
@@ -671,7 +671,7 @@ async def get_usage_history(
             .order_by(UsageStats.date)
         )
 
-        daily_stats_dict = {row.date: row.count for row in result.all()}
+        daily_stats_dict = {row.date: row.event_count for row in result.all()}
 
         # Fill in missing dates with 0
         daily_stats = []
@@ -736,7 +736,7 @@ async def get_usage_breakdown(
         result = await db.execute(
             select(
                 UsageStats.endpoint,
-                func.count(UsageStats.id).label("count"),
+                func.count(UsageStats.id).label("event_count"),
             )
             .where(usage_filter, UsageStats.date >= start_date)
             .group_by(UsageStats.endpoint)
@@ -744,13 +744,13 @@ async def get_usage_breakdown(
         )
 
         endpoint_stats = result.all()
-        total_requests = sum(row.count for row in endpoint_stats)
+        total_requests = sum(row.event_count for row in endpoint_stats)
 
         by_endpoint = [
             EndpointUsage(
                 endpoint=row.endpoint,
-                count=row.count,
-                percentage=round((row.count / total_requests * 100), 2)
+                count=row.event_count,
+                percentage=round((row.event_count / total_requests * 100), 2)
                 if total_requests > 0
                 else 0.0,
             )

--- a/backend/src/api/routes/workspace.py
+++ b/backend/src/api/routes/workspace.py
@@ -466,7 +466,7 @@ async def get_workspace_usage_history(
         daily_stats_result = await db.execute(
             select(
                 UsageStatsModel.date,
-                func.count(UsageStatsModel.id).label("count"),
+                func.count(UsageStatsModel.id).label("event_count"),
             )
             .where(
                 UsageStatsModel.workspace_id == workspace_id,
@@ -479,7 +479,7 @@ async def get_workspace_usage_history(
 
         # Build daily stats list
         daily_stats = [
-            DailyUsage(date=row.date.isoformat(), count=row.count)
+            DailyUsage(date=row.date.isoformat(), count=row.event_count)
             for row in daily_stats_result.all()
         ]
 
@@ -532,7 +532,7 @@ async def get_workspace_usage_breakdown(
         breakdown_result = await db.execute(
             select(
                 UsageStatsModel.endpoint,
-                func.count(UsageStatsModel.id).label("count"),
+                func.count(UsageStatsModel.id).label("event_count"),
             )
             .where(
                 UsageStatsModel.workspace_id == workspace_id,
@@ -544,14 +544,14 @@ async def get_workspace_usage_breakdown(
         )
 
         endpoint_stats = breakdown_result.all()
-        total_requests = sum(row.count for row in endpoint_stats)
+        total_requests = sum(row.event_count for row in endpoint_stats)
 
         # Build endpoint usage list with percentages
         by_endpoint = [
             EndpointUsage(
                 endpoint=row.endpoint,
-                count=row.count,
-                percentage=round((row.count / total_requests * 100), 2)
+                count=row.event_count,
+                percentage=round((row.event_count / total_requests * 100), 2)
                 if total_requests > 0
                 else 0.0,
             )
@@ -730,7 +730,7 @@ async def get_embedding_status(
     status_stmt = (
         select(
             Memory.embedding_status,
-            func.count(Memory.id).label("count"),
+            func.count(Memory.id).label("memory_count"),
         )
         .where(*conditions)
         .group_by(Memory.embedding_status)

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -608,7 +608,7 @@ async def list_members(
         # API Keys
         api_keys_result = await db.execute(
             select(
-                func.count(APIKey.id).label("count"),
+                func.count(APIKey.id).label("api_key_count"),
                 func.bool_or(APIKey.hidden_at.is_(None)).label("any_visible"),
             ).where(
                 and_(
@@ -619,7 +619,9 @@ async def list_members(
             )
         )
         api_key_stats = api_keys_result.one_or_none()
-        api_key_count = api_key_stats.count if api_key_stats and api_key_stats.count else 0
+        api_key_count = (
+            api_key_stats.api_key_count if api_key_stats and api_key_stats.api_key_count else 0
+        )
         api_key_visible = (
             bool(api_key_stats.any_visible)
             if api_key_stats and api_key_stats.any_visible is not None

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -1259,7 +1259,7 @@ class WorkspaceService:
             daily_counts_stmt = (
                 select(
                     func.date(Memory.created_at).label("date"),
-                    func.count(Memory.id).label("count"),
+                    func.count(Memory.id).label("memory_count"),
                 )
                 .where(*conditions)
                 .group_by(func.date(Memory.created_at))
@@ -1273,7 +1273,7 @@ class WorkspaceService:
         # Zero-fill missing dates for continuous timeline
         daily_counts = []
         current_date = start_date
-        counts_by_date = {row.date: row.count for row in daily_rows}
+        counts_by_date = {row.date: row.memory_count for row in daily_rows}
 
         while current_date <= end_date:
             daily_counts.append(
@@ -1379,7 +1379,7 @@ class WorkspaceService:
 
         # Timeline (daily aggregation)
         timeline_result = await self.db.execute(
-            select(UsageStats.date, func.count(UsageStats.id).label("count"))
+            select(UsageStats.date, func.count(UsageStats.id).label("event_count"))
             .where(
                 ingest_base_filter,
                 UsageStats.date >= start_date,
@@ -1390,7 +1390,7 @@ class WorkspaceService:
         )
 
         # Fill missing dates with zeros (helper: fill_timeline)
-        events_by_date = {row.date: row.count for row in timeline_result.all()}
+        events_by_date = {row.date: row.event_count for row in timeline_result.all()}
         events_timeline = [
             {"date": day.isoformat(), "count": events_by_date.get(day, 0)}
             for day in (


### PR DESCRIPTION
Closes #611

## Summary

- Renames SQLAlchemy `func.count(...).label("count")` → `label("<noun>_count")` at 8 sister sites across 4 files, completing the convention pattern PR #610 established for `contexts.py:366`.
- Resolves the pyright `tuple.count` resolution collision repo-wide; unblocks #612 (Tier B pyright re-enable) and #613 (schema-drift detector) follow-ups.
- Hybrid noun convention chosen via gate1 design review (`/ask` → CTO lens): `memory_count` for `Memory.id` (2 sites), `api_key_count` for `APIKey.id` (1 site), `event_count` for `UsageStats.id` (5 sites — preferred over awkward `usage_stats_count`).
- Zero SQL semantics change. Pydantic API response fields (`DailyUsage.count`, `EndpointUsage.count`) preserved — only the kwarg value source name was renamed.

## Implementation notes

| File | Site | Old → new alias | Consumer changes |
|---|---|---|---|
| `backend/src/services/workspace_service.py:1262` | `Memory.id` | `count` → `memory_count` | `row.memory_count` at 1276 |
| `backend/src/services/workspace_service.py:1382` | `UsageStats.id` | `count` → `event_count` | `row.event_count` at 1393 |
| `backend/src/api/routes/usage.py:663` | `UsageStats.id` | `count` → `event_count` | `row.event_count` at 674 |
| `backend/src/api/routes/usage.py:739` | `UsageStats.id` | `count` → `event_count` | `row.event_count` at 747, 752, 753 |
| `backend/src/api/routes/workspace.py:469` | `UsageStatsModel.id` | `count` → `event_count` | `DailyUsage(count=row.event_count)` at 482 |
| `backend/src/api/routes/workspace.py:535` | `UsageStatsModel.id` | `count` → `event_count` | `EndpointUsage(count=row.event_count)` at 547, 553, 554 |
| `backend/src/api/routes/workspace.py:733` | `Memory.id` | `count` → `memory_count` | NONE — consumer uses positional `row[1]` |
| `backend/src/api/routes/workspaces.py:611` | `APIKey.id` | `count` → `api_key_count` | `api_key_stats.api_key_count` at 622-624 |

**Preserved Pydantic field names**: `DailyUsage.count` and `EndpointUsage.count` are API response fields; the kwarg `count=` is unchanged, only the value source (`row.<noun>_count`) was renamed. No OpenAPI schema delta, no frontend break.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens)
- review provider: code-review

### Verification
- `make lint`: All checks passed
- Unit suite: **2708 passed / 0 failed / 6 skipped / 15 xfailed** (pre-existing fixture gaps)
- Pre-impl test grep `tests/` for `row.count` / `Mock(count=...)`: **0 hits** (only `result.count("*")` string method in `test_masking.py`, unrelated)

### Out of scope (follow-up candidates)
- `workspace_service.py:1392,1483` carry orphan `# helper: fill_timeline` TODO; same zero-fill date series pattern duplicated 4x across `usage.py` / `workspace.py` / `workspace_service.py` — candidate for v0.17.x extraction issue.
- 15 xfailed integration tests (`async_client` / `authenticated_user` fixtures not available) — overlaps with v0.16.3 #613 schema-drift detector scope.

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/611-feat-chore-api-services-rename-func-count-lab.gate1.md
- ~/.claude/cache/gh-issue-driven/611-feat-chore-api-services-rename-func-count-lab.gate2.md

🤖 Generated via /gh-issue-driven:ship
