### PR TITLE
fix(models): align ORM unique-index expression with alembic (#613 Cat E)

### DIFF
--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -817,8 +817,8 @@ class OAuth2DeviceCode(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
-    device_code: Mapped[str] = mapped_column(String(255), nullable=False, unique=True, index=True)
-    user_code: Mapped[str] = mapped_column(String(8), nullable=False, unique=True, index=True)
+    device_code: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    user_code: Mapped[str] = mapped_column(String(8), nullable=False, index=True)
     client_id: Mapped[str] = mapped_column(
         String(48),
         ForeignKey("oauth_clients.client_id", ondelete="CASCADE"),

--- a/backend/src/models/file_objects.py
+++ b/backend/src/models/file_objects.py
@@ -114,12 +114,13 @@ class FileObject(Base):
         # Active dedup: a workspace can hold one row per sha256 at a time;
         # soft-deleted and failed rows are excluded so a redo upload
         # of a previously-deleted file is allowed.
+        # Case-insensitive lower(sha256) mirrors alembic e07_556_sha256_lowercase_index (#556).
         Index(
             "uq_file_objects_workspace_sha256_active",
-            "workspace_id",
-            "sha256",
+            text("workspace_id"),
+            text("lower(sha256)"),
             unique=True,
-            postgresql_where=("deleted_at IS NULL AND status <> 'failed'"),
+            postgresql_where="deleted_at IS NULL AND status <> 'failed'",
         ),
         # Orphan sweep helper: only matters for in-flight reservations.
         Index(

--- a/backend/src/models/file_objects.py
+++ b/backend/src/models/file_objects.py
@@ -117,7 +117,7 @@ class FileObject(Base):
         # Case-insensitive lower(sha256) mirrors alembic e07_556_sha256_lowercase_index (#556).
         Index(
             "uq_file_objects_workspace_sha256_active",
-            text("workspace_id"),
+            "workspace_id",
             text("lower(sha256)"),
             unique=True,
             postgresql_where="deleted_at IS NULL AND status <> 'failed'",

--- a/backend/tests/integration/test_create_all_vs_alembic_drift.py
+++ b/backend/tests/integration/test_create_all_vs_alembic_drift.py
@@ -250,8 +250,6 @@ _KNOWN_DRIFT: frozenset[str] = frozenset(
         #       on the model.
         # Follow-up: uniqueness / expression drift fix Cat E (alignment,
         # not data-integrity correction).
-        "oauth_device_codes.ix_oauth_device_codes_device_code.index.value_mismatch",
-        "oauth_device_codes.ix_oauth_device_codes_user_code.index.value_mismatch",
         "file_objects.uq_file_objects_workspace_sha256_active.index.value_mismatch",
     }
 )

--- a/backend/tests/integration/test_create_all_vs_alembic_drift.py
+++ b/backend/tests/integration/test_create_all_vs_alembic_drift.py
@@ -218,39 +218,7 @@ _KNOWN_DRIFT: frozenset[str] = frozenset(
         "oauth_device_codes.oauth_device_codes_device_code_key.index.alembic_only",
         "oauth_device_codes.oauth_device_codes_user_code_key.index.alembic_only",
         "contexts.ux_contexts_resource_id_active.index.alembic_only",
-        # ─── Cat E: uniqueness / expression drift (3 entries — fix ORM side) ───
-        # The ORM and alembic disagree on the uniqueness flag or column
-        # expression of indexes that share a name. Production (alembic)
-        # is the canonical truth; the fix is to align the ORM model.
-        #   * ix_oauth_device_codes_device_code (is_unique=True/False)
-        #   * ix_oauth_device_codes_user_code   (is_unique=True/False)
-        #     → ORM declares ``unique=True, index=True``; alembic emits
-        #       ``op.create_index(unique=False)``. **Not a correctness
-        #       gap** — migration ``d08_536_device_code_grant`` already
-        #       declares ``device_code`` / ``user_code`` columns with
-        #       ``unique=True``, so uniqueness is enforced via the
-        #       implicit UNIQUE constraint + backing unique index. The
-        #       drift is index redundancy: the ORM's ``unique=True,
-        #       index=True`` produces two distinct unique indexes per
-        #       column, while alembic emits one unique-backing + one
-        #       non-unique secondary. Fix: drop ``unique=True`` from
-        #       the ORM ``mapped_column`` (keep ``index=True`` only)
-        #       so it matches alembic's "lookup index over an already-
-        #       unique column" intent.
-        #   * uq_file_objects_workspace_sha256_active (column expression)
-        #     → ORM declares UNIQUE ``(workspace_id, sha256)``
-        #       (case-sensitive). Alembic produces UNIQUE
-        #       ``(workspace_id, lower(sha256::text))`` (case-insensitive,
-        #       per migration ``e07_556_sha256_lowercase_index`` — #556
-        #       follow-up). NOT a data-integrity bug: production correctly
-        #       enforces case-insensitive sha256 dedup. The drift is that
-        #       the ORM ``UniqueConstraint`` declaration didn't migrate
-        #       alongside the index change. Fix: declare
-        #       ``UniqueConstraint('workspace_id', func.lower(sha256), ...)``
-        #       on the model.
-        # Follow-up: uniqueness / expression drift fix Cat E (alignment,
-        # not data-integrity correction).
-        "file_objects.uq_file_objects_workspace_sha256_active.index.value_mismatch",
+        # Cat E: uniqueness / expression drift — RESOLVED (this PR / issue #613 Cat E).
     }
 )
 

--- a/backend/tests/models/test_file_objects.py
+++ b/backend/tests/models/test_file_objects.py
@@ -45,9 +45,11 @@ class TestFileObjectModel:
         for arg in FileObject.__table_args__:
             if hasattr(arg, "name") and arg.name == "uq_file_objects_workspace_sha256_active":
                 assert arg.unique is True
-                # Expression-based: column 0 = workspace_id, column 1 = lower(sha256)
+                # Expression-based: column 0 = workspace_id (bare column ref,
+                # SQLAlchemy resolves to ``file_objects.workspace_id``),
+                # column 1 = lower(sha256) functional expression.
                 exprs = [str(c) for c in arg.expressions]
-                assert exprs[0] == "workspace_id"
+                assert "workspace_id" in exprs[0]
                 assert "lower(" in exprs[1]
                 assert "sha256" in exprs[1]
                 # Partial WHERE clause stored as a dialect-specific option

--- a/backend/tests/models/test_file_objects.py
+++ b/backend/tests/models/test_file_objects.py
@@ -39,12 +39,17 @@ class TestFileObjectModel:
         assert "valid_file_storage_shape" in names
 
     def test_partial_unique_index_declared(self):
-        """The (workspace_id, sha256) WHERE deleted_at IS NULL AND
-        status != 'failed' partial unique index is the dedup gate."""
+        """The (workspace_id, lower(sha256)) WHERE deleted_at IS NULL AND
+        status != 'failed' case-insensitive partial unique index is the
+        dedup gate (mirrors alembic e07_556_sha256_lowercase_index #556)."""
         for arg in FileObject.__table_args__:
             if hasattr(arg, "name") and arg.name == "uq_file_objects_workspace_sha256_active":
-                # Index objects expose `unique` and `dialect_options`
                 assert arg.unique is True
+                # Expression-based: column 0 = workspace_id, column 1 = lower(sha256)
+                exprs = [str(c) for c in arg.expressions]
+                assert exprs[0] == "workspace_id"
+                assert "lower(" in exprs[1]
+                assert "sha256" in exprs[1]
                 # Partial WHERE clause stored as a dialect-specific option
                 where = arg.dialect_options.get("postgresql", {}).get("where")
                 assert where is not None


### PR DESCRIPTION
## Summary

Aligns 3 ORM Index declarations with their alembic counterparts. Clears all 3 Cat E entries from the schema-drift detector baseline (`backend/tests/integration/test_create_all_vs_alembic_drift.py`). After this PR, both Cat A and Cat E categories of the #613 detector baseline are empty.

**Changes:**

1. **`backend/src/models/auth.py`** — drops redundant `unique=True` from `OAuth2DeviceCode.device_code` and `.user_code` `mapped_column(...)` declarations (keeps `index=True`). Uniqueness is already enforced by alembic's table-level UNIQUE constraint declared via `Column(..., unique=True)` inside `op.create_table(...)` (`d08_536_device_code_grant.py:22-23`). The ORM's `unique=True, index=True` was producing a *redundant* secondary unique index — that redundancy is gone.
2. **`backend/src/models/file_objects.py`** — rewrites `uq_file_objects_workspace_sha256_active` Index to functional `(workspace_id, lower(sha256))` form, mirroring alembic `e07_556_sha256_lowercase_index.py:97-103` (#556 follow-up that migrated existing prod schema to case-insensitive dedup).
3. **`backend/tests/models/test_file_objects.py`** — updates `test_partial_unique_index_declared` to assert the case-insensitive expression form. Uses substring matching on `arg.expressions[0]` because SQLAlchemy resolves bare column refs to `Column` objects whose `str()` renders as table-qualified `"file_objects.workspace_id"`.
4. **`backend/tests/integration/test_create_all_vs_alembic_drift.py`** — deletes 3 Cat E entries from `_KNOWN_DRIFT` and collapses the 32-line Cat E comment block into a 1-line audit note (same pattern as Cat A in PR #729).

**Detector baseline:** 26 → **23 entries** (Cat E fully cleared: 3 of 3).

## Why

Cat E entries flagged the last ORM/alembic divergences in our schema for uniqueness invariants:

- `oauth_device_codes`: ORM declared a redundant unique secondary index; production already enforces uniqueness via the table-level UNIQUE constraint.
- `file_objects.uq_file_objects_workspace_sha256_active`: ORM was case-sensitive `(workspace_id, sha256)`; production has been case-insensitive `(workspace_id, lower(sha256))` since #556 (e07_556 migration). The drift was ORM-only — production was always correct.

Production behavior is unchanged. This PR only aligns `Base.metadata.create_all()` (fresh test/dev DB) with what alembic-driven production already does.

## Test plan

- [x] `make test-local` passes (12 model unit tests; `test_partial_unique_index_declared` updated).
- [x] `make test-integration` for the modified specs in isolation:
  - `test_create_all_vs_alembic_drift.py` — drift detector accepts state with 23 baseline entries.
  - `test_alembic_migrations.py` — full chain up + down.
  - `test_e18_616_drop_pg_inline_migration.py` — sister migration test still green.
  - `test_oauth_dcr_integration.py` / `test_oauth_cascade.py` — device-flow auth unaffected (1 pre-existing PKCE test failure verified on `main`, unrelated).
- [x] `make lint` clean.
- [x] `make type-check`: only pre-existing 2 errors in `llm_providers/*` from PR #707 (unrelated).

## Follow-ups filed for v0.17.0

Remaining drift categories in the detector baseline:
- **#730** — Cat B + Cat C: configure `Base.metadata.naming_convention` for FK/UK constraint naming parity (16 entries)
- **#731** — Cat D: declare migration-only indexes in ORM for `create_all()` parity (7 entries)

After this PR ships, the baseline 23 entries are all in Cat B/C/D, tracked by #730 and #731.

## Review history

- 3 sequential implementer dispatches.
- `/simplify` pass: 1 NIT fixed (drop redundant `text("workspace_id")` wrap on bare column ref).
- `/self-review`: 0 critical / 0 warnings.

Partially addresses #613 (Cat A + Cat E complete: 11 of 34 baseline entries cleared across PR #728/#729/this PR).

After merge, #613 will be closed with a summary comment crediting the detector (#716), the 3 cleanup PRs (#728/#729/this), and the 2 v0.17.0 follow-ups (#730/#731).

🤖 Generated with [Claude Code](https://claude.com/claude-code)