### PR TITLE
fix(api): shared-context recall pays source workspace (#708)

### DIFF
--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -263,6 +263,17 @@ async def handle_recall(
                 # Option A paid_by routing has a single source-of-truth
                 # workspace. Check inline so a mismatch short-circuits
                 # before paying further permission lookups.
+                #
+                # #708 loop 6 (Copilot): also reject MIXED privacy across
+                # the list. ``SearchService`` derives a single
+                # ``is_shared_context`` value from the primary and applies
+                # it to every context's Qdrant filter. If primary is
+                # shared and a secondary is private (which the handler
+                # permits when the caller is that private context's
+                # creator / ContextMember), dropping the ``user_id`` filter
+                # would leak memories authored by other users in the
+                # private secondary. Rejecting at API boundary mirrors
+                # the same-embedding-model invariant pattern below.
                 for cid in cross_context_ids[1:]:
                     cross_ctx = await _resolve_context_for_read(db, user_id, cid)
                     if cross_ctx.workspace_id != current_context.workspace_id:
@@ -270,6 +281,12 @@ async def handle_recall(
                             "workspace_mismatch",
                             "All contexts in cross-context recall must belong to "
                             "the same workspace.",
+                        )
+                    if cross_ctx.is_private != current_context.is_private:
+                        return _error_response(
+                            "context_privacy_mismatch",
+                            "All contexts in cross-context recall must share the "
+                            "same privacy setting (all shared or all private).",
                         )
 
                 # Validate all contexts use the same embedding model

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -18,10 +18,12 @@ from mcp_server.tools._helpers import (
     _error_response,
     _log_tool_usage,
     _resolve_context,
+    _resolve_context_for_read,
     _resolve_context_id,
     _validate_memory_id,
     execute_with_timeout,
 )
+from utils.exceptions import NotFoundException
 
 logger = logging.getLogger(__name__)
 
@@ -241,19 +243,34 @@ async def handle_recall(
 
     start_time = time.time()
     async for db in get_db():
+        # Bind defensively so the NotFoundException handler below can
+        # always reference a concrete context_id. In normal flow this is
+        # re-bound at lines below before any path that raises.
+        current_context_id: UUID | None = None
         try:
             # Issue #81: Cross-context recall — context_ids overrides context_id
             context_ids_arg = args.get("context_ids")
             cross_context_ids: list[UUID] | None = None
 
             if isinstance(context_ids_arg, list) and context_ids_arg:
-                # Multi-context mode
+                # Multi-context mode. Use _resolve_context_for_read so deny
+                # reasons (private non-creator, not a workspace member, etc.)
+                # surface as a uniform context_not_found (CWE-639 / OWASP A01).
                 cross_context_ids = [_resolve_context_id(cid) for cid in context_ids_arg]
                 current_context_id = cross_context_ids[0]
-                # Validate access to all contexts, keep primary context object
-                current_context = await _resolve_context(db, user_id, current_context_id)
+                current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+                # #708 H3: all contexts must belong to the same workspace —
+                # Option A paid_by routing has a single source-of-truth
+                # workspace. Check inline so a mismatch short-circuits
+                # before paying further permission lookups.
                 for cid in cross_context_ids[1:]:
-                    await _resolve_context(db, user_id, cid)
+                    cross_ctx = await _resolve_context_for_read(db, user_id, cid)
+                    if cross_ctx.workspace_id != current_context.workspace_id:
+                        return _error_response(
+                            "workspace_mismatch",
+                            "All contexts in cross-context recall must belong to "
+                            "the same workspace.",
+                        )
 
                 # Validate all contexts use the same embedding model
                 from repositories.config_repository import ContextSearchConfigRepository
@@ -277,7 +294,7 @@ async def handle_recall(
                         "Missing required field: context_id (or provide context_ids with 2+ UUIDs).",
                     )
                 current_context_id = _resolve_context_id(args["context_id"])
-                current_context = await _resolve_context(db, user_id, current_context_id)
+                current_context = await _resolve_context_for_read(db, user_id, current_context_id)
 
             service = MemoryService(db)
             result = await execute_with_timeout(
@@ -286,6 +303,8 @@ async def handle_recall(
                     user_id=user_id,
                     current_context_id=current_context_id,
                     current_workspace_id=workspace_id,
+                    # #708 Option A: source workspace pays for shared-context reads.
+                    context_workspace_id=current_context.workspace_id,
                     context_ids=cross_context_ids,
                 ),
                 operation_name="recall",
@@ -338,6 +357,31 @@ async def handle_recall(
         except _ContextNotFoundError as e:
             await db.rollback()
             return e.to_response()
+        except NotFoundException:
+            # #708 H2: service raises NotFoundException("Context", ...) for
+            # shared-context reads that cannot proceed (e.g. source has no
+            # BYOK). Re-cast through _ContextNotFoundError so the response
+            # body is byte-identical to a regular deny — callers cannot
+            # distinguish "source missing BYOK" from "context does not
+            # exist for you" (CWE-639 / OWASP A01).
+            await db.rollback()
+            await _log_tool_usage(
+                db, user_id, "recall", start_time, 404, current_context_id, workspace_id
+            )
+            if current_context_id is None:
+                # Unreachable in practice — current_context_id is bound
+                # before any path that can raise NotFoundException — but
+                # static analysis cannot prove the invariant.
+                return _error_response(
+                    "context_not_found",
+                    "Context not found or you don't have access to it.",
+                    context_id=args.get("context_id"),
+                    help="Use list_contexts() to see contexts you have access to.",
+                )
+            return _ContextNotFoundError(
+                current_context_id,
+                "Context not found or you don't have access to it.",
+            ).to_response()
         except Exception:
             await db.rollback()
             await _log_tool_usage(
@@ -438,7 +482,10 @@ async def handle_reference(
     async for db in get_db():
         try:
             current_context_id = _resolve_context_id(args["context_id"])
-            await _resolve_context(db, user_id, current_context_id)
+            # Issue #708 bundle: migrate read paths to the CWE-639-uniform
+            # resolver so deny reasons (private non-creator, not a workspace
+            # member, etc.) cannot be distinguished by callers.
+            await _resolve_context_for_read(db, user_id, current_context_id)
 
             service = MemoryService(db)
             try:
@@ -446,16 +493,12 @@ async def handle_reference(
                     service.reference(request.memory_id, user_id=user_id),
                     operation_name="reference",
                 )
-            except Exception as e:
-                from utils.exceptions import NotFoundException
-
-                if isinstance(e, NotFoundException):
-                    return _error_response(
-                        "memory_not_found",
-                        f"Memory not found or you don't have access: {request.memory_id}",
-                        help="Use recall() to find memories you have access to.",
-                    )
-                raise
+            except NotFoundException:
+                return _error_response(
+                    "memory_not_found",
+                    f"Memory not found or you don't have access: {request.memory_id}",
+                    help="Use recall() to find memories you have access to.",
+                )
 
             reference_data = {
                 "memory_id": str(result.memory_id),

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -84,6 +84,7 @@ class EmbeddingService:
         user_id: str,
         context_id: str | None = None,
         workspace_id: str | None = None,  # Issue #146
+        disallow_env_fallback: bool = False,
     ) -> str:
         """Resolve the OpenAI API key for the calling user's workspace context.
 
@@ -104,12 +105,19 @@ class EmbeddingService:
             context_id: Optional context UUID (#82: context-scoped keys take priority).
             workspace_id: Workspace UUID (#146); when omitted the DB lookup is skipped
                 and only the env-var fallback can satisfy the request.
+            disallow_env_fallback: Issue #708 loop 7. When True, skip the
+                ``OPENAI_API_KEY`` env-var fallback at priority 3 and raise
+                ``ConfigurationError`` instead. Set by the Option A shared-context
+                read path so a TOCTOU race between the preflight ``has_byok_key``
+                probe and this resolution cannot silently route to the uncapped
+                platform key. Has no effect when a DB key is found.
 
         Returns:
             Decrypted OpenAI API key.
 
         Raises:
-            ConfigurationError: If neither a DB key nor an env var is available.
+            ConfigurationError: If neither a DB key nor an env var is available
+                (or when ``disallow_env_fallback`` is True and no DB key was found).
         """
         from uuid import UUID
 
@@ -155,14 +163,27 @@ class EmbeddingService:
             )
             return api_key
 
-        # Fallback to environment variable (development / env-only deployments).
-        env_key = os.getenv("OPENAI_API_KEY")
-        if env_key:
-            logger.debug(
-                "openai_api_key_from_env",
+        # Fallback to environment variable (development / env-only deployments),
+        # gated by the Option A shared-context contract: when the caller has
+        # explicitly required a BYOK key (disallow_env_fallback=True), do NOT
+        # silently route to the platform key — that would defeat PR #711's
+        # BYOK-only spend cap and bypass the H1 preflight guard via TOCTOU.
+        if not disallow_env_fallback:
+            env_key = os.getenv("OPENAI_API_KEY")
+            if env_key:
+                logger.debug(
+                    "openai_api_key_from_env",
+                    user_id=user_id,
+                )
+                return env_key
+        else:
+            logger.warning(
+                "openai_api_key_env_fallback_disallowed",
                 user_id=user_id,
+                workspace_id=workspace_id,
+                context_id=context_id,
+                reason="option_a_shared_context_read",
             )
-            return env_key
 
         if workspace_id:
             raise ConfigurationError(
@@ -266,16 +287,20 @@ class EmbeddingService:
         no ``workspace_id`` is provided. Tolerates both UUID and string
         ``workspace_id`` inputs.
 
-        Issue #708: ``context_id`` mirrors the priority rules of
-        ``_get_user_api_key`` — when supplied, the probe accepts either a
-        context-scoped key for the same context OR a workspace-wide key
-        (``context_id IS NULL``). Without this parameter the probe would
-        return True for a workspace whose ONLY BYOK is scoped to a
-        different context, causing the H1 deny guard in
-        ``MemoryService.recall`` to incorrectly pass while
-        ``_get_user_api_key`` later falls back to the env-var path. When
-        ``context_id`` is omitted the probe behaves as before (any
-        workspace-wide-or-context-scoped key).
+        Issue #708 (loop 1 + loop 7 fix): ``context_id`` mirrors the
+        priority rules of ``_get_user_api_key`` exactly:
+
+        - When ``context_id`` is supplied, the probe matches either a
+          context-scoped key for the same context OR a workspace-wide
+          key (``context_id IS NULL``).
+        - When ``context_id`` is omitted, the probe matches ONLY
+          workspace-wide keys (``context_id IS NULL``) — same as
+          ``_get_user_api_key(..., context_id=None)``. Without this
+          symmetric default, the probe would return True for a
+          workspace whose only BYOK is scoped to some context X, while
+          a no-context call to ``_get_user_api_key`` later would not
+          select that key and fall back to env — re-introducing the
+          accounting drift the context-aware probe is meant to close.
 
         This is a cheap existence probe (single indexed SELECT, no decrypt)
         and lives alongside ``_get_user_api_key`` to avoid duplicating its
@@ -301,6 +326,10 @@ class EmbeddingService:
                     ExternalAPIKey.context_id.is_(None),
                 )
             )
+        else:
+            # Symmetric with ``_get_user_api_key``: with no context_id, only
+            # workspace-wide keys count.
+            conditions.append(ExternalAPIKey.context_id.is_(None))
         stmt = select(ExternalAPIKey.id).where(*conditions).limit(1)
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none() is not None
@@ -310,6 +339,7 @@ class EmbeddingService:
         user_id: str,
         context_id: str | None = None,
         workspace_id: str | None = None,
+        disallow_env_fallback: bool = False,
     ) -> AsyncOpenAI:
         """Get the appropriate OpenAI-compatible client for the configured provider.
 
@@ -317,6 +347,9 @@ class EmbeddingService:
             user_id: User ID (for API key retrieval)
             context_id: Optional context ID
             workspace_id: Optional workspace ID
+            disallow_env_fallback: Forwarded to ``_get_user_api_key``. Issue
+                #708 loop 7: when True (Option A shared-context reads), no
+                ``OPENAI_API_KEY`` env fallback is allowed at key lookup.
 
         Returns:
             AsyncOpenAI client configured for the provider
@@ -344,7 +377,12 @@ class EmbeddingService:
                 api_key="ollama",  # Ollama doesn't require a real key
             )
         # OpenAI (default)
-        api_key = await self._get_user_api_key(user_id, context_id, workspace_id)
+        api_key = await self._get_user_api_key(
+            user_id,
+            context_id,
+            workspace_id,
+            disallow_env_fallback=disallow_env_fallback,
+        )
         return AsyncOpenAI(api_key=api_key)
 
     def _build_embedding_kwargs(self, input_data: str | list[str]) -> dict:
@@ -399,6 +437,7 @@ class EmbeddingService:
         user_id: str,
         context_id: str | None = None,
         workspace_id: str | None = None,
+        disallow_env_fallback: bool = False,
     ) -> tuple[list[float], int]:
         """Generate embedding and return token usage for cost tracking (#471).
 
@@ -420,6 +459,13 @@ class EmbeddingService:
             user_id: User ID for API key lookup.
             context_id: Optional context ID for scoped API key.
             workspace_id: Optional workspace ID for scoped API key.
+            disallow_env_fallback: Issue #708 loop 7. Forwarded to
+                ``_get_user_api_key`` — when True the call MUST use a BYOK
+                key from the DB or fail; the ``OPENAI_API_KEY`` env-var
+                fallback is disabled. Set by Option A shared-context reads
+                so a TOCTOU race between the preflight ``has_byok_key``
+                probe and this call cannot silently route to the platform
+                key (which would bypass PR #711's BYOK-only spend cap).
 
         Returns:
             ``(vector, tokens_used)``. ``tokens_used`` is 0 for cache
@@ -453,7 +499,12 @@ class EmbeddingService:
                 workspace_id, context_id=context_id
             )
 
-            client = await self._get_client(user_id, context_id, workspace_id)
+            client = await self._get_client(
+                user_id,
+                context_id,
+                workspace_id,
+                disallow_env_fallback=disallow_env_fallback,
+            )
             response = await client.embeddings.create(
                 **self._build_embedding_kwargs(normalized_text)
             )
@@ -515,6 +566,7 @@ class EmbeddingService:
         user_id: str,
         context_id: str | None = None,
         workspace_id: str | None = None,  # NEW: Workspace ID (Issue #146)
+        disallow_env_fallback: bool = False,
     ) -> list[list[float]]:
         """Generate embeddings for multiple texts with Redis caching.
 
@@ -523,6 +575,9 @@ class EmbeddingService:
             user_id: User ID
             context_id: Optional project ID (Issue #82: context-scoped keys)
             workspace_id: Optional workspace ID (Issue #146: workspace-scoped keys)
+            disallow_env_fallback: Issue #708 loop 7. Forwarded to
+                ``_get_user_api_key`` — no ``OPENAI_API_KEY`` env fallback
+                when True. Used by Option A shared-context reads.
 
         Returns:
             List of embedding vectors
@@ -575,7 +630,12 @@ class EmbeddingService:
                     workspace_id, context_id=context_id
                 )
 
-                client = await self._get_client(user_id, context_id, workspace_id)
+                client = await self._get_client(
+                    user_id,
+                    context_id,
+                    workspace_id,
+                    disallow_env_fallback=disallow_env_fallback,
+                )
                 response = await client.embeddings.create(
                     **self._build_embedding_kwargs(uncached_texts)
                 )

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -28,6 +28,7 @@ from utils.encryption import get_encryptor
 from utils.exceptions import (
     ConfigurationError,
     EmbeddingSpendCapExceeded,
+    NotFoundException,
     OpenAIError,
 )
 from utils.logger import get_logger
@@ -168,15 +169,16 @@ class EmbeddingService:
         # explicitly required a BYOK key (disallow_env_fallback=True), do NOT
         # silently route to the platform key — that would defeat PR #711's
         # BYOK-only spend cap and bypass the H1 preflight guard via TOCTOU.
-        if not disallow_env_fallback:
-            env_key = os.getenv("OPENAI_API_KEY")
-            if env_key:
-                logger.debug(
-                    "openai_api_key_from_env",
-                    user_id=user_id,
-                )
-                return env_key
-        else:
+        #
+        # #708 loop 8 (Copilot): when the disallow path fires we must NOT
+        # fall through to the ``ConfigurationError`` below — it would
+        # interpolate the source ``workspace_id`` into its message and the
+        # MCP exception serializer would leak that workspace UUID to the
+        # caller, defeating the H2 uniform-disclosure contract
+        # (CWE-639 / OWASP A01). Raise ``NotFoundException("Context")``
+        # instead so the recall handler maps it to the same uniform
+        # ``context_not_found`` response shape as a regular deny.
+        if disallow_env_fallback:
             logger.warning(
                 "openai_api_key_env_fallback_disallowed",
                 user_id=user_id,
@@ -184,6 +186,15 @@ class EmbeddingService:
                 context_id=context_id,
                 reason="option_a_shared_context_read",
             )
+            raise NotFoundException("Context")
+
+        env_key = os.getenv("OPENAI_API_KEY")
+        if env_key:
+            logger.debug(
+                "openai_api_key_from_env",
+                user_id=user_id,
+            )
+            return env_key
 
         if workspace_id:
             raise ConfigurationError(

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -179,6 +179,7 @@ class EmbeddingService:
     async def _prepare_spend_cap_gate(
         self,
         workspace_id: str | None,
+        context_id: str | None = None,
     ) -> tuple[EmbeddingSpendCapService | None, Workspace | None]:
         """Resolve the cap service + workspace and run the pre-call gate (#709).
 
@@ -198,10 +199,17 @@ class EmbeddingService:
         the post-call ``record_spend_from_tokens`` can reuse the row without a
         second SELECT. Raises ``EmbeddingSpendCapExceeded`` (HTTP 429,
         ``QUOTA-002``) when the BYOK daily / monthly cap has been reached.
+
+        Issue #708 loop 4: ``context_id`` mirrors ``has_byok_key``'s priority
+        so the cap gate fires only when ``_get_user_api_key`` would actually
+        select a BYOK row for THIS context — not for a key scoped to some
+        OTHER context in the same workspace. Without this parameter, a
+        workspace whose only BYOK is scoped to context_X would have the
+        cap incorrectly applied to env-fallback calls on context_Y.
         """
         if not workspace_id or self.provider == "ollama":
             return None, None
-        if not await self.has_byok_key(workspace_id):
+        if not await self.has_byok_key(workspace_id, context_id=context_id):
             return None, None
         from services.embedding_spend_cap_service import EmbeddingSpendCapService
 
@@ -212,7 +220,11 @@ class EmbeddingService:
         await cap_svc.check_cap_or_raise(cap_workspace)
         return cap_svc, cap_workspace
 
-    async def resolve_paid_by(self, workspace_id: str | None) -> str:
+    async def resolve_paid_by(
+        self,
+        workspace_id: str | None,
+        context_id: str | None = None,
+    ) -> str:
         """Resolve the ``LLMCallLog.paid_by`` value for this embed call (#709).
 
         Returns ``"byok"`` when the workspace owns the credential used for
@@ -224,10 +236,19 @@ class EmbeddingService:
         Centralizing the resolution here keeps the ``"byok" if … else
         "platform"`` rule in one place; downstream writers don't need to
         know how key sourcing works.
+
+        Issue #708 loop 4: ``context_id`` mirrors ``has_byok_key``'s
+        priority so the recorded ``paid_by`` matches what
+        ``_get_user_api_key`` actually returned. Without this parameter, a
+        workspace whose only BYOK is scoped to a different context would
+        have env-fallback calls falsely logged as ``"byok"`` — corrupting
+        billing analytics and the #524 cost-grade attribution path.
         """
         from models.llm_call_log import LLM_CALL_LOG_PAID_BY_VALUES
 
-        paid_by = "byok" if await self.has_byok_key(workspace_id) else "platform"
+        paid_by = (
+            "byok" if await self.has_byok_key(workspace_id, context_id=context_id) else "platform"
+        )
         assert paid_by in LLM_CALL_LOG_PAID_BY_VALUES
         return paid_by
 
@@ -426,7 +447,11 @@ class EmbeddingService:
                 return vector, 0
 
             # Issue #709: BYOK embedding spend cap gate.
-            cap_svc, cap_workspace = await self._prepare_spend_cap_gate(workspace_id)
+            # #708 loop 4: thread ``context_id`` so the gate's BYOK probe
+            # mirrors the same priority ``_get_user_api_key`` uses below.
+            cap_svc, cap_workspace = await self._prepare_spend_cap_gate(
+                workspace_id, context_id=context_id
+            )
 
             client = await self._get_client(user_id, context_id, workspace_id)
             response = await client.embeddings.create(
@@ -544,7 +569,11 @@ class EmbeddingService:
             if uncached_texts:
                 # Issue #709: cap gate covers the whole batch — single check
                 # before the bulk API call.
-                cap_svc, cap_workspace = await self._prepare_spend_cap_gate(workspace_id)
+                # #708 loop 4: thread ``context_id`` so the gate's BYOK probe
+                # mirrors the same priority ``_get_user_api_key`` uses below.
+                cap_svc, cap_workspace = await self._prepare_spend_cap_gate(
+                    workspace_id, context_id=context_id
+                )
 
                 client = await self._get_client(user_id, context_id, workspace_id)
                 response = await client.embeddings.create(

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -231,8 +231,12 @@ class EmbeddingService:
         assert paid_by in LLM_CALL_LOG_PAID_BY_VALUES
         return paid_by
 
-    async def has_byok_key(self, workspace_id: str | None) -> bool:
-        """Whether the workspace has an enabled BYOK key for this provider.
+    async def has_byok_key(
+        self,
+        workspace_id: str | None,
+        context_id: str | None = None,
+    ) -> bool:
+        """Whether the workspace has an enabled BYOK key applicable to this context.
 
         Issue #709: used by writers (``search_service.py``) to set
         ``LLMCallLog.paid_by`` accurately — ``'byok'`` when the workspace
@@ -241,24 +245,42 @@ class EmbeddingService:
         no ``workspace_id`` is provided. Tolerates both UUID and string
         ``workspace_id`` inputs.
 
+        Issue #708: ``context_id`` mirrors the priority rules of
+        ``_get_user_api_key`` — when supplied, the probe accepts either a
+        context-scoped key for the same context OR a workspace-wide key
+        (``context_id IS NULL``). Without this parameter the probe would
+        return True for a workspace whose ONLY BYOK is scoped to a
+        different context, causing the H1 deny guard in
+        ``MemoryService.recall`` to incorrectly pass while
+        ``_get_user_api_key`` later falls back to the env-var path. When
+        ``context_id`` is omitted the probe behaves as before (any
+        workspace-wide-or-context-scoped key).
+
         This is a cheap existence probe (single indexed SELECT, no decrypt)
         and lives alongside ``_get_user_api_key`` to avoid duplicating its
         priority rules in callers.
         """
         from uuid import UUID
 
+        from sqlalchemy import or_
+
         if not workspace_id or self.provider == "ollama":
             return False
         ws_uuid = UUID(workspace_id) if isinstance(workspace_id, str) else workspace_id
-        stmt = (
-            select(ExternalAPIKey.id)
-            .where(
-                ExternalAPIKey.workspace_id == ws_uuid,
-                ExternalAPIKey.provider == self.provider,
-                ExternalAPIKey.enabled.is_(True),
+        conditions = [
+            ExternalAPIKey.workspace_id == ws_uuid,
+            ExternalAPIKey.provider == self.provider,
+            ExternalAPIKey.enabled.is_(True),
+        ]
+        if context_id:
+            ctx_uuid = UUID(context_id) if isinstance(context_id, str) else context_id
+            conditions.append(
+                or_(
+                    ExternalAPIKey.context_id == ctx_uuid,
+                    ExternalAPIKey.context_id.is_(None),
+                )
             )
-            .limit(1)
-        )
+        stmt = select(ExternalAPIKey.id).where(*conditions).limit(1)
         result = await self.db.execute(stmt)
         return result.scalar_one_or_none() is not None
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1164,40 +1164,15 @@ class MemoryService:
         # #708 Option A: route embedding cost (key + spend cap + paid_by
         # + search + graph) to the context's owner workspace. Rate-limit
         # gating stays on the caller upstream — do NOT change it here.
+        # The H1 BYOK gate is deferred until we know hybrid_search will
+        # actually fire (after the analysis_cluster short-circuit below),
+        # so no-cost reads (empty cluster, etc.) do not get falsely 404'd.
         effective_workspace_id = current_workspace_id
         is_shared_context_read = (
             context_workspace_id is not None and context_workspace_id != current_workspace_id
         )
         if is_shared_context_read:
             effective_workspace_id = context_workspace_id  # type: ignore[assignment]
-            embed_svc = EmbeddingService(self.db)
-            # Only gate when the embedding API call would actually fire and
-            # produce a charge against the source workspace. ``keyword``
-            # mode skips ``embed_with_usage`` entirely (BM25-only), and
-            # Ollama is free/local (no platform-key fallback path exists).
-            # Both legitimate paths must not be denied by the H1 guard.
-            will_charge_embedding_cost = (
-                request.search_mode != "keyword" and embed_svc.provider != "ollama"
-            )
-            if will_charge_embedding_cost and not await embed_svc.has_byok_key(
-                str(context_workspace_id),
-                context_id=str(current_context_id),
-            ):
-                # H1 deny: source workspace has no BYOK key applicable to
-                # this context. Env fallback in ``_get_user_api_key`` would
-                # route through OPENAI_API_KEY uncapped (PR #711's spend
-                # cap is BYOK-only). Raise NotFoundException so the
-                # handler surfaces a uniform context_not_found response
-                # (CWE-639 / OWASP A01).
-                logger.warning(
-                    "shared_context_read_no_byok_deny",
-                    caller_user_id=user_id,
-                    caller_workspace_id=str(current_workspace_id),
-                    context_id=str(current_context_id),
-                    paid_by_workspace_id=str(context_workspace_id),
-                    reason="missing_byok",
-                )
-                raise NotFoundException("Context", str(current_context_id))
 
         # Check if Neural Memory is enabled
         neural_enabled = os.getenv("ENABLE_NEURAL_MEMORY", "false").lower() == "true"
@@ -1267,6 +1242,48 @@ class MemoryService:
                     results=[],
                     explore_hints=[] if request.include_explore_hints else None,
                 )
+
+        # #708 Option A H1 gate (deferred): we now know hybrid_search will
+        # actually fire (the analysis_cluster short-circuit above did not
+        # trigger). Probe the source workspace for a BYOK key applicable
+        # to this context BEFORE issuing the embedding API call, so the
+        # OPENAI_API_KEY env fallback in ``_get_user_api_key`` cannot
+        # silently bypass PR #711's BYOK-only spend cap.
+        #
+        # The probe MUST use the per-context embedding model (same source
+        # of truth ``SearchService.hybrid_search`` uses to pick its embed
+        # client at line 168). Probing with the global default would
+        # falsely deny Ollama-backed contexts (provider mismatch) and
+        # falsely pass OpenAI-backed contexts when the platform default is
+        # Ollama (gate would skip entirely).
+        if is_shared_context_read:
+            from repositories.config_repository import ContextSearchConfigRepository
+
+            ctx_config_repo = ContextSearchConfigRepository(self.db)
+            ctx_config = await ctx_config_repo.create_or_get(current_context_id)
+            byok_embed_svc = EmbeddingService(self.db, model=ctx_config.embedding_model)
+            # Only gate when the embedding API call would actually fire and
+            # produce a charge against the source workspace. ``keyword``
+            # mode skips ``embed_with_usage`` entirely (BM25-only); Ollama
+            # is free/local (no platform-key fallback path exists).
+            will_charge_embedding_cost = (
+                request.search_mode != "keyword" and byok_embed_svc.provider != "ollama"
+            )
+            if will_charge_embedding_cost and not await byok_embed_svc.has_byok_key(
+                str(context_workspace_id),
+                context_id=str(current_context_id),
+            ):
+                logger.warning(
+                    "shared_context_read_no_byok_deny",
+                    caller_user_id=user_id,
+                    caller_workspace_id=str(current_workspace_id),
+                    context_id=str(current_context_id),
+                    paid_by_workspace_id=str(context_workspace_id),
+                    embedding_model=ctx_config.embedding_model,
+                    embedding_provider=byok_embed_svc.provider,
+                    reason="missing_byok",
+                )
+                raise NotFoundException("Context", str(current_context_id))
 
         # 1. Primary Retrieval: Hybrid Search (Semantic + BM25)
         # Fetch more candidates when neural is enabled for better hybrid merge

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1305,12 +1305,16 @@ class MemoryService:
             search_mode=request.search_mode,
             include_vectors=neural_enabled,
             # #708 Option A: tell SearchService this is a cross-workspace
-            # shared-context read so it skips the redundant
-            # ``is_workspace_member(workspace_id)`` check (handler-layer
-            # ``_resolve_context_for_read`` already verified access) and
-            # treats the request as shared (drops ``user_id == caller``
-            # from the Qdrant filter, since source-workspace memories are
-            # authored by source-workspace users, not the caller).
+            # shared-context read. This ONLY bypasses the redundant
+            # ``is_workspace_member(workspace_id)`` check — handler-layer
+            # ``_resolve_context_for_read`` is the authoritative access
+            # check. The Qdrant ``user_id == caller`` filter is dropped
+            # only when the context's privacy state itself is shared
+            # (``ContextService.is_context_shared``); a private context
+            # read across workspaces still keeps the filter so other
+            # users' memories are not exposed. See loop-5 fix and the
+            # ``is_shared_context`` derivation in ``SearchService.
+            # hybrid_search``.
             is_shared_context_read=is_shared_context_read,
         )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1165,14 +1165,30 @@ class MemoryService:
         # + search + graph) to the context's owner workspace. Rate-limit
         # gating stays on the caller upstream — do NOT change it here.
         effective_workspace_id = current_workspace_id
-        if context_workspace_id is not None and context_workspace_id != current_workspace_id:
+        is_shared_context_read = (
+            context_workspace_id is not None and context_workspace_id != current_workspace_id
+        )
+        if is_shared_context_read:
+            effective_workspace_id = context_workspace_id  # type: ignore[assignment]
             embed_svc = EmbeddingService(self.db)
-            if not await embed_svc.has_byok_key(str(context_workspace_id)):
-                # Deny without BYOK: env fallback in `_get_user_api_key`
-                # would route through OPENAI_API_KEY uncapped (PR #711's
-                # spend cap is BYOK-only). Raise NotFoundException so the
-                # handler can surface a uniform context_not_found
-                # response (CWE-639 / OWASP A01).
+            # Only gate when the embedding API call would actually fire and
+            # produce a charge against the source workspace. ``keyword``
+            # mode skips ``embed_with_usage`` entirely (BM25-only), and
+            # Ollama is free/local (no platform-key fallback path exists).
+            # Both legitimate paths must not be denied by the H1 guard.
+            will_charge_embedding_cost = (
+                request.search_mode != "keyword" and embed_svc.provider != "ollama"
+            )
+            if will_charge_embedding_cost and not await embed_svc.has_byok_key(
+                str(context_workspace_id),
+                context_id=str(current_context_id),
+            ):
+                # H1 deny: source workspace has no BYOK key applicable to
+                # this context. Env fallback in ``_get_user_api_key`` would
+                # route through OPENAI_API_KEY uncapped (PR #711's spend
+                # cap is BYOK-only). Raise NotFoundException so the
+                # handler surfaces a uniform context_not_found response
+                # (CWE-639 / OWASP A01).
                 logger.warning(
                     "shared_context_read_no_byok_deny",
                     caller_user_id=user_id,
@@ -1182,7 +1198,6 @@ class MemoryService:
                     reason="missing_byok",
                 )
                 raise NotFoundException("Context", str(current_context_id))
-            effective_workspace_id = context_workspace_id
 
         # Check if Neural Memory is enabled
         neural_enabled = os.getenv("ENABLE_NEURAL_MEMORY", "false").lower() == "true"
@@ -1272,6 +1287,14 @@ class MemoryService:
             filters=request.filters,
             search_mode=request.search_mode,
             include_vectors=neural_enabled,
+            # #708 Option A: tell SearchService this is a cross-workspace
+            # shared-context read so it skips the redundant
+            # ``is_workspace_member(workspace_id)`` check (handler-layer
+            # ``_resolve_context_for_read`` already verified access) and
+            # treats the request as shared (drops ``user_id == caller``
+            # from the Qdrant filter, since source-workspace memories are
+            # authored by source-workspace users, not the caller).
+            is_shared_context_read=is_shared_context_read,
         )
 
         # Get full memory data from PostgreSQL

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1105,6 +1105,8 @@ class MemoryService:
         user_id: str,
         current_context_id: UUID | None = None,
         current_workspace_id: UUID | None = None,  # NEW: Workspace ID (Issue #146)
+        context_workspace_id: UUID
+        | None = None,  # Issue #708: source workspace for shared-context Option A
         context_ids: list[UUID] | None = None,  # Issue #81: cross-context recall
     ) -> RecallResponse:
         """Search memories with Hybrid Search + Neural Memory.
@@ -1120,10 +1122,27 @@ class MemoryService:
 
         Issue #82: Context-based multi-collection support.
 
+        Issue #708: shared-context reads pay against the context's owner
+        workspace ("Option A"). When ``context_workspace_id`` differs from
+        ``current_workspace_id`` (caller's), the embedding key lookup,
+        BYOK spend cap deduction, search filtering, and graph mutations
+        all route to ``context_workspace_id``. Upstream rate-limit gating
+        (``mcp_server.tools.__init__._check_rate_limit``) keeps the
+        caller's workspace as the rate-limit subject so attackers cannot
+        bypass their own RPS limit via shared-context reads.
+
         Args:
             request: Recall request
             user_id: User ID
             current_context_id: Current context UUID (Issue #82)
+            current_workspace_id: Caller's active workspace (#146).
+            context_workspace_id: Context owner workspace (#708 Option A).
+                When None or equal to ``current_workspace_id`` the caller
+                pays (self-workspace read). When different, the source
+                workspace pays — provided it has a BYOK key configured
+                (#708 H1; otherwise a uniform NotFoundException is raised
+                to avoid leaking existence + configuration state via
+                CWE-639 / OWASP A01).
 
         Returns:
             RecallResponse with search results
@@ -1141,6 +1160,29 @@ class MemoryService:
         # Single Collection Migration: Validate required parameters
         if not current_workspace_id or not current_context_id:
             raise ValueError("recall() requires current_workspace_id and current_context_id")
+
+        # #708 Option A: route embedding cost (key + spend cap + paid_by
+        # + search + graph) to the context's owner workspace. Rate-limit
+        # gating stays on the caller upstream — do NOT change it here.
+        effective_workspace_id = current_workspace_id
+        if context_workspace_id is not None and context_workspace_id != current_workspace_id:
+            embed_svc = EmbeddingService(self.db)
+            if not await embed_svc.has_byok_key(str(context_workspace_id)):
+                # Deny without BYOK: env fallback in `_get_user_api_key`
+                # would route through OPENAI_API_KEY uncapped (PR #711's
+                # spend cap is BYOK-only). Raise NotFoundException so the
+                # handler can surface a uniform context_not_found
+                # response (CWE-639 / OWASP A01).
+                logger.warning(
+                    "shared_context_read_no_byok_deny",
+                    caller_user_id=user_id,
+                    caller_workspace_id=str(current_workspace_id),
+                    context_id=str(current_context_id),
+                    paid_by_workspace_id=str(context_workspace_id),
+                    reason="missing_byok",
+                )
+                raise NotFoundException("Context", str(current_context_id))
+            effective_workspace_id = context_workspace_id
 
         # Check if Neural Memory is enabled
         neural_enabled = os.getenv("ENABLE_NEURAL_MEMORY", "false").lower() == "true"
@@ -1200,7 +1242,7 @@ class MemoryService:
             # circuits to empty results without leaking existence.
             cluster_memory_ids = await _analysis_query_service.get_memory_ids_in_cluster(
                 self.db,
-                workspace_id=current_workspace_id,
+                workspace_id=effective_workspace_id,
                 run_id=cluster_run_id,
                 cluster_index=cluster_index_int,
             )
@@ -1223,7 +1265,7 @@ class MemoryService:
         search_results = await self.search_service.hybrid_search(
             query=request.query,
             user_id=user_id,
-            workspace_id=str(current_workspace_id),
+            workspace_id=str(effective_workspace_id),
             context_id=search_context_id,
             k=candidates_k,
             use_rerank=request.use_rerank,
@@ -1320,7 +1362,7 @@ class MemoryService:
                 graph_service = GraphService(
                     user_id=user_id,
                     db=self.db,
-                    workspace_id=str(current_workspace_id) if current_workspace_id else None,
+                    workspace_id=str(effective_workspace_id) if effective_workspace_id else None,
                     context_id=str(current_context_id) if current_context_id else None,
                 )
 
@@ -1415,7 +1457,7 @@ class MemoryService:
                     responses,
                     user_id,
                     current_context_id,
-                    current_workspace_id,
+                    effective_workspace_id,
                     neural_enabled=neural_enabled,
                 )
             except Exception as exc:

--- a/backend/src/services/search_service.py
+++ b/backend/src/services/search_service.py
@@ -226,8 +226,17 @@ class SearchService:
             # (different model than ``self.embedding_service``) — read
             # provider/model from it directly so multi-tenant pricing
             # routes correctly.
+            # #708 loop 7: under Option A (is_shared_context_read=True), this
+            # call MUST use a BYOK key — no OPENAI_API_KEY env fallback —
+            # otherwise a TOCTOU race between the preflight ``has_byok_key``
+            # probe in ``MemoryService.recall`` and this resolution could
+            # silently route to the uncapped platform key.
             query_vector, embedding_tokens = await embed_svc.embed_with_usage(
-                normalized_query, user_id, context_id=primary_context_id, workspace_id=workspace_id
+                normalized_query,
+                user_id,
+                context_id=primary_context_id,
+                workspace_id=workspace_id,
+                disallow_env_fallback=is_shared_context_read,
             )
             if embedding_tokens > 0:
                 # Cache hits return 0 tokens and intentionally produce no

--- a/backend/src/services/search_service.py
+++ b/backend/src/services/search_service.py
@@ -224,7 +224,14 @@ class SearchService:
                     workspace_id=workspace_id,
                     context_id=primary_context_id,
                     embedding_tokens=embedding_tokens,
-                    paid_by=await embed_svc.resolve_paid_by(workspace_id),
+                    # #708 loop 4: thread context_id so paid_by reflects the
+                    # actual key ``_get_user_api_key`` selected for THIS context.
+                    # Without it, env-fallback calls on a context whose workspace
+                    # has BYOK scoped to a DIFFERENT context would be falsely
+                    # logged as "byok" — corrupts cost-grade attribution (#524).
+                    paid_by=await embed_svc.resolve_paid_by(
+                        workspace_id, context_id=primary_context_id
+                    ),
                     fail_on_error=False,
                 )
             semantic_results = await search_memories_qdrant(

--- a/backend/src/services/search_service.py
+++ b/backend/src/services/search_service.py
@@ -130,25 +130,48 @@ class SearchService:
         from services.permission_service import PermissionService
         from utils.exceptions import AuthorizationError
 
-        # Issue #708 Option A: caller's cross-workspace access has been
-        # verified at the handler layer; trust it and treat as shared so
-        # source memories are visible. Otherwise fall back to the legacy
-        # path that probes per-context ``is_context_shared`` (single-
-        # context only — list paths fall through with is_shared_context
-        # left False, matching pre-#708 behavior).
-        is_shared_context = is_shared_context_read
-        if not is_shared_context_read and not isinstance(context_id, list):
+        # ``is_shared_context`` drives the Qdrant user_id filter:
+        #   - True  → drop ``user_id == caller`` (shared context: any member can read)
+        #   - False → keep filter (private context: caller sees only their own memories)
+        #
+        # This value MUST be derived from the context's actual privacy state
+        # (``ContextService.is_context_shared``), NOT from #708's
+        # ``is_shared_context_read`` cross-workspace flag. Conflating them
+        # (loop 1 / loop 5 fix from Copilot) drops the user_id filter for a
+        # private context whose creator reads it from a different active
+        # workspace — leaking memories authored by other users into a
+        # context that was made private after being shared.
+        #
+        # The two flags are orthogonal:
+        #   - ``is_shared_context_read`` (handler-verified cross-workspace) ONLY
+        #     bypasses the redundant ``is_workspace_member`` probe below —
+        #     handler-layer ``_resolve_context_for_read`` is the authoritative
+        #     access check.
+        #   - ``is_shared_context`` is derived from privacy state and controls
+        #     the Qdrant filter independently.
+        #
+        # List-context: legacy behavior intentionally skipped the probe and
+        # left ``is_shared_context=False`` (Issue #81 conservative default).
+        # Under Option A (``is_shared_context_read=True``), we DO probe the
+        # primary context so source-workspace shared cross-context recall
+        # returns results, while a private primary still applies the filter.
+        is_shared_context = False
+        should_probe_sharing = not isinstance(context_id, list) or is_shared_context_read
+        if should_probe_sharing:
             context_service = ContextService(self.db)
-            is_shared_context = await context_service.is_context_shared(UUID(context_id))
+            is_shared_context = await context_service.is_context_shared(UUID(primary_context_id))
 
-            # For shared contexts, verify workspace membership
-            if is_shared_context:
-                perm_service = PermissionService(self.db)
-                is_member = await perm_service.is_workspace_member(user_id, UUID(workspace_id))
-                if not is_member:
-                    raise AuthorizationError(
-                        f"Access denied: not a member of workspace {workspace_id}"
-                    )
+        # Redundant workspace-membership probe — only runs for single-context
+        # same-workspace reads of a shared context. Under
+        # ``is_shared_context_read=True`` the handler already verified access,
+        # so this would just block legitimate cross-workspace callers
+        # (system_admin, ContextMember-only). List paths skip it too —
+        # source-workspace access has already been verified by the handler.
+        if is_shared_context and not is_shared_context_read and not isinstance(context_id, list):
+            perm_service = PermissionService(self.db)
+            is_member = await perm_service.is_workspace_member(user_id, UUID(workspace_id))
+            if not is_member:
+                raise AuthorizationError(f"Access denied: not a member of workspace {workspace_id}")
 
         logger.debug(
             "context_access_check",

--- a/backend/src/services/search_service.py
+++ b/backend/src/services/search_service.py
@@ -66,6 +66,7 @@ class SearchService:
         filters: dict[str, Any] | None = None,
         search_mode: SearchMode = "hybrid",
         include_vectors: bool = False,
+        is_shared_context_read: bool = False,
     ) -> list[dict]:
         """Search with configurable mode: hybrid, semantic, or keyword.
 
@@ -87,6 +88,19 @@ class SearchService:
             filters: Optional filters
             search_mode: Search strategy (hybrid/semantic/keyword)
             include_vectors: Return document embeddings from Qdrant (increases payload size)
+            is_shared_context_read: Issue #708 Option A. Set by ``MemoryService.recall``
+                when the caller's workspace differs from the context owner's
+                workspace AND handler-layer access has already been verified
+                (``_resolve_context_for_read``). When True, two things happen:
+                (1) the redundant ``is_workspace_member(workspace_id)`` check
+                is skipped — under Option A ``workspace_id`` is the SOURCE
+                workspace, of which the caller is not necessarily a member,
+                but their access via ``ContextMember`` / system_admin / etc.
+                was already confirmed upstream; and (2) the Qdrant filter
+                drops ``user_id == caller`` so memories authored by source
+                workspace members are visible to the cross-workspace reader.
+                Single-context and cross-context (``context_ids``) paths both
+                honor this flag.
 
         Returns:
             List of search results with scores
@@ -116,9 +130,14 @@ class SearchService:
         from services.permission_service import PermissionService
         from utils.exceptions import AuthorizationError
 
-        # Issue #81: For cross-context, skip shared-context optimization (use user_id filter)
-        is_shared_context = False
-        if not isinstance(context_id, list):
+        # Issue #708 Option A: caller's cross-workspace access has been
+        # verified at the handler layer; trust it and treat as shared so
+        # source memories are visible. Otherwise fall back to the legacy
+        # path that probes per-context ``is_context_shared`` (single-
+        # context only — list paths fall through with is_shared_context
+        # left False, matching pre-#708 behavior).
+        is_shared_context = is_shared_context_read
+        if not is_shared_context_read and not isinstance(context_id, list):
             context_service = ContextService(self.db)
             is_shared_context = await context_service.is_context_shared(UUID(context_id))
 

--- a/backend/tests/services/test_embedding_service.py
+++ b/backend/tests/services/test_embedding_service.py
@@ -327,11 +327,15 @@ class TestContextAwareBYOKThreading:
 
     @pytest.mark.asyncio
     async def test_prepare_spend_cap_gate_context_id_optional_for_backward_compat(self, service):
-        """``context_id`` defaults to None so legacy callers continue to compile.
+        """``context_id`` defaults to None for legacy callers.
 
-        The probe still mirrors ``_get_user_api_key``'s legacy behavior
-        when ``context_id`` is None — accepts any workspace-wide or
-        context-scoped key.
+        Loop 7 fix: when ``context_id`` is None, ``has_byok_key`` matches
+        ONLY workspace-wide keys (``ExternalAPIKey.context_id IS NULL``)
+        — mirroring ``_get_user_api_key``'s legacy priority exactly.
+        Pre-loop-7 the probe accepted any context-scoped key in the
+        workspace, which diverged from the key-lookup it claimed to
+        mirror and reintroduced the accounting drift this gate exists
+        to prevent.
         """
         service.has_byok_key = AsyncMock(return_value=False)
 
@@ -340,3 +344,127 @@ class TestContextAwareBYOKThreading:
         service.has_byok_key.assert_called_once_with(
             "00000000-0000-0000-0000-000000000001", context_id=None
         )
+
+
+class TestDisallowEnvFallback:
+    """#708 loop 7: ``disallow_env_fallback`` propagation for Option A reads.
+
+    Closes a TOCTOU race between the preflight ``has_byok_key`` probe
+    and the actual ``_get_user_api_key`` call. Without this guard, a
+    BYOK key disabled between the probe and the embed call would route
+    silently through ``OPENAI_API_KEY`` env — bypassing both the H1
+    Option A guard and PR #711's BYOK-only spend cap.
+    """
+
+    @pytest.fixture
+    def service(self):
+        return EmbeddingService(_make_mock_db())
+
+    @pytest.mark.asyncio
+    async def test_disallow_env_fallback_raises_instead_of_env(self, service, monkeypatch):
+        """When ``disallow_env_fallback=True`` and no DB key found, raise.
+
+        Even with ``OPENAI_API_KEY`` set in the environment, the env
+        fallback path MUST be skipped for Option A reads.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-platform-key")
+
+        # Mock DB: no key found
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None
+        service.db.execute = AsyncMock(return_value=execute_result)
+
+        with pytest.raises(ConfigurationError):
+            await service._get_user_api_key(
+                user_id="caller",
+                context_id="00000000-0000-0000-0000-000000000002",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                disallow_env_fallback=True,
+            )
+
+    @pytest.mark.asyncio
+    async def test_default_allows_env_fallback(self, service, monkeypatch):
+        """Regression fence: default ``disallow_env_fallback=False`` still uses env."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test-platform-key")
+
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None
+        service.db.execute = AsyncMock(return_value=execute_result)
+
+        result = await service._get_user_api_key(
+            user_id="caller",
+            context_id="00000000-0000-0000-0000-000000000002",
+            workspace_id="00000000-0000-0000-0000-000000000001",
+            # disallow_env_fallback omitted → False
+        )
+
+        assert result == "sk-test-platform-key"
+
+    @pytest.mark.asyncio
+    async def test_disallow_env_fallback_does_not_block_db_key(self, service, monkeypatch):
+        """``disallow_env_fallback=True`` MUST NOT block a legitimate DB key.
+
+        The flag only affects priority-3 env fallback. When a BYOK row
+        exists at priority 1 or 2, the lookup should still return it.
+        """
+        # The env is set but should not be consulted
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-must-not-be-used")
+
+        # Mock DB: BYOK key found
+        api_key_entry = MagicMock()
+        api_key_entry.encrypted_value = "encrypted-byok-key-data"
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = api_key_entry
+        service.db.execute = AsyncMock(return_value=execute_result)
+
+        # Patch the encryptor to return a known plaintext
+        with patch("services.embedding_service.get_encryptor") as enc:
+            enc.return_value.decrypt.return_value = "sk-actual-byok-key"
+
+            result = await service._get_user_api_key(
+                user_id="caller",
+                context_id="00000000-0000-0000-0000-000000000002",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                disallow_env_fallback=True,
+            )
+
+        assert result == "sk-actual-byok-key"
+        assert result != "sk-must-not-be-used"
+
+    @pytest.mark.asyncio
+    async def test_embed_with_usage_propagates_disallow_env_fallback(self, service, monkeypatch):
+        """``embed_with_usage(disallow_env_fallback=True)`` MUST propagate to ``_get_client``."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+        captured_kwargs: dict = {}
+
+        async def _fake_get_client(user_id, context_id, workspace_id, **kwargs):
+            captured_kwargs.update(kwargs)
+            # Return a dummy client whose embeddings.create returns a vector
+            client = MagicMock()
+            client.embeddings = MagicMock()
+            client.embeddings.create = AsyncMock(
+                return_value=MagicMock(
+                    data=[MagicMock(embedding=[0.1] * 512)],
+                    usage=MagicMock(prompt_tokens=10, total_tokens=10),
+                )
+            )
+            return client
+
+        service._get_client = _fake_get_client
+        service._prepare_spend_cap_gate = AsyncMock(return_value=(None, None))
+
+        # patch cache to skip the hit path
+        with (
+            patch("services.embedding_service.get_cache", new=AsyncMock(return_value=None)),
+            patch("services.embedding_service.set_cache", new=AsyncMock(return_value=None)),
+        ):
+            await service.embed_with_usage(
+                "test",
+                user_id="caller",
+                context_id="00000000-0000-0000-0000-000000000002",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                disallow_env_fallback=True,
+            )
+
+        assert captured_kwargs.get("disallow_env_fallback") is True

--- a/backend/tests/services/test_embedding_service.py
+++ b/backend/tests/services/test_embedding_service.py
@@ -361,12 +361,20 @@ class TestDisallowEnvFallback:
         return EmbeddingService(_make_mock_db())
 
     @pytest.mark.asyncio
-    async def test_disallow_env_fallback_raises_instead_of_env(self, service, monkeypatch):
-        """When ``disallow_env_fallback=True`` and no DB key found, raise.
+    async def test_disallow_env_fallback_raises_notfound_not_configerror(
+        self, service, monkeypatch
+    ):
+        """Loop 8 fix: TOCTOU deny path MUST raise ``NotFoundException``,
+        NOT ``ConfigurationError`` — the latter's message interpolates the
+        source ``workspace_id`` and the MCP exception serializer would
+        leak it (CWE-639 / OWASP A01).
 
-        Even with ``OPENAI_API_KEY`` set in the environment, the env
-        fallback path MUST be skipped for Option A reads.
+        Even with ``OPENAI_API_KEY`` set, the env fallback is skipped for
+        Option A reads. The raised ``NotFoundException`` is then mapped
+        by the handler to the uniform ``context_not_found`` response.
         """
+        from utils.exceptions import NotFoundException
+
         monkeypatch.setenv("OPENAI_API_KEY", "sk-test-platform-key")
 
         # Mock DB: no key found
@@ -374,13 +382,25 @@ class TestDisallowEnvFallback:
         execute_result.scalar_one_or_none.return_value = None
         service.db.execute = AsyncMock(return_value=execute_result)
 
-        with pytest.raises(ConfigurationError):
+        source_ws = "00000000-0000-0000-0000-000000000001"
+
+        with pytest.raises(NotFoundException) as exc_info:
             await service._get_user_api_key(
                 user_id="caller",
                 context_id="00000000-0000-0000-0000-000000000002",
-                workspace_id="00000000-0000-0000-0000-000000000001",
+                workspace_id=source_ws,
                 disallow_env_fallback=True,
             )
+
+        # Defense-in-depth: even though the handler crafts the response
+        # body (not the exception), assert the exception message does
+        # NOT include the source workspace_id in case it ever surfaces.
+        assert source_ws not in exc_info.value.message
+        assert source_ws not in str(exc_info.value.details)
+        # The exception type itself triggers the uniform mapping at the
+        # MCP handler — assert that's what we raised.
+        assert isinstance(exc_info.value, NotFoundException)
+        assert not isinstance(exc_info.value, ConfigurationError)
 
     @pytest.mark.asyncio
     async def test_default_allows_env_fallback(self, service, monkeypatch):

--- a/backend/tests/services/test_embedding_service.py
+++ b/backend/tests/services/test_embedding_service.py
@@ -262,3 +262,81 @@ class TestEmbeddingService:
 
                 # All users should use the same API key (from env)
                 assert mock_client.embeddings.create.call_count == len(users)
+
+
+class TestContextAwareBYOKThreading:
+    """#708 loop 4: context_id MUST thread through the BYOK probe chain.
+
+    ``_prepare_spend_cap_gate`` and ``resolve_paid_by`` both call
+    ``has_byok_key`` to decide whether the embedding cost is BYOK-billed.
+    Without ``context_id``, a workspace whose only BYOK row is scoped to
+    a DIFFERENT context would be falsely treated as having BYOK — the
+    cap would be applied to env-fallback calls and ``paid_by`` would log
+    "byok" for actually-platform-billed calls. These fences keep the
+    accounting check aligned with ``_get_user_api_key``'s key selection.
+    """
+
+    @pytest.fixture
+    def service(self):
+        """EmbeddingService with mock DB."""
+        return EmbeddingService(_make_mock_db())
+
+    @pytest.mark.asyncio
+    async def test_prepare_spend_cap_gate_passes_context_id_to_has_byok_key(self, service):
+        """``_prepare_spend_cap_gate`` MUST forward ``context_id`` to ``has_byok_key``."""
+        service.has_byok_key = AsyncMock(
+            return_value=False
+        )  # returns early; we only care about the call
+
+        ws_id = "00000000-0000-0000-0000-000000000001"
+        ctx_id = "00000000-0000-0000-0000-000000000002"
+
+        await service._prepare_spend_cap_gate(ws_id, context_id=ctx_id)
+
+        service.has_byok_key.assert_called_once_with(ws_id, context_id=ctx_id)
+
+    @pytest.mark.asyncio
+    async def test_resolve_paid_by_passes_context_id_to_has_byok_key(self, service):
+        """``resolve_paid_by`` MUST forward ``context_id`` to ``has_byok_key``."""
+        service.has_byok_key = AsyncMock(return_value=True)
+
+        ws_id = "00000000-0000-0000-0000-000000000001"
+        ctx_id = "00000000-0000-0000-0000-000000000002"
+
+        result = await service.resolve_paid_by(ws_id, context_id=ctx_id)
+
+        service.has_byok_key.assert_called_once_with(ws_id, context_id=ctx_id)
+        assert result == "byok"
+
+    @pytest.mark.asyncio
+    async def test_resolve_paid_by_returns_platform_when_byok_not_applicable(self, service):
+        """``resolve_paid_by`` returns "platform" when context-aware probe misses.
+
+        Regression fence: a workspace with BYOK scoped to a DIFFERENT
+        context (probe returns False) MUST log as "platform", matching
+        what ``_get_user_api_key`` will actually do (env fallback).
+        """
+        service.has_byok_key = AsyncMock(return_value=False)
+
+        result = await service.resolve_paid_by(
+            "00000000-0000-0000-0000-000000000001",
+            context_id="00000000-0000-0000-0000-000000000002",
+        )
+
+        assert result == "platform"
+
+    @pytest.mark.asyncio
+    async def test_prepare_spend_cap_gate_context_id_optional_for_backward_compat(self, service):
+        """``context_id`` defaults to None so legacy callers continue to compile.
+
+        The probe still mirrors ``_get_user_api_key``'s legacy behavior
+        when ``context_id`` is None — accepts any workspace-wide or
+        context-scoped key.
+        """
+        service.has_byok_key = AsyncMock(return_value=False)
+
+        await service._prepare_spend_cap_gate("00000000-0000-0000-0000-000000000001")
+
+        service.has_byok_key.assert_called_once_with(
+            "00000000-0000-0000-0000-000000000001", context_id=None
+        )

--- a/backend/tests/services/test_recall_shared_context_paid_by.py
+++ b/backend/tests/services/test_recall_shared_context_paid_by.py
@@ -135,7 +135,10 @@ async def test_shared_context_recall_calls_has_byok_with_source_workspace_id():
             context_workspace_id=source_ws,
         )
 
-    has_byok_mock.assert_called_once_with(str(source_ws))
+    # #708 F3: probe must include context_id so the priority of
+    # ``_get_user_api_key`` is mirrored — a workspace whose ONLY BYOK
+    # row is scoped to a different context must NOT pass the gate.
+    has_byok_mock.assert_called_once_with(str(source_ws), context_id=str(context_id))
 
 
 @pytest.mark.asyncio
@@ -231,3 +234,118 @@ async def test_self_workspace_recall_skips_byok_probe():
         )
 
     has_byok_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_shared_context_keyword_mode_skips_byok_gate():
+    """#708 F1: keyword-mode search does NOT call embed_with_usage.
+
+    A BM25-only search produces no embedding cost, so the H1 BYOK gate
+    must NOT deny it even when the source workspace has no BYOK key.
+    Otherwise legitimate keyword-mode shared reads silently 404.
+    """
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+
+    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
+        has_byok_mock = AsyncMock(return_value=False)
+        embed_svc_cls.return_value.has_byok_key = has_byok_mock
+        embed_svc_cls.return_value.provider = "openai"
+
+        await svc.recall(
+            request=RecallRequest(query="test", k=5, search_mode="keyword"),
+            user_id="caller_user",
+            current_context_id=context_id,
+            current_workspace_id=caller_ws,
+            context_workspace_id=source_ws,
+        )
+
+    has_byok_mock.assert_not_called()
+    svc.search_service.hybrid_search.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_shared_context_ollama_provider_skips_byok_gate():
+    """#708 F1: Ollama provider is free/local — no platform-key fallback path exists.
+
+    ``has_byok_key`` returns False for Ollama by design (it's not a paid
+    provider). The H1 gate must NOT treat that as a denial signal —
+    Ollama-backed shared reads cost nothing to the source workspace.
+    """
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+
+    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
+        has_byok_mock = AsyncMock(return_value=False)
+        embed_svc_cls.return_value.has_byok_key = has_byok_mock
+        embed_svc_cls.return_value.provider = "ollama"
+
+        await svc.recall(
+            request=RecallRequest(query="test", k=5),
+            user_id="caller_user",
+            current_context_id=context_id,
+            current_workspace_id=caller_ws,
+            context_workspace_id=source_ws,
+        )
+
+    has_byok_mock.assert_not_called()
+    svc.search_service.hybrid_search.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_shared_context_recall_propagates_is_shared_context_read():
+    """#708 F2: SearchService must learn this is a cross-workspace Option A read.
+
+    Without the kwarg, ``SearchService.hybrid_search`` treats the request
+    as same-workspace, runs ``is_workspace_member(workspace_id=source)``
+    (which fails for the cross-workspace caller), and applies the
+    ``user_id == caller`` filter (which drops source-workspace memories
+    authored by other users — the main Option A scenario returns empty).
+    """
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+
+    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
+        embed_svc_cls.return_value.has_byok_key = AsyncMock(return_value=True)
+        embed_svc_cls.return_value.provider = "openai"
+
+        await svc.recall(
+            request=RecallRequest(query="test", k=5),
+            user_id="caller_user",
+            current_context_id=context_id,
+            current_workspace_id=caller_ws,
+            context_workspace_id=source_ws,
+        )
+
+    call_kwargs = svc.search_service.hybrid_search.call_args.kwargs
+    assert call_kwargs.get("is_shared_context_read") is True
+
+
+@pytest.mark.asyncio
+async def test_self_workspace_recall_does_not_propagate_is_shared_context_read():
+    """#708 F2 fence: same-workspace path must NOT set is_shared_context_read.
+
+    Setting it spuriously would bypass the legitimate is_workspace_member
+    check for same-workspace shared contexts where the caller IS the
+    workspace they're reading from (no need to skip the check).
+    """
+    svc, _db = _make_service()
+    workspace_id = uuid4()
+    context_id = uuid4()
+
+    await svc.recall(
+        request=RecallRequest(query="test", k=5),
+        user_id="test_user",
+        current_context_id=context_id,
+        current_workspace_id=workspace_id,
+        context_workspace_id=workspace_id,
+    )
+
+    call_kwargs = svc.search_service.hybrid_search.call_args.kwargs
+    assert call_kwargs.get("is_shared_context_read") is False

--- a/backend/tests/services/test_recall_shared_context_paid_by.py
+++ b/backend/tests/services/test_recall_shared_context_paid_by.py
@@ -397,6 +397,75 @@ async def test_shared_context_byok_gate_uses_per_context_embedding_model():
 
 
 @pytest.mark.asyncio
+async def test_cross_context_recall_rejects_mixed_privacy():
+    """#708 loop 6 (Copilot): cross-context recall MUST reject mixed privacy.
+
+    SearchService derives one ``is_shared_context`` value from the
+    primary context and applies it to every context's Qdrant filter.
+    Mixed privacy in the list would either drop the user_id filter
+    for a private secondary (leaking other users' memories) or keep
+    it for a shared primary (returning empty for legitimate readers).
+    Hard-reject at the API boundary mirrors the H3 (workspace_mismatch)
+    + same-embedding-model invariant pattern.
+    """
+    import json
+
+    from mcp_server.tools.memory import handle_recall
+
+    workspace_id = uuid4()
+    shared_ctx_id = uuid4()
+    private_ctx_id = uuid4()
+
+    # Two contexts, same workspace, MIXED privacy.
+    shared_ctx = MagicMock()
+    shared_ctx.id = shared_ctx_id
+    shared_ctx.workspace_id = workspace_id
+    shared_ctx.is_private = False
+    shared_ctx.name = "shared"
+    shared_ctx.display_name = "Shared"
+    shared_ctx.is_locked = False
+    private_ctx = MagicMock()
+    private_ctx.id = private_ctx_id
+    private_ctx.workspace_id = workspace_id
+    private_ctx.is_private = True
+    private_ctx.name = "private"
+    private_ctx.display_name = "Private"
+    private_ctx.is_locked = False
+
+    resolve_mock = AsyncMock(side_effect=[shared_ctx, private_ctx])
+
+    async def _fake_get_db():
+        yield AsyncMock()
+
+    # ``get_db`` and ``_resolve_context_for_read`` are lazy-imported inside
+    # ``handle_recall``; patching at the source module is required.
+    with (
+        patch("db.base.get_db", _fake_get_db),
+        patch(
+            "mcp_server.tools._helpers._resolve_context_for_read",
+            resolve_mock,
+        ),
+        patch("mcp_server.tools.memory._resolve_context_for_read", resolve_mock),
+    ):
+        result = await handle_recall(
+            args={
+                "query": "test",
+                "context_ids": [str(shared_ctx_id), str(private_ctx_id)],
+                "k": 5,
+            },
+            user_id="caller_user",
+            workspace_id=workspace_id,
+        )
+
+    # Response is a list with one TextContent — parse it.
+    assert len(result) == 1
+    body = json.loads(result[0].text)
+    assert body["status"] == "error"
+    assert body["error"] == "context_privacy_mismatch"
+    assert "privacy" in body["message"].lower()
+
+
+@pytest.mark.asyncio
 async def test_shared_context_byok_gate_deferred_past_empty_cluster_short_circuit():
     """#708 F5 (Copilot loop 2): empty cluster → no embedding call → no gate.
 

--- a/backend/tests/services/test_recall_shared_context_paid_by.py
+++ b/backend/tests/services/test_recall_shared_context_paid_by.py
@@ -1,0 +1,233 @@
+"""Recall Option A: shared-context reads pay against source workspace (#708).
+
+Verifies the four guardrails identified during gate1 design review for
+``MemoryService.recall``:
+
+- **Self-workspace read** (``context_workspace_id == current_workspace_id``):
+  downstream ``hybrid_search`` receives ``current_workspace_id``. Regression
+  fence — no behavior change for the dominant path.
+- **Shared-context read** (``context_workspace_id != current_workspace_id``)
+  **with source BYOK present**: downstream ``hybrid_search`` and friends
+  receive ``context_workspace_id``. Option A "owner's key for owner's door".
+- **Shared-context read with source missing BYOK** (#708 H1, OWASP A04):
+  service raises ``NotFoundException("Context", ...)`` rather than falling
+  back to the uncapped ``OPENAI_API_KEY`` env path. PR #711's spend cap is
+  BYOK-only by design.
+- **Shared-context read uniform-error shape** (#708 H2, OWASP A01 /
+  CWE-639): the raised exception names "Context" and uses the same shape
+  ``_resolve_context_for_read`` produces so callers cannot distinguish
+  "source missing BYOK" from "context does not exist for you" via the
+  response body.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import RecallRequest
+from utils.exceptions import NotFoundException
+
+
+def _make_service():
+    """Return a MemoryService instance with mocked dependencies for unit tests."""
+    from services.memory_service import MemoryService
+
+    db = AsyncMock()
+    db.execute = AsyncMock()
+    svc = MemoryService(db)
+    svc.search_service = MagicMock()
+    svc.search_service.hybrid_search = AsyncMock(return_value=[])
+    svc.memory_repo = MagicMock()
+    return svc, db
+
+
+@pytest.mark.asyncio
+async def test_self_workspace_recall_uses_caller_workspace_id():
+    """Regression: caller_workspace == context_workspace → no override."""
+    svc, _db = _make_service()
+    workspace_id = uuid4()
+    context_id = uuid4()
+
+    await svc.recall(
+        request=RecallRequest(query="test", k=5),
+        user_id="test_user",
+        current_context_id=context_id,
+        current_workspace_id=workspace_id,
+        # Self-workspace read: caller and context share the same workspace.
+        context_workspace_id=workspace_id,
+    )
+
+    svc.search_service.hybrid_search.assert_called_once()
+    call_kwargs = svc.search_service.hybrid_search.call_args.kwargs
+    assert call_kwargs["workspace_id"] == str(workspace_id)
+
+
+@pytest.mark.asyncio
+async def test_self_workspace_recall_with_none_context_workspace():
+    """When ``context_workspace_id`` is None, treat as self-workspace read.
+
+    Callers that have not yet adopted the new kwarg pass ``None`` (the
+    default). The override must not trigger — the implementation falls
+    back to caller's workspace and preserves the original behavior.
+    """
+    svc, _db = _make_service()
+    workspace_id = uuid4()
+    context_id = uuid4()
+
+    await svc.recall(
+        request=RecallRequest(query="test", k=5),
+        user_id="test_user",
+        current_context_id=context_id,
+        current_workspace_id=workspace_id,
+        # context_workspace_id intentionally omitted (=None).
+    )
+
+    call_kwargs = svc.search_service.hybrid_search.call_args.kwargs
+    assert call_kwargs["workspace_id"] == str(workspace_id)
+
+
+@pytest.mark.asyncio
+async def test_shared_context_recall_routes_to_source_workspace():
+    """Shared-context Option A: downstream workspace_id = context owner."""
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+
+    # Patch EmbeddingService so the BYOK probe returns True (source has key).
+    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
+        embed_svc_cls.return_value.has_byok_key = AsyncMock(return_value=True)
+
+        await svc.recall(
+            request=RecallRequest(query="test", k=5),
+            user_id="caller_user",
+            current_context_id=context_id,
+            current_workspace_id=caller_ws,
+            context_workspace_id=source_ws,
+        )
+
+    call_kwargs = svc.search_service.hybrid_search.call_args.kwargs
+    assert call_kwargs["workspace_id"] == str(source_ws), (
+        "Shared-context read MUST route embedding cost to source workspace"
+    )
+
+
+@pytest.mark.asyncio
+async def test_shared_context_recall_calls_has_byok_with_source_workspace_id():
+    """H1: BYOK probe MUST query source workspace, not caller's."""
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+
+    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
+        has_byok_mock = AsyncMock(return_value=True)
+        embed_svc_cls.return_value.has_byok_key = has_byok_mock
+
+        await svc.recall(
+            request=RecallRequest(query="test", k=5),
+            user_id="caller_user",
+            current_context_id=context_id,
+            current_workspace_id=caller_ws,
+            context_workspace_id=source_ws,
+        )
+
+    has_byok_mock.assert_called_once_with(str(source_ws))
+
+
+@pytest.mark.asyncio
+async def test_shared_context_recall_denies_when_source_no_byok():
+    """H1 (OWASP A04): source workspace lacks BYOK → NotFoundException.
+
+    Without this guardrail the request would fall through to
+    ``OPENAI_API_KEY`` env (platform-paid + uncapped), defeating PR
+    #711's drain-attack mitigation.
+    """
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+
+    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
+        embed_svc_cls.return_value.has_byok_key = AsyncMock(return_value=False)
+
+        with pytest.raises(NotFoundException) as exc_info:
+            await svc.recall(
+                request=RecallRequest(query="test", k=5),
+                user_id="caller_user",
+                current_context_id=context_id,
+                current_workspace_id=caller_ws,
+                context_workspace_id=source_ws,
+            )
+
+    # hybrid_search MUST NOT be called — the deny happens before any
+    # external API key resolution.
+    svc.search_service.hybrid_search.assert_not_called()
+    # H2 (CWE-639): the exception names "Context" (not "BYOK" or
+    # "workspace") so the error body is indistinguishable from a regular
+    # context_not_found. The exception's resource_id carries the
+    # context_id, not the source_workspace_id, so the response body
+    # does not surface the foreign workspace UUID.
+    assert "Context" in exc_info.value.message
+    assert str(source_ws) not in exc_info.value.message
+
+
+@pytest.mark.asyncio
+async def test_shared_context_recall_uniform_error_does_not_leak_source_workspace():
+    """H2 (CWE-639 / OWASP A01): error body MUST NOT leak source workspace.
+
+    Stronger fence than the previous test: the NotFoundException details
+    dict and message together MUST NOT mention the source workspace
+    UUID. Otherwise an attacker probing context_ids can enumerate which
+    contexts belong to BYOK-less foreign workspaces.
+    """
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+
+    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
+        embed_svc_cls.return_value.has_byok_key = AsyncMock(return_value=False)
+
+        with pytest.raises(NotFoundException) as exc_info:
+            await svc.recall(
+                request=RecallRequest(query="test", k=5),
+                user_id="caller_user",
+                current_context_id=context_id,
+                current_workspace_id=caller_ws,
+                context_workspace_id=source_ws,
+            )
+
+    leaked = str(source_ws)
+    assert leaked not in exc_info.value.message
+    assert leaked not in str(exc_info.value.details)
+
+
+@pytest.mark.asyncio
+async def test_self_workspace_recall_skips_byok_probe():
+    """Optimization fence: same-workspace path must not pay the extra SELECT.
+
+    The has_byok_key probe is cheap (a single indexed SELECT) but it is
+    completely unnecessary when the override is a no-op. This test
+    ensures we do not regress into calling it on the dominant path.
+    """
+    svc, _db = _make_service()
+    workspace_id = uuid4()
+    context_id = uuid4()
+
+    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
+        has_byok_mock = AsyncMock(return_value=True)
+        embed_svc_cls.return_value.has_byok_key = has_byok_mock
+
+        await svc.recall(
+            request=RecallRequest(query="test", k=5),
+            user_id="test_user",
+            current_context_id=context_id,
+            current_workspace_id=workspace_id,
+            context_workspace_id=workspace_id,  # Same as caller
+        )
+
+    has_byok_mock.assert_not_called()

--- a/backend/tests/services/test_recall_shared_context_paid_by.py
+++ b/backend/tests/services/test_recall_shared_context_paid_by.py
@@ -22,6 +22,7 @@ Verifies the four guardrails identified during gate1 design review for
 
 from __future__ import annotations
 
+import contextlib
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -42,6 +43,34 @@ def _make_service():
     svc.search_service.hybrid_search = AsyncMock(return_value=[])
     svc.memory_repo = MagicMock()
     return svc, db
+
+
+@contextlib.contextmanager
+def _patch_byok_gate(
+    *,
+    has_key: bool = True,
+    provider: str = "openai",
+    embedding_model: str = "text-embedding-3-small",
+):
+    """Patch BOTH EmbeddingService AND ContextSearchConfigRepository.
+
+    The H1 gate in ``MemoryService.recall`` (#708 F4 / loop 2) loads the
+    context's ``ContextSearchConfig`` to derive the per-context embedding
+    model + provider before constructing ``EmbeddingService``. Tests that
+    exercise the gate must mock both dependencies in lock-step.
+
+    Yields the ``has_byok_key`` AsyncMock so tests can assert call args.
+    """
+    with (
+        patch("services.memory_service.EmbeddingService") as embed_cls,
+        patch("repositories.config_repository.ContextSearchConfigRepository") as repo_cls,
+    ):
+        embed_cls.return_value.has_byok_key = AsyncMock(return_value=has_key)
+        embed_cls.return_value.provider = provider
+        config_mock = MagicMock()
+        config_mock.embedding_model = embedding_model
+        repo_cls.return_value.create_or_get = AsyncMock(return_value=config_mock)
+        yield embed_cls.return_value.has_byok_key
 
 
 @pytest.mark.asyncio
@@ -97,10 +126,7 @@ async def test_shared_context_recall_routes_to_source_workspace():
     source_ws = uuid4()
     context_id = uuid4()
 
-    # Patch EmbeddingService so the BYOK probe returns True (source has key).
-    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
-        embed_svc_cls.return_value.has_byok_key = AsyncMock(return_value=True)
-
+    with _patch_byok_gate(has_key=True):
         await svc.recall(
             request=RecallRequest(query="test", k=5),
             user_id="caller_user",
@@ -123,10 +149,7 @@ async def test_shared_context_recall_calls_has_byok_with_source_workspace_id():
     source_ws = uuid4()
     context_id = uuid4()
 
-    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
-        has_byok_mock = AsyncMock(return_value=True)
-        embed_svc_cls.return_value.has_byok_key = has_byok_mock
-
+    with _patch_byok_gate(has_key=True) as has_byok_mock:
         await svc.recall(
             request=RecallRequest(query="test", k=5),
             user_id="caller_user",
@@ -154,9 +177,7 @@ async def test_shared_context_recall_denies_when_source_no_byok():
     source_ws = uuid4()
     context_id = uuid4()
 
-    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
-        embed_svc_cls.return_value.has_byok_key = AsyncMock(return_value=False)
-
+    with _patch_byok_gate(has_key=False):
         with pytest.raises(NotFoundException) as exc_info:
             await svc.recall(
                 request=RecallRequest(query="test", k=5),
@@ -192,9 +213,7 @@ async def test_shared_context_recall_uniform_error_does_not_leak_source_workspac
     source_ws = uuid4()
     context_id = uuid4()
 
-    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
-        embed_svc_cls.return_value.has_byok_key = AsyncMock(return_value=False)
-
+    with _patch_byok_gate(has_key=False):
         with pytest.raises(NotFoundException) as exc_info:
             await svc.recall(
                 request=RecallRequest(query="test", k=5),
@@ -249,11 +268,7 @@ async def test_shared_context_keyword_mode_skips_byok_gate():
     source_ws = uuid4()
     context_id = uuid4()
 
-    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
-        has_byok_mock = AsyncMock(return_value=False)
-        embed_svc_cls.return_value.has_byok_key = has_byok_mock
-        embed_svc_cls.return_value.provider = "openai"
-
+    with _patch_byok_gate(has_key=False, provider="openai") as has_byok_mock:
         await svc.recall(
             request=RecallRequest(query="test", k=5, search_mode="keyword"),
             user_id="caller_user",
@@ -279,11 +294,7 @@ async def test_shared_context_ollama_provider_skips_byok_gate():
     source_ws = uuid4()
     context_id = uuid4()
 
-    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
-        has_byok_mock = AsyncMock(return_value=False)
-        embed_svc_cls.return_value.has_byok_key = has_byok_mock
-        embed_svc_cls.return_value.provider = "ollama"
-
+    with _patch_byok_gate(has_key=False, provider="ollama") as has_byok_mock:
         await svc.recall(
             request=RecallRequest(query="test", k=5),
             user_id="caller_user",
@@ -311,10 +322,7 @@ async def test_shared_context_recall_propagates_is_shared_context_read():
     source_ws = uuid4()
     context_id = uuid4()
 
-    with patch("services.memory_service.EmbeddingService") as embed_svc_cls:
-        embed_svc_cls.return_value.has_byok_key = AsyncMock(return_value=True)
-        embed_svc_cls.return_value.provider = "openai"
-
+    with _patch_byok_gate(has_key=True, provider="openai"):
         await svc.recall(
             request=RecallRequest(query="test", k=5),
             user_id="caller_user",
@@ -349,3 +357,81 @@ async def test_self_workspace_recall_does_not_propagate_is_shared_context_read()
 
     call_kwargs = svc.search_service.hybrid_search.call_args.kwargs
     assert call_kwargs.get("is_shared_context_read") is False
+
+
+@pytest.mark.asyncio
+async def test_shared_context_byok_gate_uses_per_context_embedding_model():
+    """#708 F4 (Copilot loop 2): gate must use context's configured model.
+
+    The H1 BYOK probe constructs ``EmbeddingService`` from the context's
+    ``ContextSearchConfig.embedding_model``, not the platform default. A
+    context configured with one provider (e.g. Voyage) running on a
+    platform whose default is OpenAI would otherwise be denied
+    incorrectly, because ``has_byok_key`` would probe for OpenAI keys.
+    """
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+
+    with (
+        patch("services.memory_service.EmbeddingService") as embed_cls,
+        patch("repositories.config_repository.ContextSearchConfigRepository") as repo_cls,
+    ):
+        embed_cls.return_value.has_byok_key = AsyncMock(return_value=True)
+        embed_cls.return_value.provider = "openai"  # derived from model
+        config_mock = MagicMock()
+        config_mock.embedding_model = "voyage-3-large"
+        repo_cls.return_value.create_or_get = AsyncMock(return_value=config_mock)
+
+        await svc.recall(
+            request=RecallRequest(query="test", k=5),
+            user_id="caller_user",
+            current_context_id=context_id,
+            current_workspace_id=caller_ws,
+            context_workspace_id=source_ws,
+        )
+
+    # EmbeddingService MUST be constructed with the context's model, not the default.
+    embed_cls.assert_called_once_with(svc.db, model="voyage-3-large")
+
+
+@pytest.mark.asyncio
+async def test_shared_context_byok_gate_deferred_past_empty_cluster_short_circuit():
+    """#708 F5 (Copilot loop 2): empty cluster → no embedding call → no gate.
+
+    When ``analysis_cluster`` filter pre-resolves to an empty/unknown
+    cluster, ``MemoryService.recall`` returns ``results=[]`` immediately
+    without calling ``hybrid_search`` or generating any embedding. The
+    H1 gate must not fire on this path — otherwise a no-cost filtered
+    read becomes a misleading ``context_not_found`` error.
+    """
+    svc, _db = _make_service()
+    caller_ws = uuid4()
+    source_ws = uuid4()
+    context_id = uuid4()
+    run_id = uuid4()
+
+    with (
+        _patch_byok_gate(has_key=False) as has_byok_mock,
+        patch(
+            "services.analysis.query_service.get_memory_ids_in_cluster",
+            AsyncMock(return_value=[]),  # empty cluster — short-circuit fires
+        ),
+    ):
+        response = await svc.recall(
+            request=RecallRequest(
+                query="test",
+                k=5,
+                filters={"analysis_cluster": {"run_id": str(run_id), "cluster_index": 0}},
+            ),
+            user_id="caller_user",
+            current_context_id=context_id,
+            current_workspace_id=caller_ws,
+            context_workspace_id=source_ws,
+        )
+
+    assert response.results == []
+    # No embedding cost was charged → gate must NOT have fired.
+    has_byok_mock.assert_not_called()
+    svc.search_service.hybrid_search.assert_not_called()

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -377,3 +377,156 @@ class TestSearchServiceMergeResults:
         result = service._merge_results(semantic, [])
         scores = [r["hybrid_score"] for r in result]
         assert scores == sorted(scores, reverse=True)
+
+
+class TestSharedContextReadFlag:
+    """Test ``is_shared_context_read`` flag behavior in ``hybrid_search`` (#708 F2).
+
+    The flag controls an authorization-sensitive bypass and the Qdrant
+    user filter, so its semantics must be directly verified at the
+    SearchService layer (not only at the MemoryService.recall caller).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _routing(self, _patch_routing):
+        """Activate the module-level routing patch for every test in this class."""
+
+    @pytest.fixture
+    def mock_db(self):
+        return MagicMock()
+
+    @pytest.fixture
+    def service(self, mock_db):
+        return SearchService(mock_db)
+
+    @pytest.fixture
+    def default_search_config(self):
+        return type(
+            "DefaultConfig",
+            (),
+            {
+                "semantic_weight": 0.6,
+                "bm25_weight": 0.4,
+                "fetch_factor": 3,
+                "use_rerank": False,
+                "embedding_model": "text-embedding-3-small",
+                "embedding_dimensions": 512,
+            },
+        )()
+
+    @pytest.mark.asyncio
+    async def test_flag_true_skips_context_and_permission_probes(
+        self, service, default_search_config
+    ):
+        """``is_shared_context_read=True`` MUST skip both probes.
+
+        Handler-layer ``_resolve_context_for_read`` already verified
+        access; the redundant ``is_context_shared`` + ``is_workspace_member``
+        SELECTs would (a) waste a round-trip and (b) raise
+        AuthorizationError for cross-workspace callers (system_admin,
+        ContextMember-only) even though the handler granted access. This
+        test fences both anti-behaviors.
+        """
+        service._get_search_config = AsyncMock(return_value=default_search_config)
+
+        mock_ctx_svc = MagicMock()
+        mock_ctx_svc.is_context_shared = AsyncMock(return_value=False)
+        mock_perm_svc = MagicMock()
+        mock_perm_svc.is_workspace_member = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "services.search_service.search_memories_qdrant",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "services.search_service.search_memories_fulltext",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("services.context_service.ContextService", return_value=mock_ctx_svc),
+            patch("services.permission_service.PermissionService", return_value=mock_perm_svc),
+        ):
+            await service.hybrid_search(
+                query="test",
+                user_id="caller_user",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                context_id="00000000-0000-0000-0000-000000000002",
+                k=5,
+                is_shared_context_read=True,
+            )
+
+        mock_ctx_svc.is_context_shared.assert_not_called()
+        mock_perm_svc.is_workspace_member.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_flag_true_propagates_to_both_qdrant_calls(self, service, default_search_config):
+        """``is_shared_context_read=True`` MUST forward ``is_shared_context=True``
+        to BOTH the semantic and the keyword/BM25 Qdrant call sites.
+
+        Either call missing the propagation would re-introduce the
+        ``user_id == caller`` filter and silently drop source-workspace
+        memories authored by other users — the Option A scenario would
+        return empty results despite the routing fix.
+        """
+        service._get_search_config = AsyncMock(return_value=default_search_config)
+
+        mock_qdrant = AsyncMock(return_value=[])
+        mock_fulltext = AsyncMock(return_value=[])
+
+        with (
+            patch("services.search_service.search_memories_qdrant", new=mock_qdrant),
+            patch("services.search_service.search_memories_fulltext", new=mock_fulltext),
+        ):
+            await service.hybrid_search(
+                query="test",
+                user_id="caller_user",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                context_id="00000000-0000-0000-0000-000000000002",
+                k=5,
+                is_shared_context_read=True,
+            )
+
+        assert mock_qdrant.call_args.kwargs["is_shared_context"] is True, (
+            "Semantic Qdrant call MUST receive is_shared_context=True"
+        )
+        assert mock_fulltext.call_args.kwargs["is_shared_context"] is True, (
+            "Keyword Qdrant call MUST receive is_shared_context=True"
+        )
+
+    @pytest.mark.asyncio
+    async def test_flag_false_runs_legacy_probe(self, service, default_search_config):
+        """Default (flag=False): legacy ``is_context_shared`` probe still runs.
+
+        Regression fence: the bypass MUST be opt-in. Same-workspace reads
+        (the dominant path) must continue to call ``is_context_shared``
+        + ``is_workspace_member`` so callers who legitimately need the
+        check still get it. Without this fence, any operator who flips
+        the default to True would silently disable the legacy
+        authorization probe for every recall.
+        """
+        service._get_search_config = AsyncMock(return_value=default_search_config)
+
+        mock_ctx_svc = MagicMock()
+        mock_ctx_svc.is_context_shared = AsyncMock(return_value=False)
+
+        with (
+            patch(
+                "services.search_service.search_memories_qdrant",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "services.search_service.search_memories_fulltext",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch("services.context_service.ContextService", return_value=mock_ctx_svc),
+        ):
+            await service.hybrid_search(
+                query="test",
+                user_id="caller_user",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                context_id="00000000-0000-0000-0000-000000000002",
+                k=5,
+                # is_shared_context_read omitted (defaults to False)
+            )
+
+        mock_ctx_svc.is_context_shared.assert_called_once()

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -583,3 +583,64 @@ class TestSharedContextReadFlag:
             )
 
         mock_ctx_svc.is_context_shared.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_flag_true_propagates_disallow_env_fallback_to_embed(
+        self, service, default_search_config
+    ):
+        """#708 loop 7: ``is_shared_context_read=True`` MUST forward
+        ``disallow_env_fallback=True`` to ``embed_svc.embed_with_usage``.
+
+        Without this, a TOCTOU race between the H1 preflight
+        ``has_byok_key`` probe in ``MemoryService.recall`` and the actual
+        ``_get_user_api_key`` call here could route Option A reads
+        through ``OPENAI_API_KEY`` env fallback — bypassing the BYOK-only
+        spend cap (PR #711) the H1 gate is meant to enforce.
+        """
+        service._get_search_config = AsyncMock(return_value=default_search_config)
+
+        # Capture the kwargs embed_with_usage receives.
+        embed_calls: list[dict] = []
+
+        async def _capture_embed(*args, **kwargs):
+            embed_calls.append(kwargs)
+            return ([0.1] * 512, 10)  # (vector, tokens)
+
+        mock_embed_svc = MagicMock()
+        mock_embed_svc.embed_with_usage = _capture_embed
+        mock_embed_svc.provider = "openai"
+        mock_embed_svc.model = "text-embedding-3-small"
+        mock_embed_svc.resolve_paid_by = AsyncMock(return_value="byok")
+
+        mock_ctx_svc = MagicMock()
+        mock_ctx_svc.is_context_shared = AsyncMock(return_value=True)
+
+        with (
+            patch(
+                "services.search_service.search_memories_qdrant",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "services.search_service.search_memories_fulltext",
+                new=AsyncMock(return_value=[]),
+            ),
+            patch(
+                "services.search_service.resolve_routing_from_config",
+                return_value=("kagura_memories", mock_embed_svc),
+            ),
+            patch("services.context_service.ContextService", return_value=mock_ctx_svc),
+        ):
+            await service.hybrid_search(
+                query="test",
+                user_id="caller_user",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                context_id="00000000-0000-0000-0000-000000000002",
+                k=5,
+                is_shared_context_read=True,
+            )
+
+        # Exactly one embed call (semantic path), and it received the flag.
+        assert len(embed_calls) == 1
+        assert embed_calls[0].get("disallow_env_fallback") is True, (
+            "Option A reads MUST forward disallow_env_fallback=True"
+        )

--- a/backend/tests/services/test_search_service.py
+++ b/backend/tests/services/test_search_service.py
@@ -415,22 +415,25 @@ class TestSharedContextReadFlag:
         )()
 
     @pytest.mark.asyncio
-    async def test_flag_true_skips_context_and_permission_probes(
+    async def test_flag_true_skips_permission_probe_but_still_checks_sharing(
         self, service, default_search_config
     ):
-        """``is_shared_context_read=True`` MUST skip both probes.
+        """``is_shared_context_read=True`` MUST skip ONLY the workspace-member
+        probe, NOT the ``is_context_shared`` probe.
 
-        Handler-layer ``_resolve_context_for_read`` already verified
-        access; the redundant ``is_context_shared`` + ``is_workspace_member``
-        SELECTs would (a) waste a round-trip and (b) raise
-        AuthorizationError for cross-workspace callers (system_admin,
-        ContextMember-only) even though the handler granted access. This
-        test fences both anti-behaviors.
+        Loop 5 fix (Copilot): conflating the two probes was the security
+        bug. The handler-layer ``_resolve_context_for_read`` is the
+        authoritative access check, so the workspace-member probe is
+        redundant. But ``is_context_shared`` controls the Qdrant user_id
+        filter and remains essential — a private context's filter must
+        stay applied even when the caller's access has been verified at
+        a higher layer.
         """
         service._get_search_config = AsyncMock(return_value=default_search_config)
 
         mock_ctx_svc = MagicMock()
-        mock_ctx_svc.is_context_shared = AsyncMock(return_value=False)
+        # Shared context — so is_shared_context=True is the expected outcome.
+        mock_ctx_svc.is_context_shared = AsyncMock(return_value=True)
         mock_perm_svc = MagicMock()
         mock_perm_svc.is_workspace_member = AsyncMock(return_value=False)
 
@@ -455,27 +458,31 @@ class TestSharedContextReadFlag:
                 is_shared_context_read=True,
             )
 
-        mock_ctx_svc.is_context_shared.assert_not_called()
+        # ``is_context_shared`` MUST run — drives the user_id filter decision.
+        mock_ctx_svc.is_context_shared.assert_called_once()
+        # ``is_workspace_member`` MUST be skipped — handler already verified.
         mock_perm_svc.is_workspace_member.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_flag_true_propagates_to_both_qdrant_calls(self, service, default_search_config):
-        """``is_shared_context_read=True`` MUST forward ``is_shared_context=True``
-        to BOTH the semantic and the keyword/BM25 Qdrant call sites.
-
-        Either call missing the propagation would re-introduce the
-        ``user_id == caller`` filter and silently drop source-workspace
-        memories authored by other users — the Option A scenario would
-        return empty results despite the routing fix.
+    async def test_flag_true_shared_context_propagates_to_both_qdrant_calls(
+        self, service, default_search_config
+    ):
+        """``is_shared_context_read=True`` + shared context MUST forward
+        ``is_shared_context=True`` to BOTH the semantic and keyword Qdrant
+        call sites. Either site missing propagation re-introduces the
+        ``user_id == caller`` filter and silently drops source memories.
         """
         service._get_search_config = AsyncMock(return_value=default_search_config)
 
+        mock_ctx_svc = MagicMock()
+        mock_ctx_svc.is_context_shared = AsyncMock(return_value=True)
         mock_qdrant = AsyncMock(return_value=[])
         mock_fulltext = AsyncMock(return_value=[])
 
         with (
             patch("services.search_service.search_memories_qdrant", new=mock_qdrant),
             patch("services.search_service.search_memories_fulltext", new=mock_fulltext),
+            patch("services.context_service.ContextService", return_value=mock_ctx_svc),
         ):
             await service.hybrid_search(
                 query="test",
@@ -487,10 +494,56 @@ class TestSharedContextReadFlag:
             )
 
         assert mock_qdrant.call_args.kwargs["is_shared_context"] is True, (
-            "Semantic Qdrant call MUST receive is_shared_context=True"
+            "Semantic Qdrant call MUST receive is_shared_context=True for shared contexts"
         )
         assert mock_fulltext.call_args.kwargs["is_shared_context"] is True, (
-            "Keyword Qdrant call MUST receive is_shared_context=True"
+            "Keyword Qdrant call MUST receive is_shared_context=True for shared contexts"
+        )
+
+    @pytest.mark.asyncio
+    async def test_flag_true_private_context_keeps_user_id_filter(
+        self, service, default_search_config
+    ):
+        """#708 loop 5 security fence: PRIVATE context + cross-workspace caller
+        MUST keep the Qdrant ``user_id == caller`` filter.
+
+        Scenario: a creator owns a now-private context in workspace W2, but
+        is reading it from their active workspace W1 (cross-workspace under
+        Option A). Without this fence, ``is_shared_context_read=True``
+        would drop the user_id filter and return memories authored by
+        OTHER users (e.g. memories written before the context was made
+        private), bypassing the private-context access rule.
+
+        ``is_shared_context`` is derived from the context's privacy state,
+        NOT from the cross-workspace flag.
+        """
+        service._get_search_config = AsyncMock(return_value=default_search_config)
+
+        mock_ctx_svc = MagicMock()
+        # Private context — is_shared_context=False is the expected outcome.
+        mock_ctx_svc.is_context_shared = AsyncMock(return_value=False)
+        mock_qdrant = AsyncMock(return_value=[])
+        mock_fulltext = AsyncMock(return_value=[])
+
+        with (
+            patch("services.search_service.search_memories_qdrant", new=mock_qdrant),
+            patch("services.search_service.search_memories_fulltext", new=mock_fulltext),
+            patch("services.context_service.ContextService", return_value=mock_ctx_svc),
+        ):
+            await service.hybrid_search(
+                query="test",
+                user_id="caller_user",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                context_id="00000000-0000-0000-0000-000000000002",
+                k=5,
+                is_shared_context_read=True,  # Cross-workspace, BUT context is private
+            )
+
+        assert mock_qdrant.call_args.kwargs["is_shared_context"] is False, (
+            "Private context MUST keep user_id filter even under Option A cross-workspace read"
+        )
+        assert mock_fulltext.call_args.kwargs["is_shared_context"] is False, (
+            "Private context MUST keep user_id filter on keyword path too"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #708

## Summary
- Implements Option A billing for shared-context MCP reads: when the caller workspace differs from the context's owner workspace, embedding cost (BYOK key + spend cap + paid_by + Qdrant collection + graph mutations) routes to the source workspace.
- Service-layer aggregation in `MemoryService.recall`: new `context_workspace_id` parameter, derives `effective_workspace_id`, threads through 4 downstream call sites.
- H1 BYOK-required deny (OWASP A04): source workspace without BYOK → `NotFoundException`. Closes the platform-key fallback uncapped path that PR #711's BYOK-only spend cap intentionally does not cover.
- H2 uniform error (OWASP A01 / CWE-639): handler re-casts `NotFoundException` to `_ContextNotFoundError`. Callers cannot distinguish "source missing BYOK" from "context does not exist for you" via the response body.
- H3 cross-context invariant: `context_ids[]` enforced same-workspace at API boundary (early-break before further permission SELECTs).
- Bundle: migrates `_resolve_context` → `_resolve_context_for_read` for read paths (recall + reference) to unify CWE-639 disclosure across all deny reasons (paid down issue #614 anti-pattern surface).

## Implementation notes
- **Rate-limit invariant preserved**: `mcp_server.tools.__init__._check_rate_limit` keeps the caller workspace as the rate-limit subject. The override scope is bounded to embedding-cost surfaces only, so attackers cannot bypass their own RPS via shared-context reads.
- **Defense-in-depth**: 3-layer model (upstream rate-limit → service H1 BYOK probe → downstream `EmbeddingSpendCapService` BYOK-only cap from PR #711).
- **Server-side audit log**: `paid_by_workspace_id` + `caller_user_id` + `reason="missing_byok"` for admin diagnosis without leaking to client.
- **Behavioral change**: `_resolve_context_for_read` migration broadens the deny-reason range surfaced as `context_not_found` (private non-creator, not-a-member, etc. now uniformly disclosed). Intentional.
- **Defensive bind**: `current_context_id: UUID | None = None` at top of handler `try` block with unreachable-branch fallback in the `NotFoundException` handler — closes a static-analysis edge case the test suite cannot exercise.

## Out of scope (intentional)
- `service.forget()` internal `self.recall(...)` at memory_service.py:1582 — pre-existing missing `current_workspace_id` (fails validation regardless of #708). Follow-up worth filing.
- REST `/api/v1/memory/recall` route — stub since #246 (passes `current_context_id=None`).
- `default_embedding_model` heterogeneity (gate1 R1) — codebase uses single global model from settings; column not yet added. Forward-looking hook: `effective_workspace_id` is the natural insertion point.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (handler-layer integration test gap — acknowledged, follow-up issue worth filing)
- cto: green
- gate1: green via /ask → CTO routing + follow-up /cso
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/708-fix-shared-context-mcp-reads-fail-when-calle.gate1.md
- ~/.claude/cache/gh-issue-driven/708-fix-shared-context-mcp-reads-fail-when-calle.gate2.md

## Tests
- 7 new service-layer unit tests covering self-workspace regression, shared-context routing, BYOK probe targeting, no-BYOK deny, uniform-error workspace-leak fence, and self-workspace BYOK-probe skip optimization.
- 230 existing tests pass (memory_service, mcp_server, recall_analysis_cluster_filter, embedding_service, embedding_spend_cap_service).

🤖 Generated via `/gh-issue-driven:ship`
