### PR TITLE
feat(frontend): sidebar version from API + drop language switcher (#921)

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.test.tsx
+++ b/frontend/src/components/dashboard/Sidebar.test.tsx
@@ -1,6 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import packageJson from "../../../package.json";
+
+// Hoisted so the vi.mock factory below can reference it (vi.mock is hoisted).
+const mockSystemInfoGet = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({ version: "9.9.9" }),
+);
 
 // Mock next-intl to return the translation key (matches KpiCards.test.tsx pattern)
 vi.mock("next-intl", () => ({
@@ -58,14 +62,7 @@ vi.mock("@/lib/api/external-keys", () => ({
 }));
 
 vi.mock("@/lib/api/base", () => ({
-  updateUserProfile: vi.fn().mockResolvedValue({}),
-}));
-
-vi.mock("sonner", () => ({
-  toast: Object.assign(vi.fn(), {
-    success: vi.fn(),
-    error: vi.fn(),
-  }),
+  apiClient: { get: mockSystemInfoGet },
 }));
 
 vi.mock("@/components/workspaces/WorkspaceSwitcher", () => ({
@@ -76,18 +73,6 @@ vi.mock("@/components/icons/KaguraLogo", () => ({
   KaguraLogo: ({ className }: { className?: string }) => (
     <svg data-testid="kagura-logo" className={className} />
   ),
-}));
-
-vi.mock("@/lib/version", () => ({
-  APP_VERSION: packageJson.version,
-}));
-
-// Mock i18n module to expose locale data without provider
-vi.mock("@/i18n", () => ({
-  useLocale: () => ({ locale: "en" as const, setLocale: vi.fn() }),
-  locales: ["en", "ja"] as const,
-  localeNames: { en: "English", ja: "日本語" } as const,
-  localeFlags: { en: "🇺🇸", ja: "🇯🇵" } as const,
 }));
 
 import { Sidebar } from "./Sidebar";
@@ -119,5 +104,13 @@ describe("Sidebar", () => {
     expect(triggers).toHaveLength(1);
     // Email is NOT rendered anywhere by default (the old DropdownMenuLabel block was removed)
     expect(screen.queryByText("test@example.com")).not.toBeInTheDocument();
+  });
+
+  it("does not fetch the system version on initial render (lazy until the user menu opens)", () => {
+    render(<Sidebar />);
+    // Issue #921: the version comes from GET /api/v1/system/info, fetched at most
+    // once per session and only when the user menu opens (onOpenChange) — never
+    // eagerly on mount.
+    expect(mockSystemInfoGet).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -8,7 +8,7 @@
  * Issue #31: Frontend Redesign Phase 5
  */
 
-import { useState, useEffect, Fragment } from "react";
+import { useState, useEffect, useRef, Fragment } from "react";
 import Link from "next/link";
 import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
@@ -64,21 +64,10 @@ import {
   ShieldCheck,
   DollarSign,
   Info,
-  Globe,
   ExternalLink,
-  Check,
   Plug,
 } from "lucide-react";
-import {
-  useLocale,
-  locales,
-  localeNames,
-  localeFlags,
-  type Locale,
-} from "@/i18n";
-import { updateUserProfile } from "@/lib/api/base";
-import { toast } from "sonner";
-import { APP_VERSION } from "@/lib/version";
+import { apiClient } from "@/lib/api/base";
 // Issue #246: ContextSelector removed - use /contexts link instead
 import { WorkspaceSwitcher } from "@/components/workspaces/WorkspaceSwitcher";
 
@@ -293,7 +282,7 @@ export function Sidebar() {
   const searchParams = useSearchParams();
   const currentTab = searchParams.get("tab");
   const router = useRouter();
-  const { user, logout, isAuthenticated } = useAuth();
+  const { user, logout } = useAuth();
 
   // Load context count on mount / workspace switch.
   // Reset to null on each run so the warning icon does not show a stale
@@ -415,37 +404,24 @@ export function Sidebar() {
     return user.name.substring(0, 2).toUpperCase();
   };
 
-  // Locale switching (inlined from LanguageSelector for cohesive submenu UI).
-  // Uses plain useState (not useTransition) because the async profile update +
-  // page reload must keep `isLocaleSwitching` true for the full duration to
-  // prevent double-clicks; React useTransition only tracks the synchronous
-  // portion of a callback (Copilot review on PR #742).
-  const { locale, setLocale } = useLocale();
-  const [isLocaleSwitching, setIsLocaleSwitching] = useState(false);
+  // App version is fetched from the backend (GET /api/v1/system/info) the first
+  // time the user menu opens, then cached for the session. The backend
+  // `constants.py` APP_VERSION is the single source of truth — no hardcoded
+  // frontend version (which drifts from the backend during blue/green deploys).
+  // `—` placeholder is shown before load and on failure (non-blocking).
+  // (Language switching lives on the profile page — see profile/page.tsx.)
+  const [systemVersion, setSystemVersion] = useState<string | null>(null);
+  const versionFetchedRef = useRef(false);
 
-  const handleLocaleChange = async (newLocale: Locale) => {
-    if (newLocale === locale) return;
-    setIsLocaleSwitching(true);
-    try {
-      setLocale(newLocale);
-      if (isAuthenticated && user) {
-        try {
-          await updateUserProfile({ locale: newLocale });
-        } catch (error) {
-          if (process.env.NODE_ENV === "development") {
-            console.error("Failed to update user locale:", error);
-          }
-        }
-      }
-      toast.success(t("languageChanged"));
-      window.location.reload();
-    } catch (error) {
-      if (process.env.NODE_ENV === "development") {
-        console.error("Failed to change locale:", error);
-      }
-      toast.error(t("languageChangeError"));
-      setIsLocaleSwitching(false);
-    }
+  const handleUserMenuOpenChange = (open: boolean) => {
+    if (!open || versionFetchedRef.current) return;
+    versionFetchedRef.current = true; // fetch at most once per session
+    apiClient
+      .get<{ version: string }>("/api/v1/system/info")
+      .then((info) => setSystemVersion(info.version))
+      .catch(() => {
+        // Leave systemVersion null → "v—" placeholder. Non-blocking by design.
+      });
   };
 
   const handleLogout = async () => {
@@ -769,7 +745,7 @@ export function Sidebar() {
       {/* User Menu at Bottom */}
       <div className={cn("px-4 py-3", "border-t", colors.border.default)}>
         {user && (
-          <DropdownMenu>
+          <DropdownMenu onOpenChange={handleUserMenuOpenChange}>
             <DropdownMenuTrigger asChild>
               <button
                 className={cn(
@@ -817,32 +793,6 @@ export function Sidebar() {
                 <UserCircle className="mr-2 h-4 w-4" />
                 <span>{t("profileSettings")}</span>
               </DropdownMenuItem>
-
-              {/* Language submenu */}
-              <DropdownMenuSub>
-                <DropdownMenuSubTrigger>
-                  <Globe className="mr-2 h-4 w-4" />
-                  <span>{t("language")}</span>
-                </DropdownMenuSubTrigger>
-                <DropdownMenuSubContent className="w-40">
-                  {locales.map((loc) => (
-                    <DropdownMenuItem
-                      key={loc}
-                      onClick={() => handleLocaleChange(loc)}
-                      className="flex items-center justify-between cursor-pointer"
-                      disabled={isLocaleSwitching}
-                    >
-                      <span className="flex items-center gap-2">
-                        <span>{localeFlags[loc]}</span>
-                        <span>{localeNames[loc]}</span>
-                      </span>
-                      {locale === loc && (
-                        <Check className="h-4 w-4 text-emerald-600" />
-                      )}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuSubContent>
-              </DropdownMenuSub>
 
               <DropdownMenuSeparator />
 
@@ -901,7 +851,7 @@ export function Sidebar() {
                   <DropdownMenuLabel className="text-[10px] font-normal text-slate-500 dark:text-slate-400">
                     {t("copyright", { year: new Date().getFullYear() })}
                     {" · "}
-                    {t("version", { version: APP_VERSION })}
+                    {t("version", { version: systemVersion ?? "—" })}
                   </DropdownMenuLabel>
                 </DropdownMenuSubContent>
               </DropdownMenuSub>

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -72,7 +72,6 @@
     "logOut": "Log out",
     "toggleMenu": "Toggle menu",
     "signupGate": "Signup Gate",
-    "language": "Language",
     "viewDetails": "View Details",
     "termsOfService": "Terms of Service",
     "privacyPolicy": "Privacy Policy",
@@ -81,8 +80,6 @@
     "copyright": "© 2024–{year} Kagura AI, Inc.",
     "version": "v{version}",
     "kaguraLogoAria": "Kagura Memory Cloud",
-    "languageChanged": "Language changed",
-    "languageChangeError": "An error occurred while changing the language",
     "connectors": "Connectors"
   },
   "auth": {

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -72,7 +72,6 @@
     "logOut": "ログアウト",
     "toggleMenu": "メニュー切替",
     "signupGate": "サインアップゲート",
-    "language": "言語",
     "viewDetails": "詳細を見る",
     "termsOfService": "利用規約",
     "privacyPolicy": "プライバシーポリシー",
@@ -81,8 +80,6 @@
     "copyright": "© 2024〜{year} Kagura AI 株式会社",
     "version": "v{version}",
     "kaguraLogoAria": "Kagura Memory Cloud",
-    "languageChanged": "言語を変更しました",
-    "languageChangeError": "言語の変更中にエラーが発生しました",
     "connectors": "コネクタ"
   },
   "auth": {


### PR DESCRIPTION
Closes #921

## Summary
- The version in the sidebar "View Details" submenu is now fetched from the existing public endpoint `GET /api/v1/system/info`, making backend `constants.py` the single source of truth and eliminating the frontend/backend version drift that occurred during blue/green deploys.
- Fetch is lazy (on the user menu `onOpenChange`), at most once per session (a `useRef` guard), and shows a `v—` placeholder before load and on failure (non-blocking, no hardcoded fallback).
- Removed the redundant language-switcher submenu from the sidebar — language switching remains on the profile page. Cleaned up now-unused imports/state and dead i18n keys.

## Implementation notes
- Net -63 LOC across 4 files. Uses the repo's standard `apiClient.get` + `useState` pattern (no react-query), per `.claude/rules/frontend.md`.
- Removed: `useLocale`/`locales`/`Globe`/`Check`/`toast`/`updateUserProfile`/`APP_VERSION`/`isAuthenticated` (now unused) and `sidebar.language`/`languageChanged`/`languageChangeError` i18n keys (en + ja).

## Verification
- `Sidebar.test.tsx` 4/4 pass (incl. new lazy-fetch assertion); `tsc --noEmit` clean.
- `login`/`invite` tests (which use a separate `LanguageSelector`) pass in isolation — unaffected.
- Note: the full vitest run shows the known vitest-forks worker-termination flake (#584) on unrelated files; the files this PR touches all pass in isolation.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green / qa-lead: green / cto: green
- gate1: green via /claude-c-suite:ask
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
