### PR TITLE
fix(tasks): guard Sleep Maintenance against cross-process double-fire (#933)

### DIFF
--- a/backend/src/tasks/single_flight.py
+++ b/backend/src/tasks/single_flight.py
@@ -1,0 +1,92 @@
+"""Cross-process single-flight guard via Postgres session-level advisory locks.
+
+Issue #933. APScheduler runs in-process with an in-memory jobstore, so when
+more than one API process is alive (e.g. both the blue and green containers
+during/after a blue-green deploy) each process fires the same cron
+independently. ``max_instances=1`` / ``coalesce`` only dedupe *within* one
+process. This guard makes a scheduled task run at most once per tick across the
+whole deployment: the first process to acquire the Postgres advisory lock runs
+the body; the others no-op.
+
+Design notes (see issue #933 gate1 review):
+
+- **Session-scoped, not transaction-scoped.** The codebase already uses
+  ``pg_advisory_xact_lock`` elsewhere (``quota_service``,
+  ``connector_provisioning``, admin workspace-create), but those locks release
+  at transaction end. Callers of this guard (e.g. ``sleep_maintenance_task``)
+  commit repeatedly inside the run, so the lock must outlive those commits —
+  hence ``pg_try_advisory_lock`` (session-level) held on a dedicated
+  connection for the lifetime of the ``async with`` block.
+- **Explicit unlock in ``finally``.** A session-level lock is bound to the
+  physical connection, and SQLAlchemy returns connections to the pool rather
+  than closing them — so the lock would *leak* onto a pooled connection if we
+  relied on connection close. We unlock explicitly before the connection is
+  returned. If the whole process dies the lock is still released automatically
+  by Postgres (the physical connection drops), so no manual cleanup table is
+  needed.
+- **Key derivation** matches the rest of the codebase:
+  ``hashtextextended(:key, 0)`` → the 64-bit bigint signature of
+  ``pg_try_advisory_lock``.
+- **Dedicated connection.** The lock is held on a connection from
+  ``engine.connect()`` that is independent of any ``AsyncSession`` the caller
+  opens (e.g. via ``get_db()``) — they are separate pool checkouts. So the
+  caller committing repeatedly on its own session does NOT release this
+  session-level lock; only this module's explicit unlock (or process death)
+  does.
+- **Lock keys must be globally unique** across all single-flight consumers in
+  the deployment, since they all share the one advisory-lock keyspace. Existing
+  callers scope theirs (``workspace_create:<id>``, ``connector_seat:<id>``); a
+  process-wide cron uses a bare name like ``sleep_maintenance``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+from sqlalchemy import text
+
+from db.base import _get_engine
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_TRY_LOCK_SQL = text("SELECT pg_try_advisory_lock(hashtextextended(:key, 0))")
+_UNLOCK_SQL = text("SELECT pg_advisory_unlock(hashtextextended(:key, 0))")
+
+
+@asynccontextmanager
+async def single_flight(lock_key: str) -> AsyncIterator[bool]:
+    """Yield ``True`` iff this process acquired the cross-process lock for ``lock_key``.
+
+    Usage::
+
+        async with single_flight("sleep_maintenance") as acquired:
+            if not acquired:
+                return
+            ...  # do the work; safe across multiple API processes
+
+    Args:
+        lock_key: stable string identifying the task. Distinct tasks MUST use
+            distinct keys so they don't block one another.
+
+    Yields:
+        ``True`` when the advisory lock was acquired (caller should run),
+        ``False`` when another process already holds it (caller should skip).
+    """
+    engine = _get_engine()
+    async with engine.connect() as conn:
+        acquired = bool(await conn.scalar(_TRY_LOCK_SQL, {"key": lock_key}))
+        if not acquired:
+            logger.info("single_flight_skipped", lock_key=lock_key)
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            released = bool(await conn.scalar(_UNLOCK_SQL, {"key": lock_key}))
+            if not released:
+                # The lock was not held by this session — indicates the lock
+                # was released out from under us (connection drift). Surface it
+                # rather than swallowing, since it points at a pooling bug.
+                logger.warning("single_flight_unlock_unexpected", lock_key=lock_key)

--- a/backend/src/tasks/single_flight.py
+++ b/backend/src/tasks/single_flight.py
@@ -32,7 +32,10 @@ Design notes (see issue #933 gate1 review):
   opens (e.g. via ``get_db()``) — they are separate pool checkouts. So the
   caller committing repeatedly on its own session does NOT release this
   session-level lock; only this module's explicit unlock (or process death)
-  does.
+  does. Consequence: a guarded task holds **two** pool slots for the run's
+  duration (the lock connection here plus the caller's work session). That is
+  fine for an off-peak nightly cron, but weigh it before applying the guard to
+  high-frequency tasks — consider a dedicated/NullPool engine for the lock there.
 - **Lock keys must be globally unique** across all single-flight consumers in
   the deployment, since they all share the one advisory-lock keyspace. Existing
   callers scope theirs (``workspace_create:<id>``, ``connector_seat:<id>``); a
@@ -45,6 +48,7 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
 
 from db.base import _get_engine
 from utils.logger import get_logger
@@ -53,6 +57,38 @@ logger = get_logger(__name__)
 
 _TRY_LOCK_SQL = text("SELECT pg_try_advisory_lock(hashtextextended(:key, 0))")
 _UNLOCK_SQL = text("SELECT pg_advisory_unlock(hashtextextended(:key, 0))")
+
+
+async def _release(conn: AsyncConnection, lock_key: str) -> None:
+    """Release the advisory lock; safe to call from a ``finally`` (never raises).
+
+    Critical invariant: the connection must NOT return to the pool while still
+    holding the session-level lock. A pooled connection is reset with ROLLBACK
+    (SQLAlchemy's default ``reset_on_return``), which does NOT release session
+    advisory locks — and a later checkout that re-runs ``pg_try_advisory_lock`` on
+    that same backend gets ``True`` (re-entrant), silently defeating the
+    cross-process guard. So whenever the unlock does not *provably* succeed we
+    ``invalidate()`` the connection: the physical backend is closed and Postgres
+    drops the lock on session end.
+    """
+    try:
+        released = bool(await conn.scalar(_UNLOCK_SQL, {"key": lock_key}))
+        if released:
+            return
+        # Unlock returned False — this backend did not hold the lock (e.g. pre-ping
+        # swapped the underlying connection). Discard it so a stale lock can't ride
+        # a pooled connection into the next caller.
+        logger.warning("single_flight_unlock_unexpected", lock_key=lock_key)
+    except Exception:
+        # Unlock failed for a reason other than provable success (statement
+        # timeout, InterfaceError, transient OSError, ...). The connection may
+        # still be alive AND still holding the lock — fall through to invalidate.
+        logger.warning("single_flight_unlock_failed", lock_key=lock_key, exc_info=True)
+
+    try:
+        await conn.invalidate()
+    except Exception:
+        logger.warning("single_flight_invalidate_failed", lock_key=lock_key, exc_info=True)
 
 
 @asynccontextmanager
@@ -78,23 +114,16 @@ async def single_flight(lock_key: str) -> AsyncIterator[bool]:
     async with engine.connect() as conn:
         acquired = bool(await conn.scalar(_TRY_LOCK_SQL, {"key": lock_key}))
         if not acquired:
-            logger.info("single_flight_skipped", lock_key=lock_key)
+            # debug, not info: the sole caller already logs a domain-level skip
+            # (e.g. sleep_maintenance_task_skipped), so an info line here just
+            # doubles it on every contended tick.
+            logger.debug("single_flight_skipped", lock_key=lock_key)
             yield False
             return
         try:
             yield True
         finally:
-            # The unlock must never mask the body's exception. If the connection
-            # died, the unlock call raises here — but a dead connection means
-            # Postgres has already dropped this session's advisory lock on close,
-            # so there is nothing to leak; we just log and let the body's
-            # exception (if any) propagate.
-            try:
-                released = bool(await conn.scalar(_UNLOCK_SQL, {"key": lock_key}))
-                if not released:
-                    # The lock was not held by this session — indicates it was
-                    # released out from under us (connection drift). Surface it
-                    # rather than swallowing, since it points at a pooling bug.
-                    logger.warning("single_flight_unlock_unexpected", lock_key=lock_key)
-            except Exception:
-                logger.warning("single_flight_unlock_failed", lock_key=lock_key, exc_info=True)
+            # ``_release`` never raises, so the body's exception (if any) still
+            # propagates, and it guarantees the lock is dropped (unlock or, on any
+            # non-success, connection invalidation) rather than leaked to the pool.
+            await _release(conn, lock_key)

--- a/backend/src/tasks/single_flight.py
+++ b/backend/src/tasks/single_flight.py
@@ -120,6 +120,12 @@ async def single_flight(lock_key: str) -> AsyncIterator[bool]:
             logger.debug("single_flight_skipped", lock_key=lock_key)
             yield False
             return
+        # End the transaction the try-lock autobegan (SQLAlchemy commit-as-you-go).
+        # The session-level advisory lock survives COMMIT, so we keep holding it
+        # while NOT pinning an idle-in-transaction snapshot for the whole run —
+        # which would hold back the vacuum xmin horizon and risk
+        # idle_in_transaction_session_timeout silently dropping the lock mid-run.
+        await conn.commit()
         try:
             yield True
         finally:

--- a/backend/src/tasks/single_flight.py
+++ b/backend/src/tasks/single_flight.py
@@ -84,9 +84,17 @@ async def single_flight(lock_key: str) -> AsyncIterator[bool]:
         try:
             yield True
         finally:
-            released = bool(await conn.scalar(_UNLOCK_SQL, {"key": lock_key}))
-            if not released:
-                # The lock was not held by this session — indicates the lock
-                # was released out from under us (connection drift). Surface it
-                # rather than swallowing, since it points at a pooling bug.
-                logger.warning("single_flight_unlock_unexpected", lock_key=lock_key)
+            # The unlock must never mask the body's exception. If the connection
+            # died, the unlock call raises here — but a dead connection means
+            # Postgres has already dropped this session's advisory lock on close,
+            # so there is nothing to leak; we just log and let the body's
+            # exception (if any) propagate.
+            try:
+                released = bool(await conn.scalar(_UNLOCK_SQL, {"key": lock_key}))
+                if not released:
+                    # The lock was not held by this session — indicates it was
+                    # released out from under us (connection drift). Surface it
+                    # rather than swallowing, since it points at a pooling bug.
+                    logger.warning("single_flight_unlock_unexpected", lock_key=lock_key)
+            except Exception:
+                logger.warning("single_flight_unlock_failed", lock_key=lock_key, exc_info=True)

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -204,10 +204,12 @@ async def sleep_maintenance_task():
             await _sleep_maintenance_run()
     except Exception as e:
         # Lock-acquisition / infra failures (e.g. Postgres unreachable when the
-        # cron fires) occur outside _sleep_maintenance_run's own handler; log them
-        # through the same structured event so they are not silently demoted to
-        # APScheduler's generic job-error log.
-        logger.error("sleep_maintenance_task_failed", error=str(e), exc_info=True)
+        # cron fires) occur outside _sleep_maintenance_run's own handler. Use a
+        # DISTINCT event name from the body-failure event (sleep_maintenance_task_failed)
+        # so alerting can route the two correctly: this one means "could not even
+        # start the sweep" (DB connectivity — wide blast radius), the inner one
+        # means "the sweep itself failed".
+        logger.error("sleep_maintenance_lock_acquire_failed", error=str(e), exc_info=True)
 
 
 async def _sleep_maintenance_run() -> None:

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -193,14 +193,21 @@ async def sleep_maintenance_task():
     # fires the nightly cron independently and every context is swept twice
     # (``max_instances=1`` only dedupes within one process). The first process to
     # acquire the Postgres advisory lock runs the sweep; the others no-op.
-    async with single_flight("sleep_maintenance") as acquired:
-        if not acquired:
-            logger.info(
-                "sleep_maintenance_task_skipped",
-                reason="lock_held_by_other_process",
-            )
-            return
-        await _sleep_maintenance_run()
+    try:
+        async with single_flight("sleep_maintenance") as acquired:
+            if not acquired:
+                logger.info(
+                    "sleep_maintenance_task_skipped",
+                    reason="lock_held_by_other_process",
+                )
+                return
+            await _sleep_maintenance_run()
+    except Exception as e:
+        # Lock-acquisition / infra failures (e.g. Postgres unreachable when the
+        # cron fires) occur outside _sleep_maintenance_run's own handler; log them
+        # through the same structured event so they are not silently demoted to
+        # APScheduler's generic job-error log.
+        logger.error("sleep_maintenance_task_failed", error=str(e), exc_info=True)
 
 
 async def _sleep_maintenance_run() -> None:

--- a/backend/src/tasks/sleep_tasks.py
+++ b/backend/src/tasks/sleep_tasks.py
@@ -12,6 +12,7 @@ from apscheduler.triggers.cron import CronTrigger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.base import get_db
+from tasks.single_flight import single_flight
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -187,6 +188,28 @@ async def sleep_maintenance_task():
         logger.info("sleep_maintenance_task_skipped", reason="sleep_disabled")
         return
 
+    # Issue #933: cross-process single-flight guard. Both the blue and green API
+    # containers run APScheduler in-process, so without this guard each process
+    # fires the nightly cron independently and every context is swept twice
+    # (``max_instances=1`` only dedupes within one process). The first process to
+    # acquire the Postgres advisory lock runs the sweep; the others no-op.
+    async with single_flight("sleep_maintenance") as acquired:
+        if not acquired:
+            logger.info(
+                "sleep_maintenance_task_skipped",
+                reason="lock_held_by_other_process",
+            )
+            return
+        await _sleep_maintenance_run()
+
+
+async def _sleep_maintenance_run() -> None:
+    """Run the Sleep Maintenance sweep across all active (user, workspace, context) tuples.
+
+    Extracted from ``sleep_maintenance_task`` (Issue #933) so the cross-process
+    advisory lock wraps the entire multi-commit run — the per-context loop below
+    commits repeatedly, so a transaction-scoped lock would not span it.
+    """
     try:
         async for db in get_db():
             from sqlalchemy import select

--- a/backend/tests/tasks/test_sleep_tasks.py
+++ b/backend/tests/tasks/test_sleep_tasks.py
@@ -94,12 +94,20 @@ async def test_single_flight_releases_lock_on_exit():
     engine = MagicMock()
     engine.connect = lambda: _fake_connect()
 
+    # Capture the exception manually rather than via ``pytest.raises`` as a
+    # context manager: the static analyzer (CodeQL) treats the post-``with``
+    # asserts as unreachable because it does not model ``pytest.raises`` swallowing
+    # the exception. try/except keeps the asserts reachable and intent identical.
+    raised = None
     with patch("tasks.single_flight._get_engine", return_value=engine):
-        with pytest.raises(RuntimeError):
+        try:
             async with single_flight("sleep_maintenance") as acquired:
                 assert acquired is True
                 raise RuntimeError("boom")
+        except RuntimeError as exc:
+            raised = exc
 
+    assert isinstance(raised, RuntimeError) and str(raised) == "boom"
     # try + unlock both ran (unlock fired from finally despite the raise).
     assert conn.scalar.await_count == 2
 
@@ -148,11 +156,18 @@ async def test_single_flight_unlock_failure_does_not_mask_body_error():
     engine = MagicMock()
     engine.connect = lambda: _fake_connect()
 
+    # Manual capture (not ``pytest.raises``) so CodeQL sees the post-block asserts
+    # as reachable. This also pins the stronger contract: only the body's
+    # RuntimeError may propagate — if the unlock's ConnectionError masked it, the
+    # ``except RuntimeError`` would not catch it and the test would error.
+    raised = None
     with patch("tasks.single_flight._get_engine", return_value=engine):
-        # The body's RuntimeError must win over the unlock's ConnectionError.
-        with pytest.raises(RuntimeError, match="boom"):
+        try:
             async with single_flight("sleep_maintenance") as acquired:
                 assert acquired is True
                 raise RuntimeError("boom")
+        except RuntimeError as exc:
+            raised = exc
 
+    assert isinstance(raised, RuntimeError) and str(raised) == "boom"
     assert conn.scalar.await_count == 2  # try + (failing) unlock both attempted

--- a/backend/tests/tasks/test_sleep_tasks.py
+++ b/backend/tests/tasks/test_sleep_tasks.py
@@ -85,6 +85,7 @@ async def test_single_flight_releases_lock_on_exit():
     # 1st scalar = pg_try_advisory_lock → True, 2nd = pg_advisory_unlock → True
     conn.scalar = AsyncMock(side_effect=[True, True])
     conn.invalidate = AsyncMock()
+    conn.commit = AsyncMock()
 
     @asynccontextmanager
     async def _fake_connect():
@@ -111,6 +112,9 @@ async def test_single_flight_releases_lock_on_exit():
     assert conn.scalar.await_count == 2
     # Unlock succeeded → the connection is clean, so it is NOT invalidated.
     conn.invalidate.assert_not_awaited()
+    # The try-lock's autobegun transaction is committed (the session lock survives
+    # COMMIT), so no idle-in-transaction is pinned for the run's duration.
+    conn.commit.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -150,6 +154,7 @@ async def test_single_flight_unlock_failure_does_not_mask_body_error():
     # 1st scalar = try_advisory_lock → True; 2nd = unlock → raises (dead conn).
     conn.scalar = AsyncMock(side_effect=[True, ConnectionError("db gone")])
     conn.invalidate = AsyncMock()
+    conn.commit = AsyncMock()
 
     @asynccontextmanager
     async def _fake_connect():
@@ -190,6 +195,7 @@ async def test_single_flight_invalidates_when_unlock_returns_false():
     # try → True (acquired); unlock → False (not held by this backend).
     conn.scalar = AsyncMock(side_effect=[True, False])
     conn.invalidate = AsyncMock()
+    conn.commit = AsyncMock()
 
     @asynccontextmanager
     async def _fake_connect():

--- a/backend/tests/tasks/test_sleep_tasks.py
+++ b/backend/tests/tasks/test_sleep_tasks.py
@@ -14,8 +14,6 @@ These tests pin the contract at two boundaries without a real Postgres:
 - helper boundary: acquire/release semantics (unlock in finally; no unlock when not held).
 """
 
-from __future__ import annotations
-
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -171,3 +169,30 @@ async def test_single_flight_unlock_failure_does_not_mask_body_error():
 
     assert isinstance(raised, RuntimeError) and str(raised) == "boom"
     assert conn.scalar.await_count == 2  # try + (failing) unlock both attempted
+
+
+@pytest.mark.asyncio
+async def test_sleep_maintenance_swallows_lock_acquisition_failure(monkeypatch):
+    """If acquiring the lock fails (e.g. Postgres down), the task logs and does not
+    propagate — the scheduler must keep running, and the failure is reported via the
+    task's own structured handler rather than escaping to APScheduler."""
+    monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+    monkeypatch.setenv("SLEEP_ENABLED", "true")
+
+    from tasks import sleep_tasks
+
+    @asynccontextmanager
+    async def _raising_single_flight(key):
+        raise ConnectionError("postgres down")
+        yield True  # pragma: no cover - unreachable, satisfies the generator contract
+
+    get_db_mock = MagicMock()
+    with (
+        patch.object(sleep_tasks, "single_flight", _raising_single_flight),
+        patch.object(sleep_tasks, "get_db", get_db_mock),
+    ):
+        # Must NOT raise — the task's try/except catches the acquisition failure.
+        await sleep_tasks.sleep_maintenance_task()
+
+    # Acquisition failed before any sweep work.
+    get_db_mock.assert_not_called()

--- a/backend/tests/tasks/test_sleep_tasks.py
+++ b/backend/tests/tasks/test_sleep_tasks.py
@@ -1,0 +1,127 @@
+"""Tests for the sleep_maintenance_task cross-process single-flight guard (Issue #933).
+
+The bug: APScheduler runs in-process with an in-memory jobstore, so when both
+the blue and green API containers are alive (during/after a blue-green deploy)
+each process fires the nightly sleep cron independently — every context was
+swept twice. ``max_instances=1`` only dedupes within one process.
+
+The fix wraps the task body in a Postgres session-level advisory lock
+(``single_flight``) so the sweep runs at most once per tick across the whole
+deployment: the first process to acquire the lock runs, the others no-op.
+
+These tests pin the contract at two boundaries without a real Postgres:
+- task boundary: skip the sweep when the lock is held elsewhere; run it when acquired.
+- helper boundary: acquire/release semantics (unlock in finally; no unlock when not held).
+"""
+
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@asynccontextmanager
+async def _fake_single_flight(acquired: bool):
+    yield acquired
+
+
+@pytest.mark.asyncio
+async def test_sleep_maintenance_skips_when_lock_not_acquired(monkeypatch):
+    """Another process holds the advisory lock → the task must do NO DB work."""
+    monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+    monkeypatch.setenv("SLEEP_ENABLED", "true")
+
+    from tasks import sleep_tasks
+
+    get_db_mock = MagicMock()
+    with (
+        patch.object(sleep_tasks, "single_flight", lambda key: _fake_single_flight(False)),
+        patch.object(sleep_tasks, "get_db", get_db_mock),
+    ):
+        await sleep_tasks.sleep_maintenance_task()
+
+    # Lock not acquired → returned early, never touched the database.
+    get_db_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_sleep_maintenance_runs_when_lock_acquired(monkeypatch):
+    """Lock acquired → the task proceeds into the sweep body (get_db iterated)."""
+    monkeypatch.setenv("ENABLE_NEURAL_MEMORY", "true")
+    monkeypatch.setenv("SLEEP_ENABLED", "true")
+
+    from tasks import sleep_tasks
+
+    db = MagicMock()
+    db.commit = AsyncMock()
+    empty = MagicMock()
+    empty.all = MagicMock(return_value=[])  # zero distinct contexts → quick exit
+    db.execute = AsyncMock(return_value=empty)
+
+    async def _get_db():
+        yield db
+
+    cfg = MagicMock()
+    cfg.tag_cooccurrence_enabled = False
+
+    with (
+        patch.object(sleep_tasks, "single_flight", lambda key: _fake_single_flight(True)),
+        patch.object(sleep_tasks, "get_db", _get_db),
+        patch("neural.config.NeuralMemoryConfig.from_db", AsyncMock(return_value=cfg)),
+        patch("neural.config.NeuralMemoryConfig.invalidate_cache", MagicMock()),
+    ):
+        await sleep_tasks.sleep_maintenance_task()
+
+    # Lock acquired → body ran → the distinct-context SELECT executed.
+    db.execute.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_single_flight_releases_lock_on_exit():
+    """single_flight must pg_advisory_unlock in finally, even when the body raises."""
+    from tasks.single_flight import single_flight
+
+    conn = MagicMock()
+    # 1st scalar = pg_try_advisory_lock → True, 2nd = pg_advisory_unlock → True
+    conn.scalar = AsyncMock(side_effect=[True, True])
+
+    @asynccontextmanager
+    async def _fake_connect():
+        yield conn
+
+    engine = MagicMock()
+    engine.connect = lambda: _fake_connect()
+
+    with patch("tasks.single_flight._get_engine", return_value=engine):
+        with pytest.raises(RuntimeError):
+            async with single_flight("sleep_maintenance") as acquired:
+                assert acquired is True
+                raise RuntimeError("boom")
+
+    # try + unlock both ran (unlock fired from finally despite the raise).
+    assert conn.scalar.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_single_flight_yields_false_when_lock_held():
+    """pg_try_advisory_lock returns False → yield False and do NOT unlock."""
+    from tasks.single_flight import single_flight
+
+    conn = MagicMock()
+    conn.scalar = AsyncMock(side_effect=[False])  # only the try; no unlock expected
+
+    @asynccontextmanager
+    async def _fake_connect():
+        yield conn
+
+    engine = MagicMock()
+    engine.connect = lambda: _fake_connect()
+
+    with patch("tasks.single_flight._get_engine", return_value=engine):
+        async with single_flight("sleep_maintenance") as acquired:
+            assert acquired is False
+
+    # Only the try call — never held the lock, so never unlocked.
+    assert conn.scalar.await_count == 1

--- a/backend/tests/tasks/test_sleep_tasks.py
+++ b/backend/tests/tasks/test_sleep_tasks.py
@@ -125,3 +125,34 @@ async def test_single_flight_yields_false_when_lock_held():
 
     # Only the try call — never held the lock, so never unlocked.
     assert conn.scalar.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_single_flight_unlock_failure_does_not_mask_body_error():
+    """A failing unlock in the finally must NOT shadow the body's exception.
+
+    If the connection dies, the unlock ``scalar`` call raises — but Postgres has
+    already dropped the session lock on connection close, so there is nothing to
+    leak. The body's original exception must still be the one that propagates.
+    """
+    from tasks.single_flight import single_flight
+
+    conn = MagicMock()
+    # 1st scalar = try_advisory_lock → True; 2nd = unlock → raises (dead conn).
+    conn.scalar = AsyncMock(side_effect=[True, ConnectionError("db gone")])
+
+    @asynccontextmanager
+    async def _fake_connect():
+        yield conn
+
+    engine = MagicMock()
+    engine.connect = lambda: _fake_connect()
+
+    with patch("tasks.single_flight._get_engine", return_value=engine):
+        # The body's RuntimeError must win over the unlock's ConnectionError.
+        with pytest.raises(RuntimeError, match="boom"):
+            async with single_flight("sleep_maintenance") as acquired:
+                assert acquired is True
+                raise RuntimeError("boom")
+
+    assert conn.scalar.await_count == 2  # try + (failing) unlock both attempted

--- a/backend/tests/tasks/test_sleep_tasks.py
+++ b/backend/tests/tasks/test_sleep_tasks.py
@@ -84,6 +84,7 @@ async def test_single_flight_releases_lock_on_exit():
     conn = MagicMock()
     # 1st scalar = pg_try_advisory_lock → True, 2nd = pg_advisory_unlock → True
     conn.scalar = AsyncMock(side_effect=[True, True])
+    conn.invalidate = AsyncMock()
 
     @asynccontextmanager
     async def _fake_connect():
@@ -108,6 +109,8 @@ async def test_single_flight_releases_lock_on_exit():
     assert isinstance(raised, RuntimeError) and str(raised) == "boom"
     # try + unlock both ran (unlock fired from finally despite the raise).
     assert conn.scalar.await_count == 2
+    # Unlock succeeded → the connection is clean, so it is NOT invalidated.
+    conn.invalidate.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -146,6 +149,7 @@ async def test_single_flight_unlock_failure_does_not_mask_body_error():
     conn = MagicMock()
     # 1st scalar = try_advisory_lock → True; 2nd = unlock → raises (dead conn).
     conn.scalar = AsyncMock(side_effect=[True, ConnectionError("db gone")])
+    conn.invalidate = AsyncMock()
 
     @asynccontextmanager
     async def _fake_connect():
@@ -169,6 +173,36 @@ async def test_single_flight_unlock_failure_does_not_mask_body_error():
 
     assert isinstance(raised, RuntimeError) and str(raised) == "boom"
     assert conn.scalar.await_count == 2  # try + (failing) unlock both attempted
+    # Unlock did not provably succeed → the connection is invalidated so the
+    # session lock cannot leak back onto a pooled connection (it would otherwise
+    # survive ROLLBACK and be re-acquired re-entrantly by the next caller).
+    conn.invalidate.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_single_flight_invalidates_when_unlock_returns_false():
+    """pg_advisory_unlock returning False means this backend no longer holds the
+    lock (e.g. pre-ping swapped the connection) — discard it rather than return a
+    possibly-stale-lock-bearing connection to the pool."""
+    from tasks.single_flight import single_flight
+
+    conn = MagicMock()
+    # try → True (acquired); unlock → False (not held by this backend).
+    conn.scalar = AsyncMock(side_effect=[True, False])
+    conn.invalidate = AsyncMock()
+
+    @asynccontextmanager
+    async def _fake_connect():
+        yield conn
+
+    engine = MagicMock()
+    engine.connect = lambda: _fake_connect()
+
+    with patch("tasks.single_flight._get_engine", return_value=engine):
+        async with single_flight("sleep_maintenance") as acquired:
+            assert acquired is True
+
+    conn.invalidate.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #933

## Summary
- Both the blue and green API containers run APScheduler in-process, so the nightly Sleep Maintenance cron fired **once per process** — every context was swept twice (confirmed in prod 2026-06-05). `max_instances=1` only dedupes within one process.
- Adds a Postgres **session-level advisory-lock** guard (`single_flight`) and wraps `sleep_maintenance_task`: the first process to acquire `pg_try_advisory_lock` runs the sweep; the others no-op.

## Implementation notes
- New `backend/src/tasks/single_flight.py`: `async with single_flight(key) as acquired` context manager. **Session-scoped** (not the repo's existing `pg_advisory_xact_lock`) because the per-context loop commits repeatedly mid-run, so a txn-scoped lock would not span it. Held on a **dedicated `engine.connect()` connection**, explicit `pg_advisory_unlock` in `finally` (a session lock would otherwise leak onto a pooled connection), auto-released by Postgres on process death. Key derivation `hashtextextended(:key, 0)` matches `quota_service` / `connector_provisioning` / `admin`.
- `sleep_tasks.py`: body extracted verbatim into `_sleep_maintenance_run()`, wrapped in the guard after the existing `ENABLE_NEURAL_MEMORY` / `SLEEP_ENABLED` gates (no body re-indent).
- Verified `AsyncConnection.scalar(statement, parameters)` is the correct SQLAlchemy 2.0.48 API (library signature).

## Tests
`backend/tests/tasks/test_sleep_tasks.py` (first unit test for this module): skip-when-held (asserts no DB work), run-when-acquired, unlock-in-finally-on-raise, yield-False-when-held. 4/4 pass, ruff clean.

## Out of scope (follow-ups)
- **Roll `single_flight` out to sibling cron tasks** that share the same double-fire exposure: embedding (30s), neural, file, bm25_drift, erasure, mcp, semantic_edge_reverify, resource_indexer.
- **Defense-in-depth**: compose `profiles:` so a bare `docker compose up -d` doesn't resurrect the inactive blue/green color (deploy.sh `--restart=no` is runtime-only). Infra surface, separate issue.
- Real-DB concurrent integration test ("two parallel invocations → one sweep").

Immediate ops mitigation (stop inactive green) already applied in prod.

## Pre-PR review summary
- gate2 mode: advisor-only / audit: skipped
- cso: green / qa-lead: green / cto: green
- gate1: green via /ask (CTO lens)
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
