### PR TITLE
docs(ci): document required status checks on main (#768)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,9 @@ Use the GitHub **Actions** tab → **CI** → **Run workflow** (the `workflow_di
 
 ### Required status checks (branch protection)
 
-The following checks are **required** to pass before a PR can be merged into `main` (strict / branch-up-to-date): **`lint`**, **`backend-unit`**, **`frontend`**, and **`backend-integration`**.
+The **intended** required-check set for `main` (strict / branch-up-to-date) is: **`lint`**, **`backend-unit`**, **`frontend`**, and **`backend-integration`** — a PR must have these green to merge.
+
+> Enforcement is applied via the `main` branch-protection ruleset (the companion operator step of #768). Until that ruleset is updated to require these checks, this section describes the target gate rather than a live one — confirm the ruleset state in the repo settings.
 
 Intentionally **not** required:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,10 +114,12 @@ CI runs via `.github/workflows/ci.yml` on pull requests against `main`, on tag p
 | `lint` | All triggers | none |
 | `backend-unit` | All triggers | redis |
 | `frontend` | All triggers | none |
+| `frontend-a11y` | All triggers (`needs: [frontend]`) | none (hermetic `next dev`) |
 | `detect-changes` | All triggers | none |
 | `backend-integration` | `detect-changes` match **or** `force-integration` label **or** `workflow_dispatch` **or** tag push | postgres + redis |
+| `frontend-a11y-authed` | `detect-changes` (frontend/backend paths) match **or** `force-integration` label **or** `workflow_dispatch` **or** tag push | postgres + redis |
 
-`backend-integration` declares `needs: [detect-changes, backend-unit]`, so unit-failing PRs never pay the integration-suite cost. See `.github/workflows/ci.yml` for exact commands.
+`backend-integration` declares `needs: [detect-changes, backend-unit]`, so unit-failing PRs never pay the integration-suite cost. `frontend-a11y-authed` runs the authenticated color-contrast specs against a full stack (migrated DB + seeded admin + API). See `.github/workflows/ci.yml` for exact commands.
 
 ### Triggering integration tests on a PR
 
@@ -130,6 +132,17 @@ For local pre-PR verification, `make test-integration` runs the same suite again
 ### Manual run
 
 Use the GitHub **Actions** tab → **CI** → **Run workflow** (the `workflow_dispatch` trigger). `backend-integration` runs unconditionally in this mode.
+
+### Required status checks (branch protection)
+
+The following checks are **required** to pass before a PR can be merged into `main` (strict / branch-up-to-date): **`lint`**, **`backend-unit`**, **`frontend`**, and **`backend-integration`**.
+
+Intentionally **not** required:
+
+- **`detect-changes`** — a conditional gate that does not meaningfully gate every PR (it only computes path filters).
+- **`frontend-a11y` / `frontend-a11y-authed`** — advisory while the authenticated a11y lane stabilizes; promote later once it has a consistent green track record.
+
+`backend-integration` was promoted to a required check only after its integration `skip` marks reached zero (#764–#767) and it produced consistent green runs (#768).
 
 ## Branch Strategy
 


### PR DESCRIPTION
Partially addresses #768

## Summary
Documents the branch-protection **required status checks** in `CONTRIBUTING.md`'s `## Continuous Integration` section (the documentation half of #768):

- **Required to merge into `main`** (strict / up-to-date): `lint`, `backend-unit`, `frontend`, `backend-integration`.
- **Intentionally not required**: `detect-changes` (conditional gate), and `frontend-a11y` / `frontend-a11y-authed` (advisory while the authed a11y lane stabilizes).
- Also adds the `frontend-a11y` and `frontend-a11y-authed` rows to the CI jobs table (the latter landed in #840) so the table is accurate.

## Why now
The #768 pre-conditions are met: `#764`–`#767` are all closed (integration `skip` marks = 0) and `backend-integration` has been consistently green across recent PRs.

## Remaining step (operator action — NOT in this PR)
The branch-protection setting itself is a repo-admin change, not a code artifact. `main` is currently governed by the `protect` ruleset (id `14472160`) which is **`enforcement=disabled`** with no required-status-checks rule. Enabling the required checks (via that ruleset or classic branch protection) is the companion operator step that fully closes #768 — deliberately left to a maintainer because it gates every contributor's merges and is hard to reverse.

🤖 Generated via /gh-issue-driven
