### PR TITLE
feat(frontend,api): tag-selection facet drill-down on context tag cloud (#830)

### DIFF
--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -751,6 +751,16 @@ async def list_context_tags(
             "treated as no filter."
         ),
     ),
+    with_tags: list[str] = Query(
+        default_factory=list,
+        description=(
+            "Repeatable tag filter for multi-tag AND drill-down (#830). When "
+            "set, only tags that co-occur on memories carrying ALL of these "
+            "tags are aggregated, and the with_tags values themselves are "
+            "excluded from the result. AND-combined with `q`. Counts reflect "
+            "the faceted (co-occurrence) subset."
+        ),
+    ),
 ) -> ContextTagsResponse:
     """List existing tag vocabulary in a context (Issue #614).
 
@@ -783,6 +793,7 @@ async def list_context_tags(
             sort=sort,
             prefix=prefix,
             q=q,
+            with_tags=with_tags,
         )
     except NotFoundException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -539,6 +539,13 @@ async def list_memories(
         "Repeat the param to pass several: ?tags=a&tags=b. Combined with other "
         "filters (e.g. q) by AND. Blank / whitespace-only entries are ignored.",
     ),
+    tags_match: str = Query(
+        "any",
+        pattern="^(any|all)$",
+        description="How to combine `tags`: `any` (default — memory has at least "
+        "one of the tags, PG array overlap; preserves #618 behavior) or `all` "
+        "(memory holds every given tag, PG array contains — #830 drill-down).",
+    ),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
@@ -642,10 +649,23 @@ async def list_memories(
         if q_pattern is not None:
             query = query.where(Memory.summary.ilike(q_pattern, escape="\\"))
 
-        # ANY-match: row has at least one of the requested tags (PG array
-        # overlap ``&&``). NULL-tags rows never overlap, so they're excluded.
+        # Tag filter (#618 ANY / #830 ALL). Built once and applied to BOTH the
+        # data and count queries so the total always reflects the same filter
+        # (the two used to carry duplicate predicates — easy to let drift).
+        # NULL-tags rows never match either operator, so they're excluded in
+        # both modes.
+        tag_filter = None
         if tags_normalized is not None:
-            query = query.where(Memory.tags.overlap(tags_normalized))
+            if tags_match == "all":
+                # ALL-match (#830): row's tags contain every requested tag
+                # (PG array contains ``@>``).
+                tag_filter = Memory.tags.contains(tags_normalized)
+            else:
+                # ANY-match (default, #618): row has at least one of the
+                # requested tags (PG array overlap ``&&``).
+                tag_filter = Memory.tags.overlap(tags_normalized)
+        if tag_filter is not None:
+            query = query.where(tag_filter)
 
         # Get total count (with same filters as data query)
         count_query = select(func.count(Memory.id)).where(Memory.deleted_at.is_(None))
@@ -659,8 +679,8 @@ async def list_memories(
             count_query = count_query.where(Memory.context_id == context_id)
         if q_pattern is not None:
             count_query = count_query.where(Memory.summary.ilike(q_pattern, escape="\\"))
-        if tags_normalized is not None:
-            count_query = count_query.where(Memory.tags.overlap(tags_normalized))
+        if tag_filter is not None:
+            count_query = count_query.where(tag_filter)
         count_result = await db.execute(count_query)
         total = count_result.scalar() or 0
 

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -1100,6 +1100,7 @@ class ContextService:
         sort: TagSortMode = "count",
         prefix: str = "",
         q: str | None = None,
+        with_tags: list[str] | None = None,
     ) -> dict:
         """Aggregate tags across non-deleted memories in a context (Issue #614).
 
@@ -1125,6 +1126,15 @@ class ContextService:
                 ``_`` / ``#`` are escaped to literal characters via
                 ``ILIKE ... ESCAPE '#'`` so the parameter cannot be used as a
                 wildcard probe.
+            q: Optional case-insensitive substring filter on ``summary``
+                (#618). Facets the cloud to tags on matching memories;
+                whitespace-only is treated as no filter.
+            with_tags: Optional multi-tag AND drill-down (#830). When set,
+                aggregate only over memories whose tags contain ALL of these
+                values (``tags @> with_tags``), and exclude the ``with_tags``
+                values from the returned tags. AND-combined with ``q``. Bound
+                as a single ``varchar[]`` param (never interpolated). Capped at
+                50 tags, each ≤ 200 chars.
 
         Returns:
             ``{"context_name": str, "rows": list[dict]}`` where each row is
@@ -1171,6 +1181,20 @@ class ContextService:
         else:
             q_pattern = ""
 
+        # #830: optional ``with_tags`` facets the cloud to tags that co-occur
+        # with ALL of the given tags (multi-tag AND drill-down). The matched
+        # memory set is narrowed via ``tags @> with_tags`` (GIN-indexed), and
+        # the with_tags values themselves are excluded from the returned cloud
+        # ("what else can I add"). Bound as a single ``varchar[]`` param — never
+        # interpolated — so each tag value is safe. An empty list is a no-op:
+        # ``tags @> '{}'`` is always true and ``tag <> ALL('{}')`` excludes
+        # nothing, so the result matches the pre-#830 (#618) behaviour exactly.
+        with_tags_clean = [t for t in (with_tags or []) if t and t.strip()]
+        if len(with_tags_clean) > 50:
+            raise ValidationError("with_tags accepts at most 50 tags.")
+        if any(len(t) > 200 for t in with_tags_clean):
+            raise ValidationError("each with_tags value must be at most 200 characters.")
+
         # sort is allow-list validated above; safe to interpolate.
         sort_clause = {
             "count": "ORDER BY cnt DESC, tag ASC",
@@ -1191,6 +1215,7 @@ class ContextService:
                   AND tags IS NOT NULL
                   AND cardinality(tags) > 0
                   AND (:q_pattern = '' OR summary ILIKE :q_pattern ESCAPE '#')
+                  AND tags @> CAST(:with_tags AS varchar[])
             ),
             tag_rows AS (
                 -- DISTINCT id, tag collapses intra-array duplicates so a
@@ -1207,6 +1232,7 @@ class ContextService:
                     MAX(last_at) AS last_used_at
                 FROM tag_rows
                 WHERE (:prefix_pattern = '' OR tag ILIKE :prefix_pattern ESCAPE '#')
+                  AND tag <> ALL(CAST(:with_tags AS varchar[]))
                 GROUP BY tag
                 HAVING COUNT(*) >= :min_count
             )
@@ -1223,6 +1249,7 @@ class ContextService:
                 "context_id": str(context_id),
                 "prefix_pattern": prefix_pattern,
                 "q_pattern": q_pattern,
+                "with_tags": with_tags_clean,
                 "min_count": min_count,
                 "limit": limit,
             },

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -1189,7 +1189,11 @@ class ContextService:
         # interpolated — so each tag value is safe. An empty list is a no-op:
         # ``tags @> '{}'`` is always true and ``tag <> ALL('{}')`` excludes
         # nothing, so the result matches the pre-#830 (#618) behaviour exactly.
-        with_tags_clean = [t for t in (with_tags or []) if t and t.strip()]
+        # Bind the STRIPPED value (not the raw one): a request like
+        # ``?with_tags=%20python%20`` must match memories tagged ``python`` and
+        # self-exclude ``python`` from the cloud, not bind a literal `" python "`
+        # that matches nothing (Copilot review on PR #833).
+        with_tags_clean = [s for t in (with_tags or []) if (s := t.strip())]
         if len(with_tags_clean) > 50:
             raise ValidationError("with_tags accepts at most 50 tags.")
         if any(len(t) > 200 for t in with_tags_clean):

--- a/backend/tests/api/test_context_tags.py
+++ b/backend/tests/api/test_context_tags.py
@@ -139,6 +139,7 @@ class TestListContextTagsRoute:
             sort="recent",
             prefix="auth",
             q="deploy",
+            with_tags=["python", "backend"],
         )
 
         mock_service.aggregate_tags.assert_awaited_once_with(
@@ -149,4 +150,5 @@ class TestListContextTagsRoute:
             sort="recent",
             prefix="auth",
             q="deploy",
+            with_tags=["python", "backend"],
         )

--- a/backend/tests/api/test_memory_list.py
+++ b/backend/tests/api/test_memory_list.py
@@ -561,3 +561,80 @@ class TestListMemoriesTagsFilter:
         for call_index in (0, 1):
             sql = _where_sql(mock_db, call_index)
             assert "&&" not in sql, f"blank tags should be ignored (call_index={call_index}): {sql}"
+
+
+class TestListMemoriesTagsMatch:
+    """Issue #830: ``tags_match`` selects ANY (default) vs ALL tag matching."""
+
+    @pytest.mark.asyncio
+    async def test_tags_match_default_is_any_overlap(self):
+        """Regression pin: omitting tags_match preserves #618 ANY-match (&&)."""
+        mock_db = _db_with_rows(total=1, rows=[_mock_memory_row()])
+
+        await list_memories(
+            user=MOCK_USER,
+            db=mock_db,
+            scope=None,
+            type=None,
+            context_id=None,
+            q=None,
+            tags=["python", "auth"],
+            limit=50,
+            offset=0,
+        )
+
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert "&&" in sql and "@>" not in sql, (
+                f"default tags_match must be ANY-overlap (&&), not @> "
+                f"(call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_tags_match_all_uses_contains(self):
+        """tags_match='all' switches to PG array contains (@>) on both queries."""
+        mock_db = _db_with_rows(total=1, rows=[_mock_memory_row()])
+
+        await list_memories(
+            user=MOCK_USER,
+            db=mock_db,
+            scope=None,
+            type=None,
+            context_id=None,
+            q=None,
+            tags=["python", "auth"],
+            tags_match="all",
+            limit=50,
+            offset=0,
+        )
+
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert "@>" in sql and "&&" not in sql, (
+                f"tags_match='all' must use ALL-contains (@>), not && "
+                f"(call_index={call_index}): {sql}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_tags_match_all_no_tags_skips_filter(self):
+        """tags_match='all' without tags adds no predicate (no empty-set pin)."""
+        mock_db = _db_with_rows(total=1, rows=[_mock_memory_row()])
+
+        await list_memories(
+            user=MOCK_USER,
+            db=mock_db,
+            scope=None,
+            type=None,
+            context_id=None,
+            q=None,
+            tags=None,
+            tags_match="all",
+            limit=50,
+            offset=0,
+        )
+
+        for call_index in (0, 1):
+            sql = _where_sql(mock_db, call_index)
+            assert "@>" not in sql and "&&" not in sql, (
+                f"no tags → no predicate (call_index={call_index}): {sql}"
+            )

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -585,3 +585,14 @@ class TestAggregateTagsWithTags:
         user_id, ctx = await self._seed_cooccurrence(db_session, now)
         with pytest.raises(ValidationError):
             await _agg_rows(db_session, user_id, ctx.id, with_tags=[f"t{i}" for i in range(51)])
+
+    async def test_with_tags_trims_whitespace(self, db_session, now):
+        """`?with_tags=%20backend%20` binds 'backend', not ' backend ' (PR #833
+        Copilot review). Surrounding whitespace must not break the @> match or
+        the self-exclusion."""
+        user_id, ctx = await self._seed_cooccurrence(db_session, now)
+
+        rows = await _agg_rows(db_session, user_id, ctx.id, with_tags=["  backend  "])
+        by_tag = {r["tag"] for r in rows}
+        assert by_tag == {"python", "api", "db"}
+        assert "backend" not in by_tag  # self-excluded despite the whitespace

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -472,3 +472,116 @@ class TestAggregateTagsCTE:
 
         with pytest.raises(ValidationError):
             await _agg_rows(db_session, user_id, ctx.id, sort="bogus")
+
+
+@pytest.mark.asyncio
+class TestAggregateTagsWithTags:
+    """#830: ``with_tags`` multi-tag AND drill-down on the tag cloud."""
+
+    async def _seed_cooccurrence(self, db_session, now):
+        """3 memories so co-occurrence is non-trivial:
+
+        m1: {python, backend, api}
+        m2: {python, backend, db}
+        m3: {python, frontend}
+        """
+        user_id = f"u_wt_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        db_session.add_all(
+            [
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["python", "backend", "api"],
+                    created_at=now,
+                ),
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["python", "backend", "db"],
+                    created_at=now,
+                ),
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["python", "frontend"],
+                    created_at=now,
+                ),
+            ]
+        )
+        await db_session.flush()
+        return user_id, ctx
+
+    async def test_with_tags_facets_to_cooccurring_and_self_excludes(self, db_session, now):
+        user_id, ctx = await self._seed_cooccurrence(db_session, now)
+
+        # Drill into "backend": only m1+m2 qualify (both hold backend).
+        # Their other tags are {python, api, db}; "backend" itself is excluded.
+        rows = await _agg_rows(db_session, user_id, ctx.id, with_tags=["backend"])
+        by_tag = {r["tag"]: r["count"] for r in rows}
+        assert set(by_tag) == {"python", "api", "db"}
+        assert "backend" not in by_tag  # self-exclusion
+        assert "frontend" not in by_tag  # m3 lacks backend
+        # Counts reflect the faceted subset: python on both m1,m2 → 2; api/db → 1.
+        assert by_tag == {"python": 2, "api": 1, "db": 1}
+
+    async def test_with_tags_and_semantics_multi(self, db_session, now):
+        user_id, ctx = await self._seed_cooccurrence(db_session, now)
+
+        # AND of python+backend → m1,m2 → remaining {api, db} (python+backend excluded).
+        rows = await _agg_rows(db_session, user_id, ctx.id, with_tags=["python", "backend"])
+        assert {r["tag"] for r in rows} == {"api", "db"}
+
+    async def test_with_tags_empty_matches_618_behavior(self, db_session, now):
+        user_id, ctx = await self._seed_cooccurrence(db_session, now)
+
+        baseline = {r["tag"] for r in await _agg_rows(db_session, user_id, ctx.id)}
+        empty = {r["tag"] for r in await _agg_rows(db_session, user_id, ctx.id, with_tags=[])}
+        assert empty == baseline == {"python", "backend", "api", "db", "frontend"}
+
+    async def test_with_tags_no_cooccurrence_returns_empty(self, db_session, now):
+        user_id, ctx = await self._seed_cooccurrence(db_session, now)
+
+        # api and frontend never co-occur (api∈m1, frontend∈m3) → empty cloud.
+        rows = await _agg_rows(db_session, user_id, ctx.id, with_tags=["api", "frontend"])
+        assert rows == []
+
+    async def test_with_tags_combines_with_q(self, db_session, now):
+        """with_tags AND q both narrow the same memory set."""
+        user_id = f"u_wtq_{uuid4().hex[:6]}"
+        ws, ctx = await _seed_workspace_context(db_session, user_id=user_id)
+        db_session.add_all(
+            [
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["python", "api"],
+                    created_at=now,
+                    summary="deploy api",
+                ),
+                _memory(
+                    ws_id=ws.id,
+                    ctx_id=ctx.id,
+                    user_id=user_id,
+                    tags=["python", "db"],
+                    created_at=now,
+                    summary="schema notes",
+                ),
+            ]
+        )
+        await db_session.flush()
+
+        # with_tags=python narrows to both; q=deploy further narrows to m1 only.
+        rows = await _agg_rows(db_session, user_id, ctx.id, with_tags=["python"], q="deploy")
+        assert {r["tag"] for r in rows} == {"api"}
+
+    async def test_with_tags_over_limit_raises(self, db_session, now):
+        from utils.exceptions import ValidationError
+
+        user_id, ctx = await self._seed_cooccurrence(db_session, now)
+        with pytest.raises(ValidationError):
+            await _agg_rows(db_session, user_id, ctx.id, with_tags=[f"t{i}" for i in range(51)])

--- a/frontend/src/components/contexts/MemoriesTabPanel.test.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.test.tsx
@@ -39,6 +39,7 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/workspace/contexts/ctx-1",
   useSearchParams: () => ({
     get: (k: string) => mockSearchParams.current.get(k),
+    getAll: (k: string) => mockSearchParams.current.getAll(k),
     toString: () => mockSearchParams.current.toString(),
   }),
 }));
@@ -495,5 +496,79 @@ describe("MemoriesTabPanel — debounced search (Issue #580)", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tag drill-down (#830)
+// ---------------------------------------------------------------------------
+
+describe("MemoriesTabPanel — tag drill-down (#830)", () => {
+  const lastFetchArgs = () =>
+    mockGetMemories.mock.calls.at(-1)?.[0] as {
+      tags?: string[];
+      tagsMatch?: string;
+    };
+
+  it("seeds selectedTags from ?tags= and sends ALL-match on the first fetch", async () => {
+    mockSearchParams.current = new URLSearchParams("tags=python&tags=backend");
+
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+
+    await waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+    const args = lastFetchArgs();
+    expect(args.tags).toEqual(["python", "backend"]);
+    expect(args.tagsMatch).toBe("all");
+  });
+
+  it("omits tags + tagsMatch entirely when nothing is selected (#618 default preserved)", async () => {
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+
+    await waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+    const args = lastFetchArgs();
+    expect(args.tags).toBeUndefined();
+    expect(args.tagsMatch).toBeUndefined();
+  });
+
+  it("de-dupes and drops blank ?tags entries", async () => {
+    mockSearchParams.current = new URLSearchParams(
+      "tags=python&tags=python&tags=%20&tags=db",
+    );
+
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+
+    await waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+    expect(lastFetchArgs().tags).toEqual(["python", "db"]);
+  });
+
+  it("renders a chip per selected tag plus a clear-all control", async () => {
+    mockSearchParams.current = new URLSearchParams("tags=python&tags=backend");
+
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+    await waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+
+    expect(
+      screen.getByLabelText("filter.clearTag:python"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("filter.clearTag:backend"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("filter.clearAll")).toBeInTheDocument();
+  });
+
+  it("removing a chip writes the reduced tag set to the URL", async () => {
+    mockSearchParams.current = new URLSearchParams("tags=python&tags=backend");
+
+    render(<MemoriesTabPanel contextId="ctx-1" />);
+    await waitFor(() => expect(mockGetMemories).toHaveBeenCalled());
+
+    fireEvent.click(screen.getByLabelText("filter.clearTag:python"));
+
+    await waitFor(() => {
+      const lastUrl = mockReplace.mock.calls.at(-1)?.[0] as string;
+      expect(lastUrl).toBeDefined();
+      expect(lastUrl).toMatch(/tags=backend/);
+      expect(lastUrl).not.toMatch(/tags=python/);
+    });
   });
 });

--- a/frontend/src/components/contexts/MemoriesTabPanel.tsx
+++ b/frontend/src/components/contexts/MemoriesTabPanel.tsx
@@ -20,7 +20,7 @@
 
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { FileText, Search, SearchX } from "lucide-react";
@@ -46,7 +46,9 @@ interface MemoriesTabPanelProps {
 
 const PAGE_SIZE = 50;
 const SEARCH_PARAM = "q";
-const TAG_PARAM = "tag";
+// #830: repeatable param for the multi-tag AND drill-down (?tags=a&tags=b).
+// Supersedes #618's single `?tag=`.
+const TAGS_PARAM = "tags";
 const DEBOUNCE_MS = 300;
 
 export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
@@ -76,36 +78,88 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   // committed to state.
   const requestIdRef = useRef(0);
 
-  // #618: tracks the previous debounced query so we reset an active tag only
-  // when the search actually *changes* (typing) — not on mount / shared links.
-  const prevDebouncedQueryRef = useRef(debouncedQuery);
-
   const dialog = useMemoryDetailDialog({ memoryIdParam, setMemoryIdParam });
 
-  // Issue #618: a single active tag filter, URL-driven (?tag=) so it's
-  // shareable and survives refresh. Clicking a TagCloud tag toggles it; the
-  // memory list re-fetches with an ANY-match tags filter (AND-ed with q).
-  // Normalize at the source: a whitespace-only ?tag (e.g. ?tag=%20) is ignored
-  // by getMemories, so collapse it to null here too — otherwise the chip /
-  // hasFilter UI would show an "active" filter the API query doesn't apply.
-  const activeTag = searchParams.get(TAG_PARAM)?.trim() || null;
+  // #830: multi-tag AND drill-down set, URL-driven (?tags=a&tags=b) so it's
+  // shareable and survives refresh. Normalized: trim, drop blanks, de-dupe
+  // (order-preserving) — mirrors the backend's tag normalization so the chips
+  // and the API query agree. AND-combined with `q` (both coexist; a changed
+  // query no longer clears the tags — they drill down together).
+  //
+  // Memoize on the value-stable joined key, NOT the `searchParams` object:
+  // `useSearchParams()` can return a fresh reference on every render, which
+  // would give `selectedTags` a new array identity each render and make every
+  // consumer (`fetchMemories`, TagCloud) re-fire on unrelated re-renders.
+  const tagsParamKey = searchParams.getAll(TAGS_PARAM).join("\u0000");
+  const selectedTags = useMemo(
+    () =>
+      Array.from(
+        new Set(
+          (tagsParamKey ? tagsParamKey.split("\u0000") : [])
+            .map((s) => s.trim())
+            .filter(Boolean),
+        ),
+      ),
+    [tagsParamKey],
+  );
 
-  const setActiveTagFilter = useCallback(
-    (tag: string | null) => {
+  // Focus targets for the a11y focus-management contract (#830) + the live
+  // region that announces facet changes to screen readers.
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const chipRowRef = useRef<HTMLDivElement>(null);
+  const [announcement, setAnnouncement] = useState("");
+
+  const setSelectedTags = useCallback(
+    (next: string[]) => {
       const params = new URLSearchParams(searchParams.toString());
-      if (tag) params.set(TAG_PARAM, tag);
-      else params.delete(TAG_PARAM);
-      const next = params.toString();
+      params.delete(TAGS_PARAM);
+      for (const tag of next) params.append(TAGS_PARAM, tag);
+      const qs = params.toString();
       setPage(1);
-      router.replace(`${pathname}${next ? `?${next}` : ""}`);
+      router.replace(`${pathname}${qs ? `?${qs}` : ""}`);
     },
     [searchParams, pathname, router],
   );
 
+  // Clicking a cloud tag ADDS it to the drill-down (additive, not replace).
+  // Selected tags are excluded from the cloud by the backend, so a click is
+  // always an "add" — no toggle-off from the cloud (use the chips for that).
   const handleTagClick = useCallback(
-    (tag: string) => setActiveTagFilter(tag === activeTag ? null : tag),
-    [activeTag, setActiveTagFilter],
+    (tag: string) => {
+      if (selectedTags.includes(tag)) return;
+      setSelectedTags([...selectedTags, tag]);
+      setAnnouncement(t("filter.announceAdded", { tag }));
+    },
+    [selectedTags, setSelectedTags, t],
   );
+
+  const removeTag = useCallback(
+    (tag: string) => {
+      const idx = selectedTags.indexOf(tag);
+      setSelectedTags(selectedTags.filter((x) => x !== tag));
+      setAnnouncement(t("filter.announceRemoved", { tag }));
+      // Move focus deterministically after the chip unmounts: the chip that
+      // shifts into this index, else the now-last chip, else the search input.
+      requestAnimationFrame(() => {
+        const chips =
+          chipRowRef.current?.querySelectorAll<HTMLButtonElement>(
+            "[data-chip-remove]",
+          );
+        if (chips && chips.length > 0) {
+          chips[Math.min(idx, chips.length - 1)]?.focus();
+        } else {
+          searchInputRef.current?.focus();
+        }
+      });
+    },
+    [selectedTags, setSelectedTags, t],
+  );
+
+  const clearAllTags = useCallback(() => {
+    setSelectedTags([]);
+    setAnnouncement(t("filter.announceCleared"));
+    requestAnimationFrame(() => searchInputRef.current?.focus());
+  }, [setSelectedTags, t]);
 
   // Debounce: schedule a single timer that promotes `searchInput` into
   // `debouncedQuery` AND resets page to 1 in one batched update. Doing
@@ -134,14 +188,8 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     } else {
       params.delete(SEARCH_PARAM);
     }
-    // #618: a *changed* search resets the active tag so a new query doesn't
-    // silently AND with a stale tag (the cloud re-facets to the query). Mount
-    // / shared-link loads (query unchanged) keep any ?tag intact.
-    const queryChanged = debouncedQuery !== prevDebouncedQueryRef.current;
-    prevDebouncedQueryRef.current = debouncedQuery;
-    if (trimmed && queryChanged) {
-      params.delete(TAG_PARAM);
-    }
+    // #830: q and the selected tags drill down TOGETHER (AND), so a changed
+    // query no longer clears the tags — unlike #618's single-tag reset.
     const next = params.toString();
     const current = searchParams.toString();
     if (next === current) return;
@@ -167,7 +215,9 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
         limit: PAGE_SIZE,
         offset,
         q: trimmed || undefined,
-        tags: activeTag ? [activeTag] : undefined,
+        // #830: ALL-match so the list mirrors the cloud's AND drill-down.
+        tags: selectedTags.length ? selectedTags : undefined,
+        tagsMatch: selectedTags.length ? "all" : undefined,
       });
       if (requestId !== requestIdRef.current) return;
       setItems(response.memories);
@@ -178,7 +228,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
     } finally {
       if (requestId === requestIdRef.current) setLoading(false);
     }
-  }, [contextId, page, debouncedQuery, activeTag, t]);
+  }, [contextId, page, debouncedQuery, selectedTags, t]);
 
   useEffect(() => {
     fetchMemories();
@@ -229,6 +279,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
           aria-hidden="true"
         />
         <Input
+          ref={searchInputRef}
           type="search"
           value={searchInput}
           onChange={(e) => setSearchInput(e.target.value)}
@@ -237,30 +288,57 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
           className="pl-9"
         />
       </div>
-      {activeTag && (
-        <div className="flex flex-wrap items-center gap-2">
+      {/*
+        #830: selected-tags chip row (generalized from #618's single chip).
+        Each chip removes one tag from the AND drill-down; "clear all" resets
+        the set. The "filtering N" count makes the additive model legible.
+      */}
+      {selectedTags.length > 0 && (
+        <div ref={chipRowRef} className="flex flex-wrap items-center gap-2">
           <span className="text-xs text-gray-500 dark:text-gray-400">
             {t("filter.activeLabel")}
           </span>
-          <Badge variant="secondary" className="gap-1">
-            {activeTag}
-            <button
-              type="button"
-              onClick={() => setActiveTagFilter(null)}
-              aria-label={t("filter.clearTag", { tag: activeTag })}
-              className="ml-0.5 rounded hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
-            >
-              <X className="h-3 w-3" />
-            </button>
-          </Badge>
+          {selectedTags.map((tag) => (
+            <Badge key={tag} variant="secondary" className="gap-1">
+              {tag}
+              <button
+                type="button"
+                data-chip-remove
+                onClick={() => removeTag(tag)}
+                aria-label={t("filter.clearTag", { tag })}
+                className="ml-0.5 rounded hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+          <button
+            type="button"
+            onClick={clearAllTags}
+            className="rounded text-xs text-gray-500 underline-offset-2 hover:text-foreground hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50 dark:text-gray-400"
+          >
+            {t("filter.clearAll")}
+          </button>
+          {/* Hide the count while a fetch is in flight so the chip row never
+              shows a stale total (0 on first paint of a shared link, or the
+              previous page's total during a refetch). */}
+          {!loading && (
+            <span className="text-xs text-gray-400 dark:text-gray-500">
+              {t("filter.filteringCount", { count: total })}
+            </span>
+          )}
         </div>
       )}
       <TagCloud
         contextId={contextId}
-        activeTag={activeTag}
+        selectedTags={selectedTags}
         onTagClick={handleTagClick}
         q={debouncedQuery}
       />
+      {/* a11y: announce facet changes — the cloud re-rendering is silent to AT. */}
+      <div aria-live="polite" className="sr-only" role="status">
+        {announcement}
+      </div>
     </div>
   );
 
@@ -274,9 +352,9 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
   }
 
   const hasQuery = debouncedQuery.trim().length > 0;
-  // Any active filter (text search OR tag) — distinguishes "no memories at all"
-  // from "no matches for the current filter".
-  const hasFilter = hasQuery || !!activeTag;
+  // Any active filter (text search OR ≥1 selected tag) — distinguishes "no
+  // memories at all" from "no matches for the current filter".
+  const hasFilter = hasQuery || selectedTags.length > 0;
 
   // No memories at all in this context — keep the existing landing copy.
   if (!loading && items.length === 0 && !hasFilter && !memoryIdParam) {
@@ -294,7 +372,7 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
 
   // Filter produced no matches — distinct copy that echoes the filter so the
   // user can tell whether they mistyped vs. ran a too-narrow filter. Prefer
-  // the tag in the message when a tag filter is active.
+  // the selected tags in the message when a tag filter is active.
   if (!loading && items.length === 0 && hasFilter && !memoryIdParam) {
     return (
       <div className="space-y-4">
@@ -303,7 +381,10 @@ export function MemoriesTabPanel({ contextId }: MemoriesTabPanelProps) {
           icon={SearchX}
           title={t("noResultsTitle")}
           description={t("noResultsDesc", {
-            query: activeTag && !hasQuery ? activeTag : debouncedQuery,
+            query:
+              selectedTags.length && !hasQuery
+                ? selectedTags.join(", ")
+                : debouncedQuery,
           })}
         />
       </div>

--- a/frontend/src/components/contexts/TagCloud.test.tsx
+++ b/frontend/src/components/contexts/TagCloud.test.tsx
@@ -1,9 +1,10 @@
 /**
- * Tests for TagCloud (#618): tag buttons, click → onTagClick, active aria-pressed,
- * and the empty state.
+ * Tests for TagCloud (#618 base + #830 drill-down): tag buttons, click →
+ * onTagClick (additive), selectedTags passed as with_tags, aria-pressed
+ * removed, and the two empty states (no tags vs. drilled-down-to-nothing).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 
 vi.mock("next-intl", () => ({
   useTranslations: () => (key: string, vars?: Record<string, unknown>) =>
@@ -41,28 +42,49 @@ beforeEach(() => {
   });
 });
 
-describe("TagCloud (#618)", () => {
-  it("renders tag buttons and calls onTagClick with the tag on click", async () => {
+describe("TagCloud", () => {
+  it("renders tag buttons and calls onTagClick with the tag on click (#618)", async () => {
     const onTagClick = vi.fn();
     render(
-      <TagCloud contextId="c1" activeTag={null} onTagClick={onTagClick} />,
+      <TagCloud contextId="c1" selectedTags={[]} onTagClick={onTagClick} />,
     );
     const authBtn = await screen.findByRole("button", { name: /"tag":"auth"/ });
     fireEvent.click(authBtn);
     expect(onTagClick).toHaveBeenCalledWith("auth");
   });
 
-  it("marks the active tag with aria-pressed=true", async () => {
-    render(<TagCloud contextId="c1" activeTag="deploy" onTagClick={vi.fn()} />);
-    const deployBtn = await screen.findByRole("button", {
-      name: /"tag":"deploy"/,
-    });
-    expect(deployBtn).toHaveAttribute("aria-pressed", "true");
+  it("passes selectedTags to the API as with_tags (#830)", async () => {
+    render(
+      <TagCloud
+        contextId="c1"
+        selectedTags={["auth", "deploy"]}
+        onTagClick={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(getContextTags).toHaveBeenCalled());
+    expect(getContextTags).toHaveBeenCalledWith(
+      "c1",
+      expect.objectContaining({ withTags: ["auth", "deploy"] }),
+    );
   });
 
-  it("renders the empty state when the context has no tags", async () => {
+  it("does NOT render aria-pressed on tag buttons (#830 — selected tags leave the cloud)", async () => {
+    render(<TagCloud contextId="c1" selectedTags={[]} onTagClick={vi.fn()} />);
+    const authBtn = await screen.findByRole("button", { name: /"tag":"auth"/ });
+    expect(authBtn).not.toHaveAttribute("aria-pressed");
+  });
+
+  it("renders the base empty state when the context has no tags", async () => {
     getContextTags.mockResolvedValue({ context_id: "c1", total: 0, tags: [] });
-    render(<TagCloud contextId="c1" activeTag={null} onTagClick={vi.fn()} />);
+    render(<TagCloud contextId="c1" selectedTags={[]} onTagClick={vi.fn()} />);
     expect(await screen.findByText("emptyTitle")).toBeInTheDocument();
+  });
+
+  it("renders the drill-down empty state when a filter leaves no co-occurring tags (#830)", async () => {
+    getContextTags.mockResolvedValue({ context_id: "c1", total: 0, tags: [] });
+    render(
+      <TagCloud contextId="c1" selectedTags={["auth"]} onTagClick={vi.fn()} />,
+    );
+    expect(await screen.findByText("emptyRefinedTitle")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/contexts/TagCloud.tsx
+++ b/frontend/src/components/contexts/TagCloud.tsx
@@ -3,12 +3,15 @@
  *
  * Frequency-weighted tag cloud for the context detail page. Fetches
  * `GET /contexts/{id}/tags` and renders each tag as a real <button> sized by
- * count (sqrt scale, clamped to a few discrete steps). Clicking a tag toggles
- * the memory-list filter (the parent owns the active-tag state + URL sync).
+ * count (stable absolute-count buckets — #830). Clicking a tag ADDS it to the
+ * multi-tag AND drill-down (`selectedTags`); the parent owns the set + URL sync
+ * and passes it back as `with_tags`, so selected tags are excluded from the
+ * cloud body (the cloud always shows "what else can I add").
  *
- * Design (gate1 / CDO): size encodes magnitude (NOT color — a11y + dark mode);
- * tags are buttons with aria-pressed + count in aria-label; a count/recent
- * toggle uses the Tabs primitive.
+ * Design (gate1 / CDO): size encodes magnitude (NOT color — a11y + dark mode)
+ * on a stable basis so a tag's size doesn't jump on drill-down; a count/recent
+ * toggle uses the Tabs primitive. aria-pressed was removed (#830) — selected
+ * tags leave the cloud, so it would be permanently false.
  */
 "use client";
 
@@ -26,25 +29,27 @@ import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { LoadingState } from "@/components/common/LoadingState";
 
 const TAG_LIMIT = 50;
-// Discrete sqrt-scaled buckets. Counts are long-tailed, so sqrt compresses the
-// head; equal counts collapse to the base size (no divide-by-zero).
-const SIZE_CLASSES = ["text-xs", "text-sm", "text-base", "text-lg"] as const;
-
-function sizeClass(count: number, min: number, max: number): string {
-  if (max <= min) return SIZE_CLASSES[1];
-  const norm = Math.sqrt((count - min) / (max - min)); // 0..1
-  const idx = Math.min(
-    SIZE_CLASSES.length - 1,
-    Math.floor(norm * SIZE_CLASSES.length),
-  );
-  return SIZE_CLASSES[idx];
+// #830: absolute count buckets — a STABLE size basis. The pre-#830 scale
+// normalized against the displayed set's min/max, so the same tag's font size
+// jumped on every drill-down (the displayed set shrinks), eroding the
+// "size = magnitude" signal. Fixed thresholds keep a tag's size constant
+// regardless of how the cloud is faceted.
+function sizeClass(count: number): string {
+  if (count >= 21) return "text-lg";
+  if (count >= 6) return "text-base";
+  if (count >= 2) return "text-sm";
+  return "text-xs";
 }
 
 export interface TagCloudProps {
   contextId: string;
-  /** The tag currently driving the memory-list filter, or null. */
-  activeTag: string | null;
-  /** Toggle a tag as the active filter (parent clears when tag === activeTag). */
+  /**
+   * #830: the multi-tag AND drill-down set. Sent as `with_tags` so the cloud
+   * facets to co-occurring tags; the backend excludes these from the result,
+   * so selected tags never appear in the cloud body.
+   */
+  selectedTags: string[];
+  /** Additively add a clicked tag to the selected set (parent owns the set). */
   onTagClick: (tag: string) => void;
   /** #618: facet the cloud to tags on memories matching this search query. */
   q?: string;
@@ -52,7 +57,7 @@ export interface TagCloudProps {
 
 export function TagCloud({
   contextId,
-  activeTag,
+  selectedTags,
   onTagClick,
   q,
 }: TagCloudProps) {
@@ -63,11 +68,21 @@ export function TagCloud({
   const [error, setError] = useState<string | null>(null);
   const reqRef = useRef(0);
 
+  // selectedTags is a fresh array each render; depend on a stable joined key so
+  // the effect only re-fetches when the actual set changes. NUL is not a valid
+  // tag character, so it is a collision-safe separator.
+  const selectedKey = selectedTags.join("\u0000");
+
   useEffect(() => {
     const reqId = ++reqRef.current;
     setLoading(true);
     setError(null);
-    getContextTags(contextId, { sort, limit: TAG_LIMIT, q })
+    getContextTags(contextId, {
+      sort,
+      limit: TAG_LIMIT,
+      q,
+      withTags: selectedTags,
+    })
       .then((res) => {
         if (reqId === reqRef.current) setTags(res.tags);
       })
@@ -84,11 +99,9 @@ export function TagCloud({
     return () => {
       reqRef.current++;
     };
-  }, [contextId, sort, q, t]);
-
-  const counts = tags.map((x) => x.count);
-  const min = counts.length ? Math.min(...counts) : 0;
-  const max = counts.length ? Math.max(...counts) : 0;
+    // selectedTags is intentionally tracked via selectedKey (stable identity).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contextId, sort, q, selectedKey, t]);
 
   return (
     <section className="rounded-lg border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-900">
@@ -111,11 +124,24 @@ export function TagCloud({
         // Shared skeleton primitive (frontend rules: never hand-roll skeletons).
         <LoadingState lines={2} />
       ) : tags.length === 0 ? (
+        // #830: distinguish "no tags at all" from "drilled down to nothing".
+        // When a drill-down (selectedTags or a non-blank q) is active, the
+        // cloud emptying means there are no further co-occurring tags. Use the
+        // trimmed q so a whitespace-only query (which the API ignores) does not
+        // flip to the "refined" copy.
         <EmptyState
           compact
           icon={TagIcon}
-          title={t("emptyTitle")}
-          description={t("emptyDesc")}
+          title={
+            selectedTags.length > 0 || q?.trim()
+              ? t("emptyRefinedTitle")
+              : t("emptyTitle")
+          }
+          description={
+            selectedTags.length > 0 || q?.trim()
+              ? t("emptyRefinedDesc")
+              : t("emptyDesc")
+          }
         />
       ) : (
         <div
@@ -123,34 +149,35 @@ export function TagCloud({
           role="group"
           aria-label={t("ariaLabel")}
         >
-          {tags.map((item) => {
-            const isActive = item.tag === activeTag;
-            return (
-              <button
-                key={item.tag}
-                type="button"
-                onClick={() => onTagClick(item.tag)}
-                aria-pressed={isActive}
-                aria-label={t("tagWithCount", {
-                  tag: item.tag,
-                  count: item.count,
-                })}
-                className={[
-                  sizeClass(item.count, min, max),
-                  "rounded px-1.5 py-0.5 transition-colors",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
-                  isActive
-                    ? "bg-primary/10 font-semibold text-primary ring-1 ring-primary/40"
-                    : "text-gray-600 hover:text-primary dark:text-gray-300 dark:hover:text-primary",
-                ].join(" ")}
-              >
-                {item.tag}
-                <span className="ml-1 align-super text-[0.65em] text-gray-400">
-                  {item.count}
-                </span>
-              </button>
-            );
-          })}
+          {/*
+            #830: selected tags are excluded from the cloud by the backend
+            (with_tags self-exclusion), so every rendered tag is an
+            "add to the drill-down" action. aria-pressed was removed — it
+            would be permanently false here and misleads screen readers into
+            announcing a toggle state that never toggles.
+          */}
+          {tags.map((item) => (
+            <button
+              key={item.tag}
+              type="button"
+              onClick={() => onTagClick(item.tag)}
+              aria-label={t("tagAddWithCount", {
+                tag: item.tag,
+                count: item.count,
+              })}
+              className={[
+                sizeClass(item.count),
+                "rounded px-1.5 py-0.5 transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
+                "text-gray-600 hover:text-primary dark:text-gray-300 dark:hover:text-primary",
+              ].join(" ")}
+            >
+              {item.tag}
+              <span className="ml-1 align-super text-[0.65em] text-gray-400">
+                {item.count}
+              </span>
+            </button>
+          ))}
         </div>
       )}
     </section>

--- a/frontend/src/lib/api/contexts.ts
+++ b/frontend/src/lib/api/contexts.ts
@@ -44,6 +44,12 @@ export interface GetContextTagsParams {
   sort?: TagSortMode;
   /** #618: facet the tags to memories whose summary matches this substring. */
   q?: string;
+  /**
+   * #830: multi-tag AND drill-down. Facets the cloud to tags that co-occur on
+   * memories carrying ALL of these tags; the with_tags values are excluded
+   * from the result. Sent as repeated `?with_tags=a&with_tags=b`.
+   */
+  withTags?: string[];
 }
 
 /**
@@ -65,6 +71,10 @@ export async function getContextTags(
   if (params.q) {
     const trimmed = params.q.trim();
     if (trimmed) sp.set("q", trimmed);
+  }
+  for (const tag of params.withTags ?? []) {
+    const trimmed = tag.trim();
+    if (trimmed) sp.append("with_tags", trimmed);
   }
   const qs = sp.toString();
   return apiClient.get<ContextTagsResponse>(

--- a/frontend/src/lib/api/memory.ts
+++ b/frontend/src/lib/api/memory.ts
@@ -26,6 +26,11 @@ export interface ListMemoriesParams {
   q?: string;
   /** ANY-match tag filter (#618). Repeated as ?tags=a&tags=b; blanks ignored. */
   tags?: string[];
+  /**
+   * #830: how to combine `tags`. `"any"` (default — overlap, preserves #618)
+   * or `"all"` (memory must hold every given tag). Only sent when `"all"`.
+   */
+  tagsMatch?: "any" | "all";
   limit?: number;
   offset?: number;
 }
@@ -52,6 +57,9 @@ export async function getMemories(
     const trimmed = tag.trim();
     if (trimmed) searchParams.append("tags", trimmed);
   }
+  // Only send tags_match when "all" — default "any" keeps the URL clean and
+  // matches the backend default (#618 behavior preserved).
+  if (params.tagsMatch === "all") searchParams.set("tags_match", "all");
   searchParams.set("limit", String(params.limit ?? 50));
   searchParams.set("offset", String(params.offset ?? 0));
 

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3066,7 +3066,12 @@
       "noResultsDesc": "No memories match \"{query}\".",
       "filter": {
         "activeLabel": "Filtered by tag:",
-        "clearTag": "Clear tag filter: {tag}"
+        "clearTag": "Clear tag filter: {tag}",
+        "clearAll": "Clear all",
+        "filteringCount": "Filtering {count, plural, one {# memory} other {# memories}}",
+        "announceAdded": "Added filter {tag}. Cloud refined to co-occurring tags.",
+        "announceRemoved": "Removed filter {tag}.",
+        "announceCleared": "Cleared all tag filters."
       }
     },
     "tagCloud": {
@@ -3077,7 +3082,10 @@
       "emptyTitle": "No tags yet",
       "emptyDesc": "Tags appear here as memories are added to this context.",
       "tagWithCount": "{tag} ({count, plural, one {# memory} other {# memories}})",
-      "loadFailed": "Failed to load tags"
+      "loadFailed": "Failed to load tags",
+      "emptyRefinedTitle": "No further tags",
+      "emptyRefinedDesc": "No other tags co-occur with the current filter. Remove a tag to widen the results.",
+      "tagAddWithCount": "Add filter {tag} ({count, plural, one {# memory} other {# memories}})"
     },
     "tagAutocomplete": {
       "suggestionsLabel": "Tag suggestions"

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3066,7 +3066,12 @@
       "noResultsDesc": "「{query}」に一致するメモリがありません。",
       "filter": {
         "activeLabel": "タグで絞り込み中:",
-        "clearTag": "タグフィルタを解除: {tag}"
+        "clearTag": "タグフィルタを解除: {tag}",
+        "clearAll": "すべて解除",
+        "filteringCount": "{count, plural, other {# 件のメモリー}}を絞り込み中",
+        "announceAdded": "フィルター {tag} を追加しました。共起するタグに絞り込みました。",
+        "announceRemoved": "フィルター {tag} を解除しました。",
+        "announceCleared": "すべてのタグフィルターを解除しました。"
       }
     },
     "tagCloud": {
@@ -3077,7 +3082,10 @@
       "emptyTitle": "タグがまだありません",
       "emptyDesc": "このコンテキストにメモリが追加されるとタグが表示されます。",
       "tagWithCount": "{tag}（{count}件）",
-      "loadFailed": "タグの読み込みに失敗しました"
+      "loadFailed": "タグの読み込みに失敗しました",
+      "emptyRefinedTitle": "これ以上のタグはありません",
+      "emptyRefinedDesc": "現在のフィルターと共起するタグはありません。タグを外すと結果が広がります。",
+      "tagAddWithCount": "フィルター追加 {tag}（{count, plural, other {# 件のメモリー}}）"
     },
     "tagAutocomplete": {
       "suggestionsLabel": "タグ候補"


### PR DESCRIPTION
Closes #830

## Summary
- Follow-up to #618. Clicking a tag in the cloud now **facets the cloud** (multi-tag AND drill-down) symmetric with the `q` search, instead of only toggling the memory list. Selected tags become a chip row; the cloud re-facets to tags co-occurring on memories that have **all** selected tags, and the selected tags drop out of the cloud ("what else can I add").
- The memory list filters by the same set with **ALL-match**, AND-ed with `q`. URL is shareable: `?q=…&tags=a&tags=b`.

## Backend
- `ContextService.aggregate_tags` gains `with_tags`: narrows the memory set with `tags @> with_tags` (GIN-indexed) and self-excludes those tags from the result, AND-combined with `q`; counts reflect the faceted subset. Bound as a single `varchar[]` param (never interpolated); capped at 50 tags / 200 chars each. **Empty list is a deliberate no-op (== #618).**
- `GET /contexts/{id}/tags` gains repeatable `with_tags`.
- `GET /memory/list` gains `tags_match` (`any|all`, **default `any` preserves #618**). One shared `tag_filter` predicate is applied to **both** the data and count queries (replacing a duplicated predicate).

## Frontend
- `TagCloud`: `activeTag` → `selectedTags` (sent as `with_tags`); click is additive; `aria-pressed` removed (selected tags leave the cloud); **stable absolute-count size buckets** (no font-jump on drill-down); drill-down-aware empty state.
- `MemoriesTabPanel`: single `?tag=` → repeatable `?tags=`; selected-tags chip list with per-chip remove + clear-all; ALL-match list fetch; **a11y**: `aria-live` announcements, deterministic focus management after chip removal, "filtering N" count.
- API clients (`withTags` / `tagsMatch`); i18n en + ja.

## UX / a11y (from the issue's CDO review — treated as spec)
aria-live facet announcements · focus moves to next chip (else search input) on remove · aria-pressed removed · stable size scale · "filtering N memories" count.

## Tests
- Backend: `with_tags` ALL-match + self-exclusion + `q`-combo + no-co-occurrence + 50-cap (real-DB integration); `tags_match=all` (`@>`) + `default=any` (`&&`) regression pin (unit).
- Frontend: `selectedTags` → `with_tags`, `aria-pressed` absent, drill-down empty state, multi-tag URL sync, de-dupe/blank drop, chip removal → reduced URL.
- 26 backend + 23 frontend tests pass. ruff / pyright / tsc clean.

## Pre-PR review summary
- gate2 mode: advisor-only — cso: green · qa-lead: green · cto: green
- gate1: green via /ask (CTO lens)
- review provider: code-review (2 independent review agents → no real bugs; 3 low-severity polish items applied: doc drift, count flicker, untrimmed-q empty-state)

🤖 Generated via /gh-issue-driven:ship
