### PR TITLE
feat(api): extend edge_type enum with continues_from + references_file (#782)

### DIFF
--- a/backend/alembic/versions/e25_782_widen_edge_type.py
+++ b/backend/alembic/versions/e25_782_widen_edge_type.py
@@ -1,0 +1,112 @@
+"""Widen the valid_edge_type CHECK to add continues_from + references_file (#782).
+
+The kagura-memory-ai-worker emits two producer-asserted structural relation
+types that did not exist in the post-#741 four-value ``edge_type`` set:
+
+* ``continues_from``  — chronological/narrative successor between chat memories.
+* ``references_file`` — structural reference from a chat memory to a file overview.
+
+Both live on the ``edge_type`` (relation) axis, coherent with the #741/#722
+two-axis model; their provenance is carried on the ``origin`` axis
+(``origin='declared'`` for the worker create_edge path). Adding them lets the
+worker drop its SDK-boundary ``_EDGE_TYPE_WORKAROUND_MAP`` — which translated
+``references_file -> declared_link``, a value #741 removed, so those edges are
+currently rejected in prod.
+
+### No data migration
+
+This is a pure CHECK-constraint widening: existing rows already satisfy the
+wider constraint, so no UPDATE is needed on upgrade. (Contrast #741, whose
+Phase 0/1 backfill was required because it *narrowed* the set and relocated
+provenance.)
+
+### Reversibility (downgrade caveats)
+
+``downgrade()`` narrows the CHECK back to the four post-#741 values. Postgres
+validates existing rows when (re)creating a CHECK constraint, so any row written
+with the new types after this migration would block the narrowing. ``downgrade``
+therefore first remaps ``continues_from`` / ``references_file`` to ``related_to``
+(the closest surviving relation; ``declared_link`` no longer exists). This is
+lossy at TWO axes — symmetric with #741's lossy collapse — and operators should
+be explicit about both before downgrading:
+
+* **edge_type axis**: the original ``continues_from`` / ``references_file``
+  distinction is gone. Re-upgrading does NOT split the collapsed ``related_to``
+  rows back out — the producer must re-ingest to recover the canonical types
+  via UPSERT (3-col uniqueness; edge_type is max-weight UPSERT metadata).
+* **directionality axis**: ``continues_from`` and ``references_file`` are
+  inherently directional (per ``services/graph_service.py`` class docstring),
+  while ``related_to`` is undirected by convention (see
+  ``services/sleep/edge_discovery.py::DIRECTED_EDGE_TYPES``). After downgrade,
+  any reader that distinguishes direction by ``edge_type`` will treat the
+  relabeled rows as undirected.
+
+``origin`` is untouched on downgrade.
+
+**Concurrency contract**: the downgrade UPDATE acquires ``ROW EXCLUSIVE``;
+the subsequent ``DROP CONSTRAINT`` / ``CREATE CONSTRAINT`` requires
+``ACCESS EXCLUSIVE``. A writer that commits a new ``continues_from`` /
+``references_file`` row between the UPDATE and the DROP would survive the
+remap and then violate the recreated narrower CHECK, aborting the migration.
+This migration is therefore intended for **offline (maintenance-window)
+downgrade**; same property as ``e20_741``'s downgrade. Operators running an
+online downgrade should ``LOCK TABLE neural_memory_edges IN ACCESS EXCLUSIVE
+MODE`` ahead of the UPDATE inside the same alembic transaction.
+
+Revision ID: e25_782_widen_edge_type
+Revises: e24_668_drop_user_plans
+Create Date: 2026-05-28
+"""
+
+from alembic import op
+
+revision = "e25_782_widen_edge_type"
+down_revision = "e24_668_drop_user_plans"
+branch_labels = None
+depends_on = None
+
+
+# Upgrade target: the post-#741 four values PLUS the two #782 additions, in the
+# exact registration order of ``_ALL_EDGE_TYPES`` in models/memory.py. Must stay
+# byte-identical to that f-string output (single quotes, ', ' separator) — pinned
+# by test_valid_edge_type_check_constraint_matches_migration_literal.
+_NEW_CHECK_SQL = (
+    "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+    "'learned_from', 'continues_from', 'references_file')"
+)
+
+# Downgrade target: the post-#741 four-value set (== e20_741's _NEW_CHECK_SQL).
+_OLD_CHECK_SQL = "edge_type IN ('neural_association', 'related_to', 'depends_on', 'learned_from')"
+
+
+def upgrade() -> None:
+    """Widen the valid_edge_type CHECK to accept the two #782 relation types."""
+    op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        _NEW_CHECK_SQL,
+    )
+
+
+def downgrade() -> None:
+    """Narrow the CHECK back to the post-#741 four values.
+
+    Remaps the two #782 relation types to ``related_to`` first so existing rows
+    do not violate the narrowed constraint. Lossy at the edge_type column level
+    (the original continues_from / references_file distinction is gone); origin
+    is preserved.
+    """
+    op.execute(
+        """
+        UPDATE neural_memory_edges
+           SET edge_type = 'related_to'
+         WHERE edge_type IN ('continues_from', 'references_file')
+        """
+    )
+    op.drop_constraint("valid_edge_type", "neural_memory_edges", type_="check")
+    op.create_check_constraint(
+        "valid_edge_type",
+        "neural_memory_edges",
+        _OLD_CHECK_SQL,
+    )

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -384,6 +384,7 @@ Response format:
 Optional relation_types filter for specific edge types:
 • 'neural_association' (default, Hebbian learning)
 • 'related_to', 'depends_on', 'learned_from'
+• 'continues_from', 'references_file' (producer-asserted structural edges)
 • Omit to explore all connection types
 
 Returns memories ranked by activation strength (graph-based relevance).
@@ -410,7 +411,7 @@ IMPORTANT: Always specify context_id to ensure you're exploring the intended con
                     "relation_types": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Optional filter for specific relation types: 'neural_association', 'related_to', 'depends_on', 'learned_from'. Omit to explore all connections.",
+                        "description": "Optional filter for specific relation types: 'neural_association', 'related_to', 'depends_on', 'learned_from', 'continues_from', 'references_file'. Omit to explore all connections.",
                     },
                     "context_id": {
                         "type": "string",
@@ -453,7 +454,7 @@ Response includes: edge_id, source_id, target_id, edge_type, weight, confidence,
                     "edge_types": {
                         "type": "array",
                         "items": {"type": "string"},
-                        "description": "Filter by edge types: 'neural_association', 'related_to', 'depends_on', 'learned_from'. Omit to list all.",
+                        "description": "Filter by edge types: 'neural_association', 'related_to', 'depends_on', 'learned_from', 'continues_from', 'references_file'. Omit to list all.",
                     },
                     "limit": {
                         "type": "integer",
@@ -479,6 +480,8 @@ Edge types:
 - 'depends_on': Target memory depends on source
 - 'learned_from': Knowledge derived from source
 - 'neural_association': Auto-created by Hebbian learning (prefer 'related_to' for manual edges)
+- 'continues_from': Chronological/narrative successor between chat memories (producer-asserted, directional; #782)
+- 'references_file': Structural reference from a chat memory to a file overview (producer-asserted, directional; #782)
 
 Weight range: 0.0 (weakest) to 3.0 (strongest). Default: 0.5 (moderate manual connection).""",
             "inputSchema": {
@@ -497,7 +500,14 @@ Weight range: 0.0 (weakest) to 3.0 (strongest). Default: 0.5 (moderate manual co
                     },
                     "edge_type": {
                         "type": "string",
-                        "enum": ["neural_association", "related_to", "depends_on", "learned_from"],
+                        "enum": [
+                            "neural_association",
+                            "related_to",
+                            "depends_on",
+                            "learned_from",
+                            "continues_from",
+                            "references_file",
+                        ],
                         "description": "Type of relationship (default: 'related_to').",
                         "default": "related_to",
                     },
@@ -526,7 +536,7 @@ Weight range: 0.0 (weakest) to 3.0 (strongest). Default: 0.5 (moderate manual co
 Use this to:
 - Strengthen an edge: increase weight when memories are confirmed related
 - Weaken an edge: decrease weight for less relevant connections
-- Change edge type: reclassify the relationship
+- Change edge type: reclassify the relationship (see create_edge for the full edge_type enumeration; all values accepted by create_edge are valid targets here)
 
 Identify edges using source_id + target_id (from list_edges or explore results).""",
             "inputSchema": {
@@ -549,7 +559,14 @@ Identify edges using source_id + target_id (from list_edges or explore results).
                     },
                     "edge_type": {
                         "type": "string",
-                        "enum": ["neural_association", "related_to", "depends_on", "learned_from"],
+                        "enum": [
+                            "neural_association",
+                            "related_to",
+                            "depends_on",
+                            "learned_from",
+                            "continues_from",
+                            "references_file",
+                        ],
                         "description": "New edge type.",
                     },
                     "context_id": {

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -24,21 +24,32 @@ from mcp_server.tools._helpers import (
 )
 from models.memory import (
     EDGE_ORIGIN_DECLARED,
+    EDGE_TYPE_CONTINUES_FROM,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
 )
 
-# Issue #461 / #741: full set of edge_types accepted by the DB CHECK constraint
-# (`models/memory.py::valid_edge_type`). Sourced from `EDGE_TYPE_*` constants
-# so this set cannot drift from the schema literal. The 4 surviving values
-# after #741 are:
+# Issue #461 / #741 / #782: full set of edge_types accepted by the DB CHECK
+# constraint (`models/memory.py::valid_edge_type`). Sourced from `EDGE_TYPE_*`
+# constants so this set cannot drift from the schema literal.
 #   - neural_association: runtime Hebbian co-activation, or the post-#741
 #     catch-all for any provenance not expressible as a relation
 #     (tag_cooccurrence + semantic_similarity merged here).
 #   - related_to / depends_on / learned_from: LLM-emittable relation types
 #     (#374 → see `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`).
+#   - continues_from / references_file (#782): producer-asserted structural
+#     relation types emitted by the kagura-memory-ai-worker ingest pipeline.
+#     NOT emitted by the sleep LLM judge (excluded from
+#     `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`); the MCP
+#     boundary does not separately enforce this — clients may pass them.
+#     Their provenance is origin='declared' (pinned below for both
+#     handle_create_edge and handle_update_edge); the MCP-only invariant
+#     does not extend to GraphService.add_edge — that path is the internal
+#     Hebbian-default writer and callers wanting a non-Hebbian origin must
+#     pass it explicitly via the optional `origin=` parameter (#782).
 # Provenance for what was previously edge_type='semantic_similarity' /
 # 'declared_link' / 'tag_cooccurrence' now lives on `origin` and
 # `edge_metadata['source']` (see migration `e20_741` docstring).
@@ -48,6 +59,8 @@ VALID_EDGE_TYPES = frozenset(
         EDGE_TYPE_RELATED_TO,
         EDGE_TYPE_DEPENDS_ON,
         EDGE_TYPE_LEARNED_FROM,
+        EDGE_TYPE_CONTINUES_FROM,
+        EDGE_TYPE_REFERENCES_FILE,
     }
 )
 
@@ -355,6 +368,12 @@ async def handle_update_edge(
                     confidence=existing.confidence,
                     workspace_id=ws_id,
                     context_id=ctx_id,
+                    # Issue #782: MCP `update_edge` is the explicit user re-assertion
+                    # path (mirrors `handle_create_edge` above); pin origin='declared'
+                    # so retyping a hebbian row to a producer-asserted edge_type
+                    # (continues_from / references_file) doesn't leave origin='hebbian'
+                    # and re-expose the row to DecayManager pruning.
+                    origin=EDGE_ORIGIN_DECLARED,
                 ),
                 operation_name="update_edge",
             )

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -317,19 +317,31 @@ EDGE_TYPE_NEURAL_ASSOCIATION = "neural_association"
 EDGE_TYPE_RELATED_TO = "related_to"
 EDGE_TYPE_DEPENDS_ON = "depends_on"
 EDGE_TYPE_LEARNED_FROM = "learned_from"
+# Issue #782: producer-asserted structural relation types emitted by the
+# kagura-memory-ai-worker ingest pipeline. They live on the edge_type
+# (relation) axis; their provenance is the ``origin`` axis (origin='declared'
+# for the worker create_edge path, pinned in mcp_server/tools/edge.py).
+#   - continues_from: chronological/narrative successor between chat memories
+#   - references_file: structural reference from a chat memory to a file overview
+EDGE_TYPE_CONTINUES_FROM = "continues_from"
+EDGE_TYPE_REFERENCES_FILE = "references_file"
 
 # Issue #509 (Phase B of #461): registration-order tuple used to derive the
 # ``valid_edge_type`` CHECK constraint string in ``NeuralMemoryEdge.__table_args__``.
-# Order MUST match the literal order ``b05_223_tag_cooccurrence.py`` installed
-# on prod (its ``_NEW_EDGE_TYPES_SQL``) so ``Base.metadata.create_all()`` produces
-# a CHECK string byte-identical to alembic head — preventing
-# ``alembic revision --autogenerate`` from generating a spurious no-op migration
-# on future runs.
+# Order MUST match the literal order the latest CHECK-altering migration installed
+# on prod (currently ``e25_782_widen_edge_type.py``'s ``_NEW_CHECK_SQL``; previously
+# ``e20_741`` then ``b05_223``) so ``Base.metadata.create_all()`` produces a CHECK
+# string byte-identical to alembic head — preventing ``alembic revision
+# --autogenerate`` from generating a spurious no-op migration on future runs. New
+# edge_types are APPENDED (never reordered) to preserve byte-identity with prior
+# literals.
 _ALL_EDGE_TYPES: tuple[str, ...] = (
     EDGE_TYPE_NEURAL_ASSOCIATION,
     EDGE_TYPE_RELATED_TO,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
+    EDGE_TYPE_CONTINUES_FROM,
+    EDGE_TYPE_REFERENCES_FILE,
 )
 
 # Edge origin discriminator (Issue #722).
@@ -417,8 +429,10 @@ class NeuralMemoryEdge(Base):
         # ``_ALL_EDGE_TYPES``, (3) update the expected literal in
         # ``test_valid_edge_type_check_constraint_matches_migration_literal``,
         # plus a corresponding alembic migration that ALTERs the prod CHECK.
-        # The f-string output is byte-identical to ``b05_223_tag_cooccurrence.py``'s
-        # ``_NEW_EDGE_TYPES_SQL`` (registration order, single quotes, exact whitespace).
+        # The f-string output is byte-identical to the latest CHECK-altering
+        # migration's literal (currently ``e25_782_widen_edge_type.py``'s
+        # ``_NEW_CHECK_SQL``; previously ``e20_741`` then ``b05_223``) — registration
+        # order, single quotes, exact whitespace.
         CheckConstraint(
             f"edge_type IN ({', '.join(repr(t) for t in _ALL_EDGE_TYPES)})",
             name="valid_edge_type",

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -15,9 +15,11 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.memory import (
+    EDGE_TYPE_CONTINUES_FROM,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
 )
 from repositories.neural_edge import NeuralEdgeRepository
@@ -49,6 +51,10 @@ class GraphService:
         - related_to: LLM-judged semantic relationship (undirected)
         - depends_on: LLM-judged dependency relationship (directed)
         - learned_from: LLM-judged learning source (directed)
+        - continues_from: producer-asserted chronological/narrative successor
+          (directed; #782, emitted by kagura-memory-ai-worker)
+        - references_file: producer-asserted structural reference, chat → file
+          overview (directed; #782, emitted by kagura-memory-ai-worker)
 
     Provenance lives on the ``origin`` axis (#722), independent of edge_type:
         - hebbian: runtime Hebbian co-activation trace
@@ -74,19 +80,21 @@ class GraphService:
     _STATS_OWNER_DEFAULT: Any = object()
 
     NODE_TYPES = ["memory", "user", "topic"]
-    # Issue #506 / #741: full set of edge_types accepted by the DB CHECK
+    # Issue #506 / #741 / #782: full set of edge_types accepted by the DB CHECK
     # constraint (mirrors ``mcp_server/tools/edge.py::VALID_EDGE_TYPES``).
     # ``frozenset`` for immutability + O(1) ``not in`` lookup at the validator
     # in ``add_edge``. Sourced from ``EDGE_TYPE_*`` constants so this set
-    # cannot drift from the schema literal. Post-#741 the set collapsed
-    # from 7 to 4 values: ``semantic_similarity``, ``declared_link``, and
-    # ``tag_cooccurrence`` moved to the ``origin`` / ``edge_metadata`` axes.
+    # cannot drift from the schema literal. Post-#741 the relation axis held 4
+    # values; #782 appended the two producer-asserted structural types
+    # (``continues_from`` / ``references_file``) emitted by the ai-worker.
     EDGE_TYPES: frozenset[str] = frozenset(
         {
             EDGE_TYPE_NEURAL_ASSOCIATION,
             EDGE_TYPE_RELATED_TO,
             EDGE_TYPE_DEPENDS_ON,
             EDGE_TYPE_LEARNED_FROM,
+            EDGE_TYPE_CONTINUES_FROM,
+            EDGE_TYPE_REFERENCES_FILE,
         }
     )
 
@@ -196,6 +204,7 @@ class GraphService:
         weight: float = 1.0,
         edge_metadata: dict[str, Any] | None = None,
         confidence: float = 1.0,
+        origin: str | None = None,
     ) -> None:
         """Add edge between nodes.
 
@@ -206,6 +215,19 @@ class GraphService:
             weight: Edge weight (0.0-3.0 for Neural Memory)
             edge_metadata: Additional edge metadata
             confidence: Confidence score (0.0-1.0)
+            origin: Optional provenance discriminator (#722; one of
+                ``EDGE_ORIGIN_HEBBIAN`` / ``EDGE_ORIGIN_SEMANTIC`` /
+                ``EDGE_ORIGIN_DECLARED``). If ``None`` (the default), the
+                column default ``hebbian`` is used — this path is the
+                Hebbian-internal writer, so the default fits the dominant
+                caller. Producer-asserted writes (e.g. the ai-worker emitting
+                ``continues_from`` / ``references_file``, #782) MUST pass
+                ``origin=EDGE_ORIGIN_DECLARED`` explicitly so the row is
+                exempt from ``DecayManager`` (which only touches
+                ``origin='hebbian'``). The MCP ``create_edge`` /
+                ``update_edge`` tools (``mcp_server/tools/edge.py``) pin
+                ``declared`` themselves for their own callers; this knob is
+                for non-MCP producer paths.
 
         Raises:
             ValueError: If rel_type is invalid
@@ -215,6 +237,13 @@ class GraphService:
 
         src_uuid = UUID(src_id) if isinstance(src_id, str) else src_id
         dst_uuid = UUID(dst_id) if isinstance(dst_id, str) else dst_id
+
+        # Only forward ``origin`` when the caller explicitly set it — passing
+        # None would override the column default and the repository's sticky-
+        # origin logic in ways that surprise existing Hebbian callers.
+        extra_kwargs: dict[str, Any] = {}
+        if origin is not None:
+            extra_kwargs["origin"] = origin
 
         await self.edge_repo.create_or_update_edge(
             user_id=self.user_id,
@@ -232,6 +261,7 @@ class GraphService:
             # Hebbian / GraphService.add_edge callers discard the return value
             # — skip the post-upsert SELECT (Issue #458 doesn't apply here).
             return_fresh_edge=False,
+            **extra_kwargs,
         )
 
         logger.debug(

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -15,6 +15,7 @@ from uuid import UUID
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.memory import (
+    _ALL_EDGE_ORIGINS,
     EDGE_TYPE_CONTINUES_FROM,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
@@ -217,30 +218,50 @@ class GraphService:
             confidence: Confidence score (0.0-1.0)
             origin: Optional provenance discriminator (#722; one of
                 ``EDGE_ORIGIN_HEBBIAN`` / ``EDGE_ORIGIN_SEMANTIC`` /
-                ``EDGE_ORIGIN_DECLARED``). If ``None`` (the default), the
-                column default ``hebbian`` is used — this path is the
-                Hebbian-internal writer, so the default fits the dominant
-                caller. Producer-asserted writes (e.g. the ai-worker emitting
+                ``EDGE_ORIGIN_DECLARED``). When ``None`` (the default), the
+                kwarg is NOT forwarded to ``NeuralEdgeRepository.create_or_update_edge``,
+                whose own ``origin: str = EDGE_ORIGIN_HEBBIAN`` keyword default
+                then takes effect (matching the ``server_default`` on the
+                column for raw-SQL paths). This path is the Hebbian-internal
+                writer, so the default fits the dominant caller. Producer-
+                asserted writes (e.g. the ai-worker emitting
                 ``continues_from`` / ``references_file``, #782) MUST pass
                 ``origin=EDGE_ORIGIN_DECLARED`` explicitly so the row is
                 exempt from ``DecayManager`` (which only touches
                 ``origin='hebbian'``). The MCP ``create_edge`` /
                 ``update_edge`` tools (``mcp_server/tools/edge.py``) pin
                 ``declared`` themselves for their own callers; this knob is
-                for non-MCP producer paths.
+                for non-MCP producer paths. When a non-None value is passed,
+                it is validated against ``_ALL_EDGE_ORIGINS`` and a
+                ``ValueError`` is raised on mismatch — fail-fast at the
+                service boundary rather than waiting for a DB CHECK violation
+                deep in the repository call (#782 Copilot review).
 
         Raises:
-            ValueError: If rel_type is invalid
+            ValueError: If ``rel_type`` is not in ``GraphService.EDGE_TYPES``,
+                or if ``origin`` is not None and not in ``_ALL_EDGE_ORIGINS``.
         """
         if rel_type not in self.EDGE_TYPES:
             raise ValueError(f"Invalid rel_type: {rel_type}. Must be one of {self.EDGE_TYPES}")
 
+        # #782 Copilot review: fail-fast on an invalid ``origin`` rather than
+        # letting an unrecognized value reach the DB CHECK constraint
+        # ``valid_edge_origin`` (which raises a deeper, less actionable
+        # IntegrityError). Cheap O(1) frozenset membership check; only runs
+        # when the caller opted into pinning ``origin`` explicitly.
+        if origin is not None and origin not in _ALL_EDGE_ORIGINS:
+            raise ValueError(
+                f"Invalid origin: {origin!r}. Must be one of {sorted(_ALL_EDGE_ORIGINS)}"
+            )
+
         src_uuid = UUID(src_id) if isinstance(src_id, str) else src_id
         dst_uuid = UUID(dst_id) if isinstance(dst_id, str) else dst_id
 
-        # Only forward ``origin`` when the caller explicitly set it — passing
-        # None would override the column default and the repository's sticky-
-        # origin logic in ways that surprise existing Hebbian callers.
+        # Only forward ``origin`` when the caller explicitly set it. Passing
+        # ``origin=None`` through to the repository would override its own
+        # ``EDGE_ORIGIN_HEBBIAN`` default (and the column ``server_default``)
+        # in ways that surprise existing Hebbian callers that have always
+        # relied on the implicit default.
         extra_kwargs: dict[str, Any] = {}
         if origin is not None:
             extra_kwargs["origin"] = origin

--- a/backend/tests/integration/test_memory_service_post_741.py
+++ b/backend/tests/integration/test_memory_service_post_741.py
@@ -292,7 +292,12 @@ async def test_deprecated_edge_type_literals_rejected_by_check(
             f"{constraint_def}"
         )
 
-    # Positive: the 4 surviving values MUST be present so the constraint is
-    # not accidentally too restrictive either.
-    for kept in ("neural_association", "related_to", "depends_on", "learned_from"):
+    # Positive: every value in ``_ALL_EDGE_TYPES`` (the canonical source of
+    # truth from models/memory.py) MUST appear in the live CHECK so the
+    # constraint is not accidentally too restrictive either. Iterating the
+    # source-of-truth tuple — instead of hand-typing the list here — means
+    # adding ``EDGE_TYPE_NEW`` requires no edit to this test (#782 self-review).
+    from models.memory import _ALL_EDGE_TYPES
+
+    for kept in _ALL_EDGE_TYPES:
         assert kept in constraint_def, f"surviving edge_type {kept!r} missing from CHECK constraint"

--- a/backend/tests/services/test_graph_service_edge_types.py
+++ b/backend/tests/services/test_graph_service_edge_types.py
@@ -1,4 +1,4 @@
-"""Tests for GraphService.EDGE_TYPES drift fix (#506, updated for #741).
+"""Tests for GraphService.EDGE_TYPES drift fix (#506, updated for #741 / #782).
 
 PR #460 introduced ``EDGE_TYPE_*`` constants in ``models/memory.py`` to
 mirror the DB CHECK constraint values. PR #507 (#461 Phase A) wired
@@ -9,12 +9,15 @@ subset in ``services/sleep/edge_discovery.py`` to those constants.
 ``GraphService.EDGE_TYPES``. #741 then collapsed the edge_type axis to four
 values (``neural_association`` / ``related_to`` / ``depends_on`` /
 ``learned_from``) by moving provenance to the ``origin`` axis and tag
-seeding to ``edge_metadata['source']``. The remaining set drift tests pin
-the post-#741 shape.
+seeding to ``edge_metadata['source']``. #782 widened the set back to six by
+appending two producer-asserted structural relation types
+(``continues_from`` / ``references_file``) emitted by the
+kagura-memory-ai-worker pipeline. The drift tests in this file pin the
+current shape.
 
-Tests pin both invariants:
+Tests pin three invariants:
 
-1. ``GraphService.EDGE_TYPES`` equals the union of the four surviving
+1. ``GraphService.EDGE_TYPES`` equals the union of the surviving
    ``EDGE_TYPE_*`` constants (matching the DB CHECK constraint), so future
    drift between the constants block and this validator set fails CI before
    the inconsistency can ship.
@@ -23,6 +26,10 @@ Tests pin both invariants:
    non-relational write (formerly ``semantic_similarity`` / ``declared_link``
    / ``tag_cooccurrence``) goes through ``neural_association`` and discriminates
    via ``origin`` + ``edge_metadata``.
+
+3. ``add_edge(rel_type=<producer-asserted>)`` succeeds and, when called with
+   ``origin=EDGE_ORIGIN_DECLARED``, forwards both ``edge_type`` and
+   ``origin`` to the repository — the #782 producer-asserted path.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -31,9 +38,12 @@ from uuid import uuid4
 import pytest
 
 from models.memory import (
+    EDGE_ORIGIN_DECLARED,
+    EDGE_TYPE_CONTINUES_FROM,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
 )
 from services.graph_service import GraphService
@@ -55,6 +65,8 @@ def test_edge_types_matches_constants() -> None:
             EDGE_TYPE_RELATED_TO,
             EDGE_TYPE_DEPENDS_ON,
             EDGE_TYPE_LEARNED_FROM,
+            EDGE_TYPE_CONTINUES_FROM,
+            EDGE_TYPE_REFERENCES_FILE,
         }
     )
 
@@ -94,16 +106,107 @@ async def test_add_edge_accepts_neural_association() -> None:
     assert kwargs["edge_type"] == EDGE_TYPE_NEURAL_ASSOCIATION
 
 
+@pytest.mark.parametrize(
+    "rel_type",
+    [EDGE_TYPE_CONTINUES_FROM, EDGE_TYPE_REFERENCES_FILE],
+)
+@pytest.mark.asyncio
+async def test_add_edge_accepts_producer_asserted_types(rel_type: str) -> None:
+    """#782: ``add_edge`` accepts the two producer-asserted structural types.
+
+    ``continues_from`` / ``references_file`` are emitted by the
+    kagura-memory-ai-worker ingest pipeline (not the LLM judge). The validator
+    must accept them and forward ``edge_type`` unchanged to
+    ``NeuralEdgeRepository``. Origin pinning is the caller's responsibility on
+    this path (see the sibling ``test_add_edge_propagates_explicit_origin``
+    for the producer-asserted contract): when ``origin`` is omitted the
+    repository column default ``hebbian`` applies — which is wrong for the
+    producer-asserted relation types, hence #782's explicit ``origin=`` knob.
+    """
+    src_id = uuid4()
+    dst_id = uuid4()
+
+    mock_edge_repo = MagicMock()
+    mock_edge_repo.create_or_update_edge = AsyncMock()
+
+    graph = GraphService.__new__(GraphService)
+    graph.user_id = "test_user_782"
+    graph.workspace_id = str(uuid4())
+    graph.context_id = str(uuid4())
+    graph.db = MagicMock()
+    graph.edge_repo = mock_edge_repo
+
+    await graph.add_edge(
+        src_id=src_id,
+        dst_id=dst_id,
+        rel_type=rel_type,
+        weight=0.8,
+    )
+
+    mock_edge_repo.create_or_update_edge.assert_awaited_once()
+    kwargs = mock_edge_repo.create_or_update_edge.await_args.kwargs
+    assert kwargs["edge_type"] == rel_type
+    # When `origin` is omitted, `add_edge` does NOT forward it — the
+    # repository column default (`hebbian`) takes over. Pinning this here so
+    # a future "set origin to hebbian by default" refactor (which would mask
+    # the producer-asserted contract documented above) fails fast.
+    assert "origin" not in kwargs
+
+
+@pytest.mark.parametrize(
+    "rel_type",
+    [EDGE_TYPE_CONTINUES_FROM, EDGE_TYPE_REFERENCES_FILE],
+)
+@pytest.mark.asyncio
+async def test_add_edge_propagates_explicit_origin(rel_type: str) -> None:
+    """#782: when a non-MCP producer-asserted caller passes
+    ``origin=EDGE_ORIGIN_DECLARED``, ``add_edge`` forwards it to the
+    repository so the row is exempt from ``DecayManager``.
+
+    Mirrors the contract pinned by ``mcp_server/tools/edge.py:handle_create_edge``
+    (which sets ``origin=EDGE_ORIGIN_DECLARED`` for MCP create_edge callers)
+    but exercises the in-process ``GraphService`` path used by any non-MCP
+    producer (sleep service, future consolidation workers, integration tests).
+    Without explicit propagation the producer-asserted rows would land with
+    ``origin='hebbian'`` and silently decay over time.
+    """
+    src_id = uuid4()
+    dst_id = uuid4()
+
+    mock_edge_repo = MagicMock()
+    mock_edge_repo.create_or_update_edge = AsyncMock()
+
+    graph = GraphService.__new__(GraphService)
+    graph.user_id = "test_user_782_origin"
+    graph.workspace_id = str(uuid4())
+    graph.context_id = str(uuid4())
+    graph.db = MagicMock()
+    graph.edge_repo = mock_edge_repo
+
+    await graph.add_edge(
+        src_id=src_id,
+        dst_id=dst_id,
+        rel_type=rel_type,
+        weight=0.8,
+        origin=EDGE_ORIGIN_DECLARED,
+    )
+
+    mock_edge_repo.create_or_update_edge.assert_awaited_once()
+    kwargs = mock_edge_repo.create_or_update_edge.await_args.kwargs
+    assert kwargs["edge_type"] == rel_type
+    assert kwargs["origin"] == EDGE_ORIGIN_DECLARED
+
+
 @pytest.mark.asyncio
 async def test_add_edge_rejects_unknown_rel_type() -> None:
     """Validator still rejects values outside ``EDGE_TYPES``.
 
     Negative-side complement to ``test_add_edge_accepts_neural_association``:
-    confirms the validator narrowed to four values without becoming a no-op.
-    Post-#741 the deprecated ``semantic_similarity`` / ``declared_link`` /
-    ``tag_cooccurrence`` strings are also no longer in the set, but this
-    test uses a clearly invalid string so the assertion does not need to
-    enumerate them.
+    confirms the validator (post-#741 = 4 values, post-#782 = 6 values)
+    did not become a no-op. The deprecated ``semantic_similarity`` /
+    ``declared_link`` / ``tag_cooccurrence`` strings are also still rejected,
+    but this test uses a clearly invalid string so the assertion does not
+    need to enumerate the historical drift surface.
     """
     src_id = uuid4()
     dst_id = uuid4()

--- a/backend/tests/services/test_graph_service_edge_types.py
+++ b/backend/tests/services/test_graph_service_edge_types.py
@@ -198,6 +198,38 @@ async def test_add_edge_propagates_explicit_origin(rel_type: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_add_edge_rejects_invalid_origin() -> None:
+    """#782 Copilot review: invalid ``origin`` fails fast at the service boundary.
+
+    Without this check, an unrecognized origin string would silently flow
+    through ``GraphService.add_edge`` and reach the DB CHECK constraint
+    ``valid_edge_origin``, surfacing as a deep IntegrityError. The fail-fast
+    ValueError at the service boundary is more actionable for non-MCP callers
+    (the MCP path pins origin to a constant and never hits this).
+    """
+    graph = GraphService.__new__(GraphService)
+    graph.user_id = "test_user_782_origin_invalid"
+    graph.workspace_id = str(uuid4())
+    graph.context_id = str(uuid4())
+    graph.db = MagicMock()
+    graph.edge_repo = MagicMock()
+    graph.edge_repo.create_or_update_edge = AsyncMock()
+
+    with pytest.raises(ValueError, match="Invalid origin"):
+        await graph.add_edge(
+            src_id=uuid4(),
+            dst_id=uuid4(),
+            rel_type=EDGE_TYPE_CONTINUES_FROM,
+            weight=0.8,
+            origin="not_a_real_origin",
+        )
+
+    # Validator must reject BEFORE reaching the repo — proves "fail-fast"
+    # is at the right layer (not merely earlier-than-DB).
+    graph.edge_repo.create_or_update_edge.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_add_edge_rejects_unknown_rel_type() -> None:
     """Validator still rejects values outside ``EDGE_TYPES``.
 

--- a/backend/tests/test_edge_type_constants.py
+++ b/backend/tests/test_edge_type_constants.py
@@ -3,9 +3,11 @@
 Pins:
 
 1. ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` equals the union of the
-   seven ``EDGE_TYPE_*`` constants exported from ``models/memory.py`` — i.e.
+   ``EDGE_TYPE_*`` constants exported from ``models/memory.py`` — i.e.
    the runtime set used by MCP edge tools is exactly the set the DB CHECK
    constraint accepts (the latter is mirrored as the constants in #460).
+   Post-#741 the set was four values; #782 appended ``continues_from`` and
+   ``references_file`` (producer-asserted structural relation types).
 
 2. ``services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`` is a
    subset of ``VALID_EDGE_TYPES`` — the LLM judge can only emit a deliberate
@@ -20,11 +22,15 @@ runtime test is the next safety net after pyright.
 
 from mcp_server.tools.edge import VALID_EDGE_TYPES
 from models.memory import (
+    _ALL_EDGE_TYPES,
+    EDGE_TYPE_CONTINUES_FROM,
     EDGE_TYPE_DEPENDS_ON,
     EDGE_TYPE_LEARNED_FROM,
     EDGE_TYPE_NEURAL_ASSOCIATION,
+    EDGE_TYPE_REFERENCES_FILE,
     EDGE_TYPE_RELATED_TO,
 )
+from services.graph_service import GraphService
 from services.sleep.edge_discovery import LLM_EMITTABLE_EDGE_TYPES
 
 
@@ -41,8 +47,37 @@ def test_valid_edge_types_matches_constants() -> None:
             EDGE_TYPE_RELATED_TO,
             EDGE_TYPE_DEPENDS_ON,
             EDGE_TYPE_LEARNED_FROM,
+            EDGE_TYPE_CONTINUES_FROM,
+            EDGE_TYPE_REFERENCES_FILE,
         }
     )
+
+
+def test_all_edge_type_validator_sets_match_all_edge_types() -> None:
+    """All three validator sets equal ``frozenset(_ALL_EDGE_TYPES)`` (#782).
+
+    The model's ``_ALL_EDGE_TYPES`` tuple (``models/memory.py``) is the
+    canonical source of truth for the relation axis (it drives the DB CHECK
+    constraint f-string). The two runtime guard sets —
+    ``mcp_server/tools/edge.py::VALID_EDGE_TYPES`` and
+    ``services/graph_service.py::GraphService.EDGE_TYPES`` — must equal the
+    same set, otherwise the MCP boundary and the in-process validator drift
+    (e.g. one accepts a new type that the other rejects).
+
+    The sibling ``test_valid_edge_types_matches_constants`` and
+    ``test_edge_types_matches_constants`` in
+    ``tests/services/test_graph_service_edge_types.py`` each pin one set
+    against a hand-typed frozenset of named constants — useful as a NAME
+    coverage check, but they cannot catch a drift WITHIN that hand-typed
+    set (e.g. a refactor that updates one site but not the other). This
+    chain-equality assertion pins all three sites to the same source so
+    adding ``EDGE_TYPE_NEW`` requires only appending to ``_ALL_EDGE_TYPES``
+    and the two frozensets — the test set in each sibling file no longer
+    needs hand-curation.
+    """
+    expected = frozenset(_ALL_EDGE_TYPES)
+    assert VALID_EDGE_TYPES == expected
+    assert GraphService.EDGE_TYPES == expected
 
 
 def test_llm_emittable_edge_types_subset_of_valid_edge_types() -> None:
@@ -78,7 +113,10 @@ def test_valid_edge_type_check_constraint_matches_migration_literal() -> None:
     """
     from models.memory import NeuralMemoryEdge
 
-    expected = "edge_type IN ('neural_association', 'related_to', 'depends_on', 'learned_from')"
+    expected = (
+        "edge_type IN ('neural_association', 'related_to', 'depends_on', "
+        "'learned_from', 'continues_from', 'references_file')"
+    )
 
     valid_edge_type_check = next(
         c for c in NeuralMemoryEdge.__table_args__ if getattr(c, "name", None) == "valid_edge_type"


### PR DESCRIPTION
Closes #782

## Summary
- Extends the server-side `edge_type` enum with two **producer-asserted structural relation types** (`continues_from`, `references_file`) emitted by the kagura-memory-ai-worker — coherent with the post-#741 two-axis model (`edge_type` = relation, `origin` = provenance).
- Fixes a **live cross-repo prod breakage**: ai-worker currently maps `references_file → declared_link` at the SDK boundary, but `declared_link` was removed from `edge_type` by #741 — so those edges are being rejected right now. Landing this lets the worker delete `_EDGE_TYPE_WORKAROUND_MAP` after the next redeploy.
- New alembic CHECK-widening migration `e25_782_widen_edge_type.py` (`down_revision=e24_668_drop_user_plans`); pure widening on upgrade (no data migration), lossy remap-to-`related_to` then shrink on downgrade (documented as offline-only).
- 3-layer drift coverage extended + a new chain-drift test that pins `VALID_EDGE_TYPES == GraphService.EDGE_TYPES == frozenset(_ALL_EDGE_TYPES)` so future enum additions can't desync the 3 validator sites.

## Implementation notes
- **Model** (`backend/src/models/memory.py`): appends `EDGE_TYPE_CONTINUES_FROM` / `EDGE_TYPE_REFERENCES_FILE` to `_ALL_EDGE_TYPES`; the `valid_edge_type` CHECK auto-regenerates to 6 values via the `__table_args__` f-string. Append-only — preserves byte-identity with the migration literal.
- **MCP validation guards** (`edge.py`, `graph_service.py`): both `VALID_EDGE_TYPES` and `GraphService.EDGE_TYPES` frozensets widened. `handle_update_edge` now pins `origin=EDGE_ORIGIN_DECLARED` symmetric with `handle_create_edge` (#738) so retyping a hebbian row to a producer-asserted type doesn't leave it decay-eligible.
- **MCP tool schemas** (`_definitions.py`): widened `create_edge` / `update_edge` JSON-Schema `edge_type` enums (functional fix — schema-validating clients would otherwise reject the new values), and updated `create_edge` / `explore` / `list_edges` description prose.
- **`GraphService.add_edge`**: adds optional `origin: str | None = None` parameter so non-MCP producer-asserted callers can pin `origin=EDGE_ORIGIN_DECLARED` (defaults to None → column-default `hebbian` for backward compatibility with existing Hebbian internal callers).
- **Migration**: drop+recreate CHECK (the only Postgres pattern). Downgrade is documented as offline-only — UPDATE → DROP → CREATE has the same ROW EXCLUSIVE / ACCESS EXCLUSIVE race window as `e20_741`'s downgrade.
- **Tests**: 3-layer drift pins (constant + `_ALL_EDGE_TYPES` tuple + migration CHECK literal) updated; new `test_all_edge_type_validator_sets_match_all_edge_types` chain-drift test; parametrized positive tests for both new types covering both `add_edge` validator-accepts AND explicit `origin=EDGE_ORIGIN_DECLARED` propagation; integration `kept` tuple now iterates `_ALL_EDGE_TYPES` so future enum additions need no test edit.
- `LLM_EMITTABLE_EDGE_TYPES` is intentionally NOT widened — these types are producer-asserted (worker pipeline), not LLM-chosen.

## Out of scope (separate-repo follow-ups, tracked on the issue)
- `kagura-memory-python-sdk` Edge model docstring (separate repo; `sdk/python/` in this repo holds only build artifacts).
- `kagura-memory-ai-worker` `_EDGE_TYPE_WORKAROUND_MAP` deletion (gated on this landing + server redeploy).
- `_definitions.py` enum drift CI pin (systemic pre-existing gap; surfaced by gate2 self-review; candidate for a broader 5-layer drift coverage epic).

## Pre-PR review summary
- gate2 mode: advisor-only (binary_gate: (none))
- audit: skipped
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask → CTO (re-rolled after a yellow on stale baseline; issue body + AC updated then re-reviewed)
- review provider: code-review

## Verification (local, pre-push)
- `ruff check` + `ruff format --check`: clean on all 8 changed files
- Targeted unit tests: 11/11 pass (`test_edge_type_constants.py` + `test_graph_service_edge_types.py`)
- Integration tests: 16/16 pass (`test_alembic_migrations.py` exercised the full chain through `e25_782` including the autogenerate-no-op + byte-identical CHECK literal check; `test_memory_service_post_741.py` confirmed the live DB CHECK contains all 6 values)

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/782-feat-feat-api-extend-edge-type-enum-with-cont.gate1.md
- ~/.claude/cache/gh-issue-driven/782-feat-feat-api-extend-edge-type-enum-with-cont.gate2.md

🤖 Generated via /gh-issue-driven:ship
