### PR TITLE
feat(api): REST routes for agent session-state lane (#906)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -389,6 +389,7 @@ from api.routes import (  # noqa: E402
     admin_plans,
     admin_signup_gate,  # Issue #358: admin-configurable signup gate
     admin_sleep,  # Issue #247: Manual Sleep Maintenance trigger
+    agent_state,  # Issue #906: REST surface for the agent session-state lane
     analyses,  # Issue #496: Memory Broadlistening API endpoints
     api_keys,
     attachments,  # Issue #330 → deprecated by #555 (returns HTTP 410 Gone)
@@ -508,6 +509,9 @@ app.include_router(contexts.router, prefix="/api/v1")
 
 # Context Search Config routes (Issue #130 → #160 - Context-scoped search settings, renamed from project)
 app.include_router(context_search_config.router)
+
+# Agent session-state lane REST routes (Issue #906, follow-up to #889 — router carries its own prefix)
+app.include_router(agent_state.router)
 
 # MCP API routes (Issue #45 - MCP tools list and status)
 app.include_router(mcp.router, prefix="/api/v1")

--- a/backend/src/api/routes/agent_state.py
+++ b/backend/src/api/routes/agent_state.py
@@ -1,0 +1,216 @@
+"""REST routes for the agent session-state lane (Issue #906, follow-up to #889).
+
+#889 shipped the ``set_state`` / ``get_state`` MCP tools + ``AgentStateService``
++ ``agent_states`` table. This module exposes the same lane over REST so non-MCP
+/ dashboard consumers get the full set/get/list/delete surface.
+
+Access control mirrors the MCP handler (``mcp_server/tools/state.py``) using the
+REST-layer equivalents:
+- **reads** (get one / list) → ``PermissionService.check_context_access`` at
+  ``VIEWER`` (IDOR guard — uniform 404 ``NotFoundException`` on an unreachable
+  context, CWE-639 safe).
+- **writes** (set / delete) → ``PermissionService.check_context_write`` (editor/
+  owner only; read-only viewers get 403 ``AuthorizationError``). It resolves the
+  context first, so a missing context still surfaces a uniform 404.
+
+The agent_states lane is TTL-bounded and structurally excluded from ``recall()``
+(separate table, never embedded). ``expires_at`` is not surfaced here because
+``AgentStateService`` returns values, not rows — exposing remaining TTL is a
+tracked follow-up, not in scope for this REST-wrapper issue.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import APIKeyOrSessionUser
+from auth.workspace_roles import ContextRole
+from db.base import get_db
+from services.agent_state_service import AgentStateService
+from services.permission_service import PermissionService
+from utils.exceptions import MemoryCloudException, NotFoundException
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/contexts", tags=["agent-state"])
+
+# Mirrors the agent_states.key column (VARCHAR(255)) and the MCP handler's
+# _STATE_KEY_MAX_LEN — keep the three in lock-step.
+_STATE_KEY_MAX_LEN = 255
+
+
+# === Schemas ===============================================================
+class AgentStateSetRequest(BaseModel):
+    """Body for upserting an agent-state entry.
+
+    ``value`` is arbitrary JSON (stored in the JSONB column) but must not be
+    null — the column is NOT NULL, and a null value is rejected up front as a
+    422 rather than surfacing as a DB-layer 500.
+    """
+
+    value: Any = Field(..., description="Arbitrary JSON value to store (must not be null)")
+    ttl_seconds: int | None = Field(
+        None,
+        gt=0,
+        description=(
+            "Optional TTL in seconds (clamped server-side to 30 days). "
+            "Omit to persist until explicitly deleted."
+        ),
+    )
+
+
+class AgentStateKeyResponse(BaseModel):
+    """Envelope for a write that returns just the affected key (set / delete)."""
+
+    key: str
+
+
+class AgentStateValueResponse(BaseModel):
+    """Envelope for a single-key read."""
+
+    key: str
+    value: Any
+
+
+class AgentStateListResponse(BaseModel):
+    """Envelope for listing all live entries in a context."""
+
+    states: dict[str, Any]
+    count: int
+
+
+# === Dependency factories ==================================================
+async def get_agent_state_service(db: AsyncSession = Depends(get_db)) -> AgentStateService:
+    return AgentStateService(db)
+
+
+async def get_permission_service(db: AsyncSession = Depends(get_db)) -> PermissionService:
+    return PermissionService(db)
+
+
+# === Routes ================================================================
+@router.put("/{context_id}/state/{key}", response_model=AgentStateKeyResponse)
+async def set_agent_state(
+    context_id: UUID,
+    user: APIKeyOrSessionUser,
+    body: AgentStateSetRequest,
+    key: str = Path(..., min_length=1, max_length=_STATE_KEY_MAX_LEN),
+    service: AgentStateService = Depends(get_agent_state_service),
+    perm: PermissionService = Depends(get_permission_service),
+):
+    """Upsert ``value`` at ``(context_id, key)`` (PUT = idempotent, 200 on replace)."""
+    if body.value is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="'value' must not be null",
+        )
+    user_id = user.get("user_id")
+    logger.info("agent_state_set_requested", user_id=user_id, context_id=str(context_id), key=key)
+    try:
+        # Write gate (editor/owner). Resolves the context first → uniform 404.
+        await perm.check_context_write(user_id, context_id)
+        await service.set_state(context_id, key, body.value, ttl_seconds=body.ttl_seconds)
+        return AgentStateKeyResponse(key=key)
+    except (HTTPException, MemoryCloudException):
+        raise
+    except Exception as e:
+        logger.error(
+            "agent_state_set_failed", user_id=user_id, context_id=str(context_id), error=str(e)
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to set agent state",
+        ) from e
+
+
+@router.get("/{context_id}/state/{key}", response_model=AgentStateValueResponse)
+async def get_agent_state(
+    context_id: UUID,
+    user: APIKeyOrSessionUser,
+    key: str = Path(..., min_length=1, max_length=_STATE_KEY_MAX_LEN),
+    service: AgentStateService = Depends(get_agent_state_service),
+    perm: PermissionService = Depends(get_permission_service),
+):
+    """Read one key's live value. 404 when absent or expired."""
+    user_id = user.get("user_id")
+    logger.info("agent_state_get_requested", user_id=user_id, context_id=str(context_id), key=key)
+    try:
+        # Read gate (VIEWER). Uniform 404 on an unreachable context (IDOR guard).
+        await perm.check_context_access(user_id, context_id, required_role=ContextRole.VIEWER)
+        value = await service.get_state(context_id, key)
+        if value is None:
+            raise NotFoundException("AgentState")
+        return AgentStateValueResponse(key=key, value=value)
+    except (HTTPException, MemoryCloudException):
+        raise
+    except Exception as e:
+        logger.error(
+            "agent_state_get_failed", user_id=user_id, context_id=str(context_id), error=str(e)
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to get agent state",
+        ) from e
+
+
+@router.get("/{context_id}/state", response_model=AgentStateListResponse)
+async def list_agent_state(
+    context_id: UUID,
+    user: APIKeyOrSessionUser,
+    service: AgentStateService = Depends(get_agent_state_service),
+    perm: PermissionService = Depends(get_permission_service),
+):
+    """List all live ``key → value`` entries for the context (200, empty = {})."""
+    user_id = user.get("user_id")
+    logger.info("agent_state_list_requested", user_id=user_id, context_id=str(context_id))
+    try:
+        await perm.check_context_access(user_id, context_id, required_role=ContextRole.VIEWER)
+        states = await service.list_state(context_id)
+        return AgentStateListResponse(states=states, count=len(states))
+    except (HTTPException, MemoryCloudException):
+        raise
+    except Exception as e:
+        logger.error(
+            "agent_state_list_failed", user_id=user_id, context_id=str(context_id), error=str(e)
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to list agent state",
+        ) from e
+
+
+@router.delete("/{context_id}/state/{key}", response_model=AgentStateKeyResponse)
+async def delete_agent_state(
+    context_id: UUID,
+    user: APIKeyOrSessionUser,
+    key: str = Path(..., min_length=1, max_length=_STATE_KEY_MAX_LEN),
+    service: AgentStateService = Depends(get_agent_state_service),
+    perm: PermissionService = Depends(get_permission_service),
+):
+    """Delete ``(context_id, key)``. 404 when the key was not present."""
+    user_id = user.get("user_id")
+    logger.info(
+        "agent_state_delete_requested", user_id=user_id, context_id=str(context_id), key=key
+    )
+    try:
+        await perm.check_context_write(user_id, context_id)
+        removed = await service.delete_state(context_id, key)
+        if not removed:
+            raise NotFoundException("AgentState")
+        return AgentStateKeyResponse(key=key)
+    except (HTTPException, MemoryCloudException):
+        raise
+    except Exception as e:
+        logger.error(
+            "agent_state_delete_failed", user_id=user_id, context_id=str(context_id), error=str(e)
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete agent state",
+        ) from e

--- a/backend/src/api/routes/agent_state.py
+++ b/backend/src/api/routes/agent_state.py
@@ -5,13 +5,15 @@
 / dashboard consumers get the full set/get/list/delete surface.
 
 Access control mirrors the MCP handler (``mcp_server/tools/state.py``) using the
-REST-layer equivalents:
-- **reads** (get one / list) → ``PermissionService.check_context_access`` at
-  ``VIEWER`` (IDOR guard — uniform 404 ``NotFoundException`` on an unreachable
-  context, CWE-639 safe).
-- **writes** (set / delete) → ``PermissionService.check_context_write`` (editor/
-  owner only; read-only viewers get 403 ``AuthorizationError``). It resolves the
-  context first, so a missing context still surfaces a uniform 404.
+REST-layer equivalents — every path resolves the context with a UNIFORM 404 first
+so a cross-workspace context never leaks its existence via a 403 (CWE-639 / OWASP
+A01), exactly like the MCP ``_resolve_context_for_read``:
+- **reads** (get one / list) → ``PermissionService.resolve_context_for_workspace_read``
+  (uniform 404 on unreachable/cross-workspace context).
+- **writes** (set / delete) → ``resolve_context_for_workspace_read`` (uniform-404
+  reach check) **then** ``check_context_write`` (editor/owner; a read-only viewer
+  who CAN reach the context gets 403 — safe, since workspace membership is already
+  confirmed so the 403 leaks nothing cross-workspace).
 
 The agent_states lane is TTL-bounded and structurally excluded from ``recall()``
 (separate table, never embedded). ``expires_at`` is not surfaced here because
@@ -29,11 +31,10 @@ from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import APIKeyOrSessionUser
-from auth.workspace_roles import ContextRole
 from db.base import get_db
 from services.agent_state_service import AgentStateService
 from services.permission_service import PermissionService
-from utils.exceptions import MemoryCloudException, NotFoundException
+from utils.exceptions import MemoryCloudException, NotFoundException, ValidationError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -106,14 +107,17 @@ async def set_agent_state(
 ):
     """Upsert ``value`` at ``(context_id, key)`` (PUT = idempotent, 200 on replace)."""
     if body.value is None:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="'value' must not be null",
-        )
+        # ValidationError (not a raw HTTPException) so the client gets the
+        # standard {error, message, details} envelope + VAL-001 code via the
+        # global MemoryCloudException handler.
+        raise ValidationError("'value' must not be null", field="value")
     user_id = user.get("user_id")
     logger.info("agent_state_set_requested", user_id=user_id, context_id=str(context_id), key=key)
     try:
-        # Write gate (editor/owner). Resolves the context first → uniform 404.
+        # Reach check with UNIFORM 404 first (CWE-639: a cross-workspace context
+        # must not leak its existence via a 403), then the editor/owner write
+        # gate — whose 403 is safe once workspace membership is confirmed.
+        await perm.resolve_context_for_workspace_read(user_id, context_id)
         await perm.check_context_write(user_id, context_id)
         await service.set_state(context_id, key, body.value, ttl_seconds=body.ttl_seconds)
         return AgentStateKeyResponse(key=key)
@@ -141,8 +145,9 @@ async def get_agent_state(
     user_id = user.get("user_id")
     logger.info("agent_state_get_requested", user_id=user_id, context_id=str(context_id), key=key)
     try:
-        # Read gate (VIEWER). Uniform 404 on an unreachable context (IDOR guard).
-        await perm.check_context_access(user_id, context_id, required_role=ContextRole.VIEWER)
+        # Read gate with UNIFORM 404 on an unreachable/cross-workspace context
+        # (CWE-639 IDOR guard; mirrors the MCP handler's _resolve_context_for_read).
+        await perm.resolve_context_for_workspace_read(user_id, context_id)
         value = await service.get_state(context_id, key)
         if value is None:
             raise NotFoundException("AgentState")
@@ -170,7 +175,8 @@ async def list_agent_state(
     user_id = user.get("user_id")
     logger.info("agent_state_list_requested", user_id=user_id, context_id=str(context_id))
     try:
-        await perm.check_context_access(user_id, context_id, required_role=ContextRole.VIEWER)
+        # Uniform-404 read gate (CWE-639 IDOR guard).
+        await perm.resolve_context_for_workspace_read(user_id, context_id)
         states = await service.list_state(context_id)
         return AgentStateListResponse(states=states, count=len(states))
     except (HTTPException, MemoryCloudException):
@@ -199,6 +205,8 @@ async def delete_agent_state(
         "agent_state_delete_requested", user_id=user_id, context_id=str(context_id), key=key
     )
     try:
+        # Uniform-404 reach check, then the editor/owner write gate (CWE-639).
+        await perm.resolve_context_for_workspace_read(user_id, context_id)
         await perm.check_context_write(user_id, context_id)
         removed = await service.delete_state(context_id, key)
         if not removed:

--- a/backend/tests/api/test_agent_state_routes.py
+++ b/backend/tests/api/test_agent_state_routes.py
@@ -211,3 +211,25 @@ class TestDeleteAgentState:
             await delete_agent_state(
                 context_id=context_id, user=MOCK_USER, key="missing", service=service, perm=perm
             )
+
+    @pytest.mark.asyncio
+    async def test_delete_viewer_denied_propagates_403(self, service, perm, context_id):
+        # Reach check passes; the write gate 403s a read-only viewer.
+        perm.check_context_write.side_effect = AuthorizationError()
+        with pytest.raises(AuthorizationError):
+            await delete_agent_state(
+                context_id=context_id, user=MOCK_USER, key="k", service=service, perm=perm
+            )
+        service.delete_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_unreachable_context_propagates_uniform_404(
+        self, service, perm, context_id
+    ):
+        perm.resolve_context_for_workspace_read.side_effect = NotFoundException("Context")
+        with pytest.raises(NotFoundException):
+            await delete_agent_state(
+                context_id=context_id, user=MOCK_USER, key="k", service=service, perm=perm
+            )
+        perm.check_context_write.assert_not_awaited()
+        service.delete_state.assert_not_awaited()

--- a/backend/tests/api/test_agent_state_routes.py
+++ b/backend/tests/api/test_agent_state_routes.py
@@ -1,15 +1,14 @@
 """Route-surface tests for the agent session-state REST lane (Issue #906).
 
-Pins the REST wiring around a mocked ``AgentStateService`` + mocked
-``PermissionService`` (the CRUD itself is integration-tested via #889). The
-load-bearing contracts here are:
-- the read/write gate split mirrors the MCP handler: writes (set/delete) go
-  through ``check_context_write``, reads (get/list) through
-  ``check_context_access`` at VIEWER;
-- gate denials propagate as the structured ``MemoryCloudException`` (404/403),
+Pins the REST wiring around a mocked AgentStateService + mocked PermissionService.
+Load-bearing contracts (post-#914 Copilot review):
+- every path resolves the context with a UNIFORM 404 first
+  (``resolve_context_for_workspace_read``) so a cross-workspace context never
+  leaks via a 403 (CWE-639); writes then apply ``check_context_write``;
+- a gate denial propagates as the structured MemoryCloudException (404/403),
   not swallowed into a 500;
-- absent key → 404 on get and delete; null value → 422 on set;
-- envelope shapes (key / value / states+count).
+- null value → ``ValidationError`` (422 with the standard error envelope), not a
+  bare HTTPException.
 """
 
 from __future__ import annotations
@@ -18,8 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
-from fastapi import HTTPException
-from pydantic import ValidationError
+from pydantic import ValidationError as PydanticValidationError
 
 from api.routes.agent_state import (
     AgentStateSetRequest,
@@ -28,8 +26,7 @@ from api.routes.agent_state import (
     list_agent_state,
     set_agent_state,
 )
-from auth.workspace_roles import ContextRole
-from utils.exceptions import AuthorizationError, NotFoundException
+from utils.exceptions import AuthorizationError, NotFoundException, ValidationError
 
 MOCK_USER = {"user_id": "test_user"}
 
@@ -52,42 +49,42 @@ def service():
 @pytest.fixture
 def perm():
     return MagicMock(
+        resolve_context_for_workspace_read=AsyncMock(),
         check_context_write=AsyncMock(),
-        check_context_access=AsyncMock(),
     )
 
 
 class TestSetAgentState:
     @pytest.mark.asyncio
-    async def test_set_success_returns_key_and_uses_write_gate(self, service, perm, context_id):
+    async def test_set_success_resolves_then_write_gates(self, service, perm, context_id):
         body = AgentStateSetRequest(value={"step": 3}, ttl_seconds=60)
         resp = await set_agent_state(
             context_id=context_id, user=MOCK_USER, body=body, key="run", service=service, perm=perm
         )
         assert resp.key == "run"
+        # Uniform-404 reach check happens, AND the editor/owner write gate.
+        perm.resolve_context_for_workspace_read.assert_awaited_once_with("test_user", context_id)
         perm.check_context_write.assert_awaited_once_with("test_user", context_id)
-        perm.check_context_access.assert_not_awaited()  # write path must NOT use the read gate
         service.set_state.assert_awaited_once_with(context_id, "run", {"step": 3}, ttl_seconds=60)
 
     @pytest.mark.asyncio
-    async def test_set_null_value_returns_422_before_touching_service(
+    async def test_set_null_value_raises_validation_error_before_touching_service(
         self, service, perm, context_id
     ):
-        body = AgentStateSetRequest(value=None)
-        with pytest.raises(HTTPException) as exc:
+        with pytest.raises(ValidationError):  # utils.exceptions → 422 + VAL-001 envelope
             await set_agent_state(
                 context_id=context_id,
                 user=MOCK_USER,
-                body=body,
+                body=AgentStateSetRequest(value=None),
                 key="k",
                 service=service,
                 perm=perm,
             )
-        assert exc.value.status_code == 422
         service.set_state.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_set_viewer_denied_propagates_403(self, service, perm, context_id):
+        # Reach check passes (workspace member); the write gate 403s a viewer.
         perm.check_context_write.side_effect = AuthorizationError()
         with pytest.raises(AuthorizationError):
             await set_agent_state(
@@ -101,8 +98,10 @@ class TestSetAgentState:
         service.set_state.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_set_unreachable_context_propagates_404(self, service, perm, context_id):
-        perm.check_context_write.side_effect = NotFoundException("Context")
+    async def test_set_unreachable_context_propagates_uniform_404(self, service, perm, context_id):
+        # Cross-workspace/unreachable → the RESOLVE step raises a uniform 404
+        # before the write gate can 403-leak existence.
+        perm.resolve_context_for_workspace_read.side_effect = NotFoundException("Context")
         with pytest.raises(NotFoundException):
             await set_agent_state(
                 context_id=context_id,
@@ -112,27 +111,27 @@ class TestSetAgentState:
                 service=service,
                 perm=perm,
             )
+        perm.check_context_write.assert_not_awaited()
+        service.set_state.assert_not_awaited()
 
     @pytest.mark.parametrize("bad_ttl", [0, -1, -3600])
     def test_non_positive_ttl_rejected_by_schema(self, bad_ttl):
         # gt=0 on the schema is the enforcement point: a 0/negative TTL is a 422
-        # ValidationError at request parsing, before the route runs.
-        with pytest.raises(ValidationError):
+        # at request parsing, before the route runs.
+        with pytest.raises(PydanticValidationError):
             AgentStateSetRequest(value=1, ttl_seconds=bad_ttl)
 
 
 class TestGetAgentState:
     @pytest.mark.asyncio
-    async def test_get_present_returns_value_and_uses_read_gate(self, service, perm, context_id):
+    async def test_get_present_returns_value_via_uniform_read_gate(self, service, perm, context_id):
         service.get_state.return_value = {"cursor": "abc"}
         resp = await get_agent_state(
             context_id=context_id, user=MOCK_USER, key="run", service=service, perm=perm
         )
         assert resp.key == "run"
         assert resp.value == {"cursor": "abc"}
-        perm.check_context_access.assert_awaited_once_with(
-            "test_user", context_id, required_role=ContextRole.VIEWER
-        )
+        perm.resolve_context_for_workspace_read.assert_awaited_once_with("test_user", context_id)
         perm.check_context_write.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -144,10 +143,8 @@ class TestGetAgentState:
             )
 
     @pytest.mark.asyncio
-    async def test_get_unreachable_context_propagates_404(self, service, perm, context_id):
-        # Cross-workspace / IDOR: the read gate raises a uniform 404 and the route
-        # must propagate it (not swallow into the except-Exception 500 arm).
-        perm.check_context_access.side_effect = NotFoundException("Context")
+    async def test_get_unreachable_context_propagates_uniform_404(self, service, perm, context_id):
+        perm.resolve_context_for_workspace_read.side_effect = NotFoundException("Context")
         with pytest.raises(NotFoundException):
             await get_agent_state(
                 context_id=context_id, user=MOCK_USER, key="k", service=service, perm=perm
@@ -174,9 +171,7 @@ class TestListAgentState:
         )
         assert resp.states == {"a": 1, "b": {"x": 2}}
         assert resp.count == 2
-        perm.check_context_access.assert_awaited_once_with(
-            "test_user", context_id, required_role=ContextRole.VIEWER
-        )
+        perm.resolve_context_for_workspace_read.assert_awaited_once_with("test_user", context_id)
 
     @pytest.mark.asyncio
     async def test_list_empty_returns_200_with_empty_dict(self, service, perm, context_id):
@@ -188,10 +183,10 @@ class TestListAgentState:
         assert resp.count == 0
 
     @pytest.mark.asyncio
-    async def test_list_denied_propagates_403(self, service, perm, context_id):
-        # No-access caller: the read gate raises 403 and the route propagates it.
-        perm.check_context_access.side_effect = AuthorizationError()
-        with pytest.raises(AuthorizationError):
+    async def test_list_unreachable_context_propagates_uniform_404(self, service, perm, context_id):
+        # No-reach caller: the resolve step raises a uniform 404 (not a 403 leak).
+        perm.resolve_context_for_workspace_read.side_effect = NotFoundException("Context")
+        with pytest.raises(NotFoundException):
             await list_agent_state(
                 context_id=context_id, user=MOCK_USER, service=service, perm=perm
             )
@@ -200,14 +195,14 @@ class TestListAgentState:
 
 class TestDeleteAgentState:
     @pytest.mark.asyncio
-    async def test_delete_present_returns_key_and_uses_write_gate(self, service, perm, context_id):
+    async def test_delete_present_resolves_then_write_gates(self, service, perm, context_id):
         service.delete_state.return_value = True
         resp = await delete_agent_state(
             context_id=context_id, user=MOCK_USER, key="run", service=service, perm=perm
         )
         assert resp.key == "run"
+        perm.resolve_context_for_workspace_read.assert_awaited_once_with("test_user", context_id)
         perm.check_context_write.assert_awaited_once_with("test_user", context_id)
-        perm.check_context_access.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_delete_absent_returns_404(self, service, perm, context_id):

--- a/backend/tests/api/test_agent_state_routes.py
+++ b/backend/tests/api/test_agent_state_routes.py
@@ -1,0 +1,218 @@
+"""Route-surface tests for the agent session-state REST lane (Issue #906).
+
+Pins the REST wiring around a mocked ``AgentStateService`` + mocked
+``PermissionService`` (the CRUD itself is integration-tested via #889). The
+load-bearing contracts here are:
+- the read/write gate split mirrors the MCP handler: writes (set/delete) go
+  through ``check_context_write``, reads (get/list) through
+  ``check_context_access`` at VIEWER;
+- gate denials propagate as the structured ``MemoryCloudException`` (404/403),
+  not swallowed into a 500;
+- absent key → 404 on get and delete; null value → 422 on set;
+- envelope shapes (key / value / states+count).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from api.routes.agent_state import (
+    AgentStateSetRequest,
+    delete_agent_state,
+    get_agent_state,
+    list_agent_state,
+    set_agent_state,
+)
+from auth.workspace_roles import ContextRole
+from utils.exceptions import AuthorizationError, NotFoundException
+
+MOCK_USER = {"user_id": "test_user"}
+
+
+@pytest.fixture
+def context_id():
+    return uuid4()
+
+
+@pytest.fixture
+def service():
+    return MagicMock(
+        set_state=AsyncMock(return_value=None),
+        get_state=AsyncMock(),
+        list_state=AsyncMock(),
+        delete_state=AsyncMock(),
+    )
+
+
+@pytest.fixture
+def perm():
+    return MagicMock(
+        check_context_write=AsyncMock(),
+        check_context_access=AsyncMock(),
+    )
+
+
+class TestSetAgentState:
+    @pytest.mark.asyncio
+    async def test_set_success_returns_key_and_uses_write_gate(self, service, perm, context_id):
+        body = AgentStateSetRequest(value={"step": 3}, ttl_seconds=60)
+        resp = await set_agent_state(
+            context_id=context_id, user=MOCK_USER, body=body, key="run", service=service, perm=perm
+        )
+        assert resp.key == "run"
+        perm.check_context_write.assert_awaited_once_with("test_user", context_id)
+        perm.check_context_access.assert_not_awaited()  # write path must NOT use the read gate
+        service.set_state.assert_awaited_once_with(context_id, "run", {"step": 3}, ttl_seconds=60)
+
+    @pytest.mark.asyncio
+    async def test_set_null_value_returns_422_before_touching_service(
+        self, service, perm, context_id
+    ):
+        body = AgentStateSetRequest(value=None)
+        with pytest.raises(HTTPException) as exc:
+            await set_agent_state(
+                context_id=context_id,
+                user=MOCK_USER,
+                body=body,
+                key="k",
+                service=service,
+                perm=perm,
+            )
+        assert exc.value.status_code == 422
+        service.set_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_viewer_denied_propagates_403(self, service, perm, context_id):
+        perm.check_context_write.side_effect = AuthorizationError()
+        with pytest.raises(AuthorizationError):
+            await set_agent_state(
+                context_id=context_id,
+                user=MOCK_USER,
+                body=AgentStateSetRequest(value=1),
+                key="k",
+                service=service,
+                perm=perm,
+            )
+        service.set_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_set_unreachable_context_propagates_404(self, service, perm, context_id):
+        perm.check_context_write.side_effect = NotFoundException("Context")
+        with pytest.raises(NotFoundException):
+            await set_agent_state(
+                context_id=context_id,
+                user=MOCK_USER,
+                body=AgentStateSetRequest(value=1),
+                key="k",
+                service=service,
+                perm=perm,
+            )
+
+    @pytest.mark.parametrize("bad_ttl", [0, -1, -3600])
+    def test_non_positive_ttl_rejected_by_schema(self, bad_ttl):
+        # gt=0 on the schema is the enforcement point: a 0/negative TTL is a 422
+        # ValidationError at request parsing, before the route runs.
+        with pytest.raises(ValidationError):
+            AgentStateSetRequest(value=1, ttl_seconds=bad_ttl)
+
+
+class TestGetAgentState:
+    @pytest.mark.asyncio
+    async def test_get_present_returns_value_and_uses_read_gate(self, service, perm, context_id):
+        service.get_state.return_value = {"cursor": "abc"}
+        resp = await get_agent_state(
+            context_id=context_id, user=MOCK_USER, key="run", service=service, perm=perm
+        )
+        assert resp.key == "run"
+        assert resp.value == {"cursor": "abc"}
+        perm.check_context_access.assert_awaited_once_with(
+            "test_user", context_id, required_role=ContextRole.VIEWER
+        )
+        perm.check_context_write.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_absent_returns_404(self, service, perm, context_id):
+        service.get_state.return_value = None
+        with pytest.raises(NotFoundException):
+            await get_agent_state(
+                context_id=context_id, user=MOCK_USER, key="missing", service=service, perm=perm
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_unreachable_context_propagates_404(self, service, perm, context_id):
+        # Cross-workspace / IDOR: the read gate raises a uniform 404 and the route
+        # must propagate it (not swallow into the except-Exception 500 arm).
+        perm.check_context_access.side_effect = NotFoundException("Context")
+        with pytest.raises(NotFoundException):
+            await get_agent_state(
+                context_id=context_id, user=MOCK_USER, key="k", service=service, perm=perm
+            )
+        service.get_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_get_falsy_but_present_value_is_returned_not_404(self, service, perm, context_id):
+        # A stored ``0`` / ``False`` / ``""`` is a real value — get_state returns
+        # None ONLY for absent/expired, so only None maps to 404.
+        service.get_state.return_value = 0
+        resp = await get_agent_state(
+            context_id=context_id, user=MOCK_USER, key="counter", service=service, perm=perm
+        )
+        assert resp.value == 0
+
+
+class TestListAgentState:
+    @pytest.mark.asyncio
+    async def test_list_returns_states_and_count(self, service, perm, context_id):
+        service.list_state.return_value = {"a": 1, "b": {"x": 2}}
+        resp = await list_agent_state(
+            context_id=context_id, user=MOCK_USER, service=service, perm=perm
+        )
+        assert resp.states == {"a": 1, "b": {"x": 2}}
+        assert resp.count == 2
+        perm.check_context_access.assert_awaited_once_with(
+            "test_user", context_id, required_role=ContextRole.VIEWER
+        )
+
+    @pytest.mark.asyncio
+    async def test_list_empty_returns_200_with_empty_dict(self, service, perm, context_id):
+        service.list_state.return_value = {}
+        resp = await list_agent_state(
+            context_id=context_id, user=MOCK_USER, service=service, perm=perm
+        )
+        assert resp.states == {}
+        assert resp.count == 0
+
+    @pytest.mark.asyncio
+    async def test_list_denied_propagates_403(self, service, perm, context_id):
+        # No-access caller: the read gate raises 403 and the route propagates it.
+        perm.check_context_access.side_effect = AuthorizationError()
+        with pytest.raises(AuthorizationError):
+            await list_agent_state(
+                context_id=context_id, user=MOCK_USER, service=service, perm=perm
+            )
+        service.list_state.assert_not_awaited()
+
+
+class TestDeleteAgentState:
+    @pytest.mark.asyncio
+    async def test_delete_present_returns_key_and_uses_write_gate(self, service, perm, context_id):
+        service.delete_state.return_value = True
+        resp = await delete_agent_state(
+            context_id=context_id, user=MOCK_USER, key="run", service=service, perm=perm
+        )
+        assert resp.key == "run"
+        perm.check_context_write.assert_awaited_once_with("test_user", context_id)
+        perm.check_context_access.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_delete_absent_returns_404(self, service, perm, context_id):
+        service.delete_state.return_value = False
+        with pytest.raises(NotFoundException):
+            await delete_agent_state(
+                context_id=context_id, user=MOCK_USER, key="missing", service=service, perm=perm
+            )


### PR DESCRIPTION
Closes #906

## Summary
- Follow-up to #889 (PR #905), which shipped the `set_state`/`get_state` MCP tools + `AgentStateService` + `agent_states` table. This adds the REST surface so non-MCP / dashboard consumers get the full set/get/list/delete lane.
- 4 endpoints under `/api/v1/contexts/{context_id}/state[/{key}]`: `PUT` (upsert, 200), `GET` one (404 on absent), `GET` list (200, `{}` when empty), `DELETE` (404 on absent).

## Implementation notes
- **Access mirrors the MCP handler** (`mcp_server/tools/state.py`): reads gate on `PermissionService.check_context_access(VIEWER)` (IDOR-safe uniform 404), writes gate on `check_context_write` (editor/owner; read-only viewers → 403). Domain exceptions (`NotFoundException`/`AuthorizationError`) propagate to the global handler — caught before the generic `except Exception → 500`.
- Service + PermissionService injected via `get_*_service` `Depends` factories (mirrors `contexts.py`), so route functions are unit-testable directly.
- Inline Pydantic schemas (route-specific): `value: Any` (null → 422), `ttl_seconds` `gt=0`, `key` length 255 (lock-step with the column + MCP `_STATE_KEY_MAX_LEN`).
- 16 route tests: gate composition (opposite gate `assert_not_awaited`), viewer-403, cross-workspace-404, non-positive-TTL-422, null-value-422, absent-key-404, falsy-but-present value, empty-list, envelope shapes. ruff + pyright clean.

## Follow-up (out of scope here)
- `expires_at` (remaining TTL) is not surfaced — `AgentStateService` returns values, not rows; exposing it needs a service change and is deferred as a tracked follow-up.
- SDK `set_state`/`get_state` → kagura-memory-python-sdk#171.

## Pre-PR review summary
- gate2 mode: advisor-only — cso: green, qa-lead: green, cto: green
- gate1: green via /ask (DX Lead lens)
- review provider: code-review (2 findings addressed pre-PR: TTL-422 + read-path denial tests)

🤖 Generated via /gh-issue-driven:ship
