### PR TITLE
docs(skill): kagura-memory skill review fixes (install/types/tags)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.14.0",
+  "version": "0.16.3",
   "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -42,11 +42,12 @@ The canonical runtime version is `APP_VERSION` in `backend/src/config/constants.
 - `backend/src/__init__.py` — `__version__ = "X.Y.Z"` (compat alias; must stay in sync with `APP_VERSION`)
 - `frontend/package.json` — `"version": "X.Y.Z"`
 - `frontend/package-lock.json` — run `cd frontend && npm install` to sync lock file
+- `.claude-plugin/plugin.json` — `"version": "X.Y.Z"` (kagura-memory plugin manifest; kept in lockstep so marketplace consumers see the same version as the backend)
 
 ### 5. Commit and tag
 
 ```bash
-git add backend/pyproject.toml backend/src/config/constants.py backend/src/__init__.py frontend/package.json frontend/package-lock.json
+git add backend/pyproject.toml backend/src/config/constants.py backend/src/__init__.py frontend/package.json frontend/package-lock.json .claude-plugin/plugin.json
 git commit -m "chore(release): vX.Y.Z"
 git tag vX.Y.Z
 ```

--- a/claude-skills/guide.md
+++ b/claude-skills/guide.md
@@ -78,7 +78,7 @@ Use `source_uri` and `source_type` with `remember` to track where knowledge orig
 
 ### 4. Optional: SessionStart hook
 
-To automatically remind yourself to restore session context, add this hook to your project's `.claude/settings.json`:
+To automatically remind yourself to restore session context, add this hook to your project's `.claude/settings.json`. Substitute `{server_url}` with the same URL you put in `.mcp.json` (e.g. `https://memory.kagura-ai.com` for the hosted service or `http://localhost:8080` for a local instance):
 
 ```json
 {
@@ -89,7 +89,7 @@ To automatically remind yourself to restore session context, add this hook to yo
         "hooks": [
           {
             "type": "command",
-            "command": "curl -sf http://localhost:8080/health >/dev/null 2>&1 && echo 'Kagura Memory Cloud is connected. Run /kagura-memory:session-start to restore previous session context.' || true"
+            "command": "curl -sf {server_url}/health >/dev/null 2>&1 && echo 'Kagura Memory Cloud is connected. Run /kagura-memory:session-start to restore previous session context.' || true"
           }
         ]
       }
@@ -117,20 +117,23 @@ If you're setting up Kagura Memory Cloud plugin in a new project or on another m
 
 **Option A: Marketplace install (recommended)**
 
-Run `/install-plugin` in Claude Code and search for `kagura-memory`, or install directly:
+Inside Claude Code, run:
 
-```bash
-claude /install-plugin kagura-memory-cloud
 ```
+/plugin install kagura-memory@kagura-memory-cloud
+```
+
+The argument is `<plugin-name>@<marketplace-name>` — the plugin is `kagura-memory` and it lives in the `kagura-memory-cloud` marketplace.
 
 After install, the plugin skills (`/kagura-memory:*`) become available. Proceed to Step 2 above to configure the MCP server connection.
 
 **Option B: Local install (from this repository)**
 
-If you have the `memory-cloud` repo cloned locally:
+If you have the `memory-cloud` repo cloned locally, first add it as a local marketplace, then install:
 
-```bash
-claude /install-plugin /path/to/memory-cloud
+```
+/plugin marketplace add /path/to/memory-cloud
+/plugin install kagura-memory@kagura-memory-cloud
 ```
 
 This installs the plugin from `.claude-plugin/plugin.json` and `claude-skills/` in the repo.

--- a/claude-skills/recall.md
+++ b/claude-skills/recall.md
@@ -52,14 +52,22 @@ When enabled, the response includes up to 3 `explore_hints` — each with a `mem
 ```
 recall(context_id=..., query="...", k=10, filters={"type": "decision"})
 recall(context_id=..., query="...", k=10, filters={"tags": ["python", "fastapi"]})
+recall(context_id=..., query="...", k=10, filters={"tags": ["python", "fastapi"], "tags_match": "all"})
 recall(context_id=..., query="...", k=10, filters={"importance": {"gte": 0.8}})
 recall(context_id=..., query="...", k=10, filters={"created_after": "2026-01-01T00:00:00Z"})
 recall(context_id=..., query="...", k=10, filters={"source_uri_prefix": "vault://my-vault/"})
 recall(context_id=..., query="...", k=10, filters={"source_type": "file"})
 ```
 
+- `tags`: matches **ANY** of the listed tags by default (OR). Add `"tags_match": "all"` to require all tags (AND). Before building a tag filter, call `list_tags(context_id=...)` to discover the actual tag spellings in this context — `troubleshoot` vs `troubleshooting` drift silently kills tag filters.
 - `source_uri_prefix`: Filter by origin URI prefix (e.g. `"file://"`, `"vault://my-vault/"`). Useful for querying memories from a specific vault or directory.
 - `source_type`: Filter by origin type — `"file"` | `"url"` | `"vault"` | `"api"` | `"manual"`.
+
+**Cross-context search** — to query 2-20 contexts at once (all must share the same embedding model), use `context_ids` instead of `context_id`:
+
+```
+recall(context_ids=["<uuid-1>", "<uuid-2>"], query="...", k=10)
+```
 
 Filters can be combined:
 

--- a/claude-skills/remember.md
+++ b/claude-skills/remember.md
@@ -19,14 +19,15 @@ If only one context exists, use it. If multiple, pick the one most relevant to t
 ### 2. Parse the input
 
 - Extract a clear summary (first sentence or line, 10-500 chars)
-- Determine the appropriate type:
-  - `pattern`: Implementation patterns, code examples
-  - `troubleshooting`: Error fixes, debugging solutions
-  - `decision`: Design decisions, architecture choices
-  - `learning`: General learnings
-  - `bug-fix`: Bug fix details
+- Determine the appropriate type. The `type` field is a free-form string, but standardize on this vocabulary so `recall(filters={"type": ...})` keeps working:
+  - `decision`: Design decisions, architecture choices, rejected alternatives with WHY
+  - `pattern`: Implementation patterns, reusable approaches, code examples
+  - `bug-fix`: Bug fix details, root-cause notes
+  - `troubleshooting`: Error fixes, workarounds, environment-specific gotchas
+  - `learning`: General learnings, benchmark results, tool limitations
+  - `note`: Status updates, milestone notes, roadmap changes
 - Set importance based on impact (default: 0.8, design decisions: 0.9, core principles: 1.0)
-- Generate relevant tags (technology, domain, feature area)
+- Generate relevant tags (technology, domain, feature area). **Call `list_tags(context_id=...)` first** to discover existing tag spellings so you reuse them instead of inventing drift (e.g. `troubleshoot` vs `troubleshooting`).
 
 ### 3. Save
 

--- a/claude-skills/session-summary.md
+++ b/claude-skills/session-summary.md
@@ -16,16 +16,16 @@ Review the conversation and collect all GitHub issue numbers that were worked on
 
 ### 2. Identify what to remember
 
-Review the conversation and categorize knowledge into:
+Review the conversation and categorize knowledge into one of the six canonical types (see `remember` skill for the full vocabulary):
 
 | Type | What to capture | Importance |
 |------|----------------|------------|
 | `decision` | Architecture decisions, approach choices, rejected alternatives with WHY | 0.8-1.0 |
 | `pattern` | Implementation patterns, technical solutions, reusable approaches | 0.7-0.9 |
 | `bug-fix` | Root cause analysis, regression lessons, "never do this again" | 0.8-0.9 |
-| `note` | Milestone status, roadmap changes, issue relationships | 0.6-0.8 |
-| `learning` | SDK benchmark results, performance findings, tool limitations | 0.6-0.8 |
 | `troubleshooting` | Error solutions, workarounds, environment-specific fixes | 0.5-0.7 |
+| `learning` | SDK benchmark results, performance findings, tool limitations | 0.6-0.8 |
+| `note` | Milestone status, roadmap changes, issue relationships | 0.6-0.8 |
 
 ### 3. Get the target context
 

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -3,8 +3,13 @@ description: Run comprehensive smoke test of all MCP tools via live MCP connecti
 ---
 
 Verify MCP tools work correctly by executing them in sequence against temporary test contexts.
-Tests 33 non-resource tools (excludes `analyze_context` which requires billing, BYOK, workspace owner role, and Pro-tier feature access).
-Optionally tests 5 resource tools (6 PRO-only rows including delete_context cleanup) if the workspace has a PRO plan.
+Exercises 35 non-resource test rows covering the core memory/edge/context/tag/analysis/sleep tools.
+Optionally exercises 6 PRO-only rows for resource tools (setup_resource, ingest_events, get_resource_impact, get_resource_schema, list_resource_tokens, plus delete_context cleanup) if the workspace has a PRO plan.
+
+Excluded by design:
+- `analyze_context` — requires billing, BYOK, workspace owner role, and Pro-tier feature access.
+- File-upload tools (`init_file_upload`, `complete_file_upload`, `get_file_download_url`, `delete_file`, `list_files`) — require multipart S3/R2 upload flows that can't be exercised inline; cover them separately.
+
 Use this after deployments, tool description changes, or MCP server updates.
 
 **Prerequisite:** MCP server must be running and connected.
@@ -122,6 +127,17 @@ update_edge(context_id=..., source_id=<memory_id>, target_id=<memory_id_2>, weig
 
 delete_edge(context_id=..., source_id=<memory_id>, target_id=<memory_id_2>)
 -> Verify: success response (edge deleted)
+```
+
+### 6.5. Tag discovery
+
+```
+list_tags(context_id=...)
+-> Verify: returns {status: "success", tags: [...], total: N} with N >= 1
+-> Verify: at least one entry has tag="smoke-test" (created via remember in step 3)
+
+list_tags(context_id=..., prefix="smoke")
+-> Verify: every returned tag starts with "smoke"
 ```
 
 ### 7. Merge & usage tools
@@ -269,27 +285,29 @@ Print a summary table:
 | 18 | list_edges | List edges | PASS/FAIL |
 | 19 | update_edge | Update edge weight | PASS/FAIL |
 | 20 | delete_edge | Delete edge | PASS/FAIL |
-| 21 | create_context | Create merge target context | PASS/FAIL |
-| 22 | merge_contexts | Merge source into target | PASS/FAIL |
-| 23 | get_usage | Get workspace usage | PASS/FAIL |
-| 24 | delete_context | Soft-delete merge target and its memories | PASS/FAIL |
-| 25 | forget | Delete memory 2 | PASS/FAIL |
-| 26 | delete_context | Delete source context | PASS/FAIL |
-| 27 | setup_resource | Create resource context + token (PRO only) | PASS/FAIL/SKIP |
-| 28 | ingest_events | Batch ingest 2 test events (PRO only) | PASS/FAIL/SKIP |
-| 29 | get_resource_impact | Get resource stats (PRO only) | PASS/FAIL/SKIP |
-| 30 | get_resource_schema | Get schema (expect not_found) (PRO only) | PASS/FAIL/SKIP |
-| 31 | list_resource_tokens | List tokens for resource (PRO only) | PASS/FAIL/SKIP |
-| 32 | delete_context | Delete resource context (PRO only) | PASS/FAIL/SKIP |
-| 33 | list_analyses | List analysis runs | PASS/FAIL |
-| 34 | get_active_analysis | Get latest succeeded analysis | PASS/FAIL |
-| 35 | get_analysis | Get analysis by run_id (fake ID, error handling) | PASS/FAIL |
-| 36 | get_cluster | Get cluster detail (fake run_id, error handling) | PASS/FAIL |
-| 37 | get_sleep_history | Get sleep maintenance history | PASS/FAIL |
-| 38 | get_sleep_report | Get sleep report (fake ID, error handling) | PASS/FAIL |
-| 39 | rollback_sleep_run | Rollback sleep run (fake ID, error handling) | PASS/FAIL |
+| 21 | list_tags | List tags in context | PASS/FAIL |
+| 22 | list_tags | List tags with prefix filter | PASS/FAIL |
+| 23 | create_context | Create merge target context | PASS/FAIL |
+| 24 | merge_contexts | Merge source into target | PASS/FAIL |
+| 25 | get_usage | Get workspace usage | PASS/FAIL |
+| 26 | delete_context | Soft-delete merge target and its memories | PASS/FAIL |
+| 27 | forget | Delete memory 2 | PASS/FAIL |
+| 28 | delete_context | Delete source context | PASS/FAIL |
+| 29 | setup_resource | Create resource context + token (PRO only) | PASS/FAIL/SKIP |
+| 30 | ingest_events | Batch ingest 2 test events (PRO only) | PASS/FAIL/SKIP |
+| 31 | get_resource_impact | Get resource stats (PRO only) | PASS/FAIL/SKIP |
+| 32 | get_resource_schema | Get schema (expect not_found) (PRO only) | PASS/FAIL/SKIP |
+| 33 | list_resource_tokens | List tokens for resource (PRO only) | PASS/FAIL/SKIP |
+| 34 | delete_context | Delete resource context (PRO only) | PASS/FAIL/SKIP |
+| 35 | list_analyses | List analysis runs | PASS/FAIL |
+| 36 | get_active_analysis | Get latest succeeded analysis | PASS/FAIL |
+| 37 | get_analysis | Get analysis by run_id (fake ID, error handling) | PASS/FAIL |
+| 38 | get_cluster | Get cluster detail (fake run_id, error handling) | PASS/FAIL |
+| 39 | get_sleep_history | Get sleep maintenance history | PASS/FAIL |
+| 40 | get_sleep_report | Get sleep report (fake ID, error handling) | PASS/FAIL |
+| 41 | rollback_sleep_run | Rollback sleep run (fake ID, error handling) | PASS/FAIL |
 
-**Result: N/33 passed** (+ N/6 resource tools passed, or skipped if not PRO)
+**Result: N/35 passed** (+ N/6 resource tools passed, or skipped if not PRO)
 
 Test context: smoke-test-{timestamp} (cleaned up)
 


### PR DESCRIPTION
## Summary

Skill-file audit of the `kagura-memory` plugin against the live MCP tool surface (37 tools in `backend/src/mcp_server/tools/_definitions.py`). Found 2 critical and 4 warning-level drift issues; all fixed in 5 atomic commits.

### Fixes
- **C1 — `guide.md`**: Install command was the wrong syntax (`claude /install-plugin <marketplace>`). Replaced with the in-Claude-Code form `/plugin install kagura-memory@kagura-memory-cloud` that matches `README.md:312`. Option B (local install) now walks through `/plugin marketplace add` + install.
- **C2 — `guide.md`**: SessionStart hook had a hardcoded `http://localhost:8080/health`, which never fires for hosted users (`memory.kagura-ai.com`). Replaced with a `{server_url}` placeholder + explicit substitution instructions.
- **W1 — `remember.md` + `session-summary.md`**: The two skills listed different `type` vocabularies. Standardized both on the same six-type set (decision, pattern, bug-fix, troubleshooting, learning, note) so `recall(filters={"type": ...})` keeps matching across sessions.
- **W2 — `remember.md` + `recall.md` + `smoke-test.md`**: `list_tags` (Issue #614, the canonical tag-drift mitigation) was unmentioned in every skill. `remember` now calls `list_tags` before generating tags; `recall` documents it before tag filters; `smoke-test` exercises both basic and `prefix` forms.
- **W3 — `recall.md`**: The default `tags` filter is **OR** (matches ANY), with `tags_match: "all"` for AND. Documented both, previous skill showed an example without explaining the operator.
- **W4 — `recall.md`**: Added a `context_ids=[...]` example for cross-context recall (Issue #81), which was completely missing.
- **W5 — `smoke-test.md`**: Header claimed "33 non-resource tools" — actually 33 test rows, not 33 unique tools, with file-upload tools silently excluded. Renumbered table (now 35 non-resource rows after `list_tags` addition), made the excluded set explicit.
- **W6 — `plugin.json` + `.claude/commands/release.md`**: Plugin manifest was pinned at `0.14.0` while backend HEAD shipped through `0.16.3`. Bumped to match, and added `.claude-plugin/plugin.json` to the `/release` command's update list + `git add` example so future bumps stay in lockstep.

### Files

```
.claude-plugin/plugin.json       |  2 +-
.claude/commands/release.md      |  3 +-
claude-skills/guide.md           | 19 ++++++++-----
claude-skills/recall.md          |  8 +++++
claude-skills/remember.md        | 15 ++++++-----
claude-skills/session-summary.md |  6 ++--
claude-skills/smoke-test.md      | 64 +++++++++++++++++++++++++---------------
7 files changed, 74 insertions(+), 43 deletions(-)
```

Docs-only — no production code, no migrations, no API surface change.

## Test plan

- [ ] CI green (lint/typecheck/unit; should be no-op since no code changed)
- [ ] `claude /plugin install kagura-memory@kagura-memory-cloud` works on a fresh clone (C1 verification — manual)
- [ ] `/kagura-memory:smoke-test` PASSes the new `list_tags` rows (rows 21-22 in updated table)
- [ ] `/kagura-memory:remember` and `/kagura-memory:recall` invocations work as documented (manual smoke against `kagura-dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)