### PR TITLE
refactor(auth): remove deprecated users.auth_provider read-dependence (#938)

### DIFF
--- a/backend/src/auth/roles.py
+++ b/backend/src/auth/roles.py
@@ -301,13 +301,18 @@ class RoleManager:
 
         async for db in get_db():
             user = None
-            # Provider link for (auth_provider, user_id). Fetched in the new
-            # path below and reused by the self-heal block, so it must be in
-            # scope even when known_provider is False.
-            link = None
 
-            # NEW path (#517): resolve by (provider, oauth_sub) so a secondary
-            # provider linked to an existing user maps back to that owner.
+            # Resolve the owning user by (provider, oauth_sub) — the sole legacy-
+            # free read path as of #938. The pre-#517 ``users.user_id == oauth_sub``
+            # fallback and its self-heal insert were removed once the e37_517
+            # backfill saturated: a prod probe confirmed 0 un-migrated
+            # google/github users, so every such identity has a
+            # ``user_oauth_providers`` row and this lookup is authoritative.
+            # (``users.auth_provider`` is retained as the denormalized "primary"
+            # pointer that account-linking writes — only the READ-dependence is
+            # removed here.) A known provider that somehow still lacks a row falls
+            # through to the new-user path below, whose IntegrityError(user_id)
+            # retry re-resolves the existing user without creating a duplicate.
             if known_provider:
                 link = (
                     await db.execute(
@@ -323,50 +328,6 @@ class RoleManager:
                     if user is not None:
                         # Touch last_used_at; committed by _sync_existing_user.
                         link.last_used_at = utcnow()
-
-            # LEGACY fallback: user_id == oauth_sub (un-backfilled / pre-#361
-            # rows, or non-google/github providers). Guarantees production reads
-            # never split while the legacy users.user_id column remains intact.
-            if user is None:
-                user = (
-                    await db.execute(select(User).filter_by(user_id=user_id))
-                ).scalar_one_or_none()
-                if user is not None and known_provider:
-                    # SELF-HEAL: backfill the missing provider row so the next
-                    # login resolves via the new path. Reuse the link fetched
-                    # in the new path above (same session/transaction, no
-                    # intervening write to user_oauth_providers) — guarding on
-                    # link is None keeps the insert idempotent. The orphan-link
-                    # edge case (link present but its owner User missing) is
-                    # correctly skipped here: link is not None, so no duplicate
-                    # row is added for the user resolved via the legacy path.
-                    if link is None:
-                        # Wrap the self-heal insert in a SAVEPOINT: two
-                        # concurrent first-logins of the SAME legacy user via the
-                        # SAME provider both reach this backfill and race on the
-                        # uq_user_oauth_providers_* UNIQUE constraints. Without a
-                        # savepoint the loser's IntegrityError would poison the
-                        # outer transaction that _sync_existing_user commits.
-                        # The concurrent winner already created the row, so a
-                        # UNIQUE violation here is benign — swallow and continue;
-                        # the legacy user is still resolved via the user_id path.
-                        try:
-                            async with db.begin_nested():
-                                db.add(
-                                    UserOAuthProvider(
-                                        user_id=user.user_id,
-                                        provider=auth_provider,
-                                        oauth_sub=user_id,
-                                        last_used_at=utcnow(),
-                                    )
-                                )
-                                await db.flush()
-                        except IntegrityError:
-                            logger.info(
-                                "oauth_provider_self_heal_race",
-                                user_id=user.user_id,
-                                provider=auth_provider,
-                            )
 
             if user is not None:
                 return await self._sync_existing_user(

--- a/backend/src/services/account_linking_service.py
+++ b/backend/src/services/account_linking_service.py
@@ -139,18 +139,14 @@ class AccountLinkingService:
             raise NotFoundException("OAuth provider", resource_id=provider)
 
         has_password = user.auth_method == "password" and user.password_hash is not None
-        # Legacy-fallback method: a pre-#517 user can resolve via
-        # ``users.auth_provider`` through the ensure_user legacy path even with
-        # no ``user_oauth_providers`` row yet. Count it as a usable sign-in
-        # method so unlinking a newly-linked provider doesn't wrongly 409 while
-        # the legacy provider still works — but only when it isn't already one
-        # of ``rows`` (avoid double-counting once self-heal has backfilled it).
-        legacy_provider_usable = user.auth_provider in ("google", "github") and not any(
-            r.provider == user.auth_provider for r in rows
-        )
-        remaining_methods = (
-            (len(rows) - 1) + (1 if has_password else 0) + (1 if legacy_provider_usable else 0)
-        )
+        # As of #938 the ensure_user legacy ``users.user_id``-as-sub fallback is
+        # gone (the e37_517 backfill saturated — a prod probe confirmed 0
+        # un-migrated google/github users), so every usable OAuth sign-in method
+        # is now represented by a ``user_oauth_providers`` row. Remaining methods
+        # = the other linked providers + password; no separate legacy-provider
+        # term is needed. (``users.auth_provider`` is still WRITTEN below as the
+        # denormalized "primary" pointer — only the read-dependence was removed.)
+        remaining_methods = (len(rows) - 1) + (1 if has_password else 0)
         if remaining_methods < 1:
             raise ConflictError("Cannot unlink the only remaining sign-in method")
 

--- a/backend/tests/api/test_account_linking.py
+++ b/backend/tests/api/test_account_linking.py
@@ -222,27 +222,39 @@ async def test_unlink_not_linked_raises_not_found(db_session: AsyncSession):
 
 
 @pytest.mark.asyncio
-async def test_unlink_with_legacy_fallback_provider_succeeds(db_session: AsyncSession):
-    """FIX 3: a pre-#517 legacy user has ``auth_provider='google'`` resolvable
-    via the ensure_user fallback but NO ``user_oauth_providers`` row for google
-    yet. After linking github, unlinking github must NOT 409 — the legacy google
-    method still works, so remaining_methods must count it."""
+async def test_unlink_secondary_keeps_primary_succeeds(db_session: AsyncSession):
+    """Unlinking a secondary provider succeeds while the primary remains.
+
+    Post-#938 (legacy ``users.user_id``-as-sub fallback + self-heal removed,
+    backfill saturated) every usable OAuth method has a ``user_oauth_providers``
+    row, so ``remaining_methods`` is computed purely from the rows + password.
+    A user with both a google and a github row unlinks github → remaining_methods
+    = (2-1)+0 = 1 → succeeds, the google row stays, and ``auth_provider`` (the
+    denormalized primary pointer) is untouched because we unlinked the secondary.
+
+    (This replaces the old ``test_unlink_with_legacy_fallback_provider_succeeds``,
+    which pinned the removed legacy_provider_usable term. Its scenario — a user
+    with ``auth_provider='google'`` but NO google row — can no longer occur:
+    the e37_517 backfill covered all such users and the new-user path always
+    writes a provider row for known providers.)"""
     suffix = uuid4().hex[:8]
     user = await _make_user(db_session, suffix=suffix, auth_provider="google")
     svc = AccountLinkingService(db_session)
-    # Only github gets a provider row; google remains a legacy-fallback method.
+    # Backfill model: the primary (google) has a real provider row, as does github.
+    await svc.link(
+        user_id=user.user_id, provider="google", oauth_sub=f"g-{suffix}", email=user.email
+    )
     await svc.link(
         user_id=user.user_id, provider="github", oauth_sub=f"gh-{suffix}", email=user.email
     )
 
-    # Unlinking github would naively compute (1-1)+0 = 0 → wrong 409. The legacy
-    # google method keeps remaining_methods at 1, so this must succeed.
+    # Unlink the secondary: (2-1)+0 = 1 remaining → succeeds.
     await svc.unlink(user_id=user.user_id, provider="github")
 
     remaining = await svc.list_providers(user.user_id)
-    assert remaining == []
+    assert {r.provider for r in remaining} == {"google"}
 
-    # auth_provider untouched (we unlinked github, not the legacy primary).
+    # auth_provider untouched (we unlinked github, not the primary).
     refreshed = (
         await db_session.execute(select(User).filter_by(user_id=user.user_id))
     ).scalar_one()

--- a/backend/tests/auth/test_ensure_user_dual_read.py
+++ b/backend/tests/auth/test_ensure_user_dual_read.py
@@ -1,10 +1,14 @@
-"""Integration tests for RoleManager.ensure_user dual-read (#517).
+"""Integration tests for RoleManager.ensure_user provider resolution (#517, #938).
 
-Task 3 of #517 (multi-provider OAuth account linking): ``ensure_user`` resolves
-the owning user by ``(provider, oauth_sub)`` against ``user_oauth_providers``
-(the NEW path) and falls back to the legacy ``users.user_id == oauth_sub``
-lookup (un-backfilled rows). On a fallback hit it self-heals by inserting the
-missing ``UserOAuthProvider`` row so future logins resolve via the new path.
+``ensure_user`` resolves the owning user by ``(provider, oauth_sub)`` against
+``user_oauth_providers`` (the NEW path from #517).
+
+#938 removed the legacy ``users.user_id == oauth_sub`` fallback read and its
+self-heal insert, after the e37_517 backfill saturated (a prod probe confirmed
+0 un-migrated google/github users). The second test below now pins the
+post-removal behavior: a user that somehow lacks a provider row still resolves
+to the same account via the new-user path's IntegrityError(user_id) retry —
+without spawning a duplicate User and without a self-heal provider row.
 
 These run against a real PostgreSQL test DB (``conftest.async_engine`` skips
 when unreachable). Each test seeds uuid-suffixed identifiers so parallel /
@@ -111,11 +115,16 @@ async def test_login_via_linked_secondary_provider_resolves_owner(db_session: As
 
 
 @pytest.mark.asyncio
-async def test_legacy_user_without_provider_row_resolves_via_fallback_and_self_heals(
+async def test_user_without_provider_row_still_resolves_without_selfheal(
     db_session: AsyncSession,
 ):
-    """An un-backfilled user (no user_oauth_providers row) resolves via the
-    legacy user_id fallback, and a provider row is self-healed afterward."""
+    """#938: the legacy user_id-as-sub fallback + self-heal are removed.
+
+    A user that lacks a ``user_oauth_providers`` row (post-backfill this should
+    never happen — prod probe = 0 — but the path must degrade safely) still
+    resolves to the SAME account via the new-user path's IntegrityError(user_id)
+    retry: no duplicate User is created. And no self-heal provider row is added
+    (that behavior was intentionally removed)."""
     suffix = uuid4().hex[:8]
     legacy_sub = f"g-dr-3-{suffix}"
     email = f"dual-read-legacy-{suffix}@example.com"
@@ -139,6 +148,8 @@ async def test_legacy_user_without_provider_row_resolves_via_fallback_and_self_h
     ).scalar_one_or_none()
     assert pre is None
 
+    users_before = (await db_session.execute(select(func.count()).select_from(User))).scalar()
+
     rm = RoleManager(use_postgres=True)
     with _patch_get_db_with_fresh_session(db_session.bind):
         role = await rm.ensure_user(
@@ -151,12 +162,14 @@ async def test_legacy_user_without_provider_row_resolves_via_fallback_and_self_h
 
     assert role == Role.USER
 
-    # Self-heal: a (google, legacy_sub) provider row now exists, owned by legacy.
+    # Resolved to the SAME user — no duplicate row spawned by the collision retry.
+    users_after = (await db_session.execute(select(func.count()).select_from(User))).scalar()
+    assert users_after == users_before
+
+    # No self-heal: the missing provider row is NOT created (removed in #938).
     healed = (
         await db_session.execute(
             select(UserOAuthProvider).filter_by(provider="google", oauth_sub=legacy_sub)
         )
     ).scalar_one_or_none()
-    assert healed is not None
-    assert healed.user_id == legacy_sub
-    assert healed.last_used_at is not None
+    assert healed is None

--- a/backend/tests/auth/test_role_manager_postgres.py
+++ b/backend/tests/auth/test_role_manager_postgres.py
@@ -151,18 +151,22 @@ class TestLookupKeyIsUserId:
     @pytest.mark.asyncio
     async def test_lookup_uses_user_id_filter(self, role_manager):
         existing = _user_row(user_id="github-999", email="alice@old.com")
-        db = _make_db_mock(_execute_returns(existing))
+        # #517 NEW path: link lookup (execute #1) → owner User load (execute #2).
+        # #938 removed the legacy user_id fallback, so the owner is loaded via the
+        # link; the User SELECT (#2) must still filter by user_id, not email (#481).
+        db = _make_db_mock(_execute_returns(_oauth_link_row(user_id="github-999"), existing))
 
         with _patch_get_db(db):
             await role_manager.ensure_user(
                 email="alice@old.com",
                 user_id="github-999",
+                auth_provider="github",
                 email_verified=True,
             )
 
-        # Inspect the executed SELECT statement: must filter by user_id.
-        first_stmt = db.execute.call_args_list[0].args[0]
-        compiled = str(first_stmt.compile(compile_kwargs={"literal_binds": True}))
+        # Inspect the User SELECT (the 2nd execute — owner load by link.user_id).
+        user_stmt = db.execute.call_args_list[1].args[0]
+        compiled = str(user_stmt.compile(compile_kwargs={"literal_binds": True}))
         assert "users.user_id" in compiled
         assert "WHERE" in compiled
         # Ensure email is not the primary lookup criterion in this SELECT.
@@ -173,12 +177,14 @@ class TestSyncEmail:
     @pytest.mark.asyncio
     async def test_syncs_email_when_verified_and_changed(self, role_manager):
         existing = _user_row(email="alice@old.com")
-        db = _make_db_mock(_execute_returns(existing))
+        # NEW path (#517): link lookup → owner load. Legacy user_id fallback gone (#938).
+        db = _make_db_mock(_execute_returns(_oauth_link_row(), existing))
 
         with _patch_get_db(db):
             role = await role_manager.ensure_user(
                 email="alice@new.com",
                 user_id="u1",
+                auth_provider="google",
                 email_verified=True,
             )
 
@@ -196,12 +202,13 @@ class TestSyncEmail:
     @pytest.mark.asyncio
     async def test_skips_sync_when_email_not_verified(self, role_manager):
         existing = _user_row(email="alice@old.com")
-        db = _make_db_mock(_execute_returns(existing))
+        db = _make_db_mock(_execute_returns(_oauth_link_row(), existing))
 
         with _patch_get_db(db):
             await role_manager.ensure_user(
                 email="alice@new.com",
                 user_id="u1",
+                auth_provider="google",
                 email_verified=False,
             )
 
@@ -212,12 +219,13 @@ class TestSyncEmail:
     @pytest.mark.asyncio
     async def test_skips_sync_when_email_unchanged(self, role_manager):
         existing = _user_row(email="alice@example.com")
-        db = _make_db_mock(_execute_returns(existing))
+        db = _make_db_mock(_execute_returns(_oauth_link_row(), existing))
 
         with _patch_get_db(db):
             await role_manager.ensure_user(
                 email="alice@example.com",
                 user_id="u1",
+                auth_provider="google",
                 email_verified=True,
             )
 
@@ -229,13 +237,14 @@ class TestSyncName:
     @pytest.mark.asyncio
     async def test_syncs_name_independently_of_email(self, role_manager):
         existing = _user_row(email="alice@example.com", name="Alice Old")
-        db = _make_db_mock(_execute_returns(existing))
+        db = _make_db_mock(_execute_returns(_oauth_link_row(), existing))
 
         with _patch_get_db(db):
             await role_manager.ensure_user(
                 email="alice@example.com",
                 user_id="u1",
                 name="Alice New",
+                auth_provider="google",
                 email_verified=False,  # email won't sync, name still should
             )
 
@@ -246,13 +255,14 @@ class TestSyncName:
     @pytest.mark.asyncio
     async def test_does_not_sync_name_when_unchanged(self, role_manager):
         existing = _user_row(name="Alice")
-        db = _make_db_mock(_execute_returns(existing))
+        db = _make_db_mock(_execute_returns(_oauth_link_row(), existing))
 
         with _patch_get_db(db):
             await role_manager.ensure_user(
                 email=existing.email,
                 user_id="u1",
                 name="Alice",
+                auth_provider="google",
             )
 
         # last_login_at still updated, but no add/audit
@@ -263,7 +273,7 @@ class TestAuditLogStructure:
     @pytest.mark.asyncio
     async def test_audit_log_uses_hmac_not_plaintext(self, role_manager):
         existing = _user_row(email="alice@old.com")
-        db = _make_db_mock(_execute_returns(existing))
+        db = _make_db_mock(_execute_returns(_oauth_link_row(), existing))
         test_key = "test-key-32"
 
         with patch.dict("os.environ", {"AUDIT_HMAC_KEY": test_key}, clear=False):
@@ -275,6 +285,7 @@ class TestAuditLogStructure:
                 await role_manager.ensure_user(
                     email="alice@new.com",
                     user_id="u1",
+                    auth_provider="google",
                     email_verified=True,
                 )
             cs._settings = None  # cleanup
@@ -347,13 +358,15 @@ class TestUpdateCollision:
 class TestCreatePath:
     @pytest.mark.asyncio
     async def test_first_user_gets_admin(self, role_manager):
-        # Sequence: User lookup miss → count=0 → commit succeeds
+        # Sequence (#517 NEW path, #938 no legacy fallback): link lookup miss →
+        # count=0 → commit succeeds.
         db = _make_db_mock(_execute_returns(None, {"scalar": 0}))
 
         with _patch_get_db(db):
             role = await role_manager.ensure_user(
                 email="first@example.com",
                 user_id="u1",
+                auth_provider="google",
                 email_verified=True,
             )
 
@@ -364,13 +377,15 @@ class TestCreatePath:
 
     @pytest.mark.asyncio
     async def test_second_user_gets_user(self, role_manager):
-        # Sequence: User lookup miss → count=1 → commit succeeds
+        # Sequence (#517 NEW path, #938 no legacy fallback): link lookup miss →
+        # count=1 → commit succeeds.
         db = _make_db_mock(_execute_returns(None, {"scalar": 1}))
 
         with _patch_get_db(db):
             role = await role_manager.ensure_user(
                 email="second@example.com",
                 user_id="u2",
+                auth_provider="google",
                 email_verified=True,
             )
 
@@ -394,10 +409,10 @@ class TestCreatePath:
         # precisely model the user_id-collision shape rather than reusing
         # the email helper) → re-lookup hits → sync_existing_user commits
         # the update
-        # #517 dual-read: link lookup MISS → legacy lookup MISS → count → race
-        # re-lookup HIT. Known provider also inserts a UserOAuthProvider row in
+        # #517 NEW path (#938 legacy fallback removed): link lookup MISS → count →
+        # race re-lookup HIT. Known provider also inserts a UserOAuthProvider row in
         # the create unit of work (rolled back with the user on the race).
-        db = _make_db_mock(_execute_returns(None, None, {"scalar": 0}, race_existing))
+        db = _make_db_mock(_execute_returns(None, {"scalar": 0}, race_existing))
         db.commit = AsyncMock(side_effect=[_user_id_unique_violation(), None])
 
         with _patch_get_db(db):
@@ -421,9 +436,9 @@ class TestCreatePath:
 
     @pytest.mark.asyncio
     async def test_email_collision_on_create_raises_conflict(self, role_manager):
-        # #517 dual-read: link lookup MISS → legacy lookup MISS → count=5 →
-        # commit raises → re-lookup also miss → ConflictError.
-        db = _make_db_mock(_execute_returns(None, None, {"scalar": 5}, None))
+        # #517 NEW path (#938 legacy fallback removed): link lookup MISS → count=5
+        # → commit raises → re-lookup also miss → ConflictError.
+        db = _make_db_mock(_execute_returns(None, {"scalar": 5}, None))
         db.commit = AsyncMock(side_effect=_email_unique_violation())
 
         with _patch_get_db(db), structlog.testing.capture_logs() as logs:


### PR DESCRIPTION
Closes #938.

Post-#517 follow-up. Removes the legacy `users.user_id`-as-`oauth_sub` fallback read (and its self-heal) from `ensure_user`, now that the #517 backfill has saturated.

## Why it's safe now (verified, not assumed)
- #517 **is deployed** to prod, and `e37_517` **eagerly backfills** existing google/github users into `user_oauth_providers` at migrate-time (not lazy self-heal).
- **Prod probe**: `users` with `auth_provider IN ('google','github') AND auth_method <> 'password'` that have **no** `user_oauth_providers` row = **0** (7 OAuth users, 7 provider rows). The `(provider, oauth_sub)` lookup is authoritative.
- Both production callers (`auth.py` google/github callbacks) always pass `auth_provider="google"|"github"`, so the `known_provider=False` branch the fallback also covered is unreachable in prod.

## Changes
- **`roles.py`** — drop the legacy fallback resolution + self-heal SAVEPOINT block. The new-user path's existing `IntegrityError(user_id)` retry stays as race protection and degrades safely for any hypothetical missing-link user (resolves the same account, just no self-heal row).
- **`account_linking_service.py`** — drop the `legacy_provider_usable` term from the unlink last-method check; every usable OAuth method now has a row.
- **`users.auth_provider` column is KEPT** — still written by unlink as the denormalized "primary" pointer. Only the **read**-dependence is removed (the column-drop sub-item is a conditional follow-on, intentionally not done here).

## Tests
- Rewrote the self-heal integration test → pins the post-removal behavior (resolves to same account via the collision retry, **no** self-heal row, no duplicate User).
- Updated the mock-sequence unit tests in `test_role_manager_postgres.py` to the known-provider NEW path (link → owner load), matching real call sites.
- Replaced `test_unlink_with_legacy_fallback_provider_succeeds` with a two-row backfill-model equivalent (`test_unlink_secondary_keeps_primary_succeeds`).
- **159 auth + account-linking tests pass** locally against a real Postgres; `ruff` clean. (The `e37_517` migration integration test is unaffected — my diff touches no `alembic/` files; it's exercised by the CI `backend-integration` lane.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)