### PR TITLE
fix(frontend): omit pii_guardrail_config on connector create (was 422)

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -138,7 +138,10 @@ export default function ConnectorsPage() {
         display_name: displayName || undefined,
         auto_create_context_name: contextName || undefined,
         slack_install_handle: installHandle,
-        pii_guardrail_config: { enabled: true },
+        // Omit pii_guardrail_config (null): the backend rejects `{enabled:true}`
+        // without a non-empty `detectors` list, and per the contract a null
+        // config makes the worker fail-closed (scrub) at ingest. A detector-
+        // configuration UI is a follow-up.
       });
       setPending(null);
       setCreated(result);

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -138,10 +138,11 @@ export default function ConnectorsPage() {
         display_name: displayName || undefined,
         auto_create_context_name: contextName || undefined,
         slack_install_handle: installHandle,
-        // Omit pii_guardrail_config (null): the backend rejects `{enabled:true}`
-        // without a non-empty `detectors` list, and per the contract a null
-        // config makes the worker fail-closed (scrub) at ingest. A detector-
-        // configuration UI is a follow-up.
+        // pii_guardrail_config is intentionally left unset: the backend rejects
+        // `{enabled:true}` without a non-empty `detectors` list. An omitted field
+        // is received by FastAPI as None, which the contract treats as
+        // fail-closed (the ai-worker scrubs at ingest). A detector-config UI is
+        // a follow-up.
       });
       setPending(null);
       setCreated(result);


### PR DESCRIPTION
## Problem

The Connectors page (#879) hardcoded `pii_guardrail_config: { enabled: true }` in the create-connector request. The backend `validate_pii_guardrail_config` rejects `enabled=true` without a non-empty `detectors` list (`VAL-001`), so **every "Create connector" submit failed with HTTP 422** — no connector or context was created. Found during local Docker verification of the Slack OAuth flow.

## Fix

Omit `pii_guardrail_config` from the request. Per the contract, a null config makes the ai-worker fail-closed (scrub) at ingest, so this is the safe default. A detector-configuration UI is a follow-up.

## Test plan

- [x] Local Docker: Connect Slack → Create connector now succeeds; connector row persists with team_id + context_id + kmc key + oauth token; private context `slack-<team>` created
- [x] frontend `tsc --noEmit` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)