### PR TITLE
feat(neural): separate semantic edges from Hebbian decay (#722)

### DIFF
--- a/backend/alembic/versions/e17_722_neural_edge_origin.py
+++ b/backend/alembic/versions/e17_722_neural_edge_origin.py
@@ -52,6 +52,7 @@ def upgrade() -> None:
         "idx_edges_origin",
         "neural_memory_edges",
         ["origin"],
+        postgresql_where=sa.text("origin = 'semantic'"),
     )
 
 

--- a/backend/alembic/versions/e17_722_neural_edge_origin.py
+++ b/backend/alembic/versions/e17_722_neural_edge_origin.py
@@ -1,0 +1,61 @@
+"""Add origin discriminator to neural_memory_edges (Issue #722).
+
+Adds an ``origin`` column to distinguish how each edge was created:
+
+* ``hebbian``  — runtime co-activation trace (subject to decay/prune)
+* ``semantic`` — sleep edge_discovery's cosine-similarity find (decay-exempt)
+* ``declared`` — user-asserted link (decay-exempt)
+
+Default ``'hebbian'`` correctly classifies every existing row (all pre-issue
+edges are co-activation traces), so no backfill is needed. The downstream
+decay carve-out lands in a subsequent task in the same PR.
+
+Revision string length: 26 chars (well within ``alembic_version.version_num``
+VARCHAR(32)).
+
+Revision ID: e17_722_neural_edge_origin
+Revises: e16_709_embedding_spend_cap
+Create Date: 2026-05-19
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "e17_722_neural_edge_origin"
+down_revision = "e16_709_embedding_spend_cap"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "neural_memory_edges",
+        sa.Column(
+            "origin",
+            sa.String(length=20),
+            nullable=False,
+            server_default="hebbian",
+        ),
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TABLE neural_memory_edges
+                ADD CONSTRAINT valid_edge_origin
+                CHECK (origin IN ('hebbian', 'semantic', 'declared'));
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+    op.create_index(
+        "idx_edges_origin",
+        "neural_memory_edges",
+        ["origin"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_edges_origin", table_name="neural_memory_edges")
+    op.execute("ALTER TABLE neural_memory_edges DROP CONSTRAINT IF EXISTS valid_edge_origin")
+    op.drop_column("neural_memory_edges", "origin")

--- a/backend/scripts/backfill_semantic_edges.py
+++ b/backend/scripts/backfill_semantic_edges.py
@@ -31,7 +31,6 @@ from typing import Any, Protocol
 from uuid import UUID
 
 _HERE = Path(__file__).parent
-sys.path.insert(0, str(_HERE.parent))  # backend/  → enables `from src.X`
 sys.path.insert(0, str(_HERE.parent / "src"))  # backend/src/ → enables `from X`
 
 from sqlalchemy import func, select  # noqa: E402
@@ -61,7 +60,7 @@ class QdrantNeighborClient(Protocol):
         top_k: int,
     ) -> list[tuple[UUID, float]]:
         """Return up to top_k (neighbor_uuid, cosine_score) pairs for memory_id."""
-        ...
+        pass
 
 
 class RealQdrantNeighborClient:
@@ -326,8 +325,12 @@ async def _main(args: argparse.Namespace) -> int:
                 )
                 try:
                     await db.rollback()
-                except Exception:
-                    pass
+                except Exception as rollback_exc:
+                    logger.warning(
+                        "backfill_rollback_failed",
+                        context_id=str(ctx_id),
+                        error=str(rollback_exc),
+                    )
                 continue
             total_contexts += 1
             if result.get("skipped"):

--- a/backend/scripts/backfill_semantic_edges.py
+++ b/backend/scripts/backfill_semantic_edges.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""One-shot backfill of origin='semantic' edges from cosine similarity.
+
+Issue #722. Recovers semantic graph structure lost to the Hebbian decay
+loop before the origin discriminator was introduced. Idempotent via
+ON CONFLICT DO NOTHING on the (user_id, src_id, dst_id) unique index.
+
+Usage:
+    python -m scripts.backfill_semantic_edges \\
+        [--context-id <uuid>] \\
+        [--min-memories 50] [--sim-threshold 0.7] [--top-k 10] [--dry-run]
+
+If --context-id is omitted, every context with >= --min-memories alive
+memories is backfilled.
+
+Operational notes:
+    * Commits per-context, so a failure mid-run loses at most one context's work.
+    * The DB session is held open across Qdrant I/O for the full run; on very
+      large contexts (>1000 memories) consider running with --context-id once
+      per context instead of the all-contexts sweep.
+    * Use --dry-run first to size the impact before committing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any, Protocol
+from uuid import UUID
+
+_HERE = Path(__file__).parent
+sys.path.insert(0, str(_HERE.parent))  # backend/  → enables `from src.X`
+sys.path.insert(0, str(_HERE.parent / "src"))  # backend/src/ → enables `from X`
+
+from sqlalchemy import func, select  # noqa: E402
+from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
+
+from db.base import _get_session_factory  # noqa: E402
+from models.memory import EDGE_ORIGIN_SEMANTIC, Memory  # noqa: E402
+from repositories.neural_edge import NeuralEdgeRepository  # noqa: E402
+from utils.logger import get_logger  # noqa: E402
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Qdrant neighbour protocol — decouples backfill_context() from the real
+# Qdrant client so the tests can pass a simple MagicMock.
+# ---------------------------------------------------------------------------
+
+
+class QdrantNeighborClient(Protocol):
+    """Minimal interface required by backfill_context()."""
+
+    async def query_neighbors(
+        self,
+        memory_id: UUID,
+        context_id: UUID,
+        user_id: str,
+        workspace_id: UUID,
+        top_k: int,
+    ) -> list[tuple[UUID, float]]:
+        """Return up to top_k (neighbor_uuid, cosine_score) pairs for memory_id."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Real Qdrant adapter
+# ---------------------------------------------------------------------------
+
+
+class RealQdrantNeighborClient:
+    """Wraps the real Qdrant client to satisfy the QdrantNeighborClient protocol.
+
+    Strategy: retrieve the stored dense vector for memory_id via
+    client.retrieve(with_vectors=True), then pass that vector as the query
+    to search_memories_qdrant() with limit=top_k+1 (excluding the self-hit).
+    """
+
+    def __init__(self) -> None:
+        from db.qdrant import (
+            KAGURA_MEMORIES_COLLECTION,
+            KAGURA_MEMORIES_VECTOR_NAME,
+            get_qdrant_client,
+            search_memories_qdrant,
+        )
+
+        self._client = get_qdrant_client()
+        self._collection = KAGURA_MEMORIES_COLLECTION
+        self._vector_name = KAGURA_MEMORIES_VECTOR_NAME
+        self._search = search_memories_qdrant
+
+    async def query_neighbors(
+        self,
+        memory_id: UUID,
+        context_id: UUID,
+        user_id: str,
+        workspace_id: UUID,
+        top_k: int,
+    ) -> list[tuple[UUID, float]]:
+        """Retrieve stored vector then find top-K neighbors in the same context."""
+        points = await self._client.retrieve(
+            collection_name=self._collection,
+            ids=[str(memory_id)],
+            with_vectors=True,
+            with_payload=False,
+        )
+        if not points or points[0].vector is None:
+            return []
+
+        vector_obj = points[0].vector
+        if isinstance(vector_obj, dict):
+            dense_vec = vector_obj.get(self._vector_name, [])
+        else:
+            # Anonymous vector (shouldn't happen in this collection but be safe)
+            dense_vec = list(vector_obj) if vector_obj else []
+
+        if not dense_vec:
+            return []
+
+        results = await self._search(
+            user_id=user_id,
+            query_vector=dense_vec,
+            workspace_id=str(workspace_id),
+            context_id=str(context_id),
+            limit=top_k + 1,  # +1 because the self-hit will be in results
+        )
+
+        out: list[tuple[UUID, float]] = []
+        for hit in results:
+            hit_id = UUID(str(hit["id"]))
+            if hit_id == memory_id:
+                continue
+            out.append((hit_id, hit["score"]))
+            if len(out) >= top_k:
+                break
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Core backfill logic (pure — uses the protocol, not the real client)
+# ---------------------------------------------------------------------------
+
+
+async def backfill_context(
+    db: AsyncSession,
+    qdrant: QdrantNeighborClient,
+    context_id: UUID,
+    *,
+    min_memories: int = 50,
+    sim_threshold: float = 0.7,
+    top_k: int = 10,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Backfill origin='semantic' edges for one context.
+
+    Args:
+        db: Async SQLAlchemy session.
+        qdrant: QdrantNeighborClient exposing ``query_neighbors(memory_id,
+            context_id, user_id, workspace_id, top_k) -> list[(UUID, float)]``.
+        context_id: Target context UUID.
+        min_memories: Skip context when alive memory count is below this floor.
+        sim_threshold: Minimum cosine score for an edge to be inserted.
+        top_k: Number of nearest neighbours to retrieve per memory.
+        dry_run: If True, count pairs but do not write to DB.
+
+    Returns:
+        Dict with keys: skipped, reason (on skip), memory_count,
+        pairs_evaluated, edges_inserted, edges_failed, pairs_would_insert, dry_run.
+    """
+    # ---- 1. Count alive memories in this context --------------------------
+    count_q = await db.execute(
+        select(func.count(Memory.id)).where(
+            Memory.context_id == context_id,
+            Memory.deleted_at.is_(None),
+            Memory.workspace_id.isnot(None),
+        )
+    )
+    memory_count: int = count_q.scalar_one()
+
+    if memory_count < min_memories:
+        return {
+            "skipped": True,
+            "reason": "below_memory_floor",
+            "memory_count": memory_count,
+        }
+
+    # ---- 2. Load alive memories (need user_id + workspace_id per memory) --
+    mem_q = await db.execute(
+        select(Memory.id, Memory.user_id, Memory.workspace_id).where(
+            Memory.context_id == context_id,
+            Memory.deleted_at.is_(None),
+            Memory.workspace_id.isnot(None),
+        )
+    )
+    memories = mem_q.all()
+
+    # ---- 3. Iterate memories, query neighbours, build deduplicated pairs ---
+    edge_repo = NeuralEdgeRepository(db)
+    seen_pairs: set[tuple[UUID, UUID]] = set()
+    pairs_evaluated = 0
+    edges_inserted = 0
+    edges_failed = 0
+    pairs_would_insert = 0
+
+    for row in memories:
+        mem_id: UUID = row.id
+        user_id: str = row.user_id
+        workspace_id: UUID = row.workspace_id
+
+        try:
+            neighbors = await qdrant.query_neighbors(
+                mem_id, context_id, user_id, workspace_id, top_k
+            )
+        except Exception as exc:
+            logger.warning(
+                "backfill_semantic_qdrant_error",
+                memory_id=str(mem_id),
+                context_id=str(context_id),
+                error=str(exc),
+            )
+            continue
+
+        for neighbor_id, score in neighbors:
+            if score < sim_threshold:
+                continue
+
+            # Canonical pair to deduplicate (A,B) vs (B,A)
+            a, b = sorted([mem_id, neighbor_id], key=str)
+            pair_key = (a, b)
+            if pair_key in seen_pairs:
+                continue
+            seen_pairs.add(pair_key)
+            pairs_evaluated += 1
+
+            if dry_run:
+                pairs_would_insert += 1
+                continue
+
+            try:
+                async with db.begin_nested():
+                    edge = await edge_repo.create_edge_if_absent(
+                        user_id=user_id,
+                        src_id=a,
+                        dst_id=b,
+                        edge_type="related_to",
+                        weight=score,
+                        confidence=1.0,
+                        workspace_id=str(workspace_id),
+                        context_id=str(context_id),
+                        origin=EDGE_ORIGIN_SEMANTIC,
+                    )
+                if edge is not None:
+                    edges_inserted += 1
+            except Exception as exc:
+                edges_failed += 1
+                logger.warning(
+                    "backfill_semantic_edge_error",
+                    src_id=str(a),
+                    dst_id=str(b),
+                    context_id=str(context_id),
+                    error=str(exc),
+                )
+
+    if not dry_run:
+        await db.commit()
+
+    logger.info(
+        "backfill_context_done",
+        context_id=str(context_id),
+        memory_count=memory_count,
+        pairs_evaluated=pairs_evaluated,
+        edges_inserted=edges_inserted,
+        edges_failed=edges_failed,
+        pairs_would_insert=pairs_would_insert,
+        dry_run=dry_run,
+    )
+
+    return {
+        "skipped": False,
+        "memory_count": memory_count,
+        "pairs_evaluated": pairs_evaluated,
+        "edges_inserted": edges_inserted,
+        "edges_failed": edges_failed,
+        "pairs_would_insert": pairs_would_insert,
+        "dry_run": dry_run,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+async def _main(args: argparse.Namespace) -> int:
+    session_factory = _get_session_factory()
+    qdrant = RealQdrantNeighborClient()
+
+    total_inserted = 0
+    total_failed = 0
+    total_would_insert = 0
+    total_contexts = 0
+    skipped = 0
+
+    async with session_factory() as db:
+        if args.context_id:
+            context_ids = [UUID(args.context_id)]
+        else:
+            # Discover all contexts with >= min_memories alive memories
+            q = await db.execute(
+                select(Memory.context_id, func.count(Memory.id).label("cnt"))
+                .where(
+                    Memory.deleted_at.is_(None),
+                    Memory.workspace_id.isnot(None),
+                    Memory.context_id.isnot(None),
+                )
+                .group_by(Memory.context_id)
+                .having(func.count(Memory.id) >= args.min_memories)
+            )
+            context_ids = [UUID(str(row.context_id)) for row in q.all()]
+
+        n_contexts = len(context_ids)
+        for ctx_id in context_ids:
+            result = await backfill_context(
+                db,
+                qdrant,
+                ctx_id,
+                min_memories=args.min_memories,
+                sim_threshold=args.sim_threshold,
+                top_k=args.top_k,
+                dry_run=args.dry_run,
+            )
+            total_contexts += 1
+            if result.get("skipped"):
+                skipped += 1
+            else:
+                total_inserted += result.get("edges_inserted", 0)
+                total_failed += result.get("edges_failed", 0)
+                total_would_insert += result.get("pairs_would_insert", 0)
+
+    mode = "DRY-RUN" if args.dry_run else "EXECUTE"
+    print(f"\n=== semantic edge backfill ({mode}) ===")
+    print(f"  Contexts processed:  {total_contexts}")
+    print(f"  Contexts skipped:    {skipped}")
+    if args.dry_run:
+        print(
+            f"  Dry run: {total_would_insert} edges would be inserted across {n_contexts} contexts"
+        )
+    else:
+        print(
+            f"  Inserted {total_inserted} edges ({total_failed} failures) across {n_contexts} contexts"
+        )
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill origin='semantic' edges from cosine similarity (Issue #722)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--context-id",
+        help="Restrict to one context UUID; omit to backfill all eligible contexts.",
+    )
+    parser.add_argument(
+        "--min-memories",
+        type=int,
+        default=50,
+        help="Skip contexts with fewer alive memories than this (default: 50).",
+    )
+    parser.add_argument(
+        "--sim-threshold",
+        type=float,
+        default=0.7,
+        help="Minimum cosine similarity to create an edge (default: 0.7).",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=10,
+        help="Nearest neighbours to query per memory (default: 10).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log counts but do not insert edges.",
+    )
+    args = parser.parse_args()
+    sys.exit(asyncio.run(_main(args)))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/backfill_semantic_edges.py
+++ b/backend/scripts/backfill_semantic_edges.py
@@ -38,21 +38,19 @@ from sqlalchemy import func, select  # noqa: E402
 from sqlalchemy.ext.asyncio import AsyncSession  # noqa: E402
 
 from db.base import _get_session_factory  # noqa: E402
-from models.memory import EDGE_ORIGIN_SEMANTIC, Memory  # noqa: E402
+from models.memory import (  # noqa: E402
+    EDGE_ORIGIN_SEMANTIC,
+    EDGE_TYPE_RELATED_TO,
+    Memory,
+)
 from repositories.neural_edge import NeuralEdgeRepository  # noqa: E402
 from utils.logger import get_logger  # noqa: E402
 
 logger = get_logger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Qdrant neighbour protocol — decouples backfill_context() from the real
-# Qdrant client so the tests can pass a simple MagicMock.
-# ---------------------------------------------------------------------------
-
-
 class QdrantNeighborClient(Protocol):
-    """Minimal interface required by backfill_context()."""
+    """Decouples backfill_context from the real Qdrant client (tests pass a mock)."""
 
     async def query_neighbors(
         self,
@@ -64,11 +62,6 @@ class QdrantNeighborClient(Protocol):
     ) -> list[tuple[UUID, float]]:
         """Return up to top_k (neighbor_uuid, cosine_score) pairs for memory_id."""
         ...
-
-
-# ---------------------------------------------------------------------------
-# Real Qdrant adapter
-# ---------------------------------------------------------------------------
 
 
 class RealQdrantNeighborClient:
@@ -139,11 +132,6 @@ class RealQdrantNeighborClient:
         return out
 
 
-# ---------------------------------------------------------------------------
-# Core backfill logic (pure — uses the protocol, not the real client)
-# ---------------------------------------------------------------------------
-
-
 async def backfill_context(
     db: AsyncSession,
     qdrant: QdrantNeighborClient,
@@ -170,7 +158,6 @@ async def backfill_context(
         Dict with keys: skipped, reason (on skip), memory_count,
         pairs_evaluated, edges_inserted, edges_failed, pairs_would_insert, dry_run.
     """
-    # ---- 1. Count alive memories in this context --------------------------
     count_q = await db.execute(
         select(func.count(Memory.id)).where(
             Memory.context_id == context_id,
@@ -187,7 +174,6 @@ async def backfill_context(
             "memory_count": memory_count,
         }
 
-    # ---- 2. Load alive memories (need user_id + workspace_id per memory) --
     mem_q = await db.execute(
         select(Memory.id, Memory.user_id, Memory.workspace_id).where(
             Memory.context_id == context_id,
@@ -197,7 +183,6 @@ async def backfill_context(
     )
     memories = mem_q.all()
 
-    # ---- 3. Iterate memories, query neighbours, build deduplicated pairs ---
     edge_repo = NeuralEdgeRepository(db)
     seen_pairs: set[tuple[UUID, UUID]] = set()
     pairs_evaluated = 0
@@ -245,7 +230,7 @@ async def backfill_context(
                         user_id=user_id,
                         src_id=a,
                         dst_id=b,
-                        edge_type="related_to",
+                        edge_type=EDGE_TYPE_RELATED_TO,
                         weight=score,
                         confidence=1.0,
                         workspace_id=str(workspace_id),
@@ -287,11 +272,6 @@ async def backfill_context(
         "pairs_would_insert": pairs_would_insert,
         "dry_run": dry_run,
     }
-
-
-# ---------------------------------------------------------------------------
-# CLI entry point
-# ---------------------------------------------------------------------------
 
 
 async def _main(args: argparse.Namespace) -> int:

--- a/backend/scripts/backfill_semantic_edges.py
+++ b/backend/scripts/backfill_semantic_edges.py
@@ -302,16 +302,33 @@ async def _main(args: argparse.Namespace) -> int:
             context_ids = [UUID(str(row.context_id)) for row in q.all()]
 
         n_contexts = len(context_ids)
+        context_errors = 0
         for ctx_id in context_ids:
-            result = await backfill_context(
-                db,
-                qdrant,
-                ctx_id,
-                min_memories=args.min_memories,
-                sim_threshold=args.sim_threshold,
-                top_k=args.top_k,
-                dry_run=args.dry_run,
-            )
+            try:
+                result = await backfill_context(
+                    db,
+                    qdrant,
+                    ctx_id,
+                    min_memories=args.min_memories,
+                    sim_threshold=args.sim_threshold,
+                    top_k=args.top_k,
+                    dry_run=args.dry_run,
+                )
+            except Exception as exc:
+                # Roll the aborted transaction back so the next iteration starts
+                # clean; record and continue so one bad context doesn't halt the
+                # whole sweep (per-edge errors are already savepoint-caught).
+                context_errors += 1
+                logger.exception(
+                    "backfill_context_failed",
+                    context_id=str(ctx_id),
+                    error=str(exc),
+                )
+                try:
+                    await db.rollback()
+                except Exception:
+                    pass
+                continue
             total_contexts += 1
             if result.get("skipped"):
                 skipped += 1
@@ -324,6 +341,7 @@ async def _main(args: argparse.Namespace) -> int:
     print(f"\n=== semantic edge backfill ({mode}) ===")
     print(f"  Contexts processed:  {total_contexts}")
     print(f"  Contexts skipped:    {skipped}")
+    print(f"  Contexts errored:    {context_errors}")
     if args.dry_run:
         print(
             f"  Dry run: {total_would_insert} edges would be inserted across {n_contexts} contexts"

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -76,6 +76,7 @@ async def lifespan(app: FastAPI):
         schedule_mcp_tasks,
         schedule_neural_tasks,
         schedule_resource_indexer_jobs,
+        schedule_semantic_edge_reverify_tasks,
         schedule_sleep_tasks,
         start_scheduler,
     )
@@ -90,6 +91,7 @@ async def lifespan(app: FastAPI):
     schedule_bm25_drift_tasks(scheduler)
     schedule_erasure_tasks(scheduler)
     schedule_file_tasks(scheduler)
+    schedule_semantic_edge_reverify_tasks(scheduler)
     start_scheduler()
     logger.info("background_tasks_scheduled")
 

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -322,6 +322,20 @@ _ALL_EDGE_TYPES: tuple[str, ...] = (
     EDGE_TYPE_TAG_COOCCURRENCE,
 )
 
+# Edge origin discriminator (Issue #722).
+# 'hebbian' = runtime co-activation (HebbianLearner) — decays
+# 'semantic' = sleep edge_discovery (cosine-similarity-derived) — does not decay
+# 'declared' = user-asserted links — does not decay
+EDGE_ORIGIN_HEBBIAN = "hebbian"
+EDGE_ORIGIN_SEMANTIC = "semantic"
+EDGE_ORIGIN_DECLARED = "declared"
+
+_ALL_EDGE_ORIGINS: tuple[str, ...] = (
+    EDGE_ORIGIN_HEBBIAN,
+    EDGE_ORIGIN_SEMANTIC,
+    EDGE_ORIGIN_DECLARED,
+)
+
 
 class NeuralMemoryEdge(Base):
     """Neural Memory edge model (Issue #84 Phase 1).
@@ -364,6 +378,10 @@ class NeuralMemoryEdge(Base):
     )
     weight: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
     confidence: Mapped[float] = mapped_column(Float, nullable=False, default=1.0)
+    # Edge origin (Issue #722). Decay/prune skip origin != 'hebbian'.
+    origin: Mapped[str] = mapped_column(
+        String(20), nullable=False, default=EDGE_ORIGIN_HEBBIAN, server_default=EDGE_ORIGIN_HEBBIAN
+    )
 
     # Metadata (flexible JSONB for future extensions)
     # Note: 'metadata' is reserved in SQLAlchemy, use edge_metadata
@@ -406,6 +424,16 @@ class NeuralMemoryEdge(Base):
             "workspace_id IS NOT NULL AND context_id IS NOT NULL",
             name="ck_neural_memory_edges_ws_ctx_not_null",
         ),
+        # Issue #722: CHECK constraint derived from ``_ALL_EDGE_ORIGINS``.
+        # Adding a new origin requires THREE coordinated edits (caught by the
+        # regression test if any are missed): (1) add ``EDGE_ORIGIN_NEW`` to the
+        # constants block above, (2) append it to ``_ALL_EDGE_ORIGINS``, (3) update
+        # the expected literal in ``test_valid_edge_origin_check_constraint_matches_migration_literal``,
+        # plus a corresponding alembic migration that ALTERs the prod CHECK.
+        CheckConstraint(
+            f"origin IN ({', '.join(repr(o) for o in _ALL_EDGE_ORIGINS)})",
+            name="valid_edge_origin",
+        ),
         Index("idx_edges_user_src", "user_id", "src_id"),
         Index("idx_edges_user_dst", "user_id", "dst_id"),
         # Issue #383: composite indexes matching the new PermissionService-driven
@@ -414,6 +442,7 @@ class NeuralMemoryEdge(Base):
         # shared-context visualization without relying on ``user_id``.
         Index("idx_edges_ws_ctx_src", "workspace_id", "context_id", "src_id"),
         Index("idx_edges_ws_ctx_dst", "workspace_id", "context_id", "dst_id"),
+        Index("idx_edges_origin", "origin"),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -424,12 +424,8 @@ class NeuralMemoryEdge(Base):
             "workspace_id IS NOT NULL AND context_id IS NOT NULL",
             name="ck_neural_memory_edges_ws_ctx_not_null",
         ),
-        # Issue #722: CHECK constraint derived from ``_ALL_EDGE_ORIGINS``.
-        # Adding a new origin requires THREE coordinated edits (caught by the
-        # regression test if any are missed): (1) add ``EDGE_ORIGIN_NEW`` to the
-        # constants block above, (2) append it to ``_ALL_EDGE_ORIGINS``, (3) update
-        # the expected literal in ``test_valid_edge_origin_check_constraint_matches_migration_literal``,
-        # plus a corresponding alembic migration that ALTERs the prod CHECK.
+        # Drift between this CHECK and the e17_722 migration literal is pinned
+        # by test_valid_edge_origin_check_constraint_matches_migration_literal.
         CheckConstraint(
             f"origin IN ({', '.join(repr(o) for o in _ALL_EDGE_ORIGINS)})",
             name="valid_edge_origin",

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -27,6 +27,7 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column
@@ -438,7 +439,11 @@ class NeuralMemoryEdge(Base):
         # shared-context visualization without relying on ``user_id``.
         Index("idx_edges_ws_ctx_src", "workspace_id", "context_id", "src_id"),
         Index("idx_edges_ws_ctx_dst", "workspace_id", "context_id", "dst_id"),
-        Index("idx_edges_origin", "origin"),
+        Index(
+            "idx_edges_origin",
+            "origin",
+            postgresql_where=text("origin = 'semantic'"),
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/neural/decay.py
+++ b/backend/src/neural/decay.py
@@ -12,6 +12,7 @@ import math
 from datetime import datetime, timedelta
 from typing import Any
 
+from models.memory import EDGE_ORIGIN_HEBBIAN
 from src.services.graph_service import GraphService as GraphMemory
 from utils.datetime import utcnow
 
@@ -67,12 +68,15 @@ class DecayManager:
             return {"edges_decayed": 0, "edges_pruned": 0}
 
         # Apply decay to all edges (Issue #84: SQL backend bulk operation)
+        # Issue #722: semantic edges are decay-exempt; only Hebbian edges are decayed/pruned
         decay_factor = math.exp(-self.config.decay_rate * delta_seconds)
-        edges_decayed = await self.graph.edge_repo.bulk_decay_weights(user_id, decay_factor)
+        edges_decayed = await self.graph.edge_repo.bulk_decay_weights(
+            user_id, decay_factor, only_origin=EDGE_ORIGIN_HEBBIAN
+        )
 
         # Prune weak edges
         edges_pruned = await self.graph.edge_repo.prune_weak_edges(
-            user_id, self.config.prune_threshold
+            user_id, self.config.prune_threshold, only_origin=EDGE_ORIGIN_HEBBIAN
         )
 
         self._last_decay_time = current_time
@@ -102,7 +106,9 @@ class DecayManager:
         threshold = threshold if threshold is not None else self.config.prune_threshold
 
         # SQL backend: use bulk prune (Issue #84)
-        pruned_count = await self.graph.edge_repo.prune_weak_edges(user_id, threshold)
+        pruned_count = await self.graph.edge_repo.prune_weak_edges(
+            user_id, threshold, only_origin=EDGE_ORIGIN_HEBBIAN
+        )
 
         logger.info(f"Pruned {pruned_count} weak edges (threshold={threshold:.4f})")
 

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -1207,26 +1207,43 @@ class NeuralEdgeRepository:
         """Delete origin='semantic' edges whose src or dst memory is soft-deleted.
 
         Monthly hygiene for semantic edges, which are exempt from the Hebbian
-        decay/prune loop and so need their own dead-endpoint sweep. The
+        decay/prune loop and so need their own dead-endpoint sweep. Iterates
+        per user_id so the DELETE transaction stays scoped to one tenant at a
+        time, bounding lock width on multi-tenant deployments. The
         ``memories.deleted_at`` column is unindexed — Postgres falls back to a
         sequential scan, tolerable at monthly cadence below ~1M rows.
 
         Returns:
-            Number of edges deleted.
+            Total number of edges deleted across all users.
         """
-        sub_dead = select(Memory.id).where(Memory.deleted_at.is_not(None)).scalar_subquery()
-
-        stmt = delete(NeuralMemoryEdge).where(
-            and_(
-                NeuralMemoryEdge.origin == EDGE_ORIGIN_SEMANTIC,
-                or_(
-                    NeuralMemoryEdge.src_id.in_(sub_dead),
-                    NeuralMemoryEdge.dst_id.in_(sub_dead),
-                ),
+        user_ids = (
+            (
+                await self.db.execute(
+                    select(NeuralMemoryEdge.user_id)
+                    .where(NeuralMemoryEdge.origin == EDGE_ORIGIN_SEMANTIC)
+                    .distinct()
+                )
             )
+            .scalars()
+            .all()
         )
-        result = cast(CursorResult[Any], await self.db.execute(stmt))
-        return result.rowcount or 0
+
+        total = 0
+        for user_id in user_ids:
+            sub_dead = select(Memory.id).where(Memory.deleted_at.is_not(None)).scalar_subquery()
+            stmt = delete(NeuralMemoryEdge).where(
+                and_(
+                    NeuralMemoryEdge.user_id == user_id,
+                    NeuralMemoryEdge.origin == EDGE_ORIGIN_SEMANTIC,
+                    or_(
+                        NeuralMemoryEdge.src_id.in_(sub_dead),
+                        NeuralMemoryEdge.dst_id.in_(sub_dead),
+                    ),
+                )
+            )
+            result = cast(CursorResult[Any], await self.db.execute(stmt))
+            total += result.rowcount or 0
+        return total
 
     async def delete_all_edges(self, user_id: str) -> int:
         """Delete all edges for a user (graph reset).

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -1197,6 +1197,38 @@ class NeuralEdgeRepository:
 
         return transferred
 
+    async def delete_semantic_edges_for_dead_pairs(self) -> int:
+        """Delete origin='semantic' edges whose src or dst memory is soft-deleted.
+
+        Issue #722: monthly hygiene for semantic edges, which are exempt from
+        the Hebbian decay/prune loop and so need their own dead-endpoint sweep.
+
+        Note:
+            The ``memories.deleted_at`` column is not indexed; this subquery
+            falls back to a sequential scan. Tolerable at monthly cadence for
+            current scale (≤1M memory rows). Add a partial index
+            (``WHERE deleted_at IS NOT NULL``) before this query is run more
+            frequently or on much larger tables.
+
+        Returns:
+            Number of edges deleted.
+        """
+        from models.memory import EDGE_ORIGIN_SEMANTIC, Memory
+
+        sub_dead = select(Memory.id).where(Memory.deleted_at.is_not(None)).scalar_subquery()
+
+        stmt = delete(NeuralMemoryEdge).where(
+            and_(
+                NeuralMemoryEdge.origin == EDGE_ORIGIN_SEMANTIC,
+                or_(
+                    NeuralMemoryEdge.src_id.in_(sub_dead),
+                    NeuralMemoryEdge.dst_id.in_(sub_dead),
+                ),
+            )
+        )
+        result = cast(CursorResult[Any], await self.db.execute(stmt))
+        return result.rowcount or 0
+
     async def delete_all_edges(self, user_id: str) -> int:
         """Delete all edges for a user (graph reset).
 

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -20,7 +20,13 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.memory import EDGE_ORIGIN_HEBBIAN, EDGE_TYPE_DECLARED_LINK, Memory, NeuralMemoryEdge
+from models.memory import (
+    EDGE_ORIGIN_HEBBIAN,
+    EDGE_ORIGIN_SEMANTIC,
+    EDGE_TYPE_DECLARED_LINK,
+    Memory,
+    NeuralMemoryEdge,
+)
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -134,7 +140,7 @@ class NeuralEdgeRepository:
         protect_declared_link: bool = False,
         return_fresh_edge: bool = True,
         *,
-        origin: str = EDGE_ORIGIN_HEBBIAN,  # Issue #722
+        origin: str = EDGE_ORIGIN_HEBBIAN,
     ) -> NeuralMemoryEdge:
         """Create or update an edge (upsert) with 3-level isolation.
 
@@ -197,7 +203,7 @@ class NeuralEdgeRepository:
             edge_metadata=edge_metadata,
             workspace_id=ws_uuid,  # Required for 3-level isolation
             context_id=ctx_uuid,  # Required for 3-level isolation
-            origin=origin,  # Issue #722
+            origin=origin,
             created_at=utcnow(),
             last_updated=utcnow(),
         )
@@ -217,15 +223,15 @@ class NeuralEdgeRepository:
         else:
             edge_type_set = stmt.excluded.edge_type
 
-        # Issue #722: never demote semantic/declared edges on Hebbian co-recall.
-        # Sticky origin — only 'hebbian' can be overwritten by the upsert.
-        # Mirrors the protect_declared_link CASE pattern above.
+        # Sticky origin (mirrors protect_declared_link CASE above): semantic
+        # and declared edges survive a Hebbian co-recall upsert; only existing
+        # hebbian rows can be overwritten. Without this, a runtime co-recall
+        # would silently demote sleep-discovered edges back into the decay loop.
         origin_set = case(
             (NeuralMemoryEdge.origin != EDGE_ORIGIN_HEBBIAN, NeuralMemoryEdge.origin),
             else_=stmt.excluded.origin,
         )
 
-        # ON CONFLICT: Update existing edge
         stmt = stmt.on_conflict_do_update(
             constraint="unique_edge",  # (user_id, src_id, dst_id)
             set_={
@@ -233,7 +239,7 @@ class NeuralEdgeRepository:
                 "weight": stmt.excluded.weight,
                 "confidence": stmt.excluded.confidence,
                 "metadata": stmt.excluded.metadata,
-                "origin": origin_set,  # Issue #722: sticky origin
+                "origin": origin_set,
                 "last_updated": utcnow(),
             },
         ).returning(NeuralMemoryEdge)
@@ -272,7 +278,7 @@ class NeuralEdgeRepository:
         workspace_id: str | None = None,
         context_id: str | None = None,
         *,
-        origin: str = EDGE_ORIGIN_HEBBIAN,  # Issue #722
+        origin: str = EDGE_ORIGIN_HEBBIAN,
     ) -> NeuralMemoryEdge | None:
         """Create an edge only if no edge exists for (user_id, src_id, dst_id).
 
@@ -309,7 +315,7 @@ class NeuralEdgeRepository:
                 confidence=confidence,
                 workspace_id=ws_uuid,
                 context_id=ctx_uuid,
-                origin=origin,  # Issue #722
+                origin=origin,
                 created_at=utcnow(),
                 last_updated=utcnow(),
             )
@@ -721,7 +727,7 @@ class NeuralEdgeRepository:
         user_id: str,
         decay_factor: float = 0.95,
         *,
-        only_origin: str | None = None,  # Issue #722
+        only_origin: str | None = None,
     ) -> int:
         """Apply exponential decay to all edge weights (Issue #84 Phase 1).
 
@@ -730,7 +736,7 @@ class NeuralEdgeRepository:
             decay_factor: Multiplicative decay (0.95 = 5% decay)
             only_origin: When set, only edges with this origin are decayed.
                 Pass ``EDGE_ORIGIN_HEBBIAN`` to skip semantic edges during
-                Hebbian maintenance cycles. (Issue #722)
+                Hebbian maintenance cycles.
 
         Returns:
             Number of edges updated
@@ -762,7 +768,7 @@ class NeuralEdgeRepository:
         user_id: str,
         weight_threshold: float = 0.01,
         *,
-        only_origin: str | None = None,  # Issue #722
+        only_origin: str | None = None,
     ) -> int:
         """Remove edges below weight threshold.
 
@@ -771,7 +777,7 @@ class NeuralEdgeRepository:
             weight_threshold: Minimum weight to keep
             only_origin: When set, only edges with this origin are pruned.
                 Pass ``EDGE_ORIGIN_HEBBIAN`` to preserve semantic edges
-                during Hebbian maintenance cycles. (Issue #722)
+                during Hebbian maintenance cycles.
 
         Returns:
             Number of edges deleted
@@ -1200,21 +1206,14 @@ class NeuralEdgeRepository:
     async def delete_semantic_edges_for_dead_pairs(self) -> int:
         """Delete origin='semantic' edges whose src or dst memory is soft-deleted.
 
-        Issue #722: monthly hygiene for semantic edges, which are exempt from
-        the Hebbian decay/prune loop and so need their own dead-endpoint sweep.
-
-        Note:
-            The ``memories.deleted_at`` column is not indexed; this subquery
-            falls back to a sequential scan. Tolerable at monthly cadence for
-            current scale (≤1M memory rows). Add a partial index
-            (``WHERE deleted_at IS NOT NULL``) before this query is run more
-            frequently or on much larger tables.
+        Monthly hygiene for semantic edges, which are exempt from the Hebbian
+        decay/prune loop and so need their own dead-endpoint sweep. The
+        ``memories.deleted_at`` column is unindexed — Postgres falls back to a
+        sequential scan, tolerable at monthly cadence below ~1M rows.
 
         Returns:
             Number of edges deleted.
         """
-        from models.memory import EDGE_ORIGIN_SEMANTIC, Memory
-
         sub_dead = select(Memory.id).where(Memory.deleted_at.is_not(None)).scalar_subquery()
 
         stmt = delete(NeuralMemoryEdge).where(

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -20,7 +20,7 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.memory import EDGE_TYPE_DECLARED_LINK, Memory, NeuralMemoryEdge
+from models.memory import EDGE_ORIGIN_HEBBIAN, EDGE_TYPE_DECLARED_LINK, Memory, NeuralMemoryEdge
 from utils.datetime import utcnow
 from utils.logger import get_logger
 
@@ -133,6 +133,8 @@ class NeuralEdgeRepository:
         context_id: str | None = None,
         protect_declared_link: bool = False,
         return_fresh_edge: bool = True,
+        *,
+        origin: str = EDGE_ORIGIN_HEBBIAN,  # Issue #722
     ) -> NeuralMemoryEdge:
         """Create or update an edge (upsert) with 3-level isolation.
 
@@ -160,6 +162,10 @@ class NeuralEdgeRepository:
                 RETURNING actually wrote (Issue #458). Hot-path callers that
                 discard the return value (Hebbian via GraphService.add_edge,
                 Sleep edge_discovery) pass False to skip the extra SELECT.
+            origin: Edge origin (``EDGE_ORIGIN_HEBBIAN`` default). On upsert,
+                non-hebbian origins are preserved — only ``hebbian`` rows can
+                be overwritten. Sleep/declared writers should pass the explicit
+                enum value.
 
         Returns:
             Created or updated edge. When ``return_fresh_edge=False`` the
@@ -191,6 +197,7 @@ class NeuralEdgeRepository:
             edge_metadata=edge_metadata,
             workspace_id=ws_uuid,  # Required for 3-level isolation
             context_id=ctx_uuid,  # Required for 3-level isolation
+            origin=origin,  # Issue #722
             created_at=utcnow(),
             last_updated=utcnow(),
         )
@@ -210,6 +217,14 @@ class NeuralEdgeRepository:
         else:
             edge_type_set = stmt.excluded.edge_type
 
+        # Issue #722: never demote semantic/declared edges on Hebbian co-recall.
+        # Sticky origin — only 'hebbian' can be overwritten by the upsert.
+        # Mirrors the protect_declared_link CASE pattern above.
+        origin_set = case(
+            (NeuralMemoryEdge.origin != EDGE_ORIGIN_HEBBIAN, NeuralMemoryEdge.origin),
+            else_=stmt.excluded.origin,
+        )
+
         # ON CONFLICT: Update existing edge
         stmt = stmt.on_conflict_do_update(
             constraint="unique_edge",  # (user_id, src_id, dst_id)
@@ -218,6 +233,7 @@ class NeuralEdgeRepository:
                 "weight": stmt.excluded.weight,
                 "confidence": stmt.excluded.confidence,
                 "metadata": stmt.excluded.metadata,
+                "origin": origin_set,  # Issue #722: sticky origin
                 "last_updated": utcnow(),
             },
         ).returning(NeuralMemoryEdge)
@@ -255,6 +271,8 @@ class NeuralEdgeRepository:
         confidence: float = 1.0,
         workspace_id: str | None = None,
         context_id: str | None = None,
+        *,
+        origin: str = EDGE_ORIGIN_HEBBIAN,  # Issue #722
     ) -> NeuralMemoryEdge | None:
         """Create an edge only if no edge exists for (user_id, src_id, dst_id).
 
@@ -291,6 +309,7 @@ class NeuralEdgeRepository:
                 confidence=confidence,
                 workspace_id=ws_uuid,
                 context_id=ctx_uuid,
+                origin=origin,  # Issue #722
                 created_at=utcnow(),
                 last_updated=utcnow(),
             )
@@ -697,12 +716,21 @@ class NeuralEdgeRepository:
     # Bulk Operations
     # ========================================================================
 
-    async def bulk_decay_weights(self, user_id: str, decay_factor: float = 0.95) -> int:
+    async def bulk_decay_weights(
+        self,
+        user_id: str,
+        decay_factor: float = 0.95,
+        *,
+        only_origin: str | None = None,  # Issue #722
+    ) -> int:
         """Apply exponential decay to all edge weights (Issue #84 Phase 1).
 
         Args:
             user_id: User identifier
             decay_factor: Multiplicative decay (0.95 = 5% decay)
+            only_origin: When set, only edges with this origin are decayed.
+                Pass ``EDGE_ORIGIN_HEBBIAN`` to skip semantic edges during
+                Hebbian maintenance cycles. (Issue #722)
 
         Returns:
             Number of edges updated
@@ -710,7 +738,10 @@ class NeuralEdgeRepository:
         Formula:
             w_new = w_old * decay_factor
         """
-        stmt = select(NeuralMemoryEdge).where(NeuralMemoryEdge.user_id == user_id).with_for_update()
+        stmt = select(NeuralMemoryEdge).where(NeuralMemoryEdge.user_id == user_id)
+        if only_origin is not None:
+            stmt = stmt.where(NeuralMemoryEdge.origin == only_origin)
+        stmt = stmt.with_for_update()
 
         result = await self.db.execute(stmt)
         edges = list(result.scalars().all())
@@ -721,25 +752,37 @@ class NeuralEdgeRepository:
             edge.last_updated = utcnow()
             count += 1
 
-        logger.info("bulk_decay_applied", user_id=user_id, edges_updated=count)
+        logger.info(
+            "bulk_decay_applied", user_id=user_id, edges_updated=count, only_origin=only_origin
+        )
         return count
 
-    async def prune_weak_edges(self, user_id: str, weight_threshold: float = 0.01) -> int:
+    async def prune_weak_edges(
+        self,
+        user_id: str,
+        weight_threshold: float = 0.01,
+        *,
+        only_origin: str | None = None,  # Issue #722
+    ) -> int:
         """Remove edges below weight threshold.
 
         Args:
             user_id: User identifier
             weight_threshold: Minimum weight to keep
+            only_origin: When set, only edges with this origin are pruned.
+                Pass ``EDGE_ORIGIN_HEBBIAN`` to preserve semantic edges
+                during Hebbian maintenance cycles. (Issue #722)
 
         Returns:
             Number of edges deleted
         """
-        stmt = delete(NeuralMemoryEdge).where(
-            and_(
-                NeuralMemoryEdge.user_id == user_id,
-                NeuralMemoryEdge.weight < weight_threshold,
-            )
-        )
+        conds = [
+            NeuralMemoryEdge.user_id == user_id,
+            NeuralMemoryEdge.weight < weight_threshold,
+        ]
+        if only_origin is not None:
+            conds.append(NeuralMemoryEdge.origin == only_origin)
+        stmt = delete(NeuralMemoryEdge).where(and_(*conds))
 
         result = cast(CursorResult[Any], await self.db.execute(stmt))
         deleted_count = result.rowcount or 0
@@ -749,6 +792,7 @@ class NeuralEdgeRepository:
             user_id=user_id,
             threshold=weight_threshold,
             deleted=deleted_count,
+            only_origin=only_origin,
         )
 
         return deleted_count

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -552,8 +552,8 @@ class EdgeDiscoveryPhase:
         user_id: str,
         workspace_id: str | None,
         context_id: str | None,
-        reporter: "SleepReporter | None",
-        report_id: "UUID | None",
+        reporter: SleepReporter | None,
+        report_id: UUID | None,
     ) -> int:
         """Persist sleep-discovered edges with origin='semantic' and weight=cosine.
 

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -574,10 +574,14 @@ class EdgeDiscoveryPhase:
         Returns:
             Number of edges successfully created or updated.
         """
-        score_by_pair = {(s, d): score for s, d, score in batch}
+        # Canonical pair key: undirected `related_to` edges may come back from the
+        # LLM with src/dst swapped relative to the input batch (see _llm_judge_batch
+        # frozenset hallucination guard). Match `dedup_merge.py` keying so the
+        # cosine lookup survives the swap.
+        score_by_pair = {tuple(sorted([s, d], key=str)): score for s, d, score in batch}
         created = 0
         for edge in confirmed:
-            pair = (edge.src_id, edge.dst_id)
+            pair = tuple(sorted([edge.src_id, edge.dst_id], key=str))
             if pair in score_by_pair:
                 cosine = score_by_pair[pair]
             else:
@@ -599,13 +603,14 @@ class EdgeDiscoveryPhase:
                     confidence=edge.confidence,
                     workspace_id=workspace_id,
                     context_id=context_id,
-                    edge_metadata={"source": "sleep_edge_discovery", "cosine": cosine},
+                    edge_metadata={"source": "sleep_edge_discovery"},
                     # Issue #457: automated writer; preserve declared_link.
                     protect_declared_link=True,
                     # Sleep edge_discovery discards the return; skip the
                     # post-upsert SELECT for the same reason as Hebbian.
                     return_fresh_edge=False,
-                    # Issue #722: tag as semantic so decay carve-out skips it.
+                    # Tag as semantic so DecayManager's only_origin='hebbian'
+                    # filter leaves these edges alone.
                     origin=EDGE_ORIGIN_SEMANTIC,
                 )
                 created += 1

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -35,7 +35,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.qdrant import search_memories_qdrant
-from models.memory import Memory, NeuralMemoryEdge
+from models.memory import EDGE_ORIGIN_SEMANTIC, Memory, NeuralMemoryEdge
 from repositories.neural_edge import NeuralEdgeRepository
 from services.embedding_service import EmbeddingService
 from services.llm_service import LLMService
@@ -476,45 +476,15 @@ class EdgeDiscoveryPhase:
                 ]
                 auto_accepted += len(confirmed)
 
-            for edge in confirmed:
-                try:
-                    await self.edge_repo.create_or_update_edge(
-                        user_id=user_id,
-                        src_id=edge.src_id,
-                        dst_id=edge.dst_id,
-                        edge_type=edge.edge_type,
-                        weight=DISCOVERY_EDGE_WEIGHT,
-                        confidence=edge.confidence,
-                        workspace_id=workspace_id,
-                        context_id=context_id,
-                        edge_metadata={"source": "sleep_edge_discovery"},
-                        # Issue #457: automated writer; preserve declared_link.
-                        protect_declared_link=True,
-                        # Sleep edge_discovery discards the return; skip the
-                        # post-upsert SELECT for the same reason as Hebbian.
-                        return_fresh_edge=False,
-                    )
-                    edges_created += 1
-                    if reporter and report_id:
-                        await reporter.add_action(
-                            report_id=report_id,
-                            phase="edge_discovery",
-                            action_type="create_edge",
-                            memory_id=edge.src_id,
-                            target_id=edge.dst_id,
-                            details={
-                                "edge_type": edge.edge_type,
-                                "confidence": edge.confidence,
-                                "weight": DISCOVERY_EDGE_WEIGHT,
-                            },
-                        )
-                except Exception as e:
-                    logger.warning(
-                        "edge_creation_failed",
-                        src=str(edge.src_id),
-                        dst=str(edge.dst_id),
-                        error=str(e),
-                    )
+            edges_created += await self._persist_confirmed_edges(
+                confirmed=confirmed,
+                batch=batch,
+                user_id=user_id,
+                workspace_id=workspace_id,
+                context_id=context_id,
+                reporter=reporter,
+                report_id=report_id,
+            )
 
         confidence_summary = _summarize_confidences(agg.confidences)
         confidence_histogram = _build_confidence_histogram(agg.confidences)
@@ -574,6 +544,93 @@ class EdgeDiscoveryPhase:
         )
 
         return result
+
+    async def _persist_confirmed_edges(
+        self,
+        confirmed: list[ConfirmedEdge],
+        batch: list[tuple[UUID, UUID, float]],
+        user_id: str,
+        workspace_id: str | None,
+        context_id: str | None,
+        reporter: "SleepReporter | None",
+        report_id: "UUID | None",
+    ) -> int:
+        """Persist sleep-discovered edges with origin='semantic' and weight=cosine.
+
+        Issue #722: previously wrote a fixed DISCOVERY_EDGE_WEIGHT (0.5) that was
+        immediately attacked by the Hebbian decay loop. Now writes the cosine
+        similarity directly as weight and tags origin='semantic' so the decay
+        carve-out in DecayManager skips it.
+
+        Args:
+            confirmed: Post-LLM edges with src_id, dst_id, edge_type, confidence.
+            batch: Raw Qdrant tuples (src_id, dst_id, cosine_score) for this batch.
+            user_id: Owning user.
+            workspace_id: Owning workspace (may be None).
+            context_id: Owning context (may be None).
+            reporter: Optional SleepReporter for audit log entries.
+            report_id: Report UUID required when reporter is provided.
+
+        Returns:
+            Number of edges successfully created or updated.
+        """
+        score_by_pair = {(s, d): score for s, d, score in batch}
+        created = 0
+        for edge in confirmed:
+            pair = (edge.src_id, edge.dst_id)
+            if pair in score_by_pair:
+                cosine = score_by_pair[pair]
+            else:
+                cosine = DISCOVERY_EDGE_WEIGHT
+                logger.warning(
+                    "edge_score_missing_in_batch",
+                    src=str(edge.src_id),
+                    dst=str(edge.dst_id),
+                    fallback_weight=cosine,
+                    edge_type=edge.edge_type,
+                )
+            try:
+                await self.edge_repo.create_or_update_edge(
+                    user_id=user_id,
+                    src_id=edge.src_id,
+                    dst_id=edge.dst_id,
+                    edge_type=edge.edge_type,
+                    weight=cosine,
+                    confidence=edge.confidence,
+                    workspace_id=workspace_id,
+                    context_id=context_id,
+                    edge_metadata={"source": "sleep_edge_discovery", "cosine": cosine},
+                    # Issue #457: automated writer; preserve declared_link.
+                    protect_declared_link=True,
+                    # Sleep edge_discovery discards the return; skip the
+                    # post-upsert SELECT for the same reason as Hebbian.
+                    return_fresh_edge=False,
+                    # Issue #722: tag as semantic so decay carve-out skips it.
+                    origin=EDGE_ORIGIN_SEMANTIC,
+                )
+                created += 1
+                if reporter and report_id:
+                    await reporter.add_action(
+                        report_id=report_id,
+                        phase="edge_discovery",
+                        action_type="create_edge",
+                        memory_id=edge.src_id,
+                        target_id=edge.dst_id,
+                        details={
+                            "edge_type": edge.edge_type,
+                            "confidence": edge.confidence,
+                            "weight": cosine,
+                            "origin": EDGE_ORIGIN_SEMANTIC,
+                        },
+                    )
+            except Exception as e:
+                logger.warning(
+                    "edge_creation_failed",
+                    src=str(edge.src_id),
+                    dst=str(edge.dst_id),
+                    error=str(e),
+                )
+        return created
 
     async def _sample_memories(
         self,

--- a/backend/src/tasks/__init__.py
+++ b/backend/src/tasks/__init__.py
@@ -7,6 +7,7 @@ Implements scheduled tasks for:
 - MCP session cleanup (every 10 minutes)
 - Auto-hide expired credentials (hourly) - Migration 034
 - Resource indexer (every 5 minutes) - Issue #238
+- Semantic edge dead-endpoint sweep (monthly) — Issue #722
 """
 
 from .bm25_drift_tasks import schedule_bm25_drift_tasks
@@ -18,6 +19,7 @@ from .mcp_tasks import schedule_mcp_tasks
 from .neural_tasks import schedule_neural_tasks
 from .resource_indexer_job import schedule_resource_indexer_jobs
 from .scheduler import get_scheduler, shutdown_scheduler, start_scheduler
+from .semantic_edge_reverify import schedule_semantic_edge_reverify_tasks
 from .sleep_tasks import schedule_sleep_tasks
 
 __all__ = [
@@ -33,4 +35,5 @@ __all__ = [
     "schedule_sleep_tasks",
     "schedule_bm25_drift_tasks",
     "schedule_file_tasks",
+    "schedule_semantic_edge_reverify_tasks",
 ]

--- a/backend/src/tasks/semantic_edge_reverify.py
+++ b/backend/src/tasks/semantic_edge_reverify.py
@@ -2,10 +2,8 @@
 
 Semantic edges are exempt from the Hebbian decay/prune loop because they
 represent a static property (cosine similarity) rather than a usage trace.
-This task runs monthly to:
-
-* Delete edges whose src or dst memory has been soft-deleted.
-* (Future) Re-verify cosine similarity has not drifted below threshold.
+This task runs monthly to delete edges whose src or dst memory has been
+soft-deleted.
 """
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler

--- a/backend/src/tasks/semantic_edge_reverify.py
+++ b/backend/src/tasks/semantic_edge_reverify.py
@@ -46,7 +46,9 @@ async def _scheduled_entrypoint() -> None:
                     "semantic_edge_reverify_completed",
                     semantic_edges_deleted=result["semantic_edges_deleted"],
                 )
-                return  # break the async for so get_db's auto-commit on clean exit is a no-op
+                return  # exiting the async-for here sends GeneratorExit into get_db at the yield,
+                # so get_db's post-yield commit() never runs — our explicit commit above is
+                # the only one that executes.
             except Exception:
                 logger.exception("semantic_edge_reverify_failed")
                 await db.rollback()

--- a/backend/src/tasks/semantic_edge_reverify.py
+++ b/backend/src/tasks/semantic_edge_reverify.py
@@ -1,0 +1,75 @@
+"""Monthly hygiene for origin='semantic' edges (Issue #722).
+
+Semantic edges are exempt from the Hebbian decay/prune loop because they
+represent a static property (cosine similarity) rather than a usage trace.
+This task runs monthly to:
+
+* Delete edges whose src or dst memory has been soft-deleted.
+* (Future) Re-verify cosine similarity has not drifted below threshold.
+"""
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.cron import CronTrigger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.base import get_db
+from repositories.neural_edge import NeuralEdgeRepository
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+async def semantic_edge_reverify_run(db: AsyncSession) -> dict[str, int]:
+    """Run one pass of semantic-edge re-verification.
+
+    Caller is responsible for committing or rolling back the session.
+    The scheduled entrypoint commits; tests can verify without committing
+    so the db_session fixture's rollback isolation is preserved.
+
+    Args:
+        db: SQLAlchemy async session (caller owns commit/rollback).
+
+    Returns:
+        Dict with ``semantic_edges_deleted`` count.
+    """
+    repo = NeuralEdgeRepository(db)
+    deleted = await repo.delete_semantic_edges_for_dead_pairs()
+    return {"semantic_edges_deleted": deleted}
+
+
+async def _scheduled_entrypoint() -> None:
+    """APScheduler entry point — owns its own session via get_db()."""
+    try:
+        async for db in get_db():
+            try:
+                result = await semantic_edge_reverify_run(db)
+                await db.commit()
+                logger.info(
+                    "semantic_edge_reverify_completed",
+                    semantic_edges_deleted=result["semantic_edges_deleted"],
+                )
+                return  # break the async for so get_db's auto-commit on clean exit is a no-op
+            except Exception:
+                logger.exception("semantic_edge_reverify_failed")
+                await db.rollback()
+                return
+    except Exception:
+        logger.exception("semantic_edge_reverify_session_error")
+
+
+def schedule_semantic_edge_reverify_tasks(scheduler: AsyncIOScheduler) -> None:
+    """Register the monthly reverify job. Called from api/main.py startup.
+
+    Args:
+        scheduler: The shared APScheduler instance.
+    """
+    scheduler.add_job(
+        _scheduled_entrypoint,
+        trigger=CronTrigger(
+            day=1, hour=4, minute=15
+        ),  # 1st of month, 04:15 UTC — offset from neural_tasks consolidation at 03:00 UTC
+        id="semantic_edge_reverify",
+        name="Semantic Edge Reverify (#722)",
+        replace_existing=True,
+    )
+    logger.info("scheduled_semantic_edge_reverify")

--- a/backend/tests/neural/conftest.py
+++ b/backend/tests/neural/conftest.py
@@ -1,8 +1,13 @@
 """Shared fixtures for neural module tests."""
 
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 import pytest
+import pytest_asyncio
+
+from models.auth import Context, Workspace
+from models.memory import Memory
 
 
 @pytest.fixture
@@ -31,3 +36,57 @@ def mock_graph():
     graph.remove_edge = AsyncMock()
     graph.update_edge = AsyncMock()
     return graph
+
+
+@pytest_asyncio.fixture
+async def sample_memory_pair(db_session):
+    """Create two Memory rows sharing a Workspace + Context for edge constraint tests.
+
+    The two memories share workspace_id and context_id, which is required by
+    the ``ck_neural_memory_edges_ws_ctx_not_null`` CHECK constraint on edges.
+    """
+    ws = Workspace(
+        id=uuid4(),
+        name=f"neural-test-ws-{uuid4().hex[:8]}",
+        plan_name="free",
+        owner_user_id="test_user",
+        memory_limit=10000,
+        daily_api_limit=5000,
+        weekly_api_limit=25000,
+    )
+    db_session.add(ws)
+    await db_session.flush()
+
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"neural-test-ctx-{uuid4().hex[:8]}",
+        created_by="test_user",
+        is_private=False,
+    )
+    db_session.add(ctx)
+    await db_session.flush()
+
+    src = Memory(
+        id=uuid4(),
+        user_id="test_user",
+        workspace_id=ws.id,
+        context_id=ctx.id,
+        summary="source memory",
+        content="src content",
+        type="note",
+        client="test",
+    )
+    dst = Memory(
+        id=uuid4(),
+        user_id="test_user",
+        workspace_id=ws.id,
+        context_id=ctx.id,
+        summary="destination memory",
+        content="dst content",
+        type="note",
+        client="test",
+    )
+    db_session.add_all([src, dst])
+    await db_session.flush()
+    return src, dst

--- a/backend/tests/neural/test_decay.py
+++ b/backend/tests/neural/test_decay.py
@@ -4,6 +4,7 @@ import math
 
 import pytest
 
+from models.memory import EDGE_ORIGIN_HEBBIAN
 from neural.config import NeuralMemoryConfig
 from neural.decay import DecayManager
 
@@ -60,7 +61,7 @@ class TestDecayManager:
         # Verify decay factor calculated correctly
         expected_factor = math.exp(-0.01 * 60)
         mock_graph.edge_repo.bulk_decay_weights.assert_called_once_with(
-            "test_user", expected_factor
+            "test_user", expected_factor, only_origin=EDGE_ORIGIN_HEBBIAN
         )
 
     @pytest.mark.asyncio
@@ -85,20 +86,26 @@ class TestDecayManager:
     async def test_apply_decay_prunes_weak_edges(self, manager, mock_graph):
         """Test that weak edges are pruned after decay."""
         await manager.apply_decay("test_user")
-        mock_graph.edge_repo.prune_weak_edges.assert_called_once_with("test_user", 0.1)
+        mock_graph.edge_repo.prune_weak_edges.assert_called_once_with(
+            "test_user", 0.1, only_origin=EDGE_ORIGIN_HEBBIAN
+        )
 
     @pytest.mark.asyncio
     async def test_prune_weak_edges(self, manager, mock_graph):
         """Test direct pruning of weak edges."""
         result = await manager.prune_weak_edges("test_user")
         assert result == 2
-        mock_graph.edge_repo.prune_weak_edges.assert_called_with("test_user", 0.1)
+        mock_graph.edge_repo.prune_weak_edges.assert_called_with(
+            "test_user", 0.1, only_origin=EDGE_ORIGIN_HEBBIAN
+        )
 
     @pytest.mark.asyncio
     async def test_prune_weak_edges_custom_threshold(self, manager, mock_graph):
         """Test pruning with custom threshold."""
         await manager.prune_weak_edges("test_user", threshold=0.5)
-        mock_graph.edge_repo.prune_weak_edges.assert_called_with("test_user", 0.5)
+        mock_graph.edge_repo.prune_weak_edges.assert_called_with(
+            "test_user", 0.5, only_origin=EDGE_ORIGIN_HEBBIAN
+        )
 
     @pytest.mark.asyncio
     async def test_consolidate_deprecated(self, manager):

--- a/backend/tests/neural/test_decay_origin.py
+++ b/backend/tests/neural/test_decay_origin.py
@@ -1,0 +1,47 @@
+"""DecayManager passes only_origin='hebbian' to repository (Issue #722)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.memory import EDGE_ORIGIN_HEBBIAN
+from neural.decay import DecayManager
+
+
+@pytest.mark.asyncio
+async def test_apply_decay_passes_only_origin_hebbian():
+    edge_repo = MagicMock()
+    edge_repo.bulk_decay_weights = AsyncMock(return_value=5)
+    edge_repo.prune_weak_edges = AsyncMock(return_value=1)
+    graph = MagicMock(edge_repo=edge_repo)
+    config = MagicMock(
+        decay_rate=0.001,
+        prune_threshold=0.01,
+        decay_background_interval=3600,
+    )
+    mgr = DecayManager(graph=graph, config=config)
+
+    await mgr.apply_decay("user1")
+
+    # Tight assertions: catch user_id drift AND missing kwarg in one place.
+    bd_call = edge_repo.bulk_decay_weights.await_args
+    assert bd_call.args[0] == "user1"
+    assert bd_call.kwargs.get("only_origin") == EDGE_ORIGIN_HEBBIAN
+
+    pw_call = edge_repo.prune_weak_edges.await_args
+    assert pw_call.args[0] == "user1"
+    assert pw_call.kwargs.get("only_origin") == EDGE_ORIGIN_HEBBIAN
+
+
+@pytest.mark.asyncio
+async def test_standalone_prune_weak_edges_passes_only_origin_hebbian():
+    edge_repo = MagicMock()
+    edge_repo.prune_weak_edges = AsyncMock(return_value=0)
+    graph = MagicMock(edge_repo=edge_repo)
+    config = MagicMock(prune_threshold=0.01)
+    mgr = DecayManager(graph=graph, config=config)
+
+    await mgr.prune_weak_edges("user1")
+
+    edge_repo.prune_weak_edges.assert_awaited_once()
+    assert edge_repo.prune_weak_edges.await_args.kwargs.get("only_origin") == EDGE_ORIGIN_HEBBIAN

--- a/backend/tests/neural/test_models.py
+++ b/backend/tests/neural/test_models.py
@@ -7,11 +7,11 @@ from sqlalchemy import inspect
 from sqlalchemy.exc import IntegrityError
 
 from models.memory import (
+    _ALL_EDGE_ORIGINS,
     EDGE_ORIGIN_DECLARED,
     EDGE_ORIGIN_HEBBIAN,
     EDGE_ORIGIN_SEMANTIC,
     NeuralMemoryEdge,
-    _ALL_EDGE_ORIGINS,
 )
 from neural.models import (
     ActivationState,

--- a/backend/tests/neural/test_models.py
+++ b/backend/tests/neural/test_models.py
@@ -3,7 +3,16 @@
 from datetime import datetime
 
 import pytest
+from sqlalchemy import inspect
+from sqlalchemy.exc import IntegrityError
 
+from models.memory import (
+    EDGE_ORIGIN_DECLARED,
+    EDGE_ORIGIN_HEBBIAN,
+    EDGE_ORIGIN_SEMANTIC,
+    NeuralMemoryEdge,
+    _ALL_EDGE_ORIGINS,
+)
 from neural.models import (
     ActivationState,
     CoActivationRecord,
@@ -187,3 +196,80 @@ class TestRecallResult:
             components={"semantic": 0.9, "recency": 0.7},
         )
         assert result.components["semantic"] == 0.9
+
+
+# ---------------------------------------------------------------------------
+# NeuralMemoryEdge.origin column tests (Issue #722)
+# ---------------------------------------------------------------------------
+
+
+def test_origin_column_present_with_default_hebbian():
+    cols = {c.name: c for c in inspect(NeuralMemoryEdge).columns}
+    assert "origin" in cols
+    assert cols["origin"].nullable is False
+    assert cols["origin"].default.arg == EDGE_ORIGIN_HEBBIAN
+
+
+def test_all_edge_origins_constants():
+    assert _ALL_EDGE_ORIGINS == (
+        EDGE_ORIGIN_HEBBIAN,
+        EDGE_ORIGIN_SEMANTIC,
+        EDGE_ORIGIN_DECLARED,
+    )
+
+
+@pytest.mark.asyncio
+async def test_invalid_origin_rejected_by_check_constraint(db_session, sample_memory_pair):
+    src, dst = sample_memory_pair
+    bad = NeuralMemoryEdge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        workspace_id=src.workspace_id,
+        context_id=src.context_id,
+        edge_type="neural_association",
+        weight=0.1,
+        confidence=1.0,
+        origin="bogus",
+    )
+    db_session.add(bad)
+    with pytest.raises(IntegrityError):
+        await db_session.flush()
+    await db_session.rollback()
+
+
+def test_valid_edge_origin_check_constraint_matches_migration_literal():
+    """``valid_edge_origin`` CHECK constraint text is byte-identical to e17_722.
+
+    Mirrors ``test_valid_edge_type_check_constraint_matches_migration_literal``
+    in ``tests/test_edge_type_constants.py`` for the new origin discriminator.
+
+    The CHECK constraint is derived from ``_ALL_EDGE_ORIGINS`` via f-string.
+    This test pins the *exact* output string against the literal that
+    ``e17_722_neural_edge_origin.py`` installs on production via its
+    ``op.execute(...)`` block. Two reasons:
+
+    1. ``Base.metadata.create_all()`` (used by tests + fresh dev DBs) must
+       produce a CHECK constraint identical to the alembic head, so test
+       fixtures and prod schema stay in sync.
+    2. ``alembic revision --autogenerate`` compares the model's CheckConstraint
+       string against the migration head; any textual divergence (sorted vs
+       registration order, whitespace, quote style) generates a spurious
+       no-op migration. This test catches such drift before it lands.
+
+    If a future PR legitimately changes the CHECK string (adds a new origin,
+    reorders, etc.), update this expected literal AND write the accompanying
+    alembic migration in the same PR.
+    """
+    expected = "origin IN ('hebbian', 'semantic', 'declared')"
+
+    valid_edge_origin_check = next(
+        c
+        for c in NeuralMemoryEdge.__table_args__
+        if getattr(c, "name", None) == "valid_edge_origin"
+    )
+    # Use ``.text`` (raw TextClause attribute) instead of ``str()`` which
+    # would route through SQLAlchemy compilation and could shift across
+    # SQLAlchemy/dialect versions. ``.text`` is the original CheckConstraint
+    # string, so byte-identical comparison stays stable across upgrades.
+    assert valid_edge_origin_check.sqltext.text == expected

--- a/backend/tests/repositories/conftest.py
+++ b/backend/tests/repositories/conftest.py
@@ -1,0 +1,52 @@
+"""Fixtures for repository tests (Issue #722).
+
+Re-exports sample_memory_pair from tests/neural/conftest.py so it is
+discoverable by pytest in this subdirectory, and adds fixtures specific
+to neural-edge origin tests.
+"""
+
+import pytest_asyncio
+
+from models.memory import (
+    EDGE_ORIGIN_HEBBIAN,
+    EDGE_ORIGIN_SEMANTIC,
+    NeuralMemoryEdge,
+)
+
+# Re-export so pytest can discover it in this directory tree.
+from tests.neural.conftest import sample_memory_pair  # noqa: F401
+
+
+@pytest_asyncio.fixture
+async def two_edges_one_hebbian_one_semantic(db_session, sample_memory_pair):
+    """Create two edges: one hebbian, one semantic, in opposite directions.
+
+    Uses opposite src/dst direction so both satisfy the unique_edge constraint
+    (user_id, src_id, dst_id) which does not allow duplicate (src, dst) pairs.
+    """
+    src, dst = sample_memory_pair
+    hebbian = NeuralMemoryEdge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        workspace_id=src.workspace_id,
+        context_id=src.context_id,
+        edge_type="neural_association",
+        weight=0.5,
+        confidence=1.0,
+        origin=EDGE_ORIGIN_HEBBIAN,
+    )
+    semantic = NeuralMemoryEdge(
+        user_id=src.user_id,
+        src_id=dst.id,  # opposite direction — unique_edge constraint safe
+        dst_id=src.id,
+        workspace_id=src.workspace_id,
+        context_id=src.context_id,
+        edge_type="related_to",
+        weight=0.7,
+        confidence=1.0,
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+    db_session.add_all([hebbian, semantic])
+    await db_session.flush()
+    return hebbian, semantic

--- a/backend/tests/repositories/conftest.py
+++ b/backend/tests/repositories/conftest.py
@@ -19,14 +19,16 @@ from tests.neural.conftest import sample_memory_pair  # noqa: F401
 
 @pytest_asyncio.fixture
 async def two_edges_one_hebbian_one_semantic(db_session, sample_memory_pair):
-    """Create two edges: one hebbian, one semantic, in opposite directions.
-
-    Uses opposite src/dst direction so both satisfy the unique_edge constraint
-    (user_id, src_id, dst_id) which does not allow duplicate (src, dst) pairs.
+    """Create two edges (hebbian + semantic, opposite directions) under a
+    unique user_id so per-test bulk operations are immune to leaked data
+    from earlier tests.
     """
+    from uuid import uuid4
+
     src, dst = sample_memory_pair
+    unique_user = f"edge-isolate-{uuid4().hex[:8]}"
     hebbian = NeuralMemoryEdge(
-        user_id=src.user_id,
+        user_id=unique_user,
         src_id=src.id,
         dst_id=dst.id,
         workspace_id=src.workspace_id,
@@ -37,8 +39,8 @@ async def two_edges_one_hebbian_one_semantic(db_session, sample_memory_pair):
         origin=EDGE_ORIGIN_HEBBIAN,
     )
     semantic = NeuralMemoryEdge(
-        user_id=src.user_id,
-        src_id=dst.id,  # opposite direction — unique_edge constraint safe
+        user_id=unique_user,
+        src_id=dst.id,  # reversed direction to satisfy unique_edge constraint
         dst_id=src.id,
         workspace_id=src.workspace_id,
         context_id=src.context_id,

--- a/backend/tests/repositories/conftest.py
+++ b/backend/tests/repositories/conftest.py
@@ -18,7 +18,7 @@ from tests.neural.conftest import sample_memory_pair  # noqa: F401
 
 
 @pytest_asyncio.fixture
-async def two_edges_one_hebbian_one_semantic(db_session, sample_memory_pair):
+async def two_edges_one_hebbian_one_semantic(db_session, sample_memory_pair):  # noqa: F811
     """Create two edges (hebbian + semantic, opposite directions) under a
     unique user_id so per-test bulk operations are immune to leaked data
     from earlier tests.

--- a/backend/tests/repositories/test_neural_edge_origin.py
+++ b/backend/tests/repositories/test_neural_edge_origin.py
@@ -1,0 +1,195 @@
+"""Repository contract tests for edge.origin plumbing (Issue #722).
+
+Verifies:
+- create_or_update_edge writes the supplied origin value
+- create_or_update_edge defaults to EDGE_ORIGIN_HEBBIAN
+- create_edge_if_absent writes the supplied origin value
+- bulk_decay_weights(only_origin=...) skips non-matching edges
+- prune_weak_edges(only_origin=...) skips non-matching edges
+"""
+
+import pytest
+
+from models.memory import (
+    EDGE_ORIGIN_HEBBIAN,
+    EDGE_ORIGIN_SEMANTIC,
+)
+from repositories.neural_edge import NeuralEdgeRepository
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_edge_writes_origin(db_session, sample_memory_pair):
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="related_to",
+        weight=0.8,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+    edge = await repo.get_edge(src.user_id, src.id, dst.id)
+    assert edge is not None
+    assert edge.origin == EDGE_ORIGIN_SEMANTIC
+
+
+@pytest.mark.asyncio
+async def test_create_or_update_edge_default_origin_is_hebbian(db_session, sample_memory_pair):
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="neural_association",
+        weight=0.1,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+    )
+    edge = await repo.get_edge(src.user_id, src.id, dst.id)
+    assert edge is not None
+    assert edge.origin == EDGE_ORIGIN_HEBBIAN
+
+
+@pytest.mark.asyncio
+async def test_create_edge_if_absent_writes_origin(db_session, sample_memory_pair):
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    edge = await repo.create_edge_if_absent(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="related_to",
+        weight=0.7,
+        confidence=0.9,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+    assert edge is not None
+    assert edge.origin == EDGE_ORIGIN_SEMANTIC
+
+
+@pytest.mark.asyncio
+async def test_bulk_decay_only_origin_hebbian_skips_semantic(
+    db_session, two_edges_one_hebbian_one_semantic
+):
+    hebbian, semantic = two_edges_one_hebbian_one_semantic
+    repo = NeuralEdgeRepository(db_session)
+    user_id = hebbian.user_id
+
+    initial_h_weight = hebbian.weight
+    initial_s_weight = semantic.weight
+
+    n = await repo.bulk_decay_weights(user_id, decay_factor=0.5, only_origin=EDGE_ORIGIN_HEBBIAN)
+    # flush so ORM-layer weight updates are persisted before refresh re-reads from DB
+    await db_session.flush()
+    await db_session.refresh(hebbian)
+    await db_session.refresh(semantic)
+
+    assert n == 1
+    assert hebbian.weight == pytest.approx(initial_h_weight * 0.5)
+    assert semantic.weight == initial_s_weight  # untouched
+
+
+@pytest.mark.asyncio
+async def test_prune_only_origin_hebbian_skips_semantic(
+    db_session, two_edges_one_hebbian_one_semantic
+):
+    hebbian, semantic = two_edges_one_hebbian_one_semantic
+    user_id = hebbian.user_id
+    # Force both below the threshold the test will use
+    hebbian.weight = 0.001
+    semantic.weight = 0.001
+    await db_session.flush()
+
+    repo = NeuralEdgeRepository(db_session)
+    deleted = await repo.prune_weak_edges(
+        user_id, weight_threshold=0.01, only_origin=EDGE_ORIGIN_HEBBIAN
+    )
+    assert deleted == 1
+
+    surviving = await repo.get_edge(user_id, semantic.src_id, semantic.dst_id)
+    assert surviving is not None
+    assert surviving.origin == EDGE_ORIGIN_SEMANTIC
+
+
+@pytest.mark.asyncio
+async def test_upsert_does_not_demote_semantic_to_hebbian(db_session, sample_memory_pair):
+    """Hebbian co-recall must NOT downgrade an existing semantic edge."""
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    # First write: semantic edge
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="related_to",
+        weight=0.8,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+
+    # Second write: Hebbian co-recall upsert with default origin
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="neural_association",
+        weight=0.5,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        # origin omitted — defaults to EDGE_ORIGIN_HEBBIAN
+    )
+
+    edge = await repo.get_edge(src.user_id, src.id, dst.id)
+    assert edge is not None
+    assert edge.origin == EDGE_ORIGIN_SEMANTIC  # preserved, not demoted
+
+
+@pytest.mark.asyncio
+async def test_upsert_promotes_hebbian_to_semantic(db_session, sample_memory_pair):
+    """Sleep edge_discovery upsert MUST be able to promote a hebbian edge to semantic."""
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    # First write: Hebbian edge (default)
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="neural_association",
+        weight=0.05,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+    )
+
+    # Second write: sleep edge_discovery upsert with semantic origin
+    await repo.create_or_update_edge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="related_to",
+        weight=0.85,
+        confidence=1.0,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+
+    edge = await repo.get_edge(src.user_id, src.id, dst.id)
+    assert edge is not None
+    assert edge.origin == EDGE_ORIGIN_SEMANTIC  # promoted

--- a/backend/tests/scripts/conftest.py
+++ b/backend/tests/scripts/conftest.py
@@ -1,0 +1,111 @@
+"""Shared fixtures for scripts tests (Issue #722)."""
+
+from __future__ import annotations
+
+from uuid import UUID, uuid4
+
+import pytest_asyncio
+
+from models.auth import Context, Workspace
+from models.memory import Memory
+
+
+@pytest_asyncio.fixture
+async def small_context_30_memories(db_session) -> UUID:
+    """Create a workspace + context with 30 alive memories.
+
+    Returns the context UUID. Used to test the 'below_memory_floor' skip path.
+    Uses a unique user_id to avoid leakage across tests (Task 6 pattern).
+    """
+    uid = f"backfill-{uuid4().hex[:8]}"
+    ws = Workspace(
+        id=uuid4(),
+        name=f"backfill-small-ws-{uuid4().hex[:8]}",
+        owner_user_id=uid,
+    )
+    db_session.add(ws)
+    await db_session.flush()
+
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"backfill-small-{uuid4().hex[:8]}",
+        created_by=uid,
+        is_private=False,
+    )
+    db_session.add(ctx)
+    await db_session.flush()
+
+    for i in range(30):
+        db_session.add(
+            Memory(
+                id=uuid4(),
+                user_id=uid,
+                workspace_id=ws.id,
+                context_id=ctx.id,
+                summary=f"small context memory {i}",
+                content=f"content {i}",
+                type="note",
+                client="test",
+            )
+        )
+    await db_session.flush()
+    return ctx.id
+
+
+@pytest_asyncio.fixture
+async def large_context_60_memories(db_session) -> dict:
+    """Create a workspace + context with 60 alive memories.
+
+    Returns a dict with:
+        - "context_id": UUID of the context
+        - "memory_ids": list of UUID for all 60 memories (deterministic order)
+        - "user_id": the owner user_id string
+        - "workspace_id": UUID of the workspace
+
+    Used to test the happy-path and dry-run paths.
+    Uses a unique user_id to avoid leakage across tests.
+    """
+    uid = f"backfill-{uuid4().hex[:8]}"
+    ws = Workspace(
+        id=uuid4(),
+        name=f"backfill-large-ws-{uuid4().hex[:8]}",
+        owner_user_id=uid,
+    )
+    db_session.add(ws)
+    await db_session.flush()
+
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"backfill-large-{uuid4().hex[:8]}",
+        created_by=uid,
+        is_private=False,
+    )
+    db_session.add(ctx)
+    await db_session.flush()
+
+    memory_ids: list[UUID] = []
+    for i in range(60):
+        mid = uuid4()
+        memory_ids.append(mid)
+        db_session.add(
+            Memory(
+                id=mid,
+                user_id=uid,
+                workspace_id=ws.id,
+                context_id=ctx.id,
+                summary=f"large context memory {i}",
+                content=f"content {i}",
+                type="note",
+                client="test",
+            )
+        )
+    await db_session.flush()
+
+    return {
+        "context_id": ctx.id,
+        "memory_ids": memory_ids,
+        "user_id": uid,
+        "workspace_id": ws.id,
+    }

--- a/backend/tests/scripts/conftest.py
+++ b/backend/tests/scripts/conftest.py
@@ -5,103 +5,54 @@ from __future__ import annotations
 from uuid import UUID, uuid4
 
 import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import Context, Workspace
 from models.memory import Memory
 
 
-@pytest_asyncio.fixture
-async def small_context_30_memories(db_session) -> UUID:
-    """Create a workspace + context with 30 alive memories.
+async def _make_context_with_n_memories(db: AsyncSession, n: int, prefix: str) -> dict:
+    """Build a fresh workspace + context + ``n`` alive memories under a unique user_id.
 
-    Returns the context UUID. Used to test the 'below_memory_floor' skip path.
-    Uses a unique user_id to avoid leakage across tests (Task 6 pattern).
+    Unique user_id prevents fixture data from leaking across tests that share
+    the integration DB (see Task 6 isolation pattern).
     """
     uid = f"backfill-{uuid4().hex[:8]}"
     ws = Workspace(
         id=uuid4(),
-        name=f"backfill-small-ws-{uuid4().hex[:8]}",
+        name=f"backfill-{prefix}-ws-{uuid4().hex[:8]}",
         owner_user_id=uid,
     )
-    db_session.add(ws)
-    await db_session.flush()
+    db.add(ws)
+    await db.flush()
 
     ctx = Context(
         id=uuid4(),
         workspace_id=ws.id,
-        name=f"backfill-small-{uuid4().hex[:8]}",
+        name=f"backfill-{prefix}-{uuid4().hex[:8]}",
         created_by=uid,
         is_private=False,
     )
-    db_session.add(ctx)
-    await db_session.flush()
-
-    for i in range(30):
-        db_session.add(
-            Memory(
-                id=uuid4(),
-                user_id=uid,
-                workspace_id=ws.id,
-                context_id=ctx.id,
-                summary=f"small context memory {i}",
-                content=f"content {i}",
-                type="note",
-                client="test",
-            )
-        )
-    await db_session.flush()
-    return ctx.id
-
-
-@pytest_asyncio.fixture
-async def large_context_60_memories(db_session) -> dict:
-    """Create a workspace + context with 60 alive memories.
-
-    Returns a dict with:
-        - "context_id": UUID of the context
-        - "memory_ids": list of UUID for all 60 memories (deterministic order)
-        - "user_id": the owner user_id string
-        - "workspace_id": UUID of the workspace
-
-    Used to test the happy-path and dry-run paths.
-    Uses a unique user_id to avoid leakage across tests.
-    """
-    uid = f"backfill-{uuid4().hex[:8]}"
-    ws = Workspace(
-        id=uuid4(),
-        name=f"backfill-large-ws-{uuid4().hex[:8]}",
-        owner_user_id=uid,
-    )
-    db_session.add(ws)
-    await db_session.flush()
-
-    ctx = Context(
-        id=uuid4(),
-        workspace_id=ws.id,
-        name=f"backfill-large-{uuid4().hex[:8]}",
-        created_by=uid,
-        is_private=False,
-    )
-    db_session.add(ctx)
-    await db_session.flush()
+    db.add(ctx)
+    await db.flush()
 
     memory_ids: list[UUID] = []
-    for i in range(60):
+    for i in range(n):
         mid = uuid4()
         memory_ids.append(mid)
-        db_session.add(
+        db.add(
             Memory(
                 id=mid,
                 user_id=uid,
                 workspace_id=ws.id,
                 context_id=ctx.id,
-                summary=f"large context memory {i}",
+                summary=f"{prefix} memory {i}",
                 content=f"content {i}",
                 type="note",
                 client="test",
             )
         )
-    await db_session.flush()
+    await db.flush()
 
     return {
         "context_id": ctx.id,
@@ -109,3 +60,21 @@ async def large_context_60_memories(db_session) -> dict:
         "user_id": uid,
         "workspace_id": ws.id,
     }
+
+
+@pytest_asyncio.fixture
+async def small_context_30_memories(db_session) -> UUID:
+    """Context with 30 alive memories — exercises the 'below_memory_floor' skip path."""
+    data = await _make_context_with_n_memories(db_session, 30, "small")
+    return data["context_id"]
+
+
+@pytest_asyncio.fixture
+async def large_context_60_memories(db_session) -> dict:
+    """Context with 60 alive memories — exercises the happy-path and dry-run paths.
+
+    Returns a dict with ``context_id``, ``memory_ids`` (deterministic order),
+    ``user_id``, and ``workspace_id`` so tests can mock Qdrant against the
+    same set of memory UUIDs the fixture wrote.
+    """
+    return await _make_context_with_n_memories(db_session, 60, "large")

--- a/backend/tests/scripts/test_backfill_semantic_edges.py
+++ b/backend/tests/scripts/test_backfill_semantic_edges.py
@@ -1,0 +1,135 @@
+"""Backfill script tests (Issue #722)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy import select
+
+from models.memory import EDGE_ORIGIN_SEMANTIC, NeuralMemoryEdge
+
+# Scripts are not an importable package — add backend/scripts to sys.path so
+# pytest can import the CLI module. This mirrors the sys.path manipulation in
+# test_measure_embedding_threshold.py.
+_SCRIPTS_DIR = Path(__file__).resolve().parents[2] / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import backfill_semantic_edges as bse  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_skips_contexts_below_floor(db_session, small_context_30_memories):
+    ctx_id = small_context_30_memories
+    fake_qdrant = MagicMock()
+    result = await bse.backfill_context(
+        db_session,
+        fake_qdrant,  # type: ignore[arg-type]
+        ctx_id,
+        min_memories=50,
+        sim_threshold=0.7,
+        top_k=10,
+    )
+    assert result["skipped"] is True
+    assert result["reason"] == "below_memory_floor"
+
+
+@pytest.mark.asyncio
+async def test_inserts_semantic_edges_for_pairs_above_threshold(
+    db_session, large_context_60_memories
+):
+    ctx_id = large_context_60_memories["context_id"]
+    memory_ids = large_context_60_memories["memory_ids"]
+
+    async def mock_query_neighbors(memory_id, context_id, user_id, workspace_id, top_k):
+        out = []
+        for i, mid in enumerate(memory_ids[: top_k + 1]):
+            if mid == memory_id:
+                continue
+            score = max(0.95 - 0.02 * i, 0.0)
+            out.append((mid, score))
+        return out[:top_k]
+
+    fake_qdrant = MagicMock()
+    fake_qdrant.query_neighbors = AsyncMock(side_effect=mock_query_neighbors)
+
+    result = await bse.backfill_context(
+        db_session,
+        fake_qdrant,  # type: ignore[arg-type]
+        ctx_id,
+        min_memories=50,
+        sim_threshold=0.7,
+        top_k=10,
+    )
+    assert result["skipped"] is False
+    assert result["edges_inserted"] > 0
+
+    # Inspect the persisted edges
+    edges = (
+        (
+            await db_session.execute(
+                select(NeuralMemoryEdge).where(NeuralMemoryEdge.context_id == ctx_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(edges) == result["edges_inserted"]
+    for e in edges:
+        assert e.origin == EDGE_ORIGIN_SEMANTIC
+        assert 0.7 <= e.weight <= 1.0
+
+    # Re-run should be idempotent
+    result2 = await bse.backfill_context(
+        db_session,
+        fake_qdrant,  # type: ignore[arg-type]
+        ctx_id,
+        min_memories=50,
+        sim_threshold=0.7,
+        top_k=10,
+    )
+    assert result2["edges_inserted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_dry_run_does_not_insert(db_session, large_context_60_memories):
+    ctx_id = large_context_60_memories["context_id"]
+    memory_ids = large_context_60_memories["memory_ids"]
+
+    async def mock_query_neighbors(memory_id, context_id, user_id, workspace_id, top_k):
+        out = []
+        for i, mid in enumerate(memory_ids[: top_k + 1]):
+            if mid == memory_id:
+                continue
+            out.append((mid, max(0.95 - 0.02 * i, 0.0)))
+        return out[:top_k]
+
+    fake_qdrant = MagicMock()
+    fake_qdrant.query_neighbors = AsyncMock(side_effect=mock_query_neighbors)
+
+    result = await bse.backfill_context(
+        db_session,
+        fake_qdrant,  # type: ignore[arg-type]
+        ctx_id,
+        min_memories=50,
+        sim_threshold=0.7,
+        top_k=10,
+        dry_run=True,
+    )
+    assert result["edges_inserted"] == 0  # dry run reports 0 actual inserts
+    assert result.get("pairs_would_insert", 0) > 0  # but tracks would-be count
+
+    # Verify nothing landed in the DB
+    edges = (
+        (
+            await db_session.execute(
+                select(NeuralMemoryEdge).where(NeuralMemoryEdge.context_id == ctx_id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(edges) == 0

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -272,7 +272,10 @@ class TestEdgeDiscoveryPhase:
         assert result.details["edges_created"] == 1
         edge_phase.edge_repo.create_or_update_edge.assert_called_once()
         call_kwargs = edge_phase.edge_repo.create_or_update_edge.call_args[1]
-        assert call_kwargs["weight"] == DISCOVERY_EDGE_WEIGHT
+        # Issue #722: weight is now the cosine score from the batch tuple (0.75),
+        # not the fixed DISCOVERY_EDGE_WEIGHT constant.
+        assert call_kwargs["weight"] == pytest.approx(0.75)
+        assert call_kwargs["origin"] == "semantic"
         assert call_kwargs["edge_type"] == "related_to"
         # #306: auto-accept path increments `auto_accepted`, not `llm_accepted`.
         # avg_confidence / edge_type_dist / histogram stay zero (no pollution).

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -272,11 +272,14 @@ class TestEdgeDiscoveryPhase:
         assert result.details["edges_created"] == 1
         edge_phase.edge_repo.create_or_update_edge.assert_called_once()
         call_kwargs = edge_phase.edge_repo.create_or_update_edge.call_args[1]
-        # Issue #722: weight is now the cosine score from the batch tuple (0.75),
-        # not the fixed DISCOVERY_EDGE_WEIGHT constant.
+        # weight is the cosine score from the batch tuple (0.75), not the
+        # fixed DISCOVERY_EDGE_WEIGHT constant; origin is tagged 'semantic'
+        # so DecayManager's only_origin='hebbian' filter leaves it alone.
+        from models.memory import EDGE_ORIGIN_SEMANTIC, EDGE_TYPE_RELATED_TO
+
         assert call_kwargs["weight"] == pytest.approx(0.75)
-        assert call_kwargs["origin"] == "semantic"
-        assert call_kwargs["edge_type"] == "related_to"
+        assert call_kwargs["origin"] == EDGE_ORIGIN_SEMANTIC
+        assert call_kwargs["edge_type"] == EDGE_TYPE_RELATED_TO
         # #306: auto-accept path increments `auto_accepted`, not `llm_accepted`.
         # avg_confidence / edge_type_dist / histogram stay zero (no pollution).
         assert result.details["auto_accepted"] == 1

--- a/backend/tests/services/sleep/test_edge_discovery_origin.py
+++ b/backend/tests/services/sleep/test_edge_discovery_origin.py
@@ -1,0 +1,108 @@
+"""Sleep edge_discovery writes origin='semantic' with cosine weight (Issue #722)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+
+from models.memory import EDGE_ORIGIN_SEMANTIC
+from services.sleep.edge_discovery import DISCOVERY_EDGE_WEIGHT, ConfirmedEdge, EdgeDiscoveryPhase
+
+
+def _make_phase():
+    """Build an EdgeDiscoveryPhase with all external deps mocked out."""
+    db = AsyncMock()
+    llm_service = MagicMock()
+    with (
+        patch("services.sleep.edge_discovery.NeuralEdgeRepository"),
+        patch("services.sleep.edge_discovery.EmbeddingService"),
+    ):
+        phase = EdgeDiscoveryPhase(db, llm_service)
+        phase.edge_repo = MagicMock()
+        phase.edge_repo.create_or_update_edge = AsyncMock(return_value=MagicMock())
+    return phase
+
+
+@pytest.mark.asyncio
+async def test_persist_confirmed_edges_uses_origin_semantic_and_cosine_weight():
+    """Each persisted sleep edge must carry origin='semantic' and weight = batch cosine."""
+    phase = _make_phase()
+
+    src1, dst1 = uuid4(), uuid4()
+    src2, dst2 = uuid4(), uuid4()
+    batch = [(src1, dst1, 0.82), (src2, dst2, 0.71)]
+    confirmed = [
+        ConfirmedEdge(src_id=s, dst_id=d, edge_type="related_to", confidence=0.9)
+        for s, d, _ in batch
+    ]
+
+    created = await phase._persist_confirmed_edges(
+        confirmed=confirmed,
+        batch=batch,
+        user_id="u",
+        workspace_id="w",
+        context_id="c",
+        reporter=None,
+        report_id=None,
+    )
+
+    assert created == 2
+    calls = phase.edge_repo.create_or_update_edge.await_args_list
+    assert len(calls) == 2
+
+    kwargs_by_src = {c.kwargs["src_id"]: c.kwargs for c in calls}
+    assert kwargs_by_src[src1]["weight"] == pytest.approx(0.82)
+    assert kwargs_by_src[src1]["origin"] == EDGE_ORIGIN_SEMANTIC
+    assert kwargs_by_src[src2]["weight"] == pytest.approx(0.71)
+    assert kwargs_by_src[src2]["origin"] == EDGE_ORIGIN_SEMANTIC
+
+
+@pytest.mark.asyncio
+async def test_persist_falls_back_when_batch_lacks_score():
+    """If a confirmed edge's (src,dst) is not in the batch score map, use a sensible default."""
+    phase = _make_phase()
+
+    src, dst = uuid4(), uuid4()
+    batch: list[tuple[UUID, UUID, float]] = []  # empty score map
+    confirmed = [ConfirmedEdge(src_id=src, dst_id=dst, edge_type="related_to", confidence=0.7)]
+
+    await phase._persist_confirmed_edges(
+        confirmed=confirmed,
+        batch=batch,
+        user_id="u",
+        workspace_id="w",
+        context_id="c",
+        reporter=None,
+        report_id=None,
+    )
+    kwargs = phase.edge_repo.create_or_update_edge.await_args.kwargs
+    assert kwargs["origin"] == EDGE_ORIGIN_SEMANTIC
+    # Default weight when no score is known — DISCOVERY_EDGE_WEIGHT (0.5) is the fallback.
+    assert kwargs["weight"] == pytest.approx(DISCOVERY_EDGE_WEIGHT)
+
+
+@pytest.mark.asyncio
+async def test_persist_records_origin_in_reporter_details():
+    """Reporter audit log captures origin='semantic' for each persisted edge."""
+    phase = _make_phase()
+    reporter = MagicMock()
+    reporter.add_action = AsyncMock()
+
+    src, dst = uuid4(), uuid4()
+    batch: list[tuple[UUID, UUID, float]] = [(src, dst, 0.77)]
+    confirmed = [ConfirmedEdge(src_id=src, dst_id=dst, edge_type="related_to", confidence=0.9)]
+
+    await phase._persist_confirmed_edges(
+        confirmed=confirmed,
+        batch=batch,
+        user_id="u",
+        workspace_id="w",
+        context_id="c",
+        reporter=reporter,
+        report_id="report-1",
+    )
+
+    reporter.add_action.assert_awaited_once()
+    kwargs = reporter.add_action.await_args.kwargs
+    assert kwargs["details"]["origin"] == EDGE_ORIGIN_SEMANTIC
+    assert kwargs["details"]["weight"] == pytest.approx(0.77)

--- a/backend/tests/tasks/conftest.py
+++ b/backend/tests/tasks/conftest.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+# Re-export fixtures from sibling test directories so pytest can discover
+# them in this subdirectory tree.  F401 suppressed because the import
+# side-effect (fixture registration) is the whole point.
+from tests.neural.conftest import sample_memory_pair  # noqa: F401
+from tests.repositories.conftest import two_edges_one_hebbian_one_semantic  # noqa: F401
+
 
 def mock_get_db_factory(mock_db):
     """Build an async generator that yields ``mock_db`` once.
@@ -15,10 +21,3 @@ def mock_get_db_factory(mock_db):
         yield mock_db
 
     return get_db
-
-
-# Re-export fixtures from sibling test directories so pytest can discover
-# them in this subdirectory tree.  F401 suppressed because the import
-# side-effect (fixture registration) is the whole point.
-from tests.neural.conftest import sample_memory_pair  # noqa: F401
-from tests.repositories.conftest import two_edges_one_hebbian_one_semantic  # noqa: F401

--- a/backend/tests/tasks/conftest.py
+++ b/backend/tests/tasks/conftest.py
@@ -15,3 +15,10 @@ def mock_get_db_factory(mock_db):
         yield mock_db
 
     return get_db
+
+
+# Re-export fixtures from sibling test directories so pytest can discover
+# them in this subdirectory tree.  F401 suppressed because the import
+# side-effect (fixture registration) is the whole point.
+from tests.neural.conftest import sample_memory_pair  # noqa: F401
+from tests.repositories.conftest import two_edges_one_hebbian_one_semantic  # noqa: F401

--- a/backend/tests/tasks/test_semantic_edge_reverify.py
+++ b/backend/tests/tasks/test_semantic_edge_reverify.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from models.memory import EDGE_ORIGIN_HEBBIAN, EDGE_ORIGIN_SEMANTIC, NeuralMemoryEdge
+from models.memory import NeuralMemoryEdge
 from tasks.semantic_edge_reverify import semantic_edge_reverify_run
 from utils.datetime import utcnow
 

--- a/backend/tests/tasks/test_semantic_edge_reverify.py
+++ b/backend/tests/tasks/test_semantic_edge_reverify.py
@@ -1,0 +1,33 @@
+"""Monthly semantic_edge_reverify cron (Issue #722)."""
+
+import pytest
+
+from models.memory import EDGE_ORIGIN_HEBBIAN, EDGE_ORIGIN_SEMANTIC, NeuralMemoryEdge
+from tasks.semantic_edge_reverify import semantic_edge_reverify_run
+from utils.datetime import utcnow
+
+
+@pytest.mark.asyncio
+async def test_reverify_drops_edges_whose_endpoint_is_soft_deleted(
+    db_session, sample_memory_pair, two_edges_one_hebbian_one_semantic
+):
+    """Soft-delete dst → semantic edge gone, hebbian sister untouched."""
+    src, dst = sample_memory_pair
+    hebbian, semantic = two_edges_one_hebbian_one_semantic
+    dst.deleted_at = utcnow()
+    await db_session.flush()
+
+    result = await semantic_edge_reverify_run(db_session)
+    assert result["semantic_edges_deleted"] == 1
+
+    refetch_hebbian = await db_session.get(NeuralMemoryEdge, hebbian.id)
+    assert refetch_hebbian is not None  # hebbian sister survives — not this task's domain
+
+
+@pytest.mark.asyncio
+async def test_reverify_keeps_edges_with_live_endpoints(
+    db_session, two_edges_one_hebbian_one_semantic
+):
+    """Both endpoints alive → no deletion."""
+    result = await semantic_edge_reverify_run(db_session)
+    assert result["semantic_edges_deleted"] == 0

--- a/docs/operations/semantic-edge-rollout.md
+++ b/docs/operations/semantic-edge-rollout.md
@@ -1,0 +1,172 @@
+# Semantic Edge Origin Rollout (Issue #722)
+
+Operator runbook for shipping the semantic / Hebbian edge split. The PR makes sleep-discovered edges survive the decay loop; this runbook covers the deploy steps and the one-shot backfill that restores edges previously erased by decay.
+
+## What changed
+
+| Layer | Before | After |
+|---|---|---|
+| `neural_memory_edges.origin` | (column did not exist) | `hebbian` \| `semantic` \| `declared`, default `hebbian` |
+| `DecayManager` | decays + prunes all edges | only `origin='hebbian'` |
+| `sleep edge_discovery` | writes fixed `weight=0.5` | writes `weight = cosine_sim`, `origin='semantic'` |
+| `create_or_update_edge` upsert | unconditionally overwrites origin | sticky — only `hebbian` can be overwritten |
+| `semantic_edge_reverify` cron | (did not exist) | monthly, 04:15 UTC, drops semantic edges with soft-deleted endpoints |
+| Backfill | (did not exist) | `python -m scripts.backfill_semantic_edges` |
+
+Production impact: zero user-visible change to `recall` (the graph is `explore`-only per Issue #120). The graph view and `explore()` go from near-empty to populated.
+
+## Pre-flight
+
+1. Verify the migration head locally:
+
+   ```bash
+   cd backend && alembic heads
+   # expect: e17_722_neural_edge_origin (head)
+   ```
+
+2. Verify the running prod API is on a build that contains the merge of this PR. The deployed image SHA must include both the migration (`e17_722_neural_edge_origin`) and the new `tasks/semantic_edge_reverify.py` module.
+
+## Deploy
+
+1. Standard blue/green deploy via `terraform/single-server/scripts/deploy.sh`. The script handles the new color, healthchecks, and traffic flip.
+
+2. After the new color is healthy, run the migration on the VM:
+
+   ```bash
+   gcloud compute ssh kagura-memory-vm \
+     --zone=asia-northeast1-a --tunnel-through-iap --project=kagura-492509 \
+     --command='docker exec kagura-api-$(cat /opt/kagura-memory/active-color) \
+       alembic -c /app/alembic.ini upgrade head'
+   ```
+
+3. Verify the column landed:
+
+   ```bash
+   gcloud compute ssh kagura-memory-vm \
+     --zone=asia-northeast1-a --tunnel-through-iap --project=kagura-492509 \
+     --command='docker exec kagura-postgres psql -U kagura -d kagura -c "\d neural_memory_edges"' \
+     | grep -E "origin|valid_edge_origin|idx_edges_origin"
+   ```
+
+   Expected lines (whitespace tolerant):
+
+   ```
+    origin       | character varying(20)  | not null | 'hebbian'::character varying
+       "idx_edges_origin" btree (origin)
+       "valid_edge_origin" CHECK (origin IN ('hebbian','semantic','declared'))
+   ```
+
+## Backfill
+
+The backfill is opt-in. Skipping it means existing contexts gradually accumulate semantic edges as the next nightly sleep runs land — but historical edges already pruned by decay stay gone.
+
+1. Dry-run with a strict threshold first to see what the impact would be on the largest context:
+
+   ```bash
+   gcloud compute ssh kagura-memory-vm \
+     --zone=asia-northeast1-a --tunnel-through-iap --project=kagura-492509 \
+     --command="docker exec kagura-api-\$(cat /opt/kagura-memory/active-color) \
+       python -m scripts.backfill_semantic_edges \
+         --context-id abfd654d-c489-47fe-a1d3-e6471041259b \
+         --sim-threshold 0.85 --top-k 10 --dry-run"
+   ```
+
+   The final log line prints `Dry run: <N> edges would be inserted across 1 contexts`. If N is unreasonable (e.g. tens of thousands), lower `--top-k` or raise `--sim-threshold`.
+
+2. Execute against the same context with the chosen threshold:
+
+   ```bash
+   gcloud compute ssh kagura-memory-vm \
+     --zone=asia-northeast1-a --tunnel-through-iap --project=kagura-492509 \
+     --command="docker exec kagura-api-\$(cat /opt/kagura-memory/active-color) \
+       python -m scripts.backfill_semantic_edges \
+         --context-id abfd654d-c489-47fe-a1d3-e6471041259b \
+         --sim-threshold 0.7 --top-k 10"
+   ```
+
+3. Inspect:
+
+   ```bash
+   gcloud compute ssh kagura-memory-vm \
+     --zone=asia-northeast1-a --tunnel-through-iap --project=kagura-492509 \
+     --command="docker exec kagura-postgres psql -U kagura -d kagura -c \
+       \"SELECT origin, COUNT(*) FROM neural_memory_edges \
+         WHERE context_id = 'abfd654d-c489-47fe-a1d3-e6471041259b' GROUP BY origin;\""
+   ```
+
+   Expect a non-trivial `semantic` count (hundreds to low thousands for `kagura-dev` at 1,494 memories) and an unchanged `hebbian` count.
+
+4. Open production backfill for all contexts (optional, can be deferred):
+
+   ```bash
+   gcloud compute ssh kagura-memory-vm \
+     --zone=asia-northeast1-a --tunnel-through-iap --project=kagura-492509 \
+     --command="docker exec kagura-api-\$(cat /opt/kagura-memory/active-color) \
+       python -m scripts.backfill_semantic_edges \
+         --sim-threshold 0.7 --top-k 10"
+   ```
+
+## Post-flight verification
+
+* Web UI `/neural-memory` for `kagura-dev` (or any other backfilled context) shows ≥ 100 nodes / ≥ 200 edges (was 2 / 2 pre-PR).
+* The next decay cycle logs `edges_pruned` ≈ 0 — the carve-out is now active. Confirm with:
+
+   ```bash
+   docker logs kagura-api-$(cat /opt/kagura-memory/active-color) --since 2h \
+     | grep -E "weak_edges_pruned|bulk_decay_applied"
+   ```
+
+* `get_sleep_history(context_id='abfd654d-c489-47fe-a1d3-e6471041259b')` on the next nightly run shows `edges_created > 0` AND those edges survive in the DB past one hour:
+
+   ```bash
+   docker exec kagura-postgres psql -U kagura -d kagura -c \
+     "SELECT COUNT(*) FROM neural_memory_edges \
+      WHERE context_id = 'abfd654d-c489-47fe-a1d3-e6471041259b' \
+        AND created_at > NOW() - INTERVAL '24 hours' \
+        AND origin = 'semantic';"
+   ```
+
+* The `semantic_edge_reverify` cron will fire on the 1st of next month at 04:15 UTC. Verify the job is registered:
+
+   ```bash
+   docker logs kagura-api-$(cat /opt/kagura-memory/active-color) --since 1d \
+     | grep "scheduled_semantic_edge_reverify"
+   ```
+
+## Optional config rollback
+
+The 2026-05-19 hotfix that lowered `prune_threshold` to `0.001` and raised `sleep_edge_discovery_sample_size` to `200` is no longer load-bearing — semantic edges are now decay-exempt by design. The hotfix values can stay or be reset to defaults; neither choice changes correctness. To reset:
+
+```bash
+docker exec kagura-postgres psql -U kagura -d kagura -c "
+UPDATE neural_config SET value='0.01', updated_at=NOW() WHERE key='prune_threshold';
+UPDATE neural_config SET value='30', updated_at=NOW() WHERE key='sleep_edge_discovery_sample_size';
+"
+# API config cache TTL is 5 min — wait or restart the api container to pick up.
+```
+
+## Rollback
+
+If something goes wrong after deploy:
+
+1. **Code rollback**: deploy the previous color back. Both the column-additive migration AND the new code defaulting `origin='hebbian'` are forward- and backward-compatible at the wire level.
+
+2. **Migration rollback** (only needed if the column itself is the problem — almost never):
+
+   ```bash
+   docker exec kagura-api-$(cat /opt/kagura-memory/active-color) \
+     alembic -c /app/alembic.ini downgrade -1
+   ```
+
+   The downgrade is idempotent (`DROP CONSTRAINT IF EXISTS`).
+
+3. **Backfill rollback**: bulk-delete the inserted rows by origin. They cannot have been inserted before this deploy, so the time bound is a safe filter:
+
+   ```bash
+   docker exec kagura-postgres psql -U kagura -d kagura -c \
+     "DELETE FROM neural_memory_edges \
+      WHERE origin = 'semantic' \
+        AND created_at > '<deploy_timestamp>';"
+   ```
+
+Backfill rows are additive — leaving them in place is safe even when rolling back code.


### PR DESCRIPTION
Closes #722.

## Summary

`neural_memory_edges` gets an `origin` discriminator (`hebbian` | `semantic` | `declared`). Decay and prune now skip non-Hebbian origins, so sleep-discovered edges survive. Sleep `edge_discovery` writes `weight = cosine_sim` (was a fixed 0.5) and tags `origin='semantic'`. The upsert path is sticky: a Hebbian co-recall can no longer demote an existing semantic/declared edge. A monthly `semantic_edge_reverify` cron drops semantic edges whose endpoint memory has been soft-deleted. A one-shot `scripts/backfill_semantic_edges.py` CLI restores historical edges erased by decay before this PR.

User-visible behavior: `recall` is unchanged (the graph is `explore`-only per #120). The web `/neural-memory` view and `explore()` go from near-empty to populated once the backfill runs.

### Before / after on `kagura-dev` (the motivating context)

- Before: 1,494 memories, **4 edges** (all created today by Hebbian co-recall; 31 sleep-discovered edges all-time, **27 pruned by decay**)
- After (with backfill): expected hundreds–low thousands of `origin='semantic'` edges, surviving decay

## What's in this PR

| Layer | Change |
|---|---|
| Migration `e17_722` | Adds `origin VARCHAR(20) NOT NULL DEFAULT 'hebbian'` + `valid_edge_origin` CHECK + `idx_edges_origin`. Column-additive (PG metadata-only), idempotent CHECK install, `DROP CONSTRAINT IF EXISTS` downgrade |
| Model `NeuralMemoryEdge` | New `origin` column + `EDGE_ORIGIN_*` constants + drift-pinned CHECK literal |
| `NeuralEdgeRepository` | `origin` kwarg on both write paths; **sticky-origin CASE** in `on_conflict_do_update`; `only_origin` filter on `bulk_decay_weights` + `prune_weak_edges`; new `delete_semantic_edges_for_dead_pairs` helper |
| `DecayManager` | Passes `only_origin='hebbian'` everywhere |
| `sleep edge_discovery` | Extracts `_persist_confirmed_edges` helper; canonical-pair-keyed `score_by_pair` lookup; writes `origin='semantic'` + `weight=cosine`; warns on score-lookup miss |
| `semantic_edge_reverify` cron | Monthly, day=1 04:15 UTC (offset from neural consolidation at 03:00) |
| `backfill_semantic_edges.py` | Idempotent CLI; `--dry-run`, `--sim-threshold`, `--top-k`, `--min-memories`, `--context-id`; per-context try/except isolation |
| Runbook | `docs/operations/semantic-edge-rollout.md` |

## Known gaps (filed as follow-ups before merge)

These are pre-existing code paths that bypass the new `origin` carve-out. Neither causes permanent data loss (next nightly sleep regenerates affected edges), but both should be tightened.

- **#724** — `HebbianLearner.prune_weak_edges` (per-node top-M pruner) is not origin-aware.
- **#725** — `transfer_edges` conflict resolution in sleep dedup merge is not origin-aware.

## Test plan

- [x] Migration upgrade + downgrade + re-upgrade cycle verified live against the dev DB.
- [x] Model CHECK constraint rejects invalid origin (IntegrityError).
- [x] `_ALL_EDGE_ORIGINS` tuple pinned by `test_valid_edge_origin_check_constraint_matches_migration_literal`.
- [x] Repository writes `origin`, defaults to `EDGE_ORIGIN_HEBBIAN`, respects `only_origin` filter.
- [x] Sticky upsert: Hebbian co-recall does NOT demote a semantic edge; sleep CAN promote a hebbian to semantic.
- [x] DecayManager passes `only_origin='hebbian'` to both `bulk_decay_weights` and `prune_weak_edges`.
- [x] Sleep `_persist_confirmed_edges` writes `origin='semantic'`, `weight=cosine`, records `origin` in the reporter audit log; falls back to `DISCOVERY_EDGE_WEIGHT` with a warning when the batch lookup misses.
- [x] `semantic_edge_reverify` drops dead-endpoint semantic edges, keeps live ones, leaves Hebbian siblings untouched.
- [x] `backfill_semantic_edges` is idempotent, honors `--dry-run`, isolates per-context failures, persists `origin='semantic'` + cosine weight.
- [x] `make lint` clean (incl. Tier B pyright).
- [x] All task-touched test files green (99 pass post-simplify).
- [x] `make test-integration` 227 pass / 16 fail / 7 skip — the 16 failures are pre-existing on `main` in files this PR does NOT touch (`test_list_tags_aggregation`, `test_llm_pricing`, `test_memory_analyses_schema`, `test_oauth_dcr_integration`).
- [ ] (Post-deploy) `kagura-dev` graph view shows ≥ 100 nodes / ≥ 200 edges after backfill runs.
- [ ] (Post-deploy) Next nightly sleep reports `edges_created > 0` AND those edges survive past one decay cycle.

## Deploy

Standard blue/green via `terraform/single-server/scripts/deploy.sh` → `alembic upgrade head` on the new color → optional `backfill_semantic_edges.py --dry-run` first, then execute. Full runbook: `docs/operations/semantic-edge-rollout.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)