### PR TITLE
test(frontend): make authed-a11y auth deterministic (#959)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,11 +243,13 @@ jobs:
   # the detect-changes path filter (same pattern as backend-integration).
   #
   # Scope (#840, first slice): runs the 3 existing specs (device / invite
-  # unknown-token / workspace-dashboard) with the current login-based
-  # admin-auth fixture (trace:off). The storageState globalSetup migration and
-  # the Pro-workspace/invitation happy-path seed are deferred follow-ups.
-  # This is a new CI-only lane — boot env / port-wait timing may need tuning
-  # over the first runs; it is NOT yet a Required check (#768).
+  # unknown-token / workspace-dashboard). Auth is deterministic via the
+  # storageState `setup` project (#959): the admin logs in once, every spec
+  # reuses the session cookie — no per-test re-login, so parallel workers can't
+  # clobber each other's session (#114). The Pro-workspace/invitation
+  # happy-path seed is still a deferred follow-up. This is a new CI-only lane —
+  # boot env / port-wait timing may need tuning over the first runs; it is NOT
+  # yet a Required check (#768).
   frontend-a11y-authed:
     runs-on: ubuntu-latest
     needs: [detect-changes, frontend]

--- a/.gitignore
+++ b/.gitignore
@@ -268,3 +268,6 @@ docs/superpowers/
 frontend/test-results/
 frontend/playwright-report/
 frontend/blob-report/
+# Pre-seeded auth storageState written by the `setup` project (#959) — contains
+# a live session cookie; never commit.
+frontend/e2e/.auth/

--- a/frontend/e2e/README.md
+++ b/frontend/e2e/README.md
@@ -55,12 +55,33 @@ npm run test:a11y:authed
 Authenticated specs combine `assertNoColorContrastViolations` / `gotoAndWaitStable`
 from `e2e/fixtures.ts` with the `test` from `e2e/fixtures/admin-auth.ts`.
 
-> **Not yet in CI.** Wiring `e2e/authed-a11y/` into a full-stack a11y CI lane
-> (backend services + seed + `storageState` `globalSetup`) — and contrast-testing
-> the fully-seeded happy paths (e.g. a valid invitation, which needs a Pro-plan
-> workspace) — is tracked as a follow-up to #785. The specs here currently cover
-> only the states reachable without seeding (e.g. `/invite` with an unknown
-> token → error screen).
+> **In CI** as the `frontend-a11y-authed` lane (`.github/workflows/ci.yml`),
+> which stands up postgres + redis + a migrated schema + a seeded admin
+> (`python -m src.cli.seed_e2e_admin`), starts the API, then runs
+> `npm run test:a11y:authed`. Contrast-testing the fully-seeded happy paths
+> (e.g. a valid invitation, which needs a Pro-plan workspace + a created
+> invitation) is still a deferred follow-up to #785; the specs here currently
+> cover the states reachable without that extra seed (e.g. `/invite` with an
+> unknown token → error screen).
+
+### How authentication works (deterministic, #959)
+
+The `authed` Playwright project does **not** log in per test. Instead a `setup`
+project (`e2e/auth.setup.ts`) runs first — as a declared dependency — and logs
+the test admin in **exactly once** via `POST /api/v1/auth/login`, persisting the
+session cookie to `e2e/.auth/admin.json` (gitignored). The `authed` project then
+loads that cookie into every test's browser context via `use.storageState`.
+
+This is load-bearing, not a convenience: the backend enforces
+single-session-per-user (Issue #114 — `delete_user_sessions` runs on **every**
+login). When the old fixture re-logged-in per test, two parallel Playwright
+workers sharing the one `e2e-admin` account would clobber each other's session,
+producing intermittent 401s ("Not authenticated"). Logging in once removes the
+race. It also keeps the password out of every traced browser context — only the
+`setup` project ever sends it, and that project runs with `trace: "off"`.
+
+`npm run test:a11y` selects the backend-free `hermetic` project; it has **no**
+dependency on `setup`, so the hermetic CI lane never attempts a login.
 
 ## OAuth account-linking E2E (mock IdP) — `oauth-account-linking.spec.ts` (#937)
 
@@ -119,9 +140,12 @@ test("my admin smoke", async ({ page }) => {
 });
 ```
 
-The fixture logs the test admin in via `POST /api/v1/auth/login` and shares
-cookies with the browser context, so `page.goto("/admin/...")` is
-authenticated.
+Auth is provided by the `authed` project's pre-seeded `storageState` (see "How
+authentication works" above), so `page.goto("/admin/...")` is already
+authenticated — no per-spec login and no `test.use({ trace: "off" })` needed
+(the password never reaches the spec). New authed root specs must match the
+`authed` project's `testMatch` in `playwright.config.ts` (`admin-*.spec.ts` or
+add an entry); a spec that doesn't match runs with no `storageState` and 401s.
 
 **Required env vars** before running an admin spec:
 
@@ -162,18 +186,11 @@ Before wiring `make test-e2e-frontend` into CI, address these:
 
 1. **Secret management for `E2E_ADMIN_LOGIN_ID` / `E2E_ADMIN_PASSWORD`.**
    GitHub Actions secrets, vault, or equivalent — never commit.
-2. **Password leak in failure traces.** `playwright.config.ts` sets
-   `trace: "retain-on-failure"`, which captures network request bodies
-   including the login POST body. A failed CI run would publish
-   `E2E_ADMIN_PASSWORD` in the trace artifact. Fix BEFORE CI by either:
-   - Pre-seeded storage state: add `globalSetup` to `playwright.config.ts`
-     that performs the login once and writes cookies to a gitignored
-     file, then reference via `use.storageState` on an admin-only
-     project. The fixture's API-login path goes away (or stays as a
-     fallback for the no-storage-state case).
-   - Per-spec opt-out: `test.use({ trace: "off" })` at the top of
-     `admin-*.spec.ts` files. Loses trace coverage on those specs but
-     trivially closes the leak.
+2. **Password leak in failure traces — RESOLVED (#959).** The login now happens
+   only in the `setup` project (`e2e/auth.setup.ts`), which runs with
+   `trace: "off"`; authed specs reuse the resulting `storageState` cookie and
+   never send the password, so they keep the default `retain-on-failure` trace
+   coverage with no leak.
 3. **DB residue from interrupted round-trip specs.** Add a
    `test.afterEach` that PATCHes `workspace_slot_bonus` back to its
    pre-test value via the admin API, so an interrupted run leaves no

--- a/frontend/e2e/admin-user-detail.spec.ts
+++ b/frontend/e2e/admin-user-detail.spec.ts
@@ -2,24 +2,11 @@ import type { Page } from "@playwright/test";
 import { test, expect, API_URL } from "./fixtures/admin-auth";
 import { USER_DETAIL_TEST_IDS as T } from "@/app/(authenticated)/admin/users/[userId]/testids";
 
-// Disable trace capture for this spec.
-//
-// `playwright.config.ts` sets `trace: "retain-on-failure"`, which captures
-// network request bodies in the retained trace artifact on test failure.
-// The admin-auth fixture POSTs `E2E_ADMIN_PASSWORD` via the test runner's
-// request context, and Playwright records that body unless tracing is off.
-// A failed CI run would otherwise leave the password in
-// `test-results/<spec>/trace.zip`.
-//
-// Trade-off: we lose trace-based debugging on admin-spec failures. The
-// spec is 2 cases and 100 lines — `console.log` + screenshots from
-// `test.afterEach` are sufficient if a regression needs investigation.
-// Pre-seeded `globalSetup` storage state (so the password never touches a
-// browser-context request at all) is the proper long-term fix and is
-// tracked in `frontend/e2e/README.md` as a CI prerequisite.
-//
-// Surfaced by Copilot review on PR #807 (loops 1 + 2).
-test.use({ trace: "off" });
+// Trace capture stays on (project default `retain-on-failure`). The password
+// is no longer sent from this spec: auth comes from the `authed` project's
+// pre-seeded `storageState`, and only the `setup` project's login POST handles
+// the password (with trace off). This closed the #807 trace-leak concern at the
+// source (#959) and restores trace-based debugging on admin-spec failures.
 
 /**
  * Admin user detail page E2E smoke (#688).

--- a/frontend/e2e/auth.setup.ts
+++ b/frontend/e2e/auth.setup.ts
@@ -1,0 +1,57 @@
+import { test as setup, expect } from "@playwright/test";
+import fs from "node:fs";
+import path from "node:path";
+import { API_URL, ADMIN_LOGIN_ID, ADMIN_PASSWORD } from "./fixtures/admin-auth";
+
+/**
+ * One-time auth setup for the `authed` Playwright project (#959).
+ *
+ * Runs as the `setup` project (a dependency of `authed` in
+ * `playwright.config.ts`). Logs the test admin in via the API **exactly once**
+ * and writes the resulting session cookie to `e2e/.auth/admin.json`. Every
+ * authed spec then reuses that cookie through the `authed` project's
+ * `use.storageState` — no per-test re-login.
+ *
+ * This is the fix for the `frontend-a11y-authed` flake: the repo enforces
+ * single-session-per-user (Issue #114, `delete_user_sessions` on every login),
+ * so re-logging-in per test let parallel workers sharing the one `e2e-admin`
+ * account clobber each other's session → intermittent 401s. Logging in once
+ * removes the race.
+ *
+ * `trace: "off"` is set for this project in `playwright.config.ts` so the login
+ * POST body (which carries E2E_ADMIN_PASSWORD) is never captured in a retained
+ * trace artifact.
+ */
+
+// Must match `STORAGE_STATE` in playwright.config.ts.
+const STORAGE_STATE = path.join(__dirname, ".auth", "admin.json");
+
+setup("authenticate as e2e-admin", async ({ request }) => {
+  if (!ADMIN_LOGIN_ID || !ADMIN_PASSWORD) {
+    throw new Error(
+      "E2E_ADMIN_LOGIN_ID and E2E_ADMIN_PASSWORD must be set. " +
+        "See frontend/e2e/README.md for setup.",
+    );
+  }
+
+  const response = await request.post(`${API_URL}/api/v1/auth/login`, {
+    data: { login_id: ADMIN_LOGIN_ID, password: ADMIN_PASSWORD },
+  });
+  expect(
+    response.ok(),
+    `admin login failed (${response.status()}): ${await response.text()}`,
+  ).toBe(true);
+
+  const body = await response.json();
+  if (body.mfa_required) {
+    throw new Error(
+      "E2E admin has MFA enabled — disable MFA on the test admin " +
+        "or use a dedicated non-MFA admin for E2E.",
+    );
+  }
+
+  // The login Set-Cookie lands in the `request` context's cookie jar;
+  // persist it (cookies only, no password) for the authed project to load.
+  fs.mkdirSync(path.dirname(STORAGE_STATE), { recursive: true });
+  await request.storageState({ path: STORAGE_STATE });
+});

--- a/frontend/e2e/authed-a11y/device-contrast.spec.ts
+++ b/frontend/e2e/authed-a11y/device-contrast.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "../fixtures/admin-auth";
+import { expect, test } from "../fixtures/admin-auth";
 import {
   assertNoColorContrastViolations,
   gotoAndWaitStable,
@@ -8,16 +8,17 @@ import {
  * Color-contrast a11y guard for /device (Issue #785).
  *
  * /device is auth-guarded: unauthenticated users are redirected to /login
- * (see src/app/device/page.tsx). The `adminAuth` auto-fixture keeps us logged
- * in so the device-consent chrome (RFC 8628, #633 parity with /login) renders.
- * With no `user_code` query param the manual code-entry surface is shown —
- * sufficient for color-contrast coverage of the page's color tokens.
+ * (see src/app/device/page.tsx). Auth comes from the `authed` project's
+ * pre-seeded `storageState` (#959), so the device-consent chrome (RFC 8628,
+ * #633 parity with /login) renders. With no `user_code` query param the manual
+ * code-entry surface is shown — sufficient for color-contrast coverage.
  *
  * NON-HERMETIC (needs a live backend + authenticated admin) → lives outside the
  * hermetic `e2e/a11y` job (#786). Run via `npm run test:a11y:authed`.
+ *
+ * Trace capture stays on (project default): the password never reaches this
+ * spec — only the `setup` project's login POST handles it, with trace off (#959).
  */
-test.use({ trace: "off" });
-
 test.describe("/device color-contrast (#785)", () => {
   for (const colorScheme of ["light", "dark"] as const) {
     test(`${colorScheme} mode has no color-contrast violations`, async ({
@@ -25,6 +26,12 @@ test.describe("/device color-contrast (#785)", () => {
     }) => {
       await page.emulateMedia({ colorScheme });
       await gotoAndWaitStable(page, "/device");
+      // Assert we landed on the REAL authenticated device surface, not the
+      // /login redirect that an unauthenticated (or clobbered-session, #959)
+      // request would produce. The code-entry input only renders once the auth
+      // guard passes; #userCode is locale-independent.
+      await expect(page).toHaveURL(/\/device(\?|$)/);
+      await expect(page.locator("#userCode")).toBeVisible();
       await assertNoColorContrastViolations(page);
     });
   }

--- a/frontend/e2e/authed-a11y/invite-contrast.spec.ts
+++ b/frontend/e2e/authed-a11y/invite-contrast.spec.ts
@@ -17,6 +17,11 @@ import {
  * mismatch" / "success" screens, which require a Pro-plan workspace + a created
  * invitation) is part of the deferred full-stack a11y CI lane (see the #785
  * follow-up issue). NON-HERMETIC → outside the hermetic `e2e/a11y` job (#786).
+ *
+ * Unlike the other authed-a11y specs, /invite is a PUBLIC route — it imports the
+ * plain Playwright `test` (no auth) and the unknown-token error screen is its
+ * intended target, NOT the "Not authenticated" auth-failure state that #959
+ * fixed for the genuinely authenticated /device and /workspace/dashboard specs.
  */
 test.describe("/invite/[token] color-contrast (#785)", () => {
   for (const colorScheme of ["light", "dark"] as const) {

--- a/frontend/e2e/authed-a11y/workspace-dashboard-contrast.spec.ts
+++ b/frontend/e2e/authed-a11y/workspace-dashboard-contrast.spec.ts
@@ -1,4 +1,4 @@
-import { test } from "../fixtures/admin-auth";
+import { expect, test } from "../fixtures/admin-auth";
 import {
   assertNoColorContrastViolations,
   gotoAndWaitStable,
@@ -7,20 +7,15 @@ import {
 /**
  * Color-contrast a11y guard for /workspace/dashboard (Issue #785).
  *
- * NON-HERMETIC: requires a live backend + an authenticated admin (the
- * `adminAuth` auto-fixture logs in via the API). This is why the spec lives
- * under `e2e/authed-a11y/` — the path is deliberately NOT matched by the
- * hermetic `playwright test e2e/a11y` job (#786). Run locally via
+ * NON-HERMETIC: requires a live backend + an authenticated admin. Auth comes
+ * from the `authed` project's pre-seeded `storageState` (#959). This is why the
+ * spec lives under `e2e/authed-a11y/` — the path is deliberately NOT matched by
+ * the hermetic `playwright test e2e/a11y` job (#786). Run locally via
  * `npm run test:a11y:authed` with E2E_ADMIN_* set and the stack up.
  *
- * Wiring these authenticated specs into a full-stack CI lane (backend services
- * + seed + storageState globalSetup) is the deferred follow-up issue.
- *
- * `trace: off` per the admin-auth fixture contract — the login POST body would
- * otherwise be captured in a retained trace on failure.
+ * Trace capture stays on (project default): the password never reaches this
+ * spec — only the `setup` project's login POST handles it, with trace off (#959).
  */
-test.use({ trace: "off" });
-
 test.describe("/workspace/dashboard color-contrast (#785)", () => {
   for (const colorScheme of ["light", "dark"] as const) {
     test(`${colorScheme} mode has no color-contrast violations`, async ({
@@ -28,6 +23,12 @@ test.describe("/workspace/dashboard color-contrast (#785)", () => {
     }) => {
       await page.emulateMedia({ colorScheme });
       await gotoAndWaitStable(page, "/workspace/dashboard");
+      // Assert we rendered the REAL authenticated dashboard, not the /login
+      // redirect (unauthenticated) or the "Not authenticated" error state that
+      // a clobbered session (#959) produced. The seeded admin owns a Pro
+      // workspace, so it is not redirected to /workspace/contexts (viewer-only).
+      await expect(page).toHaveURL(/\/workspace\/dashboard(\?|$)/);
+      await expect(page.locator("h1")).toBeVisible();
       await assertNoColorContrastViolations(page);
     });
   }

--- a/frontend/e2e/fixtures/admin-auth.ts
+++ b/frontend/e2e/fixtures/admin-auth.ts
@@ -1,31 +1,31 @@
-import { test as base, expect } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 
 /**
- * Admin auth fixture for non-a11y E2E specs (#688).
+ * Admin auth helpers for authenticated E2E specs (#688, made deterministic in #959).
  *
- * Logs the test admin in via the API (POST /api/v1/auth/login) and injects
- * the resulting session cookie into the browser context, so any subsequent
- * page.goto("/admin/...") is already authenticated.
+ * Authentication is no longer performed per-test. Instead the `setup` project
+ * (`e2e/auth.setup.ts`) logs the test admin in **once** before the suite and
+ * persists the session cookie to a `storageState` file; the `authed` project in
+ * `playwright.config.ts` injects that cookie into every test's browser context
+ * via `use.storageState`. Specs under that project are therefore already
+ * authenticated when they start — `page.goto("/admin/...")` just works.
  *
- * Why API login (not /login UI):
- * - Deterministic (no /login form rendering / OAuth button noise to wait on).
- * - Decouples admin-feature specs from /login UI changes — /login is a
- *   separate surface and exercised by frontend/e2e/a11y/login-contrast.spec.ts.
+ * Why this matters (the #959 fix): the repo enforces single-session-per-user
+ * (Issue #114 — `delete_user_sessions` runs on every login). The old fixture
+ * re-logged-in on *every* test, so two parallel workers sharing the one
+ * `e2e-admin` account would clobber each other's session → intermittent 401s.
+ * Logging in exactly once removes the clobbering entirely. It also keeps the
+ * password out of any traced browser context (only the `setup` project ever
+ * sends it, and that project runs with `trace: "off"`).
  *
- * Required env vars (set before `make test-e2e-frontend` or `npm run test:e2e`):
+ * Specs import `test`/`expect` from here purely for a stable, documented import
+ * path; the `test` is the unmodified Playwright base test. Auth comes from the
+ * project's `storageState`, not from a fixture.
+ *
+ * Required env vars (read by `auth.setup.ts`; set before `npm run test:e2e`,
+ * `npm run test:a11y:authed`, or `make test-e2e-frontend`):
  *   E2E_ADMIN_LOGIN_ID   — login_id for an existing admin user without MFA
  *   E2E_ADMIN_PASSWORD   — that user's password
- *
- * Trace-capture mitigation (current): every spec that uses this fixture
- * MUST set `test.use({ trace: "off" })` at the top of the file —
- * `playwright.config.ts` defaults to `trace: "retain-on-failure"`, which
- * would capture the E2E_ADMIN_PASSWORD POST body in the retained trace
- * artifact on test failure. `admin-user-detail.spec.ts` is the reference
- * example. Long-term, switch to pre-seeded storage state via
- * `playwright.config.ts` `globalSetup` + project `use.storageState` so
- * the password never touches a traced context at all — tracked in
- * `frontend/e2e/README.md` as a CI prerequisite. Surfaced by Copilot
- * review on PR #807 (loops 1 + 2).
  * Optional:
  *   E2E_API_URL          — backend API base URL (default: NEXT_PUBLIC_API_URL
  *                          else http://localhost:8080). Required because the
@@ -37,75 +37,22 @@ import { test as base, expect } from "@playwright/test";
  *                          `page.goto`.
  *
  * The test admin must:
- *   - Exist (create with `make admin` if needed)
+ *   - Exist (create with `make admin`, or `python -m src.cli.seed_e2e_admin`)
  *   - Have role = admin
  *   - NOT have MFA enabled (TOTP fixture would require a shared secret)
  *
- * Cookie capture: context.request.post() shares the cookie jar with browser
- * pages opened from the same context, so we don't need an explicit
- * `context.addCookies(...)` step after the login call. The session cookie
- * is scoped to the API origin (`E2E_API_URL`); subsequent cross-origin
- * fetches from a `:3000` page work because (a) `localhost:3000` and
- * `localhost:8080` are the same SameSite "site" (same eTLD+1 `localhost`),
- * and (b) apiClient sets `credentials: "include"` and backend CORS allows
- * the Next.js origin.
+ * Cookie origin: the session cookie is scoped to the API origin
+ * (`E2E_API_URL`). Subsequent cross-origin fetches from a `:3000` page work
+ * because (a) `localhost:3000` and `localhost:8080` are the same SameSite
+ * "site" (same eTLD+1 `localhost`), and (b) apiClient sets
+ * `credentials: "include"` and backend CORS allows the Next.js origin.
  */
 
-const ADMIN_LOGIN_ID = process.env.E2E_ADMIN_LOGIN_ID ?? "";
-const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD ?? "";
+export const ADMIN_LOGIN_ID = process.env.E2E_ADMIN_LOGIN_ID ?? "";
+export const ADMIN_PASSWORD = process.env.E2E_ADMIN_PASSWORD ?? "";
 export const API_URL =
   process.env.E2E_API_URL ??
   process.env.NEXT_PUBLIC_API_URL ??
   "http://localhost:8080";
 
-type AdminAuthFixtures = {
-  adminAuth: void;
-};
-
-export const test = base.extend<AdminAuthFixtures>({
-  adminAuth: [
-    async ({ context }, use) => {
-      if (!ADMIN_LOGIN_ID || !ADMIN_PASSWORD) {
-        throw new Error(
-          "E2E_ADMIN_LOGIN_ID and E2E_ADMIN_PASSWORD must be set. " +
-            "See frontend/e2e/README.md for setup.",
-        );
-      }
-
-      const response = await context.request.post(
-        `${API_URL}/api/v1/auth/login`,
-        {
-          data: { login_id: ADMIN_LOGIN_ID, password: ADMIN_PASSWORD },
-        },
-      );
-      expect(
-        response.ok(),
-        `admin login failed (${response.status()}): ${await response.text()}`,
-      ).toBe(true);
-
-      const body = await response.json();
-      if (body.mfa_required) {
-        throw new Error(
-          "E2E admin has MFA enabled — disable MFA on the test admin " +
-            "or use a dedicated non-MFA admin for E2E.",
-        );
-      }
-
-      // NOTE: this fixture is still subject to the #957 flake — the shared
-      // e2e-admin account hits the single-session-per-user invalidation
-      // (Issue #114: login deletes all of the user's prior sessions), so two
-      // parallel workers re-logging-in as the same admin clobber each other's
-      // session and the loser's cookie 401s. The /auth/me poll attempted here
-      // could not fix that (the session is genuinely deleted), so it was
-      // removed. Deterministic auth (login-once storageState globalSetup, or a
-      // per-worker admin) is tracked as a follow-up — see frontend/e2e/README.md.
-      // The contrast half of #957 (readable destructive Alert) is what makes the
-      // authed-a11y specs pass even when this race surfaces the error state.
-
-      await use();
-    },
-    { auto: true, scope: "test" },
-  ],
-});
-
-export { expect };
+export { test, expect };

--- a/frontend/e2e/oauth-account-linking.spec.ts
+++ b/frontend/e2e/oauth-account-linking.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect, API_URL } from "./fixtures/admin-auth";
 import { CONNECTED_ACCOUNTS_TEST_IDS as T } from "@/components/auth/connected-accounts.testids";
 
-// Disable trace capture: the admin-auth fixture POSTs E2E_ADMIN_PASSWORD via the
-// request context, and `playwright.config.ts` retains traces on failure — same
-// rationale as admin-user-detail.spec.ts (Copilot review PR #807).
-test.use({ trace: "off" });
+// Trace capture stays on (project default `retain-on-failure`). Auth comes from
+// the `authed` project's pre-seeded `storageState`; the password is only sent
+// by the `setup` project's login POST (trace off), so no credential reaches a
+// trace from this spec (#959, supersedes the PR #807 per-spec opt-out).
 
 /**
  * Account-linking E2E: link → unlink → re-link (Issue #937, follow-up to #517).

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,9 +19,9 @@
     "test:watch": "vitest",
     "test:cov": "vitest run --coverage",
     "test:e2e": "playwright test",
-    "test:a11y": "playwright test e2e/a11y/",
-    "test:a11y:authed": "playwright test e2e/authed-a11y/",
-    "test:e2e:oauth": "PW_OAUTH_IDP=1 playwright test e2e/oauth-account-linking.spec.ts",
+    "test:a11y": "playwright test --project=hermetic",
+    "test:a11y:authed": "playwright test --project=authed e2e/authed-a11y/",
+    "test:e2e:oauth": "PW_OAUTH_IDP=1 playwright test --project=authed e2e/oauth-account-linking.spec.ts",
     "mock-idp": "node e2e/mock-idp/server.mjs"
   },
   "dependencies": {

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,13 +1,32 @@
 import { defineConfig } from "@playwright/test";
+import path from "node:path";
 
 /**
  * Playwright config for a11y / e2e tests (Issue #780).
  *
- * Currently scoped to color-contrast checks via @axe-core/playwright. Local
- * runs auto-start `next dev` on :3000. CI integration is a follow-up.
+ * Three projects (#959):
+ *   - `setup`    — logs the test admin in once (e2e/auth.setup.ts) and writes a
+ *                  storageState file. Runs with trace off so the login POST
+ *                  body (the admin password) is never captured.
+ *   - `hermetic` — no-auth, no-backend color-contrast specs (e2e/a11y/). Has no
+ *                  dependency on `setup`, so the hermetic CI lane stays
+ *                  backend-free. Run via `npm run test:a11y`.
+ *   - `authed`   — backend-dependent specs (e2e/authed-a11y/, admin-*, OAuth).
+ *                  Depends on `setup` and reuses its session cookie via
+ *                  `use.storageState`, so there is no per-test re-login. This is
+ *                  what makes `frontend-a11y-authed` deterministic: with
+ *                  single-session-per-user (#114) a per-test login let parallel
+ *                  workers clobber each other's session. Run authed-a11y via
+ *                  `npm run test:a11y:authed`.
  *
- * To add coverage for more pages, drop new specs into `e2e/a11y/`.
+ * To add coverage for more pages, drop new specs into `e2e/a11y/` (hermetic) or
+ * `e2e/authed-a11y/` (authenticated).
  */
+
+// Session cookie produced by the `setup` project and consumed by `authed`.
+// Must match `STORAGE_STATE` in e2e/auth.setup.ts. Gitignored (e2e/.auth/).
+const STORAGE_STATE = path.join(__dirname, "e2e", ".auth", "admin.json");
+
 export default defineConfig({
   testDir: "./e2e",
   fullyParallel: false,
@@ -50,8 +69,22 @@ export default defineConfig({
   ],
   projects: [
     {
-      name: "chromium",
+      name: "setup",
+      testMatch: /auth\.setup\.ts$/,
+      // The login POST carries E2E_ADMIN_PASSWORD — never retain it in a trace.
+      use: { trace: "off" },
+    },
+    {
+      name: "hermetic",
+      testMatch: /e2e\/a11y\/.*\.spec\.ts$/,
       use: { browserName: "chromium" },
+    },
+    {
+      name: "authed",
+      testMatch:
+        /e2e\/(authed-a11y\/.*|admin-.*|oauth-account-linking)\.spec\.ts$/,
+      dependencies: ["setup"],
+      use: { browserName: "chromium", storageState: STORAGE_STATE },
     },
   ],
 });


### PR DESCRIPTION
Closes #959

## Summary

The `frontend-a11y-authed` lane flaked because the admin-auth fixture re-logged-in per test on a shared `e2e-admin` account. With single-session-per-user (#114, `delete_user_sessions` on every login), two parallel Playwright workers clobbered each other's session → intermittent 401s ("Not authenticated").

Implements the issue's **recommended Option 1 (`storageState` setup project)**:

- New `e2e/auth.setup.ts` `setup` project logs in **once** and persists the session cookie to a gitignored `storageState` file; the `authed` project reuses it via `use.storageState` — no per-test re-login, so the #114 single-session policy can't clobber a concurrent worker.
- The backend-free `hermetic` project has no setup dependency → the hermetic lane stays login-free.
- `device` / `workspace-dashboard` specs now assert the **real** authenticated page (URL + content), not the auth-failure state (AC #3).
- Password flows only through the setup project (trace off), so the per-spec `trace: off` opt-outs (#807) are removed — trace coverage restored on admin/oauth specs with no leak.
- npm scripts select projects by name; README + CI comment updated.

## Acceptance criteria
- [x] `frontend-a11y-authed` deterministic across repeated / parallel-worker runs
- [x] Approach documented in `frontend/e2e/README.md`
- [x] The 3 authed-a11y specs assert the real authenticated pages

## Verification
- Commit-level: 4 consecutive authed-a11y runs at `--workers=4` all green (login once, cookie reused); hermetic lane green with no admin creds.
- `kagura-engineer review` (free Ollama gate, branch vs main): **green, 0 findings**.

## Provenance
Implemented by the `kagura-engineer` harness (`run-959` worktree). The harness completed implementation but its **ship phase failed on a transient memory-cloud `/health` 401** (savepoint dependency), before push/PR — so the branch was pushed and this PR opened manually. No code/quality block was involved; the free review gate is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)