### PR TITLE
chore(db): drop dead graph_memory cache columns (#658)

### DIFF
--- a/backend/alembic/versions/e29_658_drop_graph_cache_cols.py
+++ b/backend/alembic/versions/e29_658_drop_graph_cache_cols.py
@@ -1,0 +1,73 @@
+"""Drop the dead ``graph_memory`` cache columns (#658).
+
+Issue #658 (follow-up to PR #656 / #651): the four statistics columns on
+``graph_memory`` —
+
+- ``total_nodes``
+- ``total_edges``
+- ``avg_edge_weight``
+- ``max_edge_weight``
+
+— were a per-user cache that PR #656 stopped maintaining. ``weight_decay_task``
+used to refresh them every hour, but that write was removed because it tripped
+the 3-level isolation validator and the cache semantics (per-user, aggregated
+across workspaces/contexts) are incompatible with PR #394's invariant
+(``get_stats`` explicitly forbids cross-tenant aggregation). A grep confirmed
+**zero readers**: the live ``/graph/stats`` surface and the frontend compute
+node/edge/weight stats on the fly from ``graph_data`` via
+``GraphService.stats()`` — they never read these columns. With #656 merged the
+columns are write-free as well, so they are fully dead and removed here.
+
+### Downgrade
+
+``downgrade()`` re-adds the four columns as ``nullable=False`` with
+``server_default 0 / 0.0``. Note this server_default is *not* a restoration of
+the baseline definition — the baseline (157247e0df86) declared these columns
+``nullable=False`` with **no** server_default and relied on the model's
+app-layer ``default=0``. The server_default is added here deliberately because
+re-adding a ``NOT NULL`` column to an already-populated ``graph_memory`` table
+would fail without one. The pre-drop values cannot be reconstructed (a cache
+with no surviving source beyond re-deriving from ``graph_data``), but since the
+columns were write-only dead cache, restoring them as zeros is the honest
+reversible path — old code finds zeros, matching the unmaintained state they
+were already in.
+
+Revision ID: e29_658_drop_graph_cache_cols
+Revises: e28_850_workspace_connectors
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# NOTE: revision id kept <= 32 chars — alembic_version.version_num is VARCHAR(32).
+revision = "e29_658_drop_graph_cache_cols"
+down_revision = "e28_850_workspace_connectors"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_column("graph_memory", "total_nodes")
+    op.drop_column("graph_memory", "total_edges")
+    op.drop_column("graph_memory", "avg_edge_weight")
+    op.drop_column("graph_memory", "max_edge_weight")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "graph_memory",
+        sa.Column("total_nodes", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "graph_memory",
+        sa.Column("total_edges", sa.Integer(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "graph_memory",
+        sa.Column("avg_edge_weight", sa.Float(), nullable=False, server_default="0"),
+    )
+    op.add_column(
+        "graph_memory",
+        sa.Column("max_edge_weight", sa.Float(), nullable=False, server_default="0"),
+    )

--- a/backend/alembic/versions/e29_658_drop_graph_cache_cols.py
+++ b/backend/alembic/versions/e29_658_drop_graph_cache_cols.py
@@ -65,7 +65,7 @@ def downgrade() -> None:
     )
     op.add_column(
         "graph_memory",
-        sa.Column("avg_edge_weight", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("avg_edge_weight", sa.Float(), nullable=False, server_default="0.0"),
     )
     op.add_column(
         "graph_memory",

--- a/backend/alembic/versions/e29_658_drop_graph_cache_cols.py
+++ b/backend/alembic/versions/e29_658_drop_graph_cache_cols.py
@@ -69,5 +69,5 @@ def downgrade() -> None:
     )
     op.add_column(
         "graph_memory",
-        sa.Column("max_edge_weight", sa.Float(), nullable=False, server_default="0"),
+        sa.Column("max_edge_weight", sa.Float(), nullable=False, server_default="0.0"),
     )

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -300,10 +300,6 @@ class GraphMemory(Base):
         id: Primary key
         user_id: Owner user ID (unique - one graph per user)
         graph_data: NetworkX graph as JSON
-        total_nodes: Node count (cached)
-        total_edges: Edge count (cached)
-        avg_edge_weight: Average edge weight (cached)
-        max_edge_weight: Max edge weight (cached)
         created_at: Creation timestamp
         updated_at: Last modification timestamp
         last_decay_at: Last decay operation timestamp
@@ -318,12 +314,6 @@ class GraphMemory(Base):
     # NetworkX グラフ全体（node_link_data形式）
     graph_data: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
 
-    # 統計情報（キャッシュ・監視用）
-    total_nodes: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    total_edges: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
-    avg_edge_weight: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
-    max_edge_weight: Mapped[float] = mapped_column(Float, nullable=False, default=0.0)
-
     # タイムスタンプ
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()
@@ -337,7 +327,7 @@ class GraphMemory(Base):
     last_consolidation_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     def __repr__(self) -> str:
-        return f"<GraphMemory(user='{self.user_id}', nodes={self.total_nodes}, edges={self.total_edges})>"
+        return f"<GraphMemory(id={self.id}, user='{self.user_id}')>"
 
 
 # Edge type constants — named aliases for the persisted edge_type string values.

--- a/backend/src/repositories/graph.py
+++ b/backend/src/repositories/graph.py
@@ -118,10 +118,6 @@ class GraphRepository(BaseRepository[GraphMemory]):
 
         # Update fields
         existing.graph_data = graph.graph_data
-        existing.total_nodes = graph.total_nodes
-        existing.total_edges = graph.total_edges
-        existing.avg_edge_weight = graph.avg_edge_weight
-        existing.max_edge_weight = graph.max_edge_weight
         existing.updated_at = utcnow()
 
         if graph.last_decay_at:
@@ -141,16 +137,14 @@ class GraphRepository(BaseRepository[GraphMemory]):
         self,
         user_id: str,
         graph_data: dict[str, Any],
-        stats: dict[str, Any] | None = None,
     ) -> GraphMemory:
         """Update graph data for user.
 
-        Convenience method for updating graph JSON and stats.
+        Convenience method for updating graph JSON.
 
         Args:
             user_id: User ID
             graph_data: NetworkX node_link_data JSON
-            stats: Optional stats (nodes, edges, weights)
 
         Returns:
             Updated GraphMemory
@@ -166,22 +160,10 @@ class GraphRepository(BaseRepository[GraphMemory]):
         existing.graph_data = graph_data
         existing.updated_at = utcnow()
 
-        # Update stats if provided
-        if stats:
-            existing.total_nodes = stats.get("total_nodes", 0)
-            existing.total_edges = stats.get("total_edges", 0)
-            existing.avg_edge_weight = stats.get("avg_edge_weight", 0.0)
-            existing.max_edge_weight = stats.get("max_edge_weight", 0.0)
-
         await self.db.flush()
         await self.db.refresh(existing)
 
-        logger.info(
-            "graph_data_updated",
-            user_id=user_id,
-            nodes=existing.total_nodes,
-            edges=existing.total_edges,
-        )
+        logger.info("graph_data_updated", user_id=user_id)
 
         return existing
 
@@ -260,10 +242,6 @@ class GraphRepository(BaseRepository[GraphMemory]):
         new_graph = GraphMemory(
             user_id=user_id,
             graph_data={"directed": True, "multigraph": False, "nodes": [], "links": []},
-            total_nodes=0,
-            total_edges=0,
-            avg_edge_weight=0.0,
-            max_edge_weight=0.0,
         )
 
         return await self.create(new_graph)

--- a/backend/tests/repositories/test_graph_repository.py
+++ b/backend/tests/repositories/test_graph_repository.py
@@ -26,8 +26,6 @@ class TestGraphRepository:
         graph = GraphMemory(
             user_id=f"test_user_{uid}",
             graph_data={"nodes": [], "links": []},
-            total_nodes=0,
-            total_edges=0,
             created_at=datetime.utcnow(),
             updated_at=datetime.utcnow(),
         )
@@ -85,8 +83,6 @@ class TestGraphRepository:
             graph = GraphMemory(
                 user_id=f"page_user_{uid}_{i}",
                 graph_data={"nodes": [], "links": []},
-                total_nodes=0,
-                total_edges=0,
                 created_at=datetime.utcnow(),
                 updated_at=datetime.utcnow(),
             )
@@ -110,8 +106,6 @@ class TestGraphRepository:
         new_graph = GraphMemory(
             user_id=f"new_user_{uid}",
             graph_data=graph_data,
-            total_nodes=1,
-            total_edges=0,
             created_at=datetime.utcnow(),
             updated_at=datetime.utcnow(),
         )
@@ -120,7 +114,7 @@ class TestGraphRepository:
 
         assert created.id is not None
         assert created.user_id == new_graph.user_id
-        assert created.total_nodes == 1
+        assert created.graph_data["nodes"][0]["id"] == "node1"
 
         # Verify in DB
         fetched = await repository.get_by_user_id(new_graph.user_id)
@@ -134,16 +128,15 @@ class TestGraphRepository:
             "nodes": [{"id": "node1", "type": "memory"}],
             "links": [],
         }
-        sample_graph.total_nodes = 1
         sample_graph.updated_at = datetime.utcnow()
 
         updated = await repository.update(sample_graph.id, sample_graph)
 
-        assert updated.total_nodes == 1
+        assert updated.graph_data["nodes"][0]["id"] == "node1"
 
         # Verify in DB
         fetched = await repository.get(sample_graph.id)
-        assert fetched.total_nodes == 1
+        assert fetched.graph_data["nodes"][0]["id"] == "node1"
 
     @pytest.mark.asyncio
     async def test_delete(self, repository, sample_graph):
@@ -173,8 +166,6 @@ class TestGraphRepository:
         graph = GraphMemory(
             user_id=f"json_user_{uid}",
             graph_data=complex_graph,
-            total_nodes=2,
-            total_edges=1,
             created_at=datetime.utcnow(),
             updated_at=datetime.utcnow(),
         )
@@ -193,8 +184,6 @@ class TestGraphRepository:
         duplicate_graph = GraphMemory(
             user_id=sample_graph.user_id,  # Same user as sample_graph
             graph_data={"nodes": [], "links": []},
-            total_nodes=0,
-            total_edges=0,
             created_at=datetime.utcnow(),
             updated_at=datetime.utcnow(),
         )
@@ -205,14 +194,3 @@ class TestGraphRepository:
         with pytest.raises(IntegrityError):
             db_session.add(duplicate_graph)
             await db_session.commit()
-
-    @pytest.mark.asyncio
-    async def test_stats_update(self, repository, sample_graph):
-        """Test updating node/edge counts."""
-        sample_graph.total_nodes = 10
-        sample_graph.total_edges = 15
-
-        updated = await repository.update(sample_graph.id, sample_graph)
-
-        assert updated.total_nodes == 10
-        assert updated.total_edges == 15

--- a/backend/tests/tasks/test_neural_tasks.py
+++ b/backend/tests/tasks/test_neural_tasks.py
@@ -30,11 +30,6 @@ def _make_graph(user_id: str = "user-1"):
     graph.user_id = user_id
     graph.last_decay_at = None
     graph.updated_at = None
-    # Pre-existing cache columns — we assert these are NOT touched by the task.
-    graph.total_nodes = 0
-    graph.total_edges = 0
-    graph.avg_edge_weight = 0.0
-    graph.max_edge_weight = 0.0
     return graph
 
 
@@ -152,11 +147,6 @@ class TestWeightDecayTask:
         # Telemetry was refreshed.
         assert graph.last_decay_at is not None
         assert graph.updated_at is not None
-        # Dead cache columns were left untouched.
-        assert graph.total_nodes == 0
-        assert graph.total_edges == 0
-        assert graph.avg_edge_weight == 0.0
-        assert graph.max_edge_weight == 0.0
 
     @pytest.mark.asyncio
     async def test_skips_timestamp_update_when_no_edges_decayed(self, monkeypatch):


### PR DESCRIPTION
Closes #658

## Summary
- Drop the four write-only cache columns from the `graph_memory` table and `GraphMemory` model: `total_nodes`, `total_edges`, `avg_edge_weight`, `max_edge_weight`.
- Follow-up to PR #656 (#651), which stopped maintaining these columns (the hourly cache update tripped the 3-level isolation validator, and the per-user cross-workspace cache semantics conflict with #394's cross-tenant aggregation ban).
- Confirmed **zero readers**: the live `/graph/stats` surface, `graph_service.py`, `neural_edge.py`, `consolidation.py`, and the frontend all compute node/edge/weight stats on the fly from `graph_data` — they never read these ORM columns. API response shape is unchanged.

## Implementation notes
- `models/memory.py`: removed the 4 `mapped_column` defs + docstring lines; simplified `__repr__` to `id`/`user_id`.
- `repositories/graph.py`: removed the column writes in `update()` and `get_or_create()`; removed the now-orphaned `stats` param + `if stats:` block from `update_graph_data()` (zero callers); dropped `nodes=`/`edges=` from the `graph_data_updated` log.
- `alembic/versions/e29_658_drop_graph_cache_cols.py`: drops the 4 columns; `downgrade()` re-adds them `NOT NULL` with `server_default 0/0.0` — deliberately added (the baseline had none; app-layer `default=0` supplied values) so the re-add survives a populated table. Revises `e28_850_workspace_connectors` (current head).
- Tests: assertions moved from dropped-column checks to persisted `graph_data` (stronger); removed the obsolete `test_stats_update` and the #656 cache-untouched guard.

Verification: lint + type-check clean (0 new errors); `test_graph_repository.py` (11) + `test_neural_tasks.py` (9) pass; migration upgrade→downgrade→upgrade roundtrip verified on a real PostgreSQL DB.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- review provider: copilot

🤖 Generated via /gh-issue-driven:ship
