### PR TITLE
chore(db): pg_trgm GIN index on memories.summary for /memory/list ?q (#818)

### DIFF
--- a/backend/alembic/versions/e26_818_summary_trgm_idx.py
+++ b/backend/alembic/versions/e26_818_summary_trgm_idx.py
@@ -1,0 +1,119 @@
+"""Add pg_trgm GIN index on memories.summary for /memory/list ?q ILIKE (#818).
+
+Issue #580 added an optional ``q`` substring filter to ``GET /api/v1/memory/list``
+implemented as ``Memory.summary.ilike(f"%{q}%", escape="\\")``. ``summary`` is a
+plain ``Text`` column with no index, so the filter (and its paired ``count(*)``)
+does a sequential scan per request — fine at current per-workspace sizes, but a
+latency cliff as memories grow into the 10k+ range.
+
+This migration accelerates that filter with a trigram GIN index.
+
+### Why plain ``summary``, not ``lower(summary)``
+
+The call site issues ``summary ILIKE '%foo%'`` (case-insensitive, on the bare
+column). ``pg_trgm``'s ``gin_trgm_ops`` operator class supports the ``ILIKE``
+operator directly — ``show_trgm`` lowercases before extracting trigrams, so a
+GIN index on the **plain** column already serves case-insensitive matching.
+
+The issue body floated ``gin (lower(summary) gin_trgm_ops)``, but a functional
+index on ``lower(summary)`` is only consulted for predicates whose expression is
+literally ``lower(summary)`` (e.g. ``lower(summary) LIKE lower(:p)``). It would
+*not* be matched by the existing ``summary ILIKE :p`` call, so the index would
+sit unused unless we also rewrote the query. Indexing the bare column keeps the
+#580 ``q`` contract (literal substring, ``ILIKE``) byte-for-byte intact — no
+query change — which is the stated goal. Verified via ``EXPLAIN (ANALYZE)``: the
+plan switches from ``Seq Scan`` to ``Bitmap Index Scan on
+idx_memories_summary_trgm`` for ``summary ILIKE '%foo%' ESCAPE '\'``.
+
+### pg_trgm extension
+
+``CREATE EXTENSION IF NOT EXISTS pg_trgm`` is idempotent. ``pg_trgm`` is a
+*trusted* extension since PostgreSQL 13, so a role with ``CREATE`` on the
+database (not necessarily superuser) can install it; the single-server prod
+target runs the standard ``postgres`` image where it ships in ``contrib``. The
+extension statement is transactional and runs before the autocommit block, so
+``CREATE INDEX CONCURRENTLY`` sees a committed extension.
+
+### Zero-downtime build
+
+``memories`` is a high-write table. A plain transactional ``CREATE INDEX`` takes
+``ACCESS EXCLUSIVE`` for the build duration, blocking writes. Following the
+a96/a97/b02 pattern, the index is built with ``CREATE INDEX CONCURRENTLY IF NOT
+EXISTS`` inside ``autocommit_block`` (env.py wraps migrations in a transaction;
+CONCURRENTLY cannot run inside one), with an INVALID-leftover guard so a retry
+after a mid-build failure rebuilds cleanly rather than skipping on the name.
+
+### Downgrade
+
+Drops the index ``CONCURRENTLY``. The ``pg_trgm`` extension is intentionally
+**left installed** — other objects may depend on it, and dropping an extension
+is a heavier, riskier operation than this migration owns.
+
+Revision ID: e26_818_summary_trgm_idx
+Revises: e25_782_widen_edge_type
+Create Date: 2026-05-29
+
+(Revision ID kept ≤ 32 chars to fit ``alembic_version.version_num
+varchar(32)``; the longer descriptive name lives in the filename.)
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e26_818_summary_trgm_idx"
+down_revision: str | Sequence[str] | None = "e25_782_widen_edge_type"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+_INDEX_NAME = "idx_memories_summary_trgm"
+_INDEX_DDL = (
+    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} "
+    "ON memories USING gin (summary gin_trgm_ops)"
+)
+
+
+def _index_is_invalid(name: str) -> bool:
+    """Return True if ``name`` exists in ``pg_index`` in an INVALID state.
+
+    A mid-build failure of ``CREATE INDEX CONCURRENTLY`` leaves the index row
+    with ``indisvalid = false``. A retry's ``IF NOT EXISTS`` would skip it (the
+    name exists) without rebuilding, leaving the cluster permanently without a
+    usable index — so the leftover must be dropped first.
+    """
+    bind = op.get_bind()
+    row = bind.execute(
+        sa.text(
+            "SELECT 1 "
+            "FROM pg_class c JOIN pg_index i ON c.oid = i.indexrelid "
+            "WHERE c.relname = :name AND i.indisvalid IS FALSE"
+        ),
+        {"name": name},
+    ).first()
+    return row is not None
+
+
+def upgrade() -> None:
+    """Enable pg_trgm and build the trigram GIN index on summary concurrently."""
+    # Transactional: committed when autocommit_block opens, so the CONCURRENTLY
+    # build below sees the extension.
+    op.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+
+    invalid = _index_is_invalid(_INDEX_NAME)
+
+    with op.get_context().autocommit_block():
+        # Drop an INVALID leftover from a prior failed attempt before the
+        # IF NOT EXISTS rebuild (IF NOT EXISTS alone would skip the rebuild).
+        if invalid:
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))
+        op.execute(sa.text(_INDEX_DDL))
+
+
+def downgrade() -> None:
+    """Drop the trigram index concurrently; leave the pg_trgm extension installed."""
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import (
+    DDL,
     JSON,
     BigInteger,
     Boolean,
@@ -26,6 +27,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    event,
     func,
     text,
 )
@@ -48,7 +50,9 @@ class Memory(Base):
     Attributes:
         id: UUID primary key
         user_id: Owner user ID
-        summary: Layer 1 - 検索用サマリー (50-200文字)
+        summary: Layer 1 - 検索用サマリー (50-200文字). Backed by a pg_trgm
+            GIN index (``idx_memories_summary_trgm``, #818) accelerating the
+            ``summary ILIKE '%q%'`` substring filter on GET /memory/list.
         summary_embedding_id: Qdrant point ID
         context_summary: Layer 2 - 文脈説明 (200-1000文字)
         content: Layer 3 - 基本内容
@@ -219,10 +223,37 @@ class Memory(Base):
             "external_blob_ref",
             postgresql_where=text("external_blob_ref IS NOT NULL"),
         ),
+        # Issue #818 trigram GIN index on summary, accelerating the
+        # `summary ILIKE '%q%'` substring filter on GET /memory/list (#580)
+        # (migration e26_818_summary_trgm_idx). Indexed on the bare
+        # column — gin_trgm_ops serves ILIKE case-insensitively, so no
+        # lower(summary) expression is needed and the #580 query is unchanged.
+        Index(
+            "idx_memories_summary_trgm",
+            "summary",
+            postgresql_using="gin",
+            postgresql_ops={"summary": "gin_trgm_ops"},
+        ),
     )
 
     def __repr__(self) -> str:
         return f"<Memory(id='{self.id}', type='{self.type}', scope='{self.scope}')>"
+
+
+# The ``idx_memories_summary_trgm`` GIN index (#818) uses the ``gin_trgm_ops``
+# operator class, which only exists once the ``pg_trgm`` extension is installed.
+# Alembic migration e26 installs it on the upgrade path, but the
+# ``Base.metadata.create_all()`` path (test session setup + the create_all-vs-
+# alembic drift guard, which runs after ``DROP SCHEMA public CASCADE`` wipes the
+# extension) has no such step — create_all would fail emitting the index. This
+# ``before_create`` hook installs the extension first so the model is fully
+# create_all-able. Guarded to PostgreSQL so non-PG dialects (e.g. SQLite in unit
+# tests) skip it; ``IF NOT EXISTS`` keeps it idempotent against the migrated DB.
+event.listen(
+    Base.metadata,
+    "before_create",
+    DDL("CREATE EXTENSION IF NOT EXISTS pg_trgm").execute_if(dialect="postgresql"),
+)
 
 
 class Attachment(Base):

--- a/backend/tests/integration/test_e26_818_memory_summary_trgm_migration.py
+++ b/backend/tests/integration/test_e26_818_memory_summary_trgm_migration.py
@@ -104,8 +104,15 @@ def test_e26_upgrade_creates_trgm_index_and_extension() -> None:
 
         with engine.connect() as conn:
             conn.execute(text("SET enable_seqscan = off"))
+            # Mirror the route's exact predicate shape: it builds
+            # ``Memory.summary.ilike(q_pattern, escape="\\")`` which compiles
+            # with a trailing ``ESCAPE '\'``. Including it here guards that the
+            # trigram index stays eligible for the production predicate, not
+            # just a bare ILIKE.
             plan = "\n".join(
-                conn.execute(text("EXPLAIN SELECT id FROM memories WHERE summary ILIKE '%auth%'"))
+                conn.execute(
+                    text(r"EXPLAIN SELECT id FROM memories WHERE summary ILIKE '%auth%' ESCAPE '\'")
+                )
                 .scalars()
                 .all()
             )

--- a/backend/tests/integration/test_e26_818_memory_summary_trgm_migration.py
+++ b/backend/tests/integration/test_e26_818_memory_summary_trgm_migration.py
@@ -1,0 +1,134 @@
+"""Migration round-trip test for #818 (e26_818_memory_summary_trgm_index).
+
+Verifies:
+1. Upgrade installs the ``pg_trgm`` extension and creates the
+   ``idx_memories_summary_trgm`` GIN index with the ``gin_trgm_ops``
+   operator class.
+2. The planner uses that index for the #580 ``summary ILIKE '%q%'`` filter
+   (the exact predicate the route emits) — proving the bare-column index is
+   the right shape, not a ``lower(summary)`` expression index.
+3. Downgrade drops the index but intentionally leaves ``pg_trgm`` installed.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from alembic import command
+from tests.integration.test_alembic_migrations import (
+    _alembic_at_test_db,
+    _get_alembic_config,
+    _reset_alembic_state,
+    _sync_engine,
+)
+
+E26_REVISION = "e26_818_summary_trgm_idx"
+PRIOR_HEAD = "e25_782_widen_edge_type"
+INDEX_NAME = "idx_memories_summary_trgm"
+
+
+def _leave_db_at_head() -> None:
+    """Convention: integration suite expects the test DB at head after each test."""
+    with _alembic_at_test_db():
+        command.upgrade(_get_alembic_config(), "head")
+
+
+def _index_def(conn: Connection) -> str | None:
+    """Return the ``pg_indexes`` definition for the trigram index, or None."""
+    return conn.execute(
+        text("SELECT indexdef FROM pg_indexes WHERE indexname = :n"),
+        {"n": INDEX_NAME},
+    ).scalar_one_or_none()
+
+
+def _pg_trgm_installed(conn: Connection) -> bool:
+    return (
+        conn.execute(
+            text("SELECT 1 FROM pg_extension WHERE extname = 'pg_trgm'")
+        ).scalar_one_or_none()
+        is not None
+    )
+
+
+def _seed_memory(conn: Connection, summary: str) -> None:
+    """Insert one minimal active memory row (only NOT NULL cols without defaults)."""
+    # NOT NULL columns on `memories` carry Python-side ORM defaults, not server
+    # defaults, so a raw INSERT must supply them all explicitly.
+    conn.execute(
+        text(
+            "INSERT INTO memories "
+            "(id, user_id, summary, content, type, embedding_status, importance, "
+            " confidence, scope, long_term, use_count, access_count, client, "
+            " source, created_at) "
+            "VALUES (gen_random_uuid(), 'tester-818', :summary, 'body', 'note', "
+            "'success', 0.5, 1.0, 'working', false, 0, 0, 'test', "
+            "'mcp_remember', now())"
+        ),
+        {"summary": summary},
+    )
+
+
+def test_e26_upgrade_creates_trgm_index_and_extension() -> None:
+    """Upgrade enables pg_trgm and builds a gin_trgm_ops index the ILIKE filter uses."""
+    _reset_alembic_state()
+    with _alembic_at_test_db():
+        command.upgrade(_get_alembic_config(), PRIOR_HEAD)
+
+    engine = _sync_engine()
+    try:
+        # Before the migration: neither extension nor index exists on a clean
+        # (DROP SCHEMA-reset) test DB.
+        with engine.connect() as conn:
+            assert _index_def(conn) is None
+
+        with _alembic_at_test_db():
+            command.upgrade(_get_alembic_config(), E26_REVISION)
+
+        with engine.connect() as conn:
+            assert _pg_trgm_installed(conn)
+
+            indexdef = _index_def(conn)
+            assert indexdef is not None, f"{INDEX_NAME} not created by upgrade"
+            # Bare-column trigram GIN index — not lower(summary).
+            assert "USING gin" in indexdef
+            assert "gin_trgm_ops" in indexdef
+            assert "lower(" not in indexdef.lower()
+
+        # Planner check: with seqscan disabled the trigram index must back the
+        # exact predicate the #580 route emits (summary ILIKE '%q%'). A
+        # lower(summary) expression index would NOT be matched here.
+        with engine.begin() as conn:
+            for s in ("authentication flow", "auth token refresh", "unrelated topic"):
+                _seed_memory(conn, s)
+
+        with engine.connect() as conn:
+            conn.execute(text("SET enable_seqscan = off"))
+            plan = "\n".join(
+                conn.execute(text("EXPLAIN SELECT id FROM memories WHERE summary ILIKE '%auth%'"))
+                .scalars()
+                .all()
+            )
+            assert INDEX_NAME in plan, f"trigram index not used; plan was:\n{plan}"
+    finally:
+        engine.dispose()
+        _leave_db_at_head()
+
+
+def test_e26_downgrade_drops_index_keeps_extension() -> None:
+    """Downgrade removes the index but leaves pg_trgm installed (documented contract)."""
+    _reset_alembic_state()
+    with _alembic_at_test_db():
+        command.upgrade(_get_alembic_config(), E26_REVISION)
+        command.downgrade(_get_alembic_config(), PRIOR_HEAD)
+
+    engine = _sync_engine()
+    try:
+        with engine.connect() as conn:
+            assert _index_def(conn) is None, "index should be dropped on downgrade"
+            # Extension is intentionally retained — dropping it is out of scope
+            # for this migration (other objects may come to depend on it).
+            assert _pg_trgm_installed(conn)
+    finally:
+        engine.dispose()
+        _leave_db_at_head()


### PR DESCRIPTION
Closes #818

## Summary

#580 added an optional `q` substring filter on `GET /api/v1/memory/list`
(`Memory.summary.ilike("%q%")`). `summary` had **no index**, so the filter —
plus its paired `count(*)` — did a sequential scan per request. Fine today,
a latency cliff as workspaces grow past ~10k memories.

This adds a **trigram (`pg_trgm`) GIN index** on `summary`.

## Design decision: A (pg_trgm) — indexed on the **bare** column

The acceptance criteria asked to resolve A (pg_trgm) vs B (tsvector), and the
issue body tentatively floated `gin (lower(summary) gin_trgm_ops)`. Chose **A
on the plain column**:

- The route emits `summary ILIKE '%q%'`. `gin_trgm_ops` supports `ILIKE`
  directly (trigrams are case-folded internally), so a **bare-column** GIN
  index already serves case-insensitive matching — **no query change**, the
  #580 `q` contract stays byte-for-byte intact.
- An expression index on `lower(summary)` would only be consulted for
  predicates literally over `lower(summary)`; it would sit **unused** by the
  existing `.ilike()` call unless we also rewrote the query. The round-trip
  test asserts the planner actually uses the bare-column index for the exact
  predicate.
- B (tsvector) changes semantics (token match, not substring) — rejected.

## Changes

- **`e26` migration**: `CREATE EXTENSION IF NOT EXISTS pg_trgm` (trusted
  extension, PG13+) + `CREATE INDEX CONCURRENTLY IF NOT EXISTS
  idx_memories_summary_trgm ... USING gin (summary gin_trgm_ops)` inside
  `autocommit_block`, with the INVALID-leftover guard — same zero-downtime
  pattern as a96/a97/b02. Downgrade drops the index `CONCURRENTLY` and
  intentionally leaves the extension installed.
- **`Memory` model**: declares the matching `Index(...)` (per the #719
  create_all-vs-alembic convention) + a `before_create` DDL hook that installs
  `pg_trgm` so `Base.metadata.create_all()` (test session + drift guard, which
  runs after `DROP SCHEMA public CASCADE`) stays buildable. Hook is
  PostgreSQL-guarded and idempotent; never fires in production (alembic path).
- **Docstring** on `summary` mentions the index (acceptance criterion).

## Testing

- New `test_e26_818_memory_summary_trgm_migration.py`:
  - upgrade installs `pg_trgm` + the `gin_trgm_ops` index,
  - **planner check**: `EXPLAIN` (seqscan off) shows
    `idx_memories_summary_trgm` backs `summary ILIKE '%q%'`,
  - downgrade drops the index, keeps the extension.
- `make lint` clean; changed files type-check clean (pre-existing unrelated
  pyright errors only). Full alembic round-trip + create_all-vs-alembic drift
  + the new test: **15 passed**.

## Acceptance criteria
- [x] Decide A vs B + rationale (A, bare column — see above)
- [x] Migration enables `pg_trgm` + creates the GIN index
- [x] Verify the index is used by `Memory.summary.ilike(...)` (planner test)
- [x] Non-blocking build (`CREATE INDEX CONCURRENTLY`)
- [x] `Memory` docstring mentions the index
- [x] Integration test (query-plan check on a populated test DB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)