### PR TITLE
ci(frontend): build with webpack on CI runner (#855)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,15 @@ jobs:
       - name: Type check
         run: cd frontend && npx tsc --noEmit
 
+      # CI builds with the webpack compiler (`--webpack`) instead of the
+      # Next.js 16 default (Turbopack). Turbopack's `next build` hard-requires
+      # the native @next/swc-* binding, which `npm ci` fails to provide on the
+      # GitHub Actions runner (only the WASM fallback loads), aborting the
+      # build on every PR. The prod Docker build (frontend/Dockerfile) still
+      # uses Turbopack, so this flag is scoped to CI only — package.json's
+      # shared `build` script is left as the canonical Turbopack build. See #855.
       - name: Build
-        run: cd frontend && npm run build
+        run: cd frontend && npm run build -- --webpack
         env:
           NEXT_PUBLIC_API_URL: http://localhost:8080
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -20,7 +20,11 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   webServer: {
-    command: "npm run dev",
+    // In CI, force the webpack compiler — Turbopack (the Next.js 16 default)
+    // can't load its native @next/swc binding on the GitHub Actions runner,
+    // the same failure that breaks `next build` there. Locally, keep the
+    // default (Turbopack) for the faster dev experience. See #855.
+    command: process.env.CI ? "npm run dev -- --webpack" : "npm run dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/frontend/src/app/(authenticated)/profile/page.test.tsx
+++ b/frontend/src/app/(authenticated)/profile/page.test.tsx
@@ -15,10 +15,11 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import ProfilePage, {
+import ProfilePage from "./page";
+import {
   getSignInMethodLabel,
   getRefreshProviderName,
-} from "./page";
+} from "./signInLabels";
 
 // ---------- Mocks ------------------------------------------------------------
 

--- a/frontend/src/app/(authenticated)/profile/page.tsx
+++ b/frontend/src/app/(authenticated)/profile/page.tsx
@@ -34,41 +34,8 @@ import { useToast } from "@/hooks/use-toast";
 import { User, Moon, Sun, Save, RefreshCw } from "lucide-react";
 import { COMMON_TIMEZONES } from "@/lib/utils/datetime";
 import { apiClient, ApiError } from "@/lib/api/base";
-import type { User as AuthUser } from "@/lib/auth/auth";
 import { PageContainer } from "@/components/common/PageContainer";
-
-/**
- * Issue #514: derive the i18n label for the user's sign-in method.
- * Password users always show "Email + Password" regardless of auth_provider.
- * OAuth users with a known provider show that provider's name.
- * Pre-#361 OAuth users may have auth_provider=null; fall back to "Other".
- */
-export function getSignInMethodLabel(
-  user: Pick<AuthUser, "auth_method" | "auth_provider">,
-  t: (key: string) => string,
-): string {
-  if (user.auth_method === "password") return t("signInMethodPassword");
-  if (user.auth_provider === "google") return t("signInMethodGoogle");
-  if (user.auth_provider === "github") return t("signInMethodGitHub");
-  return t("signInMethodOther");
-}
-
-/**
- * Issue #515: localized provider name for i18n message interpolation.
- * Returns null when refresh is not available for the user (password auth
- * or legacy OAuth row with no recorded provider). The brand name itself
- * comes from ``signInMethodGoogle`` / ``signInMethodGitHub`` so all
- * user-visible text — even brand names — flows through next-intl.
- */
-export function getRefreshProviderName(
-  user: Pick<AuthUser, "auth_method" | "auth_provider">,
-  t: (key: string) => string,
-): string | null {
-  if (user.auth_method !== "oauth") return null;
-  if (user.auth_provider === "google") return t("signInMethodGoogle");
-  if (user.auth_provider === "github") return t("signInMethodGitHub");
-  return null;
-}
+import { getSignInMethodLabel, getRefreshProviderName } from "./signInLabels";
 
 export default function ProfilePage() {
   const t = useTranslations("profile");

--- a/frontend/src/app/(authenticated)/profile/signInLabels.ts
+++ b/frontend/src/app/(authenticated)/profile/signInLabels.ts
@@ -1,0 +1,43 @@
+/**
+ * Sign-in method label helpers for the profile page.
+ *
+ * Extracted from page.tsx because Next.js 16 App Router rejects arbitrary
+ * named exports from a `page.tsx` ("not a valid Page export field"). Keeping
+ * these pure i18n helpers in a sibling module lets both the page and its unit
+ * tests import them while page.tsx exports only its default component. See #855.
+ */
+
+import type { User as AuthUser } from "@/lib/auth/auth";
+
+/**
+ * Issue #514: derive the i18n label for the user's sign-in method.
+ * Password users always show "Email + Password" regardless of auth_provider.
+ * OAuth users with a known provider show that provider's name.
+ * Pre-#361 OAuth users may have auth_provider=null; fall back to "Other".
+ */
+export function getSignInMethodLabel(
+  user: Pick<AuthUser, "auth_method" | "auth_provider">,
+  t: (key: string) => string,
+): string {
+  if (user.auth_method === "password") return t("signInMethodPassword");
+  if (user.auth_provider === "google") return t("signInMethodGoogle");
+  if (user.auth_provider === "github") return t("signInMethodGitHub");
+  return t("signInMethodOther");
+}
+
+/**
+ * Issue #515: localized provider name for i18n message interpolation.
+ * Returns null when refresh is not available for the user (password auth
+ * or legacy OAuth row with no recorded provider). The brand name itself
+ * comes from ``signInMethodGoogle`` / ``signInMethodGitHub`` so all
+ * user-visible text — even brand names — flows through next-intl.
+ */
+export function getRefreshProviderName(
+  user: Pick<AuthUser, "auth_method" | "auth_provider">,
+  t: (key: string) => string,
+): string | null {
+  if (user.auth_method !== "oauth") return null;
+  if (user.auth_provider === "google") return t("signInMethodGoogle");
+  if (user.auth_provider === "github") return t("signInMethodGitHub");
+  return null;
+}


### PR DESCRIPTION
Closes #855

## Summary
- The `frontend` CI Build step (`npm run build`) fails on every PR: Next.js 16 defaults `next build` to **Turbopack**, which hard-requires the native `@next/swc-*` binding that `npm ci` fails to install on the GitHub Actions runner (only the WASM fallback loads → build aborts).
- Switch the CI build to the webpack compiler via `npm run build -- --webpack`, scoped to CI only — `package.json`'s `build` script and the prod Docker build (`frontend/Dockerfile`) keep Turbopack.
- Fixing the build surfaced a **latent, separate bug** it had been masking: `profile/page.tsx` exported two helper functions, which Next.js 16 App Router rejects (`"not a valid Page export field"`). Extracted them to a sibling module so the build-time type check passes.
- Also force webpack for the a11y `next dev` server **in CI** (`playwright.config.ts`), because the build fix unblocks the previously-skipped `frontend-a11y` / `frontend-a11y-authed` jobs (gated on `needs: [frontend]`), which also run a Turbopack-default dev server.

## Implementation notes
- `.github/workflows/ci.yml` — Build step → `npm run build -- --webpack` (+ comment explaining the CI-only scoping).
- `frontend/playwright.config.ts` — webServer command gated: `process.env.CI ? "npm run dev -- --webpack" : "npm run dev"` (local dev keeps Turbopack).
- `frontend/src/app/(authenticated)/profile/signInLabels.ts` (new) — `getSignInMethodLabel` / `getRefreshProviderName` moved verbatim out of `page.tsx`.
- `page.tsx` / `page.test.tsx` — import the helpers from `./signInLabels`.
- `--webpack` confirmed as a registered flag for both `next build` and `next dev` in the installed Next 16.2.6 CLI.

## Verification
- `next build --webpack`: compile ✓, Next build-time TypeScript check ✓ (the page-export error is gone).
- `tsc --noEmit`: no errors. Profile unit tests: 23/23 pass (helpers imported from the new module).
- A `/login` error during the *local* full build was traced to the local Docker dev container (`kagura-web-dev`) writing the shared `.next` dir — not reproducible on a clean CI runner.

## ⚠️ Reviewer watch-item (gate2 qa-lead yellow)
This fix **unblocks** `frontend-a11y` and `frontend-a11y-authed`, which were silently skipped on every prior PR (their `needs: [frontend]` dependency always failed). They now execute for the first time. The playwright CI→webpack change pre-empts the native-binding failure for their dev server, but **please confirm on the first CI run that `frontend`, `frontend-a11y`, and `frontend-a11y-authed` are all green** — that is the de-facto acceptance check.

## Trade-off (by design)
CI now builds with webpack while prod builds with Turbopack, so Turbopack-specific build regressions (cf. #643 class) won't be caught in CI. Accepted because the prod Turbopack build runs on every deploy. Follow-up: revert CI to Turbopack once the upstream npm optionalDependencies resolution bug is fixed.

## Pre-PR review summary
- gate2 mode: advisor-only (binary_gate: none)
- cso: green
- qa-lead: yellow (a11y-unblock watch-item above; code change itself low-risk)
- cto: green
- gate1: green via /claude-c-suite:ask (routed to COO)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/855-fix-ci-frontend-turbopack-native-binding.gate1.md
- ~/.claude/cache/gh-issue-driven/855-fix-ci-frontend-turbopack-native-binding.gate2.md

🤖 Generated via /gh-issue-driven:ship
