### PR TITLE
feat(frontend): make past analysis runs clickable in Analyses tab (#732)

### DIFF
--- a/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
@@ -359,6 +359,24 @@ export function AnalysesTabPanel({
   // even while the selected run is still loading).
   const viewingPastRun = !!selectedRunId && selectedRunId !== latestRunId;
 
+  // Localized status label for the non-succeeded past-run empty state — reuse
+  // the history table's status.* keys so it isn't a raw English enum dropped
+  // into the ja sentence.
+  const displayRunStatusLabel = !displayRun
+    ? ""
+    : displayRun.status === "cancelled"
+      ? t("history.status.cancelled", {
+          reason: displayRun.cancellation_reason ?? "",
+        })
+      : ["running", "succeeded", "failed"].includes(displayRun.status)
+        ? t(
+            `history.status.${displayRun.status}` as
+              | "history.status.running"
+              | "history.status.succeeded"
+              | "history.status.failed",
+          )
+        : t("history.status.unknown", { raw: displayRun.status });
+
   const allowedClusterIndexes = useMemo(
     () => displayClusters.map((c) => c.cluster_index),
     [displayClusters],
@@ -566,7 +584,7 @@ export function AnalysesTabPanel({
             icon={History}
             title={t("states.pastRunEmpty.title")}
             description={t("states.pastRunEmpty.description", {
-              status: displayRun?.status ?? "",
+              status: displayRunStatusLabel,
             })}
           />
         ) : (
@@ -611,7 +629,7 @@ export function AnalysesTabPanel({
               runs={state.history}
               total={state.history.length}
               activeRunId={state.activeRun?.run_id ?? null}
-              selectedRunId={displayRun?.run_id ?? null}
+              selectedRunId={selectedView?.run.run_id ?? null}
               onSelectRun={setSelectedRunId}
             />
             <PropertyStats

--- a/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
@@ -26,6 +26,7 @@ import { ApiError } from "@/lib/api/base";
 import {
   cancelAnalysisRun,
   getActiveAnalysis,
+  getAnalysisRun,
   listAnalysisRuns,
   listRunClusters,
   listRunPositions,
@@ -50,6 +51,7 @@ import {
   DollarSign,
   Award,
   Clock,
+  History,
 } from "lucide-react";
 import { ScatterPlot } from "./ScatterPlot";
 import { ClusterList } from "./ClusterList";
@@ -71,6 +73,13 @@ interface BootstrapState {
   clusters: AnalysisCluster[];
   positions: ScatterPosition[];
   history: AnalysisRunRow[];
+  // Issue #732: a past run selected via ?run_id. When non-null it drives the
+  // KPI/scatter/cluster/stats view in place of ``activeRun`` (the latest run),
+  // which stays the source of truth for polling + the "is latest" comparison.
+  // Null when no selection, or when the selected id equals the latest run.
+  selectedRun: AnalysisRunRow | null;
+  selectedClusters: AnalysisCluster[];
+  selectedPositions: ScatterPosition[];
   error: string | null;
   notEnabled: boolean;
   loading: boolean;
@@ -81,6 +90,9 @@ const EMPTY_BOOTSTRAP: BootstrapState = {
   clusters: [],
   positions: [],
   history: [],
+  selectedRun: null,
+  selectedClusters: [],
+  selectedPositions: [],
   error: null,
   notEnabled: false,
   loading: true,
@@ -108,6 +120,22 @@ export function AnalysesTabPanel({
       const params = new URLSearchParams(searchParams.toString());
       if (next) params.set("new", "1");
       else params.delete("new");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname);
+    },
+    [searchParams, pathname, router],
+  );
+
+  // Issue #732: the past run being viewed is URL-driven (?run_id=<uuid>) so the
+  // view is bookmarkable / shareable / survives refresh. ``null`` clears it and
+  // returns to the latest-run view. Other params (tab, new) are preserved.
+  const selectedRunId = searchParams.get("run_id");
+
+  const setSelectedRunId = useCallback(
+    (next: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (next) params.set("run_id", next);
+      else params.delete("run_id");
       const query = params.toString();
       router.replace(query ? `${pathname}?${query}` : pathname);
     },
@@ -197,11 +225,45 @@ export function AnalysesTabPanel({
         return;
       }
 
+      // Issue #732: when ?run_id points at a run *other* than the latest, load
+      // it for the view. Only succeeded runs have clusters/positions — for a
+      // failed/running/cancelled selection we still show its KPI row + status
+      // (clusters stay empty → the empty-state branch renders). A bad / out-of-
+      // scope id throws (403/404) and surfaces as an error banner; the latest
+      // view is one "Back to latest" click away once the id is cleared.
+      let selectedRun: AnalysisRunRow | null = null;
+      let selectedClusters: AnalysisCluster[] = [];
+      let selectedPositions: ScatterPosition[] = [];
+      if (selectedRunId && selectedRunId !== activeRun?.run_id) {
+        try {
+          selectedRun = await getAnalysisRun(contextId, selectedRunId);
+          if (selectedRun.status === "succeeded") {
+            const [clusterRes, positionRes] = await Promise.all([
+              listRunClusters(contextId, selectedRunId),
+              listRunPositions(contextId, selectedRunId),
+            ]);
+            selectedClusters = clusterRes.items;
+            selectedPositions = positionRes.items;
+          }
+        } catch (err) {
+          setState({
+            ...EMPTY_BOOTSTRAP,
+            history,
+            error: err instanceof Error ? err.message : t("states.loadFailed"),
+            loading: false,
+          });
+          return;
+        }
+      }
+
       setState({
         activeRun,
         clusters,
         positions,
         history,
+        selectedRun,
+        selectedClusters,
+        selectedPositions,
         error: null,
         notEnabled: false,
         loading: false,
@@ -221,7 +283,7 @@ export function AnalysesTabPanel({
         loading: false,
       });
     }
-  }, [contextId, t]);
+  }, [contextId, selectedRunId, t]);
 
   useEffect(() => {
     bootstrap();
@@ -265,9 +327,22 @@ export function AnalysesTabPanel({
     }
   }, [contextId, polling]);
 
+  // Issue #732: the run shown in the KPI strip + scatter + cluster list +
+  // property stats is the ?run_id-selected past run when one is active,
+  // otherwise the latest run. ``activeRun`` (the latest) is kept separately for
+  // polling + the "is this the latest run?" comparison below.
+  const displayRun = state.selectedRun ?? state.activeRun;
+  const displayClusters = state.selectedRun
+    ? state.selectedClusters
+    : state.clusters;
+  const displayPositions = state.selectedRun
+    ? state.selectedPositions
+    : state.positions;
+  const viewingPastRun = state.selectedRun !== null;
+
   const allowedClusterIndexes = useMemo(
-    () => state.clusters.map((c) => c.cluster_index),
-    [state.clusters],
+    () => displayClusters.map((c) => c.cluster_index),
+    [displayClusters],
   );
   const { focusedClusterId, setFocusedClusterId, toggleFocusedClusterId } =
     useFocusedClusterId(allowedClusterIndexes);
@@ -279,9 +354,9 @@ export function AnalysesTabPanel({
   const focusedCluster = useMemo(() => {
     if (focusedClusterId === null) return null;
     return (
-      state.clusters.find((c) => c.cluster_index === focusedClusterId) ?? null
+      displayClusters.find((c) => c.cluster_index === focusedClusterId) ?? null
     );
-  }, [focusedClusterId, state.clusters]);
+  }, [focusedClusterId, displayClusters]);
 
   const handleRunStarted = useCallback(
     (runId: string) => {
@@ -378,31 +453,54 @@ export function AnalysesTabPanel({
         </div>
       )}
 
+      {/* Issue #732: past-run viewing banner — shown when ?run_id selects a
+          run other than the latest. "Back to latest" clears the param. */}
+      {viewingPastRun && displayRun && (
+        <div className="flex items-center justify-between gap-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-900/30">
+          <div className="flex items-center gap-3">
+            <History className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            <div className="text-sm text-gray-700 dark:text-gray-300">
+              {t("pastRun.banner", {
+                when: new Date(displayRun.started_at).toLocaleString(),
+              })}
+            </div>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setSelectedRunId(null)}
+            className="shrink-0"
+          >
+            {t("pastRun.backToLatest")}
+          </Button>
+        </div>
+      )}
+
       {/* KPI strip */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
         <KpiCard
           icon={Clock}
           label={t("kpi.lastRun")}
           value={
-            state.activeRun
-              ? new Date(state.activeRun.started_at).toLocaleString()
+            displayRun
+              ? new Date(displayRun.started_at).toLocaleString()
               : t("kpi.neverRun")
           }
-          tone={state.activeRun ? "primary" : "muted"}
+          tone={displayRun ? "primary" : "muted"}
         />
         <KpiCard
           icon={Activity}
           label={t("kpi.memoriesSurveyed")}
-          value={state.activeRun ? state.activeRun.input_count : "—"}
+          value={displayRun ? displayRun.input_count : "—"}
         />
         <KpiCard
           icon={DollarSign}
           label={t("kpi.runCost")}
           value={
-            state.activeRun
+            displayRun
               ? formatCostCents(
-                  state.activeRun.cost_actual_cents ??
-                    state.activeRun.cost_estimated_cents,
+                  displayRun.cost_actual_cents ??
+                    displayRun.cost_estimated_cents,
                 )
               : "—"
           }
@@ -411,40 +509,54 @@ export function AnalysesTabPanel({
           icon={Award}
           label={t("kpi.quality")}
           value={
-            state.clusters.length === 0
+            displayClusters.length === 0
               ? t("kpi.qualityNoData")
               : t("kpi.qualityValue", {
                   value: formatConfidence(
-                    state.clusters
+                    displayClusters
                       .map((c) => c.label_confidence)
-                      .reduce((acc, n) => acc + n, 0) / state.clusters.length,
+                      .reduce((acc, n) => acc + n, 0) / displayClusters.length,
                   ),
                 })
           }
-          tone={state.clusters.length === 0 ? "muted" : "secondary"}
+          tone={displayClusters.length === 0 ? "muted" : "secondary"}
         />
       </div>
 
       {/* main scatter + cluster list grid */}
-      {state.clusters.length === 0 ? (
-        <EmptyState
-          icon={Sparkles}
-          title={t("states.empty.title")}
-          description={t("states.empty.description")}
-          // Hide the action button while a run is in flight — the
-          // running banner above already provides the visual signal
-          // and a Cancel control. Re-enabling on terminal lets the
-          // user fire a follow-up run if the first one failed.
-          actionLabel={runInProgress ? undefined : t("actions.newAnalysis")}
-          onAction={runInProgress ? undefined : () => setShowModal(true)}
-        />
+      {displayClusters.length === 0 ? (
+        viewingPastRun ? (
+          // Issue #732: a selected past run with no clusters (failed / running /
+          // cancelled, or not-yet-succeeded) — explain its status instead of the
+          // "run your first analysis" CTA, which would misleadingly imply the
+          // context has never been analyzed.
+          <EmptyState
+            icon={History}
+            title={t("states.pastRunEmpty.title")}
+            description={t("states.pastRunEmpty.description", {
+              status: displayRun?.status ?? "",
+            })}
+          />
+        ) : (
+          <EmptyState
+            icon={Sparkles}
+            title={t("states.empty.title")}
+            description={t("states.empty.description")}
+            // Hide the action button while a run is in flight — the
+            // running banner above already provides the visual signal
+            // and a Cancel control. Re-enabling on terminal lets the
+            // user fire a follow-up run if the first one failed.
+            actionLabel={runInProgress ? undefined : t("actions.newAnalysis")}
+            onAction={runInProgress ? undefined : () => setShowModal(true)}
+          />
+        )
       ) : (
         <>
           <div className="grid grid-cols-1 gap-4 lg:grid-cols-[minmax(0,1.55fr)_minmax(0,1fr)]">
             <div className="space-y-4">
               <ScatterPlot
-                clusters={state.clusters}
-                positions={state.positions}
+                clusters={displayClusters}
+                positions={displayPositions}
                 focusedClusterId={focusedClusterId}
                 focusedCluster={focusedCluster}
                 onClearFocus={() => setFocusedClusterId(null)}
@@ -455,7 +567,7 @@ export function AnalysesTabPanel({
               />
             </div>
             <ClusterList
-              clusters={state.clusters}
+              clusters={displayClusters}
               focusedClusterId={focusedClusterId}
               onToggleFocus={toggleFocusedClusterId}
               onClearFocus={() => setFocusedClusterId(null)}
@@ -467,9 +579,11 @@ export function AnalysesTabPanel({
               runs={state.history}
               total={state.history.length}
               activeRunId={state.activeRun?.run_id ?? null}
+              selectedRunId={displayRun?.run_id ?? null}
+              onSelectRun={setSelectedRunId}
             />
             <PropertyStats
-              clusters={state.clusters}
+              clusters={displayClusters}
               focusedCluster={focusedCluster}
             />
           </div>

--- a/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysesTabPanel.tsx
@@ -53,6 +53,7 @@ import {
   Clock,
   History,
 } from "lucide-react";
+import { formatLocalDate } from "@/lib/utils/datetime";
 import { ScatterPlot } from "./ScatterPlot";
 import { ClusterList } from "./ClusterList";
 import { RepresentativesPanel } from "./RepresentativesPanel";
@@ -73,13 +74,6 @@ interface BootstrapState {
   clusters: AnalysisCluster[];
   positions: ScatterPosition[];
   history: AnalysisRunRow[];
-  // Issue #732: a past run selected via ?run_id. When non-null it drives the
-  // KPI/scatter/cluster/stats view in place of ``activeRun`` (the latest run),
-  // which stays the source of truth for polling + the "is latest" comparison.
-  // Null when no selection, or when the selected id equals the latest run.
-  selectedRun: AnalysisRunRow | null;
-  selectedClusters: AnalysisCluster[];
-  selectedPositions: ScatterPosition[];
   error: string | null;
   notEnabled: boolean;
   loading: boolean;
@@ -90,9 +84,6 @@ const EMPTY_BOOTSTRAP: BootstrapState = {
   clusters: [],
   positions: [],
   history: [],
-  selectedRun: null,
-  selectedClusters: [],
-  selectedPositions: [],
   error: null,
   notEnabled: false,
   loading: true,
@@ -109,6 +100,18 @@ export function AnalysesTabPanel({
 
   const [state, setState] = useState<BootstrapState>(EMPTY_BOOTSTRAP);
   const [activeRunId, setActiveRunId] = useState<string | null>(null);
+
+  // Issue #732: a ?run_id-selected past run, loaded *independently* of
+  // bootstrap (see the effect below) so clicking a history row neither tears
+  // the whole panel down into the loading skeleton nor re-fetches the latest
+  // run / history. ``null`` = viewing the latest run.
+  const [selectedView, setSelectedView] = useState<{
+    run: AnalysisRunRow;
+    clusters: AnalysisCluster[];
+    positions: ScatterPosition[];
+  } | null>(null);
+  const [selectedLoading, setSelectedLoading] = useState(false);
+  const [selectedError, setSelectedError] = useState<string | null>(null);
 
   // Modal state is URL-driven (?new=1). Reading + writing the URL is
   // the single source of truth so back/forward keeps the modal closed
@@ -225,45 +228,11 @@ export function AnalysesTabPanel({
         return;
       }
 
-      // Issue #732: when ?run_id points at a run *other* than the latest, load
-      // it for the view. Only succeeded runs have clusters/positions — for a
-      // failed/running/cancelled selection we still show its KPI row + status
-      // (clusters stay empty → the empty-state branch renders). A bad / out-of-
-      // scope id throws (403/404) and surfaces as an error banner; the latest
-      // view is one "Back to latest" click away once the id is cleared.
-      let selectedRun: AnalysisRunRow | null = null;
-      let selectedClusters: AnalysisCluster[] = [];
-      let selectedPositions: ScatterPosition[] = [];
-      if (selectedRunId && selectedRunId !== activeRun?.run_id) {
-        try {
-          selectedRun = await getAnalysisRun(contextId, selectedRunId);
-          if (selectedRun.status === "succeeded") {
-            const [clusterRes, positionRes] = await Promise.all([
-              listRunClusters(contextId, selectedRunId),
-              listRunPositions(contextId, selectedRunId),
-            ]);
-            selectedClusters = clusterRes.items;
-            selectedPositions = positionRes.items;
-          }
-        } catch (err) {
-          setState({
-            ...EMPTY_BOOTSTRAP,
-            history,
-            error: err instanceof Error ? err.message : t("states.loadFailed"),
-            loading: false,
-          });
-          return;
-        }
-      }
-
       setState({
         activeRun,
         clusters,
         positions,
         history,
-        selectedRun,
-        selectedClusters,
-        selectedPositions,
         error: null,
         notEnabled: false,
         loading: false,
@@ -283,11 +252,61 @@ export function AnalysesTabPanel({
         loading: false,
       });
     }
-  }, [contextId, selectedRunId, t]);
+  }, [contextId, t]);
 
   useEffect(() => {
     bootstrap();
   }, [bootstrap]);
+
+  // Issue #732: load the ?run_id-selected past run on its own, leaving the
+  // latest-run view + polling mounted (no skeleton flash, no latest re-fetch on
+  // every row click). Skips when there's no selection or the selection IS the
+  // latest run (that view is already shown). The cancelled guard drops stale
+  // responses when the user clicks through several rows quickly.
+  const latestRunId = state.activeRun?.run_id ?? null;
+  useEffect(() => {
+    if (!selectedRunId || selectedRunId === latestRunId) {
+      setSelectedView(null);
+      setSelectedError(null);
+      setSelectedLoading(false);
+      return;
+    }
+    let cancelled = false;
+    setSelectedLoading(true);
+    setSelectedError(null);
+    (async () => {
+      try {
+        const run = await getAnalysisRun(contextId, selectedRunId);
+        let clusters: AnalysisCluster[] = [];
+        let positions: ScatterPosition[] = [];
+        // Only succeeded runs have clusters/positions; a failed/running/
+        // cancelled selection renders the "no results" past-run state.
+        if (run.status === "succeeded") {
+          const [clusterRes, positionRes] = await Promise.all([
+            listRunClusters(contextId, selectedRunId),
+            listRunPositions(contextId, selectedRunId),
+          ]);
+          clusters = clusterRes.items;
+          positions = positionRes.items;
+        }
+        if (!cancelled) setSelectedView({ run, clusters, positions });
+      } catch (err) {
+        // Bad / out-of-scope run_id (403/404) etc. — surface inline; the
+        // latest view stays mounted and "Back to latest" clears the param.
+        if (!cancelled) {
+          setSelectedView(null);
+          setSelectedError(
+            err instanceof Error ? err.message : t("states.loadFailed"),
+          );
+        }
+      } finally {
+        if (!cancelled) setSelectedLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [contextId, selectedRunId, latestRunId, t]);
 
   // Polling: armed only when activeRunId points at a *running* run.
   // The terminal callback re-runs bootstrap so the cluster+position
@@ -331,14 +350,14 @@ export function AnalysesTabPanel({
   // property stats is the ?run_id-selected past run when one is active,
   // otherwise the latest run. ``activeRun`` (the latest) is kept separately for
   // polling + the "is this the latest run?" comparison below.
-  const displayRun = state.selectedRun ?? state.activeRun;
-  const displayClusters = state.selectedRun
-    ? state.selectedClusters
-    : state.clusters;
-  const displayPositions = state.selectedRun
-    ? state.selectedPositions
+  const displayRun = selectedView?.run ?? state.activeRun;
+  const displayClusters = selectedView ? selectedView.clusters : state.clusters;
+  const displayPositions = selectedView
+    ? selectedView.positions
     : state.positions;
-  const viewingPastRun = state.selectedRun !== null;
+  // True as soon as a non-latest run is selected (banner shows immediately,
+  // even while the selected run is still loading).
+  const viewingPastRun = !!selectedRunId && selectedRunId !== latestRunId;
 
   const allowedClusterIndexes = useMemo(
     () => displayClusters.map((c) => c.cluster_index),
@@ -453,16 +472,28 @@ export function AnalysesTabPanel({
         </div>
       )}
 
-      {/* Issue #732: past-run viewing banner — shown when ?run_id selects a
-          run other than the latest. "Back to latest" clears the param. */}
-      {viewingPastRun && displayRun && (
+      {/* Issue #732: past-run viewing banner — shown as soon as ?run_id selects
+          a non-latest run. While it loads, the latest view stays mounted and
+          the banner shows a spinner (no full-panel skeleton flash). "Back to
+          latest" clears the param. */}
+      {viewingPastRun && (
         <div className="flex items-center justify-between gap-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-800 dark:bg-amber-900/30">
           <div className="flex items-center gap-3">
-            <History className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            {selectedLoading ? (
+              <InlineSpinner size="sm" variant="brand" />
+            ) : (
+              <History className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            )}
             <div className="text-sm text-gray-700 dark:text-gray-300">
-              {t("pastRun.banner", {
-                when: new Date(displayRun.started_at).toLocaleString(),
-              })}
+              {selectedLoading
+                ? t("pastRun.loading")
+                : selectedView
+                  ? t("pastRun.banner", {
+                      when: formatLocalDate(
+                        new Date(selectedView.run.started_at),
+                      ),
+                    })
+                  : t("pastRun.generic")}
             </div>
           </div>
           <Button
@@ -475,6 +506,7 @@ export function AnalysesTabPanel({
           </Button>
         </div>
       )}
+      {selectedError && <ErrorBanner error={selectedError} />}
 
       {/* KPI strip */}
       <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">

--- a/frontend/src/components/contexts/analyses/AnalysisHistory.test.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysisHistory.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for AnalysisHistory clickable rows (#732).
+ *
+ * The past-runs table became row-clickable so a user can open a past run's
+ * results. These pin the interactive contract the parent (AnalysesTabPanel)
+ * depends on: clicking / Enter invokes onSelectRun with the row's run_id, the
+ * viewed row is marked aria-current, and rows stay non-interactive when no
+ * onSelectRun is supplied (backward compatible with read-only callers).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import type { AnalysisRunRow } from "@/lib/api/analyses";
+
+vi.mock("next-intl", () => ({
+  useTranslations: (_ns: string) => (key: string) => key,
+}));
+
+import { AnalysisHistory } from "./AnalysisHistory";
+
+function makeRun(overrides: Partial<AnalysisRunRow> = {}): AnalysisRunRow {
+  return {
+    run_id: "run-1",
+    status: "succeeded",
+    started_at: "2026-05-01T00:00:00Z",
+    input_count: 10,
+    cost_actual_cents: 5,
+    cost_estimated_cents: 5,
+    cancellation_reason: null,
+    ...overrides,
+  } as AnalysisRunRow;
+}
+
+describe("AnalysisHistory — clickable rows (#732)", () => {
+  it("calls onSelectRun with the run_id when a row is clicked", () => {
+    const onSelectRun = vi.fn();
+    render(
+      <AnalysisHistory
+        runs={[makeRun({ run_id: "run-a" }), makeRun({ run_id: "run-b" })]}
+        total={2}
+        activeRunId={null}
+        onSelectRun={onSelectRun}
+      />,
+    );
+    const rows = screen.getAllByRole("button");
+    expect(rows).toHaveLength(2);
+    fireEvent.click(rows[1]);
+    expect(onSelectRun).toHaveBeenCalledWith("run-b");
+  });
+
+  it("triggers selection on Enter key (keyboard accessible)", () => {
+    const onSelectRun = vi.fn();
+    render(
+      <AnalysisHistory
+        runs={[makeRun({ run_id: "run-a" })]}
+        total={1}
+        activeRunId={null}
+        onSelectRun={onSelectRun}
+      />,
+    );
+    fireEvent.keyDown(screen.getByRole("button"), { key: "Enter" });
+    expect(onSelectRun).toHaveBeenCalledWith("run-a");
+  });
+
+  it("marks the currently-viewed row with aria-current", () => {
+    render(
+      <AnalysisHistory
+        runs={[makeRun({ run_id: "run-a" }), makeRun({ run_id: "run-b" })]}
+        total={2}
+        activeRunId={null}
+        selectedRunId="run-b"
+        onSelectRun={vi.fn()}
+      />,
+    );
+    const current = screen
+      .getAllByRole("button")
+      .filter((el) => el.getAttribute("aria-current") === "true");
+    expect(current).toHaveLength(1);
+  });
+
+  it("renders non-interactive rows when onSelectRun is omitted", () => {
+    render(<AnalysisHistory runs={[makeRun()]} total={1} activeRunId={null} />);
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+});

--- a/frontend/src/components/contexts/analyses/AnalysisHistory.tsx
+++ b/frontend/src/components/contexts/analyses/AnalysisHistory.tsx
@@ -27,6 +27,10 @@ interface AnalysisHistoryProps {
   runs: AnalysisRunRow[];
   total: number | null;
   activeRunId: string | null;
+  // Issue #732: when ``onSelectRun`` is provided, rows become clickable to view
+  // that run's results; ``selectedRunId`` marks the row currently being viewed.
+  selectedRunId?: string | null;
+  onSelectRun?: (runId: string) => void;
 }
 
 // Translatable status labels — keyed by the canonical
@@ -39,6 +43,8 @@ export function AnalysisHistory({
   runs,
   total,
   activeRunId,
+  selectedRunId = null,
+  onSelectRun,
 }: AnalysisHistoryProps) {
   const t = useTranslations("analyses.history");
 
@@ -77,12 +83,45 @@ export function AnalysisHistory({
         <TableBody>
           {runs.map((run) => {
             const isActive = activeRunId === run.run_id;
+            const isSelected = selectedRunId === run.run_id;
+            const clickable = !!onSelectRun;
+            const handleSelect = () => onSelectRun?.(run.run_id);
             return (
               <TableRow
                 key={run.run_id}
-                className={
-                  isActive ? "bg-emerald-50/40 dark:bg-emerald-900/20" : ""
+                onClick={clickable ? handleSelect : undefined}
+                onKeyDown={
+                  clickable
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          handleSelect();
+                        }
+                      }
+                    : undefined
                 }
+                tabIndex={clickable ? 0 : undefined}
+                role={clickable ? "button" : undefined}
+                aria-current={isSelected ? "true" : undefined}
+                aria-label={
+                  clickable
+                    ? t("viewRunAria", {
+                        when: formatLocalDate(new Date(run.started_at)),
+                      })
+                    : undefined
+                }
+                className={[
+                  isSelected
+                    ? "bg-blue-50 ring-1 ring-inset ring-blue-300 dark:bg-blue-900/30 dark:ring-blue-700"
+                    : isActive
+                      ? "bg-emerald-50/40 dark:bg-emerald-900/20"
+                      : clickable
+                        ? "hover:bg-gray-50 dark:hover:bg-gray-800/50"
+                        : "",
+                  clickable ? "cursor-pointer" : "",
+                ]
+                  .filter(Boolean)
+                  .join(" ")}
               >
                 <TableCell className="font-mono text-xs">
                   {formatLocalDate(new Date(run.started_at))}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3444,6 +3444,7 @@
       "headerCost": "Cost",
       "noRunsTitle": "No runs yet",
       "noRunsDescription": "Run your first analysis to populate the history.",
+      "viewRunAria": "View results for the run from {when}",
       "status": {
         "running": "running",
         "succeeded": "succeeded",
@@ -3451,6 +3452,10 @@
         "cancelled": "cancelled · {reason}",
         "unknown": "{raw}"
       }
+    },
+    "pastRun": {
+      "banner": "Viewing a past run from {when} — not the latest.",
+      "backToLatest": "Back to latest"
     },
     "modal": {
       "title": "Analysis",
@@ -3495,6 +3500,10 @@
       "empty": {
         "title": "No analyses yet",
         "description": "Run your first analysis to surface the cluster overview, scatter map, and per-cluster property stats."
+      },
+      "pastRunEmpty": {
+        "title": "This run has no results to show",
+        "description": "The selected run is {status} — only succeeded runs have clusters, scatter positions, and property stats. Use \"Back to latest\" to return to the current view."
       },
       "notEnabled": {
         "title": "Analyses are not yet enabled for this workspace",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3455,6 +3455,8 @@
     },
     "pastRun": {
       "banner": "Viewing a past run from {when} — not the latest.",
+      "generic": "Viewing a past run — not the latest.",
+      "loading": "Loading the selected run…",
       "backToLatest": "Back to latest"
     },
     "modal": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3444,6 +3444,7 @@
       "headerCost": "コスト",
       "noRunsTitle": "まだ run がありません",
       "noRunsDescription": "最初の分析を実行すると履歴がここに表示されます。",
+      "viewRunAria": "{when} の run の結果を表示",
       "status": {
         "running": "実行中",
         "succeeded": "成功",
@@ -3451,6 +3452,10 @@
         "cancelled": "キャンセル · {reason}",
         "unknown": "{raw}"
       }
+    },
+    "pastRun": {
+      "banner": "{when} の過去 run を表示中 — 最新ではありません。",
+      "backToLatest": "最新に戻る"
     },
     "modal": {
       "title": "分析を実行",
@@ -3495,6 +3500,10 @@
       "empty": {
         "title": "まだ分析がありません",
         "description": "最初の分析を実行するとクラスタ俯瞰、scatter map、各クラスタのプロパティ統計が表示されます。"
+      },
+      "pastRunEmpty": {
+        "title": "この run には表示できる結果がありません",
+        "description": "選択した run は {status} です — クラスタ・scatter 座標・プロパティ統計を持つのは成功した run のみです。「最新に戻る」で現在の表示に戻れます。"
       },
       "notEnabled": {
         "title": "この workspace では Analyses はまだ有効化されていません",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3455,6 +3455,8 @@
     },
     "pastRun": {
       "banner": "{when} の過去 run を表示中 — 最新ではありません。",
+      "generic": "過去 run を表示中 — 最新ではありません。",
+      "loading": "選択した run を読み込み中…",
       "backToLatest": "最新に戻る"
     },
     "modal": {


### PR DESCRIPTION
Closes #732

## Summary

The Analyses tab's "Past runs" table was read-only. Now each row is clickable to view that run's clusters / scatter / property-stats, with the selected run reflected in `?run_id=<uuid>` (bookmarkable, shareable, refresh-safe). **Frontend-only — no backend/API/DB change** (`GET /{run_id}`, `/clusters`, `/positions` already exist).

## Design (per gate1 / CTO review)

- **URL `?run_id` is the source of truth**, reusing the file's existing `?new=1` / `?tab` param pattern (`router.replace`, so the back button leaves the tab rather than walking every click).
- **Active/polling path is untouched.** `AnalysesTabPanel` keeps `state.activeRun` = the latest run (drives polling + the running banner). A new `selectedRun`/`selectedClusters`/`selectedPositions` is layered on top; the view renders `display* = selected ?? active`. When `?run_id` is absent the flow is byte-identical to before — the regression risk the review flagged.
- **Non-succeeded selection handled** (the edge the review called out): selecting a failed/running/cancelled run (no clusters) shows a dedicated *"This run has no results to show"* state, not the misleading "run your first analysis" CTA.
- **Bad / out-of-scope `run_id`** → the existing 403/404 error surface (`ErrorBanner`).
- **"Back to latest"** amber banner clears the param; the viewed row is highlighted distinctly from the latest-run (green) marker.

## AnalysisHistory
Rows become clickable (`role=button`, `tabIndex`, Enter/Space, `aria-current`, `aria-label`) **only when `onSelectRun` is supplied** — backward compatible with read-only callers.

## Testing
- `AnalysisHistory.test.tsx` (new): row click + Enter → `onSelectRun(run_id)`, `aria-current` on the viewed row, and read-only fallback when `onSelectRun` is omitted → 4 passed.
- `tsc --noEmit` clean; en/ja JSON valid (new keys in both locales).
- The panel-level `?run_id` branch was **manually verified on local Docker** (seeded runs) rather than unit-tested — `AnalysesTabPanel` has no existing test harness and mocking its full data/polling/navigation surface is disproportionate; the branch is type-checked and the `display* = selected ?? active` logic is simple. Flagging as a known coverage gap.

## Out of scope (per issue)
Multi-run diff view; history filter/sort; re-run button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)