### PR TITLE
fix(admin): route addon PUT through WorkspaceAddon rows (#665)

### DIFF
--- a/backend/alembic/versions/e21_665_workspace_addon_source.py
+++ b/backend/alembic/versions/e21_665_workspace_addon_source.py
@@ -1,0 +1,133 @@
+"""Add workspace_addons.source column + composite uniqueness (#665).
+
+Issue #665: The admin handler ``PUT /admin/plans/workspaces/{id}/quotas``
+was writing ``workspace.addon_*_bonus`` cache columns directly, bypassing
+the cache-invalidation contract established in #570 (see
+``AddonCalculatorService.recalculate_workspace_bonuses`` docstring).
+
+Once Stripe addon webhooks land, every recalculate call would re-derive
+the cache from ``WorkspaceAddon`` rows and silently wipe the admin's
+manual grants. Fix: route admin grants through ``WorkspaceAddon`` rows so
+both Stripe and admin paths share a single source of truth, then call
+``recalculate_workspace_bonuses`` to refresh the cache.
+
+To distinguish admin-granted rows from Stripe-purchased rows (so future
+Stripe webhooks know which rows belong to them, and admin re-grants UPSERT
+into the right row), add a ``source`` discriminator column. A composite
+UNIQUE index on ``(workspace_id, addon_type, source)`` enforces "at most
+one row per (workspace, addon type, provenance)" — this is what makes
+admin grants UPSERT-safe (LD-2 in the gate1 review).
+
+### Why a column instead of extending ``addon_type``
+
+``addon_type`` already enumerates 9 SKU-like values via ``check_addon_type``.
+Encoding provenance there (e.g. ``admin_extra_memory``) would double the
+enum count, force every read site to strip a prefix, and tie SKU semantics
+to provenance — bad SSoT design. A separate ``source VARCHAR(20)`` keeps
+``addon_type`` meaning "what the units are" and ``source`` meaning "where
+the row came from"; future provenances (``partner_promo``,
+``support_bonus``) only add CHECK enum values, never new SKU rows.
+
+### Why ``NOT NULL DEFAULT 'stripe'``
+
+``NOT NULL`` blocks application code from forgetting to set ``source`` and
+silently breaking the unique-key UPSERT. ``DEFAULT 'stripe'`` is the safe
+historical interpretation: every row written before this migration was
+written as part of the (not-yet-implemented) Stripe purchase flow scaffolding,
+so back-filling them as ``'stripe'`` preserves their meaning. PG >= 11
+treats ``ADD COLUMN ... NOT NULL DEFAULT <const>`` as a metadata-only
+operation (no table rewrite), so the migration is fast even on large tables.
+
+### Constraint naming
+
+Follows the existing ``workspace_addons`` constraints (``check_addon_type``,
+``check_quantity_positive``):
+
+* ``check_addon_source`` — CHECK ``source IN ('stripe', 'admin_grant')``.
+* ``uq_workspace_addons_workspace_addon_source`` — UNIQUE
+  ``(workspace_id, addon_type, source)``. This is the key the admin handler
+  UPSERT clauses against (``ON CONFLICT (workspace_id, addon_type, source)``).
+
+### Downgrade
+
+Drop the unique index, then the CHECK, then the column. Reverses cleanly;
+no data loss because the upgrade only adds a discriminator that older code
+paths never read.
+
+Revision ID: e21_665_workspace_addon_source
+Revises: e20_741_deprecate_edge_type
+"""
+
+from alembic import op
+
+
+revision = "e21_665_workspace_addon_source"
+down_revision = "e20_741_deprecate_edge_type"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add ``source`` column + CHECK + composite UNIQUE (idempotent)."""
+    # 1. Add the column. NOT NULL DEFAULT 'stripe' is metadata-only on PG >= 11
+    #    so existing rows are back-filled without a table rewrite. Idempotent
+    #    via the same information_schema guard pattern used in #485, #560, #675.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'workspace_addons'
+                  AND column_name = 'source'
+            ) THEN
+                ALTER TABLE workspace_addons
+                  ADD COLUMN source VARCHAR(20) NOT NULL DEFAULT 'stripe';
+            END IF;
+        END $$;
+        """
+    )
+
+    # 2. CHECK constraint as a separate ALTER so the schema-drift detector
+    #    (tests/test_schema_drift.py) picks it up. Inline column-level CHECK
+    #    in ADD COLUMN is not a shape the detector parses. Wrapped in a
+    #    DO ... EXCEPTION block for re-run idempotency (mirrors e15_675).
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TABLE workspace_addons
+              ADD CONSTRAINT check_addon_source
+                CHECK (source IN ('stripe', 'admin_grant'));
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+    # 3. Composite UNIQUE — the contract that makes admin UPSERTs safe.
+    #    (workspace_id, addon_type, source) uniquely identifies "the
+    #    admin-grant row for the extra_memory addon on workspace X" so
+    #    the handler can ``ON CONFLICT ... DO UPDATE`` without scanning.
+    #    Idempotent via DO ... EXCEPTION — ``ADD CONSTRAINT UNIQUE``
+    #    raises ``duplicate_object`` on re-run (same shape as e15_675).
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            ALTER TABLE workspace_addons
+              ADD CONSTRAINT uq_workspace_addons_workspace_addon_source
+                UNIQUE (workspace_id, addon_type, source);
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    """Drop UNIQUE, CHECK, and column (reverse order)."""
+    op.execute(
+        "ALTER TABLE workspace_addons "
+        "DROP CONSTRAINT IF EXISTS uq_workspace_addons_workspace_addon_source"
+    )
+    op.execute("ALTER TABLE workspace_addons DROP CONSTRAINT IF EXISTS check_addon_source")
+    op.drop_column("workspace_addons", "source")

--- a/backend/alembic/versions/e22_665_backfill_admin_grants.py
+++ b/backend/alembic/versions/e22_665_backfill_admin_grants.py
@@ -135,10 +135,19 @@ def upgrade() -> None:
                 'pre_665_migration_backfill'
             FROM workspaces w
             LEFT JOIN (
+                -- Subtract ONLY active non-admin rows. Match the active-window
+                -- predicate used by AddonCalculatorService.recalculate_workspace_bonuses
+                -- (addon_calculator_service.py:99-104). Including expired or
+                -- future rows in the subtraction would understate the admin
+                -- portion: at the next recalc, those rows are excluded from
+                -- the SUM, so the cache would drop by the amount they
+                -- previously contributed (Copilot review #797 round 3).
                 SELECT workspace_id, SUM(quantity) AS non_admin_sum
                 FROM workspace_addons
                 WHERE addon_type = '{addon_type}'
                   AND source != 'admin_grant'
+                  AND active_from <= NOW()
+                  AND (active_until IS NULL OR active_until > NOW())
                 GROUP BY workspace_id
             ) na ON w.id = na.workspace_id
             WHERE w.deleted_at IS NULL

--- a/backend/alembic/versions/e22_665_backfill_admin_grants.py
+++ b/backend/alembic/versions/e22_665_backfill_admin_grants.py
@@ -1,0 +1,146 @@
+"""Backfill pre-#665 admin grants into WorkspaceAddon rows (#665).
+
+Issue #665 review-finding #1: e21_665 added the ``source`` column +
+``UNIQUE`` constraint that makes admin grants UPSERT-safe, but did not
+backfill any ``WorkspaceAddon`` rows for cache values that the pre-#665
+admin handler had written directly to ``Workspace.addon_*_bonus``.
+
+Without this migration, a typical post-deploy sequence would be:
+
+1. Workspace W has ``addon_memory_bonus=30000`` from a pre-#665 admin grant
+   (legacy handler wrote the cache column directly; no
+   ``WorkspaceAddon`` row exists).
+2. Any later call to ``AddonCalculatorService.recalculate_workspace_bonuses``
+   for W — e.g. a future Stripe webhook, OR an admin PUT touching an
+   unrelated addon — SUMs zero matching rows for ``extra_memory`` and
+   resets ``addon_memory_bonus`` to 0.
+3. The admin's pre-#665 grant is silently wiped.
+
+This migration walks every workspace and every ``addon_*_bonus`` column
+with a non-zero value, and INSERTs a corresponding
+``WorkspaceAddon(source='admin_grant', quantity=bonus/unit_value)`` row.
+``ON CONFLICT DO NOTHING`` guards the rare case of a pre-existing row at
+the composite UNIQUE.
+
+### Divisibility loss
+
+If a legacy cache value is not a multiple of the addon's ``unit_value``
+(e.g. ``addon_storage_bonus_mb=250`` with ``unit_value=100``), we use
+integer floor division. The backfilled row covers ``2 × 100 = 200 MB``
+and the recalc that follows on the next mutation drops the cache from
+250 to 200. This 50-MB loss is intentional and aligned with the post-#665
+contract that values must be multiples of ``unit_value`` (enforced by
+the admin handler's divisibility check). The legacy non-multiple values
+are a small population and the rounding-down direction errs toward
+preserving "at most what the admin granted".
+
+### Idempotency
+
+The migration is idempotent on re-run because every INSERT carries
+``ON CONFLICT (workspace_id, addon_type, source) DO NOTHING``. Re-running
+after a partial-success or after admins have manually adjusted grants
+in the new path leaves their adjustments intact.
+
+### Atomicity / lock semantics
+
+The migration acquires ``LOCK TABLE workspaces IN SHARE ROW EXCLUSIVE
+MODE`` and ``LOCK TABLE workspace_addons IN SHARE ROW EXCLUSIVE MODE``
+to prevent a concurrent INSERT from a brand-new admin PUT path racing
+with the backfill. The locks are released at the migration's commit
+boundary (Alembic wraps every migration in a transaction).
+
+In production, per ``.claude/rules/dev-environment.md``, the API container
+is stopped during migrations, so there is no live admin-PUT path to race.
+The locks are belt-and-suspenders correctness for dev / manual runs.
+
+### Downgrade
+
+The downgrade DELETEs admin_grant rows that the upgrade inserted. We
+cannot perfectly distinguish "backfill-inserted admin_grant row" from
+"post-deploy admin-created admin_grant row" without a discriminator
+column. The downgrade therefore deletes ALL admin_grant rows — which is
+acceptable because a downgrade is reverting to the pre-#665 cache-write
+behavior, and any post-deploy admin grants would have been written
+ONLY as WorkspaceAddon rows that the downgraded code can't read anyway.
+Operators downgrading should be aware that this is a destructive
+revert of admin-grant history.
+
+Revision ID: e22_665_backfill_admin_grants
+Revises: e21_665_workspace_addon_source
+"""
+
+from alembic import op
+
+
+revision = "e22_665_backfill_admin_grants"
+down_revision = "e21_665_workspace_addon_source"
+branch_labels = None
+depends_on = None
+
+
+# Mapping of Workspace cache column → (WorkspaceAddon.addon_type, unit_value)
+# Mirrors ``admin_plans._ADDON_FIELD_SPECS`` and ``ADDON_UNIT_VALUES`` from
+# ``services/addon_calculator_service``. Kept inline here (instead of imported)
+# so the migration is self-contained and survives future refactors of the spec
+# table. Adding a new addon type requires touching this list AND the spec table
+# AND the recalc service — schema-drift test will fail loudly if they diverge.
+_ADDON_BACKFILL: tuple[tuple[str, str, int], ...] = (
+    ("addon_memory_bonus", "extra_memory", 10000),
+    ("addon_mcp_quota_bonus", "extra_mcp_quota", 5000),
+    ("addon_rest_quota_bonus", "extra_rest_quota", 1000),
+    ("addon_public_quota_bonus", "extra_public_quota", 500),
+    ("addon_member_bonus", "extra_members", 5),
+    ("addon_context_bonus", "extra_contexts", 5),
+    ("addon_analysis_bonus", "extra_analysis_runs", 1),
+    ("addon_storage_bonus_mb", "extra_storage", 100),
+    ("addon_sleep_contexts_bonus", "extra_sleep_contexts", 1),
+)
+
+
+def upgrade() -> None:
+    """Insert admin_grant rows for every non-zero cache column on every workspace.
+
+    Per-column INSERT ... SELECT with floor-divide and a positive-only WHERE
+    filter (``quantity > 0`` ensures we never insert a zero-quantity row,
+    which would violate ``check_quantity_positive``). ``ON CONFLICT DO
+    NOTHING`` on the composite UNIQUE makes the migration idempotent.
+    """
+    op.execute("LOCK TABLE workspaces IN SHARE ROW EXCLUSIVE MODE")
+    op.execute("LOCK TABLE workspace_addons IN SHARE ROW EXCLUSIVE MODE")
+
+    for cache_col, addon_type, unit_value in _ADDON_BACKFILL:
+        op.execute(
+            f"""
+            INSERT INTO workspace_addons
+                (workspace_id, addon_type, quantity, source, active_from, created_by)
+            SELECT
+                w.id,
+                '{addon_type}',
+                w.{cache_col} / {unit_value},
+                'admin_grant',
+                NOW(),
+                'pre_665_migration_backfill'
+            FROM workspaces w
+            WHERE w.{cache_col} >= {unit_value}
+              AND w.deleted_at IS NULL
+            ON CONFLICT ON CONSTRAINT uq_workspace_addons_workspace_addon_source
+                DO NOTHING
+            """
+        )
+
+
+def downgrade() -> None:
+    """Remove backfilled admin_grant rows.
+
+    This is intentionally aggressive: it deletes ALL admin_grant rows, not
+    just rows where ``created_by='pre_665_migration_backfill'``. Rationale
+    is in the module docstring — a downgrade is reverting to pre-#665
+    cache-write semantics, so post-deploy admin grants would be ghosts in
+    the downgraded world anyway.
+    """
+    op.execute(
+        """
+        DELETE FROM workspace_addons
+        WHERE source = 'admin_grant'
+        """
+    )

--- a/backend/alembic/versions/e22_665_backfill_admin_grants.py
+++ b/backend/alembic/versions/e22_665_backfill_admin_grants.py
@@ -98,12 +98,25 @@ _ADDON_BACKFILL: tuple[tuple[str, str, int], ...] = (
 
 
 def upgrade() -> None:
-    """Insert admin_grant rows for every non-zero cache column on every workspace.
+    """Insert admin_grant rows for the admin-only portion of each cache column.
 
-    Per-column INSERT ... SELECT with floor-divide and a positive-only WHERE
-    filter (``quantity > 0`` ensures we never insert a zero-quantity row,
-    which would violate ``check_quantity_positive``). ``ON CONFLICT DO
-    NOTHING`` on the composite UNIQUE makes the migration idempotent.
+    Per-column INSERT ... SELECT with floor-divide. The admin portion is
+    ``cache_bonus - SUM(non_admin_quantity) * unit_value`` so that
+    pre-existing ``source='stripe'`` (or any future non-admin source) rows
+    already covered by the cache are subtracted out — avoids
+    double-counting if a workspace somehow already has non-admin
+    workspace_addons rows AND a non-zero cache (e.g. data inserted via
+    direct SQL or a Stripe webhook landing before this migration runs).
+
+    The ``GREATEST(0, ...)`` clamp guards against negative deltas (could
+    occur if the cache has drifted lower than the SUM of non-admin rows).
+    The WHERE clause filters to workspaces where the admin portion is
+    actually >= unit_value, so we never INSERT quantity=0 (would violate
+    ``check_quantity_positive``).
+
+    ``ON CONFLICT DO NOTHING`` on the composite UNIQUE makes the migration
+    idempotent on re-run AND preserves any admin_grant row that already
+    exists (e.g. landed via the new handler before backfill was applied).
     """
     op.execute("LOCK TABLE workspaces IN SHARE ROW EXCLUSIVE MODE")
     op.execute("LOCK TABLE workspace_addons IN SHARE ROW EXCLUSIVE MODE")
@@ -116,13 +129,20 @@ def upgrade() -> None:
             SELECT
                 w.id,
                 '{addon_type}',
-                w.{cache_col} / {unit_value},
+                GREATEST(0, w.{cache_col} - COALESCE(na.non_admin_sum, 0) * {unit_value}) / {unit_value},
                 'admin_grant',
                 NOW(),
                 'pre_665_migration_backfill'
             FROM workspaces w
-            WHERE w.{cache_col} >= {unit_value}
-              AND w.deleted_at IS NULL
+            LEFT JOIN (
+                SELECT workspace_id, SUM(quantity) AS non_admin_sum
+                FROM workspace_addons
+                WHERE addon_type = '{addon_type}'
+                  AND source != 'admin_grant'
+                GROUP BY workspace_id
+            ) na ON w.id = na.workspace_id
+            WHERE w.deleted_at IS NULL
+              AND (w.{cache_col} - COALESCE(na.non_admin_sum, 0) * {unit_value}) >= {unit_value}
             ON CONFLICT ON CONSTRAINT uq_workspace_addons_workspace_addon_source
                 DO NOTHING
             """

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -16,7 +16,9 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
+from sqlalchemy import delete as sql_delete
 from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import require_admin as auth_require_admin
@@ -24,6 +26,8 @@ from config.plan_tiers import PLAN_TIERS, PlanName, get_plan_tier
 from db.base import get_db
 from models.auth import Context, PlanChange, User, Workspace, WorkspaceInvitation, WorkspaceMember
 from models.memory import Memory
+from models.resource import WorkspaceAddon  # Issue #665: row-based admin grants
+from services.addon_calculator_service import ADDON_UNIT_VALUES, AddonCalculatorService
 from services.effective_quota_service import EffectiveQuotaService
 from utils import db_transaction
 from utils.datetime import to_utc_iso, utcnow
@@ -75,13 +79,22 @@ class QuotaBreakdown(BaseModel):
 
 
 class AddonValues(BaseModel):
-    """Addon bonus values."""
+    """Addon bonus values.
+
+    Issue #665: Extended to expose all 9 addon cache columns so the admin
+    UI can read back any value the PUT handler accepts. Pre-#665 only the
+    5 that were directly writable from the legacy handler were surfaced.
+    """
 
     memory_bonus: int = 0
     mcp_quota_bonus: int = 0
+    rest_quota_bonus: int = 0
+    public_quota_bonus: int = 0
     member_bonus: int = 0
     context_bonus: int = 0
     analysis_bonus: int = 0
+    storage_bonus_mb: int = 0
+    sleep_contexts_bonus: int = 0
 
 
 class UsageValues(BaseModel):
@@ -125,13 +138,36 @@ class WorkspaceQuotaDetail(BaseModel):
 
 
 class UpdateAddonRequest(BaseModel):
-    """Request to update workspace addon bonuses."""
+    """Request to update workspace addon bonuses (Issue #665).
+
+    All 9 fields are absolute desired effective-bonus values (per the
+    existing API contract, unchanged from the pre-#665 5-field shape).
+
+    The 5 legacy fields keep their pre-#665 defaults (``int = Field(0)``)
+    so callers that omit them get the documented "set to zero" behavior.
+    Wire-format-compatible: a request body with only those 5 fields
+    behaves identically to before.
+
+    The 4 new fields (``addon_rest_quota_bonus``, ``addon_public_quota_bonus``,
+    ``addon_storage_bonus_mb``, ``addon_sleep_contexts_bonus``) default to
+    ``None`` with **no-touch semantics**: when omitted, the corresponding
+    admin grant is left untouched, preserving frontend back-compat for the
+    legacy 5-field admin UI.
+
+    All concrete values must be ``>= 0``; the per-handler logic additionally
+    rejects values lower than the active Stripe-purchased SUM for the same
+    addon type (HTTP 400) so silent clamping cannot happen.
+    """
 
     addon_memory_bonus: int = Field(0, ge=0)
     addon_mcp_quota_bonus: int = Field(0, ge=0)
     addon_member_bonus: int = Field(0, ge=0)
     addon_context_bonus: int = Field(0, ge=0)
     addon_analysis_bonus: int = Field(0, ge=0)
+    addon_rest_quota_bonus: int | None = Field(None, ge=0)
+    addon_public_quota_bonus: int | None = Field(None, ge=0)
+    addon_storage_bonus_mb: int | None = Field(None, ge=0)
+    addon_sleep_contexts_bonus: int | None = Field(None, ge=0)
 
 
 class UpdateSpendCapRequest(BaseModel):
@@ -611,9 +647,13 @@ async def get_workspace_quotas(
             addon=AddonValues(
                 memory_bonus=workspace.addon_memory_bonus,
                 mcp_quota_bonus=workspace.addon_mcp_quota_bonus,
+                rest_quota_bonus=workspace.addon_rest_quota_bonus,
+                public_quota_bonus=workspace.addon_public_quota_bonus,
                 member_bonus=workspace.addon_member_bonus,
                 context_bonus=workspace.addon_context_bonus,
                 analysis_bonus=workspace.addon_analysis_bonus,
+                storage_bonus_mb=workspace.addon_storage_bonus_mb,
+                sleep_contexts_bonus=workspace.addon_sleep_contexts_bonus,
             ),
             effective=QuotaBreakdown(
                 memory_limit=effective["memory_limit"],
@@ -631,6 +671,167 @@ async def get_workspace_quotas(
         )
 
 
+# ---------------------------------------------------------------------------
+# Issue #665: addon UPSERT spec table + helpers
+# ---------------------------------------------------------------------------
+# Each addon cache column maps 1:1 to:
+#   - a request field on ``UpdateAddonRequest``,
+#   - a ``WorkspaceAddon.addon_type`` enum value,
+#   - a unit value from ``ADDON_UNIT_VALUES`` (used to convert between the
+#     request's bonus integer and the row's ``quantity`` integer), and
+#   - an optional "guard kind" — the name of a usage counter that must
+#     not exceed the new effective limit when the bonus is reduced (LD-7).
+#
+# The handler iterates the spec table once for validation (raising 400 on
+# any conflict BEFORE writing) and once for mutation (UPSERT or DELETE the
+# admin_grant row). Adding a new addon type is a one-line change here.
+
+
+@dataclasses.dataclass(frozen=True)
+class _AddonFieldSpec:
+    """One row in the addon UPSERT spec table (Issue #665).
+
+    ``field_name`` doubles as the ``Workspace.addon_*_bonus`` cache column
+    name; the two are identical by convention (e.g. ``addon_memory_bonus``)
+    and the spec keeps a single source of truth so they cannot drift.
+    """
+
+    field_name: str  # ``UpdateAddonRequest`` AND ``Workspace`` attribute (same name)
+    addon_type: str  # the ``WorkspaceAddon.addon_type`` enum value
+    unit_value: int  # from ``ADDON_UNIT_VALUES`` — bonus = quantity * unit_value
+    guard_kind: str | None  # 'member' / 'context' / 'memory' / 'sleep_contexts' / None
+
+
+_ADDON_FIELD_SPECS: tuple[_AddonFieldSpec, ...] = (
+    _AddonFieldSpec(
+        "addon_memory_bonus",
+        "extra_memory",
+        ADDON_UNIT_VALUES["extra_memory"],
+        "memory",
+    ),
+    _AddonFieldSpec(
+        "addon_mcp_quota_bonus",
+        "extra_mcp_quota",
+        ADDON_UNIT_VALUES["extra_mcp_quota"],
+        None,  # daily Redis-reset quota; admin throttling mid-day is allowed
+    ),
+    _AddonFieldSpec(
+        "addon_rest_quota_bonus",
+        "extra_rest_quota",
+        ADDON_UNIT_VALUES["extra_rest_quota"],
+        None,
+    ),
+    _AddonFieldSpec(
+        "addon_public_quota_bonus",
+        "extra_public_quota",
+        ADDON_UNIT_VALUES["extra_public_quota"],
+        None,
+    ),
+    _AddonFieldSpec(
+        "addon_member_bonus",
+        "extra_members",
+        ADDON_UNIT_VALUES["extra_members"],
+        "member",
+    ),
+    _AddonFieldSpec(
+        "addon_context_bonus",
+        "extra_contexts",
+        ADDON_UNIT_VALUES["extra_contexts"],
+        "context",
+    ),
+    _AddonFieldSpec(
+        "addon_analysis_bonus",
+        "extra_analysis_runs",
+        ADDON_UNIT_VALUES["extra_analysis_runs"],
+        None,  # daily counter; admin reduction is acceptable
+    ),
+    _AddonFieldSpec(
+        "addon_storage_bonus_mb",
+        "extra_storage",
+        ADDON_UNIT_VALUES["extra_storage"],
+        None,  # Storage-usage tracking not yet implemented; guard pending follow-up.
+    ),
+    _AddonFieldSpec(
+        "addon_sleep_contexts_bonus",
+        "extra_sleep_contexts",
+        ADDON_UNIT_VALUES["extra_sleep_contexts"],
+        "sleep_contexts",
+    ),
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _GrantPlan:
+    """Pending mutation produced by validation pass; consumed by mutation pass."""
+
+    addon_type: str
+    quantity: int  # >= 0; 0 means "delete existing admin_grant row (if any)"
+
+
+async def _count_addon_usage(db: AsyncSession, workspace_id: UUID, guard_kind: str) -> int:
+    """Current usage for an LD-7 persistent-addon overflow guard."""
+    if guard_kind == "member":
+        # Match the get_workspace_quotas accounting: active members + pending invitations.
+        members_result = await db.execute(
+            select(func.count(WorkspaceMember.id)).where(
+                WorkspaceMember.workspace_id == workspace_id
+            )
+        )
+        invites_result = await db.execute(
+            select(func.count(WorkspaceInvitation.id)).where(
+                WorkspaceInvitation.workspace_id == workspace_id,
+                WorkspaceInvitation.accepted_at.is_(None),
+                WorkspaceInvitation.expires_at > func.now(),
+            )
+        )
+        return (members_result.scalar() or 0) + (invites_result.scalar() or 0)
+    if guard_kind == "context":
+        result = await db.execute(
+            select(func.count(Context.id)).where(
+                Context.workspace_id == workspace_id,
+                Context.deleted_at.is_(None),
+            )
+        )
+        return result.scalar() or 0
+    if guard_kind == "memory":
+        result = await db.execute(
+            select(func.count(Memory.id)).where(
+                Memory.workspace_id == workspace_id,
+                Memory.deleted_at.is_(None),
+            )
+        )
+        return result.scalar() or 0
+    if guard_kind == "sleep_contexts":
+        result = await db.execute(
+            select(func.count(Context.id)).where(
+                Context.workspace_id == workspace_id,
+                Context.deleted_at.is_(None),
+                Context.sleep_mode != "skip",
+            )
+        )
+        return result.scalar() or 0
+    raise ValueError(f"unknown guard_kind: {guard_kind!r}")
+
+
+def _effective_for_guard(plan_tier, guard_kind: str, requested_bonus: int) -> int:
+    """New effective limit for an LD-7 guard, mirroring ``_zero_floor``.
+
+    A tier with base ``0`` always yields ``0`` regardless of the addon —
+    matches the runtime ``Workspace.effective_*`` properties so admins
+    cannot bypass the tier gate via a manual grant (#569 defense).
+    """
+    base_map = {
+        "memory": plan_tier.memory_limit,
+        "member": plan_tier.max_members_per_workspace,
+        "context": plan_tier.max_contexts_per_workspace,
+        "sleep_contexts": plan_tier.sleep_enabled_contexts_limit,
+    }
+    base = base_map[guard_kind]
+    if base == 0:
+        return 0
+    return base + requested_bonus
+
+
 @router.put("/workspaces/{workspace_id}/quotas")
 async def update_workspace_quotas(
     workspace_id: str,
@@ -638,94 +839,221 @@ async def update_workspace_quotas(
     admin_user: dict = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):
-    """Update workspace addon bonuses.
+    """Update workspace addon bonuses via WorkspaceAddon row UPSERT (#665).
 
-    Validates that reducing addons won't put usage over effective limits.
+    Pre-#665 this handler wrote ``Workspace.addon_*_bonus`` cache columns
+    directly, bypassing the #570 contract. Once Stripe addon webhooks
+    land, the cache recalc would silently overwrite admin grants. This
+    handler now UPSERTs ``WorkspaceAddon`` rows with
+    ``source='admin_grant'`` for each touched addon type, then calls
+    ``AddonCalculatorService.recalculate_workspace_bonuses`` so the
+    cache is regenerated from the union of Stripe rows + admin grants.
+
+    Per LD-3: no ``db_transaction`` wrapper. The recalc service performs
+    its own atomic commit that flushes the staged UPSERTs together. The
+    validation pass below raises BEFORE any mutation, so there is no
+    rollback target between mutation and recalc — ``db_transaction`` was
+    only an error-boundary rollback, never an outer commit boundary
+    (``utils/db_helpers.py:45-82``).
+
+    Per LD-4: 9-field request schema. Legacy 5 fields keep their pre-#665
+    ``int = 0`` defaults so callers that send only those fields behave
+    identically; the new 4 fields are ``int | None = None`` with no-touch
+    semantics. The pre-#665 frontend admin UI continues to work unchanged.
+
+    Per LD-2: absolute-value semantics. For each touched field, compute
+    ``non_admin_total = SUM(active WorkspaceAddon rows WHERE source !=
+    'admin_grant') * unit_value`` and reject (HTTP 400) when the request
+    would require a negative admin grant — admin reductions cannot
+    silently fall below the Stripe-purchased floor. The admin sees the
+    conflict instead of getting an unexpected effective value.
+
+    Per LD-7: persistent-addon overflow guard (member / context / memory
+    / sleep_contexts). Reject (HTTP 400) when the new effective limit
+    falls below current usage. Daily-reset quotas (mcp / rest / public /
+    analysis) are intentionally NOT guarded — admin throttling mid-day
+    is acceptable since the counter resets at next reset boundary. The
+    ``addon_storage_bonus_mb`` guard is also deferred: per-workspace
+    storage usage tracking does not yet exist in the codebase. Filed as
+    a follow-up to add the storage guard once usage tracking lands.
+
+    Per LD-9: ``extra_sleep_contexts`` PRO-tier check is intentionally
+    NOT enforced here. ``_zero_floor`` clamps the effective limit to 0
+    for tiers with base ``sleep_enabled_contexts_limit == 0`` (FREE,
+    BASIC), so an admin grant on those tiers is harmless to user-facing
+    behavior; the admin UI (#663) should display "no effect on this tier"
+    rather than rejecting the request from this handler.
     """
     ws_uuid = UUID(workspace_id)
+    now = utcnow()
 
-    async with db_transaction(db, "update_workspace_quotas", "Failed to update quotas"):
-        # Get workspace
-        result = await db.execute(
-            select(Workspace).where(
-                Workspace.id == ws_uuid,
-                Workspace.deleted_at.is_(None),  # #687 / #681 pattern: soft-delete safe
-            )
+    # 1. Fetch + soft-delete-safe workspace lookup (#687 / #681 pattern).
+    result = await db.execute(
+        select(Workspace).where(
+            Workspace.id == ws_uuid,
+            Workspace.deleted_at.is_(None),
         )
-        workspace = result.scalar_one_or_none()
-        if not workspace:
-            raise HTTPException(status_code=404, detail="Workspace not found")
+    )
+    workspace = result.scalar_one_or_none()
+    if not workspace:
+        raise HTTPException(status_code=404, detail="Workspace not found")
 
-        plan_tier = get_plan_tier(workspace.plan_name)
+    plan_tier = get_plan_tier(workspace.plan_name)
 
-        # Calculate new effective values
-        new_effective_members = plan_tier.max_members_per_workspace + request.addon_member_bonus
-        new_effective_contexts = plan_tier.max_contexts_per_workspace + request.addon_context_bonus
+    # 2. Validation pass — no DB writes. Build the mutation plan; raise
+    #    400 on any conflict so the caller sees the first reason cleanly
+    #    rather than discovering it mid-mutation.
+    grants_to_apply: list[_GrantPlan] = []
+    audit_changes: dict[str, str] = {}
 
-        # Hard limit: members — cannot reduce below current count + pending invitations
-        member_count_result = await db.execute(
-            select(func.count(WorkspaceMember.id)).where(WorkspaceMember.workspace_id == ws_uuid)
-        )
-        pending_invite_result = await db.execute(
-            select(func.count(WorkspaceInvitation.id)).where(
-                WorkspaceInvitation.workspace_id == ws_uuid,
-                WorkspaceInvitation.accepted_at.is_(None),
-                WorkspaceInvitation.expires_at > func.now(),
-            )
-        )
-        member_count = (member_count_result.scalar() or 0) + (pending_invite_result.scalar() or 0)
+    for spec in _ADDON_FIELD_SPECS:
+        requested = getattr(request, spec.field_name)
+        if requested is None:
+            continue  # no-touch (LD-4: only the 4 new optional fields can be None)
 
-        if member_count > new_effective_members:
+        # field_name doubles as the Workspace cache-column name by convention.
+        old_bonus = getattr(workspace, spec.field_name)
+
+        # 2a. Divisibility — addons are sold in fixed-unit increments
+        #     (see ``ADDON_UNIT_VALUES``). Reject early with a clear
+        #     "value must be a multiple of N" error before the floor
+        #     and overflow queries run. Stripe rows are integer-quantity
+        #     by schema, so this check on ``requested`` implies the same
+        #     check on the derived admin-portion below.
+        if requested % spec.unit_value != 0:
             raise HTTPException(
                 status_code=400,
-                detail=f"Cannot reduce member quota: current member count ({member_count}) exceeds new effective limit ({new_effective_members})",
+                detail=(
+                    f"{spec.field_name} value {requested} must be a multiple of "
+                    f"{spec.unit_value} (addon type {spec.addon_type!r})"
+                ),
             )
 
-        # Hard limit: contexts — cannot reduce below current count
-        context_count_result = await db.execute(
-            select(func.count(Context.id)).where(
-                Context.workspace_id == ws_uuid,
-                Context.deleted_at.is_(None),
+        # 2b. Compute Stripe-side floor for this addon_type. Predicate
+        #     mirrors ``recalculate_workspace_bonuses`` (active window
+        #     check at addon_calculator_service.py:99-104) so floor and
+        #     cache cannot diverge.
+        sum_result = await db.execute(
+            select(func.coalesce(func.sum(WorkspaceAddon.quantity), 0)).where(
+                WorkspaceAddon.workspace_id == ws_uuid,
+                WorkspaceAddon.addon_type == spec.addon_type,
+                WorkspaceAddon.source != "admin_grant",
+                WorkspaceAddon.active_from <= now,
+                ((WorkspaceAddon.active_until.is_(None)) | (WorkspaceAddon.active_until > now)),
             )
         )
-        context_count = context_count_result.scalar() or 0
+        non_admin_quantity = int(sum_result.scalar() or 0)
+        non_admin_total = non_admin_quantity * spec.unit_value
 
-        if context_count > new_effective_contexts:
+        # 2c. Reject silent clamp (LD-2). Admins must see when their
+        #     requested value would fall below the Stripe-purchased floor.
+        if requested < non_admin_total:
             raise HTTPException(
                 status_code=400,
-                detail=f"Cannot reduce context quota: current context count ({context_count}) exceeds new effective limit ({new_effective_contexts})",
+                detail=(
+                    f"Cannot reduce {spec.field_name} below the Stripe-purchased floor "
+                    f"of {non_admin_total} (active subscription provides "
+                    f"{non_admin_quantity} unit(s) x {spec.unit_value}). "
+                    f"Cancel or wait for the subscription to expire before reducing."
+                ),
             )
 
-        # Store old values for logging
-        old_memory_bonus = workspace.addon_memory_bonus
-        old_mcp_bonus = workspace.addon_mcp_quota_bonus
-        old_member_bonus = workspace.addon_member_bonus
-        old_context_bonus = workspace.addon_context_bonus
-        old_analysis_bonus = workspace.addon_analysis_bonus
+        # 2d. Persistent-addon overflow guard (LD-7). Only fires when the
+        #     bonus is actually changing AND the addon has a usage counter
+        #     in the codebase; daily-reset quotas and storage (no tracking
+        #     yet) skip via ``guard_kind is None``.
+        if spec.guard_kind is not None and requested != old_bonus:
+            usage_count = await _count_addon_usage(db, ws_uuid, spec.guard_kind)
+            new_effective = _effective_for_guard(plan_tier, spec.guard_kind, requested)
+            if usage_count > new_effective:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Cannot reduce {spec.field_name}: current "
+                        f"{spec.guard_kind} count ({usage_count}) exceeds new "
+                        f"effective limit ({new_effective})"
+                    ),
+                )
 
-        # Update addon bonuses
-        workspace.addon_memory_bonus = request.addon_memory_bonus
-        workspace.addon_mcp_quota_bonus = request.addon_mcp_quota_bonus
-        workspace.addon_member_bonus = request.addon_member_bonus
-        workspace.addon_context_bonus = request.addon_context_bonus
-        workspace.addon_analysis_bonus = request.addon_analysis_bonus
+        # 2e. Compute admin_grant quantity. ``check_quantity_positive``
+        #     forbids storing ``quantity == 0`` — the mutation pass DELETEs
+        #     the row when this is 0. Divisibility is guaranteed by 2a +
+        #     integer-quantity Stripe rows.
+        admin_grant_quantity = (requested - non_admin_total) // spec.unit_value
 
-        await db.commit()
-
-        logger.info(
-            "workspace_addon_updated",
-            workspace_id=workspace_id,
-            admin_user=admin_user["user_id"],
-            changes={
-                "memory_bonus": f"{old_memory_bonus} -> {request.addon_memory_bonus}",
-                "mcp_quota_bonus": f"{old_mcp_bonus} -> {request.addon_mcp_quota_bonus}",
-                "member_bonus": f"{old_member_bonus} -> {request.addon_member_bonus}",
-                "context_bonus": f"{old_context_bonus} -> {request.addon_context_bonus}",
-                "analysis_bonus": f"{old_analysis_bonus} -> {request.addon_analysis_bonus}",
-            },
+        grants_to_apply.append(
+            _GrantPlan(addon_type=spec.addon_type, quantity=admin_grant_quantity)
         )
+        if old_bonus != requested:
+            audit_changes[spec.field_name] = f"{old_bonus} -> {requested}"
 
-        return {"message": f"Quota addons updated for workspace {workspace.name}"}
+    # 3. Mutation pass. Use ``INSERT ... ON CONFLICT DO UPDATE`` so
+    #    concurrent admin PUTs against the same (workspace, addon_type)
+    #    are race-free at the DB layer — the composite UNIQUE
+    #    ``uq_workspace_addons_workspace_addon_source`` is the conflict
+    #    target. A naive SELECT-then-INSERT pattern could race two
+    #    admins past the SELECT and crash one of them on the UNIQUE
+    #    constraint (HTTP 500 via UniqueViolation). The UPSERT statement
+    #    has well-defined "first-write wins on insert, last-write wins
+    #    on update" semantics, mirroring the user-visible single-admin
+    #    PUT API contract.
+    for plan in grants_to_apply:
+        if plan.quantity == 0:
+            # check_quantity_positive forbids quantity=0 storage; DELETE
+            # the admin grant row instead. Single-statement is race-safe
+            # (no-op when the row doesn't exist).
+            await db.execute(
+                sql_delete(WorkspaceAddon).where(
+                    WorkspaceAddon.workspace_id == ws_uuid,
+                    WorkspaceAddon.addon_type == plan.addon_type,
+                    WorkspaceAddon.source == "admin_grant",
+                )
+            )
+            continue
+
+        stmt = (
+            pg_insert(WorkspaceAddon)
+            .values(
+                workspace_id=ws_uuid,
+                addon_type=plan.addon_type,
+                source="admin_grant",
+                quantity=plan.quantity,
+                purchase_price_cents=None,
+                stripe_product_id=None,
+                active_from=now,
+                active_until=None,
+                created_by=admin_user["user_id"],
+            )
+            .on_conflict_do_update(
+                constraint="uq_workspace_addons_workspace_addon_source",
+                set_={
+                    "quantity": plan.quantity,
+                    "active_until": None,
+                    "created_by": admin_user["user_id"],
+                    # ``active_from`` intentionally NOT updated on conflict —
+                    # preserve the original-grant timestamp so the audit trail
+                    # tracks "when this admin override was first applied",
+                    # not "when it was last touched" (Phase 6 review A1.1).
+                },
+            )
+        )
+        await db.execute(stmt)
+
+    # 4. Recalculate. Commits the staged ``WorkspaceAddon`` UPSERTs and
+    #    the refreshed ``addon_*_bonus`` cache columns atomically per the
+    #    #570 contract docstring on ``AddonCalculatorService`` — which is
+    #    also why this handler has no ``db_transaction(...)`` wrapper
+    #    (LD-3, see function docstring).
+    await AddonCalculatorService(db).recalculate_workspace_bonuses(ws_uuid)
+
+    logger.info(
+        "workspace_addon_updated",
+        workspace_id=workspace_id,
+        admin_user=admin_user["user_id"],
+        changes=audit_changes,
+    )
+
+    return {"message": f"Quota addons updated for workspace {workspace.name}"}
 
 
 def _reject_above_tier(

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -881,10 +881,13 @@ async def update_workspace_quotas(
     only an error-boundary rollback, never an outer commit boundary
     (``utils/db_helpers.py:45-82``).
 
-    Per LD-4: 9-field request schema. Legacy 5 fields keep their pre-#665
-    ``int = 0`` defaults so callers that send only those fields behave
-    identically; the new 4 fields are ``int | None = None`` with no-touch
-    semantics. The pre-#665 frontend admin UI continues to work unchanged.
+    Per LD-4 (revised by review-fix #2): all 9 request fields are
+    ``int | None = None`` with no-touch semantics — omit a field to leave
+    its admin grant untouched; send explicit ``0`` to zero it out. The
+    pre-#665 legacy 5-field admin UI continues to work because it always
+    sends all 5 values explicitly. The unified optional shape closes the
+    partial-update footgun where omitted-default 0 silently DELETEd
+    existing admin_grant rows.
 
     Per LD-2: absolute-value semantics. For each touched field, compute
     ``non_admin_total = SUM(active WorkspaceAddon rows WHERE source !=
@@ -934,7 +937,7 @@ async def update_workspace_quotas(
     for spec in _ADDON_FIELD_SPECS:
         requested = getattr(request, spec.field_name)
         if requested is None:
-            continue  # no-touch (LD-4: only the 4 new optional fields can be None)
+            continue  # no-touch (LD-4 revised by review-fix #2: any of the 9 fields can be None)
 
         # field_name doubles as the Workspace cache-column name by convention.
         old_bonus = getattr(workspace, spec.field_name)

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -69,13 +69,27 @@ class UpdatePlanRequest(BaseModel):
 
 
 class QuotaBreakdown(BaseModel):
-    """Quota values for a single tier."""
+    """Quota values for a single tier (Issue #665).
+
+    Extended to 9 fields so the GET ``effective`` block surfaces every
+    addon type the PUT handler accepts — review-finding #8 fixed the
+    write-only hole where storage / rest_quota / public_quota /
+    sleep_contexts could be set but not read back as an effective value.
+
+    The legacy 5 fields stay required (callers always populated them);
+    the 4 new fields default to 0 so existing TS consumers ignore the
+    additive keys without runtime impact.
+    """
 
     memory_limit: int
     mcp_calls_per_day: int
     max_contexts: int
     max_members: int
     analysis_runs_per_day: int
+    rest_calls_per_day: int = 0
+    public_calls_per_day: int = 0
+    storage_bytes_limit: int = 0
+    sleep_enabled_contexts_limit: int = 0
 
 
 class AddonValues(BaseModel):
@@ -140,34 +154,37 @@ class WorkspaceQuotaDetail(BaseModel):
 class UpdateAddonRequest(BaseModel):
     """Request to update workspace addon bonuses (Issue #665).
 
-    All 9 fields are absolute desired effective-bonus values (per the
-    existing API contract, unchanged from the pre-#665 5-field shape).
+    All 9 fields are **optional with no-touch semantics**: when a field is
+    omitted from the request body, the corresponding admin grant is left
+    untouched. To zero out an addon, the client must send the field
+    explicitly with value ``0``.
 
-    The 5 legacy fields keep their pre-#665 defaults (``int = Field(0)``)
-    so callers that omit them get the documented "set to zero" behavior.
-    Wire-format-compatible: a request body with only those 5 fields
-    behaves identically to before.
+    Concrete values are bounded ``0 <= value <= 2_000_000_000``. The upper
+    bound is below PostgreSQL ``INTEGER`` max (2_147_483_647) so the
+    multiplied-out cache-column write at recalc time never overflows.
+    Per-handler logic additionally rejects values lower than the active
+    Stripe-purchased SUM for the same addon type (HTTP 400) so silent
+    clamping cannot happen.
 
-    The 4 new fields (``addon_rest_quota_bonus``, ``addon_public_quota_bonus``,
-    ``addon_storage_bonus_mb``, ``addon_sleep_contexts_bonus``) default to
-    ``None`` with **no-touch semantics**: when omitted, the corresponding
-    admin grant is left untouched, preserving frontend back-compat for the
-    legacy 5-field admin UI.
-
-    All concrete values must be ``>= 0``; the per-handler logic additionally
-    rejects values lower than the active Stripe-purchased SUM for the same
-    addon type (HTTP 400) so silent clamping cannot happen.
+    Wire-format compatibility note (#665 review fix #2): pre-#665 the 5
+    legacy fields defaulted to ``int = Field(0)`` so omitting them meant
+    "set to zero". That semantics is incompatible with the row-based SSoT
+    design — an omitted-default 0 would silently DELETE existing
+    WorkspaceAddon admin_grant rows on partial-update PUTs. The unified
+    optional shape closes this footgun. Clients that intentionally want
+    to zero a field continue to work by sending the field explicitly with
+    value 0; clients that omit the field get the safer no-touch behavior.
     """
 
-    addon_memory_bonus: int = Field(0, ge=0)
-    addon_mcp_quota_bonus: int = Field(0, ge=0)
-    addon_member_bonus: int = Field(0, ge=0)
-    addon_context_bonus: int = Field(0, ge=0)
-    addon_analysis_bonus: int = Field(0, ge=0)
-    addon_rest_quota_bonus: int | None = Field(None, ge=0)
-    addon_public_quota_bonus: int | None = Field(None, ge=0)
-    addon_storage_bonus_mb: int | None = Field(None, ge=0)
-    addon_sleep_contexts_bonus: int | None = Field(None, ge=0)
+    addon_memory_bonus: int | None = Field(None, ge=0, le=2_000_000_000)
+    addon_mcp_quota_bonus: int | None = Field(None, ge=0, le=2_000_000_000)
+    addon_member_bonus: int | None = Field(None, ge=0, le=2_000_000_000)
+    addon_context_bonus: int | None = Field(None, ge=0, le=2_000_000_000)
+    addon_analysis_bonus: int | None = Field(None, ge=0, le=2_000_000_000)
+    addon_rest_quota_bonus: int | None = Field(None, ge=0, le=2_000_000_000)
+    addon_public_quota_bonus: int | None = Field(None, ge=0, le=2_000_000_000)
+    addon_storage_bonus_mb: int | None = Field(None, ge=0, le=2_000_000_000)
+    addon_sleep_contexts_bonus: int | None = Field(None, ge=0, le=2_000_000_000)
 
 
 class UpdateSpendCapRequest(BaseModel):
@@ -643,6 +660,10 @@ async def get_workspace_quotas(
                 max_contexts=plan_tier.max_contexts_per_workspace,
                 max_members=plan_tier.max_members_per_workspace,
                 analysis_runs_per_day=plan_tier.analysis_runs_per_day,
+                rest_calls_per_day=plan_tier.rest_calls_per_day,
+                public_calls_per_day=plan_tier.public_calls_per_day,
+                storage_bytes_limit=plan_tier.storage_limit_bytes,
+                sleep_enabled_contexts_limit=plan_tier.sleep_enabled_contexts_limit,
             ),
             addon=AddonValues(
                 memory_bonus=workspace.addon_memory_bonus,
@@ -661,6 +682,10 @@ async def get_workspace_quotas(
                 max_contexts=effective["max_contexts"],
                 max_members=effective["max_members"],
                 analysis_runs_per_day=effective["analysis_runs_per_day"],
+                rest_calls_per_day=effective["rest_calls_per_day"],
+                public_calls_per_day=effective["public_calls_per_day"],
+                storage_bytes_limit=effective["storage_bytes_limit"],
+                sleep_enabled_contexts_limit=effective["sleep_enabled_contexts_limit"],
             ),
             usage=UsageValues(
                 memories=memory_count,
@@ -958,11 +983,15 @@ async def update_workspace_quotas(
                 ),
             )
 
-        # 2d. Persistent-addon overflow guard (LD-7). Only fires when the
-        #     bonus is actually changing AND the addon has a usage counter
-        #     in the codebase; daily-reset quotas and storage (no tracking
-        #     yet) skip via ``guard_kind is None``.
-        if spec.guard_kind is not None and requested != old_bonus:
+        # 2d. Persistent-addon overflow guard (LD-7). Fires whenever the
+        #     addon has a usage counter (member/context/memory/sleep_contexts),
+        #     regardless of whether ``requested`` matches the cached
+        #     ``old_bonus``. Review-finding #6: keying the skip on cache
+        #     equality let upstream cache drift (e.g. operator SQL leaving
+        #     the cache stale relative to actual usage) slip through a
+        #     re-PUT of the cached value. The cost is one extra COUNT per
+        #     touched persistent-addon field — admin-only path, acceptable.
+        if spec.guard_kind is not None:
             usage_count = await _count_addon_usage(db, ws_uuid, spec.guard_kind)
             new_effective = _effective_for_guard(plan_tier, spec.guard_kind, requested)
             if usage_count > new_effective:
@@ -1028,23 +1057,34 @@ async def update_workspace_quotas(
                 constraint="uq_workspace_addons_workspace_addon_source",
                 set_={
                     "quantity": plan.quantity,
-                    "active_until": None,
-                    "created_by": admin_user["user_id"],
-                    # ``active_from`` intentionally NOT updated on conflict —
-                    # preserve the original-grant timestamp so the audit trail
-                    # tracks "when this admin override was first applied",
-                    # not "when it was last touched" (Phase 6 review A1.1).
+                    # ``active_from``, ``active_until``, and ``created_by``
+                    # are intentionally NOT updated on conflict — the audit
+                    # trail records the original grant (when it first applied
+                    # AND who first applied it). Subsequent re-grants only
+                    # adjust the quantity; the structured log entry
+                    # ``workspace_addon_updated`` captures the changing admin
+                    # identity per-PUT. Review-finding #5 + #7: an unset
+                    # ``set_`` for ``active_until`` previously clobbered any
+                    # pre-existing expiration to NULL, silently extending
+                    # time-bound grants; clobbering ``created_by`` made the
+                    # audit trail half-preserved (timestamp from T1, attribution
+                    # from T_last). Preserving all three closes both gaps.
                 },
             )
         )
         await db.execute(stmt)
 
-    # 4. Recalculate. Commits the staged ``WorkspaceAddon`` UPSERTs and
-    #    the refreshed ``addon_*_bonus`` cache columns atomically per the
-    #    #570 contract docstring on ``AddonCalculatorService`` — which is
-    #    also why this handler has no ``db_transaction(...)`` wrapper
-    #    (LD-3, see function docstring).
-    await AddonCalculatorService(db).recalculate_workspace_bonuses(ws_uuid)
+    # 4. Recalculate (skipped when validation produced no mutations).
+    #    Commits the staged ``WorkspaceAddon`` UPSERTs and the refreshed
+    #    ``addon_*_bonus`` cache columns atomically per the #570 contract
+    #    docstring on ``AddonCalculatorService`` — also why this handler
+    #    has no ``db_transaction(...)`` wrapper (LD-3, see function docstring).
+    #
+    # Review-finding #14: skip the recalc when ``grants_to_apply`` is empty
+    # (e.g. an all-no-touch PUT) so we don't commit a no-op transaction and
+    # emit a misleading ``addon_bonuses_recalculated`` log entry.
+    if grants_to_apply:
+        await AddonCalculatorService(db).recalculate_workspace_bonuses(ws_uuid)
 
     logger.info(
         "workspace_addon_updated",

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -367,6 +367,9 @@ class WorkspaceAddon(Base):
     """Workspace addon model (Addon purchase system).
 
     Issue #238: Tracks addon purchases for variable quotas.
+    Issue #665: ``source`` discriminator added so the admin grant path
+    and the (future) Stripe webhook path can share this table as a
+    single source of truth without overwriting each other.
 
     Attributes:
         id: Primary key
@@ -375,6 +378,12 @@ class WorkspaceAddon(Base):
         quantity: Number of addon units purchased
         purchase_price_cents: Purchase price in cents
         stripe_product_id: Stripe product/price ID (optional)
+        source: Provenance discriminator (``'stripe'`` for purchase
+            flow, ``'admin_grant'`` for manual admin grants). The
+            composite UNIQUE ``(workspace_id, addon_type, source)``
+            enforces "at most one row per provenance per addon type",
+            which is what makes the admin handler's UPSERT semantics
+            safe (Issue #665, LD-2).
         active_from: Addon activation timestamp
         active_until: Addon expiration timestamp (NULL = permanent)
         created_at: Purchase timestamp
@@ -394,6 +403,9 @@ class WorkspaceAddon(Base):
     quantity: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
     purchase_price_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
     stripe_product_id: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    source: Mapped[str] = mapped_column(
+        String(20), nullable=False, default="stripe", server_default="stripe"
+    )
     active_from: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()
     )
@@ -411,6 +423,16 @@ class WorkspaceAddon(Base):
             name="check_addon_type",
         ),
         CheckConstraint("quantity > 0", name="check_quantity_positive"),
+        CheckConstraint(
+            "source IN ('stripe', 'admin_grant')",
+            name="check_addon_source",
+        ),
+        UniqueConstraint(
+            "workspace_id",
+            "addon_type",
+            "source",
+            name="uq_workspace_addons_workspace_addon_source",
+        ),
     )
 
 

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -155,6 +155,32 @@ class AddonCalculatorService:
                 bonuses["addon_analysis_bonus"] += total_bonus
             elif addon_type == "extra_sleep_contexts":
                 bonuses["addon_sleep_contexts_bonus"] += total_bonus  # Issue #560
+            else:
+                # Issue #665 review-finding #3: a WorkspaceAddon row exists
+                # for an addon_type that has no corresponding cache-column
+                # mapping here. The row passes the check_addon_type CHECK
+                # constraint, so it's a valid enum value the spec table
+                # (admin_plans._ADDON_FIELD_SPECS) added without updating
+                # this method. The contribution is silently dropped; cache
+                # stays at 0; downstream quota check uses the base-tier
+                # value as if the admin grant never happened. Log loudly
+                # so the drift surfaces in production logs at the first
+                # recalc for an affected workspace.
+                logger.warning(
+                    "addon_type_no_bonus_column_mapping",
+                    addon_type=addon_type,
+                    workspace_id=workspace_id,
+                    addon_id=addon.id,
+                    quantity=addon.quantity,
+                    note=(
+                        "WorkspaceAddon row exists for an addon_type with "
+                        "no entry in the if/elif chain above. The grant "
+                        "will not appear in the workspace.addon_*_bonus "
+                        "cache. Update both this method AND "
+                        "admin_plans._ADDON_FIELD_SPECS when introducing "
+                        "a new addon type."
+                    ),
+                )
 
         # Update workspace table
         result = await self.db.execute(select(Workspace).where(Workspace.id == workspace_id))

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -191,7 +191,8 @@ class AddonCalculatorService:
         workspace = result.scalar_one_or_none()
 
         if not workspace:
-            logger.error("workspace_not_found", workspace_id=workspace_id)
+            # Cast UUID to str for JSONRenderer compatibility (see line 169).
+            logger.error("workspace_not_found", workspace_id=str(workspace_id))
             return bonuses
 
         workspace.addon_storage_bonus_mb = bonuses["addon_storage_bonus_mb"]
@@ -206,9 +207,10 @@ class AddonCalculatorService:
 
         await self.db.commit()
 
+        # Cast UUID to str for JSONRenderer compatibility (see line 169).
         logger.info(
             "addon_bonuses_recalculated",
-            workspace_id=workspace_id,
+            workspace_id=str(workspace_id),
             active_addons=len(active_addons),
             bonuses=bonuses,
         )

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -47,12 +47,25 @@ class AddonCalculatorService:
 
         Any code that mutates ``WorkspaceAddon`` rows
         (INSERT / UPDATE active_until / DELETE / future Stripe webhook
-        handlers / admin scripts) **MUST** call
+        handlers / admin scripts / the admin HTTP handler
+        ``PUT /admin/plans/workspaces/{id}/quotas``) **MUST** call
         ``recalculate_workspace_bonuses(workspace_id)`` after staging
         the mutation in the session (``db.add(...)`` / ``db.delete(...)``).
         Skipping the call leaves the cache stale and every downstream
         quota check returns wrong numbers until something else
         triggers a recalc.
+
+        Provenance discriminator (Issue #665):
+            ``WorkspaceAddon.source`` distinguishes ``'stripe'`` rows
+            (purchase flow) from ``'admin_grant'`` rows (admin manual
+            override). The composite UNIQUE
+            ``(workspace_id, addon_type, source)`` ensures admin grants
+            and Stripe purchases co-exist without overwriting each other
+            — this method's SUM aggregation reads BOTH sources, so the
+            cache always reflects the union. The admin handler
+            UPSERTs the ``(workspace_id, addon_type, 'admin_grant')``
+            row and then calls this method, exactly as Stripe webhooks
+            will when they land.
 
         Commit semantics: ``recalculate_workspace_bonuses`` calls
         ``db.commit()`` internally, which flushes BOTH the caller's

--- a/backend/src/services/addon_calculator_service.py
+++ b/backend/src/services/addon_calculator_service.py
@@ -166,10 +166,14 @@ class AddonCalculatorService:
                 # value as if the admin grant never happened. Log loudly
                 # so the drift surfaces in production logs at the first
                 # recalc for an affected workspace.
+                # Cast UUID to str — utils/logger.py uses JSONRenderer in
+                # production (LOG_COLORIZE=false) without a default=str
+                # serializer, so raw UUID kwargs would fail JSON encoding
+                # and the warning would silently drop. Copilot review #797.
                 logger.warning(
                     "addon_type_no_bonus_column_mapping",
                     addon_type=addon_type,
-                    workspace_id=workspace_id,
+                    workspace_id=str(workspace_id),
                     addon_id=addon.id,
                     quantity=addon.quantity,
                     note=(

--- a/backend/tests/integration/_addon_helpers.py
+++ b/backend/tests/integration/_addon_helpers.py
@@ -1,0 +1,75 @@
+"""Cross-table addon invariant helper for integration tests (#665).
+
+Reusable contract assertion for the SSoT relationship documented in
+``AddonCalculatorService`` (Issue #570):
+
+    SUM(WorkspaceAddon active rows) × ADDON_UNIT_VALUES[addon_type]
+    == workspace.addon_<addon_type>_bonus
+
+Future quota-related PRs can call ``assert_addon_invariant(db, ws_id)``
+after any code path that mutates ``WorkspaceAddon`` rows to confirm the
+cache column was refreshed in lock-step. Originally added to satisfy
+Issue #665 AC #3.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin_plans import _ADDON_FIELD_SPECS
+from models.auth import Workspace
+from models.resource import WorkspaceAddon
+from services.addon_calculator_service import ADDON_UNIT_VALUES
+from utils.datetime import utcnow
+
+# Map ``Workspace.addon_*_bonus`` cache column → ``WorkspaceAddon.addon_type``,
+# derived from the single source of truth in ``admin_plans._ADDON_FIELD_SPECS``
+# so that adding a new addon type in one place propagates to this helper
+# automatically — no manual sync, no drift surface.
+_CACHE_TO_ADDON_TYPE: dict[str, str] = {
+    spec.field_name: spec.addon_type for spec in _ADDON_FIELD_SPECS
+}
+
+
+async def assert_addon_invariant(db: AsyncSession, workspace_id: UUID) -> None:
+    """Assert SUM(active WorkspaceAddon rows) matches each cache column.
+
+    Args:
+        db: AsyncSession bound to the test database.
+        workspace_id: Workspace to verify.
+
+    Raises:
+        AssertionError: On any cache vs source mismatch, with the
+            offending column and both values in the message so the
+            failure points at the addon type that drifted.
+    """
+    now = utcnow()
+
+    ws_result = await db.execute(select(Workspace).where(Workspace.id == workspace_id))
+    workspace = ws_result.scalar_one_or_none()
+    assert workspace is not None, f"Workspace {workspace_id} not found"
+
+    for cache_col, addon_type in _CACHE_TO_ADDON_TYPE.items():
+        sum_result = await db.execute(
+            select(func.coalesce(func.sum(WorkspaceAddon.quantity), 0)).where(
+                WorkspaceAddon.workspace_id == workspace_id,
+                WorkspaceAddon.addon_type == addon_type,
+                WorkspaceAddon.active_from <= now,
+                ((WorkspaceAddon.active_until.is_(None)) | (WorkspaceAddon.active_until > now)),
+            )
+        )
+        total_quantity = int(sum_result.scalar() or 0)
+        expected_bonus = total_quantity * ADDON_UNIT_VALUES[addon_type]
+        actual_bonus = getattr(workspace, cache_col)
+
+        assert actual_bonus == expected_bonus, (
+            f"Addon invariant violation: workspace.{cache_col}={actual_bonus} "
+            f"but SUM(WorkspaceAddon.quantity WHERE addon_type={addon_type!r}) "
+            f"× {ADDON_UNIT_VALUES[addon_type]} = {expected_bonus}. "
+            f"Some caller mutated WorkspaceAddon rows without invoking "
+            f"AddonCalculatorService.recalculate_workspace_bonuses afterward "
+            f"(see #570 contract docstring)."
+        )

--- a/backend/tests/integration/test_addon_cache_invariant.py
+++ b/backend/tests/integration/test_addon_cache_invariant.py
@@ -71,12 +71,14 @@ async def pro_workspace(db_session: AsyncSession) -> dict:
 
 
 def _zero_legacy_request(**overrides) -> UpdateAddonRequest:
-    """Construct an UpdateAddonRequest with the legacy 5 fields all zeroed.
+    """Construct an UpdateAddonRequest with the legacy 5 fields explicitly zeroed.
 
-    Avoids the per-test boilerplate of restating all 5 required fields,
-    while leaving the new 4 optional fields as ``None`` (no-touch) unless
-    a test explicitly sets one. ``overrides`` keyword arguments take
-    precedence and may include any of the 9 fields.
+    Since #665 review-fix #2 unified all 9 fields as optional with no-touch
+    semantics, this helper now passes the 5 legacy fields as *explicit* zeros
+    (matching the legacy admin UI's behavior of always sending all 5 values).
+    The new 4 optional fields remain ``None`` (no-touch) unless an override
+    sets them. ``overrides`` may include any of the 9 fields and take
+    precedence over the explicit-zero defaults.
     """
     base: dict = {
         "addon_memory_bonus": 0,
@@ -431,3 +433,227 @@ class TestGetResponseShape:
         assert addon.analysis_bonus == 2
         assert addon.storage_bonus_mb == 300
         assert addon.sleep_contexts_bonus == 2
+
+    @pytest.mark.asyncio
+    async def test_get_response_exposes_all_9_effective_fields(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        """Review fix #8: GET ``effective`` block surfaces all 9 fields.
+
+        Pre-fix, ``effective`` was a 5-field QuotaBreakdown — the 4 new
+        addon types (rest_quota, public_quota, storage, sleep_contexts)
+        had no read-back path even though PUT accepted them. Confirms the
+        write-only hole is closed.
+        """
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(
+                addon_storage_bonus_mb=200,
+                addon_rest_quota_bonus=1000,
+                addon_public_quota_bonus=500,
+                addon_sleep_contexts_bonus=2,
+            ),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        response = await get_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+        eff = response.effective
+
+        # Effective values reflect tier base + admin grant for all 9
+        # addon types. PRO base values come from config/plan_tiers.py.
+        assert eff.rest_calls_per_day > 0  # PRO base 5000 + addon 1000
+        assert eff.public_calls_per_day > 0  # PRO base 1000 + addon 500
+        assert eff.storage_bytes_limit > 0  # PRO base 10 GiB + addon 200 MB
+        assert eff.sleep_enabled_contexts_limit > 0  # PRO base 3 + addon 2
+
+
+# --- Review fixes ----------------------------------------------------------
+
+
+class TestAlwaysFireOverflowGuard:
+    """Review fix #6: LD-7 overflow guard fires regardless of cache match.
+
+    Pre-fix, the guard was keyed on ``requested != old_bonus``. If the cache
+    column was stale (e.g. operator SQL bypassing the application path), a
+    re-PUT of the cached value silently skipped the check and let over-cap
+    state persist. The fix runs the guard whenever the addon has a usage
+    counter, regardless of cache equality.
+    """
+
+    @pytest.mark.asyncio
+    async def test_guard_fires_when_requested_equals_cached_bonus(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+        user_id = pro_workspace["user_id"]
+
+        # Set up: grant sleep_contexts_bonus=5 (effective = 3 + 5 = 8),
+        # create 5 sleep-enabled contexts, then simulate a cache desync
+        # by leaving 5 in the cache but having actual usage that would
+        # exceed the post-reduction effective. We do this by re-asserting
+        # the same bonus value AFTER the contexts exist — pre-fix the
+        # guard skipped; post-fix it fires.
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_sleep_contexts_bonus=5),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+        for _ in range(8):  # exactly at effective cap (3 + 5)
+            db_session.add(
+                Context(
+                    workspace_id=ws_uuid,
+                    name=f"sleep-ctx-{uuid4().hex[:8]}",
+                    created_by=user_id,
+                    is_private=False,
+                    sleep_mode="full",
+                )
+            )
+        await db_session.commit()
+
+        # Re-PUT the SAME bonus value (5). Pre-fix this skipped the guard
+        # because requested == old_bonus. Post-fix the guard fires and
+        # confirms usage (8) <= effective (8), so it passes. To prove the
+        # guard *runs*, we add one more sleep context to push over the
+        # limit, then re-PUT — the guard should now reject 400.
+        db_session.add(
+            Context(
+                workspace_id=ws_uuid,
+                name=f"sleep-ctx-{uuid4().hex[:8]}",
+                created_by=user_id,
+                is_private=False,
+                sleep_mode="full",
+            )
+        )
+        await db_session.commit()
+
+        # Usage=9, requested=5 (same as old), effective=8. 9 > 8 → 400.
+        with pytest.raises(HTTPException) as exc_info:
+            await update_workspace_quotas(
+                workspace_id=str(ws_uuid),
+                request=_zero_legacy_request(addon_sleep_contexts_bonus=5),
+                admin_user=mock_admin(),
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "sleep_contexts" in exc_info.value.detail
+
+
+class TestUpsertPreservesActiveUntilAndCreatedBy:
+    """Review fix #5 + #7: UPSERT preserves active_until and created_by.
+
+    Pre-fix, ON CONFLICT DO UPDATE set_={active_until: None, created_by: ...}
+    silently clobbered any prior expiration to NULL (un-expiring time-bound
+    grants) and overwrote the original-grantor attribution while preserving
+    active_from — half-preserved audit trail. The fix excludes both fields
+    from set_, preserving the full original-grant record.
+    """
+
+    @pytest.mark.asyncio
+    async def test_upsert_preserves_original_grantor_and_expiration(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        # Admin A grants memory_bonus=10000 — creates admin_grant row.
+        original_admin = {
+            "user_id": "admin_A_original",
+            "email": "a@test.invalid",
+            "role": "admin",
+        }
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_memory_bonus=10000),
+            admin_user=original_admin,
+            db=db_session,
+        )
+
+        # Simulate ops manually setting active_until on the row (would
+        # represent a future time-bound-grant feature or a manual revoke
+        # scheduled by ops).
+        from datetime import timedelta
+
+        sentinel_expiry = utcnow() + timedelta(days=30)
+        existing = (
+            await db_session.execute(
+                select(WorkspaceAddon).where(
+                    WorkspaceAddon.workspace_id == ws_uuid,
+                    WorkspaceAddon.addon_type == "extra_memory",
+                    WorkspaceAddon.source == "admin_grant",
+                )
+            )
+        ).scalar_one()
+        existing.active_until = sentinel_expiry
+        await db_session.commit()
+
+        # Admin B re-grants the same memory_bonus value. Pre-fix this would
+        # have wiped active_until → None AND overwritten created_by → 'admin_B'.
+        # Post-fix both fields are preserved.
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_memory_bonus=20000),
+            admin_user={
+                "user_id": "admin_B_later",
+                "email": "b@test.invalid",
+                "role": "admin",
+            },
+            db=db_session,
+        )
+
+        await db_session.refresh(existing)
+        # active_until preserved (NOT clobbered to NULL)
+        assert existing.active_until is not None
+        # created_by preserved (NOT overwritten to admin_B)
+        assert existing.created_by == "admin_A_original"
+        # quantity updated as expected
+        assert existing.quantity == 2  # 20000 / 10000
+
+
+class TestSkipRecalcOnEmptyMutations:
+    """Review fix #14: no-op PUT should not trigger recalc commit + log.
+
+    When every field in the request body is None (or matches the no-op
+    case where grants_to_apply is empty after validation), the handler
+    should skip ``recalculate_workspace_bonuses`` entirely — avoiding a
+    misleading ``addon_bonuses_recalculated`` structured log entry that
+    implies state changed.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_none_request_does_not_create_admin_grant_rows(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        # Send a request with every field omitted (all None default).
+        # Post-fix: validation produces zero grants_to_apply, mutation pass
+        # is a no-op, recalc is skipped — no admin_grant rows created.
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=UpdateAddonRequest(),  # all 9 None
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        # No admin_grant rows should exist for this workspace.
+        rows = (
+            (
+                await db_session.execute(
+                    select(WorkspaceAddon).where(
+                        WorkspaceAddon.workspace_id == ws_uuid,
+                        WorkspaceAddon.source == "admin_grant",
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(rows) == 0

--- a/backend/tests/integration/test_addon_cache_invariant.py
+++ b/backend/tests/integration/test_addon_cache_invariant.py
@@ -1,0 +1,433 @@
+"""Integration tests for admin quota PUT row-based SSoT (#665).
+
+Covers Issue #665 acceptance criteria + locked decisions:
+
+* AC #1 / LD-1 / LD-3: admin grant via ``WorkspaceAddon`` row survives a
+  subsequent ``recalculate_workspace_bonuses`` call (the headline bug fix).
+* AC #2: admin grant is visible in ``EffectiveQuotaService`` output.
+* AC #3 / LD-6: the cross-table invariant
+  ``SUM(WorkspaceAddon active * unit_value) == workspace.addon_*_bonus``
+  holds after admin-only, Stripe-only, and mixed scenarios — exercised
+  via the reusable ``assert_addon_invariant`` helper.
+* LD-2: HTTP 400 when admin would silently clamp below the active
+  Stripe-purchased floor, and when the admin portion is not divisible
+  by the addon's ``unit_value``.
+* LD-4 / LD-8: 9-field ``UpdateAddonRequest`` with no-touch semantics on
+  the 4 new optional fields; ``AddonValues`` GET response surfaces all 9.
+* LD-7: persistent-addon overflow guard (``sleep_contexts`` case) rejects
+  reductions that would put current usage above the new effective limit.
+
+Direct-function-call pattern: matches ``test_admin_workspace_slot_bonus``
+so the route handler runs against the real Postgres test session — a
+MagicMock DB would silently pass on broken WHERE clauses or non-atomic
+read-modify-write loops.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from fastapi import HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin_plans import (
+    UpdateAddonRequest,
+    get_workspace_quotas,
+    update_workspace_quotas,
+)
+from auth.workspace_roles import WorkspaceRole
+from models.auth import Context, Workspace, WorkspaceMember
+from models.resource import WorkspaceAddon
+from services.addon_calculator_service import AddonCalculatorService
+from services.effective_quota_service import EffectiveQuotaService
+from utils.datetime import utcnow
+
+from ._addon_helpers import assert_addon_invariant
+from ._admin_helpers import make_user, make_workspace, mock_admin
+
+# --- fixtures ---------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def pro_workspace(db_session: AsyncSession) -> dict:
+    """Bare PRO workspace with an OWNER member, no addon rows."""
+    user = make_user(name="Addon Test Owner")
+    db_session.add(user)
+    await db_session.flush()
+
+    ws = make_workspace(owner_user_id=user.user_id, plan_name="pro")
+    db_session.add(ws)
+    await db_session.flush()
+
+    db_session.add(
+        WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role=WorkspaceRole.OWNER)
+    )
+    await db_session.commit()
+
+    return {"workspace_id": str(ws.id), "ws_uuid": ws.id, "user_id": user.user_id}
+
+
+def _zero_legacy_request(**overrides) -> UpdateAddonRequest:
+    """Construct an UpdateAddonRequest with the legacy 5 fields all zeroed.
+
+    Avoids the per-test boilerplate of restating all 5 required fields,
+    while leaving the new 4 optional fields as ``None`` (no-touch) unless
+    a test explicitly sets one. ``overrides`` keyword arguments take
+    precedence and may include any of the 9 fields.
+    """
+    base: dict = {
+        "addon_memory_bonus": 0,
+        "addon_mcp_quota_bonus": 0,
+        "addon_member_bonus": 0,
+        "addon_context_bonus": 0,
+        "addon_analysis_bonus": 0,
+    }
+    base.update(overrides)
+    return UpdateAddonRequest(**base)
+
+
+# --- AC #1, LD-1, LD-3 -----------------------------------------------------
+
+
+class TestAdminGrantSurvivesRecalc:
+    """AC #1: admin grant persists across a recalculate_workspace_bonuses call."""
+
+    @pytest.mark.asyncio
+    async def test_admin_grant_creates_admin_grant_row(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_memory_bonus=20000),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        row_result = await db_session.execute(
+            select(WorkspaceAddon).where(
+                WorkspaceAddon.workspace_id == ws_uuid,
+                WorkspaceAddon.addon_type == "extra_memory",
+                WorkspaceAddon.source == "admin_grant",
+            )
+        )
+        admin_row = row_result.scalar_one()
+        # 20000 / unit_value 10000 = 2 units
+        assert admin_row.quantity == 2
+        assert admin_row.source == "admin_grant"
+        assert admin_row.active_until is None  # permanent until admin changes
+        assert admin_row.created_by == mock_admin()["user_id"]
+
+    @pytest.mark.asyncio
+    async def test_admin_grant_survives_independent_recalc(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        """The bug being fixed: a stray recalc must NOT wipe the admin grant."""
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_memory_bonus=30000),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        # Simulate an unrelated recalc trigger (e.g. a future Stripe
+        # webhook calling recalculate after touching a different addon).
+        await AddonCalculatorService(db_session).recalculate_workspace_bonuses(ws_uuid)
+
+        # Re-read the workspace from the DB
+        ws_result = await db_session.execute(select(Workspace).where(Workspace.id == ws_uuid))
+        workspace = ws_result.scalar_one()
+        assert workspace.addon_memory_bonus == 30000  # NOT wiped
+
+
+# --- AC #2 -----------------------------------------------------------------
+
+
+class TestEffectiveQuotaReflection:
+    """AC #2: admin grant flows through to EffectiveQuotaService output."""
+
+    @pytest.mark.asyncio
+    async def test_admin_grant_increases_effective_memory_limit(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+        before = await EffectiveQuotaService(db_session).get_effective_quotas(ws_uuid)
+
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_memory_bonus=50000),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        after = await EffectiveQuotaService(db_session).get_effective_quotas(ws_uuid)
+        assert after["memory_limit"] == before["memory_limit"] + 50000
+
+
+# --- AC #3, LD-6 ------------------------------------------------------------
+
+
+class TestAddonInvariant:
+    """AC #3: SUM(active WorkspaceAddon rows) == cache column, all addons."""
+
+    @pytest.mark.asyncio
+    async def test_invariant_holds_after_admin_only_grant(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(
+                addon_memory_bonus=10000,
+                addon_mcp_quota_bonus=5000,
+                addon_member_bonus=5,
+                addon_context_bonus=10,
+                addon_analysis_bonus=2,
+                addon_storage_bonus_mb=200,
+                addon_sleep_contexts_bonus=3,
+            ),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        await assert_addon_invariant(db_session, ws_uuid)
+
+    @pytest.mark.asyncio
+    async def test_invariant_holds_with_mixed_stripe_and_admin(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        """Stripe row + admin row both contribute to the SUM == cache invariant."""
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        # Simulate a Stripe purchase (a future webhook would do this).
+        db_session.add(
+            WorkspaceAddon(
+                workspace_id=ws_uuid,
+                addon_type="extra_memory",
+                source="stripe",
+                quantity=3,  # +30000 memory
+                purchase_price_cents=10000,
+                stripe_product_id="prod_test",
+                active_from=utcnow(),
+                active_until=None,
+                created_by="stripe_webhook",
+            )
+        )
+        await db_session.commit()
+        await AddonCalculatorService(db_session).recalculate_workspace_bonuses(ws_uuid)
+
+        # Admin layers an additional grant on top.
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_memory_bonus=50000),  # 30000 stripe + 20000 admin
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        await assert_addon_invariant(db_session, ws_uuid)
+
+        ws = (
+            await db_session.execute(select(Workspace).where(Workspace.id == ws_uuid))
+        ).scalar_one()
+        assert ws.addon_memory_bonus == 50000
+
+
+# --- LD-2 ------------------------------------------------------------------
+
+
+class TestStripeFloorReject:
+    """LD-2: admin reductions below the Stripe floor return HTTP 400."""
+
+    @pytest.mark.asyncio
+    async def test_reduce_below_stripe_floor_returns_400(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        db_session.add(
+            WorkspaceAddon(
+                workspace_id=ws_uuid,
+                addon_type="extra_memory",
+                source="stripe",
+                quantity=3,  # +30000 memory floor
+                purchase_price_cents=10000,
+                stripe_product_id="prod_x",
+                active_from=utcnow(),
+                active_until=None,
+                created_by="stripe_webhook",
+            )
+        )
+        await db_session.commit()
+        await AddonCalculatorService(db_session).recalculate_workspace_bonuses(ws_uuid)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await update_workspace_quotas(
+                workspace_id=str(ws_uuid),
+                request=_zero_legacy_request(addon_memory_bonus=10000),  # < 30000 floor
+                admin_user=mock_admin(),
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "Stripe-purchased floor" in exc_info.value.detail
+
+
+class TestDivisibilityReject:
+    """LD-2 implementation detail: non-multiples of unit_value return HTTP 400."""
+
+    @pytest.mark.asyncio
+    async def test_non_multiple_storage_value_returns_400(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        # extra_storage unit_value=100MB; 250 is not a multiple
+        with pytest.raises(HTTPException) as exc_info:
+            await update_workspace_quotas(
+                workspace_id=str(ws_uuid),
+                request=_zero_legacy_request(addon_storage_bonus_mb=250),
+                admin_user=mock_admin(),
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "must be a multiple of" in exc_info.value.detail
+
+
+# --- LD-7 ------------------------------------------------------------------
+
+
+class TestPersistentOverflowGuard:
+    """LD-7: reducing a persistent addon below current usage returns HTTP 400."""
+
+    @pytest.mark.asyncio
+    async def test_reduce_sleep_contexts_below_usage_returns_400(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+        user_id = pro_workspace["user_id"]
+
+        # Grant 5 extra sleep contexts (effective = pro_base 3 + 5 = 8)
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_sleep_contexts_bonus=5),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        # Insert 5 contexts with sleep_mode != 'skip' (direct insert
+        # bypasses runtime quota check — we are testing the admin
+        # reduce-guard, not the runtime create-guard).
+        for _ in range(5):
+            db_session.add(
+                Context(
+                    workspace_id=ws_uuid,
+                    name=f"sleep-ctx-{uuid4().hex[:8]}",
+                    created_by=user_id,
+                    is_private=False,
+                    sleep_mode="full",
+                )
+            )
+        await db_session.commit()
+
+        # Attempt to reduce bonus to 0 → effective drops to 3 < 5 usage → 400
+        with pytest.raises(HTTPException) as exc_info:
+            await update_workspace_quotas(
+                workspace_id=str(ws_uuid),
+                request=_zero_legacy_request(addon_sleep_contexts_bonus=0),
+                admin_user=mock_admin(),
+                db=db_session,
+            )
+
+        assert exc_info.value.status_code == 400
+        assert "sleep_contexts" in exc_info.value.detail
+
+
+# --- LD-4, LD-8 -------------------------------------------------------------
+
+
+class TestNoTouchSemantics:
+    """LD-4: the 4 new optional fields preserve their value when omitted."""
+
+    @pytest.mark.asyncio
+    async def test_omitting_optional_field_does_not_change_it(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        # Establish a non-zero baseline on a new (optional) field
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_storage_bonus_mb=500),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        ws = (
+            await db_session.execute(select(Workspace).where(Workspace.id == ws_uuid))
+        ).scalar_one()
+        assert ws.addon_storage_bonus_mb == 500
+
+        # Second call: only touch the legacy 5 fields. Storage should NOT change.
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(addon_memory_bonus=10000),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        await db_session.refresh(ws)
+        assert ws.addon_storage_bonus_mb == 500  # preserved
+        assert ws.addon_memory_bonus == 10000  # updated
+
+
+class TestGetResponseShape:
+    """LD-8: GET /admin/plans/workspaces/{id}/quotas exposes all 9 addon fields."""
+
+    @pytest.mark.asyncio
+    async def test_get_response_exposes_all_9_addon_fields(
+        self, db_session: AsyncSession, pro_workspace: dict
+    ) -> None:
+        ws_uuid = pro_workspace["ws_uuid"]
+
+        await update_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            request=_zero_legacy_request(
+                addon_memory_bonus=10000,
+                addon_mcp_quota_bonus=5000,
+                addon_member_bonus=5,
+                addon_context_bonus=10,
+                addon_analysis_bonus=2,
+                addon_storage_bonus_mb=300,
+                addon_sleep_contexts_bonus=2,
+                addon_rest_quota_bonus=1000,
+                addon_public_quota_bonus=500,
+            ),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        response = await get_workspace_quotas(
+            workspace_id=str(ws_uuid),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        addon = response.addon
+        # All 9 fields surfaced with the values we just set
+        assert addon.memory_bonus == 10000
+        assert addon.mcp_quota_bonus == 5000
+        assert addon.rest_quota_bonus == 1000
+        assert addon.public_quota_bonus == 500
+        assert addon.member_bonus == 5
+        assert addon.context_bonus == 10
+        assert addon.analysis_bonus == 2
+        assert addon.storage_bonus_mb == 300
+        assert addon.sleep_contexts_bonus == 2

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -135,6 +135,14 @@ export interface QuotaBreakdown {
   max_contexts: number;
   max_members: number;
   analysis_runs_per_day: number;
+  // Issue #665 review fix #8: extended to 9 fields so GET surfaces the
+  // effective value for every addon type the PUT accepts. New fields
+  // default to 0 server-side; UI components that don't render them yet
+  // (#663 picks that up) simply ignore the additive keys.
+  rest_calls_per_day?: number;
+  public_calls_per_day?: number;
+  storage_bytes_limit?: number;
+  sleep_enabled_contexts_limit?: number;
 }
 
 export interface WorkspaceQuotaDetail {
@@ -164,17 +172,22 @@ export interface WorkspaceQuotaDetail {
 }
 
 export interface UpdateAddonRequest {
-  // Issue #665: absolute-value semantics, all values >= 0. The legacy 5
-  // fields are required (matches pre-#665 wire format — callers that
-  // send only these continue to work). The 4 new fields are optional
-  // with no-touch semantics: omit to leave the corresponding admin grant
-  // unchanged. Backend rejects values below the active Stripe SUM
-  // (HTTP 400) — no silent clamping.
-  addon_memory_bonus: number;
-  addon_mcp_quota_bonus: number;
-  addon_member_bonus: number;
-  addon_context_bonus: number;
-  addon_analysis_bonus: number;
+  // Issue #665 review-fix #2: all 9 fields are optional with no-touch
+  // semantics. Omit a field to leave the corresponding admin grant
+  // unchanged; send explicit ``0`` to zero it out. The pre-#665 5-field
+  // required-default-0 shape silently DELETEd grants on partial PUTs;
+  // unified optional closes that footgun. Existing callers that always
+  // send all 5 legacy fields continue to behave identically (explicit
+  // values, no omissions).
+  //
+  // Absolute-value semantics: every concrete value is the desired
+  // effective bonus contribution, NOT a delta. Backend rejects values
+  // below the active Stripe SUM (HTTP 400) — no silent clamping.
+  addon_memory_bonus?: number;
+  addon_mcp_quota_bonus?: number;
+  addon_member_bonus?: number;
+  addon_context_bonus?: number;
+  addon_analysis_bonus?: number;
   addon_rest_quota_bonus?: number;
   addon_public_quota_bonus?: number;
   addon_storage_bonus_mb?: number;

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -136,13 +136,15 @@ export interface QuotaBreakdown {
   max_members: number;
   analysis_runs_per_day: number;
   // Issue #665 review fix #8: extended to 9 fields so GET surfaces the
-  // effective value for every addon type the PUT accepts. New fields
-  // default to 0 server-side; UI components that don't render them yet
-  // (#663 picks that up) simply ignore the additive keys.
-  rest_calls_per_day?: number;
-  public_calls_per_day?: number;
-  storage_bytes_limit?: number;
-  sleep_enabled_contexts_limit?: number;
+  // effective value for every addon type the PUT accepts. The backend
+  // populates these unconditionally (Pydantic ``int = 0`` defaults), so
+  // they are typed as required ``number`` not optional — matches the
+  // actual wire format and avoids ``undefined`` creeping into UI math
+  // (Copilot review feedback on #797).
+  rest_calls_per_day: number;
+  public_calls_per_day: number;
+  storage_bytes_limit: number;
+  sleep_enabled_contexts_limit: number;
 }
 
 export interface WorkspaceQuotaDetail {

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -142,12 +142,21 @@ export interface WorkspaceQuotaDetail {
   workspace_name: string;
   plan_name: string;
   base: QuotaBreakdown;
+  // Issue #665: 9 addon cache columns surfaced. The 4 new fields
+  // (rest_quota_bonus, public_quota_bonus, storage_bonus_mb,
+  // sleep_contexts_bonus) are always present in the response; UI
+  // components that don't render them yet (#663 picks that up) simply
+  // ignore the extra keys.
   addon: {
     memory_bonus: number;
     mcp_quota_bonus: number;
+    rest_quota_bonus: number;
+    public_quota_bonus: number;
     member_bonus: number;
     context_bonus: number;
     analysis_bonus: number;
+    storage_bonus_mb: number;
+    sleep_contexts_bonus: number;
   };
   effective: QuotaBreakdown;
   usage: { memories: number; contexts: number; members: number };
@@ -155,11 +164,21 @@ export interface WorkspaceQuotaDetail {
 }
 
 export interface UpdateAddonRequest {
+  // Issue #665: absolute-value semantics, all values >= 0. The legacy 5
+  // fields are required (matches pre-#665 wire format — callers that
+  // send only these continue to work). The 4 new fields are optional
+  // with no-touch semantics: omit to leave the corresponding admin grant
+  // unchanged. Backend rejects values below the active Stripe SUM
+  // (HTTP 400) — no silent clamping.
   addon_memory_bonus: number;
   addon_mcp_quota_bonus: number;
   addon_member_bonus: number;
   addon_context_bonus: number;
   addon_analysis_bonus: number;
+  addon_rest_quota_bonus?: number;
+  addon_public_quota_bonus?: number;
+  addon_storage_bonus_mb?: number;
+  addon_sleep_contexts_bonus?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #665

## Summary

- Route admin quota PUT through `WorkspaceAddon` rows (with a new `source='admin_grant'` discriminator) instead of writing cache columns directly — closes the #570 contract violation that would have wiped admin grants the moment Stripe addon webhooks land.
- Race-free under concurrent admin PUTs via PostgreSQL `INSERT...ON CONFLICT DO UPDATE` keyed by the new composite `UNIQUE (workspace_id, addon_type, source)`.
- Extend the admin quota request/response from 5 → 9 addon cache columns (4 new ones are optional with no-touch semantics, so the legacy 5-field admin UI continues to work unchanged).
- Add a reusable `assert_addon_invariant(db, ws_id)` integration test helper that asserts `SUM(WorkspaceAddon active * unit_value) == workspace.addon_*_bonus` — the cross-table contract that #570 established but had no runtime check until now.

## Implementation notes

- **Schema (commit 1+2)**: new `workspace_addons.source VARCHAR(20) NOT NULL DEFAULT 'stripe'` with `CHECK (source IN ('stripe', 'admin_grant'))` and composite `UNIQUE (workspace_id, addon_type, source)`. Migration `e21_665_workspace_addon_source` follows the established `information_schema` + `DO ... EXCEPTION` idempotency pattern (mirrors `e15_675`). `NOT NULL DEFAULT 'stripe'` is metadata-only on PG ≥ 11 so existing rows back-fill without table rewrite.
- **Contract docstring (commit 3)**: `AddonCalculatorService.recalculate_workspace_bonuses` now explicitly enumerates the admin handler as a MUST caller and documents how `source` lets admin and Stripe rows co-exist (AC #4).
- **Handler rewrite (commit 4)**: `update_workspace_quotas` becomes a 2-pass validate-then-mutate body. Validation raises HTTP 400 before any DB write (Stripe-floor reject, divisibility-on-requested, persistent-addon overflow guard). Mutation pass UPSERTs the `admin_grant` row per touched addon or DELETEs it when the admin portion is zero (`check_quantity_positive` forbids storing 0). `db_transaction` wrapper is intentionally NOT used (recalc commits internally); a call-site comment documents the divergence from sibling handlers.
- **Spec-table driven**: 9 addon types live in `_ADDON_FIELD_SPECS` (1 row per addon). Adding a new addon type is a one-line change; the test helper `_CACHE_TO_ADDON_TYPE` is derived from the same table so manual sync is impossible.
- **Persistent vs daily-reset overflow guard split (LD-7)**: member / context / memory / sleep_contexts have persistent usage counters → guard rejects reductions that would put current usage above the new effective limit. mcp / rest / public / analysis are daily-reset Redis counters → guard skipped (admin throttling mid-day is acceptable). `addon_storage_bonus_mb` guard deferred because per-workspace storage usage tracking does not yet exist (filed as a follow-up).
- **`extra_sleep_contexts` PRO tier (LD-9)**: tier-feature gating is NOT enforced in this handler. `_zero_floor` clamps the effective limit to 0 for tiers with base 0, so admin grants on FREE/BASIC are harmless to user-facing behavior; the admin UI (#663) should display "no effect on this tier" rather than reject.
- **Frontend (commit 5)**: TS-types-only — `WorkspaceQuotaDetail.addon` and `UpdateAddonRequest` extended to 9 fields (4 new are `number?` optional). UI rendering for the new fields lands with #663 per the gate1 scope decision.
- **Tests (commit 6)**: 10 integration tests across 8 classes covering AC #1-4 plus LD-1/2/3/4/6/7/8. Direct-handler-call pattern matches `test_admin_workspace_slot_bonus`.

## Pre-PR review summary

- gate2 mode: advisor-only
- audit: skipped (gate2.binary_gate = null)
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (CIO lens, operator approved with "推奨で"; 9 locked decisions appended to gate1.md)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/665-fix-fix-admin-addon-put-bypasses-recalculate.gate1.md
- ~/.claude/cache/gh-issue-driven/665-fix-fix-admin-addon-put-bypasses-recalculate.gate2.md

## Phase 6 review fixes applied (6 of 6)

Three parallel code-reviewer agents returned 6 actionable findings, all applied before this PR:

1. `active_from` preserved on UPSERT (audit trail integrity)
2. Divisibility check moved to `requested` early (clearer error)
3. `INSERT ... ON CONFLICT DO UPDATE` (race-free under concurrent admin PUTs)
4. `_AddonFieldSpec.cache_column` removed (was always == `field_name` — DRY)
5. `_CACHE_TO_ADDON_TYPE` derived from `_ADDON_FIELD_SPECS` (no manual sync)
6. Call-site comment at recalc invocation explaining the `db_transaction` omission

Self-review: 0 critical / 0 warning.

## Follow-ups (separate issues, out of scope here)

- Storage usage tracking + `addon_storage_bonus_mb` LD-7 guard (blocked on storage instrumentation)
- `AddonChange` DB audit table (currently structlog-only; `PlanChange` is tier-only)
- Legacy 5-field defaults → uniform optional once #663 retires the legacy admin UI

🤖 Generated via /gh-issue-driven:ship
