### PR TITLE
docs(neural): edge origins — hippocampus vs cortex (#734)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -124,18 +124,90 @@ Results A       Results B
 
 ## Neural Memory Engine
 
-### Hebbian Learning
-Automatic relationship learning based on co-activation:
+### Edge Origins
 
-```python
-# When memories A and B are accessed together
-weight(A, B) += learning_rate * activation(A) * activation(B)
+Neural Memory edges carry an `origin` discriminator (`neural_memory_edges.origin`, `VARCHAR(20)`, CHECK constraint `valid_edge_origin`) that controls their lifetime. Three values exist:
+
+| | **`hebbian`** | **`semantic`** | **`declared`** |
+|---|---|---|---|
+| Source | runtime co-activation in `HebbianLearner` (write side of `recall()` — see Issue #120) | sleep `edge_discovery` (cosine sim ≥ 0.5) | user-asserted via MCP `create_edge` |
+| Weight rule | `weight(A,B) += learning_rate * activation(A) * activation(B)`, clamped 0.0–3.0 | `cosine_sim` at creation (0.5–1.0); never modified by decay | user-supplied (default 1.0) |
+| Decays | yes — nightly `DecayManager.bulk_decay_weights(only_origin='hebbian')` | no | no |
+| Pruned | yes — `DecayManager.prune_weak_edges(only_origin='hebbian')` below `prune_threshold` | no | no |
+| Re-verified | n/a | monthly `semantic_edge_reverify` cron drops rows whose endpoint memory has been soft-deleted | n/a |
+
+**Sticky-upsert invariant**: the `create_or_update_edge` upsert path is one-way — a runtime Hebbian co-recall can **promote** a missing or existing `hebbian` edge to a `semantic` or `declared` origin, but it cannot **demote** an existing `semantic` or `declared` edge back to `hebbian`. This guarantees that user-asserted or sleep-discovered associations cannot be silently downgraded by access patterns.
+
+**Background jobs maintaining `neural_memory_edges`**:
+
+- **`DecayManager`** (nightly) — applies exponential decay and prune-below-threshold to `origin='hebbian'` rows only. `semantic` and `declared` rows are skipped.
+- **`semantic_edge_reverify`** (monthly, 04:15 UTC on the 1st) — walks `origin='semantic'` rows and deletes any whose endpoint memory has been soft-deleted. Cost is O(edges), not O(memory²), so it stays cheap as contexts grow.
+
+#### Formulas
+
+**Hebbian update** (`backend/src/neural/hebbian.py` — applied per `recall()` for co-activated pairs that pass the semantic-gating threshold `min_similarity_for_edge`):
+
+```
+Δw_ij ← η · (a_i · C_i) · (a_j · C_j) − λ · w_ij
 ```
 
-**Features**:
-- Decays over time (forgetting curve)
-- Strengthens with repeated co-access
-- Creates knowledge graph automatically
+- `η` — learning rate (`config.learning_rate`)
+- `a_i, a_j` — activation strengths of the co-activated nodes
+- `C_i, C_j` — confidence / trust scores of each node (poisoning defense — low-trust nodes contribute less)
+- `λ` — L2 decay coefficient applied per update (prevents weight explosion; separate from the nightly time-based decay below)
+- `w_ij` — current edge weight, clamped to `[0.0, 3.0]`
+
+**Time-based decay** (`backend/src/neural/decay.py` — applied nightly to `origin='hebbian'` only):
+
+```
+w_ij(t + Δt) = w_ij(t) · exp(−decay_rate · Δt)
+```
+
+After decay, any row with `w_ij < prune_threshold` is removed by `prune_weak_edges`. `semantic` and `declared` rows are decay-exempt by construction (`only_origin='hebbian'` filter), so they survive arbitrarily long Δt — which is the load-bearing property for content-based edge survival as N grows.
+
+#### Edge lifecycle
+
+```
+hebbian
+  recall() co-activation                 reinforced by next co-recall
+  + semantic gating passed         ┌─► weight rises (Δw_ij update)
+       │                           │
+       ▼                           │
+  create_or_update_edge ───────────┘
+  (origin='hebbian')               not reinforced
+       │                          ┌─► nightly DecayManager
+       ▼                          │   weight *= exp(−decay_rate · Δt)
+  edge exists ────────────────────┘
+       │                          weight < prune_threshold
+       └──────────────────────────► prune_weak_edges() removes row
+
+semantic
+  sleep edge_discovery
+  + cosine_sim ≥ min_similarity_for_edge
+       │
+       ▼
+  create_or_update_edge ──► edge exists (origin='semantic')
+  (origin='semantic',           │
+   weight=cosine_sim)           │   endpoint memory soft-deleted
+                                └─► monthly semantic_edge_reverify removes row
+                                    (never touched by DecayManager)
+
+declared
+  MCP create_edge tool
+       │
+       ▼
+  create_or_update_edge ──► edge exists (origin='declared')
+  (origin='declared')           │
+                                │   MCP delete_edge / update_edge
+                                └─► row removed or weight updated
+                                    (never touched by DecayManager or reverify)
+```
+
+**Sticky-upsert detail**: when a co-recall triggers `create_or_update_edge` on a pair that already has a `semantic` or `declared` edge, the existing row's `origin` is **preserved** (no demotion). The weight may still be modified by the Hebbian formula, but the row will continue to be exempt from the nightly decay loop.
+
+For the reader-friendly framing (hippocampus / cortex analogy and the `1/N²` motivation), see [Neural Memory § Edge Origins](concepts.md#edge-origins) in the concepts doc. For the migration history, deploy runbook, and backfill procedure, see [`docs/operations/semantic-edge-rollout.md`](operations/semantic-edge-rollout.md). For the `Memory.scope` (`working` / `persistent`) lifecycle — which is **orthogonal** to edge origin and managed by Sleep Consolidation — see [Sleep Maintenance](sleep-maintenance.md).
+
+> **Note**: the schema documented above reflects the shipped state as of v0.16.x. A richer two-axis provenance schema (relation × origin × frozen flag) is in design as RFC #84 and may extend this taxonomy in a future release.
 
 ### Activation Spreading
 Graph-based exploration from seed memory:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -106,11 +106,34 @@ When you search with `recall()`, Kagura uses **Hybrid Search** combining two app
 
 **Neural Memory** creates automatic relationships between memories using brain-inspired algorithms.
 
-### Hebbian Learning
+### Edge Origins
 
-> "Neurons that fire together, wire together."
+Neural Memory edges are tagged with one of three **origins**, each with different lifetime semantics. This mirrors the **complementary learning systems** view from cognitive neuroscience — short-lived episodic associations vs durable content-based associations vs user-pinned ones.
 
-When memories are accessed together (e.g., recalled in the same session), a connection (edge) is created or strengthened between them. Edge weights range from 0.0 to 3.0.
+| | **Hebbian** (hippocampus-like) | **Semantic** (cortex-like) | **Declared** |
+|---|---|---|---|
+| Encodes | "fired together recently" — episodic co-activation | "about similar things" — content neighborhood | "I'm telling you these are related" — explicit user assertion |
+| Created by | runtime `recall()` co-activation | sleep `edge_discovery` (cosine sim ≥ 0.5) | MCP `create_edge` tool |
+| Weight | 0.0–3.0 co-activation amplitude | `cosine_sim` at creation (0.5–1.0) | user-supplied (default 1.0) |
+| Decays? | yes — strengthens with co-recall, fades without | **no** — content similarity is a static property | **no** — user-asserted, never auto-removed |
+| Maintenance | nightly Hebbian decay + prune below threshold | monthly `semantic_edge_reverify` drops edges with deleted endpoints | none — lives until the user deletes it |
+
+> This is a **pedagogical analogy, not an implementation claim**. The system does not model the hippocampus or cortex directly — the parallel is in lifetime semantics: episodic-decay vs static-content vs user-pinned.
+
+### Why three origins?
+
+Conflating "recently co-recalled" with "content-similar" causes edge survival to scale as ~1/N² with context size — every doubled context loses a disproportionate share of its semantic edges to decay. The `origin` discriminator lets the decay loop touch only `hebbian` edges while `semantic` and `declared` survive as long as their endpoints exist.
+
+### Edge origin vs memory scope
+
+Edge `origin` and `Memory.scope` (`working` / `persistent`) are **two independent axes** managed by different subsystems:
+
+- **`origin`** controls *edge* lifetime — see the table above.
+- **`scope`** controls *memory node* lifetime — `working` memories are promoted to `persistent` (or archived) by the Sleep Consolidation phase based on access patterns and LLM judgment. See [Sleep Maintenance](sleep-maintenance.md).
+
+Hebbian edges supply *signal* to consolidation (a working memory that gets reinforced via co-recall is more likely to be promoted), but Hebbian learning itself does not look at `scope` — `HebbianLearner.queue_update` creates edges between any co-activated pair regardless of whether the endpoints are `working` or `persistent`. In the neuroscience analogy, this is a two-level consolidation: edge consolidation (Hebbian → Semantic) and node consolidation (working → persistent) happen on different timescales and via different mechanisms.
+
+For the migration history (PR #726 / Issue #722) and operator runbook, see [`docs/operations/semantic-edge-rollout.md`](operations/semantic-edge-rollout.md). For schema-level details, formulas, and the edge lifecycle flowchart, see [Neural Memory Engine § Edge Origins](architecture.md#edge-origins) in the architecture doc.
 
 ### Activation Spreading
 

--- a/docs/operations/semantic-edge-rollout.md
+++ b/docs/operations/semantic-edge-rollout.md
@@ -1,5 +1,7 @@
 # Semantic Edge Origin Rollout (Issue #722)
 
+> **Related**: [Neural Memory § Edge Origins](../concepts.md#edge-origins) (reader framing) · [Neural Memory Engine § Edge Origins](../architecture.md#edge-origins) (schema and background jobs)
+
 Operator runbook for shipping the semantic / Hebbian edge split. The PR makes sleep-discovered edges survive the decay loop; this runbook covers the deploy steps and the one-shot backfill that restores edges previously erased by decay.
 
 ## What changed


### PR DESCRIPTION
Closes #734

## Summary
- Document the `origin` discriminator on `neural_memory_edges` (`hebbian` | `semantic` | `declared`) that PR #726 shipped in v0.16.x but did not propagate into user-facing concept and architecture docs.
- Introduce a hippocampus / cortex / user-pinned framing with a "pedagogical analogy, not implementation claim" disclaimer; explain the `1/N²` motivation for the split.
- Add the exact Hebbian update formula and exponential decay formula (direct quotes from `hebbian.py:7` and `decay.py:46`), plus an ASCII edge-lifecycle flowchart for all three origins, the sticky-upsert invariant, and references to the `DecayManager` / `semantic_edge_reverify` background jobs.
- Clarify that `Edge.origin` and `Memory.scope` (`working` / `persistent`) are orthogonal axes managed by different subsystems, with Hebbian co-recall supplying signal to Sleep Consolidation indirectly via access patterns.
- Add `Related:` cross-links so concepts.md ↔ architecture.md ↔ semantic-edge-rollout.md form a coherent hub-spoke reader's journey.

## Implementation notes
- `docs/concepts.md`: replace the single "Hebbian Learning" paragraph with three subsections (`### Edge Origins`, `### Why three origins?`, `### Edge origin vs memory scope`).
- `docs/architecture.md`: replace the single "Hebbian Learning" block with a schema-focused `### Edge Origins` section (3-column table, sticky-upsert invariant, `#### Formulas`, `#### Edge lifecycle` ASCII flowcharts). End with a hedge noting RFC #84 may extend this taxonomy in a future release.
- `docs/operations/semantic-edge-rollout.md`: single `> **Related**:` line near the top with back-links.
- No code, test, migration, or CI changes. `docs/sleep-maintenance.md` is left untouched — grep confirmed no stale `weight=0.5` claim exists there.
- Reader test (issue AC #4): the Decays? row of the concepts.md table plus the "Why three origins?" subsection together let a reader who lands on the doc answer "why won't this edge be deleted by decay?" without reading source.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (routed to DX Lead)
- review provider: code-review (skipped this run — docs-only PR, /code-review overkill)

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/734-docs-docs-neural-document-edge-origin-discrim.gate1.md
- ~/.claude/cache/gh-issue-driven/734-docs-docs-neural-document-edge-origin-discrim.gate2.md

## Follow-ups (recorded by gate2, out of scope here)
- CI: add a markdown link checker (e.g. `lychee`) — would catch broken `#anchor` references that this PR's cross-links rely on. Filed as a v0.17.x candidate.
- Convention: note in `.claude/rules/development-workflow.md` that `hebbian.py` / `decay.py` docstring formula changes require a docs-sibling edit.

🤖 Generated via /gh-issue-driven:ship
