### PR TITLE
fix(api): race-safe connector seat-cap via advisory lock (#857)

### DIFF
--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -14,7 +14,8 @@ from datetime import datetime
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.resource_tokens import ResourceTokenManager
@@ -166,6 +167,15 @@ class ConnectorProvisioningService:
         return workspace
 
     async def _enforce_connector_seat_cap(self, workspace: Workspace, workspace_id: UUID) -> None:
+        # Issue #857: acquire a per-workspace ``pg_advisory_xact_lock`` before
+        # the count read so two concurrent provisions for the last seat cannot
+        # both observe ``count < cap`` and both insert (TOCTOU over-provision).
+        # The lock is xact-scoped, so the caller's transaction — which extends
+        # from this gate through ``db.flush()`` of the new connector — keeps the
+        # serialization across the read-then-write. Mirrors the workspace-create
+        # cap (#677, ``quota_service.py``) and the admin-bonus path (``admin.py``).
+        await self._acquire_connector_seat_lock(workspace_id)
+
         max_connectors = workspace.effective_max_connectors
         active_count_result = await self.db.execute(
             select(func.count(WorkspaceConnector.id)).where(
@@ -181,6 +191,55 @@ class ConnectorProvisioningService:
                 max_connectors=max_connectors,
                 active_connectors=active_count,
             )
+
+    async def _acquire_connector_seat_lock(self, workspace_id: UUID) -> None:
+        """Take the per-workspace advisory lock guarding seat-cap enforcement.
+
+        Unlike the workspace-creation cap (#677), connector seat-cap is always
+        enforced — there is no log-only rollout flag — so the lock-error policy
+        is unconditionally **fail-closed**: a lock-acquire failure denies the
+        provision rather than letting it through.
+
+        ``SET LOCAL lock_timeout = '5s'`` bounds the wait so a pathologically
+        long peer transaction cannot stall the worker indefinitely. On SQLSTATE
+        ``55P03`` (``lock_not_available``) we rollback the poisoned session and
+        raise a retriable 503; any other DB error propagates after rollback. The
+        reset to ``'0'`` after a successful acquire keeps the 5s timeout from
+        bleeding into the subsequent count SELECT, connector INSERT, and token
+        mint that share this transaction.
+
+        ``hashtextextended(:key, 0)`` returns the 64-bit hash matching the
+        bigint signature of single-key ``pg_advisory_xact_lock``; 32-bit
+        ``hashtext`` would collide at ~65k workspaces and block unrelated
+        tenants (PR #686 loop 4).
+        """
+        lock_key = f"connector_seat:{workspace_id}"
+        await self.db.execute(text("SET LOCAL lock_timeout = '5s'"))
+        try:
+            await self.db.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:key, 0))").bindparams(
+                    key=lock_key
+                )
+            )
+        except DBAPIError as exc:
+            sqlstate = getattr(exc.orig, "sqlstate", None) or getattr(exc.orig, "pgcode", None)
+            # The session is poisoned until rollback — issue it before raising
+            # so the next request on this session starts clean.
+            await self.db.rollback()
+            if sqlstate == "55P03":
+                logger.warning(
+                    "connector_seat_lock_timeout",
+                    workspace_id=str(workspace_id),
+                )
+                raise MemoryCloudException(
+                    "Connector seat lock unavailable; please retry.",
+                    status_code=503,
+                    error_code="CONNECTOR-002",
+                ) from exc
+            raise
+        # Reset is on the success path only; on failure the rollback above has
+        # already cleared the SET LOCAL along with the rest of the transaction.
+        await self.db.execute(text("SET LOCAL lock_timeout = '0'"))
 
     async def _get_connector_for_resource(
         self,

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -167,16 +167,32 @@ class ConnectorProvisioningService:
         return workspace
 
     async def _enforce_connector_seat_cap(self, workspace: Workspace, workspace_id: UUID) -> None:
-        # Issue #857: acquire a per-workspace ``pg_advisory_xact_lock`` before
-        # the count read so two concurrent provisions for the last seat cannot
-        # both observe ``count < cap`` and both insert (TOCTOU over-provision).
-        # The lock is xact-scoped, so the caller's transaction — which extends
-        # from this gate through ``db.flush()`` of the new connector — keeps the
-        # serialization across the read-then-write. Mirrors the workspace-create
-        # cap (#677, ``quota_service.py``) and the admin-bonus path (``admin.py``).
+        max_connectors = workspace.effective_max_connectors
+
+        # Zero-cap plans (Free: max_connectors == 0) can never provision, so deny
+        # deterministically WITHOUT taking the advisory lock. Acquiring it first
+        # would let lock contention / lock_timeout turn this guaranteed 403
+        # (CONNECTOR-001) into a retriable 503 (CONNECTOR-002) for a request that
+        # can never succeed — and waste a lock + count round-trip (PR #860 review).
+        if max_connectors <= 0:
+            raise MemoryCloudException(
+                (f"Connector seat limit reached. Your plan allows {max_connectors} connector(s)."),
+                status_code=403,
+                error_code="CONNECTOR-001",
+                max_connectors=max_connectors,
+                active_connectors=0,
+            )
+
+        # Issue #857: for a positive cap, acquire a per-workspace
+        # ``pg_advisory_xact_lock`` before the count read so two concurrent
+        # provisions for the last seat cannot both observe ``count < cap`` and
+        # both insert (TOCTOU over-provision). The lock is xact-scoped, so the
+        # caller's transaction — which extends from this gate through
+        # ``db.flush()`` of the new connector — keeps the serialization across
+        # the read-then-write. Mirrors the workspace-create cap (#677,
+        # ``quota_service.py``) and the admin-bonus path (``admin.py``).
         await self._acquire_connector_seat_lock(workspace_id)
 
-        max_connectors = workspace.effective_max_connectors
         active_count_result = await self.db.execute(
             select(func.count(WorkspaceConnector.id)).where(
                 WorkspaceConnector.workspace_id == workspace_id

--- a/backend/tests/integration/test_connector_seat_cap_advisory_lock.py
+++ b/backend/tests/integration/test_connector_seat_cap_advisory_lock.py
@@ -1,0 +1,263 @@
+"""Integration tests for the connector seat-cap advisory lock (#857).
+
+These tests exercise the real Postgres ``pg_advisory_xact_lock`` primitive
+that ``ConnectorProvisioningService._enforce_connector_seat_cap`` acquires
+before counting active connectors. Mocked unit tests in
+``tests/services/test_connector_provisioning.py`` cannot reproduce the TOCTOU
+race because they bypass transaction-level concurrency — the very thing we
+guard against. This mirrors the workspace-creation cap test
+(``test_quota_service_advisory_lock.py``, #677), which established the pattern.
+
+Two layers (the #677 layer-3 ``lock_wait_ms`` metric assertion is intentionally
+out of scope here — connector provisioning does not log a per-acquire wait):
+
+1. **Deterministic race** — N >> cap parallel provisions must yield exactly
+   ``cap`` connectors, never more. Positive proof the lock serializes the
+   read-then-write under contention (AC: "exactly one succeeds, the other 403"
+   generalized to N).
+
+2. **Negative control** — with the advisory lock monkeypatched to a no-op, an
+   ``asyncio.Barrier`` forces all workers to finish the cap-count SELECT before
+   any of them inserts, deterministically reproducing ``count > cap``. Proves
+   the test setup is genuinely racy when the safeguard is removed, so the
+   positive test above cannot pass by lucky scheduling.
+
+The ``pro`` plan grants ``max_connectors = 5`` (cap = 5). The fixture
+pre-creates ``_PARALLEL_ATTEMPTS`` resource rows (the 1:1 FK target each
+connector needs) so every attempt can stage an insert against a distinct
+``resource_pk`` and the only thing bounding inserts is the seat cap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from models.auth import User, Workspace
+from models.resource import Resource, WorkspaceConnector
+from services.connector_provisioning import ConnectorProvisioningService
+from utils.exceptions import MemoryCloudException
+
+_CAP = 5  # pro plan max_connectors
+_PARALLEL_ATTEMPTS = 20
+
+
+async def _count_connectors(session: AsyncSession, workspace_id) -> int:
+    result = await session.execute(
+        select(func.count(WorkspaceConnector.id)).where(
+            WorkspaceConnector.workspace_id == workspace_id
+        )
+    )
+    return int(result.scalar() or 0)
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def pro_workspace_with_resources(
+    db_session: AsyncSession,
+) -> AsyncIterator[tuple[object, list[object]]]:
+    """A ``pro`` workspace (cap=5) plus N spare resources for connector inserts.
+
+    Cleans up connectors → resources → workspace → user after the test so
+    repeated suite runs do not accumulate rows that skew later fixtures.
+    """
+    user_id = f"u_{uuid4().hex[:8]}"
+    workspace_id = uuid4()
+    db_session.add(
+        User(
+            email=f"{user_id}@connector-toctou.invalid",
+            user_id=user_id,
+            name="Connector TOCTOU User",
+            role="user",
+            is_initial_admin=False,
+            auth_method="oauth",
+            auth_provider="google",
+        )
+    )
+    db_session.add(
+        Workspace(
+            id=workspace_id,
+            name=f"conn-toctou-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=user_id,
+            daily_api_limit=500,
+            weekly_api_limit=2500,
+            deleted_at=None,
+        )
+    )
+    resource_pks: list[object] = []
+    for i in range(_PARALLEL_ATTEMPTS):
+        rid = uuid4()
+        db_session.add(
+            Resource(
+                id=rid,
+                workspace_id=workspace_id,
+                resource_id=f"conn-res-{i}-{uuid4().hex[:6]}",
+                name=f"connector resource {i}",
+                created_by=user_id,
+            )
+        )
+        resource_pks.append(rid)
+    await db_session.commit()
+
+    yield workspace_id, resource_pks
+
+    await db_session.execute(
+        WorkspaceConnector.__table__.delete().where(WorkspaceConnector.workspace_id == workspace_id)
+    )
+    await db_session.execute(
+        Resource.__table__.delete().where(Resource.workspace_id == workspace_id)
+    )
+    await db_session.execute(Workspace.__table__.delete().where(Workspace.id == workspace_id))
+    await db_session.execute(User.__table__.delete().where(User.user_id == user_id))
+    await db_session.commit()
+
+
+async def _attempt_one_provision(
+    session_maker: async_sessionmaker[AsyncSession],
+    workspace_id,
+    resource_pk,
+) -> bool:
+    """Try to provision one connector; return True iff the insert committed.
+
+    The seat-cap gate (which takes the xact-scoped advisory lock) and the
+    connector INSERT run inside a single ``session.begin()`` block so the lock
+    holds across both — the contract ``provision_connector`` honors in
+    production (gate → ``db.flush()`` of the connector in the same tx).
+    """
+    async with session_maker() as session:
+        async with session.begin():
+            svc = ConnectorProvisioningService(session)
+            workspace = await svc._get_workspace(workspace_id)
+            try:
+                await svc._enforce_connector_seat_cap(workspace, workspace_id)
+            except MemoryCloudException:
+                return False
+            session.add(
+                WorkspaceConnector(
+                    resource_pk=resource_pk,
+                    workspace_id=workspace_id,
+                    connector_type="slack",
+                    created_by="connector-toctou",
+                )
+            )
+            return True
+
+
+class TestConnectorSeatCapSerializesAtCap:
+    """The lock must hold ``count <= cap`` under any level of concurrency."""
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_n_parallel_provisions_produce_exactly_cap(
+        self, async_engine, pro_workspace_with_resources
+    ):
+        workspace_id, resource_pks = pro_workspace_with_resources
+        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+        results = await asyncio.gather(
+            *[
+                _attempt_one_provision(session_maker, workspace_id, resource_pks[i])
+                for i in range(_PARALLEL_ATTEMPTS)
+            ],
+            return_exceptions=True,
+        )
+
+        unexpected = [r for r in results if not isinstance(r, bool)]
+        assert not unexpected, f"unexpected exceptions from attempts: {unexpected!r}"
+
+        successes = sum(1 for r in results if r is True)
+        assert successes == _CAP, (
+            f"expected exactly {_CAP} successful provisions, got {successes} (results: {results!r})"
+        )
+
+        async with session_maker() as session:
+            count = await _count_connectors(session, workspace_id)
+        assert count == _CAP, f"final connector count is {count}, must equal cap={_CAP}"
+
+
+class TestConnectorSeatCapNegativeControl:
+    """Without the lock, the same parallel pattern MUST reproduce ``count > cap``.
+
+    Regression safeguard for the positive test: if the production advisory lock
+    silently breaks, the positive test could still pass by lucky scheduling.
+    This negative control confirms the test setup is genuinely racy when the
+    lock is removed.
+    """
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_count_exceeds_cap_when_lock_is_noop(
+        self, async_engine, pro_workspace_with_resources, monkeypatch
+    ):
+        async def _noop(self_, workspace_id) -> None:
+            return None
+
+        monkeypatch.setattr(
+            ConnectorProvisioningService,
+            "_acquire_connector_seat_lock",
+            _noop,
+            raising=True,
+        )
+
+        workspace_id, resource_pks = pro_workspace_with_resources
+        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+        # Without a barrier between the cap-count SELECT and the INSERT,
+        # asyncio's cooperative scheduler can interleave each task's
+        # check+insert serially (later tasks observing prior commits) and the
+        # race never materializes. The barrier forces all N workers to finish
+        # the count read BEFORE any of them inserts, deterministically
+        # reproducing the TOCTOU when the lock is disabled (mirrors #677).
+        all_read = asyncio.Barrier(_PARALLEL_ATTEMPTS)
+
+        async def attempt_with_barrier(resource_pk) -> bool:
+            try:
+                async with session_maker() as session:
+                    async with session.begin():
+                        svc = ConnectorProvisioningService(session)
+                        workspace = await svc._get_workspace(workspace_id)
+                        try:
+                            await svc._enforce_connector_seat_cap(workspace, workspace_id)
+                            over_cap = False
+                        except MemoryCloudException:
+                            over_cap = True
+                        # All workers must have read before any of us inserts.
+                        await all_read.wait()
+                        if over_cap:
+                            return False
+                        session.add(
+                            WorkspaceConnector(
+                                resource_pk=resource_pk,
+                                workspace_id=workspace_id,
+                                connector_type="slack",
+                                created_by="connector-toctou",
+                            )
+                        )
+                        return True
+            except Exception:
+                # Any pre-barrier failure must release peer waiters so
+                # asyncio.gather does not deadlock. abort() is idempotent.
+                try:
+                    await all_read.abort()
+                except Exception:
+                    pass
+                raise
+
+        await asyncio.gather(
+            *[attempt_with_barrier(resource_pks[i]) for i in range(_PARALLEL_ATTEMPTS)],
+            return_exceptions=True,
+        )
+
+        async with session_maker() as session:
+            count = await _count_connectors(session, workspace_id)
+
+        assert count > _CAP, (
+            f"with lock disabled, expected count > cap={_CAP}; got {count}. "
+            f"Either the barrier did not synchronize all workers before the "
+            f"INSERT phase, or production has a second serialization path "
+            f"besides the advisory lock that this test does not reach."
+        )

--- a/backend/tests/integration/test_connector_seat_cap_advisory_lock.py
+++ b/backend/tests/integration/test_connector_seat_cap_advisory_lock.py
@@ -244,13 +244,21 @@ class TestConnectorSeatCapNegativeControl:
                 try:
                     await all_read.abort()
                 except Exception:
+                    # Best-effort: the original exception is re-raised below, so a
+                    # failure to abort the (possibly already-broken) barrier must
+                    # not mask it.
                     pass
                 raise
 
-        await asyncio.gather(
+        results = await asyncio.gather(
             *[attempt_with_barrier(resource_pks[i]) for i in range(_PARALLEL_ATTEMPTS)],
             return_exceptions=True,
         )
+        # Surface unexpected worker exceptions instead of letting them masquerade
+        # as the race outcome (mirrors the positive test's guard). Every worker
+        # must return a bool; a non-bool entry is a setup failure, not contention.
+        unexpected = [r for r in results if not isinstance(r, bool)]
+        assert not unexpected, f"unexpected exceptions from barrier workers: {unexpected!r}"
 
         async with session_maker() as session:
             count = await _count_connectors(session, workspace_id)

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -47,10 +47,10 @@ class TestConnectorProvisioningService:
     @pytest.mark.asyncio
     async def test_free_plan_zero_connector_cap_blocks_before_writes(self, mock_db):
         workspace_id = uuid4()
+        # #857/PR #860: a zero-cap plan short-circuits to 403 BEFORE the advisory
+        # lock and count — so only the workspace lookup runs (no lock results).
         mock_db.execute.side_effect = [
             _result(one=SimpleNamespace(effective_max_connectors=0)),
-            *_lock_results(),
-            _result(scalar=0),
         ]
 
         with patch("services.connector_provisioning.upsert_resource", new=AsyncMock()) as upsert:
@@ -66,6 +66,9 @@ class TestConnectorProvisioningService:
         assert exc_info.value.error_code == "CONNECTOR-001"
         upsert.assert_not_awaited()
         mock_db.add.assert_not_called()
+        # Only the workspace lookup ran — the zero-cap path never reached the
+        # advisory-lock SET LOCAL / pg_advisory_xact_lock or the count query.
+        assert mock_db.execute.call_count == 1
 
     @pytest.mark.asyncio
     async def test_basic_plan_at_cap_blocks_paid_boundary(self, mock_db):

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from sqlalchemy.exc import DBAPIError
 
 from services.connector_provisioning import (
     ConnectorProvisioningService,
@@ -20,6 +21,19 @@ def _result(*, one=None, scalar=None):
     return result
 
 
+def _lock_results():
+    """Mock execute() results for the #857 advisory-lock acquire sequence.
+
+    ``_acquire_connector_seat_lock`` issues three statements before the
+    seat-count SELECT — ``SET LOCAL lock_timeout='5s'``, the
+    ``pg_advisory_xact_lock`` SELECT, then ``SET LOCAL lock_timeout='0'`` — and
+    ignores all three return values. Splice these into ``execute.side_effect``
+    right after the workspace lookup so the count read still lands on the
+    intended mock result.
+    """
+    return [_result(), _result(), _result()]
+
+
 class TestConnectorProvisioningService:
     @pytest.fixture
     def mock_db(self):
@@ -27,6 +41,7 @@ class TestConnectorProvisioningService:
         db.execute = AsyncMock()
         db.add = MagicMock()
         db.flush = AsyncMock()
+        db.rollback = AsyncMock()
         return db
 
     @pytest.mark.asyncio
@@ -34,6 +49,7 @@ class TestConnectorProvisioningService:
         workspace_id = uuid4()
         mock_db.execute.side_effect = [
             _result(one=SimpleNamespace(effective_max_connectors=0)),
+            *_lock_results(),
             _result(scalar=0),
         ]
 
@@ -57,6 +73,7 @@ class TestConnectorProvisioningService:
         workspace_id = uuid4()
         mock_db.execute.side_effect = [
             _result(one=SimpleNamespace(effective_max_connectors=1)),
+            *_lock_results(),
             _result(scalar=1),
         ]
 
@@ -82,6 +99,7 @@ class TestConnectorProvisioningService:
         token = SimpleNamespace(id=123, quota_events_per_hour=1000)
         mock_db.execute.side_effect = [
             _result(one=SimpleNamespace(effective_max_connectors=1)),
+            *_lock_results(),
             _result(scalar=0),
             _result(one=None),
         ]
@@ -120,6 +138,7 @@ class TestConnectorProvisioningService:
             _result(
                 one=SimpleNamespace(effective_max_connectors=1, effective_max_resource_tokens=0)
             ),
+            *_lock_results(),
             _result(scalar=0),
             _result(one=None),
         ]
@@ -151,12 +170,43 @@ class TestConnectorProvisioningService:
         assert mock_db.add.call_args.args[0].resource_pk == resource_pk
 
     @pytest.mark.asyncio
+    async def test_seat_lock_timeout_fails_closed_503(self, mock_db):
+        """#857: lock-acquire 55P03 → rollback + retriable 503 (fail-closed)."""
+        workspace_id = uuid4()
+
+        class _Orig(Exception):
+            sqlstate = "55P03"
+
+        lock_timeout = DBAPIError("SELECT pg_advisory_xact_lock(...)", {}, _Orig())
+        mock_db.execute.side_effect = [
+            _result(one=SimpleNamespace(effective_max_connectors=1)),
+            _result(),  # SET LOCAL lock_timeout = '5s'
+            lock_timeout,  # pg_advisory_xact_lock raises
+        ]
+
+        with patch("services.connector_provisioning.upsert_resource", new=AsyncMock()) as upsert:
+            with pytest.raises(MemoryCloudException) as exc_info:
+                await ConnectorProvisioningService(mock_db).provision_connector(
+                    workspace_id=workspace_id,
+                    user_id="user-1",
+                    connector_type="slack",
+                    resource_id="slack_general",
+                )
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.error_code == "CONNECTOR-002"
+        mock_db.rollback.assert_awaited_once()
+        upsert.assert_not_awaited()
+        mock_db.add.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_existing_connector_for_resource_rejects_duplicate(self, mock_db):
         workspace_id = uuid4()
         resource_pk = uuid4()
         connector_id = uuid4()
         mock_db.execute.side_effect = [
             _result(one=SimpleNamespace(effective_max_connectors=5)),
+            *_lock_results(),
             _result(scalar=0),
             _result(one=SimpleNamespace(id=connector_id)),
         ]
@@ -191,6 +241,7 @@ class TestConnectorProvisioningService:
         resource_pk = uuid4()
         mock_db.execute.side_effect = [
             _result(one=SimpleNamespace(effective_max_connectors=5)),
+            *_lock_results(),
             _result(scalar=0),
             _result(one=None),
         ]


### PR DESCRIPTION
Closes #857

## Summary
- Fix a TOCTOU race in connector seat-cap enforcement: `_enforce_connector_seat_cap` did a count-then-insert with no lock between, so two concurrent provisions for the last seat could both pass the cap check and both insert (`max_connectors + 1`).
- Acquire a per-workspace `pg_advisory_xact_lock(hashtextextended('connector_seat:'||workspace_id, 0))` before the count, reusing the #677 workspace-create idiom. The xact-scoped lock holds across count → connector insert → commit (both REST and MCP callers commit the same open session).
- Connector cap is always enforced (no rollout flag), so the lock-error policy is unconditionally **fail-closed**: SQLSTATE 55P03 → rollback + retriable 503 (`CONNECTOR-002`); other DB errors propagate after rollback.

## Implementation notes
- New `_acquire_connector_seat_lock(workspace_id)` mirrors `quota_service.py` / `admin.py`: `SET LOCAL lock_timeout='5s'` bracket + reset to `'0'` on success so the 5s timeout doesn't bleed into the subsequent count/insert/token-mint. Uses 64-bit `hashtextextended` (not 32-bit `hashtext`) to avoid the ~65k-workspace collision that #686 loop 4 fixed.
- Existing 6 unit-test `side_effect` lists updated via a `_lock_results()` helper for the +3 `db.execute` calls the lock adds (the "mock execute-count drift" trap from #856).

## Tests
- Unit: `test_seat_lock_timeout_fails_closed_503` (55P03 → 503 `CONNECTOR-002`, rollback, no writes). All 10 unit tests pass.
- Integration (real Postgres, mirrors #677 `test_quota_service_advisory_lock.py`): **layer 1** deterministic race — pro plan (cap=5), 20 parallel provisions → exactly 5 succeed and final count == 5; **layer 2** negative control — lock no-op'd + `asyncio.Barrier(20)` → count > 5 (proves the test is genuinely racy without the lock). Both pass.

## Deferred (follow-ups)
- `resource_tokens.py:327` sibling cap is the same race class — deferred to keep this PR atomic; the same #677 pattern applies.
- This is the 3rd copy of the bounded-advisory-xact-lock idiom (`quota_service` / `admin` / connector). Extracting a shared `acquire_advisory_xact_lock(db, key, *, enforce)` helper is legitimate debt — a separate follow-up (CTO gate2 note).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green / qa-lead: green / cto: green
- gate1: green via /ask (QA Lead lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
