### PR TITLE
fix(auth): distinguish 401 from transient errors in refetchUser silent-refresh (#683)

### DIFF
--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -199,4 +199,34 @@ describe("AuthContext silent refresh (issue #678)", () => {
       expect(screen.getByTestId("user").textContent).toBe("null");
     });
   });
+
+  it("refetchUser clears user when getCurrentUser THROWS a 401 (issue #683)", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce(USER_A);
+
+    render(
+      <AuthProvider>
+        <Probe loadingLog={[]} />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe(USER_A.email);
+    });
+
+    // Future-proofing: even if getCurrentUser's contract changes to THROW on
+    // 401 (instead of returning null), the catch in refetchUser branches on
+    // status === 401 and still clears the session. This path is impossible
+    // under the current null-return contract, hence the explicit thrown error.
+    const error: Error & { status?: number } = new Error("Unauthorized");
+    error.status = 401;
+    mockGetCurrentUser.mockRejectedValueOnce(error);
+
+    await act(async () => {
+      screen.getByTestId("refetch").click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("user").textContent).toBe("null");
+    });
+  });
 });

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -98,9 +98,17 @@ export function AuthProvider({ children }: { children: ReactNode }) {
    * mid-flow. See issue #678 for the tree-killer pattern.
    *
    * Transient refetch errors do NOT log the user out — a network blip should
-   * not eject a logged-in session. Real 401s still set `user` to null because
-   * `getCurrentUser` returns null in that case (see its public-contract
-   * docblock in `lib/auth/auth.ts`), which triggers the normal
+   * not eject a logged-in session. Definitive auth failures (401) DO clear the
+   * session. Two paths reach that outcome:
+   *   - `getCurrentUser` returns null for a 401 under its current public
+   *     contract (see its docblock in `lib/auth/auth.ts`); the success path
+   *     then `setUser(null)`-s.
+   *   - If a 401 ever surfaces as a thrown error instead, the catch below
+   *     branches on `status === 401` and clears the user directly. This makes
+   *     the 401-vs-transient distinction explicit at the AuthContext layer and
+   *     removes the implicit dependency on `getCurrentUser`'s null-for-401
+   *     contract (issue #683).
+   * Either way the user lands on null, triggering the normal
    * redirect-to-login path through DashboardContent.
    *
    * In dev mock-auth mode (`useMockAuth`), refetch is a no-op — the mock
@@ -115,8 +123,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       const currentUser = await getCurrentUser();
       setUser(currentUser);
     } catch (error) {
-      console.error("Failed to refetch user (silent):", error);
-      // Intentionally do not setUser(null) here — see the docblock above.
+      const status = (error as { status?: number } | null | undefined)?.status;
+      if (status === 401) {
+        // Definitive auth failure — fall through the normal logout path.
+        setUser(null);
+      } else {
+        // Transient (5xx, network, etc.) — preserve current user state.
+        console.error("Failed to refetch user (silent, transient):", error);
+      }
     }
   };
 

--- a/frontend/src/lib/auth/auth.ts
+++ b/frontend/src/lib/auth/auth.ts
@@ -101,10 +101,12 @@ export async function handleAuthCallback(
  * - 401 → returns null (caller treats null as "session ended, go to /login")
  * - other errors (5xx, network) → throws (caller preserves current user state)
  *
- * Changing the 401-returns-null branch to throw will silently break the
- * in-session logout path in `AuthContext.refetchUser` — the catch there
- * intentionally preserves the user on errors, so a 401 thrown instead of
- * returned-as-null would leave a logged-out session displayed as logged-in.
+ * The 401-returns-null branch is the primary in-session logout path. As of
+ * issue #683, `AuthContext.refetchUser` ALSO branches on `status === 401` in
+ * its catch, so a future change that makes this throw on 401 (with the status
+ * preserved on the error) would still clear the session correctly rather than
+ * silently leaving a logged-out session displayed as logged-in. Other thrown
+ * errors (5xx, network) are still treated as transient and preserve the user.
  */
 export async function getCurrentUser(): Promise<User | null> {
   try {


### PR DESCRIPTION
Closes #683

## Summary
- Branch `refetchUser`'s catch on the error status: a thrown `401` calls `setUser(null)` (definitive auth failure → normal logout path); 5xx/network are treated as transient and preserve the current user state.
- Removes AuthContext's implicit dependency on `getCurrentUser` returning `null` for 401, so `getCurrentUser` can later be refactored to throw-with-status without silently regressing the in-session logout path.
- Follow-up to #678 (silent-refresh discipline); the new branch is defensive — under the current `getCurrentUser` contract a 401 never reaches the catch.

## Implementation notes
- `AuthContext.tsx`: catch now reads `(error as { status?: number } | null | undefined)?.status` and branches on `=== 401`. Optional chaining keeps null/undefined errors safe. `useMockAuth` early-return and the `isLoading`-untouched silent-refresh invariant (#678 tree-killer guard) are preserved.
- `auth.ts`: `getCurrentUser` body unchanged; docblock updated so the #678 contract comment reflects the new two-path 401 handling instead of becoming misleading.
- `AuthContext.test.tsx`: adds a regression test that mocks `getCurrentUser` to **throw** `{status:401}` and asserts the user clears; all 4 prior tests retained (incl. transient-5xx-preserves-user).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
