### PR TITLE
docs: document AI Agent Memory Substrate (epic #885) (#918)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <strong>チーム向けセルフホスト LLM Knowledge Base</strong> — RAG を超えて。<br>
-  MCP-as-compile-API + Hebbian 学習 + Sleep Maintenance。<br>
-  <a href="https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f">Karpathy の LLM Wiki パターン</a> をチーム規模 + 永続化対応に拡張。
+  <strong>AI エージェントとチームのための適応的メモリ</strong> — セルフホスト、RAG を超えて。<br>
+  検索するたびに賢くなる MCP サーバー:<br>
+  ハイブリッド検索 + どのメモリ同士が関連するかを学習する neural memory graph。
 </p>
 
 <p align="center">
@@ -49,7 +49,8 @@
 | **Hybrid Search** | Semantic (OpenAI/Ollama) + BM25 キーワード — top-1 精度 96% |
 | **AI Reranking** | Ollama (ローカル・無料)、Voyage AI、Cohere — cross-encoder reranker で精度向上 |
 | **Neural Memory Graph** | Hebbian 学習がバックグラウンドで知識グラフを構築。`explore()` がそれを辿り偶発的発見を提供 |
-| **37 の MCP ツール** | Memory、Neural edges、Contexts、Tags、Files (R2)、Analyses (broadlistening)、Resources、Sleep Maintenance、Usage |
+| **Agent Memory Substrate** | 単なる知識ストアを超えて — delivery mode (pin / 時刻トリガ)、サーバー署名の trust boundary、agent state レーン、retrieval feedback シグナル。自律エージェントのループに必要なプリミティブ群 |
+| **45 の MCP ツール** | Memory、Agent Substrate、Neural edges、Contexts、Tags、Files (R2)、Analyses (broadlistening)、Resources、Sleep Maintenance、Usage、API-Key Bindings |
 | **マルチプロバイダ** | 埋め込みに OpenAI か Ollama (ローカル・非公開・コストゼロ) |
 | **チーム対応** | Workspace、RBAC、context 分離、共有メモリ |
 | **Web UI** | Next.js ダッシュボード — context、検索設定、メンバー管理 |
@@ -281,18 +282,30 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP ツール
 
-9 カテゴリ・全 37 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
+11 カテゴリ・全 45 ツール。Workspace ロール: **Owner** > Admin > Member > **Viewer** (read-only)。Context ロール: **Owner** > Editor > Viewer。Private context は作成者のみ閲覧可。Member を特定 context に allowlist で制限可能。
 
 ### Memory (6)
 
 | ツール | 説明 | 必要ロール |
 |--------|------|------------|
-| `remember` | 新規メモリ保存 (summary + content + type) | Member+ |
-| `recall` | Hybrid Search でメモリ検索 | Viewer+ |
+| `remember` | 新規メモリ保存 (summary + content + type、任意で `delivery_mode`) | Member+ |
+| `recall` | Hybrid Search でメモリ検索 (`trust_tier` フィルタ対応) | Viewer+ |
 | `reference` | メモリの 3 層詳細取得 | Viewer+ |
 | `update_memory` | メモリ更新 / 外部 ID で upsert | Member+ |
 | `forget` | ソフト削除 (30 日保持) | Member+ |
 | `explore` | Neural Memory graph で関連メモリ発見 | Viewer+ |
+
+### Agent Substrate (5)
+
+自律エージェントのループに必要なプリミティブ群 — 詳細は [Concepts › Agent Memory Substrate](docs/concepts.md#agent-memory-substrate)。
+
+| ツール | 説明 | 必要ロール |
+|--------|------|------------|
+| `load_pinned` | always-load メモリ (`delivery_mode="always"`) を決定的にロード — Goal / Guardrail / ポリシー用 | Viewer+ |
+| `recall_upcoming` | 近日の Time Memory (`type="time"`、`delivery_mode="on_trigger"`) を列挙 | Viewer+ |
+| `set_state` | エージェントの scratch state を upsert (key→value、任意 TTL、recall から除外) | Editor+ |
+| `get_state` | state を 1 件取得、または context の全 live state を列挙 | Viewer+ |
+| `feedback` | recall したメモリが有用だったかを記録 (append-only シグナル) | Viewer+ |
 
 ### Neural Edges (4)
 
@@ -343,11 +356,12 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | `get_active_analysis` | 実行中分析の取得 (あれば) | Owner |
 | `get_cluster` | 単一クラスタの所属メモリを drilldown | Owner |
 
-### Resources — 外部データ取り込み (5)
+### Resources — 外部データ取り込み (6)
 
 | ツール | 説明 | 必要ロール |
 |--------|------|------------|
 | `setup_resource` | public context 作成 + resource token 発行 | Owner/Admin + Pro プラン |
+| `setup_connector` | ai-worker チャットコネクタを provision (resource + connector 行 + token) | Owner/Admin + connector seats |
 | `list_resource_tokens` | workspace の有効 resource token 一覧 | Owner/Admin |
 | `ingest_events` | resource に batch upsert/delete events (最大 100 events、session-auth MCP 経路) | Member+ |
 | `get_resource_impact` | resource 統計 (token 数、memory 数、schema version) | Viewer+ |
@@ -368,6 +382,13 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 | ツール | 説明 | 必要ロール |
 |--------|------|------------|
 | `get_usage` | workspace の現在使用量 (memory / context / member / MCP 呼出/日) | Viewer+ |
+
+### API-Key Bindings (2)
+
+| ツール | 説明 | 必要ロール |
+|--------|------|------------|
+| `list_my_bindings` | public-bound API キー一覧 (read-only、owner スコープ) | Viewer+ |
+| `describe_binding` | `key_id` か `context_id` の一方で binding を 1 件記述 (read-only、owner スコープ) | Viewer+ |
 
 ## REST API
 
@@ -473,6 +494,7 @@ STRIPE_PRICE_PRO=price_yyy
 - [Resource Tokens Guide](docs/resource-tokens-guide.md) — resource token 経由の外部データ取込
 - [Neural Memory Evaluation](docs/neural-memory-evaluation.md) — ベンチマーク結果、設計判断
 - [Search Quality Benchmark](docs/search-quality-benchmark.md) — 精度テスト、reranking、ベストプラクティス
+- [Retrieval Feedback & Eval Gate](docs/eval/retrieval-feedback-and-eval-gate.md) — feedback シグナル + 自己更新ループ禁止ポリシー (Agent Memory Substrate)
 - [Deployment](docs/deployment.md) — Caddy リバースプロキシを用いた production 配備
 - [Contributing](CONTRIBUTING.md) — 開発セットアップ、コードスタイル、PR ワークフロー
 - [Security](SECURITY.md) — 脆弱性報告、セキュリティ設計

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 </p>
 
 <p align="center">
-  <strong>Self-hosted LLM Knowledge Base for teams</strong> — beyond RAG.<br>
-  MCP-as-compile-API + Hebbian learning + Sleep Maintenance.<br>
-  <a href="https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f">Karpathy's LLM Wiki pattern</a>, scaled for teams and persistence.
+  <strong>Adaptive memory for AI agents and teams</strong> — self-hosted, beyond RAG.<br>
+  An MCP server that gets smarter every time you search:<br>
+  hybrid search + a neural memory graph that learns which memories belong together.
 </p>
 
 <p align="center">
@@ -49,7 +49,8 @@ Most AI memory tools are just vector databases with a chat wrapper. Kagura is di
 | **Hybrid Search** | Semantic (OpenAI/Ollama) + BM25 keyword — 96% top-1 accuracy |
 | **AI Reranking** | Ollama (local, free), Voyage AI, or Cohere — cross-encoder reranking for precision |
 | **Neural Memory Graph** | Hebbian learning builds a knowledge graph in the background. `explore()` traverses it for serendipitous discovery. |
-| **39 MCP Tools** | Memory, Neural edges, Contexts, Tags, Files (R2), Analyses (broadlistening), Resources, Sleep Maintenance, Usage |
+| **Agent Memory Substrate** | Beyond a knowledge store: delivery modes (pinned / time-triggered), a server-stamped trust boundary, an agent state lane, and a retrieval-feedback signal — the primitives an autonomous agent loop needs. |
+| **45 MCP Tools** | Memory, Agent Substrate, Neural edges, Contexts, Tags, Files (R2), Analyses (broadlistening), Resources, Sleep Maintenance, Usage, API-Key Bindings |
 | **Multi-Provider** | OpenAI or Ollama (local, private, zero cost) for embeddings |
 | **Team Ready** | Workspaces, RBAC, context isolation, shared memory |
 | **Web UI** | Next.js dashboard — contexts, search settings, member management |
@@ -404,18 +405,30 @@ curl -X POST -H "Authorization: Bearer kagura_{your_key}" \
 
 ## MCP Tools
 
-39 tools across 10 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
+45 tools across 11 categories. Workspace roles: **Owner** > Admin > Member > **Viewer** (read-only). Context roles: **Owner** > Editor > Viewer. Private contexts are visible only to the creator. Members may be restricted to specific contexts via allowlist.
 
 ### Memory (6)
 
 | Tool | Description | Required Role |
 |------|------------|---------------|
-| `remember` | Store a new memory (summary + content + type) | Member+ |
-| `recall` | Search memories with Hybrid Search | Viewer+ |
+| `remember` | Store a new memory (summary + content + type; optional `delivery_mode`) | Member+ |
+| `recall` | Search memories with Hybrid Search (supports `trust_tier` filter) | Viewer+ |
 | `reference` | Get full 3-layer details of a memory | Viewer+ |
 | `update_memory` | Update an existing memory in-place or upsert by external ID | Member+ |
 | `forget` | Soft-delete a memory (30-day retention) | Member+ |
 | `explore` | Discover related memories via Neural Memory graph | Viewer+ |
+
+### Agent Substrate (5)
+
+The primitives an autonomous agent loop needs beyond a knowledge store — see [Concepts › Agent Memory Substrate](docs/concepts.md#agent-memory-substrate).
+
+| Tool | Description | Required Role |
+|------|------------|---------------|
+| `load_pinned` | Deterministically load always-load memories (`delivery_mode="always"`) — Goal / Guardrail / policy | Viewer+ |
+| `recall_upcoming` | List upcoming Time Memories (`type="time"`, `delivery_mode="on_trigger"`) | Viewer+ |
+| `set_state` | Upsert agent scratch state (key→value, optional TTL; excluded from recall) | Editor+ |
+| `get_state` | Read one state key, or list all live state for a context | Viewer+ |
+| `feedback` | Record whether a recalled memory was helpful (append-only signal) | Viewer+ |
 
 ### Neural Edges (4)
 
@@ -466,11 +479,12 @@ Cluster memories into themes (kouchou-ai-style UMAP + KMeans + LLM labeling) for
 | `get_active_analysis` | Get the in-flight analysis for a context (if any) | Owner |
 | `get_cluster` | Drill into a single cluster's member memories | Owner |
 
-### Resources — External Data Ingestion (5)
+### Resources — External Data Ingestion (6)
 
 | Tool | Description | Required Role |
 |------|------------|---------------|
 | `setup_resource` | Create public context + issue resource token | Owner/Admin + Pro plan |
+| `setup_connector` | Provision an ai-worker chat connector (resource + connector row + token) | Owner/Admin + connector seats |
 | `list_resource_tokens` | List active resource tokens for your workspace | Owner/Admin |
 | `ingest_events` | Batch upsert/delete events into a resource (max 100 events; session-auth MCP variant) | Member+ |
 | `get_resource_impact` | Resource stats (tokens, memories, schema version) | Viewer+ |
@@ -620,6 +634,7 @@ This project is designed to be developed **with** Claude Code and Kagura Memory 
 - [Resource Tokens Guide](docs/resource-tokens-guide.md) — External data ingestion via resource tokens
 - [Neural Memory Evaluation](docs/neural-memory-evaluation.md) — Benchmark results, architecture decisions
 - [Search Quality Benchmark](docs/search-quality-benchmark.md) — Accuracy tests, reranking, best practices
+- [Retrieval Feedback & Eval Gate](docs/eval/retrieval-feedback-and-eval-gate.md) — Feedback signal + the no-self-update-loop policy (Agent Memory Substrate)
 - [Deployment](docs/deployment.md) — Production deployment with Caddy reverse proxy
 - [Contributing](CONTRIBUTING.md) — Development setup, code style, PR workflow
 - [Security](SECURITY.md) — Vulnerability reporting, security design

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -172,6 +172,23 @@ openapi_tags = [
         ),
     },
     {"name": "graph", "description": "Neural Memory graph operations"},
+    {
+        "name": "agent-state",
+        "description": (
+            "Agent Memory Substrate (epic #885): per-context key→value scratch "
+            "state lane with optional TTL. Structurally excluded from recall(). "
+            "REST companion to the set_state / get_state MCP tools."
+        ),
+    },
+    {
+        "name": "retrieval-feedback",
+        "description": (
+            "Agent Memory Substrate (epic #885): append-only retrieval-helpful "
+            "signal per (context, memory). Read-adjacent (Viewer+); collected but "
+            "not auto-acted-on until the golden eval gate (#344) is green. REST "
+            "companion to the feedback MCP tool."
+        ),
+    },
     # Integrations
     {"name": "api-keys", "description": "MCP API key management"},
     {"name": "oauth2-server", "description": "OAuth2 client management"},

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -269,7 +269,7 @@ Search memories using Hybrid Search (60% semantic + 40% BM25) with optional Neur
 |-------|------|----------|-------------|
 | `query` | string | Yes | Natural language search query |
 | `k` | integer | No | Number of results (default: 5, max: 100) |
-| `filters` | object | No | Filter by type, tags, importance, date ranges. `tags_match: "all"` for AND logic. Date: `created_after`, `created_before`, `updated_after`, `updated_before` (ISO 8601) |
+| `filters` | object | No | Filter by type, tags, importance, date ranges. `tags_match: "all"` for AND logic. Date: `created_after`, `created_before`, `updated_after`, `updated_before` (ISO 8601). **Trust:** `trust_tier: "trusted"` excludes `external`-tier contexts and `connector`-sourced memories — pass it for behaviour-influencing reads (see [Trust tier](concepts.md#agent-memory-substrate)) |
 | `use_rerank` | boolean | No | Request reranking (default: false). Only effective if reranking is also enabled in the context's search config and a provider (Voyage/Cohere) is configured. |
 
 **Response:**
@@ -561,6 +561,78 @@ Update a context. All fields are optional.
 Soft-delete a context. The context row is marked deleted (sets `deleted_at`) so it stops appearing in listings, but the record and its memories are retained for recovery / audit purposes.
 
 **Response:** `204 No Content` (no response body)
+
+---
+
+## Agent State APIs
+
+A per-context key→value scratch lane for autonomous agent loops (current task, plan step, cursor). Stored in a dedicated `agent_states` table — **structurally excluded from `recall()`** so it never pollutes semantic search. Part of the [Agent Memory Substrate](concepts.md#agent-memory-substrate). Reads require `Viewer`; writes require `Editor`.
+
+### PUT /api/v1/contexts/{context_id}/state/{key}
+
+Set (upsert) a state value under a key.
+
+**Request Body:**
+
+```json
+{
+  "value": {"step": 3, "plan": "refactor auth"},
+  "ttl_seconds": 3600
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `value` | any (JSON) | Yes | Arbitrary JSON value to store |
+| `ttl_seconds` | integer | No | Time-to-live; clamped server-side to a 30-day max. Omit for no expiry |
+
+**Response:** `{ "key": "<key>" }`
+
+### GET /api/v1/contexts/{context_id}/state/{key}
+
+Get one key's live value. Expired entries are reaped lazily and reported as not found.
+
+**Response:** `{ "key": "<key>", "value": <json> }`
+
+### GET /api/v1/contexts/{context_id}/state
+
+List all live state entries for the context.
+
+**Response:** `{ "states": { "<key>": <json>, ... }, "count": 2 }`
+
+### DELETE /api/v1/contexts/{context_id}/state/{key}
+
+Delete one entry.
+
+**Response:** `{ "key": "<key>" }`
+
+---
+
+## Retrieval Feedback API
+
+Record an explicit, attributable signal on whether a recalled memory was helpful. Stored **append-only** in a dedicated `retrieval_feedback` table (a time series — contradicting signals are kept), embedded nowhere and excluded from `recall()`. Recording is **read-adjacent**: any `Viewer` who consumes recall may rate it. See the [eval-gate policy](eval/retrieval-feedback-and-eval-gate.md) — feedback is collected now but **not acted on automatically** until the golden eval gate (#344) is green.
+
+### POST /api/v1/contexts/{context_id}/feedback
+
+**Request Body:**
+
+```json
+{
+  "memory_id": "550e8400-e29b-41d4-a716-446655440000",
+  "helpful": true,
+  "query": "how do I rotate JWT refresh tokens?",
+  "note": "exact match, used verbatim"
+}
+```
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `memory_id` | string (UUID) | Yes | The recalled memory being rated (must belong to the context) |
+| `helpful` | boolean | Yes | Whether the memory was useful for the query |
+| `query` | string | No | The originating query (max 1024 chars) |
+| `note` | string | No | Free-text rationale (max 2000 chars) |
+
+**Response:** `201 Created` — `{ "feedback_id": "<uuid>", "memory_id": "<uuid>", "helpful": true }`
 
 ---
 
@@ -870,7 +942,7 @@ Sleep and Neural Memory tuning knobs (LLM provider, budgets, per-phase toggles, 
 
 ## MCP Tools
 
-Kagura Memory Cloud provides 39 MCP tools for AI assistants across 10 categories (Memory, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
+Kagura Memory Cloud provides 45 MCP tools for AI assistants across 11 categories (Memory, Agent Substrate, Neural Edges, Contexts, Tags, Files / R2, Analyses, Resources, Sleep Maintenance, Usage, API-Key Bindings). See [README › MCP Tools](../README.md#mcp-tools) for the full table with required roles. The examples below illustrate the most commonly used tools; every other tool shares the same JSON-RPC call shape.
 
 ### 1. remember
 
@@ -975,6 +1047,75 @@ Describe one of your bindings by **exactly one** of `key_id` (integer) or `conte
 ```
 
 > **Read-only boundary:** minting and revoking bindings stay on the SDK / CLI / HTTP API / dashboard (design decision from #626). Public-bound API keys cannot call any MCP tool — they are rejected at MCP authentication — so these introspection tools are only reachable by the binding's **owner** via a session or workspace-scoped key.
+
+### Agent Substrate tools
+
+These tools back the [Agent Memory Substrate](concepts.md#agent-memory-substrate). `load_pinned` and `recall_upcoming` are delivery-mode-aware reads; `set_state` / `get_state` drive the agent state lane; `feedback` records the retrieval signal.
+
+#### 8. load_pinned
+
+Deterministically load a context's always-load memories (`delivery_mode="always"`) — the complete, unranked set, every call. The deterministic counterpart to probabilistic `recall()`; use it for an agent's Goal / Guardrail / critical policy.
+
+```python
+{
+  "name": "load_pinned",
+  "arguments": { "context_id": "550e8400-..." }
+}
+```
+
+#### 9. recall_upcoming
+
+List forward-looking Time Memories (`type="time"`, `delivery_mode="on_trigger"`) whose scheduled window is upcoming — deadlines, dated follow-ups. A deterministic time query, not semantic search.
+
+```python
+{
+  "name": "recall_upcoming",
+  "arguments": { "context_id": "550e8400-...", "from": "now" }
+}
+```
+
+#### 10. set_state
+
+Upsert agent scratch state (excluded from `recall()`). Requires `Editor`.
+
+```python
+{
+  "name": "set_state",
+  "arguments": {
+    "context_id": "550e8400-...",
+    "key": "current_task",
+    "value": {"step": 3, "plan": "refactor auth"},
+    "ttl_seconds": 3600
+  }
+}
+```
+
+#### 11. get_state
+
+Read one key, or omit `key` to list all live state for the context.
+
+```python
+{
+  "name": "get_state",
+  "arguments": { "context_id": "550e8400-...", "key": "current_task" }
+}
+```
+
+#### 12. feedback
+
+Record whether a recalled memory was helpful (read-adjacent; any `Viewer` may call). Append-only; **collected but not auto-acted-on** (see [eval gate](eval/retrieval-feedback-and-eval-gate.md)).
+
+```python
+{
+  "name": "feedback",
+  "arguments": {
+    "context_id": "550e8400-...",
+    "memory_id": "660e8400-...",
+    "helpful": true,
+    "query": "how do I rotate JWT refresh tokens?"
+  }
+}
+```
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -31,11 +31,12 @@ Karpathy's pattern describes any "living knowledge base" as 5 layers. Kagura's i
                               ↓
 ┌──────────────────────┬──────────────────────────────────────┐
 │   MCP Server (HTTP)  │          REST API (FastAPI)          │
-│  - 37 MCP Tools      │  - Memory CRUD                       │
-│    (memory / edges / │  - OAuth2 endpoints                  │
-│     contexts / tags /│  - API Key management                │
-│     files / analyses │  - Resource Ingest API               │
-│     resources /      │  - Admin: sleep-reports, neural cfg  │
+│  - 45 MCP Tools      │  - Memory CRUD                       │
+│    (memory / agent   │  - OAuth2 endpoints                  │
+│     substrate / edges│  - API Key management                │
+│     / contexts / tags│  - Agent state + feedback lanes      │
+│     / files /analyses│  - Resource Ingest API               │
+│     / resources /    │  - Admin: sleep-reports, neural cfg  │
 │     sleep / usage)   │                                      │
 │  - Session Mgmt      │                                      │
 │  - JSON-RPC          │                                      │
@@ -242,6 +243,36 @@ score = (
 )
 ```
 
+## Agent Memory Substrate Lanes
+
+Beyond the human-facing knowledge base, Kagura is an **agent memory substrate** (epic #885, v0.24.0 / v0.25.0). An autonomous agent loop needs three things a semantic memory store must *not* provide directly: durable exact-match scratch state, an explicit usefulness signal, and a provenance/trust boundary on what may influence behaviour. These ship as **dedicated lanes that sit beside `memories`** — deliberately separate tables so they are **structurally excluded from `recall()`** rather than filtered out at query time. For the reader-facing concept model (the four primitives — delivery / trust / state / feedback — and the "primitives, not new types" decision), see [Concepts › Agent Memory Substrate](concepts.md#agent-memory-substrate).
+
+### Lane separation
+
+| Lane | Table | In `recall()`? | Why a separate lane |
+|---|---|---|---|
+| Knowledge | `memories` | Yes (Hybrid Search) | The searchable corpus |
+| Agent state | `agent_states` | **No** | Exact-match key→value scratch (task, plan step, cursor); semantic search over it is meaningless and would poison results |
+| Feedback | `retrieval_feedback` | **No** | Append-only signal *about* recall quality; embedding it would create a feedback-of-feedback loop |
+
+`agent_states` is read by `set_state` / `get_state` (MCP) and `/api/v1/contexts/{id}/state*` (REST); `retrieval_feedback` by `feedback` (MCP) and `POST /api/v1/contexts/{id}/feedback` (REST). Both FK to `contexts` with `ON DELETE CASCADE`, so an agent's state and feedback are erased with their context (GDPR/APPI erasure follows automatically).
+
+### Trust boundary (provenance & behaviour-influencing reads)
+
+The substrate adds a server-enforced trust boundary so that **untrusted external content cannot be silently treated as instructions** (indirect prompt injection — [OWASP LLM01 / LLM03](https://owasp.org/www-project-top-10-for-large-language-model-applications/)):
+
+- **`memories.source_type`** (`VARCHAR(20)`, NOT NULL, CHECK) — **server-stamped** provenance, never client-supplied: `manual` / `file` / `url` / `vault` / `api` / `connector`. Backfilled to `manual` for pre-existing rows by migration `e35_887`.
+- **`contexts.trust_tier`** (`VARCHAR(20)`, NOT NULL, default `trusted`, CHECK) — `trusted` or `external`. Connector-fed contexts are `external`.
+- **Trust filter** — `recall(filters={"trust_tier": "trusted"})` excludes memories whose context is `external`-tier **and** any `source_type="connector"` memory (defence-in-depth). Applied inside `MemoryService` recall (`backend/src/services/memory_service.py`). Opt-in; intended for any read whose results are fed back to the model as context.
+
+### Feedback eval gate — no self-update loop
+
+The feedback signal is the prerequisite for a future Eval→Skill self-update loop, but **closing that loop is gated**: no mechanism that promotes, demotes, re-ranks, or rewrites memories from feedback ships before the golden retrieval eval gate (#344) is green. The deterministic layer of the eval harness ([`backend/tests/eval/`](../backend/tests/eval/README.md) — leakage check, corpus-schema, stratification, metrics) runs in normal CI; the live P@5 / MRR measurement (`make eval-retrieval`) is the numeric regression gate, not yet wired into CI (#336). Full policy: [Retrieval Feedback & Eval Gate](eval/retrieval-feedback-and-eval-gate.md).
+
+### Connector canonical chat schema
+
+Connectors provisioned via `setup_connector` (#910 / #911) seed a canonical chat **resource schema** at registration: a single `text` field (fulltext+vector indexed) holding the ai-worker's per-message LLM summary. Lineage (`source_uri` / memory details) stays in `event_metadata`, not the payload. Defined in `ConnectorProvisioningService` (`backend/src/services/connector_provisioning.py`).
+
 ## Database Design
 
 ### PostgreSQL Tables
@@ -265,10 +296,15 @@ Tables are grouped by domain. The authoritative list lives in `backend/src/model
 - **context_search_configs** — Per-context hybrid search weights and reranker tuning
 
 **Memories & graph**
-- **memories** — 3-layer memory storage
+- **memories** — 3-layer memory storage. Carries server-stamped `source_type` (provenance) and `delivery_mode` (`on_recall` / `always` / `on_trigger`)
 - **attachments** — File attachments linked to memories
 - **neural_memory_edges** — Primary Hebbian edge storage (workspace + context scoped)
 - **graph_memory** — Legacy NetworkX JSON (read paths still reference it; new writes go to `neural_memory_edges`)
+
+**Agent memory substrate** (epic #885, v0.24.0 / v0.25.0 — see [Agent Memory Substrate Lanes](#agent-memory-substrate-lanes))
+- **agent_states** — Per-context key→value JSON scratch state with optional TTL (`expires_at`); unique on `(context_id, key)`. Structurally excluded from `recall()`
+- **retrieval_feedback** — Append-only `helpful` signal per `(context_id, memory_id)`, attributed to `user_id`. Structurally excluded from `recall()`
+- (`contexts.trust_tier` + `memories.source_type` add the provenance/trust boundary — see column notes above)
 
 **Resource ingest** (v0.12.0 Resource Foundation)
 - **resources** — Normalized Resource entity (UUID PK); satellite tables FK via `resource_pk`

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -165,21 +165,71 @@ Each context has a `sleep_mode` setting (`full`, `edges_only`, or `skip`) that c
 
 See [Sleep Maintenance](sleep-maintenance.md) for the complete reference.
 
+## Agent Memory Substrate
+
+Kagura is a **knowledge store** for humans *and* an **agent memory substrate** for autonomous LLM loops. The substrate (epic #885, shipped v0.24.0 / v0.25.0) adds four primitives an agent loop needs that a pure knowledge base lacks — **delivery**, **trust**, **state**, and **feedback** — without inflating the memory taxonomy.
+
+> **Design decision — primitives, not types.** A memory is classified by its `type` (`code`, `note`, `decision`, …) *and*, orthogonally, by **how it is delivered**. We deliberately did **not** add agent-loop memory types (Goal / Skill / Eval / Guardrail / …); the same effect is achieved with `delivery_mode` + dedicated lanes. See the rationale in [`docs/eval/retrieval-feedback-and-eval-gate.md`](eval/retrieval-feedback-and-eval-gate.md).
+
+### 1. Delivery mode — *when* a memory surfaces
+
+`delivery_mode` is orthogonal to `type`. It controls **when** a memory reaches the agent:
+
+| `delivery_mode` | Surfaced | Read with | Use for |
+|---|---|---|---|
+| `on_recall` (default) | Probabilistically, via Hybrid Search | `recall()` | Ordinary knowledge |
+| `always` | **Deterministically, every turn** | `load_pinned()` | An agent's Goal / Guardrail / critical policy |
+| `on_trigger` | Inside a scheduled time window | `recall_upcoming()` | Deadlines, dated follow-ups (Time Memories, `type="time"`) |
+
+- **`always` (pinned)** — `load_pinned()` returns the *complete, unranked* always-load set every call — the deterministic counterpart to probabilistic `recall()`. Pin with `remember(delivery_mode="always")` (or `update_memory(...)`); pinning also forces `scope="persistent"` so there is no sleep-consolidation wait. Unpin with `update_memory(delivery_mode="on_recall")`.
+- **`on_trigger` (time)** — a Time Memory (`type="time"`, `details.trigger={year, month, day?}`) surfaces via `recall_upcoming()` when its window is upcoming. This is a deterministic time query, not semantic search.
+
+### 2. Trust tier — provenance & behaviour-influencing reads
+
+Not all memories are equally trustworthy as *instructions*. Connector-ingested content (Slack/Discord/etc.) is data, not commands — treating it as instructions is an indirect prompt-injection vector ([OWASP LLM01 / LLM03](https://owasp.org/www-project-top-10-for-large-language-model-applications/)).
+
+- **`Memory.source_type`** — server-stamped provenance, never client-trusted: one of `manual`, `file`, `url`, `vault`, `api`, `connector` (NOT NULL + CHECK).
+- **`Context.trust_tier`** — `trusted` (default) or `external`. Connector-fed contexts are marked `external`.
+- **Trust filter** — pass `recall(filters={"trust_tier": "trusted"})` for any **behaviour-influencing read** (one whose results are fed back to the model as context/instructions). It excludes memories from `external`-tier contexts **and** any `source_type="connector"` memory (defence-in-depth). Default recall returns everything; the filter is opt-in and protective on connector-mixed workspaces, a no-op on manual-only ones.
+
+The session-start bootstrap recalls use `trust_tier: "trusted"` for exactly this reason.
+
+### 3. Agent state lane — scratchpad, never recalled
+
+An agent loop needs durable, *exact-match* scratch state (current task, plan step, cursor) that must **never** pollute semantic search. This lives in a **dedicated `agent_states` table**, structurally excluded from `recall()`:
+
+- `set_state(context_id, key, value)` — upsert a JSON value under a key (optional `ttl_seconds`, clamped to 30 days).
+- `get_state(context_id, key)` — read one key, or omit `key` to list all live state for the context.
+- Expired entries are reaped lazily on read. REST equivalents live under `/api/v1/contexts/{id}/state`.
+
+### 4. Retrieval feedback signal — explicit, gated
+
+`access_count` / `last_used` are weak implicit proxies for "was this recall useful". The **feedback signal** makes that judgment explicit and attributable:
+
+- `feedback(context_id, memory_id, helpful, query?, note?)` — recording is **read-adjacent** (a `Viewer` who consumes recall may rate it).
+- Stored **append-only** in a dedicated `retrieval_feedback` table — a time series (contradicting signals are kept), embedded nowhere, structurally excluded from `recall()`.
+
+> **Eval-gate policy (HARD RULE).** Feedback is *collected* now; it is **not acted on automatically**. No self-update / auto-promotion loop ships before the golden retrieval eval gate (#344) is green — otherwise the substrate degrades into noisy implicit RL that optimizes for confident-but-wrong results. The golden eval harness lives in [`backend/tests/eval/`](../backend/tests/eval/README.md); the full policy is in [Retrieval Feedback & Eval Gate](eval/retrieval-feedback-and-eval-gate.md).
+
+See [Architecture › Agent Memory Substrate](architecture.md#agent-memory-substrate-lanes) for the table-level design and how these lanes sit beside `memories`.
+
 ## MCP Tools
 
-Kagura Memory Cloud exposes 37 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), grouped into 9 categories:
+Kagura Memory Cloud exposes 45 tools via the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/), grouped into 11 categories:
 
 | Category | Tools | Purpose |
 |----------|-------|---------|
 | Memory | 6 | `remember`, `recall`, `reference`, `update_memory`, `forget`, `explore` — store / search / discover memories |
+| Agent Substrate | 5 | `load_pinned`, `recall_upcoming`, `set_state`, `get_state`, `feedback` — delivery-mode-aware retrieval, agent state lane, feedback signal (see [Agent Memory Substrate](#agent-memory-substrate)) |
 | Neural Edges | 4 | `list_edges`, `create_edge`, `update_edge`, `delete_edge` — manage the Hebbian graph manually |
 | Contexts | 7 | `get_context_info`, `list_contexts`, `create_context`, `update_context`, `delete_context`, `merge_contexts`, `update_search_config` |
 | Tags | 1 | `list_tags` — tag vocabulary discovery for alignment before `remember`/`recall` |
 | Files / R2 | 5 | `init_file_upload`, `complete_file_upload`, `list_files`, `get_file_download_url`, `delete_file` — binary attachments via R2 |
 | Analyses (Broadlistening) | 5 | `analyze_context`, `list_analyses`, `get_analysis`, `get_active_analysis`, `get_cluster` — large-scale qualitative clustering (Owner + Pro plan) |
-| Resources | 5 | `setup_resource`, `list_resource_tokens`, `ingest_events`, `get_resource_impact`, `get_resource_schema` — external data ingestion |
+| Resources | 6 | `setup_resource`, `setup_connector`, `list_resource_tokens`, `ingest_events`, `get_resource_impact`, `get_resource_schema` — external data ingestion + connector provisioning |
 | Sleep Maintenance | 3 | `get_sleep_history`, `get_sleep_report`, `rollback_sleep_run` — background consolidation observability |
 | Usage | 1 | `get_usage` — workspace quota and usage queries |
+| API-Key Bindings | 2 | `list_my_bindings`, `describe_binding` — introspect public-bound API keys (read-only, owner-scoped) |
 
 See [README › MCP Tools](../README.md#mcp-tools) for the full per-tool table with descriptions and required roles.
 


### PR DESCRIPTION
## Summary

Documents the **AI Agent Memory Substrate** (epic #885, shipped v0.24.0 / v0.25.0) across the architect-level docs, which had drifted with **zero** coverage of the new primitives.

| Surface | Change |
|---|---|
| `docs/concepts.md` | New **Agent Memory Substrate** section: delivery_mode vs type, trust tier, agent state lane, feedback signal + eval-gate policy; the "primitives, not new types" decision |
| `docs/architecture.md` | **Agent Memory Substrate Lanes** section (lane-separation table, trust boundary, eval gate, connector chat schema); `agent_states` / `retrieval_feedback` / `source_type` / `delivery_mode` added to DB design |
| `docs/api-reference.md` | **Agent State APIs** (4 REST routes) + **Retrieval Feedback API**; `trust_tier` recall filter; substrate MCP tool examples |
| `README.md` / `README.ja.md` | Substrate positioning, MCP tools `39 → 45` / `11` categories, **Agent Substrate** + **API-Key Bindings** categories, `setup_connector`, eval-gate doc link |
| `backend/src/api/main.py` | Declare `agent-state` + `retrieval-feedback` in `openapi_tags` (were orphaned in ReDoc) |

All tool counts reconciled to the verified shipped reality (**45 tools / 11 categories**). Every factual claim (source_type enum, trust_tier default, TTL, query/note limits, REST routes/roles, response shapes) was verified against source.

## Acceptance criteria (#918)

- [x] `architecture.md` documents `agent_states` + `retrieval_feedback` lanes and the trust-tier layer
- [x] `concepts.md` covers the agent-memory-substrate primitives + eval-gate policy
- [x] `api-reference.md` lists the new REST routes + MCP tools + `trust_tier` filter
- [x] eval harness cross-linked from arch/concepts
- [x] `/api-docs-audit` passes for the substrate surface (`agent-state` + `retrieval-feedback` now declared)

## Notes

- Docs + additive OpenAPI metadata only — no logic, routes, schema, or migrations.
- Self-review: 0 critical / 0 warnings.
- Pre-existing tag drift for *other* epics (`bm25-drift` suffix mismatch, undeclared `resources`/`connectors`/`workers`/etc.) was surfaced by the audit but left out of scope.

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)