### PR TITLE
refactor(api): cache pricing + dedup BYOK probe on recall (#713)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
 
     # Cache & Queue
     "redis>=5.2.0",
+    "cachetools>=5.3.0",  # Process-local TTL cache for llm_pricing hot path (#713)
 
     # HTTP Client
     "httpx>=0.27.0",

--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import json
 import os
 import unicodedata
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import xxhash
 from openai import AsyncOpenAI
@@ -37,6 +37,12 @@ if TYPE_CHECKING:
     from services.embedding_spend_cap_service import EmbeddingSpendCapService
 
 logger = get_logger(__name__)
+
+# The credential tier ``_get_user_api_key`` resolved a key from. ``"workspace"``
+# / ``"context"`` are BYOK rows in ``external_api_keys``; ``"env"`` is the
+# platform ``OPENAI_API_KEY`` fallback. Maps directly to ``LLMCallLog.paid_by``
+# (``"env"`` → ``"platform"``, otherwise → ``"byok"``) — see ``resolve_paid_by``.
+KeySource = Literal["workspace", "context", "env"]
 
 
 class EmbeddingService:
@@ -79,6 +85,12 @@ class EmbeddingService:
             self.provider = settings.embedding_provider
         self.ollama_base_url = settings.ollama_base_url
         self._ollama_verified = False
+        # Issue #713: the credential tier the most recent ``_get_client`` OpenAI
+        # call resolved (set in ``_get_client``). ``resolve_paid_by`` reads it to
+        # derive ``paid_by`` without re-probing ``external_api_keys`` — the
+        # service is request-scoped (one per recall, holding a per-request
+        # session) so this state is never shared across concurrent requests.
+        self._last_key_source: KeySource | None = None
 
     async def _get_user_api_key(
         self,
@@ -86,7 +98,7 @@ class EmbeddingService:
         context_id: str | None = None,
         workspace_id: str | None = None,  # Issue #146
         disallow_env_fallback: bool = False,
-    ) -> str:
+    ) -> tuple[str, KeySource]:
         """Resolve the OpenAI API key for the calling user's workspace context.
 
         Issue #105: DB-first lookup with environment variable fallback.
@@ -114,7 +126,12 @@ class EmbeddingService:
                 platform key. Has no effect when a DB key is found.
 
         Returns:
-            Decrypted OpenAI API key.
+            ``(api_key, source)`` where ``source`` is the credential tier the
+            key came from — ``"context"`` / ``"workspace"`` for a BYOK row,
+            ``"env"`` for the platform ``OPENAI_API_KEY`` fallback. Issue #713:
+            callers derive ``LLMCallLog.paid_by`` from ``source`` (``"env"`` →
+            ``"platform"``, else ``"byok"``) instead of re-running the BYOK
+            probe via ``has_byok_key``.
 
         Raises:
             ConfigurationError: If neither a DB key nor an env var is available
@@ -156,13 +173,18 @@ class EmbeddingService:
         if api_key_entry:
             encryptor = get_encryptor()
             api_key = encryptor.decrypt(str(api_key_entry.encrypted_value))
+            # The ORDER BY context_id DESC NULLS LAST in the query above means a
+            # context-scoped row wins over a workspace-wide one; a non-NULL
+            # ``context_id`` therefore identifies a context-scoped credential.
+            source: KeySource = "context" if api_key_entry.context_id is not None else "workspace"
             logger.debug(
                 "openai_api_key_from_db",
                 user_id=user_id,
                 context_id=context_id,
                 workspace_id=workspace_id,
+                source=source,
             )
-            return api_key
+            return api_key, source
 
         # Fallback to environment variable (development / env-only deployments),
         # gated by the Option A shared-context contract: when the caller has
@@ -194,7 +216,7 @@ class EmbeddingService:
                 "openai_api_key_from_env",
                 user_id=user_id,
             )
-            return env_key
+            return env_key, "env"
 
         if workspace_id:
             raise ConfigurationError(
@@ -263,24 +285,40 @@ class EmbeddingService:
         the call, ``"platform"`` when the call would fall back to the env
         var (or Ollama / no workspace context). Callers must pass the
         returned value through to ``LLMCallLogWriter.record(paid_by=...)``
-        — see ``search_service.py:200-210`` for the canonical usage.
+        — see the recall embed branch in ``SearchService`` for the
+        canonical usage.
 
         Centralizing the resolution here keeps the ``"byok" if … else
         "platform"`` rule in one place; downstream writers don't need to
         know how key sourcing works.
 
-        Issue #708 loop 4: ``context_id`` mirrors ``has_byok_key``'s
-        priority so the recorded ``paid_by`` matches what
-        ``_get_user_api_key`` actually returned. Without this parameter, a
-        workspace whose only BYOK is scoped to a different context would
-        have env-fallback calls falsely logged as ``"byok"`` — corrupting
-        billing analytics and the #524 cost-grade attribution path.
+        Issue #713: when a key has already been resolved on this instance
+        (the recall hot path: ``embed_with_usage`` → ``_get_client`` →
+        ``_get_user_api_key`` ran on a cache miss), derive ``paid_by`` from
+        the recorded ``_last_key_source`` instead of re-querying
+        ``external_api_keys``. ``_get_user_api_key``'s actual return is the
+        ground truth for which key was used — strictly more accurate than a
+        second ``has_byok_key`` probe — so this both removes a DB round-trip
+        and closes the #708 loop-4 probe/lookup drift by construction. The
+        ``has_byok_key`` fallback below covers only the off-hot-path case
+        where ``resolve_paid_by`` is called without a preceding embed (no
+        source resolved yet, e.g. Ollama or a standalone caller); recall
+        never reaches it because ``search_service`` calls ``resolve_paid_by``
+        only after a cache-miss embed recorded the source. ``context_id`` is
+        still forwarded to that fallback so it mirrors ``_get_user_api_key``'s
+        priority — without it, a workspace whose only BYOK is scoped to a
+        different context would falsely log env-fallback calls as ``"byok"``.
         """
         from models.llm_call_log import LLM_CALL_LOG_PAID_BY_VALUES
 
-        paid_by = (
-            "byok" if await self.has_byok_key(workspace_id, context_id=context_id) else "platform"
-        )
+        if self._last_key_source is not None:
+            paid_by = "platform" if self._last_key_source == "env" else "byok"
+        else:
+            paid_by = (
+                "byok"
+                if await self.has_byok_key(workspace_id, context_id=context_id)
+                else "platform"
+            )
         assert paid_by in LLM_CALL_LOG_PAID_BY_VALUES
         return paid_by
 
@@ -388,12 +426,16 @@ class EmbeddingService:
                 api_key="ollama",  # Ollama doesn't require a real key
             )
         # OpenAI (default)
-        api_key = await self._get_user_api_key(
+        api_key, source = await self._get_user_api_key(
             user_id,
             context_id,
             workspace_id,
             disallow_env_fallback=disallow_env_fallback,
         )
+        # Issue #713: remember which credential tier this call used so the
+        # post-embed ``resolve_paid_by`` can derive ``paid_by`` without a
+        # second ``external_api_keys`` SELECT.
+        self._last_key_source = source
         return AsyncOpenAI(api_key=api_key)
 
     def _build_embedding_kwargs(self, input_data: str | list[str]) -> dict:
@@ -486,6 +528,12 @@ class EmbeddingService:
             OpenAIError: If embedding generation fails.
             ConfigurationError: If API key not configured.
         """
+        # Issue #713: clear any source recorded by a prior embed on this
+        # (reused) instance so ``resolve_paid_by`` can never read a stale tier.
+        # A cache hit returns before ``_get_client`` runs, leaving it None — and
+        # ``search_service`` skips ``resolve_paid_by`` on a hit (0 tokens) — so
+        # the only value it ever reads is the one this call resolves below.
+        self._last_key_source = None
         try:
             normalized_text = unicodedata.normalize("NFC", text)
 

--- a/backend/src/services/llm_pricing_service.py
+++ b/backend/src/services/llm_pricing_service.py
@@ -32,8 +32,10 @@ Design rationale:
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
+from typing import Final
 
+from cachetools import TTLCache
 from sqlalchemy import and_, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -41,6 +43,39 @@ from models.llm_pricing import LLM_PRICING_UNIT_TYPES, LLMPricing
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Process-local price cache (Issue #713). Pricing rows in ``llm_pricing`` are
+# read-mostly — they change at most a few times per year — yet the recall hot
+# path resolves the same ``(provider, model, embedding_tokens)`` price TWICE per
+# call: once in ``EmbeddingSpendCapService.record_spend_from_tokens`` for the
+# BYOK spend cap, once in ``LLMCallLogWriter.record`` for the cost ledger. A
+# small in-process TTL cache collapses both to a single SELECT and shares the
+# result across every request in the worker, since pricing is global, not
+# tenant-scoped. Process-local (not Redis) is deliberate — the value it replaces
+# is itself one indexed SELECT, so a Redis round-trip would not beat it; the
+# issue records Redis as out of scope for the same reason. The 60-minute TTL
+# bounds post-change staleness to one hour (acceptable per the issue) at the
+# cost of up-to-1h cross-worker skew after a price change; explicit invalidation
+# is therefore unnecessary for v1, but ``clear_pricing_cache()`` is exposed for
+# tests and post-seed refresh. Misses are cached too (value ``None``) so an
+# unseeded model doesn't re-query.
+_PRICING_CACHE_TTL_SECONDS: Final = 3600
+_PRICING_CACHE_MAXSIZE: Final = 1024
+# key: (provider, model, unit_type, started_at.date(), context_tokens)
+# value: (price_per_unit, unit_denominator) | None
+_pricing_cache: TTLCache[tuple[str, str, str, date, int], tuple[float, float] | None] = TTLCache(
+    maxsize=_PRICING_CACHE_MAXSIZE, ttl=_PRICING_CACHE_TTL_SECONDS
+)
+
+
+def clear_pricing_cache() -> None:
+    """Drop all entries from the process-local pricing cache.
+
+    Exposed for two callers: tests that need a deterministic cache state,
+    and ops tooling that wants newly-seeded ``llm_pricing`` rows to take
+    effect immediately rather than after the 60-minute TTL.
+    """
+    _pricing_cache.clear()
 
 
 class LLMPricingService:
@@ -181,6 +216,54 @@ class LLMPricingService:
         if units == 0:
             return 0.0
 
+        components = await self._cached_price_components(
+            provider=provider,
+            model=model,
+            unit_type=unit_type,
+            started_at=started_at,
+            context_tokens=context_tokens,
+        )
+        if components is None:
+            return None
+
+        price_per_unit, unit_denominator = components
+        return float(units) * price_per_unit / unit_denominator
+
+    async def _cached_price_components(
+        self,
+        *,
+        provider: str,
+        model: str,
+        unit_type: str,
+        started_at: datetime,
+        context_tokens: int,
+    ) -> tuple[float, float] | None:
+        """Return ``(price_per_unit, unit_denominator)`` for a call, cached (#713).
+
+        Wraps ``lookup()`` with the process-local ``_pricing_cache`` so the
+        duplicate per-recall pricing SELECT collapses to a single round-trip.
+        Returns ``None`` for a lookup miss (caller writes ``cost_usd = NULL``),
+        and that ``None`` is cached so an unseeded model doesn't re-query every
+        call.
+
+        The cache key keeps ``context_tokens`` so multi-tier models (e.g. Gemini
+        2.5 Pro's 200k breakpoint) still resolve to the correct tier — the AC's
+        ``(provider, model, unit_type, date)`` key is a subset of this one. The
+        snapshot axis is ``started_at.date()`` so calls milliseconds apart share
+        an entry, while a date rollover plus the 60-minute TTL bound staleness.
+        """
+        cache_key = (provider, model, unit_type, started_at.date(), context_tokens)
+        # A single ``__getitem__`` reads the TTL clock once, so it is race-free
+        # (unlike ``key in cache`` then ``cache[key]``, which read the clock
+        # twice and can raise on an entry expiring between them). A stored ``None``
+        # (negative cache) returns ``None`` here; only an absent OR expired key
+        # raises ``KeyError``, both of which mean "re-query". Typed value, so a
+        # wrong-typed cache write is still caught by the checker.
+        try:
+            return _pricing_cache[cache_key]
+        except KeyError:
+            pass
+
         row = await self.lookup(
             provider=provider,
             model=model,
@@ -188,7 +271,8 @@ class LLMPricingService:
             started_at=started_at,
             context_tokens=context_tokens,
         )
-        if row is None:
-            return None
-
-        return float(units) * float(row.price_per_unit) / float(row.unit_denominator)
+        components = (
+            None if row is None else (float(row.price_per_unit), float(row.unit_denominator))
+        )
+        _pricing_cache[cache_key] = components
+        return components

--- a/backend/src/services/llm_pricing_service.py
+++ b/backend/src/services/llm_pricing_service.py
@@ -248,9 +248,30 @@ class LLMPricingService:
 
         The cache key keeps ``context_tokens`` so multi-tier models (e.g. Gemini
         2.5 Pro's 200k breakpoint) still resolve to the correct tier — the AC's
-        ``(provider, model, unit_type, date)`` key is a subset of this one. The
-        snapshot axis is ``started_at.date()`` so calls milliseconds apart share
-        an entry, while a date rollover plus the 60-minute TTL bound staleness.
+        ``(provider, model, unit_type, date)`` key is a subset of this one.
+
+        **Snapshot axis = ``started_at.date()`` (day granularity), deliberately.**
+        The two hot-path lookups for one recall
+        (``EmbeddingSpendCapService.record_spend_from_tokens`` and
+        ``LLMCallLogWriter.record``) each call ``utcnow()`` independently, so they
+        carry timestamps milliseconds apart; day-bucketing is what collapses them
+        into the single SELECT this cache exists to save. A finer key (e.g. full
+        ``started_at``) would never hit between those two calls and would defeat
+        the optimization.
+
+        Reproducibility bound this trades away: ``lookup()`` documents
+        ``effective_from <= started_at`` for *exact* historical reproducibility,
+        but ``effective_from`` is an unconstrained ``DateTime`` (it MAY be
+        intra-day). Day-bucketing therefore guarantees reproducibility only at
+        **day granularity** — two calls on the same UTC date that straddle an
+        intra-day ``effective_from`` change collapse to whichever price was cached
+        first. This is bounded and acceptable today because: (a) on the live path
+        ``started_at`` is always ``utcnow()`` and the 60-minute TTL already caps
+        staleness to ≤1h regardless of key granularity; (b) the historical-replay
+        path (``record_spend_from_tokens(occurred_at=...)``) has no live caller.
+        **If sub-day-precise historical replay is ever wired up, this key needs a
+        finer time component OR the replay must bypass the cache** (Copilot review
+        on PR #811).
         """
         cache_key = (provider, model, unit_type, started_at.date(), context_tokens)
         # A single ``__getitem__`` reads the TTL clock once, so it is race-free

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -36,6 +36,23 @@ from utils.logger import setup_logger as _setup_logger  # noqa: E402
 _setup_logger()
 
 
+@pytest.fixture(autouse=True)
+def _clear_pricing_cache():
+    """Reset the process-local ``llm_pricing`` cache around every test (#713).
+
+    ``LLMPricingService`` caches resolved prices in a module-global ``TTLCache``
+    for the recall hot path. Without clearing it between tests, a pricing row
+    seeded by one test would leak into another that seeds a different price for
+    the same ``(provider, model, unit_type, date)`` key — making cost
+    assertions order-dependent. Cheap (a dict clear) so applied unconditionally.
+    """
+    from services.llm_pricing_service import clear_pricing_cache
+
+    clear_pricing_cache()
+    yield
+    clear_pricing_cache()
+
+
 def pytest_configure(config: pytest.Config) -> None:
     """Validate asyncio_default_test_loop_scope matches fixture loop scope.
 

--- a/backend/tests/services/test_embedding_service.py
+++ b/backend/tests/services/test_embedding_service.py
@@ -59,11 +59,16 @@ class TestEmbeddingService:
 
     @pytest.mark.asyncio
     async def test_get_user_api_key_from_env(self, service):
-        """Test getting API key from environment variable."""
+        """Test getting API key from environment variable.
+
+        Issue #713: returns ``(api_key, source)``; the env fallback is the
+        platform key, so ``source`` is ``"env"``.
+        """
         with patch.dict("os.environ", {"OPENAI_API_KEY": "test-api-key"}):
-            api_key = await service._get_user_api_key("test_user")
+            api_key, source = await service._get_user_api_key("test_user")
 
             assert api_key == "test-api-key"
+            assert source == "env"
 
     @pytest.mark.asyncio
     async def test_get_user_api_key_not_configured(self, service):
@@ -346,6 +351,154 @@ class TestContextAwareBYOKThreading:
         )
 
 
+class TestKeySourceAndPaidByDedup:
+    """#713: ``_get_user_api_key`` returns the key tier so ``resolve_paid_by``
+    derives ``paid_by`` without a second ``external_api_keys`` SELECT.
+    """
+
+    @pytest.fixture
+    def service(self):
+        return EmbeddingService(_make_mock_db())
+
+    @pytest.mark.asyncio
+    async def test_get_user_api_key_context_scoped_source(self, service):
+        """A non-NULL ``context_id`` on the resolved row → ``"context"`` tier."""
+        api_key_entry = MagicMock()
+        api_key_entry.encrypted_value = "enc"
+        api_key_entry.context_id = "00000000-0000-0000-0000-000000000002"
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = api_key_entry
+        service.db.execute = AsyncMock(return_value=execute_result)
+
+        with patch("services.embedding_service.get_encryptor") as enc:
+            enc.return_value.decrypt.return_value = "sk-ctx"
+            api_key, source = await service._get_user_api_key(
+                user_id="caller",
+                context_id="00000000-0000-0000-0000-000000000002",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+            )
+
+        assert api_key == "sk-ctx"
+        assert source == "context"
+
+    @pytest.mark.asyncio
+    async def test_get_client_records_last_key_source(self, service, monkeypatch):
+        """``_get_client`` stores the resolved tier for ``resolve_paid_by``."""
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+        # No DB key → env fallback → source "env".
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = None
+        service.db.execute = AsyncMock(return_value=execute_result)
+
+        with patch("services.embedding_service.AsyncOpenAI", return_value=MagicMock()):
+            await service._get_client("caller", workspace_id="00000000-0000-0000-0000-000000000001")
+
+        assert service._last_key_source == "env"
+
+    @pytest.mark.asyncio
+    async def test_get_client_records_workspace_source_from_db_key(self, service):
+        """A DB BYOK row drives ``_get_client`` to record the ``"workspace"`` tier."""
+        api_key_entry = MagicMock()
+        api_key_entry.encrypted_value = "enc"
+        api_key_entry.context_id = None  # workspace-wide row
+        execute_result = MagicMock()
+        execute_result.scalar_one_or_none.return_value = api_key_entry
+        service.db.execute = AsyncMock(return_value=execute_result)
+
+        with (
+            patch("services.embedding_service.get_encryptor") as enc,
+            patch("services.embedding_service.AsyncOpenAI", return_value=MagicMock()),
+        ):
+            enc.return_value.decrypt.return_value = "sk-ws"
+            await service._get_client("caller", workspace_id="00000000-0000-0000-0000-000000000001")
+
+        assert service._last_key_source == "workspace"
+
+    @pytest.mark.asyncio
+    async def test_embed_with_usage_resets_stale_source_on_cache_hit(self, service):
+        """A cache hit must clear a source left by a prior embed on the instance.
+
+        Guards the #713 staleness class: without the reset, a reused instance
+        whose previous embed resolved a BYOK key would leak ``"workspace"`` into
+        a later cache-hit call's ``resolve_paid_by``.
+        """
+        service._last_key_source = "workspace"  # left over from a prior call
+
+        with (
+            patch(
+                "services.embedding_service.get_cache",
+                new=AsyncMock(return_value="[0.1, 0.2, 0.3]"),
+            ),
+            patch("services.embedding_service.set_cache", new=AsyncMock()),
+        ):
+            _, tokens = await service.embed_with_usage(
+                "cached text",
+                user_id="caller",
+                workspace_id="00000000-0000-0000-0000-000000000001",
+            )
+
+        assert tokens == 0  # cache hit
+        assert service._last_key_source is None
+
+    @pytest.mark.asyncio
+    async def test_resolve_paid_by_uses_cached_source_skips_probe(self, service):
+        """With a cached source, ``resolve_paid_by`` does NOT re-probe the DB.
+
+        Pins the #713 optimization: ``has_byok_key`` (the duplicate SELECT)
+        must not be called. The cached source is ground truth — even when a
+        probe *would* say "byok", a cached ``"env"`` source resolves to
+        ``"platform"``.
+        """
+        service.has_byok_key = AsyncMock(return_value=True)
+        service._last_key_source = "env"
+
+        result = await service.resolve_paid_by(
+            "00000000-0000-0000-0000-000000000001",
+            context_id="00000000-0000-0000-0000-000000000002",
+        )
+
+        assert result == "platform"
+        service.has_byok_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("source", "expected"),
+        [("workspace", "byok"), ("context", "byok"), ("env", "platform")],
+    )
+    async def test_resolve_paid_by_maps_cached_source(self, service, source, expected):
+        """Cached tier → ``paid_by``: BYOK rows bill the workspace, env is platform."""
+        service.has_byok_key = AsyncMock()
+        service._last_key_source = source
+
+        result = await service.resolve_paid_by("00000000-0000-0000-0000-000000000001")
+
+        assert result == expected
+        service.has_byok_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_resolve_paid_by_falls_back_to_probe_when_no_source(self, service):
+        """Off-hot-path (no embed ran): fall back to the ``has_byok_key`` probe.
+
+        ``_last_key_source`` stays ``None`` (e.g. Ollama or a standalone
+        caller), so correctness is preserved via the legacy probe — which
+        recall never reaches because it only resolves ``paid_by`` after a
+        cache-miss embed that recorded the source.
+        """
+        service.has_byok_key = AsyncMock(return_value=True)
+        assert service._last_key_source is None
+
+        result = await service.resolve_paid_by(
+            "00000000-0000-0000-0000-000000000001",
+            context_id="00000000-0000-0000-0000-000000000002",
+        )
+
+        assert result == "byok"
+        service.has_byok_key.assert_called_once_with(
+            "00000000-0000-0000-0000-000000000001",
+            context_id="00000000-0000-0000-0000-000000000002",
+        )
+
+
 class TestDisallowEnvFallback:
     """#708 loop 7: ``disallow_env_fallback`` propagation for Option A reads.
 
@@ -411,7 +564,7 @@ class TestDisallowEnvFallback:
         execute_result.scalar_one_or_none.return_value = None
         service.db.execute = AsyncMock(return_value=execute_result)
 
-        result = await service._get_user_api_key(
+        result, source = await service._get_user_api_key(
             user_id="caller",
             context_id="00000000-0000-0000-0000-000000000002",
             workspace_id="00000000-0000-0000-0000-000000000001",
@@ -419,6 +572,7 @@ class TestDisallowEnvFallback:
         )
 
         assert result == "sk-test-platform-key"
+        assert source == "env"
 
     @pytest.mark.asyncio
     async def test_disallow_env_fallback_does_not_block_db_key(self, service, monkeypatch):
@@ -430,9 +584,11 @@ class TestDisallowEnvFallback:
         # The env is set but should not be consulted
         monkeypatch.setenv("OPENAI_API_KEY", "sk-must-not-be-used")
 
-        # Mock DB: BYOK key found
+        # Mock DB: workspace-wide BYOK key found (context_id IS NULL → the
+        # ORDER BY context_id DESC NULLS LAST winner for a no-context match).
         api_key_entry = MagicMock()
         api_key_entry.encrypted_value = "encrypted-byok-key-data"
+        api_key_entry.context_id = None
         execute_result = MagicMock()
         execute_result.scalar_one_or_none.return_value = api_key_entry
         service.db.execute = AsyncMock(return_value=execute_result)
@@ -441,7 +597,7 @@ class TestDisallowEnvFallback:
         with patch("services.embedding_service.get_encryptor") as enc:
             enc.return_value.decrypt.return_value = "sk-actual-byok-key"
 
-            result = await service._get_user_api_key(
+            result, source = await service._get_user_api_key(
                 user_id="caller",
                 context_id="00000000-0000-0000-0000-000000000002",
                 workspace_id="00000000-0000-0000-0000-000000000001",
@@ -450,6 +606,8 @@ class TestDisallowEnvFallback:
 
         assert result == "sk-actual-byok-key"
         assert result != "sk-must-not-be-used"
+        # Issue #713: a NULL-context row resolves as the "workspace" tier.
+        assert source == "workspace"
 
     @pytest.mark.asyncio
     async def test_embed_with_usage_propagates_disallow_env_fallback(self, service, monkeypatch):

--- a/backend/tests/services/test_llm_pricing_service.py
+++ b/backend/tests/services/test_llm_pricing_service.py
@@ -1,0 +1,177 @@
+"""Unit tests for ``LLMPricingService``'s process-local price cache (#713).
+
+The recall hot path resolves the same ``(provider, model, embedding_tokens)``
+price twice per call (spend cap + cost ledger). ``_cached_price_components``
+collapses that to a single ``lookup()`` round-trip with a 60-minute TTL. These
+tests mock ``lookup`` directly so they assert the caching contract without a DB.
+
+Cross-test isolation is provided by the autouse ``_clear_pricing_cache`` fixture
+in ``tests/conftest.py`` — every test starts from an empty cache.
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from services.llm_pricing_service import LLMPricingService, clear_pricing_cache
+
+_STARTED_AT = datetime(2026, 5, 27, 12, 0, 0)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pricing_cache():
+    """Clear the module-global price cache around every test in this file.
+
+    Every assertion here is on ``lookup`` call-count, which is meaningless
+    unless the cache starts empty. The root ``conftest`` also clears it, but
+    this file's correctness depends on the clear directly, so it is pinned
+    locally too — the redundancy is a free ``dict.clear()`` and keeps the
+    call-count tests honest even if the root fixture is ever removed.
+    """
+    clear_pricing_cache()
+    yield
+    clear_pricing_cache()
+
+
+def _service() -> LLMPricingService:
+    """Service with a dummy session — ``lookup`` is mocked, DB never touched."""
+    return LLMPricingService(MagicMock())
+
+
+def _pricing_row(price_per_unit: str, unit_denominator: int) -> MagicMock:
+    row = MagicMock()
+    row.price_per_unit = Decimal(price_per_unit)
+    row.unit_denominator = unit_denominator
+    return row
+
+
+@pytest.mark.asyncio
+async def test_repeated_calls_hit_cache_single_lookup():
+    """100 ``compute_cost_usd`` calls with the same key → ``lookup`` called once."""
+    service = _service()
+    service.lookup = AsyncMock(return_value=_pricing_row("0.02", 1_000_000))
+
+    costs = [
+        await service.compute_cost_usd(
+            provider="openai",
+            model="text-embedding-3-small",
+            unit_type="embedding_tokens",
+            started_at=_STARTED_AT,
+            units=1_000_000,
+        )
+        for _ in range(100)
+    ]
+
+    assert service.lookup.await_count == 1
+    # Result still computed correctly per-call (units * price / denominator).
+    assert all(c == pytest.approx(0.02) for c in costs)
+
+
+@pytest.mark.asyncio
+async def test_units_scale_per_call_despite_shared_cache():
+    """The cached value is the price row, not the cost — units still vary."""
+    service = _service()
+    service.lookup = AsyncMock(return_value=_pricing_row("0.02", 1_000_000))
+
+    cost_1m = await service.compute_cost_usd(
+        provider="openai",
+        model="text-embedding-3-small",
+        unit_type="embedding_tokens",
+        started_at=_STARTED_AT,
+        units=1_000_000,
+    )
+    cost_2m = await service.compute_cost_usd(
+        provider="openai",
+        model="text-embedding-3-small",
+        unit_type="embedding_tokens",
+        started_at=_STARTED_AT,
+        units=2_000_000,
+    )
+
+    assert cost_1m == pytest.approx(0.02)
+    assert cost_2m == pytest.approx(0.04)
+    assert service.lookup.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_distinct_keys_each_trigger_lookup():
+    """Different (provider, model, unit_type, date) keys are cached separately."""
+    service = _service()
+    service.lookup = AsyncMock(return_value=_pricing_row("0.02", 1_000_000))
+
+    base = {"unit_type": "embedding_tokens", "started_at": _STARTED_AT, "units": 100}
+    await service.compute_cost_usd(provider="openai", model="m-a", **base)
+    await service.compute_cost_usd(provider="openai", model="m-b", **base)
+    await service.compute_cost_usd(provider="voyage", model="m-a", **base)
+    await service.compute_cost_usd(
+        provider="openai",
+        model="m-a",
+        unit_type="embedding_tokens",
+        started_at=datetime(2026, 5, 28, 12, 0, 0),  # different date
+        units=100,
+    )
+
+    assert service.lookup.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_lookup_miss_is_negatively_cached():
+    """A miss (``None``) is cached so an unseeded model doesn't re-query."""
+    service = _service()
+    service.lookup = AsyncMock(return_value=None)
+
+    results = [
+        await service.compute_cost_usd(
+            provider="openai",
+            model="brand-new-model",
+            unit_type="embedding_tokens",
+            started_at=_STARTED_AT,
+            units=100,
+        )
+        for _ in range(5)
+    ]
+
+    assert all(r is None for r in results)
+    assert service.lookup.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_clear_pricing_cache_forces_relookup():
+    """``clear_pricing_cache()`` drops entries so the next call re-queries."""
+    service = _service()
+    service.lookup = AsyncMock(return_value=_pricing_row("0.02", 1_000_000))
+
+    call = {
+        "provider": "openai",
+        "model": "text-embedding-3-small",
+        "unit_type": "embedding_tokens",
+        "started_at": _STARTED_AT,
+        "units": 100,
+    }
+    await service.compute_cost_usd(**call)
+    assert service.lookup.await_count == 1
+
+    clear_pricing_cache()
+
+    await service.compute_cost_usd(**call)
+    assert service.lookup.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_zero_units_short_circuits_before_lookup():
+    """``units == 0`` returns 0.0 without consulting the cache or DB."""
+    service = _service()
+    service.lookup = AsyncMock()
+
+    result = await service.compute_cost_usd(
+        provider="openai",
+        model="text-embedding-3-small",
+        unit_type="embedding_tokens",
+        started_at=_STARTED_AT,
+        units=0,
+    )
+
+    assert result == 0.0
+    service.lookup.assert_not_awaited()


### PR DESCRIPTION
Closes #713

## Summary
- Removes **2 DB round-trips per recall** on the embedding hot path (the last open issue in milestone v0.17.0).
- Collapses the duplicate `llm_pricing` SELECT (`record_spend_from_tokens` + `LLMCallLogWriter.record`) into one via a process-local TTL cache.
- Eliminates the duplicate `external_api_keys` SELECT by deriving `paid_by` from the key tier already resolved during the embed, instead of a second `has_byok_key` probe.

## Implementation notes
- **`LLMPricingService`**: new module-global `cachetools.TTLCache` (60-min TTL, `maxsize=1024`) keyed by `(provider, model, unit_type, started_at.date(), context_tokens)` — `context_tokens` retained so tier-priced models stay correct. `compute_cost_usd` routes through `_cached_price_components` (single `__getitem__` via `try/except KeyError` — race-free, negative-caches misses). `clear_pricing_cache()` exposed for tests + post-seed refresh.
- **`EmbeddingService`**: `_get_user_api_key` now returns `(api_key, source: Literal["workspace","context","env"])`; `_get_client` records `self._last_key_source`; `resolve_paid_by` derives `paid_by` (`env`→`platform`, else `byok`) from it. The source is the actual key used — strictly more accurate than the prior probe — so the #708 loop-4 probe/lookup parity is closed by construction. `has_byok_key` retained as a defensive fallback (Ollama / standalone callers). The memo is reset at each `embed_*` entry so a reused, request-scoped instance can never read a stale tier.
- New dependency `cachetools>=5.3.0` (this repo's lock did not pull it transitively). Autouse `conftest` fixture clears the global price cache between tests to prevent cross-test price bleed.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- review provider: code-review
- prior review: `/code-review` at high + max effort (3 finder agents × 9 angles) + `/self-review` — all findings addressed (TTL-clock race → `try/except`, lock/dep, stale-memo reset, doc/type tightening); correctness pass found no behavior bugs.

Tests: 122 unit + 32 integration pass; ruff clean; pyright 0 errors on changed `src/`.

Full gate2 review saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/713-refactor-spend-cap-hotpath-perf.gate2.md

🤖 Generated via /gh-issue-driven:ship
