### PR TITLE
test(a11y): Playwright + axe-core scaffold + /login color-contrast (#780)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -263,3 +263,8 @@ backend/uv.lock
 .playwright-mcp/
 .superpowers/
 docs/superpowers/
+
+# Playwright (#780)
+frontend/test-results/
+frontend/playwright-report/
+frontend/blob-report/

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,0 +1,24 @@
+# Frontend a11y / e2e tests (Playwright + axe-core)
+
+Issue #780 introduced this directory with a single color-contrast spec for `/login`.
+Run locally:
+
+```bash
+cd frontend
+npx playwright install chromium  # first time only
+npm run test:e2e
+```
+
+`npm run test:e2e` auto-starts `next dev` on :3000 via the `webServer` block in
+`playwright.config.ts`. If you already have a dev server running, the existing
+process is reused (`reuseExistingServer: !process.env.CI`).
+
+## Adding a new page
+
+Drop a new spec into `e2e/a11y/<page>-contrast.spec.ts` following the
+`login-contrast.spec.ts` shape — `await page.goto("/<path>")` then
+`await new AxeBuilder({ page }).options({ runOnly: ["color-contrast"] }).analyze()`.
+
+## CI
+
+Not yet wired into `.github/workflows/ci.yml` — tracked as a follow-up.

--- a/frontend/e2e/a11y/login-contrast.spec.ts
+++ b/frontend/e2e/a11y/login-contrast.spec.ts
@@ -28,15 +28,25 @@ async function assertNoColorContrastViolations(
 test.describe("/login color-contrast (#780 scaffold)", () => {
   test("light mode has no color-contrast violations", async ({ page }) => {
     await page.emulateMedia({ colorScheme: "light" });
-    await page.goto("/login");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/login", { waitUntil: "domcontentloaded" });
+    // `networkidle` is unreliable against `next dev` because the HMR websocket
+    // keeps the network busy indefinitely. Wait on a stable DOM signal instead.
+    await page.locator("h1, form, main button").first().waitFor({
+      state: "visible",
+      timeout: 15_000,
+    });
     await assertNoColorContrastViolations(page);
   });
 
   test("dark mode has no color-contrast violations", async ({ page }) => {
     await page.emulateMedia({ colorScheme: "dark" });
-    await page.goto("/login");
-    await page.waitForLoadState("networkidle");
+    await page.goto("/login", { waitUntil: "domcontentloaded" });
+    // `networkidle` is unreliable against `next dev` because the HMR websocket
+    // keeps the network busy indefinitely. Wait on a stable DOM signal instead.
+    await page.locator("h1, form, main button").first().waitFor({
+      state: "visible",
+      timeout: 15_000,
+    });
     await assertNoColorContrastViolations(page);
   });
 });

--- a/frontend/e2e/a11y/login-contrast.spec.ts
+++ b/frontend/e2e/a11y/login-contrast.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/**
+ * Color-contrast a11y guard for /login (Issue #780 scaffold).
+ *
+ * Covers WCAG 2.1 AA color-contrast (1.4.3) in both light and dark mode via
+ * prefers-color-scheme emulation. /login is a deliberate scaffold target
+ * because it is always reachable without auth and exercises both the password
+ * form and OAuth button surfaces.
+ *
+ * Broader coverage (/device, /invite/[token], /workspace/dashboard) is tracked
+ * as a follow-up.
+ */
+async function assertNoColorContrastViolations(
+  page: import("@playwright/test").Page,
+) {
+  const results = await new AxeBuilder({ page })
+    .options({ runOnly: ["color-contrast"] })
+    .analyze();
+
+  expect(
+    results.violations,
+    JSON.stringify(results.violations, null, 2),
+  ).toEqual([]);
+}
+
+test.describe("/login color-contrast (#780 scaffold)", () => {
+  test("light mode has no color-contrast violations", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "light" });
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+    await assertNoColorContrastViolations(page);
+  });
+
+  test("dark mode has no color-contrast violations", async ({ page }) => {
+    await page.emulateMedia({ colorScheme: "dark" });
+    await page.goto("/login");
+    await page.waitForLoadState("networkidle");
+    await assertNoColorContrastViolations(page);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -46,6 +46,8 @@
         "zod": "^4.1.12"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.11.3",
+        "@playwright/test": "^1.60.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/d3-drag": "^3.0.7",
@@ -149,6 +151,19 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.11.3.tgz",
+      "integrity": "sha512-h/kfksv4F0cVIDlKpT4700OehdRgpvuVskuQ2nb7/JmtWUXpe9ftHAPtwyXGvVSsa6SJ64A9ER7Zrzc/sIvC4w==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.11.4"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -2434,6 +2449,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -6382,9 +6413,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-      "integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -10156,6 +10187,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/po-parser": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,8 @@
     "lint": "echo 'No linter configured (next lint removed in Next.js 16)'",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:cov": "vitest run --coverage"
+    "test:cov": "vitest run --coverage",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -57,6 +58,8 @@
     "zod": "^4.1.12"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.11.3",
+    "@playwright/test": "^1.60.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/d3-drag": "^3.0.7",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * Playwright config for a11y / e2e tests (Issue #780).
+ *
+ * Currently scoped to color-contrast checks via @axe-core/playwright. Local
+ * runs auto-start `next dev` on :3000. CI integration is a follow-up.
+ *
+ * To add coverage for more pages, drop new specs into `e2e/a11y/`.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: "npm run dev",
+    url: "http://localhost:3000",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "pipe",
+    stderr: "pipe",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { browserName: "chromium" },
+    },
+  ],
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "e2e"
   ]
 }


### PR DESCRIPTION
## Summary
- Introduce Playwright + `@axe-core/playwright` as devDependencies, scoped to color-contrast a11y checks.
- Add `frontend/playwright.config.ts` with `webServer` auto-start of `next dev` (both stdout + stderr piped for diagnosability).
- Add `frontend/e2e/a11y/login-contrast.spec.ts` — light + dark mode color-contrast on `/login`.
- Add `npm run test:e2e` script and `frontend/e2e/README.md` local-run instructions.
- Add `"e2e"` to `frontend/tsconfig.json` exclude so Next.js's `tsc --noEmit` doesn't try to compile Playwright specs.
- Update `.gitignore` to exclude Playwright artifacts (`test-results/`, `playwright-report/`, `blob-report/`).

## Out of scope (filed as follow-ups)
- Extending coverage to `/device`, `/invite/[token]`, `/workspace/dashboard` — needs auth fixtures. (Issue #785)
- Wiring the a11y job into `.github/workflows/ci.yml` as a Required check. (Issue #786)

## Test plan
- [x] `cd frontend && npm run test:e2e` — 2 tests PASS (light + dark mode)
- [x] Mutation check: forcing low-contrast text on `/login` via `* { color/background !important }` causes both mode tests to FAIL with contrast ratio 1.18
- [x] Reverting the mutation restores both tests to PASS

Closes #780

🤖 Generated with [Claude Code](https://claude.com/claude-code)