### PR TITLE
feat(frontend,api): tag cloud + autocomplete on context detail (#618)

### DIFF
--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -741,6 +741,16 @@ async def list_context_tags(
             "a wildcard probe."
         ),
     ),
+    q: str | None = Query(
+        None,
+        max_length=200,
+        description=(
+            "Optional case-insensitive substring filter on memory.summary "
+            "(#618). When set, only tags on matching memories are aggregated, "
+            "so the tag cloud facets to the current search. Whitespace-only is "
+            "treated as no filter."
+        ),
+    ),
 ) -> ContextTagsResponse:
     """List existing tag vocabulary in a context (Issue #614).
 
@@ -772,6 +782,7 @@ async def list_context_tags(
             min_count=min_count,
             sort=sort,
             prefix=prefix,
+            q=q,
         )
     except NotFoundException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -533,6 +533,12 @@ async def list_memories(
         description="Optional case-insensitive substring filter on memory.summary. "
         "Whitespace-only values are treated as None.",
     ),
+    tags: list[str] | None = Query(
+        None,
+        description="Filter to memories having ANY of these tags (exact match). "
+        "Repeat the param to pass several: ?tags=a&tags=b. Combined with other "
+        "filters (e.g. q) by AND. Blank / whitespace-only entries are ignored.",
+    ),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
@@ -604,6 +610,14 @@ async def list_memories(
             q_escaped = q_normalized.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
             q_pattern = f"%{q_escaped}%"
 
+        # Normalize the tag filter (#618): strip blanks, drop whitespace-only
+        # entries, de-dup (order-preserving). An all-blank list collapses to
+        # None so a stray ``?tags=`` doesn't pin results to the empty set.
+        tags_normalized: list[str] | None = None
+        if tags:
+            cleaned = list(dict.fromkeys(t.strip() for t in tags if t and t.strip()))
+            tags_normalized = cleaned or None
+
         # Build query. Exclude soft-deleted rows — POST /forget sets
         # ``deleted_at`` rather than removing the row, and the list view
         # must not surface tombstones.
@@ -623,6 +637,11 @@ async def list_memories(
         if q_pattern is not None:
             query = query.where(Memory.summary.ilike(q_pattern, escape="\\"))
 
+        # ANY-match: row has at least one of the requested tags (PG array
+        # overlap ``&&``). NULL-tags rows never overlap, so they're excluded.
+        if tags_normalized is not None:
+            query = query.where(Memory.tags.overlap(tags_normalized))
+
         # Get total count (with same filters as data query)
         count_query = select(func.count(Memory.id)).where(Memory.deleted_at.is_(None))
         if owner_filter is not None:
@@ -635,6 +654,8 @@ async def list_memories(
             count_query = count_query.where(Memory.context_id == context_id)
         if q_pattern is not None:
             count_query = count_query.where(Memory.summary.ilike(q_pattern, escape="\\"))
+        if tags_normalized is not None:
+            count_query = count_query.where(Memory.tags.overlap(tags_normalized))
         count_result = await db.execute(count_query)
         total = count_result.scalar() or 0
 
@@ -677,6 +698,7 @@ async def list_memories(
             total=total,
             q_present=q_normalized is not None,
             q_len=len(q_normalized) if q_normalized else 0,
+            tag_filter_count=len(tags_normalized) if tags_normalized else 0,
         )
 
         return MemoryListResponse(memories=memory_items, total=total, has_more=has_more)

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -615,7 +615,12 @@ async def list_memories(
         # None so a stray ``?tags=`` doesn't pin results to the empty set.
         tags_normalized: list[str] | None = None
         if tags:
-            cleaned = list(dict.fromkeys(t.strip() for t in tags if t and t.strip()))
+            # Bound the filter to the write-path caps (<=64 chars/tag, <=100
+            # tags): drop blank / over-length entries, de-dup (order-preserving),
+            # then cap — so an oversized query string can't reach the DB.
+            cleaned = list(dict.fromkeys(s for t in tags if (s := t.strip()) and len(s) <= 64))[
+                :100
+            ]
             tags_normalized = cleaned or None
 
         # Build query. Exclude soft-deleted rows — POST /forget sets

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -1099,6 +1099,7 @@ class ContextService:
         min_count: int = 1,
         sort: TagSortMode = "count",
         prefix: str = "",
+        q: str | None = None,
     ) -> dict:
         """Aggregate tags across non-deleted memories in a context (Issue #614).
 
@@ -1160,6 +1161,16 @@ class ContextService:
         else:
             prefix_pattern = ""
 
+        # #618: optional ``q`` facets the cloud to tags on memories whose summary
+        # matches (same substring semantics as GET /memory/list?q). Escape
+        # #/%/_ to literals so it can't be used as a wildcard probe.
+        q_clean = (q or "").strip()
+        if q_clean:
+            eq = q_clean.replace("#", "##").replace("%", "#%").replace("_", "#_")
+            q_pattern = f"%{eq}%"
+        else:
+            q_pattern = ""
+
         # sort is allow-list validated above; safe to interpolate.
         sort_clause = {
             "count": "ORDER BY cnt DESC, tag ASC",
@@ -1179,6 +1190,7 @@ class ContextService:
                   AND deleted_at IS NULL
                   AND tags IS NOT NULL
                   AND cardinality(tags) > 0
+                  AND (:q_pattern = '' OR summary ILIKE :q_pattern ESCAPE '#')
             ),
             tag_rows AS (
                 -- DISTINCT id, tag collapses intra-array duplicates so a
@@ -1210,6 +1222,7 @@ class ContextService:
                 "workspace_id": str(context.workspace_id),
                 "context_id": str(context_id),
                 "prefix_pattern": prefix_pattern,
+                "q_pattern": q_pattern,
                 "min_count": min_count,
                 "limit": limit,
             },

--- a/backend/tests/api/test_context_tags.py
+++ b/backend/tests/api/test_context_tags.py
@@ -138,6 +138,7 @@ class TestListContextTagsRoute:
             min_count=3,
             sort="recent",
             prefix="auth",
+            q="deploy",
         )
 
         mock_service.aggregate_tags.assert_awaited_once_with(
@@ -147,4 +148,5 @@ class TestListContextTagsRoute:
             min_count=3,
             sort="recent",
             prefix="auth",
+            q="deploy",
         )

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -76,6 +76,7 @@ class TestListMemoriesContextFilter:
                 type=None,
                 context_id=None,
                 q=None,
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -117,6 +118,7 @@ class TestListMemoriesContextFilter:
                 type=None,
                 context_id=context_id,
                 q=None,
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -169,6 +171,7 @@ class TestListMemoriesContextFilter:
                 type=None,
                 context_id=context_id,
                 q=None,
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -213,6 +216,7 @@ class TestListMemoriesContextFilter:
                 type=None,
                 context_id=None,
                 q=None,
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -234,6 +238,7 @@ class TestListMemoriesContextFilter:
                 type=None,
                 context_id=None,
                 q=None,
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -297,6 +302,7 @@ class TestListMemoriesQueryFilter:
                 type=None,
                 context_id=None,
                 q=None,
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -323,6 +329,7 @@ class TestListMemoriesQueryFilter:
                 type=None,
                 context_id=None,
                 q="hello",
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -348,6 +355,7 @@ class TestListMemoriesQueryFilter:
                 type=None,
                 context_id=None,
                 q="   ",
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -386,6 +394,7 @@ class TestListMemoriesQueryFilter:
                 type=None,
                 context_id=context_id,
                 q="found",
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -424,6 +433,7 @@ class TestListMemoriesQueryFilter:
                 type=None,
                 context_id=None,
                 q="  hello  ",
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -455,6 +465,7 @@ class TestListMemoriesQueryFilter:
                 type=None,
                 context_id=None,
                 q="50%_\\bar",
+                tags=None,
                 limit=50,
                 offset=0,
             )
@@ -471,4 +482,84 @@ class TestListMemoriesQueryFilter:
             # interprets the backslash-prefixed metacharacters correctly.
             assert "ESCAPE '\\'" in literal_sql, (
                 f"ESCAPE clause missing (call_index={call_index}): {literal_sql}"
+            )
+
+
+class TestListMemoriesTagsFilter:
+    """Issue #618: ANY-match ``tags`` filter on GET /memory/list."""
+
+    @pytest.mark.asyncio
+    async def test_tags_filter_applied_to_both_queries(self):
+        """When tags are given, the array-overlap predicate is added to the data
+        AND count queries (so the total reflects the filter)."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        response = await list_memories(
+            user=MOCK_USER,
+            db=mock_db,
+            scope=None,
+            type=None,
+            context_id=None,
+            q=None,
+            tags=["python", "auth"],
+            limit=50,
+            offset=0,
+        )
+
+        assert response.total == 1
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            # Array overlap (&&) on memories.tags — ANY-match.
+            assert "tags" in sql and "&&" in sql, (
+                f"tags overlap predicate missing (call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_no_tags_skips_filter(self):
+        """Omitting tags leaves the tags predicate out of both queries."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        await list_memories(
+            user=MOCK_USER,
+            db=mock_db,
+            scope=None,
+            type=None,
+            context_id=None,
+            q=None,
+            tags=None,
+            limit=50,
+            offset=0,
+        )
+
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert "&&" not in sql, (
+                f"tags overlap unexpectedly present when omitted (call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_blank_tags_ignored(self):
+        """Whitespace-only / empty tag entries normalize to no filter, so a stray
+        ``?tags=`` does not pin results to the empty set."""
+        mem = _mock_memory_row()
+        mock_db = _db_with_rows(total=1, rows=[mem])
+
+        await list_memories(
+            user=MOCK_USER,
+            db=mock_db,
+            scope=None,
+            type=None,
+            context_id=None,
+            q=None,
+            tags=["   ", ""],
+            limit=50,
+            offset=0,
+        )
+
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert "&&" not in sql, (
+                f"blank tags should be ignored (call_index={call_index}): {sql}"
             )

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -560,6 +560,4 @@ class TestListMemoriesTagsFilter:
 
         for call_index in (0, 1):
             sql = _where_sql(mock_db, call_index)
-            assert "&&" not in sql, (
-                f"blank tags should be ignored (call_index={call_index}): {sql}"
-            )
+            assert "&&" not in sql, f"blank tags should be ignored (call_index={call_index}): {sql}"

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -99,13 +99,14 @@ def _memory(
     created_at: datetime,
     updated_at: datetime | None = None,
     deleted_at: datetime | None = None,
+    summary: str | None = None,
 ) -> Memory:
     return Memory(
         id=uuid4(),
         user_id=user_id,
         workspace_id=ws_id,
         context_id=ctx_id,
-        summary=f"mem-{uuid4().hex[:6]}",
+        summary=summary or f"mem-{uuid4().hex[:6]}",
         content="x",
         type="note",
         client="test",
@@ -145,6 +146,43 @@ class TestAggregateTagsCTE:
 
         counts = {r["tag"]: r["count"] for r in rows}
         assert counts == {"python": 1, "backend": 1}
+
+    async def test_q_facets_tags_to_matching_summaries(self, db_session, now):
+        """#618: ``q`` filters the scope by summary substring, so only tags on
+        matching memories are aggregated. Blank / absent q → all tags."""
+        user_id = f"u_q_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        db_session.add_all(
+            [
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["ops"],
+                    created_at=now,
+                    summary="deploy runbook",
+                ),
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["security"],
+                    created_at=now,
+                    summary="auth flow",
+                ),
+            ]
+        )
+        await db_session.flush()
+
+        # q matches only "deploy runbook" → just its tag.
+        facet = {r["tag"] for r in await _agg_rows(db_session, user_id, ctx.id, q="deploy")}
+        assert facet == {"ops"}
+        # No q → all tags in the context.
+        all_tags = {r["tag"] for r in await _agg_rows(db_session, user_id, ctx.id)}
+        assert all_tags == {"ops", "security"}
+        # Whitespace-only q is treated as no filter (no accidental empty set).
+        blank = {r["tag"] for r in await _agg_rows(db_session, user_id, ctx.id, q="   ")}
+        assert blank == {"ops", "security"}
 
     async def test_soft_deleted_memory_excluded(self, db_session, now):
         user_id = f"u_softdel_{uuid4().hex[:6]}"

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -106,7 +106,7 @@ def _memory(
         user_id=user_id,
         workspace_id=ws_id,
         context_id=ctx_id,
-        summary=summary or f"mem-{uuid4().hex[:6]}",
+        summary=summary if summary is not None else f"mem-{uuid4().hex[:6]}",
         content="x",
         type="note",
         client="test",

--- a/frontend/src/components/contexts/GraphTabPanel.tsx
+++ b/frontend/src/components/contexts/GraphTabPanel.tsx
@@ -314,6 +314,7 @@ export function GraphTabPanel({ contextId }: GraphTabPanelProps) {
           open={dialog.editOpen}
           onOpenChange={dialog.handleEditOpenChange}
           onSuccess={handleEditSuccess}
+          contextId={contextId}
         />
       )}
     </>

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -35,6 +35,9 @@ import { useToast } from "@/hooks/use-toast";
 import { useMemoryDetailDialog } from "@/hooks/useMemoryDetailDialog";
 import { useMemoryIdParam } from "@/hooks/useMemoryIdParam";
 import { getMemories } from "@/lib/api/memory";
+import { TagCloud } from "@/components/contexts/TagCloud";
+import { Badge } from "@/components/ui/badge";
+import { X } from "lucide-react";
 import type { MemoryListItem, MemoryReference } from "@/lib/types/memory";
 
 interface MemoriesTabPanelProps {
@@ -43,6 +46,7 @@ interface MemoriesTabPanelProps {
 
 const PAGE_SIZE = 50;
 const SEARCH_PARAM = "q";
+const TAG_PARAM = "tag";
 const DEBOUNCE_MS = 300;
 
 export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
@@ -73,6 +77,28 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   const requestIdRef = useRef(0);
 
   const dialog = useMemoryDetailDialog({ memoryIdParam, setMemoryIdParam });
+
+  // Issue #618: a single active tag filter, URL-driven (?tag=) so it's
+  // shareable and survives refresh. Clicking a TagCloud tag toggles it; the
+  // memory list re-fetches with an ANY-match tags filter (AND-ed with q).
+  const activeTag = searchParams.get(TAG_PARAM);
+
+  const setActiveTagFilter = useCallback(
+    (tag: string | null) => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (tag) params.set(TAG_PARAM, tag);
+      else params.delete(TAG_PARAM);
+      const next = params.toString();
+      setPage(1);
+      router.replace(`${pathname}${next ? `?${next}` : ""}`);
+    },
+    [searchParams, pathname, router],
+  );
+
+  const handleTagClick = useCallback(
+    (tag: string) => setActiveTagFilter(tag === activeTag ? null : tag),
+    [activeTag, setActiveTagFilter],
+  );
 
   // Debounce: schedule a single timer that promotes `searchInput` into
   // `debouncedQuery` AND resets page to 1 in one batched update. Doing
@@ -126,6 +152,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
         limit: PAGE_SIZE,
         offset,
         q: trimmed || undefined,
+        tags: activeTag ? [activeTag] : undefined,
       });
       if (requestId !== requestIdRef.current) return;
       setItems(response.memories);
@@ -136,7 +163,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     } finally {
       if (requestId === requestIdRef.current) setLoading(false);
     }
-  }, [contextId, page, debouncedQuery, t]);
+  }, [contextId, page, debouncedQuery, activeTag, t]);
 
   useEffect(() => {
     fetchMemories();
@@ -175,41 +202,70 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     }
   }, [dialog, fetchMemories, toast, t, items.length, page]);
 
-  // Search input renders above any state branch (error / empty) so the
-  // user can always clear or refine the query without re-mounting it.
-  const searchBar = (
-    <div className="relative">
-      <Search
-        className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
-        aria-hidden="true"
+  // Tag cloud + search input + active-tag chip render above any state branch
+  // (error / empty) so the user can always discover tags, filter, or clear a
+  // filter without re-mounting the controls.
+  const filterControls = (
+    <div className="space-y-3">
+      <TagCloud
+        contextId={contextId}
+        activeTag={activeTag}
+        onTagClick={handleTagClick}
       />
-      <Input
-        type="search"
-        value={searchInput}
-        onChange={(e) => setSearchInput(e.target.value)}
-        placeholder={t("search.placeholder")}
-        aria-label={t("search.label")}
-        className="pl-9"
-      />
+      <div className="relative">
+        <Search
+          className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+          aria-hidden="true"
+        />
+        <Input
+          type="search"
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.target.value)}
+          placeholder={t("search.placeholder")}
+          aria-label={t("search.label")}
+          className="pl-9"
+        />
+      </div>
+      {activeTag && (
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {t("filter.activeLabel")}
+          </span>
+          <Badge variant="secondary" className="gap-1">
+            {activeTag}
+            <button
+              type="button"
+              onClick={() => setActiveTagFilter(null)}
+              aria-label={t("filter.clearTag", { tag: activeTag })}
+              className="ml-0.5 rounded hover:text-foreground"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </Badge>
+        </div>
+      )}
     </div>
   );
 
   if (error) {
     return (
       <div className="space-y-4">
-        {searchBar}
+        {filterControls}
         <ErrorBanner error={error} />
       </div>
     );
   }
 
   const hasQuery = debouncedQuery.trim().length > 0;
+  // Any active filter (text search OR tag) — distinguishes "no memories at all"
+  // from "no matches for the current filter".
+  const hasFilter = hasQuery || !!activeTag;
 
   // No memories at all in this context — keep the existing landing copy.
-  if (!loading && items.length === 0 && !hasQuery && !memoryIdParam) {
+  if (!loading && items.length === 0 && !hasFilter && !memoryIdParam) {
     return (
       <div className="space-y-4">
-        {searchBar}
+        {filterControls}
         <EmptyState
           icon={FileText}
           title={t("emptyTitle")}
@@ -219,16 +275,19 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     );
   }
 
-  // Query produced no matches — distinct copy that echoes the query so the
-  // user can tell whether they mistyped vs. ran a too-narrow filter.
-  if (!loading && items.length === 0 && hasQuery && !memoryIdParam) {
+  // Filter produced no matches — distinct copy that echoes the filter so the
+  // user can tell whether they mistyped vs. ran a too-narrow filter. Prefer
+  // the tag in the message when a tag filter is active.
+  if (!loading && items.length === 0 && hasFilter && !memoryIdParam) {
     return (
       <div className="space-y-4">
-        {searchBar}
+        {filterControls}
         <EmptyState
           icon={SearchX}
           title={t("noResultsTitle")}
-          description={t("noResultsDesc", { query: debouncedQuery })}
+          description={t("noResultsDesc", {
+            query: activeTag && !hasQuery ? activeTag : debouncedQuery,
+          })}
         />
       </div>
     );
@@ -237,7 +296,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   return (
     <>
       <div className="space-y-4">
-        {searchBar}
+        {filterControls}
         <MemoriesTable
           memories={items}
           loading={loading}
@@ -276,6 +335,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
           open={dialog.editOpen}
           onOpenChange={dialog.handleEditOpenChange}
           onSuccess={handleEditSuccess}
+          contextId={contextId}
         />
       )}
     </>

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -76,6 +76,10 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   // committed to state.
   const requestIdRef = useRef(0);
 
+  // #618: tracks the previous debounced query so we reset an active tag only
+  // when the search actually *changes* (typing) — not on mount / shared links.
+  const prevDebouncedQueryRef = useRef(debouncedQuery);
+
   const dialog = useMemoryDetailDialog({ memoryIdParam, setMemoryIdParam });
 
   // Issue #618: a single active tag filter, URL-driven (?tag=) so it's
@@ -126,6 +130,14 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
       params.set(SEARCH_PARAM, trimmed);
     } else {
       params.delete(SEARCH_PARAM);
+    }
+    // #618: a *changed* search resets the active tag so a new query doesn't
+    // silently AND with a stale tag (the cloud re-facets to the query). Mount
+    // / shared-link loads (query unchanged) keep any ?tag intact.
+    const queryChanged = debouncedQuery !== prevDebouncedQueryRef.current;
+    prevDebouncedQueryRef.current = debouncedQuery;
+    if (trimmed && queryChanged) {
+      params.delete(TAG_PARAM);
     }
     const next = params.toString();
     const current = searchParams.toString();
@@ -244,6 +256,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
         contextId={contextId}
         activeTag={activeTag}
         onTagClick={handleTagClick}
+        q={debouncedQuery}
       />
     </div>
   );

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -248,7 +248,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
               type="button"
               onClick={() => setActiveTagFilter(null)}
               aria-label={t("filter.clearTag", { tag: activeTag })}
-              className="ml-0.5 rounded hover:text-foreground"
+              className="ml-0.5 rounded hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
             >
               <X className="h-3 w-3" />
             </button>

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -85,7 +85,10 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   // Issue #618: a single active tag filter, URL-driven (?tag=) so it's
   // shareable and survives refresh. Clicking a TagCloud tag toggles it; the
   // memory list re-fetches with an ANY-match tags filter (AND-ed with q).
-  const activeTag = searchParams.get(TAG_PARAM);
+  // Normalize at the source: a whitespace-only ?tag (e.g. ?tag=%20) is ignored
+  // by getMemories, so collapse it to null here too — otherwise the chip /
+  // hasFilter UI would show an "active" filter the API query doesn't apply.
+  const activeTag = searchParams.get(TAG_PARAM)?.trim() || null;
 
   const setActiveTagFilter = useCallback(
     (tag: string | null) => {

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -202,16 +202,12 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     }
   }, [dialog, fetchMemories, toast, t, items.length, page]);
 
-  // Tag cloud + search input + active-tag chip render above any state branch
-  // (error / empty) so the user can always discover tags, filter, or clear a
-  // filter without re-mounting the controls.
+  // Search input → active-tag chip → tag cloud, rendered above any state branch
+  // (error / empty) so the user can always search, see/clear the active filter,
+  // or discover tags. Search leads (primary, familiar control); the tag cloud —
+  // which can be tall — sits below so it never pushes search off-screen.
   const filterControls = (
     <div className="space-y-3">
-      <TagCloud
-        contextId={contextId}
-        activeTag={activeTag}
-        onTagClick={handleTagClick}
-      />
       <div className="relative">
         <Search
           className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
@@ -244,6 +240,11 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
           </Badge>
         </div>
       )}
+      <TagCloud
+        contextId={contextId}
+        activeTag={activeTag}
+        onTagClick={handleTagClick}
+      />
     </div>
   );
 

--- a/frontend/src/components/contexts/TagAutocomplete.test.tsx
+++ b/frontend/src/components/contexts/TagAutocomplete.test.tsx
@@ -55,13 +55,18 @@ describe("TagAutocomplete (#618)", () => {
     expect(screen.queryByRole("option", { name: /auth/ })).toBeNull();
   });
 
-  it("does not query or open the listbox for an empty trailing token", async () => {
-    render(
-      <TagAutocomplete contextId="c1" value="auth, " onChange={vi.fn()} />,
-    );
-    // Give any (incorrect) debounce a chance to fire.
-    await new Promise((r) => setTimeout(r, 400));
-    expect(getContextTags).not.toHaveBeenCalled();
-    expect(screen.queryByRole("listbox")).toBeNull();
+  it("does not query or open the listbox for an empty trailing token", () => {
+    vi.useFakeTimers();
+    try {
+      render(
+        <TagAutocomplete contextId="c1" value="auth, " onChange={vi.fn()} />,
+      );
+      // Advance well past the debounce deterministically — no real sleep.
+      vi.advanceTimersByTime(400);
+      expect(getContextTags).not.toHaveBeenCalled();
+      expect(screen.queryByRole("listbox")).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/frontend/src/components/contexts/TagAutocomplete.test.tsx
+++ b/frontend/src/components/contexts/TagAutocomplete.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * Tests for TagAutocomplete (#618): debounced prefix suggestions for the
+ * trailing CSV token, insert-on-select, and exclusion of already-present tags.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+const getContextTags = vi.fn();
+vi.mock("@/lib/api/contexts", () => ({
+  getContextTags: (...args: unknown[]) => getContextTags(...args),
+}));
+
+import { TagAutocomplete } from "./TagAutocomplete";
+
+beforeEach(() => {
+  getContextTags.mockReset();
+});
+
+describe("TagAutocomplete (#618)", () => {
+  it("suggests for the trailing token and inserts the selection with a trailing comma", async () => {
+    getContextTags.mockResolvedValue({
+      context_id: "c1",
+      total: 1,
+      tags: [{ tag: "auth", count: 5 }],
+    });
+    const onChange = vi.fn();
+    render(<TagAutocomplete contextId="c1" value="au" onChange={onChange} />);
+    const option = await screen.findByRole(
+      "option",
+      { name: /auth/ },
+      { timeout: 2000 },
+    );
+    fireEvent.mouseDown(option);
+    expect(onChange).toHaveBeenCalledWith("auth, ");
+  });
+
+  it("excludes tags already present in the CSV value", async () => {
+    getContextTags.mockResolvedValue({
+      context_id: "c1",
+      total: 2,
+      tags: [
+        { tag: "deploy", count: 4 },
+        { tag: "auth", count: 5 },
+      ],
+    });
+    render(
+      <TagAutocomplete contextId="c1" value="auth, de" onChange={vi.fn()} />,
+    );
+    // "deploy" is suggested; "auth" (already in the CSV) is filtered out.
+    await screen.findByRole("option", { name: /deploy/ }, { timeout: 2000 });
+    expect(screen.queryByRole("option", { name: /auth/ })).toBeNull();
+  });
+
+  it("does not query or open the listbox for an empty trailing token", async () => {
+    render(
+      <TagAutocomplete contextId="c1" value="auth, " onChange={vi.fn()} />,
+    );
+    // Give any (incorrect) debounce a chance to fire.
+    await new Promise((r) => setTimeout(r, 400));
+    expect(getContextTags).not.toHaveBeenCalled();
+    expect(screen.queryByRole("listbox")).toBeNull();
+  });
+});

--- a/frontend/src/components/contexts/TagAutocomplete.tsx
+++ b/frontend/src/components/contexts/TagAutocomplete.tsx
@@ -59,6 +59,9 @@ export function TagAutocomplete({
   useEffect(() => {
     const trimmed = token.trim();
     if (trimmed.length < 1) {
+      // Invalidate any in-flight request (bump the id) so a prior fetch that
+      // resolves after the token was cleared can't re-open the listbox.
+      reqRef.current++;
       setSuggestions([]);
       setOpen(false);
       return;

--- a/frontend/src/components/contexts/TagAutocomplete.tsx
+++ b/frontend/src/components/contexts/TagAutocomplete.tsx
@@ -116,6 +116,11 @@ export function TagAutocomplete({
         role="combobox"
         aria-expanded={open}
         aria-controls={listId}
+        aria-activedescendant={
+          open && suggestions.length > 0
+            ? `${listId}-opt-${highlight}`
+            : undefined
+        }
         aria-autocomplete="list"
         autoComplete="off"
         onChange={(e) => onChange(e.target.value)}
@@ -136,8 +141,10 @@ export function TagAutocomplete({
             setOpen(false);
           }
         }}
-        // Delay close so a mouse-down on an option still registers.
-        onBlur={() => window.setTimeout(() => setOpen(false), 120)}
+        // Close immediately — option clicks use onMouseDown + preventDefault
+        // (below) so they don't blur the input; a delayed close would otherwise
+        // risk a setState after unmount when the dialog closes while focused.
+        onBlur={() => setOpen(false)}
       />
       {open && suggestions.length > 0 && (
         <ul
@@ -149,6 +156,7 @@ export function TagAutocomplete({
           {suggestions.map((s, i) => (
             <li
               key={s.tag}
+              id={`${listId}-opt-${i}`}
               role="option"
               aria-selected={i === highlight}
               onMouseDown={(e) => {

--- a/frontend/src/components/contexts/TagAutocomplete.tsx
+++ b/frontend/src/components/contexts/TagAutocomplete.tsx
@@ -99,7 +99,12 @@ export function TagAutocomplete({
           }
         });
     }, DEBOUNCE_MS);
-    return () => window.clearTimeout(timer);
+    return () => {
+      window.clearTimeout(timer);
+      // Invalidate the in-flight request so a response that arrives after this
+      // effect re-runs or the component unmounts is ignored (no setState leak).
+      reqRef.current++;
+    };
   }, [contextId, token, before]);
 
   const select = (tag: string) => {

--- a/frontend/src/components/contexts/TagAutocomplete.tsx
+++ b/frontend/src/components/contexts/TagAutocomplete.tsx
@@ -1,0 +1,171 @@
+/**
+ * TagAutocomplete (#618)
+ *
+ * Combobox over a comma-separated tag input. As the user types the token after
+ * the last comma, it debounces a prefix query to `GET /contexts/{id}/tags` and
+ * offers the top matches (excluding tags already present). Selecting one
+ * replaces just that trailing token and appends ", " for the next entry.
+ *
+ * Accessible: role=combobox input + role=listbox/option, ArrowUp/Down to
+ * navigate, Enter to select, Esc to close.
+ */
+"use client";
+
+import { useEffect, useId, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Input } from "@/components/ui/input";
+import { getContextTags, type ContextTagItem } from "@/lib/api/contexts";
+
+const DEBOUNCE_MS = 250;
+const SUGGEST_LIMIT = 10;
+
+/** Split a CSV value into the committed prefix and the trailing token-in-progress. */
+function activeTokenOf(csv: string): { before: string; token: string } {
+  const idx = csv.lastIndexOf(",");
+  if (idx === -1) return { before: "", token: csv.trimStart() };
+  return {
+    before: csv.slice(0, idx + 1),
+    token: csv.slice(idx + 1).trimStart(),
+  };
+}
+
+export interface TagAutocompleteProps {
+  contextId: string;
+  /** The full CSV string (e.g. "python, auth"). */
+  value: string;
+  onChange: (csv: string) => void;
+  id?: string;
+  placeholder?: string;
+  ariaLabel?: string;
+}
+
+export function TagAutocomplete({
+  contextId,
+  value,
+  onChange,
+  id,
+  placeholder,
+  ariaLabel,
+}: TagAutocompleteProps) {
+  const t = useTranslations("contextDetail.tagAutocomplete");
+  const [open, setOpen] = useState(false);
+  const [suggestions, setSuggestions] = useState<ContextTagItem[]>([]);
+  const [highlight, setHighlight] = useState(0);
+  const reqRef = useRef(0);
+  const listId = useId();
+
+  const { before, token } = activeTokenOf(value);
+
+  useEffect(() => {
+    const trimmed = token.trim();
+    if (trimmed.length < 1) {
+      setSuggestions([]);
+      setOpen(false);
+      return;
+    }
+    const timer = window.setTimeout(() => {
+      const reqId = ++reqRef.current;
+      getContextTags(contextId, {
+        prefix: trimmed,
+        limit: SUGGEST_LIMIT,
+        sort: "count",
+      })
+        .then((res) => {
+          if (reqId !== reqRef.current) return;
+          // Don't suggest tags already in the CSV (case-insensitive).
+          const present = new Set(
+            before
+              .split(",")
+              .map((s) => s.trim().toLowerCase())
+              .filter(Boolean),
+          );
+          const filtered = res.tags.filter(
+            (x) => !present.has(x.tag.toLowerCase()),
+          );
+          setSuggestions(filtered);
+          setHighlight(0);
+          setOpen(filtered.length > 0);
+        })
+        .catch(() => {
+          if (reqId === reqRef.current) {
+            setSuggestions([]);
+            setOpen(false);
+          }
+        });
+    }, DEBOUNCE_MS);
+    return () => window.clearTimeout(timer);
+  }, [contextId, token, before]);
+
+  const select = (tag: string) => {
+    const prefix = before ? `${before.replace(/\s*$/, "")} ` : "";
+    onChange(`${prefix}${tag}, `);
+    setOpen(false);
+    setSuggestions([]);
+  };
+
+  return (
+    <div className="relative">
+      <Input
+        id={id}
+        value={value}
+        placeholder={placeholder}
+        aria-label={ariaLabel}
+        role="combobox"
+        aria-expanded={open}
+        aria-controls={listId}
+        aria-autocomplete="list"
+        autoComplete="off"
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => {
+          if (!open || suggestions.length === 0) return;
+          if (e.key === "ArrowDown") {
+            e.preventDefault();
+            setHighlight((h) => (h + 1) % suggestions.length);
+          } else if (e.key === "ArrowUp") {
+            e.preventDefault();
+            setHighlight(
+              (h) => (h - 1 + suggestions.length) % suggestions.length,
+            );
+          } else if (e.key === "Enter") {
+            e.preventDefault();
+            select(suggestions[highlight].tag);
+          } else if (e.key === "Escape") {
+            setOpen(false);
+          }
+        }}
+        // Delay close so a mouse-down on an option still registers.
+        onBlur={() => window.setTimeout(() => setOpen(false), 120)}
+      />
+      {open && suggestions.length > 0 && (
+        <ul
+          id={listId}
+          role="listbox"
+          aria-label={t("suggestionsLabel")}
+          className="absolute z-50 mt-1 max-h-56 w-full overflow-auto rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+        >
+          {suggestions.map((s, i) => (
+            <li
+              key={s.tag}
+              role="option"
+              aria-selected={i === highlight}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                select(s.tag);
+              }}
+              onMouseEnter={() => setHighlight(i)}
+              className={[
+                "flex cursor-pointer items-center justify-between px-3 py-1.5 text-sm",
+                i === highlight
+                  ? "bg-primary/10 text-primary"
+                  : "text-gray-700 dark:text-gray-300",
+              ].join(" ")}
+            >
+              <span>{s.tag}</span>
+              <span className="text-xs text-gray-400">{s.count}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/contexts/TagAutocomplete.tsx
+++ b/frontend/src/components/contexts/TagAutocomplete.tsx
@@ -115,7 +115,7 @@ export function TagAutocomplete({
         aria-label={ariaLabel}
         role="combobox"
         aria-expanded={open}
-        aria-controls={listId}
+        aria-controls={open ? listId : undefined}
         aria-activedescendant={
           open && suggestions.length > 0
             ? `${listId}-opt-${highlight}`

--- a/frontend/src/components/contexts/TagAutocomplete.tsx
+++ b/frontend/src/components/contexts/TagAutocomplete.tsx
@@ -58,12 +58,15 @@ export function TagAutocomplete({
 
   useEffect(() => {
     const trimmed = token.trim();
+    // On any token change, immediately invalidate any in-flight request and
+    // close the listbox. This both stops a late prior response from re-opening
+    // for a cleared token, and prevents Enter from selecting a stale suggestion
+    // that no longer matches what's being typed. The debounced fetch below then
+    // reopens with fresh suggestions for the current token.
+    reqRef.current++;
+    setOpen(false);
     if (trimmed.length < 1) {
-      // Invalidate any in-flight request (bump the id) so a prior fetch that
-      // resolves after the token was cleared can't re-open the listbox.
-      reqRef.current++;
       setSuggestions([]);
-      setOpen(false);
       return;
     }
     const timer = window.setTimeout(() => {

--- a/frontend/src/components/contexts/TagCloud.test.tsx
+++ b/frontend/src/components/contexts/TagCloud.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for TagCloud (#618): tag buttons, click → onTagClick, active aria-pressed,
+ * and the empty state.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+// Avoid Radix Tabs context in the test harness.
+vi.mock("@/components/ui/tabs", () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  TabsList: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+const getContextTags = vi.fn();
+vi.mock("@/lib/api/contexts", () => ({
+  getContextTags: (...args: unknown[]) => getContextTags(...args),
+}));
+
+import { TagCloud } from "./TagCloud";
+
+beforeEach(() => {
+  getContextTags.mockReset();
+  getContextTags.mockResolvedValue({
+    context_id: "c1",
+    total: 3,
+    tags: [
+      { tag: "auth", count: 10 },
+      { tag: "deploy", count: 3 },
+      { tag: "ui", count: 1 },
+    ],
+  });
+});
+
+describe("TagCloud (#618)", () => {
+  it("renders tag buttons and calls onTagClick with the tag on click", async () => {
+    const onTagClick = vi.fn();
+    render(
+      <TagCloud contextId="c1" activeTag={null} onTagClick={onTagClick} />,
+    );
+    const authBtn = await screen.findByRole("button", { name: /"tag":"auth"/ });
+    fireEvent.click(authBtn);
+    expect(onTagClick).toHaveBeenCalledWith("auth");
+  });
+
+  it("marks the active tag with aria-pressed=true", async () => {
+    render(<TagCloud contextId="c1" activeTag="deploy" onTagClick={vi.fn()} />);
+    const deployBtn = await screen.findByRole("button", {
+      name: /"tag":"deploy"/,
+    });
+    expect(deployBtn).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("renders the empty state when the context has no tags", async () => {
+    getContextTags.mockResolvedValue({ context_id: "c1", total: 0, tags: [] });
+    render(<TagCloud contextId="c1" activeTag={null} onTagClick={vi.fn()} />);
+    expect(await screen.findByText("emptyTitle")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/contexts/TagCloud.tsx
+++ b/frontend/src/components/contexts/TagCloud.tsx
@@ -23,6 +23,7 @@ import {
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { LoadingState } from "@/components/common/LoadingState";
 
 const TAG_LIMIT = 50;
 // Discrete sqrt-scaled buckets. Counts are long-tailed, so sqrt compresses the
@@ -94,14 +95,8 @@ export function TagCloud({ contextId, activeTag, onTagClick }: TagCloudProps) {
       {error ? (
         <ErrorBanner error={error} />
       ) : loading ? (
-        <div className="flex flex-wrap gap-2" aria-hidden="true">
-          {Array.from({ length: 12 }).map((_, i) => (
-            <span
-              key={i}
-              className="h-6 w-16 animate-pulse rounded bg-gray-100 dark:bg-gray-800"
-            />
-          ))}
-        </div>
+        // Shared skeleton primitive (frontend rules: never hand-roll skeletons).
+        <LoadingState lines={2} />
       ) : tags.length === 0 ? (
         <EmptyState
           compact

--- a/frontend/src/components/contexts/TagCloud.tsx
+++ b/frontend/src/components/contexts/TagCloud.tsx
@@ -78,6 +78,12 @@ export function TagCloud({
       .finally(() => {
         if (reqId === reqRef.current) setLoading(false);
       });
+    // Invalidate the in-flight request on re-run / unmount so a late response
+    // can't setState after the component is gone (the reqId guards above will
+    // no longer match).
+    return () => {
+      reqRef.current++;
+    };
   }, [contextId, sort, q, t]);
 
   const counts = tags.map((x) => x.count);

--- a/frontend/src/components/contexts/TagCloud.tsx
+++ b/frontend/src/components/contexts/TagCloud.tsx
@@ -1,0 +1,149 @@
+/**
+ * TagCloud (#618)
+ *
+ * Frequency-weighted tag cloud for the context detail page. Fetches
+ * `GET /contexts/{id}/tags` and renders each tag as a real <button> sized by
+ * count (sqrt scale, clamped to a few discrete steps). Clicking a tag toggles
+ * the memory-list filter (the parent owns the active-tag state + URL sync).
+ *
+ * Design (gate1 / CDO): size encodes magnitude (NOT color — a11y + dark mode);
+ * tags are buttons with aria-pressed + count in aria-label; a count/recent
+ * toggle uses the Tabs primitive.
+ */
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Tag as TagIcon } from "lucide-react";
+import {
+  getContextTags,
+  type ContextTagItem,
+  type TagSortMode,
+} from "@/lib/api/contexts";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+
+const TAG_LIMIT = 50;
+// Discrete sqrt-scaled buckets. Counts are long-tailed, so sqrt compresses the
+// head; equal counts collapse to the base size (no divide-by-zero).
+const SIZE_CLASSES = ["text-xs", "text-sm", "text-base", "text-lg"] as const;
+
+function sizeClass(count: number, min: number, max: number): string {
+  if (max <= min) return SIZE_CLASSES[1];
+  const norm = Math.sqrt((count - min) / (max - min)); // 0..1
+  const idx = Math.min(
+    SIZE_CLASSES.length - 1,
+    Math.floor(norm * SIZE_CLASSES.length),
+  );
+  return SIZE_CLASSES[idx];
+}
+
+export interface TagCloudProps {
+  contextId: string;
+  /** The tag currently driving the memory-list filter, or null. */
+  activeTag: string | null;
+  /** Toggle a tag as the active filter (parent clears when tag === activeTag). */
+  onTagClick: (tag: string) => void;
+}
+
+export function TagCloud({ contextId, activeTag, onTagClick }: TagCloudProps) {
+  const t = useTranslations("contextDetail.tagCloud");
+  const [sort, setSort] = useState<TagSortMode>("count");
+  const [tags, setTags] = useState<ContextTagItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const reqRef = useRef(0);
+
+  useEffect(() => {
+    const reqId = ++reqRef.current;
+    setLoading(true);
+    setError(null);
+    getContextTags(contextId, { sort, limit: TAG_LIMIT })
+      .then((res) => {
+        if (reqId === reqRef.current) setTags(res.tags);
+      })
+      .catch((err) => {
+        if (reqId === reqRef.current)
+          setError(err instanceof Error ? err.message : t("loadFailed"));
+      })
+      .finally(() => {
+        if (reqId === reqRef.current) setLoading(false);
+      });
+  }, [contextId, sort, t]);
+
+  const counts = tags.map((x) => x.count);
+  const min = counts.length ? Math.min(...counts) : 0;
+  const max = counts.length ? Math.max(...counts) : 0;
+
+  return (
+    <section className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
+      <header className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+          <TagIcon className="h-4 w-4 text-gray-400" aria-hidden="true" />
+          {t("title")}
+        </div>
+        <Tabs value={sort} onValueChange={(v) => setSort(v as TagSortMode)}>
+          <TabsList>
+            <TabsTrigger value="count">{t("sortCount")}</TabsTrigger>
+            <TabsTrigger value="recent">{t("sortRecent")}</TabsTrigger>
+          </TabsList>
+        </Tabs>
+      </header>
+
+      {error ? (
+        <ErrorBanner error={error} />
+      ) : loading ? (
+        <div className="flex flex-wrap gap-2" aria-hidden="true">
+          {Array.from({ length: 12 }).map((_, i) => (
+            <span
+              key={i}
+              className="h-6 w-16 animate-pulse rounded bg-gray-100 dark:bg-gray-800"
+            />
+          ))}
+        </div>
+      ) : tags.length === 0 ? (
+        <EmptyState
+          compact
+          icon={TagIcon}
+          title={t("emptyTitle")}
+          description={t("emptyDesc")}
+        />
+      ) : (
+        <div
+          className="flex flex-wrap items-baseline gap-x-3 gap-y-2"
+          role="group"
+          aria-label={t("ariaLabel")}
+        >
+          {tags.map((item) => {
+            const isActive = item.tag === activeTag;
+            return (
+              <button
+                key={item.tag}
+                type="button"
+                onClick={() => onTagClick(item.tag)}
+                aria-pressed={isActive}
+                aria-label={t("tagWithCount", {
+                  tag: item.tag,
+                  count: item.count,
+                })}
+                className={[
+                  sizeClass(item.count, min, max),
+                  "rounded px-1.5 py-0.5 transition-colors",
+                  isActive
+                    ? "bg-primary/10 font-semibold text-primary ring-1 ring-primary/40"
+                    : "text-gray-600 hover:text-primary dark:text-gray-300 dark:hover:text-primary",
+                ].join(" ")}
+              >
+                {item.tag}
+                <span className="ml-1 align-super text-[0.65em] text-gray-400">
+                  {item.count}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/contexts/TagCloud.tsx
+++ b/frontend/src/components/contexts/TagCloud.tsx
@@ -138,6 +138,7 @@ export function TagCloud({
                 className={[
                   sizeClass(item.count, min, max),
                   "rounded px-1.5 py-0.5 transition-colors",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
                   isActive
                     ? "bg-primary/10 font-semibold text-primary ring-1 ring-primary/40"
                     : "text-gray-600 hover:text-primary dark:text-gray-300 dark:hover:text-primary",

--- a/frontend/src/components/contexts/TagCloud.tsx
+++ b/frontend/src/components/contexts/TagCloud.tsx
@@ -46,9 +46,16 @@ export interface TagCloudProps {
   activeTag: string | null;
   /** Toggle a tag as the active filter (parent clears when tag === activeTag). */
   onTagClick: (tag: string) => void;
+  /** #618: facet the cloud to tags on memories matching this search query. */
+  q?: string;
 }
 
-export function TagCloud({ contextId, activeTag, onTagClick }: TagCloudProps) {
+export function TagCloud({
+  contextId,
+  activeTag,
+  onTagClick,
+  q,
+}: TagCloudProps) {
   const t = useTranslations("contextDetail.tagCloud");
   const [sort, setSort] = useState<TagSortMode>("count");
   const [tags, setTags] = useState<ContextTagItem[]>([]);
@@ -60,7 +67,7 @@ export function TagCloud({ contextId, activeTag, onTagClick }: TagCloudProps) {
     const reqId = ++reqRef.current;
     setLoading(true);
     setError(null);
-    getContextTags(contextId, { sort, limit: TAG_LIMIT })
+    getContextTags(contextId, { sort, limit: TAG_LIMIT, q })
       .then((res) => {
         if (reqId === reqRef.current) setTags(res.tags);
       })
@@ -71,7 +78,7 @@ export function TagCloud({ contextId, activeTag, onTagClick }: TagCloudProps) {
       .finally(() => {
         if (reqId === reqRef.current) setLoading(false);
       });
-  }, [contextId, sort, t]);
+  }, [contextId, sort, q, t]);
 
   const counts = tags.map((x) => x.count);
   const min = counts.length ? Math.min(...counts) : 0;

--- a/frontend/src/components/memories/EditMemoryDialog.tsx
+++ b/frontend/src/components/memories/EditMemoryDialog.tsx
@@ -32,6 +32,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { TagAutocomplete } from "@/components/contexts/TagAutocomplete";
 import { Textarea } from "@/components/ui/textarea";
 import { updateMemoryById, type UpdateMemoryByIdPatch } from "@/lib/api/memory";
 import type { KnownMemoryType, MemoryReference } from "@/lib/types/memory";
@@ -41,6 +42,8 @@ interface EditMemoryDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onSuccess: (updated: MemoryReference) => void;
+  /** When set, the tag field uses prefix-autocomplete against this context (#618). */
+  contextId?: string;
 }
 
 // `MemoryType` is a free string at the column level (`String(50)`), but the
@@ -77,6 +80,7 @@ export function EditMemoryDialog({
   open,
   onOpenChange,
   onSuccess,
+  contextId,
 }: EditMemoryDialogProps) {
   const t = useTranslations("contextDetail.editDialog");
   const [loading, setLoading] = useState(false);
@@ -332,12 +336,25 @@ export function EditMemoryDialog({
             </div>
             <div className="space-y-2">
               <Label htmlFor="edit-tags">{t("tagsLabel")}</Label>
-              <Input
-                id="edit-tags"
-                value={tagsCsv}
-                onChange={(e) => setTagsCsv(e.target.value)}
-                placeholder={t("tagsPlaceholder")}
-              />
+              {/* #618: prefix-autocomplete the tag field when the context is
+                  known; fall back to a plain input otherwise (backward compat). */}
+              {contextId ? (
+                <TagAutocomplete
+                  id="edit-tags"
+                  contextId={contextId}
+                  value={tagsCsv}
+                  onChange={setTagsCsv}
+                  placeholder={t("tagsPlaceholder")}
+                  ariaLabel={t("tagsLabel")}
+                />
+              ) : (
+                <Input
+                  id="edit-tags"
+                  value={tagsCsv}
+                  onChange={(e) => setTagsCsv(e.target.value)}
+                  placeholder={t("tagsPlaceholder")}
+                />
+              )}
             </div>
           </div>
 

--- a/frontend/src/lib/api/contexts.ts
+++ b/frontend/src/lib/api/contexts.ts
@@ -42,6 +42,8 @@ export interface GetContextTagsParams {
   limit?: number;
   minCount?: number;
   sort?: TagSortMode;
+  /** #618: facet the tags to memories whose summary matches this substring. */
+  q?: string;
 }
 
 /**
@@ -60,6 +62,10 @@ export async function getContextTags(
   if (params.limit != null) sp.set("limit", String(params.limit));
   if (params.minCount != null) sp.set("min_count", String(params.minCount));
   if (params.sort) sp.set("sort", params.sort);
+  if (params.q) {
+    const trimmed = params.q.trim();
+    if (trimmed) sp.set("q", trimmed);
+  }
   const qs = sp.toString();
   return apiClient.get<ContextTagsResponse>(
     `/api/v1/contexts/${contextId}/tags${qs ? `?${qs}` : ""}`,

--- a/frontend/src/lib/api/contexts.ts
+++ b/frontend/src/lib/api/contexts.ts
@@ -17,6 +17,55 @@ import type {
 // Re-export types for consumers
 export type { Context, ContextListResponse, ContextStats };
 
+// ---------------------------------------------------------------------------
+// Tags (#614 / #618): GET /contexts/{id}/tags drives the tag cloud + autocomplete
+// ---------------------------------------------------------------------------
+
+export type TagSortMode = "count" | "recent" | "alpha";
+
+export interface ContextTagItem {
+  tag: string;
+  count: number;
+  /** ISO-8601 UTC; present on list_tags (#614). */
+  last_used_at?: string | null;
+  sample_summary?: string | null;
+}
+
+export interface ContextTagsResponse {
+  context_id: string;
+  tags: ContextTagItem[];
+  total: number;
+}
+
+export interface GetContextTagsParams {
+  prefix?: string;
+  limit?: number;
+  minCount?: number;
+  sort?: TagSortMode;
+}
+
+/**
+ * List a context's tags with counts (#614). Powers the TagCloud (sort=count)
+ * and TagAutocomplete (prefix + sort=count) on the context detail page (#618).
+ */
+export async function getContextTags(
+  contextId: string,
+  params: GetContextTagsParams = {},
+): Promise<ContextTagsResponse> {
+  const sp = new URLSearchParams();
+  if (params.prefix) {
+    const trimmed = params.prefix.trim();
+    if (trimmed) sp.set("prefix", trimmed);
+  }
+  if (params.limit != null) sp.set("limit", String(params.limit));
+  if (params.minCount != null) sp.set("min_count", String(params.minCount));
+  if (params.sort) sp.set("sort", params.sort);
+  const qs = sp.toString();
+  return apiClient.get<ContextTagsResponse>(
+    `/api/v1/contexts/${contextId}/tags${qs ? `?${qs}` : ""}`,
+  );
+}
+
 /**
  * Get all contexts for the current user
  */

--- a/frontend/src/lib/api/memory.ts
+++ b/frontend/src/lib/api/memory.ts
@@ -24,6 +24,8 @@ export interface ListMemoriesParams {
   scope?: MemoryScope;
   type?: string;
   q?: string;
+  /** ANY-match tag filter (#618). Repeated as ?tags=a&tags=b; blanks ignored. */
+  tags?: string[];
   limit?: number;
   offset?: number;
 }
@@ -45,6 +47,10 @@ export async function getMemories(
   if (params.q) {
     const trimmed = params.q.trim();
     if (trimmed) searchParams.set("q", trimmed);
+  }
+  for (const tag of params.tags ?? []) {
+    const trimmed = tag.trim();
+    if (trimmed) searchParams.append("tags", trimmed);
   }
   searchParams.set("limit", String(params.limit ?? 50));
   searchParams.set("offset", String(params.offset ?? 0));

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3076,7 +3076,7 @@
       "sortRecent": "Recent",
       "emptyTitle": "No tags yet",
       "emptyDesc": "Tags appear here as memories are added to this context.",
-      "tagWithCount": "{tag} ({count} memories)",
+      "tagWithCount": "{tag} ({count, plural, one {# memory} other {# memories}})",
       "loadFailed": "Failed to load tags"
     },
     "tagAutocomplete": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3063,7 +3063,24 @@
         "label": "Search"
       },
       "noResultsTitle": "No results",
-      "noResultsDesc": "No memories match \"{query}\"."
+      "noResultsDesc": "No memories match \"{query}\".",
+      "filter": {
+        "activeLabel": "Filtered by tag:",
+        "clearTag": "Clear tag filter: {tag}"
+      }
+    },
+    "tagCloud": {
+      "title": "Tags",
+      "ariaLabel": "Tag cloud — click a tag to filter memories",
+      "sortCount": "Most used",
+      "sortRecent": "Recent",
+      "emptyTitle": "No tags yet",
+      "emptyDesc": "Tags appear here as memories are added to this context.",
+      "tagWithCount": "{tag} ({count} memories)",
+      "loadFailed": "Failed to load tags"
+    },
+    "tagAutocomplete": {
+      "suggestionsLabel": "Tag suggestions"
     },
     "memoriesTable": {
       "loading": "Loading memories...",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3063,7 +3063,24 @@
         "label": "検索"
       },
       "noResultsTitle": "該当なし",
-      "noResultsDesc": "「{query}」に一致するメモリがありません。"
+      "noResultsDesc": "「{query}」に一致するメモリがありません。",
+      "filter": {
+        "activeLabel": "タグで絞り込み中:",
+        "clearTag": "タグフィルタを解除: {tag}"
+      }
+    },
+    "tagCloud": {
+      "title": "タグ",
+      "ariaLabel": "タグクラウド — タグをクリックでメモリを絞り込み",
+      "sortCount": "使用頻度順",
+      "sortRecent": "最近使用",
+      "emptyTitle": "タグがまだありません",
+      "emptyDesc": "このコンテキストにメモリが追加されるとタグが表示されます。",
+      "tagWithCount": "{tag}（{count}件）",
+      "loadFailed": "タグの読み込みに失敗しました"
+    },
+    "tagAutocomplete": {
+      "suggestionsLabel": "タグ候補"
     },
     "memoriesTable": {
       "loading": "メモリを読み込み中...",


### PR DESCRIPTION
Closes #618

## Summary

#614/#617 shipped `list_tags` (`GET /contexts/{id}/tags`). This builds the UI surface (tag cloud + autocomplete) **and** the memory-list tag filter it drives.

## API
- `/memory/list` gains an **ANY-match `tags`** query param (repeated `?tags=a&tags=b`, Postgres array overlap `&&`, AND-ed with `q`; blank entries ignored). Operator-approved scope addition (the click-to-filter needs it; the endpoint had no tag filter before).
- Pin tests: predicate lands on **both** data + count queries; omitted/blank tags skip it.

## Frontend
- `getContextTags()` client + `ContextTag*` types; `getMemories()` gains `tags[]`.
- **TagCloud** (context Memories tab): top tags by count, **sqrt-scaled font (size = magnitude, not color** — a11y + dark-mode safe), count/recent toggle, each tag a real `<button>` with `aria-pressed` + count in `aria-label`. Click toggles a single **URL-driven `?tag=`** filter (AND-ed with `?q=`); an active-tag chip clears it; the empty state distinguishes "no memories" from "no matches".
- **TagAutocomplete**: combobox over the `EditMemoryDialog` CSV tag field — debounced prefix query on the **trailing token**, top-10 by count, excludes already-present tags, keyboard nav (Arrow/Enter/Esc), inserts `"tag, "`. Gated on a new optional `EditMemoryDialog.contextId` prop (passed from the Memories + Graph tabs); plain-input fallback when absent.
- i18n (en + ja); dark mode + responsive.

## Design discussion (AC item 1)
Captured via gate1 CDO review: sqrt font scaling (clamped, equal-counts → base), no count→color coding, tags as buttons, `?tag` AND `?q` shown as independently-clearable filters, v1 single active tag, combobox a11y for the CSV field.

## Testing
- Backend: `test_memory_list.py` → 15 passed (3 new tags-filter tests); ruff + pyright clean.
- Frontend: `TagCloud.test.tsx` + `TagAutocomplete.test.tsx` → 6 passed; `MemoriesTabPanel` 13 + `EditMemoryDialog` 10 still pass; `tsc` clean; en/ja JSON valid.

## Out of scope (per issue)
Tag rename/merge; co-occurrence viz; multi-tag selection (backend `tags` is already a list, so it's a clean follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Post-review UX refinements (local + Copilot)

- **q-faceting:** the tag cloud now narrows to tags on memories matching the search box (`/contexts/{id}/tags?q=`); empty q → all context tags.
- **q resets the tag (intentional):** typing a *new* search clears a stale `?tag` (a `prevDebouncedQueryRef` gates this to real query changes, so mount / shared-links keep an existing `?tag`). Clicking a faceted tag still ANDs `?tag` with `?q`, and the active-tag chip clears it independently. This supersedes the earlier "q AND tag" note above.
- **Layout:** search box sits above the tag cloud.
- **a11y:** combobox exposes `aria-activedescendant` + stable option ids; `aria-controls` only set when open; blank `?tag` normalized to no-filter.