### PR TITLE
fix(neural): origin-aware conflict resolution in transfer_edges (#725)

### DIFF
--- a/backend/src/repositories/neural_edge.py
+++ b/backend/src/repositories/neural_edge.py
@@ -1243,15 +1243,40 @@ class NeuralEdgeRepository:
             existing_edge = conflict_result.scalar_one_or_none()
 
             if existing_edge and existing_edge.id != edge.id:
-                # Keep the edge with higher weight, delete the other
-                if existing_edge.weight >= edge.weight:
-                    await self.db.delete(edge)
+                # Origin-aware conflict resolution (#725). A non-hebbian edge
+                # (semantic/declared) must not be displaced by a hebbian one
+                # regardless of weight, mirroring the sticky-upsert guard in
+                # create_or_update_edge (#722). Only same-origin-tier conflicts
+                # fall back to the weight tie-break (heavier wins, existing on
+                # tie — preserving the pre-#725 behavior). Declared and semantic
+                # share the non-hebbian tier here, so neither can lose to a
+                # hebbian edge; declared-vs-semantic merges are resolved by
+                # weight, which is acceptable for the dedup-merge path.
+                existing_is_hebbian = existing_edge.origin == EDGE_ORIGIN_HEBBIAN
+                incoming_is_hebbian = edge.origin == EDGE_ORIGIN_HEBBIAN
+
+                if existing_is_hebbian and not incoming_is_hebbian:
+                    keep_incoming = True
+                elif not existing_is_hebbian and incoming_is_hebbian:
+                    keep_incoming = False
                 else:
+                    keep_incoming = edge.weight > existing_edge.weight
+
+                if keep_incoming:
                     await self.db.delete(existing_edge)
+                    # Flush the DELETE before re-pointing the incoming edge onto
+                    # the now-freed (new_src, new_dst) slot. Without this the
+                    # unit-of-work can emit the UPDATE before the DELETE, both
+                    # rows momentarily occupy the (user_id, src_id, dst_id)
+                    # unique_edge key, and Postgres raises UniqueViolationError.
+                    # flush() (not commit()) keeps the caller's tx boundary.
+                    await self.db.flush()
                     edge.src_id = new_src
                     edge.dst_id = new_dst
                     edge.last_updated = utcnow()
                     transferred += 1
+                else:
+                    await self.db.delete(edge)
                 continue
 
             # Update edge to point to winner

--- a/backend/tests/repositories/conftest.py
+++ b/backend/tests/repositories/conftest.py
@@ -5,16 +5,67 @@ discoverable by pytest in this subdirectory, and adds fixtures specific
 to neural-edge origin tests.
 """
 
+from uuid import uuid4
+
 import pytest_asyncio
 
+from models.auth import Context, Workspace
 from models.memory import (
     EDGE_ORIGIN_HEBBIAN,
     EDGE_ORIGIN_SEMANTIC,
+    Memory,
     NeuralMemoryEdge,
 )
 
 # Re-export so pytest can discover it in this directory tree.
 from tests.neural.conftest import sample_memory_pair  # noqa: F401
+
+
+@pytest_asyncio.fixture
+async def sample_memory_triple(db_session):
+    """Create three Memory rows (A, B, C) sharing a Workspace + Context.
+
+    Used by transfer_edges conflict tests (#725): A and B both have an
+    outgoing edge to C, so merging B into A forces a (A, C) edge conflict.
+    """
+    ws = Workspace(
+        id=uuid4(),
+        name=f"transfer-test-ws-{uuid4().hex[:8]}",
+        plan_name="free",
+        owner_user_id="test_user",
+        memory_limit=10000,
+        daily_api_limit=5000,
+        weekly_api_limit=25000,
+    )
+    db_session.add(ws)
+    await db_session.flush()
+
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"transfer-test-ctx-{uuid4().hex[:8]}",
+        created_by="test_user",
+        is_private=False,
+    )
+    db_session.add(ctx)
+    await db_session.flush()
+
+    nodes = [
+        Memory(
+            id=uuid4(),
+            user_id="test_user",
+            workspace_id=ws.id,
+            context_id=ctx.id,
+            summary=f"node {label}",
+            content=f"{label} content",
+            type="note",
+            client="test",
+        )
+        for label in ("A", "B", "C")
+    ]
+    db_session.add_all(nodes)
+    await db_session.flush()
+    return tuple(nodes)
 
 
 @pytest_asyncio.fixture

--- a/backend/tests/repositories/test_neural_edge_transfer_origin.py
+++ b/backend/tests/repositories/test_neural_edge_transfer_origin.py
@@ -1,0 +1,112 @@
+"""Origin-aware conflict resolution in transfer_edges (Issue #725).
+
+Sleep dedup merge calls NeuralEdgeRepository.transfer_edges to reassign edges
+from a merged (loser) memory onto the winner. When both memories have an edge
+to the same neighbor, the resulting (winner, neighbor) edges conflict. Before
+#725 the tie-break was weight-only, so a heavier hebbian edge could silently
+delete a lighter semantic edge. These tests pin the origin-aware behavior:
+a non-hebbian (semantic/declared) edge must survive a hebbian conflict
+regardless of weight, while same-origin-tier conflicts still use weight.
+"""
+
+import pytest
+
+from models.memory import (
+    EDGE_ORIGIN_HEBBIAN,
+    EDGE_ORIGIN_SEMANTIC,
+    NeuralMemoryEdge,
+)
+from repositories.neural_edge import NeuralEdgeRepository
+
+
+def _make_edge(src, neighbor, *, origin, weight):
+    """Build a src->neighbor edge sharing the nodes' workspace/context."""
+    return NeuralMemoryEdge(
+        user_id=src.user_id,
+        src_id=src.id,
+        dst_id=neighbor.id,
+        workspace_id=src.workspace_id,
+        context_id=src.context_id,
+        edge_type="related_to" if origin == EDGE_ORIGIN_SEMANTIC else "neural_association",
+        weight=weight,
+        confidence=1.0,
+        origin=origin,
+    )
+
+
+async def _merge_b_into_a(db_session, a, b):
+    """Run transfer_edges(from=B, to=A) and flush pending mutations."""
+    repo = NeuralEdgeRepository(db_session)
+    transferred = await repo.transfer_edges(
+        from_node_id=b.id,
+        to_node_id=a.id,
+        user_id=a.user_id,
+        workspace_id=str(a.workspace_id),
+        context_id=str(a.context_id),
+    )
+    await db_session.flush()
+    return repo, transferred
+
+
+@pytest.mark.asyncio
+async def test_transfer_semantic_survives_heavier_hebbian(db_session, sample_memory_triple):
+    """A(semantic 0.75 -> C) + B(hebbian 0.80 -> C); merging B into A keeps semantic."""
+    a, b, c = sample_memory_triple
+    db_session.add_all(
+        [
+            _make_edge(a, c, origin=EDGE_ORIGIN_SEMANTIC, weight=0.75),
+            _make_edge(b, c, origin=EDGE_ORIGIN_HEBBIAN, weight=0.80),
+        ]
+    )
+    await db_session.flush()
+
+    repo, _ = await _merge_b_into_a(db_session, a, b)
+
+    surviving = await repo.get_edge(a.user_id, a.id, c.id)
+    assert surviving is not None
+    assert surviving.origin == EDGE_ORIGIN_SEMANTIC  # not displaced by heavier hebbian
+    assert surviving.weight == pytest.approx(0.75)
+
+
+@pytest.mark.asyncio
+async def test_transfer_same_origin_uses_weight_tiebreak(db_session, sample_memory_triple):
+    """A(semantic 0.75 -> C) + B(semantic 0.80 -> C); same tier -> heavier wins."""
+    a, b, c = sample_memory_triple
+    db_session.add_all(
+        [
+            _make_edge(a, c, origin=EDGE_ORIGIN_SEMANTIC, weight=0.75),
+            _make_edge(b, c, origin=EDGE_ORIGIN_SEMANTIC, weight=0.80),
+        ]
+    )
+    await db_session.flush()
+
+    repo, _ = await _merge_b_into_a(db_session, a, b)
+
+    surviving = await repo.get_edge(a.user_id, a.id, c.id)
+    assert surviving is not None
+    assert surviving.origin == EDGE_ORIGIN_SEMANTIC
+    assert surviving.weight == pytest.approx(0.80)  # heavier incoming replaced existing
+
+
+@pytest.mark.asyncio
+async def test_transfer_semantic_replaces_heavier_hebbian_existing(
+    db_session, sample_memory_triple
+):
+    """A(hebbian 0.80 -> C) + B(semantic 0.75 -> C); incoming semantic still wins."""
+    a, b, c = sample_memory_triple
+    db_session.add_all(
+        [
+            _make_edge(a, c, origin=EDGE_ORIGIN_HEBBIAN, weight=0.80),
+            _make_edge(b, c, origin=EDGE_ORIGIN_SEMANTIC, weight=0.75),
+        ]
+    )
+    await db_session.flush()
+
+    repo, _ = await _merge_b_into_a(db_session, a, b)
+
+    surviving = await repo.get_edge(a.user_id, a.id, c.id)
+    assert surviving is not None
+    assert (
+        surviving.origin == EDGE_ORIGIN_SEMANTIC
+    )  # replaces existing hebbian despite lower weight
+    assert surviving.weight == pytest.approx(0.75)


### PR DESCRIPTION
Closes #725

## Summary
- Make `NeuralEdgeRepository.transfer_edges` conflict resolution origin-aware before weight: a non-hebbian (semantic/declared) edge is never displaced by a hebbian one during sleep dedup merge.
- Same-origin-tier conflicts still use the weight tie-break (heavier wins, existing on tie — preserves pre-#725 behavior), mirroring the #722 sticky-upsert guard in `create_or_update_edge`.
- Fix a latent `unique_edge` `UniqueViolationError` on the replace path by flushing the DELETE of the displaced edge before re-pointing the incoming edge onto the freed `(user_id, src_id, dst_id)` slot. This path had no test coverage and prod `merged=0`, so it was never exercised.

## Implementation notes
- `backend/src/repositories/neural_edge.py`: 2-tier origin priority (declared+semantic = non-hebbian) before the weight comparison; `await self.db.flush()` between delete-existing and reassign-incoming. `flush()` (not `commit()`) keeps the caller's transaction boundary intact.
- `origin` is `nullable=False server_default='hebbian'`, so the equality checks are safe (no NULL/legacy path).
- Tests: new `sample_memory_triple` fixture + `test_neural_edge_transfer_origin.py` (3 DB-backed tests). 12 targeted + 72 regression (dedup-merge + all repository tests) pass.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
