### PR TITLE
feat(api): delivery_mode + pin-on-write for deterministic load (#886)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -160,6 +160,12 @@ ENABLE_NEURAL_MEMORY=true
 # Research Tools
 ENABLE_RESEARCH_TOOLS=true
 
+# Deterministic always-load cap (Issue #886). Max memories returned by the
+# load_pinned read path (delivery_mode='always'). Bounded server-side; when a
+# context has more pinned memories than this, the response flags truncated=true
+# with the true total_available. Commented = default 100.
+# PINNED_LOAD_CAP=100
+
 # -----------------------------------------------------------------------------
 # Embedding Configuration
 # -----------------------------------------------------------------------------

--- a/backend/alembic/versions/e32_886_delivery_mode.py
+++ b/backend/alembic/versions/e32_886_delivery_mode.py
@@ -91,7 +91,11 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
+    # Symmetric retry-safety with upgrade(): the autocommit_block commits the
+    # concurrent index drop before the transactional constraint/column drops, so
+    # a mid-downgrade failure must also be re-runnable. IF EXISTS guards on the
+    # constraint and column make the transactional part idempotent.
     with op.get_context().autocommit_block():
         op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))
-    op.drop_constraint("valid_delivery_mode", "memories", type_="check")
-    op.drop_column("memories", "delivery_mode")
+    op.execute(sa.text("ALTER TABLE memories DROP CONSTRAINT IF EXISTS valid_delivery_mode"))
+    op.execute(sa.text("ALTER TABLE memories DROP COLUMN IF EXISTS delivery_mode"))

--- a/backend/alembic/versions/e32_886_delivery_mode.py
+++ b/backend/alembic/versions/e32_886_delivery_mode.py
@@ -73,8 +73,10 @@ def upgrade() -> None:
     # INVALID-leftover pattern). Column + CHECK are metadata-only on PG11+
     # (constant DEFAULT, no table rewrite).
     op.execute(
-        "ALTER TABLE memories "
-        "ADD COLUMN IF NOT EXISTS delivery_mode VARCHAR(20) NOT NULL DEFAULT 'on_recall'"
+        sa.text(
+            "ALTER TABLE memories "
+            "ADD COLUMN IF NOT EXISTS delivery_mode VARCHAR(20) NOT NULL DEFAULT 'on_recall'"
+        )
     )
     if not _constraint_exists("valid_delivery_mode"):
         op.create_check_constraint(

--- a/backend/alembic/versions/e32_886_delivery_mode.py
+++ b/backend/alembic/versions/e32_886_delivery_mode.py
@@ -1,0 +1,97 @@
+"""Add delivery_mode column + CHECK + partial always-load index (#886).
+
+``delivery_mode`` is an orthogonal delivery attribute on Memory (design memory
+242cb28a), the sibling of ``scope`` — NOT a new memory ``type``. Default
+'on_recall' = current probabilistic-only behavior, so existing rows are
+unaffected (NOT NULL is safe with the server-side DEFAULT backfilling them in
+the same ALTER; PG11+ applies a constant default as metadata-only, no rewrite).
+The CHECK literal is byte-identical (modulo the drift detector's whitespace +
+IN-list normalization) to the ORM ``valid_delivery_mode`` CheckConstraint
+f-string in models/memory.py.
+
+The partial index backs the deterministic always-load read path
+(MemoryService.load_pinned): ``WHERE context_id = ? AND delivery_mode = 'always'
+AND deleted_at IS NULL``. It is built ``CONCURRENTLY`` inside an autocommit_block
+(mirroring e29_619) so the build does not take an ACCESS EXCLUSIVE lock on the
+large ``memories`` table during deploy.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers
+revision = "e32_886_delivery_mode"
+down_revision = "e31_connector_addon"
+branch_labels = None
+depends_on = None
+
+_INDEX_NAME = "idx_memories_delivery_always"
+_INDEX_DDL = (
+    f"CREATE INDEX CONCURRENTLY IF NOT EXISTS {_INDEX_NAME} "
+    "ON memories (context_id) "
+    "WHERE delivery_mode = 'always' AND deleted_at IS NULL"
+)
+
+
+def _index_is_invalid(name: str) -> bool:
+    """Return True if ``name`` exists in ``pg_index`` in an INVALID state.
+
+    A mid-build failure of ``CREATE INDEX CONCURRENTLY`` leaves the index row
+    with ``indisvalid = false``; a retry's ``IF NOT EXISTS`` would skip it, so
+    the leftover must be dropped first. Mirrors e29_619.
+    """
+    bind = op.get_bind()
+    row = bind.execute(
+        sa.text(
+            "SELECT 1 FROM pg_class c JOIN pg_index i ON c.oid = i.indexrelid "
+            "WHERE c.relname = :name AND i.indisvalid IS FALSE"
+        ),
+        {"name": name},
+    ).first()
+    return row is not None
+
+
+def _constraint_exists(name: str) -> bool:
+    """Return True if a constraint named ``name`` already exists."""
+    bind = op.get_bind()
+    return (
+        bind.execute(
+            sa.text("SELECT 1 FROM pg_constraint WHERE conname = :name"),
+            {"name": name},
+        ).first()
+        is not None
+    )
+
+
+def upgrade() -> None:
+    # Retry-safety: the autocommit_block below COMMITS the column + CHECK before
+    # the CONCURRENTLY index runs, so a mid-build index failure leaves the column
+    # committed while alembic_version is NOT bumped. The whole upgrade must
+    # therefore be re-runnable: ADD COLUMN IF NOT EXISTS + a guarded CHECK make
+    # the transactional part idempotent (the index part already is, via e29_619's
+    # INVALID-leftover pattern). Column + CHECK are metadata-only on PG11+
+    # (constant DEFAULT, no table rewrite).
+    op.execute(
+        "ALTER TABLE memories "
+        "ADD COLUMN IF NOT EXISTS delivery_mode VARCHAR(20) NOT NULL DEFAULT 'on_recall'"
+    )
+    if not _constraint_exists("valid_delivery_mode"):
+        op.create_check_constraint(
+            "valid_delivery_mode",
+            "memories",
+            "delivery_mode IN ('always', 'on_recall', 'on_trigger')",
+        )
+    # Index must be built CONCURRENTLY (no table lock) → outside the transaction.
+    invalid = _index_is_invalid(_INDEX_NAME)
+    with op.get_context().autocommit_block():
+        if invalid:
+            op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))
+        op.execute(sa.text(_INDEX_DDL))
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(sa.text(f"DROP INDEX CONCURRENTLY IF EXISTS {_INDEX_NAME}"))
+    op.drop_constraint("valid_delivery_mode", "memories", type_="check")
+    op.drop_column("memories", "delivery_mode")

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -253,7 +253,7 @@ async def load_pinned(
     real count — never a silent truncation.
 
     Request:
-        {"context_id": "550e8400-e29b-41d4-a716-446655440000", "cap": 100}
+        {"context_id": "<context-uuid>", "cap": 100}
 
     Example:
         POST /api/v1/memory/pinned

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -20,6 +20,8 @@ from models.schemas import (
     ExploreResponse,
     ForgetRequest,
     ForgetResponse,
+    LoadPinnedRequest,
+    LoadPinnedResponse,
     MemoryStatsResponse,
     PatchMemoryRequest,
     RecallRequest,
@@ -232,6 +234,55 @@ async def recall(
     )
 
     return result
+
+
+@router.post("/pinned", response_model=LoadPinnedResponse)
+async def load_pinned(
+    request: LoadPinnedRequest,
+    user: APIKeyOrSessionUser,
+    memory_service: MemoryServiceDep,
+):
+    """Deterministically load a context's always-delivery memories (Issue #886).
+
+    The deterministic counterpart to ``/recall``: returns the complete,
+    unranked, ordered ``delivery_mode='always'`` set for the given context —
+    no semantic ranking, no rerank. Items carry L1 + L2 only (summary +
+    context_summary); fetch full content via ``/reference``. Bounded by
+    ``settings.pinned_load_cap`` (or the request ``cap``); when the pinned set
+    exceeds the cap, ``truncated`` is true and ``total_available`` reports the
+    real count — never a silent truncation.
+
+    Request:
+        {"context_id": "my-context", "cap": 100}
+
+    Example:
+        POST /api/v1/memory/pinned
+        Authorization: Bearer <session_token>
+    """
+    logger.info("load_pinned_request", user_id=user["user_id"], context_id=request.context_id)
+
+    # Parse context_id to a UUID up front: a non-UUID string would otherwise
+    # reach `Context.id == <str>` and raise a DB DataError, which the global
+    # SQLAlchemyError handler maps to a misleading 503. Reject it as a 422 here.
+    context_uuid: UUID | None = None
+    if request.context_id is not None:
+        try:
+            context_uuid = UUID(request.context_id)
+        except (ValueError, AttributeError) as e:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=f"context_id must be a valid UUID: {request.context_id!r}",
+            ) from e
+
+    try:
+        return await memory_service.load_pinned(
+            user_id=user["user_id"],
+            current_context_id=context_uuid,
+            current_workspace_id=user.get("current_workspace_id"),
+            cap=request.cap,
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
 
 
 @router.patch("/{memory_id}", response_model=ReferenceResponse)

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -253,7 +253,7 @@ async def load_pinned(
     real count — never a silent truncation.
 
     Request:
-        {"context_id": "my-context", "cap": 100}
+        {"context_id": "550e8400-e29b-41d4-a716-446655440000", "cap": 100}
 
     Example:
         POST /api/v1/memory/pinned

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -181,7 +181,8 @@ class Settings(BaseSettings):
     # exceeds it, the read is bounded and the response flags truncated=true with
     # the true total_available (never silently dropped).
     pinned_load_cap: int = Field(
-        default=100, description="Max memories returned by the deterministic always-load path (#886)"
+        default=100,
+        description="Max memories returned by the deterministic always-load path (#886)",
     )
 
     # Ollama Configuration (Issue #44)

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -175,6 +175,15 @@ class Settings(BaseSettings):
     )
     embedding_dimensions: int = Field(default=512, description="Embedding vector dimensions")
 
+    # Issue #886: hard cap on the deterministic always-load (load_pinned) set.
+    # always-load memories are injected into the agent's context every turn, so
+    # the cap is a safety valve against runaway pinning. When the pinned set
+    # exceeds it, the read is bounded and the response flags truncated=true with
+    # the true total_available (never silently dropped).
+    pinned_load_cap: int = Field(
+        default=100, description="Max memories returned by the deterministic always-load path (#886)"
+    )
+
     # Ollama Configuration (Issue #44)
     ollama_base_url: str = Field(
         default="http://localhost:11434", description="Ollama API base URL"

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -78,6 +78,7 @@ _RATE_LIMIT_EXEMPT_TOOLS = frozenset(
         "list_files",  # Issue #485: read-only workspace listing
         "list_tags",  # Issue #614: read-only tag discovery
         "recall_upcoming",  # Issue #877: deterministic read-only Time Memory window query (no Hebbian write)
+        "load_pinned",  # Issue #886: deterministic always-load read (must run every turn; no Hebbian write)
     }
 )
 
@@ -146,6 +147,7 @@ def _build_registry() -> dict[str, Any]:
         "update_memory": handle_update_memory,
         "recall": handle_recall,
         "recall_upcoming": handle_recall_upcoming,
+        "load_pinned": handle_load_pinned,
         "forget": handle_forget,
         "reference": handle_reference,
         "explore": handle_explore,
@@ -332,6 +334,7 @@ async def execute_tool_call(
 from mcp_server.tools.explore import handle_explore  # noqa: E402, F401
 from mcp_server.tools.memory import (  # noqa: E402, F401
     handle_forget,
+    handle_load_pinned,
     handle_recall,
     handle_recall_upcoming,
     handle_reference,

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -155,6 +155,11 @@ IMPORTANT: Always specify context_id to ensure you're using the intended context
                         "type": "object",
                         "description": "Additional context metadata as JSON. Can include context info, related issue numbers, or custom fields.",
                     },
+                    "delivery_mode": {
+                        "type": "string",
+                        "enum": ["always", "on_recall", "on_trigger"],
+                        "description": "When this memory is surfaced (orthogonal to type). 'on_recall' (default): only via probabilistic recall(). 'always': pinned and deterministically loaded EVERY turn via load_pinned() — use ONLY for an agent's Goal / Guardrail / critical policy, and it is pinned to persistent on write (no sleep-consolidation wait). 'on_trigger': time-windowed (set via Time Memory type='time').",
+                    },
                     "context_id": {
                         "type": "string",
                         "format": "uuid",
@@ -246,6 +251,11 @@ IMPORTANT: Always specify context_id.""",
                     "context": {
                         "type": "object",
                         "description": "Updated context metadata.",
+                    },
+                    "delivery_mode": {
+                        "type": "string",
+                        "enum": ["always", "on_recall", "on_trigger"],
+                        "description": "Change when this memory is surfaced. Set 'always' to pin it (deterministically loaded every turn via load_pinned, pinned to persistent). Set 'on_recall' to unpin (back to probabilistic recall only; the memory stays persistent). Omit to leave unchanged.",
                     },
                     "context_id": {
                         "type": "string",
@@ -395,6 +405,39 @@ IMPORTANT: Always specify context_id to ensure you're retrieving from the intend
                     "k": {
                         "type": "integer",
                         "description": "Max results (default 20, max 100).",
+                    },
+                },
+            },
+        },
+        {
+            "name": "load_pinned",
+            "readOnly": True,
+            "description": (
+                "Deterministically load a context's always-load memories "
+                "(delivery_mode='always'). This is the DETERMINISTIC counterpart to "
+                "recall(): it returns the COMPLETE, UNRANKED set every call — no "
+                "semantic search, no ranking, no rerank — so an agent's Goal / "
+                "Guardrail / critical policy loads identically every turn. recall() "
+                "is probabilistic; load_pinned() is exact. Pin a memory with "
+                "remember(delivery_mode='always') or update_memory(delivery_mode="
+                "'always'); unpin with update_memory(delivery_mode='on_recall'). "
+                "Results are summary + context_summary only (Layer 1+2) — fetch full "
+                "content with reference(memory_id). The set is bounded: if more "
+                "pinned memories exist than the cap, 'truncated' is true and "
+                "'total_available' reports the real count (never silently dropped)."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "required": ["context_id"],
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Target context UUID from list_contexts(). Do NOT fabricate.",
+                    },
+                    "cap": {
+                        "type": "integer",
+                        "description": "Optional override for the max returned (1-1000; server default applies if omitted).",
                     },
                 },
             },

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -51,6 +51,7 @@ async def handle_remember(
         importance=args.get("importance", 0.5),
         tags=args.get("tags", []),
         context=args.get("context"),
+        delivery_mode=args.get("delivery_mode", "on_recall"),  # Issue #886
         source_uri=args.get("source_uri"),
         source_type=args.get("source_type"),
         linked_memory_ids=args.get("linked_memory_ids"),
@@ -154,6 +155,7 @@ async def handle_update_memory(
             importance=args.get("importance"),
             tags=args.get("tags"),
             context=args.get("context"),
+            delivery_mode=args.get("delivery_mode"),  # Issue #886 (pin/unpin)
         )
     except (ValueError, ValidationError) as e:
         return _error_response("validation_error", str(e))
@@ -326,6 +328,83 @@ async def handle_recall_upcoming(
                 db, user_id, "recall_upcoming", start_time, 404, current_context_id, workspace_id
             )
             return e.to_response()
+
+    return _error_response("internal_error", "Database session unavailable")
+
+
+async def handle_load_pinned(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Deterministically load a context's always-delivery memories (#886).
+
+    The deterministic counterpart to recall(): returns the complete, unranked,
+    bounded delivery_mode='always' set for the context — no embeddings, no
+    Hebbian write side-effects (the recall()-vs-list design rule). Items are
+    L1+L2 only; fetch full content via reference(). On cap-exceeded the response
+    carries truncated=true + total_available (never a silent truncation).
+    """
+    if "context_id" not in args:
+        return _error_response("missing_fields", "Missing required field: context_id")
+
+    from db.base import get_db
+    from services.memory_service import MemoryService
+
+    cap = args.get("cap")
+    start_time = time.time()
+    async for db in get_db():
+        current_context_id: UUID | None = None
+        try:
+            current_context_id = _resolve_context_id(args["context_id"])
+            # Read path: uniform context_not_found on any deny (CWE-639 / OWASP
+            # A01), mirroring handle_recall / handle_recall_upcoming.
+            current_context = await _resolve_context_for_read(db, user_id, current_context_id)
+
+            service = MemoryService(db)
+            result = await execute_with_timeout(
+                service.load_pinned(
+                    user_id=user_id,
+                    current_context_id=current_context_id,
+                    current_workspace_id=workspace_id,
+                    cap=cap,
+                ),
+                operation_name="load_pinned",
+            )
+
+            await _log_tool_usage(
+                db, user_id, "load_pinned", start_time, 200, current_context_id, workspace_id
+            )
+            return [
+                TextContent(
+                    type="text",
+                    text=json.dumps(
+                        {
+                            "status": "success",
+                            "memories": [
+                                {
+                                    "memory_id": str(m.memory_id),
+                                    "summary": m.summary,
+                                    "context_summary": m.context_summary,
+                                    "type": m.type,
+                                    "importance": m.importance,
+                                    "delivery_mode": m.delivery_mode,
+                                }
+                                for m in result.memories
+                            ],
+                            "total_available": result.total_available,
+                            "truncated": result.truncated,
+                            "cap": result.cap,
+                            **_context_response_fields(current_context),
+                        }
+                    ),
+                )
+            ]
+        except _ContextNotFoundError as e:
+            await _log_tool_usage(
+                db, user_id, "load_pinned", start_time, 404, current_context_id, workspace_id
+            )
+            return e.to_response()
+        except ValueError as e:
+            return _error_response("validation_error", str(e))
 
     return _error_response("internal_error", "Database session unavailable")
 

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -36,6 +36,27 @@ from sqlalchemy.orm import Mapped, mapped_column
 
 from db.base import Base
 
+# Delivery mode constants (Issue #886, design memory 242cb28a) — an ORTHOGONAL
+# delivery attribute on Memory, deliberately NOT a new memory ``type``. It
+# controls *when* a memory is surfaced, independent of *what* it is about:
+#   - always:     deterministically loaded every turn (Goal / Guardrail / policy)
+#   - on_recall:  surfaced only via probabilistic recall() (the default)
+#   - on_trigger: surfaced when a trigger fires — already realized as Time Memory
+#                 (type='time' + details.trigger + Computed trigger_from)
+# The DB CHECK constraint is generated from the ordered ``_ALL_DELIVERY_MODES``
+# tuple (see ``Memory.__table_args__``), mirroring the edge_type/origin pattern on
+# NeuralMemoryEdge. New modes are APPENDED (never reordered) to preserve
+# byte-identity with the alembic migration literal.
+DELIVERY_MODE_ALWAYS = "always"
+DELIVERY_MODE_ON_RECALL = "on_recall"
+DELIVERY_MODE_ON_TRIGGER = "on_trigger"
+
+_ALL_DELIVERY_MODES: tuple[str, ...] = (
+    DELIVERY_MODE_ALWAYS,
+    DELIVERY_MODE_ON_RECALL,
+    DELIVERY_MODE_ON_TRIGGER,
+)
+
 
 class Memory(Base):
     """Memory model with 3-layer architecture.
@@ -122,6 +143,19 @@ class Memory(Base):
     # Working/Persistent メモリ
     scope: Mapped[str] = mapped_column(String(20), nullable=False, default="working", index=True)
     long_term: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+
+    # Issue #886: orthogonal delivery attribute (sibling of ``scope``, NOT a
+    # new ``type``). Default 'on_recall' = current probabilistic-only behavior,
+    # so existing rows are unaffected. server_default keeps the migration
+    # backfill and ORM default in lock-step. The partial index supporting the
+    # deterministic always-load read path is created in the alembic migration
+    # (on (context_id, delivery_mode) WHERE delivery_mode='always').
+    delivery_mode: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=DELIVERY_MODE_ON_RECALL,
+        server_default=DELIVERY_MODE_ON_RECALL,
+    )
     promoted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # 利用統計（Consolidation判定用）
@@ -217,6 +251,14 @@ class Memory(Base):
         CheckConstraint("importance BETWEEN 0 AND 1", name="valid_importance"),
         CheckConstraint("confidence BETWEEN 0 AND 1", name="valid_confidence"),
         CheckConstraint("scope IN ('working', 'persistent')", name="valid_scope"),
+        # Issue #886: CHECK derived from ``_ALL_DELIVERY_MODES`` (registration
+        # order, single quotes, exact whitespace), byte-identical to the alembic
+        # migration literal. Drift is pinned by
+        # test_valid_delivery_mode_check_constraint_matches_migration_literal.
+        CheckConstraint(
+            f"delivery_mode IN ({', '.join(repr(d) for d in _ALL_DELIVERY_MODES)})",
+            name="valid_delivery_mode",
+        ),
         CheckConstraint(
             "embedding_status IN ('pending', 'processing', 'success', 'failed')",
             name="valid_embedding_status",
@@ -264,6 +306,16 @@ class Memory(Base):
             "workspace_id",
             "context_id",
             postgresql_where=text("deleted_at IS NULL"),
+        ),
+        # Issue #886: partial B-tree supporting the deterministic always-load
+        # read path (load_pinned). Scopes to context_id and is partial on
+        # delivery_mode='always' AND deleted_at IS NULL so only pinned, live
+        # rows carry the index — the always-set is bounded and small per
+        # context. Created in migration e32_886_delivery_mode.
+        Index(
+            "idx_memories_delivery_always",
+            "context_id",
+            postgresql_where=text("delivery_mode = 'always' AND deleted_at IS NULL"),
         ),
         # Time Memory (type="time") partial btree on the generated lower bound,
         # supporting the window-overlap query + ORDER BY trigger_from on

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -88,6 +88,16 @@ class RememberRequest(BaseModel):
     tags: list[str] = Field(default_factory=list, description="タグ")
     context: dict | None = Field(default=None, description="コンテキスト情報")
 
+    # Issue #886: orthogonal delivery attribute (NOT a memory type). 'always'
+    # pins the memory to persistent on write (deterministic always-load); the
+    # default 'on_recall' is the legacy probabilistic-only behavior. The Literal
+    # set is pinned to models.memory._ALL_DELIVERY_MODES by a cross-module drift
+    # test. 'on_trigger' is realized via Time Memory (type='time').
+    delivery_mode: Literal["always", "on_recall", "on_trigger"] = Field(
+        default="on_recall",
+        description="Delivery mode: always (pin, load every turn) | on_recall (default) | on_trigger",
+    )
+
     # Issue #213: Origin tracking for external integration
     source_uri: str | None = Field(
         default=None,
@@ -192,6 +202,57 @@ class MemoryResponse(TZAwareBaseModel):
 
     class Config:
         from_attributes = True
+
+
+class PinnedMemoryItem(TZAwareBaseModel):
+    """A single always-load memory (Issue #886).
+
+    Deliberately L1 + L2 only (summary + context_summary) — the deterministic
+    always-load path injects these into the agent's context every turn, so the
+    full L3 ``content`` is intentionally omitted and fetched on demand via
+    ``reference(memory_id)``. No ``score`` field: this path is unranked.
+    """
+
+    memory_id: UUID
+    summary: str
+    context_summary: str | None
+    type: str
+    importance: float
+    delivery_mode: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class LoadPinnedRequest(BaseModel):
+    """Request for the deterministic always-load read path (Issue #886).
+
+    ``context_id`` selects which context's always-load set to return (the set
+    is per-context). ``cap`` optionally overrides ``settings.pinned_load_cap``.
+    """
+
+    context_id: str | None = Field(
+        default=None, description="Context UUID whose pinned memories to load"
+    )
+    cap: int | None = Field(
+        default=None, ge=1, le=1000, description="Optional override for the max returned (bounded)"
+    )
+
+
+class LoadPinnedResponse(BaseModel):
+    """Response for the deterministic always-load read path (Issue #886).
+
+    ``memories`` is the complete, unranked, ordered set up to ``cap``. When the
+    context holds more pinned memories than ``cap``, ``truncated`` is true and
+    ``total_available`` reports the real count — the set is never silently cut.
+    """
+
+    status: str = "success"
+    memories: list[PinnedMemoryItem]
+    total_available: int
+    truncated: bool
+    cap: int
 
 
 class RelatedTagItem(TZAwareBaseModel):
@@ -333,6 +394,13 @@ class UpdateMemoryRequest(BaseModel):
     importance: float | None = Field(None, ge=0.0, le=1.0, description="Updated importance")
     tags: list[str] | None = Field(None, description="Updated tags")
     context: dict | None = Field(None, description="Updated context metadata")
+    # Issue #886: change delivery_mode in place. Setting 'always' pins the
+    # memory to persistent (like remember's pin-on-write); setting 'on_recall'
+    # unpins it (the memory stays persistent — delivery_mode controls loading,
+    # not lifecycle). None leaves it unchanged.
+    delivery_mode: Literal["always", "on_recall", "on_trigger"] | None = Field(
+        None, description="Updated delivery mode (always pins to persistent; on_recall unpins)"
+    )
 
     @model_validator(mode="after")
     def validate_identifier_and_required_fields(self) -> "UpdateMemoryRequest":

--- a/backend/src/repositories/memory.py
+++ b/backend/src/repositories/memory.py
@@ -274,9 +274,24 @@ class MemoryRepository(BaseRepository[Memory]):
         )
         return result.scalars().first()
 
+    # Issue #886: the always-load read returns L1 (summary) + L2
+    # (context_summary) + a few metadata fields only — never L3 (content /
+    # details). Selecting just these columns keeps the every-turn load_pinned
+    # path from fetching the potentially large content/details TEXT+JSONB it
+    # would only discard. Order matches PinnedMemoryItem field access.
+    _PINNED_COLUMNS = (
+        Memory.id,
+        Memory.summary,
+        Memory.context_summary,
+        Memory.type,
+        Memory.importance,
+        Memory.delivery_mode,
+        Memory.created_at,
+    )
+
     async def list_pinned(
         self, workspace_id: UUID, context_id: UUID, limit: int
-    ) -> tuple[list[Memory], int]:
+    ) -> tuple[list, int]:
         """Deterministic always-load set for a context (Issue #886).
 
         Returns up to ``limit`` always-delivery memories ordered by
@@ -284,6 +299,10 @@ class MemoryRepository(BaseRepository[Memory]):
         to the ``id`` tie-break, so the same context yields the same ordered set
         every call. Also returns the total count of matching rows so the caller
         can report ``truncated`` / ``total_available`` without silent loss.
+
+        Rows are partial (L1 + L2 + metadata only — see ``_PINNED_COLUMNS``); the
+        L3 ``content`` / ``details`` are intentionally not loaded. Each row
+        exposes the selected columns by name (``row.summary`` etc.).
 
         This is the deterministic counterpart to ``recall()``: no embedding, no
         Qdrant, no rerank — a plain indexed SQL scan (backed by the partial
@@ -295,7 +314,7 @@ class MemoryRepository(BaseRepository[Memory]):
             limit: Hard cap on returned rows (bound; total may exceed it).
 
         Returns:
-            ``(rows, total)`` — the bounded ordered rows and the full count.
+            ``(rows, total)`` — the bounded ordered partial rows and full count.
         """
         conditions = (
             Memory.workspace_id == workspace_id,
@@ -309,12 +328,12 @@ class MemoryRepository(BaseRepository[Memory]):
         # the true total_available. load_pinned runs every agent turn, so saving
         # the COUNT on the hot path matters.
         result = await self.db.execute(
-            select(Memory)
+            select(*self._PINNED_COLUMNS)
             .where(*conditions)
             .order_by(desc(Memory.importance), Memory.created_at.asc(), Memory.id.asc())
             .limit(limit + 1)
         )
-        rows = list(result.scalars().all())
+        rows = list(result.all())
         if len(rows) <= limit:
             return rows, len(rows)
 

--- a/backend/src/repositories/memory.py
+++ b/backend/src/repositories/memory.py
@@ -7,7 +7,7 @@ from uuid import UUID
 from sqlalchemy import and_, desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from models.memory import Memory
+from models.memory import DELIVERY_MODE_ALWAYS, Memory
 from repositories.base import BaseRepository
 from utils.datetime import utcnow
 from utils.exceptions import NotFoundException
@@ -273,6 +273,55 @@ class MemoryRepository(BaseRepository[Memory]):
             .limit(1)
         )
         return result.scalars().first()
+
+    async def list_pinned(
+        self, workspace_id: UUID, context_id: UUID, limit: int
+    ) -> tuple[list[Memory], int]:
+        """Deterministic always-load set for a context (Issue #886).
+
+        Returns up to ``limit`` always-delivery memories ordered by
+        ``importance DESC, created_at ASC, id ASC`` — fully deterministic down
+        to the ``id`` tie-break, so the same context yields the same ordered set
+        every call. Also returns the total count of matching rows so the caller
+        can report ``truncated`` / ``total_available`` without silent loss.
+
+        This is the deterministic counterpart to ``recall()``: no embedding, no
+        Qdrant, no rerank — a plain indexed SQL scan (backed by the partial
+        index ``idx_memories_delivery_always``).
+
+        Args:
+            workspace_id: Workspace isolation scope.
+            context_id: Context whose pinned memories to load.
+            limit: Hard cap on returned rows (bound; total may exceed it).
+
+        Returns:
+            ``(rows, total)`` — the bounded ordered rows and the full count.
+        """
+        conditions = (
+            Memory.workspace_id == workspace_id,
+            Memory.context_id == context_id,
+            Memory.delivery_mode == DELIVERY_MODE_ALWAYS,
+            Memory.deleted_at.is_(None),
+        )
+        # Fetch limit+1 so the common (untruncated) case needs a single query:
+        # if we get <= limit rows, that count IS the exact total. Only when the
+        # probe row appears (set exceeds the cap) do we pay for a COUNT to report
+        # the true total_available. load_pinned runs every agent turn, so saving
+        # the COUNT on the hot path matters.
+        result = await self.db.execute(
+            select(Memory)
+            .where(*conditions)
+            .order_by(desc(Memory.importance), Memory.created_at.asc(), Memory.id.asc())
+            .limit(limit + 1)
+        )
+        rows = list(result.scalars().all())
+        if len(rows) <= limit:
+            return rows, len(rows)
+
+        total = (
+            await self.db.execute(select(func.count(Memory.id)).where(*conditions))
+        ).scalar_one()
+        return rows[:limit], total
 
     async def get_old_working_memories(self, user_id: str, age_days: int = 30) -> list[Memory]:
         """Get old working memories for cleanup.

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -22,6 +22,7 @@ from db.qdrant import (
 )
 from models.auth import Context
 from models.memory import (
+    DELIVERY_MODE_ALWAYS,
     EDGE_ORIGIN_DECLARED,
     EDGE_ORIGIN_HEBBIAN,
     EDGE_ORIGIN_SEMANTIC,
@@ -35,9 +36,11 @@ from models.schemas import (
     ForgetRequest,
     ForgetResponse,
     LinkedMemoryRef,
+    LoadPinnedResponse,
     MemoryResponse,
     MemoryStatsResponse,
     PatchMemoryRequest,
+    PinnedMemoryItem,
     RecallRequest,
     RecallResponse,
     ReferenceResponse,
@@ -63,6 +66,11 @@ from utils.exceptions import (
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
+
+# Issue #886: upper bound for the always-load cap, matching the REST schema's
+# ``LoadPinnedRequest.cap`` le=1000. The MCP path sends the raw arg with no
+# Pydantic validation, so the service clamps defensively (see _clamp_pinned_cap).
+_PINNED_LOAD_CAP_MAX = 1000
 
 
 def _log_embedding_task_result(task: asyncio.Task, memory_id: str) -> None:
@@ -130,6 +138,41 @@ class MemoryService:
 
         context = await self.context_service.get_context(user_id, context_id)
         return context, str(context.workspace_id), str(context_id)
+
+    @staticmethod
+    def _apply_pin_on_write(memory: Memory) -> None:
+        """Pin a memory to persistent when delivery_mode='always' (Issue #886).
+
+        Centralizes the pin-on-write rule shared by ``remember`` and
+        ``_update_in_place`` (and any future write path), mirroring how
+        ``_apply_time_trigger`` centralizes the Time Memory invariant — so the
+        two sites cannot drift. Idempotent and matches ``promote_to_persistent``
+        semantics (scope='persistent' + promoted_at stamped); a memory already
+        persistent keeps its original promoted_at.
+        """
+        if memory.delivery_mode == DELIVERY_MODE_ALWAYS and memory.scope != "persistent":
+            memory.scope = "persistent"
+            memory.promoted_at = utcnow()
+
+    @staticmethod
+    def _clamp_pinned_cap(cap: int | str | None, default: int) -> int:
+        """Coerce + bound the always-load cap (Issue #886).
+
+        The REST path validates ``cap`` via Pydantic (int, 1..1000), but the MCP
+        path forwards the raw tool arg, so the service is the shared chokepoint
+        that must defend the LIMIT: ``None`` → default; otherwise coerce to int
+        and clamp to [1, _PINNED_LOAD_CAP_MAX]. Clamping the lower bound to 1 is
+        load-bearing — a 0 would emit ``LIMIT 0`` (empty set + a false
+        truncated=true) and a negative would emit ``LIMIT -1`` (no cap at all,
+        defeating the safety valve).
+        """
+        if cap is None:
+            return default
+        try:
+            cap_int = int(cap)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"cap must be an integer, got {cap!r}") from exc
+        return max(1, min(cap_int, _PINNED_LOAD_CAP_MAX))
 
     @staticmethod
     def _apply_time_trigger(memory_type: str | None, details: dict | None) -> dict | None:
@@ -298,12 +341,17 @@ class MemoryService:
             tags=request.tags,
             context=request.context,
             scope="working",
+            delivery_mode=request.delivery_mode,  # Issue #886
             client=client,
             summary_embedding_id=memory_id,  # Same as memory_id
             embedding_status="pending",  # Issue #122: Track embedding state
             source_uri=request.source_uri,
             source_type=request.source_type,
         )
+        # Issue #886: pin-on-write. delivery_mode='always' pins straight to
+        # persistent (so it is exempt from sleep consolidation — which only acts
+        # on scope='working' — without waiting for a consolidation pass).
+        self._apply_pin_on_write(memory)
 
         try:
             # Save to PostgreSQL first (with pending status)
@@ -331,7 +379,7 @@ class MemoryService:
                 functools.partial(_log_embedding_task_result, memory_id=str(memory_id))
             )
 
-            return RememberResponse(memory_id=memory_id, scope="working")
+            return RememberResponse(memory_id=memory_id, scope=memory.scope)
 
         except Exception as e:
             await self.db.rollback()
@@ -465,6 +513,14 @@ class MemoryService:
             memory.tags = request.tags
         if request.context is not None:
             memory.context = request.context
+        # Issue #886: in-place delivery_mode change. Setting 'always' pins to
+        # persistent via the shared helper (mirrors remember's pin-on-write);
+        # other modes leave scope untouched so unpinning ('always' → 'on_recall')
+        # keeps the memory persistent — delivery_mode controls loading, scope
+        # controls lifecycle.
+        if request.delivery_mode is not None:
+            memory.delivery_mode = request.delivery_mode
+            self._apply_pin_on_write(memory)
 
         memory.updated_at = utcnow()
 
@@ -1590,6 +1646,73 @@ class MemoryService:
 
         return RecallResponse(
             results=responses, related_tags=related_tags, explore_hints=explore_hints
+        )
+
+    async def load_pinned(
+        self,
+        user_id: str,
+        current_context_id: UUID | None = None,
+        current_workspace_id: UUID | None = None,
+        cap: int | str | None = None,
+    ) -> LoadPinnedResponse:
+        """Deterministically load a context's always-delivery memories (#886).
+
+        The deterministic counterpart to ``recall()``: returns the complete,
+        unranked, ordered always-load set for the bound context — no embedding,
+        no Qdrant, no rerank. Bounded by ``cap`` (default
+        ``settings.pinned_load_cap``); when the pinned set exceeds it, the
+        response flags ``truncated`` with the true ``total_available`` and logs
+        a warning (never a silent truncation). Items carry L1 + L2 only; full
+        content is fetched on demand via ``reference()``.
+
+        Args:
+            user_id: Caller user ID.
+            current_context_id: Bound context (the always-load set is per-context).
+            current_workspace_id: Bound workspace (isolation scope).
+            cap: Optional override for the hard cap (defaults to settings).
+
+        Returns:
+            LoadPinnedResponse with the bounded ordered set + truncation flags.
+        """
+        from config.settings import get_settings
+
+        context, workspace_id_str, context_id_str = await self._get_context_isolation_params(
+            user_id, current_context_id
+        )
+        if not workspace_id_str or not context_id_str:
+            raise ValueError("load_pinned() requires current_context_id")
+
+        effective_cap = self._clamp_pinned_cap(cap, get_settings().pinned_load_cap)
+
+        rows, total = await self.memory_repo.list_pinned(
+            UUID(workspace_id_str), UUID(context_id_str), effective_cap
+        )
+        truncated = total > effective_cap
+        if truncated:
+            logger.warning(
+                "pinned_load_capped",
+                context_id=context_id_str,
+                workspace_id=workspace_id_str,
+                total_available=total,
+                cap=effective_cap,
+            )
+
+        return LoadPinnedResponse(
+            memories=[
+                PinnedMemoryItem(
+                    memory_id=m.id,
+                    summary=m.summary,
+                    context_summary=m.context_summary,
+                    type=m.type,
+                    importance=m.importance,
+                    delivery_mode=m.delivery_mode,
+                    created_at=m.created_at,
+                )
+                for m in rows
+            ],
+            total_available=total,
+            truncated=truncated,
+            cap=effective_cap,
         )
 
     async def forget(

--- a/backend/tests/api/test_memory_pinned_route.py
+++ b/backend/tests/api/test_memory_pinned_route.py
@@ -1,0 +1,79 @@
+"""Route tests for POST /memory/pinned (#886).
+
+Direct-call convention (like test_memory_list_time.py): invoke the handler with
+a mocked MemoryService, asserting argument plumbing and the ValueError→422 map.
+"""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.memory import load_pinned
+from models.schemas import LoadPinnedRequest, LoadPinnedResponse, PinnedMemoryItem
+from utils.datetime import utcnow
+
+MOCK_USER = {"user_id": "u1", "current_workspace_id": uuid4()}
+
+
+def _response(n=1, total=1, truncated=False, cap=100):
+    return LoadPinnedResponse(
+        memories=[
+            PinnedMemoryItem(
+                memory_id=uuid4(),
+                summary=f"goal {i}",
+                context_summary="why",
+                type="note",
+                importance=0.9,
+                delivery_mode="always",
+                created_at=utcnow(),
+            )
+            for i in range(n)
+        ],
+        total_available=total,
+        truncated=truncated,
+        cap=cap,
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_route_passes_context_and_cap_through():
+    svc = AsyncMock()
+    svc.load_pinned = AsyncMock(return_value=_response(n=2, total=2))
+    ctx = uuid4()
+    req = LoadPinnedRequest(context_id=str(ctx), cap=50)
+
+    result = await load_pinned(request=req, user=MOCK_USER, memory_service=svc)
+
+    assert len(result.memories) == 2
+    svc.load_pinned.assert_awaited_once()
+    kwargs = svc.load_pinned.await_args.kwargs
+    # Route parses the string into a UUID before forwarding.
+    assert kwargs["current_context_id"] == ctx
+    assert kwargs["cap"] == 50
+    assert kwargs["current_workspace_id"] == MOCK_USER["current_workspace_id"]
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_route_rejects_malformed_context_id_with_422():
+    """A non-UUID context_id is a 422, not a DB DataError → 503 (finding #3)."""
+    svc = AsyncMock()
+    svc.load_pinned = AsyncMock(return_value=_response())
+    req = LoadPinnedRequest(context_id="not-a-uuid")
+
+    with pytest.raises(HTTPException) as exc:
+        await load_pinned(request=req, user=MOCK_USER, memory_service=svc)
+    assert exc.value.status_code == 422
+    svc.load_pinned.assert_not_awaited()  # rejected before reaching the service
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_route_maps_value_error_to_422():
+    svc = AsyncMock()
+    svc.load_pinned = AsyncMock(side_effect=ValueError("load_pinned() requires current_context_id"))
+    req = LoadPinnedRequest(context_id=None)
+
+    with pytest.raises(HTTPException) as exc:
+        await load_pinned(request=req, user=MOCK_USER, memory_service=svc)
+    assert exc.value.status_code == 422

--- a/backend/tests/integration/test_e32_886_delivery_mode_migration.py
+++ b/backend/tests/integration/test_e32_886_delivery_mode_migration.py
@@ -1,0 +1,71 @@
+"""Integration pins for #886 delivery_mode column DB-level behavior.
+
+Covers what the AST drift guard and create_all parity test cannot: the actual
+PostgreSQL DEFAULT backfill and the ``valid_delivery_mode`` CHECK rejecting
+out-of-set values at the engine level.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+
+def _insert_memory_sql(delivery_mode_clause: str) -> str:
+    return f"""
+        INSERT INTO memories
+          (id, user_id, summary, content, type, importance, confidence,
+           scope, embedding_status, client, source, long_term, use_count,
+           access_count{delivery_mode_clause[0]})
+        VALUES
+          (:id, 'u1', 's', 'c', 'note', 0.5, 1.0,
+           'working', 'success', 'test', 'mcp_remember', false, 0, 0{delivery_mode_clause[1]})
+    """
+
+
+@pytest.mark.asyncio
+async def test_delivery_mode_defaults_to_on_recall(db_session):
+    """A row inserted WITHOUT delivery_mode backfills to 'on_recall' (the
+    server-side DEFAULT), so existing/legacy write paths are unaffected."""
+    mem_id = uuid.uuid4()
+    await db_session.execute(
+        text(_insert_memory_sql(("", ""))),
+        {"id": mem_id},
+    )
+    row = (
+        await db_session.execute(
+            text("SELECT delivery_mode FROM memories WHERE id = :id"),
+            {"id": mem_id},
+        )
+    ).one()
+    assert row.delivery_mode == "on_recall"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["always", "on_recall", "on_trigger"])
+async def test_delivery_mode_accepts_valid_modes(db_session, mode):
+    """All three orthogonal delivery modes are accepted by the CHECK."""
+    mem_id = uuid.uuid4()
+    await db_session.execute(
+        text(_insert_memory_sql((", delivery_mode", ", :mode"))),
+        {"id": mem_id, "mode": mode},
+    )
+    row = (
+        await db_session.execute(
+            text("SELECT delivery_mode FROM memories WHERE id = :id"),
+            {"id": mem_id},
+        )
+    ).one()
+    assert row.delivery_mode == mode
+
+
+@pytest.mark.asyncio
+async def test_delivery_mode_check_rejects_unknown_value(db_session):
+    """``valid_delivery_mode`` CHECK rejects a value outside the enum set."""
+    mem_id = uuid.uuid4()
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(_insert_memory_sql((", delivery_mode", ", :mode"))),
+            {"id": mem_id, "mode": "eventually"},
+        )

--- a/backend/tests/integration/test_load_pinned_repo.py
+++ b/backend/tests/integration/test_load_pinned_repo.py
@@ -88,12 +88,30 @@ async def test_list_pinned_returns_only_always_in_context(db_session):
     await _seed_context(db_session, ws, ctx_a)
     await _seed_context(db_session, ws, ctx_b)
     a1, a2 = uuid.uuid4(), uuid.uuid4()
-    await _insert_memory(db_session, mem_id=a1, workspace_id=ws, context_id=ctx_a, delivery_mode="always")
-    await _insert_memory(db_session, mem_id=a2, workspace_id=ws, context_id=ctx_a, delivery_mode="always")
-    await _insert_memory(db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx_a, delivery_mode="on_recall")
-    await _insert_memory(db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx_a, delivery_mode="on_trigger")
+    await _insert_memory(
+        db_session, mem_id=a1, workspace_id=ws, context_id=ctx_a, delivery_mode="always"
+    )
+    await _insert_memory(
+        db_session, mem_id=a2, workspace_id=ws, context_id=ctx_a, delivery_mode="always"
+    )
+    await _insert_memory(
+        db_session,
+        mem_id=uuid.uuid4(),
+        workspace_id=ws,
+        context_id=ctx_a,
+        delivery_mode="on_recall",
+    )
+    await _insert_memory(
+        db_session,
+        mem_id=uuid.uuid4(),
+        workspace_id=ws,
+        context_id=ctx_a,
+        delivery_mode="on_trigger",
+    )
     # always memory in a DIFFERENT context must not leak in
-    await _insert_memory(db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx_b, delivery_mode="always")
+    await _insert_memory(
+        db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx_b, delivery_mode="always"
+    )
 
     repo = MemoryRepository(db_session)
     rows, total = await repo.list_pinned(ws, ctx_a, limit=100)
@@ -110,9 +128,30 @@ async def test_list_pinned_deterministic_order(db_session):
     high = uuid.uuid4()
     early = uuid.uuid4()
     late = uuid.uuid4()
-    await _insert_memory(db_session, mem_id=late, workspace_id=ws, context_id=ctx, importance=0.5, created_at="2026-06-02T00:00:00")
-    await _insert_memory(db_session, mem_id=early, workspace_id=ws, context_id=ctx, importance=0.5, created_at="2026-06-01T00:00:00")
-    await _insert_memory(db_session, mem_id=high, workspace_id=ws, context_id=ctx, importance=0.9, created_at="2026-06-03T00:00:00")
+    await _insert_memory(
+        db_session,
+        mem_id=late,
+        workspace_id=ws,
+        context_id=ctx,
+        importance=0.5,
+        created_at="2026-06-02T00:00:00",
+    )
+    await _insert_memory(
+        db_session,
+        mem_id=early,
+        workspace_id=ws,
+        context_id=ctx,
+        importance=0.5,
+        created_at="2026-06-01T00:00:00",
+    )
+    await _insert_memory(
+        db_session,
+        mem_id=high,
+        workspace_id=ws,
+        context_id=ctx,
+        importance=0.9,
+        created_at="2026-06-03T00:00:00",
+    )
 
     repo = MemoryRepository(db_session)
     rows, total = await repo.list_pinned(ws, ctx, limit=100)
@@ -129,7 +168,10 @@ async def test_list_pinned_excludes_soft_deleted(db_session):
     live = uuid.uuid4()
     await _insert_memory(db_session, mem_id=live, workspace_id=ws, context_id=ctx)
     await _insert_memory(
-        db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx,
+        db_session,
+        mem_id=uuid.uuid4(),
+        workspace_id=ws,
+        context_id=ctx,
         deleted_at="2026-06-01T00:00:00",
     )
     repo = MemoryRepository(db_session)
@@ -145,8 +187,12 @@ async def test_list_pinned_cap_bounds_rows_but_total_is_accurate(db_session):
     await _seed_context(db_session, ws, ctx)
     for i in range(5):
         await _insert_memory(
-            db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx,
-            importance=0.5, created_at=f"2026-06-0{i + 1}T00:00:00",
+            db_session,
+            mem_id=uuid.uuid4(),
+            workspace_id=ws,
+            context_id=ctx,
+            importance=0.5,
+            created_at=f"2026-06-0{i + 1}T00:00:00",
         )
     repo = MemoryRepository(db_session)
     rows, total = await repo.list_pinned(ws, ctx, limit=3)

--- a/backend/tests/integration/test_load_pinned_repo.py
+++ b/backend/tests/integration/test_load_pinned_repo.py
@@ -1,0 +1,154 @@
+"""Integration pins for the deterministic always-load query (#886).
+
+MemoryRepository.list_pinned is the determinism-critical read path: it must be
+complete (no ranking), bounded (LIMIT cap + accurate total), and fully ordered
+down to the tie-break. These properties only hold against a real PostgreSQL
+engine, so they are pinned here rather than with mocks.
+"""
+
+import uuid
+from datetime import datetime
+
+import pytest
+from sqlalchemy import text
+
+from repositories.memory import MemoryRepository
+
+
+def _dt(value):
+    """asyncpg binds timestamp params as datetime objects, not ISO strings."""
+    return datetime.fromisoformat(value) if value is not None else None
+
+
+async def _seed_workspace(db_session, workspace_id, owner="user-886"):
+    await db_session.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_user_id, plan_name) "
+            "VALUES (:id, :name, :owner, 'free')"
+        ),
+        {"id": workspace_id, "name": f"ws-{workspace_id.hex[:8]}", "owner": owner},
+    )
+
+
+async def _seed_context(db_session, workspace_id, context_id, owner="user-886"):
+    await db_session.execute(
+        text(
+            "INSERT INTO contexts (id, workspace_id, name, created_by, is_private, is_public) "
+            "VALUES (:id, :ws, :name, :owner, false, false)"
+        ),
+        {"id": context_id, "ws": workspace_id, "name": f"ctx-{context_id.hex[:8]}", "owner": owner},
+    )
+
+
+async def _insert_memory(
+    db_session,
+    *,
+    mem_id,
+    workspace_id,
+    context_id,
+    delivery_mode="always",
+    importance=0.5,
+    created_at="2026-06-01T00:00:00",
+    deleted_at=None,
+    owner="user-886",
+):
+    await db_session.execute(
+        text(
+            """
+            INSERT INTO memories
+              (id, user_id, workspace_id, context_id, summary, context_summary, content,
+               type, importance, confidence, scope, delivery_mode, embedding_status,
+               client, source, long_term, use_count, access_count, created_at, deleted_at)
+            VALUES
+              (:id, :owner, :ws, :ctx, :summary, :ctxsum, :content,
+               'note', :imp, 1.0, 'persistent', :dm, 'success',
+               'test', 'mcp_remember', false, 0, 0, :created, :deleted)
+            """
+        ),
+        {
+            "id": mem_id,
+            "owner": owner,
+            "ws": workspace_id,
+            "ctx": context_id,
+            "summary": f"summary-{mem_id.hex[:6]}",
+            "ctxsum": f"ctxsum-{mem_id.hex[:6]}",
+            "content": "FULL CONTENT should never be in the pinned read",
+            "imp": importance,
+            "dm": delivery_mode,
+            "created": _dt(created_at),
+            "deleted": _dt(deleted_at),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_pinned_returns_only_always_in_context(db_session):
+    ws, ctx_a, ctx_b = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    await _seed_workspace(db_session, ws)
+    await _seed_context(db_session, ws, ctx_a)
+    await _seed_context(db_session, ws, ctx_b)
+    a1, a2 = uuid.uuid4(), uuid.uuid4()
+    await _insert_memory(db_session, mem_id=a1, workspace_id=ws, context_id=ctx_a, delivery_mode="always")
+    await _insert_memory(db_session, mem_id=a2, workspace_id=ws, context_id=ctx_a, delivery_mode="always")
+    await _insert_memory(db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx_a, delivery_mode="on_recall")
+    await _insert_memory(db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx_a, delivery_mode="on_trigger")
+    # always memory in a DIFFERENT context must not leak in
+    await _insert_memory(db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx_b, delivery_mode="always")
+
+    repo = MemoryRepository(db_session)
+    rows, total = await repo.list_pinned(ws, ctx_a, limit=100)
+    assert total == 2
+    assert {r.id for r in rows} == {a1, a2}
+
+
+@pytest.mark.asyncio
+async def test_list_pinned_deterministic_order(db_session):
+    """importance DESC, then created_at ASC, then id ASC (full tie-break)."""
+    ws, ctx = uuid.uuid4(), uuid.uuid4()
+    await _seed_workspace(db_session, ws)
+    await _seed_context(db_session, ws, ctx)
+    high = uuid.uuid4()
+    early = uuid.uuid4()
+    late = uuid.uuid4()
+    await _insert_memory(db_session, mem_id=late, workspace_id=ws, context_id=ctx, importance=0.5, created_at="2026-06-02T00:00:00")
+    await _insert_memory(db_session, mem_id=early, workspace_id=ws, context_id=ctx, importance=0.5, created_at="2026-06-01T00:00:00")
+    await _insert_memory(db_session, mem_id=high, workspace_id=ws, context_id=ctx, importance=0.9, created_at="2026-06-03T00:00:00")
+
+    repo = MemoryRepository(db_session)
+    rows, total = await repo.list_pinned(ws, ctx, limit=100)
+    assert total == 3
+    # highest importance first; among equal importance, earlier created_at first
+    assert [r.id for r in rows] == [high, early, late]
+
+
+@pytest.mark.asyncio
+async def test_list_pinned_excludes_soft_deleted(db_session):
+    ws, ctx = uuid.uuid4(), uuid.uuid4()
+    await _seed_workspace(db_session, ws)
+    await _seed_context(db_session, ws, ctx)
+    live = uuid.uuid4()
+    await _insert_memory(db_session, mem_id=live, workspace_id=ws, context_id=ctx)
+    await _insert_memory(
+        db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx,
+        deleted_at="2026-06-01T00:00:00",
+    )
+    repo = MemoryRepository(db_session)
+    rows, total = await repo.list_pinned(ws, ctx, limit=100)
+    assert total == 1
+    assert [r.id for r in rows] == [live]
+
+
+@pytest.mark.asyncio
+async def test_list_pinned_cap_bounds_rows_but_total_is_accurate(db_session):
+    ws, ctx = uuid.uuid4(), uuid.uuid4()
+    await _seed_workspace(db_session, ws)
+    await _seed_context(db_session, ws, ctx)
+    for i in range(5):
+        await _insert_memory(
+            db_session, mem_id=uuid.uuid4(), workspace_id=ws, context_id=ctx,
+            importance=0.5, created_at=f"2026-06-0{i + 1}T00:00:00",
+        )
+    repo = MemoryRepository(db_session)
+    rows, total = await repo.list_pinned(ws, ctx, limit=3)
+    assert len(rows) == 3
+    assert total == 5

--- a/backend/tests/services/test_load_pinned_service.py
+++ b/backend/tests/services/test_load_pinned_service.py
@@ -1,0 +1,122 @@
+"""Tests for MemoryService.load_pinned — the deterministic always-load wrapper (#886).
+
+The repo query (ordering/exclusion/bounding) is pinned in
+tests/integration/test_load_pinned_repo.py. Here we pin the service contract:
+layered output (L1+L2 only, never L3 content), the truncated / total_available
+reporting, and the settings-driven default cap. memory_repo.list_pinned is
+mocked so no DB is needed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import LoadPinnedResponse, PinnedMemoryItem
+from services.memory_service import MemoryService
+from utils.datetime import utcnow
+
+
+@pytest.fixture
+def service():
+    svc = MemoryService(MagicMock())
+    ctx = MagicMock()
+    ctx.id = uuid4()
+    ctx.workspace_id = uuid4()
+    svc._get_context_isolation_params = AsyncMock(
+        return_value=(ctx, str(ctx.workspace_id), str(ctx.id))
+    )
+    svc.memory_repo = MagicMock()
+    svc._mock_context = ctx
+    return svc
+
+
+def _row(**overrides):
+    m = MagicMock()
+    m.id = overrides.get("id", uuid4())
+    m.summary = overrides.get("summary", "agent goal")
+    m.context_summary = overrides.get("context_summary", "why it matters")
+    m.content = "FULL CONTENT — must not appear in the pinned item"
+    m.type = overrides.get("type", "note")
+    m.importance = overrides.get("importance", 0.9)
+    m.delivery_mode = "always"
+    m.created_at = utcnow()
+    return m
+
+
+async def _call(service, cap=None):
+    return await service.load_pinned(
+        user_id="u1",
+        current_context_id=service._mock_context.id,
+        current_workspace_id=service._mock_context.workspace_id,
+        cap=cap,
+    )
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_returns_layered_items_without_content(service):
+    rows = [_row(summary="goal A"), _row(summary="guardrail B")]
+    service.memory_repo.list_pinned = AsyncMock(return_value=(rows, 2))
+
+    result = await _call(service)
+    assert isinstance(result, LoadPinnedResponse)
+    assert len(result.memories) == 2
+    assert all(isinstance(m, PinnedMemoryItem) for m in result.memories)
+    # L1 + L2 are present; L3 content is structurally absent from the item.
+    assert result.memories[0].summary == "goal A"
+    assert result.memories[0].context_summary == "why it matters"
+    assert not hasattr(result.memories[0], "content")
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_not_truncated_when_total_within_cap(service):
+    rows = [_row(), _row()]
+    service.memory_repo.list_pinned = AsyncMock(return_value=(rows, 2))
+    result = await _call(service, cap=10)
+    assert result.truncated is False
+    assert result.total_available == 2
+    assert result.cap == 10
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_flags_truncated_with_true_total(service):
+    rows = [_row() for _ in range(3)]  # bounded to cap
+    service.memory_repo.list_pinned = AsyncMock(return_value=(rows, 12))
+    result = await _call(service, cap=3)
+    assert result.truncated is True
+    assert result.total_available == 12  # true total, not silently dropped
+    assert len(result.memories) == 3
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_uses_settings_cap_by_default(service):
+    service.memory_repo.list_pinned = AsyncMock(return_value=([], 0))
+    result = await _call(service)  # no explicit cap
+    # The default cap from settings (100) is passed to the repo and echoed back.
+    service.memory_repo.list_pinned.assert_awaited_once()
+    assert service.memory_repo.list_pinned.await_args.args[2] == 100
+    assert result.cap == 100
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (0, 1),  # falsy-zero is a real value (not None); clamp up to 1, never LIMIT 0
+        (-5, 1),  # negative would be Postgres LIMIT -1 (no cap) — clamp up to 1
+        (5000, 1000),  # clamp down to the upper bound (matches REST le=1000)
+        ("50", 50),  # MCP sends JSON; coerce numeric string
+    ],
+)
+async def test_load_pinned_coerces_and_clamps_cap(service, raw, expected):
+    service.memory_repo.list_pinned = AsyncMock(return_value=([], 0))
+    result = await _call(service, cap=raw)
+    assert service.memory_repo.list_pinned.await_args.args[2] == expected
+    assert result.cap == expected
+
+
+@pytest.mark.asyncio
+async def test_load_pinned_rejects_non_integer_cap(service):
+    service.memory_repo.list_pinned = AsyncMock(return_value=([], 0))
+    with pytest.raises(ValueError):
+        await _call(service, cap="abc")

--- a/backend/tests/services/test_remember_delivery_mode.py
+++ b/backend/tests/services/test_remember_delivery_mode.py
@@ -1,0 +1,108 @@
+"""Tests for the delivery_mode + pin-on-write write path of remember() (#886).
+
+Mirrors the mocked-DB pattern in test_remember_time_memory.py: memory_repo.create
+is mocked, so we inspect the Memory entity handed to it to assert delivery_mode
+and the pin-on-write scope transition — no real DB needed.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import RememberRequest
+from services.memory_service import MemoryService
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def service(mock_db):
+    svc = MemoryService(mock_db)
+    mock_context = MagicMock()
+    mock_context.id = uuid4()
+    mock_context.workspace_id = uuid4()
+    svc._get_context_isolation_params = AsyncMock(
+        return_value=(mock_context, str(mock_context.workspace_id), str(mock_context.id))
+    )
+    svc.memory_repo = MagicMock()
+    svc.memory_repo.create = AsyncMock()
+    svc._create_declared_links = AsyncMock()
+    svc._mock_context = mock_context
+    return svc
+
+
+def _req(**kwargs):
+    base = {"summary": "agent goal: ship #886", "content": "deliver delivery_mode", "type": "note"}
+    base.update(kwargs)
+    return RememberRequest(**base)
+
+
+async def _call(service, req):
+    with (
+        patch("services.memory_service.process_pending_embedding", new=AsyncMock()),
+        patch("services.quota_service.QuotaService"),
+    ):
+        return await service.remember(
+            req,
+            user_id="test_user",
+            client="test",
+            current_context_id=service._mock_context.id,
+            current_workspace_id=None,
+        )
+
+
+def _created_memory(service):
+    return service.memory_repo.create.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_default_delivery_mode_is_on_recall_and_working(service):
+    """No delivery_mode supplied → on_recall + working scope (legacy behavior)."""
+    result = await _call(service, _req())
+    mem = _created_memory(service)
+    assert mem.delivery_mode == "on_recall"
+    assert mem.scope == "working"
+    assert mem.promoted_at is None
+    assert result.scope == "working"
+
+
+@pytest.mark.asyncio
+async def test_explicit_on_recall_stays_working(service):
+    result = await _call(service, _req(delivery_mode="on_recall"))
+    mem = _created_memory(service)
+    assert mem.delivery_mode == "on_recall"
+    assert mem.scope == "working"
+    assert result.scope == "working"
+
+
+@pytest.mark.asyncio
+async def test_always_pins_to_persistent_on_write(service):
+    """delivery_mode='always' pins to persistent immediately (no sleep wait)."""
+    result = await _call(service, _req(delivery_mode="always"))
+    mem = _created_memory(service)
+    assert mem.delivery_mode == "always"
+    # Pin-on-write: persistent immediately, with promoted_at stamped (mirrors
+    # promote_to_persistent), so consolidation (scope='working' only) skips it.
+    assert mem.scope == "persistent"
+    assert mem.promoted_at is not None
+    assert result.scope == "persistent"
+
+
+def test_remember_request_delivery_mode_defaults_to_on_recall():
+    assert RememberRequest(summary="x" * 10, content="c", type="note").delivery_mode == "on_recall"
+
+
+def test_remember_request_rejects_unknown_delivery_mode():
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError):
+        RememberRequest(summary="x" * 10, content="c", type="note", delivery_mode="eventually")

--- a/backend/tests/services/test_update_memory_delivery_mode.py
+++ b/backend/tests/services/test_update_memory_delivery_mode.py
@@ -1,0 +1,106 @@
+"""Tests for delivery_mode on the update path (#886): unpin + pin-via-update.
+
+unpin = flip delivery_mode back to 'on_recall' (the memory stays persistent —
+delivery_mode controls *loading*, scope controls *lifecycle*). Updating to
+'always' pins to persistent, mirroring remember()'s pin-on-write.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import UpdateMemoryRequest
+from services.memory_service import MemoryService
+
+
+@pytest.fixture
+def mock_db():
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.flush = AsyncMock()
+    db.rollback = AsyncMock()
+    db.execute = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def service(mock_db):
+    return MemoryService(mock_db)
+
+
+def _make_memory(**overrides):
+    memory = MagicMock()
+    memory.id = overrides.get("id", uuid4())
+    memory.user_id = "test_user"
+    memory.workspace_id = uuid4()
+    memory.context_id = uuid4()
+    memory.summary = "Original summary for testing"
+    memory.context_summary = None
+    memory.content = "Original content"
+    memory.details = None
+    memory.type = "note"
+    memory.importance = 0.5
+    memory.tags = ["original"]
+    memory.context = None
+    memory.scope = overrides.get("scope", "working")
+    memory.delivery_mode = overrides.get("delivery_mode", "on_recall")
+    memory.promoted_at = overrides.get("promoted_at", None)
+    memory.client = "mcp"
+    memory.created_at = None
+    memory.updated_at = None
+    memory.deleted_at = None
+    memory.embedding_status = "success"
+    return memory
+
+
+async def _update(service, memory, **fields):
+    service.memory_repo.get = AsyncMock(return_value=memory)
+    with (
+        patch("services.permission_service.PermissionService") as mock_perm_cls,
+        patch("services.memory_service.update_memory_payload_in_qdrant", new=AsyncMock()),
+        patch(
+            "services.memory_service.resolve_collection_name",
+            new=AsyncMock(return_value="kagura_memories"),
+        ),
+    ):
+        mock_perm_cls.return_value.can_access_memory = AsyncMock(return_value=True)
+        request = UpdateMemoryRequest(memory_id=memory.id, **fields)
+        return await service._update_in_place(request, user_id="test_user")
+
+
+@pytest.mark.asyncio
+async def test_unpin_resets_delivery_mode_but_keeps_persistent(service):
+    """Unpin: 'always' → 'on_recall'. Memory stays persistent (lifecycle intact)."""
+    memory = _make_memory(delivery_mode="always", scope="persistent")
+    await _update(service, memory, delivery_mode="on_recall")
+    assert memory.delivery_mode == "on_recall"
+    assert memory.scope == "persistent"
+
+
+@pytest.mark.asyncio
+async def test_update_to_always_pins_to_persistent(service):
+    """Updating delivery_mode to 'always' on a working memory pins it persistent."""
+    memory = _make_memory(delivery_mode="on_recall", scope="working")
+    await _update(service, memory, delivery_mode="always")
+    assert memory.delivery_mode == "always"
+    assert memory.scope == "persistent"
+    assert memory.promoted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_update_without_delivery_mode_leaves_it_unchanged(service):
+    """Omitting delivery_mode does not touch it (only non-None fields apply)."""
+    memory = _make_memory(delivery_mode="always", scope="persistent")
+    await _update(service, memory, importance=0.9)
+    assert memory.delivery_mode == "always"
+
+
+def test_update_memory_request_accepts_delivery_mode():
+    req = UpdateMemoryRequest(memory_id=uuid4(), delivery_mode="always")
+    assert req.delivery_mode == "always"
+
+
+def test_update_memory_request_rejects_unknown_delivery_mode():
+    with pytest.raises(ValueError):
+        UpdateMemoryRequest(memory_id=uuid4(), delivery_mode="eventually")

--- a/backend/tests/test_delivery_mode_constants.py
+++ b/backend/tests/test_delivery_mode_constants.py
@@ -1,0 +1,64 @@
+"""Regression tests for #886: delivery_mode constant + CHECK invariants.
+
+``delivery_mode`` is an orthogonal delivery attribute on Memory (NOT a new
+memory ``type``): ``always`` | ``on_recall`` | ``on_trigger`` (#885 design memory
+242cb28a). Like ``edge_type``/``origin`` on NeuralMemoryEdge, the DB CHECK
+constraint is derived from an ordered Python tuple (``_ALL_DELIVERY_MODES``) so
+``Base.metadata.create_all()`` (tests, fresh dev DBs) produces a CHECK string
+byte-identical to the alembic head — preventing ``alembic revision
+--autogenerate`` from emitting a spurious no-op migration.
+
+Adding a new delivery_mode requires THREE coordinated edits (caught here if any
+are missed): (1) add ``DELIVERY_MODE_NEW`` to the constants block, (2) append it
+to ``_ALL_DELIVERY_MODES``, (3) update the expected literal below — plus an
+alembic migration that ALTERs the prod CHECK.
+"""
+
+from models.memory import (
+    _ALL_DELIVERY_MODES,
+    DELIVERY_MODE_ALWAYS,
+    DELIVERY_MODE_ON_RECALL,
+    DELIVERY_MODE_ON_TRIGGER,
+    Memory,
+)
+
+
+def test_all_delivery_modes_tuple_matches_constants() -> None:
+    """``_ALL_DELIVERY_MODES`` enumerates exactly the three named constants.
+
+    Registration order is fixed (always, on_recall, on_trigger); new modes are
+    APPENDED (never reordered) to preserve byte-identity with the migration
+    literal.
+    """
+    assert _ALL_DELIVERY_MODES == (
+        DELIVERY_MODE_ALWAYS,
+        DELIVERY_MODE_ON_RECALL,
+        DELIVERY_MODE_ON_TRIGGER,
+    )
+
+
+def test_delivery_mode_values_are_orthogonal_not_types() -> None:
+    """The delivery_mode values are the design-fixed orthogonal set (242cb28a)."""
+    assert DELIVERY_MODE_ALWAYS == "always"
+    assert DELIVERY_MODE_ON_RECALL == "on_recall"
+    assert DELIVERY_MODE_ON_TRIGGER == "on_trigger"
+
+
+def test_valid_delivery_mode_check_constraint_matches_migration_literal() -> None:
+    """``valid_delivery_mode`` CHECK text is byte-identical to the migration.
+
+    The CHECK is derived from ``_ALL_DELIVERY_MODES`` via f-string (registration
+    order, single quotes, exact whitespace). This pins the exact output against
+    the literal the alembic migration installs on production, so create_all and
+    the migration head stay in sync and autogenerate sees no drift.
+    """
+    expected = "delivery_mode IN ('always', 'on_recall', 'on_trigger')"
+
+    check = next(
+        c
+        for c in Memory.__table_args__
+        if getattr(c, "name", None) == "valid_delivery_mode"
+    )
+    # ``.sqltext.text`` is the raw CheckConstraint string (no SQLAlchemy
+    # compilation), so byte-identical comparison stays stable across upgrades.
+    assert check.sqltext.text == expected

--- a/backend/tests/test_delivery_mode_constants.py
+++ b/backend/tests/test_delivery_mode_constants.py
@@ -55,9 +55,7 @@ def test_valid_delivery_mode_check_constraint_matches_migration_literal() -> Non
     expected = "delivery_mode IN ('always', 'on_recall', 'on_trigger')"
 
     check = next(
-        c
-        for c in Memory.__table_args__
-        if getattr(c, "name", None) == "valid_delivery_mode"
+        c for c in Memory.__table_args__ if getattr(c, "name", None) == "valid_delivery_mode"
     )
     # ``.sqltext.text`` is the raw CheckConstraint string (no SQLAlchemy
     # compilation), so byte-identical comparison stays stable across upgrades.

--- a/backend/tests/test_delivery_mode_cross_module.py
+++ b/backend/tests/test_delivery_mode_cross_module.py
@@ -1,0 +1,62 @@
+"""Cross-module delivery_mode invariants (#886).
+
+The canonical source of truth is ``models.memory._ALL_DELIVERY_MODES``. Every
+surface that enumerates the modes — the API request schemas' ``Literal`` and the
+MCP tool ``enum`` lists — must equal that set, or a value accepted at one layer
+is rejected at another. These cannot be expressed at the type-checker layer
+(``Literal`` needs string literals, the MCP defs are plain dicts), so this
+runtime test is the safety net (mirrors test_edge_type_constants.py).
+"""
+
+import typing
+
+from models.memory import _ALL_DELIVERY_MODES
+from models.schemas import RememberRequest, UpdateMemoryRequest
+
+EXPECTED = frozenset(_ALL_DELIVERY_MODES)
+
+
+def _literal_values(model, field_name):
+    """Extract the set of literal values from a (possibly Optional) Literal field."""
+    annotation = model.model_fields[field_name].annotation
+    values: set[str] = set()
+    # Optional[Literal[...]] is Union[Literal[...], None]; walk the args.
+    for arg in typing.get_args(annotation) or (annotation,):
+        if typing.get_origin(arg) is typing.Literal:
+            values.update(typing.get_args(arg))
+    # Bare Literal[...] (non-optional) case.
+    if typing.get_origin(annotation) is typing.Literal:
+        values.update(typing.get_args(annotation))
+    return values
+
+
+def test_remember_request_literal_matches_canonical_set():
+    assert _literal_values(RememberRequest, "delivery_mode") == EXPECTED
+
+
+def test_update_memory_request_literal_matches_canonical_set():
+    assert _literal_values(UpdateMemoryRequest, "delivery_mode") == EXPECTED
+
+
+def _tool(defs, name):
+    return next(d for d in defs if d["name"] == name)
+
+
+def test_mcp_remember_and_update_enums_match_canonical_set():
+    from mcp_server.tools._definitions import get_tool_definitions
+
+    defs = get_tool_definitions()
+    for tool_name in ("remember", "update_memory"):
+        props = _tool(defs, tool_name)["inputSchema"]["properties"]
+        assert "delivery_mode" in props, f"{tool_name} missing delivery_mode property"
+        assert frozenset(props["delivery_mode"]["enum"]) == EXPECTED
+
+
+def test_mcp_load_pinned_tool_is_registered_and_read_only():
+    from mcp_server.tools import _RATE_LIMIT_EXEMPT_TOOLS
+    from mcp_server.tools._definitions import get_tool_definitions
+
+    load_pinned = _tool(get_tool_definitions(), "load_pinned")
+    assert load_pinned.get("readOnly") is True
+    # Read-only + deterministic-every-turn ⇒ must be rate-limit exempt.
+    assert "load_pinned" in _RATE_LIMIT_EXEMPT_TOOLS


### PR DESCRIPTION
Closes #886

## Summary
- Add `delivery_mode` ∈ {always, on_recall, on_trigger} as an **orthogonal** delivery attribute on `Memory` (sibling of `scope`), NOT a new memory `type` — per design memory 242cb28a.
- **Pin-on-write**: `delivery_mode="always"` pins straight to `scope=persistent` (+ `promoted_at`) on write, exempt from sleep consolidation without waiting for a pass.
- **Deterministic always-load read**: new `load_pinned` path (`POST /memory/pinned` + MCP `load_pinned` tool) returns the complete, unranked, bounded `always` set — no embedding / Qdrant / rerank. The deterministic counterpart to probabilistic `recall()`.

## Implementation notes
- **model**: `delivery_mode` column + `valid_delivery_mode` CHECK generated from the `_ALL_DELIVERY_MODES` tuple (mirrors the `edge_type`/`origin` pattern), drift-pinned by test; partial index `idx_memories_delivery_always`.
- **migration e32_886**: column + CHECK + `CONCURRENTLY` index inside `autocommit_block` (no `ACCESS EXCLUSIVE` lock on deploy); fully retry-safe (`ADD COLUMN IF NOT EXISTS` + guarded CHECK + INVALID-leftover handling).
- **service**: pin-on-write centralized in `_apply_pin_on_write` (used by `remember` + `update_memory`); `load_pinned` returns L1+L2 only (full content via `reference()`), cap-bounded (`settings.pinned_load_cap=100`) with `truncated`/`total_available`; `cap` coerced + clamped `[1,1000]` at the service layer (defends the raw MCP arg).
- **repo**: `list_pinned` deterministic order (`importance DESC, created_at ASC, id ASC`), single query in the untruncated case.
- **surface**: REST route UUID-validates `context_id` (→422, not a misleading 503); MCP `load_pinned` is read-only + rate-limit-exempt; `delivery_mode` added to `remember`/`update_memory` tools; cross-module enum drift pinned.
- SDK kwarg tracked in kagura-ai/kagura-memory-python-sdk#171.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask → CIO
- review provider: code-review

Verification: 2821 unit + 234 integration pass; ruff + pyright clean; migration up/down + create_all↔alembic drift verified.

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/886-feat-feat-api-delivery-mode-pin-on-write-for.gate1.md
- ~/.claude/cache/gh-issue-driven/886-feat-feat-api-delivery-mode-pin-on-write-for.gate2.md

🤖 Generated via /gh-issue-driven:ship
