### PR TITLE
chore(admin): soft-delete filter audit on Workspace JOINs (#687)

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -1004,9 +1004,15 @@ async def delete_user(
         await db.execute(delete(Context).where(Context.created_by == user_id))
 
         # Remove user from workspace memberships
+        # #687: operation-on-deleted — full user erasure must purge memberships
+        # from soft-deleted workspaces too; otherwise a workspace restore would
+        # resurrect ghost members for an account that no longer exists.
         await db.execute(delete(WorkspaceMember).where(WorkspaceMember.user_id == user_id))
 
         # Delete workspaces owned by the user
+        # #687: operation-on-deleted — hard-delete cascades over soft-deleted
+        # workspaces; the user is leaving the system entirely, so any workspace
+        # they own (active or soft-deleted) must be removed.
         await db.execute(delete(Workspace).where(Workspace.owner_user_id == user_id))
 
         # Note: Qdrant points are automatically cleaned up via context deletion cascade

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -351,7 +351,10 @@ async def update_workspace_plan(
     async with db_transaction(db, "update_workspace_plan", "Failed to update workspace plan"):
         # Get workspace
         workspace_result = await db.execute(
-            select(Workspace).where(Workspace.id == UUID(workspace_id))
+            select(Workspace).where(
+                Workspace.id == UUID(workspace_id),
+                Workspace.deleted_at.is_(None),  # #687 / #681 pattern: soft-delete safe
+            )
         )
         workspace = workspace_result.scalar_one_or_none()
 
@@ -463,7 +466,11 @@ async def get_plan_change_audit(
         List of plan change audit entries
     """
     async with db_transaction(db, "get_plan_audit", "Failed to get audit log"):
-        # Get audit entries with workspace names and user names
+        # Get audit entries with workspace names and user names.
+        # #687: audit/history — intentionally NO Workspace.deleted_at filter.
+        # The audit log records historical plan changes; entries for workspaces
+        # that have since been soft-deleted must remain visible so admins can
+        # reconcile past billing / plan transitions.
         audit_result = await db.execute(
             select(PlanChange, Workspace.name, User.name)
             .join(Workspace, PlanChange.workspace_id == Workspace.id)
@@ -512,7 +519,12 @@ async def get_workspace_quotas(
 
     async with db_transaction(db, "get_workspace_quotas", "Failed to get quota details"):
         # Get workspace
-        result = await db.execute(select(Workspace).where(Workspace.id == ws_uuid))
+        result = await db.execute(
+            select(Workspace).where(
+                Workspace.id == ws_uuid,
+                Workspace.deleted_at.is_(None),  # #687 / #681 pattern: soft-delete safe
+            )
+        )
         workspace = result.scalar_one_or_none()
         if not workspace:
             raise HTTPException(status_code=404, detail="Workspace not found")
@@ -634,7 +646,12 @@ async def update_workspace_quotas(
 
     async with db_transaction(db, "update_workspace_quotas", "Failed to update quotas"):
         # Get workspace
-        result = await db.execute(select(Workspace).where(Workspace.id == ws_uuid))
+        result = await db.execute(
+            select(Workspace).where(
+                Workspace.id == ws_uuid,
+                Workspace.deleted_at.is_(None),  # #687 / #681 pattern: soft-delete safe
+            )
+        )
         workspace = result.scalar_one_or_none()
         if not workspace:
             raise HTTPException(status_code=404, detail="Workspace not found")
@@ -759,7 +776,12 @@ async def update_workspace_spend_cap(
     ws_uuid = UUID(workspace_id)
 
     async with db_transaction(db, "update_workspace_spend_cap", "Failed to update spend cap"):
-        result = await db.execute(select(Workspace).where(Workspace.id == ws_uuid))
+        result = await db.execute(
+            select(Workspace).where(
+                Workspace.id == ws_uuid,
+                Workspace.deleted_at.is_(None),  # #687 / #681 pattern: soft-delete safe
+            )
+        )
         workspace = result.scalar_one_or_none()
         if not workspace:
             raise HTTPException(status_code=404, detail="Workspace not found")

--- a/backend/tests/integration/test_admin_plans_soft_delete_filter.py
+++ b/backend/tests/integration/test_admin_plans_soft_delete_filter.py
@@ -1,0 +1,191 @@
+"""Regression tests for #687 — admin_plans routes must filter soft-deleted workspaces.
+
+Sibling of ``test_admin_users_soft_delete_filter.py`` (#681) covering the
+follow-up audit class identified in #687: ``backend/src/api/routes/admin_plans.py``
+endpoints that fetch a single ``Workspace`` by ID for mutation or detail-view
+purposes had no ``Workspace.deleted_at IS NULL`` filter, so admin operations
+were silently applicable to soft-deleted workspaces.
+
+Endpoints under test:
+
+| Endpoint                                              | Classification         | Test type        |
+|-------------------------------------------------------|------------------------|------------------|
+| ``PUT /admin/plans/workspaces/{id}/plan``             | current-state (mut)    | 404 (filter)     |
+| ``GET /admin/plans/workspaces/{id}/quotas``           | current-state (read)   | 404 (filter)     |
+| ``PUT /admin/plans/workspaces/{id}/quotas``           | current-state (mut)    | 404 (filter)     |
+| ``PUT /admin/plans/workspaces/{id}/spend-cap``        | current-state (mut)    | 404 (filter)     |
+| ``GET /admin/plans/audit``                            | audit/history (intentional include) | pin (include)    |
+
+The audit-endpoint pin test guards against a future "consistency patch"
+reviewer adding the filter for symmetry — the audit log must keep entries
+for workspaces that have since been soft-deleted (otherwise historical
+plan changes disappear when an admin retires a workspace).
+
+Hits a real Postgres test DB because the existing mock-DB tests in
+``tests/api/test_admin_plans*.py`` cannot detect SQL ``WHERE`` clause
+omissions.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin_plans import (
+    UpdateAddonRequest,
+    UpdatePlanRequest,
+    UpdateSpendCapRequest,
+    get_plan_change_audit,
+    get_workspace_quotas,
+    update_workspace_plan,
+    update_workspace_quotas,
+    update_workspace_spend_cap,
+)
+from models.auth import PlanChange
+
+from ._admin_helpers import make_user, make_workspace, mock_admin
+
+
+@pytest_asyncio.fixture
+async def soft_deleted_workspace(db_session: AsyncSession) -> dict:
+    """A ``pro`` workspace with ``deleted_at`` set, owned by an active user."""
+    user = make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    ws = make_workspace(owner_user_id=user.user_id, soft_deleted=True)
+    db_session.add(ws)
+    await db_session.commit()
+
+    return {"user_id": user.user_id, "workspace_id": str(ws.id)}
+
+
+class TestUpdateWorkspacePlan:
+    """``PUT /admin/plans/workspaces/{id}/plan`` returns 404 for soft-deleted (#687)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_soft_deleted_workspace(
+        self,
+        db_session: AsyncSession,
+        soft_deleted_workspace: dict,
+    ) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await update_workspace_plan(
+                workspace_id=soft_deleted_workspace["workspace_id"],
+                request=UpdatePlanRequest(plan_name="basic", reason="test"),
+                admin_user=mock_admin(),
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 404, (
+            "soft-deleted workspace must 404 on plan mutation (#687)"
+        )
+
+
+class TestGetWorkspaceQuotas:
+    """``GET /admin/plans/workspaces/{id}/quotas`` returns 404 for soft-deleted (#687)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_soft_deleted_workspace(
+        self,
+        db_session: AsyncSession,
+        soft_deleted_workspace: dict,
+    ) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await get_workspace_quotas(
+                workspace_id=soft_deleted_workspace["workspace_id"],
+                admin_user=mock_admin(),
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 404, (
+            "soft-deleted workspace must 404 on quota detail read (#687)"
+        )
+
+
+class TestUpdateWorkspaceQuotas:
+    """``PUT /admin/plans/workspaces/{id}/quotas`` returns 404 for soft-deleted (#687)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_soft_deleted_workspace(
+        self,
+        db_session: AsyncSession,
+        soft_deleted_workspace: dict,
+    ) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await update_workspace_quotas(
+                workspace_id=soft_deleted_workspace["workspace_id"],
+                request=UpdateAddonRequest(),
+                admin_user=mock_admin(),
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 404, (
+            "soft-deleted workspace must 404 on addon-bonus mutation (#687)"
+        )
+
+
+class TestUpdateWorkspaceSpendCap:
+    """``PUT /admin/plans/workspaces/{id}/spend-cap`` returns 404 for soft-deleted (#687)."""
+
+    @pytest.mark.asyncio
+    async def test_returns_404_for_soft_deleted_workspace(
+        self,
+        db_session: AsyncSession,
+        soft_deleted_workspace: dict,
+    ) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await update_workspace_spend_cap(
+                workspace_id=soft_deleted_workspace["workspace_id"],
+                request=UpdateSpendCapRequest(),
+                admin_user=mock_admin(),
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 404, (
+            "soft-deleted workspace must 404 on spend-cap mutation (#687)"
+        )
+
+
+class TestGetPlanChangeAuditIncludesSoftDeleted:
+    """``GET /admin/plans/audit`` intentionally INCLUDES soft-deleted workspaces (#687).
+
+    Pin test against future "consistency patch" — the audit log records historical
+    plan changes for workspaces that may have since been soft-deleted; entries
+    must remain visible so admins can reconcile past billing / plan transitions.
+    """
+
+    @pytest.mark.asyncio
+    async def test_audit_log_includes_plan_change_on_soft_deleted_workspace(
+        self,
+        db_session: AsyncSession,
+        soft_deleted_workspace: dict,
+    ) -> None:
+        from uuid import UUID
+
+        ws_uuid = UUID(soft_deleted_workspace["workspace_id"])
+        db_session.add(
+            PlanChange(
+                workspace_id=ws_uuid,
+                old_plan="free",
+                new_plan="pro",
+                changed_by=soft_deleted_workspace["user_id"],
+                reason="pre-delete test fixture",
+            )
+        )
+        await db_session.commit()
+
+        entries = await get_plan_change_audit(
+            admin_user=mock_admin(),
+            db=db_session,
+            limit=100,
+        )
+
+        matching = [e for e in entries if e.workspace_id == str(ws_uuid)]
+        assert matching, (
+            "plan-change audit log must include entries for soft-deleted "
+            "workspaces (#687 audit/history classification — pin against "
+            "future consistency-patch reviewer)"
+        )


### PR DESCRIPTION
Closes #687

## Summary

- 3-value taxonomy (current-state / audit-history / operation-on-deleted) で admin route の全 `Workspace`/`WorkspaceMember` JOIN を分類監査
- `admin_plans.py` の 4 endpoint に `Workspace.deleted_at.is_(None)` filter を追加 (current-state)
- `admin.delete_user` (operation-on-deleted) と `admin_plans.get_plan_change_audit` (audit/history) に intentional-include コメントを追加 — 将来の "consistency patch" 退行を防ぐ documentation 防御
- `admin_sleep.py` / `admin_neural.py` / `admin_signup_gate.py` は **Workspace JOIN を一切持たない** ことを grep で確認、out-of-scope と確定 (issue body の speculative scope を訂正)
- 5 件の integration test を追加 (real Postgres DB) — 4 × 404 mutation/read tests + 1 pin test for audit endpoint (consistency-patch reviewer 退行防止)

## Implementation notes

### admin.py (operation-on-deleted, comment-only)
- L1006 / L1010 `delete_user` の 2 DELETE 操作にコメント追加: ユーザー消去では soft-deleted workspace も含めて hard-delete cascade する意図を明文化

### admin_plans.py (current-state filter + audit/history comment)
| Site | Function | Action |
|---|---|---|
| L354 | `update_workspace_plan` | filter 追加 (PUT /admin/plans/workspaces/{id}/plan) |
| L468-469 | `get_plan_change_audit` | audit/history intentional comment (filter なし) |
| L515 | `get_workspace_quotas` | filter 追加 (GET /admin/plans/workspaces/{id}/quotas) |
| L637 | `update_workspace_quotas` | filter 追加 (PUT /admin/plans/workspaces/{id}/quotas) |
| L762 | `update_workspace_spend_cap` | filter 追加 (PUT /admin/plans/workspaces/{id}/spend-cap) |

### test_admin_plans_soft_delete_filter.py (new)
`test_admin_users_soft_delete_filter.py` (#681 sibling) のパターンに従い、direct-handler-invocation + `_admin_helpers.py` fixtures で 5 件構成。

### Issue body との差分 (実調査結果)
- `e94d29e` SHA は誤記 — 実 fix は `65abae75` (PR #685)
- `admin.py:147-160 / 232-240 / 399-407` の line 番号は現 HEAD と乖離、5 SELECT JOIN site は既に filter 適用済 (PR #685 由来)
- `WorkspaceMember.deleted_at` column は **存在しない** — filter は `Workspace.deleted_at` のみで十分
- 実際の audit 対象は `admin.py` (DELETE 2 site, comment-only) + `admin_plans.py` (4 filter + 1 comment) の 2 file のみ

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped (gate2.binary_gate=null)
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask
- review provider: code-review

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/687-feat-chore-audit-systematic-soft-delete-filte.gate1.md`
- `~/.claude/cache/gh-issue-driven/687-feat-chore-audit-systematic-soft-delete-filte.gate2.md`

🤖 Generated via /gh-issue-driven:ship
