### PR TITLE
ci(a11y): full-stack lane to run e2e/authed-a11y (#840)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       backend-integration: ${{ steps.filter.outputs.backend-integration }}
+      frontend-a11y-authed: ${{ steps.filter.outputs.frontend-a11y-authed }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -151,6 +152,13 @@ jobs:
               - 'backend/tests/integration/**'
               - 'backend/tests/smoke/test_all_routes.py'
               - 'backend/pyproject.toml'
+              - '.github/workflows/ci.yml'
+            frontend-a11y-authed:
+              - 'frontend/e2e/**'
+              - 'frontend/src/app/**'
+              - 'frontend/playwright.config.ts'
+              - 'backend/src/**'
+              - 'backend/alembic/versions/**'
               - '.github/workflows/ci.yml'
 
   # Integration tests + the all-routes smoke test — both require a live
@@ -210,3 +218,128 @@ jobs:
           TEST_DATABASE_URL: postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test
           REDIS_URL: redis://localhost:6379
         run: cd backend && pytest tests/integration/ tests/smoke/test_all_routes.py -v --timeout=120 --maxfail=3
+
+  # Authenticated a11y (color-contrast) lane (#840). Unlike the hermetic
+  # frontend-a11y job (next dev only), the e2e/authed-a11y/ specs need a LIVE
+  # backend + an authenticated admin, so this job provisions a full stack:
+  # postgres + redis + migrated schema + a seeded admin, starts the API, then
+  # runs Playwright (which auto-starts `next dev` via webServer). Boot needs
+  # only postgres + redis (Qdrant is /readiness-only, not /health). Gated by
+  # the detect-changes path filter (same pattern as backend-integration).
+  #
+  # Scope (#840, first slice): runs the 3 existing specs (device / invite
+  # unknown-token / workspace-dashboard) with the current login-based
+  # admin-auth fixture (trace:off). The storageState globalSetup migration and
+  # the Pro-workspace/invitation happy-path seed are deferred follow-ups.
+  # This is a new CI-only lane — boot env / port-wait timing may need tuning
+  # over the first runs; it is NOT yet a Required check (#768).
+  frontend-a11y-authed:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, frontend]
+    if: |
+      needs.detect-changes.outputs.frontend-a11y-authed == 'true' ||
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'force-integration')) ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push'
+    env:
+      # cd backend (cwd → resolves `src.api.main`) + PYTHONPATH=src (resolves the
+      # bare `config`/`api` imports) mirrors how pytest (pythonpath=src) and the
+      # docker CMD (uvicorn src.api.main:app) run.
+      PYTHONPATH: src
+      DATABASE_URL: postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test
+      REDIS_URL: redis://localhost:6379
+      CORS_ORIGINS: http://localhost:3000
+      E2E_ADMIN_LOGIN_ID: e2e-admin
+      E2E_API_URL: http://localhost:8080
+      NEXT_PUBLIC_API_URL: http://localhost:8080
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: kagura
+          POSTGRES_PASSWORD: kagura_dev_password
+          POSTGRES_DB: kagura_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U kagura -d kagura_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install backend dependencies
+        run: cd backend && pip install -e ".[dev]"
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Install Playwright browser
+        run: cd frontend && npx playwright install chromium --with-deps
+
+      - name: Generate ephemeral secrets + admin password
+        # Throwaway values for an ephemeral CI database — never reused. A valid
+        # Fernet key is generated for API_KEY_SECRET in case the encryptor is
+        # constructed at boot/import.
+        run: |
+          {
+            echo "API_KEY_SECRET=$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
+            echo "JWT_SECRET=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+            echo "AUDIT_HMAC_KEY=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+            echo "E2E_ADMIN_PASSWORD=Ci-$(python -c 'import secrets; print(secrets.token_urlsafe(18))')-9X"
+          } >> "$GITHUB_ENV"
+
+      - name: Migrate schema
+        run: cd backend && alembic upgrade head
+
+      - name: Seed e2e admin
+        run: cd backend && python -m src.cli.seed_e2e_admin
+
+      - name: Start API server
+        run: |
+          cd backend
+          python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8080 --log-level warning &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health >/dev/null; then
+              echo "API is up after $((i * 2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::API did not become healthy on :8080 within 60s"
+          exit 1
+
+      - name: Run authed a11y tests
+        run: cd frontend && npm run test:a11y:authed
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-authed
+          path: frontend/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,11 +154,19 @@ jobs:
               - 'backend/pyproject.toml'
               - '.github/workflows/ci.yml'
             frontend-a11y-authed:
+              # Broad on purpose: this lane installs + runs the full stack, so any
+              # file it consumes can break it. Cover the whole frontend source tree
+              # (app + components + lib — the rendered /device, /invite, /workspace
+              # pages pull in shared components), the e2e specs, the npm + backend
+              # dependency/script manifests, and the backend it migrates/serves.
               - 'frontend/e2e/**'
-              - 'frontend/src/app/**'
+              - 'frontend/src/**'
+              - 'frontend/package.json'
+              - 'frontend/package-lock.json'
               - 'frontend/playwright.config.ts'
               - 'backend/src/**'
               - 'backend/alembic/versions/**'
+              - 'backend/pyproject.toml'
               - '.github/workflows/ci.yml'
 
   # Integration tests + the all-routes smoke test — both require a live

--- a/backend/src/cli/seed_e2e_admin.py
+++ b/backend/src/cli/seed_e2e_admin.py
@@ -1,0 +1,104 @@
+"""Non-interactive admin seed for the authed-a11y CI lane (#840).
+
+Unlike ``create_admin`` (interactive: prompts for login id / password / MFA, and
+also provisions an API key + embedding provider + ``.mcp.json``), this script
+creates the MINIMAL fixture the authenticated a11y specs need:
+
+- a password admin user (``auth_method="password"``, **no MFA**) whose
+  ``login_id`` / password come from ``E2E_ADMIN_LOGIN_ID`` / ``E2E_ADMIN_PASSWORD``,
+- a personal Pro-plan workspace + owner membership (so ``/workspace/dashboard``
+  renders for the seeded admin).
+
+It does NOT create an API key or configure an embedding provider, so it needs
+neither ``API_KEY_SECRET`` nor a provider — only ``DATABASE_URL`` (read by
+``cli.db.get_sync_database_url``). It is idempotent: if a password admin with the
+given ``login_id`` already exists it exits 0 without changes, so re-runs in a
+re-used CI database are safe.
+
+Usage (CI):
+    E2E_ADMIN_LOGIN_ID=e2e-admin E2E_ADMIN_PASSWORD='...' \\
+        python -m src.cli.seed_e2e_admin
+"""
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from sqlalchemy import create_engine, func, select  # noqa: E402
+from sqlalchemy.orm import Session  # noqa: E402
+
+from auth.password import hash_password  # noqa: E402
+from cli.db import get_sync_database_url  # noqa: E402
+from models.auth import User, Workspace, WorkspaceMember  # noqa: E402
+from utils.datetime import utcnow  # noqa: E402
+
+
+def seed_e2e_admin() -> None:
+    login_id = os.environ.get("E2E_ADMIN_LOGIN_ID", "").strip()
+    password = os.environ.get("E2E_ADMIN_PASSWORD", "")
+    if not login_id or not password:
+        print("✗ E2E_ADMIN_LOGIN_ID and E2E_ADMIN_PASSWORD must be set.")
+        sys.exit(1)
+
+    engine = create_engine(get_sync_database_url())
+    try:
+        with Session(engine) as db:
+            existing = db.execute(
+                select(func.count())
+                .select_from(User)
+                .where(User.login_id == login_id, User.auth_method == "password")
+            ).scalar()
+            if existing and existing > 0:
+                print(f"✓ Password admin '{login_id}' already exists — nothing to do.")
+                return
+
+            is_first_admin = (
+                db.execute(
+                    select(func.count())
+                    .select_from(User)
+                    .where(User.auth_method == "password", User.role == "admin")
+                ).scalar()
+                or 0
+            ) == 0
+
+            admin = User(
+                login_id=login_id,
+                email=f"{login_id}@local",
+                user_id=f"local:{login_id}",
+                name=login_id,
+                role="admin",
+                auth_method="password",
+                password_hash=hash_password(password),
+                totp_secret=None,
+                totp_enabled=False,
+                is_initial_admin=is_first_admin,
+                last_login_at=utcnow(),
+            )
+            db.add(admin)
+            db.flush()
+
+            workspace = Workspace(
+                name="E2E Personal Workspace",
+                owner_user_id=admin.user_id,
+                plan_name="pro",
+            )
+            db.add(workspace)
+            db.flush()
+            db.add(
+                WorkspaceMember(
+                    workspace_id=workspace.id,
+                    user_id=admin.user_id,
+                    role="owner",
+                )
+            )
+            admin.current_workspace_id = workspace.id
+            db.commit()
+            print(f"✓ Seeded e2e admin '{login_id}' + Pro workspace {workspace.id}")
+    finally:
+        engine.dispose()
+
+
+if __name__ == "__main__":
+    seed_e2e_admin()

--- a/frontend/e2e/authed-a11y/invite-contrast.spec.ts
+++ b/frontend/e2e/authed-a11y/invite-contrast.spec.ts
@@ -24,7 +24,10 @@ test.describe("/invite/[token] color-contrast (#785)", () => {
       page,
     }) => {
       await page.emulateMedia({ colorScheme });
-      await gotoAndWaitStable(page, "/invite/e2e-a11y-nonexistent-token");
+      // The unknown-token error screen renders its heading as <h2> inside plain
+      // <div>s — no h1/form/main — so wait on that h2 rather than the default
+      // landmark set (which would time out, #840).
+      await gotoAndWaitStable(page, "/invite/e2e-a11y-nonexistent-token", "h2");
       await assertNoColorContrastViolations(page);
     });
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,8 +19,8 @@
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:a11y": "playwright test e2e/a11y",
-    "test:a11y:authed": "playwright test e2e/authed-a11y"
+    "test:a11y": "playwright test e2e/a11y/",
+    "test:a11y:authed": "playwright test e2e/authed-a11y/"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -510,9 +510,12 @@ export function Sidebar() {
                   >
                     <h3
                       className={cn(
+                        // typography.caption already carries dark:text-slate-400
+                        // (WCAG-AA on the dark sidebar). Layering colors.text.muted
+                        // (dark:text-slate-500) on top loses contrast in dark mode
+                        // — keep caption's color only (#840 a11y fix).
                         typography.caption,
                         "uppercase tracking-wider",
-                        colors.text.muted,
                       )}
                     >
                       {groupTitle}
@@ -530,9 +533,11 @@ export function Sidebar() {
                   <h3
                     className={cn(
                       "px-3 mb-2",
+                      // See the collapsible h3 above — caption's dark:text-slate-400
+                      // is WCAG-AA on the dark sidebar; colors.text.muted would
+                      // drop it to slate-500 and fail dark-mode contrast (#840).
                       typography.caption,
                       "uppercase tracking-wider",
-                      colors.text.muted,
                     )}
                   >
                     {groupTitle}


### PR DESCRIPTION
Closes #840

## Summary
Wire the authenticated color-contrast specs (`frontend/e2e/authed-a11y/`, added in #785) into CI. They previously ran only locally via `npm run test:a11y:authed` because the hermetic `frontend-a11y` job (#786) has no backend.

- **New `frontend-a11y-authed` CI job** — provisions a full stack (postgres + redis + migrated schema + a seeded admin), starts the API, then runs `npm run test:a11y:authed` (Playwright auto-starts `next dev`). Boot needs only postgres + redis (Qdrant is `/readiness`-only, not `/health`). Gated by a `detect-changes` path filter (same pattern as `backend-integration`); uploads `playwright-report-authed` on failure.
- **`backend/src/cli/seed_e2e_admin.py`** — a non-interactive seed (vs the interactive `create_admin`): a password admin (no MFA) + a Pro workspace from `E2E_ADMIN_LOGIN_ID`/`E2E_ADMIN_PASSWORD`. Idempotent; needs neither `API_KEY_SECRET` nor an embedding provider.
- **Glob tighten** — `test:a11y` → `playwright test e2e/a11y/` (trailing slash) so the authed specs can never be substring-matched by the hermetic job (issue's robustness note).

## Scope (first slice) + deferred follow-ups
This runs the **3 existing specs** (`/device`, `/invite/[token]` unknown-token error screen, `/workspace/dashboard`) with the current login-based `admin-auth` fixture (`trace: off`). Per review, two issue items are **deferred to follow-ups** to keep this slice focused and reviewable:
1. **storageState `globalSetup`** migration (the long-term security hardening; the current `trace: off` fixture already keeps the password out of retained traces).
2. **Pro-workspace + invitation-token happy-path seed** for the `/invite/[token]` *success* screens.

I'll file those as follow-up issues after this lands.

## Validation note
The live-stack orchestration (uvicorn boot env, port-wait timing, Playwright `next dev`) is **only truly validatable in GitHub Actions** — it could not be exercised locally. This PR's own CI run is the first real signal; the lane may need a round or two of tuning. It is intentionally **not yet a Required check** (#768), so a first-run hiccup does not block merges. Locally validated: ci.yml YAML parses (7 jobs), the seed is ruff-clean and its import chain resolves, package.json is valid.

## Pre-PR review summary
- gate2 mode: advisor-only · audit: skipped · binary_gate: (none)
- cso: green · qa-lead: green · cto: green
- gate1: yellow via /claude-c-suite:ask (COO lens) — scope-split, CI-iteration caveat
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
