### PR TITLE
feat(frontend,api): in-tab search on context Memories tab (#580)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -527,6 +527,12 @@ async def list_memories(
     context_id: UUID | None = Query(
         None, description="Optional context ID to scope results to a single context"
     ),
+    q: str | None = Query(
+        None,
+        max_length=200,
+        description="Optional case-insensitive substring filter on memory.summary. "
+        "Whitespace-only values are treated as None.",
+    ),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
@@ -544,6 +550,12 @@ async def list_memories(
             only the creator sees their own. Mirrors the graph routes'
             ``owner_filter = user_id if context.is_private else None`` pattern
             in ``api/routes/graph.py``.
+        q: Optional case-insensitive substring filter applied to
+            ``Memory.summary`` via SQL ``ILIKE``. Surrounding whitespace is
+            stripped, and whitespace-only / empty values are normalized to
+            ``None`` (no filter). Independent of ``owner_filter`` — works
+            for both private (creator-only) and shared (all-members)
+            contexts.
         limit: Maximum number of memories to return
         offset: Pagination offset
 
@@ -574,6 +586,24 @@ async def list_memories(
             )
             owner_filter = user_id if context.is_private else None
 
+        # Normalize the substring filter: strip surrounding whitespace and
+        # treat empty / whitespace-only values as "no filter" so callers
+        # that bind an empty input box don't accidentally pin results to
+        # rows whose summary literally contains spaces. Independent of
+        # ``owner_filter`` — applies uniformly to both private and shared
+        # context paths.
+        q_normalized = (q or "").strip() or None
+
+        # Escape SQL LIKE wildcards in user input so a literal ``%`` or
+        # ``_`` is matched as a character, not as a wildcard. Without this,
+        # ``q="50%"`` matches every summary containing "50" followed by
+        # anything, and ``q="_"`` matches every single-character row.
+        # Escape backslash first to avoid double-escaping the escape itself.
+        q_pattern: str | None = None
+        if q_normalized:
+            q_escaped = q_normalized.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+            q_pattern = f"%{q_escaped}%"
+
         # Build query. Exclude soft-deleted rows — POST /forget sets
         # ``deleted_at`` rather than removing the row, and the list view
         # must not surface tombstones.
@@ -590,6 +620,9 @@ async def list_memories(
         if context_id is not None:
             query = query.where(Memory.context_id == context_id)
 
+        if q_pattern is not None:
+            query = query.where(Memory.summary.ilike(q_pattern, escape="\\"))
+
         # Get total count (with same filters as data query)
         count_query = select(func.count(Memory.id)).where(Memory.deleted_at.is_(None))
         if owner_filter is not None:
@@ -600,6 +633,8 @@ async def list_memories(
             count_query = count_query.where(Memory.type == type)
         if context_id is not None:
             count_query = count_query.where(Memory.context_id == context_id)
+        if q_pattern is not None:
+            count_query = count_query.where(Memory.summary.ilike(q_pattern, escape="\\"))
         count_result = await db.execute(count_query)
         total = count_result.scalar() or 0
 
@@ -632,7 +667,17 @@ async def list_memories(
 
         has_more = offset + len(memories) < total
 
-        logger.info("memory_list_retrieved", user_id=user_id, count=len(memories), total=total)
+        # Log presence + length of `q` rather than the value — user search
+        # strings can carry PII or secrets the operator did not intend to
+        # persist in log aggregation.
+        logger.info(
+            "memory_list_retrieved",
+            user_id=user_id,
+            count=len(memories),
+            total=total,
+            q_present=q_normalized is not None,
+            q_len=len(q_normalized) if q_normalized else 0,
+        )
 
         return MemoryListResponse(memories=memory_items, total=total, has_more=has_more)
 

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -75,6 +75,7 @@ class TestListMemoriesContextFilter:
                 scope=None,
                 type=None,
                 context_id=None,
+                q=None,
                 limit=50,
                 offset=0,
             )
@@ -115,6 +116,7 @@ class TestListMemoriesContextFilter:
                 scope=None,
                 type=None,
                 context_id=context_id,
+                q=None,
                 limit=50,
                 offset=0,
             )
@@ -166,6 +168,7 @@ class TestListMemoriesContextFilter:
                 scope=None,
                 type=None,
                 context_id=context_id,
+                q=None,
                 limit=50,
                 offset=0,
             )
@@ -209,6 +212,7 @@ class TestListMemoriesContextFilter:
                 scope=None,
                 type=None,
                 context_id=None,
+                q=None,
                 limit=50,
                 offset=0,
             )
@@ -229,6 +233,7 @@ class TestListMemoriesContextFilter:
                 scope=None,
                 type=None,
                 context_id=None,
+                q=None,
                 limit=50,
                 offset=0,
             )
@@ -258,9 +263,212 @@ class TestListMemoriesContextFilter:
                     scope=None,
                     type=None,
                     context_id=context_id,
+                    q=None,
                     limit=50,
                     offset=0,
                 )
 
         assert exc.value.status_code == 404
         mock_db.execute.assert_not_called()
+
+
+class TestListMemoriesQueryFilter:
+    """Issue #580: optional ``q`` substring filter on GET /memory/list.
+
+    The filter compiles to ``lower(memories.summary) LIKE lower(:param)`` under
+    SQLAlchemy's default dialect — assertions target that exact substring so
+    they aren't fooled by ``memories.summary`` appearing in ``select(Memory)``'s
+    projection list (it does, by definition).
+    """
+
+    ILIKE_PREDICATE = "lower(memories.summary) LIKE lower("
+
+    @pytest.mark.asyncio
+    async def test_q_omitted_does_not_add_summary_filter(self):
+        """When ``q`` is omitted, neither query carries the ILIKE predicate."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        with patch("api.routes.memory.PermissionService"):
+            response = await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=None,
+                q=None,
+                limit=50,
+                offset=0,
+            )
+
+        assert response.total == 1
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert self.ILIKE_PREDICATE not in sql, (
+                f"summary ILIKE unexpectedly present when q omitted "
+                f"(call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_q_provided_adds_summary_ilike_to_both_queries(self):
+        """With ``q="hello"``, the ILIKE predicate appears in count + data queries."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        with patch("api.routes.memory.PermissionService"):
+            response = await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=None,
+                q="hello",
+                limit=50,
+                offset=0,
+            )
+
+        assert response.total == 1
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert self.ILIKE_PREDICATE in sql, (
+                f"summary ILIKE missing when q provided (call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_q_whitespace_only_treated_as_none(self):
+        """``q="   "`` normalizes to None — neither query carries the predicate."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        with patch("api.routes.memory.PermissionService"):
+            await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=None,
+                q="   ",
+                limit=50,
+                offset=0,
+            )
+
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert self.ILIKE_PREDICATE not in sql, (
+                f"summary ILIKE unexpectedly present for whitespace-only q "
+                f"(call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_q_works_on_shared_context_without_user_id_filter(self):
+        """Critical regression guard for #435: q filter must work for non-creator
+        workspace members searching a shared context. The WHERE clause must
+        contain the ILIKE predicate AND ``context_id`` AND must NOT carry a
+        ``memories.user_id =`` predicate.
+        """
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+        context_id = uuid4()
+
+        mock_context = MagicMock()
+        mock_context.is_private = False
+
+        mock_perm_instance = MagicMock()
+        mock_perm_instance.resolve_context_for_workspace_read = AsyncMock(return_value=mock_context)
+
+        with patch(
+            "api.routes.memory.PermissionService", return_value=mock_perm_instance
+        ) as mock_perm_cls:
+            response = await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=context_id,
+                q="found",
+                limit=50,
+                offset=0,
+            )
+
+        mock_perm_cls.assert_called_once_with(mock_db)
+        mock_perm_instance.resolve_context_for_workspace_read.assert_awaited_once_with(
+            user_id="test_user_123", context_id=context_id
+        )
+        assert response.total == 1
+
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert self.ILIKE_PREDICATE in sql, (
+                f"summary ILIKE missing on shared-context q path (call_index={call_index}): {sql}"
+            )
+            assert "context_id" in sql, (
+                f"context_id predicate missing on shared-context q path "
+                f"(call_index={call_index}): {sql}"
+            )
+            assert "memories.user_id" not in sql, (
+                f"user_id predicate must be dropped for shared context "
+                f"(call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_q_strips_surrounding_whitespace(self):
+        """Surrounding whitespace is stripped before composing the ILIKE pattern."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        with patch("api.routes.memory.PermissionService"):
+            await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=None,
+                q="  hello  ",
+                limit=50,
+                offset=0,
+            )
+
+        for call_index in (0, 1):
+            stmt = mock_db.execute.call_args_list[call_index].args[0]
+            literal_sql = str(stmt.whereclause.compile(compile_kwargs={"literal_binds": True}))
+            assert "'%hello%'" in literal_sql, (
+                f"trimmed ILIKE pattern missing (call_index={call_index}): {literal_sql}"
+            )
+            assert "'%  hello  %'" not in literal_sql, (
+                f"un-trimmed ILIKE pattern leaked (call_index={call_index}): {literal_sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_q_escapes_like_wildcards(self):
+        """SQL LIKE wildcards in user input must be escaped so ``q="50%"``
+        searches for the literal substring "50%", not "50 followed by
+        anything". Same for ``_`` (single-character wildcard) and ``\\``
+        (the escape character itself)."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        with patch("api.routes.memory.PermissionService"):
+            await list_memories(
+                user=MOCK_USER,
+                db=mock_db,
+                scope=None,
+                type=None,
+                context_id=None,
+                q="50%_\\bar",
+                limit=50,
+                offset=0,
+            )
+
+        for call_index in (0, 1):
+            stmt = mock_db.execute.call_args_list[call_index].args[0]
+            literal_sql = str(stmt.whereclause.compile(compile_kwargs={"literal_binds": True}))
+            # The compiled pattern must contain the escaped form (each of %, _, \
+            # prefixed with a backslash), surrounded by the implicit % wildcards.
+            assert "'%50\\%\\_\\\\bar%'" in literal_sql, (
+                f"escaped ILIKE pattern missing (call_index={call_index}): {literal_sql}"
+            )
+            # And the SQL must declare the escape character so the DB engine
+            # interprets the backslash-prefixed metacharacters correctly.
+            assert "ESCAPE '\\'" in literal_sql, (
+                f"ESCAPE clause missing (call_index={call_index}): {literal_sql}"
+            )

--- a/frontend/src/components/contexts/MemoriesTabPanel.test.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.test.tsx
@@ -1,5 +1,6 @@
 /**
- * Tests for MemoriesTabPanel deep-link behavior (Issues #434 / #440).
+ * Tests for MemoriesTabPanel deep-link behavior (Issues #434 / #440)
+ * and debounced ?q= search (Issue #580).
  *
  * Covers:
  *   - ?memoryId= on mount auto-opens the dialog and renders ref data
@@ -7,9 +8,20 @@
  *     notFound mode (no toast)
  *   - URL is cleaned (memoryId param dropped) when the dialog closes
  *   - Backlink click hydrates the linked memory and updates the URL
+ *   - Typing the search input fires a debounced fetch carrying `q`
+ *   - Clearing the input drops `q` from the next fetch and the URL
+ *   - URL is updated with ?q= for shareable links
+ *   - Changing the query resets pagination to page 1
+ *   - No-results empty state quotes the query text back at the user
  */
 
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+} from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { MemoriesTabPanel } from "./MemoriesTabPanel";
@@ -44,8 +56,20 @@ vi.mock("@/hooks/use-toast", () => ({
   useToast: () => ({ toast: mockToast }),
 }));
 
+// `t(key)` returns the key verbatim, `t(key, { query: "foo" })` returns
+// `<key>:foo` so query-echoing copy stays assertable without dragging in
+// the real ICU compiler. Identity is stable across renders so `useCallback`
+// deps that close over `t` don't churn (and we don't get spurious refetches
+// on every keystroke).
+const { stableT } = vi.hoisted(() => ({
+  stableT: (k: string, values?: Record<string, unknown>) => {
+    if (!values) return k;
+    const parts = Object.values(values).map((v) => String(v));
+    return parts.length > 0 ? `${k}:${parts.join(",")}` : k;
+  },
+}));
 vi.mock("next-intl", () => ({
-  useTranslations: (_ns: string) => (k: string) => k,
+  useTranslations: (_ns: string) => stableT,
   useLocale: () => "en",
 }));
 
@@ -201,5 +225,275 @@ describe("MemoriesTabPanel — backlink navigation (Issue #440 + #434)", () => {
     // URL should have been updated to point at LINKED_ID.
     const writtenUrls = mockReplace.mock.calls.map((c) => c[0] as string);
     expect(writtenUrls.some((u) => u.includes(LINKED_ID))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Debounced search (Issue #580)
+// ---------------------------------------------------------------------------
+
+describe("MemoriesTabPanel — debounced search (Issue #580)", () => {
+  // Locate the search input by its translated aria-label key — the i18n
+  // mock returns the key string verbatim, so this is stable across copy
+  // changes.
+  const getSearchInput = (): HTMLInputElement =>
+    screen.getByLabelText("search.label") as HTMLInputElement;
+
+  // Pull the most recent call's `q` value (undefined if omitted entirely).
+  const lastFetchQ = (): string | undefined => {
+    const lastArgs = mockGetMemories.mock.calls.at(-1)?.[0] as
+      | { q?: string }
+      | undefined;
+    return lastArgs?.q;
+  };
+
+  it("renders the search input above the table on initial paint", async () => {
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+
+    // Input is present immediately, even before the first fetch resolves.
+    expect(getSearchInput()).toBeInTheDocument();
+    // And the initial fetch carries no q.
+    await waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+    expect(lastFetchQ()).toBeUndefined();
+  });
+
+  it("seeds the input from ?q= on mount and forwards it on the first fetch", async () => {
+    mockSearchParams.current = new URLSearchParams("q=foo");
+
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+
+    expect(getSearchInput().value).toBe("foo");
+    await waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+    expect(lastFetchQ()).toBe("foo");
+  });
+
+  it("debounces keystrokes — only the trailing value triggers a q-bearing fetch", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<MemoriesTabPanel contextId="ctx-1" />);
+
+      // Drain the initial mount fetch.
+      await vi.waitFor(() => expect(mockGetMemories).toHaveBeenCalledTimes(1));
+      const baselineCalls = mockGetMemories.mock.calls.length;
+
+      // Type a 3-char query in quick succession (well under 300ms).
+      fireEvent.change(getSearchInput(), { target: { value: "h" } });
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      fireEvent.change(getSearchInput(), { target: { value: "he" } });
+      act(() => {
+        vi.advanceTimersByTime(100);
+      });
+      fireEvent.change(getSearchInput(), { target: { value: "hel" } });
+
+      // Mid-stream: no extra fetch yet — debounce hasn't elapsed.
+      expect(mockGetMemories.mock.calls.length).toBe(baselineCalls);
+
+      // Cross the 300ms threshold from the LAST keystroke.
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await vi.waitFor(() =>
+        expect(mockGetMemories.mock.calls.length).toBeGreaterThan(
+          baselineCalls,
+        ),
+      );
+      expect(lastFetchQ()).toBe("hel");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clearing the input drops q from the next fetch", async () => {
+    vi.useFakeTimers();
+    try {
+      mockSearchParams.current = new URLSearchParams("q=foo");
+
+      render(<MemoriesTabPanel contextId="ctx-1" />);
+
+      await vi.waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+      expect(lastFetchQ()).toBe("foo");
+
+      fireEvent.change(getSearchInput(), { target: { value: "" } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await vi.waitFor(() => expect(lastFetchQ()).toBeUndefined());
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("syncs ?q= into the URL via router.replace after the debounce", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<MemoriesTabPanel contextId="ctx-1" />);
+      await vi.waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+
+      fireEvent.change(getSearchInput(), { target: { value: "alpha" } });
+      // Pre-debounce: no URL write for the query.
+      const preCalls = mockReplace.mock.calls.length;
+      expect(
+        mockReplace.mock.calls.slice(0, preCalls).some((c) => {
+          const url = c[0] as string;
+          return /[?&]q=alpha/.test(url);
+        }),
+      ).toBe(false);
+
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await vi.waitFor(() => {
+        const urls = mockReplace.mock.calls.map((c) => c[0] as string);
+        expect(urls.some((u) => /[?&]q=alpha/.test(u))).toBe(true);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("strips ?q= from the URL when the input is cleared", async () => {
+    vi.useFakeTimers();
+    try {
+      mockSearchParams.current = new URLSearchParams("q=foo");
+
+      render(<MemoriesTabPanel contextId="ctx-1" />);
+      await vi.waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+
+      fireEvent.change(getSearchInput(), { target: { value: "" } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await vi.waitFor(() => {
+        const lastUrl = mockReplace.mock.calls.at(-1)?.[0] as string;
+        expect(lastUrl).toBeDefined();
+        expect(lastUrl).not.toMatch(/[?&]q=/);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets pagination to page 1 when the debounced query changes", async () => {
+    // Seed a multi-page result so the Next button is rendered & enabled.
+    mockGetMemories.mockResolvedValue({
+      memories: [
+        {
+          id: "99999999-9999-9999-9999-999999999999",
+          summary: "Some row",
+          type: "note",
+          scope: "working",
+          importance: 0.4,
+          created_at: "2026-04-25T00:00:00Z",
+          updated_at: "2026-04-25T00:00:00Z",
+        },
+      ],
+      total: 120,
+      has_more: true,
+    });
+
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+
+    // Wait for the table to render — paginationNext only appears once
+    // loading resolves and the table is mounted.
+    const nextBtn = await screen.findByRole("button", {
+      name: "paginationNext",
+    });
+    fireEvent.click(nextBtn);
+
+    // The second fetch should carry offset=50 (page 2).
+    await waitFor(() => {
+      const lastArgs = mockGetMemories.mock.calls.at(-1)?.[0] as {
+        offset: number;
+      };
+      expect(lastArgs.offset).toBe(50);
+    });
+
+    // Now switch to fake timers for the debounced typing — but we already
+    // have the post-page-2 fetch in hand, so the new fetch comparison is
+    // safe.
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(getSearchInput(), { target: { value: "needle" } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await vi.waitFor(() => {
+        const lastArgs = mockGetMemories.mock.calls.at(-1)?.[0] as {
+          offset: number;
+          q?: string;
+        };
+        expect(lastArgs.q).toBe("needle");
+        expect(lastArgs.offset).toBe(0);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("renders the no-results empty state with the query when nothing matches", async () => {
+    // Start with a populated context so the empty-context branch doesn't
+    // hijack the render — we only want to exercise the no-results branch.
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+    await waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+
+    // Now flip the mock to return an empty set for the upcoming search.
+    mockGetMemories.mockResolvedValue({
+      memories: [],
+      total: 0,
+      has_more: false,
+    });
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.change(getSearchInput(), { target: { value: "zzz" } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    // i18n mock encodes "{key}:{value}" — the description must contain
+    // the query value.
+    await screen.findByText(/noResultsDesc:zzz/);
+    // And the no-results title is used, not the zero-memories title.
+    expect(screen.queryByText("emptyTitle")).not.toBeInTheDocument();
+    expect(screen.getByText("noResultsTitle")).toBeInTheDocument();
+  });
+
+  it("whitespace-only input is treated as absent (q omitted, no URL noise)", async () => {
+    vi.useFakeTimers();
+    try {
+      render(<MemoriesTabPanel contextId="ctx-1" />);
+      await vi.waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+
+      fireEvent.change(getSearchInput(), { target: { value: "   " } });
+      act(() => {
+        vi.advanceTimersByTime(300);
+      });
+
+      // Whitespace-only debouncedQuery is trimmed inside the component
+      // before the fetch call — q must be undefined on the wire (a server
+      // that received `"   "` would be a regression).
+      await vi.waitFor(() => {
+        const lastArgs = mockGetMemories.mock.calls.at(-1)?.[0] as {
+          q?: string;
+        };
+        expect(lastArgs.q).toBeUndefined();
+      });
+
+      // And no URL was written with `q=` set to a whitespace-only value.
+      const urls = mockReplace.mock.calls.map((c) => c[0] as string);
+      expect(urls.some((u) => /[?&]q=(?:%20|\s)/.test(u))).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -10,20 +10,27 @@
  * Dialog state machine extracted to `useMemoryDetailDialog` (Issue #435)
  * so GraphTabPanel can reuse it.
  *
+ * Issue #580: adds a debounced (300ms) search input that drives the
+ * `q` query-string parameter end-to-end — URL-synced via `?q=` for
+ * shareable links, page reset to 1 on every debounced change, two
+ * distinct empty states (zero memories vs. zero matches).
+ *
  * Create is still deferred — needs an MCP-shape form rewrite.
  */
 
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { FileText } from "lucide-react";
+import { FileText, Search, SearchX } from "lucide-react";
 import { MemoriesTable } from "@/components/memories/MemoriesTable";
 import { MemoryDetailDialog } from "@/components/memories/MemoryDetailDialog";
 import { DeleteMemoryDialog } from "@/components/memories/DeleteMemoryDialog";
 import { EditMemoryDialog } from "@/components/memories/EditMemoryDialog";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { EmptyState } from "@/components/ui/empty-state";
+import { Input } from "@/components/ui/input";
 import { useToast } from "@/hooks/use-toast";
 import { useMemoryDetailDialog } from "@/hooks/useMemoryDetailDialog";
 import { useMemoryIdParam } from "@/hooks/useMemoryIdParam";
@@ -35,11 +42,23 @@ interface MemoriesTabPanelProps {
 }
 
 const PAGE_SIZE = 50;
+const SEARCH_PARAM = "q";
+const DEBOUNCE_MS = 300;
 
 export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   const t = useTranslations("contextDetail.memoriesPanel");
   const { toast } = useToast();
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
   const [memoryIdParam, setMemoryIdParam] = useMemoryIdParam();
+
+  // Seed both the controlled-input state and the debounced query from the
+  // URL so the first paint reflects a shared link (`?q=foo`) without an
+  // extra render cycle.
+  const initialQuery = searchParams.get(SEARCH_PARAM) ?? "";
+  const [searchInput, setSearchInput] = useState<string>(initialQuery);
+  const [debouncedQuery, setDebouncedQuery] = useState<string>(initialQuery);
 
   const [items, setItems] = useState<MemoryListItem[]>([]);
   const [total, setTotal] = useState(0);
@@ -47,26 +66,77 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // Monotonic request id — guards against a slow earlier fetch resolving
+  // after a faster later one and overwriting `items` with stale results.
+  // Each call increments the ref; only the latest call's response is
+  // committed to state.
+  const requestIdRef = useRef(0);
+
   const dialog = useMemoryDetailDialog({ memoryIdParam, setMemoryIdParam });
 
+  // Debounce: schedule a single timer that promotes `searchInput` into
+  // `debouncedQuery` AND resets page to 1 in one batched update. Doing
+  // both inside the same setTimeout callback lets React 18 batch the two
+  // state updates into a single render, so `fetchMemories` regenerates
+  // exactly once per debounced change. Splitting the page reset into a
+  // separate effect would cause a double fetch (first with the stale
+  // page, then with page=1).
+  useEffect(() => {
+    if (searchInput === debouncedQuery) return;
+    const timer = window.setTimeout(() => {
+      setDebouncedQuery(searchInput);
+      setPage(1);
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [searchInput, debouncedQuery]);
+
+  // Sync the URL whenever the *debounced* query changes — per-keystroke
+  // navigation would spam history and trigger refetches for every
+  // intermediate prefix.
+  useEffect(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    const trimmed = debouncedQuery.trim();
+    if (trimmed) {
+      params.set(SEARCH_PARAM, trimmed);
+    } else {
+      params.delete(SEARCH_PARAM);
+    }
+    const next = params.toString();
+    const current = searchParams.toString();
+    if (next === current) return;
+    router.replace(`${pathname}${next ? `?${next}` : ""}`);
+    // We deliberately exclude `searchParams`/`router`/`pathname` from the
+    // dependency array — those identities can flip on any URL change
+    // (including ones we just made), and re-running would race with the
+    // setMemoryIdParam writer. The debounced value is the only real input.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedQuery]);
+
   const fetchMemories = useCallback(async () => {
+    const requestId = ++requestIdRef.current;
     setLoading(true);
     setError(null);
     try {
       const offset = (page - 1) * PAGE_SIZE;
+      // Trim before sending — whitespace-only is equivalent to no filter
+      // on the backend, but the client should not waste a request on it.
+      const trimmed = debouncedQuery.trim();
       const response = await getMemories({
         context_id: contextId,
         limit: PAGE_SIZE,
         offset,
+        q: trimmed || undefined,
       });
+      if (requestId !== requestIdRef.current) return;
       setItems(response.memories);
       setTotal(response.total);
     } catch (err) {
+      if (requestId !== requestIdRef.current) return;
       setError(err instanceof Error ? err.message : t("loadFailed"));
     } finally {
-      setLoading(false);
+      if (requestId === requestIdRef.current) setLoading(false);
     }
-  }, [contextId, page, t]);
+  }, [contextId, page, debouncedQuery, t]);
 
   useEffect(() => {
     fetchMemories();
@@ -105,32 +175,80 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     }
   }, [dialog, fetchMemories, toast, t, items.length, page]);
 
+  // Search input renders above any state branch (error / empty) so the
+  // user can always clear or refine the query without re-mounting it.
+  const searchBar = (
+    <div className="relative">
+      <Search
+        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+        aria-hidden="true"
+      />
+      <Input
+        type="search"
+        value={searchInput}
+        onChange={(e) => setSearchInput(e.target.value)}
+        placeholder={t("search.placeholder")}
+        aria-label={t("search.label")}
+        className="pl-9"
+      />
+    </div>
+  );
+
   if (error) {
-    return <ErrorBanner error={error} />;
+    return (
+      <div className="space-y-4">
+        {searchBar}
+        <ErrorBanner error={error} />
+      </div>
+    );
   }
 
-  if (!loading && items.length === 0 && !memoryIdParam) {
+  const hasQuery = debouncedQuery.trim().length > 0;
+
+  // No memories at all in this context — keep the existing landing copy.
+  if (!loading && items.length === 0 && !hasQuery && !memoryIdParam) {
     return (
-      <EmptyState
-        icon={FileText}
-        title={t("emptyTitle")}
-        description={t("emptyDesc")}
-      />
+      <div className="space-y-4">
+        {searchBar}
+        <EmptyState
+          icon={FileText}
+          title={t("emptyTitle")}
+          description={t("emptyDesc")}
+        />
+      </div>
+    );
+  }
+
+  // Query produced no matches — distinct copy that echoes the query so the
+  // user can tell whether they mistyped vs. ran a too-narrow filter.
+  if (!loading && items.length === 0 && hasQuery && !memoryIdParam) {
+    return (
+      <div className="space-y-4">
+        {searchBar}
+        <EmptyState
+          icon={SearchX}
+          title={t("noResultsTitle")}
+          description={t("noResultsDesc", { query: debouncedQuery })}
+        />
+      </div>
     );
   }
 
   return (
     <>
-      <MemoriesTable
-        memories={items}
-        loading={loading}
-        onView={handleView}
-        onDelete={handleDelete}
-        page={page}
-        pageSize={PAGE_SIZE}
-        total={total}
-        onPageChange={setPage}
-      />
+      <div className="space-y-4">
+        {searchBar}
+        <MemoriesTable
+          memories={items}
+          loading={loading}
+          onView={handleView}
+          onDelete={handleDelete}
+          page={page}
+          pageSize={PAGE_SIZE}
+          total={total}
+          onPageChange={setPage}
+        />
+      </div>
       <MemoryDetailDialog
         memory={dialog.hydrated}
         open={dialog.detailOpen}

--- a/frontend/src/lib/api/memory.ts
+++ b/frontend/src/lib/api/memory.ts
@@ -12,12 +12,18 @@ import type {
   MemoryReference,
 } from "../types/memory";
 
-// Issue #431/#433: Backend `GET /api/v1/memory/list` accepts only
-// {context_id, scope, type, limit, offset}.
+// Issue #431/#433/#580: Backend `GET /api/v1/memory/list` accepts only
+// {context_id, scope, type, q, limit, offset}.
+//
+// `q` (Issue #580): case-insensitive substring filter on memory summary.
+// Trimmed client-side; whitespace-only values are dropped (the param is not
+// sent at all) so the URL stays clean and the backend treats absent and
+// whitespace-only identically.
 export interface ListMemoriesParams {
   context_id?: string;
   scope?: MemoryScope;
   type?: string;
+  q?: string;
   limit?: number;
   offset?: number;
 }
@@ -36,6 +42,10 @@ export async function getMemories(
   if (params.context_id) searchParams.set("context_id", params.context_id);
   if (params.scope) searchParams.set("scope", params.scope);
   if (params.type) searchParams.set("type", params.type);
+  if (params.q) {
+    const trimmed = params.q.trim();
+    if (trimmed) searchParams.set("q", trimmed);
+  }
   searchParams.set("limit", String(params.limit ?? 50));
   searchParams.set("offset", String(params.offset ?? 0));
 

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3056,7 +3056,13 @@
       "loadFailed": "Failed to load memories",
       "hydrateFailed": "Failed to load memory details",
       "deleteSuccess": "Memory deleted",
-      "editSuccess": "Memory updated"
+      "editSuccess": "Memory updated",
+      "search": {
+        "placeholder": "Search memories…",
+        "label": "Search"
+      },
+      "noResultsTitle": "No results",
+      "noResultsDesc": "No memories match \"{query}\"."
     },
     "memoriesTable": {
       "loading": "Loading memories...",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3056,7 +3056,13 @@
       "loadFailed": "メモリの読み込みに失敗しました",
       "hydrateFailed": "メモリ詳細の取得に失敗しました",
       "deleteSuccess": "メモリを削除しました",
-      "editSuccess": "メモリを更新しました"
+      "editSuccess": "メモリを更新しました",
+      "search": {
+        "placeholder": "メモリを検索…",
+        "label": "検索"
+      },
+      "noResultsTitle": "該当なし",
+      "noResultsDesc": "「{query}」に一致するメモリがありません。"
     },
     "memoriesTable": {
       "loading": "メモリを読み込み中...",


### PR DESCRIPTION
Closes #580

## Summary
- Extends the existing Memories tab on `/workspace/contexts/[id]` with a debounced (300ms), URL-synced search box (`?q=…`).
- Backend `GET /api/v1/memory/list` gains an optional `q: str | None` substring filter (case-insensitive `ILIKE` on `Memory.summary`) with LIKE metacharacters (`%` / `_` / `\`) properly escaped.
- Race-condition guard via monotonic `requestIdRef` drops stale fetch responses; whitespace-only input is normalized client-side and treated as `None` server-side.
- PII-safe structured logging (`q_present` / `q_len` instead of the raw query string).

## Implementation notes

- **Backend** (`backend/src/api/routes/memory.py`): `q` is normalized via `(q or "").strip() or None`; LIKE wildcards (`%` / `_` / `\`) are escaped before composing the pattern; the filter is applied symmetrically to both the data query AND the count query so pagination totals stay coherent. Orthogonal to the existing `owner_filter` so the shared-context regression pattern from #435 / PR #453 is preserved (asserted in tests).
- **Frontend** (`MemoriesTabPanel.tsx`): `setDebouncedQuery` + `setPage(1)` are batched inside the same `setTimeout` callback so React 18 auto-batches them into a single render — avoids the double-fetch trap where a query change while on page > 1 would otherwise fire one fetch with stale page=N and a second with page=1.
- **URL sync**: hand-rolled via `router.replace` keyed only on `debouncedQuery`; preserves sibling params (`?tab=memories`, `?memoryId=…`). Not yet factored into a generic `useUrlParam` hook — Rule of Three not met.
- **i18n**: new keys `contextDetail.memoriesPanel.search.{placeholder,label}` + `noResultsTitle` + `noResultsDesc` (with `{query}` ICU placeholder) added to both `en.json` and `ja.json`.

## Pre-PR review summary

- gate2 mode: **advisor-only**
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green (via /ask)
- review provider: copilot

Full reviews are saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/580-feat-feat-frontend-api-object-list-search-in.gate1.md`
- `~/.claude/cache/gh-issue-driven/580-feat-feat-frontend-api-object-list-search-in.gate2.md`

## Out of scope / Follow-ups

- **#818** (this repo) — `chore(db): trigram (pg_trgm) index on memory.summary` for `/memory/list` `q` filter performance at scale. The current ILIKE scan is acceptable at sub-10k memories per workspace; the index becomes load-bearing past that.
- **kagura-ai/kagura-memory-python-sdk#143** — `feat(client): expose optional q kwarg on list_memories()` for SDK parity. Non-breaking; can be picked up independently.
- `Memory.context_summary` (Layer 2) is **deliberately not** in the search target — Option A in #580's design decision restricts v1 to `summary` only. The `/recall` surface remains the hybrid-search path for deeper queries.
- Files tab and Resources surfacing on the context detail page were explicitly deferred at design time (see #580 body) — not in this PR.

🤖 Generated via /gh-issue-driven:ship
