### PR TITLE
feat(api): expiry + rotation for connector KMC write keys (#892)

### DIFF
--- a/backend/alembic/versions/e33_892_kmc_key_expiry.py
+++ b/backend/alembic/versions/e33_892_kmc_key_expiry.py
@@ -1,0 +1,25 @@
+"""Add kmc_api_key_expires_at to workspace_connectors (#892).
+
+Tracks when the per-connector KMC write key expires so operators can
+rotate before expiry. NULL = non-expiring (legacy rows provisioned before
+this migration). The rotate endpoint sets this to now + configurable TTL.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e33_892_kmc_key_expiry"
+down_revision = "e32_886_delivery_mode"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspace_connectors",
+        sa.Column("kmc_api_key_expires_at", sa.DateTime(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspace_connectors", "kmc_api_key_expires_at")

--- a/backend/src/api/routes/workers.py
+++ b/backend/src/api/routes/workers.py
@@ -95,6 +95,15 @@ async def get_worker_config(
             detail="No ready connector for this team",
         )
 
+    from utils.datetime import utcnow
+
+    if connector.kmc_api_key_expires_at and connector.kmc_api_key_expires_at < utcnow():
+        logger.warning(
+            "connector_kmc_key_expired",
+            connector_id=str(connector.id),
+            expired_at=connector.kmc_api_key_expires_at.isoformat(),
+        )
+
     oauth = connector.get_oauth_tokens() or {}
     slack = {
         "bot_token": oauth.get("bot_token"),

--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -320,20 +320,11 @@ async def rotate_connector_kmc_key(
         )
     user_id = admin["user_id"]
     try:
-        plaintext_key = await ConnectorProvisioningService(db).rotate_kmc_key(
+        rotation = await ConnectorProvisioningService(db).rotate_kmc_key(
             workspace_id=workspace_id,
             connector_id=connector_id,
             user_id=user_id,
         )
-        # Re-fetch to return the updated connector fields.
-        from sqlalchemy import select as sa_select
-
-        from models.resource import WorkspaceConnector
-
-        result = await db.execute(
-            sa_select(WorkspaceConnector).where(WorkspaceConnector.id == connector_id)
-        )
-        connector = result.scalar_one()
         await db.commit()
     except NotFoundException:
         await db.rollback()
@@ -357,7 +348,7 @@ async def rotate_connector_kmc_key(
         ) from exc
     return RotateKmcKeyResponse(
         connector_id=connector_id,
-        kmc_api_key=plaintext_key,
-        kmc_api_key_expires_at=connector.kmc_api_key_expires_at,
-        config_version=connector.config_version,
+        kmc_api_key=rotation.plaintext_kmc_api_key,
+        kmc_api_key_expires_at=rotation.expires_at,
+        config_version=rotation.config_version,
     )

--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -310,7 +310,8 @@ async def rotate_connector_kmc_key(
     this call returns. A grace-period dual-key approach is deferred to a
     follow-up issue once usage patterns are better understood.
     """
-    from utils.exceptions import NotFoundException, ValidationError as SvcValidationError
+    from utils.exceptions import NotFoundException
+    from utils.exceptions import ValidationError as SvcValidationError
 
     workspace_id = admin.get("current_workspace_id")
     if workspace_id is None:
@@ -326,12 +327,16 @@ async def rotate_connector_kmc_key(
             user_id=user_id,
         )
         await db.commit()
-    except NotFoundException:
+    except NotFoundException as exc:
         await db.rollback()
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found"
+        ) from exc
     except SvcValidationError as exc:
         await db.rollback()
-        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc)
+        ) from exc
     except HTTPException:
         raise
     except Exception as exc:

--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -93,6 +93,15 @@ class WorkspaceConnectorSummary(TZAwareBaseModel):
     created_by: str | None = None
 
 
+class RotateKmcKeyResponse(TZAwareBaseModel):
+    """Response after rotating a connector's KMC write key. Shown exactly once."""
+
+    connector_id: UUID
+    kmc_api_key: str = Field(..., description="New plaintext KMC write key; save immediately")
+    kmc_api_key_expires_at: datetime
+    config_version: int
+
+
 @router.post(
     "", response_model=WorkspaceConnectorCreateResponse, status_code=status.HTTP_201_CREATED
 )
@@ -278,3 +287,77 @@ async def delete_workspace_connector(
             detail="Failed to delete workspace connector",
         ) from exc
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post(
+    "/{connector_id}/rotate-kmc-key",
+    response_model=RotateKmcKeyResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def rotate_connector_kmc_key(
+    connector_id: UUID,
+    admin: WorkspaceAdmin,
+    db: AsyncSession = Depends(get_db),
+) -> RotateKmcKeyResponse:
+    """Rotate the KMC write key for a connector (workspace-admin scoped).
+
+    Revokes the current key immediately, mints a replacement with a 365-day
+    expiry, and bumps ``config_version`` so the worker re-fetches on its next
+    poll. The new plaintext key is returned exactly once.
+
+    **No grace period (v1)**: coordinate rotation during a maintenance window
+    or a brief pause in ai-worker activity; the old key is invalid as soon as
+    this call returns. A grace-period dual-key approach is deferred to a
+    follow-up issue once usage patterns are better understood.
+    """
+    from utils.exceptions import NotFoundException, ValidationError as SvcValidationError
+
+    workspace_id = admin.get("current_workspace_id")
+    if workspace_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No workspace selected. Please select a workspace first.",
+        )
+    user_id = admin["user_id"]
+    try:
+        plaintext_key = await ConnectorProvisioningService(db).rotate_kmc_key(
+            workspace_id=workspace_id,
+            connector_id=connector_id,
+            user_id=user_id,
+        )
+        # Re-fetch to return the updated connector fields.
+        from sqlalchemy import select as sa_select
+
+        from models.resource import WorkspaceConnector
+
+        result = await db.execute(
+            sa_select(WorkspaceConnector).where(WorkspaceConnector.id == connector_id)
+        )
+        connector = result.scalar_one()
+        await db.commit()
+    except NotFoundException:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Connector not found")
+    except SvcValidationError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(exc))
+    except HTTPException:
+        raise
+    except Exception as exc:
+        await db.rollback()
+        logger.error(
+            "workspace_connector_rotate_kmc_key_failed",
+            connector_id=str(connector_id),
+            workspace_id=str(workspace_id),
+            error=str(exc),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to rotate KMC write key",
+        ) from exc
+    return RotateKmcKeyResponse(
+        connector_id=connector_id,
+        kmc_api_key=plaintext_key,
+        kmc_api_key_expires_at=connector.kmc_api_key_expires_at,
+        config_version=connector.config_version,
+    )

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -518,6 +518,9 @@ class WorkspaceConnector(Base):
     # holds the encrypted plaintext so the worker config endpoint can hand it
     # back on every config fetch.
     kmc_api_key_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Expiry of the KMC write key. NULL = non-expiring (legacy). Set by the
+    # rotate endpoint; the worker config endpoint logs a warning when expired.
+    kmc_api_key_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     pii_guardrail_config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     litellm_virtual_key_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     config_version: Mapped[int] = mapped_column(

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -501,6 +501,82 @@ class ConnectorProvisioningService:
         await self.db.execute(delete(Resource).where(Resource.id == connector.resource_pk))
         return True
 
+    async def rotate_kmc_key(
+        self,
+        workspace_id: UUID,
+        connector_id: UUID,
+        user_id: str,
+        expires_days: int = 365,
+    ) -> str:
+        """Revoke the current KMC write key and mint a replacement.
+
+        Revokes the existing ``connector:{id}`` API key, mints a fresh
+        workspace-scoped key with the given expiry, Fernet-encrypts it on
+        the connector row, and bumps ``config_version`` so the worker
+        re-fetches on its next poll.
+
+        Returns:
+            Plaintext new KMC write key (shown exactly once to the caller).
+
+        Raises:
+            NotFoundException: if no matching connector exists in workspace.
+            ValidationError: if the connector has no KMC key to rotate
+                (registration flow was not completed).
+        """
+        from datetime import timedelta
+
+        from auth.api_keys import APIKeyManager
+        from models.auth import APIKey
+        from utils.datetime import utcnow
+
+        result = await self.db.execute(
+            select(WorkspaceConnector).where(
+                WorkspaceConnector.id == connector_id,
+                WorkspaceConnector.workspace_id == workspace_id,
+            )
+        )
+        connector = result.scalar_one_or_none()
+        if connector is None:
+            raise NotFoundException(f"Connector {connector_id} not found")
+        if not connector.kmc_api_key_encrypted:
+            raise ValidationError(
+                "Connector has no KMC write key; register with a write-target context first"
+            )
+
+        # Revoke the old key immediately — no grace period for v1.
+        # Operators should schedule rotation before the worker is active or
+        # during a brief maintenance window.
+        await self.db.execute(
+            update(APIKey)
+            .where(
+                APIKey.workspace_id == workspace_id,
+                APIKey.name == f"connector:{connector_id}",
+                APIKey.revoked_at.is_(None),
+            )
+            .values(revoked_at=utcnow())
+        )
+
+        # Mint replacement key.
+        plaintext_new_key, _ = await APIKeyManager(self.db).create_key(
+            name=f"connector:{connector_id}",
+            user_id=user_id,
+            workspace_id=workspace_id,
+            expires_days=expires_days,
+        )
+        connector.set_kmc_api_key(plaintext_new_key)
+        connector.kmc_api_key_expires_at = utcnow() + timedelta(days=expires_days)
+        connector.config_version = connector.config_version + 1
+        await self.db.flush()
+
+        logger.info(
+            "connector_kmc_key_rotated",
+            connector_id=str(connector_id),
+            workspace_id=str(workspace_id),
+            user_id=user_id,
+            expires_days=expires_days,
+        )
+        return plaintext_new_key
+
     async def _get_connector_for_resource(
         self,
         resource_pk: UUID,

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -47,6 +47,15 @@ class ConnectorProvisioningResult:
     plaintext_kmc_api_key: str | None = None
 
 
+@dataclass(frozen=True)
+class KmcKeyRotationResult:
+    """Result returned after rotating a connector's KMC write key (#892)."""
+
+    plaintext_kmc_api_key: str
+    expires_at: datetime
+    config_version: int
+
+
 class ConnectorProvisioningService:
     """Provision ai-worker chat-ingest connectors atomically.
 
@@ -507,7 +516,7 @@ class ConnectorProvisioningService:
         connector_id: UUID,
         user_id: str,
         expires_days: int = 365,
-    ) -> str:
+    ) -> KmcKeyRotationResult:
         """Revoke the current KMC write key and mint a replacement.
 
         Revokes the existing ``connector:{id}`` API key, mints a fresh
@@ -516,15 +525,15 @@ class ConnectorProvisioningService:
         re-fetches on its next poll.
 
         Returns:
-            Plaintext new KMC write key (shown exactly once to the caller).
+            ``KmcKeyRotationResult`` with the one-time plaintext key, the new
+            expiry, and the bumped config_version (so the caller need not
+            re-query the connector).
 
         Raises:
             NotFoundException: if no matching connector exists in workspace.
             ValidationError: if the connector has no KMC key to rotate
                 (registration flow was not completed).
         """
-        from datetime import timedelta
-
         from auth.api_keys import APIKeyManager
         from models.auth import APIKey
         from utils.datetime import utcnow
@@ -556,15 +565,17 @@ class ConnectorProvisioningService:
             .values(revoked_at=utcnow())
         )
 
-        # Mint replacement key.
-        plaintext_new_key, _ = await APIKeyManager(self.db).create_key(
+        # Mint replacement key. create_key computes and stores expires_at on the
+        # APIKey row; reuse that exact value for the connector column so the two
+        # never drift (a second utcnow() would differ by microseconds).
+        plaintext_new_key, new_key_row = await APIKeyManager(self.db).create_key(
             name=f"connector:{connector_id}",
             user_id=user_id,
             workspace_id=workspace_id,
             expires_days=expires_days,
         )
         connector.set_kmc_api_key(plaintext_new_key)
-        connector.kmc_api_key_expires_at = utcnow() + timedelta(days=expires_days)
+        connector.kmc_api_key_expires_at = new_key_row.expires_at
         connector.config_version = connector.config_version + 1
         await self.db.flush()
 
@@ -575,7 +586,11 @@ class ConnectorProvisioningService:
             user_id=user_id,
             expires_days=expires_days,
         )
-        return plaintext_new_key
+        return KmcKeyRotationResult(
+            plaintext_kmc_api_key=plaintext_new_key,
+            expires_at=new_key_row.expires_at,
+            config_version=connector.config_version,
+        )
 
     async def _get_connector_for_resource(
         self,

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -554,30 +554,42 @@ class ConnectorProvisioningService:
                 "Connector has no KMC write key; register with a write-target context first"
             )
 
-        # Revoke the old key immediately — no grace period for v1.
-        # Operators should schedule rotation before the worker is active or
-        # during a brief maintenance window.
-        #
-        # Revoke by the exact key_hash of the key currently stored on the
-        # connector — NOT by name. create_key only enforces name uniqueness
-        # per (user_id, workspace_id), so a name-only revoke could touch an
-        # unrelated user's key that happens to share the connector:{id} name.
-        await self.db.execute(
-            update(APIKey)
-            .where(
+        # Locate the exact active APIKey row backing the stored key (matched by
+        # key_hash, NOT name — create_key only enforces name uniqueness per
+        # (user_id, workspace_id), so a name match could hit an unrelated user's
+        # key). Fetching the row lets us (a) fail loudly if the stored key is
+        # stale instead of silently minting a duplicate, and (b) preserve the
+        # original owner's user_id on the replacement so rotation by a different
+        # admin doesn't transfer key ownership.
+        old_key_result = await self.db.execute(
+            select(APIKey).where(
                 APIKey.workspace_id == workspace_id,
                 APIKey.key_hash == sha256_hex(current_key),
                 APIKey.revoked_at.is_(None),
             )
-            .values(revoked_at=utcnow())
         )
+        old_key = old_key_result.scalar_one_or_none()
+        if old_key is None:
+            # Stored key matches no active APIKey row (Fernet secret rotated,
+            # external revocation, or DB drift). Fail with a clear diagnostic
+            # rather than letting create_key surface an opaque 500.
+            raise ValidationError(
+                "Connector's stored KMC key matches no active API key; "
+                "re-register the connector to mint a fresh key"
+            )
+        owner_user_id = old_key.user_id
 
-        # Mint replacement key. create_key computes and stores expires_at on the
-        # APIKey row; reuse that exact value for the connector column so the two
-        # never drift (a second utcnow() would differ by microseconds).
+        # Revoke the old key immediately — no grace period for v1. Operators
+        # should schedule rotation during a maintenance window or worker pause.
+        old_key.revoked_at = utcnow()
+
+        # Mint replacement key under the ORIGINAL owner (not the rotating admin)
+        # so per-user key listings stay correct. create_key computes and stores
+        # expires_at on the row; reuse that exact value for the connector column
+        # so the two never drift (a second utcnow() would differ by microseconds).
         plaintext_new_key, new_key_row = await APIKeyManager(self.db).create_key(
             name=f"connector:{connector_id}",
-            user_id=user_id,
+            user_id=owner_user_id,
             workspace_id=workspace_id,
             expires_days=expires_days,
         )
@@ -590,7 +602,8 @@ class ConnectorProvisioningService:
             "connector_kmc_key_rotated",
             connector_id=str(connector_id),
             workspace_id=str(workspace_id),
-            user_id=user_id,
+            rotated_by=user_id,
+            key_owner=owner_user_id,
             expires_days=expires_days,
         )
         return KmcKeyRotationResult(

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -537,6 +537,7 @@ class ConnectorProvisioningService:
         from auth.api_keys import APIKeyManager
         from models.auth import APIKey
         from utils.datetime import utcnow
+        from utils.hashing import sha256_hex
 
         result = await self.db.execute(
             select(WorkspaceConnector).where(
@@ -546,8 +547,9 @@ class ConnectorProvisioningService:
         )
         connector = result.scalar_one_or_none()
         if connector is None:
-            raise NotFoundException(f"Connector {connector_id} not found")
-        if not connector.kmc_api_key_encrypted:
+            raise NotFoundException("Connector", str(connector_id))
+        current_key = connector.get_kmc_api_key()
+        if not current_key:
             raise ValidationError(
                 "Connector has no KMC write key; register with a write-target context first"
             )
@@ -555,11 +557,16 @@ class ConnectorProvisioningService:
         # Revoke the old key immediately — no grace period for v1.
         # Operators should schedule rotation before the worker is active or
         # during a brief maintenance window.
+        #
+        # Revoke by the exact key_hash of the key currently stored on the
+        # connector — NOT by name. create_key only enforces name uniqueness
+        # per (user_id, workspace_id), so a name-only revoke could touch an
+        # unrelated user's key that happens to share the connector:{id} name.
         await self.db.execute(
             update(APIKey)
             .where(
                 APIKey.workspace_id == workspace_id,
-                APIKey.name == f"connector:{connector_id}",
+                APIKey.key_hash == sha256_hex(current_key),
                 APIKey.revoked_at.is_(None),
             )
             .values(revoked_at=utcnow())

--- a/backend/tests/api/test_workers.py
+++ b/backend/tests/api/test_workers.py
@@ -57,6 +57,8 @@ async def test_get_worker_config_returns_secrets_for_ready_connector():
         "installing_admin_user_id": "U01",
     }
     conn.get_kmc_api_key.return_value = "kagura_writekey"
+    # #892: expiry check reads this; None = non-expiring (avoids MagicMock < datetime)
+    conn.kmc_api_key_expires_at = None
     conn.get_llm_config.return_value = {"provider": "anthropic", "model": "m", "api_key": "sk"}
 
     with (

--- a/backend/tests/api/test_workspace_connectors.py
+++ b/backend/tests/api/test_workspace_connectors.py
@@ -184,3 +184,89 @@ async def test_delete_workspace_connector_404_when_missing():
     assert exc.value.status_code == 404
     db.rollback.assert_awaited_once()
     db.commit.assert_not_awaited()
+
+
+# --- rotate-kmc-key (#892) ---
+
+
+@pytest.mark.asyncio
+async def test_rotate_kmc_key_returns_new_key_on_success():
+    from datetime import datetime
+
+    from api.routes.workspace_connectors import rotate_connector_kmc_key
+    from services.connector_provisioning import KmcKeyRotationResult
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    ws_id = uuid4()
+    conn_id = uuid4()
+    admin = {"user_id": "user-1", "current_workspace_id": ws_id}
+    expires = datetime(2099, 1, 1)
+
+    with patch("api.routes.workspace_connectors.ConnectorProvisioningService") as service_cls:
+        service_cls.return_value.rotate_kmc_key = AsyncMock(
+            return_value=KmcKeyRotationResult(
+                plaintext_kmc_api_key="kmc-new-plaintext",
+                expires_at=expires,
+                config_version=3,
+            )
+        )
+        resp = await rotate_connector_kmc_key(conn_id, admin, db)
+
+    assert resp.connector_id == conn_id
+    assert resp.kmc_api_key == "kmc-new-plaintext"
+    assert resp.kmc_api_key_expires_at == expires
+    assert resp.config_version == 3
+    db.commit.assert_awaited_once()
+    service_cls.return_value.rotate_kmc_key.assert_awaited_once_with(
+        workspace_id=ws_id, connector_id=conn_id, user_id="user-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_rotate_kmc_key_404_when_connector_missing():
+    from fastapi import HTTPException
+
+    from api.routes.workspace_connectors import rotate_connector_kmc_key
+    from utils.exceptions import NotFoundException
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    admin = {"user_id": "user-1", "current_workspace_id": uuid4()}
+
+    with patch("api.routes.workspace_connectors.ConnectorProvisioningService") as service_cls:
+        service_cls.return_value.rotate_kmc_key = AsyncMock(
+            side_effect=NotFoundException("Connector", str(uuid4()))
+        )
+        with pytest.raises(HTTPException) as exc:
+            await rotate_connector_kmc_key(uuid4(), admin, db)
+
+    assert exc.value.status_code == 404
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rotate_kmc_key_422_when_no_kmc_key():
+    from fastapi import HTTPException
+
+    from api.routes.workspace_connectors import rotate_connector_kmc_key
+    from utils.exceptions import ValidationError
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+    db.rollback = AsyncMock()
+    admin = {"user_id": "user-1", "current_workspace_id": uuid4()}
+
+    with patch("api.routes.workspace_connectors.ConnectorProvisioningService") as service_cls:
+        service_cls.return_value.rotate_kmc_key = AsyncMock(
+            side_effect=ValidationError("Connector has no KMC write key")
+        )
+        with pytest.raises(HTTPException) as exc:
+            await rotate_connector_kmc_key(uuid4(), admin, db)
+
+    assert exc.value.status_code == 422
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_awaited()


### PR DESCRIPTION
Closes #892

## Summary
- Add `kmc_api_key_expires_at` column to `workspace_connectors` (migration e33; nullable, NULL = non-expiring legacy)
- Add `rotate_kmc_key()` service method: revoke current key → mint replacement (365-day expiry) → bump `config_version` → return `KmcKeyRotationResult`
- Add `POST /workspace-connectors/{connector_id}/rotate-kmc-key` (WorkspaceAdmin-gated); returns the new plaintext key exactly once
- Log a warning in `workers/config` when a connector's KMC key is expired (fail-open: key is still returned so the worker keeps running)

## Implementation notes
- **No grace period (v1)**: the old key is revoked immediately on rotate. Coordinate rotation with a maintenance window or a pause in ai-worker activity. A dual-key grace-period approach is deferred to a follow-up (see below).
- `revoke-before-mint` ordering avoids `create_key`'s same-name active-key conflict and ensures no two active keys coexist.
- Connector column reuses `new_key_row.expires_at` (the value `create_key` already computed) so `APIKey.expires_at` and `workspace_connectors.kmc_api_key_expires_at` never drift.
- `config_version` bump triggers the worker's existing re-fetch path — no new mechanism.

## Design decision (gate1 yellow)
Per CSO review, the scope is intentionally limited to expiry + rotation. Context-scoped least-privilege (narrowing blast radius from workspace to context) requires a non-public context-binding mechanism that does not exist yet — out of scope.

## Follow-ups (not in this PR)
- **Tests** (gate2 qa-lead yellow): rotate happy path, no-KMC-key 422, cross-workspace 404, expiry-warning firing. Deferred because the test infra requires Docker (pytest unavailable in the dev shell); CI runs them.
- **Grace-period dual-key** rotation once usage patterns are understood.
- **Expiry alerting/metrics** beyond the fail-open warning log.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green
- qa-lead: yellow (test follow-up)
- cto: green
- gate1: yellow via /ask (CSO — grace-period design note)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
