### PR TITLE
feat(admin): user detail page i18n + E2E smoke + role badge localization (#688, #691)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ help:
 	@echo "  make test-neural     - Run Neural Memory tests only"
 	@echo "  make test-neural-cov - Run Neural Memory tests with coverage"
 	@echo "  make test-smoke      - Run smoke tests (health, auth, well-known)"
-	@echo "  make test-e2e        - Run E2E tests (memory lifecycle, rate limit)"
+	@echo "  make test-e2e        - Run backend E2E tests (memory lifecycle, rate limit)"
+	@echo "  make test-e2e-frontend - Run frontend E2E tests (Playwright; admin specs need E2E_ADMIN_* env)"
 	@echo "  make test-integration - Run integration tests (DB, migrations, attachments)"
 	@echo "  make test-urls       - Run URL validation (all routes != 500)"
 	@echo "  make test-watch      - Run tests in watch mode (local)"
@@ -130,6 +131,13 @@ test-e2e:
 	@echo "Running E2E tests..."
 	cd $(BACKEND_DIR) && pytest tests/e2e/ -v --timeout=60
 	@echo "E2E tests complete."
+
+.PHONY: test-e2e-frontend
+test-e2e-frontend:
+	@echo "Running frontend E2E tests (Playwright)..."
+	@echo "Note: a11y specs run without auth; admin specs require E2E_ADMIN_LOGIN_ID + E2E_ADMIN_PASSWORD env vars (see frontend/e2e/README.md)."
+	cd frontend && npm run test:e2e
+	@echo "Frontend E2E tests complete."
 
 .PHONY: test-integration
 test-integration:

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -71,3 +71,30 @@ A11y job (`/login` contrast) is tracked for `.github/workflows/ci.yml` wiring
 in #786. Admin smoke specs (#688) require backend + DB up and admin credentials
 seeded — CI wiring is deferred until secret management for E2E admin
 credentials is decided.
+
+### CI prerequisites for admin specs
+
+Before wiring `make test-e2e-frontend` into CI, address these:
+
+1. **Secret management for `E2E_ADMIN_LOGIN_ID` / `E2E_ADMIN_PASSWORD`.**
+   GitHub Actions secrets, vault, or equivalent — never commit.
+2. **Password leak in failure traces.** `playwright.config.ts` sets
+   `trace: "retain-on-failure"`, which captures network request bodies
+   including the login POST body. A failed CI run would publish
+   `E2E_ADMIN_PASSWORD` in the trace artifact. Fix BEFORE CI by either:
+   - Pre-seeded storage state: add `globalSetup` to `playwright.config.ts`
+     that performs the login once and writes cookies to a gitignored
+     file, then reference via `use.storageState` on an admin-only
+     project. The fixture's API-login path goes away (or stays as a
+     fallback for the no-storage-state case).
+   - Per-spec opt-out: `test.use({ trace: "off" })` at the top of
+     `admin-*.spec.ts` files. Loses trace coverage on those specs but
+     trivially closes the leak.
+3. **DB residue from interrupted round-trip specs.** Add a
+   `test.afterEach` that PATCHes `workspace_slot_bonus` back to its
+   pre-test value via the admin API, so an interrupted run leaves no
+   state behind. For local dev this is acceptable to defer (admin can
+   reset via UI); for CI it is mandatory.
+4. **Tighten the 15s `waitFor` timeout** in `admin-user-detail.spec.ts`
+   to ~30s. Cold `next dev` first-paint can take 8–12s on slow CI
+   runners — 15s leaves no safety margin.

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -1,24 +1,73 @@
 # Frontend a11y / e2e tests (Playwright + axe-core)
 
-Issue #780 introduced this directory with a single color-contrast spec for `/login`.
-Run locally:
+`/login` color-contrast spec was introduced by #780; `/admin/users/[userId]`
+smoke spec by #688. Run locally:
 
 ```bash
 cd frontend
 npx playwright install chromium  # first time only
 npm run test:e2e
+# or from repo root:
+make test-e2e-frontend
 ```
 
-`npm run test:e2e` auto-starts `next dev` on :3000 via the `webServer` block in
-`playwright.config.ts`. If you already have a dev server running, the existing
-process is reused (`reuseExistingServer: !process.env.CI`).
+`npm run test:e2e` auto-starts `next dev` on :3000 via the `webServer` block
+in `playwright.config.ts`. If you already have a dev server running, the
+existing process is reused (`reuseExistingServer: !process.env.CI`).
 
-## Adding a new page
+## Adding a new a11y page
 
 Drop a new spec into `e2e/a11y/<page>-contrast.spec.ts` following the
 `login-contrast.spec.ts` shape — `await page.goto("/<path>")` then
 `await new AxeBuilder({ page }).options({ runOnly: ["color-contrast"] }).analyze()`.
 
+## Adding a new authenticated admin spec
+
+Use the admin auth fixture at `e2e/fixtures/admin-auth.ts`:
+
+```ts
+import { test, expect } from "./fixtures/admin-auth";
+
+test("my admin smoke", async ({ page }) => {
+  await page.goto("/admin/your-feature");
+  await page.getByTestId("your-feature-anchor").waitFor({ state: "visible" });
+  // ...
+});
+```
+
+The fixture logs the test admin in via `POST /api/v1/auth/login` and shares
+cookies with the browser context, so `page.goto("/admin/...")` is
+authenticated.
+
+**Required env vars** before running an admin spec:
+
+```bash
+export E2E_ADMIN_LOGIN_ID="admin"          # login_id for an admin user
+export E2E_ADMIN_PASSWORD="<password>"     # that user's password
+# Optional — backend API base URL (default falls back to NEXT_PUBLIC_API_URL,
+# then http://localhost:8080). Override if your backend listens elsewhere.
+export E2E_API_URL="http://localhost:8080"
+```
+
+The test admin must (a) exist (create with `make admin`), (b) have role =
+admin, (c) NOT have MFA enabled.
+
+**API origin vs Next.js origin.** Playwright's `baseURL` points at Next.js
+(`:3000`) so `page.goto("/admin/...")` works as expected. Direct API calls
+(login, list users, etc.) MUST use the `API_URL` constant exported from
+`admin-auth.ts` because there is no Next.js `/api/*` rewrite — a relative
+`/api/...` path on `:3000` would 404. The session cookie set by the API on
+`:8080` flows to subsequent browser fetches because `localhost:3000` and
+`localhost:8080` are the same SameSite "site", and the frontend's apiClient
+sets `credentials: "include"`.
+
+**Locator discipline** (#688 / QA Lead gate1): use `getByTestId`, `getByRole`,
+`getByLabel` — never `getByText`. Page content is localized through
+`next-intl` and would shift under `lang != "en"` browser sessions.
+
 ## CI
 
-Not yet wired into `.github/workflows/ci.yml` — tracked as a follow-up.
+A11y job (`/login` contrast) is tracked for `.github/workflows/ci.yml` wiring
+in #786. Admin smoke specs (#688) require backend + DB up and admin credentials
+seeded — CI wiring is deferred until secret management for E2E admin
+credentials is decided.

--- a/frontend/e2e/admin-user-detail.spec.ts
+++ b/frontend/e2e/admin-user-detail.spec.ts
@@ -27,42 +27,68 @@ import { USER_DETAIL_TEST_IDS as T } from "@/app/(authenticated)/admin/users/[us
  */
 
 /**
- * Navigate to the first admin user's detail page and wait for the
- * Workspace Capacity section to render. The list is guaranteed non-empty
- * because the test admin themselves is in it. Returns the targeted user_id
- * for tests that need it for further assertions.
- *
- * `waitFor` with an explicit 15s timeout (rather than relying on the
- * follow-on `toBeVisible` auto-wait) is the gate that absorbs slow
- * `next dev` first-paint — `networkidle` is unreliable against `next dev`
- * because the HMR websocket keeps the network busy indefinitely.
+ * Direct API call — must use API_URL (backend), not the Playwright config's
+ * baseURL which points at Next.js (:3000). There is no Next.js /api/*
+ * rewrite, so a relative path would 404.
  */
-async function gotoFirstUserDetail(page: Page): Promise<string> {
-  // Direct API call — must use API_URL (backend), not the Playwright config's
-  // baseURL which points at Next.js (:3000). There is no Next.js /api/*
-  // rewrite, so a relative path would 404.
+async function listAdminUsers(page: Page): Promise<Array<{ id: string }>> {
   const usersRes = await page.request.get(`${API_URL}/api/v1/admin/users`);
   expect(usersRes.ok()).toBe(true);
-  const usersBody = (await usersRes.json()) as {
-    users: Array<{ id: string }>;
-  };
+  const usersBody = (await usersRes.json()) as { users: Array<{ id: string }> };
   expect(usersBody.users.length).toBeGreaterThan(0);
-  const targetUserId = usersBody.users[0].id;
+  return usersBody.users;
+}
 
-  await page.goto(`/admin/users/${targetUserId}`, {
+async function gotoUserDetail(page: Page, userId: string): Promise<void> {
+  await page.goto(`/admin/users/${userId}`, {
     waitUntil: "domcontentloaded",
   });
+  // Explicit 15s waitFor (rather than relying on follow-on toBeVisible
+  // auto-wait) absorbs slow `next dev` first-paint — `networkidle` is
+  // unreliable against `next dev` because the HMR websocket keeps the
+  // network busy indefinitely.
   await page
     .getByTestId(T.workspaceCapacitySection)
     .waitFor({ state: "visible", timeout: 15_000 });
-  return targetUserId;
+}
+
+/**
+ * Fetch the workspace_summary block for a user via the admin detail API.
+ * Returns null if the response shape lacks the block (older API or
+ * un-backfilled user).
+ */
+async function getWorkspaceSummary(
+  page: Page,
+  userId: string,
+): Promise<{
+  owned_count: number;
+  cap: number;
+  base_cap: number;
+  workspace_slot_bonus: number;
+  is_at_cap: boolean;
+} | null> {
+  const detailRes = await page.request.get(
+    `${API_URL}/api/v1/admin/users/${userId}`,
+  );
+  if (!detailRes.ok()) return null;
+  const detail = (await detailRes.json()) as {
+    workspace_summary?: {
+      owned_count: number;
+      cap: number;
+      base_cap: number;
+      workspace_slot_bonus: number;
+      is_at_cap: boolean;
+    } | null;
+  };
+  return detail.workspace_summary ?? null;
 }
 
 test.describe("/admin/users/[userId] smoke (#688)", () => {
   test("renders the workspace capacity section after admin login", async ({
     page,
   }) => {
-    await gotoFirstUserDetail(page);
+    const users = await listAdminUsers(page);
+    await gotoUserDetail(page, users[0].id);
 
     await expect(page.getByTestId(T.workspaceCapacityCapDisplay)).toBeVisible();
     await expect(page.getByTestId(T.workspaceCapacityBonusValue)).toBeVisible();
@@ -73,7 +99,27 @@ test.describe("/admin/users/[userId] smoke (#688)", () => {
   test("[+] then [-] round-trip via real backend (idempotent)", async ({
     page,
   }) => {
-    await gotoFirstUserDetail(page);
+    // Round-trip mutation requires a target with safe decrement headroom
+    // (cap > owned_count). If the test admin is at-cap or over-cap, the
+    // [-] step triggers the destructive reason modal instead of a direct
+    // PATCH, leaving the +1 bonus in DB after the test times out.
+    // Pick the first non-at-cap candidate via the admin detail API
+    // before navigating — surfaced by Copilot review on PR #807.
+    const users = await listAdminUsers(page);
+    let targetUserId: string | null = null;
+    for (const user of users) {
+      const summary = await getWorkspaceSummary(page, user.id);
+      if (summary && summary.cap > summary.owned_count) {
+        targetUserId = user.id;
+        break;
+      }
+    }
+    test.skip(
+      targetUserId === null,
+      "no admin user has cap > owned_count headroom — seed a non-at-cap user before running the round-trip spec",
+    );
+
+    await gotoUserDetail(page, targetUserId as string);
 
     const bonusValue = page.getByTestId(T.workspaceCapacityBonusValue);
     const beforeText = await bonusValue.textContent();
@@ -86,10 +132,9 @@ test.describe("/admin/users/[userId] smoke (#688)", () => {
     await page.getByTestId(T.workspaceCapacityIncrement).click();
     await expect(bonusValue).toHaveText(String(before + 1));
 
-    // [-] counter-mutation restores the original bonus so this spec is
-    // idempotent and leaves no DB residue. The non-destructive decrement
-    // path (projectedCap >= owned_count) skips the reason modal and
-    // commits immediately.
+    // [-] counter-mutation restores the original bonus. Safe because the
+    // pre-test filter above guarantees projectedCap >= owned_count (the
+    // non-destructive decrement path).
     await page.getByTestId(T.workspaceCapacityDecrement).click();
     await expect(bonusValue).toHaveText(String(before));
   });

--- a/frontend/e2e/admin-user-detail.spec.ts
+++ b/frontend/e2e/admin-user-detail.spec.ts
@@ -1,0 +1,96 @@
+import type { Page } from "@playwright/test";
+import { test, expect, API_URL } from "./fixtures/admin-auth";
+import { USER_DETAIL_TEST_IDS as T } from "@/app/(authenticated)/admin/users/[userId]/testids";
+
+/**
+ * Admin user detail page E2E smoke (#688).
+ *
+ * Carves the missing E2E layer for #676's Workspace Capacity feature: URL
+ * contract, real RBAC integration (`require_admin` decorator), real
+ * audit_log INSERT, and full frontend → backend round-trip via Playwright.
+ *
+ * Per #688 gate1 (QA Lead): locators are locale-independent (testid only,
+ * never visible text) so this spec survives #691's next-intl migration.
+ * Testids are imported from a shared `testids.ts` so renames are caught
+ * at compile time across page.tsx / page.test.tsx / this spec.
+ *
+ * Per-issue test coverage map:
+ * - #676 unit (Vitest, jsdom)              → covers reducer + reason modal
+ * - #676 integration (pytest)              → covers PATCH endpoint contract
+ * - #688 E2E (this spec)                   → covers admin auth + URL + UI round-trip
+ *
+ * The destructive [-] reason-modal path is intentionally NOT covered here
+ * because triggering it requires a specific target user state
+ * (`projectedCap < owned_count`). That path is fully covered by the
+ * Vitest cases in page.test.tsx — duplicating it in E2E adds setup
+ * complexity without proportional value.
+ */
+
+/**
+ * Navigate to the first admin user's detail page and wait for the
+ * Workspace Capacity section to render. The list is guaranteed non-empty
+ * because the test admin themselves is in it. Returns the targeted user_id
+ * for tests that need it for further assertions.
+ *
+ * `waitFor` with an explicit 15s timeout (rather than relying on the
+ * follow-on `toBeVisible` auto-wait) is the gate that absorbs slow
+ * `next dev` first-paint — `networkidle` is unreliable against `next dev`
+ * because the HMR websocket keeps the network busy indefinitely.
+ */
+async function gotoFirstUserDetail(page: Page): Promise<string> {
+  // Direct API call — must use API_URL (backend), not the Playwright config's
+  // baseURL which points at Next.js (:3000). There is no Next.js /api/*
+  // rewrite, so a relative path would 404.
+  const usersRes = await page.request.get(`${API_URL}/api/v1/admin/users`);
+  expect(usersRes.ok()).toBe(true);
+  const usersBody = (await usersRes.json()) as {
+    users: Array<{ id: string }>;
+  };
+  expect(usersBody.users.length).toBeGreaterThan(0);
+  const targetUserId = usersBody.users[0].id;
+
+  await page.goto(`/admin/users/${targetUserId}`, {
+    waitUntil: "domcontentloaded",
+  });
+  await page
+    .getByTestId(T.workspaceCapacitySection)
+    .waitFor({ state: "visible", timeout: 15_000 });
+  return targetUserId;
+}
+
+test.describe("/admin/users/[userId] smoke (#688)", () => {
+  test("renders the workspace capacity section after admin login", async ({
+    page,
+  }) => {
+    await gotoFirstUserDetail(page);
+
+    await expect(page.getByTestId(T.workspaceCapacityCapDisplay)).toBeVisible();
+    await expect(page.getByTestId(T.workspaceCapacityBonusValue)).toBeVisible();
+    await expect(page.getByTestId(T.workspaceCapacityIncrement)).toBeVisible();
+    await expect(page.getByTestId(T.workspaceCapacityDecrement)).toBeVisible();
+  });
+
+  test("[+] then [-] round-trip via real backend (idempotent)", async ({
+    page,
+  }) => {
+    await gotoFirstUserDetail(page);
+
+    const bonusValue = page.getByTestId(T.workspaceCapacityBonusValue);
+    const beforeText = await bonusValue.textContent();
+    const before = parseInt((beforeText ?? "0").trim(), 10);
+    expect(Number.isFinite(before)).toBe(true);
+
+    // [+] → bonus increments by 1. This exercises PATCH /api/v1/admin/users/
+    // {user_id}/workspace_slot_bonus end-to-end: real require_admin gate,
+    // real DB UPDATE, real audit_log INSERT, real response reconciliation.
+    await page.getByTestId(T.workspaceCapacityIncrement).click();
+    await expect(bonusValue).toHaveText(String(before + 1));
+
+    // [-] counter-mutation restores the original bonus so this spec is
+    // idempotent and leaves no DB residue. The non-destructive decrement
+    // path (projectedCap >= owned_count) skips the reason modal and
+    // commits immediately.
+    await page.getByTestId(T.workspaceCapacityDecrement).click();
+    await expect(bonusValue).toHaveText(String(before));
+  });
+});

--- a/frontend/e2e/admin-user-detail.spec.ts
+++ b/frontend/e2e/admin-user-detail.spec.ts
@@ -2,6 +2,25 @@ import type { Page } from "@playwright/test";
 import { test, expect, API_URL } from "./fixtures/admin-auth";
 import { USER_DETAIL_TEST_IDS as T } from "@/app/(authenticated)/admin/users/[userId]/testids";
 
+// Disable trace capture for this spec.
+//
+// `playwright.config.ts` sets `trace: "retain-on-failure"`, which captures
+// network request bodies in the retained trace artifact on test failure.
+// The admin-auth fixture POSTs `E2E_ADMIN_PASSWORD` via the test runner's
+// request context, and Playwright records that body unless tracing is off.
+// A failed CI run would otherwise leave the password in
+// `test-results/<spec>/trace.zip`.
+//
+// Trade-off: we lose trace-based debugging on admin-spec failures. The
+// spec is 2 cases and 100 lines — `console.log` + screenshots from
+// `test.afterEach` are sufficient if a regression needs investigation.
+// Pre-seeded `globalSetup` storage state (so the password never touches a
+// browser-context request at all) is the proper long-term fix and is
+// tracked in `frontend/e2e/README.md` as a CI prerequisite.
+//
+// Surfaced by Copilot review on PR #807 (loops 1 + 2).
+test.use({ trace: "off" });
+
 /**
  * Admin user detail page E2E smoke (#688).
  *

--- a/frontend/e2e/fixtures/admin-auth.ts
+++ b/frontend/e2e/fixtures/admin-auth.ts
@@ -1,0 +1,89 @@
+import { test as base, expect } from "@playwright/test";
+
+/**
+ * Admin auth fixture for non-a11y E2E specs (#688).
+ *
+ * Logs the test admin in via the API (POST /api/v1/auth/login) and injects
+ * the resulting session cookie into the browser context, so any subsequent
+ * page.goto("/admin/...") is already authenticated.
+ *
+ * Why API login (not /login UI):
+ * - Deterministic (no /login form rendering / OAuth button noise to wait on).
+ * - Decouples admin-feature specs from /login UI changes — /login is a
+ *   separate surface and exercised by frontend/e2e/a11y/login-contrast.spec.ts.
+ *
+ * Required env vars (set before `make test-e2e-frontend` or `npm run test:e2e`):
+ *   E2E_ADMIN_LOGIN_ID   — login_id for an existing admin user without MFA
+ *   E2E_ADMIN_PASSWORD   — that user's password
+ * Optional:
+ *   E2E_API_URL          — backend API base URL (default: NEXT_PUBLIC_API_URL
+ *                          else http://localhost:8080). Required because the
+ *                          Playwright config's baseURL points at Next.js
+ *                          (:3000) for `page.goto`, but the API lives on a
+ *                          different origin and there is no Next.js rewrite
+ *                          for `/api/*`. Use `API_URL` (exported below) for
+ *                          all direct API calls; reserve baseURL for
+ *                          `page.goto`.
+ *
+ * The test admin must:
+ *   - Exist (create with `make admin` if needed)
+ *   - Have role = admin
+ *   - NOT have MFA enabled (TOTP fixture would require a shared secret)
+ *
+ * Cookie capture: context.request.post() shares the cookie jar with browser
+ * pages opened from the same context, so we don't need an explicit
+ * `context.addCookies(...)` step after the login call. The session cookie
+ * is scoped to the API origin (`E2E_API_URL`); subsequent cross-origin
+ * fetches from a `:3000` page work because (a) `localhost:3000` and
+ * `localhost:8080` are the same SameSite "site" (same eTLD+1 `localhost`),
+ * and (b) apiClient sets `credentials: "include"` and backend CORS allows
+ * the Next.js origin.
+ */
+
+const ADMIN_LOGIN_ID = process.env.E2E_ADMIN_LOGIN_ID ?? "";
+const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD ?? "";
+export const API_URL =
+  process.env.E2E_API_URL ??
+  process.env.NEXT_PUBLIC_API_URL ??
+  "http://localhost:8080";
+
+type AdminAuthFixtures = {
+  adminAuth: void;
+};
+
+export const test = base.extend<AdminAuthFixtures>({
+  adminAuth: [
+    async ({ context }, use) => {
+      if (!ADMIN_LOGIN_ID || !ADMIN_PASSWORD) {
+        throw new Error(
+          "E2E_ADMIN_LOGIN_ID and E2E_ADMIN_PASSWORD must be set. " +
+            "See frontend/e2e/README.md for setup.",
+        );
+      }
+
+      const response = await context.request.post(
+        `${API_URL}/api/v1/auth/login`,
+        {
+          data: { login_id: ADMIN_LOGIN_ID, password: ADMIN_PASSWORD },
+        },
+      );
+      expect(
+        response.ok(),
+        `admin login failed (${response.status()}): ${await response.text()}`,
+      ).toBe(true);
+
+      const body = await response.json();
+      if (body.mfa_required) {
+        throw new Error(
+          "E2E admin has MFA enabled — disable MFA on the test admin " +
+            "or use a dedicated non-MFA admin for E2E.",
+        );
+      }
+
+      await use();
+    },
+    { auto: true, scope: "test" },
+  ],
+});
+
+export { expect };

--- a/frontend/e2e/fixtures/admin-auth.ts
+++ b/frontend/e2e/fixtures/admin-auth.ts
@@ -15,6 +15,18 @@ import { test as base, expect } from "@playwright/test";
  * Required env vars (set before `make test-e2e-frontend` or `npm run test:e2e`):
  *   E2E_ADMIN_LOGIN_ID   — login_id for an existing admin user without MFA
  *   E2E_ADMIN_PASSWORD   — that user's password
+ *
+ * CI prerequisite (not a local-dev concern): `playwright.config.ts` sets
+ * `trace: "retain-on-failure"`, which captures network request bodies in
+ * the retained trace artifact on test failure. Because the login POST
+ * below sends E2E_ADMIN_PASSWORD as form data, a failed E2E run would
+ * leave the password in `test-results/.../trace.zip`. Local dev runs do
+ * not propagate this anywhere, but before this spec is added to CI:
+ * either switch to pre-seeded storage state (`playwright.config.ts`
+ * `globalSetup` + project `use.storageState`) so the password never
+ * touches a traced context, OR disable tracing for this spec via
+ * `test.use({ trace: "off" })`. See frontend/e2e/README.md for the full
+ * decision. Surfaced by Copilot review on PR #807.
  * Optional:
  *   E2E_API_URL          — backend API base URL (default: NEXT_PUBLIC_API_URL
  *                          else http://localhost:8080). Required because the

--- a/frontend/e2e/fixtures/admin-auth.ts
+++ b/frontend/e2e/fixtures/admin-auth.ts
@@ -16,17 +16,16 @@ import { test as base, expect } from "@playwright/test";
  *   E2E_ADMIN_LOGIN_ID   — login_id for an existing admin user without MFA
  *   E2E_ADMIN_PASSWORD   — that user's password
  *
- * CI prerequisite (not a local-dev concern): `playwright.config.ts` sets
- * `trace: "retain-on-failure"`, which captures network request bodies in
- * the retained trace artifact on test failure. Because the login POST
- * below sends E2E_ADMIN_PASSWORD as form data, a failed E2E run would
- * leave the password in `test-results/.../trace.zip`. Local dev runs do
- * not propagate this anywhere, but before this spec is added to CI:
- * either switch to pre-seeded storage state (`playwright.config.ts`
- * `globalSetup` + project `use.storageState`) so the password never
- * touches a traced context, OR disable tracing for this spec via
- * `test.use({ trace: "off" })`. See frontend/e2e/README.md for the full
- * decision. Surfaced by Copilot review on PR #807.
+ * Trace-capture mitigation (current): every spec that uses this fixture
+ * MUST set `test.use({ trace: "off" })` at the top of the file —
+ * `playwright.config.ts` defaults to `trace: "retain-on-failure"`, which
+ * would capture the E2E_ADMIN_PASSWORD POST body in the retained trace
+ * artifact on test failure. `admin-user-detail.spec.ts` is the reference
+ * example. Long-term, switch to pre-seeded storage state via
+ * `playwright.config.ts` `globalSetup` + project `use.storageState` so
+ * the password never touches a traced context at all — tracked in
+ * `frontend/e2e/README.md` as a CI prerequisite. Surfaced by Copilot
+ * review on PR #807 (loops 1 + 2).
  * Optional:
  *   E2E_API_URL          — backend API base URL (default: NEXT_PUBLIC_API_URL
  *                          else http://localhost:8080). Required because the

--- a/frontend/src/app/(authenticated)/admin/users/[userId]/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/[userId]/page.test.tsx
@@ -44,6 +44,23 @@ vi.mock("next/navigation", () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+// next-intl mock matches the project convention (see frontend/src/app/login/
+// page.test.tsx): useTranslations returns the key verbatim. For calls that
+// pass params, we echo `key var1=value1 var2=value2` so tests can assert
+// data interpolation flowed through without needing the real message
+// catalog. Tests assert on data-testid / role queries (#688) rather than
+// visible English text, so the key-as-text is fine.
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) => {
+    if (!params) return key;
+    const tail = Object.entries(params)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(" ");
+    return `${key} ${tail}`;
+  },
+  useLocale: () => "en",
+}));
+
 // Reduce layout chrome.
 vi.mock("@/components/common/PageContainer", () => ({
   PageContainer: ({ children }: { children: React.ReactNode }) => (
@@ -55,6 +72,7 @@ vi.mock("@/components/common/PageHeader", () => ({
 }));
 
 import UserDetailPage from "./page";
+import { USER_DETAIL_TEST_IDS } from "./testids";
 
 const BASE_USER_DETAIL = {
   user: {
@@ -90,12 +108,14 @@ describe("Workspace Capacity section (#676)", () => {
     render(<UserDetailPage />);
     // Wait for the page to actually finish loading by waiting for a
     // post-load element (the user's name from the fetched payload).
-    // Without this anchor, `queryByText(/Workspace Capacity/)` returns
-    // null both *before* the fetch resolves AND when the section is
-    // correctly absent — making the test a false positive that would
+    // Without this anchor, `queryByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection)`
+    // returns null both *before* the fetch resolves AND when the section
+    // is correctly absent — making the test a false positive that would
     // pass even if the section was rendered after load.
     await screen.findByText(BASE_USER_DETAIL.user.name);
-    expect(screen.queryByText(/Workspace Capacity/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection),
+    ).not.toBeInTheDocument();
   });
 
   it("renders cap formula and badge variant from workspace_summary", async () => {
@@ -113,11 +133,18 @@ describe("Workspace Capacity section (#676)", () => {
       }),
     );
     render(<UserDetailPage />);
-    await screen.findByText(/Workspace Capacity/);
-    expect(screen.getByText(/Owned: 2/)).toBeInTheDocument();
-    expect(screen.getByText(/Cap: 3/)).toBeInTheDocument();
-    expect(screen.getByText(/1 base \+ 2 bonus/)).toBeInTheDocument();
-    expect(screen.getByText(/67% used/)).toBeInTheDocument();
+    await screen.findByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection);
+    // Cap-display text is rendered via the i18n mock as
+    // `<key> <param>=<value> ...` so we assert on the data flowed
+    // through rather than the localized message.
+    const capDisplay = screen.getByTestId(
+      USER_DETAIL_TEST_IDS.workspaceCapacityCapDisplay,
+    );
+    expect(capDisplay.textContent).toMatch(/count=2/);
+    expect(capDisplay.textContent).toMatch(/cap=3/);
+    expect(capDisplay.textContent).toMatch(/base=1/);
+    expect(capDisplay.textContent).toMatch(/bonus=2/);
+    expect(capDisplay.parentElement?.textContent).toMatch(/pct=67/);
     expect(screen.getByText("Personal")).toBeInTheDocument();
     expect(screen.getByText("Side project")).toBeInTheDocument();
   });
@@ -134,7 +161,10 @@ describe("Workspace Capacity section (#676)", () => {
       }),
     );
     render(<UserDetailPage />);
-    await screen.findByText(/at cap/);
+    const section = await screen.findByTestId(
+      USER_DETAIL_TEST_IDS.workspaceCapacitySection,
+    );
+    expect(section.textContent).toMatch(/workspaceCapacity\.atCapBadge/);
   });
 
   it("commits +1 immediately and updates the displayed bonus on success", async () => {
@@ -158,9 +188,11 @@ describe("Workspace Capacity section (#676)", () => {
       reason: null,
     });
     render(<UserDetailPage />);
-    await screen.findByText(/Workspace Capacity/);
+    await screen.findByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection);
 
-    fireEvent.click(screen.getByLabelText("Increment slot bonus"));
+    fireEvent.click(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.workspaceCapacityIncrement),
+    );
 
     await waitFor(() => {
       expect(mockUpdateBonus).toHaveBeenCalledWith("u_test_123", {
@@ -170,7 +202,9 @@ describe("Workspace Capacity section (#676)", () => {
     });
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(
-        expect.objectContaining({ title: "Updated" }),
+        expect.objectContaining({
+          title: "messages.bonusUpdateSuccessTitle",
+        }),
       );
     });
   });
@@ -196,9 +230,11 @@ describe("Workspace Capacity section (#676)", () => {
       reason: null,
     });
     render(<UserDetailPage />);
-    await screen.findByText(/Workspace Capacity/);
+    await screen.findByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection);
 
-    fireEvent.click(screen.getByLabelText("Decrement slot bonus"));
+    fireEvent.click(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.workspaceCapacityDecrement),
+    );
 
     await waitFor(() => {
       expect(mockUpdateBonus).toHaveBeenCalledWith("u_test_123", {
@@ -207,7 +243,9 @@ describe("Workspace Capacity section (#676)", () => {
       });
     });
     // No modal should be visible.
-    expect(screen.queryByText(/Reason required/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(USER_DETAIL_TEST_IDS.reasonModal),
+    ).not.toBeInTheDocument();
   });
 
   it("opens reason modal for destructive -1 and submits with reason", async () => {
@@ -231,28 +269,37 @@ describe("Workspace Capacity section (#676)", () => {
       reason: "finance request",
     });
     render(<UserDetailPage />);
-    await screen.findByText(/Workspace Capacity/);
+    await screen.findByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection);
 
-    fireEvent.click(screen.getByLabelText("Decrement slot bonus"));
+    fireEvent.click(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.workspaceCapacityDecrement),
+    );
 
     // Modal opens — no PATCH yet.
-    await screen.findByText(/Reason required/);
+    const modal = await screen.findByTestId(USER_DETAIL_TEST_IDS.reasonModal);
     expect(mockUpdateBonus).not.toHaveBeenCalled();
 
-    // Warning text mentions the shortfall and that workspaces aren't removed.
-    expect(
-      screen.getByText(/Existing workspaces are NOT removed/),
-    ).toBeInTheDocument();
+    // Warning text is built from the t() messages.overCapWarn message; the
+    // mock echoes the params so we can assert that the shortfall / cap
+    // values flowed through correctly.
+    expect(modal.textContent).toMatch(/messages\.overCapWarn/);
+    expect(modal.textContent).toMatch(/owned=4/);
+    expect(modal.textContent).toMatch(/projected=2/);
+    expect(modal.textContent).toMatch(/cap=3/);
+    expect(modal.textContent).toMatch(/shortfall=1/);
 
     // Confirm button is disabled until reason is non-empty.
-    const confirmBtn = screen.getByRole("button", {
-      name: /Confirm decrement/,
-    });
+    const confirmBtn = screen.getByTestId(
+      USER_DETAIL_TEST_IDS.reasonModalConfirm,
+    );
     expect(confirmBtn).toBeDisabled();
 
-    fireEvent.change(screen.getByLabelText(/Reason \(required\)/), {
-      target: { value: "finance request" },
-    });
+    fireEvent.change(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.reasonModalInput),
+      {
+        target: { value: "finance request" },
+      },
+    );
     expect(confirmBtn).not.toBeDisabled();
 
     fireEvent.click(confirmBtn);
@@ -277,18 +324,23 @@ describe("Workspace Capacity section (#676)", () => {
       }),
     );
     render(<UserDetailPage />);
-    await screen.findByText(/Workspace Capacity/);
+    await screen.findByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection);
 
-    fireEvent.click(screen.getByLabelText("Decrement slot bonus"));
-    await screen.findByText(/Reason required/);
+    fireEvent.click(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.workspaceCapacityDecrement),
+    );
+    await screen.findByTestId(USER_DETAIL_TEST_IDS.reasonModal);
 
-    fireEvent.change(screen.getByLabelText(/Reason \(required\)/), {
-      target: { value: "   " },
-    });
+    fireEvent.change(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.reasonModalInput),
+      {
+        target: { value: "   " },
+      },
+    );
 
-    const confirmBtn = screen.getByRole("button", {
-      name: /Confirm decrement/,
-    });
+    const confirmBtn = screen.getByTestId(
+      USER_DETAIL_TEST_IDS.reasonModalConfirm,
+    );
     expect(confirmBtn).toBeDisabled();
     expect(mockUpdateBonus).not.toHaveBeenCalled();
   });
@@ -309,20 +361,25 @@ describe("Workspace Capacity section (#676)", () => {
     mockGet.mockResolvedValueOnce(initialDetail);
     mockUpdateBonus.mockRejectedValueOnce(new Error("network down"));
     render(<UserDetailPage />);
-    await screen.findByText(/Workspace Capacity/);
+    await screen.findByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection);
 
-    fireEvent.click(screen.getByLabelText("Increment slot bonus"));
+    fireEvent.click(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.workspaceCapacityIncrement),
+    );
 
     await waitFor(() => {
       expect(mockToast).toHaveBeenCalledWith(
         expect.objectContaining({
-          title: "Error",
+          title: "error",
           variant: "destructive",
         }),
       );
     });
     // Displayed bonus should be back to the pre-call value (2), proving rollback.
-    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.workspaceCapacityBonusValue)
+        .textContent,
+    ).toBe("2");
   });
 
   it("disables [-] when bonus is already 0", async () => {
@@ -337,7 +394,9 @@ describe("Workspace Capacity section (#676)", () => {
       }),
     );
     render(<UserDetailPage />);
-    await screen.findByText(/Workspace Capacity/);
-    expect(screen.getByLabelText("Decrement slot bonus")).toBeDisabled();
+    await screen.findByTestId(USER_DETAIL_TEST_IDS.workspaceCapacitySection);
+    expect(
+      screen.getByTestId(USER_DETAIL_TEST_IDS.workspaceCapacityDecrement),
+    ).toBeDisabled();
   });
 });

--- a/frontend/src/app/(authenticated)/admin/users/[userId]/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/[userId]/page.tsx
@@ -110,6 +110,8 @@ const KNOWN_ROLE_VALUES = [
   "editor",
 ] as const;
 
+const KNOWN_PLAN_VALUES = ["free", "basic", "pro"] as const;
+
 export default function UserDetailPage() {
   const params = useParams();
   const router = useRouter();
@@ -149,9 +151,19 @@ export default function UserDetailPage() {
   const { toast } = useToast();
 
   const getLocalizedRole = (role: string) => {
-    return KNOWN_ROLE_VALUES.includes(role as (typeof KNOWN_ROLE_VALUES)[number])
+    return KNOWN_ROLE_VALUES.includes(
+      role as (typeof KNOWN_ROLE_VALUES)[number],
+    )
       ? t(`roles.${role}`)
       : role;
+  };
+
+  const getLocalizedPlan = (plan: string) => {
+    return KNOWN_PLAN_VALUES.includes(
+      plan as (typeof KNOWN_PLAN_VALUES)[number],
+    )
+      ? t(`changePlanDialog.planOptions.${plan as "free" | "basic" | "pro"}`)
+      : plan;
   };
 
   useEffect(() => {
@@ -746,7 +758,9 @@ export default function UserDetailPage() {
                       {ctx.workspace_name}
                     </TableCell>
                     <TableCell>
-                      <Badge variant="outline">{getLocalizedRole(ctx.role)}</Badge>
+                      <Badge variant="outline">
+                        {getLocalizedRole(ctx.role)}
+                      </Badge>
                     </TableCell>
                     <TableCell className="text-sm text-gray-500">
                       {ctx.last_used_at
@@ -827,7 +841,9 @@ export default function UserDetailPage() {
                     planDialog.currentPlan === "pro" ? "destructive" : "default"
                   }
                 >
-                  {planDialog.currentPlan}
+                  {planDialog.currentPlan
+                    ? getLocalizedPlan(planDialog.currentPlan)
+                    : ""}
                 </Badge>
               </div>
             </div>

--- a/frontend/src/app/(authenticated)/admin/users/[userId]/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/[userId]/page.tsx
@@ -100,6 +100,16 @@ interface UserDetail {
   workspace_summary?: WorkspaceSummary | null; // #676 (optional during rollout)
 }
 
+const KNOWN_ROLE_VALUES = [
+  "admin",
+  "user",
+  "read_only",
+  "owner",
+  "member",
+  "viewer",
+  "editor",
+] as const;
+
 export default function UserDetailPage() {
   const params = useParams();
   const router = useRouter();
@@ -137,6 +147,12 @@ export default function UserDetailPage() {
   }>({ open: false, delta: -1, reason: "", warnText: "", submitting: false });
 
   const { toast } = useToast();
+
+  const getLocalizedRole = (role: string) => {
+    return KNOWN_ROLE_VALUES.includes(role as (typeof KNOWN_ROLE_VALUES)[number])
+      ? t(`roles.${role}`)
+      : role;
+  };
 
   useEffect(() => {
     loadUserDetail();
@@ -432,7 +448,7 @@ export default function UserDetailPage() {
                   {userDetail.user.role === "admin" && (
                     <Shield className="h-3 w-3 mr-1" />
                   )}
-                  {userDetail.user.role}
+                  {getLocalizedRole(userDetail.user.role)}
                 </Badge>
                 {userDetail.user.is_initial_admin && (
                   <Badge
@@ -510,7 +526,7 @@ export default function UserDetailPage() {
                       </div>
                     </TableCell>
                     <TableCell>
-                      <Badge>{workspace.role}</Badge>
+                      <Badge>{getLocalizedRole(workspace.role)}</Badge>
                     </TableCell>
                     <TableCell>
                       <Badge
@@ -730,7 +746,7 @@ export default function UserDetailPage() {
                       {ctx.workspace_name}
                     </TableCell>
                     <TableCell>
-                      <Badge variant="outline">{ctx.role}</Badge>
+                      <Badge variant="outline">{getLocalizedRole(ctx.role)}</Badge>
                     </TableCell>
                     <TableCell className="text-sm text-gray-500">
                       {ctx.last_used_at

--- a/frontend/src/app/(authenticated)/admin/users/[userId]/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/users/[userId]/page.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
+import { useTranslations, useLocale } from "next-intl";
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
 import { LoadingState, InlineSpinner } from "@/components/common/LoadingState";
@@ -59,8 +60,9 @@ import {
   updateWorkspaceSlotBonus,
   type WorkspaceSummary,
 } from "@/lib/api/admin";
-import { formatDistanceToNow } from "date-fns";
+import { formatRelativeTime } from "@/lib/utils/datetime";
 import { useToast } from "@/hooks/use-toast";
+import { USER_DETAIL_TEST_IDS } from "./testids";
 
 interface UserDetail {
   user: {
@@ -101,6 +103,9 @@ interface UserDetail {
 export default function UserDetailPage() {
   const params = useParams();
   const router = useRouter();
+  const t = useTranslations("admin.users.detail");
+  const tCommon = useTranslations("admin.common");
+  const locale = useLocale();
   const userId = params.userId as string;
   const [userDetail, setUserDetail] = useState<UserDetail | null>(null);
   const [loading, setLoading] = useState(true);
@@ -150,7 +155,7 @@ export default function UserDetailPage() {
       // error-surface rule). No toast for the same event — one channel per
       // error class.
       const message =
-        error instanceof Error ? error.message : "Failed to load user details";
+        error instanceof Error ? error.message : t("messages.loadError");
       setLoadError(message);
     } finally {
       setLoading(false);
@@ -180,8 +185,11 @@ export default function UserDetailPage() {
       );
 
       toast({
-        title: "Success",
-        description: `Plan changed to ${newPlan} for ${planDialog.workspaceName}`,
+        title: tCommon("success"),
+        description: t("messages.planChangeSuccessDesc", {
+          plan: newPlan,
+          workspace: planDialog.workspaceName ?? "",
+        }),
       });
 
       setPlanDialog({
@@ -193,9 +201,11 @@ export default function UserDetailPage() {
       loadUserDetail();
     } catch (error: unknown) {
       const message =
-        error instanceof Error ? error.message : "Failed to change plan";
+        error instanceof Error
+          ? error.message
+          : t("messages.planChangeErrorDesc");
       toast({
-        title: "Error",
+        title: tCommon("error"),
         description: message,
         variant: "destructive",
       });
@@ -258,8 +268,11 @@ export default function UserDetailPage() {
           : prev,
       );
       toast({
-        title: "Updated",
-        description: `Slot bonus: ${response.before_value} → ${response.after_value}.`,
+        title: t("messages.bonusUpdateSuccessTitle"),
+        description: t("messages.bonusUpdateSuccessDesc", {
+          before: response.before_value,
+          after: response.after_value,
+        }),
       });
     } catch (error: unknown) {
       // Refetch authoritative state on PATCH failure. A naive
@@ -272,9 +285,11 @@ export default function UserDetailPage() {
       // post-failure state always reflects truth. Extra round-trip on
       // the rare failure path is acceptable for admin-only endpoint.
       const message =
-        error instanceof Error ? error.message : "Failed to update slot bonus";
+        error instanceof Error
+          ? error.message
+          : t("messages.bonusUpdateErrorDesc");
       toast({
-        title: "Error",
+        title: tCommon("error"),
         description: message,
         variant: "destructive",
       });
@@ -296,8 +311,8 @@ export default function UserDetailPage() {
 
     if (projectedBonus < 0) {
       toast({
-        title: "Cannot decrement",
-        description: "Slot bonus is already at 0.",
+        title: t("messages.bonusAt0Title"),
+        description: t("messages.bonusAt0Desc"),
         variant: "destructive",
       });
       return;
@@ -310,12 +325,12 @@ export default function UserDetailPage() {
         open: true,
         delta,
         reason: "",
-        warnText:
-          `User currently owns ${summary.owned_count} workspaces. ` +
-          `Setting bonus to ${projectedBonus} caps them at ${projectedCap}. ` +
-          `They cannot create new workspaces until ${shortfall} existing ` +
-          `workspace${shortfall === 1 ? " is" : "s are"} deleted. ` +
-          `Existing workspaces are NOT removed.`,
+        warnText: t("messages.overCapWarn", {
+          owned: summary.owned_count,
+          projected: projectedBonus,
+          cap: projectedCap,
+          shortfall,
+        }),
         submitting: false,
       });
       return;
@@ -345,15 +360,15 @@ export default function UserDetailPage() {
     return (
       <PageContainer>
         <PageHeader
-          title="User Detail"
-          description="Failed to load user information"
+          title={t("title")}
+          description={t("descriptionError")}
           actions={
             <Button
               variant="outline"
               onClick={() => router.push("/admin/users")}
             >
               <ArrowLeft className="h-4 w-4 mr-2" />
-              Back to Users
+              {t("backToUsers")}
             </Button>
           }
         />
@@ -366,8 +381,8 @@ export default function UserDetailPage() {
     return (
       <PageContainer>
         <PageHeader
-          title="User Details"
-          description="Loading user information..."
+          title={t("titleLoading")}
+          description={t("descriptionLoading")}
         />
         <LoadingState lines={5} />
       </PageContainer>
@@ -377,12 +392,12 @@ export default function UserDetailPage() {
   return (
     <PageContainer>
       <PageHeader
-        title="User Detail"
+        title={t("title")}
         description={`${userDetail.user.name} (${userDetail.user.email})`}
         actions={
           <Button variant="outline" onClick={() => router.push("/admin/users")}>
             <ArrowLeft className="h-4 w-4 mr-2" />
-            Back to Users
+            {t("backToUsers")}
           </Button>
         }
       />
@@ -390,7 +405,7 @@ export default function UserDetailPage() {
       {/* User Info Card */}
       <Card>
         <CardHeader>
-          <CardTitle>User Information</CardTitle>
+          <CardTitle>{t("userInfo.title")}</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="flex items-center gap-4 mb-6">
@@ -424,7 +439,7 @@ export default function UserDetailPage() {
                     variant="secondary"
                     className="bg-amber-100 text-amber-800"
                   >
-                    Initial Admin
+                    {t("userInfo.initialAdminBadge")}
                   </Badge>
                 )}
               </div>
@@ -433,22 +448,17 @@ export default function UserDetailPage() {
 
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
-              <p className="text-gray-500">Created</p>
+              <p className="text-gray-500">{t("userInfo.created")}</p>
               <p className="font-medium">
-                {formatDistanceToNow(new Date(userDetail.user.created_at), {
-                  addSuffix: true,
-                })}
+                {formatRelativeTime(userDetail.user.created_at, locale)}
               </p>
             </div>
             <div>
-              <p className="text-gray-500">Last Login</p>
+              <p className="text-gray-500">{t("userInfo.lastLogin")}</p>
               <p className="font-medium">
                 {userDetail.user.last_login_at
-                  ? formatDistanceToNow(
-                      new Date(userDetail.user.last_login_at),
-                      { addSuffix: true },
-                    )
-                  : "Never"}
+                  ? formatRelativeTime(userDetail.user.last_login_at, locale)
+                  : t("userInfo.never")}
               </p>
             </div>
           </div>
@@ -460,7 +470,11 @@ export default function UserDetailPage() {
         <CardHeader>
           <div className="flex items-center gap-2">
             <Building2 className="h-5 w-5" />
-            <CardTitle>Workspaces ({userDetail.workspaces.length})</CardTitle>
+            <CardTitle>
+              {t("workspaces.title", {
+                count: userDetail.workspaces.length,
+              })}
+            </CardTitle>
           </div>
         </CardHeader>
         <CardContent>
@@ -468,11 +482,13 @@ export default function UserDetailPage() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Workspace</TableHead>
-                  <TableHead>Role</TableHead>
-                  <TableHead>Plan</TableHead>
-                  <TableHead>Joined</TableHead>
-                  <TableHead className="text-right">Actions</TableHead>
+                  <TableHead>{t("workspaces.table.workspace")}</TableHead>
+                  <TableHead>{t("workspaces.table.role")}</TableHead>
+                  <TableHead>{t("workspaces.table.plan")}</TableHead>
+                  <TableHead>{t("workspaces.table.joined")}</TableHead>
+                  <TableHead className="text-right">
+                    {t("workspaces.table.actions")}
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -488,7 +504,7 @@ export default function UserDetailPage() {
                         </span>
                         {workspace.is_primary && (
                           <Badge variant="outline" className="text-xs">
-                            Primary
+                            {t("workspaces.primaryBadge")}
                           </Badge>
                         )}
                       </div>
@@ -511,10 +527,8 @@ export default function UserDetailPage() {
                     </TableCell>
                     <TableCell className="text-sm text-gray-500">
                       {workspace.joined_at
-                        ? formatDistanceToNow(new Date(workspace.joined_at), {
-                            addSuffix: true,
-                          })
-                        : "N/A"}
+                        ? formatRelativeTime(workspace.joined_at, locale)
+                        : t("workspaces.notAvailable")}
                     </TableCell>
                     <TableCell className="text-right">
                       <Button
@@ -523,7 +537,7 @@ export default function UserDetailPage() {
                         onClick={() => openPlanDialog(workspace)}
                       >
                         <CreditCard className="h-4 w-4 mr-2" />
-                        Change Plan
+                        {t("workspaces.changePlanButton")}
                       </Button>
                     </TableCell>
                   </TableRow>
@@ -531,18 +545,18 @@ export default function UserDetailPage() {
               </TableBody>
             </Table>
           ) : (
-            <p className="text-gray-500 text-sm">No workspaces</p>
+            <p className="text-gray-500 text-sm">{t("workspaces.empty")}</p>
           )}
         </CardContent>
       </Card>
 
       {/* Workspace Capacity Card (#676) */}
       {userDetail.workspace_summary && (
-        <Card>
+        <Card data-testid={USER_DETAIL_TEST_IDS.workspaceCapacitySection}>
           <CardHeader>
             <div className="flex items-center gap-2">
               <Layers className="h-5 w-5" />
-              <CardTitle>Workspace Capacity</CardTitle>
+              <CardTitle>{t("workspaceCapacity.title")}</CardTitle>
             </div>
           </CardHeader>
           <CardContent>
@@ -560,27 +574,45 @@ export default function UserDetailPage() {
               return (
                 <div className="space-y-4">
                   <div className="flex items-baseline gap-3">
-                    <p className="text-sm">
+                    <p
+                      className="text-sm"
+                      data-testid={
+                        USER_DETAIL_TEST_IDS.workspaceCapacityCapDisplay
+                      }
+                    >
                       <span className="font-medium">
-                        Owned: {summary.owned_count}
+                        {t("workspaceCapacity.ownedLabel", {
+                          count: summary.owned_count,
+                        })}
                       </span>{" "}
-                      / Cap: {summary.cap}
+                      / {t("workspaceCapacity.capLabel", { cap: summary.cap })}
                       <span className="text-gray-500 ml-2">
-                        ({summary.base_cap} base +{" "}
-                        {summary.workspace_slot_bonus} bonus)
+                        {t("workspaceCapacity.formula", {
+                          base: summary.base_cap,
+                          bonus: summary.workspace_slot_bonus,
+                        })}
                       </span>
                     </p>
                     <Badge variant={badgeVariant}>
-                      {summary.is_at_cap ? "at cap" : `${usagePct}% used`}
+                      {summary.is_at_cap
+                        ? t("workspaceCapacity.atCapBadge")
+                        : t("workspaceCapacity.usagePctBadge", {
+                            pct: usagePct,
+                          })}
                     </Badge>
                   </div>
 
                   <div className="flex items-center gap-3">
-                    <span className="text-sm text-gray-500">Slot bonus:</span>
+                    <span className="text-sm text-gray-500">
+                      {t("workspaceCapacity.slotBonusLabel")}
+                    </span>
                     <Button
                       variant="outline"
                       size="sm"
-                      aria-label="Decrement slot bonus"
+                      aria-label={t("workspaceCapacity.decrementAria")}
+                      data-testid={
+                        USER_DETAIL_TEST_IDS.workspaceCapacityDecrement
+                      }
                       onClick={() => handleBonusDelta(-1)}
                       disabled={
                         bonusPending !== null ||
@@ -593,13 +625,21 @@ export default function UserDetailPage() {
                         <Minus className="h-4 w-4" />
                       )}
                     </Button>
-                    <span className="font-mono font-medium text-lg min-w-[2ch] text-center">
+                    <span
+                      className="font-mono font-medium text-lg min-w-[2ch] text-center"
+                      data-testid={
+                        USER_DETAIL_TEST_IDS.workspaceCapacityBonusValue
+                      }
+                    >
                       {summary.workspace_slot_bonus}
                     </span>
                     <Button
                       variant="outline"
                       size="sm"
-                      aria-label="Increment slot bonus"
+                      aria-label={t("workspaceCapacity.incrementAria")}
+                      data-testid={
+                        USER_DETAIL_TEST_IDS.workspaceCapacityIncrement
+                      }
                       onClick={() => handleBonusDelta(1)}
                       disabled={bonusPending !== null}
                     >
@@ -614,7 +654,9 @@ export default function UserDetailPage() {
                   {summary.owned_workspaces.length > 0 ? (
                     <div>
                       <p className="text-xs text-gray-500 mb-2">
-                        Owned workspaces ({summary.owned_workspaces.length})
+                        {t("workspaceCapacity.ownedWorkspacesLabel", {
+                          count: summary.owned_workspaces.length,
+                        })}
                       </p>
                       <ul className="space-y-1">
                         {summary.owned_workspaces.map((ws) => (
@@ -641,7 +683,7 @@ export default function UserDetailPage() {
                     </div>
                   ) : (
                     <p className="text-xs text-gray-500">
-                      User owns no workspaces.
+                      {t("workspaceCapacity.noOwnedWorkspaces")}
                     </p>
                   )}
                 </div>
@@ -657,7 +699,9 @@ export default function UserDetailPage() {
           <div className="flex items-center gap-2">
             <FolderOpen className="h-5 w-5" />
             <CardTitle>
-              Accessible Contexts ({userDetail.accessible_contexts.length})
+              {t("accessibleContexts.title", {
+                count: userDetail.accessible_contexts.length,
+              })}
             </CardTitle>
           </div>
         </CardHeader>
@@ -666,10 +710,14 @@ export default function UserDetailPage() {
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead>Context</TableHead>
-                  <TableHead>Workspace</TableHead>
-                  <TableHead>Role</TableHead>
-                  <TableHead>Last Used</TableHead>
+                  <TableHead>{t("accessibleContexts.table.context")}</TableHead>
+                  <TableHead>
+                    {t("accessibleContexts.table.workspace")}
+                  </TableHead>
+                  <TableHead>{t("accessibleContexts.table.role")}</TableHead>
+                  <TableHead>
+                    {t("accessibleContexts.table.lastUsed")}
+                  </TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -686,17 +734,17 @@ export default function UserDetailPage() {
                     </TableCell>
                     <TableCell className="text-sm text-gray-500">
                       {ctx.last_used_at
-                        ? formatDistanceToNow(new Date(ctx.last_used_at), {
-                            addSuffix: true,
-                          })
-                        : "Never"}
+                        ? formatRelativeTime(ctx.last_used_at, locale)
+                        : t("userInfo.never")}
                     </TableCell>
                   </TableRow>
                 ))}
               </TableBody>
             </Table>
           ) : (
-            <p className="text-gray-500 text-sm">No accessible contexts</p>
+            <p className="text-gray-500 text-sm">
+              {t("accessibleContexts.empty")}
+            </p>
           )}
         </CardContent>
       </Card>
@@ -706,23 +754,29 @@ export default function UserDetailPage() {
         <CardHeader>
           <div className="flex items-center gap-2">
             <BarChart2 className="h-5 w-5" />
-            <CardTitle>Usage Statistics</CardTitle>
+            <CardTitle>{t("stats.title")}</CardTitle>
           </div>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-2 gap-6">
             <div>
-              <p className="text-sm text-gray-500">Total Memories</p>
+              <p className="text-sm text-gray-500">
+                {t("stats.totalMemories")}
+              </p>
               <p className="text-3xl font-bold">
                 {userDetail.stats.total_memories}
               </p>
               <p className="text-xs text-gray-500 mt-1">
-                Working: {userDetail.stats.working_memories} | Persistent:{" "}
-                {userDetail.stats.persistent_memories}
+                {t("stats.memoryBreakdown", {
+                  working: userDetail.stats.working_memories,
+                  persistent: userDetail.stats.persistent_memories,
+                })}
               </p>
             </div>
             <div>
-              <p className="text-sm text-gray-500">Active API Keys</p>
+              <p className="text-sm text-gray-500">
+                {t("stats.activeApiKeys")}
+              </p>
               <p className="text-3xl font-bold">
                 {userDetail.stats.active_api_keys}
               </p>
@@ -738,15 +792,19 @@ export default function UserDetailPage() {
       >
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>Change Workspace Plan</DialogTitle>
+            <DialogTitle>{t("changePlanDialog.title")}</DialogTitle>
             <DialogDescription>
-              Change plan tier for <strong>{planDialog.workspaceName}</strong>
+              {t("changePlanDialog.description", {
+                workspaceName: planDialog.workspaceName ?? "",
+              })}
             </DialogDescription>
           </DialogHeader>
 
           <div className="space-y-4 py-4">
             <div>
-              <label className="text-sm font-medium">Current Plan</label>
+              <label className="text-sm font-medium">
+                {t("changePlanDialog.currentPlanLabel")}
+              </label>
               <div className="mt-2">
                 <Badge
                   variant={
@@ -759,23 +817,30 @@ export default function UserDetailPage() {
             </div>
 
             <div>
-              <label className="text-sm font-medium">New Plan</label>
+              <label className="text-sm font-medium">
+                {t("changePlanDialog.newPlanLabel")}
+              </label>
               <Select value={newPlan} onValueChange={setNewPlan}>
                 <SelectTrigger className="mt-2">
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="free">Free</SelectItem>
-                  <SelectItem value="basic">Basic</SelectItem>
-                  <SelectItem value="pro">Pro</SelectItem>
+                  <SelectItem value="free">
+                    {t("changePlanDialog.planOptions.free")}
+                  </SelectItem>
+                  <SelectItem value="basic">
+                    {t("changePlanDialog.planOptions.basic")}
+                  </SelectItem>
+                  <SelectItem value="pro">
+                    {t("changePlanDialog.planOptions.pro")}
+                  </SelectItem>
                 </SelectContent>
               </Select>
             </div>
 
             <div className="bg-yellow-50 border border-yellow-200 rounded p-3">
               <p className="text-sm text-yellow-800">
-                ⚠️ Plan changes take effect immediately and will update quota
-                limits.
+                {t("changePlanDialog.warningText")}
               </p>
             </div>
           </div>
@@ -792,13 +857,13 @@ export default function UserDetailPage() {
                 })
               }
             >
-              Cancel
+              {tCommon("cancel")}
             </Button>
             <Button
               onClick={handleChangePlan}
               disabled={newPlan === planDialog.currentPlan}
             >
-              Change Plan
+              {t("changePlanDialog.confirm")}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -812,12 +877,11 @@ export default function UserDetailPage() {
           setDestructiveModal({ ...destructiveModal, open })
         }
       >
-        <DialogContent>
+        <DialogContent data-testid={USER_DETAIL_TEST_IDS.reasonModal}>
           <DialogHeader>
-            <DialogTitle>Reason required</DialogTitle>
+            <DialogTitle>{t("reasonModal.title")}</DialogTitle>
             <DialogDescription>
-              This change reduces the cap below the user&apos;s current owned
-              count.
+              {t("reasonModal.description")}
             </DialogDescription>
           </DialogHeader>
 
@@ -832,10 +896,11 @@ export default function UserDetailPage() {
 
             <div>
               <label htmlFor="bonus-reason" className="text-sm font-medium">
-                Reason (required)
+                {t("reasonModal.reasonLabel")}
               </label>
               <Textarea
                 id="bonus-reason"
+                data-testid={USER_DETAIL_TEST_IDS.reasonModalInput}
                 value={destructiveModal.reason}
                 onChange={(e) =>
                   setDestructiveModal({
@@ -843,14 +908,16 @@ export default function UserDetailPage() {
                     reason: e.target.value,
                   })
                 }
-                placeholder="Why is this admin operation needed?"
+                placeholder={t("reasonModal.reasonPlaceholder")}
                 rows={3}
                 maxLength={500}
                 disabled={destructiveModal.submitting}
                 className="mt-2"
               />
               <p className="text-xs text-gray-500 mt-1">
-                {destructiveModal.reason.length}/500
+                {t("reasonModal.charCounter", {
+                  count: destructiveModal.reason.length,
+                })}
               </p>
             </div>
           </div>
@@ -869,18 +936,19 @@ export default function UserDetailPage() {
               }
               disabled={destructiveModal.submitting}
             >
-              Cancel
+              {tCommon("cancel")}
             </Button>
             <Button
               variant="destructive"
+              data-testid={USER_DETAIL_TEST_IDS.reasonModalConfirm}
               onClick={submitDestructive}
               disabled={
                 !destructiveModal.reason.trim() || destructiveModal.submitting
               }
             >
               {destructiveModal.submitting
-                ? "Confirming…"
-                : "Confirm decrement"}
+                ? t("reasonModal.confirming")
+                : t("reasonModal.confirmButton")}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/app/(authenticated)/admin/users/[userId]/testids.ts
+++ b/frontend/src/app/(authenticated)/admin/users/[userId]/testids.ts
@@ -1,0 +1,21 @@
+/**
+ * Stable data-testid values for /admin/users/[userId].
+ *
+ * Shared contract between:
+ * - the page itself (page.tsx)
+ * - Vitest unit tests (page.test.tsx)
+ * - Playwright E2E (frontend/e2e/admin-user-detail.spec.ts, #688)
+ *
+ * Centralizing here removes the rename foot-gun: TypeScript catches drift
+ * across all three consumers instead of relying on a comment to coordinate.
+ */
+export const USER_DETAIL_TEST_IDS = {
+  workspaceCapacitySection: "workspace-capacity-section",
+  workspaceCapacityCapDisplay: "workspace-capacity-cap-display",
+  workspaceCapacityBonusValue: "workspace-capacity-bonus-value",
+  workspaceCapacityIncrement: "workspace-capacity-increment",
+  workspaceCapacityDecrement: "workspace-capacity-decrement",
+  reasonModal: "reason-modal",
+  reasonModalInput: "reason-modal-input",
+  reasonModalConfirm: "reason-modal-confirm",
+} as const;

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2343,6 +2343,15 @@
           "bonusAt0Title": "Cannot decrement",
           "bonusAt0Desc": "Slot bonus is already at 0.",
           "overCapWarn": "User currently owns {owned} workspaces. Setting bonus to {projected} caps them at {cap}. They cannot create new workspaces until {shortfall, plural, one {# existing workspace is} other {# existing workspaces are}} deleted. Existing workspaces are NOT removed."
+        },
+        "roles": {
+          "admin": "Admin",
+          "user": "User",
+          "read_only": "Read-only",
+          "owner": "Owner",
+          "member": "Member",
+          "viewer": "Viewer",
+          "editor": "Editor"
         }
       }
     },

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2254,6 +2254,96 @@
         "deleteConfirm": "Delete user {name}? This will permanently delete all their memories.",
         "deleteSuccess": "User {name} deleted successfully",
         "deleteError": "Failed to delete user"
+      },
+      "detail": {
+        "title": "User Detail",
+        "titleLoading": "User Details",
+        "descriptionError": "Failed to load user information",
+        "descriptionLoading": "Loading user information...",
+        "backToUsers": "Back to Users",
+        "userInfo": {
+          "title": "User Information",
+          "initialAdminBadge": "Initial Admin",
+          "created": "Created",
+          "lastLogin": "Last Login",
+          "never": "Never"
+        },
+        "workspaces": {
+          "title": "Workspaces ({count})",
+          "table": {
+            "workspace": "Workspace",
+            "role": "Role",
+            "plan": "Plan",
+            "joined": "Joined",
+            "actions": "Actions"
+          },
+          "primaryBadge": "Primary",
+          "notAvailable": "N/A",
+          "changePlanButton": "Change Plan",
+          "empty": "No workspaces"
+        },
+        "workspaceCapacity": {
+          "title": "Workspace Capacity",
+          "ownedLabel": "Owned: {count}",
+          "capLabel": "Cap: {cap}",
+          "formula": "({base} base + {bonus} bonus)",
+          "atCapBadge": "at cap",
+          "usagePctBadge": "{pct}% used",
+          "slotBonusLabel": "Slot bonus:",
+          "decrementAria": "Decrement slot bonus",
+          "incrementAria": "Increment slot bonus",
+          "ownedWorkspacesLabel": "Owned workspaces ({count})",
+          "noOwnedWorkspaces": "User owns no workspaces."
+        },
+        "accessibleContexts": {
+          "title": "Accessible Contexts ({count})",
+          "table": {
+            "context": "Context",
+            "workspace": "Workspace",
+            "role": "Role",
+            "lastUsed": "Last Used"
+          },
+          "empty": "No accessible contexts"
+        },
+        "stats": {
+          "title": "Usage Statistics",
+          "totalMemories": "Total Memories",
+          "memoryBreakdown": "Working: {working} | Persistent: {persistent}",
+          "activeApiKeys": "Active API Keys"
+        },
+        "changePlanDialog": {
+          "title": "Change Workspace Plan",
+          "description": "Change plan tier for {workspaceName}",
+          "currentPlanLabel": "Current Plan",
+          "newPlanLabel": "New Plan",
+          "planOptions": {
+            "free": "Free",
+            "basic": "Basic",
+            "pro": "Pro"
+          },
+          "warningText": "⚠️ Plan changes take effect immediately and will update quota limits.",
+          "confirm": "Change Plan"
+        },
+        "reasonModal": {
+          "title": "Reason required",
+          "description": "This change reduces the cap below the user's current owned count.",
+          "reasonLabel": "Reason (required)",
+          "reasonPlaceholder": "Why is this admin operation needed?",
+          "charCounter": "{count}/500",
+          "confirming": "Confirming…",
+          "confirmButton": "Confirm decrement"
+        },
+        "messages": {
+          "loadError": "Failed to load user details",
+          "planChangeSuccessDesc": "Plan changed to {plan} for {workspace}",
+          "planChangeErrorDesc": "Failed to change plan",
+          "bonusUpdateSuccessTitle": "Updated",
+          "bonusUpdateSuccessDesc": "Slot bonus: {before} → {after}.",
+          "bonusUpdateErrorDesc": "Failed to update slot bonus",
+          "bonusAt0Title": "Cannot decrement",
+          "bonusAt0Desc": "Slot bonus is already at 0.",
+          "overCapWarn": "User currently owns {owned} workspaces. Setting bonus to {projected} caps them at {cap}. They cannot create new workspaces until {shortfall, plural, one {# existing workspace is} other {# existing workspaces are}} deleted. Existing workspaces are NOT removed."
+        }
       }
     },
     "systemAdmins": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2254,6 +2254,96 @@
         "deleteConfirm": "ユーザー{name}を削除しますか？すべてのメモリーが完全に削除されます。",
         "deleteSuccess": "ユーザー{name}を正常に削除しました",
         "deleteError": "ユーザーの削除に失敗しました"
+      },
+      "detail": {
+        "title": "ユーザー詳細",
+        "titleLoading": "ユーザー詳細",
+        "descriptionError": "ユーザー情報の読み込みに失敗しました",
+        "descriptionLoading": "ユーザー情報を読み込み中...",
+        "backToUsers": "ユーザー一覧へ戻る",
+        "userInfo": {
+          "title": "ユーザー情報",
+          "initialAdminBadge": "初期管理者",
+          "created": "作成日",
+          "lastLogin": "最終ログイン",
+          "never": "未ログイン"
+        },
+        "workspaces": {
+          "title": "ワークスペース ({count})",
+          "table": {
+            "workspace": "ワークスペース",
+            "role": "ロール",
+            "plan": "プラン",
+            "joined": "参加日",
+            "actions": "操作"
+          },
+          "primaryBadge": "プライマリ",
+          "notAvailable": "N/A",
+          "changePlanButton": "プラン変更",
+          "empty": "ワークスペースなし"
+        },
+        "workspaceCapacity": {
+          "title": "ワークスペース上限",
+          "ownedLabel": "保有: {count}",
+          "capLabel": "上限: {cap}",
+          "formula": "({base} 基本 + {bonus} ボーナス)",
+          "atCapBadge": "上限到達",
+          "usagePctBadge": "{pct}% 使用",
+          "slotBonusLabel": "スロットボーナス:",
+          "decrementAria": "スロットボーナスを減らす",
+          "incrementAria": "スロットボーナスを増やす",
+          "ownedWorkspacesLabel": "保有ワークスペース ({count})",
+          "noOwnedWorkspaces": "保有ワークスペースなし"
+        },
+        "accessibleContexts": {
+          "title": "アクセス可能コンテキスト ({count})",
+          "table": {
+            "context": "コンテキスト",
+            "workspace": "ワークスペース",
+            "role": "ロール",
+            "lastUsed": "最終使用"
+          },
+          "empty": "アクセス可能コンテキストなし"
+        },
+        "stats": {
+          "title": "使用状況",
+          "totalMemories": "メモリ合計",
+          "memoryBreakdown": "Working: {working} | Persistent: {persistent}",
+          "activeApiKeys": "有効な API キー"
+        },
+        "changePlanDialog": {
+          "title": "ワークスペースプラン変更",
+          "description": "{workspaceName} のプラン階層を変更",
+          "currentPlanLabel": "現在のプラン",
+          "newPlanLabel": "新しいプラン",
+          "planOptions": {
+            "free": "Free",
+            "basic": "Basic",
+            "pro": "Pro"
+          },
+          "warningText": "⚠️ プラン変更は即時反映され、クォータ上限が更新されます。",
+          "confirm": "プラン変更"
+        },
+        "reasonModal": {
+          "title": "理由を入力してください",
+          "description": "この変更はユーザーの現在の保有数より下に上限を下げます。",
+          "reasonLabel": "理由 (必須)",
+          "reasonPlaceholder": "この管理者操作が必要な理由は?",
+          "charCounter": "{count}/500",
+          "confirming": "確認中…",
+          "confirmButton": "減算を確認"
+        },
+        "messages": {
+          "loadError": "ユーザー詳細の読み込みに失敗しました",
+          "planChangeSuccessDesc": "{workspace} のプランを {plan} に変更しました",
+          "planChangeErrorDesc": "プラン変更に失敗しました",
+          "bonusUpdateSuccessTitle": "更新しました",
+          "bonusUpdateSuccessDesc": "スロットボーナス: {before} → {after}",
+          "bonusUpdateErrorDesc": "スロットボーナスの更新に失敗しました",
+          "bonusAt0Title": "減算できません",
+          "bonusAt0Desc": "スロットボーナスは既に 0 です",
+          "overCapWarn": "ユーザーは現在 {owned} 件のワークスペースを保有しています。ボーナスを {projected} にすると上限は {cap} になります。{shortfall, plural, other {既存ワークスペースを # 件削除}}するまで新規作成はできません。既存ワークスペースは削除されません。"
+        }
       }
     },
     "systemAdmins": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2343,6 +2343,15 @@
           "bonusAt0Title": "減算できません",
           "bonusAt0Desc": "スロットボーナスは既に 0 です",
           "overCapWarn": "ユーザーは現在 {owned} 件のワークスペースを保有しています。ボーナスを {projected} にすると上限は {cap} になります。{shortfall, plural, other {既存ワークスペースを # 件削除}}するまで新規作成はできません。既存ワークスペースは削除されません。"
+        },
+        "roles": {
+          "admin": "管理者",
+          "user": "ユーザー",
+          "read_only": "閲覧専用",
+          "owner": "オーナー",
+          "member": "メンバー",
+          "viewer": "閲覧者",
+          "editor": "編集者"
         }
       }
     },


### PR DESCRIPTION
## Related Issue

## Summary

Localized remaining role badges on the admin user detail page so backend enum values are translated for user, workspace, and context role displays.

## Changes

- Added role-label mapping in `frontend/src/app/(authenticated)/admin/users/[userId]/page.tsx` and applied it to all role badges called out in review feedback.
- Added `admin.users.detail.roles` translation keys in `frontend/src/messages/en.json` and `frontend/src/messages/ja.json` for `admin`, `user`, `read_only`, `owner`, `member`, `viewer`, and `editor`.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests passing
- [ ] Manual testing completed
- [ ] All tests passing locally (`make test-local`)

## Quality Checklist

- [x] Code follows DRY/SOLID principles
- [ ] Type hints added (target: 85%+ coverage)
- [ ] No lint errors (`make lint`)
- [ ] No type errors (`make type-check`)
- [x] No code duplication
- [ ] Functions < 50 lines (Single Responsibility)
- [ ] Files < 500 lines
- [ ] Documentation updated (if needed)

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

---

To request AI review, comment `/review` on this PR.