### PR TITLE
ci(frontend): wire Playwright a11y job into CI (#786)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,45 @@ jobs:
         env:
           NEXT_PUBLIC_API_URL: http://localhost:8080
 
+  # Accessibility (color-contrast) checks via Playwright + @axe-core (#780).
+  # Scoped to `e2e/a11y` only — the full `test:e2e` suite includes
+  # admin-user-detail.spec.ts, whose admin-auth fixture hard-requires a live
+  # backend + E2E_ADMIN_* secrets and would fail here. The a11y specs are
+  # hermetic: playwright.config.ts auto-starts `next dev` and /login renders
+  # without auth. Required-check promotion is deferred to #768 (after 5
+  # consecutive green runs).
+  frontend-a11y:
+    runs-on: ubuntu-latest
+    needs: [frontend]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: cd frontend && npm ci
+
+      - name: Install Playwright browser
+        run: cd frontend && npx playwright install chromium --with-deps
+
+      - name: Run a11y tests
+        run: cd frontend && npm run test:a11y
+        env:
+          NEXT_PUBLIC_API_URL: http://localhost:8080
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7
+
   # Detect which paths changed so backend-integration only runs when
   # relevant. GHA does not expose `github.event.pull_request.changed_files`
   # — this is the standard monorepo path-gating pattern via

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:a11y": "playwright test e2e/a11y"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -11,7 +11,10 @@ import { defineConfig } from "@playwright/test";
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: false,
-  reporter: process.env.CI ? "github" : "list",
+  // CI: `github` emits inline log annotations; `html` writes the
+  // `playwright-report/` directory that the frontend-a11y job uploads as a
+  // failure artifact (#786). `open: never` keeps the run non-interactive.
+  reporter: process.env.CI ? [["github"], ["html", { open: "never" }]] : "list",
   use: {
     baseURL: "http://localhost:3000",
     trace: "retain-on-failure",


### PR DESCRIPTION
Closes #786

## Summary
- Add a `frontend-a11y` CI job (`needs: [frontend]`) that runs the Playwright color-contrast a11y suite on a self-started `next dev` server.
- Scope the job to `e2e/a11y` via a new `test:a11y` npm script — the full `test:e2e` suite includes `admin-user-detail.spec.ts`, whose `auto`-applied admin-auth fixture hard-throws without a live backend + `E2E_ADMIN_*` secrets and would fail CI.
- Add the `html` reporter under CI so `playwright-report/` is actually produced for the on-failure artifact upload (the `github` reporter alone only emits log annotations).

## Implementation notes
- `playwright.config.ts` already sets `webServer: { command: "npm run dev", reuseExistingServer: !CI }`, so the job needs no separate server step.
- The new job duplicates the `setup-node` + `npm ci` block from `frontend` (inherent to GHA's separate-runner model; a composite/reusable workflow is overkill for two jobs).
- **Scope note vs the issue text**: the issue says `npm run test:e2e`, but that runs the whole `e2e/` dir (incl. the backend-requiring admin spec). Implemented as `test:a11y` (`playwright test e2e/a11y`) instead — verified the filter selects exactly the 2 `login-contrast` tests and excludes `admin-user-detail`.
- Required-check promotion is **deferred to #768** (after 5 consecutive green runs), per the issue.

## Follow-ups (non-blocking, from gate2 qa-lead)
- Consider uploading `test-results/` too, so the html report's "view trace" links resolve in the failure artifact.
- Confirm dev-server-in-CI stability across 5 green runs before #768 flips it to a Required check.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (non-blocking follow-ups above)
- cto: green
- gate1: green via /claude-c-suite:ask (COO)
- review provider: code-review

Full reviews saved in the plugin cache (gate1.md / gate2.md).

🤖 Generated via /gh-issue-driven:ship
