### PR TITLE
docs(test): update declared-link protection test docstring for #741

### DIFF
--- a/backend/tests/integration/test_declared_link_protection.py
+++ b/backend/tests/integration/test_declared_link_protection.py
@@ -89,13 +89,16 @@ async def declared_link_scenario(db_session: AsyncSession):
 async def test_protect_declared_link_preserves_edge_type(
     db_session: AsyncSession, declared_link_scenario
 ):
-    """Hebbian-style retyping must not clobber declared_link edge_type.
+    """Hebbian-style retyping must not clobber a declared-origin edge.
 
-    Scenario: a `declared_link` edge exists (user-declared). Hebbian
+    Scenario: a user-declared edge exists (origin='declared'). Hebbian
     co-activation later fires and tries to upsert the same (src, dst)
-    with edge_type="neural_association" via GraphService.add_edge,
-    which passes protect_declared_link=True. The edge_type must stay
-    "declared_link"; weight/last_updated may update.
+    with edge_type="neural_association" via GraphService.add_edge, which
+    passes protect_declared_link=True. The existing edge_type AND origin
+    must stay pinned (#741: declared-link semantics now key on the origin
+    discriminator, and the preserved edge_type is whatever value the user
+    asserted — `related_to` in this fixture); weight/last_updated may
+    update.
     """
     repo = NeuralEdgeRepository(db_session)
     s = declared_link_scenario


### PR DESCRIPTION
## Summary
Copilot returned a documentation nit on the (now-merged) PR #792 (#741): the test docstring at `test_declared_link_protection.py::test_protect_declared_link_preserves_edge_type` still described pre-#741 semantics ("declared_link edge_type must stay pinned") even though the test was updated to seed `origin='declared'` with a non-deprecated `edge_type` (`related_to`) and assert preservation of the user-asserted value.

This PR rewrites the 7-line docstring to match the post-#741 contract:
- The discriminator is `origin='declared'` (not the legacy `edge_type='declared_link'`).
- The preserved value is **the existing edge_type** (whatever the user asserted), not a hardcoded literal.
- The fixture uses `related_to` to demonstrate the "any user-asserted edge_type is preserved" invariant.

No code change — docstring only.

## Test plan
- [x] `pytest tests/integration/test_declared_link_protection.py -v` → 3 passed (unchanged from pre-fix).

Follow-up to PR #792 / Issue #741.

🤖 Generated with [Claude Code](https://claude.com/claude-code)