### PR TITLE
fix(test): unskip DCR PKCE-only token-exchange test (#767)

### DIFF
--- a/backend/tests/integration/test_oauth_dcr_integration.py
+++ b/backend/tests/integration/test_oauth_dcr_integration.py
@@ -215,21 +215,12 @@ def client():
     # exception. Matches the convention used by other integration tests
     # in this repo.
     #
-    # ``base_url="http://localhost:8080"`` makes the request URL pass
-    # authlib's ``is_secure_transport`` guard
-    # (``authlib.common.security.is_secure_transport``) — authlib rejects
-    # plain ``http://`` URIs at ``OAuth2Request.__init__`` with
-    # ``InsecureTransportError`` unless the URI starts with ``https://``
-    # or ``http://localhost:`` (note the trailing colon: an explicit port
-    # is required; ``127.0.0.1`` is NOT in authlib's allowlist — see
-    # ``authlib/common/security.py``). TestClient's default
-    # ``http://testserver`` URL fails that check and the ``/oauth/token``
-    # exchange in ``test_dcr_token_exchange_with_pkce_only_returns_200``
-    # would otherwise return ``500 server_error`` before ever reaching the
-    # grant handler. In production this is handled by the
-    # ``X-Forwarded-Proto: https`` rewrite in ``StarletteOAuth2Request``
-    # (Caddy → API container), so this localhost base_url is a test-only
-    # transport concern, not an auth-stack regression. (#767)
+    # ``base_url="http://localhost:8080"`` satisfies authlib's
+    # ``is_secure_transport`` allowlist (``http://localhost:`` with an
+    # explicit port, or ``https://``; ``127.0.0.1`` and TestClient's default
+    # ``http://testserver`` both fail the check and the ``/oauth/token``
+    # exchange returns 500 before reaching the grant handler — see
+    # ``authlib/common/security.py``).
     with TestClient(app, base_url="http://localhost:8080", raise_server_exceptions=False) as c:
         yield c
 

--- a/backend/tests/integration/test_oauth_dcr_integration.py
+++ b/backend/tests/integration/test_oauth_dcr_integration.py
@@ -219,9 +219,10 @@ def client():
     # authlib's ``is_secure_transport`` guard
     # (``authlib.common.security.is_secure_transport``) — authlib rejects
     # plain ``http://`` URIs at ``OAuth2Request.__init__`` with
-    # ``InsecureTransportError`` unless the URI starts with ``https://``,
-    # ``http://localhost:``, or ``http://127.0.0.1:`` (note the trailing
-    # colon: an explicit port is required). TestClient's default
+    # ``InsecureTransportError`` unless the URI starts with ``https://``
+    # or ``http://localhost:`` (note the trailing colon: an explicit port
+    # is required; ``127.0.0.1`` is NOT in authlib's allowlist — see
+    # ``authlib/common/security.py``). TestClient's default
     # ``http://testserver`` URL fails that check and the ``/oauth/token``
     # exchange in ``test_dcr_token_exchange_with_pkce_only_returns_200``
     # would otherwise return ``500 server_error`` before ever reaching the

--- a/backend/tests/integration/test_oauth_dcr_integration.py
+++ b/backend/tests/integration/test_oauth_dcr_integration.py
@@ -214,7 +214,22 @@ def client():
     # this test pins) instead of having TestClient re-raise the underlying
     # exception. Matches the convention used by other integration tests
     # in this repo.
-    with TestClient(app, raise_server_exceptions=False) as c:
+    #
+    # ``base_url="http://localhost:8080"`` makes the request URL pass
+    # authlib's ``is_secure_transport`` guard
+    # (``authlib.common.security.is_secure_transport``) — authlib rejects
+    # plain ``http://`` URIs at ``OAuth2Request.__init__`` with
+    # ``InsecureTransportError`` unless the URI starts with ``https://``,
+    # ``http://localhost:``, or ``http://127.0.0.1:`` (note the trailing
+    # colon: an explicit port is required). TestClient's default
+    # ``http://testserver`` URL fails that check and the ``/oauth/token``
+    # exchange in ``test_dcr_token_exchange_with_pkce_only_returns_200``
+    # would otherwise return ``500 server_error`` before ever reaching the
+    # grant handler. In production this is handled by the
+    # ``X-Forwarded-Proto: https`` rewrite in ``StarletteOAuth2Request``
+    # (Caddy → API container), so this localhost base_url is a test-only
+    # transport concern, not an auth-stack regression. (#767)
+    with TestClient(app, base_url="http://localhost:8080", raise_server_exceptions=False) as c:
         yield c
 
 
@@ -315,13 +330,6 @@ class TestDcrLoopbackPersistsNullOwnerId:
         assert row.client_secret_hash == ""
         assert row.plaintext_secret_encrypted is None
 
-    @pytest.mark.skip(
-        reason=(
-            "Baseline-skip for #721 (backend-integration CI activation). "
-            "Fails on main; root cause TBD (last touched by #689 543b0970). "
-            "Tracked in #767."
-        )
-    )
     def test_dcr_token_exchange_with_pkce_only_returns_200(self, client, sync_db):
         """Issue #689 regression: DCR + token exchange end-to-end with no client_secret.
 


### PR DESCRIPTION
Closes #767

## Summary
- Re-enable `test_dcr_token_exchange_with_pkce_only_returns_200` (DCR + PKCE-only `/oauth/token` regression pin for #689) by giving the `client` fixture a `base_url` that satisfies authlib's `is_secure_transport` allowlist.
- Remove the `@pytest.mark.skip` decorator that #721 added as the `backend-integration` CI baseline.
- Test-only change — production code is untouched.

## Root cause
`authlib.common.security.is_secure_transport` only returns `True` for URIs starting with `https://` or `http://localhost:`. FastAPI `TestClient` defaults to `http://testserver`, which fails the check at `OAuth2Request.__init__`, so the `/oauth/token` POST returned `500 server_error` (RFC 6749 shape, wrapped by the bare-`except` in `_run_oauth_sync`) **before reaching the grant handler**. The 500 made the test fail in a way that looked like a token-exchange auth bug, when in fact the grant handler was never invoked.

Production is unaffected: Caddy → API container always carries `X-Forwarded-Proto: https`, and `StarletteOAuth2Request` (`backend/src/auth/starlette_oauth2_request.py:128-130`) rewrites the URI to `https://...` before authlib sees it.

## Implementation notes
- `client` fixture now constructs `TestClient(app, base_url="http://localhost:8080", raise_server_exceptions=False)` — `localhost:` (with explicit port) is the lighter-touch alternative to `AUTHLIB_INSECURE_TRANSPORT=1` (kills the guard globally) or `monkeypatch`ing authlib (version-fragile).
- Comment block explains the non-obvious WHY (allowlist quirk + explicit-port requirement + `127.0.0.1` trap) and stays within the density of the adjacent `raise_server_exceptions=False` comment.
- RFC 7591 §3.2.1 invariant (#689) preserved — DCR `response_model_exclude={"client_secret", "plaintext_secret"}` (`oauth.py:646`) is unchanged. No `client_secret` reintroduced; no rate-limit mock added around `/oauth/token`.

## Acceptance criteria (#767)
- [x] Investigate why DCR loopback token exchange with PKCE-only does not return 200
- [x] Fix and re-enable the test
- [x] Remove the `@pytest.mark.skip` decorator added by #721
- [x] Confirm the live `/oauth/token` endpoint behaves correctly for the PKCE-only DCR flow

Live `/oauth/token` smoke against the running local stack:
- DCR registers a `token_endpoint_auth_method="none"` client (response omits `client_secret`).
- POST `/oauth/token` with form `grant_type=authorization_code` + `code` (synthetic) + `code_verifier` + `redirect_uri` + `client_id` (no `Authorization: Basic`) → **400 `invalid_grant`** for the synthetic code (not 500, not `invalid_client`). The public-client form path reaches the grant handler; the only rejection is the synthetic code itself.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (QA Lead lens; no escalation to /ceo)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/767-fix-fix-test-test-dcr-token-exchange-with-pk.gate1.md
- ~/.claude/cache/gh-issue-driven/767-fix-fix-test-test-dcr-token-exchange-with-pk.gate2.md

## Follow-up candidates (not in this PR)
- A focused unit test for `StarletteOAuth2Request`'s `X-Forwarded-Proto: https` rewrite branch (this PR exercises authlib's `localhost:` short-circuit instead, leaving the proxy-rewrite branch uncovered). Low priority — the rewrite is two straight-line statements.

🤖 Generated via /gh-issue-driven:ship
