### PR TITLE
test(neural): pin neural-metrics consolidation under 3-level isolation (#659)

### DIFF
--- a/backend/tests/services/sleep/test_consolidation.py
+++ b/backend/tests/services/sleep/test_consolidation.py
@@ -220,6 +220,25 @@ def _isolation_memory(*, importance, access_count, age_days):
     return m
 
 
+def _assert_graph_service_isolation(mock_graph_service):
+    """Pin that GraphService was constructed with the isolation identifiers.
+
+    The #659 requirement is 3-level isolation: execute() must build
+    ``GraphService(user_id, db, workspace_id, context_id)``. Without this
+    assertion a regression to ``GraphService(user_id, db)`` — or swapped /
+    dropped ws/ctx — would still pass the behavioral checks while silently
+    violating the isolation contract (Copilot review on PR #838).
+    """
+    mock_graph_service.assert_called_once()
+    args, kwargs = mock_graph_service.call_args
+    # consolidation.py constructs it positionally:
+    #   GraphService(user_id, self.db, workspace_id, context_id)
+    passed_workspace = args[2] if len(args) > 2 else kwargs.get("workspace_id")
+    passed_context = args[3] if len(args) > 3 else kwargs.get("context_id")
+    assert passed_workspace == "ws", "GraphService must receive workspace_id (3-level isolation)"
+    assert passed_context == "ctx", "GraphService must receive context_id (3-level isolation)"
+
+
 class TestNeuralMetricsUnderIsolation:
     """Issue #659: drive ConsolidationPhase.execute() end-to-end to pin the
     neural-metrics promotion criteria and the is_isolated deletion guard under
@@ -249,7 +268,9 @@ class TestNeuralMetricsUnderIsolation:
         )
         with (
             patch("services.sleep.consolidation.MemoryRepository"),
-            patch("services.sleep.consolidation.GraphService", return_value=graph),
+            patch(
+                "services.sleep.consolidation.GraphService", return_value=graph
+            ) as mock_graph_service,
             patch(
                 "services.sleep.consolidation.delete_memory_from_qdrant", new_callable=AsyncMock
             ) as del_qdrant,
@@ -260,6 +281,7 @@ class TestNeuralMetricsUnderIsolation:
             # LLM off → borderline memories are left untouched.
             result = await phase.execute(_make_config(provider=""), "u", "ws", "ctx", SleepBudget())
 
+        _assert_graph_service_isolation(mock_graph_service)
         phase.memory_repo.delete.assert_not_called()
         del_qdrant.assert_not_called()
         phase.memory_repo.promote_to_persistent.assert_not_called()
@@ -282,7 +304,9 @@ class TestNeuralMetricsUnderIsolation:
         )
         with (
             patch("services.sleep.consolidation.MemoryRepository"),
-            patch("services.sleep.consolidation.GraphService", return_value=graph),
+            patch(
+                "services.sleep.consolidation.GraphService", return_value=graph
+            ) as mock_graph_service,
             patch("services.sleep.consolidation.delete_memory_from_qdrant", new_callable=AsyncMock),
         ):
             phase = ConsolidationPhase(mock_db, mock_llm)
@@ -290,6 +314,7 @@ class TestNeuralMetricsUnderIsolation:
             phase._fetch_working_memories = AsyncMock(return_value=[mem])
             result = await phase.execute(_make_config(provider=""), "u", "ws", "ctx", SleepBudget())
 
+        _assert_graph_service_isolation(mock_graph_service)
         phase.memory_repo.promote_to_persistent.assert_awaited_once_with(mem.id)
         assert result.details["rule_promoted"] == 1
 
@@ -312,7 +337,9 @@ class TestNeuralMetricsUnderIsolation:
         )
         with (
             patch("services.sleep.consolidation.MemoryRepository"),
-            patch("services.sleep.consolidation.GraphService", return_value=graph),
+            patch(
+                "services.sleep.consolidation.GraphService", return_value=graph
+            ) as mock_graph_service,
             patch("services.sleep.consolidation.delete_memory_from_qdrant", new_callable=AsyncMock),
         ):
             phase = ConsolidationPhase(mock_db, mock_llm)
@@ -320,5 +347,6 @@ class TestNeuralMetricsUnderIsolation:
             phase._fetch_working_memories = AsyncMock(return_value=[mem])
             await phase.execute(_make_config(provider=""), "u", "ws", "ctx", SleepBudget())
 
+        _assert_graph_service_isolation(mock_graph_service)
         graph.get_node_metrics.assert_awaited()
         assert graph.get_node_metrics.await_count == 1

--- a/backend/tests/services/sleep/test_consolidation.py
+++ b/backend/tests/services/sleep/test_consolidation.py
@@ -4,6 +4,7 @@ Issue #103: Rule-based parity with legacy consolidation_task,
 LLM borderline path, bridge node protection.
 """
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -11,6 +12,7 @@ import pytest
 
 from services.sleep.consolidation import ConsolidationPhase
 from services.sleep.reporter import SleepBudget
+from utils.datetime import utcnow
 
 
 @pytest.fixture
@@ -202,3 +204,121 @@ class TestLLMJudgeParsing:
                 decisions[label_to_id[label]] = action
 
         assert len(decisions) == 0
+
+
+def _isolation_memory(*, importance, access_count, age_days):
+    """Build a working Memory with a concrete created_at so the age computed
+    inside ConsolidationPhase.execute() matches `age_days` exactly."""
+    m = MagicMock()
+    m.id = uuid4()
+    m.summary = "isolation test memory"
+    m.type = "note"
+    m.importance = importance
+    m.access_count = access_count
+    m.scope = "working"
+    m.created_at = utcnow() - timedelta(days=age_days)
+    return m
+
+
+class TestNeuralMetricsUnderIsolation:
+    """Issue #659: drive ConsolidationPhase.execute() end-to-end to pin the
+    neural-metrics promotion criteria and the is_isolated deletion guard under
+    the 3-level isolation model.
+
+    Unlike TestDeletionSafety / TestRuleBasedPromotion (which re-implement the
+    boolean formulas inline), these tests exercise the real code path so they
+    catch the Issue #44 class of regression — e.g. a missing ``await`` on
+    ``get_node_metrics`` that previously made the whole neural branch a silent
+    no-op (#651 root cause).
+    """
+
+    @pytest.mark.asyncio
+    async def test_does_not_delete_connected_memory(self, mock_db, mock_llm):
+        """is_isolated=False old/unused memory is NOT deleted (bridge protection)."""
+        mem = _isolation_memory(importance=0.3, access_count=0, age_days=40)
+        graph = MagicMock()
+        graph.stats = AsyncMock(return_value={"total_edges": 3})
+        graph.get_node_metrics = AsyncMock(
+            return_value={
+                "centrality": 0.1,
+                "edge_count": 2,
+                "avg_edge_weight": 0.2,
+                "is_hub_node": False,
+                "is_isolated": False,
+            }
+        )
+        with (
+            patch("services.sleep.consolidation.MemoryRepository"),
+            patch("services.sleep.consolidation.GraphService", return_value=graph),
+            patch(
+                "services.sleep.consolidation.delete_memory_from_qdrant", new_callable=AsyncMock
+            ) as del_qdrant,
+        ):
+            phase = ConsolidationPhase(mock_db, mock_llm)
+            phase.memory_repo = AsyncMock()
+            phase._fetch_working_memories = AsyncMock(return_value=[mem])
+            # LLM off → borderline memories are left untouched.
+            result = await phase.execute(_make_config(provider=""), "u", "ws", "ctx", SleepBudget())
+
+        phase.memory_repo.delete.assert_not_called()
+        del_qdrant.assert_not_called()
+        phase.memory_repo.promote_to_persistent.assert_not_called()
+        assert result.details["rule_deleted"] == 0
+
+    @pytest.mark.asyncio
+    async def test_neural_metrics_promotion_under_isolation(self, mock_db, mock_llm):
+        """High centrality promotes a memory that no Issue #1 rule would promote."""
+        mem = _isolation_memory(importance=0.3, access_count=0, age_days=5)
+        graph = MagicMock()
+        graph.stats = AsyncMock(return_value={"total_edges": 10})
+        graph.get_node_metrics = AsyncMock(
+            return_value={
+                "centrality": 0.9,  # >= NEURAL_CENTRALITY_THRESHOLD (0.7)
+                "edge_count": 2,
+                "avg_edge_weight": 0.2,
+                "is_hub_node": False,
+                "is_isolated": False,
+            }
+        )
+        with (
+            patch("services.sleep.consolidation.MemoryRepository"),
+            patch("services.sleep.consolidation.GraphService", return_value=graph),
+            patch("services.sleep.consolidation.delete_memory_from_qdrant", new_callable=AsyncMock),
+        ):
+            phase = ConsolidationPhase(mock_db, mock_llm)
+            phase.memory_repo = AsyncMock()
+            phase._fetch_working_memories = AsyncMock(return_value=[mem])
+            result = await phase.execute(_make_config(provider=""), "u", "ws", "ctx", SleepBudget())
+
+        phase.memory_repo.promote_to_persistent.assert_awaited_once_with(mem.id)
+        assert result.details["rule_promoted"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_node_metrics_is_awaited(self, mock_db, mock_llm):
+        """Regression guard for the #44/#651 missing-await: get_node_metrics is
+        actually awaited (an unawaited coroutine would raise TypeError on the
+        ``neural_metrics['centrality']`` subscript and be silently swallowed)."""
+        mem = _isolation_memory(importance=0.3, access_count=0, age_days=5)
+        graph = MagicMock()
+        graph.stats = AsyncMock(return_value={"total_edges": 4})
+        graph.get_node_metrics = AsyncMock(
+            return_value={
+                "centrality": 0.9,
+                "edge_count": 1,
+                "avg_edge_weight": 0.2,
+                "is_hub_node": False,
+                "is_isolated": False,
+            }
+        )
+        with (
+            patch("services.sleep.consolidation.MemoryRepository"),
+            patch("services.sleep.consolidation.GraphService", return_value=graph),
+            patch("services.sleep.consolidation.delete_memory_from_qdrant", new_callable=AsyncMock),
+        ):
+            phase = ConsolidationPhase(mock_db, mock_llm)
+            phase.memory_repo = AsyncMock()
+            phase._fetch_working_memories = AsyncMock(return_value=[mem])
+            await phase.execute(_make_config(provider=""), "u", "ws", "ctx", SleepBudget())
+
+        graph.get_node_metrics.assert_awaited()
+        assert graph.get_node_metrics.await_count == 1


### PR DESCRIPTION
Closes #659

## Summary
- Add `TestNeuralMetricsUnderIsolation` to `tests/services/sleep/test_consolidation.py` — the three regression tests issue #659 specifies, all driving `ConsolidationPhase.execute()` end-to-end.
- **Scope clarification (Option c):** the Issue #44 neural-metrics promotion + `is_isolated` deletion guard already exist — correct and fully awaited — in `services/sleep/consolidation.py` (the production `SLEEP_ENABLED=true` path), which constructs `GraphService(user_id, db, workspace_id, context_id)` and awaits `get_node_metrics` (lines 87/106/205). #651 only dropped the broken copy from the legacy global `consolidation_task`. The legacy task intentionally stays neural-free (it is global cross-tenant and reviving metrics there would re-introduce the #651 isolation anti-pattern).
- So #659's real gap was **test coverage**: the existing `TestDeletionSafety` / `TestRuleBasedPromotion` tests re-implement the boolean formulas inline and never exercise the production code path.

## Implementation notes
- New tests (test-only PR — no production code changed):
  - `test_does_not_delete_connected_memory` — `is_isolated=False` old/unused memory is NOT deleted (bridge-node protection; the qa-lead caveat from PR #656).
  - `test_neural_metrics_promotion_under_isolation` — `centrality >= 0.7` promotes a memory no Issue #1 rule would promote.
  - `test_get_node_metrics_is_awaited` — async-correctness guard for the #44/#651 missing-`await` class of regression (an unawaited coroutine TypeErrors on the `["centrality"]` subscript and is silently swallowed).
- `_isolation_memory` helper sets a concrete `created_at` so the age computed inside `execute()` matches the intended `age_days`.
- 150 sleep + neural-task tests pass.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /ask (CTO lens) — scope clarified to test-only (implementation pre-exists in sleep path); auto-accepted under /goal autonomy
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
