### PR TITLE
feat(frontend): redesign /device authorization page to match login/MFA visual identity (#633)

### DIFF
--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -9,6 +9,11 @@
  * Auth guard: unauthenticated users are redirected to /login with a return_to
  * param that preserves the user_code so the code is NOT burned before the user
  * logs in. See issue #772.
+ *
+ * Visual chrome (Issue #633): brought to parity with the /login (MFA) screen —
+ * grid + blur-orb background, centered KaguraLogo, top-right LanguageSelector,
+ * glassmorphism card, ping-ring Suspense fallback. The state machine, copy,
+ * i18n keys, and double-submit guard are unchanged from #536.
  */
 
 import { useEffect, useRef, useState, Suspense } from "react";
@@ -20,7 +25,8 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-import { SpinnerLoading } from "@/components/common/LoadingState";
+import { KaguraLogo } from "@/components/icons/KaguraLogo";
+import { LanguageSelector } from "@/components/LanguageSelector";
 import { ApiError } from "@/lib/api";
 import { apiClient } from "@/lib/api/base";
 import {
@@ -47,6 +53,40 @@ const SCOPE_LABEL_MAP: Record<string, string> = {
   "memory:admin": "device.scopeAdmin",
   offline_access: "device.scopeOffline",
 };
+
+/** Grid + blur-orb gradient background, shared with /login (Issue #633). */
+function PageBackground() {
+  return (
+    <>
+      <div className="absolute inset-0 -z-10 bg-[linear-gradient(to_right,#8080800a_1px,transparent_1px),linear-gradient(to_bottom,#8080800a_1px,transparent_1px)] bg-[size:14px_24px]" />
+      <div className="absolute inset-0 -z-10 bg-gradient-to-b from-white via-gray-50/50 to-white" />
+      <div className="pointer-events-none absolute -left-1/4 -top-1/4 h-96 w-96 rounded-full bg-brand-green-300/30 blur-3xl" />
+      <div className="pointer-events-none absolute -right-1/4 -bottom-1/4 h-96 w-96 rounded-full bg-emerald-300/30 blur-3xl" />
+    </>
+  );
+}
+
+/** Animated ping-ring spinner, shared with /login's Suspense fallback. */
+function BrandSpinner() {
+  return (
+    <div className="relative">
+      <div className="h-16 w-16 animate-spin rounded-full border-4 border-brand-green-200 border-t-brand-green-600" />
+      <div className="absolute inset-0 h-16 w-16 animate-ping rounded-full border-4 border-brand-green-600 opacity-20" />
+    </div>
+  );
+}
+
+/** "Device authorization" context pill shown on the input / consent phases. */
+function DeviceBadge({ label }: { label: string }) {
+  return (
+    <div className="mb-6 flex justify-center">
+      <div className="inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-brand-green-100 to-emerald-100 px-4 py-1.5 text-sm font-semibold text-brand-green-700">
+        <Monitor className="h-4 w-4" />
+        <span>{label}</span>
+      </div>
+    </div>
+  );
+}
 
 function DevicePageInner() {
   const t = useTranslations();
@@ -203,186 +243,217 @@ function DevicePageInner() {
   // This prevents a flash of the empty input form before redirect fires.
   if (authLoading || !user) {
     return (
-      <div className="flex min-h-screen items-center justify-center bg-background px-4">
-        <SpinnerLoading size="lg" />
+      <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-white px-4">
+        <PageBackground />
+        <BrandSpinner />
       </div>
     );
   }
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background px-4">
-      <Card className="w-full max-w-md">
-        <CardContent className="pt-8 pb-8 space-y-6">
-          {phase === "success" && (
-            <div className="text-center space-y-4">
-              <CheckCircle2 className="mx-auto h-12 w-12 text-green-500" />
-              <h1 className="text-xl font-semibold text-foreground">
-                {t("device.successTitle")}
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                {t("device.successMessage")}
-              </p>
-            </div>
-          )}
+    <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-white px-4">
+      <PageBackground />
 
-          {phase === "denied" && (
-            <div className="text-center space-y-4">
-              <XCircle className="mx-auto h-12 w-12 text-red-500" />
-              <h1 className="text-xl font-semibold text-foreground">
-                {t("device.deniedTitle")}
-              </h1>
-              <p className="text-sm text-muted-foreground">
-                {t("device.deniedMessage")}
-              </p>
-              <Button variant="outline" onClick={resetToInput} className="mt-4">
-                {t("device.backToVerify")}
-              </Button>
-            </div>
-          )}
+      <div className="absolute top-4 right-4 z-10">
+        <LanguageSelector
+          className="!bg-white/90 backdrop-blur-sm border border-gray-300 shadow-sm hover:!bg-white !text-gray-700 hover:!text-gray-900"
+          showLabel
+        />
+      </div>
 
-          {(phase === "input" ||
-            phase === "verifying" ||
-            phase === "error") && (
-            <div className="text-center space-y-4">
-              <Monitor className="mx-auto h-10 w-10 text-muted-foreground" />
-              <div>
-                <h1 className="text-xl font-semibold text-foreground">
-                  {t("device.title")}
+      <div className="relative w-full max-w-md px-4">
+        <div className="mb-8 flex justify-center">
+          <KaguraLogo className="h-24 w-auto" />
+        </div>
+
+        <Card className="overflow-hidden border-gray-200 bg-white/80 shadow-2xl backdrop-blur-xl">
+          <CardContent className="p-8 space-y-6">
+            {phase === "success" && (
+              <div className="text-center space-y-4">
+                <CheckCircle2 className="mx-auto h-12 w-12 text-green-500" />
+                <h1 className="text-2xl font-bold text-gray-900">
+                  {t("device.successTitle")}
                 </h1>
-                <p className="mt-1 text-sm text-muted-foreground">
-                  {t("device.description")}
-                </p>
+                <p className="text-gray-600">{t("device.successMessage")}</p>
               </div>
+            )}
 
-              <div className="space-y-2">
-                <Label htmlFor="userCode" className="text-foreground">
-                  {t("device.codeLabel")}
-                </Label>
-                <Input
-                  id="userCode"
-                  type="text"
-                  maxLength={8}
-                  value={userCode}
-                  onChange={(e) => handleCodeChange(e.target.value)}
-                  onKeyDown={handleKeyDown}
-                  placeholder={t("device.codePlaceholder")}
-                  className="text-center text-2xl tracking-[0.3em]"
-                  autoFocus
-                  autoComplete="off"
-                  disabled={phase === "verifying"}
-                />
+            {phase === "denied" && (
+              <div className="text-center space-y-4">
+                <XCircle className="mx-auto h-12 w-12 text-red-500" />
+                <h1 className="text-2xl font-bold text-gray-900">
+                  {t("device.deniedTitle")}
+                </h1>
+                <p className="text-gray-600">{t("device.deniedMessage")}</p>
+                <Button
+                  variant="outline"
+                  onClick={resetToInput}
+                  className="mt-4"
+                >
+                  {t("device.backToVerify")}
+                </Button>
               </div>
+            )}
 
-              {phase === "verifying" && (
-                <p className="text-sm text-muted-foreground">
-                  {t("device.verifying")}
+            {(phase === "input" ||
+              phase === "verifying" ||
+              phase === "error") && (
+              <div className="text-center space-y-4">
+                <DeviceBadge label={t("device.badge")} />
+                <div>
+                  <h1 className="text-3xl font-bold text-gray-900">
+                    {t("device.title")}
+                  </h1>
+                  <p className="mt-2 text-gray-600">
+                    {t("device.description")}
+                  </p>
+                </div>
+
+                <div className="space-y-2 text-left">
+                  <Label htmlFor="userCode" className="text-gray-700">
+                    {t("device.codeLabel")}
+                  </Label>
+                  <Input
+                    id="userCode"
+                    type="text"
+                    maxLength={8}
+                    value={userCode}
+                    onChange={(e) => handleCodeChange(e.target.value)}
+                    onKeyDown={handleKeyDown}
+                    placeholder={t("device.codePlaceholder")}
+                    className="bg-white text-center text-2xl tracking-[0.3em] text-gray-900"
+                    autoFocus
+                    autoComplete="off"
+                    disabled={phase === "verifying"}
+                  />
+                </div>
+
+                {phase === "verifying" && (
+                  <p className="text-sm text-gray-600">
+                    {t("device.verifying")}
+                  </p>
+                )}
+
+                {phase === "error" && error && (
+                  <Alert
+                    variant="destructive"
+                    className="border-red-200 bg-red-50 text-left"
+                  >
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription>{error}</AlertDescription>
+                  </Alert>
+                )}
+
+                {phase === "error" && (
+                  <Button variant="outline" onClick={resetToInput}>
+                    {t("device.backToVerify")}
+                  </Button>
+                )}
+              </div>
+            )}
+
+            {(phase === "consent" || phase === "submitting") && deviceInfo && (
+              <div className="text-center space-y-4">
+                <DeviceBadge label={t("device.badge")} />
+                <div>
+                  <h1 className="text-3xl font-bold text-gray-900">
+                    {t("device.consentTitle")}
+                  </h1>
+                  <p className="mt-2 text-gray-600">
+                    {t("device.consentDescription")}
+                  </p>
+                </div>
+
+                <p className="text-lg font-medium text-gray-900">
+                  {deviceInfo.client_name}
                 </p>
-              )}
 
-              {phase === "error" && error && (
-                <Alert variant="destructive">
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                    {t("device.permissionsLabel")}
+                  </p>
+                  {renderScopeBadges(deviceInfo.scope)}
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+                    {t("device.identityShareLabel")}
+                  </p>
+                  <div className="flex flex-wrap gap-2 justify-center">
+                    <Badge variant="secondary">
+                      {t("device.identityEmail")}
+                    </Badge>
+                    <Badge variant="secondary">
+                      {t("device.identityWorkspace")}
+                    </Badge>
+                  </div>
+                </div>
+
+                <div className="flex gap-3 justify-center pt-2">
+                  <Button
+                    variant="outline"
+                    onClick={() => handleConfirm(false)}
+                    disabled={phase === "submitting"}
+                    className="h-12 flex-1"
+                  >
+                    {phase === "submitting"
+                      ? t("device.denying")
+                      : t("device.deny")}
+                  </Button>
+                  <Button
+                    onClick={() => handleConfirm(true)}
+                    disabled={phase === "submitting"}
+                    className="h-12 flex-1 bg-gradient-to-r from-brand-green-600 to-emerald-600 text-base font-semibold text-white shadow-lg hover:from-brand-green-700 hover:to-emerald-700 disabled:opacity-50"
+                  >
+                    {phase === "submitting"
+                      ? t("device.approving")
+                      : t("device.approve")}
+                  </Button>
+                </div>
+              </div>
+            )}
+
+            {phase === "error" && error && deviceInfo && (
+              <div className="text-center space-y-4">
+                <Alert
+                  variant="destructive"
+                  className="border-red-200 bg-red-50 text-left"
+                >
                   <AlertCircle className="h-4 w-4" />
                   <AlertDescription>{error}</AlertDescription>
                 </Alert>
-              )}
-
-              {phase === "error" && (
-                <Button variant="outline" onClick={resetToInput}>
-                  {t("device.backToVerify")}
-                </Button>
-              )}
-            </div>
-          )}
-
-          {(phase === "consent" || phase === "submitting") && deviceInfo && (
-            <div className="text-center space-y-4">
-              <div>
-                <h1 className="text-xl font-semibold text-foreground">
-                  {t("device.consentTitle")}
-                </h1>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {t("device.consentDescription")}
-                </p>
-              </div>
-
-              <p className="text-lg font-medium text-foreground">
-                {deviceInfo.client_name}
-              </p>
-
-              <div className="space-y-2">
-                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                  {t("device.permissionsLabel")}
-                </p>
-                {renderScopeBadges(deviceInfo.scope)}
-              </div>
-
-              <div className="space-y-2">
-                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
-                  {t("device.identityShareLabel")}
-                </p>
-                <div className="flex flex-wrap gap-2 justify-center">
-                  <Badge variant="secondary">{t("device.identityEmail")}</Badge>
-                  <Badge variant="secondary">
-                    {t("device.identityWorkspace")}
-                  </Badge>
+                <div className="flex gap-3 justify-center">
+                  <Button variant="outline" onClick={resetToInput}>
+                    {t("device.backToVerify")}
+                  </Button>
+                  <Button
+                    variant="default"
+                    onClick={() => {
+                      setPhase("consent");
+                      setError(null);
+                    }}
+                  >
+                    {t("device.tryAgain")}
+                  </Button>
                 </div>
               </div>
-
-              <div className="flex gap-3 justify-center pt-2">
-                <Button
-                  variant="outline"
-                  onClick={() => handleConfirm(false)}
-                  disabled={phase === "submitting"}
-                  className="min-w-[120px]"
-                >
-                  {phase === "submitting"
-                    ? t("device.denying")
-                    : t("device.deny")}
-                </Button>
-                <Button
-                  onClick={() => handleConfirm(true)}
-                  disabled={phase === "submitting"}
-                  className="min-w-[120px] bg-gradient-to-r from-brand-green-600 to-emerald-600 text-white shadow-lg hover:from-brand-green-700 hover:to-emerald-700 disabled:opacity-50"
-                >
-                  {phase === "submitting"
-                    ? t("device.approving")
-                    : t("device.approve")}
-                </Button>
-              </div>
-            </div>
-          )}
-
-          {phase === "error" && error && deviceInfo && (
-            <div className="text-center space-y-4">
-              <Alert variant="destructive">
-                <AlertCircle className="h-4 w-4" />
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-              <div className="flex gap-3 justify-center">
-                <Button variant="outline" onClick={resetToInput}>
-                  {t("device.backToVerify")}
-                </Button>
-                <Button
-                  variant="default"
-                  onClick={() => {
-                    setPhase("consent");
-                    setError(null);
-                  }}
-                >
-                  {t("device.tryAgain")}
-                </Button>
-              </div>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }
 
 export default function DevicePage() {
   return (
-    <Suspense fallback={<SpinnerLoading size="lg" />}>
+    <Suspense
+      fallback={
+        <div className="flex min-h-screen items-center justify-center bg-white">
+          <BrandSpinner />
+        </div>
+      }
+    >
       <DevicePageInner />
     </Suspense>
   );

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3533,6 +3533,7 @@
   },
   "device": {
     "title": "Device Authorization",
+    "badge": "Device authorization",
     "description": "Enter the code displayed in your CLI to authorize this device.",
     "codeLabel": "Device Code",
     "codePlaceholder": "XXXXXXXX",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3533,6 +3533,7 @@
   },
   "device": {
     "title": "デバイス認証",
+    "badge": "デバイス認証",
     "description": "CLIに表示されたコードを入力してデバイスを認証してください。",
     "codeLabel": "デバイスコード",
     "codePlaceholder": "XXXXXXXX",


### PR DESCRIPTION
Closes #633

## Summary
The OAuth2 device authorization / consent page (`/device`, RFC 8628 — #536; made user-facing via #624/#626) looked like an internal admin tool next to `/login`. This brings it to visual parity with the `/login` (MFA) screen while keeping its state machine, copy, and double-submit guard untouched.

## What changed (chrome only)
- Grid + blur-orb gradient background (ported from `/login` as a local `PageBackground`).
- Centered `KaguraLogo` (h-24) + top-right `LanguageSelector`.
- Glassmorphism card (`bg-white/80 backdrop-blur-xl shadow-2xl`).
- `Monitor` "Device authorization" badge pill on the input + consent phases.
- Bigger titles (`text-2xl/3xl font-bold`) + `text-gray-600` subtitles; light-theme grays to match `/login`.
- Consent Deny/Approve → `h-12 flex-1` pair, gradient Approve (`/login` submit proportions).
- Suspense fallback + auth-loading guard → `/login`'s ping-ring `BrandSpinner`.

## What did NOT change
The state machine, all 7 phase conditionals (`input`/`verifying`/`consent`/`submitting`/`success`/`denied`/`error`), every handler (`verifyCode`, `handleConfirm`, `handleCodeChange`, `handleKeyDown`, `resetToInput`), the `useEffect` (unauth audit-ping + `return_to` redirect + `user_code` normalization), and the `submittingRef` double-submit guard are **byte-identical** to #536 (a diff grep for every logic token returns zero `+`/`-` lines). No API/contract/copy change.

## Tests / verification
- `frontend/src/app/device/page.test.tsx`: **19/19 pass, UNMODIFIED** (acceptance criterion). The `animate-spin` assertion in the auth-loading guard still holds (the ping-ring `BrandSpinner` carries `animate-spin`).
- tsc clean. New i18n key `device.badge` added to **both** en + ja.
- E2E / visual-regression intentionally out of scope per the issue.

## Pre-PR review summary
- gate2 mode: advisor-only — cso: green · qa-lead: green · cto: green
- gate1: green via /ask (CDO lens)
- review provider: code-review (1 review agent → no logic drift, no real bugs)

## Follow-up (not in this PR)
`PageBackground` / `BrandSpinner` now exist in both `/login` (inline) and `/device` (extracted) — a future PR could hoist them to `components/auth/` for reuse.

🤖 Generated via /gh-issue-driven:ship
