### PR TITLE
chore(frontend): remove unused WorkspaceContext.setCreatedWorkspace (#682)

### DIFF
--- a/frontend/src/contexts/WorkspaceContext.tsx
+++ b/frontend/src/contexts/WorkspaceContext.tsx
@@ -25,7 +25,6 @@ interface WorkspaceContextType {
   loading: boolean;
   refreshWorkspaces: () => Promise<void>;
   switchWorkspace: (workspaceId: string) => Promise<void>;
-  setCreatedWorkspace: (workspace: Workspace) => void;
 }
 
 const WorkspaceContext = createContext<WorkspaceContextType | undefined>(undefined);
@@ -75,14 +74,6 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     await loadWorkspaces(true);
   };
 
-  // Directly set workspace after creation (bypasses API call)
-  const setCreatedWorkspace = (workspace: Workspace) => {
-    workspacesRef.current = [workspace];
-    setWorkspaces([workspace]);
-    setCurrentWorkspace(workspace);
-    setLoading(false);
-  };
-
   const switchWorkspace = async (workspaceId: string) => {
     try {
       // Call API to update backend current_workspace_id
@@ -113,7 +104,6 @@ export function WorkspaceProvider({ children }: { children: ReactNode }) {
     loading,
     refreshWorkspaces,
     switchWorkspace,
-    setCreatedWorkspace,
   };
 
   return (


### PR DESCRIPTION
Closes #682

## Summary
- Remove `WorkspaceContext.setCreatedWorkspace` — a defined-but-unused member (type declaration, implementation, and context `value` entry) with zero callers
- It was meant to seed workspace state synchronously to dodge the `refetchUser → spinner → unmount` race; #678 fixed that race at the `AuthContext.refetchUser` layer, leaving this dead (Option B per gate1 CTO review)

## Implementation notes
- `workspacesRef` (used in `loadWorkspaces`) and the `Workspace` import (used 22×) are retained
- Minimal/atomic diff: the auto-format hook initially reflowed the whole file (single→double quotes); that cosmetic churn was reverted so the PR is the 10-line dead-code removal only (repo has no `.prettierrc`/eslint enforcement, so quote style is not CI-gated)
- Verification: `tsc --noEmit` clean; `vitest run src/contexts src/app/(authenticated)/workspace` → 63 tests pass

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /claude-c-suite:ask (CTO lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
