### PR TITLE
fix(eval): eval-harness teardown + README corpus_overlap (#344 follow-up)

### DIFF
--- a/backend/tests/eval/README.md
+++ b/backend/tests/eval/README.md
@@ -18,7 +18,7 @@ An **offline harness** for detecting hybrid-search (dense + BM25) retrieval-qual
 | `metrics.py` | Pure P@k / MRR@k / source-recall functions | ✅ (`test_metrics.py`) |
 | `tools/corpus.py` | Corpus loader + BM25-aligned tokenization + IDF stats | ✅ |
 | `tools/leakage_check.py` | Leakage detector (3 rules) | ✅ (`test_leakage.py`) |
-| `tools/stratify.py` | Difficulty stratification (IDF-spec, BM25-rank, corpus-Jaccard) | ✅ (`test_stratification.py`) |
+| `tools/stratify.py` | Difficulty stratification (IDF-spec, BM25-rank, corpus-overlap) | ✅ (`test_stratification.py`) |
 | `test_corpus_schema.py` | Structural contract (buckets, labels, sources) | ✅ |
 | `test_retrieval_quality.py` + `runner.py` | **Live** P@5/MRR measurement → `results/<date>.json` | ❌ skip-guarded |
 
@@ -87,7 +87,9 @@ Descriptive difficulty signals — **coverage characterization, not pass/fail ga
 - **spec(q)** = avg corpus IDF of query terms (high = specific vocabulary).
 - **bm25_rank** = rank of the first relevant doc under BM25-only → `easy` (1) /
   `medium` (2–3) / `hard` (>3 or unranked). The lexical-difficulty pseudo-label.
-- **corpus_jaccard** = overlap with the top-1000 most-frequent corpus tokens.
+- **corpus_overlap** = overlap coefficient (|q ∩ top| / |q|) with the top-1000
+  most-frequent corpus tokens. (Overlap coefficient, not true Jaccard — see
+  `tools/stratify.py`.)
 
 `test_stratification.py` only asserts the set spans ≥2 regimes and has ≥1 `hard`
 query (hiragana-only is BM25-hard by construction), so an all-easy corpus — which

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -157,7 +157,9 @@ async def _teardown(
 
     for mid in memory_ids:
         try:
-            # forget() deletes from BOTH Postgres and Qdrant.
+            # forget() soft-deletes in Postgres (sets deleted_at/deleted_by) and
+            # hard-deletes the Qdrant point. The PG row is physically removed below
+            # by the Context DELETE via ON DELETE CASCADE.
             await svc.forget(ForgetRequest(memory_id=UUID(mid)), owner, ctx_id)
         except Exception:  # noqa: BLE001 — best-effort cleanup
             pass

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Any
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 from tests.eval.metrics import (
     mean_precision_at_k,
@@ -85,7 +85,6 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
     from auth.workspace_roles import WorkspaceRole
     from db.base import get_db
     from models.auth import Context, Workspace, WorkspaceMember
-    from models.schemas import RecallRequest
     from services.memory_service import MemoryService
     from utils.datetime import utcnow
 
@@ -122,64 +121,108 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
 
         svc = MemoryService(db)
         id_map = await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id)
-
-        # Per-query rankings, grouped by bucket.
-        per_bucket_rankings: dict[str, list[tuple[list[str], set[str]]]] = {b: [] for b in BUCKETS}
-        all_rankings: list[tuple[list[str], set[str]]] = []
-        # Source label of every retrieved top-k result across ALL queries — the
-        # overall memory-vs-resource share is computed over this whole pool (NOT
-        # sliced to a single k window, which would reflect only one query).
-        all_retrieved_sources: list[str] = []
-
-        for q in corpus.queries:
-            resp = await svc.recall(
-                request=RecallRequest(query=q.text, k=_RECALL_K, search_mode="hybrid"),
-                user_id=owner,
-                current_context_id=ctx.id,
-                current_workspace_id=ws.id,
+        try:
+            return await _run_queries_and_score(
+                svc, corpus, docs_by_id, id_map, owner, ctx.id, ws.id, run_date, write
             )
-            ranked_docs = [id_map.get(str(r.memory_id), "?") for r in resp.results]
-            relevant = set(q.relevant)
-            per_bucket_rankings[q.bucket].append((ranked_docs, relevant))
-            all_rankings.append((ranked_docs, relevant))
-            all_retrieved_sources.extend(
-                docs_by_id[d].source for d in ranked_docs[:_RECALL_K] if d in docs_by_id
-            )
-
-        def _bucket_metrics(rankings: list[tuple[list[str], set[str]]]) -> dict[str, Any]:
-            return {
-                "n": len(rankings),
-                **{f"p@{k}": round(mean_precision_at_k(rankings, k), 4) for k in _P_AT},
-                f"mrr@{_MRR_AT}": round(mrr_at_k(rankings, _MRR_AT), 4),
-            }
-
-        results: dict[str, Any] = {
-            "run_date": run_date,
-            "sudachi_version": _sudachi_version(),
-            "corpus_version": corpus.meta.get("version"),
-            "query_count": len(corpus.queries),
-            "doc_count": len(corpus.documents),
-            "recall_k": _RECALL_K,
-            "overall": _bucket_metrics(all_rankings),
-            "per_bucket": {b: _bucket_metrics(per_bucket_rankings[b]) for b in BUCKETS},
-            "source_recall@10": {
-                k: round(v, 4)
-                for k, v in source_recall_share(
-                    all_retrieved_sources, len(all_retrieved_sources)
-                ).items()
-            },
-        }
-
-        if write:
-            _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
-            out = _RESULTS_DIR / f"{run_date}.json"
-            out.write_text(
-                json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
-            )
-            print(f"eval-retrieval: wrote {out}")
-        return results
+        finally:
+            await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
 
     raise RuntimeError("database session unavailable — is the stack up?")
+
+
+async def _teardown(
+    svc: Any, db: Any, owner: str, ctx_id: Any, ws_id: Any, memory_ids: list[str]
+) -> None:
+    """Remove the throwaway eval data so repeated runs don't accumulate
+    workspaces / Qdrant points / DB rows (best-effort, never raises)."""
+    from sqlalchemy import delete as _delete
+
+    from models.auth import Context, Workspace, WorkspaceMember
+    from models.schemas import ForgetRequest
+
+    for mid in memory_ids:
+        try:
+            # forget() deletes from BOTH Postgres and Qdrant.
+            await svc.forget(ForgetRequest(memory_id=UUID(mid)), owner, ctx_id)
+        except Exception:  # noqa: BLE001 — best-effort cleanup
+            pass
+    try:
+        await db.execute(_delete(WorkspaceMember).where(WorkspaceMember.workspace_id == ws_id))
+        await db.execute(_delete(Context).where(Context.id == ctx_id))
+        await db.execute(_delete(Workspace).where(Workspace.id == ws_id))
+        await db.commit()
+    except Exception:  # noqa: BLE001 — best-effort cleanup
+        await db.rollback()
+
+
+async def _run_queries_and_score(
+    svc: Any,
+    corpus: Corpus,
+    docs_by_id: dict[str, Any],
+    id_map: dict[str, str],
+    owner: str,
+    ctx_id: Any,
+    ws_id: Any,
+    run_date: str,
+    write: bool,
+) -> dict[str, Any]:
+    """Recall every query, compute metrics, optionally write results JSON."""
+    from models.schemas import RecallRequest
+
+    # Per-query rankings, grouped by bucket.
+    per_bucket_rankings: dict[str, list[tuple[list[str], set[str]]]] = {b: [] for b in BUCKETS}
+    all_rankings: list[tuple[list[str], set[str]]] = []
+    # Source label of every retrieved top-k result across ALL queries — the
+    # overall memory-vs-resource share is computed over this whole pool (NOT
+    # sliced to a single k window, which would reflect only one query).
+    all_retrieved_sources: list[str] = []
+
+    for q in corpus.queries:
+        resp = await svc.recall(
+            request=RecallRequest(query=q.text, k=_RECALL_K, search_mode="hybrid"),
+            user_id=owner,
+            current_context_id=ctx_id,
+            current_workspace_id=ws_id,
+        )
+        ranked_docs = [id_map.get(str(r.memory_id), "?") for r in resp.results]
+        relevant = set(q.relevant)
+        per_bucket_rankings[q.bucket].append((ranked_docs, relevant))
+        all_rankings.append((ranked_docs, relevant))
+        all_retrieved_sources.extend(
+            docs_by_id[d].source for d in ranked_docs[:_RECALL_K] if d in docs_by_id
+        )
+
+    def _bucket_metrics(rankings: list[tuple[list[str], set[str]]]) -> dict[str, Any]:
+        return {
+            "n": len(rankings),
+            **{f"p@{k}": round(mean_precision_at_k(rankings, k), 4) for k in _P_AT},
+            f"mrr@{_MRR_AT}": round(mrr_at_k(rankings, _MRR_AT), 4),
+        }
+
+    results: dict[str, Any] = {
+        "run_date": run_date,
+        "sudachi_version": _sudachi_version(),
+        "corpus_version": corpus.meta.get("version"),
+        "query_count": len(corpus.queries),
+        "doc_count": len(corpus.documents),
+        "recall_k": _RECALL_K,
+        "overall": _bucket_metrics(all_rankings),
+        "per_bucket": {b: _bucket_metrics(per_bucket_rankings[b]) for b in BUCKETS},
+        "source_recall@10": {
+            k: round(v, 4)
+            for k, v in source_recall_share(
+                all_retrieved_sources, len(all_retrieved_sources)
+            ).items()
+        },
+    }
+
+    if write:
+        _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        out = _RESULTS_DIR / f"{run_date}.json"
+        out.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"eval-retrieval: wrote {out}")
+    return results
 
 
 def _main() -> int:

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -72,12 +72,14 @@ async def _ingest_corpus(
             current_context_id=ctx_id,
             current_workspace_id=ws_id,
         )
-        # Record BEFORE awaiting indexing so a failure in
-        # process_pending_embedding still leaves the id in the caller's map for
-        # teardown (the PG/Qdrant write from remember() already happened).
+        # remember() has already COMMITTED the Postgres memory row; the embedding
+        # + Qdrant upsert is what process_pending_embedding does below (remember
+        # also schedules it as a background task). Record the id BEFORE awaiting
+        # that step, so if it raises, teardown's forget() can still clean up the
+        # committed PG row (and any partial Qdrant points).
         id_map[str(resp.memory_id)] = doc.id
-        # Deterministically drive the embedding/upsert to completion before any
-        # recall runs (idempotent with the background task remember() fired).
+        # Deterministically drive the embedding/Qdrant upsert to completion before
+        # any recall runs (idempotent with the background task remember() fired).
         await process_pending_embedding(resp.memory_id)
 
 

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -38,8 +38,15 @@ def _sudachi_version() -> str:
         return "unknown"
 
 
-async def _ingest_corpus(svc: Any, corpus: Corpus, user_id: str, ctx_id, ws_id) -> dict[str, str]:
-    """Ingest every corpus doc as a memory; return memory_id → corpus_doc_id.
+async def _ingest_corpus(
+    svc: Any, corpus: Corpus, user_id: str, ctx_id, ws_id, id_map: dict[str, str]
+) -> None:
+    """Ingest every corpus doc as a memory, populating ``id_map`` (memory_id →
+    corpus_doc_id) INCREMENTALLY as each doc lands.
+
+    The caller owns ``id_map`` so that if this raises partway (a remember /
+    indexing failure), teardown still sees the memories created so far and can
+    clean them up — no leaked rows on a partial ingest.
 
     ``remember()`` schedules embedding + Qdrant upsert as a fire-and-forget
     ``asyncio.create_task`` and returns before indexing completes. For a
@@ -50,7 +57,6 @@ async def _ingest_corpus(svc: Any, corpus: Corpus, user_id: str, ctx_id, ws_id) 
     from models.schemas import RememberRequest
     from services.memory_service import process_pending_embedding
 
-    id_map: dict[str, str] = {}
     for doc in corpus.documents:
         # summary must be >= 10 chars; corpus docs comfortably exceed that.
         req = RememberRequest(
@@ -66,11 +72,13 @@ async def _ingest_corpus(svc: Any, corpus: Corpus, user_id: str, ctx_id, ws_id) 
             current_context_id=ctx_id,
             current_workspace_id=ws_id,
         )
+        # Record BEFORE awaiting indexing so a failure in
+        # process_pending_embedding still leaves the id in the caller's map for
+        # teardown (the PG/Qdrant write from remember() already happened).
+        id_map[str(resp.memory_id)] = doc.id
         # Deterministically drive the embedding/upsert to completion before any
         # recall runs (idempotent with the background task remember() fired).
         await process_pending_embedding(resp.memory_id)
-        id_map[str(resp.memory_id)] = doc.id
-    return id_map
 
 
 async def run_retrieval_eval(write: bool = True, run_date: str | None = None) -> dict[str, Any]:
@@ -120,8 +128,12 @@ async def run_retrieval_eval(write: bool = True, run_date: str | None = None) ->
         await db.commit()
 
         svc = MemoryService(db)
-        id_map = await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id)
+        # id_map is owned here and populated incrementally by _ingest_corpus, so
+        # the finally below ALWAYS cleans up whatever was created — even if
+        # ingest itself raises partway through (no leaked workspace/context/rows).
+        id_map: dict[str, str] = {}
         try:
+            await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
             return await _run_queries_and_score(
                 svc, corpus, docs_by_id, id_map, owner, ctx.id, ws.id, run_date, write
             )

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -97,8 +97,12 @@ async def _await_indexed(
     ``_ingest_corpus`` can return before the Qdrant upsert finishes when
     ``remember()``'s background task wins the claim. We poll ``embedding_status``
     (a column-only SELECT, so it reads committed state past the session identity
-    map under READ COMMITTED) until ``success``/``failed``. Raises on timeout
-    rather than letting a half-indexed corpus silently produce flaky metrics.
+    map under READ COMMITTED) until it is terminal.
+
+    A ``failed`` status is an ERROR, not a stop condition: the failed memory was
+    never upserted to Qdrant, so it is unsearchable and recalls against it would
+    silently understate metrics. Both ``failed`` and timeout raise, so the eval
+    never runs against a half-indexed corpus.
     """
     import asyncio
 
@@ -107,11 +111,21 @@ async def _await_indexed(
     from models.memory import Memory
 
     for _ in range(attempts):
-        status = (
-            await svc.db.execute(select(Memory.embedding_status).where(Memory.id == memory_id))
-        ).scalar_one_or_none()
-        if status in ("success", "failed"):
+        row = (
+            await svc.db.execute(
+                select(Memory.embedding_status, Memory.embedding_error).where(
+                    Memory.id == memory_id
+                )
+            )
+        ).first()
+        status = row[0] if row else None
+        if status == "success":
             return
+        if status == "failed":
+            raise RuntimeError(
+                f"embedding FAILED for memory {memory_id}: {row[1]} — that doc is "
+                "not in Qdrant, so eval would run against a half-indexed corpus"
+            )
         await asyncio.sleep(interval_s)
     raise RuntimeError(
         f"embedding for memory {memory_id} never reached a terminal state "
@@ -199,7 +213,10 @@ async def _teardown(
             # by the Context DELETE via ON DELETE CASCADE.
             await svc.forget(ForgetRequest(memory_id=UUID(mid)), owner, ctx_id)
         except Exception:  # noqa: BLE001 — best-effort cleanup
-            pass
+            # forget() shares this session; a mid-op failure can leave it needing
+            # a rollback, which would poison the Workspace/Context DELETEs below.
+            # Roll back so the rest of teardown still runs.
+            await db.rollback()
     try:
         await db.execute(_delete(WorkspaceMember).where(WorkspaceMember.workspace_id == ws_id))
         await db.execute(_delete(Context).where(Context.id == ctx_id))

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -51,8 +51,9 @@ async def _ingest_corpus(
     ``remember()`` schedules embedding + Qdrant upsert as a fire-and-forget
     ``asyncio.create_task`` and returns before indexing completes. For a
     deterministic eval we must NOT recall before the docs are searchable, so we
-    AWAIT ``process_pending_embedding`` for each memory here — turning the async
-    write into a synchronous "ingested AND indexed" barrier.
+    drive ``process_pending_embedding`` and then poll ``embedding_status`` to a
+    terminal state for each memory here — turning the async write into a
+    synchronous "ingested AND indexed" barrier.
     """
     from models.schemas import RememberRequest
     from services.memory_service import process_pending_embedding
@@ -78,9 +79,45 @@ async def _ingest_corpus(
         # that step, so if it raises, teardown's forget() can still clean up the
         # committed PG row (and any partial Qdrant points).
         id_map[str(resp.memory_id)] = doc.id
-        # Deterministically drive the embedding/Qdrant upsert to completion before
-        # any recall runs (idempotent with the background task remember() fired).
+        # Drive the embedding/Qdrant upsert before any recall runs. This call is
+        # claim-based: if the background task remember() fired wins the claim, our
+        # call returns immediately WITHOUT the upsert being done. So we then poll
+        # embedding_status to a terminal state — only that guarantees the doc is
+        # searchable, regardless of which task did the work.
         await process_pending_embedding(resp.memory_id)
+        await _await_indexed(svc, resp.memory_id)
+
+
+async def _await_indexed(
+    svc: Any, memory_id: UUID, *, attempts: int = 300, interval_s: float = 0.1
+) -> None:
+    """Block until ``memory_id``'s embedding reaches a terminal state.
+
+    ``process_pending_embedding`` is claim-based, so the explicit call in
+    ``_ingest_corpus`` can return before the Qdrant upsert finishes when
+    ``remember()``'s background task wins the claim. We poll ``embedding_status``
+    (a column-only SELECT, so it reads committed state past the session identity
+    map under READ COMMITTED) until ``success``/``failed``. Raises on timeout
+    rather than letting a half-indexed corpus silently produce flaky metrics.
+    """
+    import asyncio
+
+    from sqlalchemy import select
+
+    from models.memory import Memory
+
+    for _ in range(attempts):
+        status = (
+            await svc.db.execute(select(Memory.embedding_status).where(Memory.id == memory_id))
+        ).scalar_one_or_none()
+        if status in ("success", "failed"):
+            return
+        await asyncio.sleep(interval_s)
+    raise RuntimeError(
+        f"embedding for memory {memory_id} never reached a terminal state "
+        f"within {attempts * interval_s:.0f}s — eval would run against a "
+        "half-indexed corpus"
+    )
 
 
 async def run_retrieval_eval(write: bool = True, run_date: str | None = None) -> dict[str, Any]:


### PR DESCRIPTION
Post-merge follow-up to #915 (#344) addressing the final Copilot review comments.

- **runner.py teardown**: `run_retrieval_eval` now removes its throwaway workspace/context/memories in a `finally` — `forget()` clears each memory from Postgres **and** Qdrant, then the WorkspaceMember/Context/Workspace rows are deleted, so repeated `make eval-retrieval` runs don't accumulate eval data. Best-effort (never raises).
- **README**: aligned the stratification indicator name to `corpus_overlap` (the code was renamed from `corpus_jaccard` but the README lagged) — overlap coefficient, not true Jaccard.

26 deterministic eval tests pass; ruff clean. The live harness stays skip-guarded (KAGURA_EVAL_LIVE=1).

🤖 Follow-up for #344
