### PR TITLE
fix(auth): commit last_used_at on the MCP API-key auth path (#945)

### DIFF
--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -250,6 +250,17 @@ async def verify_api_key(api_key: str) -> VerifiedKey | None:
                     bound_context_id=str(verified.bound_context_id),
                 )
                 return None
+            # #945: this wrapper consumes get_db() via `async for ... return`,
+            # so the early return raises GeneratorExit at get_db's yield and its
+            # post-yield `await session.commit()` never runs — the last_used_at
+            # flushed by verify_key would be rolled back. Commit explicitly.
+            # Isolated try/except: a commit failure must NOT fail auth
+            # (last_used_at is non-critical metadata, and the outer
+            # `except Exception: return None` would otherwise reject a valid key).
+            try:
+                await db.commit()
+            except Exception as commit_err:
+                logger.warning("api_key_last_used_commit_failed", error=str(commit_err))
             return verified
     except Exception:
         # Silent failure - return None on any error

--- a/backend/tests/auth/test_api_key_binding.py
+++ b/backend/tests/auth/test_api_key_binding.py
@@ -214,3 +214,68 @@ class TestCreateKeyBoundContextValidation:
         db.add.assert_called_once()
         added_key = db.add.call_args.args[0]
         assert added_key is returned_key
+
+
+class TestVerifyApiKeyStandaloneCommitsLastUsed:
+    """#945: the standalone ``verify_api_key`` (MCP auth path) consumes
+    ``get_db()`` via ``async for db in get_db(): ... return verified`` — the
+    early ``return`` raises ``GeneratorExit`` at the generator's ``yield``, so
+    ``get_db``'s post-yield ``await session.commit()`` never runs and the
+    ``last_used_at`` flushed by ``verify_key`` is rolled back. The wrapper must
+    commit explicitly. A commit failure must NOT fail authentication
+    (``last_used_at`` is non-critical metadata, and the outer
+    ``except Exception: return None`` would otherwise reject a valid key)."""
+
+    @staticmethod
+    def _ok_key() -> object:
+        from auth.api_keys import VerifiedKey
+
+        return VerifiedKey(id=1, user_id="user-1", workspace_id=None, bound_context_id=None)
+
+    @pytest.mark.asyncio
+    async def test_standalone_commits_on_success(self) -> None:
+        from auth.dependencies import verify_api_key
+
+        ok = self._ok_key()
+        db = AsyncMock()
+
+        async def _fake_get_db():
+            yield db
+
+        with (
+            patch("db.base.get_db", new=_fake_get_db),
+            patch(
+                "auth.api_keys.APIKeyManager.verify_key",
+                new=AsyncMock(return_value=ok),
+            ),
+        ):
+            result = await verify_api_key("kagura_test")
+
+        assert result is ok
+        # The explicit commit is what persists last_used_at past the
+        # GeneratorExit that skips get_db's own commit.
+        db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_standalone_commit_failure_does_not_fail_auth(self) -> None:
+        from auth.dependencies import verify_api_key
+
+        ok = self._ok_key()
+        db = AsyncMock()
+        db.commit = AsyncMock(side_effect=RuntimeError("commit boom"))
+
+        async def _fake_get_db():
+            yield db
+
+        with (
+            patch("db.base.get_db", new=_fake_get_db),
+            patch(
+                "auth.api_keys.APIKeyManager.verify_key",
+                new=AsyncMock(return_value=ok),
+            ),
+        ):
+            result = await verify_api_key("kagura_test")
+
+        # A non-critical last_used_at commit failure must not turn a valid key
+        # into an auth rejection (would otherwise hit `except Exception: None`).
+        assert result is ok

--- a/backend/tests/auth/test_api_key_binding.py
+++ b/backend/tests/auth/test_api_key_binding.py
@@ -15,11 +15,12 @@ constraint is covered by ``tests/integration/test_e10_626_apikey_bound_context_i
 from __future__ import annotations
 
 import uuid
+from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from auth.api_keys import APIKeyManager
+from auth.api_keys import APIKeyManager, VerifiedKey
 
 
 def _execute_result(value: object | None = None):
@@ -227,17 +228,16 @@ class TestVerifyApiKeyStandaloneCommitsLastUsed:
     ``except Exception: return None`` would otherwise reject a valid key)."""
 
     @staticmethod
-    def _ok_key() -> object:
-        from auth.api_keys import VerifiedKey
-
+    def _ok_key() -> VerifiedKey:
         return VerifiedKey(id=1, user_id="user-1", workspace_id=None, bound_context_id=None)
 
-    @pytest.mark.asyncio
-    async def test_standalone_commits_on_success(self) -> None:
-        from auth.dependencies import verify_api_key
-
-        ok = self._ok_key()
-        db = AsyncMock()
+    @staticmethod
+    @contextmanager
+    def _patched(db: AsyncMock, verified: VerifiedKey):
+        """Patch the standalone ``verify_api_key``'s inner ``get_db()`` to yield
+        ``db`` and its ``verify_key`` to return ``verified``. The standalone opens
+        its own session via ``async for db in get_db()``, so both the generator
+        and the manager method must be patched."""
 
         async def _fake_get_db():
             yield db
@@ -246,9 +246,19 @@ class TestVerifyApiKeyStandaloneCommitsLastUsed:
             patch("db.base.get_db", new=_fake_get_db),
             patch(
                 "auth.api_keys.APIKeyManager.verify_key",
-                new=AsyncMock(return_value=ok),
+                new=AsyncMock(return_value=verified),
             ),
         ):
+            yield
+
+    @pytest.mark.asyncio
+    async def test_standalone_commits_on_success(self) -> None:
+        from auth.dependencies import verify_api_key
+
+        ok = self._ok_key()
+        db = AsyncMock()
+
+        with self._patched(db, ok):
             result = await verify_api_key("kagura_test")
 
         assert result is ok
@@ -264,16 +274,7 @@ class TestVerifyApiKeyStandaloneCommitsLastUsed:
         db = AsyncMock()
         db.commit = AsyncMock(side_effect=RuntimeError("commit boom"))
 
-        async def _fake_get_db():
-            yield db
-
-        with (
-            patch("db.base.get_db", new=_fake_get_db),
-            patch(
-                "auth.api_keys.APIKeyManager.verify_key",
-                new=AsyncMock(return_value=ok),
-            ),
-        ):
+        with self._patched(db, ok):
             result = await verify_api_key("kagura_test")
 
         # A non-critical last_used_at commit failure must not turn a valid key


### PR DESCRIPTION
## Summary

Fixes the bug behind #945: MCP-authenticated API keys never persisted `last_used_at`, so the **Last used** column shipped in #943 (v0.26.1) showed "—" for every MCP client (Claude Code, Codex, Slack connector, Copilot, …).

## Root cause

The standalone `verify_api_key()` (`backend/src/auth/dependencies.py`), used by the MCP auth path via `mcp_server/auth.py::_verify_api_key`, consumes the `get_db()` async-generator and returns **inside** the loop:

```python
async for db in get_db():
    verified = await manager.verify_key(api_key)  # flushes last_used_at
    ...
    return verified                                # early return
```

`get_db()` is `yield session; await session.commit()`. The early `return` raises `GeneratorExit` at the `yield` (not caught by `except Exception`), so only `finally: session.close()` runs and the session closes **without committing** — the `last_used_at` flushed by `verify_key()` is rolled back. REST API-key usage goes through FastAPI `Depends(get_db)`, which is driven to completion → commit runs → `last_used_at` persists (that's why only a REST/CLI key was populated in prod).

## Fix

Commit explicitly in the standalone wrapper before returning the verified key. The commit is **isolated in its own try/except** so a failure to persist this non-critical metadata cannot fail authentication — the outer `except Exception: return None` would otherwise turn a metadata-write error into a rejection of a valid key (gate1/CTO must-fix).

`verify_key()` is left unchanged (still `flush()`-only): it also runs inside larger REST request transactions where an early commit would prematurely persist partial work.

## Test plan

`tests/auth/test_api_key_binding.py` (mock the `get_db` generator + `verify_key`):
- commit is awaited on the success path (pins the fix);
- a commit failure still returns the verified key (auth survives the guard).

`pytest tests/auth/ tests/mcp_server/test_api_keys.py` → 143 passed. ruff + pyright clean.

## Scope notes

- Out of scope: the bound-key / invalid-key early-return paths (bound keys are rejected on MCP regardless; invalid keys never flush).
- Follow-up candidate (gate1): a dedicated `async with get_db_session()` helper for non-FastAPI callers would eliminate this `get_db` early-return trap class (it has recurred — see the #604/#607 rollback sibling).

Closes #945

🤖 Generated with [Claude Code](https://claude.com/claude-code)
