### PR TITLE
fix(models): mirror server_default to ORM for 7 columns (#613 Cat A)

### DIFF
--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -116,10 +116,12 @@ class User(Base):
     )
     password_hash: Mapped[str | None] = mapped_column(String(255), nullable=True)
     auth_method: Mapped[str] = mapped_column(
-        String(20), nullable=False, default="oauth", index=True
+        String(20), nullable=False, default="oauth", server_default=text("'oauth'"), index=True
     )
     totp_secret: Mapped[str | None] = mapped_column(String(255), nullable=True)  # Fernet-encrypted
-    totp_enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    totp_enabled: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default=text("false")
+    )
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/models/erasure.py
+++ b/backend/src/models/erasure.py
@@ -100,12 +100,22 @@ class ErasureRequest(Base):
     # Self user_id (self-service) or admin user_id (admin force-erase).
     initiated_by: Mapped[str] = mapped_column(String(255), nullable=False)
 
-    is_self_service: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_self_service: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("false"),
+    )
 
     reason_code: Mapped[str] = mapped_column(String(50), nullable=False)
     reason_detail: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    status: Mapped[str] = mapped_column(String(20), nullable=False, default=STATUS_PENDING)
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=STATUS_PENDING,
+        server_default=text(f"'{STATUS_PENDING}'"),
+    )
 
     # SHA256 of the one-time token; raw token in Redis only. Size is
     # exact (SHA256 hex = 64 chars) so the column does not imply a

--- a/backend/src/models/llm_pricing.py
+++ b/backend/src/models/llm_pricing.py
@@ -57,6 +57,7 @@ from sqlalchemy import (
     String,
     UniqueConstraint,
     func,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -122,7 +123,12 @@ class LLMPricing(Base):
     # lower bound). ``context_max_tokens`` is nullable for "no upper bound";
     # most rows have NULL here. Gemini 2.5 Pro is the canonical multi-tier
     # case in the 2026-04-28 seed.
-    context_min_tokens: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    context_min_tokens: Mapped[int] = mapped_column(
+        Integer,
+        nullable=False,
+        default=0,
+        server_default=text("0"),
+    )
     context_max_tokens: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # NUMERIC(14, 10) gives 4 digits before the decimal and 10 after — enough
@@ -136,12 +142,22 @@ class LLMPricing(Base):
     )
 
     price_per_unit: Mapped[Decimal] = mapped_column(Numeric(14, 10), nullable=False)
-    currency: Mapped[str] = mapped_column(String(3), nullable=False, default="USD")
+    currency: Mapped[str] = mapped_column(
+        String(3),
+        nullable=False,
+        default="USD",
+        server_default=text("'USD'"),
+    )
 
     # Bridges per-1M-tokens (1_000_000) and per-1k-search-units (1_000)
     # so both fit the same row shape. Default 1_000_000 matches the
     # majority-case (token-based providers).
-    unit_denominator: Mapped[int] = mapped_column(BigInteger, nullable=False, default=1_000_000)
+    unit_denominator: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        default=1_000_000,
+        server_default=text("1000000"),
+    )
 
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()

--- a/backend/tests/integration/test_create_all_vs_alembic_drift.py
+++ b/backend/tests/integration/test_create_all_vs_alembic_drift.py
@@ -157,15 +157,7 @@ _EXCLUDED_TABLES: frozenset[str] = frozenset({"alembic_version"})
 # regression. Format: ``<table>.<name>.<kind>.<side>``.
 _KNOWN_DRIFT: frozenset[str] = frozenset(
     {
-        # ─── Cat A: server_default drift (3 columns) ────────────────────
-        # ORM models declare the column without ``server_default=...``
-        # while the alembic migration emits a literal default. Same class
-        # of bug as PR #610 (which fixed 16 columns on models/sleep.py).
-        # Each entry below should be eliminated by adding the missing
-        # ``server_default=...`` to the matching ORM mapped_column.
-        # Follow-up: server_default audit Cat A (see #613 PR body).
-        "users.auth_method.column.value_mismatch",
-        "users.totp_enabled.column.value_mismatch",
+        # Cat A: server_default drift — RESOLVED (PR #728 #616 + PR-B #613 Cat A residual).
         # ─── Cat B: FK naming-convention drift (14 entries / 7 pairs) ───
         # SQLAlchemy auto-names FK constraints ``<table>_<col>_fkey``
         # while the alembic migrations assigned explicit ``fk_<table>_*``

--- a/backend/tests/integration/test_create_all_vs_alembic_drift.py
+++ b/backend/tests/integration/test_create_all_vs_alembic_drift.py
@@ -157,15 +157,13 @@ _EXCLUDED_TABLES: frozenset[str] = frozenset({"alembic_version"})
 # regression. Format: ``<table>.<name>.<kind>.<side>``.
 _KNOWN_DRIFT: frozenset[str] = frozenset(
     {
-        # ─── Cat A: server_default drift (8 columns) ────────────────────
+        # ─── Cat A: server_default drift (6 columns) ────────────────────
         # ORM models declare the column without ``server_default=...``
         # while the alembic migration emits a literal default. Same class
         # of bug as PR #610 (which fixed 16 columns on models/sleep.py).
         # Each entry below should be eliminated by adding the missing
         # ``server_default=...`` to the matching ORM mapped_column.
         # Follow-up: server_default audit Cat A (see #613 PR body).
-        "erasure_requests.is_self_service.column.value_mismatch",
-        "erasure_requests.status.column.value_mismatch",
         "llm_pricing.context_min_tokens.column.value_mismatch",
         "llm_pricing.currency.column.value_mismatch",
         "llm_pricing.unit_denominator.column.value_mismatch",

--- a/backend/tests/integration/test_create_all_vs_alembic_drift.py
+++ b/backend/tests/integration/test_create_all_vs_alembic_drift.py
@@ -157,7 +157,7 @@ _EXCLUDED_TABLES: frozenset[str] = frozenset({"alembic_version"})
 # regression. Format: ``<table>.<name>.<kind>.<side>``.
 _KNOWN_DRIFT: frozenset[str] = frozenset(
     {
-        # Cat A: server_default drift — RESOLVED (PR #728 #616 + PR-B #613 Cat A residual).
+        # Cat A: server_default drift — RESOLVED (PR #728 / issue #616 + this PR / issue #613 Cat A residual).
         # ─── Cat B: FK naming-convention drift (14 entries / 7 pairs) ───
         # SQLAlchemy auto-names FK constraints ``<table>_<col>_fkey``
         # while the alembic migrations assigned explicit ``fk_<table>_*``

--- a/backend/tests/integration/test_create_all_vs_alembic_drift.py
+++ b/backend/tests/integration/test_create_all_vs_alembic_drift.py
@@ -157,16 +157,13 @@ _EXCLUDED_TABLES: frozenset[str] = frozenset({"alembic_version"})
 # regression. Format: ``<table>.<name>.<kind>.<side>``.
 _KNOWN_DRIFT: frozenset[str] = frozenset(
     {
-        # ─── Cat A: server_default drift (6 columns) ────────────────────
+        # ─── Cat A: server_default drift (3 columns) ────────────────────
         # ORM models declare the column without ``server_default=...``
         # while the alembic migration emits a literal default. Same class
         # of bug as PR #610 (which fixed 16 columns on models/sleep.py).
         # Each entry below should be eliminated by adding the missing
         # ``server_default=...`` to the matching ORM mapped_column.
         # Follow-up: server_default audit Cat A (see #613 PR body).
-        "llm_pricing.context_min_tokens.column.value_mismatch",
-        "llm_pricing.currency.column.value_mismatch",
-        "llm_pricing.unit_denominator.column.value_mismatch",
         "users.auth_method.column.value_mismatch",
         "users.totp_enabled.column.value_mismatch",
         # ─── Cat B: FK naming-convention drift (14 entries / 7 pairs) ───


### PR DESCRIPTION
## Summary

Adds `server_default=text(...)` to 7 ORM `mapped_column(...)` declarations whose alembic counterpart already emits a literal default. After this PR, the Cat A category of the #613 drift detector baseline is **empty** (8 of 8 entries cleared — 1 via PR #728 / #616, 7 via this PR).

Columns updated:
- `erasure_requests.is_self_service` → `server_default=text("false")` (mirrors `c01_360_erasure_requests`)
- `erasure_requests.status` → `server_default=text(f"'{STATUS_PENDING}'")` (mirrors `c01_360_erasure_requests`)
- `llm_pricing.context_min_tokens` → `server_default=text("0")` (mirrors `c02_471_cost_grade_schema`)
- `llm_pricing.currency` → `server_default=text("'USD'")` (mirrors `c02_471_cost_grade_schema`)
- `llm_pricing.unit_denominator` → `server_default=text("1000000")` (mirrors `c02_471_cost_grade_schema`)
- `users.auth_method` → `server_default=text("'oauth'")` (mirrors `a51_add_password_mfa_columns`)
- `users.totp_enabled` → `server_default=text("false")` (mirrors `a51_add_password_mfa_columns`)

Detector baseline: 33 entries → **26 entries** (7 Cat A residuals cleared). The 7-line Cat A comment block in `_KNOWN_DRIFT` is replaced with a 1-line audit note.

## Why

When the ORM's `mapped_column(...)` lacks `server_default=` but the alembic migration emits a literal default, `Base.metadata.create_all()` produces a column with no DB-level default. Raw INSERT paths (test fixtures, bulk loaders, future migrations) then fail `NOT NULL` on omitted columns instead of getting the documented default. Same bug class PR #610 already fixed for 16 columns on `models/sleep.py`.

The Python-side `default=` keyword remains alongside `server_default=text(...)` — SQLAlchemy uses `default=` for ORM-managed inserts and `server_default=` for DDL/raw paths. Pattern matches existing repo precedent (`analysis.py`, `sleep.py:SleepReportLLMUsage`, `file_objects.py:id` after PR #728).

## Test plan

- [x] `make test-local` passes (55 model unit tests).
- [x] `make test-integration` for the modified-model specs passes in isolation:
  - `test_create_all_vs_alembic_drift.py` — drift detector accepts new state with 26 baseline entries.
  - `test_alembic_migrations.py` — full chain up + down.
  - `test_account_erasure_integration.py` — erasure workflow unaffected.
  - `test_llm_pricing.py` — pricing read paths unaffected (14 tests in isolation).
- [x] `make lint` clean.
- [x] `make type-check`: only pre-existing 2 errors in `llm_providers/*` from PR #707 (unrelated).

## Pre-existing test flake

When `test_account_erasure_integration.py` and `test_llm_pricing.py` are run in the same pytest batch, 2 tests in `test_llm_pricing.py` fail (seed-data leakage between integration tests). **This flake reproduces on `main` with no PR-B changes applied** — verified. Not caused by this PR; should be filed as a separate follow-up.

## Review history

- 3 sequential implementer dispatches (one per model file).
- `/simplify` pass: 1 NIT fixed (comment clarity).
- `/self-review`: 0 critical / 0 warnings.

Partially addresses #613 (Cat A complete: 8 of 8 entries cleared across PR #728 + this PR).

Remaining baseline drift to be paid down:
- Cat E (3 entries): targeted by upcoming PR-C
- Cat B + Cat C (16 entries): filed as v0.17.0 follow-up
- Cat D (7 entries): filed as v0.17.0 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)