### PR TITLE
fix(neural): decay Hebbian edges by half-life in days, not per-second (#970)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -271,3 +271,7 @@ frontend/blob-report/
 # Pre-seeded auth storageState written by the `setup` project (#959) — contains
 # a live session cookie; never commit.
 frontend/e2e/.auth/
+
+# kagura-engineer local dev config
+repo.yaml
+.kagura/

--- a/backend/src/api/routes/neural_config.py
+++ b/backend/src/api/routes/neural_config.py
@@ -98,7 +98,8 @@ DEFAULT_VALUES: dict[str, str] = {
     "recency_tau_days": "14.0",
     "importance_ema_alpha": "0.3",
     # Decay
-    "decay_rate": "0.001",
+    "decay_rate": "0.001",  # DEPRECATED (Issue #970): unused; see hebbian_decay_half_life_days
+    "hebbian_decay_half_life_days": "14.0",  # Issue #970: Hebbian edge half-life (days)
     "prune_threshold": "0.01",
     "decay_background_interval": "3600",
     # Co-Activation

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -59,7 +59,13 @@ class NeuralMemoryConfig:
         # Forgetting/Decay
         enable_decay: Enable automatic edge weight decay
         decay_background_interval: Interval (seconds) for background decay task
-        decay_rate: Exponential decay rate for unused edges
+        decay_rate: DEPRECATED (Issue #970) — the old per-second exp decay rate.
+            No longer used for edge decay; retained only so existing env/DB
+            neural_config values load without error. Use
+            hebbian_decay_half_life_days instead.
+        hebbian_decay_half_life_days: Hebbian edge weight half-life in days
+            (Issue #970). After this many days an unreinforced edge's weight
+            halves. Matches the recency_tau_days "days" convention.
         prune_threshold: Remove edges below this weight
 
         # Consolidation (Short-term → Long-term)
@@ -137,7 +143,8 @@ class NeuralMemoryConfig:
     # Forgetting/Decay
     enable_decay: bool = True
     decay_background_interval: int = 3600  # 1 hour
-    decay_rate: float = 0.001
+    decay_rate: float = 0.001  # DEPRECATED (Issue #970): unused; see hebbian_decay_half_life_days
+    hebbian_decay_half_life_days: float = 14.0  # Issue #970: Hebbian edge half-life (days)
     prune_threshold: float = 0.01  # Lowered to allow weak initial edges (was 0.05)
 
     # Consolidation
@@ -268,6 +275,11 @@ class NeuralMemoryConfig:
 
         if not self.decay_rate >= 0:
             raise ValueError(f"decay_rate must be non-negative, got {self.decay_rate}")
+        if not self.hebbian_decay_half_life_days > 0:
+            raise ValueError(
+                "hebbian_decay_half_life_days must be positive, got "
+                f"{self.hebbian_decay_half_life_days}"
+            )
         if not (0.0 <= self.prune_threshold <= 1.0):
             raise ValueError(f"prune_threshold must be in [0, 1], got {self.prune_threshold}")
 
@@ -456,6 +468,7 @@ class NeuralMemoryConfig:
             enable_decay=get_bool("ENABLE_DECAY", True),
             decay_background_interval=get_int("DECAY_BACKGROUND_INTERVAL", 3600),
             decay_rate=get_float("DECAY_RATE", 0.001),
+            hebbian_decay_half_life_days=get_float("HEBBIAN_DECAY_HALF_LIFE_DAYS", 14.0),
             prune_threshold=get_float("PRUNE_THRESHOLD", 0.01),
             # Consolidation
             consolidation_use_count_min=get_int("CONSOLIDATION_USE_COUNT_MIN", 3),
@@ -570,6 +583,9 @@ class NeuralMemoryConfig:
                 "decay_background_interval", base_config.decay_background_interval
             ),
             decay_rate=configs.get("decay_rate", base_config.decay_rate),
+            hebbian_decay_half_life_days=configs.get(
+                "hebbian_decay_half_life_days", base_config.hebbian_decay_half_life_days
+            ),
             prune_threshold=configs.get("prune_threshold", base_config.prune_threshold),
             # Consolidation
             consolidation_use_count_min=configs.get(

--- a/backend/src/neural/decay.py
+++ b/backend/src/neural/decay.py
@@ -8,7 +8,6 @@ allowing new information to be learned without interference.
 """
 
 import logging
-import math
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -39,14 +38,28 @@ class DecayManager:
         self.config = config
         self._last_decay_time: datetime | None = None
 
-    async def apply_decay(self, user_id: str) -> dict[str, int | float]:
-        """Apply exponential decay to all edge weights.
+    async def apply_decay(
+        self, user_id: str, last_decay_at: datetime | None = None
+    ) -> dict[str, int | float]:
+        """Apply half-life decay to all Hebbian edge weights.
 
-        Formula:
-            w_ij(t+Δt) = w_ij(t) · exp(-decay_rate · Δt)
+        Formula (Issue #970):
+            w_ij(t+Δt) = w_ij(t) · 0.5 ** (Δt / half_life)
+
+        where ``half_life = config.hebbian_decay_half_life_days · 86400`` seconds.
+        Parameterising decay by a half-life *in days* (matching ``recency_tau_days``)
+        makes the intended multi-week forgetting explicit and removes the old
+        per-second ``exp(-decay_rate · Δt)`` formula whose ``decay_rate=0.001`` gave
+        an ~12-minute half-life that evaporated every Hebbian edge within hours.
 
         Args:
             user_id: User ID (for filtering user-specific edges)
+            last_decay_at: Timestamp of the previous decay pass for this graph.
+                When provided, ``Δt`` is the real elapsed time since then — this is
+                how the per-run caller (``weight_decay_task``) supplies real time,
+                since a freshly-constructed ``DecayManager`` has no instance state
+                across task runs. Falls back to ``self._last_decay_time`` and then
+                to ``decay_background_interval`` on the first run.
 
         Returns:
             Dict with statistics (edges_decayed, edges_pruned, delta_seconds)
@@ -57,9 +70,11 @@ class DecayManager:
 
         current_time = utcnow()
 
-        # Calculate time delta
-        if self._last_decay_time:
-            delta_seconds = (current_time - self._last_decay_time).total_seconds()
+        # Calculate time delta. Precedence: caller-supplied last_decay_at (real
+        # elapsed time across task runs) > instance state > default interval.
+        prior = last_decay_at if last_decay_at is not None else self._last_decay_time
+        if prior:
+            delta_seconds = (current_time - prior).total_seconds()
         else:
             # First run - use default interval
             delta_seconds = self.config.decay_background_interval
@@ -69,7 +84,9 @@ class DecayManager:
 
         # Apply decay to all edges (Issue #84: SQL backend bulk operation)
         # Issue #722: semantic edges are decay-exempt; only Hebbian edges are decayed/pruned
-        decay_factor = math.exp(-self.config.decay_rate * delta_seconds)
+        # Issue #970: half-life decay (days), not per-second exp rate
+        half_life_seconds = self.config.hebbian_decay_half_life_days * 86400.0
+        decay_factor = 0.5 ** (delta_seconds / half_life_seconds)
         edges_decayed = await self.graph.edge_repo.bulk_decay_weights(
             user_id, decay_factor, only_origin=EDGE_ORIGIN_HEBBIAN
         )

--- a/backend/src/tasks/neural_tasks.py
+++ b/backend/src/tasks/neural_tasks.py
@@ -55,9 +55,15 @@ async def weight_decay_task():
 
                 graph_service = GraphService(user_id, db)
 
-                # Apply decay (uses SQL backend directly)
+                # Apply decay (uses SQL backend directly). Issue #970: pass the
+                # persisted last_decay_at so Δt reflects REAL elapsed time — a
+                # fresh DecayManager is constructed per run and has no instance
+                # state across runs, so without this the decay always used the
+                # default interval (the "dead _last_decay_time" bug).
                 decay_manager = DecayManager(graph_service, config)
-                decay_result = await decay_manager.apply_decay(user_id)
+                decay_result = await decay_manager.apply_decay(
+                    user_id, last_decay_at=graph_model.last_decay_at
+                )
                 edges_decayed = decay_result.get("edges_decayed", 0)
 
                 if edges_decayed > 0:

--- a/backend/tests/neural/test_decay.py
+++ b/backend/tests/neural/test_decay.py
@@ -1,12 +1,13 @@
 """Tests for DecayManager."""
 
-import math
+from datetime import timedelta
 
 import pytest
 
 from models.memory import EDGE_ORIGIN_HEBBIAN
 from neural.config import NeuralMemoryConfig
 from neural.decay import DecayManager
+from utils.datetime import utcnow
 
 
 class TestDecayManager:
@@ -58,8 +59,9 @@ class TestDecayManager:
         assert result["edges_pruned"] == 2
         assert result["delta_seconds"] == 60  # decay_background_interval
 
-        # Verify decay factor calculated correctly
-        expected_factor = math.exp(-0.01 * 60)
+        # Verify decay factor calculated correctly (Issue #970: half-life based,
+        # default hebbian_decay_half_life_days=14.0)
+        expected_factor = 0.5 ** (60 / (14.0 * 86400))
         mock_graph.edge_repo.bulk_decay_weights.assert_called_once_with(
             "test_user", expected_factor, only_origin=EDGE_ORIGIN_HEBBIAN
         )
@@ -128,12 +130,65 @@ class TestDecayManager:
         assert isinstance(result, dict)
 
     @pytest.mark.asyncio
-    async def test_decay_exponential_formula(self, manager, mock_graph):
-        """Test exponential decay formula: w(t+dt) = w(t) * exp(-rate * dt)."""
+    async def test_decay_half_life_formula(self, manager, mock_graph):
+        """Test half-life decay formula: w(t+dt) = w(t) * 0.5 ** (dt / half_life).
+
+        Issue #970: decay is parameterised by hebbian_decay_half_life_days (days),
+        NOT a per-second exp rate. With the default 14-day half-life and dt=60s,
+        the per-run factor is ~1.0 (negligible), matching multi-week forgetting.
+        """
         await manager.apply_decay("test_user")
 
-        # With rate=0.01 and dt=60: factor = exp(-0.6) ≈ 0.5488
-        expected_factor = math.exp(-0.01 * 60)
+        expected_factor = 0.5 ** (60 / (14.0 * 86400))
         call_args = mock_graph.edge_repo.bulk_decay_weights.call_args
         actual_factor = call_args[0][1]
-        assert abs(actual_factor - expected_factor) < 0.0001
+        assert abs(actual_factor - expected_factor) < 1e-9
+        # Sanity: a 60s slice of a 14-day half-life barely moves the weight.
+        assert actual_factor > 0.9999
+
+    @pytest.mark.asyncio
+    async def test_decay_factor_halves_after_one_half_life(self, mock_graph):
+        """After exactly one half-life elapses, the weight is multiplied by 0.5.
+
+        Issue #970 regression: this is the load-bearing invariant — at the
+        configured half-life the factor must be 0.5, not a per-second exp value.
+        """
+        half_life_days = 14.0
+        config = NeuralMemoryConfig(
+            enable_decay=True,
+            hebbian_decay_half_life_days=half_life_days,
+            prune_threshold=0.1,
+        )
+        manager = DecayManager(mock_graph, config)
+        prior = utcnow() - timedelta(days=half_life_days)
+
+        await manager.apply_decay("test_user", last_decay_at=prior)
+
+        factor = mock_graph.edge_repo.bulk_decay_weights.call_args[0][1]
+        assert factor == pytest.approx(0.5, rel=1e-3)
+
+    @pytest.mark.asyncio
+    async def test_apply_decay_honors_last_decay_at(self, manager):
+        """Issue #970 secondary bug: apply_decay must use the caller-supplied
+        last_decay_at so delta_seconds reflects REAL elapsed time (the per-run
+        DecayManager can no longer rely on instance state across task runs)."""
+        prior = utcnow() - timedelta(days=14)
+
+        result = await manager.apply_decay("test_user", last_decay_at=prior)
+
+        assert result["delta_seconds"] == pytest.approx(14 * 86400, rel=1e-2)
+
+    @pytest.mark.asyncio
+    async def test_apply_decay_semantic_edges_exempt(self, manager, mock_graph):
+        """Issue #722 non-regression: decay/prune target ONLY hebbian edges,
+        leaving semantic/declared edges untouched (must survive the #970 change)."""
+        await manager.apply_decay("test_user")
+
+        assert (
+            mock_graph.edge_repo.bulk_decay_weights.call_args.kwargs["only_origin"]
+            == EDGE_ORIGIN_HEBBIAN
+        )
+        assert (
+            mock_graph.edge_repo.prune_weak_edges.call_args.kwargs["only_origin"]
+            == EDGE_ORIGIN_HEBBIAN
+        )


### PR DESCRIPTION
Closes #970

## Summary
- Hebbian edge decay was applied per-**second** (`exp(-decay_rate·Δt)`, decay_rate=0.001), giving an ~11.6 min half-life that evaporated every Hebbian edge within hours — the compounding-memory graph never accumulated (prod: hebbian = 1.3% of edges, all <33 min old).
- Switch to a half-life-in-days formula `0.5 ** (Δt / (hebbian_decay_half_life_days·86400))`, default 14 days, matching the existing `recency_tau_days` "days" convention.
- Wire real elapsed time into the background decay task, fixing a dead `_last_decay_time` that always defaulted to the interval.
- Semantic/declared edges remain decay-exempt (#722); #967 Tier A unaffected.

## Implementation notes
- New config `hebbian_decay_half_life_days` (default 14.0) with validation (>0), env (`HEBBIAN_DECAY_HALF_LIFE_DAYS`), DB loader, and admin-route default.
- `decay_rate` is deprecated but retained so existing env/DB `neural_config` rows load without error — it no longer drives decay, neutralizing the stale prod DB value (`decay_rate=0.001`) **without a migration**.
- `apply_decay(last_decay_at=…)` added; `weight_decay_task` passes `graph_model.last_decay_at`.
- Tests: half-life formula, factor==0.5 at one half-life, `last_decay_at` threading, and #722 semantic-exemption non-regression. 138 neural tests pass; ruff + pyright clean.
- Follow-up (advisor rec): retire `decay_rate` once DB rows are cleaned.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: code-review

🤖 Generated via /gh-issue-driven:ship
