### PR TITLE
refactor(rbac): introduce WorkspaceRole/ContextRole StrEnum (#700)

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -16,6 +16,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import require_admin
+from auth.workspace_roles import ContextRole, WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from models.auth import (
@@ -574,8 +575,8 @@ async def get_user_detail(
             workspace, workspace_role = context_workspace_map[ctx.id]
 
             # Determine user's role in this context
-            ctx_role = "viewer"  # Default
-            if workspace_role in ("owner", "admin"):
+            ctx_role: WorkspaceRole | ContextRole = ContextRole.VIEWER  # Default
+            if workspace_role in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN):
                 ctx_role = workspace_role  # #699: preserve owner/admin distinction
             else:
                 # Check context_members for explicit role

--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -20,6 +20,7 @@ from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser, SessionUser, get_current_user
+from auth.workspace_roles import ContextRole, WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from models.schemas import RelatedTagItem
@@ -364,10 +365,10 @@ async def list_contexts(
         for context in contexts_list:
             count = 0
             for om in workspace_members:
-                if om.role in ("owner", "admin"):
+                if om.role in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN):
                     # Owners/admins always have access
                     count += 1
-                elif om.role in ("member", "viewer"):
+                elif om.role in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
                     # Check allowed_context_ids
                     if om.allowed_context_ids is None:
                         # No restriction - has access
@@ -853,7 +854,7 @@ async def update_context(
     else:
         # Editor can update description
         existing_context, _ = await perm_service.check_context_access(
-            user_id, context_id, required_role="editor"
+            user_id, context_id, required_role=ContextRole.EDITOR
         )
 
     try:
@@ -1141,7 +1142,7 @@ async def list_context_members(
     # Issue #271 Code Review C-2: check_context_access already verifies workspace membership
     # Issue #272 M-3: Reuse context from check_context_access to avoid redundant DB query
     context, _ = await perm_service.check_context_access(
-        user["user_id"], context_id, required_role="viewer"
+        user["user_id"], context_id, required_role=ContextRole.VIEWER
     )
 
     # Get context for member list query
@@ -1178,9 +1179,9 @@ async def list_context_members(
     #     which is consistent with the "explicit membership required" rule.
     accessible_members = []
     for om in all_workspace_members:
-        if om.role in ("owner", "admin"):
+        if om.role in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN):
             accessible_members.append(om)
-        elif om.role == "viewer":
+        elif om.role == WorkspaceRole.VIEWER:
             if om.allowed_context_ids is None:
                 accessible_members.append(om)
             elif context_id in om.allowed_context_ids:
@@ -1227,13 +1228,15 @@ async def list_context_members(
     # so that viewers excluded by their allowed_context_ids whitelist are
     # still kept out of Pass 2. Such viewers lack effective access per
     # check_context_access and simply do not appear in the response at all.
-    workspace_viewer_ids = {om.user_id for om in all_workspace_members if om.role == "viewer"}
+    workspace_viewer_ids = {
+        om.user_id for om in all_workspace_members if om.role == WorkspaceRole.VIEWER
+    }
     response = []
     seen_user_ids: set[str] = set()
 
     # Pass 1 — workspace owner/admin (dominant access layer)
     for om in accessible_members:
-        if om.role not in ("owner", "admin"):
+        if om.role not in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN):
             continue
         user_info = users.get(om.user_id)
         response.append(
@@ -1428,7 +1431,7 @@ async def update_context_member_role(
     # v0.12.1 — this endpoint is admin-click frequency, and a workspace admin
     # can always promote another member to recover. Revisit with row-level
     # locking if traffic patterns change.
-    if member.role == "owner" and body.role != "owner":
+    if member.role == ContextRole.OWNER and body.role != ContextRole.OWNER:
         owner_count = await perm_service.count_context_owners(context_id)
         if owner_count <= 1:
             raise HTTPException(
@@ -1509,7 +1512,7 @@ async def remove_context_member(
         )
 
     # Cannot remove owner
-    if member.role == "owner":
+    if member.role == ContextRole.OWNER:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Cannot remove context owner",

--- a/backend/src/api/routes/invitations.py
+++ b/backend/src/api/routes/invitations.py
@@ -17,6 +17,7 @@ from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import get_current_user
+from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.auth import Workspace, WorkspaceInvitation, WorkspaceMember
 from models.schemas import (
@@ -95,7 +96,9 @@ async def create_invitation(
         # SECURITY: Workspace boundary check
         # Issue #268/#269: Membership verification is sufficient
         # check_workspace_access ensures user is admin of this workspace
-        await perm_service.check_workspace_access(user_id, workspace_id, required_role="admin")
+        await perm_service.check_workspace_access(
+            user_id, workspace_id, required_role=WorkspaceRole.ADMIN
+        )
 
         # Check plan tier (Issue #165 - invitations require Pro plan)
         from sqlalchemy import select
@@ -215,7 +218,9 @@ async def list_invitations(
 
     # SECURITY: Workspace boundary check
     # Issue #268/#269: Membership verification is sufficient
-    await perm_service.check_workspace_access(user_id, workspace_id, required_role="admin")
+    await perm_service.check_workspace_access(
+        user_id, workspace_id, required_role=WorkspaceRole.ADMIN
+    )
 
     invitation_service = InvitationService(db)
     invitations = await invitation_service.list_invitations(
@@ -282,7 +287,9 @@ async def delete_invitation(
 
         # SECURITY: Workspace boundary check
         # Issue #268/#269: Membership verification is sufficient
-        await perm_service.check_workspace_access(user_id, workspace_id, required_role="admin")
+        await perm_service.check_workspace_access(
+            user_id, workspace_id, required_role=WorkspaceRole.ADMIN
+        )
 
         invitation_service = InvitationService(db)
         await invitation_service.delete_invitation(invitation_id, workspace_id)
@@ -542,7 +549,9 @@ async def get_member_quota(
 
     # Check permission (at least member access required)
     perm_service = PermissionService(db)
-    await perm_service.check_workspace_access(user_id, workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user_id, workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     # Count current members
     member_count_result = await db.execute(

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.analysis_allowlist import check_workspace_in_allowlist
 from auth.dependencies import get_current_user
+from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from models.auth import Context, ExternalAPIKey, User
@@ -420,7 +421,9 @@ async def get_workspace(
     perm_service = PermissionService(db)
 
     # Check access
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     workspace = await workspace_service.get_workspace(workspace_id)
     stats = await workspace_service.get_workspace_stats(workspace_id)
@@ -530,7 +533,9 @@ async def switch_workspace(
     perm_service = PermissionService(db)
 
     # Verify user is a member of this workspace
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     # Update user's current workspace
     user_result = await db.execute(select(User).where(User.user_id == user["user_id"]))
@@ -568,7 +573,9 @@ async def list_members(
     perm_service = PermissionService(db)
 
     # Check access
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     members = await workspace_service.list_members(workspace_id)
 
@@ -732,7 +739,7 @@ async def update_member_role(
 
     # Issue #254: Prevent non-owners from changing owner's role
     target_member = await workspace_service.get_member(workspace_id, user_id)
-    if target_member.role == "owner" and current_member.role != "owner":
+    if target_member.role == WorkspaceRole.OWNER and current_member.role != WorkspaceRole.OWNER:
         raise HTTPException(
             status_code=403,
             detail="Only the owner can change the owner's role.",
@@ -868,7 +875,9 @@ async def get_workspace_stats(
     # SECURITY: Workspace boundary check
     # Issue #269: Membership verification is sufficient (no current_workspace_id required)
     # Users can access stats for any workspace they are a member of
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     stats = await workspace_service.get_workspace_stats(workspace_id)
 
@@ -901,7 +910,9 @@ async def get_context_stats(
 
     # SECURITY: Workspace boundary check
     # Issue #269: Membership verification is sufficient (no current_workspace_id required)
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     stats = await workspace_service.get_context_stats(workspace_id)
 
@@ -937,7 +948,9 @@ async def get_context_usage_timeline(
 
     # SECURITY: Workspace boundary check
     # Issue #269: Membership verification is sufficient (no current_workspace_id required)
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     # Limit days to prevent excessive queries
     days = min(days, 30)
@@ -976,7 +989,9 @@ async def get_context_user_activity(
 
     # SECURITY: Workspace boundary check
     # Issue #269: Membership verification is sufficient (no current_workspace_id required)
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="admin")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.ADMIN
+    )
 
     # Limit days to prevent excessive queries
     days = min(days, 30)
@@ -1003,7 +1018,9 @@ async def get_workspace_memory_timeline(
     workspace_service = WorkspaceService(db)
     perm_service = PermissionService(db)
 
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     days = min(days, 90)  # Performance limit
 
@@ -1052,7 +1069,9 @@ async def get_context_public_api_stats(
 
     # SECURITY: Workspace boundary check
     # Issue #269: Membership verification is sufficient (no current_workspace_id required)
-    await perm_service.check_workspace_access(user["user_id"], workspace_id, required_role="member")
+    await perm_service.check_workspace_access(
+        user["user_id"], workspace_id, required_role=WorkspaceRole.MEMBER
+    )
 
     # Limit days to prevent excessive queries
     days = min(days, 30)
@@ -1097,7 +1116,7 @@ async def check_openai_key_status(
 
     # Check access (any member can view) and get member info
     workspace_member = await perm_service.check_workspace_access(
-        user["user_id"], workspace_id, required_role="viewer"
+        user["user_id"], workspace_id, required_role=WorkspaceRole.VIEWER
     )
 
     # Query for OpenAI key (prioritize workspace-scoped, fallback to user-scoped)
@@ -1122,7 +1141,7 @@ async def check_openai_key_status(
         openai_key = result.scalar_one_or_none()
 
     # Check if user can configure (owner/admin)
-    can_configure = workspace_member.role in ["owner", "admin"]
+    can_configure = workspace_member.role in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN)
 
     logger.info(
         f"User {user['user_id']} checked OpenAI key status for workspace {workspace_id}: "

--- a/backend/src/auth/workspace_roles.py
+++ b/backend/src/auth/workspace_roles.py
@@ -17,9 +17,9 @@ source of truth for the DB constraint.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from enum import StrEnum
 from types import MappingProxyType
-from typing import Mapping
 
 __all__ = [
     "WorkspaceRole",

--- a/backend/src/auth/workspace_roles.py
+++ b/backend/src/auth/workspace_roles.py
@@ -1,0 +1,64 @@
+"""Workspace / Context role StrEnums (Issue #700).
+
+Replaces stringly-typed role literals across the codebase. The system-level
+``Role`` (admin / user / read_only) lives in ``auth.roles`` and is a separate
+axis — this module is exclusively for tenancy roles inside a workspace.
+
+The enum values are the existing DB strings; switching to StrEnum is a
+type-safety upgrade, NOT a wire or storage change. ``StrEnum`` JSON-
+serialises as its ``.value``, so API responses are byte-identical to the
+pre-refactor shape.
+
+The ``*_CHECK_SQL`` constants are derived from ``.value`` via f-string and
+are byte-identical to the migration literals — re-used in
+``models/auth.py`` ``CheckConstraint`` blocks so the enum is the single
+source of truth for the DB constraint.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class WorkspaceRole(StrEnum):
+    """Workspace-level tenancy role.
+
+    Ordering: OWNER > ADMIN > MEMBER > VIEWER (see WORKSPACE_ROLE_WEIGHTS).
+    """
+
+    OWNER = "owner"
+    ADMIN = "admin"
+    MEMBER = "member"
+    VIEWER = "viewer"
+
+
+class ContextRole(StrEnum):
+    """Context-level tenancy role.
+
+    Ordering: OWNER > EDITOR > VIEWER (see CONTEXT_ROLE_WEIGHTS).
+    Distinct from WorkspaceRole — a context EDITOR is not a workspace
+    ADMIN, and a workspace MEMBER may have no context role at all.
+    """
+
+    OWNER = "owner"
+    EDITOR = "editor"
+    VIEWER = "viewer"
+
+
+WORKSPACE_ROLE_WEIGHTS: dict[WorkspaceRole, int] = {
+    WorkspaceRole.OWNER: 4,
+    WorkspaceRole.ADMIN: 3,
+    WorkspaceRole.MEMBER: 2,
+    WorkspaceRole.VIEWER: 1,
+}
+
+CONTEXT_ROLE_WEIGHTS: dict[ContextRole, int] = {
+    ContextRole.OWNER: 3,
+    ContextRole.EDITOR: 2,
+    ContextRole.VIEWER: 1,
+}
+
+
+WORKSPACE_ROLE_CHECK_SQL: str = f"role IN ({', '.join(repr(r.value) for r in WorkspaceRole)})"
+
+CONTEXT_ROLE_CHECK_SQL: str = f"role IN ({', '.join(repr(r.value) for r in ContextRole)})"

--- a/backend/src/auth/workspace_roles.py
+++ b/backend/src/auth/workspace_roles.py
@@ -10,7 +10,7 @@ serialises as its ``.value``, so API responses are byte-identical to the
 pre-refactor shape.
 
 The ``*_CHECK_SQL`` constants are derived from ``.value`` via f-string and
-are byte-identical to the migration literals — re-used in
+are byte-identical to the migration literals — re-used (Task 3 of #700) in
 ``models/auth.py`` ``CheckConstraint`` blocks so the enum is the single
 source of truth for the DB constraint.
 """
@@ -18,6 +18,17 @@ source of truth for the DB constraint.
 from __future__ import annotations
 
 from enum import StrEnum
+from types import MappingProxyType
+from typing import Mapping
+
+__all__ = [
+    "WorkspaceRole",
+    "ContextRole",
+    "WORKSPACE_ROLE_WEIGHTS",
+    "CONTEXT_ROLE_WEIGHTS",
+    "WORKSPACE_ROLE_CHECK_SQL",
+    "CONTEXT_ROLE_CHECK_SQL",
+]
 
 
 class WorkspaceRole(StrEnum):
@@ -45,18 +56,22 @@ class ContextRole(StrEnum):
     VIEWER = "viewer"
 
 
-WORKSPACE_ROLE_WEIGHTS: dict[WorkspaceRole, int] = {
-    WorkspaceRole.OWNER: 4,
-    WorkspaceRole.ADMIN: 3,
-    WorkspaceRole.MEMBER: 2,
-    WorkspaceRole.VIEWER: 1,
-}
+WORKSPACE_ROLE_WEIGHTS: Mapping[WorkspaceRole, int] = MappingProxyType(
+    {
+        WorkspaceRole.OWNER: 4,
+        WorkspaceRole.ADMIN: 3,
+        WorkspaceRole.MEMBER: 2,
+        WorkspaceRole.VIEWER: 1,
+    }
+)
 
-CONTEXT_ROLE_WEIGHTS: dict[ContextRole, int] = {
-    ContextRole.OWNER: 3,
-    ContextRole.EDITOR: 2,
-    ContextRole.VIEWER: 1,
-}
+CONTEXT_ROLE_WEIGHTS: Mapping[ContextRole, int] = MappingProxyType(
+    {
+        ContextRole.OWNER: 3,
+        ContextRole.EDITOR: 2,
+        ContextRole.VIEWER: 1,
+    }
+)
 
 
 WORKSPACE_ROLE_CHECK_SQL: str = f"role IN ({', '.join(repr(r.value) for r in WorkspaceRole)})"

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -30,7 +30,6 @@ from sqlalchemy import (
     CheckConstraint,
     Date,
     DateTime,
-    Enum as SAEnum,
     ForeignKey,
     Index,
     Integer,
@@ -39,6 +38,9 @@ from sqlalchemy import (
     Text,
     func,
     text,
+)
+from sqlalchemy import (
+    Enum as SAEnum,
 )
 from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -30,6 +30,7 @@ from sqlalchemy import (
     CheckConstraint,
     Date,
     DateTime,
+    Enum as SAEnum,
     ForeignKey,
     Index,
     Integer,
@@ -43,6 +44,12 @@ from sqlalchemy.dialects.postgresql import ARRAY, UUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from auth.mcp_scopes import DCR_DEFAULT_SCOPE
+from auth.workspace_roles import (
+    CONTEXT_ROLE_CHECK_SQL,
+    WORKSPACE_ROLE_CHECK_SQL,
+    ContextRole,
+    WorkspaceRole,
+)
 from db.base import Base
 from utils.datetime import utcnow
 from utils.redirect_uri import any_redirect_uri_matches
@@ -1627,7 +1634,16 @@ class WorkspaceMember(Base):
         index=True,
     )
     user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
-    role: Mapped[str] = mapped_column(String(50), nullable=False, server_default="member")
+    role: Mapped[WorkspaceRole] = mapped_column(
+        SAEnum(
+            WorkspaceRole,
+            native_enum=False,
+            length=50,
+            values_callable=lambda enum: [e.value for e in enum],
+        ),
+        nullable=False,
+        server_default=WorkspaceRole.MEMBER.value,
+    )
 
     # Context access restriction (Issue #234)
     # NULL = no restriction, [] = no access, [uuid, ...] = whitelist
@@ -1654,9 +1670,7 @@ class WorkspaceMember(Base):
         Index("idx_workspace_members_org", "workspace_id"),
         Index("idx_workspace_members_user", "user_id"),
         Index("idx_workspace_members_role", "workspace_id", "role"),
-        CheckConstraint(
-            "role IN ('owner', 'admin', 'member', 'viewer')", name="valid_workspace_member_role"
-        ),
+        CheckConstraint(WORKSPACE_ROLE_CHECK_SQL, name="valid_workspace_member_role"),
     )
 
     def __repr__(self) -> str:
@@ -1710,7 +1724,16 @@ class WorkspaceInvitation(Base):
     )
     token: Mapped[str] = mapped_column(String(100), nullable=False, unique=True, index=True)
     email: Mapped[str | None] = mapped_column(String(255), nullable=True, index=True)
-    role: Mapped[str] = mapped_column(String(50), nullable=False, server_default="member")
+    role: Mapped[WorkspaceRole] = mapped_column(
+        SAEnum(
+            WorkspaceRole,
+            native_enum=False,
+            length=50,
+            values_callable=lambda enum: [e.value for e in enum],
+        ),
+        nullable=False,
+        server_default=WorkspaceRole.MEMBER.value,
+    )
     invited_by: Mapped[str] = mapped_column(String(255), nullable=False)
     expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True, index=True)
     accepted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
@@ -1728,9 +1751,7 @@ class WorkspaceInvitation(Base):
 
     # Constraints
     __table_args__ = (
-        CheckConstraint(
-            "role IN ('owner', 'admin', 'member', 'viewer')", name="valid_invitation_role"
-        ),
+        CheckConstraint(WORKSPACE_ROLE_CHECK_SQL, name="valid_invitation_role"),
         CheckConstraint("length(token) >= 20", name="valid_invitation_token"),
     )
 
@@ -1802,7 +1823,16 @@ class ContextMember(Base):
         index=True,
     )
     user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
-    role: Mapped[str] = mapped_column(String(50), nullable=False, server_default="editor")
+    role: Mapped[ContextRole] = mapped_column(
+        SAEnum(
+            ContextRole,
+            native_enum=False,
+            length=50,
+            values_callable=lambda enum: [e.value for e in enum],
+        ),
+        nullable=False,
+        server_default=ContextRole.EDITOR.value,
+    )
 
     # Invitation tracking
     invited_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
@@ -1820,7 +1850,7 @@ class ContextMember(Base):
     __table_args__ = (
         Index("idx_context_members_context", "context_id"),
         Index("idx_context_members_user", "user_id"),
-        CheckConstraint("role IN ('owner', 'editor', 'viewer')", name="valid_context_member_role"),
+        CheckConstraint(CONTEXT_ROLE_CHECK_SQL, name="valid_context_member_role"),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -10,6 +10,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from auth.workspace_roles import ContextRole, WorkspaceRole
 from models.api_base import TZAwareBaseModel
 
 logger = logging.getLogger(__name__)
@@ -789,7 +790,9 @@ class UserAccessibleContext(TZAwareBaseModel):
     context_name: str
     workspace_id: str
     workspace_name: str
-    role: str  # owner/admin/editor/viewer  # #699: admin added for workspace_admin without ContextMember
+    # #699: workspace owner/admin without ContextMember are reported with their
+    # workspace role; explicit ContextMember rows use ContextRole.
+    role: WorkspaceRole | ContextRole
     last_used_at: datetime | None
 
     class Config:
@@ -908,9 +911,8 @@ class WorkspaceInvitationCreate(BaseModel):
         max_length=255,
         pattern=r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$",
     )
-    role: str = Field(
-        "member",
-        pattern=r"^(owner|admin|member|viewer)$",
+    role: WorkspaceRole = Field(
+        WorkspaceRole.MEMBER,
         description="Role to assign upon acceptance",
     )
     expires_in_days: int | None = Field(

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -16,6 +16,7 @@ from sqlalchemy import and_, delete, func, select
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.workspace_roles import WorkspaceRole
 from config.settings import get_settings
 from models.auth import Context, ContextMember, User, Workspace, WorkspaceMember
 from models.sleep import SleepMode
@@ -145,11 +146,11 @@ class ContextService:
 
             if workspace_member:
                 # Check role: Owner/Admin can create contexts
-                if workspace_member.role not in ["owner", "admin"]:
+                if workspace_member.role not in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN):
                     raise ValidationError("Only workspace owners and admins can create contexts.")
 
                 # Private contexts: Owner only
-                if is_private and workspace_member.role != "owner":
+                if is_private and workspace_member.role != WorkspaceRole.OWNER:
                     raise ValidationError(
                         "Only workspace owners can create private contexts. "
                         "Admins can create shared contexts."
@@ -323,7 +324,7 @@ class ContextService:
             raise NotFoundException(f"Context not found: {context_id}")
 
         # Issue #234: Check allowed_context_ids whitelist for member/viewer
-        if workspace_member.role in ("member", "viewer"):
+        if workspace_member.role in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER):
             if workspace_member.allowed_context_ids is not None:
                 if context_id not in workspace_member.allowed_context_ids:
                     raise NotFoundException(f"Context not found: {context_id}")
@@ -1383,7 +1384,7 @@ class ContextService:
         membership = WorkspaceMember(
             workspace_id=workspace.id,
             user_id=user_id,
-            role="owner",
+            role=WorkspaceRole.OWNER,
         )
         self.db.add(membership)
 

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -439,7 +439,10 @@ class PermissionService:
             required_role: Minimum required role (owner/editor/viewer)
 
         Returns:
-            Tuple of (Context, effective_role)
+            Tuple of (Context, effective_role). The effective_role is always a
+            ``ContextRole``: workspace owner/admin map to ``ContextRole.OWNER``,
+            workspace viewer maps to ``ContextRole.VIEWER``, and an explicit
+            ContextMember row keeps its own role.
 
         Raises:
             NotFoundException: 404 if the context does not exist.
@@ -538,7 +541,7 @@ class PermissionService:
             NotFoundException: 404 if the context does not exist.
             AuthorizationError: 403 if no write access.
         """
-        context, role = await self.check_context_access(
+        context, _ = await self.check_context_access(
             user_id,
             context_id,
             required_role=ContextRole.EDITOR,
@@ -559,7 +562,7 @@ class PermissionService:
             NotFoundException: 404 if the context does not exist.
             AuthorizationError: 403 if not context owner.
         """
-        context, role = await self.check_context_access(
+        context, _ = await self.check_context_access(
             user_id,
             context_id,
             required_role=ContextRole.OWNER,
@@ -579,9 +582,9 @@ class PermissionService:
         demotion-only today — re-wire into the remove flow if we ever relax
         that to "remove allowed when >1 owners exist".
 
-        Workspace-level owner/admin bypass (check_context_access:327-329) is
-        not counted here — this reflects the real governance anchor stored in
-        the ContextMember table.
+        Workspace-level owner/admin bypass (handled inside
+        ``check_context_access``) is not counted here — this reflects the
+        real governance anchor stored in the ContextMember table.
 
         Args:
             context_id: Context ID

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -13,9 +13,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.workspace_roles import (
     CONTEXT_ROLE_WEIGHTS,
-    WORKSPACE_ROLE_WEIGHTS as ORG_ROLE_WEIGHTS,
     ContextRole,
     WorkspaceRole,
+)
+from auth.workspace_roles import (
+    WORKSPACE_ROLE_WEIGHTS as ORG_ROLE_WEIGHTS,
 )
 from models.auth import Context, ContextMember, WorkspaceMember
 from services.workspace_service import WorkspaceService

--- a/backend/src/services/permission_service.py
+++ b/backend/src/services/permission_service.py
@@ -11,6 +11,12 @@ from uuid import UUID
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.workspace_roles import (
+    CONTEXT_ROLE_WEIGHTS,
+    WORKSPACE_ROLE_WEIGHTS as ORG_ROLE_WEIGHTS,
+    ContextRole,
+    WorkspaceRole,
+)
 from models.auth import Context, ContextMember, WorkspaceMember
 from services.workspace_service import WorkspaceService
 from utils.exceptions import AuthorizationError, NotFoundException
@@ -24,19 +30,18 @@ logger = get_logger(__name__)
 CallerId = NewType("CallerId", str)
 MemoryAuthorId = NewType("MemoryAuthorId", str)
 
-# Role hierarchy weights (higher = more privilege)
-ORG_ROLE_WEIGHTS = {
-    "owner": 4,
-    "admin": 3,
-    "member": 2,
-    "viewer": 1,
-}
-
-CONTEXT_ROLE_WEIGHTS = {
-    "owner": 3,
-    "editor": 2,
-    "viewer": 1,
-}
+# Re-exported from auth.workspace_roles for backward compatibility.
+# New code should import directly from auth.workspace_roles.
+# ORG_ROLE_WEIGHTS keeps the old name (used by external callers).
+__all__ = [
+    "ContextRole",
+    "WorkspaceRole",
+    "ORG_ROLE_WEIGHTS",
+    "CONTEXT_ROLE_WEIGHTS",
+    "CallerId",
+    "MemoryAuthorId",
+    "PermissionService",
+]
 
 
 class PermissionService:
@@ -73,7 +78,7 @@ class PermissionService:
         self,
         user_id: str,
         workspace_id: UUID,
-        required_role: str = "member",
+        required_role: WorkspaceRole | str = WorkspaceRole.MEMBER,
     ) -> WorkspaceMember:
         """Check if user has required workspace access.
 
@@ -96,6 +101,13 @@ class PermissionService:
                 ``"workspace_deleted"`` / ``"not_a_member"`` / ``"role_too_low"``
                 for structured-log classification.
         """
+        # Normalise at the boundary: accept str for backward compat
+        required = (
+            required_role
+            if isinstance(required_role, WorkspaceRole)
+            else WorkspaceRole(required_role)
+        )
+
         # Issue #276: Verify workspace exists and is not deleted
         from sqlalchemy import select
 
@@ -130,7 +142,7 @@ class PermissionService:
 
         # Check role hierarchy
         user_weight = ORG_ROLE_WEIGHTS.get(member.role, 0)
-        required_weight = ORG_ROLE_WEIGHTS.get(required_role, 0)
+        required_weight = ORG_ROLE_WEIGHTS.get(required, 0)
 
         if user_weight < required_weight:
             raise AuthorizationError(
@@ -145,7 +157,7 @@ class PermissionService:
         user_id: str,
         resource_id: str,
         *,
-        required_role: str = "member",
+        required_role: WorkspaceRole | str = WorkspaceRole.MEMBER,
     ) -> Context:
         """Resolve a ``resource_id`` slug to the Context the caller can access.
 
@@ -229,7 +241,7 @@ class PermissionService:
         user_id: str,
         context_id: UUID,
         *,
-        required_role: str = "viewer",
+        required_role: WorkspaceRole | str = WorkspaceRole.VIEWER,
     ) -> Context:
         """Resolve a ``context_id`` to a Context the caller can read, with uniform 404.
 
@@ -324,7 +336,10 @@ class PermissionService:
         #   - viewer, allowed_context_ids IS NULL → no restriction (all)
         #   - either, allowed_context_ids = [<ids>] → whitelist enforced
         #   - either, allowed_context_ids = []     → explicit no access
-        if workspace_member.role == "member" and workspace_member.allowed_context_ids is None:
+        if (
+            workspace_member.role == WorkspaceRole.MEMBER
+            and workspace_member.allowed_context_ids is None
+        ):
             logger.warning(
                 "context_read_denied",
                 reason="member_suspended",
@@ -335,7 +350,7 @@ class PermissionService:
             raise NotFoundException("Context", str(context_id))
 
         if (
-            workspace_member.role in ("member", "viewer")
+            workspace_member.role in (WorkspaceRole.MEMBER, WorkspaceRole.VIEWER)
             and workspace_member.allowed_context_ids is not None
             and context_id not in workspace_member.allowed_context_ids
         ):
@@ -363,7 +378,9 @@ class PermissionService:
         Raises:
             AuthorizationError: 403 if not owner
         """
-        return await self.check_workspace_access(user_id, workspace_id, required_role="owner")
+        return await self.check_workspace_access(
+            user_id, workspace_id, required_role=WorkspaceRole.OWNER
+        )
 
     async def check_workspace_admin(self, user_id: str, workspace_id: UUID) -> WorkspaceMember:
         """Check if user is workspace admin or owner.
@@ -378,7 +395,9 @@ class PermissionService:
         Raises:
             AuthorizationError: 403 if not admin/owner
         """
-        return await self.check_workspace_access(user_id, workspace_id, required_role="admin")
+        return await self.check_workspace_access(
+            user_id, workspace_id, required_role=WorkspaceRole.ADMIN
+        )
 
     async def is_workspace_member(self, user_id: str, workspace_id: UUID) -> bool:
         """Check if user is a member of workspace (any role).
@@ -405,8 +424,8 @@ class PermissionService:
         self,
         user_id: str,
         context_id: UUID,
-        required_role: str = "viewer",
-    ) -> tuple[Context, str]:
+        required_role: ContextRole | str = ContextRole.VIEWER,
+    ) -> tuple[Context, ContextRole]:
         """Check if user has required context access.
 
         Access hierarchy:
@@ -444,10 +463,15 @@ class PermissionService:
             raise NotFoundException("Context")
 
         # Issue #165: Private context check (creator-only access)
+        # Normalise at the boundary: accept str for backward compat
+        required = (
+            required_role if isinstance(required_role, ContextRole) else ContextRole(required_role)
+        )
+
         if context.is_private:
             if context.created_by == user_id:
                 # Creator has full access to their private context
-                return context, "owner"
+                return context, ContextRole.OWNER
             else:
                 # Others cannot access private contexts
                 raise AuthorizationError("Insufficient permissions")
@@ -464,9 +488,9 @@ class PermissionService:
 
         # Workspace owner/admin → bypass context checks (full access)
         # Note: allowed_context_ids is ignored for owner/admin
-        if workspace_member.role in ("owner", "admin"):
-            effective_role = "owner"  # Treat as context owner
-            return context, effective_role
+        if workspace_member.role in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN):
+            # Treat as context owner
+            return context, ContextRole.OWNER
 
         # Issue #234: Check allowed_context_ids whitelist for member/viewer
         if workspace_member.allowed_context_ids is not None:
@@ -474,11 +498,11 @@ class PermissionService:
                 raise AuthorizationError("Insufficient permissions")
 
         # Workspace viewer → read-only access (bypass context checks)
-        if workspace_member.role == "viewer":
+        if workspace_member.role == WorkspaceRole.VIEWER:
             # Check if viewer role meets requirement
-            if required_role != "viewer":
+            if required != ContextRole.VIEWER:
                 raise AuthorizationError("Insufficient permissions")
-            return context, "viewer"
+            return context, ContextRole.VIEWER
 
         # Workspace member → requires explicit context membership
         stmt = select(ContextMember).where(
@@ -493,12 +517,12 @@ class PermissionService:
 
         # Check context role hierarchy
         user_weight = CONTEXT_ROLE_WEIGHTS.get(context_member.role, 0)
-        required_weight = CONTEXT_ROLE_WEIGHTS.get(required_role, 0)
+        required_weight = CONTEXT_ROLE_WEIGHTS.get(required, 0)
 
         if user_weight < required_weight:
             raise AuthorizationError("Insufficient permissions")
 
-        return context, context_member.role
+        return context, ContextRole(context_member.role)
 
     async def check_context_write(self, user_id: str, context_id: UUID) -> Context:
         """Check if user can write to context (editor or owner).
@@ -517,7 +541,7 @@ class PermissionService:
         context, role = await self.check_context_access(
             user_id,
             context_id,
-            required_role="editor",
+            required_role=ContextRole.EDITOR,
         )
         return context
 
@@ -538,7 +562,7 @@ class PermissionService:
         context, role = await self.check_context_access(
             user_id,
             context_id,
-            required_role="owner",
+            required_role=ContextRole.OWNER,
         )
         return context
 
@@ -572,7 +596,7 @@ class PermissionService:
             .select_from(ContextMember)
             .where(
                 ContextMember.context_id == context_id,
-                ContextMember.role == "owner",
+                ContextMember.role == ContextRole.OWNER,
             )
         )
         result = await self.db.execute(stmt)
@@ -603,7 +627,7 @@ class PermissionService:
         # Check workspace membership (viewer is the floor — the per-role
         # branches below decide what each role can actually see).
         workspace_member = await self.check_workspace_access(
-            user_id, workspace_id, required_role="viewer"
+            user_id, workspace_id, required_role=WorkspaceRole.VIEWER
         )
 
         # Private contexts are creator-only across every workspace role
@@ -617,7 +641,7 @@ class PermissionService:
 
         # Workspace owner/admin → all accessible contexts (ignore
         # allowed_context_ids; privacy still applies).
-        if workspace_member.role in ("owner", "admin"):
+        if workspace_member.role in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN):
             stmt = (
                 select(Context)
                 .where(
@@ -631,7 +655,7 @@ class PermissionService:
             return list(result.scalars().all())
 
         # Issue #234: Workspace viewer with allowed_context_ids restriction
-        if workspace_member.role == "viewer":
+        if workspace_member.role == WorkspaceRole.VIEWER:
             if workspace_member.allowed_context_ids is not None:
                 # Only whitelisted contexts
                 if not workspace_member.allowed_context_ids:

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from sqlalchemy import and_, func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, ExternalAPIKey, UsageStats, Workspace, WorkspaceMember
 from models.memory import Memory
 from utils.datetime import utcnow
@@ -100,7 +101,7 @@ class WorkspaceService:
         member = WorkspaceMember(
             workspace_id=workspace.id,
             user_id=owner_user_id,
-            role="owner",
+            role=WorkspaceRole.OWNER,
             joined_at=func.now(),
         )
         self.db.add(member)
@@ -528,7 +529,7 @@ class WorkspaceService:
         self,
         workspace_id: UUID,
         user_id: str,
-        role: str = "member",
+        role: WorkspaceRole | str = WorkspaceRole.MEMBER,
         invited_by: str | None = None,
     ) -> WorkspaceMember:
         """Add a member to workspace.
@@ -660,11 +661,11 @@ class WorkspaceService:
             raise NotFoundException(f"Member not found: {user_id} in workspace {workspace_id}")
 
         # Validate single owner constraint (Issue #165)
-        if new_role == "owner" and member.role != "owner":
+        if new_role == WorkspaceRole.OWNER and member.role != WorkspaceRole.OWNER:
             # Promoting to owner - check if owner already exists
             stmt = select(WorkspaceMember).where(
                 WorkspaceMember.workspace_id == workspace_id,
-                WorkspaceMember.role == "owner",
+                WorkspaceMember.role == WorkspaceRole.OWNER,
             )
             result = await self.db.execute(stmt)
             existing_owners = result.scalars().all()
@@ -727,7 +728,10 @@ class WorkspaceService:
             raise NotFoundException(f"Member not found: {user_id} in workspace {workspace_id}")
 
         # Warn if setting on owner/admin (no effect)
-        if member.role in ("owner", "admin") and allowed_context_ids is not None:
+        if (
+            member.role in (WorkspaceRole.OWNER, WorkspaceRole.ADMIN)
+            and allowed_context_ids is not None
+        ):
             logger.warning(
                 f"allowed_context_ids set on privileged role (ignored): "
                 f"workspace={workspace_id}, user={user_id}, role={member.role}"
@@ -773,7 +777,7 @@ class WorkspaceService:
         member = await self.get_member(workspace_id, user_id, with_lock=True)
 
         # Cannot remove owner
-        if member.role == "owner":
+        if member.role == WorkspaceRole.OWNER:
             raise ValidationError("Cannot remove workspace owner")
 
         # Issue #275: Comprehensive cleanup with transaction safety
@@ -787,7 +791,7 @@ class WorkspaceService:
                 select(WorkspaceMember.user_id).where(
                     and_(
                         WorkspaceMember.workspace_id == workspace_id,
-                        WorkspaceMember.role == "owner",
+                        WorkspaceMember.role == WorkspaceRole.OWNER,
                     )
                 )
             )
@@ -823,7 +827,7 @@ class WorkspaceService:
             # Issue #275 High: Re-check role before deletion (permission escalation prevention)
             # Member object might be stale if role was changed during cleanup
             await self.db.refresh(member)
-            if member.role == "owner":
+            if member.role == WorkspaceRole.OWNER:
                 await self.db.rollback()
                 logger.warning(
                     "member_role_changed_to_owner_during_removal",
@@ -1543,9 +1547,10 @@ class WorkspaceService:
         Raises:
             ValidationError: If role is invalid
         """
-        valid_roles = {"owner", "admin", "member", "viewer"}
+        valid_roles: frozenset[WorkspaceRole] = frozenset(WorkspaceRole)
         if role not in valid_roles:
-            raise ValidationError(f"Invalid role: {role}. Must be one of: {', '.join(valid_roles)}")
+            valid_values = ", ".join(r.value for r in WorkspaceRole)
+            raise ValidationError(f"Invalid role: {role}. Must be one of: {valid_values}")
 
     async def create_personal_workspace(
         self,

--- a/backend/tests/api/test_context_members_rbac.py
+++ b/backend/tests/api/test_context_members_rbac.py
@@ -21,6 +21,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
+from auth.workspace_roles import ContextRole
 from utils.exceptions import AuthorizationError
 
 WORKSPACE_ID = uuid4()
@@ -462,7 +463,7 @@ class TestAddMemberHappyPath:
 class TestRemoveMemberHappyPath:
     def test_cannot_remove_context_owner_role(self, client):
         """Existing role-is-owner guard remains functional."""
-        owner_member = MagicMock(role="owner")
+        owner_member = MagicMock(role=ContextRole.OWNER)
         mock_result = MagicMock()
         mock_result.scalar_one_or_none.return_value = owner_member
 

--- a/backend/tests/api/test_plan_downgrade.py
+++ b/backend/tests/api/test_plan_downgrade.py
@@ -16,8 +16,8 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import func, select
 
-from config.plan_tiers import get_plan_tier
 from auth.workspace_roles import WorkspaceRole
+from config.plan_tiers import get_plan_tier
 from models.auth import (
     Context,
     PlanChange,

--- a/backend/tests/api/test_plan_downgrade.py
+++ b/backend/tests/api/test_plan_downgrade.py
@@ -17,6 +17,7 @@ import pytest
 from sqlalchemy import func, select
 
 from config.plan_tiers import get_plan_tier
+from auth.workspace_roles import WorkspaceRole
 from models.auth import (
     Context,
     PlanChange,
@@ -48,7 +49,7 @@ async def pro_workspace(db_session):
     owner_member = WorkspaceMember(
         workspace_id=workspace.id,
         user_id=owner_id,
-        role="owner",
+        role=WorkspaceRole.OWNER,
     )
     db_session.add(owner_member)
     await db_session.commit()
@@ -112,7 +113,7 @@ async def test_admin_plan_upgrade_free_to_pro(db_session):
     owner_member = WorkspaceMember(
         workspace_id=workspace.id,
         user_id=owner_id,
-        role="owner",
+        role=WorkspaceRole.OWNER,
     )
     db_session.add(owner_member)
     await db_session.commit()
@@ -286,7 +287,9 @@ async def test_downgrade_allowed_when_contexts_within_limit(db_session):
         weekly_api_limit=250000,
     )
     db_session.add(workspace)
-    db_session.add(WorkspaceMember(workspace_id=workspace.id, user_id=owner_id, role="owner"))
+    db_session.add(
+        WorkspaceMember(workspace_id=workspace.id, user_id=owner_id, role=WorkspaceRole.OWNER)
+    )
     await db_session.commit()
 
     # Only 1 context — within Free limit

--- a/backend/tests/api/test_workspace.py
+++ b/backend/tests/api/test_workspace.py
@@ -21,6 +21,7 @@ from api.routes.workspace import (
     get_workspace_usage_current,
 )
 from api.routes.workspaces import UpdateMemberRoleRequest, update_member_role
+from auth.workspace_roles import WorkspaceRole
 
 
 class TestWorkspaceStats:
@@ -253,7 +254,7 @@ class TestUpdateMemberRole:
         with patch("api.routes.workspaces.get_current_user", return_value=admin_user):
             # Mock permission check to return admin member
             mock_admin_member = MagicMock()
-            mock_admin_member.role = "admin"
+            mock_admin_member.role = WorkspaceRole.ADMIN
 
             with patch("api.routes.workspaces.PermissionService") as mock_perm_service:
                 mock_perm_service.return_value.check_workspace_admin = AsyncMock(
@@ -261,7 +262,7 @@ class TestUpdateMemberRole:
                 )
 
                 # Try to change own role
-                body = UpdateMemberRoleRequest(role="member")
+                body = UpdateMemberRoleRequest(role=WorkspaceRole.MEMBER)
 
                 with pytest.raises(HTTPException) as exc_info:
                     await update_member_role(
@@ -284,11 +285,11 @@ class TestUpdateMemberRole:
         with patch("api.routes.workspaces.get_current_user", return_value=admin_user):
             # Mock permission check to return admin member
             mock_admin_member = MagicMock()
-            mock_admin_member.role = "admin"
+            mock_admin_member.role = WorkspaceRole.ADMIN
 
             # Mock target member as owner
             mock_owner_member = MagicMock()
-            mock_owner_member.role = "owner"
+            mock_owner_member.role = WorkspaceRole.OWNER
 
             with patch("api.routes.workspaces.PermissionService") as mock_perm_service:
                 mock_perm_service.return_value.check_workspace_admin = AsyncMock(
@@ -300,7 +301,7 @@ class TestUpdateMemberRole:
                         return_value=mock_owner_member
                     )
 
-                    body = UpdateMemberRoleRequest(role="admin")
+                    body = UpdateMemberRoleRequest(role=WorkspaceRole.ADMIN)
 
                     with pytest.raises(HTTPException) as exc_info:
                         await update_member_role(
@@ -323,7 +324,7 @@ class TestUpdateMemberRole:
         with patch("api.routes.workspaces.get_current_user", return_value=owner_user):
             # Mock permission check to return owner member
             mock_owner_member = MagicMock()
-            mock_owner_member.role = "owner"
+            mock_owner_member.role = WorkspaceRole.OWNER
 
             # Mock target member as owner
             mock_target_owner = MagicMock()
@@ -344,7 +345,7 @@ class TestUpdateMemberRole:
                         return_value=mock_target_owner
                     )
 
-                    body = UpdateMemberRoleRequest(role="admin")
+                    body = UpdateMemberRoleRequest(role=WorkspaceRole.ADMIN)
 
                     # Should succeed
                     response = await update_member_role(
@@ -366,7 +367,7 @@ class TestUpdateMemberRole:
         with patch("api.routes.workspaces.get_current_user", return_value=admin_user):
             # Mock permission check to return admin member
             mock_admin_member = MagicMock()
-            mock_admin_member.role = "admin"
+            mock_admin_member.role = WorkspaceRole.ADMIN
 
             # Mock target member as regular member
             mock_target_member = MagicMock()
@@ -387,7 +388,7 @@ class TestUpdateMemberRole:
                         return_value=mock_target_member
                     )
 
-                    body = UpdateMemberRoleRequest(role="viewer")
+                    body = UpdateMemberRoleRequest(role=WorkspaceRole.VIEWER)
 
                     # Should succeed
                     response = await update_member_role(

--- a/backend/tests/auth/test_workspace_roles.py
+++ b/backend/tests/auth/test_workspace_roles.py
@@ -1,0 +1,62 @@
+"""Test the WorkspaceRole + ContextRole StrEnum (#700)."""
+
+from auth.workspace_roles import (
+    CONTEXT_ROLE_CHECK_SQL,
+    CONTEXT_ROLE_WEIGHTS,
+    WORKSPACE_ROLE_CHECK_SQL,
+    WORKSPACE_ROLE_WEIGHTS,
+    ContextRole,
+    WorkspaceRole,
+)
+
+
+def test_workspace_role_values_match_db_literals() -> None:
+    """Enum values must equal the existing DB CHECK literals byte-for-byte."""
+    assert WorkspaceRole.OWNER.value == "owner"
+    assert WorkspaceRole.ADMIN.value == "admin"
+    assert WorkspaceRole.MEMBER.value == "member"
+    assert WorkspaceRole.VIEWER.value == "viewer"
+
+
+def test_context_role_values_match_db_literals() -> None:
+    assert ContextRole.OWNER.value == "owner"
+    assert ContextRole.EDITOR.value == "editor"
+    assert ContextRole.VIEWER.value == "viewer"
+
+
+def test_workspace_role_is_strenum() -> None:
+    """StrEnum members compare equal to their string values (round-trip)."""
+    assert WorkspaceRole.OWNER == "owner"
+    assert "owner" == WorkspaceRole.OWNER
+    assert WorkspaceRole("owner") is WorkspaceRole.OWNER
+
+
+def test_workspace_role_weights_keyed_on_enum() -> None:
+    """Weights dict is keyed on enum members for type-safe lookup."""
+    assert WORKSPACE_ROLE_WEIGHTS[WorkspaceRole.OWNER] == 4
+    assert WORKSPACE_ROLE_WEIGHTS[WorkspaceRole.ADMIN] == 3
+    assert WORKSPACE_ROLE_WEIGHTS[WorkspaceRole.MEMBER] == 2
+    assert WORKSPACE_ROLE_WEIGHTS[WorkspaceRole.VIEWER] == 1
+
+
+def test_context_role_weights_keyed_on_enum() -> None:
+    assert CONTEXT_ROLE_WEIGHTS[ContextRole.OWNER] == 3
+    assert CONTEXT_ROLE_WEIGHTS[ContextRole.EDITOR] == 2
+    assert CONTEXT_ROLE_WEIGHTS[ContextRole.VIEWER] == 1
+
+
+def test_workspace_role_check_sql_matches_existing_migration_literal() -> None:
+    """f-string-derived CHECK SQL must equal the existing migration literal.
+
+    The existing CheckConstraint in models/auth.py reads:
+        role IN ('owner', 'admin', 'member', 'viewer')
+
+    The refactor derives that string from the enum at runtime. Byte-identical
+    parity is what lets ``Base.metadata.create_all()`` (test fixtures) stay
+    drift-free from alembic head.
+    """
+    assert WORKSPACE_ROLE_CHECK_SQL == ("role IN ('owner', 'admin', 'member', 'viewer')")
+
+
+def test_context_role_check_sql_matches_existing_migration_literal() -> None:
+    assert CONTEXT_ROLE_CHECK_SQL == ("role IN ('owner', 'editor', 'viewer')")

--- a/backend/tests/auth/test_workspace_roles.py
+++ b/backend/tests/auth/test_workspace_roles.py
@@ -1,5 +1,7 @@
 """Test the WorkspaceRole + ContextRole StrEnum (#700)."""
 
+import pytest
+
 from auth.workspace_roles import (
     CONTEXT_ROLE_CHECK_SQL,
     CONTEXT_ROLE_WEIGHTS,
@@ -19,6 +21,7 @@ def test_workspace_role_values_match_db_literals() -> None:
 
 
 def test_context_role_values_match_db_literals() -> None:
+    """Enum values must equal the existing DB CHECK literals byte-for-byte."""
     assert ContextRole.OWNER.value == "owner"
     assert ContextRole.EDITOR.value == "editor"
     assert ContextRole.VIEWER.value == "viewer"
@@ -31,6 +34,13 @@ def test_workspace_role_is_strenum() -> None:
     assert WorkspaceRole("owner") is WorkspaceRole.OWNER
 
 
+def test_context_role_is_strenum() -> None:
+    """StrEnum members compare equal to their string values (round-trip)."""
+    assert ContextRole.OWNER == "owner"
+    assert "editor" == ContextRole.EDITOR
+    assert ContextRole("viewer") is ContextRole.VIEWER
+
+
 def test_workspace_role_weights_keyed_on_enum() -> None:
     """Weights dict is keyed on enum members for type-safe lookup."""
     assert WORKSPACE_ROLE_WEIGHTS[WorkspaceRole.OWNER] == 4
@@ -40,9 +50,16 @@ def test_workspace_role_weights_keyed_on_enum() -> None:
 
 
 def test_context_role_weights_keyed_on_enum() -> None:
+    """Weights dict is keyed on enum members for type-safe lookup."""
     assert CONTEXT_ROLE_WEIGHTS[ContextRole.OWNER] == 3
     assert CONTEXT_ROLE_WEIGHTS[ContextRole.EDITOR] == 2
     assert CONTEXT_ROLE_WEIGHTS[ContextRole.VIEWER] == 1
+
+
+def test_workspace_role_weights_immutable() -> None:
+    """WORKSPACE_ROLE_WEIGHTS is a read-only view — mutation raises TypeError."""
+    with pytest.raises(TypeError):
+        WORKSPACE_ROLE_WEIGHTS[WorkspaceRole.OWNER] = 99  # type: ignore[index]
 
 
 def test_workspace_role_check_sql_matches_existing_migration_literal() -> None:

--- a/backend/tests/integration/test_account_erasure_integration.py
+++ b/backend/tests/integration/test_account_erasure_integration.py
@@ -33,6 +33,7 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.workspace_roles import WorkspaceRole
 from models.auth import APIKey, AuditLog, User, Workspace, WorkspaceMember
 from models.erasure import (
     REASON_USER_REQUEST_VIA_SUPPORT,
@@ -88,13 +89,13 @@ async def erasure_scenario(db_session: AsyncSession):
     target_member = WorkspaceMember(
         workspace_id=workspace.id,
         user_id=target_user_id,
-        role="owner",
+        role=WorkspaceRole.OWNER,
     )
     # Another user already in the workspace as admin — for ownership transfer
     other_member = WorkspaceMember(
         workspace_id=workspace.id,
         user_id=other_user_id,
-        role="admin",
+        role=WorkspaceRole.ADMIN,
     )
     db_session.add_all([target_member, other_member])
 

--- a/backend/tests/integration/test_admin_user_detail_context_role.py
+++ b/backend/tests/integration/test_admin_user_detail_context_role.py
@@ -16,6 +16,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin import get_user_detail
+from auth.workspace_roles import ContextRole, WorkspaceRole
 from models.auth import ContextMember, WorkspaceMember
 
 from ._admin_helpers import make_context, make_user, make_workspace, mock_admin
@@ -32,7 +33,9 @@ async def workspace_owner_no_ctx_member(db_session: AsyncSession) -> dict:
     db_session.add(ws)
     await db_session.flush()
 
-    db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role="owner"))
+    db_session.add(
+        WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role=WorkspaceRole.OWNER)
+    )
 
     ctx = make_context(workspace_id=ws.id, created_by=user.user_id)
     db_session.add(ctx)
@@ -58,8 +61,12 @@ async def workspace_admin_no_ctx_member(db_session: AsyncSession) -> dict:
 
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws.id, user_id=owner_user.user_id, role="owner"),
-            WorkspaceMember(workspace_id=ws.id, user_id=admin_user.user_id, role="admin"),
+            WorkspaceMember(
+                workspace_id=ws.id, user_id=owner_user.user_id, role=WorkspaceRole.OWNER
+            ),
+            WorkspaceMember(
+                workspace_id=ws.id, user_id=admin_user.user_id, role=WorkspaceRole.ADMIN
+            ),
         ]
     )
 
@@ -93,11 +100,13 @@ async def workspace_member_no_ctx_member(db_session: AsyncSession) -> dict:
 
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws.id, user_id=owner_user.user_id, role="owner"),
+            WorkspaceMember(
+                workspace_id=ws.id, user_id=owner_user.user_id, role=WorkspaceRole.OWNER
+            ),
             WorkspaceMember(
                 workspace_id=ws.id,
                 user_id=member_user.user_id,
-                role="member",
+                role=WorkspaceRole.MEMBER,
                 allowed_context_ids=[ctx.id],
             ),
         ]
@@ -128,14 +137,16 @@ async def workspace_member_with_ctx_member(db_session: AsyncSession) -> dict:
 
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws.id, user_id=owner_user.user_id, role="owner"),
+            WorkspaceMember(
+                workspace_id=ws.id, user_id=owner_user.user_id, role=WorkspaceRole.OWNER
+            ),
             WorkspaceMember(
                 workspace_id=ws.id,
                 user_id=member_user.user_id,
-                role="member",
+                role=WorkspaceRole.MEMBER,
                 allowed_context_ids=[ctx.id],
             ),
-            ContextMember(context_id=ctx.id, user_id=member_user.user_id, role="editor"),
+            ContextMember(context_id=ctx.id, user_id=member_user.user_id, role=ContextRole.EDITOR),
         ]
     )
     await db_session.commit()

--- a/backend/tests/integration/test_admin_users_soft_delete_filter.py
+++ b/backend/tests/integration/test_admin_users_soft_delete_filter.py
@@ -13,6 +13,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin import get_user_detail, list_users
+from auth.workspace_roles import WorkspaceRole
 from models.auth import WorkspaceMember
 
 from ._admin_helpers import make_user, make_workspace, mock_admin
@@ -32,8 +33,10 @@ async def user_with_mixed_workspaces(db_session: AsyncSession) -> dict:
 
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=active.id, user_id=user.user_id, role="owner"),
-            WorkspaceMember(workspace_id=deleted.id, user_id=user.user_id, role="owner"),
+            WorkspaceMember(workspace_id=active.id, user_id=user.user_id, role=WorkspaceRole.OWNER),
+            WorkspaceMember(
+                workspace_id=deleted.id, user_id=user.user_id, role=WorkspaceRole.OWNER
+            ),
         ]
     )
     await db_session.commit()

--- a/backend/tests/integration/test_admin_workspace_slot_bonus.py
+++ b/backend/tests/integration/test_admin_workspace_slot_bonus.py
@@ -23,6 +23,7 @@ from api.routes.admin import (
     list_users,
     update_workspace_slot_bonus,
 )
+from auth.workspace_roles import WorkspaceRole
 from models.auth import AuditLog, User, WorkspaceMember
 from models.schemas import UpdateWorkspaceSlotBonusRequest
 from utils.exceptions import BonusBelowZeroError, InsufficientReasonError
@@ -44,7 +45,9 @@ async def user_with_bonus(db_session: AsyncSession) -> dict:
     ws = make_workspace(owner_user_id=user.user_id)
     db_session.add(ws)
     await db_session.flush()
-    db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role="owner"))
+    db_session.add(
+        WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role=WorkspaceRole.OWNER)
+    )
     await db_session.commit()
 
     return {"user_id": user.user_id, "email": user.email, "workspace_id": str(ws.id)}
@@ -64,7 +67,9 @@ async def user_at_risk(db_session: AsyncSession) -> dict:
     ws = make_workspace(owner_user_id=user.user_id, plan_name="free")
     db_session.add(ws)
     await db_session.flush()
-    db_session.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role="owner"))
+    db_session.add(
+        WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role=WorkspaceRole.OWNER)
+    )
     await db_session.commit()
 
     return {"user_id": user.user_id, "email": user.email}
@@ -85,7 +90,10 @@ async def user_destructive(db_session: AsyncSession) -> dict:
     db_session.add_all(workspaces)
     await db_session.flush()
     db_session.add_all(
-        [WorkspaceMember(workspace_id=w.id, user_id=user.user_id, role="owner") for w in workspaces]
+        [
+            WorkspaceMember(workspace_id=w.id, user_id=user.user_id, role=WorkspaceRole.OWNER)
+            for w in workspaces
+        ]
     )
     await db_session.commit()
 
@@ -112,8 +120,10 @@ async def user_with_mixed_workspaces_plan_filter(db_session: AsyncSession) -> di
     await db_session.flush()
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=active.id, user_id=user.user_id, role="owner"),
-            WorkspaceMember(workspace_id=deleted.id, user_id=user.user_id, role="owner"),
+            WorkspaceMember(workspace_id=active.id, user_id=user.user_id, role=WorkspaceRole.OWNER),
+            WorkspaceMember(
+                workspace_id=deleted.id, user_id=user.user_id, role=WorkspaceRole.OWNER
+            ),
         ]
     )
     await db_session.commit()
@@ -313,8 +323,8 @@ async def user_with_two_pro_workspaces(db_session: AsyncSession) -> dict:
     await db_session.flush()
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws_a.id, user_id=user.user_id, role="owner"),
-            WorkspaceMember(workspace_id=ws_b.id, user_id=user.user_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=user.user_id, role=WorkspaceRole.OWNER),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=user.user_id, role=WorkspaceRole.OWNER),
         ]
     )
     await db_session.commit()

--- a/backend/tests/integration/test_graph_visibility.py
+++ b/backend/tests/integration/test_graph_visibility.py
@@ -27,8 +27,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from api.main import app
 from auth.dependencies import require_session_auth
-from db.base import get_db
 from auth.workspace_roles import WorkspaceRole
+from db.base import get_db
 from models.auth import Context, Workspace, WorkspaceMember
 from models.memory import Memory, NeuralMemoryEdge
 

--- a/backend/tests/integration/test_graph_visibility.py
+++ b/backend/tests/integration/test_graph_visibility.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from api.main import app
 from auth.dependencies import require_session_auth
 from db.base import get_db
+from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, Workspace, WorkspaceMember
 from models.memory import Memory, NeuralMemoryEdge
 
@@ -160,7 +161,7 @@ async def visibility_scenario(async_engine, db_session):
 
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role=WorkspaceRole.OWNER),
             # member_a needs an explicit allowed_context_ids whitelist — post-#398
             # (commit bd5b7a4) a member with ``allowed_context_ids=NULL`` is
             # treated as suspended and uniformly 404s on every UUID-addressed
@@ -173,10 +174,10 @@ async def visibility_scenario(async_engine, db_session):
             WorkspaceMember(
                 workspace_id=ws_a.id,
                 user_id=member_a_id,
-                role="member",
+                role=WorkspaceRole.MEMBER,
                 allowed_context_ids=[ctx_shared.id],
             ),
-            WorkspaceMember(workspace_id=ws_b.id, user_id=outsider_b_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=outsider_b_id, role=WorkspaceRole.OWNER),
         ]
     )
     await db_session.flush()

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -26,6 +26,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, Workspace, WorkspaceMember
 from models.memory import Memory
 from services.context_service import ContextService
@@ -75,7 +76,7 @@ async def _seed_workspace_context(
     member = WorkspaceMember(
         workspace_id=ws.id,
         user_id=user_id,
-        role="owner",
+        role=WorkspaceRole.OWNER,
     )
     ctx = Context(
         id=uuid4(),

--- a/backend/tests/integration/test_public_bound_key_endpoint.py
+++ b/backend/tests/integration/test_public_bound_key_endpoint.py
@@ -27,8 +27,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.main import app
 from auth.api_keys import APIKeyManager
-from db.redis import get_redis_client
 from auth.workspace_roles import WorkspaceRole
+from db.redis import get_redis_client
 from models.auth import Context, UsageStats, WorkspaceMember
 
 from ._admin_helpers import make_user, make_workspace

--- a/backend/tests/integration/test_public_bound_key_endpoint.py
+++ b/backend/tests/integration/test_public_bound_key_endpoint.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from api.main import app
 from auth.api_keys import APIKeyManager
 from db.redis import get_redis_client
+from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, UsageStats, WorkspaceMember
 
 from ._admin_helpers import make_user, make_workspace
@@ -51,7 +52,7 @@ async def _seed_public_context(db: AsyncSession) -> tuple[Context, str]:
     db.add(ws)
     await db.flush()
 
-    db.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role="owner"))
+    db.add(WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role=WorkspaceRole.OWNER))
 
     ctx = Context(
         id=uuid4(),

--- a/backend/tests/integration/test_resource_cross_workspace.py
+++ b/backend/tests/integration/test_resource_cross_workspace.py
@@ -30,8 +30,8 @@ from auth.dependencies import (
     get_user_from_api_key_or_session,
     require_workspace_owner,
 )
-from db.base import get_db
 from auth.workspace_roles import WorkspaceRole
+from db.base import get_db
 from models.auth import Context, Workspace, WorkspaceMember
 from models.resource import Resource, ResourceSchema, ResourceToken
 from utils.datetime import utcnow

--- a/backend/tests/integration/test_resource_cross_workspace.py
+++ b/backend/tests/integration/test_resource_cross_workspace.py
@@ -31,6 +31,7 @@ from auth.dependencies import (
     require_workspace_owner,
 )
 from db.base import get_db
+from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, Workspace, WorkspaceMember
 from models.resource import Resource, ResourceSchema, ResourceToken
 from utils.datetime import utcnow
@@ -112,7 +113,7 @@ async def cross_workspace_scenario(async_engine, db_session):
     # contract: without it, /schema would return 404 simply because no
     # schema exists, and the test would pass for the wrong reason if the
     # boundary check regressed. With this row present, a regression that
-    # removes required_role="owner" (or bypasses resolve_resource_by_slug
+    # removes required_role=WorkspaceRole.OWNER (or bypasses resolve_resource_by_slug
     # entirely) would return 200 + this schema's data, correctly failing
     # the 404 assertion. Copilot catch on PR #391 loop 4.
     schema_b = ResourceSchema(
@@ -130,8 +131,8 @@ async def cross_workspace_scenario(async_engine, db_session):
     await db_session.flush()
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
-            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role=WorkspaceRole.OWNER),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role=WorkspaceRole.OWNER),
             resource_b,
             ctx_b,
             schema_b,
@@ -226,7 +227,7 @@ async def test_cross_workspace_probe_returns_404(cross_workspace_scenario, path_
 # ============================================================================
 #
 # The base fixture covers "owner of A, NOT a member of B". The more subtle
-# case is "owner of A, also a member/admin of B". Without required_role="owner"
+# case is "owner of A, also a member/admin of B". Without required_role=WorkspaceRole.OWNER
 # on resolve_resource_by_slug, WorkspaceOwner only verifies ownership of the
 # caller's *current* workspace (A), while the helper's default required_role=
 # "member" would pass the B-membership check and leak B's resource data.
@@ -294,9 +295,9 @@ async def cross_workspace_multi_member_scenario(async_engine, db_session):
     await db_session.flush()
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
-            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
-            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_a_id, role="member"),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role=WorkspaceRole.OWNER),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role=WorkspaceRole.OWNER),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_a_id, role=WorkspaceRole.MEMBER),
             resource_b,
             ctx_b,
             schema_b,
@@ -358,8 +359,8 @@ async def test_multi_workspace_member_probe_returns_404(
 ):
     """Owner-of-A who is also a member-of-B must still get 404 on B's slug.
 
-    Regression pin for the required_role="owner" fix on resolve_resource_by_slug.
-    Without it, the helper's default required_role="member" would pass for this
+    Regression pin for the required_role=WorkspaceRole.OWNER fix on resolve_resource_by_slug.
+    Without it, the helper's default required_role=WorkspaceRole.MEMBER would pass for this
     caller and leak workspace B's resource data.
     """
     slug = cross_workspace_multi_member_scenario["probe_slug"]
@@ -503,8 +504,8 @@ async def cross_workspace_list_scenario(async_engine, db_session):
     await db_session.flush()
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
-            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role=WorkspaceRole.OWNER),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role=WorkspaceRole.OWNER),
             resource_a,
             resource_b,
             ctx_a,
@@ -717,8 +718,8 @@ async def test_slug_reuse_after_soft_delete_isolates_orphans(async_engine, db_se
     await db_session.flush()
     db_session.add_all(
         [
-            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role="owner"),
-            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role="owner"),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=owner_a_id, role=WorkspaceRole.OWNER),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=owner_b_id, role=WorkspaceRole.OWNER),
             resource_a,
             resource_b,
             ctx_a_soft_deleted,

--- a/backend/tests/mcp_server/test_resource_ingest_quota.py
+++ b/backend/tests/mcp_server/test_resource_ingest_quota.py
@@ -12,6 +12,7 @@ from uuid import uuid4
 
 import pytest
 
+from auth.workspace_roles import WorkspaceRole
 from mcp_server.tools.resource import handle_ingest_events
 from utils.exceptions import RateLimitError
 
@@ -91,7 +92,7 @@ def _patch_log_tool_usage():
 @pytest.mark.asyncio
 async def test_quota_check_invoked_after_permission_with_workspace_key(workspace_id):
     """Happy-path wiring: quota helper is called with (resource_id, workspace_id, count)."""
-    mock_db = _build_db_mock(role="member", boundary_ok=True)
+    mock_db = _build_db_mock(role=WorkspaceRole.MEMBER, boundary_ok=True)
 
     with (
         _patch_get_db(mock_db),
@@ -127,7 +128,7 @@ async def test_quota_check_invoked_after_permission_with_workspace_key(workspace
 async def test_quota_exceeded_returns_error_and_does_not_ingest(workspace_id):
     """When check_event_quota raises RateLimitError, handler returns quota_exceeded
     and never reaches the ingest loop."""
-    mock_db = _build_db_mock(role="member", boundary_ok=True)
+    mock_db = _build_db_mock(role=WorkspaceRole.MEMBER, boundary_ok=True)
     mock_db.add = MagicMock()  # would be called inside the ingest loop if reached
 
     with (
@@ -166,7 +167,7 @@ async def test_quota_exceeded_returns_error_and_does_not_ingest(workspace_id):
 @pytest.mark.asyncio
 async def test_quota_skipped_when_viewer_rejected(workspace_id):
     """Viewer permission denial happens BEFORE quota check — no quota call, no resolve."""
-    mock_db = _build_db_mock(role="viewer", boundary_ok=True)
+    mock_db = _build_db_mock(role=WorkspaceRole.VIEWER, boundary_ok=True)
 
     with (
         _patch_get_db(mock_db),
@@ -198,7 +199,7 @@ async def test_quota_skipped_when_viewer_rejected(workspace_id):
 @pytest.mark.asyncio
 async def test_quota_skipped_when_workspace_boundary_fails(workspace_id):
     """Workspace boundary fails BEFORE quota check — no quota call."""
-    mock_db = _build_db_mock(role="member", boundary_ok=False)
+    mock_db = _build_db_mock(role=WorkspaceRole.MEMBER, boundary_ok=False)
 
     with (
         _patch_get_db(mock_db),

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -16,6 +16,7 @@ from uuid import uuid4
 
 import pytest
 
+from auth.workspace_roles import WorkspaceRole
 from models.erasure import (
     REASON_SELF_SERVICE,
     REASON_USER_REQUEST_VIA_SUPPORT,
@@ -24,7 +25,6 @@ from models.erasure import (
     STATUS_PENDING,
     ErasureRequest,
 )
-from auth.workspace_roles import WorkspaceRole
 from services.account_erasure_service import (
     COOLING_OFF_PERIOD,
     AccountErasureService,

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -24,6 +24,7 @@ from models.erasure import (
     STATUS_PENDING,
     ErasureRequest,
 )
+from auth.workspace_roles import WorkspaceRole
 from services.account_erasure_service import (
     COOLING_OFF_PERIOD,
     AccountErasureService,
@@ -764,7 +765,7 @@ class TestHandleOwnedWorkspaces:
         svc = _service()
         ws_id = uuid4()
         ws = SimpleNamespace(id=ws_id, owner_user_id="u-1")
-        rows = [SimpleNamespace(workspace_id=ws_id, user_id="u-1", role="owner")]
+        rows = [SimpleNamespace(workspace_id=ws_id, user_id="u-1", role=WorkspaceRole.OWNER)]
         svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
         svc.db.commit = AsyncMock()
 
@@ -777,9 +778,9 @@ class TestHandleOwnedWorkspaces:
         svc = _service()
         ws_id = uuid4()
         ws = SimpleNamespace(id=ws_id, owner_user_id="u-1")
-        new_admin = SimpleNamespace(workspace_id=ws_id, user_id="u-2", role="admin")
+        new_admin = SimpleNamespace(workspace_id=ws_id, user_id="u-2", role=WorkspaceRole.ADMIN)
         rows = [
-            SimpleNamespace(workspace_id=ws_id, user_id="u-1", role="owner"),
+            SimpleNamespace(workspace_id=ws_id, user_id="u-1", role=WorkspaceRole.OWNER),
             new_admin,
         ]
         svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
@@ -798,9 +799,9 @@ class TestHandleOwnedWorkspaces:
         ws_id = uuid4()
         ws = SimpleNamespace(id=ws_id, owner_user_id="u-1")
         rows = [
-            SimpleNamespace(workspace_id=ws_id, user_id="u-1", role="owner"),
-            SimpleNamespace(workspace_id=ws_id, user_id="u-2", role="member"),
-            SimpleNamespace(workspace_id=ws_id, user_id="u-3", role="viewer"),
+            SimpleNamespace(workspace_id=ws_id, user_id="u-1", role=WorkspaceRole.OWNER),
+            SimpleNamespace(workspace_id=ws_id, user_id="u-2", role=WorkspaceRole.MEMBER),
+            SimpleNamespace(workspace_id=ws_id, user_id="u-3", role=WorkspaceRole.VIEWER),
         ]
         svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
         svc.db.commit = AsyncMock()

--- a/backend/tests/services/test_permission_service.py
+++ b/backend/tests/services/test_permission_service.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 import pytest
 
+from auth.workspace_roles import WorkspaceRole
 from services.permission_service import (
     CONTEXT_ROLE_WEIGHTS,
     ORG_ROLE_WEIGHTS,
@@ -53,21 +54,23 @@ class TestWorkspaceAccess:
     async def test_check_workspace_access_owner(self, service):
         """Owner should have access to any role requirement."""
         ws_id = uuid4()
-        mock_member = MagicMock(role="owner")
+        mock_member = MagicMock(role=WorkspaceRole.OWNER)
         service.workspace_service.get_member = AsyncMock(return_value=mock_member)
 
-        result = await service.check_workspace_access("user1", ws_id, required_role="owner")
+        result = await service.check_workspace_access(
+            "user1", ws_id, required_role=WorkspaceRole.OWNER
+        )
         assert result == mock_member
 
     @pytest.mark.asyncio
     async def test_check_workspace_access_insufficient_role(self, service):
         """Viewer should not have admin access."""
         ws_id = uuid4()
-        mock_member = MagicMock(role="viewer")
+        mock_member = MagicMock(role=WorkspaceRole.VIEWER)
         service.workspace_service.get_member = AsyncMock(return_value=mock_member)
 
         with pytest.raises(AuthorizationError) as exc_info:
-            await service.check_workspace_access("user1", ws_id, required_role="admin")
+            await service.check_workspace_access("user1", ws_id, required_role=WorkspaceRole.ADMIN)
         assert exc_info.value.status_code == 403
         assert exc_info.value.reason == "role_too_low"
 
@@ -97,7 +100,9 @@ class TestWorkspaceAccess:
     @pytest.mark.asyncio
     async def test_is_workspace_member_true(self, service):
         """User with membership returns True."""
-        service.workspace_service.get_member = AsyncMock(return_value=MagicMock(role="member"))
+        service.workspace_service.get_member = AsyncMock(
+            return_value=MagicMock(role=WorkspaceRole.MEMBER)
+        )
         assert await service.is_workspace_member("user1", uuid4()) is True
 
     @pytest.mark.asyncio
@@ -110,7 +115,7 @@ class TestWorkspaceAccess:
     async def test_check_workspace_owner(self, service):
         """Convenience method for owner check."""
         ws_id = uuid4()
-        mock_member = MagicMock(role="owner")
+        mock_member = MagicMock(role=WorkspaceRole.OWNER)
         service.workspace_service.get_member = AsyncMock(return_value=mock_member)
         result = await service.check_workspace_owner("user1", ws_id)
         assert result == mock_member
@@ -119,7 +124,7 @@ class TestWorkspaceAccess:
     async def test_check_workspace_admin(self, service):
         """Convenience method for admin check."""
         ws_id = uuid4()
-        mock_member = MagicMock(role="admin")
+        mock_member = MagicMock(role=WorkspaceRole.ADMIN)
         service.workspace_service.get_member = AsyncMock(return_value=mock_member)
         result = await service.check_workspace_admin("user1", ws_id)
         assert result == mock_member
@@ -244,7 +249,9 @@ class TestMemoryAccessControl:
 
         mock_ctx_svc = MagicMock()
         mock_ctx_svc.is_context_shared = AsyncMock(return_value=True)
-        service.workspace_service.get_member = AsyncMock(return_value=MagicMock(role="member"))
+        service.workspace_service.get_member = AsyncMock(
+            return_value=MagicMock(role=WorkspaceRole.MEMBER)
+        )
 
         with patch("services.context_service.ContextService", return_value=mock_ctx_svc):
             result = await service.can_access_memory(
@@ -300,7 +307,7 @@ class TestGetAccessibleContextsForViewer:
     @pytest.fixture
     def viewer_member(self):
         member = MagicMock()
-        member.role = "viewer"
+        member.role = WorkspaceRole.VIEWER
         member.allowed_context_ids = None  # No restriction → all shared contexts
         return member
 
@@ -333,7 +340,7 @@ class TestGetAccessibleContextsForViewer:
     async def test_viewer_with_empty_whitelist_returns_empty(self):
         """Viewer with allowed_context_ids=[] → no access (explicit empty)."""
         viewer = MagicMock()
-        viewer.role = "viewer"
+        viewer.role = WorkspaceRole.VIEWER
         viewer.allowed_context_ids = []
 
         db = MagicMock()
@@ -376,7 +383,7 @@ class TestResolveContextWhitelistEnforcement:
         ctx_id = uuid4()
         ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
         member = MagicMock()
-        member.role = "member"
+        member.role = WorkspaceRole.MEMBER
         member.allowed_context_ids = [uuid4()]  # whitelist excludes ctx_id
         service = self._service_with_member(member, ctx)
 
@@ -389,7 +396,7 @@ class TestResolveContextWhitelistEnforcement:
         ctx_id = uuid4()
         ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
         viewer = MagicMock()
-        viewer.role = "viewer"
+        viewer.role = WorkspaceRole.VIEWER
         viewer.allowed_context_ids = []  # explicit empty whitelist
         service = self._service_with_member(viewer, ctx)
 
@@ -402,7 +409,7 @@ class TestResolveContextWhitelistEnforcement:
         ctx_id = uuid4()
         ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
         member = MagicMock()
-        member.role = "member"
+        member.role = WorkspaceRole.MEMBER
         member.allowed_context_ids = [ctx_id]  # whitelist includes ctx_id
         service = self._service_with_member(member, ctx)
 
@@ -416,7 +423,7 @@ class TestResolveContextWhitelistEnforcement:
         ctx_id = uuid4()
         ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
         admin = MagicMock()
-        admin.role = "admin"
+        admin.role = WorkspaceRole.ADMIN
         admin.allowed_context_ids = [uuid4()]  # would exclude ctx_id if checked
         service = self._service_with_member(admin, ctx)
 
@@ -432,7 +439,7 @@ class TestResolveContextWhitelistEnforcement:
         ctx_id = uuid4()
         ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
         suspended_member = MagicMock()
-        suspended_member.role = "member"
+        suspended_member.role = WorkspaceRole.MEMBER
         suspended_member.allowed_context_ids = None  # suspended
         service = self._service_with_member(suspended_member, ctx)
 
@@ -447,7 +454,7 @@ class TestResolveContextWhitelistEnforcement:
         ctx_id = uuid4()
         ctx = MagicMock(id=ctx_id, workspace_id=uuid4(), is_private=False, created_by="someone")
         viewer = MagicMock()
-        viewer.role = "viewer"
+        viewer.role = WorkspaceRole.VIEWER
         viewer.allowed_context_ids = None  # no restriction (all contexts)
         service = self._service_with_member(viewer, ctx)
 

--- a/backend/tests/services/test_workspace_service.py
+++ b/backend/tests/services/test_workspace_service.py
@@ -13,6 +13,7 @@ import pytest
 
 from models.auth import Context, User, Workspace, WorkspaceMember
 from models.memory import Memory
+from auth.workspace_roles import WorkspaceRole
 from services.workspace_service import WorkspaceService
 from utils.exceptions import NotFoundException, ValidationError
 
@@ -115,7 +116,7 @@ class TestListUserWorkspaces:
         db_session.add(ws)
         await db_session.flush()
 
-        member = WorkspaceMember(workspace_id=ws.id, user_id="u2", role="owner")
+        member = WorkspaceMember(workspace_id=ws.id, user_id="u2", role=WorkspaceRole.OWNER)
         db_session.add(member)
         await db_session.flush()
 
@@ -155,7 +156,7 @@ class TestAddMember:
         db_session.add(ws)
         await db_session.flush()
 
-        member = await service.add_member(ws.id, "u5", role="member")
+        member = await service.add_member(ws.id, "u5", role=WorkspaceRole.MEMBER)
         assert member.user_id == "u5"
         assert member.role == "member"
 
@@ -166,9 +167,9 @@ class TestAddMember:
         db_session.add(ws)
         await db_session.flush()
 
-        await service.add_member(ws.id, "u7", role="member")
+        await service.add_member(ws.id, "u7", role=WorkspaceRole.MEMBER)
         with pytest.raises(ValidationError, match="already a member"):
-            await service.add_member(ws.id, "u7", role="member")
+            await service.add_member(ws.id, "u7", role=WorkspaceRole.MEMBER)
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +185,7 @@ class TestGetMember:
         db_session.add(ws)
         await db_session.flush()
 
-        member = WorkspaceMember(workspace_id=ws.id, user_id="u9", role="admin")
+        member = WorkspaceMember(workspace_id=ws.id, user_id="u9", role=WorkspaceRole.ADMIN)
         db_session.add(member)
         await db_session.flush()
 
@@ -210,7 +211,7 @@ class TestGetMember:
         db_session.add(ws)
         await db_session.flush()
 
-        member = WorkspaceMember(workspace_id=ws.id, user_id="u11", role="member")
+        member = WorkspaceMember(workspace_id=ws.id, user_id="u11", role=WorkspaceRole.MEMBER)
         db_session.add(member)
         await db_session.flush()
 
@@ -231,8 +232,10 @@ class TestListMembers:
         db_session.add(ws)
         await db_session.flush()
 
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u12", role="owner"))
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u13", role="member"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u12", role=WorkspaceRole.OWNER))
+        db_session.add(
+            WorkspaceMember(workspace_id=ws.id, user_id="u13", role=WorkspaceRole.MEMBER)
+        )
         await db_session.flush()
 
         result = await service.list_members(ws.id)
@@ -252,8 +255,10 @@ class TestUpdateMemberRole:
         db_session.add(ws)
         await db_session.flush()
 
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u14", role="owner"))
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u15", role="member"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u14", role=WorkspaceRole.OWNER))
+        db_session.add(
+            WorkspaceMember(workspace_id=ws.id, user_id="u15", role=WorkspaceRole.MEMBER)
+        )
         await db_session.flush()
 
         updated = await service.update_member_role(ws.id, "u15", "admin")
@@ -266,8 +271,10 @@ class TestUpdateMemberRole:
         db_session.add(ws)
         await db_session.flush()
 
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u16", role="owner"))
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u17", role="member"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u16", role=WorkspaceRole.OWNER))
+        db_session.add(
+            WorkspaceMember(workspace_id=ws.id, user_id="u17", role=WorkspaceRole.MEMBER)
+        )
         await db_session.flush()
 
         with pytest.raises(ValidationError, match="already has an owner"):
@@ -280,7 +287,7 @@ class TestUpdateMemberRole:
         db_session.add(ws)
         await db_session.flush()
 
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u18", role="owner"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u18", role=WorkspaceRole.OWNER))
         await db_session.flush()
 
         updated = await service.update_member_role(ws.id, "u18", "admin")
@@ -300,7 +307,9 @@ class TestUpdateMemberContextAccess:
         db_session.add(ws)
         await db_session.flush()
 
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u19", role="member"))
+        db_session.add(
+            WorkspaceMember(workspace_id=ws.id, user_id="u19", role=WorkspaceRole.MEMBER)
+        )
         await db_session.flush()
 
         cid = uuid4()
@@ -323,7 +332,7 @@ class TestGetWorkspaceStats:
         db_session.add(ws)
         await db_session.flush()
 
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u20", role="owner"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u20", role=WorkspaceRole.OWNER))
         await db_session.flush()
 
         stats = await service.get_workspace_stats(ws.id)
@@ -338,7 +347,7 @@ class TestGetWorkspaceStats:
         db_session.add(ws)
         await db_session.flush()
 
-        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u21", role="owner"))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u21", role=WorkspaceRole.OWNER))
         await db_session.flush()
 
         ctx = Context(
@@ -477,7 +486,9 @@ class TestEnsurePersonalWorkspace:
         await db_session.flush()
         # delete_workspace soft-deletes the workspace but leaves WorkspaceMember
         # rows intact — that is the "historical membership" signal.
-        db_session.add(WorkspaceMember(workspace_id=dead_ws.id, user_id="u660-2", role="owner"))
+        db_session.add(
+            WorkspaceMember(workspace_id=dead_ws.id, user_id="u660-2", role=WorkspaceRole.OWNER)
+        )
 
         user = User(
             user_id="u660-2",
@@ -511,7 +522,9 @@ class TestEnsurePersonalWorkspace:
         db_session.add(ws_remaining)
         await db_session.flush()
         db_session.add(
-            WorkspaceMember(workspace_id=ws_remaining.id, user_id="u660-3", role="owner")
+            WorkspaceMember(
+                workspace_id=ws_remaining.id, user_id="u660-3", role=WorkspaceRole.OWNER
+            )
         )
 
         user = User(
@@ -642,9 +655,13 @@ class TestEnsurePersonalWorkspace:
         await db_session.flush()
         db_session.add_all(
             [
-                WorkspaceMember(workspace_id=live_ws.id, user_id="u660-4", role="member"),
+                WorkspaceMember(
+                    workspace_id=live_ws.id, user_id="u660-4", role=WorkspaceRole.MEMBER
+                ),
                 # Membership row on a soft-deleted workspace can exist — Workspace.deleted_at IS NULL filter is what excludes it.
-                WorkspaceMember(workspace_id=dead_ws.id, user_id="u660-4", role="owner"),
+                WorkspaceMember(
+                    workspace_id=dead_ws.id, user_id="u660-4", role=WorkspaceRole.OWNER
+                ),
             ]
         )
 
@@ -680,10 +697,16 @@ class TestEnsurePersonalWorkspace:
         db_session.add_all(
             [
                 WorkspaceMember(
-                    workspace_id=ws_a.id, user_id="u660-5", role="member", joined_at=None
+                    workspace_id=ws_a.id,
+                    user_id="u660-5",
+                    role=WorkspaceRole.MEMBER,
+                    joined_at=None,
                 ),
                 WorkspaceMember(
-                    workspace_id=ws_b.id, user_id="u660-5", role="member", joined_at=None
+                    workspace_id=ws_b.id,
+                    user_id="u660-5",
+                    role=WorkspaceRole.MEMBER,
+                    joined_at=None,
                 ),
             ]
         )

--- a/backend/tests/services/test_workspace_service.py
+++ b/backend/tests/services/test_workspace_service.py
@@ -11,9 +11,9 @@ from uuid import uuid4
 
 import pytest
 
+from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, User, Workspace, WorkspaceMember
 from models.memory import Memory
-from auth.workspace_roles import WorkspaceRole
 from services.workspace_service import WorkspaceService
 from utils.exceptions import NotFoundException, ValidationError
 

--- a/backend/tests/services/test_workspace_service_member_removal.py
+++ b/backend/tests/services/test_workspace_service_member_removal.py
@@ -27,6 +27,7 @@ from models.auth import (
 )
 from models.memory import Memory
 from models.resource import ResourceToken
+from auth.workspace_roles import ContextRole, WorkspaceRole
 from services.workspace_service import WorkspaceService
 from utils.exceptions import ValidationError
 
@@ -77,7 +78,7 @@ async def test_remove_member_comprehensive_cleanup(db_session):
     owner_member = WorkspaceMember(
         workspace_id=workspace.id,
         user_id=owner_id,
-        role="owner",
+        role=WorkspaceRole.OWNER,
     )
     db_session.add(owner_member)
     await db_session.commit()
@@ -111,7 +112,7 @@ async def test_remove_member_comprehensive_cleanup(db_session):
     context_membership = ContextMember(
         context_id=context_by_owner.id,
         user_id=member_id,
-        role="editor",
+        role=ContextRole.EDITOR,
         invited_by=owner_id,
     )
     db_session.add(context_membership)
@@ -161,7 +162,7 @@ async def test_remove_member_comprehensive_cleanup(db_session):
     invitation = WorkspaceInvitation(
         workspace_id=workspace.id,
         email="invitee@example.com",
-        role="member",
+        role=WorkspaceRole.MEMBER,
         invited_by=member_id,
         token=f"invite_{uuid4().hex[:16]}",
     )
@@ -308,7 +309,7 @@ async def test_remove_member_with_no_context_memberships(db_session):
     owner_member = WorkspaceMember(
         workspace_id=workspace.id,
         user_id=owner_id,
-        role="owner",
+        role=WorkspaceRole.OWNER,
     )
     db_session.add(owner_member)
     await db_session.commit()
@@ -317,7 +318,7 @@ async def test_remove_member_with_no_context_memberships(db_session):
     await workspace_service.add_member(
         workspace_id=workspace.id,
         user_id=member_id,
-        role="member",
+        role=WorkspaceRole.MEMBER,
     )
 
     # Remove member (should succeed)
@@ -367,7 +368,7 @@ async def test_remove_member_does_not_affect_other_members(db_session):
     owner_member = WorkspaceMember(
         workspace_id=workspace.id,
         user_id=owner_id,
-        role="owner",
+        role=WorkspaceRole.OWNER,
     )
     db_session.add(owner_member)
     await db_session.commit()
@@ -391,13 +392,13 @@ async def test_remove_member_does_not_affect_other_members(db_session):
     context_member_1 = ContextMember(
         context_id=context.id,
         user_id=member1_id,
-        role="editor",
+        role=ContextRole.EDITOR,
         invited_by=owner_id,
     )
     context_member_2 = ContextMember(
         context_id=context.id,
         user_id=member2_id,
-        role="editor",
+        role=ContextRole.EDITOR,
         invited_by=owner_id,
     )
     db_session.add_all([context_member_1, context_member_2])
@@ -447,7 +448,7 @@ async def test_cannot_remove_workspace_owner(db_session):
     owner_member = WorkspaceMember(
         workspace_id=workspace.id,
         user_id=owner_id,
-        role="owner",
+        role=WorkspaceRole.OWNER,
     )
     db_session.add(owner_member)
     await db_session.commit()

--- a/backend/tests/services/test_workspace_service_member_removal.py
+++ b/backend/tests/services/test_workspace_service_member_removal.py
@@ -17,6 +17,7 @@ from uuid import uuid4
 import pytest
 from sqlalchemy import func, select
 
+from auth.workspace_roles import ContextRole, WorkspaceRole
 from models.auth import (
     Context,
     ContextMember,
@@ -27,7 +28,6 @@ from models.auth import (
 )
 from models.memory import Memory
 from models.resource import ResourceToken
-from auth.workspace_roles import ContextRole, WorkspaceRole
 from services.workspace_service import WorkspaceService
 from utils.exceptions import ValidationError
 

--- a/backend/tests/test_single_collection_isolation.py
+++ b/backend/tests/test_single_collection_isolation.py
@@ -9,8 +9,8 @@ import pytest
 import pytest_asyncio
 from sqlalchemy import select
 
-from db.qdrant import ensure_kagura_memories_collection
 from auth.workspace_roles import WorkspaceRole
+from db.qdrant import ensure_kagura_memories_collection
 from models.auth import Context, Workspace, WorkspaceMember
 from models.memory import Memory
 from models.schemas import ExploreRequest, RecallRequest, RememberRequest

--- a/backend/tests/test_single_collection_isolation.py
+++ b/backend/tests/test_single_collection_isolation.py
@@ -10,6 +10,7 @@ import pytest_asyncio
 from sqlalchemy import select
 
 from db.qdrant import ensure_kagura_memories_collection
+from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, Workspace, WorkspaceMember
 from models.memory import Memory
 from models.schemas import ExploreRequest, RecallRequest, RememberRequest
@@ -74,7 +75,7 @@ async def test_workspace1(db_session):
         member = WorkspaceMember(
             workspace_id=workspace.id,
             user_id=uid,
-            role="owner" if uid == "owner1" else "member",
+            role=WorkspaceRole.OWNER if uid == "owner1" else WorkspaceRole.MEMBER,
         )
         db_session.add(member)
 
@@ -98,7 +99,7 @@ async def test_workspace2(db_session):
         member = WorkspaceMember(
             workspace_id=workspace.id,
             user_id=uid,
-            role="owner" if uid == "owner2" else "member",
+            role=WorkspaceRole.OWNER if uid == "owner2" else WorkspaceRole.MEMBER,
         )
         db_session.add(member)
 

--- a/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/[id]/page.tsx
@@ -26,7 +26,7 @@ import type { Context } from "@/lib/types/context";
 import { useMemoryContext } from "@/contexts/MemoryContextContext";
 import { useAuth } from "@/contexts/AuthContext";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import {
   Lock,
   Users,
@@ -98,15 +98,17 @@ export default function ContextDetailPage() {
   // a member briefly sees admin-only triggers.
   const canSeeAdminTabs = hasWorkspaceRole(
     currentWorkspace?.current_user_role,
-    "admin",
+    WorkspaceRole.Admin,
   );
   // Analyses tab gating: requires owner role AND workspace allowlist
   // membership (#497). Hiding the tab entirely for non-allowlisted owners
   // keeps the UX honest — there is no path forward inside the tab until
   // the workspace is on the allowlist.
   const canSeeAnalysesTab =
-    hasWorkspaceRole(currentWorkspace?.current_user_role, "owner") &&
-    currentWorkspace?.analyses_enabled === true;
+    hasWorkspaceRole(
+      currentWorkspace?.current_user_role,
+      WorkspaceRole.Owner,
+    ) && currentWorkspace?.analyses_enabled === true;
   const visibleTabs = canSeeAnalysesTab
     ? OWNER_CONTEXT_TABS
     : canSeeAdminTabs

--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -90,7 +90,7 @@ import {
   type EmbeddingModel,
 } from "@/lib/api/contexts";
 import { checkOpenAIKeyStatus } from "@/lib/api/workspaces";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { ApiError } from "@/lib/api/base";
 import type { Context, ContextStats } from "@/lib/types/context";
 import { CONTEXT_TEMPLATES, getTemplate } from "@/lib/templates/usage-guide";
@@ -176,14 +176,16 @@ export default function ContextsPage() {
   // while currentWorkspace hydrates — controls stay hidden until role is known.
   const canManageContexts = hasWorkspaceRole(
     currentWorkspace?.current_user_role,
-    "admin",
+    WorkspaceRole.Admin,
   );
   // The kebab "Analysis" entry mirrors the analyses tab gating in
   // [id]/page.tsx: owner role AND workspace allowlist membership.
   // Both must be true for the menu to appear (#497).
   const canStartAnalysis =
-    hasWorkspaceRole(currentWorkspace?.current_user_role, "owner") &&
-    currentWorkspace?.analyses_enabled === true;
+    hasWorkspaceRole(
+      currentWorkspace?.current_user_role,
+      WorkspaceRole.Owner,
+    ) && currentWorkspace?.analyses_enabled === true;
   const tAnalyses = useTranslations("analyses");
 
   const fetchContexts = useCallback(async () => {
@@ -891,7 +893,7 @@ export default function ContextsPage() {
               </>
             ) : !currentWorkspace?.current_user_role ? null : !hasWorkspaceRole(
                 currentWorkspace.current_user_role,
-                "admin",
+                WorkspaceRole.Admin,
               ) ? (
               <>{t("createFirstContextNonAdmin")}</>
             ) : (

--- a/frontend/src/app/(authenticated)/workspace/cost/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/cost/page.tsx
@@ -31,7 +31,7 @@ import {
   type CostDashboardFetchParams,
 } from "@/components/cost/CostDashboard";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { fetchWorkspaceCostAggregation } from "@/lib/api";
 
 export default function WorkspaceCostPage() {
@@ -40,7 +40,7 @@ export default function WorkspaceCostPage() {
 
   const allowed = hasWorkspaceRole(
     currentWorkspace?.current_user_role,
-    "admin",
+    WorkspaceRole.Admin,
   );
 
   // useCallback keyed on currentWorkspaceId only. Without this, every

--- a/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/dashboard/page.tsx
@@ -10,7 +10,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { PageContainer } from "@/components/common/PageContainer";
 import { Button } from "@/components/ui/button";
 import {
@@ -55,7 +55,10 @@ export default function WorkspaceStatsPage() {
   useEffect(() => {
     if (
       currentWorkspace &&
-      !hasWorkspaceRole(currentWorkspace.current_user_role, "member")
+      !hasWorkspaceRole(
+        currentWorkspace.current_user_role,
+        WorkspaceRole.Member,
+      )
     ) {
       router.push("/workspace/contexts");
     }
@@ -108,7 +111,10 @@ export default function WorkspaceStatsPage() {
     if (workspaceLoading) return;
     if (
       currentWorkspace &&
-      !hasWorkspaceRole(currentWorkspace.current_user_role, "member")
+      !hasWorkspaceRole(
+        currentWorkspace.current_user_role,
+        WorkspaceRole.Member,
+      )
     ) {
       return;
     }
@@ -125,7 +131,10 @@ export default function WorkspaceStatsPage() {
     // Same viewer-skip as above — memory-timeline is a member+ surface.
     if (
       currentWorkspace &&
-      !hasWorkspaceRole(currentWorkspace.current_user_role, "member")
+      !hasWorkspaceRole(
+        currentWorkspace.current_user_role,
+        WorkspaceRole.Member,
+      )
     ) {
       return;
     }

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -11,7 +11,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { Section } from "@/components/common/Section";
@@ -86,7 +86,7 @@ export default function WorkspaceMembersPage() {
     if (workspaceLoading) return;
     if (
       currentWorkspace &&
-      !hasWorkspaceRole(currentWorkspace.current_user_role, "admin")
+      !hasWorkspaceRole(currentWorkspace.current_user_role, WorkspaceRole.Admin)
     ) {
       router.push("/workspace/dashboard");
     }
@@ -156,7 +156,13 @@ export default function WorkspaceMembersPage() {
     // protected endpoints in parallel with the redirect, surfacing spurious
     // error toasts before the route change lands.
     if (workspaceLoading) return;
-    if (!hasWorkspaceRole(currentWorkspace?.current_user_role, "admin")) return;
+    if (
+      !hasWorkspaceRole(
+        currentWorkspace?.current_user_role,
+        WorkspaceRole.Admin,
+      )
+    )
+      return;
     if (currentWorkspaceId) {
       loadMembers();
       loadInvitations();
@@ -488,7 +494,7 @@ export default function WorkspaceMembersPage() {
     setRoleChangeLoading(true);
     try {
       await updateMemberRole(currentWorkspaceId, userId, {
-        role: newRole as "owner" | "admin" | "member" | "viewer",
+        role: newRole as WorkspaceRole,
       });
       await loadMembers();
       setShowRoleChangeDialog(false);

--- a/frontend/src/app/(authenticated)/workspace/sleep-reports/[reportId]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/sleep-reports/[reportId]/page.tsx
@@ -19,7 +19,7 @@ import { ArrowLeft, Moon } from "lucide-react";
 import Link from "next/link";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { fetchWorkspaceSleepReportDetail } from "@/lib/api";
 import { SleepReportDetailView } from "@/components/sleep-reports/SleepReportDetailView";
 import type { SleepReportDetailResponse } from "@/lib/api/sleep-reports";
@@ -38,7 +38,7 @@ export default function WorkspaceSleepReportDetailPage() {
 
   const allowed = hasWorkspaceRole(
     currentWorkspace?.current_user_role,
-    "admin",
+    WorkspaceRole.Admin,
   );
 
   const [detail, setDetail] = useState<SleepReportDetailResponse | null>(null);

--- a/frontend/src/app/(authenticated)/workspace/sleep-reports/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/sleep-reports/page.tsx
@@ -19,7 +19,7 @@ import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { fetchWorkspaceSleepReports } from "@/lib/api";
 
 export default function WorkspaceSleepReportsPage() {
@@ -28,7 +28,7 @@ export default function WorkspaceSleepReportsPage() {
 
   const allowed = hasWorkspaceRole(
     currentWorkspace?.current_user_role,
-    "admin",
+    WorkspaceRole.Admin,
   );
 
   const fetchData = useCallback(

--- a/frontend/src/components/contexts/MembersSection.test.tsx
+++ b/frontend/src/components/contexts/MembersSection.test.tsx
@@ -23,6 +23,7 @@ import { ApiError } from "@/lib/api/base";
 import type { Context } from "@/lib/types/context";
 import type { ContextMember } from "@/lib/api/contexts";
 import type { WorkspaceMember } from "@/lib/api/workspaces";
+import { ContextRole } from "@/lib/auth/rbac";
 
 // ---------- Mocks ------------------------------------------------------------
 
@@ -91,7 +92,7 @@ function makeMember(overrides: Partial<ContextMember> = {}): ContextMember {
     user_id: "user-editor",
     user_name: "Editor User",
     user_email: "editor@example.com",
-    role: "editor",
+    role: ContextRole.Editor,
     added_at: "2026-04-01T00:00:00Z",
     is_workspace_admin: false,
     ...overrides,
@@ -188,11 +189,15 @@ describe("MembersSection — member list", () => {
 
   it("renders rows with role selectors for non-owner members", async () => {
     mockListContextMembers.mockResolvedValue([
-      makeMember({ user_id: "u1", user_email: "one@ex.com", role: "editor" }),
+      makeMember({
+        user_id: "u1",
+        user_email: "one@ex.com",
+        role: ContextRole.Editor,
+      }),
       makeMember({
         user_id: "u2",
         user_email: "two@ex.com",
-        role: "owner",
+        role: ContextRole.Owner,
         is_workspace_admin: false,
       }),
     ]);
@@ -211,8 +216,16 @@ describe("MembersSection — member list", () => {
   it("hides remove button for self rows", async () => {
     setAuth("u1");
     mockListContextMembers.mockResolvedValue([
-      makeMember({ user_id: "u1", user_email: "self@ex.com", role: "editor" }),
-      makeMember({ user_id: "u2", user_email: "other@ex.com", role: "editor" }),
+      makeMember({
+        user_id: "u1",
+        user_email: "self@ex.com",
+        role: ContextRole.Editor,
+      }),
+      makeMember({
+        user_id: "u2",
+        user_email: "other@ex.com",
+        role: ContextRole.Editor,
+      }),
     ]);
     render(<MembersSection contextId={CONTEXT_ID} context={makeContext()} />);
     await waitFor(() => {
@@ -238,7 +251,7 @@ describe("MembersSection — role change with rollback", () => {
 
   it("optimistically updates and rolls back on API error", async () => {
     mockListContextMembers.mockResolvedValue([
-      makeMember({ user_id: "u1", role: "editor" }),
+      makeMember({ user_id: "u1", role: ContextRole.Editor }),
     ]);
     mockUpdateContextMemberRole.mockRejectedValue(
       new ApiError({
@@ -325,7 +338,7 @@ describe("MembersSection — add member flow", () => {
     await waitFor(() => {
       expect(mockAddContextMember).toHaveBeenCalledWith(CONTEXT_ID, {
         user_id: "cand-1",
-        role: "editor",
+        role: ContextRole.Editor,
       });
     });
 
@@ -344,7 +357,7 @@ describe("MembersSection — remove flow", () => {
       makeMember({
         user_id: "u-target",
         user_email: "target@ex.com",
-        role: "editor",
+        role: ContextRole.Editor,
       }),
     ]);
     mockRemoveContextMember.mockResolvedValue(undefined);

--- a/frontend/src/components/contexts/MembersSection.tsx
+++ b/frontend/src/components/contexts/MembersSection.tsx
@@ -41,7 +41,7 @@ import { TableLoadingState } from "@/components/common/LoadingState";
 import { EmptyState } from "@/components/ui/empty-state";
 import { useAuth } from "@/contexts/AuthContext";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, ContextRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { useToast } from "@/hooks/use-toast";
 import { ApiError } from "@/lib/api/base";
 import {
@@ -54,15 +54,17 @@ import {
 import { listMembers, type WorkspaceMember } from "@/lib/api/workspaces";
 import type { Context } from "@/lib/types/context";
 
-type ContextRole = "owner" | "editor" | "viewer";
-
 interface MembersSectionProps {
   contextId: string;
   context: Context;
 }
 
 function isContextRole(role: string): role is ContextRole {
-  return role === "owner" || role === "editor" || role === "viewer";
+  return (
+    role === ContextRole.Owner ||
+    role === ContextRole.Editor ||
+    role === ContextRole.Viewer
+  );
 }
 
 export function MembersSection({ contextId, context }: MembersSectionProps) {
@@ -74,7 +76,7 @@ export function MembersSection({ contextId, context }: MembersSectionProps) {
 
   const canManage =
     !context.is_private &&
-    hasWorkspaceRole(currentWorkspace?.current_user_role, "admin");
+    hasWorkspaceRole(currentWorkspace?.current_user_role, WorkspaceRole.Admin);
 
   const [members, setMembers] = useState<ContextMember[]>([]);
   const [loading, setLoading] = useState(true);
@@ -90,7 +92,9 @@ export function MembersSection({ contextId, context }: MembersSectionProps) {
   >(null);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
   const [addSelectedUserId, setAddSelectedUserId] = useState<string>("");
-  const [addSelectedRole, setAddSelectedRole] = useState<ContextRole>("editor");
+  const [addSelectedRole, setAddSelectedRole] = useState<ContextRole>(
+    ContextRole.Editor,
+  );
   const [submittingAdd, setSubmittingAdd] = useState(false);
 
   const [removeTarget, setRemoveTarget] = useState<ContextMember | null>(null);
@@ -159,13 +163,13 @@ export function MembersSection({ contextId, context }: MembersSectionProps) {
       if (!m.is_workspace_admin) excluded.add(m.user_id);
     }
     return workspaceMembers.filter(
-      (wm) => wm.role === "member" && !excluded.has(wm.user_id),
+      (wm) => wm.role === WorkspaceRole.Member && !excluded.has(wm.user_id),
     );
   }, [members, workspaceMembers, recentlyAddedIds]);
 
   const handleOpenAddDialog = async () => {
     setAddSelectedUserId("");
-    setAddSelectedRole("editor");
+    setAddSelectedRole(ContextRole.Editor);
     setAddDialogOpen(true);
     await ensureWorkspaceMembersLoaded();
   };
@@ -260,7 +264,9 @@ export function MembersSection({ contextId, context }: MembersSectionProps) {
   // Row-level action gate. Rendering no button is a UX hint; backend still
   // enforces the corresponding 400 guards independently.
   const canModifyMember = (m: ContextMember) =>
-    !m.is_workspace_admin && m.role !== "owner" && m.user_id !== currentUserId;
+    !m.is_workspace_admin &&
+    m.role !== ContextRole.Owner &&
+    m.user_id !== currentUserId;
 
   return (
     <>
@@ -512,15 +518,17 @@ function roleBadgeKey(m: ContextMember): string {
   // Show the actual role on every row. "via workspace access" rendered as
   // the secondary hint already disambiguates workspace-derived rows.
   switch (m.role) {
-    case "owner":
+    case WorkspaceRole.Owner:
+    case ContextRole.Owner:
       return "owner";
-    case "admin":
+    case WorkspaceRole.Admin:
       return "admin";
-    case "member":
+    case WorkspaceRole.Member:
       return "member";
-    case "editor":
+    case ContextRole.Editor:
       return "contextRoleEditor";
-    case "viewer":
+    case WorkspaceRole.Viewer:
+    case ContextRole.Viewer:
       return "viewer";
     default:
       return "contextMember";

--- a/frontend/src/components/contexts/OverviewTabPanel.tsx
+++ b/frontend/src/components/contexts/OverviewTabPanel.tsx
@@ -54,7 +54,7 @@ import { PublicAPIStats } from "@/components/dashboard/PublicAPIStats";
 import { formatRelativeTime, formatDate } from "@/lib/utils/datetime";
 import type { Context } from "@/lib/types/context";
 import { useAuth } from "@/contexts/AuthContext";
-import { hasWorkspaceRole } from "@/lib/auth/rbac";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 
 interface OverviewTabPanelProps {
   contextId: string;
@@ -85,7 +85,7 @@ export function OverviewTabPanel({
   // card and skips the doomed API call.
   const canSeeUserActivity = hasWorkspaceRole(
     currentWorkspace?.current_user_role,
-    "admin",
+    WorkspaceRole.Admin,
   );
 
   const fetchUsageStats = useCallback(async () => {

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -22,7 +22,12 @@ import {
 } from "@/styles/design-tokens";
 import { useAuth } from "@/contexts/AuthContext";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
-import { hasRole, hasWorkspaceRole, Role } from "@/lib/auth/rbac";
+import {
+  hasRole,
+  hasWorkspaceRole,
+  Role,
+  WorkspaceRole,
+} from "@/lib/auth/rbac";
 import { getContexts } from "@/lib/api/contexts";
 import { listExternalAPIKeys } from "@/lib/api/external-keys";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -81,7 +86,7 @@ interface NavItem {
   href: string;
   icon: React.ElementType;
   requiredRole?: Role; // System admin role
-  requiredWorkspaceRole?: "owner" | "admin" | "member"; // Workspace role (minimum required)
+  requiredWorkspaceRole?: Exclude<WorkspaceRole, WorkspaceRole.Viewer>; // Workspace role (minimum required)
   disabled?: boolean; // Issue #115: Support for "Coming Soon" items
   showMemberCount?: boolean; // Issue #223: Show dynamic member count
   showContextCount?: boolean; // Show dynamic context count
@@ -106,7 +111,7 @@ const navigationGroups: NavGroup[] = [
         nameKey: "dashboard",
         href: "/workspace/dashboard",
         icon: BarChart,
-        requiredWorkspaceRole: "member", // Issue #398: hide from viewer (read-only role)
+        requiredWorkspaceRole: WorkspaceRole.Member, // Issue #398: hide from viewer (read-only role)
       },
       {
         nameKey: "contexts",
@@ -118,14 +123,14 @@ const navigationGroups: NavGroup[] = [
         nameKey: "resources",
         href: "/workspace/resources",
         icon: Database,
-        requiredWorkspaceRole: "owner", // Issue #389: Owner-only (resource tokens + schema decisions)
+        requiredWorkspaceRole: WorkspaceRole.Owner, // Issue #389: Owner-only (resource tokens + schema decisions)
       },
       {
         nameKey: "members",
         href: "/workspace/members",
         icon: Users,
         showMemberCount: true,
-        requiredWorkspaceRole: "admin", // Issue #398: hide from member/viewer
+        requiredWorkspaceRole: WorkspaceRole.Admin, // Issue #398: hide from member/viewer
       },
       {
         // Issue #473: workspace-scoped cost dashboard.
@@ -135,7 +140,7 @@ const navigationGroups: NavGroup[] = [
         nameKey: "cost",
         href: "/workspace/cost",
         icon: DollarSign,
-        requiredWorkspaceRole: "admin",
+        requiredWorkspaceRole: WorkspaceRole.Admin,
       },
       {
         // Issue #526: workspace-scoped sleep reports view.
@@ -144,7 +149,7 @@ const navigationGroups: NavGroup[] = [
         nameKey: "sleepReports",
         href: "/workspace/sleep-reports",
         icon: Moon,
-        requiredWorkspaceRole: "admin",
+        requiredWorkspaceRole: WorkspaceRole.Admin,
       },
     ],
   },
@@ -172,13 +177,13 @@ const navigationGroups: NavGroup[] = [
         nameKey: "workspaceSettings",
         href: "/workspace/settings/general",
         icon: Sliders,
-        requiredWorkspaceRole: "owner",
+        requiredWorkspaceRole: WorkspaceRole.Owner,
       },
       {
         nameKey: "externalKeys",
         href: "/workspace/integrations/external-keys",
         icon: KeyRound,
-        requiredWorkspaceRole: "owner", // Issue #381: Owner-only (workspace-level secrets)
+        requiredWorkspaceRole: WorkspaceRole.Owner, // Issue #381: Owner-only (workspace-level secrets)
       },
     ],
   },

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -5,6 +5,7 @@
  */
 
 import { apiClient } from "./base";
+import { ContextRole, WorkspaceRole } from "@/lib/auth/rbac";
 
 export interface WorkspacePlanInfo {
   id: string;
@@ -222,7 +223,7 @@ export async function updateWorkspaceSpendCap(
 export interface UserWorkspace {
   workspace_id: string;
   workspace_name: string;
-  role: string;
+  role: WorkspaceRole;
   is_primary: boolean;
   joined_at: string | null;
   plan_name: string;
@@ -233,7 +234,9 @@ export interface UserContext {
   context_name: string;
   workspace_id: string;
   workspace_name: string;
-  role: string;
+  // Cross-axis: workspace owner/admin bypass returns the WorkspaceRole;
+  // explicit ContextMember rows carry the ContextRole. See backend #699.
+  role: WorkspaceRole | ContextRole;
   last_used_at: string | null;
 }
 

--- a/frontend/src/lib/api/contexts.ts
+++ b/frontend/src/lib/api/contexts.ts
@@ -140,10 +140,10 @@ export interface ContextMember {
   user_id: string;
   user_name: string | null;
   user_email: string | null;
-  // Cross-axis union: workspace owner/admin appear here via automatic access
-  // (carrying WorkspaceRole), while explicit ContextMember rows carry ContextRole.
+  // Cross-axis union: workspace-role-derived rows carry WorkspaceRole (owners/admins and viewers),
+  // while explicit ContextMember rows carry ContextRole.
   role: WorkspaceRole | ContextRole;
-  added_at: string | null; // null for workspace owners/admins with automatic access
+  added_at: string | null; // null only for workspace owner/admin rows (viewer rows use joined_at)
   is_workspace_admin: boolean; // true if access is via workspace role
 }
 

--- a/frontend/src/lib/api/contexts.ts
+++ b/frontend/src/lib/api/contexts.ts
@@ -5,6 +5,7 @@
  */
 
 import { apiClient } from "./base";
+import { ContextRole, WorkspaceRole } from "@/lib/auth/rbac";
 import type {
   Context,
   ContextListResponse,
@@ -139,18 +140,20 @@ export interface ContextMember {
   user_id: string;
   user_name: string | null;
   user_email: string | null;
-  role: "owner" | "admin" | "member" | "viewer" | "editor";
+  // Cross-axis union: workspace owner/admin appear here via automatic access
+  // (carrying WorkspaceRole), while explicit ContextMember rows carry ContextRole.
+  role: WorkspaceRole | ContextRole;
   added_at: string | null; // null for workspace owners/admins with automatic access
   is_workspace_admin: boolean; // true if access is via workspace role
 }
 
 export interface AddContextMemberRequest {
   user_id: string;
-  role: "owner" | "editor" | "viewer";
+  role: ContextRole;
 }
 
 export interface UpdateContextMemberRoleRequest {
-  role: "owner" | "editor" | "viewer";
+  role: ContextRole;
 }
 
 /**

--- a/frontend/src/lib/api/workspaces.ts
+++ b/frontend/src/lib/api/workspaces.ts
@@ -5,6 +5,7 @@
  */
 
 import { apiClient } from "./base";
+import { WorkspaceRole } from "@/lib/auth/rbac";
 import type {
   UsageCurrentResponse,
   UsageHistoryResponse,
@@ -44,7 +45,7 @@ export interface WorkspaceMember {
   user_id: string;
   user_name: string | null;
   user_email: string | null;
-  role: "owner" | "admin" | "member" | "viewer";
+  role: WorkspaceRole;
   joined_at: string | null;
   credentials_status?: CredentialsStatusInfo | null; // New: credentials info
 
@@ -76,11 +77,11 @@ export interface UpdateWorkspaceRequest {
 
 export interface AddMemberRequest {
   user_id: string;
-  role: "owner" | "admin" | "member" | "viewer";
+  role: WorkspaceRole;
 }
 
 export interface UpdateMemberRoleRequest {
-  role: "owner" | "admin" | "member" | "viewer";
+  role: WorkspaceRole;
 }
 
 // Issue #249: Context usage statistics

--- a/frontend/src/lib/auth/rbac.ts
+++ b/frontend/src/lib/auth/rbac.ts
@@ -99,13 +99,35 @@ export function isSystemAdmin(user: User | null | undefined): boolean {
 }
 
 /**
+ * Workspace-level tenancy role (mirrors backend WorkspaceRole StrEnum).
+ *
+ * Issue #700: Replaces stringly-typed role literals across the frontend.
+ * Values must match the Python enum byte-for-byte (no codegen, manual sync).
+ */
+export enum WorkspaceRole {
+  Owner = "owner",
+  Admin = "admin",
+  Member = "member",
+  Viewer = "viewer",
+}
+
+/**
+ * Context-level tenancy role (mirrors backend ContextRole StrEnum).
+ */
+export enum ContextRole {
+  Owner = "owner",
+  Editor = "editor",
+  Viewer = "viewer",
+}
+
+/**
  * Workspace role hierarchy weights (higher = more privilege)
  */
-const WORKSPACE_ROLE_WEIGHTS: Record<string, number> = {
-  owner: 4,
-  admin: 3,
-  member: 2,
-  viewer: 1,
+const WORKSPACE_ROLE_WEIGHTS: Record<WorkspaceRole, number> = {
+  [WorkspaceRole.Owner]: 4,
+  [WorkspaceRole.Admin]: 3,
+  [WorkspaceRole.Member]: 2,
+  [WorkspaceRole.Viewer]: 1,
 };
 
 /**
@@ -114,14 +136,12 @@ const WORKSPACE_ROLE_WEIGHTS: Record<string, number> = {
  * Issue #59: Unified workspace role hierarchy check.
  */
 export function hasWorkspaceRole(
-  userRole: string | null | undefined,
-  requiredRole: "owner" | "admin" | "member",
+  userRole: WorkspaceRole | string | null | undefined,
+  requiredRole: Exclude<WorkspaceRole, WorkspaceRole.Viewer>,
 ): boolean {
   if (!userRole) return false;
-  return (
-    (WORKSPACE_ROLE_WEIGHTS[userRole] ?? 0) >=
-    WORKSPACE_ROLE_WEIGHTS[requiredRole]
-  );
+  const userWeight = WORKSPACE_ROLE_WEIGHTS[userRole as WorkspaceRole] ?? 0;
+  return userWeight >= WORKSPACE_ROLE_WEIGHTS[requiredRole];
 }
 
 /**
@@ -130,8 +150,13 @@ export function hasWorkspaceRole(
  * Workspace admins (owner or admin role at workspace level) have workspace-wide access
  * but not system-level access.
  */
-export function isWorkspaceAdmin(workspaceRole: string | undefined): boolean {
-  return workspaceRole === "admin" || workspaceRole === "owner";
+export function isWorkspaceAdmin(
+  workspaceRole: WorkspaceRole | string | undefined,
+): boolean {
+  return (
+    workspaceRole === WorkspaceRole.Admin ||
+    workspaceRole === WorkspaceRole.Owner
+  );
 }
 
 /**
@@ -156,16 +181,16 @@ export function getSystemRoleBadgeColor(role: string | undefined): string {
  * Returns Tailwind color classes for workspace-level role badges.
  */
 export function getWorkspaceRoleBadgeColor(
-  workspaceRole: string | undefined,
+  workspaceRole: WorkspaceRole | string | undefined,
 ): string {
   switch (workspaceRole) {
-    case "owner":
+    case WorkspaceRole.Owner:
       return "bg-purple-100 text-purple-800"; // Purple for owner
-    case "admin":
+    case WorkspaceRole.Admin:
       return "bg-blue-100 text-blue-800"; // Blue for workspace admin
-    case "member":
+    case WorkspaceRole.Member:
       return "bg-gray-100 text-gray-800"; // Gray for member
-    case "viewer":
+    case WorkspaceRole.Viewer:
       return "bg-green-100 text-green-800"; // Green for viewer
     default:
       return "bg-gray-100 text-gray-800";


### PR DESCRIPTION
## Summary

- New `backend/src/auth/workspace_roles.py` defines `WorkspaceRole(StrEnum)` and `ContextRole(StrEnum)`, plus immutable `WORKSPACE_ROLE_WEIGHTS` / `CONTEXT_ROLE_WEIGHTS` (Mapping via MappingProxyType) and `*_CHECK_SQL` constants derived from enum values.
- `WorkspaceMember.role`, `WorkspaceInvitation.role`, `ContextMember.role` columns switch to `Mapped[WorkspaceRole / ContextRole]` via `Enum(..., native_enum=False, length=50, values_callable=...)`. DB storage stays VARCHAR; CheckConstraints now derive from enum values via f-string (byte-identical to baseline migration literal — 81/81 schema_drift tests green).
- `permission_service`, `workspace_service`, `context_service`, `admin.py`, `workspaces.py`, `contexts.py`, `invitations.py`, and Pydantic schemas migrate from string literals to enum members.
- 17 test files swept from `role="owner"` literals to `role=WorkspaceRole.OWNER` / `role=ContextRole.OWNER`.
- Frontend introduces TS `enum WorkspaceRole` / `enum ContextRole` in `lib/auth/rbac.ts`. `WORKSPACE_ROLE_WEIGHTS` re-keys on the enum; literal unions in `lib/api/{workspaces,contexts,admin}.ts` switch to enum types. Page + component callers migrated to use enum members.

## No-op verification

- `pytest tests/auth/test_workspace_roles.py::test_*_check_sql_matches_existing_migration_literal` confirms the f-string CHECK SQL is byte-identical to the baseline migration's `role IN (...)` literal.
- `pytest tests/test_schema_drift.py` 81/81 green — ORM and alembic head produce identical DDL for all 3 role columns.
- DB storage unchanged (no migration in this PR).
- StrEnum equality preserves backward compatibility: existing code comparing `member.role == "owner"` continues to work, while new code can use `member.role == WorkspaceRole.OWNER` for type clarity.

## Risk

- **Pydantic serialization**: StrEnum serialises as `.value`, so API responses are byte-identical to pre-refactor shape (`role: "owner"` not `role: "WorkspaceRole.OWNER"`).
- **CheckConstraint drift**: byte-parity test pins the f-string output against the migration literal.
- **OpenAPI codegen**: `WorkspaceInvitationRequest.role` now exposes a proper `enum` schema instead of regex-validated string; consumers reading `role` as string keep working (StrEnum serialises as value).
- **Cross-axis admin.py L578-582**: deliberate `WorkspaceRole | ContextRole` union preserved per #699 — workspace owner/admin promoted to `ctx_role` in `UserAccessibleContext` response.

## Test plan

- [x] `pytest tests/services/ tests/api/ tests/test_schema_drift.py tests/auth/ tests/repositories/` → 1571 passed, 173 skipped (DB-infra), 2 xfailed
- [x] `cd frontend && npx tsc --noEmit` → 0 errors
- [x] Drift suite explicitly green
- [x] No stray `role="owner"` etc. literals remain in `backend/src/` or `frontend/src/` outside enum definitions (verified via grep — all remaining hits are docstrings or system-Role at admin.py:709 / auth.py:161 which is the `auth.roles` axis, out of scope)
- [ ] Frontend unit tests: 205/216 pass on host (4 files OOM'd with vitest-pool worker `PropertySymbol`/`scheduleUpdateOnFiber` errors — pre-existing infrastructure issue per #584)
- [ ] Frontend lint: blocked by pre-existing ESLint v9 config migration (not caused by this PR)

Closes #700