### PR TITLE
chore(infra): add Caddy extension point for sibling services (#702)

### DIFF
--- a/terraform/single-server/Caddyfile
+++ b/terraform/single-server/Caddyfile
@@ -83,3 +83,11 @@ memory.kagura-ai.com {
 		format json
 	}
 }
+
+# Extension point for sibling services (one-time) — see Caddyfile.tpl and
+# README.md "Caddy extension point". Sibling services drop *.caddy vhost files
+# into /opt/kagura-caddy-extra/ (bind-mounted read-only into the container).
+# Top-level so imported files can define their own vhost blocks. Caddy tolerates
+# this matching zero files. Applying a new file or this mount on first rollout
+# needs more than `caddy reload` — see the README procedure.
+import /opt/kagura-caddy-extra/*.caddy

--- a/terraform/single-server/Caddyfile
+++ b/terraform/single-server/Caddyfile
@@ -44,6 +44,10 @@ memory.kagura-ai.com {
 		reverse_proxy api-blue:8080
 	}
 
+	handle /redoc* {
+		reverse_proxy api-blue:8080
+	}
+
 	handle /openapi.json {
 		reverse_proxy api-blue:8080
 	}

--- a/terraform/single-server/Caddyfile.tpl
+++ b/terraform/single-server/Caddyfile.tpl
@@ -98,3 +98,23 @@ memory.kagura-ai.com {
 		format json
 	}
 }
+
+# =============================================================================
+# Extension point for sibling services (one-time, do not remove)
+# =============================================================================
+# Sibling services co-resident on this VM (e.g. kagura-memory-ai-worker's
+# webhook receiver at aw.kagura-ai.com) plug their own top-level vhost blocks
+# in here by dropping a `*.caddy` file into /opt/kagura-caddy-extra/ on the
+# host. That directory is bind-mounted read-only into the caddy container
+# (see docker-compose.prod.yml). This import sits at TOP LEVEL — outside the
+# site block above — so imported files can define full vhost blocks of their
+# own (e.g. `aw.kagura-ai.com { ... }`), not just snippets.
+#
+# Glob safety: Caddy tolerates this import matching zero files, so the initial
+# (empty) state is valid. The literal path survives deploy.sh's envsubst, which
+# uses an explicit allow-list (`envsubst '${API_UPSTREAM}'`) — no interpolation.
+#
+# Applying a NEW *.caddy file (or this mount on first rollout) takes more than
+# `caddy reload` — see README.md "Caddy extension point" for the exact
+# recreate-vs-reload procedure.
+import /opt/kagura-caddy-extra/*.caddy

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -443,14 +443,11 @@ will **not** resolve. Two working options:
 
 - **Host-gateway (simplest, cross-project):** the sibling publishes a host port
   (e.g. `127.0.0.1:9000`) and the vhost proxies to `host.docker.internal:9000`
-  (as in the example above). This requires Caddy to know the host gateway — add
-  it once to the caddy service in `docker-compose.prod.yml`:
-
-  ```yaml
-  caddy:
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-  ```
+  (as in the example above). This works out-of-the-box — the caddy service in
+  `docker-compose.prod.yml` already maps `host.docker.internal` to the host
+  gateway (`extra_hosts: "host.docker.internal:host-gateway"`), so no
+  memory-cloud change is needed. The sibling just needs to publish its port on
+  the host.
 
 - **Shared network (service-name DNS):** the sibling's compose joins this
   project's network as an `external` network, after which `reverse_proxy

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -407,6 +407,68 @@ If the new color misbehaves after switching:
 This starts the previous color if it's not running, waits for readiness,
 then flips Caddy back and reloads. Safe to run at any time after a deploy.
 
+### Caddy extension point (sibling services)
+
+Other services co-resident on this VM (for example
+`kagura-memory-ai-worker`'s webhook receiver at `aw.kagura-ai.com`) can publish
+their own HTTPS vhost through this server's Caddy **without any further change
+to the memory-cloud repository**. The mechanism is a one-time extension point:
+
+- `Caddyfile.tpl` ends with a top-level `import /opt/kagura-caddy-extra/*.caddy`.
+- The caddy container bind-mounts `/opt/kagura-caddy-extra` read-only
+  (`docker-compose.prod.yml`).
+- `startup.sh` provisions `/opt/kagura-caddy-extra` (root-owned, `0755`).
+
+A sibling service publishes a vhost by dropping a `*.caddy` file into
+`/opt/kagura-caddy-extra/` on the host (requires sudo — the directory is
+root-owned). Each file may contain full top-level vhost blocks, e.g.:
+
+```caddy
+# /opt/kagura-caddy-extra/aw.caddy   (owned by the ai-worker operator)
+aw.kagura-ai.com {
+	tls /etc/caddy/origin-ca/cert.pem /etc/caddy/origin-ca/key.pem
+	reverse_proxy ai-worker:9000
+}
+```
+
+**Applying changes — recreate vs reload (read this):**
+
+| Situation | Command | Why |
+|---|---|---|
+| **First rollout of this mount** (deploying the change that adds the `/opt/kagura-caddy-extra` volume) | `docker compose -f docker-compose.prod.yml up -d caddy` | A bind mount is fixed at container **creation** time. `docker compose restart` (and `deploy.sh`'s `restart caddy`) restart the *existing* container and do **not** apply a newly-added mount — the directory would be invisible inside the container. The container must be **recreated** once. |
+| **Adding / editing a `*.caddy` file** after the mount already exists | `docker compose -f docker-compose.prod.yml exec caddy caddy reload --config /etc/caddy/Caddyfile` | The mount is already present, so Caddy only needs to re-read config. A reload is sufficient and zero-downtime. |
+
+> The issue that introduced this called for "confirm with `caddy reload`" — that
+> is correct for steady-state `*.caddy` edits, but **not** for the first rollout
+> of the mount itself, which requires the `up -d caddy` recreate above.
+
+**Verifying a rollout** (the recreate momentarily drops `:80`/`:443` as the
+container is replaced — do it in a maintenance window or accept a brief blip):
+
+```bash
+cd /opt/kagura-memory/src/terraform/single-server
+
+# 1. Validate BEFORE bouncing — never recreate the container on a broken config.
+docker compose -f docker-compose.prod.yml exec caddy \
+  caddy validate --config /etc/caddy/Caddyfile
+
+# 2. Apply: recreate (first rollout of the mount) or reload (steady-state edit).
+docker compose -f docker-compose.prod.yml up -d caddy        # first rollout
+# docker compose -f docker-compose.prod.yml exec caddy \
+#   caddy reload --config /etc/caddy/Caddyfile                # later *.caddy edits
+
+# 3. Confirm EXISTING vhosts are unaffected (acceptance: "no impact on existing
+#    vhosts") — re-check the main endpoints AFTER the recreate, not just the new one.
+curl -fsS https://memory.kagura-ai.com/health        # expect 200
+curl -fsS -o /dev/null -w '%{http_code}\n' https://memory.kagura-ai.com/   # main site
+
+# 4. Confirm the NEW sibling vhost responds.
+curl -fsS https://<sibling-domain>/...               # e.g. aw.kagura-ai.com
+```
+
+An empty `/opt/kagura-caddy-extra/` is valid — Caddy tolerates the glob import
+matching zero files, so the extension point is harmless until a sibling uses it.
+
 ## Teardown
 
 ```bash

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -469,8 +469,8 @@ will **not** resolve. Two working options:
 
 | Situation | Command | Why |
 |---|---|---|
-| **First rollout of this mount** (deploying the change that adds the `/opt/kagura-caddy-extra` volume) | `docker compose -f docker-compose.prod.yml up -d caddy` | A bind mount is fixed at container **creation** time. `docker compose restart` (and `deploy.sh`'s `restart caddy`) restart the *existing* container and do **not** apply a newly-added mount — the directory would be invisible inside the container. The container must be **recreated** once. |
-| **Adding / editing a `*.caddy` file** after the mount already exists | `docker compose -f docker-compose.prod.yml exec caddy caddy reload --config /etc/caddy/Caddyfile` | The mount is already present, so Caddy only needs to re-read config. A reload is sufficient and zero-downtime. |
+| **First rollout of this mount** (deploying the change that adds the `/opt/kagura-caddy-extra` volume) | `docker compose -f docker-compose.prod.yml --env-file .env.prod up -d caddy` | A bind mount is fixed at container **creation** time. `docker compose restart` (and `deploy.sh`'s `restart caddy`) restart the *existing* container and do **not** apply a newly-added mount — the directory would be invisible inside the container. The container must be **recreated** once. |
+| **Adding / editing a `*.caddy` file** after the mount already exists | `docker compose -f docker-compose.prod.yml --env-file .env.prod exec caddy caddy reload --config /etc/caddy/Caddyfile` | The mount is already present, so Caddy only needs to re-read config. A reload is sufficient and zero-downtime. |
 
 > The issue that introduced this called for "confirm with `caddy reload`" — that
 > is correct for steady-state `*.caddy` edits, but **not** for the first rollout
@@ -483,13 +483,15 @@ container is replaced — do it in a maintenance window or accept a brief blip):
 cd /opt/kagura-memory/src/terraform/single-server
 
 # 1. Validate BEFORE bouncing — never recreate the container on a broken config.
-docker compose -f docker-compose.prod.yml exec caddy \
+#    --env-file .env.prod matters: compose parses the whole file (all services),
+#    so omitting it mis-interpolates ${KAGURA_DOMAIN} etc. — see the build-args note above.
+docker compose -f docker-compose.prod.yml --env-file .env.prod exec caddy \
   caddy validate --config /etc/caddy/Caddyfile
 
 # 2. Apply: recreate (first rollout of the mount) or reload (steady-state edit).
-docker compose -f docker-compose.prod.yml up -d caddy        # first rollout
-# docker compose -f docker-compose.prod.yml exec caddy \
-#   caddy reload --config /etc/caddy/Caddyfile                # later *.caddy edits
+docker compose -f docker-compose.prod.yml --env-file .env.prod up -d caddy        # first rollout
+# docker compose -f docker-compose.prod.yml --env-file .env.prod exec caddy \
+#   caddy reload --config /etc/caddy/Caddyfile                                     # later *.caddy edits
 
 # 3. Confirm EXISTING vhosts are unaffected (acceptance: "no impact on existing
 #    vhosts") — re-check the main endpoints AFTER the recreate, not just the new one.

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -427,9 +427,46 @@ root-owned). Each file may contain full top-level vhost blocks, e.g.:
 # /opt/kagura-caddy-extra/aw.caddy   (owned by the ai-worker operator)
 aw.kagura-ai.com {
 	tls /etc/caddy/origin-ca/cert.pem /etc/caddy/origin-ca/key.pem
-	reverse_proxy ai-worker:9000
+	# Upstream MUST be reachable from inside the kagura-caddy container — see
+	# "Reaching the sibling's upstream" below. The host-gateway form works
+	# regardless of which compose project the sibling runs in:
+	reverse_proxy host.docker.internal:9000
 }
 ```
+
+**Reaching the sibling's upstream.** `kagura-caddy` runs on this compose
+project's default network (there is no explicit `networks:` block in
+`docker-compose.prod.yml`), so it resolves a sibling **service name** only if
+the sibling is on that same network. A service from a *separate* compose project
+is on a *different* network by default, so a bare `reverse_proxy ai-worker:9000`
+will **not** resolve. Two working options:
+
+- **Host-gateway (simplest, cross-project):** the sibling publishes a host port
+  (e.g. `127.0.0.1:9000`) and the vhost proxies to `host.docker.internal:9000`
+  (as in the example above). This requires Caddy to know the host gateway — add
+  it once to the caddy service in `docker-compose.prod.yml`:
+
+  ```yaml
+  caddy:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+  ```
+
+- **Shared network (service-name DNS):** the sibling's compose joins this
+  project's network as an `external` network, after which `reverse_proxy
+  ai-worker:9000` resolves by service name. Find the network name with
+  `docker inspect kagura-caddy -f '{{json .NetworkSettings.Networks}}'` (it is
+  this project's `*_default`), then in the sibling's compose:
+
+  ```yaml
+  networks:
+    kagura_shared:
+      external: true
+      name: <kagura-caddy's network, e.g. single-server_default>
+  services:
+    ai-worker:
+      networks: [kagura_shared]
+  ```
 
 **Applying changes — recreate vs reload (read this):**
 

--- a/terraform/single-server/docker-compose.prod.yml
+++ b/terraform/single-server/docker-compose.prod.yml
@@ -159,6 +159,13 @@ services:
       - /opt/kagura-caddy-extra:/opt/kagura-caddy-extra:ro
       - caddy_data:/data
       - caddy_config:/config
+    # Make the host gateway resolvable as host.docker.internal so sibling vhosts
+    # dropped into /opt/kagura-caddy-extra can `reverse_proxy
+    # host.docker.internal:<port>` out-of-the-box — without this, that name does
+    # not resolve on a Linux VM. Configured here once so the extension point is
+    # usable with no further memory-cloud changes. See README "Caddy extension point".
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     # No hard dependency on api-blue/api-green: during normal operation only
     # one color is active. Caddy handles upstream unavailability gracefully.
     depends_on:

--- a/terraform/single-server/docker-compose.prod.yml
+++ b/terraform/single-server/docker-compose.prod.yml
@@ -151,6 +151,12 @@ services:
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - /var/lib/kagura/origin-ca:/etc/caddy/origin-ca:ro
+      # Extension point for sibling services co-resident on this VM. They drop
+      # *.caddy vhost files here; Caddyfile imports them. Read-only so a sibling
+      # cannot mutate it from inside this container. Adding this mount to a
+      # running stack needs `docker compose up -d caddy` (recreate) — a plain
+      # `restart` does NOT apply a new mount. See README "Caddy extension point".
+      - /opt/kagura-caddy-extra:/opt/kagura-caddy-extra:ro
       - caddy_data:/data
       - caddy_config:/config
     # No hard dependency on api-blue/api-green: during normal operation only

--- a/terraform/single-server/startup.sh
+++ b/terraform/single-server/startup.sh
@@ -92,6 +92,13 @@ install -d -m 0700 /var/lib/kagura
 install -d -m 0700 /var/lib/kagura/origin-ca
 install -d -m 0755 /var/lib/kagura/volumes
 
+# Caddy extension point for sibling services co-resident on this VM (e.g.
+# kagura-memory-ai-worker). They drop *.caddy vhost files here; the caddy
+# container bind-mounts this read-only and Caddyfile imports it. root-owned
+# 0755: world-readable so the container can read it, root-write so only an
+# operator with sudo can add vhost files. See README "Caddy extension point".
+install -d -m 0755 -o root -g root /opt/kagura-caddy-extra
+
 # -----------------------------------------------------------------------------
 # Systemd unit — bring the compose stack back up on reboot
 #   The operator enables this with `sudo systemctl enable kagura-memory`


### PR DESCRIPTION
Closes #702

## Summary
- Add a one-time Caddy extension point so sibling services co-resident on the VM (e.g. `kagura-memory-ai-worker`'s `aw.kagura-ai.com` receiver) can publish their own HTTPS vhost without further memory-cloud PRs.
- `Caddyfile.tpl` gains a top-level `import /opt/kagura-caddy-extra/*.caddy` (outside the site block, so imported files can define their own vhosts); the rendered `Caddyfile` snapshot is kept consistent (deploy.sh regenerates it from `.tpl` via `envsubst '${API_UPSTREAM}'`).
- `docker-compose.prod.yml`: caddy service bind-mounts `/opt/kagura-caddy-extra` read-only.
- `startup.sh`: provisions `/opt/kagura-caddy-extra` (root:root, 0755).

## Implementation notes
- The import is top-level by design so siblings drop **full vhost blocks**, not snippets. Caddy tolerates the glob matching zero files, so the empty initial state is valid.
- envsubst uses an explicit allow-list (`deploy.sh:271`), so the literal import path passes through untouched — no interpolation hazard.
- README documents the **recreate-vs-reload** procedure: the first rollout of the mount needs `docker compose up -d caddy` (recreate) — a plain `restart` (what `deploy.sh` uses) does **not** apply a new mount; steady-state `*.caddy` edits need only `caddy reload`. Verification flow includes `caddy validate` before bouncing, a recreate-blip note, and post-recreate re-checks of existing endpoints.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (verification-completeness gap — addressed in-flight: README now re-verifies existing vhosts post-recreate)
- cto: green (follow-up suggestion noted: gitignore/CI-check the rendered Caddyfile to eliminate snapshot drift)
- gate1: yellow via /ask (COO lens — recreate-vs-reload correction, addressed)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/702-feat-chore-caddy-add-opt-kagura-caddy-extra-c.gate1.md
- ~/.claude/cache/gh-issue-driven/702-feat-chore-caddy-add-opt-kagura-caddy-extra-c.gate2.md

🤖 Generated via /gh-issue-driven:ship
