### PR TITLE
refactor(neural): deprecate edge_type values overlapping with origin (#741)

### DIFF
--- a/backend/alembic/versions/e20_741_deprecate_edge_type.py
+++ b/backend/alembic/versions/e20_741_deprecate_edge_type.py
@@ -1,0 +1,161 @@
+"""Deprecate edge_type values that overlap with origin (Issue #741).
+
+After #722 added the ``origin`` discriminator, three ``edge_type`` values
+duplicated provenance information that should live exclusively on ``origin``:
+
+* ``semantic_similarity`` — k-NN cold-start seeded edges (#221).
+* ``declared_link``       — user-asserted edges (#215).
+* ``tag_cooccurrence``    — tag-based discovery (#223).
+
+### Pre-flight finding
+
+The #722 origin-backfill ran ``server_default='hebbian'`` and did NOT
+classify existing rows by their pre-#722 edge_type. As a result, prod
+contains misclassified rows: every pre-#741 ``semantic_similarity`` /
+``declared_link`` / ``tag_cooccurrence`` edge carries ``origin='hebbian'``
+— wrong on the origin axis. Without correction the post-#741 merge would
+silently drop the provenance discrimination.
+
+### Phases
+
+* **Phase 0 — backfill**: align ``origin`` (and ``edge_metadata`` for
+  ``tag_cooccurrence``) to the post-#741 discriminator shape, BEFORE the
+  edge_type collapse. After this phase a downstream consumer that reads
+  ``origin`` or ``edge_metadata['source']`` instead of ``edge_type``
+  retains the same classification semantics the pre-#741 caller had.
+* **Phase 1 — edge_type merge**: collapse the 3 deprecated values into
+  ``neural_association``. Information loss is zero because Phase 0
+  preserved the provenance.
+* **Phase 2 — CHECK constraint shrink**: drop+recreate the
+  ``valid_edge_type`` CHECK to accept only the 4 surviving values.
+
+### Reversibility
+
+``downgrade()`` re-widens the CHECK to accept the 3 deprecated values, but
+does NOT split rows back — Phase 0 + Phase 1's UPDATEs are lossy at the
+edge_type column level (the original column value is gone). Callers that
+need the legacy edge_type strings post-downgrade should read ``origin``
+('semantic' for the former 'semantic_similarity', 'declared' for the
+former 'declared_link') or ``edge_metadata['source']``.
+
+Revision ID: e20_741_deprecate_edge_type
+Revises: e19_737_drop_redundant_ix
+Create Date: 2026-05-23
+"""
+
+from alembic import op
+
+
+revision = "e20_741_deprecate_edge_type"
+down_revision = "e19_737_drop_redundant_ix"
+branch_labels = None
+depends_on = None
+
+
+_NEW_CHECK_SQL = "edge_type IN ('neural_association', 'related_to', 'depends_on', 'learned_from')"
+
+_OLD_CHECK_SQL = (
+    "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+    "'learned_from', 'semantic_similarity', 'declared_link', "
+    "'tag_cooccurrence')"
+)
+
+
+def upgrade() -> None:
+    """Backfill origin/metadata, merge edge_type, shrink CHECK."""
+    # Phase 0: backfill misclassified origin (and metadata for tag_cooccurrence).
+    # The #722 backfill used server_default='hebbian' and did not classify by
+    # pre-#722 edge_type. Without these UPDATEs, the Phase 1 merge would
+    # silently drop the provenance discrimination.
+    #
+    # The WHERE clause is idempotent: rows already at the target origin are
+    # untouched, so re-running this migration is a no-op (assuming Phase 1
+    # hasn't yet collapsed edge_type).
+    op.execute(
+        """
+        UPDATE neural_memory_edges
+           SET origin = 'semantic'
+         WHERE edge_type = 'semantic_similarity'
+           AND origin <> 'semantic'
+        """
+    )
+    op.execute(
+        """
+        UPDATE neural_memory_edges
+           SET origin = 'declared'
+         WHERE edge_type = 'declared_link'
+           AND origin <> 'declared'
+        """
+    )
+    # tag_cooccurrence does not have a dedicated origin value (intentional —
+    # adding EDGE_ORIGIN_TAG is out of scope per #741 issue body). Preserve
+    # the discriminator via ``edge_metadata['source']`` so post-#741 readers
+    # can still distinguish tag-derived edges from generic hebbian co-
+    # activation traces.
+    #
+    # NOTE on column type: ``neural_memory_edges.metadata`` is declared
+    # ``JSON`` (not ``JSONB``) in the ORM and in the live DB. The ``||``
+    # merge operator is only defined for ``jsonb``, and reading
+    # ``metadata->>'source'`` is also unambiguous only on jsonb. We cast
+    # to jsonb for the read+merge, then back to json for storage. The
+    # CASE expression handles the NULL-metadata case (current prod state
+    # per pre-flight check) without relying on COALESCE-coerces-NULL,
+    # which postgres refuses across json/jsonb.
+    op.execute(
+        """
+        UPDATE neural_memory_edges
+           SET metadata = (
+                CASE
+                  WHEN metadata IS NULL
+                    THEN '{"source": "tag_cooccurrence"}'::json
+                  ELSE (metadata::jsonb || '{"source": "tag_cooccurrence"}'::jsonb)::json
+                END
+           )
+         WHERE edge_type = 'tag_cooccurrence'
+           AND (
+                metadata IS NULL
+             OR (metadata::jsonb ->> 'source') IS DISTINCT FROM 'tag_cooccurrence'
+           )
+        """
+    )
+
+    # Phase 1: collapse 3 deprecated edge_type values into neural_association.
+    # Phase 0 preserved the discriminating info, so this UPDATE is information-
+    # lossless at the (edge_type, origin, edge_metadata) tuple level.
+    op.execute(
+        """
+        UPDATE neural_memory_edges
+           SET edge_type = 'neural_association'
+         WHERE edge_type IN (
+            'semantic_similarity',
+            'declared_link',
+            'tag_cooccurrence'
+         )
+        """
+    )
+
+    # Phase 2: replace the valid_edge_type CHECK constraint with the 4-value
+    # version. The ORM-side CheckConstraint at models/memory.py is derived
+    # from _ALL_EDGE_TYPES via f-string and already produces the new string.
+    op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        _NEW_CHECK_SQL,
+    )
+
+
+def downgrade() -> None:
+    """Re-widen the CHECK to accept the 3 deprecated values.
+
+    Note: this is NOT a true reversal. The forward UPDATEs in Phase 0 and
+    Phase 1 are lossy at the edge_type column level. Callers that depended
+    on the legacy edge_type strings post-downgrade must read ``origin``
+    (or ``edge_metadata['source']`` for tag_cooccurrence) instead.
+    """
+    op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        _OLD_CHECK_SQL,
+    )

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -32,9 +32,16 @@ from models.memory import (
 
 # Issue #461 / #741: full set of edge_types accepted by the DB CHECK constraint
 # (`models/memory.py::valid_edge_type`). Sourced from `EDGE_TYPE_*` constants
-# so this set cannot drift from the schema literal. Covers the LLM-emittable
-# neural type (#374 → see `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`)
-# plus the three client-declared semantic types.
+# so this set cannot drift from the schema literal. The 4 surviving values
+# after #741 are:
+#   - neural_association: runtime Hebbian co-activation, or the post-#741
+#     catch-all for any provenance not expressible as a relation
+#     (tag_cooccurrence + semantic_similarity merged here).
+#   - related_to / depends_on / learned_from: LLM-emittable relation types
+#     (#374 → see `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`).
+# Provenance for what was previously edge_type='semantic_similarity' /
+# 'declared_link' / 'tag_cooccurrence' now lives on `origin` and
+# `edge_metadata['source']` (see migration `e20_741` docstring).
 VALID_EDGE_TYPES = frozenset(
     {
         EDGE_TYPE_NEURAL_ASSOCIATION,

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -24,30 +24,23 @@ from mcp_server.tools._helpers import (
 )
 from models.memory import (
     EDGE_ORIGIN_DECLARED,
-    EDGE_TYPE_DECLARED_LINK,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_RELATED_TO,
-    EDGE_TYPE_SEMANTIC_SIMILARITY,
-    EDGE_TYPE_TAG_COOCCURRENCE,
 )
 
-# Issue #461: full set of edge_types accepted by the DB CHECK constraint
+# Issue #461 / #741: full set of edge_types accepted by the DB CHECK constraint
 # (`models/memory.py::valid_edge_type`). Sourced from `EDGE_TYPE_*` constants
-# so this set cannot drift from the schema literal. Includes both LLM-emittable
-# types (#374 → see `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`)
-# and synthetic seeding types (#221 `semantic_similarity`, #223 `tag_cooccurrence`)
-# plus client-declared links (#215 `declared_link`).
+# so this set cannot drift from the schema literal. Covers the LLM-emittable
+# neural type (#374 → see `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`)
+# plus the three client-declared semantic types.
 VALID_EDGE_TYPES = frozenset(
     {
         EDGE_TYPE_NEURAL_ASSOCIATION,
         EDGE_TYPE_RELATED_TO,
         EDGE_TYPE_DEPENDS_ON,
         EDGE_TYPE_LEARNED_FROM,
-        EDGE_TYPE_SEMANTIC_SIMILARITY,
-        EDGE_TYPE_DECLARED_LINK,
-        EDGE_TYPE_TAG_COOCCURRENCE,
     }
 )
 

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -317,9 +317,6 @@ EDGE_TYPE_NEURAL_ASSOCIATION = "neural_association"
 EDGE_TYPE_RELATED_TO = "related_to"
 EDGE_TYPE_DEPENDS_ON = "depends_on"
 EDGE_TYPE_LEARNED_FROM = "learned_from"
-EDGE_TYPE_SEMANTIC_SIMILARITY = "semantic_similarity"
-EDGE_TYPE_DECLARED_LINK = "declared_link"
-EDGE_TYPE_TAG_COOCCURRENCE = "tag_cooccurrence"
 
 # Issue #509 (Phase B of #461): registration-order tuple used to derive the
 # ``valid_edge_type`` CHECK constraint string in ``NeuralMemoryEdge.__table_args__``.
@@ -333,9 +330,6 @@ _ALL_EDGE_TYPES: tuple[str, ...] = (
     EDGE_TYPE_RELATED_TO,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
-    EDGE_TYPE_SEMANTIC_SIMILARITY,
-    EDGE_TYPE_DECLARED_LINK,
-    EDGE_TYPE_TAG_COOCCURRENCE,
 )
 
 # Edge origin discriminator (Issue #722).

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -16,7 +16,8 @@ from typing import Any, cast
 from uuid import UUID
 
 from sqlalchemy import and_, case, delete, desc, func, or_, select
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import cast as sa_cast
+from sqlalchemy.dialects.postgresql import JSONB, insert
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -474,6 +475,7 @@ class NeuralEdgeRepository:
         context_id: str | None = None,
         *,
         origin: str | None = None,
+        metadata_source: str | None = None,
     ) -> list[NeuralMemoryEdge]:
         """Get outgoing edges from a node with 3-level isolation.
 
@@ -499,6 +501,16 @@ class NeuralEdgeRepository:
                 to fetch user-asserted links, etc. Mirrors the post-#741 pivot
                 where edge_type='declared_link' is replaced by
                 origin='declared'.
+            metadata_source: Optional filter on ``edge_metadata['source']``
+                (#741). Pushed into SQL via ``metadata::jsonb ->> 'source'``
+                so high-degree nodes (many co-activation edges) don't pull
+                thousands of rows into Python just to scan for a metadata
+                marker. Used by the tag-cooccurrence idempotency guard which
+                pairs ``origin=EDGE_ORIGIN_HEBBIAN`` +
+                ``metadata_source='tag_cooccurrence'`` + ``limit=1`` for an
+                O(1) early-out. ``edge_metadata`` is stored as ``JSON``
+                rather than ``JSONB`` (see ``models/memory.py``), so the
+                cast is applied here at query time.
 
         Returns:
             List of outgoing edges sorted by weight descending
@@ -524,6 +536,14 @@ class NeuralEdgeRepository:
 
         if origin is not None:
             conditions.append(NeuralMemoryEdge.origin == origin)
+
+        if metadata_source is not None:
+            # JSON → JSONB cast at query time so we can use the ->> operator
+            # via SQLAlchemy's astext accessor. Equivalent SQL:
+            #   metadata::jsonb ->> 'source' = :metadata_source
+            conditions.append(
+                sa_cast(NeuralMemoryEdge.edge_metadata, JSONB)["source"].astext == metadata_source
+            )
 
         stmt = (
             select(NeuralMemoryEdge)
@@ -551,6 +571,7 @@ class NeuralEdgeRepository:
         context_id: str | None = None,
         *,
         origin: str | None = None,
+        metadata_source: str | None = None,
     ) -> list[NeuralMemoryEdge]:
         """Get incoming edges to a node with 3-level isolation.
 
@@ -574,6 +595,10 @@ class NeuralEdgeRepository:
             context_id: Context ID (for isolation)
             origin: Optional origin filter (#741). Mirrors the kwarg on
                 ``get_outgoing_edges``.
+            metadata_source: Optional filter on ``edge_metadata['source']``
+                (#741). Mirrors the kwarg on ``get_outgoing_edges`` for
+                symmetry; same SQL-level ``metadata::jsonb ->> 'source'``
+                push-down semantics apply.
 
         Returns:
             List of incoming edges sorted by weight descending
@@ -599,6 +624,12 @@ class NeuralEdgeRepository:
 
         if origin is not None:
             conditions.append(NeuralMemoryEdge.origin == origin)
+
+        if metadata_source is not None:
+            # See get_outgoing_edges() for the JSON→JSONB cast rationale.
+            conditions.append(
+                sa_cast(NeuralMemoryEdge.edge_metadata, JSONB)["source"].astext == metadata_source
+            )
 
         stmt = (
             select(NeuralMemoryEdge)

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -21,9 +21,9 @@ from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.memory import (
+    EDGE_ORIGIN_DECLARED,
     EDGE_ORIGIN_HEBBIAN,
     EDGE_ORIGIN_SEMANTIC,
-    EDGE_TYPE_DECLARED_LINK,
     Memory,
     NeuralMemoryEdge,
 )
@@ -157,12 +157,16 @@ class NeuralEdgeRepository:
             workspace_id: Workspace ID (for 3-level isolation)
             context_id: Context ID (for 3-level isolation)
             protect_declared_link: When True, ON CONFLICT preserves the
-                existing edge_type if it is "declared_link" (only weight/
-                confidence/metadata/last_updated update). Used by automated
-                writers (Hebbian co-activation, edge discovery) so user-
-                declared links survive co-activation retyping. User-driven
-                update_edge calls leave this False so an explicit type
-                change still works. (Issue #457)
+                existing row's ``edge_type`` AND ``origin`` if it already
+                has ``origin='declared'`` (only weight/confidence/metadata/
+                last_updated update). Used by automated writers (Hebbian
+                co-activation, edge discovery) so user-declared links
+                survive co-activation retyping. User-driven update_edge
+                calls leave this False so an explicit type change still
+                works. (Issue #457; pivoted to origin discriminator
+                in #741 — the parameter name is retained for callsite
+                stability but the predicate is now ``origin='declared'``,
+                not ``edge_type='declared_link'``.)
             return_fresh_edge: When True (default), the returned ORM is
                 refreshed from the DB so its Python attributes reflect what
                 RETURNING actually wrote (Issue #458). Hot-path callers that
@@ -208,25 +212,31 @@ class NeuralEdgeRepository:
             last_updated=utcnow(),
         )
 
-        # Issue #457: declared_link rows must survive Hebbian retyping.
-        # CASE keeps the existing edge_type when it is declared_link;
-        # weight/confidence/metadata/last_updated still update so co-
-        # activation can strengthen user-declared links.
+        # Issue #457 / #741: user-asserted ("declared") links must survive
+        # Hebbian retyping. After #741 the predicate pivots from
+        # edge_type=='declared_link' to origin=='declared': a row with
+        # origin='declared' represents a user-asserted link, so both its
+        # edge_type and origin are preserved across a hebbian co-activation
+        # upsert. weight/confidence/metadata/last_updated still update so
+        # co-activation can strengthen user-declared links.
         if protect_declared_link:
             edge_type_set = case(
                 (
-                    NeuralMemoryEdge.edge_type == EDGE_TYPE_DECLARED_LINK,
-                    EDGE_TYPE_DECLARED_LINK,
+                    NeuralMemoryEdge.origin == EDGE_ORIGIN_DECLARED,
+                    NeuralMemoryEdge.edge_type,
                 ),
                 else_=stmt.excluded.edge_type,
             )
         else:
             edge_type_set = stmt.excluded.edge_type
 
-        # Sticky origin (mirrors protect_declared_link CASE above): semantic
-        # and declared edges survive a Hebbian co-recall upsert; only existing
-        # hebbian rows can be overwritten. Without this, a runtime co-recall
-        # would silently demote sleep-discovered edges back into the decay loop.
+        # Sticky origin: semantic and declared edges survive a Hebbian
+        # co-recall upsert; only existing hebbian rows can be overwritten.
+        # Without this, a runtime co-recall would silently demote sleep-
+        # discovered edges back into the decay loop. This also enforces the
+        # symmetric arm of the protect_declared_link CASE above — when the
+        # existing row has origin='declared', its origin is preserved
+        # alongside its edge_type, keeping the two columns co-managed.
         origin_set = case(
             (NeuralMemoryEdge.origin != EDGE_ORIGIN_HEBBIAN, NeuralMemoryEdge.origin),
             else_=stmt.excluded.origin,

--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -289,6 +289,7 @@ class NeuralEdgeRepository:
         context_id: str | None = None,
         *,
         origin: str = EDGE_ORIGIN_HEBBIAN,
+        edge_metadata: dict[str, Any] | None = None,
     ) -> NeuralMemoryEdge | None:
         """Create an edge only if no edge exists for (user_id, src_id, dst_id).
 
@@ -298,6 +299,13 @@ class NeuralEdgeRepository:
         This is the canonical path for **synthetic / seed edges** (k-NN
         cold-start seeding, tag co-occurrence, etc.) where we must not
         overwrite Hebbian-learned edges via upsert.
+
+        Args:
+            edge_metadata: Optional JSON metadata stored on the row's
+                ``metadata`` column. The tag-cooccurrence seed path (#741)
+                uses this to stamp ``{"source": "tag_cooccurrence"}`` on
+                otherwise-hebbian rows so the original edge-type discriminator
+                stays recoverable post-merge to ``neural_association``.
 
         Returns:
             The newly created NeuralMemoryEdge, or ``None`` if an edge
@@ -326,6 +334,7 @@ class NeuralEdgeRepository:
                 workspace_id=ws_uuid,
                 context_id=ctx_uuid,
                 origin=origin,
+                edge_metadata=edge_metadata,
                 created_at=utcnow(),
                 last_updated=utcnow(),
             )
@@ -463,6 +472,8 @@ class NeuralEdgeRepository:
         limit: int | None = None,
         workspace_id: str | None = None,
         context_id: str | None = None,
+        *,
+        origin: str | None = None,
     ) -> list[NeuralMemoryEdge]:
         """Get outgoing edges from a node with 3-level isolation.
 
@@ -484,6 +495,10 @@ class NeuralEdgeRepository:
             limit: Maximum edges to return
             workspace_id: Workspace ID (for isolation)
             context_id: Context ID (for isolation)
+            origin: Optional origin filter (#741). Pass ``EDGE_ORIGIN_DECLARED``
+                to fetch user-asserted links, etc. Mirrors the post-#741 pivot
+                where edge_type='declared_link' is replaced by
+                origin='declared'.
 
         Returns:
             List of outgoing edges sorted by weight descending
@@ -506,6 +521,9 @@ class NeuralEdgeRepository:
             conditions.append(NeuralMemoryEdge.workspace_id == UUID(workspace_id))
         if context_id:
             conditions.append(NeuralMemoryEdge.context_id == UUID(context_id))
+
+        if origin is not None:
+            conditions.append(NeuralMemoryEdge.origin == origin)
 
         stmt = (
             select(NeuralMemoryEdge)
@@ -531,6 +549,8 @@ class NeuralEdgeRepository:
         limit: int | None = None,
         workspace_id: str | None = None,
         context_id: str | None = None,
+        *,
+        origin: str | None = None,
     ) -> list[NeuralMemoryEdge]:
         """Get incoming edges to a node with 3-level isolation.
 
@@ -552,6 +572,8 @@ class NeuralEdgeRepository:
             limit: Maximum edges to return
             workspace_id: Workspace ID (for isolation)
             context_id: Context ID (for isolation)
+            origin: Optional origin filter (#741). Mirrors the kwarg on
+                ``get_outgoing_edges``.
 
         Returns:
             List of incoming edges sorted by weight descending
@@ -574,6 +596,9 @@ class NeuralEdgeRepository:
             conditions.append(NeuralMemoryEdge.workspace_id == UUID(workspace_id))
         if context_id:
             conditions.append(NeuralMemoryEdge.context_id == UUID(context_id))
+
+        if origin is not None:
+            conditions.append(NeuralMemoryEdge.origin == origin)
 
         stmt = (
             select(NeuralMemoryEdge)

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -15,13 +15,10 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.memory import (
-    EDGE_TYPE_DECLARED_LINK,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_RELATED_TO,
-    EDGE_TYPE_SEMANTIC_SIMILARITY,
-    EDGE_TYPE_TAG_COOCCURRENCE,
 )
 from repositories.neural_edge import NeuralEdgeRepository
 from utils.datetime import to_utc_iso
@@ -46,13 +43,21 @@ class GraphService:
         - user: User nodes (future)
 
     Edge Types (mirrors the DB CHECK constraint and ``EDGE_TYPE_*`` constants):
-        - neural_association: Learned associations (Hebbian)
-        - related_to: Semantic relationship
-        - depends_on: Dependency relationship
-        - learned_from: Learning source
-        - semantic_similarity: k-NN cold-start seeding (#221)
-        - declared_link: Client-declared explicit link (#215)
-        - tag_cooccurrence: Tag co-occurrence cold-start seeding (#223)
+        - neural_association: Learned associations (Hebbian) — also the
+          generic catch-all post-#741 for any provenance not expressible
+          as a relation (e.g. cold-start seeds and synthetic links)
+        - related_to: LLM-judged semantic relationship (undirected)
+        - depends_on: LLM-judged dependency relationship (directed)
+        - learned_from: LLM-judged learning source (directed)
+
+    Provenance lives on the ``origin`` axis (#722), independent of edge_type:
+        - hebbian: runtime Hebbian co-activation trace
+        - semantic: sleep edge_discovery (cosine-similarity-derived;
+          was edge_type='semantic_similarity' pre-#741)
+        - declared: user-asserted (was edge_type='declared_link' pre-#741)
+
+    Tag-cooccurrence-derived edges (was edge_type='tag_cooccurrence' pre-#741)
+    are recorded with ``edge_metadata['source']='tag_cooccurrence'``.
 
     Attributes:
         user_id: Owner user ID (GDPR compliance)
@@ -69,20 +74,19 @@ class GraphService:
     _STATS_OWNER_DEFAULT: Any = object()
 
     NODE_TYPES = ["memory", "user", "topic"]
-    # Issue #506: full set of edge_types accepted by the DB CHECK constraint
-    # (mirrors ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` from PR #507).
+    # Issue #506 / #741: full set of edge_types accepted by the DB CHECK
+    # constraint (mirrors ``mcp_server/tools/edge.py::VALID_EDGE_TYPES``).
     # ``frozenset`` for immutability + O(1) ``not in`` lookup at the validator
     # in ``add_edge``. Sourced from ``EDGE_TYPE_*`` constants so this set
-    # cannot drift from the schema literal.
+    # cannot drift from the schema literal. Post-#741 the set collapsed
+    # from 7 to 4 values: ``semantic_similarity``, ``declared_link``, and
+    # ``tag_cooccurrence`` moved to the ``origin`` / ``edge_metadata`` axes.
     EDGE_TYPES: frozenset[str] = frozenset(
         {
             EDGE_TYPE_NEURAL_ASSOCIATION,
             EDGE_TYPE_RELATED_TO,
             EDGE_TYPE_DEPENDS_ON,
             EDGE_TYPE_LEARNED_FROM,
-            EDGE_TYPE_SEMANTIC_SIMILARITY,
-            EDGE_TYPE_DECLARED_LINK,
-            EDGE_TYPE_TAG_COOCCURRENCE,
         }
     )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -21,7 +21,13 @@ from db.qdrant import (
     update_memory_payload_in_qdrant,
 )
 from models.auth import Context
-from models.memory import Memory
+from models.memory import (
+    EDGE_ORIGIN_DECLARED,
+    EDGE_ORIGIN_HEBBIAN,
+    EDGE_ORIGIN_SEMANTIC,
+    EDGE_TYPE_NEURAL_ASSOCIATION,
+    Memory,
+)
 from models.schemas import (
     ExploreHint,
     ExploreRequest,
@@ -918,21 +924,25 @@ class MemoryService:
         edge_repo = NeuralEdgeRepository(self.db)
         cap = 50
 
+        # Issue #741: discriminator pivoted from edge_type='declared_link' to
+        # origin='declared'. The post-#741 schema merges edge_type into
+        # ``neural_association`` and tracks user-asserted semantics on the
+        # ``origin`` column.
         out_edges = await edge_repo.get_outgoing_edges(
             user_id=None,
             src_id=memory_id,
-            edge_types=["declared_link"],
             limit=cap + 1,
             workspace_id=str(workspace_id),
             context_id=str(context_id),
+            origin=EDGE_ORIGIN_DECLARED,
         )
         in_edges = await edge_repo.get_incoming_edges(
             user_id=None,
             dst_id=memory_id,
-            edge_types=["declared_link"],
             limit=cap + 1,
             workspace_id=str(workspace_id),
             context_id=str(context_id),
+            origin=EDGE_ORIGIN_DECLARED,
         )
 
         out_has_more = len(out_edges) > cap
@@ -1039,15 +1049,18 @@ class MemoryService:
                     if target_id not in valid_ids:
                         logger.debug("declared_link_target_not_found", target_id=str(target_id))
                         continue
+                    # Issue #741: edge_type='declared_link' deprecated;
+                    # discriminator moved to origin='declared'.
                     await edge_repo.create_edge_if_absent(
                         user_id=user_id,
                         src_id=memory_id,
                         dst_id=target_id,
-                        edge_type="declared_link",
+                        edge_type=EDGE_TYPE_NEURAL_ASSOCIATION,
                         weight=1.0,
                         confidence=1.0,
                         workspace_id=workspace_id,
                         context_id=context_id,
+                        origin=EDGE_ORIGIN_DECLARED,
                     )
                     created += 1
 
@@ -1071,15 +1084,18 @@ class MemoryService:
                         continue
                     if target_id == memory_id:
                         continue
+                    # Issue #741: edge_type='declared_link' deprecated;
+                    # discriminator moved to origin='declared'.
                     await edge_repo.create_edge_if_absent(
                         user_id=user_id,
                         src_id=memory_id,
                         dst_id=target_id,
-                        edge_type="declared_link",
+                        edge_type=EDGE_TYPE_NEURAL_ASSOCIATION,
                         weight=1.0,
                         confidence=1.0,
                         workspace_id=workspace_id,
                         context_id=context_id,
+                        origin=EDGE_ORIGIN_DECLARED,
                     )
                     created += 1
 
@@ -2379,15 +2395,18 @@ async def _create_knn_seed_edges(
             # inserts and the final commit still succeed.
             try:
                 async with db.begin_nested():
+                    # Issue #741: edge_type='semantic_similarity' deprecated;
+                    # discriminator moved to origin='semantic'.
                     edge = await edge_repo.create_edge_if_absent(
                         user_id=memory.user_id,
                         src_id=memory.id,
                         dst_id=neighbor_id,
-                        edge_type="semantic_similarity",
+                        edge_type=EDGE_TYPE_NEURAL_ASSOCIATION,
                         weight=config.knn_seed_weight,
                         confidence=neighbor_score,
                         workspace_id=workspace_id_str,
                         context_id=context_id_str,
+                        origin=EDGE_ORIGIN_SEMANTIC,
                     )
                 # edge is None when ON CONFLICT DO NOTHING fired — existing
                 # edge was preserved (TOCTOU-safe against concurrent Hebbian
@@ -2509,23 +2528,33 @@ async def _create_tag_cooccurrence_seed_edges(
         context_id_str = str(memory.context_id)
         memory_id_str = str(memory.id)
 
-        # Edge-type-scoped idempotency guard. Unlike knn (any-type guard), we
+        # Source-scoped idempotency guard. Unlike knn (any-type guard), we
         # only skip when tag_cooccurrence edges already exist for this memory
         # — otherwise the knn seeding pass that just ran would prevent us from
         # ever writing tag_cooccurrence edges. Re-embed on update_memory()
         # would re-enter this function with the guard protecting us from
         # duplicate writes (create_edge_if_absent also protects via ON
         # CONFLICT, but skipping the SQL work is cheaper).
+        #
+        # Issue #741: the original guard filtered by ``edge_type='tag_cooccurrence'``.
+        # After #741 those rows are merged into ``neural_association`` and the
+        # tag-cooccurrence stamp moves to ``edge_metadata['source']``. We fetch
+        # hebbian-origin outgoing edges and scan in Python for the metadata
+        # marker rather than bloat the repo API for a single caller.
         edge_repo = NeuralEdgeRepository(db)
-        existing_edges = await edge_repo.get_outgoing_edges(
+        hebbian_outgoing = await edge_repo.get_outgoing_edges(
             user_id=memory.user_id,
             src_id=memory.id,
-            edge_types=["tag_cooccurrence"],
             workspace_id=workspace_id_str,
             context_id=context_id_str,
-            limit=1,
+            origin=EDGE_ORIGIN_HEBBIAN,
         )
-        if existing_edges:
+        already_seeded = any(
+            edge.edge_metadata is not None
+            and edge.edge_metadata.get("source") == "tag_cooccurrence"
+            for edge in hebbian_outgoing
+        )
+        if already_seeded:
             logger.debug(
                 "tag_cooccurrence_skip_already_seeded",
                 memory_id=memory_id_str,
@@ -2650,15 +2679,20 @@ async def _create_tag_cooccurrence_seed_edges(
             # failure cannot poison the session for the remaining inserts.
             try:
                 async with db.begin_nested():
+                    # Issue #741: edge_type='tag_cooccurrence' deprecated. The
+                    # row is still hebbian-origin (decays/prunes apply), but
+                    # the original derivation is preserved via metadata so the
+                    # idempotency guard above can detect prior seeding.
                     edge = await edge_repo.create_edge_if_absent(
                         user_id=memory.user_id,
                         src_id=memory.id,
                         dst_id=neighbor_id,
-                        edge_type="tag_cooccurrence",
+                        edge_type=EDGE_TYPE_NEURAL_ASSOCIATION,
                         weight=weight,
                         confidence=confidence,
                         workspace_id=workspace_id_str,
                         context_id=context_id_str,
+                        edge_metadata={"source": "tag_cooccurrence"},
                     )
                 # edge is None when ON CONFLICT DO NOTHING fired — e.g. a
                 # semantic_similarity edge from knn seeding already exists

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -2538,23 +2538,21 @@ async def _create_tag_cooccurrence_seed_edges(
         #
         # Issue #741: the original guard filtered by ``edge_type='tag_cooccurrence'``.
         # After #741 those rows are merged into ``neural_association`` and the
-        # tag-cooccurrence stamp moves to ``edge_metadata['source']``. We fetch
-        # hebbian-origin outgoing edges and scan in Python for the metadata
-        # marker rather than bloat the repo API for a single caller.
+        # tag-cooccurrence stamp moves to ``edge_metadata['source']``. The
+        # filter is pushed into SQL (``metadata::jsonb ->> 'source'``) with
+        # ``limit=1`` so high-degree memory nodes don't pull thousands of
+        # co-activation edges into Python just to answer "already seeded?".
         edge_repo = NeuralEdgeRepository(db)
-        hebbian_outgoing = await edge_repo.get_outgoing_edges(
+        existing_seed = await edge_repo.get_outgoing_edges(
             user_id=memory.user_id,
             src_id=memory.id,
             workspace_id=workspace_id_str,
             context_id=context_id_str,
             origin=EDGE_ORIGIN_HEBBIAN,
+            metadata_source="tag_cooccurrence",
+            limit=1,
         )
-        already_seeded = any(
-            edge.edge_metadata is not None
-            and edge.edge_metadata.get("source") == "tag_cooccurrence"
-            for edge in hebbian_outgoing
-        )
-        if already_seeded:
+        if existing_seed:
             logger.debug(
                 "tag_cooccurrence_skip_already_seeded",
                 memory_id=memory_id_str,

--- a/backend/src/services/sleep/edge_discovery.py
+++ b/backend/src/services/sleep/edge_discovery.py
@@ -67,38 +67,46 @@ DISCOVERY_EDGE_WEIGHT = 0.5
 BATCH_SIZE = 5
 
 # Issue #248: k-NN cold-start seeding (#224/#238) births every new memory
-# with weak `semantic_similarity` edges to its 0.4-0.9 Qdrant neighbors at
+# with weak semantic-origin edges to its 0.4-0.9 Qdrant neighbors at
 # `knn_seed_weight` (default 0.3, "intentionally low — synthetic signal").
-# Without an edge_type-aware filter, `_filter_existing_edges` below would
+# Without an origin-aware filter, `_filter_existing_edges` below would
 # treat those seeded pairs as "already connected" and skip LLM judgment,
 # producing 0 edges per run in production. 0.5 sits comfortably above the
 # default seed weight so the LLM judge sees the mid-similarity band again;
 # operators who configure `knn_seed_weight` >= 0.5 are implicitly opting
 # those edges back into "real connection" semantics.
+#
+# Issue #741: discriminator pivoted from edge_type='semantic_similarity'
+# to origin='semantic'. The numeric threshold itself is unchanged.
 SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD = 0.5
 
 
 def _is_synthetic_seed_edge(edge: NeuralMemoryEdge) -> bool:
-    """Return True if ``edge`` is a synthetic cold-start seed (#248, #223).
+    """Return True if ``edge`` is a synthetic cold-start seed (#248, #223, #741).
 
     Cold-start seeds must NOT block Sleep Edge Discovery from re-judging a
-    pair. Two seed types qualify:
+    pair. Two seed types qualify; post-#741 both are identified via the
+    ``origin`` axis (and ``edge_metadata['source']`` for tag_cooccurrence):
 
-    - **k-NN ``semantic_similarity`` (#221/#224/#238)**: synthetic only when
+    - **k-NN semantic-origin (#221/#224/#238)**: ``origin='semantic'`` with
       ``weight < SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD`` (0.5).
       Operators who set ``knn_seed_weight`` >= 0.5 are implicitly opting
-      those edges back into "real connection" semantics.
-    - **``tag_cooccurrence`` (#223)**: synthetic at *any* weight — the type
-      is purely seeding, weight 0.25–0.40 by spec, and there is no operator
-      knob to "promote" tag-cooccurrence to a real connection. If a pair
-      becomes truly related, Sleep Discovery should overwrite the
-      tag_cooccurrence edge with a confirmed ``related_to`` (or similar).
+      those edges back into "real connection" semantics. Pre-#741 these
+      were tagged ``edge_type='semantic_similarity'``.
+    - **tag_cooccurrence (#223)**: identified by
+      ``edge_metadata['source']=='tag_cooccurrence'``; synthetic at *any*
+      weight — the source is purely seeding, weight 0.25–0.40 by spec, and
+      there is no operator knob to "promote" tag-cooccurrence to a real
+      connection. If a pair becomes truly related, Sleep Discovery should
+      overwrite the tag_cooccurrence edge with a confirmed ``related_to``
+      (or similar). Pre-#741 these were tagged
+      ``edge_type='tag_cooccurrence'``.
 
-    All other edge types are treated as real connections regardless of weight.
+    All other edges are treated as real connections regardless of weight.
     """
-    if edge.edge_type == "semantic_similarity":
+    if edge.origin == EDGE_ORIGIN_SEMANTIC:
         return edge.weight < SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD
-    if edge.edge_type == "tag_cooccurrence":
+    if edge.edge_metadata is not None and edge.edge_metadata.get("source") == "tag_cooccurrence":
         return True
     return False
 
@@ -115,11 +123,11 @@ CONFIDENCE_HISTOGRAM_KEYS: tuple[str, ...] = ("0.0-0.5", "0.5-0.7", "0.7-0.85", 
 
 # Issue #374: `EdgeType` is the type-level source of truth for valid
 # `NeuralMemoryEdge.edge_type` values emitted by the LLM judge (a deliberate
-# subset of the DB CHECK constraint in `models/memory.py` — the DB accepts
-# additional non-LLM types like `tag_cooccurrence`). `LLM_EMITTABLE_EDGE_TYPES`
-# is derived via `get_args` so the runtime membership check and the type
-# annotation cannot drift. Adding a new LLM-emittable edge type only requires
-# editing the Literal.
+# subset of the DB CHECK constraint in `models/memory.py` — the DB also
+# accepts `neural_association`, the generic catch-all that the LLM judge
+# does not emit). `LLM_EMITTABLE_EDGE_TYPES` is derived via `get_args` so
+# the runtime membership check and the type annotation cannot drift.
+# Adding a new LLM-emittable edge type only requires editing the Literal.
 #
 # Issue #461: renamed from `VALID_EDGE_TYPES` to disambiguate from the
 # full DB-accepted set in `mcp_server/tools/edge.py::VALID_EDGE_TYPES`.
@@ -732,12 +740,15 @@ class EdgeDiscoveryPhase:
     ) -> list[tuple[UUID, UUID, float]]:
         """Remove pairs that already have a meaningful edge.
 
-        Issue #248: Low-weight ``semantic_similarity`` edges (weight <
-        ``SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD``) are synthetic
-        k-NN cold-start seeds from #224/#238 and do NOT block the pair from
-        being re-judged by Sleep Edge Discovery. All other edge types — and
-        high-weight ``semantic_similarity`` edges — are treated as real
-        connections and cause the pair to be filtered out.
+        Issue #248 / #741: Low-weight semantic-origin edges (``origin='semantic'``,
+        ``weight < SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD``) are
+        synthetic k-NN cold-start seeds from #224/#238 and do NOT block the
+        pair from being re-judged by Sleep Edge Discovery. Tag-cooccurrence
+        seeds (``edge_metadata['source']='tag_cooccurrence'``) are likewise
+        treated as synthetic at any weight. All other edges — and high-weight
+        semantic-origin edges — are treated as real connections and cause the
+        pair to be filtered out. See ``_is_synthetic_seed_edge`` for the full
+        discriminator.
         """
         # TODO: N+1 query per candidate — batch fetch edges for all src_ids in one query
         filtered = []

--- a/backend/tests/integration/test_declared_link_protection.py
+++ b/backend/tests/integration/test_declared_link_protection.py
@@ -1,9 +1,13 @@
-"""Integration test for declared_link protection in upsert (#457).
+"""Integration test for declared-link protection in upsert (#457, #741).
 
 NeuralEdgeRepository.create_or_update_edge with protect_declared_link=True
-must keep an existing edge_type="declared_link" pinned even when the
-incoming upsert tries to set edge_type="neural_association" (e.g. Hebbian
-co-activation flowing through GraphService.add_edge).
+must keep an existing row pinned (both edge_type AND origin) when the
+incoming upsert tries to retype it (e.g. Hebbian co-activation flowing
+through GraphService.add_edge with edge_type="neural_association").
+
+After #741 the preservation predicate pivots from edge_type=='declared_link'
+to origin=='declared', so the seed edge in these tests explicitly passes
+``origin=EDGE_ORIGIN_DECLARED`` to mark it as a user-asserted link.
 
 The smoke-test on v0.14.0 (2026-04-26 prod) reproduced the unprotected
 case 100% — user-declared links got retyped to neural_association as
@@ -22,7 +26,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import Context, Workspace
-from models.memory import Memory
+from models.memory import EDGE_ORIGIN_DECLARED, Memory
 from repositories.neural_edge import NeuralEdgeRepository
 
 
@@ -100,13 +104,16 @@ async def test_protect_declared_link_preserves_edge_type(
         user_id=s["owner_id"],
         src_id=s["mem_a"].id,
         dst_id=s["mem_b"].id,
-        edge_type="declared_link",
+        edge_type="related_to",
         weight=1.0,
         confidence=1.0,
         workspace_id=str(s["ws_id"]),
         context_id=str(s["ctx_id"]),
+        # #741: declared-link semantics now carried by origin, not edge_type.
+        origin=EDGE_ORIGIN_DECLARED,
     )
-    assert declared.edge_type == "declared_link"
+    assert declared.edge_type == "related_to"
+    assert declared.origin == EDGE_ORIGIN_DECLARED
     assert declared.weight == 1.0
     initial_last_updated = declared.last_updated
 
@@ -122,8 +129,12 @@ async def test_protect_declared_link_preserves_edge_type(
         protect_declared_link=True,
     )
 
-    assert retyped.edge_type == "declared_link", (
-        "protect_declared_link=True must pin the existing declared_link type"
+    assert retyped.edge_type == "related_to", (
+        "protect_declared_link=True must pin the existing edge_type when "
+        "origin='declared' (#741 pivot)"
+    )
+    assert retyped.origin == EDGE_ORIGIN_DECLARED, (
+        "origin must also be preserved — declared and edge_type are co-managed (#741)"
     )
     assert retyped.weight == 1.03, (
         "weight must still update so co-activation continues to strengthen the link"
@@ -149,10 +160,12 @@ async def test_unprotected_upsert_still_allows_user_driven_retype(
         user_id=s["owner_id"],
         src_id=s["mem_a"].id,
         dst_id=s["mem_b"].id,
-        edge_type="declared_link",
+        edge_type="related_to",
         weight=1.0,
         workspace_id=str(s["ws_id"]),
         context_id=str(s["ctx_id"]),
+        # #741: seed as user-asserted via origin='declared'.
+        origin=EDGE_ORIGIN_DECLARED,
     )
 
     retyped = await repo.create_or_update_edge(
@@ -163,11 +176,13 @@ async def test_unprotected_upsert_still_allows_user_driven_retype(
         weight=0.5,
         workspace_id=str(s["ws_id"]),
         context_id=str(s["ctx_id"]),
-        # protect_declared_link defaults to False — user-driven path
+        # protect_declared_link defaults to False — user-driven path can
+        # retype the edge. (Origin sticks via the sticky-origin CASE — that
+        # is intentional, only edge_type is mutable in the user-driven path.)
     )
 
     assert retyped.edge_type == "neural_association", (
-        "Without protection, user-driven update_edge can change the type explicitly"
+        "Without protection, user-driven update_edge can change the edge_type explicitly"
     )
     assert retyped.weight == 0.5
 

--- a/backend/tests/integration/test_memory_service_post_741.py
+++ b/backend/tests/integration/test_memory_service_post_741.py
@@ -234,23 +234,24 @@ async def test_create_tag_cooccurrence_writes_edge_metadata_source(
     assert edge.origin == EDGE_ORIGIN_HEBBIAN
     assert edge.edge_metadata == {"source": "tag_cooccurrence"}
 
-    # The idempotency guard path must recognize the stamp.
-    hebbian_outgoing = await repo.get_outgoing_edges(
+    # The idempotency guard path must recognize the stamp via the SQL-pushed
+    # metadata_source filter (#741 follow-up): origin=hebbian +
+    # metadata_source='tag_cooccurrence' + limit=1 is the O(1) early-out the
+    # producer uses on high-degree memory nodes.
+    seeded = await repo.get_outgoing_edges(
         user_id=s["owner_id"],
         src_id=s["src"].id,
         workspace_id=str(s["ws_id"]),
         context_id=str(s["ctx_id"]),
         origin=EDGE_ORIGIN_HEBBIAN,
+        metadata_source="tag_cooccurrence",
+        limit=1,
     )
-    seeded = [
-        e
-        for e in hebbian_outgoing
-        if e.edge_metadata and e.edge_metadata.get("source") == "tag_cooccurrence"
-    ]
     assert len(seeded) == 1, (
-        "idempotency guard must detect prior tag_cooccurrence seed via "
-        "metadata scan over hebbian-origin outgoing edges"
+        "idempotency guard must detect prior tag_cooccurrence seed via the "
+        "SQL-pushed metadata_source filter on hebbian-origin outgoing edges"
     )
+    assert seeded[0].edge_metadata == {"source": "tag_cooccurrence"}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_memory_service_post_741.py
+++ b/backend/tests/integration/test_memory_service_post_741.py
@@ -1,0 +1,297 @@
+"""Integration test for memory_service edge creation post-#741.
+
+After migration ``e20_741_deprecate_edge_type``:
+- ``edge_type IN ('semantic_similarity', 'declared_link', 'tag_cooccurrence')``
+  is rejected by the ``valid_edge_type`` CHECK constraint (only 4 values
+  remain: neural_association / related_to / depends_on / learned_from).
+- The discriminator carried by the deprecated edge_types moves to:
+    * declared_link        → origin='declared'
+    * semantic_similarity  → origin='semantic'
+    * tag_cooccurrence     → edge_metadata['source']='tag_cooccurrence'
+      (the row stays hebbian-origin so it still participates in
+      decay/prune; metadata records derivation.)
+
+The 4 producer sites in ``memory_service.py`` were silently failing under
+try/except + log-and-continue before #741's full pivot. This integration
+test exercises the real DB path against the live CHECK constraint so a
+future producer that drifts back to a deprecated edge_type literal —
+or forgets to attach the new discriminator — fails this suite instead
+of silently dropping edges in production.
+
+Test strategy:
+- Skip Qdrant / embedding wiring. We call the producers directly with the
+  inputs they would receive from ``remember()``.
+- Each producer test asserts: (1) edge rows persist, (2) edge_type is
+  ``neural_association``, (3) the appropriate origin / edge_metadata
+  carries the deprecated-edge-type signal.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import Context, Workspace
+from models.memory import (
+    EDGE_ORIGIN_DECLARED,
+    EDGE_ORIGIN_HEBBIAN,
+    EDGE_ORIGIN_SEMANTIC,
+    EDGE_TYPE_NEURAL_ASSOCIATION,
+    Memory,
+    NeuralMemoryEdge,
+)
+from models.schemas import RememberRequest
+from repositories.neural_edge import NeuralEdgeRepository
+
+
+@pytest_asyncio.fixture
+async def edge_producer_scenario(db_session: AsyncSession):
+    """Workspace + context + three memories ready for edge creation."""
+    owner_id = f"owner_{uuid4().hex[:8]}"
+
+    ws = Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=owner_id,
+        is_private=False,
+    )
+
+    def _mk_memory(*, tags: list[str] | None = None) -> Memory:
+        return Memory(
+            id=uuid4(),
+            user_id=owner_id,
+            workspace_id=ws.id,
+            context_id=ctx.id,
+            summary=f"mem-{uuid4().hex[:6]}",
+            content="x",
+            type="note",
+            client="test",
+            tags=tags or [],
+        )
+
+    src = _mk_memory(tags=["python", "backend", "memory-cloud"])
+    dst_a = _mk_memory(tags=["python", "backend", "memory-cloud"])
+    dst_b = _mk_memory(tags=["python", "backend", "memory-cloud"])
+
+    db_session.add(ws)
+    await db_session.flush()
+    db_session.add(ctx)
+    await db_session.flush()
+    db_session.add_all([src, dst_a, dst_b])
+    await db_session.flush()
+
+    yield {
+        "owner_id": owner_id,
+        "ws_id": ws.id,
+        "ctx_id": ctx.id,
+        "src": src,
+        "dst_a": dst_a,
+        "dst_b": dst_b,
+    }
+
+    # Best-effort cleanup; session.rollback in the global fixture also fires.
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_create_declared_links_writes_origin_declared(
+    db_session: AsyncSession, edge_producer_scenario
+):
+    """_create_declared_links must persist edges with edge_type=neural_association + origin=declared.
+
+    Pre-#741 this site wrote edge_type='declared_link'. After migration
+    e20_741, that literal trips the valid_edge_type CHECK constraint and
+    the row is silently dropped by the producer's outer try/except. The
+    test asserts the post-#741 contract — neural_association + declared
+    origin — against the real DB CHECK.
+    """
+    from services.memory_service import MemoryService
+
+    s = edge_producer_scenario
+    service = MemoryService(db_session)
+
+    request = RememberRequest(
+        summary="seed memory",
+        content="seed content",
+        type="note",
+        linked_memory_ids=[s["dst_a"].id, s["dst_b"].id],
+    )
+
+    await service._create_declared_links(
+        memory_id=s["src"].id,
+        request=request,
+        user_id=s["owner_id"],
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+    )
+
+    result = await db_session.execute(
+        select(NeuralMemoryEdge).where(NeuralMemoryEdge.src_id == s["src"].id)
+    )
+    edges = list(result.scalars().all())
+    assert len(edges) == 2, "both declared links should persist (no CHECK rejection)"
+
+    for edge in edges:
+        assert edge.edge_type == EDGE_TYPE_NEURAL_ASSOCIATION, (
+            "post-#741 declared links write neural_association, not declared_link"
+        )
+        assert edge.origin == EDGE_ORIGIN_DECLARED, (
+            "declared-link discriminator moved from edge_type to origin"
+        )
+        assert edge.weight == 1.0
+        assert edge.confidence == 1.0
+
+    # Round-trip through the consumer to prove the fetch path also pivoted.
+    out_links, _, _, _ = await service._fetch_declared_link_refs(
+        memory_id=s["src"].id,
+        workspace_id=s["ws_id"],
+        context_id=s["ctx_id"],
+    )
+    out_ids = {ref.memory_id for ref in out_links}
+    assert out_ids == {s["dst_a"].id, s["dst_b"].id}, (
+        "_fetch_declared_link_refs must surface declared links via origin filter"
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_knn_seed_edges_writes_origin_semantic(
+    db_session: AsyncSession, edge_producer_scenario
+):
+    """_create_knn_seed_edges must persist edges with edge_type=neural_association + origin=semantic.
+
+    Pre-#741 this site wrote edge_type='semantic_similarity'. The repo
+    call is exercised directly here rather than going through Qdrant
+    because Qdrant integration is out of scope for this regression
+    pin — the goal is to catch any producer that drifts back to the
+    deprecated literal.
+    """
+    s = edge_producer_scenario
+    repo = NeuralEdgeRepository(db_session)
+
+    # Mirror the kwargs the production call site (memory_service:2386) passes.
+    edge = await repo.create_edge_if_absent(
+        user_id=s["owner_id"],
+        src_id=s["src"].id,
+        dst_id=s["dst_a"].id,
+        edge_type=EDGE_TYPE_NEURAL_ASSOCIATION,
+        weight=0.3,
+        confidence=0.85,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+        origin=EDGE_ORIGIN_SEMANTIC,
+    )
+
+    assert edge is not None, "edge must persist (CHECK constraint must not reject)"
+    assert edge.edge_type == EDGE_TYPE_NEURAL_ASSOCIATION
+    assert edge.origin == EDGE_ORIGIN_SEMANTIC
+    assert edge.weight == pytest.approx(0.3)
+
+
+@pytest.mark.asyncio
+async def test_create_tag_cooccurrence_writes_edge_metadata_source(
+    db_session: AsyncSession, edge_producer_scenario
+):
+    """Tag-cooccurrence seed must persist edge_type=neural_association + edge_metadata.source.
+
+    Pre-#741 this site wrote edge_type='tag_cooccurrence'. After #741 the
+    row is plain hebbian-origin (so it still participates in decay/prune)
+    but ``edge_metadata['source']`` records the derivation so the
+    idempotency guard can detect a prior seed.
+    """
+    s = edge_producer_scenario
+    repo = NeuralEdgeRepository(db_session)
+
+    # Mirror the kwargs the production call site (memory_service:2657) passes.
+    edge = await repo.create_edge_if_absent(
+        user_id=s["owner_id"],
+        src_id=s["src"].id,
+        dst_id=s["dst_a"].id,
+        edge_type=EDGE_TYPE_NEURAL_ASSOCIATION,
+        weight=0.25,
+        confidence=0.5,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+        edge_metadata={"source": "tag_cooccurrence"},
+    )
+
+    assert edge is not None, "edge must persist (CHECK constraint must not reject)"
+    assert edge.edge_type == EDGE_TYPE_NEURAL_ASSOCIATION
+    # Default origin is hebbian; tag-cooccurrence seeds inherit decay semantics.
+    assert edge.origin == EDGE_ORIGIN_HEBBIAN
+    assert edge.edge_metadata == {"source": "tag_cooccurrence"}
+
+    # The idempotency guard path must recognize the stamp.
+    hebbian_outgoing = await repo.get_outgoing_edges(
+        user_id=s["owner_id"],
+        src_id=s["src"].id,
+        workspace_id=str(s["ws_id"]),
+        context_id=str(s["ctx_id"]),
+        origin=EDGE_ORIGIN_HEBBIAN,
+    )
+    seeded = [
+        e
+        for e in hebbian_outgoing
+        if e.edge_metadata and e.edge_metadata.get("source") == "tag_cooccurrence"
+    ]
+    assert len(seeded) == 1, (
+        "idempotency guard must detect prior tag_cooccurrence seed via "
+        "metadata scan over hebbian-origin outgoing edges"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deprecated_edge_type_literals_rejected_by_check(
+    db_session: AsyncSession,
+):
+    """Regression bait: the valid_edge_type CHECK constraint enumerates the
+    post-#741 set only.
+
+    If a future refactor accidentally re-introduces 'semantic_similarity',
+    'declared_link', or 'tag_cooccurrence' on the CHECK constraint, the
+    other tests in this file would still pass silently (they only assert
+    positive paths). This test inspects ``pg_constraint`` directly so the
+    suite catches a schema drift that would re-allow the deprecated values
+    — without needing to actually INSERT-and-fail, which is awkward to
+    structure around savepoint poisoning when the validator pre-flight
+    SELECT runs first.
+    """
+    from sqlalchemy import text
+
+    result = await db_session.execute(
+        text(
+            """
+            SELECT pg_get_constraintdef(oid)
+            FROM pg_constraint
+            WHERE conname = 'valid_edge_type'
+            """
+        )
+    )
+    rows = list(result.scalars().all())
+    assert rows, "valid_edge_type CHECK constraint must exist on neural_memory_edges"
+
+    constraint_def = rows[0]
+    for deprecated in ("semantic_similarity", "declared_link", "tag_cooccurrence"):
+        assert deprecated not in constraint_def, (
+            f"deprecated edge_type {deprecated!r} must NOT appear in the "
+            f"valid_edge_type CHECK constraint post-#741. Constraint def: "
+            f"{constraint_def}"
+        )
+
+    # Positive: the 4 surviving values MUST be present so the constraint is
+    # not accidentally too restrictive either.
+    for kept in ("neural_association", "related_to", "depends_on", "learned_from"):
+        assert kept in constraint_def, f"surviving edge_type {kept!r} missing from CHECK constraint"

--- a/backend/tests/repositories/test_neural_edge_origin.py
+++ b/backend/tests/repositories/test_neural_edge_origin.py
@@ -6,6 +6,8 @@ Verifies:
 - create_edge_if_absent writes the supplied origin value
 - bulk_decay_weights(only_origin=...) skips non-matching edges
 - prune_weak_edges(only_origin=...) skips non-matching edges
+- get_outgoing_edges(metadata_source=...) pushes the metadata filter into
+  SQL (Issue #741 follow-up: tag-cooccurrence idempotency guard perf).
 """
 
 import pytest
@@ -193,3 +195,203 @@ async def test_upsert_promotes_hebbian_to_semantic(db_session, sample_memory_pai
     edge = await repo.get_edge(src.user_id, src.id, dst.id)
     assert edge is not None
     assert edge.origin == EDGE_ORIGIN_SEMANTIC  # promoted
+
+
+@pytest.mark.asyncio
+async def test_get_outgoing_edges_metadata_source_filter(db_session, sample_memory_pair):
+    """``metadata_source`` filter must be applied in SQL (#741 follow-up).
+
+    Seeds two outgoing edges from the same src memory: one stamped with
+    ``edge_metadata['source']='tag_cooccurrence'`` and one without metadata.
+    Asserts:
+      - ``metadata_source='tag_cooccurrence'`` returns only the stamped row.
+      - ``metadata_source=None`` (default) returns both rows.
+      - ``metadata_source='nonexistent'`` returns nothing.
+      - Combined with ``origin=EDGE_ORIGIN_HEBBIAN``, the filter is
+        conjunctive (only hebbian + tag_cooccurrence rows match).
+    """
+    from uuid import uuid4
+
+    from models.memory import Memory
+
+    src, _ = sample_memory_pair
+    user_id = src.user_id
+    workspace_id = src.workspace_id
+    context_id = src.context_id
+
+    # Need a second destination memory so we can seed 2 outgoing edges from
+    # src (the ``unique_edge`` constraint covers (user, src, dst)).
+    dst_b = Memory(
+        id=uuid4(),
+        user_id=user_id,
+        workspace_id=workspace_id,
+        context_id=context_id,
+        summary="dst-b for metadata filter test",
+        content="dst-b content",
+        type="note",
+        client="test",
+    )
+    db_session.add(dst_b)
+    await db_session.flush()
+
+    # Also need a non-hebbian sibling for the conjunctive arm — seed a
+    # semantic edge that ALSO has the tag_cooccurrence stamp; the
+    # origin+metadata_source intersection should NOT include it.
+    dst_c = Memory(
+        id=uuid4(),
+        user_id=user_id,
+        workspace_id=workspace_id,
+        context_id=context_id,
+        summary="dst-c (semantic origin + tag_cooccurrence stamp)",
+        content="dst-c content",
+        type="note",
+        client="test",
+    )
+    db_session.add(dst_c)
+    await db_session.flush()
+
+    repo = NeuralEdgeRepository(db_session)
+
+    # Edge 1: tag_cooccurrence-stamped hebbian
+    await repo.create_edge_if_absent(
+        user_id=user_id,
+        src_id=src.id,
+        dst_id=sample_memory_pair[1].id,
+        edge_type="neural_association",
+        weight=0.25,
+        confidence=0.5,
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+        edge_metadata={"source": "tag_cooccurrence"},
+    )
+    # Edge 2: plain hebbian (no metadata)
+    await repo.create_edge_if_absent(
+        user_id=user_id,
+        src_id=src.id,
+        dst_id=dst_b.id,
+        edge_type="neural_association",
+        weight=0.30,
+        confidence=0.9,
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+    )
+    # Edge 3: semantic-origin tag_cooccurrence-stamped (would mismatch the
+    # conjunctive filter if SQL did NOT AND origin + metadata_source).
+    await repo.create_edge_if_absent(
+        user_id=user_id,
+        src_id=src.id,
+        dst_id=dst_c.id,
+        edge_type="related_to",
+        weight=0.40,
+        confidence=1.0,
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+        origin=EDGE_ORIGIN_SEMANTIC,
+        edge_metadata={"source": "tag_cooccurrence"},
+    )
+
+    # 1) metadata_source=None → all 3 rows
+    all_out = await repo.get_outgoing_edges(
+        user_id=user_id,
+        src_id=src.id,
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+    )
+    assert len(all_out) == 3, "default (no filter) must return every outgoing edge"
+
+    # 2) metadata_source='tag_cooccurrence' → 2 stamped rows (hebbian + semantic)
+    stamped = await repo.get_outgoing_edges(
+        user_id=user_id,
+        src_id=src.id,
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+        metadata_source="tag_cooccurrence",
+    )
+    assert len(stamped) == 2, "metadata_source filter must match every stamped row"
+    for e in stamped:
+        assert e.edge_metadata == {"source": "tag_cooccurrence"}
+
+    # 3) metadata_source='nonexistent' → 0 rows
+    none_match = await repo.get_outgoing_edges(
+        user_id=user_id,
+        src_id=src.id,
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+        metadata_source="nonexistent-source",
+    )
+    assert none_match == []
+
+    # 4) origin=hebbian AND metadata_source='tag_cooccurrence' →
+    #    exactly the stamped hebbian row (Edge 1), NOT the semantic-stamped
+    #    one (Edge 3) and NOT the unstamped hebbian (Edge 2). This proves
+    #    the filter is conjunctive.
+    intersected = await repo.get_outgoing_edges(
+        user_id=user_id,
+        src_id=src.id,
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+        origin=EDGE_ORIGIN_HEBBIAN,
+        metadata_source="tag_cooccurrence",
+    )
+    assert len(intersected) == 1
+    assert intersected[0].origin == EDGE_ORIGIN_HEBBIAN
+    assert intersected[0].edge_metadata == {"source": "tag_cooccurrence"}
+
+    # 5) limit=1 must return at most 1 row (idempotency-guard early-out).
+    early_out = await repo.get_outgoing_edges(
+        user_id=user_id,
+        src_id=src.id,
+        workspace_id=str(workspace_id),
+        context_id=str(context_id),
+        origin=EDGE_ORIGIN_HEBBIAN,
+        metadata_source="tag_cooccurrence",
+        limit=1,
+    )
+    assert len(early_out) == 1
+
+
+@pytest.mark.asyncio
+async def test_get_incoming_edges_metadata_source_filter(db_session, sample_memory_pair):
+    """Symmetric metadata_source filter on get_incoming_edges (#741 follow-up).
+
+    Mirrors the outgoing test on a single incoming edge to keep the
+    fixture footprint small — the SQL builder is identical to
+    get_outgoing_edges, so a thinner positive/negative pair is sufficient
+    to pin the kwarg is wired through.
+    """
+    src, dst = sample_memory_pair
+    repo = NeuralEdgeRepository(db_session)
+
+    await repo.create_edge_if_absent(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=dst.id,
+        edge_type="neural_association",
+        weight=0.2,
+        confidence=0.5,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        edge_metadata={"source": "tag_cooccurrence"},
+    )
+
+    # Positive: stamped incoming edge surfaces.
+    match = await repo.get_incoming_edges(
+        user_id=src.user_id,
+        dst_id=dst.id,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        metadata_source="tag_cooccurrence",
+    )
+    assert len(match) == 1
+    assert match[0].edge_metadata == {"source": "tag_cooccurrence"}
+
+    # Negative: a non-matching source returns nothing even though the row
+    # exists (proves the filter is actually pushed into SQL).
+    no_match = await repo.get_incoming_edges(
+        user_id=src.user_id,
+        dst_id=dst.id,
+        workspace_id=str(src.workspace_id),
+        context_id=str(src.context_id),
+        metadata_source="other-source",
+    )
+    assert no_match == []

--- a/backend/tests/services/sleep/test_edge_discovery.py
+++ b/backend/tests/services/sleep/test_edge_discovery.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 
+from models.memory import EDGE_ORIGIN_HEBBIAN, EDGE_ORIGIN_SEMANTIC
 from services.sleep.edge_discovery import (
     BATCH_SIZE,
     CONFIDENCE_HISTOGRAM_KEYS,
@@ -67,12 +68,23 @@ def _make_memory(memory_id=None, summary="test", importance=0.5):
     return m
 
 
-def _make_edge(edge_type, weight, dst_id=None):
-    """Build a minimal edge double with only the attributes the filter reads."""
+def _make_edge(edge_type, weight, dst_id=None, origin=EDGE_ORIGIN_HEBBIAN, edge_metadata=None):
+    """Build a minimal edge double with only the attributes the filter reads.
+
+    Issue #741: ``_is_synthetic_seed_edge`` reads ``origin`` and
+    ``edge_metadata`` (no longer ``edge_type``). Callers exercising the
+    synthetic-seed classifier must pass ``origin='semantic'`` for k-NN
+    seed edges and ``edge_metadata={'source': 'tag_cooccurrence'}`` for
+    tag-cooccurrence seed edges. Default ``origin='hebbian'`` /
+    ``edge_metadata=None`` matches the dominant "real connection" shape
+    used by the other tests in this file.
+    """
     e = MagicMock()
     e.edge_type = edge_type
     e.weight = weight
     e.dst_id = dst_id or uuid4()
+    e.origin = origin
+    e.edge_metadata = edge_metadata
     return e
 
 
@@ -335,17 +347,25 @@ class TestIsSyntheticSeedEdge:
 
     def test_knn_seed_default_weight_is_synthetic(self):
         """Default knn_seed_weight=0.3 must be classified as synthetic —
-        this is the in-production value that #248 was triggered by."""
-        edge = _make_edge("semantic_similarity", 0.3)
+        this is the in-production value that #248 was triggered by.
+
+        Issue #741: classifier now keys on ``origin='semantic'`` rather
+        than ``edge_type='semantic_similarity'``.
+        """
+        edge = _make_edge("semantic_similarity", 0.3, origin=EDGE_ORIGIN_SEMANTIC)
         assert _is_synthetic_seed_edge(edge) is True
 
     def test_high_weight_semantic_similarity_is_not_synthetic(self):
-        edge = _make_edge("semantic_similarity", 0.8)
+        edge = _make_edge("semantic_similarity", 0.8, origin=EDGE_ORIGIN_SEMANTIC)
         assert _is_synthetic_seed_edge(edge) is False
 
     def test_at_threshold_is_not_synthetic(self):
         """Threshold is strict (< 0.5); exactly 0.5 is treated as real."""
-        edge = _make_edge("semantic_similarity", SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD)
+        edge = _make_edge(
+            "semantic_similarity",
+            SEMANTIC_SIMILARITY_SYNTHETIC_WEIGHT_THRESHOLD,
+            origin=EDGE_ORIGIN_SEMANTIC,
+        )
         assert _is_synthetic_seed_edge(edge) is False
 
     def test_related_to_is_never_synthetic(self):
@@ -368,13 +388,18 @@ class TestIsSyntheticSeedEdge:
     # ---- Issue #223: tag_cooccurrence is synthetic at any weight ----
 
     def test_tag_cooccurrence_low_weight_is_synthetic(self):
-        """Default tag_cooccurrence weight (2 shared = 0.25) is synthetic."""
-        edge = _make_edge("tag_cooccurrence", 0.25)
+        """Default tag_cooccurrence weight (2 shared = 0.25) is synthetic.
+
+        Issue #741: classifier now keys on
+        ``edge_metadata['source']=='tag_cooccurrence'`` rather than
+        ``edge_type='tag_cooccurrence'``.
+        """
+        edge = _make_edge("tag_cooccurrence", 0.25, edge_metadata={"source": "tag_cooccurrence"})
         assert _is_synthetic_seed_edge(edge) is True
 
     def test_tag_cooccurrence_capped_weight_is_synthetic(self):
         """4+ shared tags caps weight at 0.40 — still synthetic."""
-        edge = _make_edge("tag_cooccurrence", 0.40)
+        edge = _make_edge("tag_cooccurrence", 0.40, edge_metadata={"source": "tag_cooccurrence"})
         assert _is_synthetic_seed_edge(edge) is True
 
     def test_tag_cooccurrence_above_threshold_is_still_synthetic(self):
@@ -385,7 +410,7 @@ class TestIsSyntheticSeedEdge:
         documented design: tag_cooccurrence is purely seeding by definition,
         and Sleep Discovery should be free to overwrite it with a confirmed
         ``related_to``."""
-        edge = _make_edge("tag_cooccurrence", 0.9)
+        edge = _make_edge("tag_cooccurrence", 0.9, edge_metadata={"source": "tag_cooccurrence"})
         assert _is_synthetic_seed_edge(edge) is True
 
 
@@ -401,10 +426,13 @@ class TestFilterExistingEdges:
 
     @pytest.mark.asyncio
     async def test_low_weight_semantic_similarity_does_not_block(self, edge_phase):
-        """A pair with only a k-NN seed edge is re-judged by discovery."""
+        """A pair with only a k-NN seed edge is re-judged by discovery.
+
+        Issue #741: seed identity is the ``origin='semantic'`` discriminator.
+        """
         src = uuid4()
         dst = uuid4()
-        seed_edge = _make_edge("semantic_similarity", 0.3, dst_id=dst)
+        seed_edge = _make_edge("semantic_similarity", 0.3, dst_id=dst, origin=EDGE_ORIGIN_SEMANTIC)
         edge_phase.edge_repo.get_outgoing_edges = AsyncMock(return_value=[seed_edge])
 
         filtered = await edge_phase._filter_existing_edges(
@@ -418,7 +446,9 @@ class TestFilterExistingEdges:
         """A strong semantic_similarity edge is treated as a real connection."""
         src = uuid4()
         dst = uuid4()
-        strong_edge = _make_edge("semantic_similarity", 0.8, dst_id=dst)
+        strong_edge = _make_edge(
+            "semantic_similarity", 0.8, dst_id=dst, origin=EDGE_ORIGIN_SEMANTIC
+        )
         edge_phase.edge_repo.get_outgoing_edges = AsyncMock(return_value=[strong_edge])
 
         filtered = await edge_phase._filter_existing_edges(
@@ -475,7 +505,9 @@ class TestFilterExistingEdges:
         src = uuid4()
         dst = uuid4()
         other = uuid4()
-        seed_to_other = _make_edge("semantic_similarity", 0.3, dst_id=other)
+        seed_to_other = _make_edge(
+            "semantic_similarity", 0.3, dst_id=other, origin=EDGE_ORIGIN_SEMANTIC
+        )
         edge_phase.edge_repo.get_outgoing_edges = AsyncMock(return_value=[seed_to_other])
 
         filtered = await edge_phase._filter_existing_edges(

--- a/backend/tests/services/test_graph_service_edge_types.py
+++ b/backend/tests/services/test_graph_service_edge_types.py
@@ -1,27 +1,28 @@
-"""Tests for GraphService.EDGE_TYPES drift fix (#506).
+"""Tests for GraphService.EDGE_TYPES drift fix (#506, updated for #741).
 
 PR #460 introduced ``EDGE_TYPE_*`` constants in ``models/memory.py`` to
 mirror the DB CHECK constraint values. PR #507 (#461 Phase A) wired
 ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` and the LLM-emittable
 subset in ``services/sleep/edge_discovery.py`` to those constants.
 
-This issue (#506) closes the last defining-site drift: ``GraphService.EDGE_TYPES``
-was missing ``tag_cooccurrence`` (introduced in #223), causing
-``add_edge(rel_type="tag_cooccurrence")`` to raise ``ValueError`` at the
-``:189`` validator. The production tag_cooccurrence write path goes through
-``NeuralEdgeRepository`` directly (memory_service), so this was a latent
-bug — but any future caller using ``GraphService`` for tag_cooccurrence
-edges would have hit it.
+#506 closed the last defining-site drift by adding ``tag_cooccurrence`` to
+``GraphService.EDGE_TYPES``. #741 then collapsed the edge_type axis to four
+values (``neural_association`` / ``related_to`` / ``depends_on`` /
+``learned_from``) by moving provenance to the ``origin`` axis and tag
+seeding to ``edge_metadata['source']``. The remaining set drift tests pin
+the post-#741 shape.
 
 Tests pin both invariants:
 
-1. ``GraphService.EDGE_TYPES`` equals the union of all ``EDGE_TYPE_*``
-   constants (matching the DB CHECK constraint), so future drift between
-   the constants block and this validator set fails CI before the
-   inconsistency can ship.
+1. ``GraphService.EDGE_TYPES`` equals the union of the four surviving
+   ``EDGE_TYPE_*`` constants (matching the DB CHECK constraint), so future
+   drift between the constants block and this validator set fails CI before
+   the inconsistency can ship.
 
-2. ``add_edge(rel_type="tag_cooccurrence")`` no longer raises — the
-   behavior change that motivated the atomic split from #461.
+2. ``add_edge(rel_type="neural_association")`` succeeds — post-#741 every
+   non-relational write (formerly ``semantic_similarity`` / ``declared_link``
+   / ``tag_cooccurrence``) goes through ``neural_association`` and discriminates
+   via ``origin`` + ``edge_metadata``.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -30,24 +31,23 @@ from uuid import uuid4
 import pytest
 
 from models.memory import (
-    EDGE_TYPE_DECLARED_LINK,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_RELATED_TO,
-    EDGE_TYPE_SEMANTIC_SIMILARITY,
-    EDGE_TYPE_TAG_COOCCURRENCE,
 )
 from services.graph_service import GraphService
 
 
 def test_edge_types_matches_constants() -> None:
-    """``GraphService.EDGE_TYPES`` is the union of all ``EDGE_TYPE_*``.
+    """``GraphService.EDGE_TYPES`` is the union of all surviving ``EDGE_TYPE_*``.
 
-    Mirrors ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` (PR #507) and
-    the DB CHECK constraint in ``models/memory.py::valid_edge_type``.
-    Adding a new edge_type must update both the constants block and this
-    set in lock-step; this test enforces the lock.
+    Mirrors ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` and the DB CHECK
+    constraint in ``models/memory.py::valid_edge_type``. Post-#741 the set
+    is the four-element union: ``neural_association`` / ``related_to`` /
+    ``depends_on`` / ``learned_from``. Adding a new edge_type must update
+    both the constants block and this set in lock-step; this test enforces
+    the lock.
     """
     assert GraphService.EDGE_TYPES == frozenset(
         {
@@ -55,22 +55,18 @@ def test_edge_types_matches_constants() -> None:
             EDGE_TYPE_RELATED_TO,
             EDGE_TYPE_DEPENDS_ON,
             EDGE_TYPE_LEARNED_FROM,
-            EDGE_TYPE_SEMANTIC_SIMILARITY,
-            EDGE_TYPE_DECLARED_LINK,
-            EDGE_TYPE_TAG_COOCCURRENCE,
         }
     )
 
 
 @pytest.mark.asyncio
-async def test_add_edge_accepts_tag_cooccurrence() -> None:
-    """``add_edge(rel_type="tag_cooccurrence")`` no longer raises ``ValueError``.
+async def test_add_edge_accepts_neural_association() -> None:
+    """``add_edge(rel_type="neural_association")`` succeeds.
 
-    Pre-#506 behavior: ``GraphService.EDGE_TYPES`` was missing
-    ``tag_cooccurrence`` (drifted from the DB CHECK constraint), so the
-    ``:189`` validator (``if rel_type not in self.EDGE_TYPES: raise``)
-    rejected legitimate tag_cooccurrence writes. Post-#506: validator
-    accepts and the call propagates to ``NeuralEdgeRepository``.
+    Post-#741 ``neural_association`` is the generic catch-all for any
+    provenance not expressible as a relation (Hebbian co-activation +
+    cold-start seeds + tag_cooccurrence + declared link). The validator
+    must accept it and forward to ``NeuralEdgeRepository``.
     """
     src_id = uuid4()
     dst_id = uuid4()
@@ -86,25 +82,28 @@ async def test_add_edge_accepts_tag_cooccurrence() -> None:
     graph.db = mock_db
     graph.edge_repo = mock_edge_repo
 
-    # Pre-#506 this would raise ValueError at graph_service.py:189.
     await graph.add_edge(
         src_id=src_id,
         dst_id=dst_id,
-        rel_type=EDGE_TYPE_TAG_COOCCURRENCE,
+        rel_type=EDGE_TYPE_NEURAL_ASSOCIATION,
         weight=0.3,
     )
 
     mock_edge_repo.create_or_update_edge.assert_awaited_once()
     kwargs = mock_edge_repo.create_or_update_edge.await_args.kwargs
-    assert kwargs["edge_type"] == EDGE_TYPE_TAG_COOCCURRENCE
+    assert kwargs["edge_type"] == EDGE_TYPE_NEURAL_ASSOCIATION
 
 
 @pytest.mark.asyncio
 async def test_add_edge_rejects_unknown_rel_type() -> None:
     """Validator still rejects values outside ``EDGE_TYPES``.
 
-    Negative-side complement to ``test_add_edge_accepts_tag_cooccurrence``:
-    confirms #506 widened the accepted set without disabling the validator.
+    Negative-side complement to ``test_add_edge_accepts_neural_association``:
+    confirms the validator narrowed to four values without becoming a no-op.
+    Post-#741 the deprecated ``semantic_similarity`` / ``declared_link`` /
+    ``tag_cooccurrence`` strings are also no longer in the set, but this
+    test uses a clearly invalid string so the assertion does not need to
+    enumerate them.
     """
     src_id = uuid4()
     dst_id = uuid4()

--- a/backend/tests/services/test_knn_seeding.py
+++ b/backend/tests/services/test_knn_seeding.py
@@ -294,7 +294,13 @@ class TestKnnSeeding:
         call = mock_repo.create_edge_if_absent.call_args
         assert call.kwargs["src_id"] == memory.id
         assert call.kwargs["dst_id"] == neighbor_id
-        assert call.kwargs["edge_type"] == "semantic_similarity"
+        # Issue #741: edge_type='semantic_similarity' deprecated; discriminator
+        # moved to origin='semantic'. The row writes neural_association with
+        # the origin kwarg carrying the semantic signal.
+        from models.memory import EDGE_ORIGIN_SEMANTIC, EDGE_TYPE_NEURAL_ASSOCIATION
+
+        assert call.kwargs["edge_type"] == EDGE_TYPE_NEURAL_ASSOCIATION
+        assert call.kwargs["origin"] == EDGE_ORIGIN_SEMANTIC
         assert call.kwargs["weight"] == 0.3
         assert call.kwargs["confidence"] == 0.85
         assert call.kwargs["workspace_id"] == str(memory.workspace_id)

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -389,9 +389,13 @@ class TestReferenceWithLinks:
 
             # Repo must have been called with limit=51 (cap+1) so service can
             # detect has_more without paginating.
+            # Issue #741: declared-link filter pivoted from edge_types=[...] to
+            # origin='declared'.
+            from models.memory import EDGE_ORIGIN_DECLARED
+
             kwargs = mock_edge_repo.get_outgoing_edges.await_args.kwargs
             assert kwargs["limit"] == 51
-            assert kwargs["edge_types"] == ["declared_link"]
+            assert kwargs.get("origin") == EDGE_ORIGIN_DECLARED
 
         assert len(response.outgoing_links) == 50
         assert response.outgoing_has_more is True
@@ -432,7 +436,15 @@ class TestReferenceWithLinks:
     async def test_passes_declared_link_filter_to_repo(
         self, source_memory, workspace_id, context_id
     ):
-        """Edge fetch is restricted to declared_link only (not semantic/cooccurrence)."""
+        """Edge fetch is restricted to user-asserted (origin='declared') edges.
+
+        Issue #741: discriminator pivoted from edge_type='declared_link' to
+        origin='declared'. The consumer in ``_fetch_declared_link_refs`` now
+        passes ``origin=EDGE_ORIGIN_DECLARED`` instead of
+        ``edge_types=['declared_link']``.
+        """
+        from models.memory import EDGE_ORIGIN_DECLARED
+
         service = self._make_service(source_memory)
         service.db.execute = self._bulk_select_returning([])
 
@@ -453,8 +465,8 @@ class TestReferenceWithLinks:
 
         out_kwargs = mock_edge_repo.get_outgoing_edges.await_args.kwargs
         in_kwargs = mock_edge_repo.get_incoming_edges.await_args.kwargs
-        assert out_kwargs["edge_types"] == ["declared_link"]
-        assert in_kwargs["edge_types"] == ["declared_link"]
+        assert out_kwargs.get("origin") == EDGE_ORIGIN_DECLARED
+        assert in_kwargs.get("origin") == EDGE_ORIGIN_DECLARED
         # Both edge fetches are scoped to the source memory's workspace+context.
         assert out_kwargs["workspace_id"] == str(workspace_id)
         assert out_kwargs["context_id"] == str(context_id)
@@ -726,13 +738,19 @@ class TestTagCooccurrenceSeeding:
     @pytest.mark.asyncio
     async def test_idempotency_guard_skips_when_seeded(self, base_memory, cfg):
         """If tag_cooccurrence edges already exist for this memory, skip the
-        SQL candidate query entirely. Edge-type-scoped — knn semantic_similarity
-        edges on the same memory must NOT trigger this skip."""
+        SQL candidate query entirely. Issue #741: edge_type='tag_cooccurrence'
+        merged into 'neural_association'; the discriminator moved to
+        ``edge_metadata['source']`` on hebbian-origin rows. Pure-semantic
+        edges (origin='semantic', no source metadata) must NOT trigger this skip."""
         from services import memory_service as ms
+
+        # Build a fake hebbian edge that carries the tag_cooccurrence stamp.
+        seeded_edge = MagicMock()
+        seeded_edge.edge_metadata = {"source": "tag_cooccurrence"}
 
         edge_repo_cls = MagicMock()
         repo_inst = MagicMock()
-        repo_inst.get_outgoing_edges = AsyncMock(return_value=[MagicMock()])  # already seeded
+        repo_inst.get_outgoing_edges = AsyncMock(return_value=[seeded_edge])
         edge_repo_cls.return_value = repo_inst
 
         # to_regclass returns table; idempotency then short-circuits
@@ -749,9 +767,13 @@ class TestTagCooccurrenceSeeding:
         # to_regclass ran (1 execute), then idempotency fired
         assert session.execute.await_count == 1
         repo_inst.get_outgoing_edges.assert_awaited_once()
-        # filter passed only the tag_cooccurrence edge_type
+        # Post-#741: filter pivots from edge_types=[...] to origin='hebbian',
+        # then Python-side scan of edge_metadata['source'].
+        from models.memory import EDGE_ORIGIN_HEBBIAN
+
         call_kwargs = repo_inst.get_outgoing_edges.call_args.kwargs
-        assert call_kwargs["edge_types"] == ["tag_cooccurrence"]
+        assert call_kwargs.get("origin") == EDGE_ORIGIN_HEBBIAN
+        assert "edge_types" not in call_kwargs or call_kwargs["edge_types"] is None
 
     @pytest.mark.asyncio
     async def test_all_tags_are_hub_skips_query(self, base_memory, cfg):
@@ -811,8 +833,14 @@ class TestTagCooccurrenceSeeding:
 
         assert repo_inst.create_edge_if_absent.await_count == 2
         # First call: shared=3 → weight=0.35, confidence=0.75
+        # Issue #741: edge_type='tag_cooccurrence' merged into
+        # 'neural_association'; the discriminator moved to
+        # edge_metadata['source'].
+        from models.memory import EDGE_TYPE_NEURAL_ASSOCIATION
+
         first = repo_inst.create_edge_if_absent.call_args_list[0].kwargs
-        assert first["edge_type"] == "tag_cooccurrence"
+        assert first["edge_type"] == EDGE_TYPE_NEURAL_ASSOCIATION
+        assert first.get("edge_metadata") == {"source": "tag_cooccurrence"}
         assert first["dst_id"] == cand_b_id
         assert first["weight"] == pytest.approx(0.35)
         assert first["confidence"] == pytest.approx(0.75)

--- a/backend/tests/test_edge_type_constants.py
+++ b/backend/tests/test_edge_type_constants.py
@@ -20,13 +20,10 @@ runtime test is the next safety net after pyright.
 
 from mcp_server.tools.edge import VALID_EDGE_TYPES
 from models.memory import (
-    EDGE_TYPE_DECLARED_LINK,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_RELATED_TO,
-    EDGE_TYPE_SEMANTIC_SIMILARITY,
-    EDGE_TYPE_TAG_COOCCURRENCE,
 )
 from services.sleep.edge_discovery import LLM_EMITTABLE_EDGE_TYPES
 
@@ -44,9 +41,6 @@ def test_valid_edge_types_matches_constants() -> None:
             EDGE_TYPE_RELATED_TO,
             EDGE_TYPE_DEPENDS_ON,
             EDGE_TYPE_LEARNED_FROM,
-            EDGE_TYPE_SEMANTIC_SIMILARITY,
-            EDGE_TYPE_DECLARED_LINK,
-            EDGE_TYPE_TAG_COOCCURRENCE,
         }
     )
 
@@ -84,11 +78,7 @@ def test_valid_edge_type_check_constraint_matches_migration_literal() -> None:
     """
     from models.memory import NeuralMemoryEdge
 
-    expected = (
-        "edge_type IN ('neural_association', 'related_to', 'depends_on', "
-        "'learned_from', 'semantic_similarity', 'declared_link', "
-        "'tag_cooccurrence')"
-    )
+    expected = "edge_type IN ('neural_association', 'related_to', 'depends_on', 'learned_from')"
 
     valid_edge_type_check = next(
         c for c in NeuralMemoryEdge.__table_args__ if getattr(c, "name", None) == "valid_edge_type"


### PR DESCRIPTION
## Summary
- Drops `semantic_similarity`, `declared_link`, `tag_cooccurrence` from `_ALL_EDGE_TYPES` registration tuple and the `valid_edge_type` CHECK constraint. These overlapped with the `origin` discriminator added in #722.
- Migration `e20_741_deprecate_edge_type` runs **3 phases**:
  - **Phase 0 — backfill**: aligns misclassified `origin` (and `edge_metadata['source']` for tag_cooccurrence) BEFORE the merge. Pre-flight on prod found 10 `semantic_similarity` + 31 `tag_cooccurrence` rows all with `origin='hebbian'` (the e17_722 backfill didn't classify by edge_type). Without Phase 0, the merge would silently drop provenance.
  - **Phase 1 — merge**: collapses the 3 deprecated edge_types into `neural_association`. Information-lossless at the (edge_type, origin, edge_metadata) tuple level because Phase 0 preserved discrimination.
  - **Phase 2 — CHECK constraint**: drop+recreate `valid_edge_type` to accept only the 4 surviving values.
- Pivots `repositories/neural_edge.py` declared-link upsert preservation from `edge_type == EDGE_TYPE_DECLARED_LINK` to `origin == EDGE_ORIGIN_DECLARED`. The preserved value is now the existing `edge_type` column (any user-asserted edge_type), not a hardcoded legacy literal.
- Pivots `services/sleep/edge_discovery.py::_is_synthetic_seed_edge` branches: `edge_type == 'semantic_similarity'` → `origin == EDGE_ORIGIN_SEMANTIC`; `edge_type == 'tag_cooccurrence'` → `edge_metadata['source'] == 'tag_cooccurrence'`.
- Shrinks `VALID_EDGE_TYPES` in `mcp_server/tools/edge.py` and the corresponding set in `graph_service.py` to 4 entries.
- Updates `_make_edge` test helper in `test_edge_discovery.py` to set `origin`/`edge_metadata` (caught 4 explicit + 5 sibling tests that were silently vacuous).
- Updates drift test (`tests/test_edge_type_constants.py`) — 3 tests now pin the 4-value shape.

## Pre-flight validation
Ran `SELECT edge_type, origin, COUNT(*) FROM neural_memory_edges WHERE edge_type IN (...) GROUP BY 1, 2` against prod (memory.kagura-ai.com via IAP tunnel):
```
semantic_similarity|hebbian|10
tag_cooccurrence|hebbian|31
```
Both deprecated edge_types had `origin='hebbian'` (misclassified by #722). Migration's Phase 0 backfill addresses this — `semantic_similarity` rows → `origin='semantic'`; `tag_cooccurrence` rows → `edge_metadata['source']='tag_cooccurrence'` (since EDGE_ORIGIN_TAG is intentionally not introduced per #741 issue body).

`declared_link` had 0 rows in prod (dev has 1 leftover row, also handled defensively by Phase 0).

## Migration design notes
- The `edge_metadata` (DB column: `metadata`) is `JSON` (not JSONB). The COALESCE-merge approach used elsewhere in the codebase wouldn't work — implementer fixed via CASE expression with explicit `::jsonb` casts for the `||` merge.
- All Phase 0 UPDATEs use idempotent WHERE clauses (skip rows already at the target shape). Re-running the upgrade is a no-op.
- `downgrade()` reverts the CHECK constraint only — Phase 0 + Phase 1 UPDATEs are lossy at the `edge_type` column level. Callers needing the legacy strings post-downgrade should read `origin`/`edge_metadata['source']`. Documented in the migration docstring.

## Test plan
- [x] `alembic upgrade head` + `downgrade -1` + re-upgrade is idempotent.
- [x] Post-upgrade dev DB: `declared_link/hebbian` row correctly remapped to `neural_association/declared`.
- [x] `tests/test_edge_type_constants.py` (3 tests) green.
- [x] `tests/integration/test_create_all_vs_alembic_drift.py` green (ORM and migration head produce byte-identical CHECK SQL).
- [x] `tests/integration/test_declared_link_protection.py` (3 tests) green — preservation invariant holds via origin discriminator.
- [x] `tests/services/sleep/test_edge_discovery.py` (64 tests) green after `_make_edge` helper update.
- [x] `tests/services/test_graph_service_edge_types.py` green.
- [x] `tests/repositories/` (58 tests, includes neural_edge) green.
- [x] `tests/mcp_server/` green.
- [x] Container-side targeted sweep: 304 passed.
- [x] `ruff check src/` and `pyright src/models/memory.py src/mcp_server/tools/edge.py src/services/graph_service.py src/services/sleep/edge_discovery.py src/repositories/neural_edge.py` clean.

## Out of scope
- Adding new relation types (`causes`, `precedes`, `is_a`, `part_of`, `contradicts`) — pilot eval at `backend/tests/services/sleep/eval/pilot_2026_04/` aborted at 40% LLM-human label agreement.
- Adding `EDGE_ORIGIN_TAG` — out of scope per issue body (tag-cooccurrence preserved via metadata).
- `protect_declared_link` parameter rename — kept (5 callsites, exceeds rename threshold); docstring updated to reflect new origin-based semantics.

Closes #741

🤖 Generated with [Claude Code](https://claude.com/claude-code)