### PR TITLE
fix(admin): base memory_limit source + addon dialog validation (#800, #801)

### DIFF
--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -754,7 +754,12 @@ async def get_workspace_quotas(
             workspace_name=workspace.name,
             plan_name=workspace.plan_name,
             base=QuotaBreakdown(
-                memory_limit=workspace.memory_limit,
+                # #801: read the plan tier, not the per-workspace cache column.
+                # Every sibling field below reads plan_tier.*; memory_limit was the
+                # lone exception, so a stale Workspace.memory_limit (e.g. a PRO
+                # workspace still carrying the FREE-tier 1000) made the admin dialog
+                # preview off by 100x. plan_tier is the SSoT the effective calc uses.
+                memory_limit=plan_tier.memory_limit,
                 mcp_calls_per_day=plan_tier.mcp_calls_per_day,
                 max_contexts=plan_tier.max_contexts_per_workspace,
                 max_members=plan_tier.max_members_per_workspace,

--- a/backend/tests/integration/_admin_helpers.py
+++ b/backend/tests/integration/_admin_helpers.py
@@ -1,10 +1,11 @@
 """Shared helpers for admin integration tests.
 
-Used by:
+Used by (grep ``from ._admin_helpers`` for the authoritative list):
 - test_admin_users_soft_delete_filter.py (#681)
 - test_admin_users_list_cap_column.py (#695)
 - test_admin_workspace_slot_bonus.py (#676)
 - test_admin_user_detail_context_role.py (#699)
+- test_admin_plans_base_memory_limit.py (#801)
 
 Each helper returns a fresh, unsaved SQLAlchemy instance with a unique
 auto-generated identifier (user_id / workspace UUID / context name) so

--- a/backend/tests/integration/test_admin_plans_base_memory_limit.py
+++ b/backend/tests/integration/test_admin_plans_base_memory_limit.py
@@ -102,3 +102,39 @@ class TestBaseMemoryLimitReadsPlanTier:
         assert (
             result.effective.memory_limit == result.base.memory_limit + result.addon.memory_bonus
         ), "effective.memory_limit must equal base + addon once base reads plan_tier (#801)"
+
+    @pytest.mark.asyncio
+    async def test_effective_includes_nonzero_addon_on_tier_base(
+        self,
+        db_session: AsyncSession,
+    ) -> None:
+        """effective == tier base + addon when a non-zero addon is present (#801).
+
+        Exercises the addon term explicitly (the parametrized fixtures carry
+        addon=0). ``effective_memory_limit`` is ``_zero_floor(plan_tier, addon)``
+        and ``base`` now reads the tier, so a PRO workspace with a 20000 memory
+        addon must report base=100000, addon=20000, effective=120000 — even with
+        the stale 1000 cache column still on the row.
+        """
+        user = make_user()
+        db_session.add(user)
+        await db_session.flush()
+
+        ws = make_workspace(owner_user_id=user.user_id, plan_name="pro")
+        ws.addon_memory_bonus = 20_000  # valid multiple of perUnit (10000)
+        db_session.add(ws)
+        await db_session.commit()
+
+        result = await get_workspace_quotas(
+            workspace_id=str(ws.id),
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        pro_tier = get_plan_tier("pro")
+        assert result.base.memory_limit == pro_tier.memory_limit
+        assert result.addon.memory_bonus == 20_000
+        assert result.effective.memory_limit == pro_tier.memory_limit + 20_000, (
+            "effective must add the non-zero addon to the tier base, not the stale "
+            "Workspace.memory_limit column (#801)"
+        )

--- a/backend/tests/integration/test_admin_plans_base_memory_limit.py
+++ b/backend/tests/integration/test_admin_plans_base_memory_limit.py
@@ -28,63 +28,77 @@ from ._admin_helpers import make_user, make_workspace, mock_admin
 
 
 @pytest_asyncio.fixture
-async def pro_workspace_stale_memory_limit(db_session: AsyncSession) -> dict:
-    """A ``pro`` workspace whose ``memory_limit`` column holds the stale FREE value.
+async def stale_memory_limit_workspace(db_session: AsyncSession, request) -> dict:
+    """A workspace whose ``memory_limit`` column holds the stale FREE value (1000).
 
-    ``make_workspace`` defaults to ``plan_name="pro"`` and ``memory_limit=1000``
-    — exactly the drift the kagura prod incident exposed (PRO plan, FREE-tier
-    column value).
+    Parametrize ``request.param`` with the plan name to exercise; defaults to
+    ``pro`` when used without ``indirect`` parametrization. ``make_workspace``
+    seeds ``memory_limit=1000`` regardless of plan — exactly the drift the
+    kagura prod incident exposed (non-FREE plan, FREE-tier column value).
     """
+    plan_name = getattr(request, "param", "pro")
     user = make_user()
     db_session.add(user)
     await db_session.flush()
 
-    ws = make_workspace(owner_user_id=user.user_id, plan_name="pro")
+    ws = make_workspace(owner_user_id=user.user_id, plan_name=plan_name)
     assert ws.memory_limit == 1000, "fixture premise: column carries the stale FREE value"
     db_session.add(ws)
     await db_session.commit()
 
-    return {"workspace_id": str(ws.id)}
+    return {"workspace_id": str(ws.id), "plan_name": plan_name}
 
 
 class TestBaseMemoryLimitReadsPlanTier:
     """``base.memory_limit`` must come from the plan tier, not the stale column (#801)."""
 
+    # BASIC (10000) and PRO (100000) both differ from the stale FREE value (1000),
+    # so each distinguishes a tier-read from a column-read. FREE is omitted: its
+    # tier value IS 1000, so it cannot tell the two sources apart (degenerate).
+    @pytest.mark.parametrize("stale_memory_limit_workspace", ["basic", "pro"], indirect=True)
     @pytest.mark.asyncio
     async def test_base_memory_limit_reflects_plan_tier_not_stale_column(
         self,
         db_session: AsyncSession,
-        pro_workspace_stale_memory_limit: dict,
+        stale_memory_limit_workspace: dict,
     ) -> None:
         result = await get_workspace_quotas(
-            workspace_id=pro_workspace_stale_memory_limit["workspace_id"],
+            workspace_id=stale_memory_limit_workspace["workspace_id"],
             admin_user=mock_admin(),
             db=db_session,
         )
 
-        pro_tier = get_plan_tier("pro")
-        assert pro_tier.memory_limit != 1000, (
-            "test premise: PRO tier memory_limit must differ from the stale 1000 "
-            "column value, otherwise this test proves nothing"
+        tier = get_plan_tier(stale_memory_limit_workspace["plan_name"])
+        assert tier.memory_limit != 1000, (
+            "test premise: this tier's memory_limit must differ from the stale "
+            "1000 column value, otherwise this test proves nothing"
         )
-        assert result.base.memory_limit == pro_tier.memory_limit, (
+        assert result.base.memory_limit == tier.memory_limit, (
             "base.memory_limit must read plan_tier.memory_limit, not the stale "
             "Workspace.memory_limit column (#801: 100x dialog preview bug)"
         )
 
     @pytest.mark.asyncio
-    async def test_effective_memory_limit_equals_base_plus_addon(
+    async def test_effective_memory_limit_tracks_plan_tier_base(
         self,
         db_session: AsyncSession,
-        pro_workspace_stale_memory_limit: dict,
+        stale_memory_limit_workspace: dict,
     ) -> None:
-        """Spot-check the preview invariant: effective == base + addon (#801)."""
+        """Preview invariant: effective == base + addon, with base from the tier.
+
+        The default fixture has no addon (addon.memory_bonus == 0), so this both
+        pins effective == base and proves base tracks the tier (not the stale
+        column): pre-fix, base would be 1000 while effective is the PRO tier
+        100000, breaking the equality.
+        """
         result = await get_workspace_quotas(
-            workspace_id=pro_workspace_stale_memory_limit["workspace_id"],
+            workspace_id=stale_memory_limit_workspace["workspace_id"],
             admin_user=mock_admin(),
             db=db_session,
         )
 
+        pro_tier = get_plan_tier("pro")
+        assert result.base.memory_limit == pro_tier.memory_limit
         assert (
             result.effective.memory_limit == result.base.memory_limit + result.addon.memory_bonus
         ), "effective.memory_limit must equal base + addon once base reads plan_tier (#801)"

--- a/backend/tests/integration/test_admin_plans_base_memory_limit.py
+++ b/backend/tests/integration/test_admin_plans_base_memory_limit.py
@@ -1,0 +1,90 @@
+"""Regression test for #801 — base.memory_limit must read plan_tier, not the column.
+
+``GET /admin/plans/workspaces/{id}/quotas`` builds its ``base`` ``QuotaBreakdown``
+from the plan tier definition for every dimension EXCEPT ``memory_limit``, which
+(pre-#801) read the per-workspace ``Workspace.memory_limit`` cache column at
+``admin_plans.py``. When that column is stale (e.g. a workspace upgraded to PRO
+without the column being synced — see the kagura prod incident 2026-05-23), the
+admin dialog's per-input "effective" preview is computed off a FREE-tier base
+(1000) while the real effective is PRO-tier (100000), a 100x discrepancy.
+
+This pins the fix: ``base.memory_limit`` must reflect ``plan_tier.memory_limit``,
+consistent with the eight sibling fields.
+
+Hits a real Postgres test DB because the bug is a field-by-field source mismatch
+that mock-DB tests in ``tests/api/test_admin_plans*.py`` cannot detect.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin_plans import get_workspace_quotas
+from config.plan_tiers import get_plan_tier
+
+from ._admin_helpers import make_user, make_workspace, mock_admin
+
+
+@pytest_asyncio.fixture
+async def pro_workspace_stale_memory_limit(db_session: AsyncSession) -> dict:
+    """A ``pro`` workspace whose ``memory_limit`` column holds the stale FREE value.
+
+    ``make_workspace`` defaults to ``plan_name="pro"`` and ``memory_limit=1000``
+    — exactly the drift the kagura prod incident exposed (PRO plan, FREE-tier
+    column value).
+    """
+    user = make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    ws = make_workspace(owner_user_id=user.user_id, plan_name="pro")
+    assert ws.memory_limit == 1000, "fixture premise: column carries the stale FREE value"
+    db_session.add(ws)
+    await db_session.commit()
+
+    return {"workspace_id": str(ws.id)}
+
+
+class TestBaseMemoryLimitReadsPlanTier:
+    """``base.memory_limit`` must come from the plan tier, not the stale column (#801)."""
+
+    @pytest.mark.asyncio
+    async def test_base_memory_limit_reflects_plan_tier_not_stale_column(
+        self,
+        db_session: AsyncSession,
+        pro_workspace_stale_memory_limit: dict,
+    ) -> None:
+        result = await get_workspace_quotas(
+            workspace_id=pro_workspace_stale_memory_limit["workspace_id"],
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        pro_tier = get_plan_tier("pro")
+        assert pro_tier.memory_limit != 1000, (
+            "test premise: PRO tier memory_limit must differ from the stale 1000 "
+            "column value, otherwise this test proves nothing"
+        )
+        assert result.base.memory_limit == pro_tier.memory_limit, (
+            "base.memory_limit must read plan_tier.memory_limit, not the stale "
+            "Workspace.memory_limit column (#801: 100x dialog preview bug)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_effective_memory_limit_equals_base_plus_addon(
+        self,
+        db_session: AsyncSession,
+        pro_workspace_stale_memory_limit: dict,
+    ) -> None:
+        """Spot-check the preview invariant: effective == base + addon (#801)."""
+        result = await get_workspace_quotas(
+            workspace_id=pro_workspace_stale_memory_limit["workspace_id"],
+            admin_user=mock_admin(),
+            db=db_session,
+        )
+
+        assert (
+            result.effective.memory_limit == result.base.memory_limit + result.addon.memory_bonus
+        ), "effective.memory_limit must equal base + addon once base reads plan_tier (#801)"

--- a/frontend/src/app/(authenticated)/admin/plans/_addon-types.test.ts
+++ b/frontend/src/app/(authenticated)/admin/plans/_addon-types.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for addon snap + non-multiple detection (Issue #800).
+ *
+ * `snapshotAddonValues` populates the admin addon dialog from the quota
+ * detail response. A legacy / broken cache can hold a value that is not a
+ * multiple of `perUnit` (e.g. pre-#665 `addon_memory_bonus = 9000` with
+ * `perUnit = 10000`). The backend rejects such values with HTTP 400 on save,
+ * so the dialog must snap them and warn the admin rather than render the
+ * invalid value verbatim and surface an opaque 400.
+ *
+ * Snap policy (#800-A): reset non-multiples to 0 (not round) so the admin's
+ * value is never silently rewritten — paired with a visible warning driven by
+ * `detectNonMultipleAddons`.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { WorkspaceQuotaDetail } from "@/lib/api/admin";
+import {
+  ADDON_TYPES,
+  detectNonMultipleAddons,
+  snapshotAddonValues,
+  type AddonKey,
+} from "./_addon-types";
+
+/** All-zero addon block, overridable per field. */
+function makeQuota(
+  addon: Partial<WorkspaceQuotaDetail["addon"]> = {},
+): WorkspaceQuotaDetail {
+  const zeroQuota = {
+    memory_limit: 0,
+    mcp_calls_per_day: 0,
+    max_contexts: 0,
+    max_members: 0,
+    analysis_runs_per_day: 0,
+    rest_calls_per_day: 0,
+    public_calls_per_day: 0,
+    storage_bytes_limit: 0,
+    sleep_enabled_contexts_limit: 0,
+    max_resource_tokens: 0,
+  };
+  return {
+    workspace_id: "ws-test",
+    workspace_name: "Test",
+    plan_name: "pro",
+    base: { ...zeroQuota },
+    addon: {
+      memory_bonus: 0,
+      mcp_quota_bonus: 0,
+      rest_quota_bonus: 0,
+      public_quota_bonus: 0,
+      member_bonus: 0,
+      context_bonus: 0,
+      analysis_bonus: 0,
+      storage_bonus_mb: 0,
+      sleep_contexts_bonus: 0,
+      ...addon,
+    },
+    effective: { ...zeroQuota },
+    usage: { memories: 0, contexts: 0, members: 0 },
+    spend_cap: null,
+  } as WorkspaceQuotaDetail;
+}
+
+/** perUnit > 1 addons are the only ones where a non-multiple is possible. */
+const SNAPPABLE = ADDON_TYPES.filter((m) => m.perUnit > 1);
+/** perUnit === 1 addons (analysis, sleep): every integer is a valid multiple. */
+const ALWAYS_VALID = ADDON_TYPES.filter((m) => m.perUnit === 1);
+
+describe("snapshotAddonValues", () => {
+  it("snaps a non-multiple memory_bonus (9000) to 0", () => {
+    const snapshot = snapshotAddonValues(makeQuota({ memory_bonus: 9000 }));
+    expect(snapshot.memory).toBe(0);
+  });
+
+  it("preserves a valid multiple verbatim", () => {
+    const snapshot = snapshotAddonValues(makeQuota({ memory_bonus: 20_000 }));
+    expect(snapshot.memory).toBe(20_000);
+  });
+
+  it.each(SNAPPABLE)(
+    "snaps a non-multiple $key value to 0 (perUnit=$perUnit)",
+    (meta) => {
+      const snapshot = snapshotAddonValues(
+        makeQuota({ [meta.addonField]: meta.perUnit - 1 }),
+      );
+      expect(snapshot[meta.key]).toBe(0);
+    },
+  );
+
+  it.each(SNAPPABLE)(
+    "preserves a valid multiple of $key (2 * perUnit)",
+    (meta) => {
+      const snapshot = snapshotAddonValues(
+        makeQuota({ [meta.addonField]: meta.perUnit * 2 }),
+      );
+      expect(snapshot[meta.key]).toBe(meta.perUnit * 2);
+    },
+  );
+
+  it.each(ALWAYS_VALID)(
+    "preserves any value for perUnit=1 addon $key",
+    (meta) => {
+      const snapshot = snapshotAddonValues(makeQuota({ [meta.addonField]: 7 }));
+      expect(snapshot[meta.key]).toBe(7);
+    },
+  );
+
+  it("leaves an all-valid snapshot untouched", () => {
+    const snapshot = snapshotAddonValues(
+      makeQuota({
+        memory_bonus: 10_000,
+        storage_bonus_mb: 300,
+        member_bonus: 5,
+      }),
+    );
+    expect(snapshot.memory).toBe(10_000);
+    expect(snapshot.storage).toBe(300);
+    expect(snapshot.members).toBe(5);
+  });
+});
+
+describe("detectNonMultipleAddons", () => {
+  it("returns [] when every addon value is a valid multiple", () => {
+    expect(
+      detectNonMultipleAddons(
+        makeQuota({ memory_bonus: 10_000, storage_bonus_mb: 200 }),
+      ),
+    ).toEqual([]);
+  });
+
+  it("returns the key of a non-zero non-multiple value", () => {
+    expect(detectNonMultipleAddons(makeQuota({ memory_bonus: 9000 }))).toEqual([
+      "memory",
+    ]);
+  });
+
+  it("ignores zero values (zero is a valid multiple, nothing to warn about)", () => {
+    expect(detectNonMultipleAddons(makeQuota({ memory_bonus: 0 }))).toEqual([]);
+  });
+
+  it("reports multiple broken keys in ADDON_TYPES order", () => {
+    const result = detectNonMultipleAddons(
+      makeQuota({ memory_bonus: 9000, storage_bonus_mb: 150 }),
+    );
+    expect(result).toEqual<AddonKey[]>(["memory", "storage"]);
+  });
+});

--- a/frontend/src/app/(authenticated)/admin/plans/_addon-types.test.ts
+++ b/frontend/src/app/(authenticated)/admin/plans/_addon-types.test.ts
@@ -1,16 +1,20 @@
 /**
- * Tests for addon snap + non-multiple detection (Issue #800).
+ * Tests for addon value validation (Issue #800).
  *
- * `snapshotAddonValues` populates the admin addon dialog from the quota
- * detail response. A legacy / broken cache can hold a value that is not a
- * multiple of `perUnit` (e.g. pre-#665 `addon_memory_bonus = 9000` with
- * `perUnit = 10000`). The backend rejects such values with HTTP 400 on save,
- * so the dialog must snap them and warn the admin rather than render the
- * invalid value verbatim and surface an opaque 400.
+ * A legacy / broken cache can hold a value that is not a multiple of `perUnit`
+ * (e.g. pre-#665 `addon_memory_bonus = 9000` with `perUnit = 10000`). The
+ * backend rejects such values with HTTP 400 on save. Rather than render an
+ * opaque 400, the dialog detects invalid values, warns the admin, and gates
+ * Save until they are corrected.
  *
- * Snap policy (#800-A): reset non-multiples to 0 (not round) so the admin's
- * value is never silently rewritten — paired with a visible warning driven by
- * `detectNonMultipleAddons`.
+ * Design note (post code-review): `snapshotAddonValues` deliberately does NOT
+ * coerce the stored value to 0. Coercing the editable form state was found to
+ * (a) silently destroy a legacy value when the admin saves after editing an
+ * unrelated field — the dialog sends all 9 fields — and (b) spuriously trigger
+ * the LD-7 reduction warning on open. Instead the raw value is preserved (so
+ * the dialog matches the read-only panel and nothing is lost), the warning is
+ * driven by the live form state, and Save is disabled while any value is
+ * invalid.
  */
 
 import { describe, expect, it } from "vitest";
@@ -18,9 +22,12 @@ import { describe, expect, it } from "vitest";
 import type { WorkspaceQuotaDetail } from "@/lib/api/admin";
 import {
   ADDON_TYPES,
-  detectNonMultipleAddons,
+  EMPTY_ADDON_VALUES,
+  findInvalidAddonValues,
+  isValidAddonValue,
   snapshotAddonValues,
   type AddonKey,
+  type AddonValuesByKey,
 } from "./_addon-types";
 
 /** All-zero addon block, overridable per field. */
@@ -62,51 +69,65 @@ function makeQuota(
   } as WorkspaceQuotaDetail;
 }
 
+/** Form values with a single key overridden. */
+function values(overrides: Partial<AddonValuesByKey> = {}): AddonValuesByKey {
+  return { ...EMPTY_ADDON_VALUES, ...overrides };
+}
+
 /** perUnit > 1 addons are the only ones where a non-multiple is possible. */
 const SNAPPABLE = ADDON_TYPES.filter((m) => m.perUnit > 1);
-/** perUnit === 1 addons (analysis, sleep): every integer is a valid multiple. */
+/** perUnit === 1 addons (analysis, sleep): every non-negative integer is valid. */
 const ALWAYS_VALID = ADDON_TYPES.filter((m) => m.perUnit === 1);
 
-describe("snapshotAddonValues", () => {
-  it("snaps a non-multiple memory_bonus (9000) to 0", () => {
-    const snapshot = snapshotAddonValues(makeQuota({ memory_bonus: 9000 }));
-    expect(snapshot.memory).toBe(0);
-  });
-
-  it("preserves a valid multiple verbatim", () => {
-    const snapshot = snapshotAddonValues(makeQuota({ memory_bonus: 20_000 }));
-    expect(snapshot.memory).toBe(20_000);
+describe("isValidAddonValue", () => {
+  it("accepts 0 (no addon is always saveable)", () => {
+    expect(isValidAddonValue(SNAPPABLE[0], 0)).toBe(true);
   });
 
   it.each(SNAPPABLE)(
-    "snaps a non-multiple $key value to 0 (perUnit=$perUnit)",
+    "accepts an exact multiple of $key (perUnit=$perUnit)",
     (meta) => {
-      const snapshot = snapshotAddonValues(
-        makeQuota({ [meta.addonField]: meta.perUnit - 1 }),
-      );
-      expect(snapshot[meta.key]).toBe(0);
+      expect(isValidAddonValue(meta, meta.perUnit * 3)).toBe(true);
     },
   );
 
-  it.each(SNAPPABLE)(
-    "preserves a valid multiple of $key (2 * perUnit)",
-    (meta) => {
-      const snapshot = snapshotAddonValues(
-        makeQuota({ [meta.addonField]: meta.perUnit * 2 }),
-      );
-      expect(snapshot[meta.key]).toBe(meta.perUnit * 2);
-    },
-  );
+  it.each(SNAPPABLE)("rejects a non-multiple of $key (perUnit-1)", (meta) => {
+    expect(isValidAddonValue(meta, meta.perUnit - 1)).toBe(false);
+  });
 
   it.each(ALWAYS_VALID)(
-    "preserves any value for perUnit=1 addon $key",
+    "accepts any non-negative integer for perUnit=1 addon $key",
     (meta) => {
-      const snapshot = snapshotAddonValues(makeQuota({ [meta.addonField]: 7 }));
-      expect(snapshot[meta.key]).toBe(7);
+      expect(isValidAddonValue(meta, 7)).toBe(true);
     },
   );
 
-  it("leaves an all-valid snapshot untouched", () => {
+  it("rejects negative values", () => {
+    expect(isValidAddonValue(SNAPPABLE[0], -SNAPPABLE[0].perUnit)).toBe(false);
+  });
+
+  it("rejects NaN / non-integers", () => {
+    expect(isValidAddonValue(SNAPPABLE[0], Number.NaN)).toBe(false);
+    expect(isValidAddonValue(SNAPPABLE[0], 1.5)).toBe(false);
+  });
+});
+
+describe("snapshotAddonValues", () => {
+  it("preserves a valid multiple verbatim", () => {
+    expect(
+      snapshotAddonValues(makeQuota({ memory_bonus: 20_000 })).memory,
+    ).toBe(20_000);
+  });
+
+  it("preserves a non-multiple verbatim — never silently coerces to 0", () => {
+    // The dialog must show the admin their real stored value; saving is gated
+    // separately. Coercing here would destroy the value on an unrelated save.
+    expect(snapshotAddonValues(makeQuota({ memory_bonus: 9000 })).memory).toBe(
+      9000,
+    );
+  });
+
+  it("maps every addon key from its cache field", () => {
     const snapshot = snapshotAddonValues(
       makeQuota({
         memory_bonus: 10_000,
@@ -120,29 +141,32 @@ describe("snapshotAddonValues", () => {
   });
 });
 
-describe("detectNonMultipleAddons", () => {
-  it("returns [] when every addon value is a valid multiple", () => {
+describe("findInvalidAddonValues", () => {
+  it("returns [] when every value is a valid multiple", () => {
     expect(
-      detectNonMultipleAddons(
-        makeQuota({ memory_bonus: 10_000, storage_bonus_mb: 200 }),
-      ),
+      findInvalidAddonValues(values({ memory: 10_000, storage: 200 })),
     ).toEqual([]);
   });
 
-  it("returns the key of a non-zero non-multiple value", () => {
-    expect(detectNonMultipleAddons(makeQuota({ memory_bonus: 9000 }))).toEqual([
-      "memory",
-    ]);
+  it("returns the key of a non-multiple value", () => {
+    expect(findInvalidAddonValues(values({ memory: 9000 }))).toEqual<
+      AddonKey[]
+    >(["memory"]);
   });
 
-  it("ignores zero values (zero is a valid multiple, nothing to warn about)", () => {
-    expect(detectNonMultipleAddons(makeQuota({ memory_bonus: 0 }))).toEqual([]);
+  it("ignores zero (a valid, saveable amount)", () => {
+    expect(findInvalidAddonValues(values({ memory: 0 }))).toEqual([]);
+  });
+
+  it("flags a negative value", () => {
+    expect(findInvalidAddonValues(values({ members: -5 }))).toEqual<AddonKey[]>(
+      ["members"],
+    );
   });
 
   it("reports multiple broken keys in ADDON_TYPES order", () => {
-    const result = detectNonMultipleAddons(
-      makeQuota({ memory_bonus: 9000, storage_bonus_mb: 150 }),
-    );
-    expect(result).toEqual<AddonKey[]>(["memory", "storage"]);
+    expect(
+      findInvalidAddonValues(values({ memory: 9000, storage: 150 })),
+    ).toEqual<AddonKey[]>(["memory", "storage"]);
   });
 });

--- a/frontend/src/app/(authenticated)/admin/plans/_addon-types.ts
+++ b/frontend/src/app/(authenticated)/admin/plans/_addon-types.ts
@@ -201,47 +201,56 @@ export function readAddonFromQuota(
 }
 
 /**
+ * Whether `value` is a saveable amount for this addon: a non-negative
+ * integer multiple of ``perUnit``. This is the single source of the
+ * divisibility rule — both the dialog's invalid-value warning and its
+ * Save gate derive from it, so snap/warn/save can never drift apart.
+ *
+ * The backend rejects non-multiples (``requested % unit_value != 0``) and
+ * negatives (``ge=0``) with HTTP 400; this mirrors that contract on the
+ * client. ``perUnit === 1`` addons (analysis, sleep) accept any
+ * non-negative integer; 0 (no addon) is always valid.
+ */
+export function isValidAddonValue(meta: AddonTypeMeta, value: number): boolean {
+  return Number.isInteger(value) && value >= 0 && value % meta.perUnit === 0;
+}
+
+/**
  * Build a complete addon snapshot from the quota detail response.
  * Used by ``openAddonDialog`` to populate the form state in one step
  * — every key in ``AddonValuesByKey`` is set from the corresponding
- * cache column.
+ * cache column, verbatim.
  *
  * Issue #800: a legacy / broken cache can hold a value that is not a
- * multiple of ``perUnit`` (e.g. pre-#665 ``addon_memory_bonus = 9000``
- * with ``perUnit = 10000``). The backend rejects such values with HTTP
- * 400 on save, so we snap non-multiples to 0 here rather than render
- * them verbatim and let the admin hit an opaque 400. Reset-to-0 (not
- * round) keeps the admin's intent honest — paired with a visible
- * warning driven by ``detectNonMultipleAddons``.
+ * multiple of ``perUnit`` (e.g. pre-#665 ``addon_memory_bonus = 9000``).
+ * We deliberately do NOT coerce such values to 0 here — coercing the
+ * editable form state would (a) silently destroy the stored value when
+ * the admin saves after editing an unrelated field (the dialog sends all
+ * 9 fields), and (b) spuriously trigger the LD-7 reduction warning on
+ * open. Instead the raw value is preserved (matching the read-only quota
+ * panel), ``findInvalidAddonValues`` drives a live warning, and the
+ * dialog disables Save until every value is valid.
  */
 export function snapshotAddonValues(
   quotaDetail: WorkspaceQuotaDetail,
 ): AddonValuesByKey {
   const snapshot = { ...EMPTY_ADDON_VALUES };
   for (const meta of ADDON_TYPES) {
-    const raw = readAddonFromQuota(quotaDetail, meta);
-    snapshot[meta.key] = raw % meta.perUnit === 0 ? raw : 0;
+    snapshot[meta.key] = readAddonFromQuota(quotaDetail, meta);
   }
   return snapshot;
 }
 
 /**
- * Detect addon cache values that are not a multiple of their ``perUnit``.
- *
- * Returns the affected ``AddonKey``s in ``ADDON_TYPES`` order so the dialog
- * can name them in a warning banner. Zero is a valid multiple (nothing to
- * warn about), and ``perUnit === 1`` addons (analysis, sleep) can never be
- * non-multiples. These are exactly the values ``snapshotAddonValues`` snaps
- * to 0 — the warning explains why the input shows 0 instead of the broken
- * cache value. See Issue #800.
+ * Addon keys in the current form state whose value is not saveable, in
+ * ``ADDON_TYPES`` order. Driven by the live form state (not the original
+ * cache) so the dialog's warning clears the moment the admin corrects a
+ * value, and the Save gate stays in lock-step. See Issue #800.
  */
-export function detectNonMultipleAddons(
-  quotaDetail: WorkspaceQuotaDetail,
-): AddonKey[] {
-  return ADDON_TYPES.filter((meta) => {
-    const raw = readAddonFromQuota(quotaDetail, meta);
-    return raw !== 0 && raw % meta.perUnit !== 0;
-  }).map((meta) => meta.key);
+export function findInvalidAddonValues(values: AddonValuesByKey): AddonKey[] {
+  return ADDON_TYPES.filter(
+    (meta) => !isValidAddonValue(meta, values[meta.key]),
+  ).map((meta) => meta.key);
 }
 
 /**

--- a/frontend/src/app/(authenticated)/admin/plans/_addon-types.ts
+++ b/frontend/src/app/(authenticated)/admin/plans/_addon-types.ts
@@ -205,15 +205,43 @@ export function readAddonFromQuota(
  * Used by ``openAddonDialog`` to populate the form state in one step
  * — every key in ``AddonValuesByKey`` is set from the corresponding
  * cache column.
+ *
+ * Issue #800: a legacy / broken cache can hold a value that is not a
+ * multiple of ``perUnit`` (e.g. pre-#665 ``addon_memory_bonus = 9000``
+ * with ``perUnit = 10000``). The backend rejects such values with HTTP
+ * 400 on save, so we snap non-multiples to 0 here rather than render
+ * them verbatim and let the admin hit an opaque 400. Reset-to-0 (not
+ * round) keeps the admin's intent honest — paired with a visible
+ * warning driven by ``detectNonMultipleAddons``.
  */
 export function snapshotAddonValues(
   quotaDetail: WorkspaceQuotaDetail,
 ): AddonValuesByKey {
   const snapshot = { ...EMPTY_ADDON_VALUES };
   for (const meta of ADDON_TYPES) {
-    snapshot[meta.key] = readAddonFromQuota(quotaDetail, meta);
+    const raw = readAddonFromQuota(quotaDetail, meta);
+    snapshot[meta.key] = raw % meta.perUnit === 0 ? raw : 0;
   }
   return snapshot;
+}
+
+/**
+ * Detect addon cache values that are not a multiple of their ``perUnit``.
+ *
+ * Returns the affected ``AddonKey``s in ``ADDON_TYPES`` order so the dialog
+ * can name them in a warning banner. Zero is a valid multiple (nothing to
+ * warn about), and ``perUnit === 1`` addons (analysis, sleep) can never be
+ * non-multiples. These are exactly the values ``snapshotAddonValues`` snaps
+ * to 0 — the warning explains why the input shows 0 instead of the broken
+ * cache value. See Issue #800.
+ */
+export function detectNonMultipleAddons(
+  quotaDetail: WorkspaceQuotaDetail,
+): AddonKey[] {
+  return ADDON_TYPES.filter((meta) => {
+    const raw = readAddonFromQuota(quotaDetail, meta);
+    return raw !== 0 && raw % meta.perUnit !== 0;
+  }).map((meta) => meta.key);
 }
 
 /**

--- a/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
@@ -412,6 +412,28 @@ describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
     ).toHaveLength(1);
   });
 
+  it("warns and snaps when the cache holds a non-multiple value (#800)", async () => {
+    // Broken cache: a pre-#665 memory_bonus of 9000 is not a multiple of the
+    // memory addon's perUnit (10000). Rendering it verbatim would let the
+    // admin hit an opaque HTTP 400 on save.
+    mockGetWorkspaceQuotas.mockResolvedValue({
+      ...QUOTA_DETAIL_PRO,
+      addon: { ...QUOTA_DETAIL_PRO.addon, memory_bonus: 9000 },
+    });
+    await openAddonDialog();
+
+    // A visible warning explains why the input was reset.
+    expect(
+      screen.getByText("admin.plans.addonDialog.snapWarning.title"),
+    ).toBeInTheDocument();
+
+    // The memory input is snapped to 0, not the invalid 9000.
+    const memoryInput = document.getElementById(
+      "addon-memory",
+    ) as HTMLInputElement;
+    expect(memoryInput.value).toBe("0");
+  });
+
   it("renders the max_resource_tokens read-only row in the expanded panel", async () => {
     render(<AdminPlansPage />);
     const workspaceCell = await screen.findByText("Pro Workspace");

--- a/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
@@ -412,26 +412,62 @@ describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
     ).toHaveLength(1);
   });
 
-  it("warns and snaps when the cache holds a non-multiple value (#800)", async () => {
+  it("warns, preserves the value, and disables Save for a non-multiple cache (#800)", async () => {
     // Broken cache: a pre-#665 memory_bonus of 9000 is not a multiple of the
-    // memory addon's perUnit (10000). Rendering it verbatim would let the
-    // admin hit an opaque HTTP 400 on save.
+    // memory addon's perUnit (10000); the backend would 400 it on save.
     mockGetWorkspaceQuotas.mockResolvedValue({
       ...QUOTA_DETAIL_PRO,
       addon: { ...QUOTA_DETAIL_PRO.addon, memory_bonus: 9000 },
     });
     await openAddonDialog();
 
-    // A visible warning explains why the input was reset.
+    // A visible warning names the offending addon.
     expect(
-      screen.getByText("admin.plans.addonDialog.snapWarning.title"),
+      screen.getByText("admin.plans.addonDialog.invalidWarning.title"),
     ).toBeInTheDocument();
 
-    // The memory input is snapped to 0, not the invalid 9000.
+    // The value is preserved verbatim (NOT coerced to 0) so it matches the
+    // read-only panel and an unrelated edit can't silently destroy it.
     const memoryInput = document.getElementById(
       "addon-memory",
     ) as HTMLInputElement;
-    expect(memoryInput.value).toBe("0");
+    expect(memoryInput.value).toBe("9000");
+
+    // Save is gated until the invalid value is corrected.
+    const saveButton = screen
+      .getByText("admin.plans.addonDialog.save")
+      .closest("button");
+    expect(saveButton).toBeDisabled();
+
+    // The LD-7 reduction warning must NOT fire spuriously — the admin has not
+    // reduced anything (form value 9000 == cache 9000).
+    expect(
+      screen.queryByText("admin.plans.addonDialog.reductionWarning"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears the warning and re-enables Save once a valid value is entered (#800)", async () => {
+    mockGetWorkspaceQuotas.mockResolvedValue({
+      ...QUOTA_DETAIL_PRO,
+      addon: { ...QUOTA_DETAIL_PRO.addon, memory_bonus: 9000 },
+    });
+    await openAddonDialog();
+
+    const memoryInput = document.getElementById(
+      "addon-memory",
+    ) as HTMLInputElement;
+    // Admin corrects the value to a valid multiple of perUnit (10000).
+    fireEvent.change(memoryInput, { target: { value: "20000" } });
+
+    // Warning clears (driven by live form state, not the original cache)...
+    expect(
+      screen.queryByText("admin.plans.addonDialog.invalidWarning.title"),
+    ).not.toBeInTheDocument();
+    // ...and Save is re-enabled.
+    const saveButton = screen
+      .getByText("admin.plans.addonDialog.save")
+      .closest("button");
+    expect(saveButton).not.toBeDisabled();
   });
 
   it("renders the max_resource_tokens read-only row in the expanded panel", async () => {

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -94,6 +94,7 @@ import {
   EMPTY_ADDON_VALUES,
   buildUpdateAddonRequest,
   computeAddonEffectivePreview,
+  detectNonMultipleAddons,
   formatAddonValue,
   formatQuotaValue,
   formatReadOnlyQuotaValue,
@@ -886,6 +887,26 @@ export default function AdminPlansPage() {
           </DialogHeader>
 
           <div className="space-y-4 py-4">
+            {/* Issue #800: a legacy / broken cache can hold a value that is
+                not a multiple of perUnit (e.g. pre-#665 memory_bonus 9000).
+                snapshotAddonValues snaps those to 0; this banner names the
+                affected addons so the admin knows why the input shows 0
+                instead of the stored value — rather than hitting an opaque
+                HTTP 400 on save. Informational gating notice, not an error
+                channel (frontend.md) → Alert, not destructive. */}
+            {quotaDetail && detectNonMultipleAddons(quotaDetail).length > 0 && (
+              <Alert>
+                <AlertTitle>{t("addonDialog.snapWarning.title")}</AlertTitle>
+                <AlertDescription>
+                  {t("addonDialog.snapWarning.body", {
+                    keys: detectNonMultipleAddons(quotaDetail)
+                      .map((key) => t(`addonDialog.${key}`))
+                      .join(", "),
+                  })}
+                </AlertDescription>
+              </Alert>
+            )}
+
             {/* Issue #663: 9 addon inputs driven by ADDON_TYPES. The
                 "effective" preview reflects the backend's _zero_floor
                 clamp for PRO-only addons (sleep_contexts) on FREE/BASIC

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -94,7 +94,7 @@ import {
   EMPTY_ADDON_VALUES,
   buildUpdateAddonRequest,
   computeAddonEffectivePreview,
-  detectNonMultipleAddons,
+  findInvalidAddonValues,
   formatAddonValue,
   formatQuotaValue,
   formatReadOnlyQuotaValue,
@@ -239,6 +239,11 @@ export default function AdminPlansPage() {
   const setAddonValue = (key: AddonKey, value: number): void => {
     setAddonValues((prev) => ({ ...prev, [key]: value }));
   };
+  // #800: addon keys whose current form value can't be saved (non-multiple of
+  // perUnit, or negative). Derived once from the live form state so the dialog
+  // warning and the Save gate stay in lock-step and clear as the admin fixes
+  // each value. Cheap pure scan of 9 entries — no memoization needed.
+  const invalidAddons = findInvalidAddonValues(addonValues);
   const { toast } = useToast();
   const [tab, setTab] = useTabParam("workspaces", "tab", PLAN_TABS);
 
@@ -888,18 +893,19 @@ export default function AdminPlansPage() {
 
           <div className="space-y-4 py-4">
             {/* Issue #800: a legacy / broken cache can hold a value that is
-                not a multiple of perUnit (e.g. pre-#665 memory_bonus 9000).
-                snapshotAddonValues snaps those to 0; this banner names the
-                affected addons so the admin knows why the input shows 0
-                instead of the stored value — rather than hitting an opaque
-                HTTP 400 on save. Informational gating notice, not an error
-                channel (frontend.md) → Alert, not destructive. */}
-            {quotaDetail && detectNonMultipleAddons(quotaDetail).length > 0 && (
+                not a multiple of perUnit (e.g. pre-#665 memory_bonus 9000),
+                which the backend rejects with HTTP 400 on save. Rather than
+                surface an opaque 400, name the offending addons here and
+                disable Save (below) until they are corrected. Driven by the
+                live form state so it clears as the admin fixes each value.
+                Informational gating notice, not an error channel
+                (frontend.md) → Alert, not destructive. */}
+            {invalidAddons.length > 0 && (
               <Alert>
-                <AlertTitle>{t("addonDialog.snapWarning.title")}</AlertTitle>
+                <AlertTitle>{t("addonDialog.invalidWarning.title")}</AlertTitle>
                 <AlertDescription>
-                  {t("addonDialog.snapWarning.body", {
-                    keys: detectNonMultipleAddons(quotaDetail)
+                  {t("addonDialog.invalidWarning.body", {
+                    keys: invalidAddons
                       .map((key) => t(`addonDialog.${key}`))
                       .join(", "),
                   })}
@@ -993,7 +999,13 @@ export default function AdminPlansPage() {
             <Button variant="outline" onClick={() => setAddonDialogOpen(false)}>
               {tCommon("cancel")}
             </Button>
-            <Button onClick={handleUpdateAddons}>
+            {/* #800: block save while any addon value is non-saveable — the
+                PUT sends all 9 fields, so an invalid one would 400 the whole
+                request. Gating here keeps the warning and the save in sync. */}
+            <Button
+              onClick={handleUpdateAddons}
+              disabled={invalidAddons.length > 0}
+            >
               <CheckCircle className="h-4 w-4 mr-2" />
               {t("addonDialog.save")}
             </Button>

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2179,9 +2179,9 @@
         "perUnitWithSuffix": "(+{count} {unit} / unit)",
         "proOnlyInline": "(PRO only)",
         "reductionWarning": "Reducing addons below current usage will be rejected by the backend. (Memories: {memories} used, Members: {members} used, Contexts: {contexts} used)",
-        "snapWarning": {
-          "title": "Some addon values were reset",
-          "body": "The stored value for {keys} is not a valid multiple of its unit and would be rejected on save, so it was reset to 0. Re-enter a valid amount if needed."
+        "invalidWarning": {
+          "title": "Some addon values can't be saved",
+          "body": "The value for {keys} is not a valid multiple of its unit (or is negative) and would be rejected on save. Saving is disabled until you enter a valid amount."
         }
       },
       "auditTable": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2178,7 +2178,11 @@
         "perUnit": "(+{count} / unit)",
         "perUnitWithSuffix": "(+{count} {unit} / unit)",
         "proOnlyInline": "(PRO only)",
-        "reductionWarning": "Reducing addons below current usage will be rejected by the backend. (Memories: {memories} used, Members: {members} used, Contexts: {contexts} used)"
+        "reductionWarning": "Reducing addons below current usage will be rejected by the backend. (Memories: {memories} used, Members: {members} used, Contexts: {contexts} used)",
+        "snapWarning": {
+          "title": "Some addon values were reset",
+          "body": "The stored value for {keys} is not a valid multiple of its unit and would be rejected on save, so it was reset to 0. Re-enter a valid amount if needed."
+        }
       },
       "auditTable": {
         "title": "Change Audit Log",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2179,9 +2179,9 @@
         "perUnitWithSuffix": "(+{count} {unit} / 単位)",
         "proOnlyInline": "(PRO 限定)",
         "reductionWarning": "現在の使用量を下回るアドオン削減は backend に拒否されます。（メモリー: {memories} 使用中、メンバー: {members} 使用中、コンテキスト: {contexts} 使用中）",
-        "snapWarning": {
-          "title": "一部のアドオン値をリセットしました",
-          "body": "{keys} の保存値が単位の倍数になっておらず、保存時に拒否されるため 0 にリセットしました。必要なら有効な値を入力し直してください。"
+        "invalidWarning": {
+          "title": "保存できないアドオン値があります",
+          "body": "{keys} の値が単位の倍数になっていない（または負の値）ため、保存時に拒否されます。有効な値を入力するまで保存は無効化されます。"
         }
       },
       "auditTable": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2178,7 +2178,11 @@
         "perUnit": "(+{count} / 単位)",
         "perUnitWithSuffix": "(+{count} {unit} / 単位)",
         "proOnlyInline": "(PRO 限定)",
-        "reductionWarning": "現在の使用量を下回るアドオン削減は backend に拒否されます。（メモリー: {memories} 使用中、メンバー: {members} 使用中、コンテキスト: {contexts} 使用中）"
+        "reductionWarning": "現在の使用量を下回るアドオン削減は backend に拒否されます。（メモリー: {memories} 使用中、メンバー: {members} 使用中、コンテキスト: {contexts} 使用中）",
+        "snapWarning": {
+          "title": "一部のアドオン値をリセットしました",
+          "body": "{keys} の保存値が単位の倍数になっておらず、保存時に拒否されるため 0 にリセットしました。必要なら有効な値を入力し直してください。"
+        }
       },
       "auditTable": {
         "title": "変更監査ログ",


### PR DESCRIPTION
Closes #800
Closes #801

## Summary
- **#801 (fix)**: the admin quota dialog's `base.memory_limit` now reads `plan_tier.memory_limit` instead of the per-workspace `Workspace.memory_limit` cache column. A stale column (e.g. a PRO workspace still carrying the FREE-tier `1000`) made the per-input "effective" preview off by **100x**. All eight sibling base fields already read the tier; this removes the lone divergent field.
- **#800 (defense)**: the addon dialog now detects cache values that are not a valid multiple of their `perUnit` (or are negative), shows a warning naming them, and **disables Save** until they are corrected — preventing the opaque HTTP 400 the backend returns for non-multiples.

## Implementation notes
- **Issue body line drift**: #801 cites `admin_plans.py:659`; the actual base block is at **`admin_plans.py:757`** (`base=QuotaBreakdown(...)`, where `memory_limit` was the only field reading `workspace.*`).
- **Scope split → #805**: the `Workspace.memory_limit` column itself is **untouched** here (its 4 writers and the cache-vs-override ownership decision are deferred). A destructive `DROP COLUMN` migration should not ride with a frontend guardrail. Follow-up: **#805** (also triages the `UserPlan.memory_limit` twin). The effective limit (`Workspace.effective_memory_limit`) already read the tier, so users were never affected — only the admin preview.
- **Design change (driven by `/code-review max`)**: the first cut snapped non-multiple values to `0` in the form state. Review found this (a) silently destroyed a legacy value when the admin saved after editing an unrelated field (the dialog PUTs all 9 addon fields), and (b) spuriously fired the LD-7 reduction warning on open. The final design **preserves the raw value**, drives the warning from **live form state** (so it clears as the admin fixes it), and **gates Save** instead of mutating data. A single `isValidAddonValue` primitive backs both the warning and the Save gate (no duplicated predicate; also rejects negatives / NaN).

## Tests
- backend `test_admin_plans_base_memory_limit.py` (NEW, integration / real Postgres): base-reads-plan-tier parametrized over `basic`+`pro`, effective==base+addon with and without a non-zero addon. RED→GREEN confirmed.
- frontend `_addon-types.test.ts` (NEW, 27 cases) + `page.test.tsx` (+3 cases): validity boundaries, no-coercion pin, no spurious reduction warning, warning-clears-and-Save-re-enables. Existing 11 dialog tests preserved.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /claude-c-suite:ask (CTO lens — scope-narrowing accepted)
- review provider: code-review (also ran `/code-review max` pre-PR; all findings addressed)

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/800-batch-800-801.gate1.md
- ~/.claude/cache/gh-issue-driven/800-batch-800-801.gate2.md

🤖 Generated via /gh-issue-driven:ship
