### PR TITLE
feat(db): workspace_connectors schema + max_connectors plan tier (#850)

### DIFF
--- a/backend/alembic/versions/e28_850_workspace_connectors.py
+++ b/backend/alembic/versions/e28_850_workspace_connectors.py
@@ -1,0 +1,110 @@
+"""Add workspace_connectors table — ai-worker chat-ingest connector profiles.
+
+Issue #850 (F6-a of epic #755, RFC-0001). The pure-backend schema foundation
+for ai-worker chat-ingest connectors, reusing memory-cloud's Resource
+Foundation. Net-new table only — the setup flow, seat-cap enforcement, and
+connector-scoped token minting land in F6-b; this migration is schema only.
+
+Design notes:
+- 1:1 with ``resources``: ``resource_pk`` is a NOT NULL FK to ``resources.id``
+  with a UNIQUE constraint. A new table has no backfill window, so
+  ``resource_pk`` is NOT NULL from creation — the Phase-1 nullable shadow
+  pattern used by the existing resource satellites (a97/#323) does not apply.
+- No ``resource_id`` slug column: the connector links purely by the
+  ``resource_pk`` UUID, sidestepping the CWE-639 slug-reuse class entirely, so
+  it is intentionally NOT hooked into the ORM ``_enforce_resource_pk_invariant``
+  before_insert listener (see models/resource.py).
+- ``oauth_tokens_encrypted`` stores Fernet ciphertext (utils/encryption.py);
+  plaintext OAuth tokens are never persisted.
+- ``workspace_id`` is denormalized for filter parity with the other resource
+  tables and CASCADE-deletes with the workspace.
+- Timestamps are naive ``DateTime`` to match the resource-table family; UTC is
+  guaranteed at the engine/container layer (see .claude/rules/backend.md).
+- The ``check_connector_type`` CHECK is kept byte-identical to the ORM
+  ``WorkspaceConnector.__table_args__`` so test_schema_drift.py stays green.
+
+Revision ID: e28_850_workspace_connectors
+Revises: e27_805_drop_ws_memory_limit
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from alembic import op
+
+# NOTE: revision id kept <= 32 chars — alembic_version.version_num is VARCHAR(32).
+revision: str = "e28_850_workspace_connectors"
+down_revision: str | Sequence[str] | None = "e27_805_drop_ws_memory_limit"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the workspace_connectors table (1:1 with resources)."""
+    op.create_table(
+        "workspace_connectors",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "resource_pk",
+            UUID(as_uuid=True),
+            sa.ForeignKey("resources.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "workspace_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("connector_type", sa.String(20), nullable=False),
+        # Fernet ciphertext of the OAuth token bundle (NULL until F6-b writes).
+        sa.Column("oauth_tokens_encrypted", sa.Text, nullable=True),
+        sa.Column("pii_guardrail_config", JSONB, nullable=True),
+        sa.Column("litellm_virtual_key_id", sa.String(255), nullable=True),
+        sa.Column(
+            "config_version",
+            sa.Integer,
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("virtual_key_valid_until", sa.DateTime, nullable=True),
+        sa.Column("created_by", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime,
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        # 1:1 connector -> resource. UNIQUE on the FK column is what enforces it.
+        sa.UniqueConstraint("resource_pk", name="uq_workspace_connectors_resource_pk"),
+        sa.CheckConstraint(
+            "connector_type IN ('slack', 'discord', 'teams')",
+            name="check_connector_type",
+        ),
+    )
+
+    # Workspace-scoped lookups (filter parity with the other resource tables).
+    op.create_index(
+        "ix_workspace_connectors_workspace_id",
+        "workspace_connectors",
+        ["workspace_id"],
+    )
+
+
+def downgrade() -> None:
+    """Drop the workspace_connectors table."""
+    op.drop_index("ix_workspace_connectors_workspace_id", table_name="workspace_connectors")
+    op.drop_table("workspace_connectors")

--- a/backend/src/config/plan_tiers.py
+++ b/backend/src/config/plan_tiers.py
@@ -41,6 +41,12 @@ class PlanTier:
         max_contexts_per_workspace: Maximum contexts per workspace
         max_members_per_workspace: Maximum members per workspace (Issue #229)
         max_resource_tokens: Maximum active resource tokens (Issue #242)
+        max_connectors: Maximum ai-worker chat-ingest connectors per
+            workspace (Issue #850, F6-a of #755). A SEPARATE seat cap from
+            ``max_resource_tokens`` — connector-owned resource tokens minted
+            by the F6-b setup flow bypass the ``max_resource_tokens`` Pro+
+            gate and are governed by this seat count instead. 0 disables
+            connector creation for the plan.
         memory_limit: Maximum memories per workspace
         daily_api_limit: Maximum API calls per day (legacy, kept for backward compatibility)
         weekly_api_limit: Maximum API calls per week (legacy, kept for backward compatibility)
@@ -68,6 +74,7 @@ class PlanTier:
     daily_api_limit: int  # Legacy field, use mcp_calls_per_day instead
     weekly_api_limit: int  # Legacy field, use mcp_calls_per_week instead
     max_resource_tokens: int = 0  # Issue #242: Active resource tokens limit
+    max_connectors: int = 0  # Issue #850 (F6-a of #755): ai-worker connector seat cap
     mcp_calls_per_day: int = 0  # Issue #238: MCP API quota
     mcp_calls_per_week: int = 0  # Issue #238: MCP API quota
     rest_calls_per_day: int = 0  # Issue #238: REST API quota
@@ -99,6 +106,7 @@ PLAN_FREE = PlanTier(
     max_contexts_per_workspace=1,
     max_members_per_workspace=1,  # Issue #229: Owner only
     max_resource_tokens=0,  # Issue #242: No resource tokens (PRO only)
+    max_connectors=0,  # Issue #850: no ai-worker connectors on Free
     memory_limit=1000,
     daily_api_limit=100,  # Legacy (backward compatibility)
     weekly_api_limit=500,  # Legacy (backward compatibility)
@@ -123,6 +131,7 @@ PLAN_BASIC = PlanTier(
     max_contexts_per_workspace=3,  # Limited to 3 contexts
     max_members_per_workspace=1,  # Issue #229: Owner only
     max_resource_tokens=3,  # Issue #242: Max 3 active tokens
+    max_connectors=1,  # Issue #850: 1 ai-worker connector seat on Basic
     allows_shared_contexts=False,  # Issue #271: Private contexts only (like Free)
     memory_limit=10000,
     daily_api_limit=2000,  # Legacy (backward compatibility)
@@ -147,6 +156,7 @@ PLAN_PRO = PlanTier(
     max_contexts_per_workspace=20,  # Issue #164: Set reasonable limit
     max_members_per_workspace=10,  # Issue #229: 10 members max for Pro plan
     max_resource_tokens=30,  # Issue #242: Max 30 active tokens
+    max_connectors=5,  # Issue #850: 5 ai-worker connector seats on Pro
     allows_shared_contexts=True,  # Issue #271: Shared contexts enabled
     memory_limit=100000,
     daily_api_limit=10000,  # Legacy (backward compatibility)

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -22,6 +22,7 @@ from models.resource import (
     ResourceSchema,
     ResourceToken,
     WorkspaceAddon,
+    WorkspaceConnector,
 )
 
 __all__ = [
@@ -34,4 +35,5 @@ __all__ = [
     "IndexerState",
     "ResourceToken",
     "WorkspaceAddon",
+    "WorkspaceConnector",
 ]

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1466,6 +1466,20 @@ class Workspace(Base):
         return self._plan_tier.max_resource_tokens
 
     @property
+    def effective_max_connectors(self) -> int:
+        """Max ai-worker connectors: tier-fixed value (Issue #850, F6-a of #755).
+
+        Like ``effective_max_resource_tokens``, this is a purely
+        tier-determined seat cap with no addon — no ``_zero_floor`` is needed
+        because there is no addon to clamp. It governs ai-worker chat-ingest
+        connector creation independently of ``max_resource_tokens``: the F6-b
+        setup flow mints a connector-owned resource token that bypasses the
+        ``max_resource_tokens`` Pro+ gate and is bounded by this count instead.
+        FREE=0 / BASIC=1 / PRO=5.
+        """
+        return self._plan_tier.max_connectors
+
+    @property
     def effective_sleep_enabled_contexts_limit(self) -> int:
         """Sleep-enabled contexts cap: plan tier base + addon (Issue #560).
 

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -10,6 +10,8 @@ Provides ORM models for:
     - ``indexer_state`` — job tracking
     - ``resource_tokens`` — Resource API authentication
     - ``workspace_addons`` — Addon purchase system
+    - ``workspace_connectors`` — ai-worker chat-ingest connector profiles
+      (Issue #850, F6-a of #755; 1:1 with ``resources``)
 
 Phase 1 (Issue #323, shipped v0.12.0): ``resource_pk`` and
 ``resource_tokens.workspace_id`` introduced as nullable shadow columns
@@ -434,6 +436,115 @@ class WorkspaceAddon(Base):
             name="uq_workspace_addons_workspace_addon_source",
         ),
     )
+
+
+class WorkspaceConnector(Base):
+    """ai-worker chat-ingest connector profile (Issue #850, F6-a of #755).
+
+    1:1 with a ``resources`` row (``resource_pk`` UNIQUE) — each connector
+    owns exactly one resource into which it ingests chat events. Net-new
+    table for the F6 epic (#755); the setup flow, seat-cap enforcement, and
+    connector-scoped token minting land in F6-b. This slice is schema only.
+
+    Unlike the other Resource Foundation satellites (events / schemas /
+    indexer_state / tokens), this table links to its resource purely by the
+    ``resource_pk`` UUID FK and carries NO ``resource_id`` slug mirror, so it
+    is intentionally **not** hooked into ``_enforce_resource_pk_invariant``
+    (that listener guards the dual-write ``resource_id``-without-``resource_pk``
+    shape). ``resource_pk`` is NOT NULL here, so the FK is always populated —
+    and the absence of a slug sidesteps the CWE-639 slug-reuse class entirely.
+
+    OAuth tokens are stored Fernet-encrypted in ``oauth_tokens_encrypted``;
+    use :meth:`set_oauth_tokens` / :meth:`get_oauth_tokens` so plaintext never
+    touches the column or the ORM identity map. See ``utils/encryption.py``.
+
+    Attributes:
+        id: Primary key (UUID)
+        resource_pk: 1:1 FK to ``resources.id`` (UNIQUE, CASCADE)
+        workspace_id: Owning workspace FK (CASCADE); denormalized for filter
+            parity with the other resource tables — MUST stay consistent with
+            ``resources.workspace_id``
+        connector_type: One of ``slack`` / ``discord`` / ``teams``
+        oauth_tokens_encrypted: Fernet ciphertext of the connector's OAuth
+            token bundle (NULL until the F6-b setup flow populates it)
+        pii_guardrail_config: PII-scrubbing config consumed by the ai-worker
+            pre-compile stage (F6-d)
+        litellm_virtual_key_id: LiteLLM virtual-key identifier (NULL until set)
+        config_version: Monotonic connector-config revision
+        virtual_key_valid_until: Expiry of the LiteLLM virtual key (NULL = none)
+        created_by: User ID who provisioned the connector
+        created_at / updated_at: Lifecycle timestamps (naive UTC, per backend.md)
+    """
+
+    __tablename__ = "workspace_connectors"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        server_default=func.gen_random_uuid(),
+    )
+    resource_pk: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("resources.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    workspace_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    connector_type: Mapped[str] = mapped_column(String(20), nullable=False)
+    oauth_tokens_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pii_guardrail_config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    litellm_virtual_key_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    config_version: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=1, server_default="1"
+    )
+    virtual_key_valid_until: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    created_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), onupdate=func.now()
+    )
+
+    __table_args__ = (
+        # 1:1 connector -> resource. UNIQUE on the FK column is what enforces it.
+        UniqueConstraint("resource_pk", name="uq_workspace_connectors_resource_pk"),
+        CheckConstraint(
+            "connector_type IN ('slack', 'discord', 'teams')",
+            name="check_connector_type",
+        ),
+    )
+
+    def set_oauth_tokens(self, tokens: dict[str, Any] | None) -> None:
+        """Encrypt and store the OAuth token bundle — no plaintext persisted.
+
+        Serializes ``tokens`` to JSON and Fernet-encrypts it into
+        ``oauth_tokens_encrypted``. A falsy bundle clears the column (stores
+        ``None``) rather than encrypting an empty string, which
+        ``APIKeyEncryption.encrypt`` rejects.
+        """
+        import json
+
+        from utils.encryption import get_encryptor
+
+        if not tokens:
+            self.oauth_tokens_encrypted = None
+            return
+        self.oauth_tokens_encrypted = get_encryptor().encrypt(json.dumps(tokens))
+
+    def get_oauth_tokens(self) -> dict[str, Any] | None:
+        """Decrypt and return the OAuth token bundle, or ``None`` if unset."""
+        import json
+
+        from utils.encryption import get_encryptor
+
+        if not self.oauth_tokens_encrypted:
+            return None
+        return json.loads(get_encryptor().decrypt(self.oauth_tokens_encrypted))
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/integration/test_e28_850_workspace_connectors_migration.py
+++ b/backend/tests/integration/test_e28_850_workspace_connectors_migration.py
@@ -1,0 +1,218 @@
+"""Integration tests for migration ``e28_850_workspace_connectors`` (#850, F6-a of #755).
+
+Covers the DB-level schema behaviour that ``TestAlembicMigrations`` does not:
+
+1. ``upgrade()`` creates ``workspace_connectors``; ``resource_pk`` is NOT NULL
+   from creation (no Phase-1 nullable shadow window for a brand-new table).
+2. The UNIQUE on ``resource_pk`` enforces the 1:1 connector -> resource contract
+   (a second connector for the same resource is rejected).
+3. The ``check_connector_type`` CHECK accepts ``slack`` / ``discord`` / ``teams``
+   and rejects anything else.
+4. Deleting the parent ``resources`` row CASCADE-deletes the connector.
+5. ``downgrade()`` drops the table.
+
+Pre-revision is ``e27_805_drop_ws_memory_limit`` — the head just before e28.
+Mirrors ``test_e16_709_embedding_spend_cap_migration.py``.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import inspect, text
+from sqlalchemy.exc import IntegrityError
+
+from alembic import command
+from tests.integration.test_alembic_migrations import (
+    _alembic_at_test_db,
+    _get_alembic_config,
+    _reset_alembic_state,
+    _sync_engine,
+)
+
+# Pinned so the test stays correct as more migrations land on top of e28.
+PRE_E28_REV = "e27_805_drop_ws_memory_limit"
+
+
+def _seed_user(conn, user_id: str | None = None) -> str:
+    uid = user_id or f"u-{uuid.uuid4().hex[:12]}"
+    conn.execute(
+        text(
+            "INSERT INTO users "
+            "(email, user_id, role, timezone, locale, is_initial_admin) "
+            "VALUES (:email, :uid, 'user', 'UTC', 'en', false)"
+        ),
+        {"email": f"{uid}@test.example", "uid": uid},
+    )
+    return uid
+
+
+def _seed_workspace(conn, owner_user_id: str) -> str:
+    ws_id = str(uuid.uuid4())
+    conn.execute(
+        text("INSERT INTO workspaces (id, name, owner_user_id) VALUES (:id, :name, :owner)"),
+        {"id": ws_id, "name": f"ws-{ws_id[:8]}", "owner": owner_user_id},
+    )
+    return ws_id
+
+
+def _seed_resource(conn, ws_id: str, slug: str | None = None) -> str:
+    res_id = str(uuid.uuid4())
+    conn.execute(
+        text("INSERT INTO resources (id, workspace_id, resource_id) VALUES (:id, :ws, :slug)"),
+        {"id": res_id, "ws": ws_id, "slug": slug or f"r-{res_id[:8]}"},
+    )
+    return res_id
+
+
+def _insert_connector(conn, *, resource_pk: str, workspace_id: str, connector_type: str = "slack"):
+    cid = str(uuid.uuid4())
+    conn.execute(
+        text(
+            "INSERT INTO workspace_connectors "
+            "(id, resource_pk, workspace_id, connector_type) "
+            "VALUES (:id, :rpk, :ws, :ct)"
+        ),
+        {"id": cid, "rpk": resource_pk, "ws": workspace_id, "ct": connector_type},
+    )
+    return cid
+
+
+def _leave_db_at_head() -> None:
+    with _alembic_at_test_db():
+        command.upgrade(_get_alembic_config(), "head")
+
+
+class TestE28WorkspaceConnectorsMigration:
+    def test_upgrade_creates_table_with_expected_columns(self):
+        _reset_alembic_state()
+        try:
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), PRE_E28_REV)
+            insp = inspect(_sync_engine())
+            assert "workspace_connectors" not in insp.get_table_names()
+
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), "e28_850_workspace_connectors")
+            insp = inspect(_sync_engine())
+            cols = {c["name"]: c for c in insp.get_columns("workspace_connectors")}
+            expected = {
+                "id",
+                "resource_pk",
+                "workspace_id",
+                "connector_type",
+                "oauth_tokens_encrypted",
+                "pii_guardrail_config",
+                "litellm_virtual_key_id",
+                "config_version",
+                "virtual_key_valid_until",
+                "created_by",
+                "created_at",
+                "updated_at",
+            }
+            assert expected <= set(cols)
+            # resource_pk is NOT NULL from creation (no shadow window).
+            assert cols["resource_pk"]["nullable"] is False
+        finally:
+            _leave_db_at_head()
+
+    def test_unique_resource_pk_enforces_one_to_one(self):
+        _reset_alembic_state()
+        try:
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), "e28_850_workspace_connectors")
+            eng = _sync_engine()
+            with eng.begin() as conn:
+                uid = _seed_user(conn)
+                ws = _seed_workspace(conn, uid)
+                res = _seed_resource(conn, ws)
+                _insert_connector(conn, resource_pk=res, workspace_id=ws)
+            # Second connector for the SAME resource must violate the UNIQUE.
+            with pytest.raises(IntegrityError) as exc_info, eng.begin() as conn:
+                _insert_connector(conn, resource_pk=res, workspace_id=ws, connector_type="discord")
+            # Pin the failure to the 1:1 constraint, not some unrelated future
+            # NOT NULL/FK that might also reject the second insert.
+            assert "uq_workspace_connectors_resource_pk" in str(exc_info.value)
+        finally:
+            _leave_db_at_head()
+
+    def test_connector_type_check_constraint(self):
+        _reset_alembic_state()
+        try:
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), "e28_850_workspace_connectors")
+            eng = _sync_engine()
+            # Valid types accepted.
+            for ct in ("slack", "discord", "teams"):
+                with eng.begin() as conn:
+                    uid = _seed_user(conn)
+                    ws = _seed_workspace(conn, uid)
+                    res = _seed_resource(conn, ws)
+                    _insert_connector(conn, resource_pk=res, workspace_id=ws, connector_type=ct)
+            # Invalid type rejected by check_connector_type.
+            with pytest.raises(IntegrityError), eng.begin() as conn:
+                uid = _seed_user(conn)
+                ws = _seed_workspace(conn, uid)
+                res = _seed_resource(conn, ws)
+                _insert_connector(conn, resource_pk=res, workspace_id=ws, connector_type="telegram")
+        finally:
+            _leave_db_at_head()
+
+    def test_resource_delete_cascades_to_connector(self):
+        _reset_alembic_state()
+        try:
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), "e28_850_workspace_connectors")
+            eng = _sync_engine()
+            with eng.begin() as conn:
+                uid = _seed_user(conn)
+                ws = _seed_workspace(conn, uid)
+                res = _seed_resource(conn, ws)
+                _insert_connector(conn, resource_pk=res, workspace_id=ws)
+            with eng.begin() as conn:
+                conn.execute(text("DELETE FROM resources WHERE id = :id"), {"id": res})
+            with eng.connect() as conn:
+                remaining = conn.execute(
+                    text("SELECT count(*) FROM workspace_connectors WHERE resource_pk = :rpk"),
+                    {"rpk": res},
+                ).scalar()
+            assert remaining == 0
+        finally:
+            _leave_db_at_head()
+
+    def test_workspace_delete_cascades_to_connector(self):
+        """Deleting the owning workspace must not orphan or block on the
+        connector — the workspace_id FK is ON DELETE CASCADE (independent of
+        the resource_pk CASCADE path)."""
+        _reset_alembic_state()
+        try:
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), "e28_850_workspace_connectors")
+            eng = _sync_engine()
+            with eng.begin() as conn:
+                uid = _seed_user(conn)
+                ws = _seed_workspace(conn, uid)
+                res = _seed_resource(conn, ws)
+                _insert_connector(conn, resource_pk=res, workspace_id=ws)
+            with eng.begin() as conn:
+                conn.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws})
+            with eng.connect() as conn:
+                remaining = conn.execute(
+                    text("SELECT count(*) FROM workspace_connectors WHERE workspace_id = :ws"),
+                    {"ws": ws},
+                ).scalar()
+            assert remaining == 0
+        finally:
+            _leave_db_at_head()
+
+    def test_downgrade_drops_table(self):
+        _reset_alembic_state()
+        try:
+            with _alembic_at_test_db():
+                command.upgrade(_get_alembic_config(), "e28_850_workspace_connectors")
+            assert "workspace_connectors" in inspect(_sync_engine()).get_table_names()
+
+            with _alembic_at_test_db():
+                command.downgrade(_get_alembic_config(), PRE_E28_REV)
+            assert "workspace_connectors" not in inspect(_sync_engine()).get_table_names()
+        finally:
+            _leave_db_at_head()

--- a/backend/tests/models/test_auth_effective_limits.py
+++ b/backend/tests/models/test_auth_effective_limits.py
@@ -124,3 +124,32 @@ class TestZeroBaseBypassClosed:
         ws._plan_tier = tier
         setattr(ws, addon_attr, None)
         assert getattr(Workspace, prop_name).fget(ws) == 100
+
+
+class TestEffectiveMaxConnectors:
+    """Issue #850 (F6-a of #755): the ai-worker connector seat cap is a
+    tier-fixed value with NO addon, mirroring ``effective_max_resource_tokens``.
+    It is therefore NOT part of the ``_zero_floor`` addon-stacking family above.
+    FREE=0 / BASIC=1 / PRO=5.
+    """
+
+    @pytest.mark.parametrize(
+        ("plan_name", "expected"),
+        [("free", 0), ("basic", 1), ("pro", 5)],
+    )
+    def test_tier_fixed_value(self, plan_name, expected):
+        from config.plan_tiers import get_plan_tier
+
+        ws = MagicMock()
+        ws._plan_tier = get_plan_tier(plan_name)
+        assert Workspace.effective_max_connectors.fget(ws) == expected
+
+    def test_reads_tier_directly_with_no_addon(self):
+        """No addon column feeds this cap — the property returns the tier value
+        unchanged (a stray addon-like attribute on the workspace is ignored)."""
+        from config.plan_tiers import get_plan_tier
+
+        ws = MagicMock()
+        ws._plan_tier = get_plan_tier("pro")
+        ws.addon_connector_bonus = 99  # no such addon exists; must be ignored
+        assert Workspace.effective_max_connectors.fget(ws) == 5

--- a/backend/tests/models/test_workspace_connector.py
+++ b/backend/tests/models/test_workspace_connector.py
@@ -1,0 +1,97 @@
+"""Unit tests for the WorkspaceConnector model (Issue #850, F6-a of #755).
+
+Schema-only slice. Verifies:
+- the Fernet round-trip helpers keep plaintext OAuth tokens off the column,
+- the 1:1 ``resource_pk`` contract (NOT NULL + UNIQUE),
+- the model is intentionally exempt from ``_enforce_resource_pk_invariant``
+  (it carries no ``resource_id`` slug, so the dual-write guard does not apply).
+
+These are ORM-mock / metadata-introspection tests (no DB) so they run under
+``make test-local``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import event
+
+from models.resource import (
+    ResourceToken,
+    WorkspaceConnector,
+    _enforce_resource_pk_invariant,
+)
+
+
+@pytest.fixture
+def _fernet_env(monkeypatch):
+    """Set a deterministic Fernet key and reset the get_encryptor singleton."""
+    monkeypatch.setenv("API_KEY_SECRET", Fernet.generate_key().decode())
+    import utils.encryption as enc_module
+
+    enc_module._encryptor = None
+    yield
+    enc_module._encryptor = None
+
+
+class TestOAuthTokenEncryption:
+    def test_round_trip(self, _fernet_env):
+        c = WorkspaceConnector()
+        tokens = {"access_token": "xoxb-abc-123", "refresh_token": "xoxr-def-456"}
+        c.set_oauth_tokens(tokens)
+
+        # Ciphertext is stored, and plaintext never appears in the column.
+        assert c.oauth_tokens_encrypted is not None
+        assert "xoxb-abc-123" not in c.oauth_tokens_encrypted
+        assert "xoxr-def-456" not in c.oauth_tokens_encrypted
+        # Round-trips back to the original bundle.
+        assert c.get_oauth_tokens() == tokens
+
+    def test_empty_bundle_clears_column(self, _fernet_env):
+        c = WorkspaceConnector()
+        c.set_oauth_tokens({"a": "b"})
+        assert c.oauth_tokens_encrypted is not None
+
+        c.set_oauth_tokens(None)
+        assert c.oauth_tokens_encrypted is None
+        assert c.get_oauth_tokens() is None
+
+    def test_get_when_unset_returns_none(self, _fernet_env):
+        assert WorkspaceConnector().get_oauth_tokens() is None
+
+
+class TestSchemaContract:
+    def test_resource_pk_not_null_and_unique(self):
+        table = WorkspaceConnector.__table__
+        assert "resource_pk" in table.columns
+        # New table => no Phase-1 nullable shadow window. NOT NULL from creation.
+        assert table.c.resource_pk.nullable is False
+        # 1:1 connector -> resource enforced by a UNIQUE on resource_pk.
+        unique_col_sets = {
+            tuple(col.name for col in uc.columns)
+            for uc in table.constraints
+            if uc.__class__.__name__ == "UniqueConstraint"
+        }
+        assert ("resource_pk",) in unique_col_sets
+
+    def test_no_resource_id_slug_column(self):
+        # Links purely by the resource_pk UUID — no slug mirror, which
+        # sidesteps the CWE-639 slug-reuse class entirely.
+        assert "resource_id" not in WorkspaceConnector.__table__.columns
+
+    def test_connector_type_check_constraint_present(self):
+        check_names = {
+            c.name
+            for c in WorkspaceConnector.__table__.constraints
+            if c.__class__.__name__ == "CheckConstraint"
+        }
+        assert "check_connector_type" in check_names
+
+    def test_exempt_from_resource_pk_invariant_listener(self):
+        # The dual-write guard hooks the slug-bearing satellites only.
+        assert not event.contains(
+            WorkspaceConnector, "before_insert", _enforce_resource_pk_invariant
+        )
+        # Sanity check that a slug-bearing satellite IS hooked, so this test
+        # would fail loudly if the listener wiring changed shape.
+        assert event.contains(ResourceToken, "before_insert", _enforce_resource_pk_invariant)


### PR DESCRIPTION
Closes #850

## Summary
- F6-a of epic #755 (RFC-0001): the pure-backend schema foundation for ai-worker chat-ingest connectors, reusing the Resource Foundation. Schema-only — setup flow, seat-cap enforcement, and connector-scoped token minting land in F6-b.
- New `workspace_connectors` table: 1:1 with `resources` via a **NOT NULL UNIQUE `resource_pk`** FK (new table → no Phase-1 nullable shadow window). Links purely by the resource_pk UUID (no `resource_id` slug), so it is intentionally exempt from `_enforce_resource_pk_invariant` and sidesteps the CWE-639 slug-reuse class.
- OAuth tokens stored Fernet-encrypted via `set_oauth_tokens`/`get_oauth_tokens` (no plaintext persisted; reuses `utils/encryption.py`).
- New `max_connectors` plan-tier dimension (FREE=0 / BASIC=1 / PRO=5) + tier-fixed `Workspace.effective_max_connectors`. This is a **separate seat cap** from `max_resource_tokens` (settled product decision: F6-b connector-token mint bypasses the resource_tokens Pro+ gate, bounded by this seat cap instead).

## Implementation notes
- `WorkspaceConnector` model added to `models/resource.py` alongside the Resource Foundation satellites; columns: resource_pk (1:1), workspace_id (CASCADE, denormalized for filter parity), connector_type (CHECK slack/discord/teams), oauth_tokens_encrypted, pii_guardrail_config (JSONB), litellm_virtual_key_id, config_version, virtual_key_valid_until, created_by, created_at/updated_at (naive UTC per backend.md).
- Alembic migration `e28_850` (down_revision `e27_805`, single head); `check_connector_type` CHECK kept byte-identical to the ORM so `test_schema_drift.py` stays green.
- `max_connectors` is additive on the frozen `PlanTier`; `admin_plans.py` asdict-spreads PlanTier but `PlanTierInfo` is Pydantic `extra=ignore`, so the field neither surfaces in the admin tiers API nor breaks it — admin-UI surfacing deferred to F6-b.

## Tests
- Unit (`test_workspace_connector.py`): Fernet round-trip (plaintext absent from ciphertext), empty-bundle clears column, schema contract (resource_pk NOT NULL + UNIQUE, no slug column, CHECK present, listener exemption with ResourceToken positive control).
- `test_auth_effective_limits.py`: `effective_max_connectors` FREE=0/BASIC=1/PRO=5.
- Integration (`test_e28_850_..._migration.py`): upgrade columns + NOT NULL, UNIQUE 1:1 pinned to constraint name, connector_type CHECK accept/reject, resource & workspace CASCADE, downgrade. 137 unit + 6 integration green; schema-drift + create_all-drift pass.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped (binary_gate = none)
- cso: green — established Fernet pattern; CWE-639 structurally closed; F6-b note to derive workspace_id from parent resource
- qa-lead: green — coverage thorough + non-vacuous; all 5 AC verified
- cto: green — right altitude; additive max_connectors; drift CI-guarded
- gate1: green via /claude-c-suite:ask (CIO lens)
- review provider: code-review

Part of epic #755 (F6-a). Full reviews in the plugin cache (gate1.md / gate2.md).

🤖 Generated via /gh-issue-driven:ship
