### PR TITLE
test(e2e): OAuth test-IdP harness for account-linking link→unlink→re-link (#937)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -358,3 +358,128 @@ jobs:
           path: frontend/playwright-report/
           if-no-files-found: ignore
           retention-days: 7
+
+  # OAuth account-linking E2E lane (#937). Like frontend-a11y-authed it needs a
+  # live backend + authenticated admin, PLUS the OAuth endpoint overrides so the
+  # server-side token/userinfo exchange hits the mock IdP (frontend/e2e/mock-idp)
+  # instead of real Google/GitHub. The mock IdP is started by Playwright's
+  # webServer (playwright.config.ts), so no separate start step is needed here.
+  # Overrides are gated by OAUTH_ENDPOINT_OVERRIDE_ENABLED and hard-blocked in
+  # production (auth/oauth_endpoints.py); ENVIRONMENT is left unset → development.
+  # Reuses the frontend-a11y-authed path filter (its globs already cover every
+  # file this lane consumes). New CI-only lane — NOT yet a Required check (#768);
+  # boot/timing may need tuning over the first runs.
+  frontend-e2e-oauth:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, frontend]
+    if: |
+      needs.detect-changes.outputs.frontend-a11y-authed == 'true' ||
+      (github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'force-integration')) ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'push'
+    env:
+      PYTHONPATH: src
+      DATABASE_URL: postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test
+      REDIS_URL: redis://localhost:6379
+      CORS_ORIGINS: http://localhost:3000
+      E2E_ADMIN_LOGIN_ID: e2e-admin
+      E2E_API_URL: http://localhost:8080
+      NEXT_PUBLIC_API_URL: http://localhost:8080
+      # OAuth test-IdP harness (#937): redirect the server-side GitHub exchange
+      # at the Playwright-managed mock IdP on :9100.
+      OAUTH_ENDPOINT_OVERRIDE_ENABLED: "true"
+      OAUTH_GITHUB_AUTH_URL: http://localhost:9100/github/login/oauth/authorize
+      OAUTH_GITHUB_TOKEN_URL: http://localhost:9100/github/login/oauth/access_token
+      OAUTH_GITHUB_USER_URL: http://localhost:9100/github/user
+      OAUTH_GITHUB_EMAILS_URL: http://localhost:9100/github/user/emails
+      GITHUB_CLIENT_ID: e2e-mock-client-id
+      GITHUB_CLIENT_SECRET: e2e-mock-client-secret
+      GITHUB_REDIRECT_URI: http://localhost:8080/api/v1/auth/github/callback
+    services:
+      postgres:
+        image: postgres:15-alpine
+        env:
+          POSTGRES_USER: kagura
+          POSTGRES_PASSWORD: kagura_dev_password
+          POSTGRES_DB: kagura_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U kagura -d kagura_test"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: backend/pyproject.toml
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install backend dependencies
+        run: cd backend && pip install -e ".[dev]"
+
+      - name: Install frontend dependencies
+        run: cd frontend && npm ci
+
+      - name: Install Playwright browser
+        run: cd frontend && npx playwright install chromium --with-deps
+
+      - name: Generate ephemeral secrets + admin password
+        run: |
+          {
+            echo "API_KEY_SECRET=$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')"
+            echo "JWT_SECRET=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+            echo "AUDIT_HMAC_KEY=$(python -c 'import secrets; print(secrets.token_urlsafe(32))')"
+            echo "E2E_ADMIN_PASSWORD=Ci-$(python -c 'import secrets; print(secrets.token_urlsafe(18))')-9X"
+          } >> "$GITHUB_ENV"
+
+      - name: Migrate schema
+        run: cd backend && alembic upgrade head
+
+      - name: Seed e2e admin
+        run: cd backend && python -m src.cli.seed_e2e_admin
+
+      - name: Start API server
+        run: |
+          cd backend
+          python -m uvicorn src.api.main:app --host 0.0.0.0 --port 8080 --log-level warning &
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/health >/dev/null; then
+              echo "API is up after $((i * 2))s"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::API did not become healthy on :8080 within 60s"
+          exit 1
+
+      - name: Run OAuth account-linking E2E
+        run: cd frontend && npm run test:e2e:oauth
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-oauth
+          path: frontend/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -383,6 +383,10 @@ jobs:
       DATABASE_URL: postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test
       REDIS_URL: redis://localhost:6379
       CORS_ORIGINS: http://localhost:3000
+      # The link callback redirects to {FRONTEND_URL}/profile?linked=1 — pin it to
+      # the Playwright next-dev origin so the round-trip lands on the frontend (not
+      # the API origin) and passes _safe_redirect_url's same-origin check.
+      FRONTEND_URL: http://localhost:3000
       E2E_ADMIN_LOGIN_ID: e2e-admin
       E2E_API_URL: http://localhost:8080
       NEXT_PUBLIC_API_URL: http://localhost:8080

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -400,6 +400,12 @@ jobs:
       GITHUB_CLIENT_ID: e2e-mock-client-id
       GITHUB_CLIENT_SECRET: e2e-mock-client-secret
       GITHUB_REDIRECT_URI: http://localhost:8080/api/v1/auth/github/callback
+      # The GitHub callback guards on `_oauth2_manager`, which main.py only
+      # initializes when GOOGLE_CLIENT_ID is set — so the GitHub-only flow still
+      # needs a (dummy) Google client id or the callback 500s "Auth managers not
+      # initialized". Non-secret throwaway values for an ephemeral CI run.
+      GOOGLE_CLIENT_ID: e2e-mock-google-client-id
+      GOOGLE_CLIENT_SECRET: e2e-mock-google-client-secret
     services:
       postgres:
         image: postgres:15-alpine

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -37,6 +37,13 @@ async def lifespan(app: FastAPI):
     # Startup
     logger.info("application_starting", version=app.version)
 
+    # Fail-closed: refuse to boot if OAuth endpoint overrides (E2E test-IdP
+    # harness, #937) are active in production — they would redirect token
+    # exchange to a non-Google/non-GitHub host.
+    from auth.oauth_endpoints import assert_oauth_endpoints_safe
+
+    assert_oauth_endpoints_safe()
+
     # Migrations are managed by Alembic: `alembic upgrade head`
 
     # Initialize auth routes (Issue #13, #31)

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -30,6 +30,7 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError, SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from auth import oauth_endpoints
 from auth.dependencies import SessionUser
 from auth.oauth2 import OAuth2Manager
 from auth.password import verify_password
@@ -963,10 +964,10 @@ async def get_current_user_info(
 
 github_router = APIRouter(prefix="/github", tags=["authentication", "github-oauth2"])
 
-GITHUB_AUTH_URL = "https://github.com/login/oauth/authorize"
-GITHUB_TOKEN_URL = "https://github.com/login/oauth/access_token"
-GITHUB_USER_URL = "https://api.github.com/user"
-GITHUB_EMAILS_URL = "https://api.github.com/user/emails"
+# GitHub OAuth endpoint URLs are resolved at call time via ``auth.oauth_endpoints``
+# so the E2E test-IdP harness (#937) can redirect the server-side token/userinfo
+# exchange at a mock IdP. Resolution returns the real GitHub URLs unless overrides
+# are explicitly enabled in a non-production environment (see oauth_endpoints).
 
 
 def build_github_authorization_url(*, client_id: str, redirect_uri: str, state: str) -> str:
@@ -992,7 +993,7 @@ def build_github_authorization_url(*, client_id: str, redirect_uri: str, state: 
         ("scope", "read:user user:email"),
         ("state", state),
     ]
-    return f"{GITHUB_AUTH_URL}?{urlencode(params)}"
+    return f"{oauth_endpoints.github_auth_url()}?{urlencode(params)}"
 
 
 @github_router.get("/login")
@@ -1038,7 +1039,7 @@ async def _github_exchange_code(code: str) -> str:
 
     async with httpx.AsyncClient() as client:
         resp = await client.post(
-            GITHUB_TOKEN_URL,
+            oauth_endpoints.github_token_url(),
             data={
                 "client_id": client_id,
                 "client_secret": client_secret,
@@ -1078,11 +1079,15 @@ async def _github_get_user_info(access_token: str) -> dict[str, Any]:
         "Accept": "application/vnd.github+json",
     }
     async with httpx.AsyncClient() as client:
-        user_resp = await client.get(GITHUB_USER_URL, headers=headers, timeout=10.0)
+        user_resp = await client.get(
+            oauth_endpoints.github_user_url(), headers=headers, timeout=10.0
+        )
         user_resp.raise_for_status()
         user_data = user_resp.json()
 
-        emails_resp = await client.get(GITHUB_EMAILS_URL, headers=headers, timeout=10.0)
+        emails_resp = await client.get(
+            oauth_endpoints.github_emails_url(), headers=headers, timeout=10.0
+        )
         emails_resp.raise_for_status()
         primary_verified = next(
             (e["email"] for e in emails_resp.json() if e.get("primary") and e.get("verified")),

--- a/backend/src/auth/oauth2.py
+++ b/backend/src/auth/oauth2.py
@@ -11,6 +11,7 @@ from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import Flow, InstalledAppFlow
 
+from auth import oauth_endpoints
 from auth.config import AuthConfig
 from auth.exceptions import (
     InvalidCredentialsError,
@@ -316,7 +317,7 @@ class OAuth2Manager:
         scope_str = " ".join(scopes)
 
         auth_url = (
-            f"https://accounts.google.com/o/oauth2/v2/auth?"
+            f"{oauth_endpoints.google_auth_url()}?"
             f"client_id={client_id}&"
             f"redirect_uri={redirect_uri}&"
             f"response_type=code&"
@@ -352,8 +353,8 @@ class OAuth2Manager:
                 "web": {
                     "client_id": client_id,
                     "client_secret": client_secret,
-                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
-                    "token_uri": "https://oauth2.googleapis.com/token",
+                    "auth_uri": oauth_endpoints.google_auth_url(),
+                    "token_uri": oauth_endpoints.google_token_url(),
                     "redirect_uris": [redirect_uri],
                 }
             }
@@ -388,7 +389,7 @@ class OAuth2Manager:
 
         headers = {"Authorization": f"Bearer {credentials.token}"}
         response = requests.get(
-            "https://www.googleapis.com/oauth2/v3/userinfo",
+            oauth_endpoints.google_userinfo_url(),
             headers=headers,
         )
         response.raise_for_status()

--- a/backend/src/auth/oauth2.py
+++ b/backend/src/auth/oauth2.py
@@ -353,7 +353,12 @@ class OAuth2Manager:
                 "web": {
                     "client_id": client_id,
                     "client_secret": client_secret,
-                    "auth_uri": oauth_endpoints.google_auth_url(),
+                    # auth_uri is metadata only — Flow.fetch_token uses token_uri,
+                    # never auth_uri — so keep the original literal to avoid any
+                    # behavior change. Only token_uri is routed through the
+                    # resolver (it IS used for the exchange, and is what a mock
+                    # IdP must override).
+                    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
                     "token_uri": oauth_endpoints.google_token_url(),
                     "redirect_uris": [redirect_uri],
                 }

--- a/backend/src/auth/oauth_endpoints.py
+++ b/backend/src/auth/oauth_endpoints.py
@@ -1,0 +1,145 @@
+"""Centralized OAuth provider endpoint resolution + production guard (Issue #937).
+
+Production talks to the real Google/GitHub OAuth endpoints. The account-linking
+E2E harness, however, needs the *server-side* token/userinfo exchange pointed at
+a mock IdP — and because that exchange runs inside the backend (a browser-level
+Playwright mock cannot intercept a server-to-server HTTP call), the endpoint URLs
+must be injectable at the backend layer.
+
+That injectability is security-sensitive: an attacker able to set these in
+production could redirect token exchange to a host they control and harvest
+codes/tokens. Two invariants keep the seam safe:
+
+  1. **Inert by default.** Overrides are honored only when
+     ``OAUTH_ENDPOINT_OVERRIDE_ENABLED`` is truthy *and* the environment is not
+     production. Resolution in production always returns the real defaults.
+  2. **Fail-closed boot guard.** :func:`assert_oauth_endpoints_safe`, called from
+     the app lifespan, refuses to start the process if *any* override mechanism
+     (the flag or a stray ``OAUTH_*_URL``) is active while
+     ``ENVIRONMENT=production``.
+
+All values are read live from ``os.environ`` on each call (the lookups are
+trivial), so tests can ``monkeypatch.setenv`` without fighting a cached
+``Settings`` singleton.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlparse
+
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# --- Real provider defaults (the only URLs used unless overrides are active) ---
+GOOGLE_AUTH_URL_DEFAULT = "https://accounts.google.com/o/oauth2/v2/auth"
+GOOGLE_TOKEN_URL_DEFAULT = "https://oauth2.googleapis.com/token"
+GOOGLE_USERINFO_URL_DEFAULT = "https://www.googleapis.com/oauth2/v3/userinfo"
+GITHUB_AUTH_URL_DEFAULT = "https://github.com/login/oauth/authorize"
+GITHUB_TOKEN_URL_DEFAULT = "https://github.com/login/oauth/access_token"
+GITHUB_USER_URL_DEFAULT = "https://api.github.com/user"
+GITHUB_EMAILS_URL_DEFAULT = "https://api.github.com/user/emails"
+
+# Master switch — overrides are inert unless this is truthy.
+OVERRIDE_FLAG_ENV = "OAUTH_ENDPOINT_OVERRIDE_ENABLED"
+
+# Logical endpoint key -> (env var name, real default).
+_ENDPOINTS: dict[str, tuple[str, str]] = {
+    "google_auth_url": ("OAUTH_GOOGLE_AUTH_URL", GOOGLE_AUTH_URL_DEFAULT),
+    "google_token_url": ("OAUTH_GOOGLE_TOKEN_URL", GOOGLE_TOKEN_URL_DEFAULT),
+    "google_userinfo_url": ("OAUTH_GOOGLE_USERINFO_URL", GOOGLE_USERINFO_URL_DEFAULT),
+    "github_auth_url": ("OAUTH_GITHUB_AUTH_URL", GITHUB_AUTH_URL_DEFAULT),
+    "github_token_url": ("OAUTH_GITHUB_TOKEN_URL", GITHUB_TOKEN_URL_DEFAULT),
+    "github_user_url": ("OAUTH_GITHUB_USER_URL", GITHUB_USER_URL_DEFAULT),
+    "github_emails_url": ("OAUTH_GITHUB_EMAILS_URL", GITHUB_EMAILS_URL_DEFAULT),
+}
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def _is_production() -> bool:
+    # Mirrors how pydantic-settings binds Settings.environment from ENVIRONMENT.
+    return os.environ.get("ENVIRONMENT", "development").strip().lower() == "production"
+
+
+def _overrides_enabled() -> bool:
+    return os.environ.get(OVERRIDE_FLAG_ENV, "").strip().lower() in _TRUTHY
+
+
+def _any_override_url_set() -> bool:
+    return any(os.environ.get(env_name) for env_name, _ in _ENDPOINTS.values())
+
+
+def _valid_http_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in ("http", "https") and bool(parsed.netloc)
+
+
+def _resolve(key: str) -> str:
+    """Resolve one logical endpoint, honoring an override only when it is safe."""
+    env_name, default = _ENDPOINTS[key]
+
+    # Production NEVER honors an override, regardless of the flag — defense in
+    # depth behind the boot guard (which should already have refused to start).
+    if _is_production() or not _overrides_enabled():
+        return default
+
+    raw = os.environ.get(env_name)
+    if not raw:
+        return default
+    if not _valid_http_url(raw):
+        logger.warning(
+            "oauth_endpoint_override_invalid_scheme",
+            endpoint=key,
+            env=env_name,
+        )
+        return default
+    return raw
+
+
+def google_auth_url() -> str:
+    return _resolve("google_auth_url")
+
+
+def google_token_url() -> str:
+    return _resolve("google_token_url")
+
+
+def google_userinfo_url() -> str:
+    return _resolve("google_userinfo_url")
+
+
+def github_auth_url() -> str:
+    return _resolve("github_auth_url")
+
+
+def github_token_url() -> str:
+    return _resolve("github_token_url")
+
+
+def github_user_url() -> str:
+    return _resolve("github_user_url")
+
+
+def github_emails_url() -> str:
+    return _resolve("github_emails_url")
+
+
+def assert_oauth_endpoints_safe() -> None:
+    """Fail-closed boot guard: refuse to start with active overrides in production.
+
+    Called from the app lifespan. Raises :class:`RuntimeError` if the override
+    flag is enabled or any ``OAUTH_*_URL`` is set while ``ENVIRONMENT=production``,
+    so a misconfiguration that would redirect token exchange to a non-Google /
+    non-GitHub host crashes the process loudly instead of silently shipping.
+    """
+    if not _is_production():
+        return
+    if _overrides_enabled() or _any_override_url_set():
+        raise RuntimeError(
+            "OAuth endpoint override is active in production "
+            f"(ENVIRONMENT=production, {OVERRIDE_FLAG_ENV} or an OAUTH_*_URL is "
+            "set). These overrides exist only for E2E testing and must never be "
+            "set in production — refusing to start. Unset them and restart."
+        )

--- a/backend/tests/auth/test_oauth_endpoints.py
+++ b/backend/tests/auth/test_oauth_endpoints.py
@@ -1,0 +1,150 @@
+"""Unit tests for centralized OAuth endpoint resolution + production guard (#937).
+
+The E2E test-IdP harness needs the *server-side* Google/GitHub token+userinfo
+exchange pointed at a mock IdP. Because that exchange runs in the backend (a
+browser-level Playwright mock cannot intercept it), the endpoint URLs must be
+injectable — but injection is security-sensitive: an attacker who could set
+these in production would redirect token exchange to a host they control.
+
+These tests pin the two invariants that make the seam safe:
+  1. Overrides are inert unless OAUTH_ENDPOINT_OVERRIDE_ENABLED is truthy.
+  2. assert_oauth_endpoints_safe() refuses to boot if any override mechanism is
+     active while ENVIRONMENT=production.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from auth import oauth_endpoints as oe
+
+# Every override env var the module recognizes — cleared before each test so a
+# stray value from the ambient environment can't leak in.
+_ALL_OVERRIDE_ENV = [
+    oe.OVERRIDE_FLAG_ENV,
+    "OAUTH_GOOGLE_AUTH_URL",
+    "OAUTH_GOOGLE_TOKEN_URL",
+    "OAUTH_GOOGLE_USERINFO_URL",
+    "OAUTH_GITHUB_AUTH_URL",
+    "OAUTH_GITHUB_TOKEN_URL",
+    "OAUTH_GITHUB_USER_URL",
+    "OAUTH_GITHUB_EMAILS_URL",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Start each test from a known-clean override environment."""
+    for name in _ALL_OVERRIDE_ENV:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "development")
+
+
+def test_defaults_returned_when_no_override() -> None:
+    assert oe.google_auth_url() == oe.GOOGLE_AUTH_URL_DEFAULT
+    assert oe.google_token_url() == oe.GOOGLE_TOKEN_URL_DEFAULT
+    assert oe.google_userinfo_url() == oe.GOOGLE_USERINFO_URL_DEFAULT
+    assert oe.github_auth_url() == oe.GITHUB_AUTH_URL_DEFAULT
+    assert oe.github_token_url() == oe.GITHUB_TOKEN_URL_DEFAULT
+    assert oe.github_user_url() == oe.GITHUB_USER_URL_DEFAULT
+    assert oe.github_emails_url() == oe.GITHUB_EMAILS_URL_DEFAULT
+
+
+def test_override_ignored_when_flag_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    # URL set but the master flag is NOT enabled → must be inert.
+    monkeypatch.setenv("OAUTH_GITHUB_TOKEN_URL", "http://localhost:9999/token")
+    assert oe.github_token_url() == oe.GITHUB_TOKEN_URL_DEFAULT
+
+
+def test_override_honored_when_enabled_and_not_production(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(oe.OVERRIDE_FLAG_ENV, "true")
+    monkeypatch.setenv("OAUTH_GITHUB_TOKEN_URL", "http://localhost:9999/token")
+    monkeypatch.setenv("OAUTH_GOOGLE_USERINFO_URL", "http://localhost:9999/userinfo")
+    assert oe.github_token_url() == "http://localhost:9999/token"
+    assert oe.google_userinfo_url() == "http://localhost:9999/userinfo"
+    # Endpoints without an explicit override still fall back to their defaults.
+    assert oe.github_user_url() == oe.GITHUB_USER_URL_DEFAULT
+
+
+def test_override_with_invalid_scheme_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv(oe.OVERRIDE_FLAG_ENV, "true")
+    monkeypatch.setenv("OAUTH_GITHUB_TOKEN_URL", "ftp://evil/x")
+    assert oe.github_token_url() == oe.GITHUB_TOKEN_URL_DEFAULT
+
+
+def test_guard_passes_in_production_with_no_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    # Must not raise.
+    oe.assert_oauth_endpoints_safe()
+
+
+def test_guard_passes_in_development_with_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(oe.OVERRIDE_FLAG_ENV, "true")
+    monkeypatch.setenv("OAUTH_GITHUB_TOKEN_URL", "http://localhost:9999/token")
+    # development → safe.
+    oe.assert_oauth_endpoints_safe()
+
+
+def test_guard_raises_in_production_when_flag_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv(oe.OVERRIDE_FLAG_ENV, "true")
+    with pytest.raises(RuntimeError, match="OAuth endpoint override"):
+        oe.assert_oauth_endpoints_safe()
+
+
+def test_guard_raises_in_production_when_override_url_present_even_without_flag(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Defense in depth: a stray override URL in prod blocks boot even if the
+    # master flag was never set.
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv("OAUTH_GOOGLE_TOKEN_URL", "http://attacker/token")
+    with pytest.raises(RuntimeError, match="OAuth endpoint override"):
+        oe.assert_oauth_endpoints_safe()
+
+
+def test_production_resolution_ignores_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Even if the guard were somehow bypassed, resolution itself must never
+    # honor an override in production.
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    monkeypatch.setenv(oe.OVERRIDE_FLAG_ENV, "true")
+    monkeypatch.setenv("OAUTH_GITHUB_TOKEN_URL", "http://attacker/token")
+    assert oe.github_token_url() == oe.GITHUB_TOKEN_URL_DEFAULT
+
+
+# --- Wiring: the route layer must resolve URLs through the seam, not bake them in ---
+
+
+def test_github_authorization_url_consumes_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """build_github_authorization_url must point at the mock IdP when overridden."""
+    from api.routes.auth import build_github_authorization_url
+
+    monkeypatch.setenv(oe.OVERRIDE_FLAG_ENV, "true")
+    monkeypatch.setenv("OAUTH_GITHUB_AUTH_URL", "http://localhost:9999/login/oauth/authorize")
+
+    url = build_github_authorization_url(
+        client_id="cid", redirect_uri="http://localhost:8080/cb", state="s"
+    )
+    assert url.startswith("http://localhost:9999/login/oauth/authorize?")
+
+
+def test_google_authorization_url_consumes_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OAuth2Manager.get_authorization_url_web must resolve the auth URL live."""
+    from auth.oauth2 import OAuth2Manager
+
+    monkeypatch.setenv("GOOGLE_CLIENT_ID", "cid")
+    monkeypatch.setenv(oe.OVERRIDE_FLAG_ENV, "true")
+    monkeypatch.setenv("OAUTH_GOOGLE_AUTH_URL", "http://localhost:9999/o/oauth2/v2/auth")
+
+    url = OAuth2Manager(provider="google").get_authorization_url_web(
+        redirect_uri="http://localhost:8080/cb", state="s"
+    )
+    assert url.startswith("http://localhost:9999/o/oauth2/v2/auth?")

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -62,6 +62,49 @@ from `e2e/fixtures.ts` with the `test` from `e2e/fixtures/admin-auth.ts`.
 > only the states reachable without seeding (e.g. `/invite` with an unknown
 > token → error screen).
 
+## OAuth account-linking E2E (mock IdP) — `oauth-account-linking.spec.ts` (#937)
+
+Covers the link → unlink → re-link flow #517 deferred. The backend performs the
+OAuth token + userinfo exchange **server-side**, so a browser-level mock cannot
+intercept it. Instead a real mock IdP (`e2e/mock-idp/server.mjs`, zero-dependency
+Node) is started by Playwright's `webServer`, and the backend is pointed at it
+via `OAUTH_*_URL` overrides.
+
+Those overrides are gated by `OAUTH_ENDPOINT_OVERRIDE_ENABLED` and **hard-blocked
+in production** — `backend/src/auth/oauth_endpoints.py::assert_oauth_endpoints_safe`
+(called at app boot) refuses to start if any override is set while
+`ENVIRONMENT=production`. See `backend/tests/auth/test_oauth_endpoints.py`.
+
+Run locally with the stack up (start the API with the overrides pointing at the
+mock IdP on :9100; Playwright manages the mock IdP + `next dev` itself):
+
+```bash
+# backend (separate shell) — overrides + dummy GitHub creds
+export ENVIRONMENT=development
+export OAUTH_ENDPOINT_OVERRIDE_ENABLED=true
+export OAUTH_GITHUB_AUTH_URL=http://localhost:9100/github/login/oauth/authorize
+export OAUTH_GITHUB_TOKEN_URL=http://localhost:9100/github/login/oauth/access_token
+export OAUTH_GITHUB_USER_URL=http://localhost:9100/github/user
+export OAUTH_GITHUB_EMAILS_URL=http://localhost:9100/github/user/emails
+export GITHUB_CLIENT_ID=e2e-mock-client-id
+export GITHUB_CLIENT_SECRET=e2e-mock-client-secret
+export GITHUB_REDIRECT_URI=http://localhost:8080/api/v1/auth/github/callback
+# ...start uvicorn as usual...
+
+# frontend
+export E2E_ADMIN_LOGIN_ID=e2e-admin
+export E2E_ADMIN_PASSWORD="<password>"
+export E2E_API_URL=http://localhost:8080
+npm run test:e2e:oauth
+```
+
+CI runs this as the `frontend-e2e-oauth` lane (`.github/workflows/ci.yml`),
+modeled on `frontend-a11y-authed`. Like that lane it is a new CI-only check, not
+yet Required (#768); boot/timing may need tuning over the first runs. The
+"last-method Disconnect is blocked" case is covered by `ConnectedAccounts.test.tsx`
+(the admin fixture user is a password user, so that UI state is unreachable in
+this E2E without seeding a dedicated OAuth-only user).
+
 ## Adding a new authenticated admin spec
 
 Use the admin auth fixture at `e2e/fixtures/admin-auth.ts`:

--- a/frontend/e2e/mock-idp/server.mjs
+++ b/frontend/e2e/mock-idp/server.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Mock OAuth IdP for the account-linking E2E harness (Issue #937).
+ *
+ * The backend performs the OAuth token + userinfo exchange *server-side*, so a
+ * browser-level Playwright mock cannot intercept it. Instead, the backend is
+ * pointed at THIS server via the `OAUTH_*_URL` overrides (gated behind
+ * `OAUTH_ENDPOINT_OVERRIDE_ENABLED`, hard-blocked in production — see
+ * backend/src/auth/oauth_endpoints.py).
+ *
+ * Zero dependencies (Node built-in `http` only) so it runs in CI without an
+ * extra install step. Currently implements the GitHub provider surface, which
+ * is the flow the #937 acceptance spec exercises ("Connect GitHub …"):
+ *
+ *   GET  /github/login/oauth/authorize   → 302 to redirect_uri?code=...&state=...
+ *   POST /github/login/oauth/access_token → { access_token, token_type, scope }
+ *   GET  /github/user                     → { id, login, name, avatar_url }
+ *   GET  /github/user/emails              → [ { email, primary, verified } ]
+ *
+ * The returned identity is controllable via env so a test can drive a specific
+ * sub/email:
+ *   MOCK_IDP_PORT        (default 9100)
+ *   MOCK_IDP_GH_SUB      (default "4242000")
+ *   MOCK_IDP_GH_LOGIN    (default "e2e-octocat")
+ *   MOCK_IDP_GH_EMAIL    (default "e2e-octocat@example.com")
+ *   MOCK_IDP_GH_NAME     (default "E2E Octocat")
+ */
+import http from "node:http";
+
+const PORT = Number(process.env.MOCK_IDP_PORT ?? 9100);
+const GH = {
+  sub: process.env.MOCK_IDP_GH_SUB ?? "4242000",
+  login: process.env.MOCK_IDP_GH_LOGIN ?? "e2e-octocat",
+  email: process.env.MOCK_IDP_GH_EMAIL ?? "e2e-octocat@example.com",
+  name: process.env.MOCK_IDP_GH_NAME ?? "E2E Octocat",
+};
+
+const ACCESS_TOKEN = "mock-github-access-token";
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    "content-type": "application/json",
+    "content-length": Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const path = url.pathname;
+
+  // --- Health: lets Playwright's webServer readiness probe (GET /) succeed. ---
+  if (req.method === "GET" && (path === "/" || path === "/health")) {
+    sendJson(res, 200, { status: "ok", provider: "github" });
+    return;
+  }
+
+  // --- GitHub authorize: bounce straight back to the backend callback. ---
+  if (req.method === "GET" && path === "/github/login/oauth/authorize") {
+    const redirectUri = url.searchParams.get("redirect_uri");
+    const state = url.searchParams.get("state") ?? "";
+    if (!redirectUri) {
+      sendJson(res, 400, { error: "missing redirect_uri" });
+      return;
+    }
+    const back = new URL(redirectUri);
+    back.searchParams.set("code", "mock-github-code");
+    back.searchParams.set("state", state);
+    res.writeHead(302, { location: back.toString() });
+    res.end();
+    return;
+  }
+
+  // --- GitHub token exchange (backend posts here with Accept: application/json). ---
+  if (req.method === "POST" && path === "/github/login/oauth/access_token") {
+    // Drain the body; the mock does not validate client_id/secret/code.
+    req.on("data", () => {});
+    req.on("end", () => {
+      sendJson(res, 200, {
+        access_token: ACCESS_TOKEN,
+        token_type: "bearer",
+        scope: "read:user,user:email",
+      });
+    });
+    return;
+  }
+
+  // --- GitHub user profile. ---
+  if (req.method === "GET" && path === "/github/user") {
+    sendJson(res, 200, {
+      id: Number(GH.sub),
+      login: GH.login,
+      name: GH.name,
+      avatar_url: `http://localhost:${PORT}/avatar.png`,
+    });
+    return;
+  }
+
+  // --- GitHub verified primary email (the backend trusts only this). ---
+  if (req.method === "GET" && path === "/github/user/emails") {
+    sendJson(res, 200, [
+      { email: GH.email, primary: true, verified: true },
+    ]);
+    return;
+  }
+
+  sendJson(res, 404, { error: "not_found", path });
+});
+
+server.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`[mock-idp] listening on http://localhost:${PORT} (github)`);
+});

--- a/frontend/e2e/oauth-account-linking.spec.ts
+++ b/frontend/e2e/oauth-account-linking.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, API_URL } from "./fixtures/admin-auth";
+import { CONNECTED_ACCOUNTS_TEST_IDS as T } from "@/components/auth/connected-accounts.testids";
+
+// Disable trace capture: the admin-auth fixture POSTs E2E_ADMIN_PASSWORD via the
+// request context, and `playwright.config.ts` retains traces on failure — same
+// rationale as admin-user-detail.spec.ts (Copilot review PR #807).
+test.use({ trace: "off" });
+
+/**
+ * Account-linking E2E: link → unlink → re-link (Issue #937, follow-up to #517).
+ *
+ * Closes the E2E gap #517 deferred. The backend performs the OAuth token +
+ * userinfo exchange server-side, so a browser mock cannot intercept it; instead
+ * a real mock IdP (frontend/e2e/mock-idp/server.mjs) is stood up and the backend
+ * is pointed at it via OAUTH_*_URL overrides (gated by
+ * OAUTH_ENDPOINT_OVERRIDE_ENABLED, hard-blocked in production — see
+ * backend/src/auth/oauth_endpoints.py + tests/auth/test_oauth_endpoints.py).
+ *
+ * Coverage map for #517 account-linking:
+ * - unit (Vitest)        → ConnectedAccounts.test.tsx (incl. last-method-blocked UI)
+ * - integration (pytest) → test_account_linking.py / test_link_callback.py
+ * - E2E (this spec)      → real browser → backend → mock-IdP → DB round-trip
+ *
+ * The "last-method Disconnect is blocked" case is NOT re-covered here: the admin
+ * fixture user is a password user (isOnlyMethod is always false), so that state
+ * is unreachable without seeding a dedicated OAuth-only user. It is fully covered
+ * by ConnectedAccounts.test.tsx ("disables Disconnect … only sign-in method").
+ *
+ * Locators are testid-only (locale-independent) per #688 gate1 (QA Lead). Linked
+ * vs unlinked state is asserted via which button is present (connect ⇄ disconnect),
+ * not via the locale-dependent "Connected"/"Not connected" status text.
+ */
+
+const PROVIDER = "github";
+const connectBtn = T.connect(PROVIDER);
+const disconnectBtn = T.disconnect(PROVIDER);
+
+test.beforeEach(async ({ context }) => {
+  // Idempotent pre-clean so re-runs against a non-ephemeral DB start unlinked.
+  // 404 (not linked) / 409 (would-be last method — impossible for the password
+  // admin) are both fine to ignore.
+  await context.request.post(`${API_URL}/api/v1/me/account/unlink-provider`, {
+    data: { provider: PROVIDER },
+  });
+});
+
+test("link → unlink → re-link a GitHub identity via the mock IdP", async ({
+  page,
+}) => {
+  await page.goto("/profile");
+
+  // Starts unlinked: the Connect affordance is present, Disconnect is not.
+  await expect(page.getByTestId(connectBtn)).toBeVisible();
+  await expect(page.getByTestId(disconnectBtn)).toHaveCount(0);
+
+  // --- Link: full-page OAuth round-trip (frontend → mock IdP → backend → /profile). ---
+  await page.getByTestId(connectBtn).click();
+  await page.waitForURL(/\/profile(\?|$)/, { timeout: 30_000 });
+
+  // Now linked: Disconnect present, Connect gone.
+  await expect(page.getByTestId(disconnectBtn)).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByTestId(connectBtn)).toHaveCount(0);
+
+  // --- Unlink: open the confirm dialog and confirm. ---
+  await page.getByTestId(disconnectBtn).click();
+  await page.getByTestId(T.disconnectConfirm).click();
+
+  // Back to unlinked (the component reloads providers on success).
+  await expect(page.getByTestId(connectBtn)).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId(disconnectBtn)).toHaveCount(0);
+
+  // --- Re-link: the same identity links again cleanly. ---
+  await page.getByTestId(connectBtn).click();
+  await page.waitForURL(/\/profile(\?|$)/, { timeout: 30_000 });
+  await expect(page.getByTestId(disconnectBtn)).toBeVisible({
+    timeout: 15_000,
+  });
+});

--- a/frontend/e2e/oauth-account-linking.spec.ts
+++ b/frontend/e2e/oauth-account-linking.spec.ts
@@ -54,16 +54,19 @@ test("link → unlink → re-link a GitHub identity via the mock IdP", async ({
   await expect(page.getByTestId(disconnectBtn)).toHaveCount(0);
 
   // --- Link: full-page OAuth round-trip (frontend → mock IdP → backend → /profile). ---
+  // Assert on DOM state (the Disconnect button appears only after the round-trip
+  // lands back on /profile AND the providers fetch reports github linked), not on
+  // the URL: waitForURL(/profile/) would match the *current* /profile before the
+  // navigation even starts, and the success "?linked=1" param persists across the
+  // later unlink — both would resolve early. The 30s timeout covers the full
+  // browser → mock IdP → backend → DB → redirect → reload chain on a cold runner.
   await page.getByTestId(connectBtn).click();
-  await page.waitForURL(/\/profile(\?|$)/, { timeout: 30_000 });
-
-  // Now linked: Disconnect present, Connect gone.
   await expect(page.getByTestId(disconnectBtn)).toBeVisible({
-    timeout: 15_000,
+    timeout: 30_000,
   });
   await expect(page.getByTestId(connectBtn)).toHaveCount(0);
 
-  // --- Unlink: open the confirm dialog and confirm. ---
+  // --- Unlink: open the confirm dialog and confirm (in-page, no navigation). ---
   await page.getByTestId(disconnectBtn).click();
   await page.getByTestId(T.disconnectConfirm).click();
 
@@ -73,8 +76,7 @@ test("link → unlink → re-link a GitHub identity via the mock IdP", async ({
 
   // --- Re-link: the same identity links again cleanly. ---
   await page.getByTestId(connectBtn).click();
-  await page.waitForURL(/\/profile(\?|$)/, { timeout: 30_000 });
   await expect(page.getByTestId(disconnectBtn)).toBeVisible({
-    timeout: 15_000,
+    timeout: 30_000,
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "test:e2e": "playwright test",
     "test:a11y": "playwright test e2e/a11y/",
     "test:a11y:authed": "playwright test e2e/authed-a11y/",
-    "test:e2e:oauth": "playwright test e2e/oauth-account-linking.spec.ts",
+    "test:e2e:oauth": "PW_OAUTH_IDP=1 playwright test e2e/oauth-account-linking.spec.ts",
     "mock-idp": "node e2e/mock-idp/server.mjs"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,9 @@
     "test:cov": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:a11y": "playwright test e2e/a11y/",
-    "test:a11y:authed": "playwright test e2e/authed-a11y/"
+    "test:a11y:authed": "playwright test e2e/authed-a11y/",
+    "test:e2e:oauth": "playwright test e2e/oauth-account-linking.spec.ts",
+    "mock-idp": "node e2e/mock-idp/server.mjs"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -32,18 +32,21 @@ export default defineConfig({
       stdout: "pipe",
       stderr: "pipe",
     },
-    {
-      // Mock OAuth IdP for the account-linking E2E (#937). Idle for other specs;
-      // the backend only calls it during the link round-trip. Kept in the shared
-      // webServer list (not a per-project hook) so `npm run test:e2e:oauth` is
-      // self-contained locally; in CI it is likewise managed by Playwright.
-      command: "npm run mock-idp",
-      url: `http://localhost:${process.env.MOCK_IDP_PORT ?? 9100}/health`,
-      reuseExistingServer: !process.env.CI,
-      timeout: 30_000,
-      stdout: "pipe",
-      stderr: "pipe",
-    },
+    // Mock OAuth IdP for the account-linking E2E (#937). Gated on PW_OAUTH_IDP
+    // (set by `npm run test:e2e:oauth`) so the a11y lanes are NOT coupled to the
+    // mock's health — a bug in the mock must never fail an unrelated a11y run.
+    ...(process.env.PW_OAUTH_IDP === "1"
+      ? [
+          {
+            command: "npm run mock-idp",
+            url: `http://localhost:${process.env.MOCK_IDP_PORT ?? 9100}/health`,
+            reuseExistingServer: !process.env.CI,
+            timeout: 30_000,
+            stdout: "pipe" as const,
+            stderr: "pipe" as const,
+          },
+        ]
+      : []),
   ],
   projects: [
     {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -19,18 +19,32 @@ export default defineConfig({
     baseURL: "http://localhost:3000",
     trace: "retain-on-failure",
   },
-  webServer: {
-    // In CI, force the webpack compiler — Turbopack (the Next.js 16 default)
-    // can't load its native @next/swc binding on the GitHub Actions runner,
-    // the same failure that breaks `next build` there. Locally, keep the
-    // default (Turbopack) for the faster dev experience. See #855.
-    command: process.env.CI ? "npm run dev -- --webpack" : "npm run dev",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-    stdout: "pipe",
-    stderr: "pipe",
-  },
+  webServer: [
+    {
+      // In CI, force the webpack compiler — Turbopack (the Next.js 16 default)
+      // can't load its native @next/swc binding on the GitHub Actions runner,
+      // the same failure that breaks `next build` there. Locally, keep the
+      // default (Turbopack) for the faster dev experience. See #855.
+      command: process.env.CI ? "npm run dev -- --webpack" : "npm run dev",
+      url: "http://localhost:3000",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+    {
+      // Mock OAuth IdP for the account-linking E2E (#937). Idle for other specs;
+      // the backend only calls it during the link round-trip. Kept in the shared
+      // webServer list (not a per-project hook) so `npm run test:e2e:oauth` is
+      // self-contained locally; in CI it is likewise managed by Playwright.
+      command: "npm run mock-idp",
+      url: `http://localhost:${process.env.MOCK_IDP_PORT ?? 9100}/health`,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30_000,
+      stdout: "pipe",
+      stderr: "pipe",
+    },
+  ],
   projects: [
     {
       name: "chromium",

--- a/frontend/src/components/auth/ConnectedAccounts.tsx
+++ b/frontend/src/components/auth/ConnectedAccounts.tsx
@@ -42,6 +42,7 @@ import { LoadingState } from "@/components/common/LoadingState";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/contexts/AuthContext";
 import { apiClient, ApiError } from "@/lib/api/base";
+import { CONNECTED_ACCOUNTS_TEST_IDS } from "@/components/auth/connected-accounts.testids";
 import { Link2, Loader2 } from "lucide-react";
 
 type Provider = "google" | "github";
@@ -220,7 +221,12 @@ export default function ConnectedAccounts() {
                         <p className="text-sm font-medium leading-none">
                           {t(provider)}
                         </p>
-                        <p className="text-xs text-slate-500 mt-1">
+                        <p
+                          className="text-xs text-slate-500 mt-1"
+                          data-testid={CONNECTED_ACCOUNTS_TEST_IDS.status(
+                            provider,
+                          )}
+                        >
                           {isLinked ? t("connected") : t("notConnected")}
                         </p>
                       </div>
@@ -236,6 +242,9 @@ export default function ConnectedAccounts() {
                             setDisconnectTarget(provider);
                           }}
                           disabled={disableDisconnect}
+                          data-testid={CONNECTED_ACCOUNTS_TEST_IDS.disconnect(
+                            provider,
+                          )}
                           aria-label={t("disconnectButton", {
                             provider: t(provider),
                           })}
@@ -257,6 +266,9 @@ export default function ConnectedAccounts() {
                         size="sm"
                         onClick={() => handleConnect(provider)}
                         disabled={isBusy}
+                        data-testid={CONNECTED_ACCOUNTS_TEST_IDS.connect(
+                          provider,
+                        )}
                         aria-label={t("connectButton", {
                           provider: t(provider),
                         })}
@@ -320,6 +332,7 @@ export default function ConnectedAccounts() {
               variant="destructive"
               onClick={handleDisconnectConfirm}
               disabled={busyProvider !== null}
+              data-testid={CONNECTED_ACCOUNTS_TEST_IDS.disconnectConfirm}
             >
               {busyProvider !== null && (
                 <Loader2 className="h-4 w-4 mr-2 animate-spin" />

--- a/frontend/src/components/auth/connected-accounts.testids.ts
+++ b/frontend/src/components/auth/connected-accounts.testids.ts
@@ -1,0 +1,17 @@
+/**
+ * Stable test IDs for the ConnectedAccounts section (#517 UI, #937 E2E).
+ *
+ * Shared between the component and the Playwright spec so renames are caught at
+ * compile time. Per #688 gate1 (QA Lead): E2E locators must be locale-independent
+ * (testid only, never visible text) so specs survive the next-intl migration.
+ */
+export const CONNECTED_ACCOUNTS_TEST_IDS = {
+  /** "Connect {provider}" button (shown when the provider is NOT linked). */
+  connect: (provider: string) => `connected-accounts-connect-${provider}`,
+  /** "Disconnect {provider}" button (shown when the provider IS linked). */
+  disconnect: (provider: string) => `connected-accounts-disconnect-${provider}`,
+  /** Per-provider status line ("Connected" / "Not connected"). */
+  status: (provider: string) => `connected-accounts-status-${provider}`,
+  /** Destructive confirm button inside the disconnect AlertDialog. */
+  disconnectConfirm: "connected-accounts-disconnect-confirm",
+} as const;


### PR DESCRIPTION
Closes #937.

Closes the E2E gap #517 deferred: a Playwright link→unlink→re-link round-trip for OAuth account linking, plus the test-IdP infrastructure it requires.

## Why this needed backend changes
The backend performs the OAuth **token + userinfo exchange server-side**, so a browser-level Playwright mock cannot intercept it. The endpoint URLs therefore had to be injectable at the backend — done safely behind a flag + a fail-closed production guard.

## What changed
**Backend — injectable endpoints + production guard**
- `auth/oauth_endpoints.py` (new): centralized resolver for Google/GitHub authorize/token/userinfo URLs. Overrides are honored **only** when `OAUTH_ENDPOINT_OVERRIDE_ENABLED` is set **and** the environment is not production. `_resolve()` returns real defaults in production regardless of the flag (resolution-level hard block).
- `assert_oauth_endpoints_safe()` wired into the app lifespan (`api/main.py`): refuses to boot if any override is active while `ENVIRONMENT=production` (fail-closed).
- Wired `auth.py` (GitHub) and `oauth2.py` (Google) through the resolver; removed the now-redundant hardcoded GitHub URL constants.

**Test harness**
- `frontend/e2e/mock-idp/server.mjs` (new): zero-dependency Node mock IdP (GitHub surface) — authorize / token / user / emails. Started by Playwright's `webServer`.
- `frontend/e2e/oauth-account-linking.spec.ts` (new): testid-only link→unlink→re-link round-trip. State asserted via connect⇄disconnect button presence (locale-independent, per #688 gate1).
- `connected-accounts.testids.ts` (new) + testids added to `ConnectedAccounts.tsx`.
- CI: `frontend-e2e-oauth` lane (modeled on `frontend-a11y-authed`); `FRONTEND_URL` pinned so the link redirect lands on the frontend origin.

## Test plan
- Backend: `tests/auth/test_oauth_endpoints.py` — 11 tests (defaults, flag-gating, scheme validation, prod-block, boot guard both ways, route wiring). Full `tests/auth/` suite green (124 passed).
- `ruff check` + `ruff format --check` clean; app import + guard behavior smoke-verified (passes in dev, raises in prod).
- Frontend: `tsc --noEmit` clean; `ConnectedAccounts.test.tsx` green (7); mock IdP smoke-tested via curl; Playwright config + spec compile-clean.
- Reviews: `/code-review --effort high` (one finding — FRONTEND_URL pin — fixed); `/cso` security review → ship (defense-in-depth, no critical/high).

## Notes
- The `frontend-e2e-oauth` lane is a **new CI-only check, not yet Required** (#768) — like the `frontend-a11y-authed` lane it follows, boot/timing may need tuning over the first runs. This PR is its first real end-to-end execution (the full stack can't be run locally here).
- "Last-method Disconnect is blocked" is covered by `ConnectedAccounts.test.tsx` (the admin fixture user has a password, so that UI state is unreachable in this E2E without seeding a dedicated OAuth-only user).
- Sibling follow-up #938 (remove deprecated `users.auth_provider` read-dependence) is **deferred** — it can't ship until #517 deploys and self-heal saturates; documented on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)