### PR TITLE
feat(indexer): preserve opaque details + source_uri in resource_indexer projection (#896)

### DIFF
--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -42,6 +42,11 @@ from utils.sparse_vector import build_resource_sparse_vector
 
 logger = get_logger(__name__)
 
+# #896: Memory.source_uri is String(2048); a longer worker-supplied URI is
+# dropped (not truncated) so a corrupted slack:// prefix can't break
+# find_by_channel and a flush DataError can't poison the event offset.
+_SOURCE_URI_MAX_LEN = 2048
+
 
 @dataclass
 class IndexerMetrics:
@@ -487,6 +492,72 @@ class ResourceIndexer:
             "metadata": metadata,
         }
 
+    # #896: details keys that drive persisted Computed columns the resource path
+    # must NOT let a worker populate — a worker-supplied external_blob would make
+    # external_blob_backend/ref non-NULL (triggering R2 blob/retention logic on a
+    # non-blob memory), and trigger would make a resource_data memory surface as a
+    # Time Memory. resource_id/doc_id are also computed-backed but the indexer
+    # overwrites those itself, so they need no stripping.
+    _LINEAGE_RESERVED_KEYS = frozenset({"external_blob", "trigger"})
+
+    def _extract_worker_lineage(self, event: ResourceEvent) -> tuple[dict[str, Any], str | None]:
+        """Extract ai-worker lineage (#896) from event_metadata.
+
+        Returns ``(memory_details, source_uri)``. Both default to empty/None for
+        non-worker events. Malformed values are dropped with a warning rather
+        than silently masked, so worker schema bugs surface in logs.
+        """
+        meta = event.event_metadata or {}
+
+        raw_details = meta.get("memory_details")
+        if raw_details is None:
+            opaque_details: dict[str, Any] = {}
+        elif isinstance(raw_details, dict):
+            opaque_details = dict(raw_details)
+            # Strip computed-column source keys (defense against pollution).
+            reserved = self._LINEAGE_RESERVED_KEYS & opaque_details.keys()
+            if reserved:
+                logger.warning(
+                    "ingest_event_lineage_reserved_keys_stripped",
+                    event_id=event.id,
+                    keys=sorted(reserved),
+                )
+                for key in reserved:
+                    opaque_details.pop(key, None)
+        else:
+            logger.warning(
+                "ingest_event_memory_details_not_dict",
+                event_id=event.id,
+                got_type=type(raw_details).__name__,
+            )
+            opaque_details = {}
+
+        raw_uri = meta.get("source_uri")
+        source_uri: str | None
+        if raw_uri is None:
+            source_uri = None
+        elif not isinstance(raw_uri, str):
+            logger.warning(
+                "ingest_event_source_uri_not_str",
+                event_id=event.id,
+                got_type=type(raw_uri).__name__,
+            )
+            source_uri = None
+        elif len(raw_uri) > _SOURCE_URI_MAX_LEN:
+            # Drop (don't truncate — a corrupted slack:// prefix would break
+            # find_by_channel) and don't poison the event with a flush DataError.
+            logger.warning(
+                "ingest_event_source_uri_too_long",
+                event_id=event.id,
+                length=len(raw_uri),
+                max_length=_SOURCE_URI_MAX_LEN,
+            )
+            source_uri = None
+        else:
+            source_uri = raw_uri
+
+        return opaque_details, source_uri
+
     async def _apply_upsert(
         self,
         event: ResourceEvent,
@@ -519,13 +590,7 @@ class ResourceIndexer:
         # Both are optional; absent (non-worker resources) → legacy behavior.
         # event_metadata lives on the event, NOT in payload, so payload/content
         # stays pure document data (mirrors the ResourceEventRequest precedent).
-        meta = event.event_metadata or {}
-        opaque_details = meta.get("memory_details") or {}
-        if not isinstance(opaque_details, dict):
-            opaque_details = {}
-        lineage_source_uri = meta.get("source_uri")
-        if not isinstance(lineage_source_uri, str):
-            lineage_source_uri = None
+        opaque_details, lineage_source_uri = self._extract_worker_lineage(event)
 
         # 1. Project payload
         projected = self._project_payload(event.payload, schema)
@@ -681,8 +746,10 @@ class ResourceIndexer:
                     # Bugfix: Keep timezone for ISO string
                     "indexed_at": to_utc_iso(utcnow()),
                 }
-                if lineage_source_uri is not None:
-                    existing_memory.source_uri = lineage_source_uri
+                # Always assign (mirrors the create branch) — re-indexing a doc
+                # whose event carries no lineage must clear a stale source_uri,
+                # not leave it matching spurious source_uri_prefix queries.
+                existing_memory.source_uri = lineage_source_uri
                 # Bugfix: Remove timezone for DB compatibility
                 existing_memory.updated_at = utcnow()
                 existing_memory.embedding_status = "success"

--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -510,6 +510,23 @@ class ResourceIndexer:
             logger.warning("upsert_event_has_no_payload", event_id=event.id)
             return
 
+        # #896: opaque lineage passthrough. The ai-worker (resource-ingest write
+        # path, worker #91 Option A) supplies the recall-contract lineage in
+        # event_metadata so an ingest_event-written Memory is byte-equivalent in
+        # details + source_uri to a remember()-written one:
+        #   event_metadata["memory_details"] -> merged into Memory.details
+        #   event_metadata["source_uri"]     -> Memory.source_uri
+        # Both are optional; absent (non-worker resources) → legacy behavior.
+        # event_metadata lives on the event, NOT in payload, so payload/content
+        # stays pure document data (mirrors the ResourceEventRequest precedent).
+        meta = event.event_metadata or {}
+        opaque_details = meta.get("memory_details") or {}
+        if not isinstance(opaque_details, dict):
+            opaque_details = {}
+        lineage_source_uri = meta.get("source_uri")
+        if not isinstance(lineage_source_uri, str):
+            lineage_source_uri = None
+
         # 1. Project payload
         projected = self._project_payload(event.payload, schema)
 
@@ -650,13 +667,22 @@ class ResourceIndexer:
                 existing_memory.importance = (
                     event.importance if event.importance is not None else 0.6
                 )
+                # #896: worker lineage keys first, indexer lifecycle keys layered
+                # on top. The two sets are orthogonal (worker: connector_id /
+                # platform / team_id / channel_id / thread_ts / source_message_ids;
+                # indexer: resource_id / doc_id / version / indexed_at), so neither
+                # clobbers the other — the spread order just makes the indexer's
+                # lifecycle identity authoritative.
                 existing_memory.details = {
+                    **opaque_details,
                     "resource_id": event.resource_id,
                     "doc_id": event.doc_id,
                     "version": event.version,
                     # Bugfix: Keep timezone for ISO string
                     "indexed_at": to_utc_iso(utcnow()),
                 }
+                if lineage_source_uri is not None:
+                    existing_memory.source_uri = lineage_source_uri
                 # Bugfix: Remove timezone for DB compatibility
                 existing_memory.updated_at = utcnow()
                 existing_memory.embedding_status = "success"
@@ -686,13 +712,20 @@ class ResourceIndexer:
                     summary=summary[:500],
                     context_summary=context_summary,
                     content=json.dumps(event.payload, ensure_ascii=False),
+                    # #896: worker lineage keys first, indexer lifecycle keys on
+                    # top (orthogonal sets — see the update branch comment).
                     details={
+                        **opaque_details,
                         "resource_id": event.resource_id,
                         "doc_id": event.doc_id,
                         "version": event.version,
                         # Bugfix: Keep timezone for ISO string
                         "indexed_at": to_utc_iso(utcnow()),
                     },
+                    # #896: source_uri from worker lineage (slack://…) so
+                    # source_uri_prefix queries (find_by_channel) work; NULL for
+                    # non-worker resources (legacy behavior).
+                    source_uri=lineage_source_uri,
                     type="resource_data",
                     # P0-2: Fix - use 'is not None' to allow importance=0.0
                     importance=event.importance if event.importance is not None else 0.6,

--- a/backend/tests/services/test_resource_indexer.py
+++ b/backend/tests/services/test_resource_indexer.py
@@ -184,6 +184,62 @@ class TestResourceIndexerNamedVectorUpsert:
 
         assert first_id == second_id
 
+    @pytest.mark.asyncio
+    async def test_apply_upsert_passes_through_worker_lineage(self, indexer, mock_db):
+        """#896: event_metadata.memory_details + source_uri project onto the
+        created Memory so an ingest_event-written memory is byte-equivalent (in
+        details + source_uri) to a remember()-written one. The 6 worker lineage
+        keys survive and coexist with the indexer's 4 lifecycle keys."""
+        event = _make_event()
+        event.event_metadata = {
+            "memory_details": {
+                "connector_id": "c-1",
+                "platform": "slack",
+                "team_id": "T01",
+                "channel_id": "C01",
+                "thread_ts": "1700000000.0001",
+                "source_message_ids": ["1700000000.0001"],
+            },
+            "source_uri": "slack://c-1/T01/C01/1700000000.0001",
+        }
+        schema = _make_schema()
+        context = _make_context()
+
+        await indexer._apply_upsert(
+            event, schema, context, "kagura_memories", indexer.embedding_service
+        )
+
+        memory = mock_db.add.call_args.args[0]
+        # All 6 worker lineage keys preserved (recall scope guard reads these).
+        assert memory.details["channel_id"] == "C01"
+        assert memory.details["thread_ts"] == "1700000000.0001"
+        assert memory.details["connector_id"] == "c-1"
+        assert memory.details["source_message_ids"] == ["1700000000.0001"]
+        # Indexer lifecycle keys coexist (authoritative).
+        assert memory.details["resource_id"] == "res_test"
+        assert memory.details["doc_id"] == "doc_1"
+        assert memory.details["version"] == 1
+        assert "indexed_at" in memory.details
+        # source_uri set so source_uri_prefix (find_by_channel) works.
+        assert memory.source_uri == "slack://c-1/T01/C01/1700000000.0001"
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_without_lineage_keeps_legacy_shape(self, indexer, mock_db):
+        """#896: non-worker resources (no event_metadata lineage) keep the legacy
+        4-key details and NULL source_uri — backward compatible."""
+        event = _make_event()
+        event.event_metadata = None
+        schema = _make_schema()
+        context = _make_context()
+
+        await indexer._apply_upsert(
+            event, schema, context, "kagura_memories", indexer.embedding_service
+        )
+
+        memory = mock_db.add.call_args.args[0]
+        assert set(memory.details.keys()) == {"resource_id", "doc_id", "version", "indexed_at"}
+        assert memory.source_uri is None
+
 
 class TestResolveContextRouting:
     """Issue #334 (Layer B) + #338 (Layer C) + #341 (shared helper).

--- a/backend/tests/services/test_resource_indexer.py
+++ b/backend/tests/services/test_resource_indexer.py
@@ -240,6 +240,119 @@ class TestResourceIndexerNamedVectorUpsert:
         assert set(memory.details.keys()) == {"resource_id", "doc_id", "version", "indexed_at"}
         assert memory.source_uri is None
 
+    @staticmethod
+    def _db_with_existing(existing_memory):
+        """Build a db whose first execute() returns an existing memory (update
+        path) and second returns an empty old-version scan."""
+        db = AsyncMock()
+        existing = MagicMock()
+        existing.scalar_one_or_none.return_value = existing_memory
+        old_versions = MagicMock()
+        old_versions.scalars.return_value.all.return_value = []
+        call_count = 0
+
+        def _side_effect(*_a, **_k):
+            nonlocal call_count
+            call_count += 1
+            return existing if call_count % 2 == 1 else old_versions
+
+        db.execute.side_effect = _side_effect
+        db.add = MagicMock()
+        return db
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_update_path_projects_lineage(self):
+        """#896: the UPDATE (re-index) branch also projects worker lineage onto
+        the existing memory's details + source_uri."""
+        existing_memory = MagicMock()
+        db = self._db_with_existing(existing_memory)
+        with patch("services.resource_indexer.get_qdrant_client", return_value=AsyncMock()):
+            indexer = ResourceIndexer(db)
+        indexer.embedding_service = MagicMock()
+        indexer.embedding_service.embed = AsyncMock(return_value=[0.1] * 512)
+
+        event = _make_event()
+        event.event_metadata = {
+            "memory_details": {"channel_id": "C01", "thread_ts": "1700000000.0001"},
+            "source_uri": "slack://c-1/T01/C01/1700000000.0001",
+        }
+        await indexer._apply_upsert(
+            event, _make_schema(), _make_context(), "kagura_memories", indexer.embedding_service
+        )
+
+        assert existing_memory.details["channel_id"] == "C01"
+        assert existing_memory.details["resource_id"] == "res_test"
+        assert existing_memory.source_uri == "slack://c-1/T01/C01/1700000000.0001"
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_update_path_clears_stale_source_uri(self):
+        """#896 (haiku review): re-indexing a doc whose event carries NO lineage
+        must CLEAR a previously-set source_uri, not leave it stale (symmetry with
+        the create branch)."""
+        existing_memory = MagicMock()
+        existing_memory.source_uri = "slack://old/stale/uri"  # from a prior index
+        db = self._db_with_existing(existing_memory)
+        with patch("services.resource_indexer.get_qdrant_client", return_value=AsyncMock()):
+            indexer = ResourceIndexer(db)
+        indexer.embedding_service = MagicMock()
+        indexer.embedding_service.embed = AsyncMock(return_value=[0.1] * 512)
+
+        event = _make_event()
+        event.event_metadata = None  # no lineage this time
+        await indexer._apply_upsert(
+            event, _make_schema(), _make_context(), "kagura_memories", indexer.embedding_service
+        )
+
+        assert existing_memory.source_uri is None
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_strips_computed_column_keys(self, indexer, mock_db):
+        """#896 (haiku review): worker-supplied external_blob/trigger keys are
+        stripped so they can't pollute the persisted Computed columns."""
+        event = _make_event()
+        event.event_metadata = {
+            "memory_details": {
+                "channel_id": "C01",
+                "external_blob": {"backend": "r2", "ref": "x"},
+                "trigger": {"from": "2099", "until": "2100"},
+            },
+        }
+        await indexer._apply_upsert(
+            event, _make_schema(), _make_context(), "kagura_memories", indexer.embedding_service
+        )
+
+        memory = mock_db.add.call_args.args[0]
+        assert memory.details["channel_id"] == "C01"
+        assert "external_blob" not in memory.details
+        assert "trigger" not in memory.details
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_drops_oversized_source_uri(self, indexer, mock_db):
+        """#896 (haiku review): a source_uri longer than the column width is
+        dropped (None), not assigned — avoids a flush DataError poisoning the
+        event offset."""
+        event = _make_event()
+        event.event_metadata = {"source_uri": "slack://" + "x" * 3000}
+        await indexer._apply_upsert(
+            event, _make_schema(), _make_context(), "kagura_memories", indexer.embedding_service
+        )
+
+        memory = mock_db.add.call_args.args[0]
+        assert memory.source_uri is None
+
+    @pytest.mark.asyncio
+    async def test_apply_upsert_non_dict_memory_details_ignored(self, indexer, mock_db):
+        """#896 (haiku review): a non-dict memory_details (worker schema bug) is
+        dropped to the legacy 4-key shape, not crashed on."""
+        event = _make_event()
+        event.event_metadata = {"memory_details": 0}  # falsy non-dict
+        await indexer._apply_upsert(
+            event, _make_schema(), _make_context(), "kagura_memories", indexer.embedding_service
+        )
+
+        memory = mock_db.add.call_args.args[0]
+        assert set(memory.details.keys()) == {"resource_id", "doc_id", "version", "indexed_at"}
+
 
 class TestResolveContextRouting:
     """Issue #334 (Layer B) + #338 (Layer C) + #341 (shared helper).


### PR DESCRIPTION
Closes #896

## Summary
- Extend the `resource_indexer` Memory projection so an `ingest_event`-written memory is byte-equivalent in `details` + `source_uri` to a `remember()`-written one (worker #91 Option A prerequisite)
- Worker lineage travels in `event_metadata` (NOT payload — keeps payload pure document data):
  - `event_metadata["memory_details"]` (dict) → merged into `Memory.details` (worker's 6 lineage keys + indexer's 4 lifecycle keys, indexer authoritative)
  - `event_metadata["source_uri"]` (str) → `Memory.source_uri`
- Applied to both create and update branches of `_apply_upsert`, symmetrically
- Legacy / non-worker resources keep the 4-key details + NULL source_uri (backward compatible)

## Why this matters
Without this, worker memories written via the resource-ingest path silently break two recall contracts:
1. recall scope guard reads `details.channel_id` / `details.thread_ts`
2. `find_by_channel` selects on `source_uri_prefix`

This is write-once / un-retrofittable — lineage cannot be added to already-written memories.

## Hardening (from haiku review)
- **source_uri symmetry**: update branch always assigns source_uri (clears a stale value on re-index without lineage)
- **reserved-key strip**: `external_blob` / `trigger` stripped from worker `memory_details` so they can't pollute the persisted Computed columns (R2 blob / Time Memory) on a `resource_data` memory
- **oversized source_uri**: a URI longer than the `String(2048)` column is dropped (not truncated/assigned) so a flush DataError can't poison the event offset
- **malformed input**: non-dict `memory_details` / non-str `source_uri` are dropped with a warning instead of silently masked

## Tests
`test_resource_indexer.py` +7 lineage tests (create + update paths, reserved-key strip, oversized drop, non-dict ignore, legacy shape). 18 pass. Conformance pairs with the worker's `test_sdk_conformance` (cross-repo).

## Follow-ups (not in this PR)
- CTO gate2: add a sync guard test asserting the reserved-key denylist (`external_blob`, `trigger`) stays in sync with Memory's `details`-backed Computed columns, so a future computed column can't silently bypass the strip.

## Pre-PR review summary
- gate2 mode: advisor-only
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (CIO)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
