### PR TITLE
feat(mcp): read-only list_my_bindings / describe_binding tools (#629)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Most AI memory tools are just vector databases with a chat wrapper. Kagura is di
 | **Hybrid Search** | Semantic (OpenAI/Ollama) + BM25 keyword — 96% top-1 accuracy |
 | **AI Reranking** | Ollama (local, free), Voyage AI, or Cohere — cross-encoder reranking for precision |
 | **Neural Memory Graph** | Hebbian learning builds a knowledge graph in the background. `explore()` traverses it for serendipitous discovery. |
-| **37 MCP Tools** | Memory, Neural edges, Contexts, Tags, Files (R2), Analyses (broadlistening), Resources, Sleep Maintenance, Usage |
+| **39 MCP Tools** | Memory, Neural edges, Contexts, Tags, Files (R2), Analyses (broadlistening), Resources, Sleep Maintenance, Usage |
 | **Multi-Provider** | OpenAI or Ollama (local, private, zero cost) for embeddings |
 | **Team Ready** | Workspaces, RBAC, context isolation, shared memory |
 | **Web UI** | Next.js dashboard — contexts, search settings, member management |
@@ -404,7 +404,7 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP Tools
 
-37 tools across 9 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
+39 tools across 10 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
 
 ### Memory (6)
 
@@ -491,6 +491,13 @@ Background consolidation of memories (decay, edge pruning, theme summarization).
 | Tool | Description | Required Role |
 |------|------------|---------------|
 | `get_usage` | Get current workspace usage (memories, contexts, members, MCP calls/day) | Viewer+ |
+
+### API-Key Bindings (2)
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `list_my_bindings` | List your public-bound API keys (read-only; owner-scoped) | Viewer+ |
+| `describe_binding` | Describe one binding by `key_id` XOR `context_id` (read-only; owner-scoped) | Viewer+ |
 
 ## REST API
 

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -27,6 +27,12 @@ logger = logging.getLogger(__name__)
 # Tools that do NOT require context_id in arguments
 _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
     {
+        # Issue #629: binding introspection — list takes no args; describe takes
+        # key_id XOR context_id (and its context_id is a *bound* context selector,
+        # not a memory-context to resolve), so neither goes through the
+        # context_id pre-dispatch.
+        "list_my_bindings",
+        "describe_binding",
         "list_contexts",
         "create_context",
         "update_context",
@@ -53,6 +59,8 @@ _TOOLS_WITHOUT_CONTEXT_ID = frozenset(
 # Read-only info tools exempt from rate limiting
 _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
     {
+        "list_my_bindings",  # Issue #629: read-only binding listing
+        "describe_binding",  # Issue #629: read-only binding detail
         "get_usage",
         "list_contexts",
         "get_context_info",  # Must remain callable so agents can inspect context even when rate-limited
@@ -90,6 +98,7 @@ def _build_registry() -> dict[str, Any]:
         handle_get_cluster,
         handle_list_analyses,
     )
+    from mcp_server.tools.api_keys import handle_describe_binding, handle_list_my_bindings
     from mcp_server.tools.context import (
         handle_create_context,
         handle_delete_context,
@@ -129,6 +138,9 @@ def _build_registry() -> dict[str, Any]:
     from mcp_server.tools.usage import handle_get_usage
 
     return {
+        # Issue #629: read-only API-key binding introspection
+        "list_my_bindings": handle_list_my_bindings,
+        "describe_binding": handle_describe_binding,
         "remember": handle_remember,
         "update_memory": handle_update_memory,
         "recall": handle_recall,

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -15,6 +15,57 @@ def get_tool_definitions() -> list[dict]:
     """
     return [
         {
+            "name": "list_my_bindings",
+            "readOnly": True,
+            "description": """List your public-bound API keys (Issue #629, read-only).
+
+Returns the bindings YOU own — API keys attributed to a single public
+(is_public=true) context for per-key rate-limit, audit, and revoke. This is
+introspection of the keys you created, not of the bound contexts themselves.
+
+Response: bindings: [{key_id, name, context_id, context_name, created_at}].
+Revoked keys are excluded. key_prefix is omitted here — use describe_binding
+for a single binding's prefix.
+
+Read-only: minting and revoking bindings stay on the SDK / CLI / HTTP API /
+dashboard. No parameters.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {},
+            },
+        },
+        {
+            "name": "describe_binding",
+            "readOnly": True,
+            "description": """Describe one of your public-bound API keys (Issue #629, read-only).
+
+Supply EXACTLY ONE selector: key_id (integer, from list_my_bindings) OR
+context_id (UUID of the bound public context). The result is scoped to the keys
+you own; an unknown or not-yours selector returns a uniform
+"binding_not_found". A context bound by several of your keys returns the most
+recently created one (with a note).
+
+Response: binding: {key_id, name, context_id, context_name, created_at,
+key_prefix}. No secret is ever returned.
+
+Read-only: minting and revoking bindings stay on the SDK / CLI / HTTP API /
+dashboard.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "key_id": {
+                        "type": "integer",
+                        "description": "API key ID from list_my_bindings(). Mutually exclusive with context_id.",
+                    },
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Bound public context UUID. Mutually exclusive with key_id.",
+                    },
+                },
+            },
+        },
+        {
             "name": "remember",
             "description": """Store important information, decisions, code snippets, or context into long-term memory. Use this when you want to preserve information for future recall across conversations.
 

--- a/backend/src/mcp_server/tools/api_keys.py
+++ b/backend/src/mcp_server/tools/api_keys.py
@@ -92,7 +92,9 @@ async def handle_list_my_bindings(
             await _log_tool_usage(
                 db, user_id, "list_my_bindings", start_time, 500, None, workspace_id
             )
-            return _error_response("list_my_bindings_error", str(e))
+            # Generic caller-facing message — the full exception (which may carry
+            # DB schema / internal detail) stays in the server-side log only.
+            return _error_response("list_my_bindings_error", "An internal error occurred.")
 
     return _error_response("internal_error", "Failed to acquire database session")
 
@@ -186,6 +188,7 @@ async def handle_describe_binding(
             await _log_tool_usage(
                 db, user_id, "describe_binding", start_time, 500, None, workspace_id
             )
-            return _error_response("describe_binding_error", str(e))
+            # Generic caller-facing message — full exception stays in the log only.
+            return _error_response("describe_binding_error", "An internal error occurred.")
 
     return _error_response("internal_error", "Failed to acquire database session")

--- a/backend/src/mcp_server/tools/api_keys.py
+++ b/backend/src/mcp_server/tools/api_keys.py
@@ -1,0 +1,191 @@
+"""MCP tool handlers for read-only API-key binding introspection (Issue #629).
+
+Two read-only tools deferred from #626 (PR #628):
+
+- ``list_my_bindings`` — list the calling user's public-bound API keys.
+- ``describe_binding`` — describe one binding by ``key_id`` XOR ``context_id``.
+
+Both are **read-only**: mint/revoke stay on SDK / CLI / HTTP / dashboard only
+(the #626 design decision, kagura memory ``2859a627``). No write path lives here.
+
+Principal restriction (#629 AC): ``api_key_bound`` principals must not be able to
+self-introspect. This is enforced **structurally** at the MCP auth boundary, not
+in these handlers: ``mcp_server.auth._verify_api_key`` rejects any key with
+``bound_context_id != None`` (``auth.dependencies.verify_api_key`` returns
+``None``), so a bound key fails authentication and **never reaches a handler**.
+The handler signature ``(args, user_id, workspace_id)`` carries no principal-type
+discriminator, so an in-handler 403 is both impossible and unnecessary. That auth
+gate is the source of truth for the restriction; a regression test
+(``test_api_keys.py``) pins it so a future loosening can't silently open
+introspection to bound principals.
+
+Owner isolation: every query ANDs ``APIKey.user_id == user_id``. A caller can only
+ever see their own bindings. ``describe_binding`` returns a uniform
+``binding_not_found`` for both "does not exist" and "exists but not yours" so the
+sequential integer ``key_id`` cannot be used as an existence oracle.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+from uuid import UUID
+
+from mcp.types import TextContent
+
+from mcp_server.tools._helpers import _error_response, _log_tool_usage, _success_response
+from utils.datetime import to_utc_iso
+
+logger = logging.getLogger(__name__)
+
+
+def _binding_dict(api_key: Any, display_name: str | None, name: str | None) -> dict[str, Any]:
+    """Shape one binding row for the response (never includes any secret)."""
+    return {
+        "key_id": api_key.id,
+        "name": api_key.name,
+        "context_id": str(api_key.bound_context_id),
+        "context_name": display_name or name,
+        "created_at": to_utc_iso(api_key.created_at),
+    }
+
+
+async def handle_list_my_bindings(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """List the calling user's active public-bound API keys (read-only).
+
+    Returns ``bindings: [{key_id, name, context_id, context_name, created_at}]``
+    for every non-revoked key the caller owns that is bound to a public context.
+    ``key_prefix`` is intentionally omitted here (it is a ``describe_binding``
+    detail). Secrets are never returned.
+    """
+    from sqlalchemy import select
+
+    from db.base import get_db
+    from models.auth import APIKey, Context
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            stmt = (
+                select(APIKey, Context.display_name, Context.name)
+                .outerjoin(Context, Context.id == APIKey.bound_context_id)
+                .where(
+                    APIKey.user_id == user_id,
+                    APIKey.bound_context_id.is_not(None),
+                    APIKey.revoked_at.is_(None),
+                )
+                .order_by(APIKey.created_at.desc())
+            )
+            rows = (await db.execute(stmt)).all()
+            bindings = [_binding_dict(key, display_name, name) for key, display_name, name in rows]
+
+            await _log_tool_usage(
+                db, user_id, "list_my_bindings", start_time, 200, None, workspace_id
+            )
+            return _success_response(bindings=bindings, count=len(bindings))
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"list_my_bindings_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db, user_id, "list_my_bindings", start_time, 500, None, workspace_id
+            )
+            return _error_response("list_my_bindings_error", str(e))
+
+    return _error_response("internal_error", "Failed to acquire database session")
+
+
+async def handle_describe_binding(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Describe one of the caller's bindings by ``key_id`` XOR ``context_id``.
+
+    Exactly one selector must be supplied. The result is scoped to
+    ``user_id == caller`` and to bound, non-revoked keys; a miss returns a uniform
+    ``binding_not_found`` (no existence oracle on the sequential ``key_id``).
+    Adds ``key_prefix`` to the ``list_my_bindings`` shape.
+    """
+    from sqlalchemy import select
+
+    from db.base import get_db
+    from models.auth import APIKey, Context
+
+    raw_key_id = args.get("key_id")
+    raw_context_id = args.get("context_id")
+
+    # Exactly-one (XOR) selector validation.
+    if (raw_key_id is None) == (raw_context_id is None):
+        return _error_response(
+            "invalid_arguments",
+            "Provide exactly one of 'key_id' (integer) or 'context_id' (UUID).",
+        )
+
+    key_id: int | None = None
+    context_id: UUID | None = None
+    if raw_key_id is not None:
+        if isinstance(raw_key_id, bool) or not isinstance(raw_key_id, int):
+            return _error_response("invalid_arguments", "'key_id' must be an integer.")
+        key_id = raw_key_id
+    else:
+        try:
+            context_id = UUID(str(raw_context_id))
+        except (ValueError, TypeError):
+            return _error_response("invalid_arguments", "'context_id' must be a valid UUID.")
+
+    start_time = time.time()
+    async for db in get_db():
+        try:
+            conditions = [
+                APIKey.user_id == user_id,
+                APIKey.bound_context_id.is_not(None),
+                APIKey.revoked_at.is_(None),
+            ]
+            if key_id is not None:
+                conditions.append(APIKey.id == key_id)
+            else:
+                conditions.append(APIKey.bound_context_id == context_id)
+
+            stmt = (
+                select(APIKey, Context.display_name, Context.name)
+                .outerjoin(Context, Context.id == APIKey.bound_context_id)
+                .where(*conditions)
+                .order_by(APIKey.created_at.desc())
+            )
+            rows = (await db.execute(stmt)).all()
+
+            if not rows:
+                # Uniform miss — do not distinguish "absent" from "not yours".
+                await _log_tool_usage(
+                    db, user_id, "describe_binding", start_time, 404, None, workspace_id
+                )
+                return _error_response("binding_not_found", "Binding not found.")
+
+            api_key, display_name, name = rows[0]
+            binding = _binding_dict(api_key, display_name, name)
+            binding["key_prefix"] = api_key.key_prefix
+
+            # bound_context_id is not UNIQUE on api_keys: a context can be bound by
+            # several of the caller's keys. Surface that rather than silently
+            # hiding the others, while still returning the most recent one.
+            extra: dict[str, Any] = {}
+            if context_id is not None and len(rows) > 1:
+                extra["note"] = (
+                    f"{len(rows)} of your keys are bound to this context; "
+                    "showing the most recently created. Use key_id for a specific one."
+                )
+
+            await _log_tool_usage(
+                db, user_id, "describe_binding", start_time, 200, None, workspace_id
+            )
+            return _success_response(binding=binding, **extra)
+        except Exception as e:
+            await db.rollback()
+            logger.error(f"describe_binding_failed: {e}", exc_info=True)
+            await _log_tool_usage(
+                db, user_id, "describe_binding", start_time, 500, None, workspace_id
+            )
+            return _error_response("describe_binding_error", str(e))
+
+    return _error_response("internal_error", "Failed to acquire database session")

--- a/backend/tests/integration/test_binding_introspection_owner_scope.py
+++ b/backend/tests/integration/test_binding_introspection_owner_scope.py
@@ -1,0 +1,150 @@
+"""Integration test: binding introspection is owner-scoped (#629, real Postgres).
+
+The IDOR / cross-user isolation of list_my_bindings / describe_binding rests on
+every query ANDing ``APIKey.user_id == caller``. A mocked ``db.execute`` cannot
+validate that WHERE clause (it returns a fixed row list regardless of the query),
+so this runs the handlers against a real DB with two users' bindings seeded and
+asserts each user sees only their own — and that user B describing user A's
+``key_id`` / ``context_id`` returns the uniform ``binding_not_found``.
+
+The handlers use ``db.base.get_db`` internally, which the integration conftest
+steers at ``TEST_DATABASE_URL``; committed fixture rows are visible to that
+session.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from mcp_server.tools.api_keys import handle_describe_binding, handle_list_my_bindings
+from models.auth import APIKey, Context, User, Workspace
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def two_users_with_bindings(db_session: AsyncSession) -> AsyncIterator[SimpleNamespace]:
+    """User A and User B each own one public-bound API key.
+
+    A's key binds ctx_a; B's key binds ctx_b (both contexts live in A's
+    workspace — workspace membership is irrelevant to the owner-scoping under
+    test, which keys on user_id). Yields ids for the assertions.
+    """
+    user_a = f"a_{uuid4().hex[:8]}"
+    user_b = f"b_{uuid4().hex[:8]}"
+    workspace_id = uuid4()
+    ctx_a = uuid4()
+    ctx_b = uuid4()
+
+    for uid in (user_a, user_b):
+        db_session.add(
+            User(
+                email=f"{uid}@binding-scope.invalid",
+                user_id=uid,
+                name="Binding Scope User",
+                role="user",
+                is_initial_admin=False,
+                auth_method="oauth",
+                auth_provider="google",
+            )
+        )
+    # Flush in dependency tiers: APIKey.bound_context_id / Context.workspace_id are
+    # plain FK columns (no ORM relationships), so the unit-of-work can't infer the
+    # insert order. Flush each tier's parents before inserting children.
+    await db_session.flush()  # users
+    db_session.add(
+        Workspace(
+            id=workspace_id,
+            name=f"bind-scope-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=user_a,
+            daily_api_limit=500,
+            weekly_api_limit=2500,
+            deleted_at=None,
+        )
+    )
+    await db_session.flush()  # workspace
+    db_session.add(Context(id=ctx_a, workspace_id=workspace_id, name="ctx-a", created_by=user_a))
+    db_session.add(Context(id=ctx_b, workspace_id=workspace_id, name="ctx-b", created_by=user_b))
+    await db_session.flush()  # contexts
+    key_a = APIKey(
+        user_id=user_a,
+        name="a-bound",
+        key_hash=f"hash_{uuid4().hex}",
+        key_prefix="kagura_pub_a",
+        bound_context_id=ctx_a,
+        workspace_id=None,
+    )
+    key_b = APIKey(
+        user_id=user_b,
+        name="b-bound",
+        key_hash=f"hash_{uuid4().hex}",
+        key_prefix="kagura_pub_b",
+        bound_context_id=ctx_b,
+        workspace_id=None,
+    )
+    db_session.add(key_a)
+    db_session.add(key_b)
+    await db_session.commit()
+
+    yield SimpleNamespace(
+        user_a=user_a,
+        user_b=user_b,
+        key_a_id=key_a.id,
+        key_b_id=key_b.id,
+        ctx_a=ctx_a,
+        ctx_b=ctx_b,
+    )
+
+    await db_session.execute(APIKey.__table__.delete().where(APIKey.user_id.in_([user_a, user_b])))
+    await db_session.execute(Context.__table__.delete().where(Context.workspace_id == workspace_id))
+    await db_session.execute(Workspace.__table__.delete().where(Workspace.id == workspace_id))
+    await db_session.execute(User.__table__.delete().where(User.user_id.in_([user_a, user_b])))
+    await db_session.commit()
+
+
+def _data(result):
+    return json.loads(result[0].text)
+
+
+class TestBindingOwnerScope:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_list_shows_only_own_bindings(self, two_users_with_bindings):
+        s = two_users_with_bindings
+
+        a = _data(await handle_list_my_bindings({}, s.user_a, None))
+        assert a["count"] == 1
+        assert a["bindings"][0]["key_id"] == s.key_a_id
+
+        b = _data(await handle_list_my_bindings({}, s.user_b, None))
+        assert b["count"] == 1
+        assert b["bindings"][0]["key_id"] == s.key_b_id  # B never sees A's binding
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_describe_cross_user_key_id_is_not_found(self, two_users_with_bindings):
+        s = two_users_with_bindings
+        # User B tries to describe User A's key by its (guessable, sequential) id.
+        result = await handle_describe_binding({"key_id": s.key_a_id}, s.user_b, None)
+        assert _data(result)["error"] == "binding_not_found"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_describe_cross_user_context_id_is_not_found(self, two_users_with_bindings):
+        s = two_users_with_bindings
+        # User B tries to describe via A's bound context_id — also owner-scoped.
+        result = await handle_describe_binding({"context_id": str(s.ctx_a)}, s.user_b, None)
+        assert _data(result)["error"] == "binding_not_found"
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_owner_describe_succeeds_with_prefix(self, two_users_with_bindings):
+        s = two_users_with_bindings
+        result = await handle_describe_binding({"key_id": s.key_a_id}, s.user_a, None)
+        data = _data(result)
+        assert data["status"] == "success"
+        assert data["binding"]["key_id"] == s.key_a_id
+        assert data["binding"]["key_prefix"] == "kagura_pub_a"
+        assert data["binding"]["context_id"] == str(s.ctx_a)

--- a/backend/tests/mcp_server/test_api_keys.py
+++ b/backend/tests/mcp_server/test_api_keys.py
@@ -1,0 +1,276 @@
+"""Unit tests for the read-only binding-introspection MCP tools (Issue #629).
+
+Covers list_my_bindings / describe_binding handler behavior: response shape,
+the key_id-XOR-context_id validation, owner-scoped uniform not-found (no
+existence oracle), and the multi-binding note. The api_key_bound 403 restriction
+is enforced at the MCP auth boundary (a bound key never reaches these handlers),
+so it is pinned by the auth-layer regression test, not here.
+"""
+
+import json
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.api_keys import handle_describe_binding, handle_list_my_bindings
+
+
+def _row(*, key_id, name, context_id, display_name, name_slug, prefix, created=None):
+    """One (APIKey, Context.display_name, Context.name) result row."""
+    api_key = SimpleNamespace(
+        id=key_id,
+        name=name,
+        bound_context_id=context_id,
+        key_prefix=prefix,
+        created_at=created or datetime(2026, 6, 1, 12, 0, 0),
+    )
+    return (api_key, display_name, name_slug)
+
+
+def _mock_db(rows):
+    db = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = rows
+    db.execute.return_value = result
+    db.rollback = AsyncMock()
+    return db
+
+
+def _patches(db):
+    async def mock_get_db():
+        yield db
+
+    return (
+        patch("db.base.get_db", new=mock_get_db),
+        patch("mcp_server.tools.api_keys._log_tool_usage", new=AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+class TestListMyBindings:
+    async def test_returns_bindings_without_prefix(self):
+        ctx = uuid4()
+        rows = [
+            _row(
+                key_id=7,
+                name="slack-bot",
+                context_id=ctx,
+                display_name="Slack Bot",
+                name_slug="slack-bot",
+                prefix="kagura_pub_abcd",
+            )
+        ]
+        db = _mock_db(rows)
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await handle_list_my_bindings({}, "user-1", None)
+
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["count"] == 1
+        b = data["bindings"][0]
+        assert b == {
+            "key_id": 7,
+            "name": "slack-bot",
+            "context_id": str(ctx),
+            "context_name": "Slack Bot",
+            "created_at": "2026-06-01T12:00:00Z",
+        }
+        assert "key_prefix" not in b  # prefix is a describe_binding detail
+
+    async def test_empty(self):
+        db = _mock_db([])
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await handle_list_my_bindings({}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["count"] == 0
+        assert data["bindings"] == []
+
+    async def test_context_name_falls_back_to_slug(self):
+        rows = [
+            _row(
+                key_id=1,
+                name="k",
+                context_id=uuid4(),
+                display_name=None,
+                name_slug="ctx-slug",
+                prefix="p",
+            )
+        ]
+        db = _mock_db(rows)
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await handle_list_my_bindings({}, "user-1", None)
+        assert json.loads(result[0].text)["bindings"][0]["context_name"] == "ctx-slug"
+
+
+@pytest.mark.asyncio
+class TestDescribeBinding:
+    async def test_by_key_id_includes_prefix(self):
+        ctx = uuid4()
+        db = _mock_db(
+            [
+                _row(
+                    key_id=42,
+                    name="bot",
+                    context_id=ctx,
+                    display_name="Bot",
+                    name_slug="bot",
+                    prefix="kagura_pub_xyz9",
+                )
+            ]
+        )
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await handle_describe_binding({"key_id": 42}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["binding"]["key_id"] == 42
+        assert data["binding"]["key_prefix"] == "kagura_pub_xyz9"
+        assert data["binding"]["context_id"] == str(ctx)
+
+    async def test_by_context_id(self):
+        ctx = uuid4()
+        db = _mock_db(
+            [_row(key_id=5, name="b", context_id=ctx, display_name="B", name_slug="b", prefix="pp")]
+        )
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await handle_describe_binding({"context_id": str(ctx)}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["binding"]["context_id"] == str(ctx)
+        assert "note" not in data
+
+    async def test_context_id_multiple_matches_adds_note(self):
+        ctx = uuid4()
+        db = _mock_db(
+            [
+                _row(
+                    key_id=9,
+                    name="b2",
+                    context_id=ctx,
+                    display_name="B",
+                    name_slug="b",
+                    prefix="p2",
+                ),
+                _row(
+                    key_id=8,
+                    name="b1",
+                    context_id=ctx,
+                    display_name="B",
+                    name_slug="b",
+                    prefix="p1",
+                ),
+            ]
+        )
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await handle_describe_binding({"context_id": str(ctx)}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"
+        assert data["binding"]["key_id"] == 9  # most recent (first row)
+        assert "note" in data and "2 of your keys" in data["note"]
+
+    async def test_not_found_is_uniform(self):
+        db = _mock_db([])
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await handle_describe_binding({"key_id": 999999}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["status"] == "error"
+        assert data["error"] == "binding_not_found"
+        assert data["message"] == "Binding not found."
+
+    async def test_both_selectors_rejected(self):
+        result = await handle_describe_binding(
+            {"key_id": 1, "context_id": str(uuid4())}, "user-1", None
+        )
+        data = json.loads(result[0].text)
+        assert data["error"] == "invalid_arguments"
+
+    async def test_neither_selector_rejected(self):
+        result = await handle_describe_binding({}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["error"] == "invalid_arguments"
+
+    async def test_key_id_must_be_int(self):
+        result = await handle_describe_binding({"key_id": "42"}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["error"] == "invalid_arguments"
+
+    async def test_key_id_bool_rejected(self):
+        # bool is an int subclass — must be rejected explicitly.
+        result = await handle_describe_binding({"key_id": True}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["error"] == "invalid_arguments"
+
+    async def test_context_id_must_be_uuid(self):
+        result = await handle_describe_binding({"context_id": "not-a-uuid"}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["error"] == "invalid_arguments"
+
+
+@pytest.mark.asyncio
+class TestBoundKeyCannotReachBindingTools:
+    """#629 principal restriction is enforced at the MCP auth boundary.
+
+    A public-bound key (``bound_context_id != None``) makes
+    ``auth.dependencies.verify_api_key`` return None (pinned by
+    ``tests/auth/test_api_key_binding.py::test_verify_api_key_standalone_rejects_bound_keys``).
+    This test pins the consequence one layer up: ``authenticate_mcp_request``
+    then raises ``AuthenticationError``, so a bound principal never authenticates
+    and therefore can never reach ``list_my_bindings`` / ``describe_binding``.
+    The "api_key_bound gets 403" AC is satisfied structurally here, not by an
+    in-handler check (the handler signature carries no principal-type flag). If a
+    future change loosens this gate, this test fails loudly.
+    """
+
+    async def test_bound_key_fails_mcp_auth(self):
+        from mcp_server.auth import authenticate_mcp_request
+        from utils.exceptions import AuthenticationError
+
+        # verify_api_key returning None is the bound-key rejection shape on MCP.
+        with (
+            patch("auth.dependencies.verify_api_key", new=AsyncMock(return_value=None)),
+            patch("mcp_server.auth._verify_oauth2_token", new=AsyncMock(return_value=None)),
+        ):
+            with pytest.raises(AuthenticationError):
+                await authenticate_mcp_request("Bearer kagura_bound_key_token")
+
+
+@pytest.mark.asyncio
+class TestExecutorWiring:
+    """The tools are registered AND exempt from the context_id pre-dispatch.
+
+    Without ``_TOOLS_WITHOUT_CONTEXT_ID`` membership, list_my_bindings (no args)
+    and describe_binding (key_id path) would be rejected with ``context_id_required``
+    before reaching their handlers. These tests pin the registry + gate wiring.
+    """
+
+    async def test_list_my_bindings_not_blocked_by_context_id_gate(self):
+        from mcp_server.tools import execute_tool_call
+
+        db = _mock_db([])
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await execute_tool_call("list_my_bindings", {}, "user-1", None)
+        data = json.loads(result[0].text)
+        assert data["status"] == "success"  # NOT context_id_required
+        assert data["count"] == 0
+
+    async def test_describe_binding_key_id_not_blocked_by_context_id_gate(self):
+        from mcp_server.tools import execute_tool_call
+
+        db = _mock_db([])
+        get_db_patch, log_patch = _patches(db)
+        with get_db_patch, log_patch:
+            result = await execute_tool_call("describe_binding", {"key_id": 1}, "user-1", None)
+        data = json.loads(result[0].text)
+        # Reaches the handler → uniform not-found, NOT context_id_required.
+        assert data["error"] == "binding_not_found"

--- a/backend/tests/mcp_server/test_api_keys.py
+++ b/backend/tests/mcp_server/test_api_keys.py
@@ -2,9 +2,11 @@
 
 Covers list_my_bindings / describe_binding handler behavior: response shape,
 the key_id-XOR-context_id validation, owner-scoped uniform not-found (no
-existence oracle), and the multi-binding note. The api_key_bound 403 restriction
-is enforced at the MCP auth boundary (a bound key never reaches these handlers),
-so it is pinned by the auth-layer regression test, not here.
+existence oracle), and the multi-binding note. The #629 AC frames the principal
+restriction as "api_key_bound gets 403", but the actual enforcement is at the MCP
+auth boundary: a bound key fails authentication (AuthenticationError, surfaced as
+HTTP 401 by the transport) and never reaches these handlers. So it is pinned by
+the auth-layer regression test, not by an in-handler check here.
 """
 
 import json
@@ -224,11 +226,14 @@ class TestBoundKeyCannotReachBindingTools:
     ``auth.dependencies.verify_api_key`` return None (pinned by
     ``tests/auth/test_api_key_binding.py::test_verify_api_key_standalone_rejects_bound_keys``).
     This test pins the consequence one layer up: ``authenticate_mcp_request``
-    then raises ``AuthenticationError``, so a bound principal never authenticates
-    and therefore can never reach ``list_my_bindings`` / ``describe_binding``.
-    The "api_key_bound gets 403" AC is satisfied structurally here, not by an
-    in-handler check (the handler signature carries no principal-type flag). If a
-    future change loosens this gate, this test fails loudly.
+    then raises ``AuthenticationError`` (surfaced as HTTP 401 by the transport),
+    so a bound principal never authenticates and therefore can never reach
+    ``list_my_bindings`` / ``describe_binding``. The #629 AC frames this as
+    "api_key_bound gets 403"; the realized mechanism is an authentication
+    rejection (401), which equally satisfies the intent (no self-introspection)
+    and is enforced structurally — not by an in-handler check (the handler
+    signature carries no principal-type flag). If a future change loosens this
+    gate, this test fails loudly.
     """
 
     async def test_bound_key_fails_mcp_auth(self):

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -870,7 +870,7 @@ Sleep and Neural Memory tuning knobs (LLM provider, budgets, per-phase toggles, 
 
 ## MCP Tools
 
-Kagura Memory Cloud provides 37 MCP tools for AI assistants across 9 categories (Memory, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Sleep Maintenance, Usage). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
+Kagura Memory Cloud provides 39 MCP tools for AI assistants across 10 categories (Memory, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
 
 ### 1. remember
 
@@ -945,6 +945,36 @@ Discover related memories via graph traversal.
   }
 }
 ```
+
+### 6. list_my_bindings
+
+List your public-bound API keys (read-only introspection, Issue #629). Returns the bindings you own — keys attributed to a single public context for per-key rate-limit, audit, and revoke. Revoked keys are excluded; `key_prefix` is omitted (use `describe_binding`). Takes no arguments.
+
+```python
+{
+  "name": "list_my_bindings",
+  "arguments": {}
+}
+# → {"status": "success", "count": 1, "bindings": [
+#     {"key_id": 7, "name": "slack-bot", "context_id": "…",
+#      "context_name": "Slack Bot", "created_at": "2026-06-01T12:00:00Z"}]}
+```
+
+### 7. describe_binding
+
+Describe one of your bindings by **exactly one** of `key_id` (integer) or `context_id` (UUID). The result is scoped to keys you own; an unknown or not-yours selector returns a uniform `binding_not_found`. Adds `key_prefix` to the `list_my_bindings` shape. No secret is ever returned.
+
+```python
+{
+  "name": "describe_binding",
+  "arguments": { "key_id": 7 }   # OR { "context_id": "<uuid>" } — not both
+}
+# → {"status": "success", "binding": {
+#     "key_id": 7, "name": "slack-bot", "context_id": "…",
+#     "context_name": "Slack Bot", "created_at": "…", "key_prefix": "kagura_pub_…"}}
+```
+
+> **Read-only boundary:** minting and revoking bindings stay on the SDK / CLI / HTTP API / dashboard (design decision from #626). Public-bound API keys cannot call any MCP tool — they are rejected at MCP authentication — so these introspection tools are only reachable by the binding's **owner** via a session or workspace-scoped key.
 
 ---
 


### PR DESCRIPTION
Closes #629

## Summary
Adds the two read-only MCP tools deferred from #626 (PR #628):
- **`list_my_bindings`** — list the caller's active public-bound API keys: `[{key_id, name, context_id, context_name, created_at}]`. No args; `key_prefix` omitted.
- **`describe_binding`** — describe one binding by **exactly one** of `key_id` (int) or `context_id` (UUID); adds `key_prefix`. Uniform `binding_not_found` on a miss; a context bound by several of the caller's keys returns the most recent (with a note).

Both are **read-only**: mint/revoke stay on SDK / CLI / HTTP / dashboard (the #626 design decision).

## Implementation notes
- New handler module `backend/src/mcp_server/tools/api_keys.py`; registered in `_TOOL_REGISTRY`, `_RATE_LIMIT_EXEMPT_TOOLS`, and `_TOOLS_WITHOUT_CONTEXT_ID` (both tools are read-only and take no memory `context_id`); schemas in `_definitions.py`. No migration, no new dependency; reuses `APIKey`/`Context`.
- **Owner isolation:** every query ANDs `APIKey.user_id == caller`. A miss returns a uniform `binding_not_found` so the sequential int `key_id` is not an existence oracle. Secrets (`plaintext_encrypted`/`key_hash`) are never selected.
- **Principal restriction (`api_key_bound` → 403):** enforced **structurally** at the MCP auth boundary — `mcp_server.auth._verify_api_key` rejects bound keys, so a bound key fails authentication and never reaches a handler. The 3-arg handler signature carries no principal-type flag, so an in-handler 403 is impossible and unnecessary; a regression test pins that a bound key raises `AuthenticationError`, failing loudly if the gate is ever loosened.

## Tests
- **Unit (15):** response shape, `key_id` XOR `context_id` validation matrix (both/neither, str, bool-is-int subclass trap, bad UUID), uniform not-found, multi-binding note, `context_name` fallback, auth-gate regression, executor no-`context_id` wiring.
- **Integration (4, real Postgres):** owner-scoping / IDOR — two users' bindings seeded; each sees only their own; user B describing user A's `key_id` **and** `context_id` both return `binding_not_found`; owner describe succeeds with `key_prefix`. (A mocked `db.execute` can't validate the `WHERE user_id==caller` clause.)
- Full `tests/mcp_server/` suite: 176 pass (no regression).

## Docs
- `docs/api-reference.md` MCP Tools section (tools 6–7) + README MCP tools table (new "API-Key Bindings" category, count 37→39).

## Deferred (follow-ups)
- `README.ja.md` MCP tool count/table not updated (i18n sync — out of this AC's scope).
- Single-declaration MCP tool registration (`read_only`/`needs_context_id` metadata → derive the 3 frozensets) to remove the 3-set registration footgun (CTO gate2 note).

## Pre-PR review summary
- gate2 mode: advisor-only — cso: green / qa-lead: green / cto: green (audit: skipped)
- gate1: green via /ask (CSO lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
