### PR TITLE
docs(skill): address Copilot review feedback from PR #743

### DIFF
--- a/claude-skills/guide.md
+++ b/claude-skills/guide.md
@@ -117,13 +117,14 @@ If you're setting up Kagura Memory Cloud plugin in a new project or on another m
 
 **Option A: Marketplace install (recommended)**
 
-Inside Claude Code, run:
+Inside Claude Code, register the marketplace first (skip this line if it's already registered — `/plugin marketplace list` shows what's there), then install:
 
 ```
+/plugin marketplace add kagura-ai/memory-cloud
 /plugin install kagura-memory@kagura-memory-cloud
 ```
 
-The argument is `<plugin-name>@<marketplace-name>` — the plugin is `kagura-memory` and it lives in the `kagura-memory-cloud` marketplace.
+The install argument is `<plugin-name>@<marketplace-name>` — the plugin is `kagura-memory` and it lives in the `kagura-memory-cloud` marketplace.
 
 After install, the plugin skills (`/kagura-memory:*`) become available. Proceed to Step 2 above to configure the MCP server connection.
 

--- a/claude-skills/recall.md
+++ b/claude-skills/recall.md
@@ -63,11 +63,16 @@ recall(context_id=..., query="...", k=10, filters={"source_type": "file"})
 - `source_uri_prefix`: Filter by origin URI prefix (e.g. `"file://"`, `"vault://my-vault/"`). Useful for querying memories from a specific vault or directory.
 - `source_type`: Filter by origin type — `"file"` | `"url"` | `"vault"` | `"api"` | `"manual"`.
 
-**Cross-context search** — to query 2-20 contexts at once (all must share the same embedding model), use `context_ids` instead of `context_id`:
+**Cross-context search** — to query 2-20 contexts at once, use `context_ids` instead of `context_id`:
 
 ```
 recall(context_ids=["<uuid-1>", "<uuid-2>"], query="...", k=10)
 ```
+
+All listed contexts must:
+- belong to the **same workspace** (otherwise `workspace_mismatch`)
+- share the **same privacy setting** — all private *or* all shared, not mixed (otherwise `context_privacy_mismatch`)
+- use the **same embedding model** (otherwise `embedding_model_mismatch`)
 
 Filters can be combined:
 

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -137,7 +137,9 @@ list_tags(context_id=...)
 -> Verify: at least one entry has tag="smoke-test" (created via remember in step 3)
 
 list_tags(context_id=..., prefix="smoke")
--> Verify: every returned tag starts with "smoke"
+-> Verify: every returned tag, lowercased, starts with "smoke" (the prefix
+   filter is case-insensitive per the MCP schema, so this stays correct even
+   if a tag was stored as "Smoke-Foo")
 ```
 
 ### 7. Merge & usage tools


### PR DESCRIPTION
## Summary

Follow-up to #743 (merged 2026-05-19) applying the 3 inline Copilot review findings as precision fixes. All three were verified against the live MCP source before applying.

### Fixes

| # | File:line | Finding | Verification |
|---|---|---|---|
| 1 | `guide.md` Option A | Missing `/plugin marketplace add` step before install | Confirmed by `README.md:308-312` which shows the same two-step flow |
| 2 | `smoke-test.md` list_tags prefix verify | Verify was case-sensitive but `prefix` is case-insensitive | Confirmed by MCP schema `_definitions.py:730-737` |
| 3 | `recall.md` cross-context | Missing `workspace_mismatch` + `context_privacy_mismatch` constraints | Confirmed by `backend/src/mcp_server/tools/memory.py:281,287` |

Docs-only, 3 files, +12/-4.

## Test plan

- [ ] CI green
- [ ] On a fresh Claude Code session, `/plugin marketplace add kagura-ai/memory-cloud` followed by `/plugin install kagura-memory@kagura-memory-cloud` succeeds (Fix #1 manual)
- [ ] `/kagura-memory:smoke-test` still passes the list_tags rows (Fix #2 doc-only change to verification text)
- [ ] Cross-context recall with mixed workspace returns `workspace_mismatch` and mixed privacy returns `context_privacy_mismatch` (Fix #3 already enforced by handler, this just documents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)