### PR TITLE
feat(frontend): gate connectors page by workspace-admin role (#903)

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * Connectors page — client-side RBAC gate (#903).
+ *
+ * Covers: non-admin (member/viewer) sees the forbidden banner and the
+ * admin-only list call is never fired; admin sees the management UI and the
+ * list loads; loading resolves before gating (no admin-UI flash); a missing
+ * workspace shows the "no workspace selected" banner rather than the role
+ * banner.
+ */
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import ConnectorsPage from "./page";
+
+const mockListConnectors = vi.fn();
+vi.mock("@/lib/api/workspace-connectors", () => ({
+  listConnectors: (...args: unknown[]) => mockListConnectors(...args),
+  deleteConnector: vi.fn(),
+  createConnector: vi.fn(),
+  getSlackPendingInstall: vi.fn(),
+  slackInstallUrl: () => "https://slack.example/install",
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => "en",
+}));
+
+const mockUseWorkspace = vi.fn();
+vi.mock("@/contexts/WorkspaceContext", () => ({
+  useWorkspace: () => mockUseWorkspace(),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("@/hooks/useCopyFeedback", () => ({
+  useCopyFeedback: () => ({ isCopied: () => false, copyToTarget: vi.fn() }),
+}));
+
+function setWorkspace(role: string | undefined, overrides = {}) {
+  mockUseWorkspace.mockReturnValue({
+    currentWorkspace: role ? { id: "ws-1", current_user_role: role } : null,
+    currentWorkspaceId: "ws-1",
+    loading: false,
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  mockListConnectors.mockResolvedValue([]);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("ConnectorsPage RBAC gate", () => {
+  it.each(["member", "viewer"])(
+    "shows forbidden banner and never lists connectors for %s",
+    async (role) => {
+      setWorkspace(role);
+      render(<ConnectorsPage />);
+
+      expect(
+        await screen.findByText("errors.forbiddenWorkspace"),
+      ).toBeInTheDocument();
+      // The admin-only list call must not fire for non-admins.
+      expect(mockListConnectors).not.toHaveBeenCalled();
+      // No connect action surfaced.
+      expect(screen.queryByText("connectSlack")).not.toBeInTheDocument();
+    },
+  );
+
+  it.each(["admin", "owner"])(
+    "renders management UI and loads connectors for %s",
+    async (role) => {
+      setWorkspace(role);
+      render(<ConnectorsPage />);
+
+      expect(await screen.findByText("connectSlack")).toBeInTheDocument();
+      await waitFor(() => expect(mockListConnectors).toHaveBeenCalled());
+      expect(
+        screen.queryByText("errors.forbiddenWorkspace"),
+      ).not.toBeInTheDocument();
+    },
+  );
+
+  it("shows a loading state (no admin-UI flash) while the workspace resolves", () => {
+    setWorkspace(undefined, { currentWorkspace: null, loading: true });
+    render(<ConnectorsPage />);
+
+    expect(screen.queryByText("connectSlack")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("errors.forbiddenWorkspace"),
+    ).not.toBeInTheDocument();
+    expect(mockListConnectors).not.toHaveBeenCalled();
+  });
+
+  it("distinguishes no-workspace from wrong-role", async () => {
+    setWorkspace(undefined, {
+      currentWorkspace: null,
+      currentWorkspaceId: null,
+    });
+    render(<ConnectorsPage />);
+
+    expect(
+      await screen.findByText("errors.noWorkspaceSelected"),
+    ).toBeInTheDocument();
+    expect(mockListConnectors).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -168,7 +168,10 @@ export default function ConnectorsPage() {
     // Don't fire the admin-only list call for non-admins — it would 403.
     if (!allowed) return;
     void reload();
-  }, [reload, allowed]);
+    // Key on currentWorkspaceId too: switching workspace (while staying
+    // admin/owner) must refetch so stale connectors from the previous
+    // workspace aren't left rendered. listConnectors is workspace-scoped.
+  }, [reload, allowed, currentWorkspaceId]);
 
   // After the Slack OAuth callback redirects back with ?slack_install=<handle>,
   // fetch the non-secret install summary and open the create dialog.

--- a/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/integrations/connectors/page.tsx
@@ -32,6 +32,8 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useToast } from "@/hooks/use-toast";
 import { useCopyFeedback } from "@/hooks/useCopyFeedback";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
 import { API_BASE_URL } from "@/lib/api/base";
 import {
   createConnector,
@@ -99,6 +101,17 @@ export default function ConnectorsPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
+  // Client-side RBAC gate (#903). All connector endpoints require workspace
+  // ADMIN/OWNER (backend `require_workspace_admin` is the source of truth);
+  // without this gate a member/viewer would hit a 403 on the list load and
+  // see a broken page with action buttons that always fail. This is
+  // defense-in-depth UX, not a security boundary.
+  const { currentWorkspace, currentWorkspaceId, loading } = useWorkspace();
+  const allowed = hasWorkspaceRole(
+    currentWorkspace?.current_user_role,
+    WorkspaceRole.Admin,
+  );
+
   // Copy with the shared per-key feedback hook (unmount-safe, 2000ms standard);
   // surface clipboard failures via the destructive-toast channel.
   const handleCopy = useCallback(
@@ -152,13 +165,16 @@ export default function ConnectorsPage() {
   }, []);
 
   useEffect(() => {
+    // Don't fire the admin-only list call for non-admins — it would 403.
+    if (!allowed) return;
     void reload();
-  }, [reload]);
+  }, [reload, allowed]);
 
   // After the Slack OAuth callback redirects back with ?slack_install=<handle>,
   // fetch the non-secret install summary and open the create dialog.
   useEffect(() => {
     if (!installHandle) return;
+    if (!allowed) return;
     let cancelled = false;
     (async () => {
       try {
@@ -190,7 +206,7 @@ export default function ConnectorsPage() {
     return () => {
       cancelled = true;
     };
-  }, [installHandle, t, toast, router]);
+  }, [installHandle, allowed, t, toast, router]);
 
   const closeCreateDialog = useCallback(() => {
     setPending(null);
@@ -263,6 +279,38 @@ export default function ConnectorsPage() {
       });
     }
   }, [toDelete, t, toast, reload]);
+
+  // Resolve loading before role gating to avoid a flash of the admin UI
+  // before the workspace role is known. All hooks above run unconditionally
+  // (these early returns are after every hook call).
+  if (loading) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} description={t("description")} />
+        <TableLoadingState rows={3} />
+      </PageContainer>
+    );
+  }
+
+  // Distinguish "no workspace selected" from "wrong role" so a brand-new
+  // account with zero workspaces doesn't see a misleading role banner.
+  if (!currentWorkspaceId) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} description={t("description")} />
+        <ErrorBanner error={t("errors.noWorkspaceSelected")} />
+      </PageContainer>
+    );
+  }
+
+  if (!allowed) {
+    return (
+      <PageContainer>
+        <PageHeader title={t("title")} description={t("description")} />
+        <ErrorBanner error={t("errors.forbiddenWorkspace")} />
+      </PageContainer>
+    );
+  }
 
   return (
     <PageContainer>

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -3626,6 +3626,10 @@
     "curlSampleTitle": "Sample request (resource-ingest API)",
     "copyResourceToken": "Copy resource token",
     "copyKmcApiKey": "Copy KMC write key",
-    "kmcApiKeyNote": "Self-hosted worker config only. For human CLI use a personal API key from the API Keys tab instead."
+    "kmcApiKeyNote": "Self-hosted worker config only. For human CLI use a personal API key from the API Keys tab instead.",
+    "errors": {
+      "noWorkspaceSelected": "No workspace selected. Select a workspace to manage its connectors.",
+      "forbiddenWorkspace": "Workspace owner or admin role required to manage connectors."
+    }
   }
 }

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -3626,6 +3626,10 @@
     "curlSampleTitle": "リクエスト例（resource-ingest API）",
     "copyResourceToken": "リソーストークンをコピー",
     "copyKmcApiKey": "KMC 書き込みキーをコピー",
-    "kmcApiKeyNote": "セルフホストワーカー設定専用。人間の CLI 用途には API Keys タブの個人 API キーを使ってください。"
+    "kmcApiKeyNote": "セルフホストワーカー設定専用。人間の CLI 用途には API Keys タブの個人 API キーを使ってください。",
+    "errors": {
+      "noWorkspaceSelected": "ワークスペースが選択されていません。コネクタを管理するにはワークスペースを選択してください。",
+      "forbiddenWorkspace": "コネクタを管理するにはワークスペースのオーナーまたは管理者権限が必要です。"
+    }
   }
 }


### PR DESCRIPTION
Closes #903

## Summary
- Add client-side RBAC gating to the connectors management page so a member/viewer no longer hits a 403 on list load and sees a broken page with always-failing action buttons.
- Mirror the existing `cost/page.tsx` pattern: `useWorkspace()` + `hasWorkspaceRole(currentWorkspace?.current_user_role, WorkspaceRole.Admin)`.
- Resolve `loading` before role gating to avoid an admin-UI flash; distinguish no-workspace from wrong-role.

## Implementation notes
- `page.tsx`: gate the list-reload and slack-install effects on `allowed` so non-admins never fire the admin-only 403; early returns (after all hooks) render `TableLoadingState` while loading, then an `ErrorBanner` for no-workspace / forbidden.
- Backend RBAC (`require_workspace_admin` → `PermissionService.check_workspace_admin`, ADMIN/OWNER) is unchanged and remains the source of truth — this is defense-in-depth UX only.
- i18n: add `connectors.errors.{noWorkspaceSelected,forbiddenWorkspace}` to en + ja.
- `page.test.tsx` (new): 6 cases — member/viewer → forbidden banner + `listConnectors` not called; admin/owner → management UI + list loads; loading → no flash; no-workspace → distinct banner.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (size: not auto-skipped; full cascade)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
