### PR TITLE
test(integration): full-chain integration test for embed_with_usage cap gate (#714)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -103,6 +103,7 @@ dev = [
     "pytest-asyncio>=0.24.0",
     "pytest-cov>=6.0.0",
     "pytest-mock>=3.12.0",
+    "fakeredis>=2.20.0",
     "playwright>=1.44.0",
     "pytest-playwright>=0.5.0",
 

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -450,3 +450,46 @@ class TestEmbedWithUsageCapGate:
         keys = [k async for k in fake_redis.scan_iter(match=f"{counter_prefix}*")]
         assert keys == []
         mock_email_service.send_embedding_spend_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_workspace_disappears_mid_call_falls_through(
+        self,
+        db_session: AsyncSession,
+        byok_workspace_with_cap: Workspace,
+        fake_redis: FakeRedis,
+        patch_openai,
+        patch_pricing,
+        mock_email_service,
+    ):
+        """Race: BYOK probe sees the workspace row, then the row is deleted
+        before ``load_workspace`` runs. The gate must return (None, None)
+        and embed must proceed — the call is no longer attributable to a
+        capped workspace, but should not 500.
+
+        The race can't be reproduced via real DELETE because
+        ``ExternalAPIKey.workspace_id`` has ``ondelete=CASCADE`` — the
+        BYOK row would vanish with the workspace. So we patch
+        ``load_workspace`` to return None for one call, simulating the
+        narrow window where the BYOK SELECT and the Workspace SELECT
+        are both real but the row vanished between them.
+        """
+        with patch(
+            "services.embedding_spend_cap_service.EmbeddingSpendCapService.load_workspace",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as mock_load:
+            svc = EmbeddingService(db_session)
+            vector, _ = await svc.embed_with_usage(
+                text="raced call",
+                user_id=byok_workspace_with_cap.owner_user_id,
+                workspace_id=str(byok_workspace_with_cap.id),
+            )
+
+        assert len(vector) == 512
+        mock_load.assert_awaited_once()
+        # No spend recorded because cap_workspace is None
+        counter_prefix = f"embed_spend:{byok_workspace_with_cap.id}:"
+        keys = [k async for k in fake_redis.scan_iter(match=f"{counter_prefix}*")]
+        assert keys == []
+        # Call still succeeded against the mocked OpenAI
+        patch_openai.embeddings.create.assert_awaited_once()

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -331,3 +331,42 @@ class TestEmbedWithUsageCapGate:
         dedup_key = f"embed_spend_alert:{byok_workspace_with_cap.id}:daily:{bucket}:80"
         assert await fake_redis.get(dedup_key) == "1"
         assert await fake_redis.ttl(dedup_key) > 0
+
+    @pytest.mark.asyncio
+    async def test_byok_at_cap_raises_before_api_call(
+        self,
+        db_session: AsyncSession,
+        byok_workspace_with_cap: Workspace,
+        fake_redis: FakeRedis,
+        patch_openai,
+        patch_pricing,
+        mock_email_service,
+    ):
+        """Pre-seed $10 spent (100% of $10 cap). Call must raise
+        EmbeddingSpendCapExceeded BEFORE any OpenAI call, and the
+        counter must NOT have been incremented past 100%."""
+        from datetime import UTC, datetime
+
+        bucket = datetime.now(UTC).strftime("%Y-%m-%d")
+        counter_key = f"embed_spend:{byok_workspace_with_cap.id}:daily:{bucket}"
+        await fake_redis.set(counter_key, str(int(Decimal("10.0") * _MICRO_USD)))
+
+        svc = EmbeddingService(db_session)
+        with pytest.raises(EmbeddingSpendCapExceeded) as exc_info:
+            await svc.embed_with_usage(
+                text="over-cap",
+                user_id=byok_workspace_with_cap.owner_user_id,
+                workspace_id=str(byok_workspace_with_cap.id),
+            )
+
+        # The exception carries the structured fields the route handler
+        # uses to render a QUOTA-002 / 429 response.
+        assert exc_info.value.details["period"] == "daily"
+        assert exc_info.value.details["cap_usd"] == 10.0
+        assert exc_info.value.status_code == 429
+
+        # OpenAI was never called — the gate fired first.
+        patch_openai.embeddings.create.assert_not_called()
+
+        # Counter is untouched (still $10).
+        assert int(await fake_redis.get(counter_key)) == int(Decimal("10.0") * _MICRO_USD)

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -282,3 +282,52 @@ class TestEmbedWithUsageCapGate:
 
         # 5% is below the 80% threshold → no alert
         mock_email_service.send_embedding_spend_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_byok_crossing_80_percent_fires_alert_once(
+        self,
+        db_session: AsyncSession,
+        byok_workspace_with_cap: Workspace,
+        fake_redis: FakeRedis,
+        patch_openai,
+        patch_pricing,
+        mock_email_service,
+    ):
+        """Pre-seed $7.50 spent (75% of $10 cap), one call → $8 (80%) →
+        alert fires exactly once. Second call same day → no second alert
+        (Redis SETNX dedup)."""
+        from datetime import UTC, datetime
+
+        bucket = datetime.now(UTC).strftime("%Y-%m-%d")
+        counter_key = f"embed_spend:{byok_workspace_with_cap.id}:daily:{bucket}"
+        await fake_redis.set(counter_key, str(int(Decimal("7.5") * _MICRO_USD)))
+
+        svc = EmbeddingService(db_session)
+
+        # First call lands at exactly 80% → alert
+        await svc.embed_with_usage(
+            text="call-1",
+            user_id=byok_workspace_with_cap.owner_user_id,
+            workspace_id=str(byok_workspace_with_cap.id),
+        )
+        assert int(await fake_redis.get(counter_key)) == int(Decimal("8.0") * _MICRO_USD)
+        mock_email_service.send_embedding_spend_alert.assert_awaited_once()
+        kwargs = mock_email_service.send_embedding_spend_alert.await_args.kwargs
+        assert kwargs["threshold_pct"] == 80
+        assert kwargs["period"] == "daily"
+
+        # Second call same day lands at 85% — still ≥80% but SETNX has
+        # already claimed the dedup key, so no second alert.
+        await svc.embed_with_usage(
+            text="call-2",
+            user_id=byok_workspace_with_cap.owner_user_id,
+            workspace_id=str(byok_workspace_with_cap.id),
+        )
+        assert int(await fake_redis.get(counter_key)) == int(Decimal("8.5") * _MICRO_USD)
+        # Still exactly one alert send across both calls
+        assert mock_email_service.send_embedding_spend_alert.await_count == 1
+
+        # Dedup key exists with TTL > 0
+        dedup_key = f"embed_spend_alert:{byok_workspace_with_cap.id}:daily:{bucket}:80"
+        assert await fake_redis.get(dedup_key) == "1"
+        assert await fake_redis.ttl(dedup_key) > 0

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -53,7 +53,6 @@ from services.embedding_spend_cap_service import _MICRO_USD  # noqa: E402
 from utils.encryption import get_encryptor  # noqa: E402
 from utils.exceptions import EmbeddingSpendCapExceeded  # noqa: E402
 
-
 # --- Redis ----------------------------------------------------------------
 
 

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -409,3 +409,44 @@ class TestEmbedWithUsageCapGate:
 
         # And no alert.
         mock_email_service.send_embedding_spend_alert.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ollama_provider_skips_cap_path(
+        self,
+        db_session: AsyncSession,
+        byok_workspace_with_cap: Workspace,
+        fake_redis: FakeRedis,
+        patch_openai,
+        patch_pricing,
+        mock_email_service,
+    ):
+        """``provider=ollama`` short-circuits the cap gate regardless of BYOK
+        row presence — Ollama is local, no real provider cost.
+
+        Use ``EmbeddingService(db, provider="ollama")`` and assert the
+        gate returns (None, None) and the counter never moves.
+        """
+        svc = EmbeddingService(db_session)
+        # ``provider`` is derived from the model in __init__; override it
+        # directly so we exercise the Ollama branch without needing a
+        # model registry entry.
+        svc.provider = "ollama"
+        # Bypass the Ollama HTTP probe that runs on first use of _get_client.
+        svc._ollama_verified = True
+
+        # The shared patch_openai fixture replaced ``AsyncOpenAI``, so the
+        # Ollama branch's ``AsyncOpenAI(base_url=..., api_key="ollama")``
+        # call returns the same stub. That's intentional — we don't run a
+        # real Ollama in tests.
+        vector, _ = await svc.embed_with_usage(
+            text="ollama call",
+            user_id=byok_workspace_with_cap.owner_user_id,
+            workspace_id=str(byok_workspace_with_cap.id),
+        )
+        assert len(vector) == 512
+
+        # No counter key — cap path was skipped before any Redis op.
+        counter_prefix = f"embed_spend:{byok_workspace_with_cap.id}:"
+        keys = [k async for k in fake_redis.scan_iter(match=f"{counter_prefix}*")]
+        assert keys == []
+        mock_email_service.send_embedding_spend_alert.assert_not_called()

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -493,3 +493,49 @@ class TestEmbedWithUsageCapGate:
         assert keys == []
         # Call still succeeded against the mocked OpenAI
         patch_openai.embeddings.create.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_redis_outage_during_check_fails_open(
+        self,
+        db_session: AsyncSession,
+        byok_workspace_with_cap: Workspace,
+        fake_redis: FakeRedis,
+        patch_openai,
+        patch_pricing,
+        mock_email_service,
+    ):
+        """``check_cap_or_raise`` swallows any Redis read error and treats
+        spend as 0 — the embed must succeed even if Redis is down at the
+        moment of the cap check. The post-call INCRBY may also fail but
+        does not raise either; the chain must remain non-raising.
+
+        Patch ``get_cache`` on the cap-service module so the pre-check
+        side errors out, and patch ``incrby_counter`` to error so the
+        post-call record is also exercised on the failure path.
+        """
+        from utils.exceptions import RedisError
+
+        with (
+            patch(
+                "services.embedding_spend_cap_service.get_cache",
+                new_callable=AsyncMock,
+                side_effect=RuntimeError("redis down"),
+            ),
+            patch(
+                "services.embedding_spend_cap_service.incrby_counter",
+                new_callable=AsyncMock,
+                side_effect=RedisError("redis down"),
+            ),
+        ):
+            svc = EmbeddingService(db_session)
+            vector, _ = await svc.embed_with_usage(
+                text="redis-out call",
+                user_id=byok_workspace_with_cap.owner_user_id,
+                workspace_id=str(byok_workspace_with_cap.id),
+            )
+
+        assert len(vector) == 512
+        # OpenAI was called (fail-open: cap check failed → treat as $0 spend)
+        patch_openai.embeddings.create.assert_awaited_once()
+        # No alert (record failed → no threshold computation)
+        mock_email_service.send_embedding_spend_alert.assert_not_called()

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -16,9 +16,9 @@ Mock surface (intentional, minimal):
       response with ``usage.prompt_tokens = 100``.
     * ``services.llm_pricing_service.LLMPricingService.compute_cost_usd`` —
       returns ``0.5`` USD per call so cap-trip math is deterministic.
-    * ``services.email_service._email_service`` singleton — replaced with
-      a ``MagicMock`` whose ``send_embedding_spend_alert`` is an
-      ``AsyncMock`` we can assert against.
+    * ``services.email_service._default_email_service`` singleton —
+      replaced with a ``MagicMock`` whose ``send_embedding_spend_alert``
+      is an ``AsyncMock`` we can assert against.
 
 Real surface (do not mock):
     * ``EmbeddingService._prepare_spend_cap_gate``, ``has_byok_key``,
@@ -375,8 +375,9 @@ class TestEmbedWithUsageCapGate:
         """``provider=ollama`` short-circuits the cap gate regardless of BYOK
         row presence — Ollama is local, no real provider cost.
 
-        Use ``EmbeddingService(db, provider="ollama")`` and assert the
-        gate returns (None, None) and the counter never moves.
+        ``EmbeddingService.__init__`` derives ``provider`` from the model
+        registry, so we override ``svc.provider`` post-construction to
+        exercise the Ollama branch without registering a fake model.
         """
         svc = EmbeddingService(db_session)
         # ``provider`` is derived from the model in __init__; override it

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -252,39 +252,44 @@ class TestEmbedWithUsageCapGate:
         """Pre-seed $7.50 spent (75% of $10 cap), one call → $8 (80%) →
         alert fires exactly once. Second call same day → no second alert
         (Redis SETNX dedup)."""
-        bucket = datetime.now(UTC).strftime("%Y-%m-%d")
-        counter_key = f"embed_spend:{byok_workspace_with_cap.id}:daily:{bucket}"
-        await fake_redis.set(counter_key, str(int(Decimal("7.5") * _MICRO_USD)))
+        frozen_now = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+        with patch(
+            "services.embedding_spend_cap_service.utcnow",
+            return_value=frozen_now,
+        ):
+            bucket = frozen_now.strftime("%Y-%m-%d")
+            counter_key = f"embed_spend:{byok_workspace_with_cap.id}:daily:{bucket}"
+            await fake_redis.set(counter_key, str(int(Decimal("7.5") * _MICRO_USD)))
 
-        svc = EmbeddingService(db_session)
+            svc = EmbeddingService(db_session)
 
-        # First call lands at exactly 80% → alert
-        await svc.embed_with_usage(
-            text="call-1",
-            user_id=byok_workspace_with_cap.owner_user_id,
-            workspace_id=str(byok_workspace_with_cap.id),
-        )
-        assert int(await fake_redis.get(counter_key)) == int(Decimal("8.0") * _MICRO_USD)
-        mock_email_service.send_embedding_spend_alert.assert_awaited_once()
-        kwargs = mock_email_service.send_embedding_spend_alert.await_args.kwargs
-        assert kwargs["threshold_pct"] == 80
-        assert kwargs["period"] == "daily"
+            # First call lands at exactly 80% → alert
+            await svc.embed_with_usage(
+                text="call-1",
+                user_id=byok_workspace_with_cap.owner_user_id,
+                workspace_id=str(byok_workspace_with_cap.id),
+            )
+            assert int(await fake_redis.get(counter_key)) == int(Decimal("8.0") * _MICRO_USD)
+            mock_email_service.send_embedding_spend_alert.assert_awaited_once()
+            kwargs = mock_email_service.send_embedding_spend_alert.await_args.kwargs
+            assert kwargs["threshold_pct"] == 80
+            assert kwargs["period"] == "daily"
 
-        # Second call same day lands at 85% — still ≥80% but SETNX has
-        # already claimed the dedup key, so no second alert.
-        await svc.embed_with_usage(
-            text="call-2",
-            user_id=byok_workspace_with_cap.owner_user_id,
-            workspace_id=str(byok_workspace_with_cap.id),
-        )
-        assert int(await fake_redis.get(counter_key)) == int(Decimal("8.5") * _MICRO_USD)
-        # Still exactly one alert send across both calls
-        assert mock_email_service.send_embedding_spend_alert.await_count == 1
+            # Second call same day lands at 85% — still ≥80% but SETNX has
+            # already claimed the dedup key, so no second alert.
+            await svc.embed_with_usage(
+                text="call-2",
+                user_id=byok_workspace_with_cap.owner_user_id,
+                workspace_id=str(byok_workspace_with_cap.id),
+            )
+            assert int(await fake_redis.get(counter_key)) == int(Decimal("8.5") * _MICRO_USD)
+            # Still exactly one alert send across both calls
+            assert mock_email_service.send_embedding_spend_alert.await_count == 1
 
-        # Dedup key exists with TTL > 0
-        dedup_key = f"embed_spend_alert:{byok_workspace_with_cap.id}:daily:{bucket}:80"
-        assert await fake_redis.get(dedup_key) == "1"
-        assert await fake_redis.ttl(dedup_key) > 0
+            # Dedup key exists with TTL > 0
+            dedup_key = f"embed_spend_alert:{byok_workspace_with_cap.id}:daily:{bucket}:80"
+            assert await fake_redis.get(dedup_key) == "1"
+            assert await fake_redis.ttl(dedup_key) > 0
 
     @pytest.mark.asyncio
     async def test_byok_at_cap_raises_before_api_call(

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -31,7 +31,7 @@ Real surface (do not mock):
 
 from __future__ import annotations
 
-import os
+from datetime import UTC, datetime
 from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -41,17 +41,15 @@ import pytest_asyncio
 from fakeredis.aioredis import FakeRedis
 from sqlalchemy.ext.asyncio import AsyncSession
 
-# Test-only API_KEY_SECRET so any ExternalAPIKey decrypt path that falls back
-# to Fernet has a stable key (mirrors backend/tests/integration/conftest.py:42).
-os.environ.setdefault("API_KEY_SECRET", "integration-test-api-key-secret-not-for-prod")
+from db import redis as redis_module
+from models.auth import ExternalAPIKey, Workspace
+from services import email_service as email_module
+from services.embedding_service import EmbeddingService
+from services.embedding_spend_cap_service import _MICRO_USD
+from utils.encryption import get_encryptor
+from utils.exceptions import EmbeddingSpendCapExceeded, RedisError
 
-from db import redis as redis_module  # noqa: E402
-from models.auth import ExternalAPIKey, User, Workspace  # noqa: E402
-from services import email_service as email_module  # noqa: E402
-from services.embedding_service import EmbeddingService  # noqa: E402
-from services.embedding_spend_cap_service import _MICRO_USD  # noqa: E402
-from utils.encryption import get_encryptor  # noqa: E402
-from utils.exceptions import EmbeddingSpendCapExceeded  # noqa: E402
+from ._admin_helpers import make_user
 
 # --- Redis ----------------------------------------------------------------
 
@@ -143,90 +141,48 @@ def mock_email_service():
 # --- DB rows --------------------------------------------------------------
 
 
-async def _commit_user(db: AsyncSession, *, user_id: str | None = None) -> User:
-    uid = user_id or f"u_{uuid4().hex[:8]}"
-    user = User(
-        email=f"{uid}@test.invalid",
-        user_id=uid,
-        name="Cap Test User",
-        role="user",
-        is_initial_admin=False,
-        auth_method="oauth",
-        auth_provider="google",
-    )
-    db.add(user)
-    await db.flush()
-    return user
-
-
-async def _commit_workspace(
-    db: AsyncSession,
+def _build_workspace(
     *,
     owner_user_id: str,
-    plan_name: str = "free",
     embedding_daily_cap_usd: Decimal | None = None,
-    embedding_monthly_cap_usd: Decimal | None = None,
 ) -> Workspace:
-    ws = Workspace(
+    return Workspace(
         id=uuid4(),
         name=f"ws-{uuid4().hex[:8]}",
-        plan_name=plan_name,
+        plan_name="free",
         owner_user_id=owner_user_id,
         memory_limit=1000,
         daily_api_limit=500,
         weekly_api_limit=2500,
         embedding_daily_cap_usd=embedding_daily_cap_usd,
-        embedding_monthly_cap_usd=embedding_monthly_cap_usd,
     )
-    db.add(ws)
-    await db.flush()
-    return ws
 
 
-async def _commit_byok_key(
-    db: AsyncSession,
-    *,
-    workspace_id,
-    user_id: str,
-    context_id=None,
-    provider: str = "openai",
-) -> ExternalAPIKey:
-    encrypted = get_encryptor().encrypt("sk-test-fake-byok-key")
-    key = ExternalAPIKey(
+def _build_byok_key(*, workspace_id, user_id: str) -> ExternalAPIKey:
+    return ExternalAPIKey(
         key_name=f"k_{uuid4().hex[:8]}",
-        provider=provider,
-        encrypted_value=encrypted,
+        provider="openai",
+        encrypted_value=get_encryptor().encrypt("sk-test-fake-byok-key"),
         user_id=user_id,
         workspace_id=workspace_id,
-        context_id=context_id,
         enabled=True,
     )
-    db.add(key)
-    await db.flush()
-    return key
-
-
-@pytest_asyncio.fixture
-async def byok_workspace(db_session: AsyncSession):
-    """Workspace + BYOK key, no cap configured (uncapped)."""
-    user = await _commit_user(db_session)
-    ws = await _commit_workspace(db_session, owner_user_id=user.user_id)
-    await _commit_byok_key(db_session, workspace_id=ws.id, user_id=user.user_id)
-    await db_session.commit()
-    yield ws
-    await db_session.rollback()
 
 
 @pytest_asyncio.fixture
 async def byok_workspace_with_cap(db_session: AsyncSession):
     """Workspace + BYOK key with a $10 daily cap, no monthly cap."""
-    user = await _commit_user(db_session)
-    ws = await _commit_workspace(
-        db_session,
+    user = make_user()
+    ws = _build_workspace(
         owner_user_id=user.user_id,
         embedding_daily_cap_usd=Decimal("10.000000"),
     )
-    await _commit_byok_key(db_session, workspace_id=ws.id, user_id=user.user_id)
+    db_session.add_all([user, ws])
+    # FK dep: external_api_keys.workspace_id → workspaces.id. The FK uses a
+    # raw UUID value (no SQLAlchemy relationship), so UoW can't sort the
+    # INSERTs — flush the parent first.
+    await db_session.flush()
+    db_session.add(_build_byok_key(workspace_id=ws.id, user_id=user.user_id))
     await db_session.commit()
     yield ws
     await db_session.rollback()
@@ -235,8 +191,9 @@ async def byok_workspace_with_cap(db_session: AsyncSession):
 @pytest_asyncio.fixture
 async def unbound_workspace(db_session: AsyncSession):
     """Workspace without any ``ExternalAPIKey`` row — platform-fallback path."""
-    user = await _commit_user(db_session)
-    ws = await _commit_workspace(db_session, owner_user_id=user.user_id)
+    user = make_user()
+    ws = _build_workspace(owner_user_id=user.user_id)
+    db_session.add_all([user, ws])
     await db_session.commit()
     yield ws
     await db_session.rollback()
@@ -295,8 +252,6 @@ class TestEmbedWithUsageCapGate:
         """Pre-seed $7.50 spent (75% of $10 cap), one call → $8 (80%) →
         alert fires exactly once. Second call same day → no second alert
         (Redis SETNX dedup)."""
-        from datetime import UTC, datetime
-
         bucket = datetime.now(UTC).strftime("%Y-%m-%d")
         counter_key = f"embed_spend:{byok_workspace_with_cap.id}:daily:{bucket}"
         await fake_redis.set(counter_key, str(int(Decimal("7.5") * _MICRO_USD)))
@@ -344,8 +299,6 @@ class TestEmbedWithUsageCapGate:
         """Pre-seed $10 spent (100% of $10 cap). Call must raise
         EmbeddingSpendCapExceeded BEFORE any OpenAI call, and the
         counter must NOT have been incremented past 100%."""
-        from datetime import UTC, datetime
-
         bucket = datetime.now(UTC).strftime("%Y-%m-%d")
         counter_key = f"embed_spend:{byok_workspace_with_cap.id}:daily:{bucket}"
         await fake_redis.set(counter_key, str(int(Decimal("10.0") * _MICRO_USD)))
@@ -512,8 +465,6 @@ class TestEmbedWithUsageCapGate:
         side errors out, and patch ``incrby_counter`` to error so the
         post-call record is also exercised on the failure path.
         """
-        from utils.exceptions import RedisError
-
         with (
             patch(
                 "services.embedding_spend_cap_service.get_cache",

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -50,6 +50,7 @@ from models.auth import ExternalAPIKey, User, Workspace  # noqa: E402
 from services import email_service as email_module  # noqa: E402
 from services.embedding_service import EmbeddingService  # noqa: E402
 from services.embedding_spend_cap_service import _MICRO_USD  # noqa: E402
+from utils.encryption import get_encryptor  # noqa: E402
 from utils.exceptions import EmbeddingSpendCapExceeded  # noqa: E402
 
 
@@ -132,12 +133,12 @@ def mock_email_service():
     """Swap the email singleton with a ``MagicMock`` for alert assertions."""
     fake = MagicMock()
     fake.send_embedding_spend_alert = AsyncMock(return_value=True)
-    prev = email_module._email_service
-    email_module._email_service = fake
+    prev = email_module._default_email_service
+    email_module._default_email_service = fake
     try:
         yield fake
     finally:
-        email_module._email_service = prev
+        email_module._default_email_service = prev
 
 
 # --- DB rows --------------------------------------------------------------
@@ -191,10 +192,11 @@ async def _commit_byok_key(
     context_id=None,
     provider: str = "openai",
 ) -> ExternalAPIKey:
+    encrypted = get_encryptor().encrypt("sk-test-fake-byok-key")
     key = ExternalAPIKey(
         key_name=f"k_{uuid4().hex[:8]}",
         provider=provider,
-        encrypted_value="fernet:placeholder",
+        encrypted_value=encrypted,
         user_id=user_id,
         workspace_id=workspace_id,
         context_id=context_id,
@@ -239,3 +241,44 @@ async def unbound_workspace(db_session: AsyncSession):
     await db_session.commit()
     yield ws
     await db_session.rollback()
+
+
+# --- Tests ----------------------------------------------------------------
+
+
+class TestEmbedWithUsageCapGate:
+    """Integration tests for embed_with_usage → cap_service chain (#714)."""
+
+    @pytest.mark.asyncio
+    async def test_byok_under_cap_passes_and_records_spend(
+        self,
+        db_session: AsyncSession,
+        byok_workspace_with_cap: Workspace,
+        fake_redis: FakeRedis,
+        patch_openai,
+        patch_pricing,
+        mock_email_service,
+    ):
+        """BYOK workspace, $10 daily cap, no prior spend → first call succeeds,
+        counter rises to $0.50 (5% of cap), no alert fires."""
+        svc = EmbeddingService(db_session)
+        vector, tokens = await svc.embed_with_usage(
+            text="hello world",
+            user_id=byok_workspace_with_cap.owner_user_id,
+            workspace_id=str(byok_workspace_with_cap.id),
+        )
+
+        assert len(vector) == 512
+        assert tokens == 100
+
+        # OpenAI was actually called (gate did not short-circuit)
+        patch_openai.embeddings.create.assert_awaited_once()
+
+        # Counter reflects $0.50 (= 500_000 micro-USD)
+        counter_key_prefix = f"embed_spend:{byok_workspace_with_cap.id}:daily:"
+        keys = [k async for k in fake_redis.scan_iter(match=f"{counter_key_prefix}*")]
+        assert len(keys) == 1
+        assert int(await fake_redis.get(keys[0])) == int(Decimal("0.5") * _MICRO_USD)
+
+        # 5% is below the 80% threshold → no alert
+        mock_email_service.send_embedding_spend_alert.assert_not_called()

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -370,3 +370,42 @@ class TestEmbedWithUsageCapGate:
 
         # Counter is untouched (still $10).
         assert int(await fake_redis.get(counter_key)) == int(Decimal("10.0") * _MICRO_USD)
+
+    @pytest.mark.asyncio
+    async def test_platform_fallback_skips_cap_path(
+        self,
+        db_session: AsyncSession,
+        unbound_workspace: Workspace,
+        fake_redis: FakeRedis,
+        patch_openai,
+        patch_pricing,
+        mock_email_service,
+        monkeypatch,
+    ):
+        """Workspace WITHOUT a BYOK row → ``has_byok_key`` returns False →
+        ``_prepare_spend_cap_gate`` returns (None, None) → embed succeeds
+        using OPENAI_API_KEY env, no counter increment, no alert.
+
+        This is the BYOK-only-cap contract documented in
+        ``_prepare_spend_cap_gate`` (issue #708 drain-attack mitigation):
+        platform-key fallback is NOT subject to the per-workspace cap.
+        """
+        monkeypatch.setenv("OPENAI_API_KEY", "test-env-key")
+
+        svc = EmbeddingService(db_session)
+        vector, _ = await svc.embed_with_usage(
+            text="platform call",
+            user_id=unbound_workspace.owner_user_id,
+            workspace_id=str(unbound_workspace.id),
+        )
+
+        assert len(vector) == 512
+        patch_openai.embeddings.create.assert_awaited_once()
+
+        # No counter key created — cap path was never entered.
+        counter_prefix = f"embed_spend:{unbound_workspace.id}:"
+        keys = [k async for k in fake_redis.scan_iter(match=f"{counter_prefix}*")]
+        assert keys == []
+
+        # And no alert.
+        mock_email_service.send_embedding_spend_alert.assert_not_called()

--- a/backend/tests/services/test_embedding_service_integration.py
+++ b/backend/tests/services/test_embedding_service_integration.py
@@ -1,0 +1,241 @@
+"""Full-chain integration tests for ``EmbeddingService.embed_with_usage`` (#714).
+
+Closes the coverage gap left by PR #711 (#709) — the per-workspace embedding
+spend cap was unit-tested in isolation in
+``test_embedding_spend_cap_service.py`` but the chain through
+``_prepare_spend_cap_gate`` (with its BYOK probe, cap pre-check, and
+post-call ``record_spend_from_tokens``) was only covered indirectly.
+
+Each test exercises the real Postgres test DB, ``fakeredis.aioredis.FakeRedis``
+in place of Redis, and ``AsyncMock`` stubs for the OpenAI SDK and the
+``LLMPricingService.compute_cost_usd`` helper. Implementation under test
+is unchanged — these tests are debt cleanup, not a behavior change.
+
+Mock surface (intentional, minimal):
+    * ``services.embedding_service.AsyncOpenAI`` — synthetic 512-dim
+      response with ``usage.prompt_tokens = 100``.
+    * ``services.llm_pricing_service.LLMPricingService.compute_cost_usd`` —
+      returns ``0.5`` USD per call so cap-trip math is deterministic.
+    * ``services.email_service._email_service`` singleton — replaced with
+      a ``MagicMock`` whose ``send_embedding_spend_alert`` is an
+      ``AsyncMock`` we can assert against.
+
+Real surface (do not mock):
+    * ``EmbeddingService._prepare_spend_cap_gate``, ``has_byok_key``,
+      ``_get_user_api_key`` — the chain under test.
+    * ``EmbeddingSpendCapService`` — full instance, real cap arithmetic.
+    * Postgres test DB via the session-scoped ``db_session`` fixture.
+    * ``fakeredis.aioredis.FakeRedis`` — speaks the Redis wire protocol;
+      ``get_cache`` / ``incrby_counter`` / ``SETNX`` all work unmodified.
+"""
+
+from __future__ import annotations
+
+import os
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from fakeredis.aioredis import FakeRedis
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Test-only API_KEY_SECRET so any ExternalAPIKey decrypt path that falls back
+# to Fernet has a stable key (mirrors backend/tests/integration/conftest.py:42).
+os.environ.setdefault("API_KEY_SECRET", "integration-test-api-key-secret-not-for-prod")
+
+from db import redis as redis_module  # noqa: E402
+from models.auth import ExternalAPIKey, User, Workspace  # noqa: E402
+from services import email_service as email_module  # noqa: E402
+from services.embedding_service import EmbeddingService  # noqa: E402
+from services.embedding_spend_cap_service import _MICRO_USD  # noqa: E402
+from utils.exceptions import EmbeddingSpendCapExceeded  # noqa: E402
+
+
+# --- Redis ----------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def fake_redis():
+    """Bind a fresh ``FakeRedis`` to ``db.redis._redis_client`` for one test.
+
+    ``get_redis_client()`` returns the module-level singleton, so every
+    helper that touches Redis (``get_cache``, ``incrby_counter``,
+    ``SETNX``) goes through this fake without further patching. Teardown
+    flushes the DB and restores the singleton so the next test rebinds.
+    """
+    fake = FakeRedis(decode_responses=True)
+    prev = redis_module._redis_client
+    redis_module._redis_client = fake
+    try:
+        yield fake
+    finally:
+        await fake.flushall()
+        await fake.aclose()
+        redis_module._redis_client = prev
+
+
+# --- OpenAI ---------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_openai_client():
+    """Stub AsyncOpenAI exposing ``.embeddings.create`` as an ``AsyncMock``.
+
+    Default response: 512-dim vector and 100 prompt_tokens. Tests can
+    override via ``mock_openai_client.embeddings.create.side_effect``.
+    """
+    client = MagicMock()
+    response = MagicMock()
+    response.data = [MagicMock(embedding=[0.1] * 512)]
+    response.usage = MagicMock(prompt_tokens=100, total_tokens=100)
+    client.embeddings = MagicMock()
+    client.embeddings.create = AsyncMock(return_value=response)
+    return client
+
+
+@pytest.fixture
+def patch_openai(mock_openai_client):
+    """Replace ``services.embedding_service.AsyncOpenAI`` with a factory."""
+    with patch(
+        "services.embedding_service.AsyncOpenAI",
+        return_value=mock_openai_client,
+    ):
+        yield mock_openai_client
+
+
+# --- Pricing --------------------------------------------------------------
+
+
+@pytest.fixture
+def patch_pricing():
+    """Pin ``LLMPricingService.compute_cost_usd`` to $0.50/call.
+
+    With this constant, a workspace with a $10 daily cap takes exactly
+    20 calls to exhaust. Combined with pre-seeded Redis counters the
+    tests can reach any %-of-cap state in one extra call.
+    """
+    with patch(
+        "services.llm_pricing_service.LLMPricingService.compute_cost_usd",
+        new_callable=AsyncMock,
+    ) as mock_cost:
+        mock_cost.return_value = 0.5
+        yield mock_cost
+
+
+# --- Email ----------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_email_service():
+    """Swap the email singleton with a ``MagicMock`` for alert assertions."""
+    fake = MagicMock()
+    fake.send_embedding_spend_alert = AsyncMock(return_value=True)
+    prev = email_module._email_service
+    email_module._email_service = fake
+    try:
+        yield fake
+    finally:
+        email_module._email_service = prev
+
+
+# --- DB rows --------------------------------------------------------------
+
+
+async def _commit_user(db: AsyncSession, *, user_id: str | None = None) -> User:
+    uid = user_id or f"u_{uuid4().hex[:8]}"
+    user = User(
+        email=f"{uid}@test.invalid",
+        user_id=uid,
+        name="Cap Test User",
+        role="user",
+        is_initial_admin=False,
+        auth_method="oauth",
+        auth_provider="google",
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+async def _commit_workspace(
+    db: AsyncSession,
+    *,
+    owner_user_id: str,
+    plan_name: str = "free",
+    embedding_daily_cap_usd: Decimal | None = None,
+    embedding_monthly_cap_usd: Decimal | None = None,
+) -> Workspace:
+    ws = Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name=plan_name,
+        owner_user_id=owner_user_id,
+        memory_limit=1000,
+        daily_api_limit=500,
+        weekly_api_limit=2500,
+        embedding_daily_cap_usd=embedding_daily_cap_usd,
+        embedding_monthly_cap_usd=embedding_monthly_cap_usd,
+    )
+    db.add(ws)
+    await db.flush()
+    return ws
+
+
+async def _commit_byok_key(
+    db: AsyncSession,
+    *,
+    workspace_id,
+    user_id: str,
+    context_id=None,
+    provider: str = "openai",
+) -> ExternalAPIKey:
+    key = ExternalAPIKey(
+        key_name=f"k_{uuid4().hex[:8]}",
+        provider=provider,
+        encrypted_value="fernet:placeholder",
+        user_id=user_id,
+        workspace_id=workspace_id,
+        context_id=context_id,
+        enabled=True,
+    )
+    db.add(key)
+    await db.flush()
+    return key
+
+
+@pytest_asyncio.fixture
+async def byok_workspace(db_session: AsyncSession):
+    """Workspace + BYOK key, no cap configured (uncapped)."""
+    user = await _commit_user(db_session)
+    ws = await _commit_workspace(db_session, owner_user_id=user.user_id)
+    await _commit_byok_key(db_session, workspace_id=ws.id, user_id=user.user_id)
+    await db_session.commit()
+    yield ws
+    await db_session.rollback()
+
+
+@pytest_asyncio.fixture
+async def byok_workspace_with_cap(db_session: AsyncSession):
+    """Workspace + BYOK key with a $10 daily cap, no monthly cap."""
+    user = await _commit_user(db_session)
+    ws = await _commit_workspace(
+        db_session,
+        owner_user_id=user.user_id,
+        embedding_daily_cap_usd=Decimal("10.000000"),
+    )
+    await _commit_byok_key(db_session, workspace_id=ws.id, user_id=user.user_id)
+    await db_session.commit()
+    yield ws
+    await db_session.rollback()
+
+
+@pytest_asyncio.fixture
+async def unbound_workspace(db_session: AsyncSession):
+    """Workspace without any ``ExternalAPIKey`` row — platform-fallback path."""
+    user = await _commit_user(db_session)
+    ws = await _commit_workspace(db_session, owner_user_id=user.user_id)
+    await db_session.commit()
+    yield ws
+    await db_session.rollback()


### PR DESCRIPTION
## Summary

Closes #714. Adds 7 integration tests covering the full chain `embed_with_usage` → `_prepare_spend_cap_gate` → `has_byok_key` → `check_cap_or_raise` → mocked OpenAI → `record_spend_from_tokens` → Redis counter + alert. Closes the test-coverage gap left by PR #711 (the existing 18 unit tests covered `EmbeddingSpendCapService` in isolation; the chain through `EmbeddingService` was covered only indirectly).

**Cases covered** (all 7 from the issue table):
- BYOK workspace under cap → counter advances, no alert
- BYOK workspace at 80% threshold → alert fires once, SETNX dedup on second call
- BYOK workspace at 100% → `EmbeddingSpendCapExceeded` raised pre-API-call, counter untouched
- Platform-fallback (no BYOK row) → cap path skipped entirely, no counter, no alert
- Ollama provider → cap path short-circuits, no counter, no alert
- Workspace deleted between BYOK probe and gate (race) → gate returns `(None, None)`, embed proceeds
- Redis outage during pre-check → fail-open, embed succeeds, no alert

## Implementation Notes

- File lives under `backend/tests/integration/` (not `backend/tests/services/`) because the chain needs the alembic-migrated `kagura_test` DB plus a Redis stand-in — neither is set up by the `backend-unit` CI job. This matches the convention named in the issue's implementation notes.
- `fakeredis.aioredis.FakeRedis` is bound to `db.redis._redis_client` by a fixture so `get_cache` / `incrby_counter` / `SETNX` all route through it without further patching. Added `fakeredis>=2.20.0` to backend dev deps.
- Mock surface (intentional, minimal): `services.embedding_service.AsyncOpenAI`, `LLMPricingService.compute_cost_usd` (pinned to $0.50/call so cap-trip math is deterministic), `services.email_service._default_email_service` singleton. Everything else is real code paths.
- BYOK fixture encrypts a stable test value via `get_encryptor().encrypt(...)` so the `_get_user_api_key` decrypt step doesn't error on a Fernet placeholder.
- Workspace fixture commits a single flush between Workspace and ExternalAPIKey because the FK uses a raw-UUID column (no `relationship()` to hint UoW topological sort). Comment in fixture explains why.
- Reuses `_admin_helpers.make_user` rather than duplicating the User-construction helper.

## CI

This file is NOT picked up by the existing `backend-unit` job (it excludes `tests/integration/`). Adding a `backend-integration` CI job is tracked by **#721** (split out of the sibling #613 schema-drift work). Locally runnable today via `make test-integration`; CI coverage lands when #721 ships.

## Test Plan

- [x] `make test-integration` — all 7 new tests pass (16 unrelated pre-existing failures in other files unchanged)
- [x] `pytest tests/services/test_embedding_spend_cap_service.py tests/services/test_embedding_service.py tests/integration/test_embedding_service_integration.py` — 45 passed (no fixture leak across suites)
- [x] `ruff check` + `ruff format --check` clean on the new file
- [x] `make type-check` unchanged (2 pre-existing errors in `gemini_provider.py` / `ollama_cloud_provider.py` are not from this branch)
- [x] Self-review via `/self-review` — 0 critical, 0 warnings after 2 docstring fixes applied
- [x] `/simplify` reduced file from 540 → 491 LOC (drop dup `API_KEY_SECRET` setdefault, reuse `make_user`, drop dead kwargs, consolidate flushes)