### PR TITLE
feat(auth): send workspace invitation emails via Resend (#654)

### DIFF
--- a/backend/src/api/routes/invitations.py
+++ b/backend/src/api/routes/invitations.py
@@ -9,7 +9,6 @@ Provides REST API endpoints for managing workspace invitations:
 - Accept invitation (authenticated users)
 """
 
-import os
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -28,7 +27,7 @@ from models.schemas import (
     WorkspaceInvitationCreate,
     WorkspaceInvitationResponse,
 )
-from services.invitation_service import InvitationService
+from services.invitation_service import InvitationService, build_invitation_url
 from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import NotFoundException, ValidationError
@@ -38,24 +37,11 @@ logger = get_logger(__name__)
 
 router = APIRouter(tags=["invitations"])
 
-
-def build_invitation_url(token: str) -> str:
-    """Build full invitation URL.
-
-    Gets base URL from environment variable FRONTEND_URL.
-    Defaults to production URL if not set.
-
-    Args:
-        token: Invitation token
-
-    Returns:
-        Full invitation URL
-
-    Environment:
-        FRONTEND_URL: Base URL for frontend (e.g., https://your-domain.com)
-    """
-    base_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
-    return f"{base_url}/invite/{token}"
+# ``build_invitation_url`` now lives in ``services.invitation_service`` so the
+# API response and the invitation email (Issue #654) share one URL builder and
+# cannot drift. Re-exported here for backward compatibility with importers of
+# ``api.routes.invitations.build_invitation_url``.
+__all__ = ["router", "build_invitation_url"]
 
 
 @router.post(

--- a/backend/src/services/email_providers/resend.py
+++ b/backend/src/services/email_providers/resend.py
@@ -238,6 +238,50 @@ class ResendEmailService:
             },
         )
 
+    async def send_workspace_invitation(
+        self,
+        *,
+        to_email: str,
+        inviter_name: str,
+        workspace_name: str,
+        accept_url: str,
+        expires_at_iso: str | None,
+    ) -> bool:
+        # ``accept_url`` embeds the single-use invitation token as a path
+        # segment, so it goes in the body (delivered to the recipient inbox)
+        # but is NEVER placed in ``log_context`` — same redaction discipline as
+        # send_erasure_confirmation (Issue #654 / #478 Phase-3 precedent).
+        expiry_line = (
+            f"This invitation expires on {expires_at_iso}.\n"
+            if expires_at_iso
+            else "This invitation does not expire.\n"
+        )
+        text = (
+            f'{inviter_name} has invited you to join the "{workspace_name}" '
+            "workspace on Kagura Memory Cloud.\n"
+            "\n"
+            "Accept the invitation by opening the link below:\n"
+            "\n"
+            f"  {accept_url}\n"
+            "\n"
+            f"{expiry_line}"
+            "\n"
+            "If you were not expecting this invitation, you can ignore this "
+            "email — no action is taken unless you open the link.\n"
+        )
+        return await self._send(
+            to_email=to_email,
+            subject=f"You're invited to the {workspace_name} workspace on Kagura",
+            text=text,
+            log_event="workspace_invitation_email",
+            log_context={
+                "to_email": to_email,
+                "workspace_name": workspace_name,
+                "expires_at": expires_at_iso,
+                "template": "workspace_invitation",
+            },
+        )
+
     async def send_erasure_confirmation(
         self,
         *,

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -112,6 +112,42 @@ class EmailService(Protocol):
         """
         ...
 
+    async def send_workspace_invitation(
+        self,
+        *,
+        to_email: str,
+        inviter_name: str,
+        workspace_name: str,
+        accept_url: str,
+        expires_at_iso: str | None,
+    ) -> bool:
+        """Deliver a workspace invitation email (Issue #654).
+
+        Sent as a **courtesy** notification after the invitation row is
+        persisted: the row is the source of truth, so an email failure MUST
+        NOT roll back the invitation. Like every method here, implementations
+        MUST NOT raise — log and return False on failure.
+
+        ``accept_url`` embeds the single-use invitation token as a path
+        segment, so it is **sensitive**: implementations MUST NOT log it (the
+        token is the credential). Mirror ``send_erasure_confirmation``'s
+        redaction discipline — deliver the URL to the recipient inbox, never
+        to local logs.
+
+        Args:
+            to_email: Invitee's email address.
+            inviter_name: Display name of the inviting admin (for the body).
+            workspace_name: Workspace display name (for the body / subject).
+            accept_url: Absolute invitation accept URL embedding the token.
+                **Sensitive** — do not log.
+            expires_at_iso: ISO-8601 UTC expiry (Z-suffixed via ``to_utc_iso``)
+                or ``None`` when the invitation never expires.
+
+        Returns:
+            True on delivery (or logging fallback), False on hard failure.
+        """
+        ...
+
     async def send_erasure_confirmation(
         self,
         *,
@@ -190,6 +226,31 @@ class LoggingEmailService:
             request_id=request_id,
             email_dispatch_required=True,
             template="erasure_complete",
+        )
+        return True
+
+    async def send_workspace_invitation(
+        self,
+        *,
+        to_email: str,
+        inviter_name: str,
+        workspace_name: str,
+        accept_url: str,
+        expires_at_iso: str | None,
+    ) -> bool:
+        # accept_url embeds the single-use token; redact it per the Protocol's
+        # no-log discipline. inviter_name (a person's name) is also kept out of
+        # the log line — the recipient address + workspace are enough for ops
+        # triage. The admin who created the invite already has the accept URL
+        # from the API response, so logging-mode delivery is not lost.
+        del accept_url, inviter_name
+        logger.info(
+            "workspace_invitation_email",
+            to_email=to_email,
+            workspace_name=workspace_name,
+            expires_at=expires_at_iso,
+            email_dispatch_required=True,
+            template="workspace_invitation",
         )
         return True
 

--- a/backend/src/services/invitation_service.py
+++ b/backend/src/services/invitation_service.py
@@ -10,6 +10,7 @@ This service handles the core business logic for workspace invitations:
 - Expiration management
 """
 
+import os
 import secrets
 from datetime import timedelta
 from uuid import UUID
@@ -18,7 +19,8 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.auth import User, Workspace, WorkspaceInvitation, WorkspaceMember
-from utils.datetime import utcnow
+from services.email_service import EmailService, get_email_service
+from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import NotFoundException, QuotaExceededError, ValidationError
 from utils.logger import get_logger
 
@@ -31,6 +33,25 @@ EXPIRY_PRESETS = {
     90: timedelta(days=90),
     365: timedelta(days=365),
 }
+
+
+def build_invitation_url(token: str) -> str:
+    """Build the absolute invitation accept URL from ``FRONTEND_URL``.
+
+    Single source of truth shared by the API response (``api/routes/
+    invitations.py``) and the invitation email (Issue #654), so the link the
+    admin sees and the link the invitee receives can never drift. Falls back
+    to the local dev origin when ``FRONTEND_URL`` is unset.
+
+    Args:
+        token: Invitation token (single-use; treat the returned URL as a
+            credential — do not log it).
+
+    Returns:
+        ``f"{FRONTEND_URL}/invite/{token}"``.
+    """
+    base_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
+    return f"{base_url}/invite/{token}"
 
 
 class InvitationService:
@@ -47,13 +68,20 @@ class InvitationService:
     - Single-use tokens (cannot be reused after acceptance)
     """
 
-    def __init__(self, db: AsyncSession):
+    def __init__(self, db: AsyncSession, email_service: EmailService | None = None):
         """Initialize invitation service.
 
         Args:
             db: Async database session
+            email_service: Optional EmailService override (Issue #654). When
+                None, the module singleton is resolved lazily at dispatch time
+                (NOT here) — ``InvitationService`` is also constructed on
+                read-only paths (e.g. the registration gate), which must not
+                pull in provider initialization. Tests inject a stub to assert
+                the courtesy-email dispatch without hitting a provider.
         """
         self.db = db
+        self._email_service_override = email_service
 
     async def create_invitation(
         self,
@@ -220,7 +248,66 @@ class InvitationService:
             f"email={email or 'any'} expires={expires_at or 'never'}"
         )
 
+        # Issue #654: dispatch the invitation email as a COURTESY notification.
+        # The invitation row above is the source of truth — an email (or
+        # inviter-resolution) failure must NEVER roll it back, so the whole
+        # dispatch is guarded and best-effort. ``email`` is validated non-empty
+        # at the top of this method, so it is always a real recipient here.
+        await self._dispatch_invitation_email(
+            workspace=workspace, invitation=invitation, invited_by=invited_by
+        )
+
         return invitation
+
+    async def _resolve_inviter_name(self, invited_by: str) -> str:
+        """Resolve a human-friendly inviter name for the email body.
+
+        Falls back to the email, then a generic label, so a missing/renamed
+        inviter never blocks the courtesy email.
+        """
+        result = await self.db.execute(select(User).where(User.user_id == invited_by))
+        user = result.scalar_one_or_none()
+        if user:
+            return (user.name or "").strip() or user.email
+        return "A Kagura workspace admin"
+
+    async def _dispatch_invitation_email(
+        self,
+        *,
+        workspace: Workspace,
+        invitation: WorkspaceInvitation,
+        invited_by: str,
+    ) -> None:
+        """Best-effort courtesy email send (Issue #654).
+
+        Wrapped so that NOTHING here — a slow/failing provider, a missing
+        inviter row, a config error — can break invitation creation. The
+        ``EmailService`` Protocol already guarantees no-raise, but the
+        surrounding resolution work could throw, hence the broad guard.
+        """
+        try:
+            # Resolve the provider lazily — only this send path needs it, so
+            # read-only InvitationService constructions never trigger provider
+            # init. get_email_service() is a cached singleton (cheap after the
+            # first send).
+            email_service = self._email_service_override or get_email_service()
+            inviter_name = await self._resolve_inviter_name(invited_by)
+            accept_url = build_invitation_url(invitation.token)
+            expires_at_iso = to_utc_iso(invitation.expires_at) if invitation.expires_at else None
+            await email_service.send_workspace_invitation(
+                to_email=invitation.email,
+                inviter_name=inviter_name,
+                workspace_name=workspace.name,
+                accept_url=accept_url,
+                expires_at_iso=expires_at_iso,
+            )
+        except Exception as exc:  # noqa: BLE001 — courtesy email must not break creation
+            # No token / accept URL in the log (it embeds the credential).
+            logger.warning(
+                "invitation_email_dispatch_error",
+                error_type=type(exc).__name__,
+                workspace_id=str(workspace.id),
+            )
 
     async def get_invitation(self, token: str) -> WorkspaceInvitation:
         """Get invitation by token.

--- a/backend/tests/integration/test_invitation_email.py
+++ b/backend/tests/integration/test_invitation_email.py
@@ -1,0 +1,128 @@
+"""Integration tests for the invitation courtesy-email dispatch (Issue #654).
+
+``InvitationService.create_invitation`` sends a workspace-invitation email
+after persisting the row. The email is a COURTESY notification: the invitation
+row is the source of truth, so an email failure (or an unexpected raise inside
+the dispatch path) must NEVER prevent the invitation from being created.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import User, Workspace, WorkspaceInvitation
+from services.invitation_service import InvitationService
+
+
+class _RecordingEmail:
+    """Stub EmailService that records calls and can simulate failure modes."""
+
+    def __init__(self, *, behavior: str = "ok") -> None:
+        self.calls: list[dict] = []
+        self.behavior = behavior  # "ok" | "false" | "raise"
+
+    async def send_workspace_invitation(self, **kwargs) -> bool:
+        self.calls.append(kwargs)
+        if self.behavior == "raise":
+            raise RuntimeError("provider exploded")
+        return self.behavior != "false"
+
+
+async def _seed(db: AsyncSession) -> tuple[Workspace, User]:
+    suffix = uuid4().hex[:8]
+    inviter = User(
+        email=f"inviter-{suffix}@example.com",
+        user_id=f"inviter-sub-{suffix}",
+        name="Alice Admin",
+        role="user",
+        auth_method="oauth",
+        auth_provider="google",
+    )
+    db.add(inviter)
+    await db.flush()
+
+    ws = Workspace(
+        id=uuid4(),
+        name=f"ws-{suffix}",
+        plan_name="pro",
+        owner_user_id=inviter.user_id,
+        memory_limit=100_000,
+        daily_api_limit=50_000,
+        weekly_api_limit=250_000,
+    )
+    db.add(ws)
+    await db.flush()
+    return ws, inviter
+
+
+@pytest.mark.asyncio
+class TestInvitationEmailDispatch:
+    async def test_create_invitation_dispatches_email_with_expected_args(self, db_session):
+        ws, inviter = await _seed(db_session)
+        stub = _RecordingEmail()
+        svc = InvitationService(db_session, email_service=stub)
+
+        invitation = await svc.create_invitation(
+            workspace_id=ws.id,
+            invited_by=inviter.user_id,
+            role="admin",
+            email="invitee@example.com",
+            expires_in_days=7,
+        )
+
+        assert len(stub.calls) == 1
+        call = stub.calls[0]
+        assert call["to_email"] == "invitee@example.com"
+        assert call["workspace_name"] == ws.name
+        assert call["inviter_name"] == "Alice Admin"
+        # The accept_url is absolute and embeds the single-use token.
+        assert call["accept_url"].endswith(f"/invite/{invitation.token}")
+        # Expiry is Z-suffixed UTC (to_utc_iso), not naive (#489 regression).
+        assert call["expires_at_iso"] is not None
+        assert call["expires_at_iso"].endswith("Z")
+
+    async def test_never_expires_passes_none_iso(self, db_session):
+        ws, inviter = await _seed(db_session)
+        stub = _RecordingEmail()
+        svc = InvitationService(db_session, email_service=stub)
+
+        await svc.create_invitation(
+            workspace_id=ws.id,
+            invited_by=inviter.user_id,
+            role="admin",
+            email="invitee2@example.com",
+            expires_in_days=None,
+        )
+
+        assert stub.calls[0]["expires_at_iso"] is None
+
+    @pytest.mark.parametrize("behavior", ["raise", "false"])
+    async def test_email_failure_does_not_block_invitation(self, db_session, behavior):
+        """A raising OR False-returning email provider must not prevent the
+        invitation row from being created (courtesy-email contract)."""
+        ws, inviter = await _seed(db_session)
+        stub = _RecordingEmail(behavior=behavior)
+        svc = InvitationService(db_session, email_service=stub)
+
+        invitation = await svc.create_invitation(
+            workspace_id=ws.id,
+            invited_by=inviter.user_id,
+            role="admin",
+            email=f"invitee-{behavior}@example.com",
+            expires_in_days=None,
+        )
+
+        # The dispatch was attempted...
+        assert len(stub.calls) == 1
+        # ...and the invitation row is present despite the email failure.
+        assert invitation.id is not None
+        found = (
+            await db_session.execute(
+                select(WorkspaceInvitation).where(WorkspaceInvitation.id == invitation.id)
+            )
+        ).scalar_one_or_none()
+        assert found is not None

--- a/backend/tests/services/email_providers/test_resend.py
+++ b/backend/tests/services/email_providers/test_resend.py
@@ -364,3 +364,137 @@ async def test_send_erasure_confirmation_failure_does_not_leak_token_in_logs():
 
     assert raw_token not in haystack, "raw confirm_token leaked into failure log"
     assert confirm_url not in haystack, "confirm_url leaked into failure log"
+
+
+# ---------------------------------------------------------------------------
+# Workspace invitation (Issue #654)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_invitation_calls_sdk_with_expected_payload():
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+    accept_url = "https://app.example.com/invite/tok-abc123"
+
+    with patch.object(
+        resend_module.resend.Emails, "send", return_value={"id": "re_inv_001"}
+    ) as mock_send:
+        result = await svc.send_workspace_invitation(
+            to_email="invitee@example.com",
+            inviter_name="Alice Admin",
+            workspace_name="Acme Research",
+            accept_url=accept_url,
+            expires_at_iso="2026-06-01T00:00:00Z",
+        )
+
+    assert result is True
+    mock_send.assert_called_once()
+    params = mock_send.call_args.args[0]
+    assert params["from"] == "noreply@example.com"
+    assert params["to"] == ["invitee@example.com"]
+    assert "Acme Research" in params["subject"]
+    assert "Alice Admin" in params["text"]
+    assert "Acme Research" in params["text"]
+    assert accept_url in params["text"]
+    assert "2026-06-01T00:00:00Z" in params["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_invitation_renders_no_expiry():
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+
+    with patch.object(
+        resend_module.resend.Emails, "send", return_value={"id": "re_inv_002"}
+    ) as mock_send:
+        result = await svc.send_workspace_invitation(
+            to_email="invitee@example.com",
+            inviter_name="Bob",
+            workspace_name="Team",
+            accept_url="https://app.example.com/invite/tok-xyz",
+            expires_at_iso=None,
+        )
+
+    assert result is True
+    params = mock_send.call_args.args[0]
+    assert "does not expire" in params["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_invitation_returns_false_when_sdk_raises():
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+
+    with patch.object(
+        resend_module.resend.Emails,
+        "send",
+        side_effect=RuntimeError("Domain not found"),
+    ):
+        result = await svc.send_workspace_invitation(
+            to_email="invitee@example.com",
+            inviter_name="Alice",
+            workspace_name="Acme",
+            accept_url="https://app.example.com/invite/tok-fail",
+            expires_at_iso=None,
+        )
+
+    assert result is False, "Protocol contract: must return False, not raise"
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_invitation_does_not_leak_token_in_logs():
+    """The accept_url embeds the single-use token — it must never reach any
+    log payload (same redaction invariant as send_erasure_confirmation)."""
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+    token = "raw-invite-token-DO-NOT-LEAK-7f"  # noqa: S105
+    accept_url = f"https://app.example.com/invite/{token}"
+
+    with (
+        patch.object(resend_module.resend.Emails, "send", return_value={"id": "ok"}),
+        patch.object(resend_module, "logger") as mock_logger,
+    ):
+        result = await svc.send_workspace_invitation(
+            to_email="invitee@example.com",
+            inviter_name="Alice",
+            workspace_name="Acme",
+            accept_url=accept_url,
+            expires_at_iso="2026-06-01T00:00:00Z",
+        )
+
+    assert result is True
+    haystack_parts: list[str] = []
+    for method_call in mock_logger.method_calls:
+        _name, args, kwargs = method_call
+        haystack_parts.extend(str(a) for a in args)
+        haystack_parts.extend(f"{k}={v}" for k, v in kwargs.items())
+    haystack = " ".join(haystack_parts)
+    assert token not in haystack, "invitation token leaked into logs"
+    assert accept_url not in haystack, "accept_url leaked into logs"
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_invitation_failure_does_not_leak_token_in_logs():
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+    token = "raw-invite-token-DO-NOT-LEAK-fail-2b"  # noqa: S105
+    accept_url = f"https://app.example.com/invite/{token}"
+    leaky_exc = f"Resend API error: invalid request body — {accept_url}"
+
+    with (
+        patch.object(resend_module.resend.Emails, "send", side_effect=RuntimeError(leaky_exc)),
+        patch.object(resend_module, "logger") as mock_logger,
+    ):
+        result = await svc.send_workspace_invitation(
+            to_email="invitee@example.com",
+            inviter_name="Alice",
+            workspace_name="Acme",
+            accept_url=accept_url,
+            expires_at_iso=None,
+        )
+
+    assert result is False
+    haystack_parts: list[str] = []
+    for method_call in mock_logger.method_calls:
+        _name, args, kwargs = method_call
+        haystack_parts.extend(str(a) for a in args)
+        haystack_parts.extend(f"{k}={v}" for k, v in kwargs.items())
+    haystack = " ".join(haystack_parts)
+    assert token not in haystack, "invitation token leaked into failure log"
+    assert accept_url not in haystack, "accept_url leaked into failure log"

--- a/backend/tests/services/test_email_service.py
+++ b/backend/tests/services/test_email_service.py
@@ -144,6 +144,46 @@ async def test_logging_send_erasure_confirmation_does_not_log_raw_token():
     assert confirm_url not in haystack, "confirm_url leaked into log payload"
 
 
+@pytest.mark.asyncio
+async def test_logging_send_workspace_invitation_logs_safe_fields_only():
+    """Issue #654: the logging stub records ops-triage metadata but MUST NOT
+    log the accept_url (it embeds the single-use token) or the inviter name."""
+    svc = LoggingEmailService()
+    token = "raw-invite-token-DO-NOT-LEAK-3c"  # noqa: S105
+    accept_url = f"https://app.example.com/invite/{token}"
+
+    with patch.object(email_service_module, "logger") as mock_logger:
+        result = await svc.send_workspace_invitation(
+            to_email="invitee@example.com",
+            inviter_name="Alice Admin",
+            workspace_name="Acme Research",
+            accept_url=accept_url,
+            expires_at_iso="2026-06-01T00:00:00Z",
+        )
+
+    assert result is True
+    mock_logger.info.assert_called_once()
+    args, kwargs = mock_logger.info.call_args
+    assert args[0] == "workspace_invitation_email"
+    assert kwargs == {
+        "to_email": "invitee@example.com",
+        "workspace_name": "Acme Research",
+        "expires_at": "2026-06-01T00:00:00Z",
+        "email_dispatch_required": True,
+        "template": "workspace_invitation",
+    }
+
+    haystack_parts: list[str] = []
+    for method_call in mock_logger.method_calls:
+        _name, m_args, m_kwargs = method_call
+        haystack_parts.extend(str(a) for a in m_args)
+        haystack_parts.extend(f"{k}={v}" for k, v in m_kwargs.items())
+    haystack = " ".join(haystack_parts)
+    assert token not in haystack, "invitation token leaked into log payload"
+    assert accept_url not in haystack, "accept_url leaked into log payload"
+    assert "Alice Admin" not in haystack, "inviter name leaked into log payload"
+
+
 # ---------------------------------------------------------------------------
 # Singleton + provider switch
 # ---------------------------------------------------------------------------

--- a/docs/ops/invitation-email-runbook.md
+++ b/docs/ops/invitation-email-runbook.md
@@ -1,0 +1,63 @@
+# Workspace Invitation Email Runbook (Issue #654)
+
+Creating a workspace invitation (`POST /api/v1/workspaces/{id}/invitations`)
+dispatches an invitation email to the invitee. This is a **courtesy
+notification**: the invitation row is the source of truth, so a failed email
+never blocks or rolls back the invitation. The admin who created the invite
+always receives the accept URL in the API response and can hand-deliver it if
+needed.
+
+## Providers
+
+Delivery is governed by `EMAIL_PROVIDER` (shared with the account-erasure
+emails — see `docs/ops/erasure-runbook.md`):
+
+| `EMAIL_PROVIDER` | Behavior |
+|---|---|
+| `logging` (default) | No email is sent. A structured log line `workspace_invitation_email` is written with `to_email`, `workspace_name`, `expires_at`, `template`. The **accept URL / token is NOT logged** (it is the credential). The admin delivers the URL from the API response. |
+| `resend` | The email ships via Resend over HTTPS. The accept URL goes to the invitee inbox only — never to local logs. |
+
+## Flipping to Resend
+
+No invitation-specific configuration exists — the invitation email reuses the
+`#478` Resend wiring. To enable real delivery (see `.env.example` lines 71–75):
+
+1. Verify a sending domain in Resend and set `RESEND_FROM_EMAIL` to an address
+   on that domain.
+2. Set `RESEND_API_KEY` (scope it to the single sending domain).
+3. **DPA prerequisite** — accept the Resend Data Processing Addendum
+   (<https://resend.com/legal/dpa>) and record it in
+   `RESEND_DPA_ACCEPTED_AT` (ISO-8601 UTC). The backend refuses to boot with
+   `EMAIL_PROVIDER=resend` unless `RESEND_FROM_EMAIL` is set
+   (`Settings._validate_resend_config`).
+4. Set `EMAIL_PROVIDER=resend` and restart the API.
+5. Ensure `FRONTEND_URL` is the deployed origin — the absolute accept URL is
+   built as `{FRONTEND_URL}/invite/{token}` (`build_invitation_url` in
+   `services/invitation_service.py`, shared with the API response so the two
+   can never drift).
+
+## Sub-processor disclosure
+
+Resend is a personal-data sub-processor (it receives the invitee email address
+and the invitation link). Its disclosure lives in the **Privacy Policy**
+sub-processor list (same entry added for `#478` / `#379`); no new disclosure is
+required for invitations — confirm the existing Resend entry is published
+before flipping `EMAIL_PROVIDER=resend` in production.
+
+## Verifying
+
+- **Logging mode**: create an invitation and grep production logs for
+  `workspace_invitation_email`. Confirm the line carries `email_dispatch_required=true`
+  and does **not** contain the token or accept URL.
+- **Resend mode** (manual pre-flip smoke): with a Resend sandbox key, create an
+  invitation to an address you control and confirm receipt + that the
+  `{FRONTEND_URL}/invite/{token}` link resolves. CI uses mocks; this smoke is a
+  manual gate (see the external-integration smoke pattern).
+- A Resend SDK failure (network / 4xx / 5xx) logs `workspace_invitation_email_failed`
+  with only `error_type` + `status_code` (no body, no URL) and returns `False`;
+  the invitation row still commits.
+
+## Out of scope (deferred)
+
+HTML/branded template, Resend webhooks (delivery/bounce), reminder emails,
+localized copy, and per-recipient rate limiting are tracked separately.


### PR DESCRIPTION
Closes #654

## Summary
Wire `InvitationService` to the existing #478 transactional-email infrastructure so creating a workspace invitation (`POST /api/v1/workspaces/{id}/invitations`) dispatches the invitation email automatically, instead of an admin hand-delivering the URL. When `EMAIL_PROVIDER=logging` (default) nothing is sent; when `EMAIL_PROVIDER=resend` the email ships via Resend.

## Implementation
- **Protocol + both providers** gain `send_workspace_invitation(*, to_email, inviter_name, workspace_name, accept_url, expires_at_iso) -> bool`. Plain-text body v1, mirroring `send_erasure_*`. The `accept_url` embeds the single-use token, so it is **never logged**: `LoggingEmailService` redacts it; `ResendEmailService` keeps it out of `log_context`, and the shared `_send` error path already logs only `error_type`/`status_code` (never `str(exc)`).
- **`InvitationService.create_invitation`** dispatches the email after the row is flushed, as a **courtesy notification** — a failing/raising provider (or inviter resolution) can never roll back the invitation (`_dispatch_invitation_email` is fully guarded). The provider is resolved **lazily at send time** so read-only `InvitationService` constructions (e.g. the registration gate) don't pull in provider init.
- **`build_invitation_url` moved** from the route into the service so the API response and the email share one builder (no URL drift); reuses `FRONTEND_URL` — **no new env var**. Expiry rendered via `to_utc_iso` (Z-suffix, #489 guard); `None` → "does not expire".
- Constructor gains an `email_service` injection param (mirrors `AccountErasureService`) for testability.

## Transactional placement (known trade-off)
The send happens inside `create_invitation` after `flush()` (the route commits later) — matching the account-erasure precedent. The do-not-rollback contract (email failure ⇏ invitation rollback) is satisfied. The inverse — an outer-commit failure after a successful send → an orphan email with a dead `/invite` link — is the accepted trade-off for a *courtesy* notification (the row, not the email, is the source of truth; the admin re-invites). A post-commit dispatch is noted as a future option if Resend latency ever pressures the connection pool.

## Tests (39 pass in scope; ruff + pyright clean)
- Resend provider (+5): happy-path SDK payload; no-expiry → "does not expire"; SDK raise → False; token/accept_url **not** in logs on success **and** failure (SDK exc echoing the URL).
- Logging provider (+1): exact safe-fields-only log; token/accept_url/inviter **not** logged.
- Integration (+4, real DB): dispatch args (`to_email`/`workspace_name`/`inviter_name`/`accept_url` ends `/invite/{token}`/Z-suffix expiry); never-expires → `None`; parametrized `[raise, false]` → invitation row still present after email failure.

## Runbook
`docs/ops/invitation-email-runbook.md`: how to flip `EMAIL_PROVIDER=resend`, the DPA prerequisite (`RESEND_DPA_ACCEPTED_AT`), and the sub-processor disclosure cross-reference.

## Pre-PR review summary
- gate2 mode: advisor-only — cso: green · qa-lead: green · cto: green
- gate1: green via /ask (CSO lens)
- review provider: code-review (2 independent agents → security clean; correctness found 2 [Med]: the orphan-email trade-off, documented above, and eager provider resolution, **fixed** via lazy resolution)

🤖 Generated via /gh-issue-driven:ship
