### PR TITLE
fix(plugin): correct guide.md MCP config to path-based /mcp/w/{workspace_id} (#927)

### DIFF
--- a/claude-skills/guide.md
+++ b/claude-skills/guide.md
@@ -35,10 +35,9 @@ Create or update `.mcp.json`:
 {
   "mcpServers": {
     "kagura-memory": {
-      "type": "streamable-http",
-      "url": "{server_url}/mcp",
+      "type": "http",
+      "url": "{server_url}/mcp/w/{workspace_id}",
       "headers": {
-        "X-Workspace-ID": "{workspace_id}",
         "Authorization": "Bearer {api_key}"
       }
     }


### PR DESCRIPTION
Closes #927

## Summary
- `guide.md` Step 2 told users to configure the MCP server with `type="streamable-http"`, `url="{server_url}/mcp"`, and an `X-Workspace-ID` header — a user following it could not connect.
- The server routes workspace by PATH (`/mcp/w/{workspace_id}{path:path}`, backend/src/api/main.py:584); there is no `X-Workspace-ID` header handling anywhere in the backend.
- Aligned the block to `.mcp.json.example` (`type="http"`, `url=".../mcp/w/{workspace_id}"`, `Authorization` header only), matching README, docs/, and the Codex `SKILL.md` form.

## Implementation notes
- Docs-only, single config block. No backend change. Surrounding Step-2 text still asks for the workspace ID (now placed in the URL path), so no other edits needed. Likely missed during the #743/#744 skill review.

## Pre-PR review summary
- gate2 mode: advisor-only (docs-only diff-scope-skip → cto only)
- cto: green
- gate1: green (size-heuristic — `documentation` label)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
