### PR TITLE
feat(api,frontend): structured workspace-quota error for i18n display (#680)

### DIFF
--- a/backend/src/services/quota_service.py
+++ b/backend/src/services/quota_service.py
@@ -311,7 +311,18 @@ class QuotaService:
                 return True, None
 
             if raise_on_denied:
-                raise QuotaExceededError(error)
+                # Issue #680: carry structured fields in ``details`` so clients
+                # (e.g. WorkspaceCreateForm) can localize the message instead of
+                # surfacing the English string verbatim. ``quota_type`` is the
+                # discriminator the frontend keys off (``error`` stays the shared
+                # ``QUOTA-001``); ``owned_count`` / ``cap`` feed the i18n
+                # placeholders. Future quota types follow the same convention.
+                raise QuotaExceededError(
+                    error,
+                    quota_type="workspace_limit_reached",
+                    owned_count=workspace_count,
+                    cap=cap,
+                )
             return False, error
 
         # Info-level success log so the 7-day observation window can

--- a/backend/tests/services/test_quota_service.py
+++ b/backend/tests/services/test_quota_service.py
@@ -285,6 +285,23 @@ class TestQuotaServiceWorkspaceCreationCap:
         assert "PRO" not in error
 
     @pytest.mark.asyncio
+    async def test_denied_raises_with_structured_details(self, service, mock_db):
+        """#680: raise_on_denied=True → QuotaExceededError carries structured
+        ``details`` (quota_type + owned_count + cap) so clients localize the
+        message instead of regex-parsing the English string. ``error_code``
+        stays the shared QUOTA-001 — ``quota_type`` is the discriminator."""
+        self._arm_db(mock_db, owned_count=3, slot_bonus=2)  # cap=3, 3 >= 3 → denied
+        with self._patch_settings(enforce=True):
+            with pytest.raises(QuotaExceededError) as exc_info:
+                await service.check_workspace_creation_allowed("user-1", raise_on_denied=True)
+        exc = exc_info.value
+        assert exc.details["quota_type"] == "workspace_limit_reached"
+        assert exc.details["owned_count"] == 3
+        assert exc.details["cap"] == 3
+        assert exc.error_code == "QUOTA-001"
+        assert exc.status_code == 429
+
+    @pytest.mark.asyncio
     async def test_one_owned_no_bonus_allowed_when_flag_off(self, service, mock_db):
         """1 owned, 0 bonus → over cap but flag=False → log-only allow."""
         self._arm_db(mock_db, owned_count=1, slot_bonus=0)

--- a/frontend/src/components/workspaces/WorkspaceCreateForm.tsx
+++ b/frontend/src/components/workspaces/WorkspaceCreateForm.tsx
@@ -13,6 +13,7 @@ import { useTranslations } from "next-intl";
 import { useWorkspace } from "@/contexts/WorkspaceContext";
 import { useToast } from "@/hooks/use-toast";
 import { createWorkspace, Workspace } from "@/lib/api/workspaces";
+import { ApiError } from "@/lib/api/base";
 import {
   Card,
   CardHeader,
@@ -28,6 +29,24 @@ import { Building2, ArrowLeft, Loader2 } from "lucide-react";
 interface WorkspaceCreateFormProps {
   onSuccess?: (workspace: Workspace) => void;
   onCancel?: () => void;
+}
+
+/**
+ * Narrow an ApiError's structured `details` to the workspace-cap quota shape
+ * (#680). Keyed off `quota_type` so other QUOTA-001 errors don't match, with
+ * runtime number checks so a malformed payload falls through to the verbatim
+ * message path instead of rendering `undefined` in the i18n placeholders.
+ */
+function isWorkspaceLimitDetails(
+  details: unknown,
+): details is { owned_count: number; cap: number } {
+  if (typeof details !== "object" || details === null) return false;
+  const d = details as Record<string, unknown>;
+  return (
+    d.quota_type === "workspace_limit_reached" &&
+    typeof d.owned_count === "number" &&
+    typeof d.cap === "number"
+  );
 }
 
 export function WorkspaceCreateForm({
@@ -85,12 +104,21 @@ export function WorkspaceCreateForm({
       const errorMessage =
         err instanceof Error ? err.message : t("failedToCreateWorkspace");
 
-      if (errorMessage.includes("Workspace limit reached")) {
-        // Surface the backend's authoritative message verbatim — it
-        // includes live ``owned N (cap: M)`` data that a cached frontend
-        // value cannot reliably match. The trade-off is that ja users see
-        // the English backend message, but the alternative (cached cap +
-        // i18n) showed stale numbers in real scenarios (Copilot review #5).
+      if (err instanceof ApiError && isWorkspaceLimitDetails(err.details)) {
+        // #680: structured quota details carry live owned_count + cap, so we
+        // render a localized message instead of the verbatim English string.
+        // (The string-only branch below remains as a fallback for older
+        // backends / un-migrated quota errors.)
+        setError(
+          t("workspaceLimitReachedDetailed", {
+            owned: err.details.owned_count,
+            limit: err.details.cap,
+          }),
+        );
+      } else if (errorMessage.includes("Workspace limit reached")) {
+        // Fallback: surface the backend's authoritative message verbatim when
+        // structured details are absent. Live ``owned N (cap: M)`` data still
+        // beats a cached frontend cap; ja users see English in this path only.
         setError(errorMessage);
       } else if (
         errorMessage.includes("validation") ||

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1084,6 +1084,7 @@
     "workspaceCreated": "Workspace created",
     "workspaceCreatedDesc": "Your new workspace has been created successfully.",
     "workspaceLimitReached": "You can own maximum {limit} workspaces.",
+    "workspaceLimitReachedDetailed": "You currently own {owned} of {limit} workspaces. Leave or transfer one, or join others via invite.",
     "lastUsedWorkspace": "Last used workspace",
     "openaiKeyOptional": "Optional. You can add this later in External API Keys settings.",
     "cancel": "Cancel",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1084,6 +1084,7 @@
     "workspaceCreated": "ワークスペースを作成しました",
     "workspaceCreatedDesc": "新しいワークスペースが正常に作成されました。",
     "workspaceLimitReached": "最大{limit}個のワークスペースまで所有できます。",
+    "workspaceLimitReachedDetailed": "現在 {limit} 個中 {owned} 個のワークスペースを所有しています。1つ手放すか譲渡するか、招待で他のワークスペースに参加できます。",
     "lastUsedWorkspace": "前回使用したワークスペース",
     "openaiKeyOptional": "オプション。後でExternal API Keys設定から追加できます。",
     "cancel": "キャンセル",


### PR DESCRIPTION
Closes #680

## Summary

The workspace-cap rejection (`QuotaService.check_workspace_creation_allowed`) raised a plain English message that `WorkspaceCreateForm` surfaced verbatim — so JP users saw English (the #675 sub-A trade-off). This carries **structured fields** so the client can localize, while keeping the live `owned/cap` numbers authoritative.

## Key finding: the handler already serializes `details`

`MemoryCloudException(**details)` stores `self.details`, and the global `@app.exception_handler` already emits `{"error", "message", "details"}`. So **no handler change was needed** — only the raise site.

## Changes

**Backend** (`quota_service.py`)
- Raise site now passes `quota_type="workspace_limit_reached"`, `owned_count`, `cap`. `error` stays the shared `QUOTA-001`; **`quota_type` is the discriminator** clients key off (it distinguishes workspace-cap from sleep/memory quota, which all share `QUOTA-001`). Reusable for future quota types.
- Pin test asserts the nested `details` shape + `error_code == "QUOTA-001"` + `status_code == 429` (pins the consumer-visible contract, per the #814/#816 drift lesson).

**Frontend** (`WorkspaceCreateForm.tsx`)
- Reads `err.details` via a runtime type guard `isWorkspaceLimitDetails` (no `any`; number checks so a malformed payload falls through rather than rendering `undefined`).
- Renders `t("workspaceLimitReachedDetailed", { owned, limit })`; **falls back** to the verbatim-message path when structured details are absent (older backends / un-migrated quota errors) — backward-compatible.
- New i18n key `workspaceLimitReachedDetailed` in `en.json` + `ja.json` with both `{owned}` and `{limit}` placeholders.

## Design note
The issue sketched a *flat* `{detail, error_code, owned_count, cap}` body; I followed the codebase convention (fields under `details`, code in `error`) so the one error-response shape and all existing `ApiError.details` plumbing stay consistent. Gate1 (DX Lead) confirmed.

## Testing
- Backend: `tests/services/test_quota_service.py` → 23 passed (incl. new `test_denied_raises_with_structured_details`); ruff clean.
- Frontend: `tsc --noEmit` clean; en/ja JSON valid. No existing `WorkspaceCreateForm` test harness — a dedicated RTL test is out of this AC's scope (backend pin test covers the contract); notable as optional follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)