### PR TITLE
feat(api): server-side max-window cap on cost-aggregation (#528)

### DIFF
--- a/backend/src/api/routes/cost_aggregation.py
+++ b/backend/src/api/routes/cost_aggregation.py
@@ -36,9 +36,11 @@ from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from models.sleep import SLEEP_REPORT_PAID_BY_VALUES, SLEEP_REPORT_SOURCES
 from services.cost_aggregation_service import (
+    MAX_LOOKBACK_DAYS,
     VALID_PERIODS,
     CostAggregationRow,
     CostAggregationService,
+    window_exceeds_cap,
 )
 from services.permission_service import PermissionService
 
@@ -153,6 +155,20 @@ def _parse_window(
     # Half-open: end-of-window is the start of the day AFTER ``to``.
     end_date = date.fromordinal(to.toordinal() + 1)
     end_dt = datetime.combine(end_date, time.min)
+    # Defense-in-depth window cap (#528): reject before the service so a
+    # non-UI caller (curl / SDK / MCP) can't scan years of sleep_reports.
+    # ``end_dt - start_dt`` is the inclusive day count (half-open end = to+1),
+    # so ``window_exceeds_cap`` mirrors the frontend's ``days > MAX_LOOKBACK_DAYS``
+    # exactly — 365 inclusive days pass, 366 reject. The service re-checks as a
+    # backstop using the same shared predicate.
+    if window_exceeds_cap(start_dt, end_dt):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"date range exceeds {MAX_LOOKBACK_DAYS}-day maximum window "
+                f"(got {(end_dt - start_dt).days} days)"
+            ),
+        )
     return period, start_dt, end_dt
 
 

--- a/backend/src/services/cost_aggregation_service.py
+++ b/backend/src/services/cost_aggregation_service.py
@@ -39,7 +39,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Sequence
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any
 from uuid import UUID
 
@@ -57,6 +57,27 @@ logger = get_logger(__name__)
 # value is bound (not interpolated), passing arbitrary strings would 500
 # the query when ``date_trunc`` rejects them.
 VALID_PERIODS: tuple[str, ...] = ("day", "week", "month")
+
+# Maximum span of a single aggregation request, in days. Mirrors the
+# frontend's UI soft cap (``CostDashboard.tsx`` ``MAX_LOOKBACK_DAYS = 365``)
+# — kept intentionally identical so a server-side rejection never contradicts
+# a selection the UI permits. This is the defense-in-depth layer (#528): a
+# non-UI caller (curl / SDK / MCP) that bypasses the UI cap must not be able
+# to scan years of ``sleep_reports``. The window is half-open ``[start, end)``,
+# so ``end - start`` equals the UI's inclusive day count (``end = to + 1 day``).
+MAX_LOOKBACK_DAYS = 365
+
+
+def window_exceeds_cap(start: datetime, end: datetime) -> bool:
+    """True if the half-open window ``[start, end)`` is wider than the cap.
+
+    Single source of truth for the off-by-one boundary so the route
+    (``_parse_window`` → 400) and the service (``aggregate`` → ValueError)
+    enforce the *same* threshold from two layers without the literal
+    drifting between them. ``> timedelta`` (not ``.days >``) rejects a
+    sub-day overage too, which a direct service caller could pass.
+    """
+    return end - start > timedelta(days=MAX_LOOKBACK_DAYS)
 
 
 class CostBreakdownByModel:
@@ -268,7 +289,8 @@ class CostAggregationService:
 
         Raises:
             ValueError: ``period``, ``source``, or ``paid_by`` outside
-                the allowed set; ``start >= end``.
+                the allowed set; ``start >= end``; window wider than
+                ``MAX_LOOKBACK_DAYS``.
         """
         # ---- Input validation (defense in depth) --------------------------
         # period feeds date_trunc directly; passing junk would 500 the
@@ -284,6 +306,13 @@ class CostAggregationService:
             )
         if start >= end:
             raise ValueError(f"start must be < end (got start={start}, end={end})")
+        # Cap the window to bound the ``sleep_reports`` scan (#528). The
+        # threshold lives in ``window_exceeds_cap`` so the route enforces the
+        # same boundary without a second copy of the literal.
+        if window_exceeds_cap(start, end):
+            raise ValueError(
+                f"date range exceeds {MAX_LOOKBACK_DAYS}-day cap (got {(end - start).days} days)"
+            )
 
         # ---- Build filter fragments ---------------------------------------
         filter_clauses, filter_params = _build_filter_clauses(

--- a/backend/src/services/cost_aggregation_service.py
+++ b/backend/src/services/cost_aggregation_service.py
@@ -310,9 +310,10 @@ class CostAggregationService:
         # threshold lives in ``window_exceeds_cap`` so the route enforces the
         # same boundary without a second copy of the literal.
         if window_exceeds_cap(start, end):
-            raise ValueError(
-                f"date range exceeds {MAX_LOOKBACK_DAYS}-day cap (got {(end - start).days} days)"
-            )
+            # Report the full span, not ``.days`` — the cap compares the whole
+            # timedelta, so a sub-day overage (e.g. 365 days + 1h) must not be
+            # truncated to a misleading "365 days" (the allowed boundary).
+            raise ValueError(f"date range exceeds {MAX_LOOKBACK_DAYS}-day cap (got {end - start})")
 
         # ---- Build filter fragments ---------------------------------------
         filter_clauses, filter_params = _build_filter_clauses(

--- a/backend/tests/api/test_cost_aggregation_routes.py
+++ b/backend/tests/api/test_cost_aggregation_routes.py
@@ -252,6 +252,29 @@ class TestAdminRoute:
         )
         assert response.status_code == 400
 
+    def test_window_exceeding_cap_returns_400(self, client):
+        # A non-UI caller bypassing the frontend's 365-day soft cap must be
+        # rejected server-side (defense-in-depth, #528). 2026-01-01..2027-01-01
+        # is 366 inclusive days — one past the boundary.
+        mock_aggregate = _install_admin_overrides(client, [])
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-01-01&to=2027-01-01"
+        )
+        assert response.status_code == 400
+        assert "exceeds" in response.json()["detail"]
+        assert mock_aggregate.await_count == 0  # rejected before SQL
+
+    def test_window_at_cap_boundary_returns_200(self, client):
+        # Exactly 365 inclusive days (2026 is not a leap year) is the UI's
+        # maximum permitted window and must pass — pins the off-by-one so the
+        # server cap never rejects a selection the UI allows.
+        mock_aggregate = _install_admin_overrides(client, [])
+        response = client.get(
+            "/api/v1/admin/cost-aggregation?period=day&from=2026-01-01&to=2026-12-31"
+        )
+        assert response.status_code == 200, response.text
+        assert mock_aggregate.await_count == 1
+
     def test_missing_required_query_returns_422(self, client):
         _install_admin_overrides(client, [])
         response = client.get("/api/v1/admin/cost-aggregation?period=day")
@@ -370,6 +393,18 @@ class TestWorkspaceRoute:
         )
         assert response.status_code == 400
         assert "Invalid paid_by" in response.json()["detail"]
+
+    def test_window_exceeding_cap_returns_400(self, client):
+        # Same defense-in-depth cap on the workspace-scoped route (#528).
+        # 2026-01-01..2027-01-01 is 366 inclusive days — past the boundary.
+        mock_aggregate = _install_workspace_overrides(client, [], user=_regular_user())
+        response = client.get(
+            f"/api/v1/workspaces/{_WORKSPACE_ID}/cost-aggregation"
+            "?period=day&from=2026-01-01&to=2027-01-01"
+        )
+        assert response.status_code == 400
+        assert "exceeds" in response.json()["detail"]
+        assert mock_aggregate.await_count == 0  # rejected before SQL
 
 
 # ============================================================================

--- a/backend/tests/integration/test_cost_aggregation_service.py
+++ b/backend/tests/integration/test_cost_aggregation_service.py
@@ -497,6 +497,40 @@ async def test_inverted_window_raises_value_error(db_session):
 
 
 @pytest.mark.asyncio
+async def test_window_exceeding_cap_raises_value_error(db_session):
+    """A window wider than ``MAX_LOOKBACK_DAYS`` raises ValueError before SQL.
+
+    Defense-in-depth guardrail: a non-UI caller (curl / SDK / MCP) that
+    bypasses the frontend's 365-day soft cap must not be able to scan
+    years of ``sleep_reports``. 366 days is one past the boundary.
+    """
+    service = CostAggregationService(db_session)
+    with pytest.raises(ValueError, match="exceeds"):
+        await service.aggregate(
+            period="day",
+            start=datetime(2026, 1, 1),
+            end=datetime(2027, 1, 2),  # 366-day half-open window
+        )
+
+
+@pytest.mark.asyncio
+async def test_window_at_cap_boundary_is_allowed(db_session):
+    """Exactly ``MAX_LOOKBACK_DAYS`` (365) does NOT raise — pins off-by-one.
+
+    The half-open window ``end - start`` equals the frontend's inclusive
+    day count (``end = to + 1 day``), so a 365-day backend window is the
+    UI's maximum permitted selection and must pass. Empty DB → empty list.
+    """
+    service = CostAggregationService(db_session)
+    rows = await service.aggregate(
+        period="day",
+        start=datetime(2026, 1, 1),
+        end=datetime(2027, 1, 1),  # 365-day half-open window (2026 is not a leap year)
+    )
+    assert rows == []
+
+
+@pytest.mark.asyncio
 async def test_period_week_collapses_seven_daily_reports_into_one_bucket(db_session):
     """Seven reports across one ISO week roll into a single weekly bucket.
 

--- a/backend/tests/integration/test_cost_aggregation_service.py
+++ b/backend/tests/integration/test_cost_aggregation_service.py
@@ -531,6 +531,27 @@ async def test_window_at_cap_boundary_is_allowed(db_session):
 
 
 @pytest.mark.asyncio
+async def test_sub_day_overage_message_reports_precise_span(db_session):
+    """A sub-day overage past the cap is rejected with a precise message.
+
+    The cap uses ``> timedelta`` so 365 days + 1 hour is rejected, but
+    reporting ``.days`` would truncate to a misleading "365 days" — the
+    *allowed* boundary. The message must carry the sub-day remainder so it
+    matches the predicate that fired. (Copilot review, PR #863.)
+    """
+    service = CostAggregationService(db_session)
+    with pytest.raises(ValueError, match="exceeds") as exc:
+        await service.aggregate(
+            period="day",
+            start=datetime(2026, 1, 1, 0, 0),
+            end=datetime(2027, 1, 1, 1, 0),  # 365 days + 1 hour
+        )
+    # Must not claim a bare "365 days" (the allowed boundary) — the message
+    # carries the sub-day remainder that pushed the window past the cap.
+    assert "1:00:00" in str(exc.value)
+
+
+@pytest.mark.asyncio
 async def test_period_week_collapses_seven_daily_reports_into_one_bucket(db_session):
     """Seven reports across one ISO week roll into a single weekly bucket.
 

--- a/frontend/src/components/cost/CostDashboard.test.ts
+++ b/frontend/src/components/cost/CostDashboard.test.ts
@@ -11,7 +11,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { CostAggregationRow } from "@/lib/api";
-import { buildChartData, formatCost } from "./CostDashboard";
+import { buildChartData, formatCost, MAX_LOOKBACK_DAYS } from "./CostDashboard";
 
 function row(overrides: Partial<CostAggregationRow>): CostAggregationRow {
   return {
@@ -30,6 +30,17 @@ function row(overrides: Partial<CostAggregationRow>): CostAggregationRow {
     ...overrides,
   };
 }
+
+describe("MAX_LOOKBACK_DAYS", () => {
+  // Cross-stack drift guard (#528): the backend enforces the identical cap in
+  // backend/src/services/cost_aggregation_service.py. The backend value is
+  // pinned by its own 365/366 boundary integration tests; this pins the UI
+  // side, so a one-sided bump here trips CI instead of silently producing a
+  // "UI accepts, API 400s" mismatch. If you change this, change the backend.
+  it("is pinned to 365 to match the backend cap", () => {
+    expect(MAX_LOOKBACK_DAYS).toBe(365);
+  });
+});
 
 describe("formatCost", () => {
   it("renders a positive number as $X.XXXX", () => {

--- a/frontend/src/components/cost/CostDashboard.tsx
+++ b/frontend/src/components/cost/CostDashboard.tsx
@@ -178,12 +178,12 @@ export function CostDashboard({
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 
-  // Client-side range validation. The server validates `period` and
-  // `from <= to` (#472), but does NOT enforce a maximum window today —
-  // so MAX_LOOKBACK_DAYS is a UI-only soft cap to keep accidental huge
-  // queries from hitting the backend. A non-UI caller (curl / SDK)
-  // can still request arbitrarily large ranges. Backend enforcement
-  // is tracked as a follow-up to #472.
+  // Client-side range validation — early inline UX before the fetch.
+  // The backend enforces MAX_LOOKBACK_DAYS as a hard cap server-side
+  // (#528: route returns 400, service raises ValueError), so a non-UI
+  // caller (curl / SDK) is rejected too. This client check just surfaces
+  // the same limit inline without a round-trip; keep it in sync with the
+  // backend constant (see the export comment above).
   const rangeError = useMemo<string | null>(() => {
     if (!from || !to) return null;
     if (from > to) return t("validation.invertedRange");

--- a/frontend/src/components/cost/CostDashboard.tsx
+++ b/frontend/src/components/cost/CostDashboard.tsx
@@ -62,7 +62,11 @@ import {
 } from "@/lib/api";
 
 const DEFAULT_LOOKBACK_DAYS = 30;
-const MAX_LOOKBACK_DAYS = 365;
+// MUST stay in sync with the backend cap (#528):
+// backend/src/services/cost_aggregation_service.py `MAX_LOOKBACK_DAYS`.
+// A one-sided bump makes the UI accept a window the API then rejects with a
+// 400. Exported + pinned by a test so a change here trips CI; bump both sides.
+export const MAX_LOOKBACK_DAYS = 365;
 
 function defaultDateRange(): { from: string; to: string } {
   const today = new Date();


### PR DESCRIPTION
Closes #528

## Summary
- Add a server-side `MAX_LOOKBACK_DAYS=365` cap to the cost-aggregation routes so non-UI callers (curl / SDK / MCP) can no longer request windows that scan years of `sleep_reports`.
- Enforced at two layers via a shared `window_exceeds_cap` predicate (single source of the off-by-one boundary): route `_parse_window` → HTTP 400, service `aggregate()` → `ValueError` backstop.
- The half-open `end - start` equals the frontend's inclusive day count (`end = to + 1 day`), so 365 days pass and 366 reject — mirroring the existing UI soft cap exactly.

## Implementation notes
- `window_exceeds_cap(start, end)` added to `cost_aggregation_service.py` and imported by the route. `> timedelta(days=365)` (not `.days >`) also rejects sub-day overage a direct service caller could pass.
- Frontend `MAX_LOOKBACK_DAYS` is now exported and pinned by a vitest; the backend boundary is pinned by 365/366 integration tests — a one-sided drift trips CI. Cross-reference comments point both directions.
- Tests: admin + workspace routes return 400 on a 366-day window (rejected before SQL, `await_count == 0`) plus a 365-day boundary 200; service integration covers 366 → `ValueError` and 365 → allowed.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO lens)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/528-feat-server-side-max-window-enforcement.gate1.md
- ~/.claude/cache/gh-issue-driven/528-feat-server-side-max-window-enforcement.gate2.md

🤖 Generated via /gh-issue-driven:ship
