### PR TITLE
refactor(db): drop redundant ix_oauth_device_codes_* indexes (#737)

### DIFF
--- a/backend/alembic/versions/e19_737_drop_oauth_device_code_redundant_ix.py
+++ b/backend/alembic/versions/e19_737_drop_oauth_device_code_redundant_ix.py
@@ -1,0 +1,60 @@
+"""Drop redundant non-unique indexes on oauth_device_codes (Issue #737).
+
+The ``unique=True`` declarations on ``device_code`` and ``user_code`` already
+materialize auto-managed unique backing indexes (``*_key``). The pair of
+non-unique ``ix_*`` indexes installed by ``d08_536_device_code_grant.py``
+duplicates that coverage and gets no traffic — pure write-amplification
+waste. This migration removes them; the ORM-side ``Index(...)`` mirror
+lines in ``OAuth2DeviceCode.__table_args__`` are removed in the same PR
+to keep ``create_all`` byte-parity with alembic head.
+
+Revision ID: e19_737_drop_redundant_ix
+Revises: e18_616_drop_pg_inline
+Create Date: 2026-05-22
+
+Note: revision ID shortened from ``e19_737_drop_oauth_device_code_redundant_ix``
+(43 chars) to ``e19_737_drop_redundant_ix`` (25 chars) to fit the
+``alembic_version.version_num`` ``VARCHAR(32)`` column. The filename keeps
+the longer descriptive form for grep-ability.
+"""
+
+from alembic import op
+
+
+revision = "e19_737_drop_redundant_ix"
+down_revision = "e18_616_drop_pg_inline"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Drop both redundant non-unique indexes.
+
+    The unique backing indexes (``oauth_device_codes_device_code_key`` and
+    ``oauth_device_codes_user_code_key``) remain in place and continue
+    covering every equality lookup these dropped indexes were serving.
+    """
+    op.drop_index(
+        "ix_oauth_device_codes_device_code",
+        table_name="oauth_device_codes",
+    )
+    op.drop_index(
+        "ix_oauth_device_codes_user_code",
+        table_name="oauth_device_codes",
+    )
+
+
+def downgrade() -> None:
+    """Re-create the two indexes with their original non-unique semantics."""
+    op.create_index(
+        "ix_oauth_device_codes_device_code",
+        "oauth_device_codes",
+        ["device_code"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_oauth_device_codes_user_code",
+        "oauth_device_codes",
+        ["user_code"],
+        unique=False,
+    )

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -844,16 +844,6 @@ class OAuth2DeviceCode(Base):
 
     client: Mapped["OAuth2Client"] = relationship("OAuth2Client")
 
-    # Redundant secondary indexes from migration d08_536: the UK auto-indexes
-    # from ``unique=True`` already cover equality lookups, but production has
-    # them as separate objects so the ORM mirrors them for create_all parity.
-    # TODO(#737): drop both ``ix_*`` indexes in one migration and remove
-    # these two lines.
-    __table_args__ = (
-        Index("ix_oauth_device_codes_device_code", "device_code"),
-        Index("ix_oauth_device_codes_user_code", "user_code"),
-    )
-
     def __repr__(self) -> str:
         return f"<OAuth2DeviceCode(device_code='{self.device_code[:8]}...', client='{self.client_id}')>"
 

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -817,11 +817,6 @@ class OAuth2DeviceCode(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
 
-    # ``unique=True`` produces the UK constraint that alembic creates. The
-    # non-unique ``ix_oauth_device_codes_<column>`` indexes are declared in
-    # ``__table_args__`` below — combining ``index=True`` with ``unique=True``
-    # here would collapse both into one unique index, but production has two
-    # separate objects.
     device_code: Mapped[str] = mapped_column(String(255), nullable=False, unique=True)
     user_code: Mapped[str] = mapped_column(String(8), nullable=False, unique=True)
     client_id: Mapped[str] = mapped_column(


### PR DESCRIPTION
## Summary
- New alembic migration `e19_737_drop_oauth_device_code_redundant_ix.py` (revision `e19_737_drop_redundant_ix`, shortened to fit VARCHAR(32)) drops both `ix_oauth_device_codes_device_code` and `ix_oauth_device_codes_user_code`. The unique backing indexes (`*_key`) from `unique=True` cover the same access patterns.
- Removes the mirror `Index(...)` decls + TODO comment block from `OAuth2DeviceCode.__table_args__`. `__table_args__` becomes unnecessary and is deleted entirely.
- Removes a separately-located stale inline comment that still referenced the deleted `__table_args__` (post-deletion the comment's "production has two separate objects" claim was no longer true).
- Downgrade re-creates the two indexes as non-unique to preserve reversibility.

## Test plan
- [x] `alembic upgrade head` → 5 indexes remain on `oauth_device_codes` (pkey + 2× `_key` + `ix_*` for `client_id`/`expires_at` which are out of scope).
- [x] `alembic downgrade -1 && alembic upgrade head` round-trip is idempotent.
- [x] `test_create_all_vs_alembic_drift.py` green (was FAILING with `ix_oauth_device_codes_device_code.index.create_all_only` until the ORM cleanup landed).
- [x] Device-flow regression tests (41 tests across `tests/auth/test_device_code_*.py`, `tests/api/test_device_code_endpoints.py`) green.
- [x] `ruff check src/` clean.
- [x] `pyright src/models/auth.py` clean (0 errors).

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)