### PR TITLE
fix(mcp): enforce workspace-boundary guard in merge_contexts (#966)

### DIFF
--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -750,6 +750,22 @@ async def handle_merge_contexts(
             else:
                 delete_source = bool(delete_source_raw)
 
+            # Workspace-boundary guard at the MCP boundary (Issue #966), mirror
+            # of handle_recall's cross-context guard. Resolve both contexts via
+            # _resolve_context_for_read so an unreadable context (not found /
+            # private non-creator / non-member) surfaces a uniform
+            # context_not_found (CWE-639) instead of leaking through the generic
+            # merge_contexts_error path, and reject a cross-workspace merge
+            # before ContextService.merge_contexts is invoked. The service still
+            # enforces owner-only access as the authorization gate.
+            source_ctx = await _resolve_context_for_read(db, user_id, source_id)
+            target_ctx = await _resolve_context_for_read(db, user_id, target_id)
+            if source_ctx.workspace_id != target_ctx.workspace_id:
+                return _error_response(
+                    "workspace_mismatch",
+                    "Source and target contexts must belong to the same workspace.",
+                )
+
             service = ContextService(db)
             result = await execute_with_timeout(
                 service.merge_contexts(

--- a/backend/tests/mcp_server/test_context_tools.py
+++ b/backend/tests/mcp_server/test_context_tools.py
@@ -21,7 +21,12 @@ from uuid import uuid4
 
 import pytest
 
-from mcp_server.tools.context import handle_delete_context, handle_update_context
+from mcp_server.tools._helpers import _ContextNotFoundError
+from mcp_server.tools.context import (
+    handle_delete_context,
+    handle_merge_contexts,
+    handle_update_context,
+)
 from utils.exceptions import AuthorizationError, NotFoundException
 
 
@@ -126,6 +131,177 @@ class TestHandleDeleteContextErrorSurface:
         assert payload["status"] == "error"
         assert payload["error"] == "context_not_found"
         mock_db.rollback.assert_awaited()
+
+
+class TestHandleMergeContextsWorkspaceBoundary:
+    """Issue #966: ``handle_merge_contexts`` must apply the workspace-boundary
+    guard at the MCP boundary (mirror of ``handle_recall``), resolving both
+    source and target via ``_resolve_context_for_read`` and rejecting a
+    cross-workspace merge with a uniform ``workspace_mismatch`` error before
+    ``ContextService.merge_contexts`` is ever called.
+
+    Without the guard a member of two workspaces could probe / merge across
+    the workspace boundary, and an access-denied context leaks through the
+    generic ``merge_contexts_error`` 500 envelope (CWE-639) instead of the
+    uniform ``context_not_found`` shape.
+    """
+
+    @pytest.fixture
+    def user_id(self):
+        return "test_user_966"
+
+    @pytest.fixture
+    def workspace_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def source_id(self):
+        return uuid4()
+
+    @pytest.fixture
+    def target_id(self):
+        return uuid4()
+
+    def _ctx(self, workspace_id):
+        ctx = MagicMock()
+        ctx.workspace_id = workspace_id
+        return ctx
+
+    @pytest.mark.asyncio
+    async def test_cross_workspace_merge_returns_workspace_mismatch(
+        self, user_id, workspace_id, source_id, target_id
+    ):
+        """Source and target in different workspaces → ``workspace_mismatch``,
+        and ``merge_contexts`` is never invoked."""
+        mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        source_ctx = self._ctx(uuid4())
+        target_ctx = self._ctx(uuid4())  # different workspace
+
+        resolve = AsyncMock(side_effect=[source_ctx, target_ctx])
+        mock_service = MagicMock()
+        mock_service.merge_contexts = AsyncMock()
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.context._resolve_context_for_read",
+                new=resolve,
+            ),
+            patch(
+                "services.context_service.ContextService",
+                return_value=mock_service,
+            ),
+            patch(
+                "mcp_server.tools.context._log_tool_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await handle_merge_contexts(
+                args={"source_id": str(source_id), "target_id": str(target_id)},
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "workspace_mismatch"
+        mock_service.merge_contexts.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unreadable_context_returns_context_not_found(
+        self, user_id, workspace_id, source_id, target_id
+    ):
+        """A context the caller can't read → uniform ``context_not_found``
+        (not the generic ``merge_contexts_error`` 500 leak), and
+        ``merge_contexts`` is never invoked."""
+        mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        resolve = AsyncMock(
+            side_effect=_ContextNotFoundError(
+                source_id, "Context not found or you don't have access to it."
+            )
+        )
+        mock_service = MagicMock()
+        mock_service.merge_contexts = AsyncMock()
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.context._resolve_context_for_read",
+                new=resolve,
+            ),
+            patch(
+                "services.context_service.ContextService",
+                return_value=mock_service,
+            ),
+            patch(
+                "mcp_server.tools.context._log_tool_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await handle_merge_contexts(
+                args={"source_id": str(source_id), "target_id": str(target_id)},
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "context_not_found"
+        mock_service.merge_contexts.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_same_workspace_proceeds_to_merge(
+        self, user_id, workspace_id, source_id, target_id
+    ):
+        """Both contexts in the same workspace → guard passes and
+        ``merge_contexts`` runs."""
+        mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
+        mock_db.commit = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        shared_ws = uuid4()
+        resolve = AsyncMock(side_effect=[self._ctx(shared_ws), self._ctx(shared_ws)])
+        mock_service = MagicMock()
+        mock_service.merge_contexts = AsyncMock(return_value={"merged": 3, "source_deleted": False})
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch(
+                "mcp_server.tools.context._resolve_context_for_read",
+                new=resolve,
+            ),
+            patch(
+                "services.context_service.ContextService",
+                return_value=mock_service,
+            ),
+            patch(
+                "mcp_server.tools.context._log_tool_usage",
+                new_callable=AsyncMock,
+            ),
+        ):
+            result = await handle_merge_contexts(
+                args={"source_id": str(source_id), "target_id": str(target_id)},
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "success"
+        assert payload["merged"] == 3
+        mock_service.merge_contexts.assert_awaited_once()
 
 
 class TestHandleUpdateContextErrorSurface:


### PR DESCRIPTION
Closes #966

## Summary
- Enforce a workspace-boundary guard in the `merge_contexts` MCP tool so a source and target context in different workspaces can no longer be merged (CWE-639 IDOR fix).
- Resolve both contexts via `_resolve_context_for_read` at the MCP boundary — mirroring `handle_recall`'s cross-context guard — so an unreadable context surfaces a uniform `context_not_found` instead of leaking through the generic `merge_contexts_error` 500 envelope.
- Reject a cross-workspace merge with a dedicated `workspace_mismatch` error **before** `ContextService.merge_contexts` is invoked; the service still enforces owner-only access as the authorization gate (defense in depth).

## Implementation notes
- `backend/src/mcp_server/tools/context.py` (+16): the guard runs after argument parsing and before service construction. `_ContextNotFoundError` raised during resolution is caught by the existing `except _ContextNotFoundError` arm and returned via `e.to_response()`.
- `backend/tests/mcp_server/test_context_tools.py` (+177): new `TestHandleMergeContextsWorkspaceBoundary` (3 async tests) mirroring the existing `handle_delete_context` error-surface class — cross-workspace → `workspace_mismatch` + merge never invoked; unreadable context → `context_not_found` + merge never invoked; same-workspace → proceeds to merge. Each pins guard ordering via `merge_contexts.assert_not_awaited()` / `assert_awaited_once()`.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/966-fix-security-merge-contexts-mcp-tool-lacks-a.gate1.md
- ~/.claude/cache/gh-issue-driven/966-fix-security-merge-contexts-mcp-tool-lacks-a.gate2.md

🤖 Generated via /gh-issue-driven:ship
