### PR TITLE
fix(device-flow): auth guard + return_to allowlist + tokens (#772)

### DIFF
--- a/frontend/src/app/device/page.test.tsx
+++ b/frontend/src/app/device/page.test.tsx
@@ -281,6 +281,58 @@ describe("DevicePage", () => {
     });
   });
 
+  // --- Auth guard tests (#772) ---
+
+  describe("auth guard", () => {
+    it("(a) redirects to login with encoded return_to when unauthenticated and user_code is present", async () => {
+      mockUseAuth.mockReturnValue({ user: null, isLoading: false });
+      mockSearchParams.set("user_code", "ABC12345");
+
+      render(<DevicePage />);
+
+      await waitFor(() => {
+        expect(mockRouterReplace).toHaveBeenCalledWith(
+          "/login?return_to=%2Fdevice%3Fuser_code%3DABC12345",
+        );
+      });
+      expect(mockVerifyDeviceCode).not.toHaveBeenCalled();
+    });
+
+    it("(b) redirects to login with bare /device return_to when unauthenticated and no user_code", async () => {
+      mockUseAuth.mockReturnValue({ user: null, isLoading: false });
+      // No user_code set in mockSearchParams (cleared in beforeEach)
+
+      render(<DevicePage />);
+
+      await waitFor(() => {
+        expect(mockRouterReplace).toHaveBeenCalledWith(
+          "/login?return_to=%2Fdevice",
+        );
+      });
+      expect(mockVerifyDeviceCode).not.toHaveBeenCalled();
+    });
+
+    it("(c) shows spinner and does not redirect or verify while auth is resolving", async () => {
+      mockUseAuth.mockReturnValue({ user: null, isLoading: true });
+
+      render(<DevicePage />);
+
+      // Spinner should be visible (SpinnerLoading renders an svg role=img or status div)
+      // The page renders a spinner for authLoading || !user, so the code input should be absent.
+      expect(screen.queryByLabelText("device.codeLabel")).toBeNull();
+      expect(mockVerifyDeviceCode).not.toHaveBeenCalled();
+      expect(mockRouterReplace).not.toHaveBeenCalled();
+    });
+
+    it("(d) authed user sees the code input form and verify works normally", async () => {
+      // Default beforeEach already sets authenticated user — confirm behavior preserved.
+      render(<DevicePage />);
+
+      expect(screen.getByLabelText("device.codeLabel")).toBeDefined();
+      expect(mockRouterReplace).not.toHaveBeenCalled();
+    });
+  });
+
   it("discloses identity fields shared with the client on consent screen (#640)", async () => {
     mockVerifyDeviceCode.mockResolvedValue({
       user_code: "ABCD1234",

--- a/frontend/src/app/device/page.test.tsx
+++ b/frontend/src/app/device/page.test.tsx
@@ -39,10 +39,29 @@ vi.mock("next-intl", () => ({
   },
 }));
 
+const mockRouterReplace = vi.fn();
 const mockSearchParams = new URLSearchParams();
 vi.mock("next/navigation", () => ({
-  useRouter: vi.fn(),
+  useRouter: () => ({ replace: mockRouterReplace, push: vi.fn() }),
   useSearchParams: () => mockSearchParams,
+}));
+
+// Default: authenticated user. Override per-test with mockUseAuth.set() when needed.
+const mockUseAuth = {
+  user: {
+    id: "u1",
+    email: "test@example.com",
+    name: "Test",
+    picture: "",
+    role: "user" as const,
+  },
+  isLoading: false,
+  isAuthenticated: true,
+  logout: vi.fn(),
+  refetchUser: vi.fn(),
+};
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuth: () => mockUseAuth,
 }));
 
 // ---------- Helpers ----------------------------------------------------------
@@ -60,6 +79,17 @@ function typeCode(code: string) {
 beforeEach(() => {
   mockVerifyDeviceCode.mockReset();
   mockConfirmDevice.mockReset();
+  mockRouterReplace.mockReset();
+  // Reset auth to authenticated user state for each test
+  mockUseAuth.user = {
+    id: "u1",
+    email: "test@example.com",
+    name: "Test",
+    picture: "",
+    role: "user" as const,
+  };
+  mockUseAuth.isLoading = false;
+  mockUseAuth.isAuthenticated = true;
   // Clear URL params between tests
   for (const key of [...mockSearchParams.keys()]) {
     mockSearchParams.delete(key);

--- a/frontend/src/app/device/page.test.tsx
+++ b/frontend/src/app/device/page.test.tsx
@@ -315,10 +315,13 @@ describe("DevicePage", () => {
     it("(c) shows spinner and does not redirect or verify while auth is resolving", async () => {
       mockUseAuth.mockReturnValue({ user: null, isLoading: true });
 
-      render(<DevicePage />);
+      const { container } = render(<DevicePage />);
 
-      // Spinner should be visible (SpinnerLoading renders an svg role=img or status div)
-      // The page renders a spinner for authLoading || !user, so the code input should be absent.
+      // SpinnerLoading renders a div with the `animate-spin` CSS class — assert
+      // it is actually present so the test fails if the component returns null
+      // instead of a spinner (negative assertion alone would not catch that).
+      expect(container.querySelector('[class*="animate-spin"]')).not.toBeNull();
+      // The code input form must be absent while auth is resolving.
       expect(screen.queryByLabelText("device.codeLabel")).toBeNull();
       expect(mockVerifyDeviceCode).not.toHaveBeenCalled();
       expect(mockRouterReplace).not.toHaveBeenCalled();

--- a/frontend/src/app/device/page.test.tsx
+++ b/frontend/src/app/device/page.test.tsx
@@ -46,22 +46,9 @@ vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
 }));
 
-// Default: authenticated user. Override per-test with mockUseAuth.set() when needed.
-const mockUseAuth = {
-  user: {
-    id: "u1",
-    email: "test@example.com",
-    name: "Test",
-    picture: "",
-    role: "user" as const,
-  },
-  isLoading: false,
-  isAuthenticated: true,
-  logout: vi.fn(),
-  refetchUser: vi.fn(),
-};
+const mockUseAuth = vi.fn();
 vi.mock("@/contexts/AuthContext", () => ({
-  useAuth: () => mockUseAuth,
+  useAuth: () => mockUseAuth(),
 }));
 
 // ---------- Helpers ----------------------------------------------------------
@@ -80,16 +67,20 @@ beforeEach(() => {
   mockVerifyDeviceCode.mockReset();
   mockConfirmDevice.mockReset();
   mockRouterReplace.mockReset();
-  // Reset auth to authenticated user state for each test
-  mockUseAuth.user = {
-    id: "u1",
-    email: "test@example.com",
-    name: "Test",
-    picture: "",
-    role: "user" as const,
-  };
-  mockUseAuth.isLoading = false;
-  mockUseAuth.isAuthenticated = true;
+  // Default: authenticated user. Override per-test with mockUseAuth.mockReturnValue({...}).
+  mockUseAuth.mockReturnValue({
+    user: {
+      id: "u1",
+      email: "test@example.com",
+      name: "Test",
+      picture: "",
+      role: "user" as const,
+    },
+    isLoading: false,
+    isAuthenticated: true,
+    logout: vi.fn(),
+    refetchUser: vi.fn(),
+  });
   // Clear URL params between tests
   for (const key of [...mockSearchParams.keys()]) {
     mockSearchParams.delete(key);

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -62,13 +62,12 @@ function DevicePageInner() {
   const submittingRef = useRef(false);
 
   useEffect(() => {
-    // Auth guard: do nothing while auth state is resolving.
     if (authLoading) return;
 
     const codeFromUrl = searchParams.get("user_code");
 
-    // Auth guard: redirect unauthenticated users to login, preserving the
-    // user_code in return_to so the code is not burned before authentication.
+    // Preserve user_code in return_to so the device code is not burned before
+    // the unauthenticated user reaches the consent page.
     if (!user) {
       const returnPath = codeFromUrl
         ? `/device?user_code=${encodeURIComponent(codeFromUrl)}`
@@ -77,7 +76,6 @@ function DevicePageInner() {
       return;
     }
 
-    // Authenticated: auto-verify if a valid user_code is present in the URL.
     if (codeFromUrl && codeFromUrl.length === 8) {
       setUserCode(codeFromUrl);
       verifyCode(codeFromUrl);

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -65,10 +65,11 @@ function DevicePageInner() {
     // Auth guard: do nothing while auth state is resolving.
     if (authLoading) return;
 
+    const codeFromUrl = searchParams.get("user_code");
+
     // Auth guard: redirect unauthenticated users to login, preserving the
     // user_code in return_to so the code is not burned before authentication.
     if (!user) {
-      const codeFromUrl = searchParams.get("user_code");
       const returnPath = codeFromUrl
         ? `/device?user_code=${encodeURIComponent(codeFromUrl)}`
         : "/device";
@@ -77,7 +78,6 @@ function DevicePageInner() {
     }
 
     // Authenticated: auto-verify if a valid user_code is present in the URL.
-    const codeFromUrl = searchParams.get("user_code");
     if (codeFromUrl && codeFromUrl.length === 8) {
       setUserCode(codeFromUrl);
       verifyCode(codeFromUrl);

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -188,23 +188,23 @@ function DevicePageInner() {
   // This prevents a flash of the empty input form before redirect fires.
   if (authLoading || !user) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+      <div className="flex min-h-screen items-center justify-center bg-background px-4">
         <SpinnerLoading size="lg" />
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-screen items-center justify-center bg-background px-4">
       <Card className="w-full max-w-md">
         <CardContent className="pt-8 pb-8 space-y-6">
           {phase === "success" && (
             <div className="text-center space-y-4">
               <CheckCircle2 className="mx-auto h-12 w-12 text-green-500" />
-              <h1 className="text-xl font-semibold text-gray-900">
+              <h1 className="text-xl font-semibold text-foreground">
                 {t("device.successTitle")}
               </h1>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-muted-foreground">
                 {t("device.successMessage")}
               </p>
             </div>
@@ -213,10 +213,10 @@ function DevicePageInner() {
           {phase === "denied" && (
             <div className="text-center space-y-4">
               <XCircle className="mx-auto h-12 w-12 text-red-500" />
-              <h1 className="text-xl font-semibold text-gray-900">
+              <h1 className="text-xl font-semibold text-foreground">
                 {t("device.deniedTitle")}
               </h1>
-              <p className="text-sm text-gray-600">
+              <p className="text-sm text-muted-foreground">
                 {t("device.deniedMessage")}
               </p>
               <Button variant="outline" onClick={resetToInput} className="mt-4">
@@ -229,18 +229,18 @@ function DevicePageInner() {
             phase === "verifying" ||
             phase === "error") && (
             <div className="text-center space-y-4">
-              <Monitor className="mx-auto h-10 w-10 text-gray-400" />
+              <Monitor className="mx-auto h-10 w-10 text-muted-foreground" />
               <div>
-                <h1 className="text-xl font-semibold text-gray-900">
+                <h1 className="text-xl font-semibold text-foreground">
                   {t("device.title")}
                 </h1>
-                <p className="mt-1 text-sm text-gray-600">
+                <p className="mt-1 text-sm text-muted-foreground">
                   {t("device.description")}
                 </p>
               </div>
 
               <div className="space-y-2">
-                <Label htmlFor="userCode" className="text-gray-700">
+                <Label htmlFor="userCode" className="text-foreground">
                   {t("device.codeLabel")}
                 </Label>
                 <Input
@@ -251,7 +251,7 @@ function DevicePageInner() {
                   onChange={(e) => handleCodeChange(e.target.value)}
                   onKeyDown={handleKeyDown}
                   placeholder={t("device.codePlaceholder")}
-                  className="bg-white text-gray-900 text-center text-2xl tracking-[0.3em]"
+                  className="text-center text-2xl tracking-[0.3em]"
                   autoFocus
                   autoComplete="off"
                   disabled={phase === "verifying"}
@@ -259,7 +259,9 @@ function DevicePageInner() {
               </div>
 
               {phase === "verifying" && (
-                <p className="text-sm text-gray-500">{t("device.verifying")}</p>
+                <p className="text-sm text-muted-foreground">
+                  {t("device.verifying")}
+                </p>
               )}
 
               {phase === "error" && error && (
@@ -280,27 +282,27 @@ function DevicePageInner() {
           {(phase === "consent" || phase === "submitting") && deviceInfo && (
             <div className="text-center space-y-4">
               <div>
-                <h1 className="text-xl font-semibold text-gray-900">
+                <h1 className="text-xl font-semibold text-foreground">
                   {t("device.consentTitle")}
                 </h1>
-                <p className="mt-2 text-sm text-gray-600">
+                <p className="mt-2 text-sm text-muted-foreground">
                   {t("device.consentDescription")}
                 </p>
               </div>
 
-              <p className="text-lg font-medium text-gray-900">
+              <p className="text-lg font-medium text-foreground">
                 {deviceInfo.client_name}
               </p>
 
               <div className="space-y-2">
-                <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
                   {t("device.permissionsLabel")}
                 </p>
                 {renderScopeBadges(deviceInfo.scope)}
               </div>
 
               <div className="space-y-2">
-                <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
                   {t("device.identityShareLabel")}
                 </p>
                 <div className="flex flex-wrap gap-2 justify-center">

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -5,11 +5,15 @@
  *
  * User enters an 8-character user_code displayed in their CLI, then approves
  * or denies the device authorization request on the consent screen.
+ *
+ * Auth guard: unauthenticated users are redirected to /login with a return_to
+ * param that preserves the user_code so the code is NOT burned before the user
+ * logs in. See issue #772.
  */
 
 import { useEffect, useRef, useState, Suspense } from "react";
 import { useTranslations } from "next-intl";
-import { useSearchParams } from "next/navigation";
+import { useSearchParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Alert, AlertDescription } from "@/components/ui/alert";
@@ -23,6 +27,7 @@ import {
   confirmDevice,
   type DeviceVerifyResponse,
 } from "@/lib/auth/auth";
+import { useAuth } from "@/contexts/AuthContext";
 import { AlertCircle, CheckCircle2, XCircle, Monitor } from "lucide-react";
 
 type Phase =
@@ -45,6 +50,8 @@ const SCOPE_LABEL_MAP: Record<string, string> = {
 function DevicePageInner() {
   const t = useTranslations();
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const { user, isLoading: authLoading } = useAuth();
 
   const [phase, setPhase] = useState<Phase>("input");
   const [userCode, setUserCode] = useState(searchParams.get("user_code") ?? "");
@@ -55,13 +62,28 @@ function DevicePageInner() {
   const submittingRef = useRef(false);
 
   useEffect(() => {
+    // Auth guard: do nothing while auth state is resolving.
+    if (authLoading) return;
+
+    // Auth guard: redirect unauthenticated users to login, preserving the
+    // user_code in return_to so the code is not burned before authentication.
+    if (!user) {
+      const codeFromUrl = searchParams.get("user_code");
+      const returnPath = codeFromUrl
+        ? `/device?user_code=${encodeURIComponent(codeFromUrl)}`
+        : "/device";
+      router.replace(`/login?return_to=${encodeURIComponent(returnPath)}`);
+      return;
+    }
+
+    // Authenticated: auto-verify if a valid user_code is present in the URL.
     const codeFromUrl = searchParams.get("user_code");
     if (codeFromUrl && codeFromUrl.length === 8) {
       setUserCode(codeFromUrl);
       verifyCode(codeFromUrl);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams]);
+  }, [authLoading, user, searchParams, router]);
 
   async function verifyCode(code: string) {
     if (submittingRef.current) return;
@@ -158,6 +180,16 @@ function DevicePageInner() {
               </Badge>
             );
           })}
+      </div>
+    );
+  }
+
+  // Show spinner while auth state is resolving or while redirecting unauth users.
+  // This prevents a flash of the empty input form before redirect fires.
+  if (authLoading || !user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+        <SpinnerLoading size="lg" />
       </div>
     );
   }

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -96,7 +96,11 @@ async function reachMfaForm(): Promise<HTMLInputElement> {
   fireEvent.change(passwordInput, { target: { value: "hunter2" } });
 
   // Tick the terms checkbox (sign-in button is gated on it).
-  const termsCheckbox = screen.getByRole("checkbox") as HTMLInputElement;
+  // Use name-scoped query to survive future renders that add a second checkbox
+  // (e.g. the OAuth-path terms checkbox in the same component tree).
+  const termsCheckbox = screen.getByRole("checkbox", {
+    name: /agreeToTerms/i,
+  }) as HTMLInputElement;
   fireEvent.click(termsCheckbox);
 
   // Submit password form.
@@ -182,7 +186,10 @@ async function submitPasswordLogin(): Promise<unknown[]> {
   fireEvent.change(loginIdInput, { target: { value: "user@example.com" } });
   fireEvent.change(passwordInput, { target: { value: "password123" } });
 
-  const termsCheckbox = screen.getByRole("checkbox") as HTMLInputElement;
+  // Use name-scoped query for resilience against multiple checkboxes.
+  const termsCheckbox = screen.getByRole("checkbox", {
+    name: /agreeToTerms/i,
+  }) as HTMLInputElement;
   fireEvent.click(termsCheckbox);
 
   const signInButton = screen.getByRole("button", { name: "signIn" });

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -220,4 +220,26 @@ describe("LoginPage return_to sanitisation via safeReturnTo (#772)", () => {
     const args = await submitPasswordLogin();
     expect(args[2]).toBe("/device?user_code=ABC");
   });
+
+  it("forwards a safe return_to through the MFA path to verifyMfa", async () => {
+    mockSearchParams.set("return_to", "/device?user_code=ABC");
+    mockVerifyMfa.mockResolvedValue({ redirect_url: null });
+
+    const totpInput = await reachMfaForm();
+    fireEvent.change(totpInput, { target: { value: "123456" } });
+    fireEvent.keyDown(totpInput, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockVerifyMfa).toHaveBeenCalledTimes(1);
+    });
+    expect(mockVerifyMfa).toHaveBeenCalledWith(
+      SESSION_TOKEN,
+      "123456",
+      "/device?user_code=ABC",
+    );
+    // Password handler also received the sanitised value
+    expect(mockLoginWithPassword.mock.calls[0][2]).toBe(
+      "/device?user_code=ABC",
+    );
+  });
 });

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -237,7 +237,6 @@ describe("LoginPage return_to sanitisation via safeReturnTo (#772)", () => {
       "123456",
       "/device?user_code=ABC",
     );
-    // Password handler also received the sanitised value
     expect(mockLoginWithPassword.mock.calls[0][2]).toBe(
       "/device?user_code=ABC",
     );

--- a/frontend/src/app/login/page.test.tsx
+++ b/frontend/src/app/login/page.test.tsx
@@ -59,6 +59,10 @@ beforeEach(() => {
   mockLoginWithPassword.mockReset();
   mockVerifyMfa.mockReset();
   mockPush.mockReset();
+  // Clear URL params between tests so return_to from one test doesn't bleed
+  for (const key of [...mockSearchParams.keys()]) {
+    mockSearchParams.delete(key);
+  }
 
   mockGetAuthConfig.mockResolvedValue({
     password_login_enabled: true,
@@ -73,6 +77,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 /** Drive password → MFA-required transition and return the totp Input. */
@@ -154,5 +159,58 @@ describe("LoginPage MFA form — Enter key submit (#484)", () => {
     expect(mockVerifyMfa).toHaveBeenCalledTimes(1);
 
     resolveVerify({ redirect_url: null });
+  });
+});
+
+// ---------- return_to integration — safeReturnTo validation (#772) -----------
+
+/**
+ * Drive the password login form to submission and return the call args passed
+ * to mockLoginWithPassword. The caller is responsible for setting up
+ * mockSearchParams and mockLoginWithPassword before calling this helper.
+ */
+async function submitPasswordLogin(): Promise<unknown[]> {
+  render(<LoginPage />);
+
+  const loginIdInput = (await screen.findByLabelText(
+    "loginId",
+  )) as HTMLInputElement;
+  const passwordInput = (await screen.findByLabelText(
+    "password",
+  )) as HTMLInputElement;
+
+  fireEvent.change(loginIdInput, { target: { value: "user@example.com" } });
+  fireEvent.change(passwordInput, { target: { value: "password123" } });
+
+  const termsCheckbox = screen.getByRole("checkbox") as HTMLInputElement;
+  fireEvent.click(termsCheckbox);
+
+  const signInButton = screen.getByRole("button", { name: "signIn" });
+  fireEvent.click(signInButton);
+
+  await waitFor(() => {
+    expect(mockLoginWithPassword).toHaveBeenCalledTimes(1);
+  });
+
+  return mockLoginWithPassword.mock.calls[0];
+}
+
+describe("LoginPage return_to sanitisation via safeReturnTo (#772)", () => {
+  it("strips a cross-origin return_to before passing to loginWithPassword", async () => {
+    // safeReturnTo should reject the cross-origin URL; loginWithPassword receives undefined.
+    mockSearchParams.set("return_to", "https://evil.com/x");
+    mockLoginWithPassword.mockResolvedValue({ mfa_required: false });
+
+    const args = await submitPasswordLogin();
+    // args: [loginId, password, returnTo]
+    expect(args[2]).toBeUndefined();
+  });
+
+  it("passes a safe relative return_to through to loginWithPassword", async () => {
+    mockSearchParams.set("return_to", "/device?user_code=ABC");
+    mockLoginWithPassword.mockResolvedValue({ mfa_required: false });
+
+    const args = await submitPasswordLogin();
+    expect(args[2]).toBe("/device?user_code=ABC");
   });
 });

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -26,6 +26,7 @@ import {
   verifyMfa,
   type AuthConfig,
 } from "@/lib/auth/auth";
+import { safeReturnTo } from "@/lib/auth/safeReturnTo";
 import { ArrowRight, AlertCircle, Sparkles, Shield, Zap } from "lucide-react";
 import { KaguraLogo } from "@/components/icons/KaguraLogo";
 import { LanguageSelector } from "@/components/LanguageSelector";
@@ -54,7 +55,10 @@ function LoginContent() {
   // re-renders. A ref flag is set/read atomically within the same tick.
   const submittingMfaRef = useRef(false);
 
-  const returnTo = searchParams.get("return_to") ?? undefined;
+  const returnTo = safeReturnTo(
+    searchParams.get("return_to"),
+    typeof window !== "undefined" ? window.location.origin : "",
+  );
 
   const isMockAuth =
     process.env.NODE_ENV === "development" &&

--- a/frontend/src/lib/auth/safeReturnTo.test.ts
+++ b/frontend/src/lib/auth/safeReturnTo.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for safeReturnTo — CWE-601 open-redirect defense (#772).
+ *
+ * safeReturnTo is a pure function with an explicit `currentOrigin` parameter,
+ * so no DOM is required.
+ */
+
+import { describe, expect, it } from "vitest";
+import { safeReturnTo } from "./safeReturnTo";
+
+const ORIGIN = "https://memory.kagura-ai.com";
+
+describe("safeReturnTo", () => {
+  // -------------------------------------------------------------------------
+  // Accept cases — same-origin relative paths
+  // -------------------------------------------------------------------------
+
+  describe("accept — relative paths", () => {
+    it("accepts a path with query string", () => {
+      expect(safeReturnTo("/device?user_code=ABC123", ORIGIN)).toBe(
+        "/device?user_code=ABC123",
+      );
+    });
+
+    it("accepts root path /", () => {
+      expect(safeReturnTo("/", ORIGIN)).toBe("/");
+    });
+
+    it("accepts a nested path with query params", () => {
+      expect(safeReturnTo("/foo/bar?x=1", ORIGIN)).toBe("/foo/bar?x=1");
+    });
+
+    it("trims leading/trailing whitespace from a relative path", () => {
+      expect(safeReturnTo("  /dashboard  ", ORIGIN)).toBe("/dashboard");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Accept cases — same-origin absolute URLs
+  // -------------------------------------------------------------------------
+
+  describe("accept — same-origin absolute URL", () => {
+    it("accepts an https absolute URL whose origin matches", () => {
+      expect(safeReturnTo(`${ORIGIN}/device?user_code=ABC`, ORIGIN)).toBe(
+        `${ORIGIN}/device?user_code=ABC`,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reject cases — null / undefined / empty
+  // -------------------------------------------------------------------------
+
+  describe("reject — null / undefined / empty inputs", () => {
+    it("rejects null", () => {
+      expect(safeReturnTo(null, ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects undefined", () => {
+      expect(safeReturnTo(undefined, ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects empty string", () => {
+      expect(safeReturnTo("", ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects whitespace-only string", () => {
+      expect(safeReturnTo("   ", ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects tab/newline-only string", () => {
+      expect(safeReturnTo("\t\n", ORIGIN)).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reject cases — protocol-relative and cross-origin
+  // -------------------------------------------------------------------------
+
+  describe("reject — protocol-relative and cross-origin", () => {
+    it("rejects protocol-relative URL //evil.com/x", () => {
+      expect(safeReturnTo("//evil.com/x", ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects cross-origin https URL", () => {
+      expect(safeReturnTo("https://evil.com/x", ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects cross-origin http URL", () => {
+      expect(safeReturnTo("http://evil.com", ORIGIN)).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reject cases — dangerous schemes
+  // -------------------------------------------------------------------------
+
+  describe("reject — dangerous non-http(s) schemes", () => {
+    it("rejects javascript: scheme", () => {
+      expect(safeReturnTo("javascript:alert(1)", ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects data: URI", () => {
+      expect(
+        safeReturnTo("data:text/html,<script>alert(1)</script>", ORIGIN),
+      ).toBeUndefined();
+    });
+
+    it("rejects vbscript: scheme", () => {
+      expect(safeReturnTo("vbscript:msgbox(1)", ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects file: scheme", () => {
+      expect(safeReturnTo("file:///etc/passwd", ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects uppercase HTTP:// scheme (not a canonical accepted prefix)", () => {
+      // The implementation uses startsWith("http://") / startsWith("https://")
+      // (lowercase), so uppercase schemes fall through to undefined.
+      expect(
+        safeReturnTo(`HTTP://${ORIGIN.replace("https://", "")}/device`, ORIGIN),
+      ).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Reject cases — relative paths without leading slash
+  // -------------------------------------------------------------------------
+
+  describe("reject — relative paths without leading slash", () => {
+    it("rejects bare relative path without leading slash", () => {
+      expect(safeReturnTo("dashboard", ORIGIN)).toBeUndefined();
+    });
+
+    it("rejects relative traversal path without leading slash", () => {
+      expect(safeReturnTo("../foo", ORIGIN)).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SSR mode — currentOrigin = ""
+  // -------------------------------------------------------------------------
+
+  describe("SSR mode (currentOrigin = '')", () => {
+    it("accepts relative paths when currentOrigin is empty (SSR)", () => {
+      expect(safeReturnTo("/foo", "")).toBe("/foo");
+    });
+
+    it("rejects absolute URLs when currentOrigin is empty (origin mismatch)", () => {
+      expect(safeReturnTo(`${ORIGIN}/foo`, "")).toBeUndefined();
+    });
+
+    it("rejects empty string even in SSR mode", () => {
+      expect(safeReturnTo("", "")).toBeUndefined();
+    });
+  });
+});

--- a/frontend/src/lib/auth/safeReturnTo.ts
+++ b/frontend/src/lib/auth/safeReturnTo.ts
@@ -1,0 +1,45 @@
+/**
+ * CWE-601 open-redirect defense for `return_to` query parameters.
+ *
+ * Accepts only:
+ *   (a) Relative paths starting with a single `/` (not `//`, not empty)
+ *   (b) Absolute URLs whose origin matches `currentOrigin` and whose
+ *       protocol is `http:` or `https:`
+ *
+ * All other values — including `javascript:`, `data:`, and cross-origin
+ * absolute URLs — are rejected and return `undefined`.
+ *
+ * @param value        The raw `return_to` query-parameter value.
+ * @param currentOrigin  `window.location.origin` at the call site (passed
+ *                       explicitly so this function is testable without a DOM).
+ * @returns The validated value, or `undefined` if unsafe.
+ */
+export function safeReturnTo(
+  value: string | null | undefined,
+  currentOrigin: string,
+): string | undefined {
+  if (!value) return undefined;
+
+  // (a) Relative path: must start with exactly one `/`, not `//`.
+  // A path like `/redirect?to=https://evil.com` is safe — the browser treats
+  // the whole string as a same-site path; what the backend does with inner
+  // query params is a separate concern.
+  if (value.startsWith("/")) {
+    if (value.startsWith("//")) return undefined; // protocol-relative
+    return value;
+  }
+
+  // (b) Absolute URL: must be same-origin and http(s)
+  try {
+    const parsed = new URL(value, currentOrigin);
+    if (
+      parsed.origin === currentOrigin &&
+      (parsed.protocol === "http:" || parsed.protocol === "https:")
+    ) {
+      return value;
+    }
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/frontend/src/lib/auth/safeReturnTo.ts
+++ b/frontend/src/lib/auth/safeReturnTo.ts
@@ -12,31 +12,40 @@
  * @param value        The raw `return_to` query-parameter value.
  * @param currentOrigin  `window.location.origin` at the call site (passed
  *                       explicitly so this function is testable without a DOM).
+ *                       Pass `""` in SSR; absolute-URL inputs will always be
+ *                       rejected in that case.
  * @returns The validated value, or `undefined` if unsafe.
  */
 export function safeReturnTo(
   value: string | null | undefined,
   currentOrigin: string,
 ): string | undefined {
-  if (!value) return undefined;
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return undefined;
 
   // (a) Relative path: must start with exactly one `/`, not `//`.
   // A path like `/redirect?to=https://evil.com` is safe — the browser treats
   // the whole string as a same-site path; what the backend does with inner
   // query params is a separate concern.
-  if (value.startsWith("/")) {
-    if (value.startsWith("//")) return undefined; // protocol-relative
-    return value;
+  if (trimmed.startsWith("/")) {
+    if (trimmed.startsWith("//")) return undefined; // protocol-relative
+    return trimmed;
   }
 
-  // (b) Absolute URL: must be same-origin and http(s)
+  // (b) Absolute URL: must be explicitly http(s), same-origin.
+  // Non-/-prefixed relative paths (e.g. "dashboard") are rejected here —
+  // they don't start with "/" (branch above) and don't carry an explicit
+  // scheme, so they fall through to the undefined return below.
+  if (!trimmed.startsWith("http://") && !trimmed.startsWith("https://")) {
+    return undefined;
+  }
   try {
-    const parsed = new URL(value, currentOrigin);
+    const parsed = new URL(trimmed);
     if (
       parsed.origin === currentOrigin &&
       (parsed.protocol === "http:" || parsed.protocol === "https:")
     ) {
-      return value;
+      return trimmed;
     }
     return undefined;
   } catch {


### PR DESCRIPTION
Partially addresses #772

## Summary
- Adds page-level auth guard on `/device` (`frontend/src/app/device/page.tsx`) — unauthenticated users hitting `/device?user_code=XXXX` now redirect to `/login?return_to=...` BEFORE `verifyDeviceCode` fires, preventing the user_code from being burned in an unauth session.
- Adds `safeReturnTo` helper (`frontend/src/lib/auth/safeReturnTo.ts`, NEW) for CWE-601 open-redirect defense. `/login/page.tsx` now sanitises `return_to` to accept only same-origin relative paths or absolute URLs, rejecting `javascript:`, `data:`, `vbscript:`, `file:`, protocol-relative (`//`), and cross-origin URLs.
- Migrates `/device/page.tsx` from hardcoded Tailwind grays (`bg-gray-50`, `text-gray-900/600/500/400`) to semantic tokens (`bg-background`, `text-foreground`, `text-muted-foreground`) — fixes invisible-text-in-dark-mode bug (`text-gray-900` on `bg-card` flipping near-black via `.dark { --card: 0 0% 3.9% }`).
- 44/44 tests pass: 4 auth guard + 23 safeReturnTo (incl. SSR-mode, dangerous-scheme rejection, whitespace trimming, bare-relative rejection) + 3 return_to integration (loginWithPassword + verifyMfa).

## Implementation notes
- `/device` is intentionally OUTSIDE the `(authenticated)/` route group (must be reachable by unauth users to trigger the login flow). Auth gate is page-level via `useAuth()`, not layout-based. Pattern matches the codebase's existing `(authenticated)/layout.tsx` guard, adapted for a single-page case.
- `safeReturnTo` is a pure function with explicit `currentOrigin` parameter — testable without a DOM, SSR-safe (passes `""` in SSR; absolute URLs always rejected in that mode by design).
- `useEffect` ordering fixed: auth check + redirect happens BEFORE any `verifyDeviceCode` call. Spinner rendered while `authLoading` or during redirect-in-flight to prevent form flash.
- Brand-green Approve button gradient and `text-red-500` / `text-green-500` status icons preserved (intentional accents, not gray-scale).
- All commits Conventional Commits with `(#772)` suffix; bisect-friendly atomic split (auth guard → test mocks → return_to validation → safeReturnTo refinement → semantic tokens → tests → hardening → MFA test).

## Deferred follow-ups (will file as separate issues post-merge)
1. Backend audit log of unauth `/device` hits (observability enhancement; requires new endpoint + alembic migration — scope creep for this fix)
2. Lighthouse/axe-core contrast automation in CI (regression prevention covering all auth-flow pages, not just `/device`)
3. `/login` + `/invite/[token]` semantic token migration (same pattern as `/device`, deferred to keep this PR's scope tight)
4. OAuth path (Google/GitHub) `return_to` integration tests (safeReturnTo unit-tested in 23 cases; OAuth integration smoke deferred)
5. Optional: `getClientOrigin()` shared helper (6+ files duplicate `typeof window !== "undefined" ? window.location.origin : ""`)

## Pre-PR review summary
- gate2 mode: advisor-only (gate2.binary_gate=null)
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask, escalated to /ceo (CSO + CDO + CTO synthesis — 4 must-fix items all addressed in this PR)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/772-fix-fix-device-flow-device-page-assumes-logg.gate1.md
- ~/.claude/cache/gh-issue-driven/772-fix-fix-device-flow-device-page-assumes-logg.gate2.md

🤖 Generated via /gh-issue-driven:ship
