### PR TITLE
feat(frontend): PII config UI + connector reveal redesign (#890, #893)

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -50,8 +50,9 @@ import {
 const CONNECTOR_NAME_MAX = 100;
 
 // #890: Presidio recognizer names offered in the PII config UI. Kept in sync
-// with the worker's recognizer set; the backend validates only that detectors
-// is a non-empty list of non-blank strings (PiiGuardrailConfig).
+// with the worker's recognizer set; the backend validates the full
+// PiiGuardrailConfig shape (extra keys forbidden, redaction enum, non-blank locale,
+// and requires detectors when enabled).
 const PII_DETECTORS = [
   "EMAIL_ADDRESS",
   "PHONE_NUMBER",

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -14,6 +14,13 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   AlertDialog,
   AlertDialogAction,
   AlertDialogCancel,
@@ -423,20 +430,21 @@ export default function ConnectorsPage() {
                     >
                       {t("piiRedaction")}
                     </label>
-                    <select
-                      id="conn-pii-redaction"
-                      className="h-9 w-full rounded-md border bg-transparent px-2 text-sm"
+                    <Select
                       value={piiRedaction}
-                      onChange={(e) =>
-                        setPiiRedaction(e.target.value as PiiRedaction)
-                      }
+                      onValueChange={(v) => setPiiRedaction(v as PiiRedaction)}
                     >
-                      {PII_REDACTION_MODES.map((m) => (
-                        <option key={m} value={m}>
-                          {t(`piiRedaction_${m}`)}
-                        </option>
-                      ))}
-                    </select>
+                      <SelectTrigger id="conn-pii-redaction" className="h-9">
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {PII_REDACTION_MODES.map((m) => (
+                          <SelectItem key={m} value={m}>
+                            {t(`piiRedaction_${m}`)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                   </div>
                   <label className="flex items-center gap-2 text-sm">
                     <input

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { Plug, Trash2 } from "lucide-react";
+import { Check, Copy, Plug, Trash2 } from "lucide-react";
 
 import { PageContainer } from "@/components/common/PageContainer";
 import { PageHeader } from "@/components/common/PageHeader";
@@ -24,6 +24,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
+import { API_BASE_URL } from "@/lib/api/base";
 import {
   createConnector,
   deleteConnector,
@@ -40,12 +41,64 @@ import {
 // limit (100); resource_id allows up to 255 so 100 is safe for both uses.
 const CONNECTOR_NAME_MAX = 100;
 
+// #890: Presidio recognizer names offered in the PII config UI. Kept in sync
+// with the worker's recognizer set; the backend validates only that detectors
+// is a non-empty list of non-blank strings (PiiGuardrailConfig).
+const PII_DETECTORS = [
+  "EMAIL_ADDRESS",
+  "PHONE_NUMBER",
+  "CREDIT_CARD",
+  "PERSON",
+  "IP_ADDRESS",
+  "IBAN_CODE",
+] as const;
+const PII_DEFAULT_DETECTORS = [
+  "EMAIL_ADDRESS",
+  "PHONE_NUMBER",
+  "CREDIT_CARD",
+  "PERSON",
+];
+const PII_REDACTION_MODES = ["mask", "hash", "remove"] as const;
+type PiiRedaction = (typeof PII_REDACTION_MODES)[number];
+
+// #893: copy-pastable curl against the resource-ingest API for manual CLI
+// testing (verify events become memories without a worker). Single-quote the
+// header value so a token with shell metacharacters is safe to paste.
+function curlSample(resourceId: string, token: string): string {
+  return [
+    `curl -X POST '${API_BASE_URL}/api/v1/resources/${resourceId}/events' \\`,
+    `  -H 'X-Resource-API-Key: ${token}' \\`,
+    `  -H 'Content-Type: application/json' \\`,
+    `  -d '{"op":"upsert","doc_id":"test-1","payload":{"text":"hello"}}'`,
+  ].join("\n");
+}
+
 function toResourceId(seed: string): string {
   const slug = seed
     .toLowerCase()
     .replace(/[^a-z0-9_-]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return `slack-${slug || "team"}`.slice(0, CONNECTOR_NAME_MAX);
+}
+
+/** Inline copy-to-clipboard button with a transient checkmark. */
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      aria-label={label}
+      onClick={() => {
+        void navigator.clipboard.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+    >
+      {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+    </Button>
+  );
 }
 
 export default function ConnectorsPage() {
@@ -67,6 +120,15 @@ export default function ConnectorsPage() {
   const [contextName, setContextName] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [createError, setCreateError] = useState<string | null>(null);
+
+  // #890: PII guardrail config for the create form. Defaults scrub on by
+  // default so an admin who touches nothing still ships a safe config.
+  const [piiEnabled, setPiiEnabled] = useState(true);
+  const [piiDetectors, setPiiDetectors] = useState<string[]>(
+    PII_DEFAULT_DETECTORS,
+  );
+  const [piiRedaction, setPiiRedaction] = useState<PiiRedaction>("mask");
+  const [piiFailClosed, setPiiFailClosed] = useState(true);
 
   // One-time credentials reveal after a successful create
   const [created, setCreated] = useState<CreateConnectorResponse | null>(null);
@@ -132,17 +194,23 @@ export default function ConnectorsPage() {
     setSubmitting(true);
     setCreateError(null);
     try {
+      // #890: build a valid pii_guardrail_config. When disabled, send an
+      // empty detectors list (backend only requires non-empty when enabled);
+      // when enabled, the UI guarantees ≥1 detector (submit is blocked
+      // otherwise) so the {enabled:true, detectors:[]} 422 can't occur.
       const result = await createConnector({
         connector_type: "slack",
         resource_id: toResourceId(pending.team_id),
         display_name: displayName || undefined,
         auto_create_context_name: contextName || undefined,
         slack_install_handle: installHandle,
-        // pii_guardrail_config is intentionally left unset: the backend rejects
-        // `{enabled:true}` without a non-empty `detectors` list. An omitted field
-        // is received by FastAPI as None, which the contract treats as
-        // fail-closed (the ai-worker scrubs at ingest). A detector-config UI is
-        // a follow-up.
+        pii_guardrail_config: {
+          enabled: piiEnabled,
+          detectors: piiEnabled ? piiDetectors : [],
+          redaction: piiRedaction,
+          locale: "en",
+          fail_closed: piiFailClosed,
+        },
       });
       setPending(null);
       setCreated(result);
@@ -153,7 +221,18 @@ export default function ConnectorsPage() {
     } finally {
       setSubmitting(false);
     }
-  }, [installHandle, pending, displayName, contextName, router, reload]);
+  }, [
+    installHandle,
+    pending,
+    displayName,
+    contextName,
+    piiEnabled,
+    piiDetectors,
+    piiRedaction,
+    piiFailClosed,
+    router,
+    reload,
+  ]);
 
   const handleDelete = useCallback(async () => {
     if (!toDelete) return;
@@ -201,13 +280,25 @@ export default function ConnectorsPage() {
               key={c.connector_id}
               className="flex items-center justify-between p-4"
             >
-              <div>
+              <div className="min-w-0">
                 <p className="font-medium capitalize">{c.connector_type}</p>
                 <p className="text-sm text-muted-foreground">
                   {c.context_id
                     ? t("contextBound", { id: c.context_id })
                     : t("contextNotReady")}
                 </p>
+                {/* #893: connector_id is non-secret — show it in the list
+                    (support / log correlation / CLI target) with a copy button,
+                    instead of in the one-time reveal. */}
+                <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground">
+                  <span className="font-mono break-all">
+                    {t("connectorIdLabel", { id: c.connector_id })}
+                  </span>
+                  <CopyButton
+                    value={c.connector_id}
+                    label={t("copyConnectorId")}
+                  />
+                </div>
               </div>
               <Button
                 variant="ghost"
@@ -272,6 +363,92 @@ export default function ConnectorsPage() {
                 {t("contextNameHelp")}
               </p>
             </div>
+
+            {/* #890: PII guardrail configuration */}
+            <div className="border-t pt-4">
+              <div className="flex items-center justify-between">
+                <div>
+                  <p className="text-sm font-medium">{t("piiTitle")}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t("piiDesc")}
+                  </p>
+                </div>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={piiEnabled}
+                    onChange={(e) => setPiiEnabled(e.target.checked)}
+                  />
+                  {t("piiEnabled")}
+                </label>
+              </div>
+
+              {piiEnabled && (
+                <div className="mt-3 space-y-3">
+                  <div>
+                    <p className="mb-1 text-xs font-medium">
+                      {t("piiDetectors")}
+                    </p>
+                    <div className="grid grid-cols-2 gap-1">
+                      {PII_DETECTORS.map((d) => (
+                        <label
+                          key={d}
+                          className="flex items-center gap-2 text-sm"
+                        >
+                          <input
+                            type="checkbox"
+                            checked={piiDetectors.includes(d)}
+                            onChange={(e) =>
+                              setPiiDetectors((prev) =>
+                                e.target.checked
+                                  ? [...prev, d]
+                                  : prev.filter((x) => x !== d),
+                              )
+                            }
+                          />
+                          <span className="font-mono text-xs">{d}</span>
+                        </label>
+                      ))}
+                    </div>
+                    {piiDetectors.length === 0 && (
+                      <p className="mt-1 text-xs text-destructive">
+                        {t("piiDetectorsRequired")}
+                      </p>
+                    )}
+                  </div>
+                  <div>
+                    <label
+                      htmlFor="conn-pii-redaction"
+                      className="mb-1 block text-xs font-medium"
+                    >
+                      {t("piiRedaction")}
+                    </label>
+                    <select
+                      id="conn-pii-redaction"
+                      className="h-9 w-full rounded-md border bg-transparent px-2 text-sm"
+                      value={piiRedaction}
+                      onChange={(e) =>
+                        setPiiRedaction(e.target.value as PiiRedaction)
+                      }
+                    >
+                      {PII_REDACTION_MODES.map((m) => (
+                        <option key={m} value={m}>
+                          {t(`piiRedaction_${m}`)}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <label className="flex items-center gap-2 text-sm">
+                    <input
+                      type="checkbox"
+                      checked={piiFailClosed}
+                      onChange={(e) => setPiiFailClosed(e.target.checked)}
+                    />
+                    {t("piiFailClosed")}
+                  </label>
+                </div>
+              )}
+            </div>
           </div>
           <AlertDialogFooter>
             <AlertDialogCancel
@@ -282,7 +459,11 @@ export default function ConnectorsPage() {
             </AlertDialogCancel>
             <AlertDialogAction
               onClick={handleCreate}
-              disabled={submitting || !contextName}
+              disabled={
+                submitting ||
+                !contextName ||
+                (piiEnabled && piiDetectors.length === 0)
+              }
             >
               {t("createConnector")}
             </AlertDialogAction>
@@ -298,25 +479,65 @@ export default function ConnectorsPage() {
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>{t("createdTitle")}</AlertDialogTitle>
-            <AlertDialogDescription>{t("createdDesc")}</AlertDialogDescription>
+            {/* #893: Model B users do nothing after registration — the worker
+                fetches credentials server-to-server. Don't frame secrets as
+                "save these now". */}
+            <AlertDialogDescription>
+              {t("createdDescModelB")}
+            </AlertDialogDescription>
           </AlertDialogHeader>
           <div className="space-y-3 text-sm">
-            <div>
-              <p className="font-medium">{t("connectorId")}</p>
-              <code className="break-all">{created?.connector_id}</code>
-            </div>
-            {created?.kmc_api_key && (
-              <div>
-                <p className="font-medium">{t("kmcApiKey")}</p>
-                <code className="break-all">{created.kmc_api_key}</code>
+            {/* #893: developer/CLI credentials collapsed by default — only
+                needed for manual curl/CLI testing or a self-hosted worker. */}
+            <details className="rounded-md border p-3">
+              <summary className="cursor-pointer text-sm font-medium">
+                {t("devDisclosureTitle")}
+              </summary>
+              <div className="mt-3 space-y-3">
+                <p className="text-xs text-muted-foreground">
+                  {t("devDisclosureNote")}
+                </p>
+                {created?.token && (
+                  <div>
+                    <div className="flex items-center justify-between">
+                      <p className="font-medium">{t("resourceToken")}</p>
+                      <CopyButton
+                        value={created.token}
+                        label={t("copyResourceToken")}
+                      />
+                    </div>
+                    <code className="block break-all text-xs">
+                      {created.token}
+                    </code>
+                  </div>
+                )}
+                {created?.token && created?.resource_id && (
+                  <div>
+                    <p className="mb-1 font-medium">{t("curlSampleTitle")}</p>
+                    <pre className="overflow-x-auto rounded bg-muted p-2 text-xs">
+                      {curlSample(created.resource_id, created.token)}
+                    </pre>
+                  </div>
+                )}
+                {created?.kmc_api_key && (
+                  <div>
+                    <div className="flex items-center justify-between">
+                      <p className="font-medium">{t("kmcApiKey")}</p>
+                      <CopyButton
+                        value={created.kmc_api_key}
+                        label={t("copyKmcApiKey")}
+                      />
+                    </div>
+                    <p className="mb-1 text-xs text-muted-foreground">
+                      {t("kmcApiKeyNote")}
+                    </p>
+                    <code className="block break-all text-xs">
+                      {created.kmc_api_key}
+                    </code>
+                  </div>
+                )}
               </div>
-            )}
-            {created?.token && (
-              <div>
-                <p className="font-medium">{t("resourceToken")}</p>
-                <code className="break-all">{created.token}</code>
-              </div>
-            )}
+            </details>
           </div>
           <AlertDialogFooter>
             <AlertDialogAction onClick={() => setCreated(null)}>

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useTranslations } from "next-intl";
+import { useTranslations, useLocale } from "next-intl";
 import { Check, Copy, Plug, Trash2 } from "lucide-react";
 
 import { PageContainer } from "@/components/common/PageContainer";
@@ -31,6 +31,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
+import { useCopyFeedback } from "@/hooks/useCopyFeedback";
 import { API_BASE_URL } from "@/lib/api/base";
 import {
   createConnector,
@@ -88,32 +89,27 @@ function toResourceId(seed: string): string {
   return `slack-${slug || "team"}`.slice(0, CONNECTOR_NAME_MAX);
 }
 
-/** Inline copy-to-clipboard button with a transient checkmark. */
-function CopyButton({ value, label }: { value: string; label: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <Button
-      type="button"
-      variant="ghost"
-      size="sm"
-      aria-label={label}
-      onClick={() => {
-        void navigator.clipboard.writeText(value);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
-      }}
-    >
-      {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-    </Button>
-  );
-}
-
 export default function ConnectorsPage() {
   const t = useTranslations("connectors");
   const tCommon = useTranslations("common");
+  const locale = useLocale();
   const { toast } = useToast();
+  const { isCopied, copyToTarget } = useCopyFeedback();
   const router = useRouter();
   const searchParams = useSearchParams();
+
+  // Copy with the shared per-key feedback hook (unmount-safe, 2000ms standard);
+  // surface clipboard failures via the destructive-toast channel.
+  const handleCopy = useCallback(
+    async (text: string, key: string) => {
+      try {
+        await copyToTarget(text, key);
+      } catch {
+        toast({ variant: "destructive", title: tCommon("error") });
+      }
+    },
+    [copyToTarget, toast, tCommon],
+  );
   const installHandle = searchParams.get("slack_install");
 
   const [connectors, setConnectors] = useState<
@@ -171,6 +167,12 @@ export default function ConnectorsPage() {
         const seed = info.team_name || info.team_id;
         setDisplayName(info.team_name || info.team_id);
         setContextName(toResourceId(seed));
+        // Reset PII config to safe defaults for each new install session so a
+        // prior session's choices don't leak into a fresh connector dialog.
+        setPiiEnabled(true);
+        setPiiDetectors(PII_DEFAULT_DETECTORS);
+        setPiiRedaction("mask");
+        setPiiFailClosed(true);
       } catch {
         if (!cancelled) {
           toast({
@@ -215,7 +217,9 @@ export default function ConnectorsPage() {
           enabled: piiEnabled,
           detectors: piiEnabled ? piiDetectors : [],
           redaction: piiRedaction,
-          locale: "en",
+          // Derive the recognizer locale from the UI locale so a ja workspace
+          // gets ja-aware PII detection instead of English-only.
+          locale,
           fail_closed: piiFailClosed,
         },
       });
@@ -237,6 +241,7 @@ export default function ConnectorsPage() {
     piiDetectors,
     piiRedaction,
     piiFailClosed,
+    locale,
     router,
     reload,
   ]);
@@ -301,10 +306,21 @@ export default function ConnectorsPage() {
                   <span className="font-mono break-all">
                     {t("connectorIdLabel", { id: c.connector_id })}
                   </span>
-                  <CopyButton
-                    value={c.connector_id}
-                    label={t("copyConnectorId")}
-                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label={t("copyConnectorId")}
+                    onClick={() =>
+                      handleCopy(c.connector_id, `cid-${c.connector_id}`)
+                    }
+                  >
+                    {isCopied(`cid-${c.connector_id}`) ? (
+                      <Check className="h-4 w-4" />
+                    ) : (
+                      <Copy className="h-4 w-4" />
+                    )}
+                  </Button>
                 </div>
               </div>
               <Button
@@ -509,10 +525,21 @@ export default function ConnectorsPage() {
                   <div>
                     <div className="flex items-center justify-between">
                       <p className="font-medium">{t("resourceToken")}</p>
-                      <CopyButton
-                        value={created.token}
-                        label={t("copyResourceToken")}
-                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        aria-label={t("copyResourceToken")}
+                        onClick={() =>
+                          handleCopy(created.token, "reveal-token")
+                        }
+                      >
+                        {isCopied("reveal-token") ? (
+                          <Check className="h-4 w-4" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                      </Button>
                     </div>
                     <code className="block break-all text-xs">
                       {created.token}
@@ -531,10 +558,21 @@ export default function ConnectorsPage() {
                   <div>
                     <div className="flex items-center justify-between">
                       <p className="font-medium">{t("kmcApiKey")}</p>
-                      <CopyButton
-                        value={created.kmc_api_key}
-                        label={t("copyKmcApiKey")}
-                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        aria-label={t("copyKmcApiKey")}
+                        onClick={() =>
+                          handleCopy(created.kmc_api_key!, "reveal-kmc")
+                        }
+                      >
+                        {isCopied("reveal-kmc") ? (
+                          <Check className="h-4 w-4" />
+                        ) : (
+                          <Copy className="h-4 w-4" />
+                        )}
+                      </Button>
                     </div>
                     <p className="mb-1 text-xs text-muted-foreground">
                       {t("kmcApiKeyNote")}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3609,6 +3609,25 @@
     "connectorDeleted": "Connector deleted",
     "deleteFailed": "Failed to delete connector",
     "installExpiredTitle": "Slack install expired",
-    "installExpiredDesc": "The Slack authorization handle is invalid or expired. Please connect again."
+    "installExpiredDesc": "The Slack authorization handle is invalid or expired. Please connect again.",
+    "piiTitle": "PII scrubbing",
+    "piiDesc": "Configure how the ai-worker redacts personal data before it is stored.",
+    "piiEnabled": "Enabled",
+    "piiDetectors": "Detectors",
+    "piiDetectorsRequired": "Select at least one detector, or turn PII scrubbing off.",
+    "piiRedaction": "Redaction mode",
+    "piiRedaction_mask": "Mask (replace with ****)",
+    "piiRedaction_hash": "Hash (replace with a hash)",
+    "piiRedaction_remove": "Remove (drop the span)",
+    "piiFailClosed": "Drop the event if scrubbing fails (fail-closed)",
+    "connectorIdLabel": "ID: {id}",
+    "copyConnectorId": "Copy connector ID",
+    "createdDescModelB": "You're all set. The Kagura-operated worker fetches its credentials automatically — there's nothing to copy or save. The values below are only for manual CLI testing or a self-hosted worker.",
+    "devDisclosureTitle": "Developer / CLI testing (optional)",
+    "devDisclosureNote": "Not needed if you use the Kagura-operated worker. Only for manual CLI/curl testing or a self-hosted worker. If you lose these, delete and recreate the connector to get fresh values.",
+    "curlSampleTitle": "Sample request (resource-ingest API)",
+    "copyResourceToken": "Copy resource token",
+    "copyKmcApiKey": "Copy KMC write key",
+    "kmcApiKeyNote": "Self-hosted worker config only. For human CLI use a personal API key from the API Keys tab instead."
   }
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3600,8 +3600,6 @@
     "contextNameHelp": "Lowercase letters, numbers, hyphen and underscore only.",
     "createConnector": "Create connector",
     "createdTitle": "Connector created",
-    "createdDesc": "Copy the worker credentials now — they are shown only once.",
-    "connectorId": "Connector ID",
     "kmcApiKey": "KMC write key",
     "resourceToken": "Resource token (resource-ingest API)",
     "deleteTitle": "Delete connector?",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3609,6 +3609,25 @@
     "connectorDeleted": "コネクタを削除しました",
     "deleteFailed": "コネクタの削除に失敗しました",
     "installExpiredTitle": "Slack 連携の期限切れ",
-    "installExpiredDesc": "Slack 認可ハンドルが無効か期限切れです。もう一度接続してください。"
+    "installExpiredDesc": "Slack 認可ハンドルが無効か期限切れです。もう一度接続してください。",
+    "piiTitle": "PII マスキング",
+    "piiDesc": "ai-worker が保存前に個人情報をどう秘匿するかを設定します。",
+    "piiEnabled": "有効",
+    "piiDetectors": "検出器",
+    "piiDetectorsRequired": "検出器を1つ以上選択するか、PII マスキングをオフにしてください。",
+    "piiRedaction": "秘匿方式",
+    "piiRedaction_mask": "マスク（**** で置換）",
+    "piiRedaction_hash": "ハッシュ（ハッシュ値で置換）",
+    "piiRedaction_remove": "削除（該当箇所を除去）",
+    "piiFailClosed": "マスキング失敗時はイベントを破棄（フェイルクローズ）",
+    "connectorIdLabel": "ID: {id}",
+    "copyConnectorId": "コネクタ ID をコピー",
+    "createdDescModelB": "設定完了です。Kagura 運用ワーカーは認証情報を自動取得するため、コピーや保存は不要です。以下の値は手動 CLI テストまたはセルフホストワーカー用です。",
+    "devDisclosureTitle": "開発者 / CLI テスト（任意）",
+    "devDisclosureNote": "Kagura 運用ワーカーを使う場合は不要です。手動 CLI/curl テストまたはセルフホストワーカー専用。紛失した場合はコネクタを削除して再作成すると新しい値を取得できます。",
+    "curlSampleTitle": "リクエスト例（resource-ingest API）",
+    "copyResourceToken": "リソーストークンをコピー",
+    "copyKmcApiKey": "KMC 書き込みキーをコピー",
+    "kmcApiKeyNote": "セルフホストワーカー設定専用。人間の CLI 用途には API Keys タブの個人 API キーを使ってください。"
   }
 }

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3600,8 +3600,6 @@
     "contextNameHelp": "英小文字・数字・ハイフン・アンダースコアのみ。",
     "createConnector": "コネクタを作成",
     "createdTitle": "コネクタを作成しました",
-    "createdDesc": "ワーカー用の認証情報を今すぐコピーしてください（一度だけ表示されます）。",
-    "connectorId": "コネクタ ID",
     "kmcApiKey": "KMC 書き込みキー",
     "resourceToken": "リソーストークン（resource-ingest API）",
     "deleteTitle": "コネクタを削除しますか？",


### PR DESCRIPTION
Closes #890
Closes #893

## Summary
- **#890 PII config UI**: add a PII guardrail section to the create-connector dialog that builds a valid `pii_guardrail_config` (`{enabled, detectors[], redaction, locale, fail_closed}`). Defaults are secure-by-default (enabled + EMAIL_ADDRESS/PHONE_NUMBER/CREDIT_CARD/PERSON, redaction=mask, fail_closed=true). Submit is blocked when enabled with zero detectors. `locale` is derived from `useLocale()` so a ja workspace gets ja-aware detection.
- **#893 reveal redesign**: `connector_id` (non-secret) moves to the connectors list row with a copy button; the post-create reveal is reframed for Model B ("you're all set, the worker fetches credentials automatically"), and the resource token + KMC key collapse into a `<details>` "Developer / CLI testing (optional)" disclosure with a copy-pastable curl sample and a self-hosted-worker note.

## Implementation notes
- Single surface (`connectors/page.tsx`) — the two issues touch the same create/reveal flow, so they batch cleanly.
- `CopyButton` uses the shared `useCopyFeedback` hook (unmount-safe, per-key 2000ms feedback, destructive toast on clipboard failure) instead of an inline reimplementation.
- Redaction-mode dropdown uses the shadcn `Select` primitive (matches the 15 other files using it).
- PII config state resets to safe defaults on each new Slack install session (no cross-session leak).
- i18n: +19 keys in en.json + ja.json; 2 orphaned keys removed.

## Pre-PR review summary
- gate2 mode: advisor-only
- cso: green
- qa-lead: yellow (page-level component test for submit guard + PII state reset recommended as follow-up; not a blocker)
- cto: green (PII form sub-component extraction recommended as follow-up)
- gate1: green via /ask (CDO)
- review provider: code-review

## Follow-ups (not in this PR)
- RTL tests for the PII submit guard + PII state reset (qa-lead).
- Extract the PII form into a `<ConnectorPiiConfig>` sub-component (cto, v0.24.0 frontend hygiene).
- Regenerate action for the resource token (needs a resource-token rotate endpoint; kmc rotation is #892).

🤖 Generated via /gh-issue-driven:ship
