### PR TITLE
fix(db): linearize alembic heads after #879 + #880 concurrent merge (#882)

### DIFF
--- a/backend/alembic/versions/e30_connector_cfg_cols.py
+++ b/backend/alembic/versions/e30_connector_cfg_cols.py
@@ -27,7 +27,7 @@ Note: chained after ``e30_877_time_trigger_cols`` (#877/#880), not its original
 (#880) branched from ``e29_619`` and merged to main independently, forking the
 revision graph into two heads. Re-pointing this migration linearises the graph
 (single head) without a merge node — safe because neither chain had been
-deployed yet (#881).
+deployed yet (#882).
 """
 
 import sqlalchemy as sa

--- a/backend/alembic/versions/e30_connector_cfg_cols.py
+++ b/backend/alembic/versions/e30_connector_cfg_cols.py
@@ -20,7 +20,14 @@ per-connector configuration that the F6-a schema-only slice did not carry:
 All columns are nullable so existing connector rows upgrade without backfill.
 
 Revision ID: e30_connector_cfg_cols
-Revises: e29_619_memories_ws_ctx_idx
+Revises: e30_877_time_trigger_cols
+
+Note: chained after ``e30_877_time_trigger_cols`` (#877/#880), not its original
+``e29_619`` parent. Both this connector chain (#879) and the Time Memory chain
+(#880) branched from ``e29_619`` and merged to main independently, forking the
+revision graph into two heads. Re-pointing this migration linearises the graph
+(single head) without a merge node — safe because neither chain had been
+deployed yet (#881).
 """
 
 import sqlalchemy as sa
@@ -30,7 +37,7 @@ from alembic import op
 
 # NOTE: revision id kept <= 32 chars — alembic_version.version_num is VARCHAR(32).
 revision = "e30_connector_cfg_cols"
-down_revision = "e29_619_memories_ws_ctx_idx"
+down_revision = "e30_877_time_trigger_cols"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Closes #882

## Problem

PRs #879 (connector, `e31_connector_addon`) and #880/#877 (Time Memory, `e30_877_time_trigger_cols`) both branched migrations from `e29_619_memories_ws_ctx_idx` and merged independently → **two alembic heads** on `main`. `alembic upgrade head` (singular, used by `deploy.sh` + migration tests) fails; only `alembic upgrade heads` (plural) works.

## Fix

Re-point `e30_connector_cfg_cols.down_revision` `e29_619` → `e30_877_time_trigger_cols` → single linear chain (head `e31_connector_addon`). No DDL change.

Merge node rejected: a merge-node-at-head breaks `test_downgrade_one_step` (`downgrade -1` can't cross a merge point; the `e11_merge_e10_heads` precedent only worked because a later migration followed it). Re-chaining is safe — neither migration was deployed yet.

## Test plan

- [x] `alembic heads` → single `e31_connector_addon`; `alembic upgrade head` (singular) ok
- [x] `tests/integration/test_alembic_migrations.py` + `tests/test_schema_drift.py` → 96 passed
- [x] Verified locally in Docker (both #879 + #880 schema applied, API healthy, new routes live)

🤖 Generated with [Claude Code](https://claude.com/claude-code)