### PR TITLE
feat(api): server-stamped provenance + context trust_tier read enforcement (#887)

### DIFF
--- a/backend/alembic/versions/e35_887_provenance_trust_tier.py
+++ b/backend/alembic/versions/e35_887_provenance_trust_tier.py
@@ -1,0 +1,59 @@
+"""Server-authoritative provenance + context trust_tier (#887).
+
+Two changes, both additive/safe:
+
+1. ``memories.source_type`` → NOT NULL + CHECK. Legacy NULL rows are backfilled
+   to 'manual' (the ratified, CSO-signed-off rule — safe because trust is
+   authoritative at the context level, not per-row, and legacy NULL rows predate
+   connector ingestion). 'connector' is added to the allowed set (server-stamped
+   by resource_indexer).
+2. ``contexts.trust_tier`` — new NOT NULL column (default 'trusted') + CHECK.
+   Connector contexts are stamped 'external' at provision time; a
+   ``recall(filters={'trust_tier':'trusted'})`` read excludes external-origin
+   contexts from behaviour-influencing reads.
+
+NOTE: shares down_revision e34 with the #889 lane migration (PR #905). If both
+land, a one-line alembic merge revision reconciles the two heads (or rebase
+whichever merges second onto the other).
+"""
+
+from alembic import op
+
+revision = "e35_887_provenance_trust_tier"
+down_revision = "e34_895_resource_token_enc"
+branch_labels = None
+depends_on = None
+
+# Byte-identical to the model CHECK literals (memory._ALL_SOURCE_TYPES /
+# auth._ALL_CONTEXT_TRUST_TIERS, repr-derived). Pinned by tests.
+_SOURCE_TYPE_CHECK = "source_type IN ('file', 'url', 'vault', 'api', 'manual', 'connector')"
+_TRUST_TIER_CHECK = "trust_tier IN ('trusted', 'external')"
+
+
+def upgrade() -> None:
+    # 1. memories.source_type → backfill, NOT NULL, default, CHECK.
+    op.execute("UPDATE memories SET source_type = 'manual' WHERE source_type IS NULL")
+    op.alter_column(
+        "memories",
+        "source_type",
+        nullable=False,
+        server_default="manual",
+    )
+    op.create_check_constraint("valid_source_type", "memories", _SOURCE_TYPE_CHECK)
+
+    # 2. contexts.trust_tier → new NOT NULL column (default 'trusted') + CHECK.
+    op.execute("ALTER TABLE contexts ADD COLUMN trust_tier VARCHAR(20) NOT NULL DEFAULT 'trusted'")
+    op.create_check_constraint("valid_context_trust_tier", "contexts", _TRUST_TIER_CHECK)
+
+
+def downgrade() -> None:
+    op.drop_constraint("valid_context_trust_tier", "contexts", type_="check")
+    op.drop_column("contexts", "trust_tier")
+
+    op.drop_constraint("valid_source_type", "memories", type_="check")
+    op.alter_column(
+        "memories",
+        "source_type",
+        nullable=True,
+        server_default=None,
+    )

--- a/backend/alembic/versions/e35_887_provenance_trust_tier.py
+++ b/backend/alembic/versions/e35_887_provenance_trust_tier.py
@@ -32,7 +32,15 @@ _TRUST_TIER_CHECK = "trust_tier IN ('trusted', 'external')"
 
 def upgrade() -> None:
     # 1. memories.source_type → backfill, NOT NULL, default, CHECK.
-    op.execute("UPDATE memories SET source_type = 'manual' WHERE source_type IS NULL")
+    # source_type was historically an unconstrained client-supplied string, so
+    # coerce BOTH NULL and any out-of-set legacy value to 'manual' before adding
+    # the CHECK — otherwise create_check_constraint would fail on pre-existing
+    # rows that violate the new IN (...) set.
+    op.execute(
+        "UPDATE memories SET source_type = 'manual' "
+        "WHERE source_type IS NULL "
+        "OR source_type NOT IN ('file', 'url', 'vault', 'api', 'manual', 'connector')"
+    )
     op.alter_column(
         "memories",
         "source_type",

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1111,6 +1111,17 @@ class UsageStats(Base):
 # Context-based Multi-Collection (Issue #82 → #160: renamed from Project)
 # ============================================================================
 
+# Issue #887: context-level trust tiers (server-authoritative). CHECK is
+# derived from this ordered tuple (single quotes), byte-identical to the alembic
+# migration literal; new values are APPENDED, never reordered.
+CONTEXT_TRUST_TIER_TRUSTED = "trusted"
+CONTEXT_TRUST_TIER_EXTERNAL = "external"
+
+_ALL_CONTEXT_TRUST_TIERS: tuple[str, ...] = (
+    CONTEXT_TRUST_TIER_TRUSTED,
+    CONTEXT_TRUST_TIER_EXTERNAL,
+)
+
 
 class Context(Base):
     """Context model for multi-collection memory workspace.
@@ -1208,6 +1219,19 @@ class Context(Base):
     # Issue #85: Context lock to prevent accidental deletion
     is_locked: Mapped[bool] = mapped_column(Boolean, nullable=False, server_default="false")
 
+    # Issue #887: server-authoritative trust tier. This is the PREFERRED trust
+    # mechanism — trust is stamped on the context at provision time (connector
+    # contexts = 'external'), so every memory in the context inherits it
+    # server-side regardless of client-supplied per-row source_type (survives
+    # BYOK key leakage). 'trusted' (default) = user-owned; 'external' =
+    # connector-ingested / untrusted-origin. A recall(filters={'trust_tier':
+    # 'trusted'}) read excludes external-origin contexts from behaviour-
+    # influencing reads. CHECK is pinned by
+    # test_valid_context_trust_tier_check_constraint_matches_migration_literal.
+    trust_tier: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=CONTEXT_TRUST_TIER_TRUSTED
+    )
+
     # Issue #101: Sleep Maintenance mode
     # 'full' = all phases (personal AI memory)
     # 'edges_only' = Edge Discovery + Reindex only (resource ingest contexts)
@@ -1218,6 +1242,12 @@ class Context(Base):
     __table_args__ = (
         # Note: Index idx_contexts_workspace_name is created in migration with WHERE deleted_at IS NULL
         CheckConstraint("name ~ '^[a-z0-9_-]+$'", name="valid_context_name"),
+        # Issue #887: CHECK derived from ``_ALL_CONTEXT_TRUST_TIERS`` (single
+        # quotes), byte-identical to the alembic migration literal.
+        CheckConstraint(
+            f"trust_tier IN ({', '.join(repr(t) for t in _ALL_CONTEXT_TRUST_TIERS)})",
+            name="valid_context_trust_tier",
+        ),
         # Issue #238 / migration a96 — global partial UNIQUE on
         # ``contexts.resource_id`` excluding soft-deleted rows. Mirrored to
         # the ORM so ``Base.metadata.create_all`` matches the production schema.

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -59,8 +59,9 @@ _ALL_DELIVERY_MODES: tuple[str, ...] = (
 
 # Issue #887: server-authoritative provenance. ``source_type`` records HOW a
 # memory entered the system; it is NOT NULL + CHECK (tuple-derived, test-pinned,
-# same discipline as delivery_mode / edge origin). Values file/url/vault/manual
-# are user-origin provenance (legitimately client-set on import — #213/#262);
+# same discipline as delivery_mode / edge origin). Values
+# file/url/vault/api/manual are user-origin provenance (legitimately client-set
+# on import — #213/#262);
 # ``connector`` is server-only (stamped by resource_indexer for external
 # ingestion). Trust is NOT carried here — it is authoritative at the context
 # level (``Context.trust_tier``); source_type is provenance, not a trust claim.

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -57,6 +57,31 @@ _ALL_DELIVERY_MODES: tuple[str, ...] = (
     DELIVERY_MODE_ON_TRIGGER,
 )
 
+# Issue #887: server-authoritative provenance. ``source_type`` records HOW a
+# memory entered the system; it is NOT NULL + CHECK (tuple-derived, test-pinned,
+# same discipline as delivery_mode / edge origin). Values file/url/vault/manual
+# are user-origin provenance (legitimately client-set on import — #213/#262);
+# ``connector`` is server-only (stamped by resource_indexer for external
+# ingestion). Trust is NOT carried here — it is authoritative at the context
+# level (``Context.trust_tier``); source_type is provenance, not a trust claim.
+# New values are APPENDED (never reordered) to preserve byte-identity with the
+# alembic migration literal.
+SOURCE_TYPE_FILE = "file"
+SOURCE_TYPE_URL = "url"
+SOURCE_TYPE_VAULT = "vault"
+SOURCE_TYPE_API = "api"
+SOURCE_TYPE_MANUAL = "manual"
+SOURCE_TYPE_CONNECTOR = "connector"
+
+_ALL_SOURCE_TYPES: tuple[str, ...] = (
+    SOURCE_TYPE_FILE,
+    SOURCE_TYPE_URL,
+    SOURCE_TYPE_VAULT,
+    SOURCE_TYPE_API,
+    SOURCE_TYPE_MANUAL,
+    SOURCE_TYPE_CONNECTOR,
+)
+
 
 class Memory(Base):
     """Memory model with 3-layer architecture.
@@ -187,8 +212,15 @@ class Memory(Base):
     # Issue #213: Origin URI for external integration (Obsidian, code ingestion, web clipping)
     # Partial index idx_memories_source_uri created in migration a95
     source_uri: Mapped[str | None] = mapped_column(String(2048), nullable=True)
-    source_type: Mapped[str | None] = mapped_column(String(20), nullable=True)
-    # source_type: file, url, vault, api, manual
+    # Issue #887: NOT NULL + CHECK; legacy NULL rows backfilled to 'manual' in
+    # the alembic migration. server_default keeps the migration backfill and ORM
+    # default in lock-step. Values are constrained by valid_source_type below.
+    source_type: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        default=SOURCE_TYPE_MANUAL,
+        server_default=SOURCE_TYPE_MANUAL,
+    )
 
     # Migration 061: Generated columns for efficient resource memory lookups
     # These columns are automatically computed from details JSONB field
@@ -258,6 +290,14 @@ class Memory(Base):
         CheckConstraint(
             f"delivery_mode IN ({', '.join(repr(d) for d in _ALL_DELIVERY_MODES)})",
             name="valid_delivery_mode",
+        ),
+        # Issue #887: CHECK derived from ``_ALL_SOURCE_TYPES`` (registration
+        # order, single quotes), byte-identical to the alembic migration literal.
+        # Drift is pinned by
+        # test_valid_source_type_check_constraint_matches_migration_literal.
+        CheckConstraint(
+            f"source_type IN ({', '.join(repr(s) for s in _ALL_SOURCE_TYPES)})",
+            name="valid_source_type",
         ),
         CheckConstraint(
             "embedding_status IN ('pending', 'processing', 'success', 'failed')",

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -198,7 +198,11 @@ class MemoryResponse(TZAwareBaseModel):
     context: dict | None
     score: float | None = Field(None, description="検索スコア（recall時のみ）")
     source_uri: str | None = None
-    source_type: Literal["file", "url", "vault", "api", "manual"] | None = None
+    # Issue #887: response models must allow 'connector' (the server-stamped
+    # value on connector-ingested memories); recall/reference of a connector
+    # memory would otherwise raise a Pydantic ValidationError. The *request*
+    # schema (RememberRequest) intentionally omits it — the forge guard.
+    source_type: Literal["file", "url", "vault", "api", "manual", "connector"] | None = None
 
     class Config:
         from_attributes = True
@@ -342,7 +346,11 @@ class ReferenceResponse(TZAwareBaseModel):
     # Use the same Literal as MemoryResponse / RememberRequest so the OpenAPI
     # contract stays consistent and unexpected values can't leak to the UI.
     source_uri: str | None = None
-    source_type: Literal["file", "url", "vault", "api", "manual"] | None = None
+    # Issue #887: response models must allow 'connector' (the server-stamped
+    # value on connector-ingested memories); recall/reference of a connector
+    # memory would otherwise raise a Pydantic ValidationError. The *request*
+    # schema (RememberRequest) intentionally omits it — the forge guard.
+    source_type: Literal["file", "url", "vault", "api", "manual", "connector"] | None = None
     # Issue #440: declared_link references for the dialog "References" section.
     # Naming: outgoing_has_more / incoming_has_more matches MemoryListResponse.has_more
     # (codebase precedent for capped collections); the issue body's `*_truncated`

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -135,20 +135,6 @@ class ConnectorProvisioningService:
                 auto_create_context_name=auto_create_context_name,
             )
             auto_created_context_id = resolved_context_id
-            # Issue #887: a freshly auto-created connector context receives
-            # external ingestion, so stamp it 'external' — the authoritative,
-            # server-side trust signal that excludes it from behaviour-
-            # influencing reads regardless of any client-supplied per-row
-            # source_type (survives BYOK key leakage). Scoped to the auto-create
-            # path only: a bring-your-own existing context is the user's own and
-            # its trust tier is not silently changed here.
-            from models.auth import CONTEXT_TRUST_TIER_EXTERNAL, Context
-
-            await self.db.execute(
-                update(Context)
-                .where(Context.id == resolved_context_id)
-                .values(trust_tier=CONTEXT_TRUST_TIER_EXTERNAL)
-            )
         else:
             await self._enforce_connector_seat_cap(workspace, workspace_id)
             resolved_context_id = await self._resolve_context(
@@ -164,6 +150,22 @@ class ConnectorProvisioningService:
             # the connector flush below without an intervening commit releasing it.
             if auto_create_context_name:
                 await self._enforce_connector_seat_cap(workspace, workspace_id)
+                # Issue #887: a freshly auto-created connector context receives
+                # external ingestion, so stamp it 'external' — the authoritative,
+                # server-side trust signal that excludes it from behaviour-
+                # influencing reads regardless of any client-supplied per-row
+                # source_type (survives BYOK key leakage). Scoped to the
+                # auto-create path; a bring-your-own existing context is the
+                # user's own and is not silently re-tiered. Placed INSIDE the
+                # try so a failure here triggers the orphan-context cleanup in
+                # the except below (it would otherwise leak a committed context).
+                from models.auth import CONTEXT_TRUST_TIER_EXTERNAL, Context
+
+                await self.db.execute(
+                    update(Context)
+                    .where(Context.id == resolved_context_id)
+                    .values(trust_tier=CONTEXT_TRUST_TIER_EXTERNAL)
+                )
 
             existing_resource_pk = await resolve_resource_pk(self.db, workspace_id, resource_id)
             resource_pk = await upsert_resource(

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -135,6 +135,20 @@ class ConnectorProvisioningService:
                 auto_create_context_name=auto_create_context_name,
             )
             auto_created_context_id = resolved_context_id
+            # Issue #887: a freshly auto-created connector context receives
+            # external ingestion, so stamp it 'external' — the authoritative,
+            # server-side trust signal that excludes it from behaviour-
+            # influencing reads regardless of any client-supplied per-row
+            # source_type (survives BYOK key leakage). Scoped to the auto-create
+            # path only: a bring-your-own existing context is the user's own and
+            # its trust tier is not silently changed here.
+            from models.auth import CONTEXT_TRUST_TIER_EXTERNAL, Context
+
+            await self.db.execute(
+                update(Context)
+                .where(Context.id == resolved_context_id)
+                .values(trust_tier=CONTEXT_TRUST_TIER_EXTERNAL)
+            )
         else:
             await self._enforce_connector_seat_cap(workspace, workspace_id)
             resolved_context_id = await self._resolve_context(

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -27,6 +27,8 @@ from models.memory import (
     EDGE_ORIGIN_HEBBIAN,
     EDGE_ORIGIN_SEMANTIC,
     EDGE_TYPE_NEURAL_ASSOCIATION,
+    SOURCE_TYPE_CONNECTOR,
+    SOURCE_TYPE_MANUAL,
     Memory,
 )
 from models.schemas import (
@@ -346,7 +348,12 @@ class MemoryService:
             summary_embedding_id=memory_id,  # Same as memory_id
             embedding_status="pending",  # Issue #122: Track embedding state
             source_uri=request.source_uri,
-            source_type=request.source_type,
+            # Issue #887: server-authoritative provenance. The request schema
+            # only permits user-origin values (file/url/vault/api/manual) — the
+            # reserved 'connector' value cannot be client-set, so a caller on the
+            # remember path can never forge external-ingestion provenance.
+            # NULL coerces to 'manual' to satisfy the NOT NULL column.
+            source_type=request.source_type or SOURCE_TYPE_MANUAL,
         )
         # Issue #886: pin-on-write. delivery_mode='always' pins straight to
         # persistent (so it is exempt from sleep consolidation — which only acts
@@ -1471,6 +1478,16 @@ class MemoryService:
                 pg_conditions.append(Memory.source_uri.like(f"{escaped}%", escape="\\"))
             if stype := request.filters.get("source_type"):
                 pg_conditions.append(Memory.source_type == stype)
+            # Issue #887: trust-tier read filter. ``trusted`` excludes
+            # external-origin (connector-ingested) memories from
+            # behaviour-influencing reads (OWASP LLM01/LLM03 — external content
+            # is data, not instructions). Connector contexts are stamped
+            # ``Context.trust_tier='external'`` (the authoritative signal) and
+            # contain only ``source_type='connector'`` rows, so this row-level
+            # exclusion matches the context-level trust in practice without
+            # restructuring the recall hot path.
+            if request.filters.get("trust_tier") == "trusted":
+                pg_conditions.append(Memory.source_type != SOURCE_TYPE_CONNECTOR)
         # Issue #496: cluster-scoped recall — restrict to the
         # cluster's member memories. ``cluster_memory_ids`` was
         # pre-resolved above and is guaranteed non-empty by the

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -20,7 +20,7 @@ from db.qdrant import (
     delete_memory_from_qdrant,
     update_memory_payload_in_qdrant,
 )
-from models.auth import Context
+from models.auth import CONTEXT_TRUST_TIER_TRUSTED, Context
 from models.memory import (
     DELIVERY_MODE_ALWAYS,
     EDGE_ORIGIN_DECLARED,
@@ -1479,14 +1479,20 @@ class MemoryService:
             if stype := request.filters.get("source_type"):
                 pg_conditions.append(Memory.source_type == stype)
             # Issue #887: trust-tier read filter. ``trusted`` excludes
-            # external-origin (connector-ingested) memories from
-            # behaviour-influencing reads (OWASP LLM01/LLM03 — external content
-            # is data, not instructions). Connector contexts are stamped
-            # ``Context.trust_tier='external'`` (the authoritative signal) and
-            # contain only ``source_type='connector'`` rows, so this row-level
-            # exclusion matches the context-level trust in practice without
-            # restructuring the recall hot path.
+            # external-origin memories from behaviour-influencing reads (OWASP
+            # LLM01/LLM03 — external content is data, not instructions).
             if request.filters.get("trust_tier") == "trusted":
+                # Authoritative check: the memory's context must itself be
+                # trusted. ``Context.trust_tier`` is the server-side trust
+                # signal (connector contexts = 'external'), so a non-connector
+                # row that somehow lives in an external context is still
+                # excluded — this does not rely on the per-row source_type.
+                pg_conditions.append(
+                    Memory.context_id.in_(
+                        select(Context.id).where(Context.trust_tier == CONTEXT_TRUST_TIER_TRUSTED)
+                    )
+                )
+                # Defense-in-depth: also drop any connector-sourced row.
                 pg_conditions.append(Memory.source_type != SOURCE_TYPE_CONNECTOR)
         # Issue #496: cluster-scoped recall — restrict to the
         # cluster's member memories. ``cluster_memory_ids`` was

--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -725,6 +725,10 @@ class ResourceIndexer:
                 # P1-5: Truncate summary to 500 chars (database limit)
                 summary = f"[{event.resource_id}] {event.doc_id} v{event.version}"
                 existing_memory.summary = summary[:500]
+                # Issue #887: keep connector provenance on re-index — a row
+                # backfilled to 'manual' (pre-#887) or any stale value is
+                # restamped 'connector' so provenance reflects the ingest path.
+                existing_memory.source_type = SOURCE_TYPE_CONNECTOR
                 # P2-10: Safe truncation with ellipsis for context_summary
                 if len(content) > 2000:
                     existing_memory.context_summary = content[:1997] + "..."

--- a/backend/src/services/resource_indexer.py
+++ b/backend/src/services/resource_indexer.py
@@ -31,7 +31,10 @@ from db.qdrant import (
     get_qdrant_client,
 )
 from models.auth import Context
-from models.memory import Memory  # Issue #262: Memory model for resource data storage
+from models.memory import (  # Issue #262: Memory model for resource data storage
+    SOURCE_TYPE_CONNECTOR,
+    Memory,
+)
 from models.resource import IndexerState, Resource, ResourceEvent, ResourceSchema
 from services.context_routing import resolve_context_routing
 from services.embedding_service import EmbeddingService
@@ -798,6 +801,10 @@ class ResourceIndexer:
                     importance=event.importance if event.importance is not None else 0.6,
                     scope="working",
                     source="resource_ingest",  # Issue #262: Track provenance
+                    # Issue #887: server-stamped provenance — connector/external
+                    # ingestion is 'connector', never client-set. (Trust is
+                    # authoritative at the context level; this is provenance.)
+                    source_type=SOURCE_TYPE_CONNECTOR,
                     tags=[],
                     context={"context_id": str(context.id)},
                     client="resource_indexer",

--- a/backend/tests/integration/test_connector_provisioning_flow.py
+++ b/backend/tests/integration/test_connector_provisioning_flow.py
@@ -310,6 +310,10 @@ async def test_admin_non_owner_can_auto_create_context(db_session: AsyncSession)
     ).scalar_one()
     # Context attributed to the owner, not the acting admin.
     assert ctx.created_by == owner_id
+    # Issue #887: an auto-created connector context is stamped 'external' — the
+    # authoritative trust signal that excludes connector-ingested memories from
+    # behaviour-influencing (trust_tier='trusted') reads.
+    assert ctx.trust_tier == "external"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/integration/test_e35_887_provenance_trust_tier_migration.py
+++ b/backend/tests/integration/test_e35_887_provenance_trust_tier_migration.py
@@ -1,0 +1,124 @@
+"""Integration pins for #887 — DB-level provenance + trust_tier behaviour.
+
+Covers what the AST/CHECK-literal unit tests cannot: the actual PostgreSQL
+DEFAULT backfill, the NOT NULL constraint, and the CHECK constraints rejecting
+out-of-set values at the engine level, for both ``memories.source_type`` and
+``contexts.trust_tier``.
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+_MEM_COLS = (
+    "id, user_id, summary, content, type, importance, confidence, scope, "
+    "embedding_status, client, source, long_term, use_count, access_count"
+)
+_MEM_VALS = (
+    ":id, 'u1', 's', 'c', 'note', 0.5, 1.0, 'working', "
+    "'success', 'test', 'mcp_remember', false, 0, 0"
+)
+
+
+@pytest.mark.asyncio
+async def test_source_type_defaults_to_manual(db_session):
+    """A row inserted WITHOUT source_type backfills to 'manual' (server DEFAULT)."""
+    mem_id = uuid.uuid4()
+    await db_session.execute(
+        text(f"INSERT INTO memories ({_MEM_COLS}) VALUES ({_MEM_VALS})"),
+        {"id": mem_id},
+    )
+    row = (
+        await db_session.execute(
+            text("SELECT source_type FROM memories WHERE id = :id"), {"id": mem_id}
+        )
+    ).one()
+    assert row.source_type == "manual"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stype", ["file", "url", "vault", "api", "manual", "connector"])
+async def test_source_type_accepts_valid_values(db_session, stype):
+    mem_id = uuid.uuid4()
+    await db_session.execute(
+        text(f"INSERT INTO memories ({_MEM_COLS}, source_type) VALUES ({_MEM_VALS}, :stype)"),
+        {"id": mem_id, "stype": stype},
+    )
+    row = (
+        await db_session.execute(
+            text("SELECT source_type FROM memories WHERE id = :id"), {"id": mem_id}
+        )
+    ).one()
+    assert row.source_type == stype
+
+
+@pytest.mark.asyncio
+async def test_source_type_check_rejects_unknown_value(db_session):
+    mem_id = uuid.uuid4()
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(f"INSERT INTO memories ({_MEM_COLS}, source_type) VALUES ({_MEM_VALS}, 'bogus')"),
+            {"id": mem_id},
+        )
+
+
+async def _make_workspace(db_session):
+    ws = uuid.uuid4()
+    await db_session.execute(
+        text("INSERT INTO workspaces (id, name, owner_user_id) VALUES (:id, :n, :o)"),
+        {"id": ws, "n": "ws-887", "o": "u-887"},
+    )
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_context_trust_tier_defaults_to_trusted(db_session):
+    ws = await _make_workspace(db_session)
+    ctx = uuid.uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO contexts (id, workspace_id, name, created_by) VALUES (:id, :ws, :n, :by)"
+        ),
+        {"id": ctx, "ws": ws, "n": "ctx-887", "by": "u-887"},
+    )
+    row = (
+        await db_session.execute(
+            text("SELECT trust_tier FROM contexts WHERE id = :id"), {"id": ctx}
+        )
+    ).one()
+    assert row.trust_tier == "trusted"
+
+
+@pytest.mark.asyncio
+async def test_context_trust_tier_accepts_external(db_session):
+    ws = await _make_workspace(db_session)
+    ctx = uuid.uuid4()
+    await db_session.execute(
+        text(
+            "INSERT INTO contexts (id, workspace_id, name, created_by, trust_tier) "
+            "VALUES (:id, :ws, :n, :by, 'external')"
+        ),
+        {"id": ctx, "ws": ws, "n": "ctx-887b", "by": "u-887"},
+    )
+    row = (
+        await db_session.execute(
+            text("SELECT trust_tier FROM contexts WHERE id = :id"), {"id": ctx}
+        )
+    ).one()
+    assert row.trust_tier == "external"
+
+
+@pytest.mark.asyncio
+async def test_context_trust_tier_check_rejects_unknown_value(db_session):
+    ws = await _make_workspace(db_session)
+    ctx = uuid.uuid4()
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(
+                "INSERT INTO contexts (id, workspace_id, name, created_by, trust_tier) "
+                "VALUES (:id, :ws, :n, :by, 'bogus')"
+            ),
+            {"id": ctx, "ws": ws, "n": "ctx-887c", "by": "u-887"},
+        )

--- a/backend/tests/services/test_recall_trust_tier_filter.py
+++ b/backend/tests/services/test_recall_trust_tier_filter.py
@@ -1,0 +1,93 @@
+"""Recall ``trust_tier`` filter test (Issue #887).
+
+Pins the security-relevant recall filter: when
+``recall(filters={"trust_tier": "trusted"})`` is set, the candidate-fetch
+SELECT must restrict to memories whose Context is authoritatively trusted
+(``Context.trust_tier == 'trusted'``) and drop connector-sourced rows
+(``source_type != 'connector'``). Without this pin, a regression that dropped
+the predicate would silently re-open the prompt-injection surface this filter
+closes (OWASP LLM01/LLM03).
+
+Mirrors the mocked-service pattern of test_recall_analysis_cluster_filter.py:
+``search_service.hybrid_search`` and ``db.execute`` are mocked, and we assert on
+the compiled SQL of the ``select(Memory).where(*pg_conditions)`` candidate fetch.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from models.schemas import RecallRequest
+
+
+def _make_service():
+    from services.memory_service import MemoryService
+
+    db = AsyncMock()
+    # db.execute(...) awaits to a result whose .scalars().all() → [] (the
+    # candidate fetch at memory_service.py:1504) and whose .scalar_one_or_none()
+    # is a truthy mock (context isolation). Same statement object is recorded in
+    # call_args_list regardless, which is what _compiled_selects inspects.
+    _result = MagicMock()
+    _result.scalars.return_value.all.return_value = []
+    db.execute = AsyncMock(return_value=_result)
+    svc = MemoryService(db)
+    svc.search_service = MagicMock()
+    # Return one fake candidate so recall proceeds past the ``if not memory_ids``
+    # early return to the ``select(Memory).where(*pg_conditions)`` candidate
+    # fetch (the statement we assert on). The row won't resolve from the mocked
+    # db.execute, so the response loop simply skips it — fine for this test.
+    svc.search_service.hybrid_search = AsyncMock(return_value=[{"id": str(uuid4()), "score": 0.9}])
+    svc.memory_repo = MagicMock()
+    return svc, db
+
+
+def _compiled_selects(db) -> str:
+    """All statements passed to db.execute, compiled to SQL, joined."""
+    sqls = []
+    for call in db.execute.call_args_list:
+        if call.args:
+            try:
+                sqls.append(str(call.args[0].compile(compile_kwargs={"literal_binds": False})))
+            except Exception:
+                sqls.append(str(call.args[0]))
+    return " ".join(sqls)
+
+
+@pytest.mark.asyncio
+async def test_trusted_filter_adds_context_and_source_predicates():
+    svc, db = _make_service()
+    request = RecallRequest(query="q", k=5, filters={"trust_tier": "trusted"})
+
+    await svc.recall(
+        request=request,
+        user_id="u",
+        current_context_id=uuid4(),
+        current_workspace_id=uuid4(),
+    )
+
+    sql = _compiled_selects(db)
+    # Authoritative context-level check + row-level connector defense-in-depth.
+    assert "trust_tier" in sql, "recall must consult Context.trust_tier when trusted"
+    assert "source_type" in sql, "recall must also drop connector-sourced rows"
+
+
+@pytest.mark.asyncio
+async def test_no_trust_filter_omits_trust_predicates():
+    svc, db = _make_service()
+    request = RecallRequest(query="q", k=5)  # no filters
+
+    await svc.recall(
+        request=request,
+        user_id="u",
+        current_context_id=uuid4(),
+        current_workspace_id=uuid4(),
+    )
+
+    sql = _compiled_selects(db)
+    # Without the filter, the candidate SELECT must NOT carry the trust predicate
+    # (default recall still returns connector/external memories for knowledge use).
+    assert "trust_tier" not in sql

--- a/backend/tests/test_context_trust_tier_constants.py
+++ b/backend/tests/test_context_trust_tier_constants.py
@@ -1,0 +1,42 @@
+"""Regression tests for #887: Context.trust_tier constant + CHECK invariants.
+
+``trust_tier`` is the server-authoritative trust signal on Context:
+``trusted`` (default) | ``external`` (connector-ingested). The CHECK is derived
+from ``_ALL_CONTEXT_TRUST_TIERS`` so ``create_all()`` stays byte-identical to the
+alembic head.
+"""
+
+from models.auth import (
+    _ALL_CONTEXT_TRUST_TIERS,
+    CONTEXT_TRUST_TIER_EXTERNAL,
+    CONTEXT_TRUST_TIER_TRUSTED,
+    Context,
+)
+
+
+def test_all_context_trust_tiers_tuple_matches_constants() -> None:
+    assert _ALL_CONTEXT_TRUST_TIERS == (
+        CONTEXT_TRUST_TIER_TRUSTED,
+        CONTEXT_TRUST_TIER_EXTERNAL,
+    )
+
+
+def test_trust_tier_values() -> None:
+    assert CONTEXT_TRUST_TIER_TRUSTED == "trusted"
+    assert CONTEXT_TRUST_TIER_EXTERNAL == "external"
+
+
+def test_valid_context_trust_tier_check_constraint_matches_migration_literal() -> None:
+    expected = "trust_tier IN ('trusted', 'external')"
+    check = next(
+        c for c in Context.__table_args__ if getattr(c, "name", None) == "valid_context_trust_tier"
+    )
+    assert check.sqltext.text == expected
+
+
+def test_trust_tier_column_defaults_to_trusted() -> None:
+    """A context with no explicit trust_tier defaults to 'trusted' (server-side),
+    so existing contexts and normal user contexts are unaffected."""
+    col = Context.__table__.c.trust_tier
+    assert col.nullable is False
+    assert col.server_default.arg == "trusted"

--- a/backend/tests/test_source_type_constants.py
+++ b/backend/tests/test_source_type_constants.py
@@ -1,0 +1,67 @@
+"""Regression tests for #887: source_type provenance constant + CHECK + forge guard.
+
+``source_type`` is server-authoritative provenance on Memory:
+``file`` | ``url`` | ``vault`` | ``api`` | ``manual`` | ``connector``. Like
+``delivery_mode`` / edge ``origin``, the DB CHECK is derived from an ordered
+Python tuple (``_ALL_SOURCE_TYPES``) so ``create_all()`` stays byte-identical to
+the alembic head. ``connector`` is server-only (resource_indexer); the request
+schema must not let a client forge it.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from models.memory import (
+    _ALL_SOURCE_TYPES,
+    SOURCE_TYPE_API,
+    SOURCE_TYPE_CONNECTOR,
+    SOURCE_TYPE_FILE,
+    SOURCE_TYPE_MANUAL,
+    SOURCE_TYPE_URL,
+    SOURCE_TYPE_VAULT,
+    Memory,
+)
+from models.schemas import RememberRequest
+
+
+def test_all_source_types_tuple_matches_constants() -> None:
+    assert _ALL_SOURCE_TYPES == (
+        SOURCE_TYPE_FILE,
+        SOURCE_TYPE_URL,
+        SOURCE_TYPE_VAULT,
+        SOURCE_TYPE_API,
+        SOURCE_TYPE_MANUAL,
+        SOURCE_TYPE_CONNECTOR,
+    )
+
+
+def test_valid_source_type_check_constraint_matches_migration_literal() -> None:
+    """``valid_source_type`` CHECK text is byte-identical to the migration literal."""
+    expected = "source_type IN ('file', 'url', 'vault', 'api', 'manual', 'connector')"
+    check = next(
+        c for c in Memory.__table_args__ if getattr(c, "name", None) == "valid_source_type"
+    )
+    assert check.sqltext.text == expected
+
+
+def test_client_cannot_forge_connector_source_type() -> None:
+    """The request schema only permits user-origin values — ``connector`` is
+    server-only, so a caller on the remember path cannot forge external-ingestion
+    provenance (the core #887 trust-integrity guarantee)."""
+    with pytest.raises(ValidationError) as exc:
+        RememberRequest(
+            summary="a valid summary",
+            content="c",
+            type="note",
+            source_type="connector",
+        )
+    # Fail specifically on source_type (not an unrelated missing/short field).
+    assert "source_type" in str(exc.value)
+
+
+@pytest.mark.parametrize("value", ["file", "url", "vault", "api", "manual"])
+def test_user_origin_source_types_are_accepted(value: str) -> None:
+    """User-origin provenance values stay client-settable (Obsidian vault / file /
+    url imports — #213/#262 — must not regress)."""
+    req = RememberRequest(summary="a valid summary", content="c", type="note", source_type=value)
+    assert req.source_type == value


### PR DESCRIPTION
Closes #887

## Summary
Establishes a server-authoritative trust boundary for the agent-memory substrate (#885): untrusted (connector-ingested) memories must not act as a control-flow / prompt-injection surface once memory drives agent behaviour (OWASP LLM01/LLM03).

## Provenance integrity — `memories.source_type`
- `NOT NULL` + CHECK, tuple-derived (`_ALL_SOURCE_TYPES`, test-pinned vs the migration literal — same discipline as edge `origin` / `delivery_mode`). Legacy NULL backfilled to `manual` (the ratified, CSO-signed-off rule — safe because trust is authoritative at the **context** level, not per-row, and legacy NULLs predate connector ingestion).
- `connector` is **server-only**: `RememberRequest.source_type` is a `Literal[…]` that omits it, so a caller on the remember path **cannot forge external-origin provenance** (Pydantic-enforced). `resource_indexer` stamps `connector` server-side.
- User-origin values (`file`/`url`/`vault`/`api`/`manual`) stay client-settable so Obsidian vault / file / url import provenance (#213/#262) does **not** regress.

## Trust — `contexts.trust_tier` (authoritative mechanism)
- New `NOT NULL` column (`trusted` default | `external`) + CHECK.
- Auto-created connector contexts are stamped `external` at provision time (scoped to the auto-create path; a bring-your-own context is the user's own and not silently changed) — so memories inherit trust server-side regardless of client per-row claims (survives BYOK key leakage).
- `recall(filters={'trust_tier':'trusted'})` excludes external-origin (connector-sourced) memories from behaviour-influencing reads.

## Design refinement vs the ratified plan (flagged for review)
The ratified design said "server-stamp `source_type` → `manual`". Implementation revealed that would **regress** existing user-origin provenance (vault/file/url imports). This PR instead **decouples** provenance (`source_type`, client user-origin) from trust (context-level, authoritative). Security intent is preserved (external identifiable + excludable + unforgeable); the regression is avoided.

## ⚠️ Honest gate2 findings (all yellow — same root; addressed as follow-up #NNN)


> **Update (post-review):** the three findings below were all addressed within this PR after Copilot independently re-flagged them — the recall filter now enforces the authoritative `Context.trust_tier == 'trusted'` subquery (commit 323eb7bd), and the semantics are pinned by `tests/services/test_recall_trust_tier_filter.py` (commit ff25009e). The original text below is kept for history; #908 now only tracks the default-vs-opt-in decision.
Three advisors (cso/qa-lead/cto) converged on one design seam in the **recall filter**:
1. **Opt-in, not default (cso)**: exclusion fires only when `filters={'trust_tier':'trusted'}` is passed; the AC's "excluded by default" would break normal connector-memory recall, so opt-in is intentional — but behaviour-influencing reads MUST set the filter.
2. **Not e2e-tested (qa-lead)**: the recall exclusion itself (vs the schema/forge guards) isn't pinned end-to-end.
3. **Row-level proxy (cto)**: the filter uses `source_type != 'connector'` (a row-level proxy), not the authoritative `Context.trust_tier` column — equivalent in practice (connector contexts hold only connector rows) but the authoritative column isn't consulted by the filter.

The security **core** (provenance NOT NULL+CHECK, unforgeable `connector`, context `external` stamp) is implemented and tested. The recall-filter refinements (wire context-level trust + default decision + e2e test) are a tracked follow-up.

## Tests
12 local (source_type/trust_tier constants + CHECK-drift pins + remember forge guard) + 6 integration migration (DB enforcement) + 1 auto-create external-stamp assertion. schema_drift 87 pass (create_all parity). Full services+mcp suites 1124 passed, 0 failed. pyright 0, ruff clean.

## Migration co-ordering
`e35_887` shares `down_revision e34` with #889 (PR #905). When both land → alembic 2-head; a one-line merge revision reconciles them (or rebase whichever merges second).

## Pre-PR review summary
- gate2 mode: advisor-only · cso: yellow · qa-lead: yellow · cto: yellow (auto-accepted, autonomous /goal red-only; findings above)
- gate1: green (ratified design dialogue + CSO sign-off, #887 comment)

🤖 Generated via /gh-issue-driven:ship

