### PR TITLE
fix(api): scope workspace memory-timeline to its workspace boundary (#822)

### DIFF
--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -1244,29 +1244,39 @@ class WorkspaceService:
         # Scoping by membership (``Memory.user_id.in_(member_ids)``) leaked
         # other workspaces' memories for users who belong to multiple
         # workspaces. Scope by ``Context.workspace_id`` instead — matching the
-        # stats-card semantics in ``api/routes/workspace.py`` — because
-        # ``Memory.workspace_id`` is nullable and would under-count legacy rows.
-        contexts_stmt = select(Context.id).where(
+        # context-scoped stats path in ``api/routes/workspace.py`` (the
+        # /workspace/stats endpoint filters ``Context.workspace_id``). We scope
+        # on ``Context`` rather than ``Memory.workspace_id`` because the latter
+        # is nullable and would under-count legacy rows. As a subquery (not a
+        # materialized id list) this stays a single round-trip and lets the DB
+        # use the ``Context`` index regardless of how many contexts exist.
+        workspace_contexts = select(Context.id).where(
             Context.workspace_id == workspace_id,
             Context.deleted_at.is_(None),
         )
-        contexts_result = await self.db.execute(contexts_stmt)
-        workspace_context_ids = [row[0] for row in contexts_result.all()]
 
         # An optional ``context_id`` filter must belong to this workspace —
         # otherwise a foreign context_id could surface another workspace's
-        # memories through this endpoint.
+        # memories. Reuse the canonical boundary check rather than re-deriving
+        # it here (single source of truth, see analysis.query_service).
         if context_id is not None:
-            scoped_context_ids = [context_id] if context_id in workspace_context_ids else []
-        else:
-            scoped_context_ids = workspace_context_ids
+            from services.analysis.query_service import verify_context_in_workspace
 
-        # Aggregate daily memory creation counts
-        if scoped_context_ids:
+            in_workspace = await verify_context_in_workspace(
+                self.db, workspace_id=workspace_id, context_id=context_id
+            )
+            memory_scope = Memory.context_id == context_id if in_workspace else None
+        else:
+            memory_scope = Memory.context_id.in_(workspace_contexts)
+
+        # Aggregate daily memory creation counts. ``memory_scope`` is None only
+        # when a foreign context_id was supplied — return an empty (zero-filled)
+        # timeline in that case.
+        if memory_scope is not None:
             # Issue #275 Performance: Use datetime range filter (idx_created_at)
             # instead of func.date() which prevents index usage
             conditions = [
-                Memory.context_id.in_(scoped_context_ids),
+                memory_scope,
                 Memory.deleted_at.is_(None),  # CRITICAL: Exclude soft-deleted
                 Memory.created_at >= start_datetime,  # ✅ Uses idx_created_at
                 Memory.created_at <= end_datetime,

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -1240,25 +1240,37 @@ class WorkspaceService:
         if not workspace:
             raise NotFoundException(f"Workspace {workspace_id} not found")
 
-        # Get workspace member user_ids (CRITICAL: workspace boundary via members)
-        members_stmt = select(WorkspaceMember.user_id).where(
-            WorkspaceMember.workspace_id == workspace_id
+        # Workspace boundary via the workspace's own contexts (Issue #822).
+        # Scoping by membership (``Memory.user_id.in_(member_ids)``) leaked
+        # other workspaces' memories for users who belong to multiple
+        # workspaces. Scope by ``Context.workspace_id`` instead — matching the
+        # stats-card semantics in ``api/routes/workspace.py`` — because
+        # ``Memory.workspace_id`` is nullable and would under-count legacy rows.
+        contexts_stmt = select(Context.id).where(
+            Context.workspace_id == workspace_id,
+            Context.deleted_at.is_(None),
         )
-        members_result = await self.db.execute(members_stmt)
-        member_ids = [row[0] for row in members_result.all()]
+        contexts_result = await self.db.execute(contexts_stmt)
+        workspace_context_ids = [row[0] for row in contexts_result.all()]
+
+        # An optional ``context_id`` filter must belong to this workspace —
+        # otherwise a foreign context_id could surface another workspace's
+        # memories through this endpoint.
+        if context_id is not None:
+            scoped_context_ids = [context_id] if context_id in workspace_context_ids else []
+        else:
+            scoped_context_ids = workspace_context_ids
 
         # Aggregate daily memory creation counts
-        if member_ids:
+        if scoped_context_ids:
             # Issue #275 Performance: Use datetime range filter (idx_created_at)
             # instead of func.date() which prevents index usage
             conditions = [
-                Memory.user_id.in_(member_ids),
+                Memory.context_id.in_(scoped_context_ids),
                 Memory.deleted_at.is_(None),  # CRITICAL: Exclude soft-deleted
                 Memory.created_at >= start_datetime,  # ✅ Uses idx_created_at
                 Memory.created_at <= end_datetime,
             ]
-            if context_id:
-                conditions.append(Memory.context_id == context_id)
 
             daily_counts_stmt = (
                 select(

--- a/backend/tests/integration/test_workspace_memory_timeline_boundary.py
+++ b/backend/tests/integration/test_workspace_memory_timeline_boundary.py
@@ -10,13 +10,29 @@ chart).
 
 This is the same defect family as #389/#391, #660/#662, and #435 (the
 ``Memory.user_id`` legacy-scoping pattern). The fix scopes the timeline to
-the workspace's own contexts, matching the stats-card semantics in
-``api/routes/workspace.py`` (``Context.workspace_id``).
+the workspace's own contexts (``Context.workspace_id``), matching the
+context-scoped stats path in ``api/routes/workspace.py``.
 
-The load-bearing predicate uses the cross-rooted-memory pattern (#614/#383):
-a single ``multi_user`` is a member of both ``ws_a`` and ``ws_b`` and creates
-memories in each. ``ws_a``'s timeline must count only the ``ws_a`` memory —
-never the one rooted in ``ws_b``.
+The fixture seeds memories chosen so that each assertion is *load-bearing* for
+a specific scoping choice — a regression to a different-but-plausible scope
+would change the count and fail the test:
+
+  * ``m_member``   — member-authored, ``Memory.workspace_id == ws_a``: the
+                     baseline ws_a memory.
+  * ``m_outsider`` — authored by a NON-member, rooted in a ws_a context: must
+                     be counted. Catches a regression that re-adds the dropped
+                     ``Memory.user_id.in_(member_ids)`` filter (#822 finding 2).
+  * ``m_null_ws``  — ``Memory.workspace_id IS NULL``, rooted in a ws_a context:
+                     must be counted. Catches a regression that scopes by the
+                     nullable ``Memory.workspace_id`` instead of
+                     ``Context.workspace_id`` (#822 finding 1).
+  * ``m_deleted_ctx`` — rooted in a *soft-deleted* ws_a context: must NOT be
+                     counted. Catches dropping ``Context.deleted_at.is_(None)``.
+  * ``m_other_ws`` — the cross-rooted leak case (#614/#383): authored by
+                     ``multi_user`` (a member of ws_a) but rooted in ws_b. Must
+                     NOT appear in ws_a's timeline.
+
+So ws_a's timeline must count exactly the 3 live ws_a-context memories.
 """
 
 from uuid import uuid4
@@ -29,6 +45,9 @@ from models.auth import Context, Workspace, WorkspaceMember
 from models.memory import Memory
 from services.workspace_service import WorkspaceService
 from utils.datetime import utcnow
+
+EXPECTED_WS_A_COUNT = 3
+TIMELINE_DAYS = 30
 
 
 def _make_workspace(owner_id: str) -> Workspace:
@@ -43,12 +62,13 @@ def _make_workspace(owner_id: str) -> Workspace:
     )
 
 
-def _make_context(workspace_id, created_by: str) -> Context:
+def _make_context(workspace_id, created_by: str, *, deleted: bool = False) -> Context:
     return Context(
         id=uuid4(),
         workspace_id=workspace_id,
         name=f"ctx-{uuid4().hex[:8]}",
         created_by=created_by,
+        deleted_at=utcnow() if deleted else None,
     )
 
 
@@ -69,15 +89,15 @@ def _make_memory(user_id: str, workspace_id, context_id) -> Memory:
 
 @pytest_asyncio.fixture
 async def cross_rooted_scenario(db_session):
-    """Two workspaces sharing one member who has a memory rooted in each.
+    """Seed two workspaces; ws_a gets memories that isolate each scoping choice.
 
-    Returns ``(ws_a_id, ws_b_id, ctx_b_id)``. ``multi_user`` is a member of
-    both workspaces and has exactly one memory in ``ws_a`` (via ``ctx_a``)
-    and one in ``ws_b`` (via ``ctx_b``).
+    Returns ``(ws_a_id, ws_b_id, ctx_b_id)``. See the module docstring for the
+    role each seeded memory plays.
     """
     owner_a = f"owner_a_{uuid4().hex[:8]}"
     owner_b = f"owner_b_{uuid4().hex[:8]}"
     multi_user = f"multi_{uuid4().hex[:8]}"
+    outsider = f"outsider_{uuid4().hex[:8]}"  # NOT a member of either workspace
 
     ws_a = _make_workspace(owner_a)
     ws_b = _make_workspace(owner_b)
@@ -88,28 +108,24 @@ async def cross_rooted_scenario(db_session):
     # member-scoped query leak ws_b activity into ws_a's timeline.
     db_session.add_all(
         [
-            WorkspaceMember(
-                workspace_id=ws_a.id,
-                user_id=multi_user,
-                role=WorkspaceRole.MEMBER,
-            ),
-            WorkspaceMember(
-                workspace_id=ws_b.id,
-                user_id=multi_user,
-                role=WorkspaceRole.MEMBER,
-            ),
+            WorkspaceMember(workspace_id=ws_a.id, user_id=multi_user, role=WorkspaceRole.MEMBER),
+            WorkspaceMember(workspace_id=ws_b.id, user_id=multi_user, role=WorkspaceRole.MEMBER),
         ]
     )
 
     ctx_a = _make_context(ws_a.id, multi_user)
+    ctx_a_deleted = _make_context(ws_a.id, multi_user, deleted=True)
     ctx_b = _make_context(ws_b.id, multi_user)
-    db_session.add_all([ctx_a, ctx_b])
+    db_session.add_all([ctx_a, ctx_a_deleted, ctx_b])
     await db_session.flush()
 
     db_session.add_all(
         [
-            _make_memory(multi_user, ws_a.id, ctx_a.id),  # belongs to ws_a
-            _make_memory(multi_user, ws_b.id, ctx_b.id),  # belongs to ws_b — must NOT leak
+            _make_memory(multi_user, ws_a.id, ctx_a.id),  # m_member   → counts
+            _make_memory(outsider, ws_a.id, ctx_a.id),  # m_outsider → counts (no member filter)
+            _make_memory(multi_user, None, ctx_a.id),  # m_null_ws  → counts (ctx scope, not ws_id)
+            _make_memory(multi_user, ws_a.id, ctx_a_deleted.id),  # m_deleted_ctx → excluded
+            _make_memory(multi_user, ws_b.id, ctx_b.id),  # m_other_ws → must NOT leak
         ]
     )
     await db_session.commit()
@@ -118,16 +134,41 @@ async def cross_rooted_scenario(db_session):
 
 
 @pytest.mark.asyncio
-async def test_timeline_excludes_other_workspace_memories(cross_rooted_scenario, db_session):
-    """ws_a's timeline counts only ws_a memories, not the shared member's ws_b memory."""
+async def test_timeline_counts_only_live_workspace_contexts(cross_rooted_scenario, db_session):
+    """ws_a's timeline counts exactly its 3 live ws_a-context memories.
+
+    The single count of 3 (not 2, not 4, not 5) simultaneously pins: the
+    cross-workspace memory is excluded, the non-member memory is included, the
+    NULL-``Memory.workspace_id`` memory is included, and the soft-deleted
+    context's memory is excluded. A regression to membership scoping,
+    ``Memory.workspace_id`` scoping, or dropping the deleted-context filter all
+    move this number.
+    """
     ws_a_id, _ws_b_id, _ctx_b_id = cross_rooted_scenario
 
     service = WorkspaceService(db_session)
-    result = await service.get_workspace_memory_timeline(ws_a_id, days=30)
+    result = await service.get_workspace_memory_timeline(ws_a_id, days=TIMELINE_DAYS)
 
-    # Exactly one memory is rooted in ws_a. The pre-fix code counted 2
-    # (it also picked up the ws_b memory because multi_user is a ws_a member).
-    assert result["memories_created_in_period"] == 1
+    assert result["memories_created_in_period"] == EXPECTED_WS_A_COUNT
+
+
+@pytest.mark.asyncio
+async def test_timeline_returns_zero_filled_window(cross_rooted_scenario, db_session):
+    """The daily_counts payload is a continuous, zero-filled window of TIMELINE_DAYS days."""
+    ws_a_id, _ws_b_id, _ctx_b_id = cross_rooted_scenario
+
+    service = WorkspaceService(db_session)
+    result = await service.get_workspace_memory_timeline(ws_a_id, days=TIMELINE_DAYS)
+
+    daily = result["daily_counts"]
+    # Continuous zero-filled range — the frontend chart depends on every day
+    # being present, not just days that had activity.
+    assert len(daily) == TIMELINE_DAYS
+    assert [d["date"] for d in daily] == sorted(d["date"] for d in daily)
+    assert sum(d["count"] for d in daily) == EXPECTED_WS_A_COUNT
+    # All three live memories were created today → bucketed into the last day.
+    assert daily[-1]["count"] == EXPECTED_WS_A_COUNT
+    assert daily[-1]["date"] == result["period_end"]
 
 
 @pytest.mark.asyncio
@@ -136,8 +177,11 @@ async def test_timeline_context_filter_rejects_foreign_context(cross_rooted_scen
     ws_a_id, _ws_b_id, ctx_b_id = cross_rooted_scenario
 
     service = WorkspaceService(db_session)
-    result = await service.get_workspace_memory_timeline(ws_a_id, days=30, context_id=ctx_b_id)
+    result = await service.get_workspace_memory_timeline(
+        ws_a_id, days=TIMELINE_DAYS, context_id=ctx_b_id
+    )
 
     # ctx_b does not belong to ws_a — filtering by it must yield no data,
     # not the ws_b memory it actually contains.
     assert result["memories_created_in_period"] == 0
+    assert len(result["daily_counts"]) == TIMELINE_DAYS  # still a full zero-filled window

--- a/backend/tests/integration/test_workspace_memory_timeline_boundary.py
+++ b/backend/tests/integration/test_workspace_memory_timeline_boundary.py
@@ -1,0 +1,143 @@
+"""Workspace boundary regression test for memory-creation timeline (Issue #822).
+
+``WorkspaceService.get_workspace_memory_timeline`` used to scope its daily
+counts by *workspace membership* only — ``Memory.user_id.in_(member_ids)``
+with no workspace/context filter. A user who belongs to multiple workspaces
+therefore had *all* their memories (created in any workspace) counted in
+*every* workspace they were a member of — a cross-tenant boundary leak of
+memory-creation activity volume (the dashboard "Memory creation timeline"
+chart).
+
+This is the same defect family as #389/#391, #660/#662, and #435 (the
+``Memory.user_id`` legacy-scoping pattern). The fix scopes the timeline to
+the workspace's own contexts, matching the stats-card semantics in
+``api/routes/workspace.py`` (``Context.workspace_id``).
+
+The load-bearing predicate uses the cross-rooted-memory pattern (#614/#383):
+a single ``multi_user`` is a member of both ``ws_a`` and ``ws_b`` and creates
+memories in each. ``ws_a``'s timeline must count only the ``ws_a`` memory —
+never the one rooted in ``ws_b``.
+"""
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+
+from auth.workspace_roles import WorkspaceRole
+from models.auth import Context, Workspace, WorkspaceMember
+from models.memory import Memory
+from services.workspace_service import WorkspaceService
+from utils.datetime import utcnow
+
+
+def _make_workspace(owner_id: str) -> Workspace:
+    return Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner_id,
+        memory_limit=100000,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+
+
+def _make_context(workspace_id, created_by: str) -> Context:
+    return Context(
+        id=uuid4(),
+        workspace_id=workspace_id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=created_by,
+    )
+
+
+def _make_memory(user_id: str, workspace_id, context_id) -> Memory:
+    return Memory(
+        id=uuid4(),
+        user_id=user_id,
+        workspace_id=workspace_id,
+        context_id=context_id,
+        summary=f"mem-{uuid4().hex[:6]}",
+        content="x",
+        type="note",
+        client="test",
+        tags=[],
+        created_at=utcnow(),
+    )
+
+
+@pytest_asyncio.fixture
+async def cross_rooted_scenario(db_session):
+    """Two workspaces sharing one member who has a memory rooted in each.
+
+    Returns ``(ws_a_id, ws_b_id, ctx_b_id)``. ``multi_user`` is a member of
+    both workspaces and has exactly one memory in ``ws_a`` (via ``ctx_a``)
+    and one in ``ws_b`` (via ``ctx_b``).
+    """
+    owner_a = f"owner_a_{uuid4().hex[:8]}"
+    owner_b = f"owner_b_{uuid4().hex[:8]}"
+    multi_user = f"multi_{uuid4().hex[:8]}"
+
+    ws_a = _make_workspace(owner_a)
+    ws_b = _make_workspace(owner_b)
+    db_session.add_all([ws_a, ws_b])
+    await db_session.flush()
+
+    # multi_user is a member of BOTH workspaces — this is what made the old
+    # member-scoped query leak ws_b activity into ws_a's timeline.
+    db_session.add_all(
+        [
+            WorkspaceMember(
+                workspace_id=ws_a.id,
+                user_id=multi_user,
+                role=WorkspaceRole.MEMBER,
+            ),
+            WorkspaceMember(
+                workspace_id=ws_b.id,
+                user_id=multi_user,
+                role=WorkspaceRole.MEMBER,
+            ),
+        ]
+    )
+
+    ctx_a = _make_context(ws_a.id, multi_user)
+    ctx_b = _make_context(ws_b.id, multi_user)
+    db_session.add_all([ctx_a, ctx_b])
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            _make_memory(multi_user, ws_a.id, ctx_a.id),  # belongs to ws_a
+            _make_memory(multi_user, ws_b.id, ctx_b.id),  # belongs to ws_b — must NOT leak
+        ]
+    )
+    await db_session.commit()
+
+    return ws_a.id, ws_b.id, ctx_b.id
+
+
+@pytest.mark.asyncio
+async def test_timeline_excludes_other_workspace_memories(cross_rooted_scenario, db_session):
+    """ws_a's timeline counts only ws_a memories, not the shared member's ws_b memory."""
+    ws_a_id, _ws_b_id, _ctx_b_id = cross_rooted_scenario
+
+    service = WorkspaceService(db_session)
+    result = await service.get_workspace_memory_timeline(ws_a_id, days=30)
+
+    # Exactly one memory is rooted in ws_a. The pre-fix code counted 2
+    # (it also picked up the ws_b memory because multi_user is a ws_a member).
+    assert result["memories_created_in_period"] == 1
+
+
+@pytest.mark.asyncio
+async def test_timeline_context_filter_rejects_foreign_context(cross_rooted_scenario, db_session):
+    """A context_id from another workspace must not surface its memories via ws_a's timeline."""
+    ws_a_id, _ws_b_id, ctx_b_id = cross_rooted_scenario
+
+    service = WorkspaceService(db_session)
+    result = await service.get_workspace_memory_timeline(ws_a_id, days=30, context_id=ctx_b_id)
+
+    # ctx_b does not belong to ws_a — filtering by it must yield no data,
+    # not the ws_b memory it actually contains.
+    assert result["memories_created_in_period"] == 0


### PR DESCRIPTION
Closes #822

## Summary
- `get_workspace_memory_timeline()` scoped its daily counts by workspace **membership** (`Memory.user_id.in_(member_ids)`) with no workspace/context filter — a cross-tenant leak: a user in multiple workspaces had all their memories counted in every workspace they belong to.
- Rescoped to the workspace's **own contexts** (`Context.workspace_id`), matching the stats-card semantics in `api/routes/workspace.py`. `Memory.workspace_id` is nullable, so context-scoping (not `Memory.workspace_id`) is the reliable boundary.
- The optional `context_id` filter is now verified to belong to the workspace — a foreign `context_id` yields no data instead of surfacing another workspace's memories.

## Production evidence (confirmed 2026-05-28)
| workspace | context-scoped (stats card) | member-scoped (old timeline) |
|---|---|---|
| kagura | 2651 | 2651 |
| personal | **0** | **29** |

The `personal` workspace showed 0 total memories but the timeline counted 29 — the member's memories created in `kagura`.

## Implementation notes
- `backend/src/services/workspace_service.py`: replaced the `WorkspaceMember.user_id` lookup with a `Context.id WHERE workspace_id = ? AND deleted_at IS NULL` lookup; same 2-SELECT shape. `WorkspaceMember` remains imported/used elsewhere in the file.
- New integration test `test_workspace_memory_timeline_boundary.py` using the cross-rooted-memory pattern (#614/#383): a member of both `ws_a` and `ws_b` must not see the `ws_b` memory in `ws_a`'s timeline, and a foreign `context_id` must yield 0. Both confirmed failing pre-fix (2/1) and passing post-fix.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CSO lens)
- review provider: code-review

Same cross-tenant leak family as #389/#391, #660/#662, #435.

🤖 Generated via /gh-issue-driven:ship
