### PR TITLE
feat(connector): provision canonical chat resource schema at registration (#910)

### DIFF
--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -20,7 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.resource_tokens import ResourceTokenManager
 from models.auth import Workspace
-from models.resource import ResourceToken, WorkspaceConnector
+from models.resource import ResourceSchema, ResourceToken, WorkspaceConnector
 from services.resource_lookup import resolve_resource_pk, upsert_resource
 from utils.exceptions import ConflictError, MemoryCloudException, NotFoundException, ValidationError
 from utils.logger import get_logger
@@ -29,6 +29,27 @@ logger = get_logger(__name__)
 
 CONNECTOR_TYPES = frozenset({"slack", "discord", "teams"})
 _RESOURCE_ID_RE = re.compile(r"^[a-z0-9_-]+$")
+
+# Issue #910: canonical chat resource schema provisioned at connector
+# registration. The ai-worker writes ``payload={"text": <llm_summary>, ...}`` on
+# every ingest_event upsert; ``text`` is the single agreed fulltext field
+# (confirmed with ai-worker 2026-06-03) so the indexer's _project_payload
+# projects the summary into ``fulltext_content`` (and the vector path). Shape
+# matches ``api.routes.resource_schema.FieldDefinition.model_dump()``. Lineage
+# (source_uri / memory_details) stays in event_metadata, NOT the payload (#896).
+_CANONICAL_CHAT_FIELD_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "name": "text",
+        "type": "text",
+        "description": "Chat message / LLM summary fulltext content (ai-worker ingest payload).",
+        "classification": "public",
+        "index_hint": "fulltext+vector",
+        "unit": None,
+        "enum_values": None,
+        "example": None,
+        "required": False,
+    }
+]
 
 
 @dataclass(frozen=True)
@@ -190,6 +211,14 @@ class ConnectorProvisioningService:
                     f"Resource '{resource_id}' already has a workspace connector.",
                     connector_id=str(existing_connector.id),
                 )
+
+            # Issue #910: provision the canonical chat resource schema so the
+            # ai-worker's LLM summary (written as ``payload={"text": ...}`` on
+            # ingest_event) lands in an indexed fulltext field. Without a schema
+            # the indexer's _project_payload skips the summary entirely (lost
+            # from search), and schema registration is owner/UI-only so the
+            # worker can't self-bootstrap one.
+            await self._ensure_chat_resource_schema(resource_pk, resource_id)
 
             connector = WorkspaceConnector(
                 resource_pk=resource_pk,
@@ -645,6 +674,31 @@ class ConnectorProvisioningService:
             select(WorkspaceConnector).where(WorkspaceConnector.resource_pk == resource_pk)
         )
         return result.scalar_one_or_none()
+
+    async def _ensure_chat_resource_schema(self, resource_pk: UUID, resource_id: str) -> None:
+        """Provision the canonical chat resource schema (v1) if none exists (#910).
+
+        Idempotent: a re-provision (or a resource that already carries a schema,
+        e.g. a manually registered one) is left untouched so an operator's custom
+        schema is never clobbered. Only the first registration seeds the
+        canonical ``text`` fulltext field the worker writes to.
+        """
+        existing = (
+            await self.db.execute(
+                select(ResourceSchema.id).where(ResourceSchema.resource_pk == resource_pk).limit(1)
+            )
+        ).scalar_one_or_none()
+        if existing is not None:
+            return
+        self.db.add(
+            ResourceSchema(
+                resource_pk=resource_pk,
+                resource_id=resource_id,
+                schema_version=1,
+                field_definitions=_CANONICAL_CHAT_FIELD_DEFINITIONS,
+            )
+        )
+        await self.db.flush()
 
 
 async def get_connector_id_for_resource_pk(

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -15,6 +15,7 @@ from typing import Any
 from uuid import UUID
 
 from sqlalchemy import delete, func, select, text, update
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -682,6 +683,12 @@ class ConnectorProvisioningService:
         e.g. a manually registered one) is left untouched so an operator's custom
         schema is never clobbered. Only the first registration seeds the
         canonical ``text`` fulltext field the worker writes to.
+
+        The pre-check skips seeding when ANY schema version already exists; the
+        insert itself is ``ON CONFLICT DO NOTHING`` on the partial unique index
+        ``uq_resource_schemas_version (resource_pk, schema_version)`` so two
+        concurrent first-provisions for the same resource can't raise a UNIQUE
+        violation (the loser's insert is a no-op — the desired end state holds).
         """
         existing = (
             await self.db.execute(
@@ -690,15 +697,19 @@ class ConnectorProvisioningService:
         ).scalar_one_or_none()
         if existing is not None:
             return
-        self.db.add(
-            ResourceSchema(
+        await self.db.execute(
+            pg_insert(ResourceSchema)
+            .values(
                 resource_pk=resource_pk,
                 resource_id=resource_id,
                 schema_version=1,
                 field_definitions=_CANONICAL_CHAT_FIELD_DEFINITIONS,
             )
+            .on_conflict_do_nothing(
+                index_elements=["resource_pk", "schema_version"],
+                index_where=text("resource_pk IS NOT NULL"),
+            )
         )
-        await self.db.flush()
 
 
 async def get_connector_id_for_resource_pk(

--- a/backend/tests/integration/test_connector_provisioning_flow.py
+++ b/backend/tests/integration/test_connector_provisioning_flow.py
@@ -218,6 +218,68 @@ async def test_registration_path_creates_context_and_mints_kmc_key(
 
 
 @pytest.mark.asyncio
+async def test_provision_seeds_canonical_chat_resource_schema(db_session: AsyncSession):
+    """Issue #910: connector registration provisions the canonical chat schema.
+
+    The ai-worker writes ``payload={"text": <summary>}`` on ingest; the indexer
+    only projects fields the ResourceSchema marks fulltext/vector. So a chat
+    connector must get a v1 schema with a fulltext ``text`` field or the summary
+    is lost from search.
+    """
+    from models.resource import ResourceSchema
+
+    user_id, workspace = await _seed_workspace(db_session, plan_name="basic")
+    resource_id = f"slack_{uuid4().hex[:8]}"
+
+    result = await ConnectorProvisioningService(db_session).provision_connector(
+        workspace_id=workspace.id,
+        user_id=user_id,
+        connector_type="slack",
+        resource_id=resource_id,
+    )
+    await db_session.flush()
+
+    schema = (
+        await db_session.execute(
+            select(ResourceSchema).where(ResourceSchema.resource_pk == result.resource_pk)
+        )
+    ).scalar_one()
+    assert schema.schema_version == 1
+    fields = {f["name"]: f for f in schema.field_definitions}
+    assert "text" in fields
+    text_field = fields["text"]
+    assert text_field["classification"] == "public"
+    assert "fulltext" in text_field["index_hint"]
+    assert "vector" in text_field["index_hint"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_chat_schema_is_idempotent(db_session: AsyncSession):
+    """A second _ensure_chat_resource_schema call does not duplicate or clobber."""
+    from sqlalchemy import func as _func
+
+    from models.resource import Resource, ResourceSchema
+
+    user_id, workspace = await _seed_workspace(db_session, plan_name="basic")
+    # Create a bare resource to attach a schema to.
+    res = Resource(workspace_id=workspace.id, resource_id="slack_idem", created_by=user_id)
+    db_session.add(res)
+    await db_session.flush()
+
+    svc = ConnectorProvisioningService(db_session)
+    await svc._ensure_chat_resource_schema(res.id, "slack_idem")
+    await svc._ensure_chat_resource_schema(res.id, "slack_idem")
+    await db_session.flush()
+
+    count = (
+        await db_session.execute(
+            select(_func.count(ResourceSchema.id)).where(ResourceSchema.resource_pk == res.id)
+        )
+    ).scalar_one()
+    assert count == 1
+
+
+@pytest.mark.asyncio
 async def test_delete_connector_revokes_kmc_key_and_removes_connector(
     db_session: AsyncSession,
 ):

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -105,6 +105,7 @@ class TestConnectorProvisioningService:
             *_lock_results(),
             _result(scalar=0),
             _result(one=None),
+            _result(one=None),  # #910: canonical chat schema existence check → none → provision
         ]
 
         with (
@@ -144,6 +145,7 @@ class TestConnectorProvisioningService:
             *_lock_results(),
             _result(scalar=0),
             _result(one=None),
+            _result(one=None),  # #910: canonical chat schema existence check → none → provision
         ]
 
         with (

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -106,6 +106,7 @@ class TestConnectorProvisioningService:
             _result(scalar=0),
             _result(one=None),
             _result(one=None),  # #910: canonical chat schema existence check → none → provision
+            _result(),  # #910: ON CONFLICT DO NOTHING insert (return not consumed)
         ]
 
         with (
@@ -146,6 +147,7 @@ class TestConnectorProvisioningService:
             _result(scalar=0),
             _result(one=None),
             _result(one=None),  # #910: canonical chat schema existence check → none → provision
+            _result(),  # #910: ON CONFLICT DO NOTHING insert (return not consumed)
         ]
 
         with (


### PR DESCRIPTION
Closes #910

## Summary
ai-worker #98 (Option A) blocker. The chat-ingest write path writes `payload={"text": <llm_summary>, ...}` on every `ingest_event`, but the indexer's `_project_payload` only projects fields the registered `ResourceSchema` marks `fulltext`/`vector`. Chat connectors previously got **no schema** (registration is owner/UI-only — the worker can't self-bootstrap one), so the summary landed in an unindexed field and was **lost from search**.

## Change
Provision a **canonical chat `ResourceSchema` (v1)** at connector registration (`connector_provisioning.provision_connector`) with the agreed fulltext field:

```
{ name: "text", type: "text", classification: "public", index_hint: "fulltext+vector", ... }
```

- The ai-worker then writes `payload={"text": <summary>, ...}` (confirmed with ai-worker 2026-06-03, single-sourced, no startup fetch).
- **Idempotent** — `_ensure_chat_resource_schema` skips if a schema already exists, so a manually registered schema is never clobbered.
- Lineage stays in `event_metadata` (`source_uri` / `memory_details`, #896), NOT the payload.

## Why server-side (not "tell the worker")
A schema must exist for the indexer to project anything, and the worker (resource-token auth) can't POST one (owner/session-only registration). So provisioning is structurally a server-side step regardless; `get_resource_schema` fetch alone can't solve the bootstrap.

## Tests
- `test_provision_seeds_canonical_chat_resource_schema` — v1 schema with the `text` fulltext+vector public field.
- `test_ensure_chat_schema_is_idempotent` — second call doesn't duplicate/clobber.
- 2 unit `side_effect` updates for the new schema-existence query.
- ruff/pyright clean; connector + schema_drift + resource/indexer suites green (55 passed).

## Cross-repo
Unblocks kagura-ai/kagura-memory-ai-worker#98 Cycle 3b (`ingest_chat()` payload mapping). Related: #895 (workers/config resource token), #896 (indexer details/source_uri projection).

🤖 Generated via gh-issue-driven
