### PR TITLE
feat(api): Time Memory pull-only + recall_upcoming (#877)

### DIFF
--- a/backend/alembic/versions/e30_877_time_trigger_cols.py
+++ b/backend/alembic/versions/e30_877_time_trigger_cols.py
@@ -10,6 +10,7 @@ the window-overlap query + ORDER BY trigger_from sort on GET /memory/list.
 """
 
 import sqlalchemy as sa
+
 from alembic import op
 
 # revision identifiers

--- a/backend/alembic/versions/e30_877_time_trigger_cols.py
+++ b/backend/alembic/versions/e30_877_time_trigger_cols.py
@@ -41,9 +41,30 @@ def upgrade() -> None:
         ["trigger_from"],
         postgresql_where=sa.text("type = 'time'"),
     )
+    # Defense-in-depth for the lexical==chronological invariant: a type='time'
+    # row MUST carry both window bounds in fixed-width zero-padded ISO. Gated on
+    # type<>'time' so non-time memories that happen to have a details.trigger.*
+    # path are unaffected. Catches raw/admin SQL or any future write path that
+    # bypasses MemoryService.normalize_trigger, where a malformed or NULL bound
+    # would silently corrupt ORDER BY / window-overlap results.
+    # The IS NOT NULL guards are load-bearing: a CHECK passes when the
+    # expression is TRUE *or NULL*, and `NULL ~ regex` is NULL — so without the
+    # explicit non-null test a type='time' row missing a bound would slip
+    # through. Spelling them out makes the predicate a definite FALSE in that
+    # case, enforcing presence as well as format.
+    op.create_check_constraint(
+        "valid_trigger_window_format",
+        "memories",
+        "type <> 'time' OR ("
+        "trigger_from IS NOT NULL "
+        "AND trigger_from ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$' "
+        "AND trigger_until IS NOT NULL "
+        "AND trigger_until ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$')",
+    )
 
 
 def downgrade() -> None:
+    op.drop_constraint("valid_trigger_window_format", "memories", type_="check")
     op.drop_index("idx_memories_trigger_from", table_name="memories")
     op.drop_column("memories", "trigger_until")
     op.drop_column("memories", "trigger_from")

--- a/backend/alembic/versions/e30_877_time_trigger_cols.py
+++ b/backend/alembic/versions/e30_877_time_trigger_cols.py
@@ -1,0 +1,48 @@
+"""Add Time Memory generated columns trigger_from / trigger_until + partial index.
+
+Mirrors the external_blob_* GENERATED ALWAYS AS ... STORED pattern from
+e03_485_file_objects. Columns are TEXT extractions of details.trigger.from/until
+(naive ISO strings written by MemoryService.remember). A plain ``->>`` extraction
+is IMMUTABLE; a ``::timestamp`` cast is only STABLE (DateStyle-dependent) and
+PostgreSQL rejects it in a STORED generated column. The from/until strings are
+fixed-width zero-padded ISO, so lexical order == chronological order, which backs
+the window-overlap query + ORDER BY trigger_from sort on GET /memory/list.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers
+revision = "e30_877_time_trigger_cols"
+down_revision = "e29_619_memories_ws_ctx_idx"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        ALTER TABLE memories
+        ADD COLUMN trigger_from VARCHAR(32)
+        GENERATED ALWAYS AS (details->'trigger'->>'from') STORED
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE memories
+        ADD COLUMN trigger_until VARCHAR(32)
+        GENERATED ALWAYS AS (details->'trigger'->>'until') STORED
+        """
+    )
+    op.create_index(
+        "idx_memories_trigger_from",
+        "memories",
+        ["trigger_from"],
+        postgresql_where=sa.text("type = 'time'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_memories_trigger_from", table_name="memories")
+    op.drop_column("memories", "trigger_until")
+    op.drop_column("memories", "trigger_from")

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -125,13 +125,21 @@ async def remember(
     # Issue #146: Pass current workspace ID for workspace-scoped API keys
     # Issue #273: Use context_id from request.context dict (if provided)
     context_id = request.context.get("context_id") if request.context else None
-    result = await memory_service.remember(
-        request,
-        user_id=user["user_id"],
-        client=user.get("client", "web"),
-        current_context_id=context_id,
-        current_workspace_id=user.get("current_workspace_id"),  # NEW: Issue #146
-    )
+    try:
+        result = await memory_service.remember(
+            request,
+            user_id=user["user_id"],
+            client=user.get("client", "web"),
+            current_context_id=context_id,
+            current_workspace_id=user.get("current_workspace_id"),  # NEW: Issue #146
+        )
+    except ValueError as e:
+        # MemoryService raises ValueError as its "bad request" signal (e.g. an
+        # invalid type="time" details.trigger). Map it to 422 rather than
+        # letting it surface as an unhandled 500.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e
 
     return result
 
@@ -688,18 +696,28 @@ async def list_memories(
         # Time Memory (#877) window overlap, built once and applied to BOTH
         # queries (same anti-drift rationale as tag_filter above). A stored
         # window [trigger_from, trigger_until] overlaps the query window
-        # [trigger_from, trigger_until] iff trigger_from <= quntil AND
-        # trigger_until >= qfrom. The columns are TEXT fixed-width ISO, so
-        # string comparison == chronological comparison. trigger_until omitted
-        # => open-ended (everything not entirely in the past).
-        # isinstance(str) (not `is not None`) so a real ISO bound is required;
-        # this also keeps direct-call unit tests safe, where an unset Query()
-        # default is the FieldInfo sentinel rather than None.
+        # [qfrom, quntil] iff trigger_from <= quntil AND trigger_until >= qfrom.
+        # The columns are TEXT fixed-width ISO, so string comparison ==
+        # chronological comparison — but ONLY if the caller's bounds are the
+        # same fixed-width form. parse_query_bound re-normalizes them (and
+        # resolves the 'now' shortcut); a malformed bound is a 422, not silent
+        # wrong results. isinstance(str) (not `is not None`) skips the unset
+        # Query() FieldInfo sentinel that direct-call unit tests pass.
+        from utils.time_trigger import TriggerValidationError, parse_query_bound
+
+        try:
+            qfrom = parse_query_bound(trigger_from) if isinstance(trigger_from, str) else None
+            quntil = parse_query_bound(trigger_until) if isinstance(trigger_until, str) else None
+        except TriggerValidationError as e:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+            ) from e
+
         window_filters = []
-        if isinstance(trigger_from, str):
-            window_filters.append(Memory.trigger_until >= trigger_from)
-        if isinstance(trigger_until, str):
-            window_filters.append(Memory.trigger_from <= trigger_until)
+        if qfrom is not None:
+            window_filters.append(Memory.trigger_until >= qfrom)
+        if quntil is not None:
+            window_filters.append(Memory.trigger_from <= quntil)
         for wf in window_filters:
             query = query.where(wf)
 

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -137,9 +137,7 @@ async def remember(
         # MemoryService raises ValueError as its "bad request" signal (e.g. an
         # invalid type="time" details.trigger). Map it to 422 rather than
         # letting it surface as an unhandled 500.
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
-        ) from e
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
 
     return result
 
@@ -283,11 +281,17 @@ async def patch_memory(
         fields=sorted(request.model_fields_set),
     )
 
-    return await memory_service.patch_memory(
-        memory_id=memory_id,
-        request=request,
-        user_id=user["user_id"],
-    )
+    try:
+        return await memory_service.patch_memory(
+            memory_id=memory_id,
+            request=request,
+            user_id=user["user_id"],
+        )
+    except ValueError as e:
+        # MemoryService raises ValueError as its "bad request" signal (e.g. a
+        # PATCH flipping type to "time" without a valid details.trigger). Map it
+        # to 422 — same as the remember route — rather than an unhandled 500.
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
 
 
 @router.post("/forget", response_model=ForgetResponse)
@@ -743,13 +747,9 @@ async def list_memories(
         # Get memories. order_by=trigger_from (#877) sorts ascending for
         # upcoming-first Time Memory listing; default stays created_at desc.
         order_clause = (
-            Memory.trigger_from.asc()
-            if order_by == "trigger_from"
-            else Memory.created_at.desc()
+            Memory.trigger_from.asc() if order_by == "trigger_from" else Memory.created_at.desc()
         )
-        result = await db.execute(
-            query.order_by(order_clause).limit(limit).offset(offset)
-        )
+        result = await db.execute(query.order_by(order_clause).limit(limit).offset(offset))
         memories = list(result.scalars().all())
 
         # Convert to response. Memory.created_at / updated_at are stored as

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -546,6 +546,24 @@ async def list_memories(
         "one of the tags, PG array overlap; preserves #618 behavior) or `all` "
         "(memory holds every given tag, PG array contains — #830 drill-down).",
     ),
+    trigger_from: str | None = Query(
+        None,
+        description="Time Memory (#877) window lower bound (naive ISO, e.g. "
+        "2026-07-01T00:00:00). Selects type='time' memories whose stored "
+        "[trigger_from, trigger_until] window overlaps the query window. "
+        "Pass 'now' here to get upcoming items.",
+    ),
+    trigger_until: str | None = Query(
+        None,
+        description="Time Memory (#877) window upper bound (naive ISO). Omit for "
+        "an open-ended (future) window.",
+    ),
+    order_by: str = Query(
+        "created_at",
+        pattern="^(created_at|trigger_from)$",
+        description="Sort key. 'created_at' (default, desc) or 'trigger_from' "
+        "(asc) for upcoming-first Time Memory listing (#877).",
+    ),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
 ):
@@ -667,6 +685,24 @@ async def list_memories(
         if tag_filter is not None:
             query = query.where(tag_filter)
 
+        # Time Memory (#877) window overlap, built once and applied to BOTH
+        # queries (same anti-drift rationale as tag_filter above). A stored
+        # window [trigger_from, trigger_until] overlaps the query window
+        # [trigger_from, trigger_until] iff trigger_from <= quntil AND
+        # trigger_until >= qfrom. The columns are TEXT fixed-width ISO, so
+        # string comparison == chronological comparison. trigger_until omitted
+        # => open-ended (everything not entirely in the past).
+        # isinstance(str) (not `is not None`) so a real ISO bound is required;
+        # this also keeps direct-call unit tests safe, where an unset Query()
+        # default is the FieldInfo sentinel rather than None.
+        window_filters = []
+        if isinstance(trigger_from, str):
+            window_filters.append(Memory.trigger_until >= trigger_from)
+        if isinstance(trigger_until, str):
+            window_filters.append(Memory.trigger_from <= trigger_until)
+        for wf in window_filters:
+            query = query.where(wf)
+
         # Get total count (with same filters as data query)
         count_query = select(func.count(Memory.id)).where(Memory.deleted_at.is_(None))
         if owner_filter is not None:
@@ -681,12 +717,20 @@ async def list_memories(
             count_query = count_query.where(Memory.summary.ilike(q_pattern, escape="\\"))
         if tag_filter is not None:
             count_query = count_query.where(tag_filter)
+        for wf in window_filters:
+            count_query = count_query.where(wf)
         count_result = await db.execute(count_query)
         total = count_result.scalar() or 0
 
-        # Get memories
+        # Get memories. order_by=trigger_from (#877) sorts ascending for
+        # upcoming-first Time Memory listing; default stays created_at desc.
+        order_clause = (
+            Memory.trigger_from.asc()
+            if order_by == "trigger_from"
+            else Memory.created_at.desc()
+        )
         result = await db.execute(
-            query.order_by(Memory.created_at.desc()).limit(limit).offset(offset)
+            query.order_by(order_clause).limit(limit).offset(offset)
         )
         memories = list(result.scalars().all())
 

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -144,6 +144,7 @@ def _build_registry() -> dict[str, Any]:
         "remember": handle_remember,
         "update_memory": handle_update_memory,
         "recall": handle_recall,
+        "recall_upcoming": handle_recall_upcoming,
         "forget": handle_forget,
         "reference": handle_reference,
         "explore": handle_explore,
@@ -331,6 +332,7 @@ from mcp_server.tools.explore import handle_explore  # noqa: E402, F401
 from mcp_server.tools.memory import (  # noqa: E402, F401
     handle_forget,
     handle_recall,
+    handle_recall_upcoming,
     handle_reference,
     handle_remember,
     handle_update_memory,

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -77,6 +77,7 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "get_file_download_url",  # Issue #485: read-only presigned GET
         "list_files",  # Issue #485: read-only workspace listing
         "list_tags",  # Issue #614: read-only tag discovery
+        "recall_upcoming",  # Issue #877: deterministic read-only Time Memory window query (no Hebbian write)
     }
 )
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -362,6 +362,44 @@ IMPORTANT: Always specify context_id to ensure you're retrieving from the intend
             },
         },
         {
+            "name": "recall_upcoming",
+            "readOnly": True,
+            "description": (
+                "List Time Memories (type='time') whose scheduled window overlaps "
+                "a time range, soonest first. Use for \"what's coming up?\" / "
+                "\"何か予定ある?\" questions. This is a deterministic time query, "
+                "NOT semantic search — for topic search use recall(). Create a "
+                "Time Memory by resolving the date yourself (you know today's date) "
+                "and calling remember(type='time', details={'trigger': {'year': "
+                "2026, 'month': 7}}). Partial dates are allowed: omit month/day for "
+                "fuzzy timing (\"2026年7月ごろ\")."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["context_id"],
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target context UUID from list_contexts(). Do NOT fabricate.",
+                    },
+                    "from": {
+                        "type": "string",
+                        "description": "Lower bound, naive ISO (e.g. 2026-06-01T00:00:00). "
+                        "Defaults to no lower bound. Typically pass 'now' to get future items.",
+                    },
+                    "until": {
+                        "type": "string",
+                        "description": "Upper bound, naive ISO. Omit for an open-ended (future) window.",
+                    },
+                    "k": {
+                        "type": "integer",
+                        "description": "Max results (default 20, max 100).",
+                    },
+                },
+            },
+        },
+        {
             "name": "forget",
             "description": """Delete memories that are no longer needed, outdated, or incorrect (soft delete, can be recovered within retention period).
 

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -366,13 +366,13 @@ IMPORTANT: Always specify context_id to ensure you're retrieving from the intend
             "readOnly": True,
             "description": (
                 "List Time Memories (type='time') whose scheduled window overlaps "
-                "a time range, soonest first. Use for \"what's coming up?\" / "
-                "\"何か予定ある?\" questions. This is a deterministic time query, "
+                'a time range, soonest first. Use for "what\'s coming up?" / '
+                '"何か予定ある?" questions. This is a deterministic time query, '
                 "NOT semantic search — for topic search use recall(). Create a "
                 "Time Memory by resolving the date yourself (you know today's date) "
                 "and calling remember(type='time', details={'trigger': {'year': "
                 "2026, 'month': 7}}). Partial dates are allowed: omit month/day for "
-                "fuzzy timing (\"2026年7月ごろ\")."
+                'fuzzy timing ("2026年7月ごろ").'
             ),
             "inputSchema": {
                 "type": "object",

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -103,6 +103,15 @@ async def handle_remember(
         except _ContextNotFoundError as e:
             await db.rollback()
             return e.to_response()
+        except ValueError as e:
+            # MemoryService raises ValueError as its "bad request" signal (e.g.
+            # an invalid type="time" details.trigger). Return a structured
+            # validation_error rather than re-raising as an opaque tool crash.
+            await db.rollback()
+            await _log_tool_usage(
+                db, user_id, "remember", start_time, 422, args.get("context_id"), workspace_id
+            )
+            return _error_response("validation_error", str(e))
         except Exception:
             await db.rollback()
             await _log_tool_usage(
@@ -231,12 +240,31 @@ async def handle_recall_upcoming(
 
     from db.base import get_db
     from models.memory import Memory
+    from utils.time_trigger import TriggerValidationError, parse_query_bound
 
-    q_from = args.get("from")  # naive ISO lower bound; None => no lower filter
-    q_until = args.get("until")  # naive ISO upper bound; None => open-ended
-    k = min(int(args.get("k", 20)), 100)
+    # Validate inputs up front (before opening a DB session) so a malformed
+    # argument is a structured validation_error, not an unhandled crash.
+    try:
+        raw_k = args.get("k", 20)
+        k = int(raw_k)
+    except (TypeError, ValueError):
+        return _error_response("validation_error", f"k must be an integer, got {args.get('k')!r}")
+    # Clamp into [1, 100]: a missing lower bound let k<=0 through as LIMIT 0
+    # (always empty) or LIMIT -1 (no cap, bypassing the 100 ceiling).
+    k = max(1, min(k, 100))
 
+    try:
+        # Re-normalize bounds to fixed-width ISO (and resolve 'now') so the
+        # lexical comparison against the TEXT columns is correct. None => no
+        # bound on that side.
+        q_from = parse_query_bound(args.get("from"))
+        q_until = parse_query_bound(args.get("until"))
+    except TriggerValidationError as e:
+        return _error_response("validation_error", str(e))
+
+    start_time = time.time()
     async for db in get_db():
+        current_context_id: UUID | None = None
         try:
             current_context_id = _resolve_context_id(args["context_id"])
             # Read path: uniform context_not_found on any deny (CWE-639 / OWASP
@@ -252,13 +280,13 @@ async def handle_recall_upcoming(
             # Window overlap: stored [trigger_from, trigger_until] overlaps the
             # query window [q_from, q_until] iff trigger_until >= q_from AND
             # trigger_from <= q_until.
-            if isinstance(q_from, str):
+            if q_from is not None:
                 query = query.where(Memory.trigger_until >= q_from)
-            if isinstance(q_until, str):
+            if q_until is not None:
                 query = query.where(Memory.trigger_from <= q_until)
             query = query.order_by(Memory.trigger_from.asc()).limit(k)
 
-            rows = list((await db.execute(query)).scalars().all())
+            rows = (await db.execute(query)).scalars().all()
             results = [
                 {
                     "memory_id": str(m.id),
@@ -268,6 +296,9 @@ async def handle_recall_upcoming(
                 }
                 for m in rows
             ]
+            await _log_tool_usage(
+                db, user_id, "recall_upcoming", start_time, 200, current_context_id, workspace_id
+            )
             return [
                 TextContent(
                     type="text",
@@ -281,6 +312,9 @@ async def handle_recall_upcoming(
                 )
             ]
         except _ContextNotFoundError as e:
+            await _log_tool_usage(
+                db, user_id, "recall_upcoming", start_time, 404, current_context_id, workspace_id
+            )
             return e.to_response()
 
     return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -206,6 +206,16 @@ async def handle_update_memory(
         except _ContextNotFoundError as e:
             await db.rollback()
             return e.to_response()
+        except ValueError as e:
+            # _apply_time_trigger raises ValueError for an invalid type="time"
+            # details.trigger on the update path. Return a structured
+            # validation_error rather than re-raising as an opaque tool crash
+            # (mirrors handle_remember).
+            await db.rollback()
+            await _log_tool_usage(
+                db, user_id, "update_memory", start_time, 422, args.get("context_id"), workspace_id
+            )
+            return _error_response("validation_error", str(e))
         except Exception:
             await db.rollback()
             await _log_tool_usage(

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -214,6 +214,78 @@ async def handle_update_memory(
     return _error_response("internal_error", "Database session unavailable")
 
 
+async def handle_recall_upcoming(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Pull Time Memories (#877) whose trigger window overlaps a time range.
+
+    Deterministic filter+sort over type='time' memories — NOT semantic recall,
+    so it has no Hebbian write side-effects (the recall()-vs-list design rule).
+    Soonest-first by trigger_from. The trigger_from/trigger_until columns are
+    TEXT fixed-width ISO, so string comparison == chronological comparison.
+    """
+    if "context_id" not in args:
+        return _error_response("missing_fields", "Missing required field: context_id")
+
+    from sqlalchemy import select
+
+    from db.base import get_db
+    from models.memory import Memory
+
+    q_from = args.get("from")  # naive ISO lower bound; None => no lower filter
+    q_until = args.get("until")  # naive ISO upper bound; None => open-ended
+    k = min(int(args.get("k", 20)), 100)
+
+    async for db in get_db():
+        try:
+            current_context_id = _resolve_context_id(args["context_id"])
+            # Read path: uniform context_not_found on any deny (CWE-639 / OWASP
+            # A01), mirroring handle_recall.
+            current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+
+            query = (
+                select(Memory)
+                .where(Memory.deleted_at.is_(None))
+                .where(Memory.type == "time")
+                .where(Memory.context_id == current_context_id)
+            )
+            # Window overlap: stored [trigger_from, trigger_until] overlaps the
+            # query window [q_from, q_until] iff trigger_until >= q_from AND
+            # trigger_from <= q_until.
+            if isinstance(q_from, str):
+                query = query.where(Memory.trigger_until >= q_from)
+            if isinstance(q_until, str):
+                query = query.where(Memory.trigger_from <= q_until)
+            query = query.order_by(Memory.trigger_from.asc()).limit(k)
+
+            rows = list((await db.execute(query)).scalars().all())
+            results = [
+                {
+                    "memory_id": str(m.id),
+                    "summary": m.summary,
+                    "type": m.type,
+                    "details": m.details,
+                }
+                for m in rows
+            ]
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "status": "success",
+                            "results": results,
+                            **_context_response_fields(current_context),
+                        }
+                    ),
+                )
+            ]
+        except _ContextNotFoundError as e:
+            return e.to_response()
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
 async def handle_recall(
     args: dict[str, Any], user_id: str, workspace_id: UUID | None
 ) -> list[TextContent]:

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -274,6 +274,19 @@ class Memory(Base):
             "trigger_from",
             postgresql_where=text("type = 'time'"),
         ),
+        # Defense-in-depth for the lexical==chronological invariant: a
+        # type="time" row must carry both window bounds in fixed-width
+        # zero-padded ISO (NULL fails the regex, so this also enforces
+        # presence). Gated on type<>'time' so other memory types are
+        # unaffected even if they use a details.trigger.* path.
+        CheckConstraint(
+            "type <> 'time' OR ("
+            "trigger_from IS NOT NULL "
+            "AND trigger_from ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$' "
+            "AND trigger_until IS NOT NULL "
+            "AND trigger_until ~ '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$')",
+            name="valid_trigger_window_format",
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -191,6 +191,27 @@ class Memory(Base):
         index=False,  # Partial btree index created in migration e03_485
     )
 
+    # Time Memory (type="time"): generated lower/upper bounds of the trigger
+    # window, extracted as TEXT from details.trigger.from/until (naive ISO
+    # strings derived in MemoryService.remember). Mirrors the external_blob_*
+    # Computed pattern — a plain ``->>'from'`` extraction is IMMUTABLE, whereas
+    # a ``::timestamp`` cast is only STABLE and PostgreSQL rejects it in a STORED
+    # generated column. The from/until strings are fixed-width zero-padded ISO
+    # (YYYY-MM-DDTHH:MM:SS), so lexical comparison == chronological comparison,
+    # which is what the window-overlap filter + ORDER BY trigger_from rely on.
+    # Partial btree index on trigger_from WHERE type='time' is created in
+    # migration e30_877_time_trigger_cols.
+    trigger_from: Mapped[str | None] = mapped_column(
+        String(32),
+        Computed("details->'trigger'->>'from'", persisted=True),
+        index=False,
+    )
+    trigger_until: Mapped[str | None] = mapped_column(
+        String(32),
+        Computed("details->'trigger'->>'until'", persisted=True),
+        index=False,
+    )
+
     # Constraints
     __table_args__ = (
         CheckConstraint("importance BETWEEN 0 AND 1", name="valid_importance"),
@@ -243,6 +264,15 @@ class Memory(Base):
             "workspace_id",
             "context_id",
             postgresql_where=text("deleted_at IS NULL"),
+        ),
+        # Time Memory (type="time") partial btree on the generated lower bound,
+        # supporting the window-overlap query + ORDER BY trigger_from on
+        # GET /memory/list (migration e30_877_time_trigger_cols). Partial so
+        # only time memories carry the index.
+        Index(
+            "idx_memories_trigger_from",
+            "trigger_from",
+            postgresql_where=text("type = 'time'"),
         ),
     )
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -131,6 +131,40 @@ class MemoryService:
         context = await self.context_service.get_context(user_id, context_id)
         return context, str(context.workspace_id), str(context_id)
 
+    @staticmethod
+    def _apply_time_trigger(memory_type: str | None, details: dict | None) -> dict | None:
+        """Validate + normalize a Time Memory trigger window (Issue #877).
+
+        When ``memory_type == "time"``, ``details.trigger`` must carry caller-
+        resolved Y/M/D[/H/M] components; this derives the canonical ``from``/
+        ``until`` window so the generated ``trigger_from``/``trigger_until``
+        columns index it. For any other type, ``details`` is returned unchanged.
+
+        Centralized here so every write path (remember, _update_in_place,
+        patch_memory) enforces the same invariant — a ``type="time"`` row that
+        skips normalization would store NULL trigger columns and become
+        invisible to recall_upcoming and the trigger_from window filter.
+
+        Raises:
+            ValueError: if a time memory has no trigger or an invalid one (the
+                established "bad request" signal inside MemoryService).
+        """
+        if memory_type != "time":
+            return details
+
+        from utils.time_trigger import TriggerValidationError, normalize_trigger
+
+        trigger = (details or {}).get("trigger")
+        if trigger is None:
+            raise ValueError(
+                "type='time' requires details.trigger with at least {'year': ...}"
+            )
+        try:
+            normalized = normalize_trigger(trigger)
+        except TriggerValidationError as exc:
+            raise ValueError(f"invalid details.trigger: {exc}") from exc
+        return {**(details or {}), "trigger": normalized}
+
     async def remember(
         self,
         request: RememberRequest,
@@ -243,20 +277,9 @@ class MemoryService:
         # them and derive the [from, until] window written back into details so
         # the generated columns trigger_from / trigger_until can index it. No LLM
         # here — the caller already resolved any relative phrasing ("来週")
-        # against its own clock.
-        if request.type == "time":
-            from utils.time_trigger import TriggerValidationError, normalize_trigger
-
-            trigger = (request.details or {}).get("trigger")
-            if trigger is None:
-                raise ValueError(
-                    "type='time' requires details.trigger with at least {'year': ...}"
-                )
-            try:
-                normalized = normalize_trigger(trigger)
-            except TriggerValidationError as exc:
-                raise ValueError(f"invalid details.trigger: {exc}") from exc
-            request.details = {**(request.details or {}), "trigger": normalized}
+        # against its own clock. Centralized in _apply_time_trigger so the
+        # update/patch paths enforce the same invariant (see those methods).
+        request.details = self._apply_time_trigger(request.type, request.details)
 
         # Create memory entity first with pending status
         memory = Memory(
@@ -427,8 +450,15 @@ class MemoryService:
             memory.context_summary = normalized_ctx_summary
         if request.content is not None:
             memory.content = request.content
-        if request.details is not None:
-            memory.details = request.details
+        # Time Memory (#877): normalize the trigger against the *effective* type
+        # and details after this update, so changing details.trigger (or flipping
+        # type to "time") on an existing memory re-derives the from/until window
+        # the generated columns index — the same invariant remember() enforces.
+        effective_type = request.type if request.type is not None else memory.type
+        effective_details = request.details if request.details is not None else memory.details
+        effective_details = self._apply_time_trigger(effective_type, effective_details)
+        if request.details is not None or effective_type == "time":
+            memory.details = effective_details
         if request.type is not None:
             memory.type = request.type
         if request.importance is not None:
@@ -617,9 +647,23 @@ class MemoryService:
             memory.importance = request.importance
         if "tags" in provided_fields:
             memory.tags = request.tags
-        if "details" in provided_fields:
-            # Explicit null clears the column; non-null replaces it.
-            memory.details = request.details
+        # Time Memory (#877): normalize the trigger against the effective type/
+        # details after this patch (mirrors remember/_update_in_place), so a
+        # PATCH that touches details.trigger or flips type to "time" still
+        # populates the generated trigger_from/trigger_until columns.
+        effective_type = (
+            request.type
+            if ("type" in provided_fields and request.type is not None)
+            else memory.type
+        )
+        effective_details = (
+            request.details if "details" in provided_fields else memory.details
+        )
+        effective_details = self._apply_time_trigger(effective_type, effective_details)
+        if "details" in provided_fields or effective_type == "time":
+            # Explicit null clears the column; non-null replaces it. A
+            # type="time" patch always (re)writes the normalized details.
+            memory.details = effective_details
 
         memory.updated_at = utcnow()
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -156,9 +156,7 @@ class MemoryService:
 
         trigger = (details or {}).get("trigger")
         if trigger is None:
-            raise ValueError(
-                "type='time' requires details.trigger with at least {'year': ...}"
-            )
+            raise ValueError("type='time' requires details.trigger with at least {'year': ...}")
         try:
             normalized = normalize_trigger(trigger)
         except TriggerValidationError as exc:
@@ -656,9 +654,7 @@ class MemoryService:
             if ("type" in provided_fields and request.type is not None)
             else memory.type
         )
-        effective_details = (
-            request.details if "details" in provided_fields else memory.details
-        )
+        effective_details = request.details if "details" in provided_fields else memory.details
         effective_details = self._apply_time_trigger(effective_type, effective_details)
         if "details" in provided_fields or effective_type == "time":
             # Explicit null clears the column; non-null replaces it. A

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -238,6 +238,26 @@ class MemoryService:
         normalized_summary = normalize_for_search(request.summary)
         normalized_context_summary = normalize_for_search(request.context_summary)
 
+        # Time Memory (Issue #877): when type="time", the caller (assistant)
+        # supplies resolved Y/M/D[/H/M] components in details.trigger. Validate
+        # them and derive the [from, until] window written back into details so
+        # the generated columns trigger_from / trigger_until can index it. No LLM
+        # here — the caller already resolved any relative phrasing ("来週")
+        # against its own clock.
+        if request.type == "time":
+            from utils.time_trigger import TriggerValidationError, normalize_trigger
+
+            trigger = (request.details or {}).get("trigger")
+            if trigger is None:
+                raise ValueError(
+                    "type='time' requires details.trigger with at least {'year': ...}"
+                )
+            try:
+                normalized = normalize_trigger(trigger)
+            except TriggerValidationError as exc:
+                raise ValueError(f"invalid details.trigger: {exc}") from exc
+            request.details = {**(request.details or {}), "trigger": normalized}
+
         # Create memory entity first with pending status
         memory = Memory(
             id=memory_id,

--- a/backend/src/utils/time_trigger.py
+++ b/backend/src/utils/time_trigger.py
@@ -6,21 +6,30 @@ the caller. ``normalize_trigger`` validates them and derives the canonical
 ``trigger_until`` index. The deepest non-null component defines the precision
 and therefore the width of the window.
 
-Window bounds are emitted as **naive ISO strings without a Z suffix** so the
-PostgreSQL ``(details->'trigger'->>'from')::timestamp`` generated-column cast is
-unambiguous (the columns are ``TIMESTAMP WITHOUT TIME ZONE``, naive UTC by
-convention).
+Window bounds are emitted as **fixed-width, zero-padded naive ISO strings
+without a Z suffix** (e.g. ``2026-07-01T00:00:00``). The generated columns
+``trigger_from`` / ``trigger_until`` are TEXT — a plain ``details->'trigger'->>
+'from'`` extraction is IMMUTABLE, whereas a ``::timestamp`` cast is only STABLE
+and PostgreSQL rejects it in a STORED generated column. The window-overlap
+filter and ``ORDER BY trigger_from`` therefore rely on **lexical order matching
+chronological order**, which holds only for this fixed-width zero-padded form —
+hence ``parse_query_bound`` re-normalizes every query bound to the same shape
+before it touches the column.
 
 This module constructs explicit naive ``datetime`` values for deterministic
-window arithmetic — it never reads a wall clock — so flake8-datetimez's DTZ001
-concern (an accidental local-tz ``datetime.now()``) does not apply here.
+window arithmetic — it never reads a wall clock except in ``parse_query_bound``
+for the ``'now'`` shortcut — so flake8-datetimez's DTZ001 concern (an accidental
+local-tz ``datetime.now()``) does not apply to the constructors here.
 """
 # ruff: noqa: DTZ001 — deterministic naive window math, no wall-clock now()
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+import calendar
+from datetime import UTC, datetime
 from typing import Any
+
+from utils.datetime import utcnow
 
 
 class TriggerValidationError(ValueError):
@@ -28,15 +37,11 @@ class TriggerValidationError(ValueError):
 
 
 def _iso(dt: datetime) -> str:
-    """Format a naive datetime as fixed-width ISO without a Z suffix.
+    """Format a naive datetime as fixed-width zero-padded ISO without a Z suffix.
 
     The year is explicitly zero-padded to 4 digits (unlike ``strftime('%Y')`` on
-    some libc builds) so the emitted strings are fixed-width. The downstream
-    generated columns ``trigger_from`` / ``trigger_until`` are TEXT (an immutable
-    ``details->'trigger'->>'from'`` extraction — a ``::timestamp`` cast is only
-    STABLE and PostgreSQL rejects it in a STORED generated column), so the
-    window-overlap and ORDER BY rely on lexical order matching chronological
-    order. That equivalence holds only for this fixed-width, zero-padded form.
+    some libc builds) so the emitted strings are fixed-width — the load-bearing
+    invariant behind the lexical==chronological comparison (see module docstring).
     """
     return (
         f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
@@ -44,9 +49,25 @@ def _iso(dt: datetime) -> str:
     )
 
 
+def _require_int(value: Any, name: str) -> int:
+    """Return ``value`` as an int, rejecting bool and non-int types.
+
+    ``bool`` is a subclass of ``int`` in Python (``True == 1``), so a bare
+    ``isinstance(x, int)`` would silently accept ``True``/``False`` as 1/0.
+    A float (``7.0``) would pass a range check but then crash inside the
+    ``datetime`` constructor with a TypeError that escapes the caller's
+    ``TriggerValidationError`` handler — so reject anything that is not a plain
+    int here, where the error maps cleanly to a 4xx.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TriggerValidationError(f"trigger.{name} must be an integer")
+    return value
+
+
 def _days_in_month(year: int, month: int) -> int:
-    first_next = datetime(year + 1, 1, 1) if month == 12 else datetime(year, month + 1, 1)
-    return (first_next - timedelta(days=1)).day
+    """Last day of the given month. Uses ``calendar`` so December does not
+    overflow ``datetime`` (year 9999 + 1 would raise)."""
+    return calendar.monthrange(year, month)[1]
 
 
 def normalize_trigger(trigger: Any) -> dict:
@@ -57,8 +78,9 @@ def normalize_trigger(trigger: Any) -> dict:
     and the derived ``from``/``until`` ISO strings.
 
     Raises:
-        TriggerValidationError: on a non-dict, missing/out-of-range year, an
-            impossible date, or a skipped precision level (e.g. day without month).
+        TriggerValidationError: on a non-dict, a non-integer/bool component, a
+            missing/out-of-range year, an impossible date, or a skipped precision
+            level (e.g. day without month).
     """
     if not isinstance(trigger, dict):
         raise TriggerValidationError("trigger must be an object")
@@ -69,8 +91,9 @@ def normalize_trigger(trigger: Any) -> dict:
     hour = trigger.get("hour")
     minute = trigger.get("minute")
 
-    if not isinstance(year, int) or isinstance(year, bool):
-        raise TriggerValidationError("trigger.year is required and must be an integer")
+    if year is None:
+        raise TriggerValidationError("trigger.year is required")
+    year = _require_int(year, "year")
     if not 1 <= year <= 9999:
         raise TriggerValidationError("trigger.year out of range (1-9999)")
 
@@ -82,14 +105,23 @@ def normalize_trigger(trigger: Any) -> dict:
     if minute is not None and hour is None:
         raise TriggerValidationError("trigger.hour required when minute set")
 
-    if month is not None and not 1 <= month <= 12:
-        raise TriggerValidationError("trigger.month out of range (1-12)")
-    if day is not None and not 1 <= day <= _days_in_month(year, month):
-        raise TriggerValidationError("trigger.day out of range for the given month")
-    if hour is not None and not 0 <= hour <= 23:
-        raise TriggerValidationError("trigger.hour out of range (0-23)")
-    if minute is not None and not 0 <= minute <= 59:
-        raise TriggerValidationError("trigger.minute out of range (0-59)")
+    # Type + range validation (reject bool/float before any datetime math).
+    if month is not None:
+        month = _require_int(month, "month")
+        if not 1 <= month <= 12:
+            raise TriggerValidationError("trigger.month out of range (1-12)")
+    if day is not None:
+        day = _require_int(day, "day")
+        if not 1 <= day <= _days_in_month(year, month):
+            raise TriggerValidationError("trigger.day out of range for the given month")
+    if hour is not None:
+        hour = _require_int(hour, "hour")
+        if not 0 <= hour <= 23:
+            raise TriggerValidationError("trigger.hour out of range (0-23)")
+    if minute is not None:
+        minute = _require_int(minute, "minute")
+        if not 0 <= minute <= 59:
+            raise TriggerValidationError("trigger.minute out of range (0-59)")
 
     if month is None:
         frm = datetime(year, 1, 1, 0, 0, 0)
@@ -118,11 +150,60 @@ def normalize_trigger(trigger: Any) -> dict:
     return result
 
 
-def format_trigger_label(trigger: dict) -> str:
-    """Precision-aware display label derived from the components.
+def parse_query_bound(value: Any) -> str | None:
+    """Normalize a recall window bound to a fixed-width ISO string (or None).
 
-    Year/month precision renders the fuzzy "ごろ" form; day and finer render the
-    exact date/time.
+    A window bound (``trigger_from`` / ``trigger_until`` on GET /memory/list,
+    ``from`` / ``until`` on the recall_upcoming MCP tool) is compared
+    **lexically** against the stored TEXT columns, so it MUST be re-emitted in
+    the same fixed-width zero-padded ISO form — otherwise a caller passing
+    ``2026-7-1T00:00:00`` (not zero-padded) would silently match the wrong rows.
+
+    - ``None`` → ``None`` (no bound).
+    - ``"now"`` (case-insensitive) → current UTC time as fixed-width ISO. This
+      resolves a *read* query bound only (never stored data), so it does not
+      reintroduce the server-side clock the storage path deliberately avoids.
+    - any other value → parsed with ``datetime.fromisoformat`` (which rejects
+      non-zero-padded / malformed input) and re-emitted via ``_iso``; aware
+      datetimes are converted to naive UTC to match the naive-UTC storage.
+
+    Raises:
+        TriggerValidationError: if the value is not ``None``/``"now"`` and is not
+            a parseable ISO datetime.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str) and value.strip().lower() == "now":
+        return _iso(utcnow())
+    if not isinstance(value, str):
+        raise TriggerValidationError("time bound must be an ISO datetime string or 'now'")
+    try:
+        dt = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise TriggerValidationError(
+            f"invalid time bound {value!r}: expected a zero-padded ISO datetime "
+            "(e.g. 2026-07-01T00:00:00) or 'now'"
+        ) from exc
+    if dt.tzinfo is not None:
+        dt = dt.astimezone(UTC).replace(tzinfo=None)
+    return _iso(dt)
+
+
+def format_trigger_label(trigger: dict) -> str:
+    """Precision-aware English display label derived from the components.
+
+    A fuzzy level carries a parenthetical granularity marker so the label
+    communicates the *width* of the window, not a false exactness:
+    year → "2026 (year)", month → "2026-07 (month)", day → "2026-07-15",
+    hour → "2026-07-15 10:00 (hour)", minute → "2026-07-15 10:30".
+
+    Note the hour vs. minute distinction: an hour-precision trigger spans the
+    whole hour ([HH:00:00, HH:59:59]), so it carries the "(hour)" marker — a
+    bare ``HH:00`` would be indistinguishable from a minute-precision trigger at
+    ``:00`` and imply a 1-minute window it does not have.
+
+    Display strings are kept English/locale-neutral here; any localized
+    rendering belongs in the presentation layer, not this backend util.
     """
     year = trigger.get("year")
     month = trigger.get("month")
@@ -130,9 +211,11 @@ def format_trigger_label(trigger: dict) -> str:
     hour = trigger.get("hour")
     minute = trigger.get("minute")
     if month is None:
-        return f"{year}年ごろ"
+        return f"{year} (year)"
     if day is None:
-        return f"{year}年{month}月ごろ"
+        return f"{year:04d}-{month:02d} (month)"
     if hour is None:
         return f"{year:04d}-{month:02d}-{day:02d}"
-    return f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute or 0:02d}"
+    if minute is None:
+        return f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:00 (hour)"
+    return f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute:02d}"

--- a/backend/src/utils/time_trigger.py
+++ b/backend/src/utils/time_trigger.py
@@ -1,0 +1,123 @@
+"""Time Memory trigger derivation (pure logic, no I/O, no LLM).
+
+A Time Memory (``type="time"``) stores fuzzy Y/M/D[/H/M] components supplied by
+the caller. ``normalize_trigger`` validates them and derives the canonical
+``[from, until]`` window that the generated columns ``trigger_from`` /
+``trigger_until`` index. The deepest non-null component defines the precision
+and therefore the width of the window.
+
+Window bounds are emitted as **naive ISO strings without a Z suffix** so the
+PostgreSQL ``(details->'trigger'->>'from')::timestamp`` generated-column cast is
+unambiguous (the columns are ``TIMESTAMP WITHOUT TIME ZONE``, naive UTC by
+convention).
+
+This module constructs explicit naive ``datetime`` values for deterministic
+window arithmetic — it never reads a wall clock — so flake8-datetimez's DTZ001
+concern (an accidental local-tz ``datetime.now()``) does not apply here.
+"""
+# ruff: noqa: DTZ001 — deterministic naive window math, no wall-clock now()
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+_ISO = "%Y-%m-%dT%H:%M:%S"
+
+
+class TriggerValidationError(ValueError):
+    """Raised when caller-supplied trigger components are invalid."""
+
+
+def _days_in_month(year: int, month: int) -> int:
+    first_next = datetime(year + 1, 1, 1) if month == 12 else datetime(year, month + 1, 1)
+    return (first_next - timedelta(days=1)).day
+
+
+def normalize_trigger(trigger: Any) -> dict:
+    """Validate Y/M/D[/H/M] components and return a dict with the derived window.
+
+    Returns a new dict carrying the echoed components (``year``/``month``/``day``/
+    ``hour``/``minute``, missing levels as ``None``), any ``text`` passed through,
+    and the derived ``from``/``until`` ISO strings.
+
+    Raises:
+        TriggerValidationError: on a non-dict, missing/out-of-range year, an
+            impossible date, or a skipped precision level (e.g. day without month).
+    """
+    if not isinstance(trigger, dict):
+        raise TriggerValidationError("trigger must be an object")
+
+    year = trigger.get("year")
+    month = trigger.get("month")
+    day = trigger.get("day")
+    hour = trigger.get("hour")
+    minute = trigger.get("minute")
+
+    if not isinstance(year, int) or isinstance(year, bool):
+        raise TriggerValidationError("trigger.year is required and must be an integer")
+    if not 1 <= year <= 9999:
+        raise TriggerValidationError("trigger.year out of range (1-9999)")
+
+    # Precision must not skip levels.
+    if month is None and any(v is not None for v in (day, hour, minute)):
+        raise TriggerValidationError("trigger.month required when day/hour/minute set")
+    if day is None and any(v is not None for v in (hour, minute)):
+        raise TriggerValidationError("trigger.day required when hour/minute set")
+    if minute is not None and hour is None:
+        raise TriggerValidationError("trigger.hour required when minute set")
+
+    if month is not None and not 1 <= month <= 12:
+        raise TriggerValidationError("trigger.month out of range (1-12)")
+    if day is not None and not 1 <= day <= _days_in_month(year, month):
+        raise TriggerValidationError("trigger.day out of range for the given month")
+    if hour is not None and not 0 <= hour <= 23:
+        raise TriggerValidationError("trigger.hour out of range (0-23)")
+    if minute is not None and not 0 <= minute <= 59:
+        raise TriggerValidationError("trigger.minute out of range (0-59)")
+
+    if month is None:
+        frm = datetime(year, 1, 1, 0, 0, 0)
+        until = datetime(year, 12, 31, 23, 59, 59)
+    elif day is None:
+        frm = datetime(year, month, 1, 0, 0, 0)
+        until = datetime(year, month, _days_in_month(year, month), 23, 59, 59)
+    elif hour is None:
+        frm = datetime(year, month, day, 0, 0, 0)
+        until = datetime(year, month, day, 23, 59, 59)
+    elif minute is None:
+        frm = datetime(year, month, day, hour, 0, 0)
+        until = datetime(year, month, day, hour, 59, 59)
+    else:
+        frm = datetime(year, month, day, hour, minute, 0)
+        until = datetime(year, month, day, hour, minute, 59)
+
+    result = dict(trigger)
+    result["year"] = year
+    result["month"] = month
+    result["day"] = day
+    result["hour"] = hour
+    result["minute"] = minute
+    result["from"] = frm.strftime(_ISO)
+    result["until"] = until.strftime(_ISO)
+    return result
+
+
+def format_trigger_label(trigger: dict) -> str:
+    """Precision-aware display label derived from the components.
+
+    Year/month precision renders the fuzzy "ごろ" form; day and finer render the
+    exact date/time.
+    """
+    year = trigger.get("year")
+    month = trigger.get("month")
+    day = trigger.get("day")
+    hour = trigger.get("hour")
+    minute = trigger.get("minute")
+    if month is None:
+        return f"{year}年ごろ"
+    if day is None:
+        return f"{year}年{month}月ごろ"
+    if hour is None:
+        return f"{year:04d}-{month:02d}-{day:02d}"
+    return f"{year:04d}-{month:02d}-{day:02d} {hour:02d}:{minute or 0:02d}"

--- a/backend/src/utils/time_trigger.py
+++ b/backend/src/utils/time_trigger.py
@@ -22,11 +22,26 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Any
 
-_ISO = "%Y-%m-%dT%H:%M:%S"
-
 
 class TriggerValidationError(ValueError):
     """Raised when caller-supplied trigger components are invalid."""
+
+
+def _iso(dt: datetime) -> str:
+    """Format a naive datetime as fixed-width ISO without a Z suffix.
+
+    The year is explicitly zero-padded to 4 digits (unlike ``strftime('%Y')`` on
+    some libc builds) so the emitted strings are fixed-width. The downstream
+    generated columns ``trigger_from`` / ``trigger_until`` are TEXT (an immutable
+    ``details->'trigger'->>'from'`` extraction — a ``::timestamp`` cast is only
+    STABLE and PostgreSQL rejects it in a STORED generated column), so the
+    window-overlap and ORDER BY rely on lexical order matching chronological
+    order. That equivalence holds only for this fixed-width, zero-padded form.
+    """
+    return (
+        f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
+        f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}"
+    )
 
 
 def _days_in_month(year: int, month: int) -> int:
@@ -98,8 +113,8 @@ def normalize_trigger(trigger: Any) -> dict:
     result["day"] = day
     result["hour"] = hour
     result["minute"] = minute
-    result["from"] = frm.strftime(_ISO)
-    result["until"] = until.strftime(_ISO)
+    result["from"] = _iso(frm)
+    result["until"] = _iso(until)
     return result
 
 

--- a/backend/src/utils/time_trigger.py
+++ b/backend/src/utils/time_trigger.py
@@ -44,8 +44,7 @@ def _iso(dt: datetime) -> str:
     invariant behind the lexical==chronological comparison (see module docstring).
     """
     return (
-        f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}"
-        f"T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}"
+        f"{dt.year:04d}-{dt.month:02d}-{dt.day:02d}T{dt.hour:02d}:{dt.minute:02d}:{dt.second:02d}"
     )
 
 

--- a/backend/tests/api/test_memory_list_time.py
+++ b/backend/tests/api/test_memory_list_time.py
@@ -1,0 +1,108 @@
+"""Tests for the Time Memory window filter + sort on GET /memory/list (#877).
+
+Follows the direct-call + mock-db + compiled-SQL-shape convention of
+test_memory_list.py: this endpoint is unit-tested by inspecting the emitted SQL
+(WHERE predicates + ORDER BY), not via an HTTP round-trip. The actual lexical
+window-overlap behavior against PostgreSQL is covered by the migration
+round-trip test (TEXT columns) + the recall_upcoming integration test.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.routes.memory import list_memories
+
+MOCK_USER = {"user_id": "test_user_123"}
+
+
+def _db_with_rows(total: int = 0, rows: list | None = None):
+    mock_db = AsyncMock()
+    count_result = MagicMock()
+    count_result.scalar.return_value = total
+    rows_result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = rows or []
+    rows_result.scalars.return_value = scalars
+    mock_db.execute.side_effect = [count_result, rows_result]
+    return mock_db
+
+
+def _where_sql(mock_db, call_index: int) -> str:
+    stmt = mock_db.execute.call_args_list[call_index].args[0]
+    return str(stmt.whereclause.compile(compile_kwargs={"literal_binds": False}))
+
+
+def _full_sql(mock_db, call_index: int) -> str:
+    stmt = mock_db.execute.call_args_list[call_index].args[0]
+    return str(stmt.compile(compile_kwargs={"literal_binds": False}))
+
+
+@pytest.mark.asyncio
+async def test_window_predicates_applied_to_both_queries():
+    """trigger_from/trigger_until add the overlap predicate to BOTH the count
+    and data queries: trigger_until >= qfrom AND trigger_from <= quntil."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type="time",
+        context_id=None,
+        q=None,
+        tags=None,
+        trigger_from="2026-06-01T00:00:00",
+        trigger_until="2026-12-31T23:59:59",
+        order_by="trigger_from",
+        limit=50,
+        offset=0,
+    )
+    for call_index in (0, 1):  # 0 = count query, 1 = data query
+        sql = _where_sql(mock_db, call_index)
+        assert "memories.trigger_until >=" in sql, sql
+        assert "memories.trigger_from <=" in sql, sql
+
+
+@pytest.mark.asyncio
+async def test_order_by_trigger_from_and_open_ended_window():
+    """order_by='trigger_from' sorts ascending; omitting trigger_until leaves an
+    open-ended (lower-bound-only) window."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type="time",
+        context_id=None,
+        q=None,
+        tags=None,
+        trigger_from="2026-06-01T00:00:00",
+        trigger_until=None,
+        order_by="trigger_from",
+        limit=50,
+        offset=0,
+    )
+    assert "ORDER BY memories.trigger_from ASC" in _full_sql(mock_db, 1)
+    where = _where_sql(mock_db, 1)
+    assert "memories.trigger_until >=" in where
+    assert "memories.trigger_from <=" not in where  # no upper bound
+
+
+@pytest.mark.asyncio
+async def test_default_order_and_no_window_when_params_omitted():
+    """Without trigger params the endpoint keeps its legacy created_at desc sort
+    and adds no window predicate (backward compatible)."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type=None,
+        context_id=None,
+        q=None,
+        tags=None,
+        limit=50,
+        offset=0,
+    )
+    assert "ORDER BY memories.created_at DESC" in _full_sql(mock_db, 1)
+    assert "trigger_from" not in _where_sql(mock_db, 1)

--- a/backend/tests/api/test_memory_list_time.py
+++ b/backend/tests/api/test_memory_list_time.py
@@ -8,11 +8,13 @@ round-trip test (TEXT columns) + the recall_upcoming integration test.
 """
 
 from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
 
-from api.routes.memory import list_memories
+from api.routes.memory import list_memories, patch_memory
+from models.schemas import PatchMemoryRequest
 
 MOCK_USER = {"user_id": "test_user_123"}
 
@@ -128,9 +130,9 @@ async def test_now_bound_resolved_not_passed_literally():
         offset=0,
     )
     data_sql = str(
-        mock_db.execute.call_args_list[1].args[0].whereclause.compile(
-            compile_kwargs={"literal_binds": True}
-        )
+        mock_db.execute.call_args_list[1]
+        .args[0]
+        .whereclause.compile(compile_kwargs={"literal_binds": True})
     )
     assert "'now'" not in data_sql  # literal must not reach the query
     assert "memories.trigger_until >=" in _where_sql(mock_db, 1)
@@ -153,5 +155,25 @@ async def test_malformed_trigger_bound_returns_422():
             order_by="trigger_from",
             limit=50,
             offset=0,
+        )
+    assert exc.value.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_route_maps_time_trigger_value_error_to_422():
+    """A PATCH that flips type to 'time' with an invalid trigger raises ValueError
+    from MemoryService._apply_time_trigger; the route must map it to 422 (same as
+    the remember route), not an unhandled 500."""
+    svc = MagicMock()
+    svc.patch_memory = AsyncMock(
+        side_effect=ValueError("invalid details.trigger: trigger.month out of range (1-12)")
+    )
+    req = PatchMemoryRequest(type="time", details={"trigger": {"year": 2026, "month": 13}})
+    with pytest.raises(HTTPException) as exc:
+        await patch_memory(
+            memory_id=uuid4(),
+            request=req,
+            user=MOCK_USER,
+            memory_service=svc,
         )
     assert exc.value.status_code == 422

--- a/backend/tests/api/test_memory_list_time.py
+++ b/backend/tests/api/test_memory_list_time.py
@@ -10,6 +10,7 @@ round-trip test (TEXT columns) + the recall_upcoming integration test.
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from fastapi import HTTPException
 
 from api.routes.memory import list_memories
 
@@ -106,3 +107,51 @@ async def test_default_order_and_no_window_when_params_omitted():
     )
     assert "ORDER BY memories.created_at DESC" in _full_sql(mock_db, 1)
     assert "trigger_from" not in _where_sql(mock_db, 1)
+
+
+@pytest.mark.asyncio
+async def test_now_bound_resolved_not_passed_literally():
+    """trigger_from='now' is resolved to a fixed-width ISO bound, not compared
+    literally (which would match nothing)."""
+    mock_db = _db_with_rows()
+    await list_memories(
+        user=MOCK_USER,
+        db=mock_db,
+        scope=None,
+        type="time",
+        context_id=None,
+        q=None,
+        tags=None,
+        trigger_from="now",
+        order_by="trigger_from",
+        limit=50,
+        offset=0,
+    )
+    data_sql = str(
+        mock_db.execute.call_args_list[1].args[0].whereclause.compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+    assert "'now'" not in data_sql  # literal must not reach the query
+    assert "memories.trigger_until >=" in _where_sql(mock_db, 1)
+
+
+@pytest.mark.asyncio
+async def test_malformed_trigger_bound_returns_422():
+    """A non-zero-padded / non-ISO bound is a 422, not silent wrong results."""
+    mock_db = _db_with_rows()
+    with pytest.raises(HTTPException) as exc:
+        await list_memories(
+            user=MOCK_USER,
+            db=mock_db,
+            scope=None,
+            type="time",
+            context_id=None,
+            q=None,
+            tags=None,
+            trigger_from="2026-7-1",
+            order_by="trigger_from",
+            limit=50,
+            offset=0,
+        )
+    assert exc.value.status_code == 422

--- a/backend/tests/integration/test_time_trigger_migration.py
+++ b/backend/tests/integration/test_time_trigger_migration.py
@@ -1,0 +1,40 @@
+import uuid
+
+import pytest
+from sqlalchemy import text
+
+
+@pytest.mark.asyncio
+async def test_generated_trigger_columns_populate_from_details(db_session):
+    """Inserting a time memory with details.trigger.from/until populates the
+    generated trigger_from / trigger_until columns."""
+    mem_id = uuid.uuid4()
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO memories
+              (id, user_id, summary, content, type, importance, confidence,
+               scope, embedding_status, client, source, long_term, use_count,
+               access_count, details)
+            VALUES
+              (:id, 'u1', 'avoid', 'avoid', 'time', 0.5, 1.0,
+               'working', 'success', 'test', 'mcp_remember', false, 0, 0,
+               CAST(:details AS JSONB))
+            """
+        ),
+        {
+            "id": mem_id,
+            "details": '{"trigger": {"from": "2026-07-01T00:00:00", '
+            '"until": "2026-07-31T23:59:59"}}',
+        },
+    )
+    row = (
+        await db_session.execute(
+            text("SELECT trigger_from, trigger_until FROM memories WHERE id = :id"),
+            {"id": mem_id},
+        )
+    ).one()
+    # TEXT generated columns preserve the stored ISO string verbatim (the 'T'
+    # separator), unlike a timestamp cast which would render with a space.
+    assert row.trigger_from == "2026-07-01T00:00:00"
+    assert row.trigger_until == "2026-07-31T23:59:59"

--- a/backend/tests/mcp_server/test_recall_upcoming.py
+++ b/backend/tests/mcp_server/test_recall_upcoming.py
@@ -7,6 +7,7 @@ PostgreSQL is covered by the migration round-trip test and the /memory/list
 SQL-shape test, which exercise the identical predicate and ORDER BY.
 """
 
+import contextlib
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -35,6 +36,25 @@ def _mock_db_returning(rows):
     return mock_db
 
 
+@contextlib.contextmanager
+def _patched(mock_db):
+    """Patch the handler's DB session, read-path context resolver, response
+    fields, and usage logger so the test exercises pure handler logic."""
+    async def mock_get_db():
+        yield mock_db
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch(
+            "mcp_server.tools.memory._resolve_context_for_read",
+            new=AsyncMock(return_value=MagicMock()),
+        ),
+        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
+        patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
+    ):
+        yield
+
+
 def _emitted_sql(mock_db) -> str:
     stmt = mock_db.execute.call_args.args[0]
     return str(stmt.compile(compile_kwargs={"literal_binds": False}))
@@ -46,19 +66,8 @@ async def test_recall_upcoming_returns_overlapping_time_memories():
     the window and sorts by trigger_from ascending (soonest first)."""
     rows = [_row(7), _row(9)]  # DB returns them in trigger_from asc order
     mock_db = _mock_db_returning(rows)
-    mock_ctx = MagicMock()
 
-    async def mock_get_db():
-        yield mock_db
-
-    with (
-        patch("db.base.get_db", new=mock_get_db),
-        patch(
-            "mcp_server.tools.memory._resolve_context_for_read",
-            new=AsyncMock(return_value=mock_ctx),
-        ),
-        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
-    ):
+    with _patched(mock_db):
         result = await handle_recall_upcoming(
             {
                 "context_id": str(uuid4()),
@@ -85,19 +94,8 @@ async def test_recall_upcoming_returns_overlapping_time_memories():
 async def test_recall_upcoming_open_ended_window_has_no_upper_bound():
     """Omitting 'until' leaves a lower-bound-only (open-ended future) window."""
     mock_db = _mock_db_returning([_row(7)])
-    mock_ctx = MagicMock()
 
-    async def mock_get_db():
-        yield mock_db
-
-    with (
-        patch("db.base.get_db", new=mock_get_db),
-        patch(
-            "mcp_server.tools.memory._resolve_context_for_read",
-            new=AsyncMock(return_value=mock_ctx),
-        ),
-        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
-    ):
+    with _patched(mock_db):
         result = await handle_recall_upcoming(
             {"context_id": str(uuid4()), "from": "2026-06-01T00:00:00"},
             user_id="u1",
@@ -108,6 +106,66 @@ async def test_recall_upcoming_open_ended_window_has_no_upper_bound():
     sql = _emitted_sql(mock_db)
     assert "memories.trigger_until >=" in sql
     assert "memories.trigger_from <=" not in sql
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_now_resolves_to_iso_bound():
+    """from='now' is resolved server-side to a fixed-width ISO lower bound, not
+    passed through literally (which would match nothing lexically)."""
+    mock_db = _mock_db_returning([])
+
+    with _patched(mock_db):
+        result = await handle_recall_upcoming(
+            {"context_id": str(uuid4()), "from": "now"},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    sql = str(mock_db.execute.call_args.args[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "'now'" not in sql  # the literal 'now' must not reach the query
+    assert "memories.trigger_until >=" in sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("k,expected_limit", [(0, 1), (-5, 1), (200, 100), (20, 20)])
+async def test_recall_upcoming_clamps_k(k, expected_limit):
+    """k is clamped into [1, 100]: 0/negative no longer produce LIMIT 0 / no-cap."""
+    mock_db = _mock_db_returning([])
+
+    with _patched(mock_db):
+        await handle_recall_upcoming(
+            {"context_id": str(uuid4()), "k": k},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    # literal_binds so the LIMIT value renders inline rather than as a bind param.
+    sql = str(mock_db.execute.call_args.args[0].compile(compile_kwargs={"literal_binds": True}))
+    assert f"LIMIT {expected_limit}" in sql
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_non_integer_k_is_validation_error():
+    """A non-numeric k returns a structured validation_error, not an unhandled
+    ValueError crash."""
+    result = await handle_recall_upcoming(
+        {"context_id": str(uuid4()), "k": "abc"}, user_id="u1", workspace_id=None
+    )
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "error"
+    assert payload["error"] == "validation_error"
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_malformed_bound_is_validation_error():
+    """A non-ISO 'from'/'until' returns a structured validation_error rather than
+    silently producing wrong lexical-comparison results."""
+    result = await handle_recall_upcoming(
+        {"context_id": str(uuid4()), "from": "2026-7-1"}, user_id="u1", workspace_id=None
+    )
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "error"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/mcp_server/test_recall_upcoming.py
+++ b/backend/tests/mcp_server/test_recall_upcoming.py
@@ -1,0 +1,117 @@
+"""Tests for the MCP recall_upcoming tool (Issue #877).
+
+Follows the mock-db handler convention of the other tests/mcp_server/ suites
+(patch db.base.get_db + the context resolver, then inspect the emitted SQL and
+the response). The actual lexical window-overlap + sort behavior against
+PostgreSQL is covered by the migration round-trip test and the /memory/list
+SQL-shape test, which exercise the identical predicate and ORDER BY.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.memory import handle_recall_upcoming
+
+
+def _row(month: int):
+    m = MagicMock()
+    m.id = uuid4()
+    m.summary = f"event in month {month}"
+    m.type = "time"
+    m.details = {"trigger": {"year": 2026, "month": month}}
+    return m
+
+
+def _mock_db_returning(rows):
+    mock_db = AsyncMock()
+    exec_result = MagicMock()
+    scalars = MagicMock()
+    scalars.all.return_value = rows
+    exec_result.scalars.return_value = scalars
+    mock_db.execute = AsyncMock(return_value=exec_result)
+    return mock_db
+
+
+def _emitted_sql(mock_db) -> str:
+    stmt = mock_db.execute.call_args.args[0]
+    return str(stmt.compile(compile_kwargs={"literal_binds": False}))
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_returns_overlapping_time_memories():
+    """Happy path: returns type='time' rows, and the emitted query filters on
+    the window and sorts by trigger_from ascending (soonest first)."""
+    rows = [_row(7), _row(9)]  # DB returns them in trigger_from asc order
+    mock_db = _mock_db_returning(rows)
+    mock_ctx = MagicMock()
+
+    async def mock_get_db():
+        yield mock_db
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch(
+            "mcp_server.tools.memory._resolve_context_for_read",
+            new=AsyncMock(return_value=mock_ctx),
+        ),
+        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
+    ):
+        result = await handle_recall_upcoming(
+            {
+                "context_id": str(uuid4()),
+                "from": "2026-06-01T00:00:00",
+                "until": "2026-12-31T23:59:59",
+            },
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "success"
+    months = [m["details"]["trigger"]["month"] for m in payload["results"]]
+    assert months == [7, 9]
+
+    sql = _emitted_sql(mock_db)
+    assert "memories.type =" in sql
+    assert "memories.trigger_until >=" in sql  # lower-bound overlap
+    assert "memories.trigger_from <=" in sql  # upper-bound overlap
+    assert "ORDER BY memories.trigger_from ASC" in sql
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_open_ended_window_has_no_upper_bound():
+    """Omitting 'until' leaves a lower-bound-only (open-ended future) window."""
+    mock_db = _mock_db_returning([_row(7)])
+    mock_ctx = MagicMock()
+
+    async def mock_get_db():
+        yield mock_db
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch(
+            "mcp_server.tools.memory._resolve_context_for_read",
+            new=AsyncMock(return_value=mock_ctx),
+        ),
+        patch("mcp_server.tools.memory._context_response_fields", return_value={}),
+    ):
+        result = await handle_recall_upcoming(
+            {"context_id": str(uuid4()), "from": "2026-06-01T00:00:00"},
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    assert json.loads(result[0].text)["status"] == "success"
+    sql = _emitted_sql(mock_db)
+    assert "memories.trigger_until >=" in sql
+    assert "memories.trigger_from <=" not in sql
+
+
+@pytest.mark.asyncio
+async def test_recall_upcoming_requires_context_id():
+    result = await handle_recall_upcoming({}, user_id="u1", workspace_id=None)
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "error"

--- a/backend/tests/mcp_server/test_recall_upcoming.py
+++ b/backend/tests/mcp_server/test_recall_upcoming.py
@@ -40,6 +40,7 @@ def _mock_db_returning(rows):
 def _patched(mock_db):
     """Patch the handler's DB session, read-path context resolver, response
     fields, and usage logger so the test exercises pure handler logic."""
+
     async def mock_get_db():
         yield mock_db
 

--- a/backend/tests/mcp_server/test_update_memory_time.py
+++ b/backend/tests/mcp_server/test_update_memory_time.py
@@ -1,0 +1,50 @@
+"""Regression test: MCP handle_update_memory maps a Time Memory trigger
+ValueError to a structured validation_error (Issue #877).
+
+When type="time" normalization (MemoryService._apply_time_trigger) is reached via
+the update path and the trigger is invalid, the handler must return a structured
+validation_error — not re-raise as an opaque tool crash (mirrors handle_remember).
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.memory import handle_update_memory
+
+
+@pytest.mark.asyncio
+async def test_handle_update_memory_time_value_error_returns_validation_error():
+    mock_db = AsyncMock()
+
+    async def mock_get_db():
+        yield mock_db
+
+    mock_service = MagicMock()
+    mock_service.update_memory = AsyncMock(
+        side_effect=ValueError("invalid details.trigger: trigger.month out of range (1-12)")
+    )
+
+    with (
+        patch("db.base.get_db", new=mock_get_db),
+        patch("mcp_server.tools.memory._check_viewer_permission", new=AsyncMock(return_value=None)),
+        patch("mcp_server.tools.memory._resolve_context", new=AsyncMock(return_value=MagicMock())),
+        patch("services.memory_service.MemoryService", return_value=mock_service),
+        patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()),
+    ):
+        result = await handle_update_memory(
+            {
+                "context_id": str(uuid4()),
+                "memory_id": str(uuid4()),
+                "type": "time",
+                "details": {"trigger": {"year": 2026, "month": 13}},
+            },
+            user_id="u1",
+            workspace_id=None,
+        )
+
+    payload = json.loads(result[0].text)
+    assert payload["status"] == "error"
+    assert payload["error"] == "validation_error"

--- a/backend/tests/services/test_remember_time_memory.py
+++ b/backend/tests/services/test_remember_time_memory.py
@@ -85,3 +85,29 @@ async def test_time_memory_invalid_trigger_raises(service):
     req = _req({"trigger": {"year": 2026, "month": 13}})
     with pytest.raises(ValueError, match="invalid details.trigger"):
         await _call(service, req)
+
+
+# _apply_time_trigger is the centralized helper used by remember(),
+# _update_in_place(), and patch_memory(), so the update/patch normalization
+# invariant is covered by testing it directly (no DB needed — it is pure).
+
+
+def test_apply_time_trigger_passthrough_for_non_time():
+    details = {"foo": "bar"}
+    assert MemoryService._apply_time_trigger("note", details) is details
+
+
+def test_apply_time_trigger_normalizes_time_window():
+    out = MemoryService._apply_time_trigger("time", {"trigger": {"year": 2026, "month": 7}})
+    assert out["trigger"]["from"] == "2026-07-01T00:00:00"
+    assert out["trigger"]["until"] == "2026-07-31T23:59:59"
+
+
+def test_apply_time_trigger_missing_trigger_raises():
+    with pytest.raises(ValueError, match="details.trigger"):
+        MemoryService._apply_time_trigger("time", {})
+
+
+def test_apply_time_trigger_invalid_trigger_raises():
+    with pytest.raises(ValueError, match="invalid details.trigger"):
+        MemoryService._apply_time_trigger("time", {"trigger": {"year": 2026, "month": 13}})

--- a/backend/tests/services/test_remember_time_memory.py
+++ b/backend/tests/services/test_remember_time_memory.py
@@ -1,0 +1,87 @@
+"""Tests for the Time Memory (type="time") branch of MemoryService.remember (Issue #877).
+
+Mirrors the mocked-DB pattern in test_async_remember.py: the time-branch is pure
+validation + window derivation that runs before any DB write, so a MagicMock db +
+mocked context isolation is sufficient and avoids a real seeded context.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import RememberRequest
+from services.memory_service import MemoryService
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def service(mock_db):
+    svc = MemoryService(mock_db)
+    mock_context = MagicMock()
+    mock_context.id = uuid4()
+    mock_context.workspace_id = uuid4()
+    svc._get_context_isolation_params = AsyncMock(
+        return_value=(mock_context, str(mock_context.workspace_id), str(mock_context.id))
+    )
+    svc.memory_repo = MagicMock()
+    svc.memory_repo.create = AsyncMock()
+    svc._mock_context = mock_context
+    return svc
+
+
+def _req(details):
+    return RememberRequest(
+        summary="運動会の準備を確認する",
+        content="運動会前に去年の反省を見直す",
+        details=details,
+        type="time",
+    )
+
+
+async def _call(service, req):
+    with (
+        patch("services.memory_service.process_pending_embedding", new=AsyncMock()),
+        patch("services.quota_service.QuotaService"),
+    ):
+        return await service.remember(
+            req,
+            user_id="test_user",
+            client="test",
+            current_context_id=service._mock_context.id,
+            current_workspace_id=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_time_memory_derives_window_into_details(service):
+    """A valid time memory has its details.trigger normalized with from/until."""
+    req = _req({"trigger": {"year": 2026, "month": 7}})
+    result = await _call(service, req)
+    assert result.memory_id is not None
+    # The request's details were normalized in place before persistence.
+    assert req.details["trigger"]["from"] == "2026-07-01T00:00:00"
+    assert req.details["trigger"]["until"] == "2026-07-31T23:59:59"
+
+
+@pytest.mark.asyncio
+async def test_time_memory_missing_trigger_raises(service):
+    req = _req({})  # no trigger
+    with pytest.raises(ValueError, match="details.trigger"):
+        await _call(service, req)
+
+
+@pytest.mark.asyncio
+async def test_time_memory_invalid_trigger_raises(service):
+    req = _req({"trigger": {"year": 2026, "month": 13}})
+    with pytest.raises(ValueError, match="invalid details.trigger"):
+        await _call(service, req)

--- a/backend/tests/utils/test_time_trigger.py
+++ b/backend/tests/utils/test_time_trigger.py
@@ -4,6 +4,7 @@ from utils.time_trigger import (
     TriggerValidationError,
     format_trigger_label,
     normalize_trigger,
+    parse_query_bound,
 )
 
 
@@ -76,11 +77,71 @@ def test_non_dict_raises():
 @pytest.mark.parametrize(
     "trigger,expected",
     [
-        ({"year": 2026}, "2026年ごろ"),
-        ({"year": 2026, "month": 7}, "2026年7月ごろ"),
+        ({"year": 2026}, "2026 (year)"),
+        ({"year": 2026, "month": 7}, "2026-07 (month)"),
         ({"year": 2026, "month": 7, "day": 15}, "2026-07-15"),
+        # hour-precision keeps the "(hour)" marker so it is distinguishable from
+        # a minute-precision trigger at :00 (the two have different windows).
+        ({"year": 2026, "month": 7, "day": 15, "hour": 10}, "2026-07-15 10:00 (hour)"),
+        ({"year": 2026, "month": 7, "day": 15, "hour": 10, "minute": 0}, "2026-07-15 10:00"),
         ({"year": 2026, "month": 7, "day": 15, "hour": 10, "minute": 30}, "2026-07-15 10:30"),
     ],
 )
 def test_format_trigger_label(trigger, expected):
     assert format_trigger_label(normalize_trigger(trigger)) == expected
+
+
+def test_year_9999_december_does_not_overflow():
+    # _days_in_month must not compute datetime(year+1, ...) which would overflow
+    # for year 9999; calendar.monthrange handles it.
+    out = normalize_trigger({"year": 9999, "month": 12})
+    assert out["from"] == "9999-12-01T00:00:00"
+    assert out["until"] == "9999-12-31T23:59:59"
+
+
+@pytest.mark.parametrize("field", ["month", "day", "hour", "minute"])
+def test_bool_component_rejected(field):
+    # bool is an int subclass; without an explicit guard True would be accepted
+    # as 1 and stored as a JSON boolean.
+    base = {"year": 2026, "month": 7, "day": 15, "hour": 10}
+    base[field] = True
+    with pytest.raises(TriggerValidationError):
+        normalize_trigger(base)
+
+
+@pytest.mark.parametrize("field", ["year", "month", "day", "hour", "minute"])
+def test_float_component_rejected(field):
+    base = {"year": 2026, "month": 7, "day": 15, "hour": 10, "minute": 30}
+    base[field] = float(base[field])
+    with pytest.raises(TriggerValidationError):
+        normalize_trigger(base)
+
+
+def test_parse_query_bound_none_returns_none():
+    assert parse_query_bound(None) is None
+
+
+def test_parse_query_bound_now_resolves_to_iso():
+    out = parse_query_bound("now")
+    # Fixed-width naive ISO, no Z suffix.
+    assert len(out) == 19
+    assert out[4] == "-" and out[10] == "T"
+
+
+def test_parse_query_bound_passes_through_valid_iso():
+    assert parse_query_bound("2026-07-01T00:00:00") == "2026-07-01T00:00:00"
+
+
+def test_parse_query_bound_date_only_normalizes_to_midnight():
+    assert parse_query_bound("2026-07-01") == "2026-07-01T00:00:00"
+
+
+def test_parse_query_bound_aware_converts_to_utc_naive():
+    # 2026-07-01T09:00:00+09:00 == 2026-07-01T00:00:00 UTC
+    assert parse_query_bound("2026-07-01T09:00:00+09:00") == "2026-07-01T00:00:00"
+
+
+@pytest.mark.parametrize("bad", ["2026-7-1T00:00:00", "", "next week", "2026/07/01"])
+def test_parse_query_bound_rejects_non_iso(bad):
+    with pytest.raises(TriggerValidationError):
+        parse_query_bound(bad)

--- a/backend/tests/utils/test_time_trigger.py
+++ b/backend/tests/utils/test_time_trigger.py
@@ -1,0 +1,86 @@
+import pytest
+
+from utils.time_trigger import (
+    TriggerValidationError,
+    format_trigger_label,
+    normalize_trigger,
+)
+
+
+def test_year_only_window_spans_whole_year():
+    out = normalize_trigger({"year": 2026})
+    assert out["from"] == "2026-01-01T00:00:00"
+    assert out["until"] == "2026-12-31T23:59:59"
+
+
+def test_month_only_window_spans_whole_month():
+    out = normalize_trigger({"year": 2026, "month": 7})
+    assert out["from"] == "2026-07-01T00:00:00"
+    assert out["until"] == "2026-07-31T23:59:59"
+
+
+def test_february_leap_year_last_day_is_29():
+    out = normalize_trigger({"year": 2028, "month": 2})
+    assert out["until"] == "2028-02-29T23:59:59"
+
+
+def test_february_non_leap_year_last_day_is_28():
+    out = normalize_trigger({"year": 2026, "month": 2})
+    assert out["until"] == "2026-02-28T23:59:59"
+
+
+def test_full_day_window_spans_whole_day():
+    out = normalize_trigger({"year": 2026, "month": 7, "day": 15})
+    assert out["from"] == "2026-07-15T00:00:00"
+    assert out["until"] == "2026-07-15T23:59:59"
+
+
+def test_full_datetime_window_is_one_minute():
+    out = normalize_trigger({"year": 2026, "month": 7, "day": 15, "hour": 10, "minute": 30})
+    assert out["from"] == "2026-07-15T10:30:00"
+    assert out["until"] == "2026-07-15T10:30:59"
+
+
+def test_components_and_text_are_echoed():
+    out = normalize_trigger({"year": 2026, "month": 7, "text": "来年度の運動会"})
+    assert out["year"] == 2026 and out["month"] == 7
+    assert out["day"] is None and out["hour"] is None and out["minute"] is None
+    assert out["text"] == "来年度の運動会"
+
+
+def test_missing_year_raises():
+    with pytest.raises(TriggerValidationError):
+        normalize_trigger({"month": 7})
+
+
+def test_day_without_month_raises():
+    with pytest.raises(TriggerValidationError):
+        normalize_trigger({"year": 2026, "day": 15})
+
+
+def test_impossible_day_raises():
+    with pytest.raises(TriggerValidationError):
+        normalize_trigger({"year": 2026, "month": 2, "day": 30})
+
+
+def test_month_out_of_range_raises():
+    with pytest.raises(TriggerValidationError):
+        normalize_trigger({"year": 2026, "month": 13})
+
+
+def test_non_dict_raises():
+    with pytest.raises(TriggerValidationError):
+        normalize_trigger("2026-07")
+
+
+@pytest.mark.parametrize(
+    "trigger,expected",
+    [
+        ({"year": 2026}, "2026年ごろ"),
+        ({"year": 2026, "month": 7}, "2026年7月ごろ"),
+        ({"year": 2026, "month": 7, "day": 15}, "2026-07-15"),
+        ({"year": 2026, "month": 7, "day": 15, "hour": 10, "minute": 30}, "2026-07-15 10:30"),
+    ],
+)
+def test_format_trigger_label(trigger, expected):
+    assert format_trigger_label(normalize_trigger(trigger)) == expected


### PR DESCRIPTION
Closes #877

## Summary
- Add a pull-only "Time Memory" subtype (`type="time"`) that stores caller-resolved fuzzy Y/M/D[/H/M] dates and is retrievable by time window ("what's coming up?").
- New generated TEXT columns `trigger_from`/`trigger_until` (+ partial index + CHECK constraint), a window-overlap filter and `order_by=trigger_from` on `GET /memory/list`, and a new MCP `recall_upcoming` tool.
- Deterministic pure-read retrieval with no Hebbian write side-effects; the caller resolves the date (no backend LLM).

## Implementation notes
- **No new table**: `Memory.type="time"` + `details.trigger` JSONB. Generated columns extract TEXT (`details->'trigger'->>'from'/'until'`), not a `::timestamp` cast — that cast is only STABLE and PostgreSQL rejects it in a STORED generated column. Bounds are fixed-width zero-padded ISO so lexical order == chronological order for the window-overlap filter + `ORDER BY trigger_from`.
- Normalization centralized in `MemoryService._apply_time_trigger`, invoked from `remember` / `_update_in_place` / `patch_memory` so no write path can leave NULL trigger columns. `parse_query_bound` validates/normalizes query bounds (resolves `'now'`, rejects malformed/non-zero-padded ISO).
- DB CHECK constraint (gated on `type <> 'time'`) enforces both bounds present + fixed-width ISO format as defense-in-depth for the ordering invariant.
- `ValueError` mapped to 422 (REST) / structured `validation_error` (MCP); `k` clamped to [1,100]; `recall_upcoming` exempt from rate limiting (read-only, no Hebbian write).

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (routed to CTO)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/877-feat-feat-api-time-memory-type-time-pull-only.gate1.md
- ~/.claude/cache/gh-issue-driven/877-feat-feat-api-time-memory-type-time-pull-only.gate2.md

🤖 Generated via /gh-issue-driven:ship
