### PR TITLE
refactor(mcp): drop unreachable update_edge weight fallback (#816)

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -555,7 +555,12 @@ Identify edges using source_id + target_id (from list_edges or explore results).
                     },
                     "weight": {
                         "type": "number",
-                        "description": "New edge weight 0.0-3.0.",
+                        "description": (
+                            "New edge weight 0.0-3.0. Omit to preserve the "
+                            "edge's current weight (pass edge_type to make a "
+                            "type-only update). There is no default — an "
+                            "omitted weight is left unchanged, not reset."
+                        ),
                     },
                     "edge_type": {
                         "type": "string",

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -105,9 +105,19 @@ def _validate_edge_endpoints(
 
 
 def _parse_float(
-    value: Any, name: str, min_val: float, max_val: float, default: float
+    value: Any, name: str, min_val: float, max_val: float, default: float | None = None
 ) -> tuple[float | None, list[TextContent] | None]:
-    """Parse and validate a float parameter."""
+    """Parse and validate a float parameter.
+
+    ``default`` is the fallback returned when ``value is None``. Pass it only
+    at call sites that are actually reachable with ``value is None`` (an
+    unguarded ``args.get(...)``). At a site already guarded by
+    ``if value is not None`` the fallback is unreachable, so omit it
+    (``default=None``) rather than passing a misleading literal — see
+    ``handle_update_edge``. ``default=None`` means "no fallback; the caller
+    guarantees ``value`` is not None", in which case the ``(None, None)``
+    return is unreachable.
+    """
     if value is None:
         return default, None
     try:
@@ -322,7 +332,12 @@ async def handle_update_edge(
 
     new_weight = None
     if new_weight_raw is not None:
-        new_weight, error = _parse_float(new_weight_raw, "weight", 0.0, 3.0, 0.5)
+        # Guarded by the `is not None` check above, so _parse_float's None
+        # fallback is unreachable here — omit it. (Contrast create_edge, which
+        # parses an unguarded args.get("weight") and passes an explicit 1.0
+        # fallback, #814.) Omitting weight from update_edge preserves the
+        # edge's current weight; pass edge_type to make a no-weight update.
+        new_weight, error = _parse_float(new_weight_raw, "weight", 0.0, 3.0)
         if error:
             return error
 

--- a/backend/tests/mcp_server/test_edge_tools.py
+++ b/backend/tests/mcp_server/test_edge_tools.py
@@ -331,3 +331,110 @@ class TestCreateEdgeOriginAndWeight:
         create_edge = next(t for t in get_tool_definitions() if t["name"] == "create_edge")
         weight_schema = create_edge["inputSchema"]["properties"]["weight"]
         assert weight_schema["default"] == 1.0
+
+
+class TestUpdateEdgeWeightNoDefault:
+    """Issue #816: update_edge has NO weight default. Omitting weight preserves
+    the edge's current value, the schema declares no default, and the guarded
+    `_parse_float` call must not carry the unreachable 0.5 fallback that drifted
+    from create_edge's 1.0 (#814)."""
+
+    @pytest.fixture
+    def user_id(self):
+        return "test_user_816"
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def context_id(self):
+        return uuid4()
+
+    @pytest.mark.asyncio
+    async def test_omitted_weight_preserves_current(self, user_id, workspace_id, context_id):
+        """edge_type-only update (weight omitted) leaves the existing weight intact.
+
+        Pins the documented contract: an omitted ``weight`` is NOT reset to any
+        handler default — the repo is called with the existing edge's weight, so
+        a type-only update never silently rewrites weight.
+        """
+        src_id = uuid4()
+        dst_id = uuid4()
+        existing = _mock_edge(src_id, dst_id, edge_type="neural_association", weight=0.5)
+        post_update = _mock_edge(src_id, dst_id, edge_type="related_to", weight=0.5)
+
+        mock_db = AsyncMock()
+        mock_db.commit = AsyncMock()
+        mock_db.rollback = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        mock_repo = MagicMock()
+        mock_repo.get_edge = AsyncMock(return_value=existing)
+        mock_repo.create_or_update_edge = AsyncMock(return_value=post_update)
+
+        mock_ctx = MagicMock()
+        mock_ctx.id = context_id
+        mock_ctx.workspace_id = workspace_id
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "repositories.neural_edge.NeuralEdgeRepository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "mcp_server.tools.edge._resolve_context",
+                new_callable=AsyncMock,
+                return_value=mock_ctx,
+            ),
+            patch(
+                "mcp_server.tools.edge._check_viewer_permission",
+                new_callable=AsyncMock,
+                return_value=None,
+            ),
+            patch(
+                "mcp_server.tools.edge._log_tool_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await handle_update_edge(
+                {
+                    "source_id": str(src_id),
+                    "target_id": str(dst_id),
+                    "edge_type": "related_to",
+                    # weight intentionally omitted
+                    "context_id": str(context_id),
+                },
+                user_id,
+                workspace_id,
+            )
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        # Repo MUST be called with the EXISTING weight (preserved), not a default.
+        kwargs = mock_repo.create_or_update_edge.await_args.kwargs
+        assert kwargs["weight"] == 0.5
+        assert kwargs["edge_type"] == "related_to"
+
+    def test_schema_has_no_weight_default(self):
+        """update_edge.weight has NO schema default — the load-bearing fact behind
+        "omitting weight preserves current value". Contrast create_edge.weight,
+        which pins default=1.0 (test_schema_default_matches_handler_default)."""
+        update_edge = next(t for t in get_tool_definitions() if t["name"] == "update_edge")
+        weight_schema = update_edge["inputSchema"]["properties"]["weight"]
+        assert "default" not in weight_schema
+
+    def test_parse_float_no_fallback_when_default_omitted(self):
+        """`_parse_float` with no ``default`` returns (None, None) on None input.
+
+        This pins the contract that lets the guarded update_edge call site omit a
+        fallback (`_parse_float(new_weight_raw, "weight", 0.0, 3.0)`) instead of
+        passing the unreachable 0.5. A provided value still parses normally.
+        """
+        from mcp_server.tools.edge import _parse_float
+
+        assert _parse_float(None, "weight", 0.0, 3.0) == (None, None)
+        assert _parse_float(0.8, "weight", 0.0, 3.0) == (0.8, None)


### PR DESCRIPTION
Closes #816

## Summary

`update_edge`'s `_parse_float(new_weight_raw, "weight", 0.0, 3.0, 0.5)` (edge.py) is guarded by `if new_weight_raw is not None`, so the `0.5` fallback is **unreachable dead code** — and it misleadingly contradicts `create_edge`'s `1.0` (#814). This removes the drift and documents the real contract.

## Changes

- **`edge.py`**: `_parse_float`'s `default` is now optional (`default: float | None = None`, with a docstring explaining when to pass it). The guarded `update_edge` site drops the dead `0.5`. The other three call sites (`list_edges` 0.0, `create_edge` weight 1.0, confidence 1.0) are **unguarded `args.get(...)`** so their fallbacks are reachable and unchanged.
- **`_definitions.py`**: `update_edge.weight.description` now states that omitting `weight` preserves the edge's current value (pass `edge_type` for a type-only update); there is no default.
- **Pin tests** (`test_edge_tools.py`, new `TestUpdateEdgeWeightNoDefault`): (a) edge_type-only update preserves the existing weight, (b) the schema declares no `weight` default, (c) `_parse_float` with no default returns `(None, None)` on `None` input.

## #816 AC#4 — handler-vs-schema default audit

Grepped all MCP tool handlers vs `_definitions.py` defaults:
- **No drift among declared defaults** — every schema `"default"` matches its handler (`create_edge.weight`=1.0, `create_edge.confidence`=1.0, `list_edges.min_weight`=0.0, `explore.min_weight`=0.05, `sleep.limit`=10).
- **No other `#816`-class bug** — the remaining `_parse_float` calls are unguarded, so their fallbacks are reachable (legitimate).
- **Residual (out of scope):** a few handlers apply a runtime default the schema doesn't declare (`remember.importance`=0.5, `recall.k`, list limits) — documentation-completeness, not correctness. Deferred; can be a no-milestone follow-up.

## Testing
- `tests/mcp_server/test_edge_tools.py` → 8 passed.
- ruff + ruff format clean; `pyright` on changed source → 0 errors.

## Acceptance criteria
- [x] Remove the misleading `0.5` 5th arg (made `_parse_float.default` optional; guarded site omits it)
- [x] Update `update_edge.weight.description` to state omitting preserves current value
- [x] Pin test: (a) weight preserved, (b) no schema default, (c) `_parse_float` structural contract
- [x] AC#4 audit (documented above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)