### PR TITLE
fix(db): normalize non-multiple addon caches to row-based SSoT (#799)

### DIFF
--- a/backend/alembic/versions/e23_799_normalize_addon_caches.py
+++ b/backend/alembic/versions/e23_799_normalize_addon_caches.py
@@ -1,0 +1,148 @@
+"""Normalize addon cache columns to the row-based SSoT (#799).
+
+Issue #799: the ``e22_665_backfill_admin_grants`` migration created
+``admin_grant`` ``WorkspaceAddon`` rows from non-zero cache columns, but
+its ``WHERE admin_portion >= unit_value`` clause and floor division left
+two classes of cache value **un-reconciled**:
+
+1. **Orphans** — a legacy cache value smaller than the addon's
+   ``unit_value`` (e.g. ``addon_memory_bonus=9000`` with
+   ``unit_value=10000``) produces a 0-unit admin portion, so no row is
+   inserted AND e22 never touched the cache column. The 9000 stays,
+   violating the SSoT invariant
+   ``cache == SUM(active WorkspaceAddon.quantity × unit_value)``.
+2. **Partial remainders** — a non-multiple value above ``unit_value``
+   (e.g. ``addon_storage_bonus_mb=250`` with ``unit_value=100``) gets a
+   floor-divided 2-unit (200 MB) row, but e22 left the cache at 250.
+
+Production impact (already mitigated): the ``kagura`` PRO workspace hit
+this 2026-05-23 when the #663 admin dialog read the stale 9000 and the
+post-#665 divisibility validator rejected the Save with HTTP 400. It was
+manually cleared; this migration normalizes any remaining workspaces and
+guarantees the invariant going forward.
+
+### Why recalc-from-rows, not "reset non-multiples to 0"
+
+Resetting a non-multiple cache to 0 would *re-break* the SSoT for the
+partial-remainder class: ``addon_storage_bonus_mb=250`` already has a
+legitimate 2-unit (200 MB) ``WorkspaceAddon`` row from e22, so cache 0 ≠
+SUM 200. Instead we recompute each cache column as
+``SUM(active rows) × unit_value`` for **all** active workspaces — exactly
+what ``AddonCalculatorService.recalculate_workspace_bonuses``
+(``services/addon_calculator_service.py:100-218``) does at runtime. This
+yields ``9000 → 0`` (orphan, no row) AND ``250 → 200`` (partial, preserves
+the backfilled row), and is idempotent because it writes the absolute SUM.
+
+### Active-window predicate
+
+The per-column SUM uses the SAME active-window predicate as the runtime
+recalc (``addon_calculator_service.py:112-118``):
+``active_from <= NOW() AND (active_until IS NULL OR active_until > NOW())``.
+Mismatching it (e.g. summing expired/future rows) would set a cache value
+that the next runtime recalc immediately contradicts — the exact subquery
+trap e22's review caught (PR #797 round 3).
+
+### Idempotency
+
+Re-running is safe: each UPDATE writes ``SUM(active rows) × unit_value``,
+an absolute value, so a second run is a no-op on already-consistent rows.
+
+### Atomicity / lock semantics
+
+Mirrors e22: ``LOCK TABLE ... IN SHARE ROW EXCLUSIVE MODE`` on both tables
+so a concurrent admin PUT cannot race the normalization. In production the
+API container is stopped during migrations (``.claude/rules/dev-environment.md``);
+the locks are belt-and-suspenders for dev / manual runs. Released at the
+migration's commit boundary (Alembic wraps every migration in a txn).
+
+### Downgrade
+
+``downgrade()`` is a deliberate no-op. The legacy non-multiple cache values
+this migration overwrites are unrecoverable (we did not snapshot them), and
+restoring them would re-introduce the SSoT violation. This is a forward-only
+data-correction migration.
+
+Revision ID: e23_799_normalize_addon_caches
+Revises: e22_665_backfill_admin_grants
+"""
+
+from alembic import op
+
+
+revision = "e23_799_normalize_addon_caches"
+down_revision = "e22_665_backfill_admin_grants"
+branch_labels = None
+depends_on = None
+
+
+# Mapping of Workspace cache column → (WorkspaceAddon.addon_type, unit_value).
+# Mirrors ``e22_665``'s ``_ADDON_BACKFILL``, ``admin_plans._ADDON_FIELD_SPECS``,
+# and ``ADDON_UNIT_VALUES`` in ``services/addon_calculator_service``. Kept inline
+# so the migration stays self-contained and survives future refactors of the
+# spec table. Adding a new addon type requires touching this list AND the spec
+# table AND the recalc service — the schema-drift test fails loudly on divergence.
+_ADDON_CACHE_COLUMNS: tuple[tuple[str, str, int], ...] = (
+    ("addon_memory_bonus", "extra_memory", 10000),
+    ("addon_mcp_quota_bonus", "extra_mcp_quota", 5000),
+    ("addon_rest_quota_bonus", "extra_rest_quota", 1000),
+    ("addon_public_quota_bonus", "extra_public_quota", 500),
+    ("addon_member_bonus", "extra_members", 5),
+    ("addon_context_bonus", "extra_contexts", 5),
+    ("addon_analysis_bonus", "extra_analysis_runs", 1),
+    ("addon_storage_bonus_mb", "extra_storage", 100),
+    ("addon_sleep_contexts_bonus", "extra_sleep_contexts", 1),
+)
+
+
+def upgrade() -> None:
+    """Recompute every addon cache column as SUM(active rows) × unit_value.
+
+    Per-column ``UPDATE ... SET cache = COALESCE(SUM(active quantity), 0) *
+    unit_value`` over all non-deleted workspaces. The correlated subquery's
+    active-window predicate matches ``recalculate_workspace_bonuses`` exactly
+    (``addon_calculator_service.py:112-118``), so the value written equals what
+    the runtime recalc would compute.
+
+    Writing the absolute SUM (not a delta) makes the statement idempotent, so
+    there is no ``WHERE cache <> SUM`` guard: re-running, or running over an
+    already-consistent workspace, simply rewrites the same value. Omitting the
+    guard keeps the active-window predicate in a single place (one fewer copy
+    to keep in sync) and avoids the SQL three-valued-logic trap where a
+    ``cache <> ...`` guard would silently skip a NULL cache column. (All 9
+    columns are currently ``NOT NULL DEFAULT 0``, but the guardless form is
+    correct regardless.) The full-table lock is already held, so writing every
+    active row rather than only drifted rows is negligible at this scale.
+
+    The identifiers interpolated below (``cache_col``, ``addon_type``,
+    ``unit_value``) come ONLY from the code-constant ``_ADDON_CACHE_COLUMNS``
+    tuple — never from user input — so the f-string is safe. Column and table
+    identifiers cannot be supplied as bind parameters; this mirrors the
+    reviewed pattern in ``e22_665_backfill_admin_grants``.
+    """
+    op.execute("LOCK TABLE workspaces IN SHARE ROW EXCLUSIVE MODE")
+    op.execute("LOCK TABLE workspace_addons IN SHARE ROW EXCLUSIVE MODE")
+
+    for cache_col, addon_type, unit_value in _ADDON_CACHE_COLUMNS:
+        op.execute(
+            f"""
+            UPDATE workspaces w
+            SET {cache_col} = COALESCE((
+                SELECT SUM(wa.quantity)
+                FROM workspace_addons wa
+                WHERE wa.workspace_id = w.id
+                  AND wa.addon_type = '{addon_type}'
+                  AND wa.active_from <= NOW()
+                  AND (wa.active_until IS NULL OR wa.active_until > NOW())
+            ), 0) * {unit_value}
+            WHERE w.deleted_at IS NULL
+            """
+        )
+
+
+def downgrade() -> None:
+    """No-op: forward-only data correction.
+
+    The legacy non-multiple cache values overwritten by ``upgrade()`` are not
+    snapshotted and are unrecoverable; restoring them would re-introduce the
+    SSoT violation this migration fixes. See the module docstring.
+    """

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -219,6 +219,23 @@ class PlanChangeAuditEntry(BaseModel):
     reason: str | None
 
 
+class AddonCacheDriftEntry(BaseModel):
+    """One drifted addon cache column for a workspace (Issue #799).
+
+    Reports a workspace whose cached ``addon_*_bonus`` column disagrees with
+    the row-based SSoT (``SUM(active WorkspaceAddon.quantity) × unit_value``).
+    A healthy system returns an empty list; the ``e23_799`` normalization
+    migration brings the live count to 0.
+    """
+
+    workspace_id: str
+    workspace_name: str
+    addon_type: str
+    cache_column: str
+    cache_value: int
+    expected_value: int
+
+
 class PlanTierInfo(BaseModel):
     """Plan tier configuration served to the admin tiers comparison table.
 
@@ -550,6 +567,87 @@ async def get_plan_change_audit(
 
         logger.info(
             f"Admin retrieved {len(entries)} audit entries", admin_user=admin_user["user_id"]
+        )
+        return entries
+
+
+@router.get("/addon-cache-consistency", response_model=list[AddonCacheDriftEntry])
+async def get_addon_cache_consistency(
+    admin_user: dict = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+):
+    """Detect workspaces whose addon cache columns drifted from the row SSoT.
+
+    Issue #799. For every active (non-deleted) workspace and every addon type
+    in ``_ADDON_FIELD_SPECS``, compares the cached ``addon_*_bonus`` column to
+    ``SUM(active WorkspaceAddon.quantity) × unit_value`` — the same invariant
+    enforced by ``AddonCalculatorService.recalculate_workspace_bonuses`` and
+    asserted by ``tests/integration/_addon_helpers.assert_addon_invariant``.
+
+    On-demand audit, not a startup probe: the ``e23_799`` migration brings the
+    live count to 0, so a per-boot full-table scan (all workspaces × 9 columns)
+    would be wasted work. Each drifted column is logged at WARNING and returned
+    for admin review.
+
+    Returns:
+        List of drifted (workspace, addon_type) entries. Empty when healthy.
+    """
+    async with db_transaction(db, "addon_cache_consistency", "Failed to audit addon caches"):
+        now = utcnow()
+
+        # All active workspaces, keyed by id for cache-column lookup.
+        ws_result = await db.execute(select(Workspace).where(Workspace.deleted_at.is_(None)))
+        workspaces = {ws.id: ws for ws in ws_result.scalars().all()}
+
+        entries: list[AddonCacheDriftEntry] = []
+
+        # One grouped SUM per addon_type → constant query count regardless of
+        # workspace count. The active-window predicate mirrors the runtime
+        # recalc (addon_calculator_service.py:112-118) so the comparison
+        # matches what the next recalc would compute.
+        for spec in _ADDON_FIELD_SPECS:
+            sum_result = await db.execute(
+                select(
+                    WorkspaceAddon.workspace_id,
+                    func.coalesce(func.sum(WorkspaceAddon.quantity), 0),
+                )
+                .where(
+                    WorkspaceAddon.addon_type == spec.addon_type,
+                    WorkspaceAddon.active_from <= now,
+                    (WorkspaceAddon.active_until.is_(None) | (WorkspaceAddon.active_until > now)),
+                )
+                .group_by(WorkspaceAddon.workspace_id)
+            )
+            summed = {ws_id: int(total) for ws_id, total in sum_result.all()}
+
+            for ws_id, workspace in workspaces.items():
+                expected = summed.get(ws_id, 0) * spec.unit_value
+                actual = getattr(workspace, spec.field_name)
+                if actual != expected:
+                    logger.warning(
+                        "addon_cache_drift",
+                        workspace_id=str(ws_id),
+                        addon_type=spec.addon_type,
+                        cache_column=spec.field_name,
+                        cache_value=actual,
+                        expected_value=expected,
+                    )
+                    entries.append(
+                        AddonCacheDriftEntry(
+                            workspace_id=str(ws_id),
+                            workspace_name=workspace.name,
+                            addon_type=spec.addon_type,
+                            cache_column=spec.field_name,
+                            cache_value=actual,
+                            expected_value=expected,
+                        )
+                    )
+
+        logger.info(
+            "addon_cache_consistency_audit",
+            admin_user=admin_user["user_id"],
+            workspaces_scanned=len(workspaces),
+            drift_count=len(entries),
         )
         return entries
 

--- a/backend/tests/integration/test_addon_cache_invariant.py
+++ b/backend/tests/integration/test_addon_cache_invariant.py
@@ -25,6 +25,7 @@ read-modify-write loops.
 
 from __future__ import annotations
 
+from datetime import timedelta
 from uuid import uuid4
 
 import pytest
@@ -35,6 +36,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin_plans import (
     UpdateAddonRequest,
+    get_addon_cache_consistency,
     get_workspace_quotas,
     update_workspace_quotas,
 )
@@ -657,3 +659,207 @@ class TestSkipRecalcOnEmptyMutations:
             .all()
         )
         assert len(rows) == 0
+
+
+# --- #799: normalization of pre-#665 broken caches -------------------------
+
+
+async def _seed_workspace_with_cache(
+    db_session: AsyncSession, cache_col: str, cache_value: int
+) -> Workspace:
+    """Create a PRO workspace with a directly-set (possibly drifted) cache column.
+
+    Returns the flushed (not yet committed) ORM instance so the caller can
+    attach ``WorkspaceAddon`` rows referencing ``ws.id`` before committing.
+    """
+    user = make_user(name="Normalization Test Owner")
+    db_session.add(user)
+    await db_session.flush()
+
+    ws = make_workspace(owner_user_id=user.user_id, plan_name="pro")
+    setattr(ws, cache_col, cache_value)
+    db_session.add(ws)
+    await db_session.flush()
+    return ws
+
+
+async def _reread_workspace(db_session: AsyncSession, ws_id) -> Workspace:
+    """Re-SELECT a workspace so assertions see post-recalc committed state."""
+    return (await db_session.execute(select(Workspace).where(Workspace.id == ws_id))).scalar_one()
+
+
+class TestNormalizationRestoresSSoT:
+    """#799: recalc-from-rows normalizes legacy non-multiple cache values.
+
+    The ``e23_799_normalize_addon_caches`` migration applies the SQL
+    equivalent of ``AddonCalculatorService.recalculate_workspace_bonuses``
+    (``cache = SUM(active rows) * unit_value``) to every active workspace.
+    These tests exercise that same service path against the classes of legacy
+    state ``e22_665`` left behind — orphan, partial-divisible, consistent, and
+    expired-row — pinning the post-migration invariant
+    ``cache == SUM(active rows × unit)`` AND the active-window predicate that
+    the migration SQL and the runtime recalc must share. The migration's raw
+    SQL is additionally exercised by ``alembic upgrade head`` in the
+    integration harness.
+    """
+
+    @pytest.mark.asyncio
+    async def test_orphan_cache_normalized_to_zero(self, db_session: AsyncSession) -> None:
+        """Legacy 9000 memory (no backing WorkspaceAddon row) → recalc resets to 0.
+
+        This is the exact prod incident: 9000 < unit_value 10000, so e22 created
+        no row and left the cache at 9000, which the #663 dialog then rejected.
+        """
+        ws = await _seed_workspace_with_cache(db_session, "addon_memory_bonus", 9000)
+        await db_session.commit()
+
+        await AddonCalculatorService(db_session).recalculate_workspace_bonuses(ws.id)
+
+        ws_after = await _reread_workspace(db_session, ws.id)
+        assert ws_after.addon_memory_bonus == 0
+        await assert_addon_invariant(db_session, ws.id)
+
+    @pytest.mark.asyncio
+    async def test_partial_divisible_cache_preserves_backfilled_row(
+        self, db_session: AsyncSession
+    ) -> None:
+        """Legacy 250 storage with a 2-unit (200) row → recalc yields 200, not 0.
+
+        This is the case the rejected "reset non-multiples to 0" design would
+        have broken: it would zero the cache while a legitimate 200 MB row
+        remained, re-violating the SSoT (cache 0 ≠ SUM 200).
+        """
+        ws = await _seed_workspace_with_cache(db_session, "addon_storage_bonus_mb", 250)
+        # e22 would have floor-divided 250 → a 2-unit (200 MB) admin_grant row.
+        db_session.add(
+            WorkspaceAddon(
+                workspace_id=ws.id,
+                addon_type="extra_storage",
+                quantity=2,
+                source="admin_grant",
+                active_from=utcnow(),
+                created_by="pre_665_migration_backfill",
+            )
+        )
+        await db_session.commit()
+
+        await AddonCalculatorService(db_session).recalculate_workspace_bonuses(ws.id)
+
+        ws_after = await _reread_workspace(db_session, ws.id)
+        assert ws_after.addon_storage_bonus_mb == 200  # preserved, NOT reset to 0
+        await assert_addon_invariant(db_session, ws.id)
+
+    @pytest.mark.asyncio
+    async def test_consistent_cache_unchanged(self, db_session: AsyncSession) -> None:
+        """An already-consistent workspace is a no-op under recalc (idempotent)."""
+        ws = await _seed_workspace_with_cache(db_session, "addon_memory_bonus", 20000)
+        db_session.add(
+            WorkspaceAddon(
+                workspace_id=ws.id,
+                addon_type="extra_memory",
+                quantity=2,  # 2 × 10000 == the 20000 cache set above
+                source="admin_grant",
+                active_from=utcnow(),
+                created_by="admin_runner",
+            )
+        )
+        await db_session.commit()
+
+        await AddonCalculatorService(db_session).recalculate_workspace_bonuses(ws.id)
+
+        ws_after = await _reread_workspace(db_session, ws.id)
+        assert ws_after.addon_memory_bonus == 20000  # unchanged
+        await assert_addon_invariant(db_session, ws.id)
+
+    @pytest.mark.asyncio
+    async def test_expired_addon_row_excluded_from_recalc(self, db_session: AsyncSession) -> None:
+        """Active-window predicate: an EXPIRED row must NOT count toward the cache.
+
+        Guards the ``active_until > NOW()`` predicate that the migration SQL and
+        the runtime recalc share (the divergence trap called out in the e23
+        docstring). A stale cache of 10000 backed only by an expired
+        ``extra_memory`` row must normalize to 0.
+        """
+        ws = await _seed_workspace_with_cache(db_session, "addon_memory_bonus", 10000)
+        db_session.add(
+            WorkspaceAddon(
+                workspace_id=ws.id,
+                addon_type="extra_memory",
+                quantity=1,
+                source="admin_grant",
+                active_from=utcnow() - timedelta(days=2),
+                active_until=utcnow() - timedelta(days=1),  # expired yesterday
+                created_by="admin_runner",
+            )
+        )
+        await db_session.commit()
+
+        await AddonCalculatorService(db_session).recalculate_workspace_bonuses(ws.id)
+
+        ws_after = await _reread_workspace(db_session, ws.id)
+        assert ws_after.addon_memory_bonus == 0  # expired row excluded from SUM
+        await assert_addon_invariant(db_session, ws.id)
+
+
+class TestAddonCacheConsistencyEndpoint:
+    """#799: GET /admin/plans/addon-cache-consistency detects drifted caches.
+
+    Direct-function-call pattern (matches the rest of this file): the handler
+    runs against the real Postgres test session. Assertions filter by the
+    workspace IDs this test created so they stay deterministic regardless of
+    any other active workspaces present in the session.
+    """
+
+    @pytest.mark.asyncio
+    async def test_endpoint_reports_drifted_and_skips_healthy(
+        self, db_session: AsyncSession
+    ) -> None:
+        # Drifted: orphan 9000 memory cache, no backing WorkspaceAddon row.
+        drifted = await _seed_workspace_with_cache(db_session, "addon_memory_bonus", 9000)
+        # Healthy: cache 20000 backed by a matching 2-unit row.
+        healthy = await _seed_workspace_with_cache(db_session, "addon_memory_bonus", 20000)
+        db_session.add(
+            WorkspaceAddon(
+                workspace_id=healthy.id,
+                addon_type="extra_memory",
+                quantity=2,
+                source="admin_grant",
+                active_from=utcnow(),
+                created_by="admin_runner",
+            )
+        )
+        await db_session.commit()
+
+        entries = await get_addon_cache_consistency(admin_user=mock_admin(), db=db_session)
+
+        by_key = {(e.workspace_id, e.cache_column): e for e in entries}
+
+        drift = by_key.get((str(drifted.id), "addon_memory_bonus"))
+        assert drift is not None, "drifted workspace must be reported"
+        assert drift.addon_type == "extra_memory"
+        assert drift.cache_value == 9000
+        assert drift.expected_value == 0
+
+        # The healthy workspace must NOT appear for any addon column.
+        assert not [k for k in by_key if k[0] == str(healthy.id)]
+
+    @pytest.mark.asyncio
+    async def test_endpoint_omits_consistent_workspace(self, db_session: AsyncSession) -> None:
+        """A fully-consistent workspace is absent from the drift report."""
+        ws = await _seed_workspace_with_cache(db_session, "addon_memory_bonus", 10000)
+        db_session.add(
+            WorkspaceAddon(
+                workspace_id=ws.id,
+                addon_type="extra_memory",
+                quantity=1,  # 1 × 10000 == the cache
+                source="admin_grant",
+                active_from=utcnow(),
+                created_by="admin_runner",
+            )
+        )
+        await db_session.commit()
+
+        entries = await get_addon_cache_consistency(admin_user=mock_admin(), db=db_session)
+
+        mine = [e for e in entries if e.workspace_id == str(ws.id)]
+        assert mine == []


### PR DESCRIPTION
Closes #799

## Summary
- Fixes the SSoT violation left by the `e22_665` backfill: legacy addon cache values that aren't a multiple of their `unit_value` (orphans like `addon_memory_bonus=9000`, and partial remainders like `addon_storage_bonus_mb=250`) were never reconciled, so the #663 admin dialog read a stale value and the post-#665 divisibility validator rejected Save with HTTP 400.
- **B (migration `e23_799`)**: recomputes all 9 `addon_*_bonus` cache columns as `SUM(active rows) × unit_value` for every active workspace — yields `9000→0` (orphan) and `250→200` (partial, preserves the e22 backfill row). Idempotent absolute-SUM write; no-op forward-only downgrade; table locks mirror e22.
- **A (endpoint)**: `GET /admin/plans/addon-cache-consistency` (admin-only) detects + WARNING-logs workspaces whose cache drifted from the row SSoT, on demand.
- **C (tests)**: orphan / partial / consistent / expired-row invariant cases + endpoint detect/skip cases (reuse `assert_addon_invariant`).

## Implementation notes
- Chosen over the issue's original "reset non-multiples to 0" (gate1/CIO review): reset-to-0 re-breaks the SSoT for partial-divisible values that already have a backfill row (cache `0` ≠ SUM `200`). Recalc-from-rows is the canonical equivalent of `AddonCalculatorService.recalculate_workspace_bonuses`.
- Migration's per-column UPDATE uses the same active-window predicate as the runtime recalc (`addon_calculator_service.py:112-118`); the `test_expired_addon_row_excluded_from_recalc` case pins that shared predicate.
- f-string SQL in the migration interpolates only code-constant identifiers from `_ADDON_CACHE_COLUMNS` (never user input) — the reviewed e22_665 precedent.
- Endpoint reuses the `_ADDON_FIELD_SPECS` SSoT (no new field map); 9 grouped SUM queries + 1 (constant, no N+1).
- Verified: lint + type-check (0 new errors), 20/20 addon integration tests, migration up/down/up cycle clean.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow → resolved in-flight (endpoint tests added)
- cto: green
- gate1: yellow via /ask → CIO (design corrected to recalc-from-SSoT before implementation)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/799-fix-fix-db-backfill-normalization-for-non-mu.gate1.md
- ~/.claude/cache/gh-issue-driven/799-fix-fix-db-backfill-normalization-for-non-mu.gate2.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
