### PR TITLE
test(frontend): SettingsTabPanel + UsageStats test bundle (#571)

### DIFF
--- a/frontend/src/components/contexts/SettingsTabPanel.test.tsx
+++ b/frontend/src/components/contexts/SettingsTabPanel.test.tsx
@@ -22,7 +22,7 @@
  */
 
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SettingsTabPanel } from "./SettingsTabPanel";
 import type { Context } from "@/lib/types/context";

--- a/frontend/src/components/contexts/SettingsTabPanel.test.tsx
+++ b/frontend/src/components/contexts/SettingsTabPanel.test.tsx
@@ -1,0 +1,430 @@
+/**
+ * Tests for SettingsTabPanel (Issue #571).
+ *
+ * Covers the gate1 scope:
+ *   - Sleep mode section gated by isOwner (workspace role === "owner")
+ *   - Sleep quota fetched on mount only for owners
+ *   - wouldExceedSleepQuota derivation across 4 branches, asserted via the
+ *     visible error-message branch (sleepQuotaTierBlocked vs sleepQuotaExceeded)
+ *     instead of opening the Radix Select. Radix interactive primitives do
+ *     not respond cleanly to fireEvent.click in happy-dom — see
+ *     MCPConfigBlock.test.tsx for the canonical side-channel approach used in
+ *     this codebase.
+ *   - Sleep quota refetched after a successful save (initial + post-save fetch)
+ *   - Privacy transition AlertDialog opens on shared → private toggle and
+ *     respects confirm/cancel
+ *   - resource_id input filters keystrokes to lowercase + [a-z0-9_] only
+ *   - Skip-mode AlertDialog (#504) is closed on mount; full open/confirm/cancel
+ *     flow requires opening the Radix Select trigger, which is the same
+ *     happy-dom limitation documented in MCPConfigBlock.test.tsx — closed-on-mount
+ *     covers the "doesn't accidentally render" regression, which is the
+ *     reachable contract.
+ */
+
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SettingsTabPanel } from "./SettingsTabPanel";
+import type { Context } from "@/lib/types/context";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockGetContext = vi.fn();
+const mockUpdateContext = vi.fn();
+vi.mock("@/lib/api/contexts", () => ({
+  getContext: (...a: unknown[]) => mockGetContext(...a),
+  updateContext: (...a: unknown[]) => mockUpdateContext(...a),
+}));
+
+const mockGetWorkspaceUsageCurrent = vi.fn();
+vi.mock("@/lib/api/workspaces", () => ({
+  getWorkspaceUsageCurrent: (...a: unknown[]) =>
+    mockGetWorkspaceUsageCurrent(...a),
+}));
+
+const mockToast = vi.fn();
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+// Stable key-as-text translator. Vars are folded into the key so we can
+// distinguish e.g. sleepQuotaUsage rendered with different used/limit values.
+const stableT = (key: string, vars?: Record<string, unknown>) => {
+  if (!vars) return key;
+  if ("used" in vars && "limit" in vars) {
+    return `${key}:${vars.used}/${vars.limit}+${vars.addon ?? 0}`;
+  }
+  if ("count" in vars) return `${key}:${vars.count}`;
+  return key;
+};
+vi.mock("next-intl", () => ({
+  useTranslations: (_ns: string) => stableT,
+}));
+
+const mockUseWorkspace = vi.fn();
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { id: "user-1" } }),
+}));
+
+// ---------- Helpers ----------------------------------------------------------
+
+const CTX_ID = "11111111-1111-1111-1111-111111111111";
+
+function makeContext(overrides: Partial<Context> = {}): Context {
+  return {
+    id: CTX_ID,
+    name: "demo",
+    display_name: "Demo Context",
+    description: "",
+    summary: "",
+    usage_guide: "",
+    collection_name: "ctx_demo",
+    is_default: false,
+    is_private: true,
+    is_public: false,
+    is_locked: false,
+    sleep_mode: "full",
+    resource_id: null,
+    created_by: "user-1",
+    created_by_name: "Owner",
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    use_rerank: null,
+    reranker_provider: null,
+    embedding_model: "text-embedding-3-small",
+    embedding_dimensions: 1536,
+    member_count: 1,
+    memory_count: 0,
+    last_activity_at: null,
+    ...overrides,
+  };
+}
+
+function setRole(role: "owner" | "admin" | "member" | "viewer") {
+  mockUseWorkspace.mockReturnValue({
+    currentWorkspace: { id: "ws-1", current_user_role: role },
+    currentWorkspaceId: "ws-1",
+  });
+}
+
+function setQuotaResponse(
+  used: number,
+  limit: number,
+  addon_bonus = 0,
+  remaining = Math.max(0, limit - used),
+) {
+  mockGetWorkspaceUsageCurrent.mockResolvedValue({
+    plan: {} as never,
+    usage: {
+      memory_count: 0,
+      api_calls_today: 0,
+      api_calls_this_week: 0,
+      mcp_calls_today: 0,
+      mcp_calls_this_week: 0,
+      rest_calls_today: 0,
+      rest_calls_this_week: 0,
+      public_calls_today: 0,
+      public_calls_this_week: 0,
+      sleep_contexts: { used, limit, addon_bonus, remaining },
+      workspaces: { used: 0, limit: 0, remaining: 0 },
+    },
+    memory_usage: {} as never,
+    daily_api_usage: {} as never,
+    weekly_api_usage: {} as never,
+  });
+}
+
+const noop = () => {};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: owner with no quota constraint. Tests override as needed.
+  setRole("owner");
+  setQuotaResponse(0, 10);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------- Sleep mode section visibility -----------------------------------
+
+describe("SettingsTabPanel — sleep mode section visibility", () => {
+  it("renders the sleep mode section and fetches quota when isOwner", async () => {
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext()}
+        onContextUpdated={noop}
+      />,
+    );
+
+    // Section title appears (Card with sleepModeTitle).
+    expect(screen.getByText("sleepModeTitle")).toBeInTheDocument();
+
+    // Owner triggers the mount-time quota fetch.
+    await waitFor(() => {
+      expect(mockGetWorkspaceUsageCurrent).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("hides the sleep mode section and skips quota fetch when not owner", () => {
+    setRole("member");
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext()}
+        onContextUpdated={noop}
+      />,
+    );
+
+    expect(screen.queryByText("sleepModeTitle")).not.toBeInTheDocument();
+    expect(mockGetWorkspaceUsageCurrent).not.toHaveBeenCalled();
+  });
+});
+
+// ---------- wouldExceedSleepQuota derivation (4 branches) -------------------
+
+describe("SettingsTabPanel — wouldExceedSleepQuota derivation", () => {
+  it("shows sleepQuotaExceeded when current mode is skip AND used >= limit AND limit > 0", async () => {
+    setQuotaResponse(3, 3);
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext({ sleep_mode: "skip" })}
+        onContextUpdated={noop}
+      />,
+    );
+
+    // The error message renders once the quota fetch resolves.
+    await screen.findByText("sleepQuotaExceeded");
+    expect(screen.queryByText("sleepQuotaTierBlocked")).not.toBeInTheDocument();
+  });
+
+  it("shows sleepQuotaTierBlocked instead when limit === 0 (tier without sleep)", async () => {
+    setQuotaResponse(0, 0);
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext({ sleep_mode: "skip" })}
+        onContextUpdated={noop}
+      />,
+    );
+
+    await screen.findByText("sleepQuotaTierBlocked");
+    expect(screen.queryByText("sleepQuotaExceeded")).not.toBeInTheDocument();
+  });
+
+  it("renders neither blocked nor exceeded message when there is headroom (used < limit)", async () => {
+    setQuotaResponse(1, 3);
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext({ sleep_mode: "skip" })}
+        onContextUpdated={noop}
+      />,
+    );
+
+    // Wait for fetch to resolve so the usage line appears, then assert no
+    // blocked/exceeded text.
+    await screen.findByText(/sleepQuotaUsage:1\/3/);
+    expect(screen.queryByText("sleepQuotaExceeded")).not.toBeInTheDocument();
+    expect(screen.queryByText("sleepQuotaTierBlocked")).not.toBeInTheDocument();
+  });
+
+  it("does NOT block lateral changes when current mode is not skip even with used >= limit", async () => {
+    // sleep_mode = "full" (already counts toward the quota), used >= limit.
+    // A lateral change to edges_only doesn't increase the count, so the
+    // derivation must NOT flag this as exceeding.
+    setQuotaResponse(3, 3);
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext({ sleep_mode: "full" })}
+        onContextUpdated={noop}
+      />,
+    );
+
+    await screen.findByText(/sleepQuotaUsage:3\/3/);
+    expect(screen.queryByText("sleepQuotaExceeded")).not.toBeInTheDocument();
+    expect(screen.queryByText("sleepQuotaTierBlocked")).not.toBeInTheDocument();
+  });
+});
+
+// ---------- Sleep quota refetched after save --------------------------------
+
+describe("SettingsTabPanel — sleep quota refetched after save", () => {
+  it("refetches getWorkspaceUsageCurrent after updateContext resolves", async () => {
+    // Initial fetch returns 1/3 (headroom). Post-save fetch returns 0/3
+    // (a skip→full transition would free a slot). The two distinct values
+    // let us assert the second fetch landed.
+    mockGetWorkspaceUsageCurrent
+      .mockResolvedValueOnce({
+        plan: {} as never,
+        usage: {
+          memory_count: 0,
+          api_calls_today: 0,
+          api_calls_this_week: 0,
+          mcp_calls_today: 0,
+          mcp_calls_this_week: 0,
+          rest_calls_today: 0,
+          rest_calls_this_week: 0,
+          public_calls_today: 0,
+          public_calls_this_week: 0,
+          sleep_contexts: { used: 1, limit: 3, addon_bonus: 0, remaining: 2 },
+          workspaces: { used: 0, limit: 0, remaining: 0 },
+        },
+        memory_usage: {} as never,
+        daily_api_usage: {} as never,
+        weekly_api_usage: {} as never,
+      })
+      .mockResolvedValueOnce({
+        plan: {} as never,
+        usage: {
+          memory_count: 0,
+          api_calls_today: 0,
+          api_calls_this_week: 0,
+          mcp_calls_today: 0,
+          mcp_calls_this_week: 0,
+          rest_calls_today: 0,
+          rest_calls_this_week: 0,
+          public_calls_today: 0,
+          public_calls_this_week: 0,
+          sleep_contexts: { used: 0, limit: 3, addon_bonus: 0, remaining: 3 },
+          workspaces: { used: 0, limit: 0, remaining: 0 },
+        },
+        memory_usage: {} as never,
+        daily_api_usage: {} as never,
+        weekly_api_usage: {} as never,
+      });
+
+    mockUpdateContext.mockResolvedValue(undefined);
+    // getContext is called by refreshContext after a save. Return the
+    // same context so the post-save state is well-defined.
+    mockGetContext.mockResolvedValue(makeContext({ sleep_mode: "full" }));
+
+    const ctx = makeContext({ sleep_mode: "full" });
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={ctx}
+        onContextUpdated={noop}
+      />,
+    );
+
+    // Wait for initial quota fetch to land.
+    await waitFor(() => {
+      expect(mockGetWorkspaceUsageCurrent).toHaveBeenCalledTimes(1);
+    });
+
+    // Mark dirty by editing display name, then save. The component's save
+    // path triggers updateContext → refreshContext → second quota fetch.
+    const displayInput = screen.getByDisplayValue("Demo Context");
+    fireEvent.change(displayInput, { target: { value: "Renamed" } });
+
+    const saveButton = await screen.findByRole("button", {
+      name: /saveChanges/,
+    });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => {
+      expect(mockUpdateContext).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(mockGetWorkspaceUsageCurrent).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+// ---------- Privacy transition dialog ---------------------------------------
+
+describe("SettingsTabPanel — privacy transition dialog", () => {
+  it("opens makePrivateTitle dialog when toggling from shared → private", async () => {
+    // Initial: shared (is_private=false). The "makePrivate" button should
+    // open the AlertDialog instead of immediately changing state.
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext({ is_private: false })}
+        onContextUpdated={noop}
+      />,
+    );
+
+    expect(screen.queryByText("makePrivateTitle")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "makePrivate" }));
+    expect(await screen.findByText("makePrivateTitle")).toBeInTheDocument();
+    expect(screen.getByText("makePrivateWarning")).toBeInTheDocument();
+  });
+
+  it("does NOT open the dialog when toggling private → shared (one-way protection)", () => {
+    // Initial: private. Clicking makeShared just flips the state with no
+    // confirmation dialog — only the destructive direction is gated.
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext({ is_private: true })}
+        onContextUpdated={noop}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "makeShared" }));
+    expect(screen.queryByText("makePrivateTitle")).not.toBeInTheDocument();
+    // The button label flips to makePrivate after toggling to shared.
+    expect(
+      screen.getByRole("button", { name: "makePrivate" }),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------- resource_id input filter ----------------------------------------
+
+describe("SettingsTabPanel — resource_id input validation", () => {
+  it("filters keystrokes to lowercase + [a-z0-9_] only when typing in the resource_id input", async () => {
+    // resource_id input renders when:
+    //   - shared (is_private=false)
+    //   - not yet public (is_public=false)
+    //   - isOwner
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext({ is_private: false, is_public: false })}
+        onContextUpdated={noop}
+      />,
+    );
+
+    const input = (await screen.findByPlaceholderText(
+      "resourceIdPlaceholder",
+    )) as HTMLInputElement;
+
+    // Mixed case + hyphen + symbol + underscore + digits → only [a-z0-9_]
+    // survives, and uppercase is lowercased before filtering.
+    fireEvent.change(input, { target: { value: "ABC-def_123!" } });
+    expect(input.value).toBe("abcdef_123");
+  });
+});
+
+// ---------- Skip-mode confirmation dialog (#504) ----------------------------
+
+describe("SettingsTabPanel — skip-mode confirmation dialog", () => {
+  it("does not render the skip-mode dialog on mount", () => {
+    render(
+      <SettingsTabPanel
+        contextId={CTX_ID}
+        context={makeContext({ sleep_mode: "full" })}
+        onContextUpdated={noop}
+      />,
+    );
+    // The AlertDialog's title only enters the DOM when open=true. Radix
+    // Select cannot be triggered via fireEvent.click in happy-dom (see
+    // MCPConfigBlock.test.tsx for the canonical limitation note), so the
+    // open/confirm/cancel flow is not exercised end-to-end. This guards
+    // the "doesn't accidentally render" regression — which is the
+    // reachable side-channel without adding @testing-library/user-event.
+    expect(screen.queryByText("sleepModeSkipTitle")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/contexts/SettingsTabPanel.test.tsx
+++ b/frontend/src/components/contexts/SettingsTabPanel.test.tsx
@@ -111,13 +111,13 @@ function setRole(role: "owner" | "admin" | "member" | "viewer") {
   });
 }
 
-function setQuotaResponse(
+function buildQuotaResponse(
   used: number,
   limit: number,
   addon_bonus = 0,
   remaining = Math.max(0, limit - used),
 ) {
-  mockGetWorkspaceUsageCurrent.mockResolvedValue({
+  return {
     plan: {} as never,
     usage: {
       memory_count: 0,
@@ -135,7 +135,18 @@ function setQuotaResponse(
     memory_usage: {} as never,
     daily_api_usage: {} as never,
     weekly_api_usage: {} as never,
-  });
+  };
+}
+
+function setQuotaResponse(
+  used: number,
+  limit: number,
+  addon_bonus = 0,
+  remaining = Math.max(0, limit - used),
+) {
+  mockGetWorkspaceUsageCurrent.mockResolvedValue(
+    buildQuotaResponse(used, limit, addon_bonus, remaining),
+  );
 }
 
 const noop = () => {};
@@ -145,10 +156,6 @@ beforeEach(() => {
   // Default: owner with no quota constraint. Tests override as needed.
   setRole("owner");
   setQuotaResponse(0, 10);
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
 });
 
 // ---------- Sleep mode section visibility -----------------------------------
@@ -259,84 +266,34 @@ describe("SettingsTabPanel — wouldExceedSleepQuota derivation", () => {
 
 describe("SettingsTabPanel — sleep quota refetched after save", () => {
   it("refetches getWorkspaceUsageCurrent after updateContext resolves", async () => {
-    // Initial fetch returns 1/3 (headroom). Post-save fetch returns 0/3
-    // (a skip→full transition would free a slot). The two distinct values
-    // let us assert the second fetch landed.
+    // Initial fetch: 1/3. Post-save fetch: 0/3 (a skip→non-skip transition
+    // would free a slot). Two distinct values let us assert the second
+    // fetch fired without polling for both side effects.
     mockGetWorkspaceUsageCurrent
-      .mockResolvedValueOnce({
-        plan: {} as never,
-        usage: {
-          memory_count: 0,
-          api_calls_today: 0,
-          api_calls_this_week: 0,
-          mcp_calls_today: 0,
-          mcp_calls_this_week: 0,
-          rest_calls_today: 0,
-          rest_calls_this_week: 0,
-          public_calls_today: 0,
-          public_calls_this_week: 0,
-          sleep_contexts: { used: 1, limit: 3, addon_bonus: 0, remaining: 2 },
-          workspaces: { used: 0, limit: 0, remaining: 0 },
-        },
-        memory_usage: {} as never,
-        daily_api_usage: {} as never,
-        weekly_api_usage: {} as never,
-      })
-      .mockResolvedValueOnce({
-        plan: {} as never,
-        usage: {
-          memory_count: 0,
-          api_calls_today: 0,
-          api_calls_this_week: 0,
-          mcp_calls_today: 0,
-          mcp_calls_this_week: 0,
-          rest_calls_today: 0,
-          rest_calls_this_week: 0,
-          public_calls_today: 0,
-          public_calls_this_week: 0,
-          sleep_contexts: { used: 0, limit: 3, addon_bonus: 0, remaining: 3 },
-          workspaces: { used: 0, limit: 0, remaining: 0 },
-        },
-        memory_usage: {} as never,
-        daily_api_usage: {} as never,
-        weekly_api_usage: {} as never,
-      });
-
+      .mockResolvedValueOnce(buildQuotaResponse(1, 3))
+      .mockResolvedValueOnce(buildQuotaResponse(0, 3));
     mockUpdateContext.mockResolvedValue(undefined);
-    // getContext is called by refreshContext after a save. Return the
-    // same context so the post-save state is well-defined.
     mockGetContext.mockResolvedValue(makeContext({ sleep_mode: "full" }));
 
-    const ctx = makeContext({ sleep_mode: "full" });
     render(
       <SettingsTabPanel
         contextId={CTX_ID}
-        context={ctx}
+        context={makeContext({ sleep_mode: "full" })}
         onContextUpdated={noop}
       />,
     );
 
-    // Wait for initial quota fetch to land.
-    await waitFor(() => {
-      expect(mockGetWorkspaceUsageCurrent).toHaveBeenCalledTimes(1);
+    // Mark dirty, then save. The save path is updateContext → refreshContext
+    // → second quota fetch — the second-fetch assertion subsumes the first.
+    fireEvent.change(screen.getByDisplayValue("Demo Context"), {
+      target: { value: "Renamed" },
     });
+    fireEvent.click(await screen.findByRole("button", { name: /saveChanges/ }));
 
-    // Mark dirty by editing display name, then save. The component's save
-    // path triggers updateContext → refreshContext → second quota fetch.
-    const displayInput = screen.getByDisplayValue("Demo Context");
-    fireEvent.change(displayInput, { target: { value: "Renamed" } });
-
-    const saveButton = await screen.findByRole("button", {
-      name: /saveChanges/,
-    });
-    fireEvent.click(saveButton);
-
-    await waitFor(() => {
-      expect(mockUpdateContext).toHaveBeenCalledTimes(1);
-    });
     await waitFor(() => {
       expect(mockGetWorkspaceUsageCurrent).toHaveBeenCalledTimes(2);
     });
+    expect(mockUpdateContext).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/src/components/dashboard/UsageStats.test.tsx
+++ b/frontend/src/components/dashboard/UsageStats.test.tsx
@@ -18,8 +18,8 @@
  * check), without depending on layout.
  */
 
-import { render, screen, waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { UsageStats } from "./UsageStats";
 import type {

--- a/frontend/src/components/dashboard/UsageStats.test.tsx
+++ b/frontend/src/components/dashboard/UsageStats.test.tsx
@@ -1,0 +1,392 @@
+/**
+ * Tests for UsageStats (Issue #571).
+ *
+ * Covers the gate1 scope:
+ *   - Sleep-enabled contexts card is rendered iff usage.sleep_contexts !== null
+ *   - Progress value clamps at 100% when used / limit > 1 (visible via the
+ *     rendered progress aria-valuenow, since used/limit text is also shown
+ *     verbatim and the clamping is a separate calculation)
+ *   - "sleepContextsWithAddon" text only shown when limit > 0 && addon > 0;
+ *     "sleepContextsTier" otherwise (defense-in-depth gate from #560 loop 8)
+ *   - Memory / API Calls Today / API Calls This Week cards render numbers
+ *   - Loading state, error state
+ *
+ * Recharts ResponsiveContainer needs DOM dimensions to render. Happy-dom
+ * reports zero-sized parents, which would normally suppress chart children
+ * silently. We mock the recharts surface to a pass-through so the trend
+ * card itself renders (and its chart container is testable as a presence
+ * check), without depending on layout.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UsageStats } from "./UsageStats";
+import type {
+  PlanLimits,
+  CurrentUsage,
+  UsageCurrentResponse,
+} from "@/lib/api/usage";
+
+// ---------- Mocks ------------------------------------------------------------
+
+const mockGetWorkspaceUsageCurrent = vi.fn();
+const mockGetWorkspaceUsageHistory = vi.fn();
+const mockGetWorkspaceUsageBreakdown = vi.fn();
+vi.mock("@/lib/api/workspaces", () => ({
+  getWorkspaceUsageCurrent: (...a: unknown[]) =>
+    mockGetWorkspaceUsageCurrent(...a),
+  getWorkspaceUsageHistory: (...a: unknown[]) =>
+    mockGetWorkspaceUsageHistory(...a),
+  getWorkspaceUsageBreakdown: (...a: unknown[]) =>
+    mockGetWorkspaceUsageBreakdown(...a),
+}));
+
+const mockApiClientGet = vi.fn();
+vi.mock("@/lib/api", () => ({
+  apiClient: { get: (...a: unknown[]) => mockApiClientGet(...a) },
+}));
+
+const stableT = (key: string, vars?: Record<string, unknown>) => {
+  if (!vars) return key;
+  if ("percent" in vars) return `${key}:${vars.percent}%`;
+  if ("addon" in vars) return `${key}:+${vars.addon}`;
+  if ("count" in vars) return `${key}:${vars.count}`;
+  return key;
+};
+vi.mock("next-intl", () => ({
+  useTranslations: (_ns: string) => stableT,
+  useLocale: () => "en",
+}));
+
+vi.mock("@/contexts/MemoryContextContext", () => ({
+  useMemoryContext: () => ({ contextId: "ctx-1" }),
+}));
+
+const mockUseWorkspace = vi.fn();
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => ({ user: { id: "user-1", timezone: "UTC" } }),
+}));
+
+vi.mock("@/lib/utils/datetime", () => ({
+  formatDate: (d: string) => d,
+}));
+
+// QuotaWarning renders its own conditional UI based on quota; stub it out
+// so the unit under test is the rest of UsageStats, not the warning banner.
+vi.mock("@/components/common/QuotaWarning", () => ({
+  QuotaWarning: () => null,
+}));
+
+// Recharts pass-through. ResponsiveContainer would otherwise depend on layout
+// dimensions that happy-dom can't compute.
+vi.mock("recharts", () => {
+  const PassThrough = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="recharts-stub">{children}</div>
+  );
+  const Empty = () => null;
+  return {
+    LineChart: PassThrough,
+    Line: Empty,
+    ResponsiveContainer: PassThrough,
+    Tooltip: Empty,
+    XAxis: Empty,
+    YAxis: Empty,
+    CartesianGrid: Empty,
+  };
+});
+
+// ---------- Helpers ----------------------------------------------------------
+
+function makePlan(overrides: Partial<PlanLimits> = {}): PlanLimits {
+  return {
+    plan_name: "free",
+    memory_limit: 1000,
+    daily_total_limit: 100,
+    weekly_total_limit: 500,
+    mcp_calls_per_day: 50,
+    mcp_calls_per_week: 250,
+    rest_calls_per_day: 40,
+    rest_calls_per_week: 200,
+    public_calls_per_day: 10,
+    public_calls_per_week: 50,
+    ...overrides,
+  };
+}
+
+function makeUsage(overrides: Partial<CurrentUsage> = {}): CurrentUsage {
+  return {
+    memory_count: 42,
+    api_calls_today: 17,
+    api_calls_this_week: 89,
+    mcp_calls_today: 7,
+    mcp_calls_this_week: 30,
+    rest_calls_today: 8,
+    rest_calls_this_week: 40,
+    public_calls_today: 2,
+    public_calls_this_week: 19,
+    sleep_contexts: null,
+    // Distinct from common sleep_contexts test ratios so getByText
+    // matchers on "1 / 3" or "5 / 2" don't accidentally hit the
+    // workspaces card too.
+    workspaces: { used: 4, limit: 8, remaining: 4 },
+    ...overrides,
+  };
+}
+
+function makeCurrentResponse(
+  overrides: Partial<UsageCurrentResponse> = {},
+): UsageCurrentResponse {
+  return {
+    plan: makePlan(),
+    usage: makeUsage(),
+    memory_usage: {
+      current: 42,
+      limit: 1000,
+      percentage: 4.2,
+      is_warning: false,
+      is_critical: false,
+      is_exceeded: false,
+    },
+    daily_api_usage: {
+      current: 17,
+      limit: 100,
+      percentage: 17,
+      is_warning: false,
+      is_critical: false,
+      is_exceeded: false,
+    },
+    weekly_api_usage: {
+      current: 89,
+      limit: 500,
+      percentage: 17.8,
+      is_warning: false,
+      is_critical: false,
+      is_exceeded: false,
+    },
+    ...overrides,
+  };
+}
+
+const HISTORY_OK = {
+  daily_stats: [{ date: "2026-05-10", count: 5 }],
+  total_requests: 5,
+  period_start: "2026-05-10T00:00:00Z",
+  period_end: "2026-05-17T00:00:00Z",
+};
+
+const BREAKDOWN_OK = {
+  by_endpoint: [
+    { endpoint: "/api/v1/memory/recall", count: 30, percentage: 60 },
+    { endpoint: "/api/v1/memory/remember", count: 20, percentage: 40 },
+  ],
+  total_requests: 50,
+  period_days: 30,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseWorkspace.mockReturnValue({ currentWorkspaceId: "ws-1" });
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------- Sleep-enabled contexts card -------------------------------------
+
+describe("UsageStats — sleep-enabled contexts card", () => {
+  it("does NOT render the sleep_contexts card when usage.sleep_contexts is null", async () => {
+    mockGetWorkspaceUsageCurrent.mockResolvedValue(
+      makeCurrentResponse({ usage: makeUsage({ sleep_contexts: null }) }),
+    );
+    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
+
+    render(<UsageStats scope="workspace" />);
+
+    // Wait for the dashboard body to land (memories card is always present).
+    await screen.findByText("memories");
+    expect(screen.queryByText("sleepEnabledContexts")).not.toBeInTheDocument();
+  });
+
+  it("renders the sleep_contexts card when sleep_contexts has values", async () => {
+    mockGetWorkspaceUsageCurrent.mockResolvedValue(
+      makeCurrentResponse({
+        usage: makeUsage({
+          sleep_contexts: { used: 1, limit: 3, addon_bonus: 0, remaining: 2 },
+        }),
+      }),
+    );
+    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
+
+    render(<UsageStats scope="workspace" />);
+
+    await screen.findByText("sleepEnabledContexts");
+    // "1 / 3" rendered. Use a function matcher because the text spans
+    // multiple spans (number, slash, number).
+    expect(
+      screen.getByText((_content, node) => node?.textContent === "1 / 3"),
+    ).toBeInTheDocument();
+  });
+
+  it("clamps the progress value at 100% when used / limit > 1", async () => {
+    mockGetWorkspaceUsageCurrent.mockResolvedValue(
+      makeCurrentResponse({
+        usage: makeUsage({
+          sleep_contexts: { used: 5, limit: 2, addon_bonus: 0, remaining: 0 },
+        }),
+      }),
+    );
+    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
+
+    render(<UsageStats scope="workspace" />);
+
+    // The local shadcn Progress (src/components/ui/progress.tsx) does not
+    // expose role="progressbar"; it renders the percentage as an inline
+    // `transform: translateX(-X%)` on an inner div with bg-brand-green-600.
+    // Without the clamp, used=5/limit=2 would compute 250 → transform
+    // would be translateX(150%) (off-screen positive). With the clamp,
+    // the indicator settles at translateX(-0%).
+    const title = await screen.findByText("sleepEnabledContexts");
+    // shadcn Card uses `rounded-xl` (src/components/ui/card.tsx). The CardTitle
+    // is two ancestors down: Card → CardHeader → CardTitle.
+    const card = title.closest("div.rounded-xl");
+    expect(card).not.toBeNull();
+    const indicator = card!.querySelector("[class*='bg-brand-green-600']");
+    expect(indicator).not.toBeNull();
+    const transform = (indicator as HTMLElement).style.transform;
+    // Clamped: translateX(-0%) (the "100 - 100" residual). The earlier
+    // un-clamped path would yield a positive translateX, which we
+    // explicitly reject.
+    expect(transform).toBe("translateX(-0%)");
+    expect(transform).not.toMatch(/translateX\((?!-0).+/);
+  });
+
+  it("shows sleepContextsWithAddon ONLY when limit > 0 AND addon_bonus > 0", async () => {
+    mockGetWorkspaceUsageCurrent.mockResolvedValue(
+      makeCurrentResponse({
+        usage: makeUsage({
+          sleep_contexts: { used: 1, limit: 5, addon_bonus: 2, remaining: 4 },
+        }),
+      }),
+    );
+    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
+
+    render(<UsageStats scope="workspace" />);
+
+    await screen.findByText("sleepContextsWithAddon:+2");
+    expect(screen.queryByText("sleepContextsTier")).not.toBeInTheDocument();
+  });
+
+  it("shows sleepContextsTier when limit > 0 but addon_bonus === 0", async () => {
+    mockGetWorkspaceUsageCurrent.mockResolvedValue(
+      makeCurrentResponse({
+        usage: makeUsage({
+          sleep_contexts: { used: 1, limit: 5, addon_bonus: 0, remaining: 4 },
+        }),
+      }),
+    );
+    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
+
+    render(<UsageStats scope="workspace" />);
+
+    await screen.findByText("sleepContextsTier");
+    expect(
+      screen.queryByText(/sleepContextsWithAddon/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows sleepContextsTier (NOT the addon text) when limit === 0 even if addon_bonus > 0", async () => {
+    // Defense-in-depth gate from #560 loop 8: backend normalizes
+    // addon_bonus to 0 for zero-base tiers, but the explicit
+    // `limit > 0` guard means the card still falls back to the tier
+    // text even if a future regression leaks a non-zero addon.
+    mockGetWorkspaceUsageCurrent.mockResolvedValue(
+      makeCurrentResponse({
+        usage: makeUsage({
+          sleep_contexts: { used: 0, limit: 0, addon_bonus: 2, remaining: 0 },
+        }),
+      }),
+    );
+    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
+
+    render(<UsageStats scope="workspace" />);
+
+    await screen.findByText("sleepContextsTier");
+    expect(
+      screen.queryByText(/sleepContextsWithAddon/),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// ---------- Memory / API Today / API This Week cards ------------------------
+
+describe("UsageStats — primary usage cards", () => {
+  it("renders Memory / API Today / API This Week cards with the right numbers", async () => {
+    mockGetWorkspaceUsageCurrent.mockResolvedValue(makeCurrentResponse());
+    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
+
+    render(<UsageStats scope="workspace" />);
+
+    // Card titles
+    await screen.findByText("memories");
+    expect(screen.getByText("apiCallsToday")).toBeInTheDocument();
+    expect(screen.getByText("apiCallsThisWeek")).toBeInTheDocument();
+
+    // The values render as separate spans split by "/". Use textContent
+    // matchers so we assert the combined "42 / 1000" form.
+    expect(
+      screen.getByText((_c, node) => node?.textContent === "42 / 1000"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((_c, node) => node?.textContent === "17 / 100"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText((_c, node) => node?.textContent === "89 / 500"),
+    ).toBeInTheDocument();
+  });
+});
+
+// ---------- Loading and error states ----------------------------------------
+
+describe("UsageStats — loading and error states", () => {
+  it("renders loading skeletons while the first fetch is in flight", () => {
+    // Resolve never within the test — the loading branch holds until then.
+    mockGetWorkspaceUsageCurrent.mockReturnValue(new Promise(() => {}));
+    mockGetWorkspaceUsageHistory.mockReturnValue(new Promise(() => {}));
+    mockGetWorkspaceUsageBreakdown.mockReturnValue(new Promise(() => {}));
+
+    render(<UsageStats scope="workspace" />);
+
+    // The loading branch renders 3 animate-pulse blocks. We don't depend on
+    // the exact count — just that the dashboard cards have NOT rendered.
+    expect(screen.queryByText("memories")).not.toBeInTheDocument();
+    expect(screen.queryByText("apiCallsToday")).not.toBeInTheDocument();
+    // And nothing crashed.
+  });
+
+  it("renders the error Alert when the current-usage fetch rejects", async () => {
+    mockGetWorkspaceUsageCurrent.mockRejectedValue(new Error("boom"));
+    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
+
+    render(<UsageStats scope="workspace" />);
+
+    // Error message from the rejected promise lands in the Alert body.
+    // The component prefers err.message over the fallback "failedToLoad" key.
+    await screen.findByText("boom");
+    // Dashboard cards must not render after error.
+    expect(screen.queryByText("memories")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/dashboard/UsageStats.test.tsx
+++ b/frontend/src/components/dashboard/UsageStats.test.tsx
@@ -42,16 +42,12 @@ vi.mock("@/lib/api/workspaces", () => ({
     mockGetWorkspaceUsageBreakdown(...a),
 }));
 
-const mockApiClientGet = vi.fn();
-vi.mock("@/lib/api", () => ({
-  apiClient: { get: (...a: unknown[]) => mockApiClientGet(...a) },
-}));
-
+// Translator returns the key plus any `addon` var that this test file
+// asserts on. Other interpolations fall through to the bare key — the
+// tests query by stable key text rather than rendered numbers, so
+// `count`/`percent` branches would never be exercised.
 const stableT = (key: string, vars?: Record<string, unknown>) => {
-  if (!vars) return key;
-  if ("percent" in vars) return `${key}:${vars.percent}%`;
-  if ("addon" in vars) return `${key}:+${vars.addon}`;
-  if ("count" in vars) return `${key}:${vars.count}`;
+  if (vars && "addon" in vars) return `${key}:+${vars.addon}`;
   return key;
 };
 vi.mock("next-intl", () => ({
@@ -70,10 +66,6 @@ vi.mock("@/contexts/WorkspaceContext", () => ({
 
 vi.mock("@/contexts/AuthContext", () => ({
   useAuth: () => ({ user: { id: "user-1", timezone: "UTC" } }),
-}));
-
-vi.mock("@/lib/utils/datetime", () => ({
-  formatDate: (d: string) => d,
 }));
 
 // QuotaWarning renders its own conditional UI based on quota; stub it out
@@ -191,10 +183,10 @@ const BREAKDOWN_OK = {
 beforeEach(() => {
   vi.clearAllMocks();
   mockUseWorkspace.mockReturnValue({ currentWorkspaceId: "ws-1" });
-});
-
-afterEach(() => {
-  vi.clearAllMocks();
+  // History/Breakdown are stable across all tests in this file — only
+  // the current-usage shape varies per case.
+  mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
+  mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
 });
 
 // ---------- Sleep-enabled contexts card -------------------------------------
@@ -204,9 +196,6 @@ describe("UsageStats — sleep-enabled contexts card", () => {
     mockGetWorkspaceUsageCurrent.mockResolvedValue(
       makeCurrentResponse({ usage: makeUsage({ sleep_contexts: null }) }),
     );
-    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
-    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
-
     render(<UsageStats scope="workspace" />);
 
     // Wait for the dashboard body to land (memories card is always present).
@@ -222,9 +211,6 @@ describe("UsageStats — sleep-enabled contexts card", () => {
         }),
       }),
     );
-    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
-    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
-
     render(<UsageStats scope="workspace" />);
 
     await screen.findByText("sleepEnabledContexts");
@@ -243,30 +229,28 @@ describe("UsageStats — sleep-enabled contexts card", () => {
         }),
       }),
     );
-    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
-    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
-
     render(<UsageStats scope="workspace" />);
 
-    // The local shadcn Progress (src/components/ui/progress.tsx) does not
-    // expose role="progressbar"; it renders the percentage as an inline
-    // `transform: translateX(-X%)` on an inner div with bg-brand-green-600.
-    // Without the clamp, used=5/limit=2 would compute 250 → transform
-    // would be translateX(150%) (off-screen positive). With the clamp,
-    // the indicator settles at translateX(-0%).
+    // The local shadcn Progress (src/components/ui/progress.tsx) renders
+    // the percentage as `transform: translateX(-${100-pct}%)` on an
+    // inner div with bg-brand-green-600 — there is no role="progressbar".
+    // Without the clamp, used=5/limit=2 would compute 250%, leaving the
+    // residual at -150 (an off-screen positive translate). The clamp
+    // must drive the residual to 0 regardless of sign convention.
     const title = await screen.findByText("sleepEnabledContexts");
-    // shadcn Card uses `rounded-xl` (src/components/ui/card.tsx). The CardTitle
-    // is two ancestors down: Card → CardHeader → CardTitle.
     const card = title.closest("div.rounded-xl");
-    expect(card).not.toBeNull();
-    const indicator = card!.querySelector("[class*='bg-brand-green-600']");
-    expect(indicator).not.toBeNull();
-    const transform = (indicator as HTMLElement).style.transform;
-    // Clamped: translateX(-0%) (the "100 - 100" residual). The earlier
-    // un-clamped path would yield a positive translateX, which we
-    // explicitly reject.
-    expect(transform).toBe("translateX(-0%)");
-    expect(transform).not.toMatch(/translateX\((?!-0).+/);
+    const indicator = card?.querySelector<HTMLElement>(
+      "[class*='bg-brand-green-600']",
+    );
+    expect(indicator).toBeTruthy();
+    const match = indicator!.style.transform.match(
+      /translateX\((-?\d+(?:\.\d+)?)%\)/,
+    );
+    expect(match).not.toBeNull();
+    // Math.abs normalizes the `Object.is(-0, +0) === false` quirk —
+    // the assertion is that the clamp drove the residual to zero,
+    // regardless of which sign convention the transform emits.
+    expect(Math.abs(Number(match![1]))).toBe(0);
   });
 
   it("shows sleepContextsWithAddon ONLY when limit > 0 AND addon_bonus > 0", async () => {
@@ -277,9 +261,6 @@ describe("UsageStats — sleep-enabled contexts card", () => {
         }),
       }),
     );
-    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
-    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
-
     render(<UsageStats scope="workspace" />);
 
     await screen.findByText("sleepContextsWithAddon:+2");
@@ -294,9 +275,6 @@ describe("UsageStats — sleep-enabled contexts card", () => {
         }),
       }),
     );
-    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
-    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
-
     render(<UsageStats scope="workspace" />);
 
     await screen.findByText("sleepContextsTier");
@@ -317,9 +295,6 @@ describe("UsageStats — sleep-enabled contexts card", () => {
         }),
       }),
     );
-    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
-    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
-
     render(<UsageStats scope="workspace" />);
 
     await screen.findByText("sleepContextsTier");
@@ -334,9 +309,6 @@ describe("UsageStats — sleep-enabled contexts card", () => {
 describe("UsageStats — primary usage cards", () => {
   it("renders Memory / API Today / API This Week cards with the right numbers", async () => {
     mockGetWorkspaceUsageCurrent.mockResolvedValue(makeCurrentResponse());
-    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
-    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
-
     render(<UsageStats scope="workspace" />);
 
     // Card titles
@@ -361,26 +333,33 @@ describe("UsageStats — primary usage cards", () => {
 // ---------- Loading and error states ----------------------------------------
 
 describe("UsageStats — loading and error states", () => {
-  it("renders loading skeletons while the first fetch is in flight", () => {
-    // Resolve never within the test — the loading branch holds until then.
-    mockGetWorkspaceUsageCurrent.mockReturnValue(new Promise(() => {}));
-    mockGetWorkspaceUsageHistory.mockReturnValue(new Promise(() => {}));
-    mockGetWorkspaceUsageBreakdown.mockReturnValue(new Promise(() => {}));
+  it("renders loading skeletons while the first fetch is in flight", async () => {
+    // Hold the current-usage fetch with a deferred promise so the loading
+    // branch is observable, then resolve before the test exits — leaving an
+    // unresolved `new Promise(() => {})` would retain worker references and
+    // contribute to vmForks teardown timeouts (memory `1961cb46`).
+    let resolveCurrent: (v: UsageCurrentResponse) => void = () => {};
+    mockGetWorkspaceUsageCurrent.mockReturnValueOnce(
+      new Promise<UsageCurrentResponse>((r) => {
+        resolveCurrent = r;
+      }),
+    );
 
     render(<UsageStats scope="workspace" />);
 
-    // The loading branch renders 3 animate-pulse blocks. We don't depend on
-    // the exact count — just that the dashboard cards have NOT rendered.
+    // Dashboard cards must NOT have rendered while the fetch is in flight.
     expect(screen.queryByText("memories")).not.toBeInTheDocument();
     expect(screen.queryByText("apiCallsToday")).not.toBeInTheDocument();
-    // And nothing crashed.
+    // Skeleton block present (component uses animate-pulse).
+    expect(document.querySelector("[class*='animate-pulse']")).not.toBeNull();
+
+    // Flush so the worker can clean up.
+    resolveCurrent(makeCurrentResponse());
+    await screen.findByText("memories");
   });
 
   it("renders the error Alert when the current-usage fetch rejects", async () => {
     mockGetWorkspaceUsageCurrent.mockRejectedValue(new Error("boom"));
-    mockGetWorkspaceUsageHistory.mockResolvedValue(HISTORY_OK);
-    mockGetWorkspaceUsageBreakdown.mockResolvedValue(BREAKDOWN_OK);
-
     render(<UsageStats scope="workspace" />);
 
     // Error message from the rejected promise lands in the Alert body.


### PR DESCRIPTION
Closes #571

## Summary
- Adds the two test files that were flagged as outstanding follow-ups at PR #557 merge and that compounded with #560 (PR #568): SettingsTabPanel.tsx and UsageStats.tsx had accumulated branching logic across recent PRs without corresponding tests.
- 20 test cases total (11 SettingsTabPanel + 9 UsageStats) covering owner-gated sleep mode, wouldExceedSleepQuota derivation across 4 branches, post-save quota refetch, privacy transition dialog, resource_id input filter, and sleep_contexts card conditional rendering / progress clamp / addon-vs-tier text branching / loading-and-error states.
- Mutation-style verification (3 mutations) confirmed each broke the corresponding test pre-simplify; 5x consecutive runs of the new files passed without any worker-termination flake.
- Zero production code changes — pure test addition. `git diff -- '*.tsx' ':!*.test.tsx'` returns 0 lines.

## Implementation notes
- Radix Select cannot be triggered via `fireEvent.click` in happy-dom (canonical limitation documented in `MCPConfigBlock.test.tsx:128-135`). Tests assert the **visible contract** (rendered error message branches `sleepQuotaTierBlocked` / `sleepQuotaExceeded`) instead of opening the Radix Select. `@testing-library/user-event` was intentionally NOT introduced, mirroring the established codebase precedent.
- The loading-state test uses a **deferred-resolve pattern** (`let resolveFn; new Promise(r => { resolveFn = r })` + flush before unmount) instead of `new Promise(() => {})` — the latter retains worker references and contributes to the pre-existing Vitest 4 worker-termination flake (memory `1961cb46` / PR #568).
- The local shadcn `Progress` component (`src/components/ui/progress.tsx`) does NOT expose `role="progressbar"`. The clamp test asserts via inline `transform: translateX(-X%)` style on the indicator div, with `Math.abs(Number(match![1])) === 0` to normalize the `Object.is(-0, +0) === false` quirk.
- During mutation testing it was discovered that shadcn `Progress` ALSO clamps internally (`progress.tsx:17`) — both layers must fail for the visible output to break. The test asserts the right invariant (visible contract), not the redundant outer clamp.
- Recharts is mocked as pass-through stubs (LineChart / ResponsiveContainer render children; Line / Tooltip / axes return null) because happy-dom can't compute layout dimensions. Kept file-local — first occurrence, simplify discipline says don't promote to a shared util until 2nd occurrence demands it.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (routed to QA Lead)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/571-feat-test-frontend-settingstabpanel-usagestat.gate1.md
- ~/.claude/cache/gh-issue-driven/571-feat-test-frontend-settingstabpanel-usagestat.gate2.md

## Test plan
- [x] `npx vitest run src/components/contexts/SettingsTabPanel.test.tsx src/components/dashboard/UsageStats.test.tsx` → 20/20 pass
- [x] 5x consecutive runs of the new files → all clean, no worker-termination
- [x] 3 mutation-style verifications broke the right tests pre-simplify
- [x] `make lint` (backend ruff) → clean
- [x] `make type-check` (pyright) → 0 errors
- [x] Frontend TypeScript portion of `npm run build` → clean (Next.js build worker SIGTRAP is environmental / unrelated to test files per memory `session_20260513_deploy`)

🤖 Generated via /gh-issue-driven:ship
