### PR TITLE
fix(api): treat date-only `to` filter as day-inclusive in analyses (#820)

### DIFF
--- a/backend/src/services/analysis/orchestrator.py
+++ b/backend/src/services/analysis/orchestrator.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -129,7 +129,7 @@ assert _PAID_BY_BYOK in MEMORY_ANALYSIS_PAID_BY_VALUES, (
 )
 
 
-def _params_iso_to_naive_utc(s: str | None) -> datetime | None:
+def _params_iso_to_naive_utc(s: str | None, *, end_of_day: bool = False) -> datetime | None:
     """Parse an ISO-8601 string into a naive UTC datetime.
 
     The API layer (#496) accepts both naive and tz-aware datetimes in
@@ -138,12 +138,27 @@ def _params_iso_to_naive_utc(s: str | None) -> datetime | None:
     TIME ZONE — naive UTC by repo convention #489). Without this
     normalization, asyncpg raises a binding error when a tz-aware
     bound parameter is compared against a naive column.
+
+    When ``end_of_day=True`` AND the input is a **date-only** string
+    (e.g. ``"2026-05-28"``, no ``T`` separator), the result is shifted
+    to the *start of the next day* so that downstream filters using
+    ``Memory.created_at < to_dt`` are effectively day-inclusive (#820).
+    The UI date picker surfaces ``to`` as the last *included* date;
+    without the shift, ``to=2026-05-28`` would silently exclude every
+    memory created on 2026-05-28. Strings carrying a time component
+    are passed through unchanged so callers that need precise-time
+    bounds keep the original semantics.
     """
     if s is None:
         return None
     dt = datetime.fromisoformat(s)
     if dt.tzinfo is not None:
         dt = dt.astimezone(UTC).replace(tzinfo=None)
+    # Date-only detection: ISO-8601 date is exactly 10 chars ("YYYY-MM-DD")
+    # and contains no time separator. Anything richer (datetime, tz suffix)
+    # is treated as caller-controlled precision.
+    if end_of_day and len(s) == 10 and "T" not in s:
+        dt = dt + timedelta(days=1)
     return dt
 
 
@@ -349,7 +364,10 @@ class AnalysisOrchestrator:
         # may submit either tz-aware (e.g. "...+09:00") or naive ISO
         # strings; both routes converge here.
         from_dt = _params_iso_to_naive_utc(params_jsonb.get("from"))
-        to_dt = _params_iso_to_naive_utc(params_jsonb.get("to"))
+        # ``to`` is inclusive at the day level for date-only inputs — see
+        # _params_iso_to_naive_utc / #820. Datetimes with time components
+        # stay exclusive so callers needing precision are not surprised.
+        to_dt = _params_iso_to_naive_utc(params_jsonb.get("to"), end_of_day=True)
 
         try:
             # Stage [C] — pull memories + their existing Qdrant vectors.

--- a/backend/tests/services/analysis/test_orchestrator.py
+++ b/backend/tests/services/analysis/test_orchestrator.py
@@ -97,6 +97,40 @@ class TestParamsIsoToNaiveUtc:
             2024, 1, 15, 10, 30, 0
         )
 
+    def test_end_of_day_shifts_date_only_to_next_day(self) -> None:
+        """Regression for #820: a date-only ``to`` value must be shifted
+        forward by one day so the SQL ``Memory.created_at < to_dt``
+        comparison effectively includes the entire calendar day. Without
+        this shift, ``to=2026-05-28`` silently excludes every memory
+        ingested on 2026-05-28.
+        """
+        assert _params_iso_to_naive_utc("2026-05-28", end_of_day=True) == datetime(
+            2026, 5, 29, 0, 0, 0
+        )
+
+    def test_end_of_day_passes_datetime_inputs_through_unchanged(self) -> None:
+        """A precise-time ``to`` (datetime with a time component) keeps
+        exclusive-bound semantics; only date-only inputs are reinterpreted.
+        """
+        # Naive datetime.
+        assert _params_iso_to_naive_utc("2026-05-28T15:00:00", end_of_day=True) == datetime(
+            2026, 5, 28, 15, 0, 0
+        )
+        # Tz-aware datetime (JST → UTC normalization still happens; no
+        # day shift because the input is not date-only).
+        assert _params_iso_to_naive_utc("2026-05-28T15:00:00+09:00", end_of_day=True) == datetime(
+            2026, 5, 28, 6, 0, 0
+        )
+
+    def test_end_of_day_none_returns_none(self) -> None:
+        assert _params_iso_to_naive_utc(None, end_of_day=True) is None
+
+    def test_default_end_of_day_false_preserves_legacy_behavior(self) -> None:
+        """Callers that do not opt in (e.g. the ``from`` lower-bound)
+        keep the original parse-as-is behavior — no accidental shift.
+        """
+        assert _params_iso_to_naive_utc("2026-05-28") == datetime(2026, 5, 28, 0, 0, 0)
+
 
 # ---------------------------------------------------------------------------
 # _resolve_pricing_row


### PR DESCRIPTION
Closes #820

## Summary

- `_params_iso_to_naive_utc` now accepts `end_of_day=True` which shifts a date-only `to` ISO string forward by one day so the downstream `Memory.created_at < to_dt` filter is effectively **day-inclusive**.
- Datetimes with a time component (`2026-05-28T15:00:00`, `…+09:00`, etc.) are passed through unchanged — precise-time callers keep their existing exclusive-bound semantics.
- The orchestrator's run loop calls the converter with `end_of_day=True` for `to` only; `from` keeps its inclusive lower-bound semantics intact.

## Why

Hit in production today against context `25bb3bce-…`. Operator triggered analyses with `from=2026-04-28, to=2026-05-28` and `from=2026-05-28, to=2026-05-28`. Both failed within ~70ms with `"No memories matched the analysis filters; refusing to start an empty run"` even though the context held 67 candidate memories (all `importance>=0.6`, `embedding_status=success`). Root cause: every memory was ingested on `2026-05-28` between 07:20 and 10:37 UTC, but `to=2026-05-28` parsed to `datetime(2026, 5, 28, 0, 0, 0)` and the SQL filter `< 2026-05-28 00:00:00` excluded the entire day.

## Tests

Added 4 new pure-function cases under `TestParamsIsoToNaiveUtc`:

- `test_end_of_day_shifts_date_only_to_next_day` — pins the regression (`"2026-05-28"` + `end_of_day=True` → `datetime(2026, 5, 29, 0, 0, 0)`).
- `test_end_of_day_passes_datetime_inputs_through_unchanged` — naive datetime and tz-aware (JST) inputs do NOT shift even with `end_of_day=True`.
- `test_end_of_day_none_returns_none` — explicit None handling.
- `test_default_end_of_day_false_preserves_legacy_behavior` — guards the `from` parsing path from any accidental shift.

Existing 4 tests in the class are untouched.

## Verification

Pre-fix: `_params_iso_to_naive_utc("2026-05-28") → 2026-05-28 00:00:00` (excludes whole day with `<`).
Post-fix: `_params_iso_to_naive_utc("2026-05-28", end_of_day=True) → 2026-05-29 00:00:00` (includes whole day with `<`).

Local verification via `docker exec kagura-api python -c "..."` against all 8 assertion cases — all pass.

`make lint` clean.

## Production debug breadcrumbs (will be auto-archived)

Failed runs that motivated this fix:
- `03f1e26b-7d76-45b6-aeb0-ed982a662ad7` — 2026-05-28 11:26:51, `from=to=2026-05-28`
- `ad4f86e4-555c-467a-af33-450b1c02b03a` — 2026-05-28 11:26:11, `from=2026-04-28, to=2026-05-28`

🤖 Generated via /gh-issue-driven:ship (lightweight path — single-file pure-function fix)
