### PR TITLE
refactor(db,models): align ORM with alembic schema (#613 Cat B+C+D)

### DIFF
--- a/backend/src/db/base.py
+++ b/backend/src/db/base.py
@@ -9,7 +9,7 @@ Note:
 
 from collections.abc import AsyncGenerator
 
-from sqlalchemy import create_engine
+from sqlalchemy import MetaData, create_engine
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Session, sessionmaker
 
@@ -19,9 +19,30 @@ from utils.url_redact import redact_db_url
 logger = get_logger(__name__)
 
 
+# Keep ``Base.metadata.create_all`` and alembic-authored DDL in sync on
+# auto-generated constraint names (issue #613). Without a convention,
+# SQLAlchemy emits anonymous ``Column(unique=True)`` and inline
+# ``ForeignKey(...)`` declarations, letting PostgreSQL pick defaults that
+# diverge wherever an alembic migration assigns an explicit name.
+#
+# ``ix`` is required when ``uq`` is set: ``Column(unique=True)``
+# instantiates BOTH an unnamed UniqueConstraint and an unnamed backing
+# Index, and the Index needs a name token or SQLAlchemy raises
+# ``AssertionError: name is not None`` at DDL compile time.
+#
+# ``ck`` and ``pk`` are intentionally omitted — every CHECK constraint
+# is explicitly named, and PostgreSQL's ``<table>_pkey`` default already
+# matches alembic-side primary keys.
+NAMING_CONVENTION: dict[str, str] = {
+    "fk": "fk_%(table_name)s_%(column_0_name)s",
+    "uq": "%(table_name)s_%(column_0_name)s_key",
+    "ix": "ix_%(column_0_label)s",
+}
+
+
 # SQLAlchemy Base for models
 class Base(DeclarativeBase):
-    pass
+    metadata = MetaData(naming_convention=NAMING_CONVENTION)
 
 
 # Lazy initialization (to avoid import-time errors)

--- a/backend/src/models/analysis.py
+++ b/backend/src/models/analysis.py
@@ -285,6 +285,13 @@ class MemoryAnalysisAssignment(Base):
             "idx_memory_analysis_assignments_cluster",
             "cluster_id",
         ),
+        # Composite for the recall analysis_cluster filter
+        # (migration d08_496_analyses_cancellation).
+        Index(
+            "idx_memory_analysis_assignments_analysis_cluster",
+            "analysis_id",
+            "cluster_id",
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -817,8 +817,13 @@ class OAuth2DeviceCode(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
-    device_code: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
-    user_code: Mapped[str] = mapped_column(String(8), nullable=False, index=True)
+    # ``unique=True`` produces the UK constraint that alembic creates. The
+    # non-unique ``ix_oauth_device_codes_<column>`` indexes are declared in
+    # ``__table_args__`` below — combining ``index=True`` with ``unique=True``
+    # here would collapse both into one unique index, but production has two
+    # separate objects.
+    device_code: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
+    user_code: Mapped[str] = mapped_column(String(8), nullable=False, unique=True)
     client_id: Mapped[str] = mapped_column(
         String(48),
         ForeignKey("oauth_clients.client_id", ondelete="CASCADE"),
@@ -838,6 +843,16 @@ class OAuth2DeviceCode(Base):
     )
 
     client: Mapped["OAuth2Client"] = relationship("OAuth2Client")
+
+    # Redundant secondary indexes from migration d08_536: the UK auto-indexes
+    # from ``unique=True`` already cover equality lookups, but production has
+    # them as separate objects so the ORM mirrors them for create_all parity.
+    # TODO(v0.16.x follow-up): drop both ``ix_*`` indexes in one migration
+    # and remove these two lines.
+    __table_args__ = (
+        Index("ix_oauth_device_codes_device_code", "device_code"),
+        Index("ix_oauth_device_codes_user_code", "user_code"),
+    )
 
     def __repr__(self) -> str:
         return f"<OAuth2DeviceCode(device_code='{self.device_code[:8]}...', client='{self.client_id}')>"
@@ -1259,6 +1274,15 @@ class Context(Base):
     __table_args__ = (
         # Note: Index idx_contexts_workspace_name is created in migration with WHERE deleted_at IS NULL
         CheckConstraint("name ~ '^[a-z0-9_-]+$'", name="valid_context_name"),
+        # Issue #238 / migration a96 — global partial UNIQUE on
+        # ``contexts.resource_id`` excluding soft-deleted rows. Mirrored to
+        # the ORM so ``Base.metadata.create_all`` matches the production schema.
+        Index(
+            "ux_contexts_resource_id_active",
+            "resource_id",
+            unique=True,
+            postgresql_where=text("resource_id IS NOT NULL AND deleted_at IS NULL"),
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -847,8 +847,8 @@ class OAuth2DeviceCode(Base):
     # Redundant secondary indexes from migration d08_536: the UK auto-indexes
     # from ``unique=True`` already cover equality lookups, but production has
     # them as separate objects so the ORM mirrors them for create_all parity.
-    # TODO(v0.16.x follow-up): drop both ``ix_*`` indexes in one migration
-    # and remove these two lines.
+    # TODO(#737): drop both ``ix_*`` indexes in one migration and remove
+    # these two lines.
     __table_args__ = (
         Index("ix_oauth_device_codes_device_code", "device_code"),
         Index("ix_oauth_device_codes_user_code", "user_code"),

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -204,6 +204,21 @@ class Memory(Base):
         Index("idx_last_used", "last_used_at"),
         # JSONB index for context_id
         Index("idx_context", func.cast(context["context_id"], String)),
+        # Issue #213 partial B-tree (migration a95_source_uri_declared_link).
+        Index(
+            "idx_memories_source_uri",
+            "source_uri",
+            postgresql_where=text("source_uri IS NOT NULL"),
+        ),
+        # Issue #223 GIN index on tags array (migration b05_223_tag_cooccurrence).
+        Index("idx_memories_tags_gin", "tags", postgresql_using="gin"),
+        # Issue #485 partial B-tree on the generated external_blob_ref column
+        # (migration e03_485_file_objects).
+        Index(
+            "idx_memories_external_blob_ref",
+            "external_blob_ref",
+            postgresql_where=text("external_blob_ref IS NOT NULL"),
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/tests/integration/test_create_all_vs_alembic_drift.py
+++ b/backend/tests/integration/test_create_all_vs_alembic_drift.py
@@ -157,68 +157,23 @@ _EXCLUDED_TABLES: frozenset[str] = frozenset({"alembic_version"})
 # regression. Format: ``<table>.<name>.<kind>.<side>``.
 _KNOWN_DRIFT: frozenset[str] = frozenset(
     {
-        # Cat A: server_default drift — RESOLVED (PR #728 / issue #616 + this PR / issue #613 Cat A residual).
-        # ─── Cat B: FK naming-convention drift (14 entries / 7 pairs) ───
-        # SQLAlchemy auto-names FK constraints ``<table>_<col>_fkey``
-        # while the alembic migrations assigned explicit ``fk_<table>_*``
-        # names. Both sides describe the SAME foreign key relationship,
-        # but the names differ, so the detector reports each as a
-        # create_all_only / alembic_only pair. Root fix: configure
-        # ``Base.metadata.naming_convention`` to match the alembic
-        # convention so SQLAlchemy and alembic emit identical names.
-        # Follow-up: FK naming-convention unification Cat B.
-        "api_keys.api_keys_bound_context_id_fkey.constraint.create_all_only",
-        "indexer_state.indexer_state_resource_pk_fkey.constraint.create_all_only",
-        "oauth_device_codes.oauth_device_codes_client_id_fkey.constraint.create_all_only",
-        "resource_events.resource_events_resource_pk_fkey.constraint.create_all_only",
-        "resource_schemas.resource_schemas_resource_pk_fkey.constraint.create_all_only",
-        "resource_tokens.resource_tokens_resource_pk_fkey.constraint.create_all_only",
-        "resource_tokens.resource_tokens_workspace_id_fkey.constraint.create_all_only",
-        "api_keys.fk_api_keys_bound_context_id.constraint.alembic_only",
-        "indexer_state.fk_indexer_state_resource_pk.constraint.alembic_only",
-        "oauth_device_codes.fk_oauth_device_codes_client_id.constraint.alembic_only",
-        "resource_events.fk_resource_events_resource_pk.constraint.alembic_only",
-        "resource_schemas.fk_resource_schemas_resource_pk.constraint.alembic_only",
-        "resource_tokens.fk_resource_tokens_resource_pk.constraint.alembic_only",
+        # Cat A: server_default drift — RESOLVED (PR #728 / issue #616).
+        # Cat B: FK naming-convention drift — RESOLVED in #718 via
+        # ``Base.metadata.naming_convention`` in ``db/base.py``. The two
+        # entries below are the ``resource_tokens.workspace_id`` legacy
+        # pair: alembic uses ``fk_resource_tokens_workspace`` (no ``_id``)
+        # while the convention generates ``fk_resource_tokens_workspace_id``.
+        # Same FK, two names — rename via follow-up migration when scope allows.
+        "resource_tokens.fk_resource_tokens_workspace_id.constraint.create_all_only",
         "resource_tokens.fk_resource_tokens_workspace.constraint.alembic_only",
-        # ─── Cat C: UK naming drift (2 entries) ─────────────────────────
-        # Same root cause as Cat B but for UNIQUE constraints on
-        # ``oauth_device_codes``. Alembic emits explicit named UK
-        # constraints; the ORM only declares ``unique=True`` on the
-        # column, which Postgres records as an implicit unique index
-        # with no named UK constraint. Resolution: declare an explicit
-        # ``UniqueConstraint(...)`` in the ORM model OR drop the named
-        # UK from alembic when the naming-convention work in Cat B
-        # makes the constraint names match.
-        # Follow-up: UK naming alignment Cat C (likely folds into Cat B).
-        "oauth_device_codes.oauth_device_codes_device_code_key.constraint.alembic_only",
-        "oauth_device_codes.oauth_device_codes_user_code_key.constraint.alembic_only",
-        # ─── Cat D: migration-only indexes (7 entries) ──────────────────
-        # Indexes that alembic creates but ``Base.metadata.create_all``
-        # does not. Causes (per index):
-        #   * idx_memories_external_blob_ref: partial WHERE clause not
-        #     declared in the ORM Index() call (or no Index() at all)
-        #   * idx_memories_source_uri: same partial-WHERE gap
-        #   * idx_memories_tags_gin: GIN access method not declared in
-        #     the ORM via ``postgresql_using='gin'``
-        #   * idx_memory_analysis_assignments_analysis_cluster: composite
-        #     index missing from ORM
-        #   * oauth_device_codes_*_key (×2): UK auto-indexes paired with
-        #     the Cat C UK names; resolved with Cat C
-        #   * ux_contexts_resource_id_active: partial UNIQUE with
-        #     compound WHERE not declared in the ORM
-        # Resolution: declare matching ``Index(...)`` / ``UniqueConstraint``
-        # entries in the ORM models, or accept these as migration-only
-        # and document them as such in the model docstring.
-        # Follow-up: ORM index parity audit Cat D.
-        "memories.idx_memories_external_blob_ref.index.alembic_only",
-        "memories.idx_memories_source_uri.index.alembic_only",
-        "memories.idx_memories_tags_gin.index.alembic_only",
-        "memory_analysis_assignments.idx_memory_analysis_assignments_analysis_cluster.index.alembic_only",
-        "oauth_device_codes.oauth_device_codes_device_code_key.index.alembic_only",
-        "oauth_device_codes.oauth_device_codes_user_code_key.index.alembic_only",
-        "contexts.ux_contexts_resource_id_active.index.alembic_only",
-        # Cat E: uniqueness / expression drift — RESOLVED (this PR / issue #613 Cat E).
+        # Cat C: oauth_device_codes UK naming — RESOLVED in #718/#719 by
+        # adding ``unique=True`` to ``OAuth2DeviceCode.device_code`` and
+        # ``OAuth2DeviceCode.user_code``. The Cat D companion entries
+        # (UK auto-indexes with the same names) clear from this fix too.
+        # Cat D: migration-only indexes — RESOLVED in #719 by declaring
+        # matching ``Index(...)`` entries in models/memory.py,
+        # models/analysis.py, and models/auth.py (Context).
+        # Cat E: uniqueness / expression drift — RESOLVED (PR #733).
     }
 )
 


### PR DESCRIPTION
Closes #718
Closes #719

## Summary

- `Base.metadata.naming_convention` (fk/uq/ix tokens) so `create_all()` matches alembic-authored constraint names (#613 Cat B+C).
- 5 missing `Index(...)` declarations added to `models/{memory,analysis,auth}.py`, mirroring partial / GIN / composite / partial-UNIQUE indexes from existing migrations (#613 Cat D).
- `OAuth2DeviceCode.{device_code,user_code}` flipped from `index=True` to `unique=True` plus explicit non-unique `ix_*` Index decls — Cat C structural sync with `d08_536_device_code_grant`.
- `_KNOWN_DRIFT` allowlist shrinks from 23 active entries to 2 documented residuals.

## Implementation notes

- **`ix` token is non-optional alongside `uq`**: `Column(unique=True)` instantiates BOTH an unnamed UniqueConstraint and an unnamed backing Index; without an `ix` token in the convention SQLAlchemy raises `AssertionError: name is not None` at DDL compile time. Documented in `db/base.py`.
- **`Column(unique=True, index=True)` collapse trap**: SQLAlchemy collapses both flags into a single unique Index. Production (alembic-authored) has these as **two separate objects** (UK constraint + auto-index + a separate non-unique `ix_<table>_<col>`). The fix keeps `unique=True` on the column and declares the non-unique `ix_*` index explicitly in `__table_args__`. `auth.py:847` carries a comment block explaining this.
- **Residual `_KNOWN_DRIFT` entries**: `resource_tokens.fk_resource_tokens_workspace` (alembic) vs `fk_resource_tokens_workspace_id` (convention) — same FK, two names. Alignment requires a separate rename migration intentionally deferred from this scope.
- **Redundant `ix_oauth_device_codes_*` indexes** filed as a follow-up: see #737 (v0.16.4 cleanup).

## Pre-PR review summary

- gate2 mode: advisor-only (gate2.binary_gate=null)
- audit: skipped
- binary_gate: (none)
- /claude-c-suite:cso: green
- /claude-c-suite:qa-lead: green
- /claude-c-suite:cto: green
- gate1: green via /ask (PM lens, batch coherence endorsed)
- review provider: /code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/718-batch-718-719.gate1.md
- ~/.claude/cache/gh-issue-driven/718-batch-718-719.gate2.md

## Verification

- `test_create_all_vs_alembic_drift.py` PASS (1 passed, 23 → 2 entries in `_KNOWN_DRIFT`)
- `tests/auth/test_device_code_grant.py` + sibling tests: 42 passed (no fixture regression from `unique=True` flip)
- `make lint` clean
- `make type-check`: 2 pre-existing errors in `llm_providers/{gemini,ollama_cloud}_provider.py` (confirmed identical on main, unrelated)

## Follow-up issues filed

- #737 — drop redundant `ix_oauth_device_codes_*` indexes (v0.16.4 cleanup)

Generated via /gh-issue-driven:ship
