### PR TITLE
chore(api): align create_edge weight default to 1.0 in tool def (#814)

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -473,7 +473,7 @@ Response includes: edge_id, source_id, target_id, edge_type, weight, confidence,
             "description": """Create a manual edge between two memories in the Neural Memory graph.
 
 Use this when you know two memories are related but the automatic Edge Discovery hasn't connected them.
-The default weight of 0.5 is suitable for most manually created edges — you only need to specify source and target.
+The default weight of 1.0 is suitable for most manually created edges — you only need to specify source and target.
 
 Edge types:
 - 'related_to' (default): General relationship between memories
@@ -483,7 +483,7 @@ Edge types:
 - 'continues_from': Chronological/narrative successor between chat memories (producer-asserted, directional; #782)
 - 'references_file': Structural reference from a chat memory to a file overview (producer-asserted, directional; #782)
 
-Weight range: 0.0 (weakest) to 3.0 (strongest). Default: 0.5 (moderate manual connection).""",
+Weight range: 0.0 (weakest) to 3.0 (strongest). Default: 1.0 (full-confidence manual edge).""",
             "inputSchema": {
                 "type": "object",
                 "required": ["source_id", "target_id", "context_id"],
@@ -513,8 +513,8 @@ Weight range: 0.0 (weakest) to 3.0 (strongest). Default: 0.5 (moderate manual co
                     },
                     "weight": {
                         "type": "number",
-                        "description": "Edge weight 0.0-3.0 (default: 0.5). Higher = stronger connection.",
-                        "default": 0.5,
+                        "description": "Edge weight 0.0-3.0 (default: 1.0). Higher = stronger connection.",
+                        "default": 1.0,
                     },
                     "confidence": {
                         "type": "number",

--- a/backend/tests/mcp_server/test_edge_tools.py
+++ b/backend/tests/mcp_server/test_edge_tools.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 
 import pytest
 
+from mcp_server.tools._definitions import get_tool_definitions
 from mcp_server.tools.edge import handle_create_edge, handle_update_edge
 from models.memory import EDGE_ORIGIN_DECLARED
 
@@ -318,3 +319,15 @@ class TestCreateEdgeOriginAndWeight:
         mock_repo.create_or_update_edge.assert_awaited_once()
         kwargs = mock_repo.create_or_update_edge.await_args.kwargs
         assert kwargs["weight"] == 1.0
+
+    def test_schema_default_matches_handler_default(self):
+        """Issue #814: MCP tool definition's `create_edge.weight.default` MUST equal
+        the handler's runtime default (1.0). Pinning both sides forces any future
+        change to the handler to update the tool definition in the same PR, which
+        prevents the docs/runtime drift that Copilot caught on PR #812 and surfaced
+        as #814. The handler-side pin is `test_default_weight_is_1` above; this is
+        its schema-side counterpart.
+        """
+        create_edge = next(t for t in get_tool_definitions() if t["name"] == "create_edge")
+        weight_schema = create_edge["inputSchema"]["properties"]["weight"]
+        assert weight_schema["default"] == 1.0

--- a/backend/tests/mcp_server/test_edge_tools.py
+++ b/backend/tests/mcp_server/test_edge_tools.py
@@ -186,8 +186,8 @@ class TestCreateEdgeOriginAndWeight:
     written with `origin='declared'` so they survive the nightly Hebbian
     decay loop, and the default weight MUST be 1.0 (full confidence)
     rather than the prior 0.5 carryover. PR #735 documented this contract
-    in concepts.md / architecture.md; this test pair pins it at the
-    handler layer.
+    in concepts.md / architecture.md; this test trio pins it at both the
+    handler layer and the MCP tool-definition schema layer (#814).
     """
 
     @pytest.fixture


### PR DESCRIPTION
Closes #814

## Summary
- Align MCP `create_edge` tool definition's weight default (`0.5 → 1.0`) with the handler runtime default that became 1.0 in #738 (`origin='declared'` user-assertion path).
- Four literals fixed in `_definitions.py`: description prose (line 476), description range line (486), JSON-Schema description (516), JSON-Schema `"default"` (517). Issue body listed three; the second prose mention was caught during implementation.
- Add `test_schema_default_matches_handler_default` paired with the existing handler-side `test_default_weight_is_1` — pinning both sides forces any future handler-default change to update the tool definition in the same PR, closing the `#812 → #814` drift-detection loop.

## Implementation notes
- `_definitions.py:486` prose descriptor `"moderate manual connection"` no longer fit weight=1.0; replaced with `"full-confidence manual edge"` (matches the `(full confidence)` language in `test_edge_tools.py:188` and #738 / PR #735).
- Pin test added to `TestCreateEdgeOriginAndWeight` (not a new file) so the `create_edge` contract — origin, handler-default weight, schema-default weight — is locked in a single test class. Class docstring updated to reflect the new schema-layer coverage.
- Out of scope: `edge.py:325` (`update_edge` handler default `0.5`) is the same-shape drift for the `update_edge` contract. Explicitly deferred per scope discipline. `edge_type` enum (`_definitions.py:503-510`) already extended with `continues_from`/`references_file` via #782 — no further alignment needed.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (DX Lead lens)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/814-feat-chore-api-align-create-edge-weight-defau.gate1.md`
- `~/.claude/cache/gh-issue-driven/814-feat-chore-api-align-create-edge-weight-defau.gate2.md`

🤖 Generated via /gh-issue-driven:ship
