### PR TITLE
refactor(db): drop vestigial Workspace.memory_limit column (#805)

### DIFF
--- a/backend/alembic/versions/e27_805_drop_ws_memory_limit.py
+++ b/backend/alembic/versions/e27_805_drop_ws_memory_limit.py
@@ -1,0 +1,70 @@
+"""Drop the vestigial ``workspaces.memory_limit`` column (#805).
+
+Issue #805: ``Workspace.memory_limit`` (``server_default '1000'``) was a
+denormalized mirror of ``plan_tier.memory_limit`` with **no live consumer**.
+The canonical effective calc (``Workspace.effective_memory_limit``) reads the
+plan tier, not the column. The column was only written on plan change (4 paths)
+and read for audit-log "old value" snapshots (3 paths). Of the base quota
+dimensions, ``memory_limit`` was the lone one mirrored onto a per-workspace
+column, and it drifted in prod (2026-05-23: a PRO workspace carrying the stale
+FREE value 1000). SSoT is ``plan_tier.memory_limit``.
+
+By this migration the last readers/writers are gone (#801 fixed the admin base
+display; #805 removed the 4 writers and re-sourced the 3 audit "old" values from
+``get_plan_tier(old_plan).memory_limit`` captured before ``plan_name`` mutates).
+``PlanChange.old_memory_limit`` / ``new_memory_limit`` are immutable historical
+records and are NOT touched.
+
+``daily_api_limit`` / ``weekly_api_limit`` are a separate "legacy API limit"
+concern (they have an ``effective_daily_api_limit`` computation) and are
+intentionally left in place — out of #805 scope.
+
+### Downgrade
+
+``downgrade()`` re-adds the column with its original ``server_default '1000'``
+and backfills each row from its plan tier (``basic`` → 10000, ``pro`` → 100000,
+everything else → 1000) so the restored column is correct rather than uniformly
+stale. This is the reversible "re-add + backfill from plan_tier" path.
+
+Revision ID: e27_805_drop_ws_memory_limit
+Revises: e26_818_summary_trgm_idx
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# NOTE: revision id kept <= 32 chars — alembic_version.version_num is VARCHAR(32).
+revision = "e27_805_drop_ws_memory_limit"
+down_revision = "e26_818_summary_trgm_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("workspaces", "memory_limit")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "memory_limit",
+            sa.Integer(),
+            nullable=False,
+            server_default="1000",
+        ),
+    )
+    # Backfill from the plan tier so the restored column is correct, not
+    # uniformly the FREE default. Canonical tier memory_limits: free=1000,
+    # basic=10000, pro=100000 (config.plan_tiers).
+    op.execute(
+        """
+        UPDATE workspaces
+        SET memory_limit = CASE plan_name
+            WHEN 'basic' THEN 10000
+            WHEN 'pro' THEN 100000
+            ELSE 1000
+        END
+        """
+    )

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -440,13 +440,14 @@ async def update_workspace_plan(
 
         # Store old values for audit
         old_plan = workspace.plan_name
-        old_memory_limit = workspace.memory_limit
+        # #805: memory_limit is no longer a Workspace column — source the audit
+        # "old" value from the old plan tier (before plan_name mutates below).
+        old_memory_limit = get_plan_tier(old_plan).memory_limit
         old_daily_limit = workspace.daily_api_limit
         old_weekly_limit = workspace.weekly_api_limit
 
         # Update workspace plan and quotas
         workspace.plan_name = request.plan_name
-        workspace.memory_limit = new_plan_tier.memory_limit
         workspace.daily_api_limit = new_plan_tier.daily_api_limit
         workspace.weekly_api_limit = new_plan_tier.weekly_api_limit
 

--- a/backend/src/api/routes/workspace_plan.py
+++ b/backend/src/api/routes/workspace_plan.py
@@ -223,7 +223,9 @@ async def update_workspace_plan(
     new_tier = PLAN_TIERS[request.plan_name]
 
     # Save old values for audit
-    old_memory_limit = workspace.memory_limit
+    # #805: memory_limit is no longer a Workspace column — source the audit
+    # "old" value from the old plan tier (before plan_name mutates below).
+    old_memory_limit = get_plan_tier(old_plan).memory_limit
     old_daily_api = workspace.daily_api_limit
     old_weekly_api = workspace.weekly_api_limit
 
@@ -318,7 +320,6 @@ async def update_workspace_plan(
 
     # Update workspace
     workspace.plan_name = request.plan_name
-    workspace.memory_limit = new_tier.memory_limit
     workspace.daily_api_limit = new_tier.daily_api_limit
     workspace.weekly_api_limit = new_tier.weekly_api_limit
 

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1277,7 +1277,6 @@ class Workspace(Base):
         description: Optional description
         owner_user_id: Owner user ID (creator)
         plan_name: Billing plan (free/pro/enterprise)
-        memory_limit: Max memories per workspace
         daily_api_limit: Daily API call limit
         weekly_api_limit: Weekly API call limit
         created_at: Creation timestamp
@@ -1304,7 +1303,11 @@ class Workspace(Base):
 
     # Billing & Plan
     plan_name: Mapped[str] = mapped_column(String(50), nullable=False, server_default="free")
-    memory_limit: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1000")
+    # #805: memory_limit column dropped — it was a vestigial denormalized mirror of
+    # plan_tier.memory_limit with no live consumer (effective_memory_limit reads the
+    # tier, not a column). SSoT is plan_tier.memory_limit. daily/weekly_api_limit are
+    # a separate "legacy API limit" concern (see effective_daily_api_limit) — out of
+    # #805 scope, intentionally left in place.
     daily_api_limit: Mapped[int] = mapped_column(Integer, nullable=False, server_default="1000")
     weekly_api_limit: Mapped[int] = mapped_column(Integer, nullable=False, server_default="5000")
 

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1288,7 +1288,7 @@ class Workspace(Base):
         contexts: Contexts owned by this workspace (one-to-many)
 
     Constraints:
-        - plan_name must be in: free, pro, enterprise
+        - plan_name must be in: free, basic, pro
     """
 
     __tablename__ = "workspaces"

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1276,7 +1276,7 @@ class Workspace(Base):
         name: Workspace display name
         description: Optional description
         owner_user_id: Owner user ID (creator)
-        plan_name: Billing plan (free/pro/enterprise)
+        plan_name: Billing plan (free/basic/pro)
         daily_api_limit: Daily API call limit
         weekly_api_limit: Weekly API call limit
         created_at: Creation timestamp

--- a/backend/src/services/stripe_service.py
+++ b/backend/src/services/stripe_service.py
@@ -264,12 +264,14 @@ async def _apply_plan_change(
         return
 
     old_plan = workspace.plan_name
-    old_memory_limit = workspace.memory_limit
+    # #805: memory_limit is no longer a Workspace column. Source the audit
+    # "old" value from the old plan tier (captured before plan_name mutates) —
+    # this is more correct than the dropped column, which could be stale.
+    old_memory_limit = get_plan_tier(old_plan).memory_limit
     new_tier = get_plan_tier(new_plan_name)
 
     # Update workspace
     workspace.plan_name = new_plan_name
-    workspace.memory_limit = new_tier.memory_limit
     workspace.daily_api_limit = new_tier.daily_api_limit
     workspace.weekly_api_limit = new_tier.weekly_api_limit
     if customer_id:
@@ -314,7 +316,6 @@ async def _handle_subscription_cancelled(
     old_plan = workspace.plan_name
 
     workspace.plan_name = "free"
-    workspace.memory_limit = free_tier.memory_limit
     workspace.daily_api_limit = free_tier.daily_api_limit
     workspace.weekly_api_limit = free_tier.weekly_api_limit
     workspace.stripe_subscription_id = None

--- a/backend/tests/api/test_plan_downgrade.py
+++ b/backend/tests/api/test_plan_downgrade.py
@@ -40,7 +40,6 @@ async def pro_workspace(db_session):
         name=f"test-ws-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -104,7 +103,6 @@ async def test_admin_plan_upgrade_free_to_pro(db_session):
         name=f"test-ws-{uuid4().hex[:8]}",
         plan_name="free",
         owner_user_id=owner_id,
-        memory_limit=1000,
         daily_api_limit=1000,
         weekly_api_limit=5000,
     )
@@ -122,7 +120,6 @@ async def test_admin_plan_upgrade_free_to_pro(db_session):
     pro_tier = get_plan_tier("pro")
     old_plan = workspace.plan_name
     workspace.plan_name = "pro"
-    workspace.memory_limit = pro_tier.memory_limit
     workspace.daily_api_limit = pro_tier.daily_api_limit
     workspace.weekly_api_limit = pro_tier.weekly_api_limit
 
@@ -140,7 +137,7 @@ async def test_admin_plan_upgrade_free_to_pro(db_session):
     # Verify
     await db_session.refresh(workspace)
     assert workspace.plan_name == "pro"
-    assert workspace.memory_limit == pro_tier.memory_limit
+    # #805: memory_limit is no longer a Workspace column (SSoT = plan_tier).
     assert workspace.daily_api_limit == pro_tier.daily_api_limit
 
     # Verify audit log
@@ -161,14 +158,13 @@ async def test_admin_plan_downgrade_pro_to_free_updates_quotas(db_session, pro_w
     free_tier = get_plan_tier("free")
 
     workspace.plan_name = "free"
-    workspace.memory_limit = free_tier.memory_limit
     workspace.daily_api_limit = free_tier.daily_api_limit
     workspace.weekly_api_limit = free_tier.weekly_api_limit
     await db_session.commit()
 
     await db_session.refresh(workspace)
     assert workspace.plan_name == "free"
-    assert workspace.memory_limit == free_tier.memory_limit
+    # #805: memory_limit is no longer a Workspace column (SSoT = plan_tier).
     assert workspace.daily_api_limit == free_tier.daily_api_limit
     assert workspace.weekly_api_limit == free_tier.weekly_api_limit
 
@@ -188,8 +184,6 @@ async def test_admin_plan_downgrade_disables_reranking(db_session, workspace_wit
 
     # Downgrade to Free and disable reranking
     workspace.plan_name = "free"
-    free_tier = get_plan_tier("free")
-    workspace.memory_limit = free_tier.memory_limit
 
     # Simulate admin endpoint's reranking disable logic
     context_ids = [ctx.id for ctx in contexts]
@@ -219,7 +213,9 @@ async def test_audit_log_records_old_and_new_limits(db_session, pro_workspace):
     workspace, _ = pro_workspace
     basic_tier = get_plan_tier("basic")
 
-    old_memory = workspace.memory_limit
+    # #805: memory_limit is no longer a Workspace column — source the audit
+    # "old" value from the workspace's current plan tier (matches production).
+    old_memory = get_plan_tier(workspace.plan_name).memory_limit
     old_daily = workspace.daily_api_limit
     old_weekly = workspace.weekly_api_limit
 
@@ -282,7 +278,6 @@ async def test_downgrade_allowed_when_contexts_within_limit(db_session):
         name=f"test-ws-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -329,9 +324,7 @@ async def test_addon_bonus_preserved_on_plan_change(db_session, pro_workspace):
     await db_session.commit()
 
     # Change plan to basic
-    basic_tier = get_plan_tier("basic")
     workspace.plan_name = "basic"
-    workspace.memory_limit = basic_tier.memory_limit
     await db_session.commit()
 
     await db_session.refresh(workspace)

--- a/backend/tests/integration/_admin_helpers.py
+++ b/backend/tests/integration/_admin_helpers.py
@@ -38,7 +38,6 @@ def make_workspace(
         name=f"{'deleted' if soft_deleted else 'active'}-{uuid4().hex[:8]}",
         plan_name=plan_name,
         owner_user_id=owner_user_id,
-        memory_limit=1000,
         daily_api_limit=500,
         weekly_api_limit=2500,
         deleted_at=(func.now() if soft_deleted else None),

--- a/backend/tests/integration/test_account_erasure_integration.py
+++ b/backend/tests/integration/test_account_erasure_integration.py
@@ -78,7 +78,6 @@ async def erasure_scenario(db_session: AsyncSession):
         name=f"ws-{uuid4().hex[:8]}",
         plan_name="free",
         owner_user_id=target_user_id,
-        memory_limit=1000,
         daily_api_limit=500,
         weekly_api_limit=2500,
     )

--- a/backend/tests/integration/test_admin_plans_base_memory_limit.py
+++ b/backend/tests/integration/test_admin_plans_base_memory_limit.py
@@ -1,18 +1,19 @@
-"""Regression test for #801 — base.memory_limit must read plan_tier, not the column.
+"""Regression test for #801 / #805 — base.memory_limit must read plan_tier.
 
 ``GET /admin/plans/workspaces/{id}/quotas`` builds its ``base`` ``QuotaBreakdown``
-from the plan tier definition for every dimension EXCEPT ``memory_limit``, which
-(pre-#801) read the per-workspace ``Workspace.memory_limit`` cache column at
-``admin_plans.py``. When that column is stale (e.g. a workspace upgraded to PRO
-without the column being synced — see the kagura prod incident 2026-05-23), the
-admin dialog's per-input "effective" preview is computed off a FREE-tier base
-(1000) while the real effective is PRO-tier (100000), a 100x discrepancy.
+from the plan tier definition for every dimension. Pre-#801, ``memory_limit`` was
+the lone exception: it read the per-workspace ``Workspace.memory_limit`` cache
+column, which could drift from the tier (the kagura prod incident 2026-05-23 — a
+PRO workspace carrying the stale FREE value 1000, a 100x dialog-preview bug).
 
-This pins the fix: ``base.memory_limit`` must reflect ``plan_tier.memory_limit``,
-consistent with the eight sibling fields.
+#801 fixed the read to use ``plan_tier.memory_limit``; **#805 then dropped the
+``Workspace.memory_limit`` column entirely**, so the drift is now structurally
+impossible — there is no column left to go stale. This test pins the surviving
+contract: ``base.memory_limit`` reflects ``plan_tier.memory_limit``, consistent
+with the eight sibling fields, and ``effective == base + addon``.
 
-Hits a real Postgres test DB because the bug is a field-by-field source mismatch
-that mock-DB tests in ``tests/api/test_admin_plans*.py`` cannot detect.
+Hits a real Postgres test DB because the original bug was a field-by-field source
+mismatch that mock-DB tests in ``tests/api/test_admin_plans*.py`` cannot detect.
 """
 
 from __future__ import annotations
@@ -28,13 +29,11 @@ from ._admin_helpers import make_user, make_workspace, mock_admin
 
 
 @pytest_asyncio.fixture
-async def stale_memory_limit_workspace(db_session: AsyncSession, request) -> dict:
-    """A workspace whose ``memory_limit`` column holds the stale FREE value (1000).
+async def quota_workspace(db_session: AsyncSession, request) -> dict:
+    """A workspace on a given plan (no per-workspace memory_limit column post-#805).
 
     Parametrize ``request.param`` with the plan name to exercise; defaults to
-    ``pro`` when used without ``indirect`` parametrization. ``make_workspace``
-    seeds ``memory_limit=1000`` regardless of plan — exactly the drift the
-    kagura prod incident exposed (non-FREE plan, FREE-tier column value).
+    ``pro`` when used without ``indirect`` parametrization.
     """
     plan_name = getattr(request, "param", "pro")
     user = make_user()
@@ -42,7 +41,6 @@ async def stale_memory_limit_workspace(db_session: AsyncSession, request) -> dic
     await db_session.flush()
 
     ws = make_workspace(owner_user_id=user.user_id, plan_name=plan_name)
-    assert ws.memory_limit == 1000, "fixture premise: column carries the stale FREE value"
     db_session.add(ws)
     await db_session.commit()
 
@@ -50,49 +48,48 @@ async def stale_memory_limit_workspace(db_session: AsyncSession, request) -> dic
 
 
 class TestBaseMemoryLimitReadsPlanTier:
-    """``base.memory_limit`` must come from the plan tier, not the stale column (#801)."""
+    """``base.memory_limit`` must come from the plan tier (#801/#805)."""
 
-    # BASIC (10000) and PRO (100000) both differ from the stale FREE value (1000),
-    # so each distinguishes a tier-read from a column-read. FREE is omitted: its
-    # tier value IS 1000, so it cannot tell the two sources apart (degenerate).
-    @pytest.mark.parametrize("stale_memory_limit_workspace", ["basic", "pro"], indirect=True)
+    # BASIC (10000) and PRO (100000) both differ from the old stale FREE value
+    # (1000), so each distinguishes a tier-read from the legacy column-read.
+    # FREE is omitted: its tier value IS 1000, so it cannot tell the two sources
+    # apart (degenerate).
+    @pytest.mark.parametrize("quota_workspace", ["basic", "pro"], indirect=True)
     @pytest.mark.asyncio
-    async def test_base_memory_limit_reflects_plan_tier_not_stale_column(
+    async def test_base_memory_limit_reflects_plan_tier(
         self,
         db_session: AsyncSession,
-        stale_memory_limit_workspace: dict,
+        quota_workspace: dict,
     ) -> None:
         result = await get_workspace_quotas(
-            workspace_id=stale_memory_limit_workspace["workspace_id"],
+            workspace_id=quota_workspace["workspace_id"],
             admin_user=mock_admin(),
             db=db_session,
         )
 
-        tier = get_plan_tier(stale_memory_limit_workspace["plan_name"])
+        tier = get_plan_tier(quota_workspace["plan_name"])
         assert tier.memory_limit != 1000, (
-            "test premise: this tier's memory_limit must differ from the stale "
-            "1000 column value, otherwise this test proves nothing"
+            "test premise: this tier's memory_limit must differ from the old "
+            "1000 column default, otherwise this test proves nothing"
         )
         assert result.base.memory_limit == tier.memory_limit, (
-            "base.memory_limit must read plan_tier.memory_limit, not the stale "
-            "Workspace.memory_limit column (#801: 100x dialog preview bug)"
+            "base.memory_limit must read plan_tier.memory_limit, consistent with "
+            "the sibling dimensions (#801 fix; #805 dropped the column entirely)"
         )
 
     @pytest.mark.asyncio
     async def test_effective_memory_limit_tracks_plan_tier_base(
         self,
         db_session: AsyncSession,
-        stale_memory_limit_workspace: dict,
+        quota_workspace: dict,
     ) -> None:
         """Preview invariant: effective == base + addon, with base from the tier.
 
         The default fixture has no addon (addon.memory_bonus == 0), so this both
-        pins effective == base and proves base tracks the tier (not the stale
-        column): pre-fix, base would be 1000 while effective is the PRO tier
-        100000, breaking the equality.
+        pins effective == base and proves base tracks the tier.
         """
         result = await get_workspace_quotas(
-            workspace_id=stale_memory_limit_workspace["workspace_id"],
+            workspace_id=quota_workspace["workspace_id"],
             admin_user=mock_admin(),
             db=db_session,
         )
@@ -101,7 +98,7 @@ class TestBaseMemoryLimitReadsPlanTier:
         assert result.base.memory_limit == pro_tier.memory_limit
         assert (
             result.effective.memory_limit == result.base.memory_limit + result.addon.memory_bonus
-        ), "effective.memory_limit must equal base + addon once base reads plan_tier (#801)"
+        ), "effective.memory_limit must equal base + addon, base reading plan_tier (#801)"
 
     @pytest.mark.asyncio
     async def test_effective_includes_nonzero_addon_on_tier_base(
@@ -112,9 +109,8 @@ class TestBaseMemoryLimitReadsPlanTier:
 
         Exercises the addon term explicitly (the parametrized fixtures carry
         addon=0). ``effective_memory_limit`` is ``_zero_floor(plan_tier, addon)``
-        and ``base`` now reads the tier, so a PRO workspace with a 20000 memory
-        addon must report base=100000, addon=20000, effective=120000 — even with
-        the stale 1000 cache column still on the row.
+        and ``base`` reads the tier, so a PRO workspace with a 20000 memory addon
+        must report base=100000, addon=20000, effective=120000.
         """
         user = make_user()
         db_session.add(user)
@@ -135,6 +131,9 @@ class TestBaseMemoryLimitReadsPlanTier:
         assert result.base.memory_limit == pro_tier.memory_limit
         assert result.addon.memory_bonus == 20_000
         assert result.effective.memory_limit == pro_tier.memory_limit + 20_000, (
-            "effective must add the non-zero addon to the tier base, not the stale "
-            "Workspace.memory_limit column (#801)"
+            "effective must add the non-zero addon to the tier base (#801)"
         )
+
+    # The DROP COLUMN itself (workspaces.memory_limit removed, reversibly) is
+    # validated by tests/integration/test_alembic_migrations.py, which applies
+    # the full chain incl. e27_805 on an ephemeral DB and exercises downgrade.

--- a/backend/tests/integration/test_declared_link_protection.py
+++ b/backend/tests/integration/test_declared_link_protection.py
@@ -40,7 +40,6 @@ async def declared_link_scenario(db_session: AsyncSession):
         name=f"ws-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )

--- a/backend/tests/integration/test_edge_context_invariant.py
+++ b/backend/tests/integration/test_edge_context_invariant.py
@@ -36,7 +36,6 @@ async def invariant_scenario(db_session: AsyncSession):
         name=f"ws-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )

--- a/backend/tests/integration/test_edge_invariant_perf.py
+++ b/backend/tests/integration/test_edge_invariant_perf.py
@@ -86,7 +86,6 @@ async def perf_scenario(db_session: AsyncSession):
         name=f"ws-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )

--- a/backend/tests/integration/test_embedding_service_integration.py
+++ b/backend/tests/integration/test_embedding_service_integration.py
@@ -151,7 +151,6 @@ def _build_workspace(
         name=f"ws-{uuid4().hex[:8]}",
         plan_name="free",
         owner_user_id=owner_user_id,
-        memory_limit=1000,
         daily_api_limit=500,
         weekly_api_limit=2500,
         embedding_daily_cap_usd=embedding_daily_cap_usd,

--- a/backend/tests/integration/test_graph_visibility.py
+++ b/backend/tests/integration/test_graph_visibility.py
@@ -81,7 +81,6 @@ async def visibility_scenario(async_engine, db_session):
         name=f"ws-a-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_a_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -90,7 +89,6 @@ async def visibility_scenario(async_engine, db_session):
         name=f"ws-b-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=outsider_b_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )

--- a/backend/tests/integration/test_invitation_email.py
+++ b/backend/tests/integration/test_invitation_email.py
@@ -50,7 +50,6 @@ async def _seed(db: AsyncSession) -> tuple[Workspace, User]:
         name=f"ws-{suffix}",
         plan_name="pro",
         owner_user_id=inviter.user_id,
-        memory_limit=100_000,
         daily_api_limit=50_000,
         weekly_api_limit=250_000,
     )

--- a/backend/tests/integration/test_list_tags_aggregation.py
+++ b/backend/tests/integration/test_list_tags_aggregation.py
@@ -66,7 +66,6 @@ async def _seed_workspace_context(
         name=f"ws-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=user_id,
-        memory_limit=100_000,
         daily_api_limit=50_000,
         weekly_api_limit=250_000,
     )

--- a/backend/tests/integration/test_memory_analyses_schema.py
+++ b/backend/tests/integration/test_memory_analyses_schema.py
@@ -60,7 +60,6 @@ async def _seed_workspace_context_pricing(
         name=f"ws-{uuid4().hex[:8]}",
         plan_name=plan,
         owner_user_id=owner_id,
-        memory_limit=100000,
         daily_api_limit=10000,
         weekly_api_limit=50000,
     )

--- a/backend/tests/integration/test_memory_service_post_741.py
+++ b/backend/tests/integration/test_memory_service_post_741.py
@@ -58,7 +58,6 @@ async def edge_producer_scenario(db_session: AsyncSession):
         name=f"ws-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )

--- a/backend/tests/integration/test_quota_service_advisory_lock.py
+++ b/backend/tests/integration/test_quota_service_advisory_lock.py
@@ -60,7 +60,6 @@ def _new_workspace(owner: str) -> Workspace:
         name=f"toctou-{uuid4().hex[:8]}",
         plan_name="free",
         owner_user_id=owner,
-        memory_limit=1000,
         daily_api_limit=500,
         weekly_api_limit=2500,
         deleted_at=None,

--- a/backend/tests/integration/test_resource_cross_workspace.py
+++ b/backend/tests/integration/test_resource_cross_workspace.py
@@ -78,7 +78,6 @@ async def cross_workspace_scenario(async_engine, db_session):
         name=f"ws-a-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_a_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -87,7 +86,6 @@ async def cross_workspace_scenario(async_engine, db_session):
         name=f"ws-b-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_b_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -250,7 +248,6 @@ async def cross_workspace_multi_member_scenario(async_engine, db_session):
         name=f"ws-a-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_a_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -259,7 +256,6 @@ async def cross_workspace_multi_member_scenario(async_engine, db_session):
         name=f"ws-b-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_b_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -425,7 +421,6 @@ async def cross_workspace_list_scenario(async_engine, db_session):
         name=f"ws-a-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_a_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -434,7 +429,6 @@ async def cross_workspace_list_scenario(async_engine, db_session):
         name=f"ws-b-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_b_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -638,7 +632,6 @@ async def test_slug_reuse_after_soft_delete_isolates_orphans(async_engine, db_se
         name=f"ws-a-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_a_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )
@@ -647,7 +640,6 @@ async def test_slug_reuse_after_soft_delete_isolates_orphans(async_engine, db_se
         name=f"ws-b-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_b_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )

--- a/backend/tests/integration/test_workspace_memory_timeline_boundary.py
+++ b/backend/tests/integration/test_workspace_memory_timeline_boundary.py
@@ -56,7 +56,6 @@ def _make_workspace(owner_id: str) -> Workspace:
         name=f"ws-{uuid4().hex[:8]}",
         plan_name="pro",
         owner_user_id=owner_id,
-        memory_limit=100000,
         daily_api_limit=50000,
         weekly_api_limit=250000,
     )

--- a/backend/tests/neural/conftest.py
+++ b/backend/tests/neural/conftest.py
@@ -50,7 +50,6 @@ async def sample_memory_pair(db_session):
         name=f"neural-test-ws-{uuid4().hex[:8]}",
         plan_name="free",
         owner_user_id="test_user",
-        memory_limit=10000,
         daily_api_limit=5000,
         weekly_api_limit=25000,
     )

--- a/backend/tests/repositories/conftest.py
+++ b/backend/tests/repositories/conftest.py
@@ -33,7 +33,6 @@ async def sample_memory_triple(db_session):
         name=f"transfer-test-ws-{uuid4().hex[:8]}",
         plan_name="free",
         owner_user_id="test_user",
-        memory_limit=10000,
         daily_api_limit=5000,
         weekly_api_limit=25000,
     )

--- a/backend/tests/services/test_effective_quota_service.py
+++ b/backend/tests/services/test_effective_quota_service.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import pytest
 
+from models.auth import Workspace
 from services.effective_quota_service import EffectiveQuotaService
 
 
@@ -48,7 +49,7 @@ class TestEffectiveQuotaService:
         PR #588 flagged this gap). Issue #663 added ``max_resource_tokens``
         as the 13th key (tier-fixed, no addon).
         """
-        ws = MagicMock()
+        ws = MagicMock(spec_set=Workspace)
         ws.plan_name = plan_name
         ws.daily_api_limit = daily_api_limit
         ws.addon_memory_bonus = addon_memory_bonus

--- a/backend/tests/services/test_effective_quota_service.py
+++ b/backend/tests/services/test_effective_quota_service.py
@@ -50,7 +50,6 @@ class TestEffectiveQuotaService:
         """
         ws = MagicMock()
         ws.plan_name = plan_name
-        ws.memory_limit = memory_limit
         ws.daily_api_limit = daily_api_limit
         ws.addon_memory_bonus = addon_memory_bonus
         ws.addon_mcp_quota_bonus = addon_mcp_quota_bonus

--- a/backend/tests/services/test_stripe_service.py
+++ b/backend/tests/services/test_stripe_service.py
@@ -375,7 +375,6 @@ async def test_apply_plan_change_success():
     workspace = MagicMock()
     workspace.id = uuid4()
     workspace.plan_name = "free"
-    workspace.memory_limit = 100
 
     result_proxy = MagicMock()
     result_proxy.scalar_one_or_none.return_value = workspace
@@ -393,7 +392,8 @@ async def test_apply_plan_change_success():
         await _apply_plan_change(db, workspace.id, "pro", "cus_123", "sub_123")
 
     assert workspace.plan_name == "pro"
-    assert workspace.memory_limit == 500
+    # #805: memory_limit is no longer a Workspace column — the plan change must
+    # NOT sync it onto the workspace (SSoT is plan_tier.memory_limit).
     assert workspace.stripe_customer_id == "cus_123"
     assert workspace.stripe_subscription_id == "sub_123"
     db.add.assert_called_once()
@@ -427,7 +427,7 @@ async def test_handle_subscription_cancelled_downgrades_to_free():
         await _handle_subscription_cancelled(db, "cus_123")
 
     assert workspace.plan_name == "free"
-    assert workspace.memory_limit == 100
+    # #805: memory_limit column dropped — downgrade no longer syncs it.
     assert workspace.stripe_subscription_id is None
     db.add.assert_called_once()
     db.commit.assert_called()

--- a/backend/tests/services/test_stripe_service.py
+++ b/backend/tests/services/test_stripe_service.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import pytest
 
 import services.stripe_service as stripe_service
+from models.auth import Workspace
 from services.stripe_service import (
     _run_stripe,
     _run_stripe_erasure,
@@ -372,7 +373,10 @@ async def test_apply_plan_change_workspace_not_found():
 
 @pytest.mark.asyncio
 async def test_apply_plan_change_success():
-    workspace = MagicMock()
+    # spec_set=Workspace: setting workspace.memory_limit would raise (the column
+    # was dropped in #805), so this mock actively prevents a writer being
+    # reintroduced — alongside the explicit daily/weekly assertions below.
+    workspace = MagicMock(spec_set=Workspace)
     workspace.id = uuid4()
     workspace.plan_name = "free"
 
@@ -392,8 +396,11 @@ async def test_apply_plan_change_success():
         await _apply_plan_change(db, workspace.id, "pro", "cus_123", "sub_123")
 
     assert workspace.plan_name == "pro"
-    # #805: memory_limit is no longer a Workspace column — the plan change must
-    # NOT sync it onto the workspace (SSoT is plan_tier.memory_limit).
+    # #805: memory_limit is no longer a Workspace column (SSoT = plan_tier) — the
+    # spec_set mock makes a reintroduced `workspace.memory_limit = ...` write fail
+    # loudly. The remaining quota columns must still be synced from the tier.
+    assert workspace.daily_api_limit == 1000
+    assert workspace.weekly_api_limit == 5000
     assert workspace.stripe_customer_id == "cus_123"
     assert workspace.stripe_subscription_id == "sub_123"
     db.add.assert_called_once()
@@ -407,7 +414,9 @@ async def test_apply_plan_change_success():
 
 @pytest.mark.asyncio
 async def test_handle_subscription_cancelled_downgrades_to_free():
-    workspace = MagicMock()
+    # spec_set=Workspace: a reintroduced workspace.memory_limit write would raise
+    # (column dropped in #805); daily/weekly remain synced from the free tier.
+    workspace = MagicMock(spec_set=Workspace)
     workspace.id = uuid4()
     workspace.plan_name = "pro"
 
@@ -427,7 +436,10 @@ async def test_handle_subscription_cancelled_downgrades_to_free():
         await _handle_subscription_cancelled(db, "cus_123")
 
     assert workspace.plan_name == "free"
-    # #805: memory_limit column dropped — downgrade no longer syncs it.
+    # #805: memory_limit column dropped — downgrade no longer syncs it (spec_set
+    # guards against reintroduction); daily/weekly are still synced from the tier.
+    assert workspace.daily_api_limit == 100
+    assert workspace.weekly_api_limit == 500
     assert workspace.stripe_subscription_id is None
     db.add.assert_called_once()
     db.commit.assert_called()

--- a/backend/tests/services/test_workspace_service_member_removal.py
+++ b/backend/tests/services/test_workspace_service_member_removal.py
@@ -69,7 +69,6 @@ async def test_remove_member_comprehensive_cleanup(db_session):
         name=f"test-workspace-{uuid4().hex[:8]}",
         owner_user_id=owner_id,
         plan_name="pro",
-        memory_limit=100000,
         daily_api_limit=10000,
         weekly_api_limit=50000,
     )
@@ -300,7 +299,6 @@ async def test_remove_member_with_no_context_memberships(db_session):
         name=f"test-workspace-{uuid4().hex[:8]}",
         owner_user_id=owner_id,
         plan_name="free",
-        memory_limit=10000,
         daily_api_limit=1000,
         weekly_api_limit=5000,
     )
@@ -359,7 +357,6 @@ async def test_remove_member_does_not_affect_other_members(db_session):
         name=f"multi-member-workspace-{uuid4().hex[:8]}",
         owner_user_id=owner_id,
         plan_name="pro",
-        memory_limit=100000,
         daily_api_limit=10000,
         weekly_api_limit=50000,
     )
@@ -439,7 +436,6 @@ async def test_cannot_remove_workspace_owner(db_session):
         name=f"test-workspace-{uuid4().hex[:8]}",
         owner_user_id=owner_id,
         plan_name="free",
-        memory_limit=10000,
         daily_api_limit=1000,
         weekly_api_limit=5000,
     )


### PR DESCRIPTION
## Summary
Drop the vestigial per-workspace `Workspace.memory_limit` column — a denormalized mirror of `plan_tier.memory_limit` with **no live consumer** (`effective_memory_limit` reads the tier + addon, not a column). It drifted in prod (2026-05-23: a PRO workspace carrying the stale FREE value `1000`). **SSoT = `plan_tier.memory_limit`** (Option 1, per gate1 CIO review).

> ⚠️ **This PR includes an Alembic migration** (`e27_805_drop_ws_memory_limit`) that **`DROP COLUMN workspaces.memory_limit`**. Run `make migrate` / `alembic upgrade head` on deploy. The down-migration is reversible (re-adds the column + backfills from the plan tier).

## Changes
1. **Re-source the 3 audit-log "old" values** from `get_plan_tier(old_plan).memory_limit`, captured **before** `plan_name` mutates (`stripe_service`, `admin_plans`, `workspace_plan`) — strictly more correct than the dropped column. `PlanChange.old_memory_limit`/`new_memory_limit` history columns are kept.
2. **Remove the 4 writer sync lines** that wrote the column on plan change.
3. **Drop the column** from the `Workspace` model + the reversible `DROP COLUMN` migration `e27_805`.
4. **Tests**: re-sourced audit-reader assertions; rewrote the obsolete `#801` stale-column fixture (the bug class is now structurally impossible); `spec_set=Workspace` mocks + daily/weekly assertions in the stripe tests so a reintroduced `memory_limit` write fails loudly (Copilot review, `1c66b525`); extended `spec_set=Workspace` to `test_effective_quota_service.py`'s `_mock_workspace` helper for the same guard (Copilot review follow-up).
5. **Docstring correction** (review follow-up, `83067b33`): the `Workspace.plan_name` docstring/constraint now lists `free, basic, pro` (the actual `CHECK` constraint), not `enterprise`.

## Scope notes
- `UserPlan.memory_limit` triage (AC item): already resolved — the `UserPlan` table was dropped wholesale in #668 (`e24_668`).
- `daily_api_limit`/`weekly_api_limit` are a separate "legacy API limit" concern (they have an `effective_daily_api_limit` computation) — intentionally **out of #805 scope**.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests passing
- [x] Manual testing completed
- [x] All tests passing locally (`make test-local`)

## Quality Checklist

- [x] Code follows DRY/SOLID principles
- [x] Type hints added (target: 85%+ coverage)
- [x] No lint errors (`make lint`)
- [x] No type errors (`make type-check`)
- [x] No code duplication
- [x] Functions < 50 lines (Single Responsibility)
- [x] Files < 500 lines
- [x] Documentation updated (if needed)

## Verification
Alembic chain test 12/12 (validates `e27` upgrade + downgrade + re-upgrade); 1737 unit tests pass; ruff clean. CI green.

## Pre-PR review summary
- gate2 advisor-only: cso green · qa-lead green · cto green
- gate1: green via /claude-c-suite:ask (CIO lens)

🤖 Generated via /gh-issue-driven:ship

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

---

To request AI review, comment `/review` on this PR.