### PR TITLE
fix(frontend): readable destructive Alert + explicit error-state a11y spec (#957)

### DIFF
--- a/frontend/e2e/a11y/signup-blocked-contrast.spec.ts
+++ b/frontend/e2e/a11y/signup-blocked-contrast.spec.ts
@@ -1,0 +1,27 @@
+import { test } from "@playwright/test";
+import {
+  assertNoColorContrastViolations,
+  gotoAndWaitStable,
+} from "../fixtures";
+
+/**
+ * Color-contrast a11y guard for the destructive Alert error state (#957).
+ *
+ * /signup-blocked is hermetic (no auth) and unconditionally renders an
+ * `<Alert variant="destructive">`, so it deterministically exercises the
+ * destructive Alert palette that previously failed WCAG AA — ~3.76:1 in light
+ * and 1.78:1 in dark (red-on-dark). That bug only ever surfaced intermittently
+ * via the authed-a11y dashboard flake; this spec catches regressions in the
+ * hermetic `frontend-a11y` job without needing auth.
+ */
+test.describe("/signup-blocked color-contrast (#957)", () => {
+  for (const colorScheme of ["light", "dark"] as const) {
+    test(`${colorScheme} mode has no color-contrast violations`, async ({
+      page,
+    }) => {
+      await page.emulateMedia({ colorScheme });
+      await gotoAndWaitStable(page, "/signup-blocked", "[role='alert']");
+      await assertNoColorContrastViolations(page);
+    });
+  }
+});

--- a/frontend/e2e/fixtures/admin-auth.ts
+++ b/frontend/e2e/fixtures/admin-auth.ts
@@ -91,6 +91,25 @@ export const test = base.extend<AdminAuthFixtures>({
         );
       }
 
+      // The login cookie is already in the context jar, but the session may not
+      // be readable on the very next request under commit/replication lag. That
+      // race surfaced as intermittent "Not authenticated" on the page's
+      // client-side fetches, which rendered the destructive error Alert and made
+      // authed-a11y flaky (#957: same commit passed → failed → passed). Poll
+      // /auth/me until the session is live before handing the context to the
+      // test, converting the race into a deterministic wait.
+      await expect
+        .poll(
+          async () =>
+            (await context.request.get(`${API_URL}/api/v1/auth/me`)).status(),
+          {
+            message: "session did not become valid after login",
+            timeout: 10_000,
+            intervals: [200, 300, 500, 1000],
+          },
+        )
+        .toBe(200);
+
       await use();
     },
     { auto: true, scope: "test" },

--- a/frontend/e2e/fixtures/admin-auth.ts
+++ b/frontend/e2e/fixtures/admin-auth.ts
@@ -91,24 +91,16 @@ export const test = base.extend<AdminAuthFixtures>({
         );
       }
 
-      // The login cookie is already in the context jar, but the session may not
-      // be readable on the very next request under commit/replication lag. That
-      // race surfaced as intermittent "Not authenticated" on the page's
-      // client-side fetches, which rendered the destructive error Alert and made
-      // authed-a11y flaky (#957: same commit passed → failed → passed). Poll
-      // /auth/me until the session is live before handing the context to the
-      // test, converting the race into a deterministic wait.
-      await expect
-        .poll(
-          async () =>
-            (await context.request.get(`${API_URL}/api/v1/auth/me`)).status(),
-          {
-            message: "session did not become valid after login",
-            timeout: 10_000,
-            intervals: [200, 300, 500, 1000],
-          },
-        )
-        .toBe(200);
+      // NOTE: this fixture is still subject to the #957 flake — the shared
+      // e2e-admin account hits the single-session-per-user invalidation
+      // (Issue #114: login deletes all of the user's prior sessions), so two
+      // parallel workers re-logging-in as the same admin clobber each other's
+      // session and the loser's cookie 401s. The /auth/me poll attempted here
+      // could not fix that (the session is genuinely deleted), so it was
+      // removed. Deterministic auth (login-once storageState globalSetup, or a
+      // per-worker admin) is tracked as a follow-up — see frontend/e2e/README.md.
+      // The contrast half of #957 (readable destructive Alert) is what makes the
+      // authed-a11y specs pass even when this race surfaces the error state.
 
       await use();
     },

--- a/frontend/src/components/ui/alert.tsx
+++ b/frontend/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils/cn"
+import { cn } from "@/lib/utils/cn";
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground [&>svg~*]:pl-7",
@@ -9,15 +9,21 @@ const alertVariants = cva(
     variants: {
       variant: {
         default: "bg-background text-foreground",
+        // `text-destructive` maps to --destructive, which is a *fill* color
+        // (used as a button background under white foreground). As Alert *text*
+        // it fails WCAG AA contrast — ~3.76:1 in light and 1.78:1 in dark
+        // (red-on-dark). Use the same readable red ramp as ErrorBanner so the
+        // title/description meet AA in both modes (#957). Border stays on the
+        // destructive token (non-text, not contrast-checked).
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+          "border-destructive/50 text-red-800 dark:border-destructive dark:text-red-300 [&>svg]:text-red-600 dark:[&>svg]:text-red-400",
       },
     },
     defaultVariants: {
       variant: "default",
     },
-  }
-)
+  },
+);
 
 const Alert = React.forwardRef<
   HTMLDivElement,
@@ -29,8 +35,8 @@ const Alert = React.forwardRef<
     className={cn(alertVariants({ variant }), className)}
     {...props}
   />
-))
-Alert.displayName = "Alert"
+));
+Alert.displayName = "Alert";
 
 const AlertTitle = React.forwardRef<
   HTMLParagraphElement,
@@ -41,8 +47,8 @@ const AlertTitle = React.forwardRef<
     className={cn("mb-1 font-medium leading-none tracking-tight", className)}
     {...props}
   />
-))
-AlertTitle.displayName = "AlertTitle"
+));
+AlertTitle.displayName = "AlertTitle";
 
 const AlertDescription = React.forwardRef<
   HTMLParagraphElement,
@@ -53,7 +59,7 @@ const AlertDescription = React.forwardRef<
     className={cn("text-sm [&_p]:leading-relaxed", className)}
     {...props}
   />
-))
-AlertDescription.displayName = "AlertDescription"
+));
+AlertDescription.displayName = "AlertDescription";
 
-export { Alert, AlertTitle, AlertDescription }
+export { Alert, AlertTitle, AlertDescription };


### PR DESCRIPTION
Partially addresses #957 (Problem 2 + Problem 3). Problem 1 (auth-fixture determinism) is split to #959.

## What this does
- **Destructive `Alert` dark-mode contrast (WCAG AA)** — `alert.tsx` switches the destructive variant to a text-only red ramp `text-red-800 dark:text-red-300` (icons `red-600`/`red-400`). The `--destructive` token (a *fill* color, white-on-red) stays on the border only, so destructive **buttons are unchanged**. Fixes the `red-900 #7f1d1d` on `slate-900 #0f172a` = 1.78:1 violation.
- **Explicit error-state a11y spec** — `e2e/a11y/signup-blocked-contrast.spec.ts` renders the destructive Alert directly (light + dark) so the contrast bug is caught **deterministically**, not only via the flake.

## What this deliberately does NOT do
The earlier `/auth/me` poll in `admin-auth.ts` was **removed**. It could not fix the authed-a11y flake: the root cause is single-session-per-user invalidation (#114) — every login calls `delete_user_sessions`, so two parallel workers sharing one `e2e-admin` clobber each other's session and the loser's cookie 401s. Polling a *deleted* session just makes the miss a deterministic 10s hard-fail. Tracked + fix options (storageState globalSetup) in **#959**.

With the AA-compliant Alert, the authed-a11y specs pass whether or not the race surfaces the "Not authenticated" error state (the contrast spec asserts contrast only), so this lane goes green without depending on #959.

## Test
- `frontend-a11y` + `frontend-a11y-authed` (latest push removes the poll).