### PR TITLE
feat(auth): throttle last_used_at writes on the API-key auth path (#947)

### DIFF
--- a/backend/src/auth/api_keys.py
+++ b/backend/src/auth/api_keys.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from config.settings import get_settings
 from models.auth import APIKey, Context
 from utils.datetime import utcnow
 from utils.hashing import sha256_hex
@@ -244,9 +245,18 @@ class APIKeyManager:
             if utcnow() > key_record.expires_at:
                 return None
 
-        # Update last_used_at
-        key_record.last_used_at = utcnow()
-        await self.db.flush()
+        # Update last_used_at — throttled (#947). This runs on EVERY auth (one
+        # per MCP tool call), so writing the row each time is hot-row
+        # write-amplification. Skip the write while the stored timestamp is
+        # fresher than the throttle window; a NULL (never-used) key always
+        # writes. The compare is naive-UTC vs naive-UTC (both via utcnow()), and
+        # guarding the assignment itself (not just the flush) keeps the session
+        # object clean so a later request-level commit cannot persist it anyway.
+        now = utcnow()
+        throttle = timedelta(seconds=get_settings().api_key_last_used_throttle_seconds)
+        if key_record.last_used_at is None or now - key_record.last_used_at >= throttle:
+            key_record.last_used_at = now
+            await self.db.flush()
 
         return VerifiedKey(
             id=key_record.id,

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -73,6 +73,14 @@ class Settings(BaseSettings):
         default="dev-secret-change-in-production",
         description="API Key encryption secret (32+ bytes)",
     )
+    # Issue #947: throttle window (seconds) for api_keys.last_used_at writes.
+    # last_used_at is updated at most once per window per key, so a hot MCP
+    # client (one auth per tool call) does not trigger a row UPDATE+commit on
+    # every request. Minute-level precision is plenty for the "Last used" UI.
+    api_key_last_used_throttle_seconds: int = Field(
+        default=60,
+        description="Min seconds between api_keys.last_used_at writes per key (Issue #947)",
+    )
     # ai-worker (kagura-memory-ai-worker) service auth. The worker presents this
     # as a Bearer token to GET /api/v1/workers/config (Spec 2026-06-02). Empty
     # disables the worker config endpoint (fail-closed). Use: openssl rand -hex 32.

--- a/backend/tests/auth/test_api_key_binding.py
+++ b/backend/tests/auth/test_api_key_binding.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 import uuid
 from contextlib import contextmanager
+from datetime import datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -280,3 +282,71 @@ class TestVerifyApiKeyStandaloneCommitsLastUsed:
         # A non-critical last_used_at commit failure must not turn a valid key
         # into an auth rejection (would otherwise hit `except Exception: None`).
         assert result is ok
+
+
+class TestVerifyKeyLastUsedThrottle:
+    """#947: ``verify_key()`` throttles ``last_used_at`` writes — at most one
+    UPDATE per window per key, so a hot MCP client (one auth per tool call) does
+    not trigger a row UPDATE+commit on every request. NULL (never used) always
+    writes; within the window the write is skipped; at/after the window it
+    writes. naive-UTC compare against ``utcnow()``."""
+
+    @staticmethod
+    def _key_record(last_used_at: datetime | None) -> SimpleNamespace:
+        return SimpleNamespace(
+            id=1,
+            user_id="user-1",
+            workspace_id=None,
+            bound_context_id=None,
+            key_hash="hash",
+            revoked_at=None,
+            expires_at=None,
+            last_used_at=last_used_at,
+        )
+
+    @staticmethod
+    async def _verify(record: SimpleNamespace, now: datetime, throttle: int = 60):
+        db = _make_db_mock(execute_results=[record])
+        manager = APIKeyManager(db)
+        fake_settings = SimpleNamespace(api_key_last_used_throttle_seconds=throttle)
+        with (
+            patch("auth.api_keys.utcnow", return_value=now),
+            patch("auth.api_keys.get_settings", return_value=fake_settings),
+        ):
+            result = await manager.verify_key("kagura_test")
+        return db, result
+
+    NOW = datetime(2026, 6, 8, 12, 0, 0)
+
+    @pytest.mark.asyncio
+    async def test_null_last_used_always_writes(self) -> None:
+        rec = self._key_record(None)
+        db, result = await self._verify(rec, self.NOW)
+        assert result is not None
+        assert rec.last_used_at == self.NOW
+        db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_within_window_skips_write(self) -> None:
+        prev = self.NOW - timedelta(seconds=30)  # 30s < 60s window
+        rec = self._key_record(prev)
+        db, result = await self._verify(rec, self.NOW)
+        assert result is not None
+        assert rec.last_used_at == prev  # unchanged — no write
+        db.flush.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_post_window_writes(self) -> None:
+        rec = self._key_record(self.NOW - timedelta(seconds=90))  # 90s >= 60s
+        db, result = await self._verify(rec, self.NOW)
+        assert result is not None
+        assert rec.last_used_at == self.NOW
+        db.flush.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_window_boundary_writes(self) -> None:
+        # Exactly at the window edge (>= threshold) → write.
+        rec = self._key_record(self.NOW - timedelta(seconds=60))
+        db, result = await self._verify(rec, self.NOW)
+        assert rec.last_used_at == self.NOW
+        db.flush.assert_awaited_once()


### PR DESCRIPTION
## Summary

Throttles `api_keys.last_used_at` writes on the API-key auth path. Since #945, every authentication commits an UPDATE of that column; on the MCP path that is one hot-row write + commit **per `recall`/`remember`/tool call** — write-amplification on a single row for high-frequency clients.

`last_used_at` does not need second-level precision (the "Last used" UI shows relative time), so we now write it **at most once per throttle window per key**.

## Implementation

- Throttle lives in **`verify_key()`** (`backend/src/auth/api_keys.py`) — the single chokepoint both REST and MCP auth pass through, so the UPDATE itself is skipped within-window for both.
- Skip the **assignment + flush** while `now - last_used_at < window` (guarding the assignment, not just the flush, keeps the session object clean so no later request-level commit can persist it). A `NULL` (never-used) key always writes on first auth.
- Window is `api_key_last_used_throttle_seconds` in `Settings` (**default 60s**, env-configurable).
- naive-UTC vs naive-UTC compare (column + `utcnow()` both naive UTC). A backwards clock yields a negative delta → skip, so the column is **never set backwards**.
- The #945 MCP-wrapper `commit()` stays **unconditional**: when throttled there is no flush → cheap empty commit; when the window elapses the flush+commit persists as before. #945's post-window guarantee is preserved (no commit-skip regression).

## Test plan

`tests/auth/test_api_key_binding.py::TestVerifyKeyLastUsedThrottle` (mock `utcnow` + `Settings`):
- NULL `last_used_at` → always writes (flush awaited);
- within window (30s < 60s) → **no write** (flush not awaited, value unchanged);
- post window (90s) and exactly at the boundary (60s, `>=`) → writes.

`pytest tests/auth/ tests/mcp_server/test_api_keys.py` → **147 passed**. ruff + pyright clean. Settings loads with the new field (default 60).

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)
