### PR TITLE
feat(api): validate pii_guardrail_config schema at connector provision (#866)

### DIFF
--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -14,7 +14,7 @@ from auth.dependencies import WorkspaceAdmin
 from db.base import get_db
 from models.schemas import validate_pii_guardrail_config
 from services.connector_provisioning import ConnectorProvisioningService
-from utils.exceptions import MemoryCloudException
+from utils.exceptions import MemoryCloudException, ValidationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -85,9 +85,7 @@ async def create_workspace_connector(
     try:
         pii_guardrail_config = validate_pii_guardrail_config(request.pii_guardrail_config)
     except ValueError as ve:
-        raise MemoryCloudException(
-            str(ve), status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, error_code="VALIDATION-001"
-        ) from ve
+        raise ValidationError(str(ve), field="pii_guardrail_config") from ve
 
     try:
         result = await ConnectorProvisioningService(db).provision_connector(

--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import WorkspaceAdmin
 from db.base import get_db
+from models.schemas import validate_pii_guardrail_config
 from services.connector_provisioning import ConnectorProvisioningService
 from utils.exceptions import MemoryCloudException
 from utils.logger import get_logger
@@ -79,6 +80,15 @@ async def create_workspace_connector(
             detail="No workspace selected. Please select a workspace first.",
         )
 
+    # #866: validate pii_guardrail_config against the documented schema before it is
+    # stored opaquely. Fail-secure — a malformed config is rejected, not silently kept.
+    try:
+        pii_guardrail_config = validate_pii_guardrail_config(request.pii_guardrail_config)
+    except ValueError as ve:
+        raise MemoryCloudException(
+            str(ve), status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, error_code="VALIDATION-001"
+        ) from ve
+
     try:
         result = await ConnectorProvisioningService(db).provision_connector(
             workspace_id=workspace_id,
@@ -87,7 +97,7 @@ async def create_workspace_connector(
             resource_id=request.resource_id,
             display_name=request.display_name,
             oauth_tokens=request.oauth_tokens,
-            pii_guardrail_config=request.pii_guardrail_config,
+            pii_guardrail_config=pii_guardrail_config,
             litellm_virtual_key_id=request.litellm_virtual_key_id,
             virtual_key_valid_until=request.virtual_key_valid_until,
             quota_events_per_hour=request.quota_events_per_hour,

--- a/backend/src/mcp_server/tools/resource.py
+++ b/backend/src/mcp_server/tools/resource.py
@@ -1094,11 +1094,17 @@ async def handle_setup_connector(
             oauth_tokens = args.get("oauth_tokens")
             if oauth_tokens is not None and not isinstance(oauth_tokens, dict):
                 return _error_response("validation_error", "oauth_tokens must be an object.")
-            pii_guardrail_config = args.get("pii_guardrail_config")
-            if pii_guardrail_config is not None and not isinstance(pii_guardrail_config, dict):
-                return _error_response(
-                    "validation_error", "pii_guardrail_config must be an object."
+            # #866: validate pii_guardrail_config against the documented schema
+            # (shared with the REST provision path). Fail-secure on malformed input;
+            # rejects unknown keys and missing detectors, not just non-objects.
+            from models.schemas import validate_pii_guardrail_config
+
+            try:
+                pii_guardrail_config = validate_pii_guardrail_config(
+                    args.get("pii_guardrail_config")
                 )
+            except ValueError as ve:
+                return _error_response("validation_error", str(ve))
 
             from services.connector_provisioning import ConnectorProvisioningService
             from utils.exceptions import MemoryCloudException

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -1265,8 +1265,11 @@ class PiiGuardrailConfig(BaseModel):
 
     @model_validator(mode="after")
     def _require_detectors_when_enabled(self) -> "PiiGuardrailConfig":
-        if self.enabled and not self.detectors:
-            raise ValueError("detectors must be non-empty when enabled=true")
+        if self.enabled:
+            if not self.detectors:
+                raise ValueError("detectors must be non-empty when enabled=true")
+            if any(not d or not d.strip() for d in self.detectors):
+                raise ValueError("detectors must not contain blank entries when enabled=true")
         return self
 
 

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -1295,8 +1295,10 @@ def validate_pii_guardrail_config(raw: dict | None) -> dict | None:
     try:
         return PiiGuardrailConfig.model_validate(raw).model_dump()
     except ValidationError as e:
-        locs = "; ".join(
-            ".".join(str(p) for p in err["loc"]) + ": " + err["msg"]
-            for err in e.errors(include_input=False)
-        )
-        raise ValueError(f"invalid pii_guardrail_config — {locs}") from e
+        parts = []
+        for err in e.errors(include_input=False):
+            loc = ".".join(str(p) for p in err["loc"])
+            # Model-level (@model_validator) errors carry an empty loc; render just
+            # the message rather than a dangling "<empty>: msg" prefix.
+            parts.append(f"{loc}: {err['msg']}" if loc else err["msg"])
+        raise ValueError(f"invalid pii_guardrail_config — {'; '.join(parts)}") from e

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -1263,6 +1263,16 @@ class PiiGuardrailConfig(BaseModel):
         True, description="On detection error: true=drop event, false=ingest with warning."
     )
 
+    @field_validator("locale")
+    @classmethod
+    def _locale_not_blank(cls, v: str) -> str:
+        # An explicitly blank locale overrides the "en" default with an unusable
+        # recognizer locale. Reject it (the default is not run through this
+        # validator, so omitting locale still yields "en").
+        if not v or not v.strip():
+            raise ValueError("locale must not be blank")
+        return v
+
     @model_validator(mode="after")
     def _require_detectors_when_enabled(self) -> "PiiGuardrailConfig":
         if self.enabled:

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -8,7 +8,14 @@ from datetime import datetime
 from typing import Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 
 from auth.workspace_roles import ContextRole, WorkspaceRole
 from models.api_base import TZAwareBaseModel
@@ -1224,3 +1231,69 @@ class ResourceEventBatchResponse(BaseModel):
     failed_count: int = Field(0, description="Number of events that failed")
     event_ids: list[int] = Field(default_factory=list, description="Created event IDs")
     errors: list[dict] = Field(default_factory=list, description="Error details for failed events")
+
+
+class PiiGuardrailConfig(BaseModel):
+    """Connector PII-scrubbing config consumed by the ai-worker pre-compile stage.
+
+    Issue #866 (F6-d follow-up). memory-cloud stores this opaquely as JSONB on
+    ``workspace_connectors.pii_guardrail_config`` but validates the shape at the
+    provision path so a malformed config (typo'd/unknown key, missing detectors)
+    is rejected loudly instead of silently accepted — a Fail-Secure guardrail.
+    The agreed schema is the contract in ``docs/pii-guardrail-consumption-contract.md``.
+
+    ``extra="forbid"`` is deliberate: this is *request* validation, so an unknown
+    key (e.g. ``detector`` vs ``detectors``) must fail rather than be ignored
+    (silently-ignore would be fail-open). This is the opposite default from
+    response models, which use ``extra="ignore"`` for forward-compat.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(..., description="Master switch for worker-side scrubbing.")
+    detectors: list[str] = Field(
+        default_factory=list,
+        description="Presidio-style recognizer names; non-empty required when enabled=true.",
+    )
+    redaction: Literal["mask", "hash", "remove"] = Field(
+        "mask", description="How a matched span is rewritten."
+    )
+    locale: str = Field("en", description="Recognizer locale (e.g. en / ja).")
+    fail_closed: bool = Field(
+        True, description="On detection error: true=drop event, false=ingest with warning."
+    )
+
+    @model_validator(mode="after")
+    def _require_detectors_when_enabled(self) -> "PiiGuardrailConfig":
+        if self.enabled and not self.detectors:
+            raise ValueError("detectors must be non-empty when enabled=true")
+        return self
+
+
+def validate_pii_guardrail_config(raw: dict | None) -> dict | None:
+    """Validate a raw ``pii_guardrail_config`` against :class:`PiiGuardrailConfig`.
+
+    Shared by both provision call-sites (REST ``POST /workspace-connectors`` and the
+    MCP ``setup_connector`` tool) so the documented schema has a single enforcement
+    point. ``None`` (unconfigured) is accepted and passed through unchanged — the
+    worker enforces fail-closed at ingest per the null asymmetry in the contract doc.
+
+    Returns the normalized config dict (defaults materialized) ready for JSONB
+    storage, or ``None``.
+
+    Raises:
+        ValueError: if ``raw`` is not a valid config. The message lists only field
+            locations and reasons — never the offending input values
+            (``include_input=False``), so a malformed config cannot echo sensitive
+            content back to the caller.
+    """
+    if raw is None:
+        return None
+    try:
+        return PiiGuardrailConfig.model_validate(raw).model_dump()
+    except ValidationError as e:
+        locs = "; ".join(
+            ".".join(str(p) for p in err["loc"]) + ": " + err["msg"]
+            for err in e.errors(include_input=False)
+        )
+        raise ValueError(f"invalid pii_guardrail_config — {locs}") from e

--- a/backend/tests/api/test_workspace_connectors.py
+++ b/backend/tests/api/test_workspace_connectors.py
@@ -36,3 +36,64 @@ async def test_create_workspace_connector_rolls_back_on_service_failure():
 
     db.rollback.assert_awaited_once()
     db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_invalid_pii_guardrail_config_before_calling_service():
+    # #866: a malformed pii_guardrail_config (typo'd key) must be rejected at the
+    # provision path with a 422, before the service / DB is touched.
+    db = MagicMock()
+    db.rollback = AsyncMock()
+    db.commit = AsyncMock()
+    request = WorkspaceConnectorCreateRequest(
+        connector_type="slack",
+        resource_id="slack_general",
+        pii_guardrail_config={"enabled": True, "detector": ["EMAIL_ADDRESS"]},  # typo: detector
+    )
+    admin = {"user_id": "user-1", "current_workspace_id": uuid4()}
+
+    with patch("api.routes.workspace_connectors.ConnectorProvisioningService") as service_cls:
+        service_cls.return_value.provision_connector = AsyncMock()
+        with pytest.raises(MemoryCloudException) as exc:
+            await create_workspace_connector(request, admin, db)
+
+    assert exc.value.status_code == 422
+    service_cls.return_value.provision_connector.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_create_passes_normalized_pii_guardrail_config_dict_to_service():
+    # Valid config is normalized (defaults materialized) and handed to the service
+    # as a plain dict for JSONB storage — not a Pydantic model.
+    db = MagicMock()
+    db.rollback = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    request = WorkspaceConnectorCreateRequest(
+        connector_type="slack",
+        resource_id="slack_general",
+        pii_guardrail_config={"enabled": True, "detectors": ["EMAIL_ADDRESS"]},
+    )
+    admin = {"user_id": "user-1", "current_workspace_id": uuid4()}
+
+    result = MagicMock()
+    result.connector.id = uuid4()
+    result.connector.connector_type = "slack"
+    result.resource_id = "slack_general"
+    result.resource_pk = uuid4()
+    result.token.id = 1
+    result.plaintext_token = "kagura_resource_x"
+    result.token.quota_events_per_hour = 1000
+
+    with patch("api.routes.workspace_connectors.ConnectorProvisioningService") as service_cls:
+        service_cls.return_value.provision_connector = AsyncMock(return_value=result)
+        await create_workspace_connector(request, admin, db)
+
+    kwargs = service_cls.return_value.provision_connector.await_args.kwargs
+    assert kwargs["pii_guardrail_config"] == {
+        "enabled": True,
+        "detectors": ["EMAIL_ADDRESS"],
+        "redaction": "mask",
+        "locale": "en",
+        "fail_closed": True,
+    }

--- a/backend/tests/api/test_workspace_connectors.py
+++ b/backend/tests/api/test_workspace_connectors.py
@@ -58,6 +58,7 @@ async def test_create_rejects_invalid_pii_guardrail_config_before_calling_servic
             await create_workspace_connector(request, admin, db)
 
     assert exc.value.status_code == 422
+    assert exc.value.error_code == "VAL-001"  # canonical validation code, not a one-off
     service_cls.return_value.provision_connector.assert_not_awaited()
 
 

--- a/backend/tests/mcp_server/test_setup_connector_pii_validation.py
+++ b/backend/tests/mcp_server/test_setup_connector_pii_validation.py
@@ -34,7 +34,7 @@ async def test_setup_connector_rejects_invalid_pii_guardrail_config():
     }
 
     with (
-        patch("db.base.get_db", side_effect=lambda: _fake_get_db()),
+        patch("db.base.get_db", side_effect=_fake_get_db),
         patch(
             "mcp_server.tools.resource._check_owner_admin_role",
             new=AsyncMock(return_value=None),

--- a/backend/tests/mcp_server/test_setup_connector_pii_validation.py
+++ b/backend/tests/mcp_server/test_setup_connector_pii_validation.py
@@ -1,0 +1,49 @@
+"""MCP setup_connector pii_guardrail_config validation (#866, F6-d follow-up).
+
+The MCP provision path must reject a malformed pii_guardrail_config with a
+validation_error before reaching the provisioning service — mirroring the REST
+path. Both call-sites share models.schemas.validate_pii_guardrail_config.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.resource import handle_setup_connector
+
+
+def _fake_get_db():
+    async def _gen():
+        db = MagicMock()
+        db.rollback = AsyncMock()
+        db.commit = AsyncMock()
+        yield db
+
+    return _gen()
+
+
+@pytest.mark.asyncio
+async def test_setup_connector_rejects_invalid_pii_guardrail_config():
+    workspace_id = uuid4()
+    args = {
+        "connector_type": "slack",
+        "resource_id": "slack_general",
+        "pii_guardrail_config": {"enabled": True, "detector": ["EMAIL_ADDRESS"]},  # typo
+    }
+
+    with (
+        patch("db.base.get_db", side_effect=lambda: _fake_get_db()),
+        patch(
+            "mcp_server.tools.resource._check_owner_admin_role",
+            new=AsyncMock(return_value=None),
+        ),
+        patch("services.connector_provisioning.ConnectorProvisioningService") as service_cls,
+    ):
+        service_cls.return_value.provision_connector = AsyncMock()
+        result = await handle_setup_connector(args, "user-1", workspace_id)
+
+    payload = json.loads(result[0].text)
+    assert payload.get("error") == "validation_error"
+    service_cls.return_value.provision_connector.assert_not_awaited()

--- a/backend/tests/models/test_pii_guardrail_config.py
+++ b/backend/tests/models/test_pii_guardrail_config.py
@@ -53,6 +53,19 @@ def test_rejects_blank_detector_names_when_enabled(bad):
         PiiGuardrailConfig(enabled=True, detectors=bad)
 
 
+@pytest.mark.parametrize("bad_locale", ["", "  "])
+def test_rejects_blank_locale(bad_locale):
+    # An explicitly blank locale overrides the "en" default with an unusable value
+    # (#868 Copilot). Reject it rather than store a misconfigured recognizer locale.
+    with pytest.raises(ValidationError):
+        PiiGuardrailConfig(enabled=True, detectors=["EMAIL_ADDRESS"], locale=bad_locale)
+
+
+def test_default_locale_is_accepted():
+    cfg = PiiGuardrailConfig(enabled=True, detectors=["EMAIL_ADDRESS"])
+    assert cfg.locale == "en"
+
+
 # --- shared validation helper (used at both the REST and MCP provision call-sites) ---
 
 

--- a/backend/tests/models/test_pii_guardrail_config.py
+++ b/backend/tests/models/test_pii_guardrail_config.py
@@ -45,6 +45,14 @@ def test_rejects_invalid_redaction_enum():
         PiiGuardrailConfig(enabled=True, detectors=["EMAIL_ADDRESS"], redaction="scramble")
 
 
+@pytest.mark.parametrize("bad", [[""], ["  "], ["EMAIL_ADDRESS", ""]])
+def test_rejects_blank_detector_names_when_enabled(bad):
+    # A non-empty list of blank strings satisfies "list is non-empty" but is a
+    # semantically empty detector set — fail-open. Must be rejected.
+    with pytest.raises(ValidationError):
+        PiiGuardrailConfig(enabled=True, detectors=bad)
+
+
 # --- shared validation helper (used at both the REST and MCP provision call-sites) ---
 
 

--- a/backend/tests/models/test_pii_guardrail_config.py
+++ b/backend/tests/models/test_pii_guardrail_config.py
@@ -74,6 +74,23 @@ def test_validate_helper_raises_valueerror_on_unknown_key():
         validate_pii_guardrail_config({"enabled": True, "detector": ["EMAIL_ADDRESS"]})
 
 
+def test_model_level_error_message_has_no_empty_loc_prefix():
+    # @model_validator(mode="after") errors carry an empty loc. The helper must
+    # not render that as a bare "— : <msg>" with a dangling colon (#868 Copilot).
+    with pytest.raises(ValueError) as exc:
+        validate_pii_guardrail_config({"enabled": True, "detectors": []})
+    msg = str(exc.value)
+    assert "— :" not in msg
+    assert "detectors must be non-empty" in msg
+
+
+def test_field_level_error_message_keeps_field_location():
+    # Field-level errors should still name the field for debuggability.
+    with pytest.raises(ValueError) as exc:
+        validate_pii_guardrail_config({"enabled": True, "detector": ["EMAIL_ADDRESS"]})
+    assert "detector" in str(exc.value)
+
+
 def test_validate_helper_error_message_does_not_echo_input_values():
     # Secret-leak guard: pydantic ValidationError echoes offending input by default.
     # The helper must surface only field locations, never the offending value.

--- a/backend/tests/models/test_pii_guardrail_config.py
+++ b/backend/tests/models/test_pii_guardrail_config.py
@@ -1,0 +1,77 @@
+"""Tests for the PiiGuardrailConfig schema (#866, F6-d follow-up).
+
+Validates the connector pii_guardrail_config contract documented in
+docs/pii-guardrail-consumption-contract.md at the provision path.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from models.schemas import PiiGuardrailConfig, validate_pii_guardrail_config
+
+
+def test_accepts_a_valid_enabled_config():
+    cfg = PiiGuardrailConfig(
+        enabled=True,
+        detectors=["EMAIL_ADDRESS", "PHONE_NUMBER"],
+        redaction="mask",
+        locale="en",
+        fail_closed=True,
+    )
+    assert cfg.enabled is True
+    assert cfg.detectors == ["EMAIL_ADDRESS", "PHONE_NUMBER"]
+    assert cfg.redaction == "mask"
+
+
+def test_accepts_disabled_opt_out_config():
+    # {"enabled": false} is the explicit opt-out — detectors not required.
+    cfg = PiiGuardrailConfig(enabled=False)
+    assert cfg.enabled is False
+
+
+def test_rejects_unknown_key():
+    # extra="forbid" — a typo'd key (detector vs detectors) must fail loudly.
+    with pytest.raises(ValidationError):
+        PiiGuardrailConfig(enabled=True, detector=["EMAIL_ADDRESS"])
+
+
+def test_rejects_missing_detectors_when_enabled():
+    with pytest.raises(ValidationError):
+        PiiGuardrailConfig(enabled=True, detectors=[])
+
+
+def test_rejects_invalid_redaction_enum():
+    with pytest.raises(ValidationError):
+        PiiGuardrailConfig(enabled=True, detectors=["EMAIL_ADDRESS"], redaction="scramble")
+
+
+# --- shared validation helper (used at both the REST and MCP provision call-sites) ---
+
+
+def test_validate_helper_returns_none_for_none():
+    # null (unconfigured) is accepted at provision; the worker enforces fail-closed at ingest.
+    assert validate_pii_guardrail_config(None) is None
+
+
+def test_validate_helper_returns_normalized_dict_for_valid_input():
+    out = validate_pii_guardrail_config({"enabled": True, "detectors": ["EMAIL_ADDRESS"]})
+    assert isinstance(out, dict)
+    assert out["enabled"] is True
+    assert out["detectors"] == ["EMAIL_ADDRESS"]
+    assert out["redaction"] == "mask"  # defaults are materialized
+
+
+def test_validate_helper_raises_valueerror_on_unknown_key():
+    with pytest.raises(ValueError):
+        validate_pii_guardrail_config({"enabled": True, "detector": ["EMAIL_ADDRESS"]})
+
+
+def test_validate_helper_error_message_does_not_echo_input_values():
+    # Secret-leak guard: pydantic ValidationError echoes offending input by default.
+    # The helper must surface only field locations, never the offending value.
+    sensitive = "SENSITIVE-VALUE-DO-NOT-ECHO-123"
+    with pytest.raises(ValueError) as exc:
+        validate_pii_guardrail_config(
+            {"enabled": True, "detectors": ["EMAIL_ADDRESS"], "leaky_key": sensitive}
+        )
+    assert sensitive not in str(exc.value)

--- a/docs/pii-guardrail-consumption-contract.md
+++ b/docs/pii-guardrail-consumption-contract.md
@@ -27,13 +27,17 @@ on the way in.
 | **Setting** the config | memory-cloud | `POST /api/v1/workspace-connectors` (`api/routes/workspace_connectors.py`) and the MCP `setup_connector` tool |
 | **Interpreting + enforcing** the config (actual scrubbing) | **ai-worker** | pre-compile stage (ai-worker#91) |
 
-**memory-cloud stores the config opaquely.** The only server-side validation is
-"must be a JSON object" — `setup_connector` rejects a non-object with a
-`validation_error` (`mcp_server/tools/resource.py:1097-1100`), and the REST
-field is typed `dict[str, Any] | None`. **No key-level schema is enforced on the
-server.** That makes *this document* the source of truth for the config shape:
-the worker and whatever sets the config must agree here, because the database
-will silently accept any object.
+**memory-cloud validates the config shape at provision, then stores it as JSONB.**
+Since #866, both provision call-sites — the REST `POST /api/v1/workspace-connectors`
+endpoint and the MCP `setup_connector` tool — validate `pii_guardrail_config`
+against the `PiiGuardrailConfig` schema (`models/schemas.py`,
+`validate_pii_guardrail_config`) before storing it. A malformed config (unknown
+key such as `detector` vs `detectors`, or `enabled: true` with empty `detectors`)
+is rejected with a `422` / `validation_error` rather than silently stored. This
+document remains the human-readable source of truth; the server schema enforces
+it at the write boundary. The column itself is untyped JSONB, so the worker should
+**still** validate what it reads as defense-in-depth (a config written before #866,
+or via a future unguarded path, is not guaranteed to match).
 
 ## Config lifecycle (current constraints)
 
@@ -43,10 +47,11 @@ will silently accept any object.
   `config_version` column exists (defaults to `1`) but there is no server route
   that bumps it yet. A connector that needs a different guardrail config must be
   re-provisioned, or an update path must be added first (track separately).
-- **`null` is allowed.** The column is nullable and the field defaults to
-  `None`. A connector can be provisioned with no guardrail config — see
-  [Null config](#null-config-fail-closed) for the contract the worker must honor
-  in that case.
+- **`null` is allowed at provision.** The column is nullable and the field
+  defaults to `None`; provision-time validation (#866) accepts `null` and only
+  validates a non-null object. A connector can therefore be provisioned with no
+  guardrail config — see [Null config](#null-config-fail-closed) for the
+  fail-closed contract the worker must honor in that case.
 - **`connector_type` is one of `slack` / `discord` / `teams`**
   (`services/connector_provisioning.py:30`). The guardrail contract is identical
   across all three; only the message-extraction differs (out of scope here).
@@ -139,9 +144,11 @@ worker (pre-compile stage, ai-worker#91)
 
 ## Known pitfalls
 
-- **The server does not validate the schema.** A typo'd key (`detector` vs
-  `detectors`) is accepted and stored. The worker must validate the config it
-  reads and fail loudly on a shape it does not recognize.
+- **The server validates the schema at provision (#866), but the worker should
+  still validate what it reads.** Provision rejects a typo'd/unknown key or
+  missing `detectors`; however the stored column is untyped JSONB, so a config
+  written before #866 or via a future unguarded path is not guaranteed valid. The
+  worker must validate the config it reads and fail loudly on an unrecognized shape.
 - **Config is write-once.** No update endpoint exists; do not assume a connector's
   guardrail can be tightened in place without re-provisioning.
 - **`null` ≠ `{"enabled": false}`.** See [Null config](#null-config-fail-closed).


### PR DESCRIPTION
Closes #866

## Summary
- Add `PiiGuardrailConfig` (Pydantic, `extra="forbid"`) + a shared `validate_pii_guardrail_config()` helper in `models/schemas.py`, enforced at **both** connector provision call-sites.
- REST `POST /api/v1/workspace-connectors`: malformed config → `422` (`VALIDATION-001`) before the service/DB is touched; normalized dict passed to the service.
- MCP `setup_connector`: replaces the `isinstance(dict)` check with the shared helper → `validation_error` on malformed input.
- Fail-secure: unknown keys (`detector` vs `detectors`), missing detectors, and blank detector names when `enabled=true` are all rejected instead of silently stored.

## Implementation notes
- Single shared model/helper = one enforcement point for both call-sites; the documented schema in `docs/pii-guardrail-consumption-contract.md` is the contract, now enforced at the write boundary.
- `ValidationError` shaped with `e.errors(include_input=False)` — offending input values are never echoed to the caller.
- `null` (unconfigured) is accepted at provision; the worker fail-closes at ingest per the contract doc's null asymmetry.
- `model_dump()` normalizes the stored JSONB (defaults materialized). No prod data affected (connectors not yet live).
- Doc updated to reflect server-side validation (the prior "server does not validate" statements).

## Pre-PR review summary
- gate2 mode: advisor-only (binary_gate: none)
- audit: skipped
- cso: green — include_input=False leak-safe, extra=forbid correct, no bypass (only 2 validated provision paths), blank-detector gap closed
- qa-lead: green — both call-sites + helper + secret-leak covered; 16 new + 52 regression tests green; mocks sound
- cto: green — right altitude, no import cycle, no tech debt
- gate1: green via /ask (CSO lens)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/866-feat-pii-guardrail-config-schema-validation.gate1.md
- ~/.claude/cache/gh-issue-driven/866-feat-pii-guardrail-config-schema-validation.gate2.md

🤖 Generated via /gh-issue-driven:ship
