### PR TITLE
fix(api): exclude soft-deleted memories from admin user-stats counts (#871)

### DIFF
--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -428,14 +428,20 @@ async def get_user_stats(
 
         # Get memory stats
         total_count_result = await db.execute(
-            select(func.count(Memory.id)).where(Memory.user_id == user_id)
+            select(func.count(Memory.id)).where(
+                Memory.user_id == user_id, Memory.deleted_at.is_(None)
+            )
         )
         total_count = total_count_result.scalar() or 0
 
         # Count by scope (working vs persistent)
         working_count_result = await db.execute(
             select(func.count(Memory.id)).where(
-                and_(Memory.user_id == user_id, Memory.scope == "working")
+                and_(
+                    Memory.user_id == user_id,
+                    Memory.scope == "working",
+                    Memory.deleted_at.is_(None),
+                )
             )
         )
         working_count = working_count_result.scalar() or 0
@@ -445,7 +451,7 @@ async def get_user_stats(
         # Count by type
         type_result = await db.execute(
             select(Memory.type, func.count(Memory.id))
-            .where(Memory.user_id == user_id)
+            .where(Memory.user_id == user_id, Memory.deleted_at.is_(None))
             .group_by(Memory.type)
         )
         by_type = {row[0]: row[1] for row in type_result.all()}
@@ -597,13 +603,19 @@ async def get_user_detail(
 
         # 4. Get stats (reuse logic from get_user_stats)
         total_memories_result = await db.execute(
-            select(func.count(Memory.id)).where(Memory.user_id == user_id)
+            select(func.count(Memory.id)).where(
+                Memory.user_id == user_id, Memory.deleted_at.is_(None)
+            )
         )
         total_memories = total_memories_result.scalar() or 0
 
         working_memories_result = await db.execute(
             select(func.count(Memory.id)).where(
-                and_(Memory.user_id == user_id, Memory.scope == "working")
+                and_(
+                    Memory.user_id == user_id,
+                    Memory.scope == "working",
+                    Memory.deleted_at.is_(None),
+                )
             )
         )
         working_memories = working_memories_result.scalar() or 0
@@ -982,7 +994,11 @@ async def delete_user(
         if not target_user:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="User not found")
 
-        # Count data to be deleted
+        # Count data to be deleted — intentionally counts ALL rows including
+        # soft-deleted (deleted_at IS NOT NULL): the user is being hard-deleted
+        # and every owned row is removed. Do NOT add a `deleted_at IS NULL`
+        # filter here (unlike the user-stats counts, which report current
+        # holdings and exclude soft-deleted). See #871.
         memory_count_result = await db.execute(
             select(func.count(Memory.id)).where(Memory.user_id == user_id)
         )

--- a/backend/tests/integration/test_admin_user_stats_deleted_filter.py
+++ b/backend/tests/integration/test_admin_user_stats_deleted_filter.py
@@ -1,0 +1,143 @@
+"""Regression test for #871 — admin user-stats/detail must exclude soft-deleted memories.
+
+``admin.py``'s ``get_user_stats`` / ``get_user_detail`` counted ALL memories for
+a user (no ``deleted_at IS NULL`` filter), so a user with soft-deleted memories
+showed an inflated count in the admin user-detail view, while the user *list*
+(``admin.py:254``) and the workspace quota (``workspace_service.py:919``) — both
+of which filter ``deleted_at IS NULL`` — showed the correct (smaller) number.
+This is the admin-side recurrence of #198 Bug D (the same fix on the quota path).
+
+Pins both handlers so their total / working / persistent counts exclude
+soft-deleted rows and therefore agree with the list/quota paths. Hits a real
+Postgres test DB because the count is computed inline in the handler against
+live rows.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.admin import get_user_detail, get_user_stats
+from auth.workspace_roles import WorkspaceRole
+from models.auth import WorkspaceMember
+from models.memory import Memory
+
+from ._admin_helpers import make_context, make_user, make_workspace, mock_admin
+
+
+def _make_memory(*, user_id, workspace_id, context_id, scope: str, deleted: bool) -> Memory:
+    return Memory(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        workspace_id=workspace_id,
+        context_id=context_id,
+        summary=f"mem-{uuid.uuid4().hex[:6]}",
+        content="x",
+        type="note",
+        client="test",
+        scope=scope,
+        deleted_at=(func.now() if deleted else None),
+    )
+
+
+@pytest_asyncio.fixture
+async def user_with_soft_deleted_memories(db_session: AsyncSession) -> dict:
+    """User owns 3 live memories (2 working + 1 persistent) and 2 soft-deleted.
+
+    The live counts (total=3 / working=2 / persistent=1) are exactly what the
+    list (``admin.py:254``) and quota (``workspace_service.py:919``) paths
+    produce, so asserting them pins cross-path consistency.
+    """
+    user = make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    ws = make_workspace(owner_user_id=user.user_id)
+    db_session.add(ws)
+    await db_session.flush()
+    db_session.add(
+        WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role=WorkspaceRole.OWNER)
+    )
+
+    ctx = make_context(workspace_id=ws.id, created_by=user.user_id)
+    db_session.add(ctx)
+    await db_session.flush()
+
+    db_session.add_all(
+        [
+            _make_memory(
+                user_id=user.user_id,
+                workspace_id=ws.id,
+                context_id=ctx.id,
+                scope="working",
+                deleted=False,
+            ),
+            _make_memory(
+                user_id=user.user_id,
+                workspace_id=ws.id,
+                context_id=ctx.id,
+                scope="working",
+                deleted=False,
+            ),
+            _make_memory(
+                user_id=user.user_id,
+                workspace_id=ws.id,
+                context_id=ctx.id,
+                scope="persistent",
+                deleted=False,
+            ),
+            # soft-deleted — must NOT be counted by the user-stats/detail views
+            _make_memory(
+                user_id=user.user_id,
+                workspace_id=ws.id,
+                context_id=ctx.id,
+                scope="working",
+                deleted=True,
+            ),
+            _make_memory(
+                user_id=user.user_id,
+                workspace_id=ws.id,
+                context_id=ctx.id,
+                scope="persistent",
+                deleted=True,
+            ),
+        ]
+    )
+    await db_session.commit()
+
+    return {"user_id": user.user_id}
+
+
+@pytest.mark.asyncio
+async def test_get_user_stats_excludes_soft_deleted(
+    user_with_soft_deleted_memories: dict, db_session: AsyncSession
+) -> None:
+    result = await get_user_stats(
+        user_id=user_with_soft_deleted_memories["user_id"],
+        admin=mock_admin(),
+        db=db_session,
+    )
+    # Without the deleted_at filter these would be 5 / 3 / 2.
+    assert result.memories["total"] == 3
+    assert result.memories["working"] == 2
+    assert result.memories["persistent"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_user_detail_excludes_soft_deleted(
+    user_with_soft_deleted_memories: dict, db_session: AsyncSession
+) -> None:
+    result = await get_user_detail(
+        user_id=user_with_soft_deleted_memories["user_id"],
+        admin=mock_admin(),
+        db=db_session,
+    )
+    # Without the deleted_at filter these would be 5 / 3 / 2.
+    assert result.stats["total_memories"] == 3
+    assert result.stats["working_memories"] == 2
+    assert result.stats["persistent_memories"] == 1


### PR DESCRIPTION
Closes #871

## Summary
- `admin.py`'s `get_user_stats` / `get_user_detail` counted ALL memories for a user (no `deleted_at` filter), so the admin **user-detail** view showed an inflated count (e.g. 4) while the **user list** (`admin.py:254`) and **workspace quota** (`workspace_service.py:919`) — both of which filter `deleted_at IS NULL` — showed the correct number (e.g. 0). The `schemas.py:497` contract ("excluding deleted") was also violated.
- Add `Memory.deleted_at.is_(None)` to the 6 count queries in `get_user_stats` (total / working / by_type) and `get_user_detail` (total / working); `persistent` is derived from `total - working` and inherits the fix.
- This is the admin-side recurrence of **#198 Bug D** (the same fix previously applied on the quota path).

## Implementation notes
- `delete_user`'s count (`admin.py:987`) is **intentionally left unfiltered** — it counts data-to-be-hard-deleted, which correctly includes soft-deleted rows, and matches the subsequent unfiltered `DELETE`. Added a comment so it is not "fixed" by mistake.
- Regression test (`tests/integration/test_admin_user_stats_deleted_filter.py`) builds a user with 3 live (2 working + 1 persistent) + 2 soft-deleted memories and pins both handlers to 3 / 2 / 1 — the same value the list/quota paths produce. Fails 5 / 3 / 2 without the filter. Verified: 6 passed on a real test DB (existing #699 suite + 2 new), no regression.

## Out of scope (follow-ups)
- `system.py:203` / `:207` (global system-stats totals) have the same missing filter but are a separate platform-wide aggregate — to be handled in a separate issue.
- **Tech-debt (CTO gate2 recommendation)**: user memory-count is computed ad-hoc inline in 5+ sites (list / stats / detail / quota / system); recurrence #198→#871 suggests consolidating into a shared count helper with `deleted_at IS NULL` as the default. Worth a follow-up tech-debt issue that also absorbs `system.py`.

## Pre-PR review summary
- gate2 mode: advisor-only — cso: green / qa-lead: green / cto: green
- gate1: green via /ask (CIO)
- /code-review (high effort): no correctness findings

🤖 Generated via /gh-issue-driven:ship
