### PR TITLE
feat(neural): origin-aware filter for HebbianLearner.prune_weak_edges (#724)

### DIFF
--- a/backend/src/neural/hebbian.py
+++ b/backend/src/neural/hebbian.py
@@ -21,6 +21,7 @@ References:
 import logging
 from collections import defaultdict
 
+from models.memory import EDGE_ORIGIN_HEBBIAN
 from src.services.graph_service import GraphService as GraphMemory
 
 from .config import NeuralMemoryConfig
@@ -371,11 +372,18 @@ class HebbianLearner:
             from uuid import UUID
 
             node_uuid = UUID(node_id) if isinstance(node_id, str) else node_id
+            # Issue #724: only Hebbian-origin edges participate in the per-node
+            # top-M cap. Semantic/declared edges (origin != 'hebbian') are exempt
+            # from this pruner — they are managed by sleep edge_discovery and the
+            # decay carve-out (#722) — so they can never be evicted here, nor do
+            # they consume the top_m_edges budget. The filter is pushed into SQL
+            # via get_outgoing_edges(origin=...) (#741).
             outgoing_edges = await self.graph.edge_repo.get_outgoing_edges(
                 user_id,
                 node_uuid,
                 workspace_id=self.graph.workspace_id,
                 context_id=self.graph.context_id,
+                origin=EDGE_ORIGIN_HEBBIAN,
             )
         except Exception as e:
             logger.error(f"Failed to get outgoing edges for node {node_id}: {e}")

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -1,9 +1,13 @@
 """Tests for HebbianLearner."""
 
 from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
 
 import pytest
 
+from models.memory import EDGE_ORIGIN_HEBBIAN, EDGE_ORIGIN_SEMANTIC
 from neural.config import NeuralMemoryConfig
 from neural.hebbian import HebbianLearner
 from neural.models import ActivationState, MemoryKind, NeuralMemoryNode
@@ -289,3 +293,46 @@ class TestHebbianLearner:
 
         # Updates should be queued (pair passed gating)
         assert len(learner._update_queue["u"]) == 2  # Bidirectional
+
+    @pytest.mark.asyncio
+    async def test_prune_weak_edges_excludes_semantic_origin(self, mock_graph):
+        """#724: the per-node top-M pruner only considers hebbian edges.
+
+        A semantic edge survives even when it is the weakest edge overall and
+        would have been pruned first under the old unfiltered weight sort.
+        """
+        config = NeuralMemoryConfig(top_m_edges=2)
+        learner = HebbianLearner(mock_graph, config)
+
+        node_id = str(uuid4())
+        # 3 hebbian edges (1 exceeds top_m=2) + 1 semantic edge that is the
+        # weakest overall — it must NOT be pruned and must NOT count toward top-M.
+        hebbian = [
+            SimpleNamespace(dst_id=uuid4(), weight=w, origin=EDGE_ORIGIN_HEBBIAN)
+            for w in (0.5, 0.6, 0.7)
+        ]
+        semantic = SimpleNamespace(dst_id=uuid4(), weight=0.05, origin=EDGE_ORIGIN_SEMANTIC)
+        all_edges = hebbian + [semantic]
+
+        async def fake_get_outgoing(user_id, src_id, **kwargs):
+            # Mirror the SQL-side origin filter (#741): return only matching rows.
+            origin = kwargs.get("origin")
+            if origin is None:
+                return all_edges
+            return [e for e in all_edges if e.origin == origin]
+
+        mock_graph.edge_repo.get_outgoing_edges = AsyncMock(side_effect=fake_get_outgoing)
+        mock_graph.remove_edge = AsyncMock()
+
+        removed = await learner.prune_weak_edges("u", node_id)
+
+        # The pruner must request the hebbian-filtered list.
+        assert (
+            mock_graph.edge_repo.get_outgoing_edges.await_args.kwargs["origin"]
+            == EDGE_ORIGIN_HEBBIAN
+        )
+        # Exactly one (weakest) hebbian edge pruned; the semantic edge is untouched.
+        assert removed == 1
+        removed_dsts = {call.args[1] for call in mock_graph.remove_edge.await_args_list}
+        assert str(semantic.dst_id) not in removed_dsts
+        assert str(hebbian[0].dst_id) in removed_dsts  # weight 0.5 — weakest hebbian


### PR DESCRIPTION
Closes #724

## Summary
- Make `HebbianLearner.prune_weak_edges` (the per-node top-M pruner) origin-aware: only `origin='hebbian'` edges participate in the top-M weight sort and prune.
- Semantic/declared edges are now exempt from this pruner — they are managed by sleep `edge_discovery` and the #722 decay carve-out — so they can no longer be evicted once enough hebbian edges exceed `top_m_edges`, and they do not consume the top-M budget.

## Implementation notes
- `backend/src/neural/hebbian.py`: pass `origin=EDGE_ORIGIN_HEBBIAN` to `get_outgoing_edges` (the SQL-side origin filter added in #741, Option B — preferred over a Python-level loop). One-line behavioral change plus the import.
- Mirrors the sibling fix #725 (origin-aware conflict resolution in `transfer_edges`); both close adjacent code paths the #722 parent PR did not cover.
- Test: new mock-based unit test in `tests/neural/test_hebbian.py` — node with 3 hebbian + 1 (weakest) semantic edge prunes one hebbian, semantic untouched, and asserts the pruner requested the hebbian-filtered list. 135 neural tests pass.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CTO lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
