### PR TITLE
feat(admin): spend cap edit dialog for /plans workspaces (#712)

### DIFF
--- a/frontend/src/app/(authenticated)/admin/plans/SpendCapEditDialog.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/SpendCapEditDialog.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Tests for SpendCapEditDialog (Issue #712, #709 follow-up).
+ *
+ * Focus is the null / 0 / positive input mapping that the CDO gate1 review
+ * flagged as the main footgun: empty -> null (clear override), explicit 0 ->
+ * lockout (warned but allowed), positive -> override. Plus the tier-ceiling
+ * 400 rejection surfacing as an in-dialog Alert (frontend.md error-surface).
+ */
+
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SpendCapEditDialog } from "./SpendCapEditDialog";
+import type { SpendCapValues } from "@/lib/api/admin";
+
+const mockUpdateWorkspaceSpendCap = vi.fn();
+
+vi.mock("@/lib/api/admin", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/lib/api/admin")>("@/lib/api/admin");
+  return {
+    ...actual,
+    updateWorkspaceSpendCap: (...args: unknown[]) =>
+      mockUpdateWorkspaceSpendCap(...args),
+  };
+});
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+// Mirror the next-intl mock used by page.test.tsx: a translator returns
+// "<namespace>.<key>" so assertions can target stable key strings.
+vi.mock("next-intl", () => ({
+  useTranslations: (namespace: string) => (key: string) =>
+    namespace ? `${namespace}.${key}` : key,
+  useLocale: () => "en",
+}));
+
+const withOverride: SpendCapValues = {
+  tier_default_daily_usd: 10,
+  tier_default_monthly_usd: 200,
+  override_daily_usd: 5,
+  override_monthly_usd: 100,
+  effective_daily_usd: 5,
+  effective_monthly_usd: 100,
+  current_daily_usd: 2,
+  current_monthly_usd: 40,
+};
+
+const noOverride: SpendCapValues = {
+  tier_default_daily_usd: 10,
+  tier_default_monthly_usd: 200,
+  override_daily_usd: null,
+  override_monthly_usd: null,
+  effective_daily_usd: 10,
+  effective_monthly_usd: 200,
+  current_daily_usd: 1,
+  current_monthly_usd: 20,
+};
+
+function renderDialog(spendCap: SpendCapValues) {
+  const onOpenChange = vi.fn();
+  const onSaved = vi.fn();
+  render(
+    <SpendCapEditDialog
+      open
+      onOpenChange={onOpenChange}
+      workspaceId="ws-1"
+      workspaceName="Acme"
+      spendCap={spendCap}
+      onSaved={onSaved}
+    />,
+  );
+  return { onOpenChange, onSaved };
+}
+
+const dailyInput = () =>
+  document.getElementById("spend-cap-daily") as HTMLInputElement;
+const monthlyInput = () =>
+  document.getElementById("spend-cap-monthly") as HTMLInputElement;
+const clickSave = () =>
+  fireEvent.click(screen.getByText("admin.plans.spendCapDialog.save"));
+
+beforeEach(() => {
+  mockUpdateWorkspaceSpendCap.mockReset();
+  mockUpdateWorkspaceSpendCap.mockResolvedValue({ message: "ok" });
+});
+
+describe("SpendCapEditDialog", () => {
+  it("prefills both inputs from the override values when an override is set", () => {
+    renderDialog(withOverride);
+    expect(dailyInput().value).toBe("5");
+    expect(monthlyInput().value).toBe("100");
+  });
+
+  it("renders empty inputs (inherit tier default) when no override is set", () => {
+    renderDialog(noOverride);
+    expect(dailyInput().value).toBe("");
+    expect(monthlyInput().value).toBe("");
+    // tier default is surfaced as the placeholder so empty reads as "inherit".
+    expect(dailyInput().placeholder).toBe("$10.00");
+    expect(monthlyInput().placeholder).toBe("$200.00");
+  });
+
+  it("submits positive values as the override payload", async () => {
+    renderDialog(withOverride);
+    fireEvent.change(dailyInput(), { target: { value: "7" } });
+    clickSave();
+
+    await waitFor(() =>
+      expect(mockUpdateWorkspaceSpendCap).toHaveBeenCalledTimes(1),
+    );
+    const [workspaceId, body] = mockUpdateWorkspaceSpendCap.mock.calls[0];
+    expect(workspaceId).toBe("ws-1");
+    expect(body).toEqual({
+      embedding_daily_cap_usd: 7,
+      embedding_monthly_cap_usd: 100,
+    });
+  });
+
+  it("submits null for emptied inputs (clears the override)", async () => {
+    const { onOpenChange, onSaved } = renderDialog(withOverride);
+    fireEvent.change(dailyInput(), { target: { value: "" } });
+    fireEvent.change(monthlyInput(), { target: { value: "" } });
+    clickSave();
+
+    await waitFor(() =>
+      expect(mockUpdateWorkspaceSpendCap).toHaveBeenCalledTimes(1),
+    );
+    expect(mockUpdateWorkspaceSpendCap.mock.calls[0][1]).toEqual({
+      embedding_daily_cap_usd: null,
+      embedding_monthly_cap_usd: null,
+    });
+    await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("warns on a 0 (lockout) value but still allows saving it", async () => {
+    renderDialog(withOverride);
+    fireEvent.change(dailyInput(), { target: { value: "0" } });
+
+    expect(
+      screen.getByText("admin.plans.spendCapDialog.lockoutWarning.title"),
+    ).toBeInTheDocument();
+
+    clickSave();
+    await waitFor(() =>
+      expect(mockUpdateWorkspaceSpendCap).toHaveBeenCalledTimes(1),
+    );
+    expect(mockUpdateWorkspaceSpendCap.mock.calls[0][1]).toEqual({
+      embedding_daily_cap_usd: 0,
+      embedding_monthly_cap_usd: 100,
+    });
+  });
+
+  it("blocks save with an inline field error for a negative value", () => {
+    renderDialog(withOverride);
+    fireEvent.change(dailyInput(), { target: { value: "-5" } });
+
+    expect(
+      screen.getByText("admin.plans.spendCapDialog.negativeNotAllowed"),
+    ).toBeInTheDocument();
+    const saveButton = screen
+      .getByText("admin.plans.spendCapDialog.save")
+      .closest("button");
+    expect(saveButton).toBeDisabled();
+
+    // A disabled button does not invoke onClick, so the API is never hit.
+    fireEvent.click(saveButton!);
+    expect(mockUpdateWorkspaceSpendCap).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a tier-ceiling 400 rejection as an in-dialog error and keeps the dialog open", async () => {
+    mockUpdateWorkspaceSpendCap.mockRejectedValueOnce(
+      new Error("daily cap exceeds tier default"),
+    );
+    const { onOpenChange, onSaved } = renderDialog(withOverride);
+    fireEvent.change(dailyInput(), { target: { value: "9999" } });
+    clickSave();
+
+    expect(
+      await screen.findByText("daily cap exceeds tier default"),
+    ).toBeInTheDocument();
+    // The dialog must not close and must not signal a successful save.
+    expect(onOpenChange).not.toHaveBeenCalledWith(false);
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/(authenticated)/admin/plans/SpendCapEditDialog.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/SpendCapEditDialog.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+/**
+ * Spend Cap Edit Dialog (Issue #712, #709 follow-up)
+ *
+ * Per-workspace BYOK embedding spend cap override editor. Clones the Edit
+ * Addons Dialog pattern (page.tsx) but extracted as a standalone component so
+ * the null/0/positive input mapping can be unit-tested in isolation.
+ *
+ * Input semantics (admin.ts:204-215):
+ * - empty  -> null payload  (clears the override, inherits the tier default)
+ * - 0      -> admin lockout (disables all embedding for the workspace)
+ * - >0     -> override (backend rejects values above the tier default, HTTP 400)
+ */
+
+import { useEffect, useMemo, useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { useToast } from "@/hooks/use-toast";
+import { updateWorkspaceSpendCap, type SpendCapValues } from "@/lib/api/admin";
+import { AlertTriangle, CheckCircle } from "lucide-react";
+
+interface SpendCapEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  workspaceId: string;
+  workspaceName: string;
+  spendCap: SpendCapValues;
+  onSaved: () => void;
+}
+
+/** Empty string maps to ``null`` (clear override); any other value to a number. */
+const parseInput = (value: string): number | null =>
+  value === "" ? null : Number(value);
+
+// Surface the localized warning once usage crosses this fraction of the
+// effective cap (mirrors the legacy QuotaWarning 80% threshold, but with
+// spend-appropriate, internationalized copy).
+const USAGE_WARNING_THRESHOLD = 80;
+
+export function SpendCapEditDialog({
+  open,
+  onOpenChange,
+  workspaceId,
+  workspaceName,
+  spendCap,
+  onSaved,
+}: SpendCapEditDialogProps) {
+  const t = useTranslations("admin.plans");
+  const tCommon = useTranslations("admin.common");
+  const locale = useLocale();
+  const { toast } = useToast();
+
+  const currencyFormatter = useMemo(
+    () => new Intl.NumberFormat(locale, { style: "currency", currency: "USD" }),
+    [locale],
+  );
+  const formatUsd = (value: number): string => currencyFormatter.format(value);
+
+  const [dailyInput, setDailyInput] = useState("");
+  const [monthlyInput, setMonthlyInput] = useState("");
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Prefill from the OVERRIDE values (not effective) each time the dialog
+  // opens, so "no override" renders as an empty input (placeholder shows the
+  // inherited tier default) and an explicit 0 renders as "0", not blank.
+  // Deps are the primitive override values (not the spendCap object) so a new
+  // object identity with identical values cannot clobber an in-progress edit.
+  useEffect(() => {
+    if (!open) return;
+    setDailyInput(
+      spendCap.override_daily_usd === null
+        ? ""
+        : String(spendCap.override_daily_usd),
+    );
+    setMonthlyInput(
+      spendCap.override_monthly_usd === null
+        ? ""
+        : String(spendCap.override_monthly_usd),
+    );
+    setSaveError(null);
+  }, [open, spendCap.override_daily_usd, spendCap.override_monthly_usd]);
+
+  const dailyValue = parseInput(dailyInput);
+  const monthlyValue = parseInput(monthlyInput);
+  // An explicit 0 is a valid-but-destructive lockout; warn loudly but still
+  // allow saving (issue #712 defines 0 as an intentional admin action).
+  const showLockoutWarning = dailyValue === 0 || monthlyValue === 0;
+
+  // Client-side validation: an empty field is valid (clears the override),
+  // but a non-numeric value (which JSON-serializes NaN to null and would
+  // silently clear the override) or a negative cap must be blocked before it
+  // reaches the backend. Surfaced as an inline field message (frontend.md).
+  const fieldError = (value: string): string | null => {
+    if (value === "") return null;
+    const n = Number(value);
+    if (!Number.isFinite(n)) return t("spendCapDialog.invalidNumber");
+    if (n < 0) return t("spendCapDialog.negativeNotAllowed");
+    return null;
+  };
+  const dailyError = fieldError(dailyInput);
+  const monthlyError = fieldError(monthlyInput);
+  const hasFieldError = dailyError !== null || monthlyError !== null;
+
+  const fields = [
+    {
+      key: "daily" as const,
+      label: t("spendCapDialog.dailyLabel"),
+      input: dailyInput,
+      setInput: setDailyInput,
+      tierDefault: spendCap.tier_default_daily_usd,
+      effective: spendCap.effective_daily_usd,
+      current: spendCap.current_daily_usd,
+      warningLabel: t("spendCapDialog.dailyWarningLabel"),
+      error: dailyError,
+    },
+    {
+      key: "monthly" as const,
+      label: t("spendCapDialog.monthlyLabel"),
+      input: monthlyInput,
+      setInput: setMonthlyInput,
+      tierDefault: spendCap.tier_default_monthly_usd,
+      effective: spendCap.effective_monthly_usd,
+      current: spendCap.current_monthly_usd,
+      warningLabel: t("spendCapDialog.monthlyWarningLabel"),
+      error: monthlyError,
+    },
+  ];
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await updateWorkspaceSpendCap(workspaceId, {
+        embedding_daily_cap_usd: dailyValue,
+        embedding_monthly_cap_usd: monthlyValue,
+      });
+      toast({
+        title: tCommon("success"),
+        description: t("messages.spendCapUpdateSuccess"),
+      });
+      onOpenChange(false);
+      onSaved();
+    } catch (err: unknown) {
+      // Tier-ceiling rejection (400) and any other save failure surface as an
+      // Alert inside the dialog — a toast behind the modal is easy to miss
+      // (frontend.md error-surface rule). The dialog stays open.
+      setSaveError(
+        err instanceof Error ? err.message : t("messages.spendCapUpdateError"),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{t("spendCapDialog.title")}</DialogTitle>
+          <DialogDescription>
+            {t("spendCapDialog.description")} <strong>{workspaceName}</strong>
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4 py-4">
+          <p className="text-xs text-muted-foreground">
+            {t("spendCapDialog.clearHint")}
+          </p>
+
+          {fields.map((field) => {
+            const limit = field.effective ?? 0;
+            const usagePct = limit > 0 ? (field.current / limit) * 100 : null;
+            return (
+              <div key={field.key} className="space-y-1">
+                <Label htmlFor={`spend-cap-${field.key}`}>{field.label}</Label>
+                <Input
+                  id={`spend-cap-${field.key}`}
+                  type="number"
+                  min={0}
+                  step={0.01}
+                  // Omit max when the tier has no ceiling (null) so the input
+                  // is unbounded; the backend still rejects values above the
+                  // tier default for tiers that have one.
+                  max={field.tierDefault ?? undefined}
+                  value={field.input}
+                  placeholder={
+                    field.tierDefault === null
+                      ? t("spendCapDialog.noLimit")
+                      : formatUsd(field.tierDefault)
+                  }
+                  onChange={(e) => field.setInput(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t("spendCapDialog.currentSpend")}: {formatUsd(field.current)}
+                  {field.tierDefault !== null && (
+                    <>
+                      {" · "}
+                      {t("spendCapDialog.tierDefaultHint", {
+                        value: formatUsd(field.tierDefault),
+                      })}
+                    </>
+                  )}
+                </p>
+                {field.error && (
+                  <p className="text-xs text-destructive">{field.error}</p>
+                )}
+                {usagePct !== null && usagePct >= USAGE_WARNING_THRESHOLD && (
+                  <Alert>
+                    <AlertTriangle className="h-4 w-4" />
+                    <AlertDescription>
+                      {t("spendCapDialog.usageWarning", {
+                        label: field.warningLabel,
+                        current: formatUsd(field.current),
+                        limit: formatUsd(limit),
+                        percentage: usagePct.toFixed(0),
+                      })}
+                    </AlertDescription>
+                  </Alert>
+                )}
+              </div>
+            );
+          })}
+
+          {showLockoutWarning && (
+            <Alert>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertTitle>
+                {t("spendCapDialog.lockoutWarning.title")}
+              </AlertTitle>
+              <AlertDescription>
+                {t("spendCapDialog.lockoutWarning.body")}
+              </AlertDescription>
+            </Alert>
+          )}
+
+          {saveError && (
+            <Alert variant="destructive">
+              <AlertTitle>{tCommon("error")}</AlertTitle>
+              <AlertDescription>{saveError}</AlertDescription>
+            </Alert>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {tCommon("cancel")}
+          </Button>
+          <Button onClick={handleSave} disabled={saving || hasFieldError}>
+            <CheckCircle className="h-4 w-4 mr-2" />
+            {t("spendCapDialog.save")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/app/(authenticated)/admin/plans/page.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.tsx
@@ -61,6 +61,7 @@ import {
   Settings,
   Info,
   Inbox,
+  DollarSign,
 } from "lucide-react";
 import {
   InlineSpinner,
@@ -102,6 +103,7 @@ import {
   type AddonKey,
   type AddonValuesByKey,
 } from "./_addon-types";
+import { SpendCapEditDialog } from "./SpendCapEditDialog";
 
 const PLAN_TABS = ["workspaces", "tiers", "audit"] as const;
 
@@ -231,6 +233,7 @@ export default function AdminPlansPage() {
   );
   const [quotaLoading, setQuotaLoading] = useState(false);
   const [addonDialogOpen, setAddonDialogOpen] = useState(false);
+  const [spendCapDialogOpen, setSpendCapDialogOpen] = useState(false);
   // Issue #663: 9 addon dimensions consolidated into a single record so
   // ``ADDON_TYPES`` can drive both the dialog inputs and the PUT body
   // construction without per-field useState plumbing.
@@ -634,7 +637,7 @@ export default function AdminPlansPage() {
                                           </div>
                                         );
                                       })}
-                                      <div className="pt-2 border-t">
+                                      <div className="pt-2 border-t flex gap-2">
                                         <Button
                                           size="sm"
                                           variant="outline"
@@ -646,6 +649,19 @@ export default function AdminPlansPage() {
                                           <Settings className="h-4 w-4 mr-1" />
                                           {t("workspacesTable.editAddons")}
                                         </Button>
+                                        {quotaDetail.spend_cap && (
+                                          <Button
+                                            size="sm"
+                                            variant="outline"
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              setSpendCapDialogOpen(true);
+                                            }}
+                                          >
+                                            <DollarSign className="h-4 w-4 mr-1" />
+                                            {t("workspacesTable.editSpendCap")}
+                                          </Button>
+                                        )}
                                       </div>
                                     </div>
                                   ) : null}
@@ -1012,6 +1028,32 @@ export default function AdminPlansPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Spend Cap Edit Dialog (Issue #712) */}
+      {quotaDetail?.spend_cap && (
+        <SpendCapEditDialog
+          open={spendCapDialogOpen}
+          onOpenChange={setSpendCapDialogOpen}
+          workspaceId={quotaDetail.workspace_id}
+          workspaceName={quotaDetail.workspace_name}
+          spendCap={quotaDetail.spend_cap}
+          onSaved={async () => {
+            // The save already succeeded; this is a best-effort refresh of the
+            // expanded panel. Catch so a failed refetch surfaces a toast
+            // instead of an unhandled rejection + silently stale cap values.
+            try {
+              const detail = await getWorkspaceQuotas(quotaDetail.workspace_id);
+              setQuotaDetail(detail);
+            } catch {
+              toast({
+                title: tCommon("error"),
+                description: t("messages.quotaRefreshError"),
+                variant: "destructive",
+              });
+            }
+          }}
+        />
+      )}
     </PageContainer>
   );
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -2092,6 +2092,7 @@
         "actions": "Actions",
         "changePlan": "Change Tier",
         "editAddons": "Edit Addons",
+        "editSpendCap": "Edit Spend Cap",
         "owner": "Owner: {name}"
       },
       "tiersTable": {
@@ -2184,6 +2185,26 @@
           "body": "The value for {keys} is not a valid multiple of its unit (or is negative) and would be rejected on save. Saving is disabled until you enter a valid amount."
         }
       },
+      "spendCapDialog": {
+        "title": "Edit Spend Cap",
+        "description": "Adjust the BYOK embedding spend cap for",
+        "dailyLabel": "Daily cap (USD)",
+        "monthlyLabel": "Monthly cap (USD)",
+        "dailyWarningLabel": "Daily spend",
+        "monthlyWarningLabel": "Monthly spend",
+        "currentSpend": "Current spend",
+        "tierDefaultHint": "tier default {value}",
+        "noLimit": "No limit",
+        "usageWarning": "{label}: {current} of {limit} used ({percentage}%)",
+        "invalidNumber": "Enter a valid number.",
+        "negativeNotAllowed": "Value cannot be negative.",
+        "clearHint": "Leave a field empty to clear the override and inherit the tier default. Enter 0 to disable embedding entirely.",
+        "lockoutWarning": {
+          "title": "0 disables all embedding",
+          "body": "A cap of 0 stops all BYOK embedding for this workspace until you raise it. Leave the field empty instead to inherit the tier default."
+        },
+        "save": "Save Spend Cap"
+      },
       "auditTable": {
         "title": "Change Audit Log",
         "description": "History of tier changes",
@@ -2206,7 +2227,10 @@
         "loadError": "Failed to load workspaces",
         "changeSuccess": "Tier changed from {oldPlan} to {newPlan}",
         "changeError": "Failed to change tier",
-        "addonUpdateSuccess": "Quota addons updated"
+        "addonUpdateSuccess": "Quota addons updated",
+        "spendCapUpdateSuccess": "Spend cap updated",
+        "spendCapUpdateError": "Failed to update spend cap",
+        "quotaRefreshError": "Failed to refresh quota details"
       }
     },
     "users": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -2092,6 +2092,7 @@
         "actions": "操作",
         "changePlan": "ティア変更",
         "editAddons": "アドオン編集",
+        "editSpendCap": "上限額を編集",
         "owner": "所有者: {name}"
       },
       "tiersTable": {
@@ -2184,6 +2185,26 @@
           "body": "{keys} の値が単位の倍数になっていない（または負の値）ため、保存時に拒否されます。有効な値を入力するまで保存は無効化されます。"
         }
       },
+      "spendCapDialog": {
+        "title": "上限額を編集",
+        "description": "BYOK embedding の上限額を調整：",
+        "dailyLabel": "日次上限 (USD)",
+        "monthlyLabel": "月次上限 (USD)",
+        "dailyWarningLabel": "日次使用額",
+        "monthlyWarningLabel": "月次使用額",
+        "currentSpend": "現在の使用額",
+        "tierDefaultHint": "ティア既定値 {value}",
+        "noLimit": "上限なし",
+        "usageWarning": "{label}：{limit} 中 {current} を使用（{percentage}%）",
+        "invalidNumber": "有効な数値を入力してください。",
+        "negativeNotAllowed": "負の値は指定できません。",
+        "clearHint": "空欄にすると override を解除してティア既定値を継承します。0 を入力すると embedding を完全に停止します。",
+        "lockoutWarning": {
+          "title": "0 は embedding を完全停止します",
+          "body": "上限を 0 にすると、引き上げるまでこのワークスペースの BYOK embedding がすべて停止します。ティア既定値を継承したい場合は空欄にしてください。"
+        },
+        "save": "上限額を保存"
+      },
       "auditTable": {
         "title": "変更監査ログ",
         "description": "ティア変更の履歴",
@@ -2206,7 +2227,10 @@
         "loadError": "ワークスペースの読み込みに失敗しました",
         "changeSuccess": "プランを{oldPlan}から{newPlan}に変更しました",
         "changeError": "ティアの変更に失敗しました",
-        "addonUpdateSuccess": "アドオンを更新しました"
+        "addonUpdateSuccess": "アドオンを更新しました",
+        "spendCapUpdateSuccess": "上限額を更新しました",
+        "spendCapUpdateError": "上限額の更新に失敗しました",
+        "quotaRefreshError": "クォータ詳細の再取得に失敗しました"
       }
     },
     "users": {


### PR DESCRIPTION
Closes #712

## Summary
- Add `SpendCapEditDialog` to the admin /plans quota panel for editing per-workspace BYOK embedding spend caps (daily / monthly USD).
- Input semantics: empty → `null` (clear override, inherit tier default), `0` → admin lockout (warned, allowed), `>0` → override. Tier-ceiling 400 rejection is shown as an in-dialog Alert.
- Client-side guard rejects NaN / negative before send; locale-aware currency formatting; localized 80% usage warning (en + ja).

## Implementation notes
- New standalone component `SpendCapEditDialog.tsx` (+ unit tests, 7 cases) wired into `page.tsx` via a trigger button in the quota-detail panel (shown only when `spend_cap` is present).
- Reuses the already-shipped `PUT /api/v1/admin/plans/workspaces/{id}/spend-cap` endpoint and `SpendCapValues` / `updateWorkspaceSpendCap` types from #709 / #711 — no backend change.
- `onSaved` refetch wrapped in try/catch (avoids unhandled rejection + stale UI); reset `useEffect` keyed off primitive override values, not the object, to avoid clobbering in-progress edits.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- (qa-lead, cto not run — fast-tracked to PR at operator request)
- gate1: yellow via /claude-c-suite:ask (CDO lens — 0=lockout guard, null/0 mapping, error-channel; all absorbed)
- review provider: copilot

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/712-feat-admin-plans-dialog-for-spend-cap-edit-ui.gate1.md
- ~/.claude/cache/gh-issue-driven/712-feat-admin-plans-dialog-for-spend-cap-edit-ui.gate2.md

🤖 Generated via /gh-issue-driven:ship
