### PR TITLE
feat(api): workers/config returns connector resource token (#895)

### DIFF
--- a/backend/alembic/versions/e34_895_resource_token_enc.py
+++ b/backend/alembic/versions/e34_895_resource_token_enc.py
@@ -1,0 +1,26 @@
+"""Add resource_token_encrypted to workspace_connectors (#895).
+
+Stores the connector's resource token (X-Resource-API-Key) Fernet-encrypted
+so the worker config endpoint can return it for the resource-ingest write
+path (worker #91 Option A). NULL on legacy rows provisioned before this
+migration — the worker falls back to the kmc/remember path for those.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "e34_895_resource_token_enc"
+down_revision = "e33_892_kmc_key_expiry"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspace_connectors",
+        sa.Column("resource_token_encrypted", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspace_connectors", "resource_token_encrypted")

--- a/backend/src/api/routes/workers.py
+++ b/backend/src/api/routes/workers.py
@@ -128,7 +128,13 @@ async def get_worker_config(
         from models.resource import Resource
 
         slug_result = await db.execute(
-            select(Resource.resource_id).where(Resource.id == connector.resource_pk)
+            select(Resource.resource_id).where(
+                Resource.id == connector.resource_pk,
+                # Defense-in-depth: workspace_id is denormalized and must match
+                # the connector's; the predicate prevents returning a slug from
+                # another workspace if the FK ever drifts.
+                Resource.workspace_id == connector.workspace_id,
+            )
         )
         resource_slug = slug_result.scalar_one_or_none()
         if resource_slug:

--- a/backend/src/api/routes/workers.py
+++ b/backend/src/api/routes/workers.py
@@ -67,6 +67,10 @@ class WorkerConnectorConfig(TZAwareBaseModel):
     locale: str | None = None
     slack: dict[str, Any]
     kmc: dict[str, Any]
+    # #895: resource-ingest credentials for worker #91 Option A. NULL on legacy
+    # connectors provisioned before the resource-token-encrypted column existed —
+    # the worker falls back to the kmc/remember write path when absent.
+    resource: dict[str, Any] | None = None
     llm: dict[str, Any] | None = None
     pii_guardrail_config: dict[str, Any] | None = None
 
@@ -111,6 +115,25 @@ async def get_worker_config(
         "installing_admin_user_id": oauth.get("installing_admin_user_id"),
         "channel_ids": connector.channel_ids or [],
     }
+
+    # #895: resource-ingest credentials for worker #91 Option A. Only emitted
+    # when the connector has a stored resource token (legacy rows lack it →
+    # worker uses the kmc/remember fallback). Resolve the resource slug from
+    # resource_pk for the POST /api/v1/resources/{resource_id}/events path.
+    resource_block = None
+    resource_token = connector.get_resource_token()
+    if resource_token:
+        from sqlalchemy import select
+
+        from models.resource import Resource
+
+        slug_result = await db.execute(
+            select(Resource.resource_id).where(Resource.id == connector.resource_pk)
+        )
+        resource_slug = slug_result.scalar_one_or_none()
+        if resource_slug:
+            resource_block = {"id": resource_slug, "api_key": resource_token}
+
     return WorkerConnectorConfig(
         connector_id=connector.id,
         workspace_id=connector.workspace_id,
@@ -119,6 +142,7 @@ async def get_worker_config(
         locale=connector.locale,
         slack=slack,
         kmc={"mcp_url": get_settings().kmc_mcp_url, "api_key": kmc_api_key},
+        resource=resource_block,
         llm=connector.get_llm_config(),
         pii_guardrail_config=connector.pii_guardrail_config,
     )

--- a/backend/src/models/resource.py
+++ b/backend/src/models/resource.py
@@ -521,6 +521,12 @@ class WorkspaceConnector(Base):
     # Expiry of the KMC write key. NULL = non-expiring (legacy). Set by the
     # rotate endpoint; the worker config endpoint logs a warning when expired.
     kmc_api_key_expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+    # Fernet ciphertext of the connector's resource token (X-Resource-API-Key,
+    # #895). resource_tokens stores only the SHA256 hash, so the one-time
+    # plaintext is captured here at provision time for the worker config
+    # endpoint to return (resource-ingest write path, worker #91 Option A).
+    # NULL on legacy rows → the worker falls back to the kmc/remember path.
+    resource_token_encrypted: Mapped[str | None] = mapped_column(Text, nullable=True)
     pii_guardrail_config: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     litellm_virtual_key_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     config_version: Mapped[int] = mapped_column(
@@ -617,6 +623,23 @@ class WorkspaceConnector(Base):
         if not self.kmc_api_key_encrypted:
             return None
         return get_encryptor().decrypt(self.kmc_api_key_encrypted)
+
+    def set_resource_token(self, plaintext: str | None) -> None:
+        """Encrypt and store the connector's resource token (X-Resource-API-Key, #895)."""
+        from utils.encryption import get_encryptor
+
+        if not plaintext:
+            self.resource_token_encrypted = None
+            return
+        self.resource_token_encrypted = get_encryptor().encrypt(plaintext)
+
+    def get_resource_token(self) -> str | None:
+        """Decrypt and return the resource token plaintext, or ``None`` if unset."""
+        from utils.encryption import get_encryptor
+
+        if not self.resource_token_encrypted:
+            return None
+        return get_encryptor().decrypt(self.resource_token_encrypted)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -216,6 +216,11 @@ class ConnectorProvisioningService:
                 quota_events_per_hour=quota_events_per_hour,
                 created_by=user_id,
             )
+            # #895: capture the one-time resource-token plaintext encrypted on
+            # the connector so the worker config endpoint can return it for the
+            # resource-ingest write path. resource_tokens only stores the hash.
+            connector.set_resource_token(plaintext_token)
+            await self.db.flush()
         except Exception:
             # Delete the committed auto-created context so it is not orphaned.
             if auto_created_context_id is not None:

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -219,8 +219,12 @@ class ConnectorProvisioningService:
             # #895: capture the one-time resource-token plaintext encrypted on
             # the connector so the worker config endpoint can return it for the
             # resource-ingest write path. resource_tokens only stores the hash.
-            connector.set_resource_token(plaintext_token)
-            await self.db.flush()
+            # Guarded by context (mirrors the kmc key): the worker config
+            # endpoint 404s without a write-target context, so a context-less
+            # connector is never worker-usable and need not store the token.
+            if resolved_context_id is not None:
+                connector.set_resource_token(plaintext_token)
+                await self.db.flush()
         except Exception:
             # Delete the committed auto-created context so it is not orphaned.
             if auto_created_context_id is not None:

--- a/backend/tests/api/test_workers.py
+++ b/backend/tests/api/test_workers.py
@@ -59,6 +59,9 @@ async def test_get_worker_config_returns_secrets_for_ready_connector():
     conn.get_kmc_api_key.return_value = "kagura_writekey"
     # #892: expiry check reads this; None = non-expiring (avoids MagicMock < datetime)
     conn.kmc_api_key_expires_at = None
+    # #895: no stored resource token → resource block skipped (avoids awaiting a
+    # MagicMock db.execute for the slug lookup). Covered separately below.
+    conn.get_resource_token.return_value = None
     conn.get_llm_config.return_value = {"provider": "anthropic", "model": "m", "api_key": "sk"}
 
     with (
@@ -77,6 +80,43 @@ async def test_get_worker_config_returns_secrets_for_ready_connector():
     svc.return_value.get_connector_for_dispatch.assert_awaited_once_with(
         connector_type="slack", external_team_id="T01"
     )
+    # #895: legacy connector (no stored resource token) → resource omitted.
+    assert result.resource is None
+
+
+@pytest.mark.asyncio
+async def test_get_worker_config_includes_resource_block_when_token_present():
+    # #895: a connector with a stored resource token returns the resource block
+    # {id, api_key} for the resource-ingest write path.
+    db = MagicMock()
+    slug_result = MagicMock()
+    slug_result.scalar_one_or_none.return_value = "slack_general"
+    db.execute = AsyncMock(return_value=slug_result)
+
+    conn = MagicMock()
+    conn.id = uuid4()
+    conn.workspace_id = uuid4()
+    conn.context_id = uuid4()
+    conn.connector_type = "slack"
+    conn.locale = "ja"
+    conn.external_team_id = "T01"
+    conn.channel_ids = ["C01"]
+    conn.pii_guardrail_config = None
+    conn.resource_pk = uuid4()
+    conn.get_oauth_tokens.return_value = {"bot_token": "xoxb-x"}
+    conn.get_kmc_api_key.return_value = "kagura_writekey"
+    conn.kmc_api_key_expires_at = None
+    conn.get_resource_token.return_value = "kgr_resource_token"
+    conn.get_llm_config.return_value = None
+
+    with (
+        patch("api.routes.workers.get_settings", return_value=_settings()),
+        patch("api.routes.workers.ConnectorProvisioningService") as svc,
+    ):
+        svc.return_value.get_connector_for_dispatch = AsyncMock(return_value=conn)
+        result = await get_worker_config(platform="slack", team_id="T01", _=None, db=db)
+
+    assert result.resource == {"id": "slack_general", "api_key": "kgr_resource_token"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #895

## Summary
- Add `resource_token_encrypted` column to `workspace_connectors` (migration e34) + `set_resource_token`/`get_resource_token` helpers mirroring the `kmc_api_key` pattern
- Capture the one-time resource-token plaintext Fernet-encrypted at provision time (`resource_tokens` stores only the SHA256 hash, so it cannot be re-derived later)
- `GET /api/v1/workers/config` now returns `resource={"id": resource_slug, "api_key": <X-Resource-API-Key>}` when the connector has a stored token — for the resource-ingest write path (worker #91 Option A)
- Legacy connectors (no stored token) return `resource=null`; the worker falls back to the kmc/remember path

## Implementation notes
- Resource token is **resource-scoped** (tighter blast radius than the workspace-scoped `kmc_api_key`); both coexist during the worker's write-path migration
- The resource slug is resolved from `resource_pk` only when a token is present (conditional single-PK lookup, negligible hot-path cost)
- Migration `e34` chains onto `e33` (#892) — single linear head, no dual-head (rebased after #892 merged)

## Security
- **#891 internal-network guard (PR #898) is the prerequisite** for returning a second secret keyed by the public `team_id` — merged.
- No-log discipline preserved: the token appears only in the response body, never in logs.

## Tests
- `test_get_worker_config_includes_resource_block_when_token_present`
- legacy `resource=None` assertion added to the existing ready-connector test
- 17 tests pass in `test_workers.py` + `test_workspace_connectors.py`

## Follow-ups (not in this PR)
- QA gate2 noted a minor untested edge: `resource_token` present but `resource_pk` slug lookup returns `None` (defensive path; `resource_pk` is non-nullable so unreachable in practice). Add a regression test in the follow-up.
- Resource-token rotation (mirror #892's KMC rotation) when needed.

## Pre-PR review summary
- gate2 mode: advisor-only
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CSO)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
