### PR TITLE
fix(test): unskip 15 baseline-skip tests from #721 (#764 #765 #766)

### DIFF
--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -53,6 +53,12 @@ async def _seed_workspace_context(
 
     All UUIDs are random so each test run is isolated within the shared
     session-scoped ``db_session`` fixture.
+
+    Flush between workspace and its children: ``WorkspaceMember.workspace_id``
+    and ``Context.workspace_id`` are column-level FKs with no ``relationship()``
+    to drive insert order, so a single flush can attempt the child rows before
+    the parent and raise ``fk_contexts_workspace_id`` /
+    ``fk_workspace_members_workspace_id``.
     """
     ws = Workspace(
         id=uuid4(),
@@ -63,6 +69,9 @@ async def _seed_workspace_context(
         daily_api_limit=50_000,
         weekly_api_limit=250_000,
     )
+    db.add(ws)
+    await db.flush()
+
     member = WorkspaceMember(
         workspace_id=ws.id,
         user_id=user_id,
@@ -75,7 +84,7 @@ async def _seed_workspace_context(
         created_by=user_id,
         is_private=is_private,
     )
-    db.add_all([ws, member, ctx])
+    db.add_all([member, ctx])
     await db.flush()
     return ws, ctx
 
@@ -106,14 +115,6 @@ def _memory(
     )
 
 
-@pytest.mark.skip(
-    reason=(
-        "Baseline-skip for #721 (backend-integration CI activation). "
-        "All 12 tests in this class fail on main with "
-        "fk_contexts_workspace_id violation inside _seed_workspace_context. "
-        "Tracked in #764."
-    )
-)
 @pytest.mark.asyncio
 class TestAggregateTagsCTE:
     async def test_empty_context_returns_empty_list(self, db_session, now):

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -56,9 +56,9 @@ async def _seed_workspace_context(
 
     Flush between workspace and its children: ``WorkspaceMember.workspace_id``
     and ``Context.workspace_id`` are column-level FKs with no ``relationship()``
-    to drive insert order, so a single flush can attempt the child rows before
-    the parent and raise ``fk_contexts_workspace_id`` /
-    ``fk_workspace_members_workspace_id``.
+    to drive insert order. Without the intermediate flush SQLAlchemy may emit
+    the child INSERTs before the parent, deterministically violating the
+    workspace FK.
     """
     ws = Workspace(
         id=uuid4(),

--- a/backend/tests/integration/test_llm_pricing.py
+++ b/backend/tests/integration/test_llm_pricing.py
@@ -27,13 +27,13 @@ from sqlalchemy.exc import IntegrityError
 from models.llm_pricing import LLMPricing
 from services.llm_pricing_service import LLMPricingService
 
-# NOTE: established provider+model combinations (e.g. ``cohere``/``rerank-3.5``,
-# ``anthropic``/``claude-sonnet-4-6``) may collide with seed migration rows
-# inserted by ``e13_474_pricing_seeds`` and ``c03_471_seed_pricing`` when
-# the integration suite runs ``test_alembic_migrations`` before this module.
-# Tests that need to assert a *miss* or INSERT a fresh pricing row use
-# unique synthetic ``(provider, model)`` names to avoid colliding with the
-# ``uq_llm_pricing_lookup_key`` UNIQUE constraint.
+# NOTE: the two ``rerank_search_units`` tests below use unique synthetic
+# ``(provider, model)`` names to avoid colliding with seed migration rows.
+# ``e13_474_pricing_seeds`` inserts ``(cohere, rerank-3.5, rerank_search_units,
+# 2026-04-28)`` which previously made the schema-miss assertion return a row
+# and the per-1k-SU INSERT raise on ``uq_llm_pricing_lookup_key``. Other tests
+# in this file use the ``effective_from`` offset trick instead — both
+# strategies are valid; pick whichever fits the assertion shape.
 
 
 def _make_row(

--- a/backend/tests/integration/test_llm_pricing.py
+++ b/backend/tests/integration/test_llm_pricing.py
@@ -19,12 +19,21 @@ Covers:
 from __future__ import annotations
 
 from datetime import datetime
+from uuid import uuid4
 
 import pytest
 from sqlalchemy.exc import IntegrityError
 
 from models.llm_pricing import LLMPricing
 from services.llm_pricing_service import LLMPricingService
+
+# NOTE: established provider+model combinations (e.g. ``cohere``/``rerank-3.5``,
+# ``anthropic``/``claude-sonnet-4-6``) may collide with seed migration rows
+# inserted by ``e13_474_pricing_seeds`` and ``c03_471_seed_pricing`` when
+# the integration suite runs ``test_alembic_migrations`` before this module.
+# Tests that need to assert a *miss* or INSERT a fresh pricing row use
+# unique synthetic ``(provider, model)`` names to avoid colliding with the
+# ``uq_llm_pricing_lookup_key`` UNIQUE constraint.
 
 
 def _make_row(
@@ -187,24 +196,23 @@ async def test_lookup_miss_returns_none(db_session):
     assert result is None
 
 
-@pytest.mark.skip(
-    reason=(
-        "Baseline-skip for #721 (backend-integration CI activation). "
-        "Fails on main; root cause TBD. Tracked in #765."
-    )
-)
 @pytest.mark.asyncio
 async def test_lookup_rerank_search_units_schema_supports_no_rows(db_session):
-    """The rerank_search_units enum exists in #471 but no rows are seeded.
+    """The ``rerank_search_units`` enum value is accepted by lookup even
+    when no row matches the requested ``(provider, model)``.
 
     This verifies the schema accepts the enum value without breaking
-    token-based queries — #474 will seed actual rerank rows. The lookup
-    must return ``None`` cleanly, not raise.
+    token-based queries. The lookup must return ``None`` cleanly, not raise.
+
+    Uses ``exotic``/``never-seeded-rerank`` rather than the real
+    ``cohere``/``rerank-3.5`` so the assertion is not invalidated by the
+    seed migration ``e13_474_pricing_seeds`` (which inserts the real
+    Cohere row at ``effective_from=2026-04-28``).
     """
     svc = LLMPricingService(db_session)
     result = await svc.lookup(
-        provider="cohere",
-        model="rerank-3.5",
+        provider="exotic",
+        model="never-seeded-rerank",
         unit_type="rerank_search_units",
         started_at=datetime(
             2026,
@@ -279,19 +287,21 @@ async def test_compute_cost_usd_per_million_tokens(db_session):
     assert cost_full == pytest.approx(3.00)
 
 
-@pytest.mark.skip(
-    reason=(
-        "Baseline-skip for #721 (backend-integration CI activation). "
-        "Fails on main; root cause TBD. Tracked in #765."
-    )
-)
 @pytest.mark.asyncio
 async def test_compute_cost_usd_per_thousand_search_units(db_session):
-    """Cohere-shaped per-1k-SU pricing: 500 search units at $2/1k → $1.00."""
+    """Cohere-shaped per-1k-SU pricing: 500 search units at $2/1k → $1.00.
+
+    Uses a unique synthetic ``model`` name so the INSERT does not collide
+    with the seed migration ``e13_474_pricing_seeds`` row
+    ``(cohere, rerank-3.5, rerank_search_units, 2026-04-28)`` on
+    ``uq_llm_pricing_lookup_key``. The cost math is independent of the
+    model identifier.
+    """
+    unique_model = f"rerank-test-{uuid4().hex[:8]}"
     db_session.add(
         _make_row(
             provider="cohere",
-            model="rerank-3.5",
+            model=unique_model,
             unit_type="rerank_search_units",
             effective_from=datetime(
                 2026,
@@ -307,7 +317,7 @@ async def test_compute_cost_usd_per_thousand_search_units(db_session):
     svc = LLMPricingService(db_session)
     cost = await svc.compute_cost_usd(
         provider="cohere",
-        model="rerank-3.5",
+        model=unique_model,
         unit_type="rerank_search_units",
         started_at=datetime(
             2026,

--- a/backend/tests/integration/test_llm_pricing.py
+++ b/backend/tests/integration/test_llm_pricing.py
@@ -204,15 +204,17 @@ async def test_lookup_rerank_search_units_schema_supports_no_rows(db_session):
     This verifies the schema accepts the enum value without breaking
     token-based queries. The lookup must return ``None`` cleanly, not raise.
 
-    Uses ``exotic``/``never-seeded-rerank`` rather than the real
+    Uses ``exotic`` + a uuid4-suffixed model rather than the real
     ``cohere``/``rerank-3.5`` so the assertion is not invalidated by the
     seed migration ``e13_474_pricing_seeds`` (which inserts the real
-    Cohere row at ``effective_from=2026-04-28``).
+    Cohere row at ``effective_from=2026-04-28``). The uuid4 suffix is
+    belt-and-suspenders against any future seed that names a literal
+    ``never-seeded-rerank`` row.
     """
     svc = LLMPricingService(db_session)
     result = await svc.lookup(
         provider="exotic",
-        model="never-seeded-rerank",
+        model=f"never-seeded-rerank-{uuid4().hex[:8]}",
         unit_type="rerank_search_units",
         started_at=datetime(
             2026,

--- a/backend/tests/integration/test_memory_analyses_schema.py
+++ b/backend/tests/integration/test_memory_analyses_schema.py
@@ -358,19 +358,7 @@ async def test_workspace_addon_check_still_rejects_unknown(
         ("pro", 5, 8),  # PRO + addon offset
         ("free", 0, 0),  # FREE base
         ("basic", 0, 0),  # BASIC base
-        pytest.param(
-            "free",
-            2,
-            2,
-            marks=pytest.mark.skip(
-                reason=(
-                    "Baseline-skip for #721 (backend-integration CI activation). "
-                    "Only the [free-2-2] variant fails on main; siblings pass. "
-                    "Tracked in #766."
-                )
-            ),
-            id="free-2-2",
-        ),  # FREE + addon (base stays 0, bonus surfaces)
+        ("free", 2, 0),  # FREE + addon -> 0 (_zero_floor #569 defense: zero base overrides addon)
     ],
 )
 def test_effective_analysis_runs(plan: str, bonus: int, expected: int) -> None:


### PR DESCRIPTION
Closes #764
Closes #765
Closes #766

## Summary
- Unskip 15 baseline-skip tests added by PR #769 (#721) by fixing 3 independent root causes — all **test-only**, zero production code, zero migrations, zero schema changes.
- Net delta: 237 passed / 22 skipped → **252 passed / 7 skipped** (only env-gated `test_r2_live.py` remain).
- 4-gate internal review pipeline: gate1 `/ask`→QA Lead green, 3 per-task spec+quality reviews approved, aggregate final review approved, `/simplify` produced 1 docstring fix-up + 1 belt-and-suspenders hardening, `/self-review` 0 critical / 0 warnings.

## Implementation notes

### #764 — `_seed_workspace_context` FK violation (12 tests)
`Context.workspace_id` and `WorkspaceMember.workspace_id` are column-level FKs without `relationship()` declarations — SQLAlchemy's unit-of-work has no edge to topo-sort `add_all([ws, member, ctx])`, so child INSERTs may be emitted before parent → `fk_contexts_workspace_id` violation. Restructured the helper to `db.add(ws) → flush() → db.add_all([member, ctx]) → flush()`, mirroring the proven pattern in `test_memory_analyses_schema.py:46-94` `_seed_workspace_context_pricing`.

### #766 — `[free-2-2]` parametrize variant (test was wrong, prod is right)
The original `("free", 2, 2)` expectation contradicted the intentional `_zero_floor` zero-base defense (`auth.py:1302-1318`, `#569`): for plan tiers with `base == 0` (FREE/BASIC analysis_runs_per_day), the addon is ignored — no addon row can grant access to a feature the tier excludes. Production code is correct; corrected to `("free", 2, 0)` with an inline comment referencing `_zero_floor` and `#569` so a future maintainer who tries to "expose" the bonus is reminded of the design decision.

### #765 — `rerank_search_units` seed-row collision (2 tests)
Seed migration `e13_474_pricing_seeds.py:148` inserts `(cohere, rerank-3.5, rerank_search_units, 2026-04-28)`, which previously made the schema-miss lookup return a row instead of `None`, and the per-1k-SU INSERT raise `IntegrityError` on `uq_llm_pricing_lookup_key`. Switched both tests to unique synthetic `(provider, model)` names: Test 1 uses `f"never-seeded-rerank-{uuid4().hex[:8]}"` (belt-and-suspenders with the `exotic` provider) mirroring sibling `test_lookup_miss_returns_none`, Test 2 uses `unique_model = f"rerank-test-{uuid4().hex[:8]}"` captured once and shared between INSERT and lookup.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (QA Lead lens)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/764-batch-764-765-766.gate1.md
- ~/.claude/cache/gh-issue-driven/764-batch-764-765-766.gate2.md

## Follow-up issues (NOT blockers for this PR — tracked separately)
- conftest extraction of `_seed_workspace_context` / `_seed_workspace_context_pricing` (3rd similar helper would land before drift becomes load-bearing)
- harden `test_lookup_miss_returns_none` with `f"never-seeded-{uuid4().hex[:8]}"` for parity with this PR's Test 1

🤖 Generated via /gh-issue-driven:ship
