### PR TITLE
feat(infra): restrict /api/v1/workers/* to internal network (#891)

### DIFF
--- a/terraform/single-server/Caddyfile.tpl
+++ b/terraform/single-server/Caddyfile.tpl
@@ -38,6 +38,14 @@ memory.kagura-ai.com {
 
 	encode zstd gzip
 
+	# /api/v1/workers/* is internal-only — must precede the /api/* catch-all.
+	# The co-resident ai-worker reaches this via the Docker internal network
+	# directly on the API container port; it must never be reachable through
+	# public ingress. Return 404 (not 403) to avoid confirming the path exists.
+	handle /api/v1/workers* {
+		respond 404
+	}
+
 	# -------------------------------------------------------------------------
 	# Backend API (FastAPI on :8080) — blue-green upstream
 	# -------------------------------------------------------------------------

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -304,13 +304,25 @@ verify_workers_blocked() {
     # intended for the co-resident ai-worker on the internal Docker network
     # only. Use -k (insecure) because the Cloudflare Origin CA cert is not
     # trusted by the system CA bundle, but we only care about the HTTP status.
+    #
+    # Domain is extracted from CADDYFILE_TPL so this stays in sync with the
+    # configured site block without manual updates here.
+    #
+    # Retry up to 3 times (2 s apart) to tolerate Caddy's brief startup window
+    # after `dc restart caddy` — avoids a false-positive abort on the first
+    # request while the process is still initialising.
     log "  Security gate: verifying /api/v1/workers/* is blocked at Caddy..."
-    local http_status
-    http_status=$(curl -sk -o /dev/null -w "%{http_code}" \
-        --max-time 5 \
-        -H "Host: memory.kagura-ai.com" \
-        "https://127.0.0.1:443/api/v1/workers/config" 2>/dev/null)
-    http_status=${http_status:-000}
+    local domain http_status attempt
+    domain=$(awk '/^[a-zA-Z]/ { gsub(/ *\{.*/, ""); print; exit }' "$CADDYFILE_TPL")
+    for attempt in 1 2 3; do
+        http_status=$(curl -sk -o /dev/null -w "%{http_code}" \
+            --max-time 5 \
+            -H "Host: ${domain}" \
+            "https://127.0.0.1:443/api/v1/workers/config" 2>/dev/null)
+        http_status=${http_status:-000}
+        [ "$http_status" = "404" ] && break
+        [ "$attempt" -lt 3 ] && sleep 2
+    done
     if [ "$http_status" = "404" ]; then
         log "  /api/v1/workers/* is correctly blocked (HTTP 404)"
     else

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -309,7 +309,8 @@ verify_workers_blocked() {
     http_status=$(curl -sk -o /dev/null -w "%{http_code}" \
         --max-time 5 \
         -H "Host: memory.kagura-ai.com" \
-        "https://127.0.0.1:443/api/v1/workers/config" 2>/dev/null) || http_status="000"
+        "https://127.0.0.1:443/api/v1/workers/config" 2>/dev/null)
+    http_status=${http_status:-000}
     if [ "$http_status" = "404" ]; then
         log "  /api/v1/workers/* is correctly blocked (HTTP 404)"
     else

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -104,6 +104,7 @@ cmd_rollback() {
     mv "${MARKER_FILE}.tmp" "$MARKER_FILE"
     generate_caddyfile "api-${inactive}"
     reload_caddy
+    verify_workers_blocked
 
     log "Rollback complete. Active: $inactive"
 }
@@ -143,6 +144,7 @@ cmd_deploy() {
     log "Step 6/7: Switching Caddy upstream -> api-${inactive}..."
     generate_caddyfile "api-${inactive}"
     reload_caddy
+    verify_workers_blocked
 
     # Step 7: Drain and stop old container
     # Disable restart policy first — otherwise `restart: always` revives
@@ -294,6 +296,27 @@ reload_caddy() {
     # re-mounts the file, guaranteeing the new Caddyfile is picked up.
     dc restart caddy
     log "  Caddy restarted"
+}
+
+verify_workers_blocked() {
+    # Security gate: /api/v1/workers/* must return 404 via Caddy after every
+    # config reload. The route carries decrypted connector secrets and is
+    # intended for the co-resident ai-worker on the internal Docker network
+    # only. Use -k (insecure) because the Cloudflare Origin CA cert is not
+    # trusted by the system CA bundle, but we only care about the HTTP status.
+    log "  Security gate: verifying /api/v1/workers/* is blocked at Caddy..."
+    local http_status
+    http_status=$(curl -sk -o /dev/null -w "%{http_code}" \
+        --max-time 5 \
+        -H "Host: memory.kagura-ai.com" \
+        "https://127.0.0.1:443/api/v1/workers/config" 2>/dev/null) || http_status="000"
+    if [ "$http_status" = "404" ]; then
+        log "  /api/v1/workers/* is correctly blocked (HTTP 404)"
+    else
+        error "/api/v1/workers/* is NOT blocked by Caddy (HTTP ${http_status}, expected 404).
+  Check Caddyfile: the 'handle /api/v1/workers*' block must appear BEFORE 'handle /api/*'.
+  Regenerate and redeploy: $0 --generate-caddyfile && dc restart caddy"
+    fi
 }
 
 cmd_generate_caddyfile() {

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -315,10 +315,14 @@ verify_workers_blocked() {
     local domain http_status attempt
     domain=$(awk '/^[a-zA-Z]/ { gsub(/ *\{.*/, ""); print; exit }' "$CADDYFILE_TPL")
     for attempt in 1 2 3; do
+        # --resolve sets both the TCP target AND the TLS SNI to $domain so
+        # Caddy selects the correct vhost. A plain -H "Host:" with 127.0.0.1
+        # in the URL leaves SNI as "127.0.0.1" and Caddy may not match the
+        # site block.
         http_status=$(curl -sk -o /dev/null -w "%{http_code}" \
             --max-time 5 \
-            -H "Host: ${domain}" \
-            "https://127.0.0.1:443/api/v1/workers/config" 2>/dev/null)
+            --resolve "${domain}:443:127.0.0.1" \
+            "https://${domain}/api/v1/workers/config" 2>/dev/null)
         http_status=${http_status:-000}
         [ "$http_status" = "404" ] && break
         [ "$attempt" -lt 3 ] && sleep 2


### PR DESCRIPTION
Closes #891

## Summary
- Add `handle /api/v1/workers*` Caddy rule returning 404 before the `/api/*` catch-all, blocking public ingress to the connector secrets endpoint
- Add `verify_workers_blocked()` deploy-time security gate: called after every `reload_caddy` in both `cmd_deploy` and `cmd_rollback`
- Fix `http_status=${http_status:-000}` fallback (command substitution always exits 0, so `|| http_status="000"` never fires)

## Implementation notes
- `Caddyfile.tpl` is the only routing change — no app-layer code modified
- `respond 404` (not 403) to avoid confirming the path exists to external probes
- `curl -sk` uses `-k` (insecure TLS) because the Cloudflare Origin CA cert is not in the system CA bundle; only the HTTP status code matters here
- `verify_workers_blocked` runs on both deploy and rollback paths to ensure the rule survives every Caddy config regeneration

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO)
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/891-feat-feat-infra-restrict-api-v1-workers-to-in.gate1.md
- ~/.claude/cache/gh-issue-driven/891-feat-feat-infra-restrict-api-v1-workers-to-in.gate2.md

🤖 Generated via /gh-issue-driven:ship
