### PR TITLE
feat(plugin): Add Codex plugin support for Kagura Memory (#802)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "kagura-memory-cloud",
+  "interface": {
+    "displayName": "Kagura Memory Cloud"
+  },
+  "plugins": [
+    {
+      "name": "kagura-memory",
+      "source": {
+        "source": "local",
+        "path": "./plugins/kagura-memory"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -42,12 +42,13 @@ The canonical runtime version is `APP_VERSION` in `backend/src/config/constants.
 - `backend/src/__init__.py` — `__version__ = "X.Y.Z"` (compat alias; must stay in sync with `APP_VERSION`)
 - `frontend/package.json` — `"version": "X.Y.Z"`
 - `frontend/package-lock.json` — run `cd frontend && npm install` to sync lock file
-- `.claude-plugin/plugin.json` — `"version": "X.Y.Z"` (kagura-memory plugin manifest; kept in lockstep so marketplace consumers see the same version as the backend)
+- `.claude-plugin/plugin.json` — `"version": "X.Y.Z"` (kagura-memory Claude Code plugin manifest; kept in lockstep so marketplace consumers see the same version as the backend)
+- `plugins/kagura-memory/.codex-plugin/plugin.json` — `"version": "X.Y.Z"` (kagura-memory Codex plugin manifest; kept in lockstep with the Claude plugin manifest)
 
 ### 5. Commit and tag
 
 ```bash
-git add backend/pyproject.toml backend/src/config/constants.py backend/src/__init__.py frontend/package.json frontend/package-lock.json .claude-plugin/plugin.json
+git add backend/pyproject.toml backend/src/config/constants.py backend/src/__init__.py frontend/package.json frontend/package-lock.json .claude-plugin/plugin.json plugins/kagura-memory/.codex-plugin/plugin.json
 git commit -m "chore(release): vX.Y.Z"
 git tag vX.Y.Z
 ```

--- a/backend/tests/test_codex_plugin_manifest.py
+++ b/backend/tests/test_codex_plugin_manifest.py
@@ -1,0 +1,127 @@
+"""Guard tests for #802: Codex plugin manifest integrity + version lockstep.
+
+The Codex plugin ships three coupled artifacts at the repo root:
+
+* ``.agents/plugins/marketplace.json``                  — Codex marketplace manifest
+* ``plugins/kagura-memory/.codex-plugin/plugin.json``    — Codex plugin manifest
+* ``plugins/kagura-memory/skills/*/SKILL.md``            — Codex skill(s)
+
+These tests pin the invariants that ``codex plugin add
+kagura-memory@kagura-memory-cloud`` depends on, and that the release process
+(``.claude/commands/release.md``) currently keeps in lockstep only
+procedurally:
+
+1. The Codex plugin version equals the canonical ``APP_VERSION`` and the Claude
+   plugin manifest version — a release that bumps one manifest but forgets the
+   other fails here (mirrors ``frontend/src/lib/version.test.ts``).
+2. The marketplace/plugin name pair spells the ``<plugin>@<marketplace>``
+   install handle from the acceptance criteria.
+3. Every path the manifests reference (plugin source dir, skills dir, icons)
+   resolves to a real file, using Codex's path-resolution roots: marketplace
+   ``source.path`` resolves relative to the repo root; plugin ``skills`` /
+   ``interface.logo`` / ``interface.composerIcon`` resolve relative to the
+   plugin root. A moved/renamed asset that silently drops the plugin from
+   Codex fails here instead.
+4. Each ``SKILL.md`` carries the YAML frontmatter (``name`` + ``description``)
+   Codex requires to register the skill.
+"""
+
+import json
+from pathlib import Path
+
+from config.constants import APP_VERSION
+
+# backend/tests/test_codex_plugin_manifest.py -> tests -> backend -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_MARKETPLACE = _REPO_ROOT / ".agents" / "plugins" / "marketplace.json"
+_CLAUDE_PLUGIN = _REPO_ROOT / ".claude-plugin" / "plugin.json"
+
+
+def _load(path: Path) -> dict:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _marketplace_plugin_entry() -> dict:
+    plugins = _load(_MARKETPLACE)["plugins"]
+    assert plugins, "marketplace manifest lists no plugins"
+    return plugins[0]
+
+
+def _plugin_root() -> Path:
+    """Resolve the plugin dir the way Codex does: marketplace ``source.path``
+    is relative to the marketplace/repo root, not to ``.agents/plugins/``.
+    """
+    rel = _marketplace_plugin_entry()["source"]["path"]
+    root = (_REPO_ROOT / rel).resolve()
+    assert root.is_dir(), f"plugin source path does not resolve to a dir: {rel}"
+    return root
+
+
+def _codex_manifest() -> dict:
+    return _load(_plugin_root() / ".codex-plugin" / "plugin.json")
+
+
+def _parse_frontmatter(path: Path) -> dict[str, str]:
+    """Minimal YAML-frontmatter reader (single-line ``key: value`` pairs).
+
+    Avoids a PyYAML dependency; SKILL.md frontmatter is flat ``key: value``.
+    """
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---"), f"{path} is missing YAML frontmatter"
+    # Frontmatter is the block between the first two ``---`` fences.
+    _, block, _ = text.split("---", 2)
+    fields: dict[str, str] = {}
+    for line in block.splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            fields[key.strip()] = value.strip()
+    return fields
+
+
+def test_codex_plugin_version_matches_app_version() -> None:
+    """Codex manifest version is in lockstep with the canonical runtime version."""
+    assert _codex_manifest()["version"] == APP_VERSION
+
+
+def test_codex_and_claude_plugin_versions_match() -> None:
+    """Both plugin manifests carry the same version (release.md lockstep rule)."""
+    assert _codex_manifest()["version"] == _load(_CLAUDE_PLUGIN)["version"]
+
+
+def test_install_handle_names_are_consistent() -> None:
+    """``kagura-memory@kagura-memory-cloud`` only resolves if these names align."""
+    marketplace = _load(_MARKETPLACE)
+    entry = marketplace["plugins"][0]
+    assert marketplace["name"] == "kagura-memory-cloud"
+    assert entry["name"] == "kagura-memory"
+    # The plugin manifest's own name must match the marketplace entry's name,
+    # otherwise the install handle points at a plugin that won't load.
+    assert _codex_manifest()["name"] == entry["name"]
+
+
+def test_codex_manifest_referenced_paths_exist() -> None:
+    """Skills dir and interface icons resolve to real files under the plugin root."""
+    plugin_root = _plugin_root()
+    manifest = _codex_manifest()
+
+    skills_dir = (plugin_root / manifest["skills"]).resolve()
+    assert skills_dir.is_dir(), f"skills path does not exist: {manifest['skills']}"
+    assert list(skills_dir.glob("*/SKILL.md")), "no SKILL.md found under skills dir"
+
+    interface = manifest["interface"]
+    for field in ("logo", "composerIcon"):
+        asset = (plugin_root / interface[field]).resolve()
+        assert asset.is_file(), f"interface.{field} does not exist: {interface[field]}"
+        # Codex rejects ``..`` traversal — keep assets inside the plugin root.
+        assert plugin_root in asset.parents or asset.parent == plugin_root
+
+
+def test_every_skill_has_required_frontmatter() -> None:
+    """Every SKILL.md declares the ``name`` + ``description`` Codex needs to register it."""
+    skills_dir = (_plugin_root() / _codex_manifest()["skills"]).resolve()
+    skill_files = sorted(skills_dir.glob("*/SKILL.md"))
+    assert skill_files, "no SKILL.md files found"
+    for skill in skill_files:
+        fields = _parse_frontmatter(skill)
+        assert fields.get("name"), f"{skill} frontmatter missing 'name'"
+        assert fields.get("description"), f"{skill} frontmatter missing 'description'"

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,0 +1,41 @@
+{
+  "name": "kagura-memory",
+  "version": "0.16.5",
+  "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
+  "author": {
+    "name": "Kagura AI, Inc.",
+    "url": "https://github.com/kagura-ai"
+  },
+  "homepage": "https://github.com/kagura-ai/memory-cloud",
+  "repository": "https://github.com/kagura-ai/memory-cloud",
+  "license": "MIT",
+  "keywords": [
+    "memory",
+    "mcp",
+    "ai-memory",
+    "session-management",
+    "knowledge-base"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Kagura Memory",
+    "shortDescription": "Restore context and save durable project knowledge from Codex.",
+    "longDescription": "Kagura Memory Cloud adds persistent project memory workflows to Codex. Use it to restore session context, recall past decisions and fixes, save reusable knowledge, inspect setup, and smoke-test the MCP connection.",
+    "developerName": "Kagura AI, Inc.",
+    "category": "Productivity",
+    "capabilities": [
+      "Read",
+      "Write",
+      "Interactive"
+    ],
+    "websiteURL": "https://github.com/kagura-ai/memory-cloud",
+    "brandColor": "#DC2626",
+    "logo": "./assets/kagura-icon.svg",
+    "composerIcon": "./assets/kagura-icon.svg",
+    "defaultPrompt": [
+      "Restore my Kagura Memory session context.",
+      "Recall prior decisions about this repository.",
+      "Save this decision to Kagura Memory."
+    ]
+  }
+}

--- a/plugins/kagura-memory/assets/kagura-icon.svg
+++ b/plugins/kagura-memory/assets/kagura-icon.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <!-- White background circle -->
+  <circle cx="50" cy="50" r="45" fill="white"/>
+  
+  <!-- Ripple patterns adjusted -->
+  <path d="M10 50 C25 40, 45 40, 60 50 S70 60, 60 65 S20 65, 10 50" 
+        fill="none" stroke="#DC2626" stroke-width="0.8" stroke-opacity="0.25"/>
+  <path d="M15 45 C30 35, 40 35, 55 45 S65 55, 55 60 S25 60, 15 45" 
+        fill="none" stroke="#059669" stroke-width="0.7" stroke-opacity="0.2"/>
+  <path d="M12 53 C27 58, 37 50, 47 55 C57 59, 62 50, 67 53" 
+        fill="none" stroke="#059669" stroke-width="0.9" stroke-opacity="0.5"/>
+  <path d="M17 58 C32 63, 42 53, 52 58 C62 63, 67 55, 72 60" 
+        fill="none" stroke="#DC2626" stroke-width="0.7" stroke-opacity="0.3"/>
+  
+  <!-- KAi text with gradient -->
+  <defs>
+    <linearGradient id="redGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" style="stop-color:#DC2626;stop-opacity:0.9"/>
+      <stop offset="100%" style="stop-color:#DC2626;stop-opacity:1"/>
+    </linearGradient>
+  </defs>
+  
+  <text x="22" y="58" font-family="Palatino, 'Palatino Linotype', 'Book Antiqua', serif" font-size="36" font-weight="bold" fill="url(#redGrad)">K</text>
+  <text x="48" y="58" font-family="Palatino, 'Palatino Linotype', 'Book Antiqua', serif" font-size="36" font-weight="bold" fill="#059669">Ai</text>
+</svg>

--- a/plugins/kagura-memory/skills/kagura-memory/SKILL.md
+++ b/plugins/kagura-memory/skills/kagura-memory/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: kagura-memory
+description: Use Kagura Memory Cloud from Codex for long-term project memory. Trigger when the user asks to start or restore a session, recall past decisions or bug fixes, save session knowledge, remember a decision or troubleshooting note, inspect memory contexts, or verify the kagura-memory MCP connection.
+---
+
+# Kagura Memory
+
+Use Kagura Memory Cloud MCP tools as Codex's persistent project memory. Local git state and files remain the source of truth for current code; memory is supplemental context for decisions, rationale, and reusable lessons.
+
+Claude Code slash commands map to natural-language Codex requests:
+
+- `/kagura-memory:session-start` -> "kagura memory session start" or "restore my Kagura Memory session"
+- `/kagura-memory:session-summary` -> "save a Kagura Memory session summary"
+- `/kagura-memory:recall` -> "recall from Kagura Memory ..."
+- `/kagura-memory:remember` -> "remember this in Kagura Memory ..."
+- `/kagura-memory:guide` -> "show the Kagura Memory guide"
+- `/kagura-memory:smoke-test` -> "smoke test Kagura Memory"
+
+## Tool Availability
+
+Use the available Kagura Memory MCP namespace, typically exposed as tools such as:
+
+- `list_contexts`
+- `get_context_info`
+- `recall`
+- `reference`
+- `explore`
+- `remember`
+- `update_memory`
+- `forget`
+- context, edge, sleep, and usage tools when exposed
+
+If the MCP tools are not available:
+
+1. Run `codex mcp list` to check whether `kagura-memory` is configured.
+2. If missing, configure the HTTP MCP server in `~/.codex/config.toml` with `[mcp_servers.kagura-memory]`.
+3. Set `url` to your Memory Cloud endpoint: a self-hosted deployment uses `https://<your-domain>/mcp/w/<workspace-id>` (or `http://localhost:8080/mcp/w/<workspace-id>` for local development).
+4. Pass auth via `bearer_token_env_var` or an `[mcp_servers.kagura-memory.http_headers]` table with `Authorization = "Bearer <api-key>"`.
+5. Restart Codex so the tools are loaded.
+
+Never print API keys or bearer tokens. When showing config, redact secrets.
+
+## Resolve Context
+
+Start by calling `list_contexts(include_stats=true)` when the context is unknown.
+
+Pick the context whose `name`, `summary`, or recent usage matches the current repository or task. If several contexts are plausible and the choice affects writes, ask the user.
+
+After choosing a context, call `get_context_info(context_id=..., include_details=true)` once per session or after switching contexts. Follow the context-specific `usage_guide` over generic defaults.
+
+## Start Session
+
+When the user asks to start, restore, or resume a Kagura Memory session:
+
+1. Inspect local state in parallel where possible:
+   - `git branch --show-current`
+   - `git log --oneline -5`
+   - `git status --short`
+   - `git diff --stat HEAD~3` if available
+2. Resolve the target context and load `get_context_info`.
+3. Recall recent and actionable memory (compute a real ISO-8601 timestamp for `created_after` — never pass the literal placeholder):
+   - `recall(context_id=..., query="session summary progress decision", k=5, filters={"created_after": "<ISO-8601 timestamp for 7 days ago>"})`
+   - `recall(context_id=..., query="blocker issue TODO pending", k=5, filters={"created_after": "<ISO-8601 timestamp for 7 days ago>"})`
+   - `recall(context_id=..., query="dev environment troubleshooting workaround", k=3, filters={"type": "troubleshooting"})`
+4. If the branch, commits, or memories mention issue numbers and `gh` is available, inspect relevant issues.
+5. Report concise restored context: branch, uncommitted changes, chosen memory context, recent work, memory highlights, open issues, and suggested next steps.
+
+Keep memory highlights selective. Do not dump long histories.
+
+## Recall
+
+When the user asks what is remembered, asks for prior decisions, or needs similar past fixes:
+
+1. Resolve the context.
+2. Use `recall(context_id=..., query=..., k=5-10)`.
+3. Choose `search_mode` deliberately:
+   - `hybrid`: default for most queries.
+   - `keyword`: exact terms, IDs, Japanese hiragana-only terms, or error strings.
+   - `semantic`: concepts where wording may differ.
+4. Use filters when the user asks for a type, date, tag, source URI, or known category. If tag spelling is uncertain, search broadly first rather than inventing tag filters.
+5. For important hits, call `reference(context_id=..., memory_id=...)` to load full details.
+6. For broad context-building, call `explore(context_id=..., memory_id=..., depth=2, min_weight=0.0)` on the strongest seed memory.
+
+Show result summaries with `memory_id`, type, importance, and tags when the user needs to choose what to inspect.
+
+## Remember
+
+When saving new knowledge, decisions, bug fixes, troubleshooting notes, or session lessons:
+
+1. Resolve the context. Ask before writing if the context is ambiguous.
+2. Store reusable conclusions, not process narration.
+3. Use this type vocabulary unless the context guide says otherwise:
+   - `decision`: architecture choices, rejected alternatives, rationale.
+   - `pattern`: reusable implementation approaches.
+   - `bug-fix`: root cause and fix.
+   - `troubleshooting`: environment gotchas and workarounds.
+   - `learning`: benchmarks, tool limits, evaluation findings.
+   - `note`: roadmap, status, milestone relationships.
+4. Set importance by reuse value:
+   - `1.0`: core principle or critical decision.
+   - `0.8-0.9`: reusable decision, bug fix, or pattern.
+   - `0.5-0.7`: troubleshooting or status note.
+5. Include tags for category, entities, features, and related issues, for example `category:auth` or `issue:#802`.
+6. When the knowledge comes from a specific file, URL, or vault, set the first-class `source_uri` and `source_type` (`"file"` | `"url"` | `"vault"` | `"api"` | `"manual"`) fields so it stays retrievable via `recall(filters={"source_uri_prefix": ...})` and `{"source_type": ...}`. Use `linked_source_uris` to connect related memories at creation time.
+7. Include `Related issues: #N` in `content` when applicable.
+
+Use `remember(context_id=..., summary=..., content=..., type=..., importance=..., tags=..., context_summary=..., source_uri=..., source_type=..., linked_source_uris=...)`.
+
+Never store passwords, API keys, bearer tokens, private customer data, or unnecessary PII.
+
+## Session Summary
+
+At the end of a development session or before switching tasks:
+
+1. Review the conversation and local work.
+2. Identify durable items only: decisions, patterns, bug fixes, troubleshooting notes, learnings, and roadmap notes.
+3. Save separate memories for separate reusable conclusions. Avoid one large transcript-style dump.
+4. Include issue tags and a `Related issues:` line in content where relevant.
+5. Report what was saved: context, count, type, summary, and importance.
+
+Skip saving ephemeral actions such as "ran tests" unless there is a reusable environment trap or command pattern.
+
+## Smoke Test
+
+Use a read-only smoke test by default:
+
+1. `list_contexts(include_stats=true)`
+2. `get_usage()` when exposed
+3. Choose a non-sensitive context and run a harmless `recall(context_id=..., query="smoke test memory", k=1)`
+
+For a write smoke test, ask the user first because it creates and deletes test data. Then create a temporary context, capture the `id` returned by `create_context`, remember one test memory in it, recall it, reference it, and pass exactly that captured `id` to `delete_context`. Never pass a guessed or pre-existing context_id to `delete_context` — it soft-deletes the entire context and all of its memories.


### PR DESCRIPTION
Closes #802

## Summary
- Add OpenAI Codex CLI plugin metadata alongside the existing Claude Code plugin so the repo also registers as a Codex marketplace and installs as `kagura-memory@kagura-memory-cloud`.
- New Codex artifacts: `.agents/plugins/marketplace.json`, `plugins/kagura-memory/.codex-plugin/plugin.json`, a `SKILL.md` wrapping the Memory Cloud MCP session-start / recall / remember / guide / smoke-test workflows, and a brand SVG.
- Keep the Codex plugin version in lockstep with the backend / Claude manifest (`0.16.5`) via the release runbook **and** a new guard test.

## Implementation notes
- Manifest format verified against the `openai/codex` source: marketplace `source.path` resolves from the repo root; plugin `skills` / `interface.logo` / `interface.composerIcon` resolve from the plugin root; `source:{local}`, `policy.installation:AVAILABLE` / `authentication:ON_INSTALL`, and free-form `category` are all valid. SVG is accepted for the icon fields.
- `SKILL.md` references self-hosted endpoints only (`https://<your-domain>/mcp/w/<workspace-id>` / `localhost`), matching the README convention — no hosted URL — and embeds redact / never-store-secrets guardrails plus a `delete_context` captured-id safety note.
- `backend/tests/test_codex_plugin_manifest.py` (stdlib only, mirrors the existing `test_edge_type_constants.py` guard pattern + frontend `version.test.ts`): pins version lockstep, install-handle name consistency, manifest referenced-path integrity (rejects `..` traversal), and SKILL.md frontmatter. 5 tests, all passing.
- `.claude/commands/release.md`: adds the Codex manifest to the version-bump checklist and `git add` list.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: not run (ship-only mode — no /gh-issue-driven:start state for this branch)
- review provider: code-review

### Known limitation
The acceptance check `codex plugin list | rg kagura-memory` depends on Codex behavior subject to an open upstream bug (`openai/codex#22078` — local-marketplace plugins/skills not surfacing). The manifests are spec-correct, but the end-to-end listing/install is a **manual** verification step, not something this PR can guarantee.

### Follow-ups (non-blocking, raised at gate2)
- SVG well-formedness guard test (qa-lead)
- Manual codex-plugin e2e verification checklist in the release runbook (qa-lead)
- `SKILL.md` <-> `claude-skills/` content-drift detection (cto)

Full gate2 review saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/802-feat-add-codex-plugin-support-for-kagura-memory.gate2.md`

🤖 Generated via /gh-issue-driven:ship
