### PR TITLE
test(a11y): authenticated-page contrast specs + shared fixtures (#785)

### DIFF
--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -17,9 +17,50 @@ existing process is reused (`reuseExistingServer: !process.env.CI`).
 
 ## Adding a new a11y page
 
+### Hermetic pages (no auth, no backend) → `e2e/a11y/`
+
 Drop a new spec into `e2e/a11y/<page>-contrast.spec.ts` following the
-`login-contrast.spec.ts` shape — `await page.goto("/<path>")` then
-`await new AxeBuilder({ page }).options({ runOnly: ["color-contrast"] }).analyze()`.
+`login-contrast.spec.ts` shape, using the shared helpers from `e2e/fixtures.ts`:
+
+```ts
+import { test } from "@playwright/test";
+import { assertNoColorContrastViolations, gotoAndWaitStable } from "../fixtures";
+
+test("light mode", async ({ page }) => {
+  await page.emulateMedia({ colorScheme: "light" });
+  await gotoAndWaitStable(page, "/your-path");
+  await assertNoColorContrastViolations(page);
+});
+```
+
+Specs here are run by the hermetic `frontend-a11y` CI job (#786): only a
+`next dev` server is started — **no backend**. Only put pages that render
+meaningfully without auth or seeded data here.
+
+### Authenticated / backend-dependent pages → `e2e/authed-a11y/` (#785)
+
+Pages that need a live backend, an authenticated user, or seeded data
+(`/device`, `/invite/[token]`, `/workspace/dashboard`) live under
+`e2e/authed-a11y/` instead. The path is deliberately **not** matched by the
+hermetic `playwright test e2e/a11y` glob, so these never run in the
+backend-free CI job. Run them locally with the stack up:
+
+```bash
+export E2E_ADMIN_LOGIN_ID="admin"
+export E2E_ADMIN_PASSWORD="<password>"
+export E2E_API_URL="http://localhost:8080"
+npm run test:a11y:authed
+```
+
+Authenticated specs combine `assertNoColorContrastViolations` / `gotoAndWaitStable`
+from `e2e/fixtures.ts` with the `test` from `e2e/fixtures/admin-auth.ts`.
+
+> **Not yet in CI.** Wiring `e2e/authed-a11y/` into a full-stack a11y CI lane
+> (backend services + seed + `storageState` `globalSetup`) — and contrast-testing
+> the fully-seeded happy paths (e.g. a valid invitation, which needs a Pro-plan
+> workspace) — is tracked as a follow-up to #785. The specs here currently cover
+> only the states reachable without seeding (e.g. `/invite` with an unknown
+> token → error screen).
 
 ## Adding a new authenticated admin spec
 

--- a/frontend/e2e/a11y/login-contrast.spec.ts
+++ b/frontend/e2e/a11y/login-contrast.spec.ts
@@ -1,5 +1,8 @@
-import { test, expect } from "@playwright/test";
-import AxeBuilder from "@axe-core/playwright";
+import { test } from "@playwright/test";
+import {
+  assertNoColorContrastViolations,
+  gotoAndWaitStable,
+} from "../fixtures";
 
 /**
  * Color-contrast a11y guard for /login (Issue #780 scaffold).
@@ -7,46 +10,22 @@ import AxeBuilder from "@axe-core/playwright";
  * Covers WCAG 2.1 AA color-contrast (1.4.3) in both light and dark mode via
  * prefers-color-scheme emulation. /login is a deliberate scaffold target
  * because it is always reachable without auth and exercises both the password
- * form and OAuth button surfaces.
+ * form and OAuth button surfaces. Hermetic — runs in the `frontend-a11y` CI
+ * job (#786). The contrast/wait helpers are shared via `e2e/fixtures.ts` (#785).
  *
- * Broader coverage (/device, /invite/[token], /workspace/dashboard) is tracked
- * as a follow-up.
+ * Authenticated-page coverage (/device, /invite/[token], /workspace/dashboard)
+ * lives under `e2e/authed-a11y/` and is NOT part of the hermetic job.
  */
-async function assertNoColorContrastViolations(
-  page: import("@playwright/test").Page,
-) {
-  const results = await new AxeBuilder({ page })
-    .options({ runOnly: ["color-contrast"] })
-    .analyze();
-
-  expect(
-    results.violations,
-    JSON.stringify(results.violations, null, 2),
-  ).toEqual([]);
-}
-
 test.describe("/login color-contrast (#780 scaffold)", () => {
   test("light mode has no color-contrast violations", async ({ page }) => {
     await page.emulateMedia({ colorScheme: "light" });
-    await page.goto("/login", { waitUntil: "domcontentloaded" });
-    // `networkidle` is unreliable against `next dev` because the HMR websocket
-    // keeps the network busy indefinitely. Wait on a stable DOM signal instead.
-    await page.locator("h1, form, main button").first().waitFor({
-      state: "visible",
-      timeout: 15_000,
-    });
+    await gotoAndWaitStable(page, "/login");
     await assertNoColorContrastViolations(page);
   });
 
   test("dark mode has no color-contrast violations", async ({ page }) => {
     await page.emulateMedia({ colorScheme: "dark" });
-    await page.goto("/login", { waitUntil: "domcontentloaded" });
-    // `networkidle` is unreliable against `next dev` because the HMR websocket
-    // keeps the network busy indefinitely. Wait on a stable DOM signal instead.
-    await page.locator("h1, form, main button").first().waitFor({
-      state: "visible",
-      timeout: 15_000,
-    });
+    await gotoAndWaitStable(page, "/login");
     await assertNoColorContrastViolations(page);
   });
 });

--- a/frontend/e2e/authed-a11y/device-contrast.spec.ts
+++ b/frontend/e2e/authed-a11y/device-contrast.spec.ts
@@ -1,0 +1,31 @@
+import { test } from "../fixtures/admin-auth";
+import {
+  assertNoColorContrastViolations,
+  gotoAndWaitStable,
+} from "../fixtures";
+
+/**
+ * Color-contrast a11y guard for /device (Issue #785).
+ *
+ * /device is auth-guarded: unauthenticated users are redirected to /login
+ * (see src/app/device/page.tsx). The `adminAuth` auto-fixture keeps us logged
+ * in so the device-consent chrome (RFC 8628, #633 parity with /login) renders.
+ * With no `user_code` query param the manual code-entry surface is shown —
+ * sufficient for color-contrast coverage of the page's color tokens.
+ *
+ * NON-HERMETIC (needs a live backend + authenticated admin) → lives outside the
+ * hermetic `e2e/a11y` job (#786). Run via `npm run test:a11y:authed`.
+ */
+test.use({ trace: "off" });
+
+test.describe("/device color-contrast (#785)", () => {
+  for (const colorScheme of ["light", "dark"] as const) {
+    test(`${colorScheme} mode has no color-contrast violations`, async ({
+      page,
+    }) => {
+      await page.emulateMedia({ colorScheme });
+      await gotoAndWaitStable(page, "/device");
+      await assertNoColorContrastViolations(page);
+    });
+  }
+});

--- a/frontend/e2e/authed-a11y/invite-contrast.spec.ts
+++ b/frontend/e2e/authed-a11y/invite-contrast.spec.ts
@@ -1,0 +1,31 @@
+import { test } from "@playwright/test";
+import {
+  assertNoColorContrastViolations,
+  gotoAndWaitStable,
+} from "../fixtures";
+
+/**
+ * Color-contrast a11y guard for /invite/[token] (Issue #785).
+ *
+ * /invite is a public route, but its content is backend-driven: the page fetches
+ * GET /api/v1/invitations/{token} and branches on the result
+ * (src/app/invite/[token]/page.tsx). This spec covers the reachable-WITHOUT-seed
+ * state — an unknown token resolves to the error screen — so it needs a live
+ * backend but no Pro-plan workspace or seeded invitation.
+ *
+ * Contrast-testing the fully-seeded happy paths ("login_required" / "email
+ * mismatch" / "success" screens, which require a Pro-plan workspace + a created
+ * invitation) is part of the deferred full-stack a11y CI lane (see the #785
+ * follow-up issue). NON-HERMETIC → outside the hermetic `e2e/a11y` job (#786).
+ */
+test.describe("/invite/[token] color-contrast (#785)", () => {
+  for (const colorScheme of ["light", "dark"] as const) {
+    test(`${colorScheme} mode (unknown token → error screen) has no color-contrast violations`, async ({
+      page,
+    }) => {
+      await page.emulateMedia({ colorScheme });
+      await gotoAndWaitStable(page, "/invite/e2e-a11y-nonexistent-token");
+      await assertNoColorContrastViolations(page);
+    });
+  }
+});

--- a/frontend/e2e/authed-a11y/workspace-dashboard-contrast.spec.ts
+++ b/frontend/e2e/authed-a11y/workspace-dashboard-contrast.spec.ts
@@ -1,0 +1,34 @@
+import { test } from "../fixtures/admin-auth";
+import {
+  assertNoColorContrastViolations,
+  gotoAndWaitStable,
+} from "../fixtures";
+
+/**
+ * Color-contrast a11y guard for /workspace/dashboard (Issue #785).
+ *
+ * NON-HERMETIC: requires a live backend + an authenticated admin (the
+ * `adminAuth` auto-fixture logs in via the API). This is why the spec lives
+ * under `e2e/authed-a11y/` — the path is deliberately NOT matched by the
+ * hermetic `playwright test e2e/a11y` job (#786). Run locally via
+ * `npm run test:a11y:authed` with E2E_ADMIN_* set and the stack up.
+ *
+ * Wiring these authenticated specs into a full-stack CI lane (backend services
+ * + seed + storageState globalSetup) is the deferred follow-up issue.
+ *
+ * `trace: off` per the admin-auth fixture contract — the login POST body would
+ * otherwise be captured in a retained trace on failure.
+ */
+test.use({ trace: "off" });
+
+test.describe("/workspace/dashboard color-contrast (#785)", () => {
+  for (const colorScheme of ["light", "dark"] as const) {
+    test(`${colorScheme} mode has no color-contrast violations`, async ({
+      page,
+    }) => {
+      await page.emulateMedia({ colorScheme });
+      await gotoAndWaitStable(page, "/workspace/dashboard");
+      await assertNoColorContrastViolations(page);
+    });
+  }
+});

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,44 @@
+import { expect, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+
+/**
+ * Shared a11y test helpers (#780 scaffold, extracted in #785).
+ *
+ * Keep this module auth-free so hermetic specs under `e2e/a11y/` can import it
+ * without pulling in the admin-auth fixture. Authenticated specs live under
+ * `e2e/authed-a11y/` and combine these helpers with `e2e/fixtures/admin-auth`.
+ */
+
+/** Assert WCAG 2.1 AA color-contrast (1.4.3) has no violations on the current page. */
+export async function assertNoColorContrastViolations(
+  page: Page,
+): Promise<void> {
+  const results = await new AxeBuilder({ page })
+    .options({ runOnly: ["color-contrast"] })
+    .analyze();
+
+  expect(
+    results.violations,
+    JSON.stringify(results.violations, null, 2),
+  ).toEqual([]);
+}
+
+/**
+ * Navigate to `path` and wait on a stable DOM signal.
+ *
+ * `networkidle` is unreliable against `next dev` because the HMR websocket keeps
+ * the network busy indefinitely (Issue #780, surfaced by Copilot on PR #790).
+ * Wait on a visible landmark instead. The default landmark set is broad enough
+ * to cover form, hero, and authenticated-shell layouts.
+ */
+export async function gotoAndWaitStable(
+  page: Page,
+  path: string,
+  landmark = "h1, form, main button, main",
+): Promise<void> {
+  await page.goto(path, { waitUntil: "domcontentloaded" });
+  await page.locator(landmark).first().waitFor({
+    state: "visible",
+    timeout: 15_000,
+  });
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
-    "test:e2e": "playwright test"
+    "test:e2e": "playwright test",
+    "test:a11y:authed": "playwright test e2e/authed-a11y"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",


### PR DESCRIPTION
Closes #785

## Summary
- Add `e2e/fixtures.ts` with shared `assertNoColorContrastViolations` +
  `gotoAndWaitStable` helpers (lifted from `login-contrast.spec.ts`, which is
  refactored to import them — removes the inline duplication).
- Add authenticated/backend-dependent color-contrast specs for /device,
  /invite/[token], and /workspace/dashboard under `e2e/authed-a11y/`.
- Add `test:a11y:authed` npm script; document the hermetic-vs-authed split in
  `e2e/README.md`.

## Why a split (gate1 = yellow, QA Lead)
#786 (PR #839) deliberately made the `frontend-a11y` CI job **hermetic** (no
backend). The three target pages all need a live backend / auth / seeded data,
so dropping their specs into `e2e/a11y/` would break that job. Per the gate1
recommendation (operator-approved), this PR ships the **light part** — specs +
shared fixtures — in `e2e/authed-a11y/`, a path **not** matched by the hermetic
`playwright test e2e/a11y` glob.

## Verification
- ✅ `playwright --list`: `e2e/a11y` selects **0** authed specs (login only, 2
  tests); `e2e/authed-a11y` selects 6 tests across 3 files; all imports resolve.
- ⚠️ **Not run by CI and not type-checked** (`frontend/tsconfig.json` excludes
  `e2e/`). These specs run only locally via `npm run test:a11y:authed` with a
  live backend + `E2E_ADMIN_*`. Wiring them into a full-stack a11y CI lane
  (backend services + seed + `storageState` globalSetup) and covering the
  Pro-plan-gated `/invite` happy path is tracked in **#840**.
- `/invite` currently covers the reachable-without-seed state (unknown token →
  error screen).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (CI-unverified specs → drift risk; #840 must wire CI)
- cto: green (substring-glob fragility documented for #840)
- gate1: yellow via /claude-c-suite:ask (QA Lead) — split recommendation, operator-approved
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
