### PR TITLE
feat(api): retrieval feedback signal + eval-gate policy (#888)

### DIFF
--- a/backend/alembic/versions/e36_888_retrieval_feedback.py
+++ b/backend/alembic/versions/e36_888_retrieval_feedback.py
@@ -1,0 +1,58 @@
+"""Add retrieval_feedback table — retrieval feedback signal (#888).
+
+A dedicated append-only event log of "was this recalled memory useful for this
+query" signals, kept out of ``memories`` so it never pollutes the knowledge
+recall space (separate table, never embedded). No unique constraint — feedback
+is a time series. Both FKs cascade on delete so feedback is erased with its
+context or memory (GDPR/APPI erasure). The (context_id, memory_id) index backs
+net-helpful aggregation reads.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "e36_888_retrieval_feedback"
+down_revision = "e35_889_agent_state"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "retrieval_feedback",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "context_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("contexts.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "memory_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("memories.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("query", sa.String(length=1024), nullable=True),
+        sa.Column("helpful", sa.Boolean(), nullable=False),
+        sa.Column("user_id", sa.String(length=255), nullable=False),
+        sa.Column("note", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "idx_retrieval_feedback_context_memory",
+        "retrieval_feedback",
+        ["context_id", "memory_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_retrieval_feedback_context_memory", table_name="retrieval_feedback")
+    op.drop_table("retrieval_feedback")

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -400,6 +400,7 @@ from api.routes import (  # noqa: E402
     contexts,
     cost_aggregation,  # Issue #472: cost aggregation API (admin + workspace-scoped)
     external_keys,
+    feedback,  # Issue #888: retrieval feedback signal
     files,  # Issue #485: platform-managed R2 file storage
     graph,
     invitations,
@@ -508,6 +509,9 @@ app.include_router(contexts.router, prefix="/api/v1")
 
 # Context Search Config routes (Issue #130 → #160 - Context-scoped search settings, renamed from project)
 app.include_router(context_search_config.router)
+
+# Retrieval feedback signal route (Issue #888 — router carries its own /api/v1/contexts prefix)
+app.include_router(feedback.router)
 
 # MCP API routes (Issue #45 - MCP tools list and status)
 app.include_router(mcp.router, prefix="/api/v1")

--- a/backend/src/api/routes/feedback.py
+++ b/backend/src/api/routes/feedback.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import APIKeyOrSessionUser
 from auth.workspace_roles import ContextRole
 from db.base import get_db
-from models.retrieval_feedback import QUERY_MAX_LEN
+from models.retrieval_feedback import NOTE_MAX_LEN, QUERY_MAX_LEN
 from services.feedback_service import FeedbackService
 from services.permission_service import PermissionService
 from utils.exceptions import MemoryCloudException
@@ -42,7 +42,11 @@ class FeedbackRequest(BaseModel):
         max_length=QUERY_MAX_LEN,
         description="The recall query this feedback is about (optional)",
     )
-    note: str | None = Field(None, description="Optional free-text note (e.g. why it was wrong)")
+    note: str | None = Field(
+        None,
+        max_length=NOTE_MAX_LEN,
+        description="Optional free-text note (e.g. why it was wrong). Max 2000 chars.",
+    )
 
 
 class FeedbackResponse(BaseModel):

--- a/backend/src/api/routes/feedback.py
+++ b/backend/src/api/routes/feedback.py
@@ -1,0 +1,108 @@
+"""REST route for the retrieval feedback signal (Issue #888, epic #885).
+
+``POST /api/v1/contexts/{context_id}/feedback`` records an append-only "was this
+recalled memory useful for this query" event. Feedback lives in its own table and
+is never embedded, so it cannot pollute ``recall()``.
+
+Access mirrors the established context-scoped pattern (#906): recording feedback
+is a **read-adjacent** action — anyone who can read the context (VIEWER) consumes
+recall and may rate it — so it gates on ``check_context_access(VIEWER)``, not
+write. The caller's ``user_id`` is stored for attribution.
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.dependencies import APIKeyOrSessionUser
+from auth.workspace_roles import ContextRole
+from db.base import get_db
+from models.retrieval_feedback import QUERY_MAX_LEN
+from services.feedback_service import FeedbackService
+from services.permission_service import PermissionService
+from utils.exceptions import MemoryCloudException
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/api/v1/contexts", tags=["retrieval-feedback"])
+
+
+class FeedbackRequest(BaseModel):
+    """Body for recording retrieval feedback."""
+
+    memory_id: UUID = Field(..., description="The recalled memory being rated")
+    helpful: bool = Field(..., description="Was this memory useful for the query?")
+    query: str | None = Field(
+        None,
+        max_length=QUERY_MAX_LEN,
+        description="The recall query this feedback is about (optional)",
+    )
+    note: str | None = Field(None, description="Optional free-text note (e.g. why it was wrong)")
+
+
+class FeedbackResponse(BaseModel):
+    feedback_id: UUID
+    memory_id: UUID
+    helpful: bool
+
+
+async def get_feedback_service(db: AsyncSession = Depends(get_db)) -> FeedbackService:
+    return FeedbackService(db)
+
+
+async def get_permission_service(db: AsyncSession = Depends(get_db)) -> PermissionService:
+    return PermissionService(db)
+
+
+@router.post(
+    "/{context_id}/feedback",
+    response_model=FeedbackResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def record_feedback(
+    context_id: UUID,
+    body: FeedbackRequest,
+    user: APIKeyOrSessionUser,
+    service: FeedbackService = Depends(get_feedback_service),
+    perm: PermissionService = Depends(get_permission_service),
+):
+    """Record an append-only retrieval-feedback event for a recalled memory."""
+    user_id = user.get("user_id")
+    logger.info(
+        "retrieval_feedback_requested",
+        user_id=user_id,
+        context_id=str(context_id),
+        memory_id=str(body.memory_id),
+        helpful=body.helpful,
+    )
+    try:
+        # Read-adjacent: VIEWER may rate recall. Uniform 404 on unreachable
+        # context (IDOR guard), same posture as the other context-scoped routes.
+        await perm.check_context_access(user_id, context_id, required_role=ContextRole.VIEWER)
+        row = await service.record_feedback(
+            context_id=context_id,
+            memory_id=body.memory_id,
+            helpful=body.helpful,
+            user_id=user_id,
+            query=body.query,
+            note=body.note,
+        )
+        return FeedbackResponse(feedback_id=row.id, memory_id=row.memory_id, helpful=row.helpful)
+    except (HTTPException, MemoryCloudException):
+        raise
+    except Exception as e:
+        logger.error(
+            "retrieval_feedback_failed",
+            user_id=user_id,
+            context_id=str(context_id),
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to record retrieval feedback",
+        ) from e

--- a/backend/src/mcp_server/tools/__init__.py
+++ b/backend/src/mcp_server/tools/__init__.py
@@ -116,6 +116,7 @@ def _build_registry() -> dict[str, Any]:
         handle_list_edges,
         handle_update_edge,
     )
+    from mcp_server.tools.feedback import handle_feedback
     from mcp_server.tools.files import (
         handle_complete_file_upload,
         handle_delete_file,
@@ -155,6 +156,8 @@ def _build_registry() -> dict[str, Any]:
         # Issue #889: agent session-state lane (TTL, recall-excluded)
         "set_state": handle_set_state,
         "get_state": handle_get_state,
+        # Issue #888: retrieval feedback signal (append-only, recall-excluded)
+        "feedback": handle_feedback,
         "get_context_info": handle_get_context_info,
         "create_context": handle_create_context,
         "update_context": handle_update_context,

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1859,7 +1859,7 @@ series). Anyone who can read the context may record feedback.""",
                     },
                     "note": {
                         "type": "string",
-                        "description": "Optional free-text note (e.g. why the result was wrong).",
+                        "description": "Optional free-text note (e.g. why the result was wrong). Max 2000 chars.",
                     },
                 },
                 "required": ["context_id", "memory_id", "helpful"],

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1828,6 +1828,44 @@ Requires action recording (reports created before this feature have no actions t
             "readOnly": True,
         },
         {
+            "name": "feedback",
+            "description": """Record whether a recalled memory was useful for a query (Issue #888).
+
+An append-only signal — "this recall result was helpful / not helpful". It is
+SEPARATE from memories: feedback is NOT embedded and is structurally excluded
+from recall(), so rating a result never pollutes the knowledge search space.
+
+Use this after recall() to teach the substrate which results were on-target.
+Each call appends a new event (repeated/contradicting signals are kept as a time
+series). Anyone who can read the context may record feedback.""",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "context_id": {
+                        "type": "string",
+                        "description": "Target context UUID (the recalled memory's context).",
+                    },
+                    "memory_id": {
+                        "type": "string",
+                        "description": "UUID of the recalled memory being rated.",
+                    },
+                    "helpful": {
+                        "type": "boolean",
+                        "description": "True if the memory was useful for the query, False if not.",
+                    },
+                    "query": {
+                        "type": "string",
+                        "description": "Optional recall query this feedback is about (max 1024 chars).",
+                    },
+                    "note": {
+                        "type": "string",
+                        "description": "Optional free-text note (e.g. why the result was wrong).",
+                    },
+                },
+                "required": ["context_id", "memory_id", "helpful"],
+            },
+        },
+        {
             "name": "set_state",
             "description": """Set ephemeral agent run-state at (context_id, key) (Issue #889).
 

--- a/backend/src/mcp_server/tools/feedback.py
+++ b/backend/src/mcp_server/tools/feedback.py
@@ -1,0 +1,90 @@
+"""MCP tool for the retrieval feedback signal (Issue #888, epic #885).
+
+``feedback`` records an append-only "was this recalled memory useful for this
+query" event. The signal lives in its own table and is never embedded, so it
+cannot pollute ``recall()``.
+
+Access mirrors the read path: ``_resolve_context_for_read`` verifies the caller
+can reach the context (uniform ``context_not_found`` on deny — CWE-639). Recording
+feedback is read-adjacent (anyone who can read the context consumes recall and may
+rate it), so no viewer write-gate is applied.
+"""
+
+from typing import Any
+from uuid import UUID
+
+from mcp.types import TextContent
+
+from mcp_server.tools._helpers import (
+    _ContextNotFoundError,
+    _error_response,
+    _resolve_context_for_read,
+    _resolve_context_id,
+    _success_response,
+)
+from utils.exceptions import NotFoundException
+
+# Matches retrieval_feedback.query VARCHAR(1024). Enforced here so an overlong
+# query returns a structured error instead of a DB-layer 500.
+_QUERY_MAX_LEN = 1024
+
+
+async def handle_feedback(
+    args: dict[str, Any], user_id: str, workspace_id: UUID | None
+) -> list[TextContent]:
+    """Record retrieval feedback for a recalled memory (append-only)."""
+    if "memory_id" not in args or "helpful" not in args:
+        return _error_response("missing_fields", "Missing required fields: memory_id, helpful")
+
+    helpful = args["helpful"]
+    if not isinstance(helpful, bool):
+        return _error_response("validation_error", "'helpful' must be a boolean")
+
+    raw_memory_id = args["memory_id"]
+    try:
+        memory_id = UUID(str(raw_memory_id))
+    except (ValueError, TypeError):
+        return _error_response("validation_error", "'memory_id' must be a valid UUID")
+
+    query = args.get("query")
+    if query is not None and (not isinstance(query, str) or len(query) > _QUERY_MAX_LEN):
+        return _error_response(
+            "validation_error",
+            f"'query' must be a string of at most {_QUERY_MAX_LEN} characters",
+        )
+    note = args.get("note")
+    if note is not None and not isinstance(note, str):
+        return _error_response("validation_error", "'note' must be a string")
+
+    from db.base import get_db
+    from services.feedback_service import FeedbackService
+
+    async for db in get_db():
+        raw_ctx = args.get("context_id")
+        if not raw_ctx:
+            return _error_response("missing_fields", "Missing required field: context_id")
+        try:
+            context_id = _resolve_context_id(str(raw_ctx))
+        except ValueError as exc:
+            return _error_response("invalid_context_id_format", str(exc))
+        try:
+            # Read-adjacent: verify the caller can reach the context (IDOR guard).
+            await _resolve_context_for_read(db, user_id, context_id)
+        except _ContextNotFoundError as exc:
+            return exc.to_response()
+
+        try:
+            row = await FeedbackService(db).record_feedback(
+                context_id=context_id,
+                memory_id=memory_id,
+                helpful=helpful,
+                user_id=user_id,
+                query=query,
+                note=note,
+            )
+        except NotFoundException:
+            # memory_id does not belong to this context (uniform, IDOR-safe).
+            return _error_response("not_found", "Memory not found in this context")
+        return _success_response(feedback_id=str(row.id), memory_id=str(memory_id), helpful=helpful)
+
+    return _error_response("internal_error", "Database session unavailable")

--- a/backend/src/mcp_server/tools/feedback.py
+++ b/backend/src/mcp_server/tools/feedback.py
@@ -22,11 +22,12 @@ from mcp_server.tools._helpers import (
     _resolve_context_id,
     _success_response,
 )
+from models.retrieval_feedback import NOTE_MAX_LEN, QUERY_MAX_LEN
 from utils.exceptions import NotFoundException
 
-# Matches retrieval_feedback.query VARCHAR(1024). Enforced here so an overlong
-# query returns a structured error instead of a DB-layer 500.
-_QUERY_MAX_LEN = 1024
+# Length caps reuse the model's single source of truth (query is VARCHAR(1024);
+# note is bounded in the service). Enforced here so an overlong value returns a
+# structured validation error instead of silent truncation / a DB-layer 500.
 
 
 async def handle_feedback(
@@ -47,14 +48,17 @@ async def handle_feedback(
         return _error_response("validation_error", "'memory_id' must be a valid UUID")
 
     query = args.get("query")
-    if query is not None and (not isinstance(query, str) or len(query) > _QUERY_MAX_LEN):
+    if query is not None and (not isinstance(query, str) or len(query) > QUERY_MAX_LEN):
         return _error_response(
             "validation_error",
-            f"'query' must be a string of at most {_QUERY_MAX_LEN} characters",
+            f"'query' must be a string of at most {QUERY_MAX_LEN} characters",
         )
     note = args.get("note")
-    if note is not None and not isinstance(note, str):
-        return _error_response("validation_error", "'note' must be a string")
+    if note is not None and (not isinstance(note, str) or len(note) > NOTE_MAX_LEN):
+        return _error_response(
+            "validation_error",
+            f"'note' must be a string of at most {NOTE_MAX_LEN} characters",
+        )
 
     from db.base import get_db
     from services.feedback_service import FeedbackService

--- a/backend/src/models/__init__.py
+++ b/backend/src/models/__init__.py
@@ -13,6 +13,7 @@ import models.analysis  # noqa: F401
 import models.file_objects  # noqa: F401  # Issue #485: file storage
 import models.llm_call_log  # noqa: F401  # Issue #474: comprehensive call ledger
 import models.llm_pricing  # noqa: F401
+import models.retrieval_feedback  # noqa: F401  # Issue #888: retrieval feedback signal
 import models.sleep  # noqa: F401
 from models.config import ContextSearchConfig
 from models.file_objects import FileObject, WorkspaceStorageUsage

--- a/backend/src/models/retrieval_feedback.py
+++ b/backend/src/models/retrieval_feedback.py
@@ -1,0 +1,79 @@
+"""Retrieval feedback signal (Issue #888, part of epic #885).
+
+An **append-only event log** of "this recalled memory was / was not useful for
+this query" signals. Kept in a **dedicated** table — NOT in ``memories`` — so it
+never pollutes the knowledge ``recall()`` space (separate table, never embedded,
+structurally excluded from search), the same isolation principle as
+``agent_states`` (#889).
+
+Append-only by design: feedback is a time series (a user may change their mind, or
+repeat a signal — repetition is itself signal), so there is no unique constraint
+and no upsert. Aggregation (net-helpful score) is a read-time concern, not a
+write-time dedup. ``user_id`` is recorded so feedback is attributable (abuse
+tracing + future signal weighting).
+
+Both FKs cascade on delete so feedback is erased with its context or its memory —
+keeping the lane consistent with GDPR/APPI erasure (a context delete removes its
+feedback automatically).
+
+This signal is the prerequisite for any future Eval→Skill self-update loop, which
+MUST stay gated behind the golden retrieval eval harness (#344) — see
+``backend/tests/eval/README.md``. No auto-promotion / self-update loop ships
+before that eval gate is green.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, Text, func, text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from db.base import Base
+
+# Query text is stored truncated to this length — the signal needs the query for
+# offline analysis, not unbounded text retention (CIO gate1 note).
+QUERY_MAX_LEN = 1024
+
+
+class RetrievalFeedback(Base):
+    """One append-only feedback event: was ``memory_id`` useful for ``query``?"""
+
+    __tablename__ = "retrieval_feedback"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    context_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("contexts.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    memory_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("memories.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    # The recall query this feedback is about (optional — a caller may rate a
+    # memory without echoing the query). Stored truncated; never embedded.
+    query: Mapped[str | None] = mapped_column(String(QUERY_MAX_LEN), nullable=True)
+    helpful: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Optional free-text note (e.g. why it was wrong). Truncation enforced in the
+    # service layer; Text column keeps the model permissive.
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Naive UTC by convention (engine pins the session to UTC).
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        # Aggregation reads (net-helpful per memory within a context) scan by
+        # this pair — the append-only log has no unique key.
+        Index("idx_retrieval_feedback_context_memory", "context_id", "memory_id"),
+    )

--- a/backend/src/models/retrieval_feedback.py
+++ b/backend/src/models/retrieval_feedback.py
@@ -36,6 +36,10 @@ from db.base import Base
 # Query text is stored truncated to this length — the signal needs the query for
 # offline analysis, not unbounded text retention (CIO gate1 note).
 QUERY_MAX_LEN = 1024
+# Free-text note cap. The column is Text (unbounded at the DB), so this is the
+# single source of truth enforced at every boundary (API schema, MCP handler,
+# service truncation) to avoid silent truncation / unbounded request bodies.
+NOTE_MAX_LEN = 2000
 
 
 class RetrievalFeedback(Base):

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -16,12 +16,8 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.memory import Memory
-from models.retrieval_feedback import QUERY_MAX_LEN, RetrievalFeedback
+from models.retrieval_feedback import NOTE_MAX_LEN, QUERY_MAX_LEN, RetrievalFeedback
 from utils.exceptions import NotFoundException
-
-# Free-text note cap (the column is Text; we still bound input to avoid unbounded
-# retention, mirroring the query truncation).
-_NOTE_MAX_LEN = 2000
 
 
 @dataclass(frozen=True)
@@ -82,7 +78,7 @@ class FeedbackService:
             helpful=helpful,
             user_id=user_id,
             query=query[:QUERY_MAX_LEN] if query is not None else None,
-            note=note[:_NOTE_MAX_LEN] if note is not None else None,
+            note=note[:NOTE_MAX_LEN] if note is not None else None,
         )
         self.db.add(row)
         await self.db.commit()

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -1,0 +1,116 @@
+"""Retrieval feedback service (Issue #888).
+
+Append-only writes of retrieval feedback events + a read-time aggregation
+(net-helpful per memory). The feedback lane lives in its own table and is never
+embedded, so it cannot pollute ``recall()`` — this service only ever READS the
+``memories`` table (to validate the target memory belongs to the context) and
+never writes to it or the search index.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.memory import Memory
+from models.retrieval_feedback import QUERY_MAX_LEN, RetrievalFeedback
+from utils.exceptions import NotFoundException
+
+# Free-text note cap (the column is Text; we still bound input to avoid unbounded
+# retention, mirroring the query truncation).
+_NOTE_MAX_LEN = 2000
+
+
+@dataclass(frozen=True)
+class FeedbackAggregate:
+    """Net-helpful tally for a single memory within a context."""
+
+    memory_id: str
+    helpful_count: int
+    not_helpful_count: int
+
+    @property
+    def net(self) -> int:
+        return self.helpful_count - self.not_helpful_count
+
+
+class FeedbackService:
+    """Record retrieval feedback events and aggregate them (read-time)."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def record_feedback(
+        self,
+        context_id: UUID,
+        memory_id: UUID,
+        helpful: bool,
+        user_id: str,
+        query: str | None = None,
+        note: str | None = None,
+    ) -> RetrievalFeedback:
+        """Append one feedback event. Query/note are truncated, never embedded.
+
+        Append-only: every call inserts a new row (no upsert) so the signal keeps
+        its time series. Returns the persisted row.
+
+        Validates that ``memory_id`` belongs to ``context_id`` (and is not
+        soft-deleted) BEFORE inserting — the caller's authorization is on the
+        context, so without this a caller could inject feedback for a memory in
+        a context they cannot read (cross-context signal injection). A uniform
+        ``NotFoundException`` is raised on miss (same IDOR-safe shape as the
+        context gate; does not reveal whether the memory exists elsewhere).
+        """
+        exists = (
+            await self.db.execute(
+                select(Memory.id).where(
+                    Memory.id == memory_id,
+                    Memory.context_id == context_id,
+                    Memory.deleted_at.is_(None),
+                )
+            )
+        ).scalar_one_or_none()
+        if exists is None:
+            raise NotFoundException("Memory")
+
+        row = RetrievalFeedback(
+            context_id=context_id,
+            memory_id=memory_id,
+            helpful=helpful,
+            user_id=user_id,
+            query=query[:QUERY_MAX_LEN] if query is not None else None,
+            note=note[:_NOTE_MAX_LEN] if note is not None else None,
+        )
+        self.db.add(row)
+        await self.db.commit()
+        await self.db.refresh(row)
+        return row
+
+    async def aggregate_for_memory(self, context_id: UUID, memory_id: UUID) -> FeedbackAggregate:
+        """Net-helpful tally for one memory in a context (read-time only)."""
+        result = await self.db.execute(
+            select(
+                RetrievalFeedback.helpful,
+                func.count().label("n"),
+            )
+            .where(
+                RetrievalFeedback.context_id == context_id,
+                RetrievalFeedback.memory_id == memory_id,
+            )
+            .group_by(RetrievalFeedback.helpful)
+        )
+        helpful_count = 0
+        not_helpful_count = 0
+        for is_helpful, n in result.all():
+            if is_helpful:
+                helpful_count = n
+            else:
+                not_helpful_count = n
+        return FeedbackAggregate(
+            memory_id=str(memory_id),
+            helpful_count=helpful_count,
+            not_helpful_count=not_helpful_count,
+        )

--- a/backend/tests/api/test_feedback_routes.py
+++ b/backend/tests/api/test_feedback_routes.py
@@ -108,3 +108,29 @@ async def test_record_feedback_wraps_unexpected_error_as_500(service, perm, cont
 def test_overlong_query_rejected_by_schema(memory_id):
     with pytest.raises(ValueError):  # pydantic ValidationError subclasses ValueError
         FeedbackRequest(memory_id=memory_id, helpful=True, query="x" * 1025)
+
+
+def test_overlong_note_rejected_by_schema(memory_id):
+    # note > 2000 chars is a 422 at the schema boundary, NOT silent truncation.
+    with pytest.raises(ValueError):
+        FeedbackRequest(memory_id=memory_id, helpful=True, note="y" * 2001)
+
+
+@pytest.mark.asyncio
+async def test_mcp_handle_feedback_rejects_overlong_note():
+    """The MCP tool rejects an overlong note with a structured validation error,
+    before touching the DB (no silent truncation)."""
+    from mcp_server.tools.feedback import handle_feedback
+
+    result = await handle_feedback(
+        {
+            "context_id": str(uuid4()),
+            "memory_id": str(uuid4()),
+            "helpful": True,
+            "note": "y" * 2001,
+        },
+        user_id="test_user",
+        workspace_id=None,
+    )
+    # _error_response returns a single TextContent whose text carries the error.
+    assert "validation_error" in result[0].text

--- a/backend/tests/api/test_feedback_routes.py
+++ b/backend/tests/api/test_feedback_routes.py
@@ -1,0 +1,110 @@
+"""Route-surface tests for the retrieval feedback endpoint (Issue #888).
+
+Pins the REST wiring around a mocked FeedbackService + mocked PermissionService
+(persistence is integration-tested separately). Load-bearing contracts:
+- feedback is gated on the READ path (check_context_access VIEWER), not write —
+  recording feedback is read-adjacent;
+- a gate denial propagates as the structured MemoryCloudException (404/403),
+  not swallowed into a 500;
+- the response envelope carries the new feedback id + the rated memory + verdict.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import HTTPException
+
+from api.routes.feedback import FeedbackRequest, record_feedback
+from auth.workspace_roles import ContextRole
+from utils.exceptions import AuthorizationError, NotFoundException
+
+MOCK_USER = {"user_id": "test_user"}
+
+
+@pytest.fixture
+def context_id():
+    return uuid4()
+
+
+@pytest.fixture
+def memory_id():
+    return uuid4()
+
+
+@pytest.fixture
+def service(memory_id):
+    row = MagicMock(id=uuid4(), memory_id=memory_id, helpful=True)
+    return MagicMock(record_feedback=AsyncMock(return_value=row))
+
+
+@pytest.fixture
+def perm():
+    return MagicMock(check_context_access=AsyncMock())
+
+
+@pytest.mark.asyncio
+async def test_record_feedback_success_uses_read_gate(service, perm, context_id, memory_id):
+    body = FeedbackRequest(memory_id=memory_id, helpful=True, query="how does recall work")
+    resp = await record_feedback(
+        context_id=context_id, body=body, user=MOCK_USER, service=service, perm=perm
+    )
+    assert resp.memory_id == memory_id
+    assert resp.helpful is True
+    perm.check_context_access.assert_awaited_once_with(
+        "test_user", context_id, required_role=ContextRole.VIEWER
+    )
+    # user_id is taken from the authenticated principal, not the body.
+    service.record_feedback.assert_awaited_once()
+    assert service.record_feedback.await_args.kwargs["user_id"] == "test_user"
+
+
+@pytest.mark.asyncio
+async def test_record_feedback_unreachable_context_propagates_404(
+    service, perm, context_id, memory_id
+):
+    perm.check_context_access.side_effect = NotFoundException("Context")
+    with pytest.raises(NotFoundException):
+        await record_feedback(
+            context_id=context_id,
+            body=FeedbackRequest(memory_id=memory_id, helpful=False),
+            user=MOCK_USER,
+            service=service,
+            perm=perm,
+        )
+    service.record_feedback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_record_feedback_denied_propagates_403(service, perm, context_id, memory_id):
+    perm.check_context_access.side_effect = AuthorizationError()
+    with pytest.raises(AuthorizationError):
+        await record_feedback(
+            context_id=context_id,
+            body=FeedbackRequest(memory_id=memory_id, helpful=True),
+            user=MOCK_USER,
+            service=service,
+            perm=perm,
+        )
+    service.record_feedback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_record_feedback_wraps_unexpected_error_as_500(service, perm, context_id, memory_id):
+    service.record_feedback.side_effect = RuntimeError("db down")
+    with pytest.raises(HTTPException) as exc:
+        await record_feedback(
+            context_id=context_id,
+            body=FeedbackRequest(memory_id=memory_id, helpful=True),
+            user=MOCK_USER,
+            service=service,
+            perm=perm,
+        )
+    assert exc.value.status_code == 500
+
+
+def test_overlong_query_rejected_by_schema(memory_id):
+    with pytest.raises(ValueError):  # pydantic ValidationError subclasses ValueError
+        FeedbackRequest(memory_id=memory_id, helpful=True, query="x" * 1025)

--- a/backend/tests/integration/test_retrieval_feedback.py
+++ b/backend/tests/integration/test_retrieval_feedback.py
@@ -1,0 +1,247 @@
+"""Integration test for the retrieval feedback signal (Issue #888).
+
+Exercises the real DB path: FeedbackService writes append-only rows into the
+dedicated ``retrieval_feedback`` table (NOT ``memories``), aggregation tallies
+net-helpful, and the lane is structurally isolated from recall (separate table,
+no row ever lands in ``memories``). Also pins the FK CASCADE erasure contract.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import Context, Workspace
+from models.memory import Memory
+from models.retrieval_feedback import RetrievalFeedback
+from services.feedback_service import FeedbackService
+from utils.exceptions import NotFoundException
+
+
+@pytest_asyncio.fixture
+async def feedback_scenario(db_session: AsyncSession):
+    owner = f"owner_{uuid4().hex[:8]}"
+    ws = Workspace(
+        id=uuid4(),
+        name=f"ws-{uuid4().hex[:8]}",
+        plan_name="pro",
+        owner_user_id=owner,
+        daily_api_limit=50000,
+        weekly_api_limit=250000,
+    )
+    ctx = Context(
+        id=uuid4(),
+        workspace_id=ws.id,
+        name=f"ctx-{uuid4().hex[:8]}",
+        created_by=owner,
+        is_private=False,
+    )
+    db_session.add(ws)
+    await db_session.flush()
+    db_session.add(ctx)
+    await db_session.flush()
+    mem = Memory(
+        id=uuid4(),
+        user_id=owner,
+        workspace_id=ws.id,
+        context_id=ctx.id,
+        summary="a memory to rate",
+        content="content",
+        type="note",
+        client="test",
+        tags=[],
+    )
+    db_session.add(mem)
+    await db_session.flush()
+    return {"owner": owner, "ws": ws, "ctx": ctx, "mem": mem}
+
+
+@pytest.mark.asyncio
+async def test_feedback_is_append_only_and_isolated_from_memories(
+    db_session: AsyncSession, feedback_scenario
+):
+    s = feedback_scenario
+    svc = FeedbackService(db_session)
+    mem_count_before = (
+        await db_session.execute(
+            select(func.count()).select_from(Memory).where(Memory.context_id == s["ctx"].id)
+        )
+    ).scalar_one()
+
+    # Append two events for the same memory (append-only: 2 rows, no upsert).
+    r1 = await svc.record_feedback(s["ctx"].id, s["mem"].id, True, s["owner"], query="q1")
+    r2 = await svc.record_feedback(s["ctx"].id, s["mem"].id, False, s["owner"], query="q1")
+
+    fb_count = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(RetrievalFeedback)
+            .where(RetrievalFeedback.memory_id == s["mem"].id)
+        )
+    ).scalar_one()
+    assert fb_count == 2, "feedback is append-only — two calls must persist two rows"
+
+    # Recording feedback must NOT touch the memories table (no recall pollution).
+    mem_count_after = (
+        await db_session.execute(
+            select(func.count()).select_from(Memory).where(Memory.context_id == s["ctx"].id)
+        )
+    ).scalar_one()
+    assert mem_count_after == mem_count_before, "feedback must not insert into memories"
+
+    # Structural isolation: a feedback row's id is NOT a memory id — the lane is a
+    # separate table, so recall's candidate query (select(Memory)) can never see it.
+    feedback_ids = [r1.id, r2.id]
+    leaked = (
+        (await db_session.execute(select(Memory.id).where(Memory.id.in_(feedback_ids))))
+        .scalars()
+        .all()
+    )
+    assert not leaked, "a feedback id must never resolve to a memory row (recall isolation)"
+
+
+@pytest.mark.asyncio
+async def test_aggregate_for_memory_tallies_net_helpful(
+    db_session: AsyncSession, feedback_scenario
+):
+    s = feedback_scenario
+    svc = FeedbackService(db_session)
+    await svc.record_feedback(s["ctx"].id, s["mem"].id, True, s["owner"])
+    await svc.record_feedback(s["ctx"].id, s["mem"].id, True, s["owner"])
+    await svc.record_feedback(s["ctx"].id, s["mem"].id, False, s["owner"])
+
+    agg = await svc.aggregate_for_memory(s["ctx"].id, s["mem"].id)
+    assert agg.helpful_count == 2
+    assert agg.not_helpful_count == 1
+    assert agg.net == 1
+
+
+@pytest.mark.asyncio
+async def test_aggregate_isolates_by_memory(db_session: AsyncSession, feedback_scenario):
+    """Aggregation must not bleed in feedback from a different memory in the context."""
+    s = feedback_scenario
+    svc = FeedbackService(db_session)
+    other = Memory(
+        id=uuid4(),
+        user_id=s["owner"],
+        workspace_id=s["ws"].id,
+        context_id=s["ctx"].id,
+        summary="a sibling memory",
+        content="content",
+        type="note",
+        client="test",
+        tags=[],
+    )
+    db_session.add(other)
+    await db_session.flush()
+
+    await svc.record_feedback(s["ctx"].id, s["mem"].id, True, s["owner"])
+    # 3 not-helpful events for the SIBLING memory — must NOT count toward mem.
+    for _ in range(3):
+        await svc.record_feedback(s["ctx"].id, other.id, False, s["owner"])
+
+    agg = await svc.aggregate_for_memory(s["ctx"].id, s["mem"].id)
+    assert agg.helpful_count == 1
+    assert agg.not_helpful_count == 0, "aggregation leaked feedback from a different memory"
+
+
+@pytest.mark.asyncio
+async def test_query_is_truncated_to_column_limit(db_session: AsyncSession, feedback_scenario):
+    s = feedback_scenario
+    svc = FeedbackService(db_session)
+    row = await svc.record_feedback(s["ctx"].id, s["mem"].id, True, s["owner"], query="x" * 5000)
+    assert row.query is not None
+    assert len(row.query) == 1024, "query must be truncated to the column limit"
+
+
+@pytest.mark.asyncio
+async def test_note_is_truncated(db_session: AsyncSession, feedback_scenario):
+    s = feedback_scenario
+    svc = FeedbackService(db_session)
+    row = await svc.record_feedback(s["ctx"].id, s["mem"].id, False, s["owner"], note="y" * 5000)
+    assert row.note is not None
+    assert len(row.note) == 2000, "note must be truncated to bound retention"
+
+
+@pytest.mark.asyncio
+async def test_feedback_for_memory_outside_context_is_rejected(
+    db_session: AsyncSession, feedback_scenario
+):
+    """A memory_id that does not belong to the context is rejected (cross-context
+    signal-injection guard) — the access gate is on the context only."""
+    s = feedback_scenario
+    # A second context (same workspace) with its own memory.
+    other_ctx = Context(
+        id=uuid4(),
+        workspace_id=s["ws"].id,
+        name=f"other-{uuid4().hex[:8]}",
+        created_by=s["owner"],
+        is_private=False,
+    )
+    db_session.add(other_ctx)
+    await db_session.flush()
+    foreign_mem = Memory(
+        id=uuid4(),
+        user_id=s["owner"],
+        workspace_id=s["ws"].id,
+        context_id=other_ctx.id,
+        summary="memory in another context",
+        content="content",
+        type="note",
+        client="test",
+        tags=[],
+    )
+    db_session.add(foreign_mem)
+    await db_session.flush()
+
+    svc = FeedbackService(db_session)
+    # Rate the foreign memory while "authorized" only on s['ctx'] → must reject.
+    with pytest.raises(NotFoundException):
+        await svc.record_feedback(s["ctx"].id, foreign_mem.id, True, s["owner"])
+
+
+@pytest.mark.asyncio
+async def test_memory_delete_cascades_feedback(db_session: AsyncSession, feedback_scenario):
+    """Deleting the rated memory cascades its feedback (isolates the memory_id FK)."""
+    s = feedback_scenario
+    svc = FeedbackService(db_session)
+    await svc.record_feedback(s["ctx"].id, s["mem"].id, True, s["owner"])
+
+    # Delete ONLY the memory (context stays) so this exercises the memory_id
+    # CASCADE specifically — a missing ondelete='CASCADE' there fails here.
+    await db_session.execute(delete(Memory).where(Memory.id == s["mem"].id))
+    await db_session.commit()
+
+    remaining = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(RetrievalFeedback)
+            .where(RetrievalFeedback.memory_id == s["mem"].id)
+        )
+    ).scalar_one()
+    assert remaining == 0, "feedback must cascade-delete with its memory"
+
+
+@pytest.mark.asyncio
+async def test_context_delete_cascades_feedback(db_session: AsyncSession, feedback_scenario):
+    s = feedback_scenario
+    svc = FeedbackService(db_session)
+    await svc.record_feedback(s["ctx"].id, s["mem"].id, True, s["owner"])
+
+    # Deleting the context must cascade-delete its feedback (erasure contract).
+    await db_session.execute(delete(Memory).where(Memory.context_id == s["ctx"].id))
+    await db_session.execute(delete(Context).where(Context.id == s["ctx"].id))
+    await db_session.commit()
+
+    remaining = (
+        await db_session.execute(
+            select(func.count())
+            .select_from(RetrievalFeedback)
+            .where(RetrievalFeedback.context_id == s["ctx"].id)
+        )
+    ).scalar_one()
+    assert remaining == 0, "feedback must cascade-delete with its context"

--- a/docs/eval/retrieval-feedback-and-eval-gate.md
+++ b/docs/eval/retrieval-feedback-and-eval-gate.md
@@ -1,0 +1,60 @@
+# Retrieval Feedback Signal & Eval Gate Policy (Issue #888)
+
+Part of the AI Agent Memory Substrate epic (#885). This document covers the
+retrieval **feedback signal** and the **policy** governing how it may be used.
+
+## Feedback signal
+
+`access_count` / `last_used` are weak, implicit proxies for "was this recall
+useful". The feedback signal makes the judgment **explicit and attributable**:
+
+- **MCP tool**: `feedback(context_id, memory_id, helpful, query?, note?)`
+- **REST**: `POST /api/v1/contexts/{context_id}/feedback`
+  (`{memory_id, helpful, query?, note?}`)
+- **SDK**: tracked separately in `kagura-ai/kagura-memory-python-sdk#171`.
+
+### Persistence — never pollutes recall
+
+Feedback is an **append-only event log** in a dedicated table
+(`retrieval_feedback`), never embedded and structurally excluded from `recall()`
+— the same isolation principle as the agent session-state lane (#889). It is a
+time series (repeated or contradicting signals are kept), so there is no unique
+constraint; net-helpful aggregation is a read-time concern. Both `context_id` and
+`memory_id` foreign keys cascade on delete, so feedback is erased with its
+context or memory (GDPR/APPI erasure follows automatically).
+
+### Access
+
+Recording feedback is a **read-adjacent** action — anyone who can read a context
+(`VIEWER`) consumes recall and may rate it — so the API gates on
+`PermissionService.check_context_access(VIEWER)`, not write. The caller's
+`user_id` is stored for attribution (abuse tracing + future signal weighting).
+
+## Eval gate policy — HARD RULE
+
+> **No self-update / auto-promotion loop ships before the golden retrieval eval
+> gate (#344) is green.**
+
+The feedback signal is the *prerequisite* for a future Eval→Skill self-update
+loop, but closing that loop is **explicitly out of scope** until the eval harness
+guards it. Without ground-truth eval, an auto-promotion loop driven by raw
+feedback degrades into implicit noisy RL (the substrate optimizes for whatever
+gets thumbs-up, including wrong-but-confident results).
+
+Concretely:
+
+1. **Recall-ranking changes** must keep the deterministic eval gate green. The
+   `backend/tests/eval/` harness (#344) runs its leakage check, corpus-schema,
+   stratification, and metric tests in normal CI — these guard corpus integrity
+   and harness correctness on every PR.
+2. **The live P@5 / MRR@10 measurement** (`make eval-retrieval`) is the numeric
+   regression gate. It is **not** in CI yet (Qdrant + embedding + Sudachi
+   cold-start is not CI-realistic — tracked in #336); until then it is a
+   maintainer-run local gate whose baseline is committed under
+   `backend/tests/eval/results/`.
+3. **Any** mechanism that promotes, demotes, re-ranks, or rewrites memories based
+   on feedback is gated behind (2) being a green, automated gate. Feedback is
+   **collected** now; it is **not acted on automatically**.
+
+Wiring the live eval as an automated CI gate is the #336 follow-up; closing the
+Eval→Skill loop is a separate, later epic gated on all of the above.


### PR DESCRIPTION
Closes #888

## Summary
Part of epic #885. Adds an explicit **"was this recall useful"** signal — `access_count` / `last_used` are weak implicit proxies. This is the prerequisite for any future Eval→Skill self-update loop, which stays gated behind the #344 golden eval harness.

## What's included
- **`retrieval_feedback` table** (alembic `e36`, chained off `e35_889` → single linear head): a dedicated **append-only** event log — `context_id` + `memory_id` FKs both `ON DELETE CASCADE` (GDPR/APPI erasure), `helpful` bool, `user_id` (attribution), `query` VARCHAR(1024) + `note` (truncated, **never embedded**). Separate table ⇒ structurally excluded from `recall()` (same isolation as `agent_states` #889). No unique constraint (time series); net-helpful aggregation is read-time.
- **`FeedbackService`**: `record_feedback` (append-only) + `aggregate_for_memory`. **Validates the memory belongs to the context before insert** → uniform `NotFoundException`, closing cross-context signal injection (the access gate is context-scoped).
- **REST** `POST /api/v1/contexts/{context_id}/feedback` + **MCP** `feedback(...)` tool. Both **read-gated** (`check_context_access(VIEWER)` / `_resolve_context_for_read`) — recording feedback is read-adjacent; `user_id` from the authenticated principal, never the body.
- **Eval-gate policy** (`docs/eval/retrieval-feedback-and-eval-gate.md`): the HARD rule that **no self-update / auto-promotion loop ships before the eval gate is green**. The deterministic #344 tests run in CI; the live numeric gate is the #336 follow-up. Feedback is **collected** now, never acted on automatically.

## Tests (13)
5 route (mocked, direct-call): read-gate composition, `user_id` from principal, 404/403 propagation, 500 wrap, overlong-query 422. 8 integration (real DB): append-only + recall isolation, aggregation net-helpful + **memory isolation**, query + note truncation, **cross-context rejection**, **both FK CASCADE paths isolated**. ruff + pyright clean.

## Pre-PR review summary
- gate2 mode: advisor-only — cso: green, qa-lead: green, cto: green
- gate1: green via /ask (CIO lens)
- review provider: code-review (key fix applied pre-PR: cross-context injection guard + 4 test-coverage hardenings)

## Follow-ups (out of scope)
- SDK `feedback()` → kagura-memory-python-sdk#171.
- Live eval-gate CI wiring → #336.
- Minor: MCP `_QUERY_MAX_LEN` literal could import the model's `QUERY_MAX_LEN` constant.

🤖 Generated via /gh-issue-driven:ship
