### PR TITLE
feat(api): cold→warm co-recall compounding eval harness (#969)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,12 @@ eval-retrieval:
 	@echo "Writes backend/tests/eval/results/<date>.json — real run only, never fabricated."
 	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.runner
 
+.PHONY: eval-compounding
+eval-compounding:
+	@echo "Running live cold→replay→warm compounding eval (Issue #969, needs the stack: make up)..."
+	@echo "Writes backend/tests/eval/results/compounding-<date>.json — real run only, never fabricated."
+	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.replay_runner
+
 .PHONY: test-cov
 test-cov:
 	@echo "Running tests with coverage in Docker..."

--- a/backend/tests/eval/README.md
+++ b/backend/tests/eval/README.md
@@ -20,12 +20,14 @@ An **offline harness** for detecting hybrid-search (dense + BM25) retrieval-qual
 | `tools/leakage_check.py` | Leakage detector (3 rules) | ✅ (`test_leakage.py`) |
 | `tools/stratify.py` | Difficulty stratification (IDF-spec, BM25-rank, corpus-overlap) | ✅ (`test_stratification.py`) |
 | `test_corpus_schema.py` | Structural contract (buckets, labels, sources) | ✅ |
+| `compounding.py` | Pure #969 experiment logic: replay plan, companion-recovery metric, lift table, gate audit | ✅ (`test_compounding.py`) |
 | `test_retrieval_quality.py` + `runner.py` | **Live** multi-arm P@5/MRR/nDCG measurement → `results/<date>.json` | ❌ skip-guarded |
+| `test_compounding_live.py` + `replay_runner.py` | **Live** cold→replay→warm compounding experiment (#969) → `results/compounding-<date>.json` | ❌ skip-guarded |
 
-The deterministic layer (everything but the last row) is pure token analysis and
-runs in normal CI. The live measurement needs Postgres + Qdrant + an embedding
-provider + Sudachi, which is **not currently CI-realistic** (#336 unscheduled),
-so it is skip-guarded behind `KAGURA_EVAL_LIVE=1`.
+The deterministic layer (everything but the live rows) is pure token analysis and
+runs in normal CI. The live measurements need Postgres + Qdrant + Redis + an
+embedding provider + Sudachi, which is **not currently CI-realistic** (#336
+unscheduled), so they are skip-guarded behind `KAGURA_EVAL_LIVE=1`.
 
 ## Running
 
@@ -36,6 +38,9 @@ cd backend && pytest tests/eval/ -m "not asyncio" -q   # all deterministic gates
 
 # Live retrieval measurement (needs the stack up: make up):
 make eval-retrieval              # sets KAGURA_EVAL_LIVE=1, writes results/<date>.json
+
+# Live compounding experiment (#969, needs the stack up: make up):
+make eval-compounding            # writes results/compounding-<date>.json
 ```
 
 ### Comparison arms (#967)
@@ -69,6 +74,47 @@ run — numbers are never hand-written or fabricated (a fabricated baseline
 silently corrupts the regression signal). If `results/` has no JSON yet, the
 baseline has not been generated in an environment with the live stack; run
 `make eval-retrieval` locally to create the first one and commit it alongside.
+
+### Compounding experiment (#969)
+
+Tier B companion to the arms above: does retrieval improve **as the context is
+used**? Per Issue #120 (decision-pinned), the neural graph is read by
+`explore()` (activation spreading), not by `recall()` ranking — so the
+experiment measures two lanes per checkpoint:
+
+- **graph lane** (primary): the 5 multi-gold `cross-source` queries are held
+  out as probes. From each probe's *seed* gold doc, can activation spreading
+  recover the *companion* gold docs? (`recovery@k`, MRR over the explore
+  ranking.)
+- **recall lane** (control): hybrid `recall()` P@5/MRR/nDCG over all queries,
+  measured with neural off (read-only). Flat-by-design; movement here is a
+  regression signal, not lift.
+
+Protocol per replay mode, each in its own throwaway workspace, corpus held
+fixed throughout (growth ≠ "more data"):
+
+```
+ingest → COLD checkpoint → replay traffic (ENABLE_NEURAL_MEMORY=true, 8 rounds)
+       → WARM_REPLAY checkpoint → Sleep edges_only run (no-LLM auto-accept)
+       → WARM_SLEEP checkpoint → per-lane lift tables
+```
+
+Two replay modes separate generalization from rehearsal: `exclude_probes`
+(probes never replayed — lift measures generalization from related traffic)
+and `include_probes` (production reality — users re-ask what matters to them).
+Checkpoints snapshot per-origin edge counts, so lift is attributable
+(`hebbian` ← replay, `semantic` ← Sleep).
+
+**Gate audit.** The results JSON carries a per-pair audit of the replay
+traffic against the two edge-formation gates in `recall()`'s write path: the
+semantic gate (pair cosine ≥ `min_similarity_for_edge`) and the prune cliff
+(a first update below `prune_threshold` is deleted, never accumulated). The
+2026-06-10 run showed why this matters: every probe gold pair co-recalls with
+healthy Δw, but **all of them are cosine-gated** (0.37–0.40 vs the 0.5
+threshold), so the graph-lane lift is structurally zero on this corpus — an
+attributable finding about gate calibration, not a mute number. See
+[`docs/eval/retrieval-compounding.md`](../../../docs/eval/retrieval-compounding.md)
+for the written result.
 
 ## Buckets (query difficulty / coverage)
 

--- a/backend/tests/eval/compounding.py
+++ b/backend/tests/eval/compounding.py
@@ -1,0 +1,226 @@
+"""Pure logic for the #969 compounding (cold→warm) retrieval experiment.
+
+Tier B companion to the #967 multi-arm harness: #967 measures the *static*
+quality of retrieval on a frozen corpus; this module plans and scores the
+*compounding* experiment — does retrieval improve as the context is used?
+
+Everything here is deterministic and infrastructure-free so it runs in normal
+CI (``test_compounding.py``). The live cold → replay → warm orchestration that
+actually drives ``recall()`` traffic lives in ``tests.eval.replay_runner``.
+
+Design facts this protocol is built on (Issue #120, decision-pinned):
+
+- ``recall()`` is the Hebbian **write** side — with neural memory enabled it
+  co-activates the top results and strengthens graph edges, but its *ranking*
+  reads only hybrid-search scores (usage-independent by design; mixing graph
+  signals into recall degrades precision).
+- ``explore()`` (activation spreading) is the **read** side — the surface
+  where accumulated edges change retrieval outcomes.
+
+So the experiment measures two lanes at every checkpoint:
+
+- **graph lane** (primary): from a probe query's seed gold doc, can
+  activation spreading recover the *companion* gold docs? Cold graphs cannot;
+  a graph warmed by co-recall traffic should. This is where compounding lives.
+- **recall lane** (control): P@5/MRR/nDCG of plain hybrid recall on the same
+  queries. Expected flat — which is itself the guarantee that warming the
+  graph never degrades the precision lane.
+
+The corpus is held fixed throughout, so any warm lift is attributable to the
+learned layer (growth ≠ "more data").
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from tests.eval.tools.corpus import Corpus
+
+#: Replay traffic never includes the probe queries — the probes are strictly
+#: held out, so warm lift measures *generalization* from related traffic.
+MODE_EXCLUDE_PROBES = "exclude_probes"
+#: Replay traffic includes every query (probes too) — models the production
+#: reality that users re-ask the questions that matter to them (rehearsal).
+MODE_INCLUDE_PROBES = "include_probes"
+
+REPLAY_MODES = (MODE_EXCLUDE_PROBES, MODE_INCLUDE_PROBES)
+
+#: Keys that appear in metric blocks but are not lift-comparable metrics.
+_NON_METRIC_KEYS = frozenset({"n"})
+
+
+@dataclass(frozen=True)
+class ProbeSpec:
+    """One held-out compounding probe: a multi-gold query, split into the
+    seed doc (the retrieval entry point) and the companion docs the graph
+    lane must recover from it."""
+
+    query_id: str
+    text: str
+    bucket: str
+    seed_doc: str
+    companion_docs: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class ReplayPlan:
+    """Deterministic plan for one cold→replay→warm experiment run."""
+
+    mode: str
+    rounds: int
+    probes: tuple[ProbeSpec, ...]
+    replay_query_ids: tuple[str, ...]
+
+
+def build_replay_plan(
+    corpus: Corpus, mode: str = MODE_EXCLUDE_PROBES, rounds: int = 8
+) -> ReplayPlan:
+    """Split the corpus queries into held-out probes and replay traffic.
+
+    Probes are exactly the queries with >= 2 gold docs (fixture order): only
+    multi-doc gold sets can show companion recovery, the graph-lane metric.
+    Replay traffic is every other query (``exclude_probes``) or every query
+    (``include_probes``), repeated ``rounds`` times by the live runner.
+    """
+    if mode not in REPLAY_MODES:
+        raise ValueError(f"unknown replay mode {mode!r}; expected one of {REPLAY_MODES}")
+    if rounds < 1:
+        raise ValueError(f"rounds must be >= 1, got {rounds}")
+
+    probes = tuple(
+        ProbeSpec(
+            query_id=q.id,
+            text=q.text,
+            bucket=q.bucket,
+            seed_doc=q.relevant[0],
+            companion_docs=tuple(q.relevant[1:]),
+        )
+        for q in corpus.queries
+        if len(q.relevant) >= 2
+    )
+    if not probes:
+        raise ValueError("corpus has no multi-gold queries — nothing to probe")
+
+    probe_ids = {p.query_id for p in probes}
+    if mode == MODE_INCLUDE_PROBES:
+        replay_ids = tuple(q.id for q in corpus.queries)
+    else:
+        replay_ids = tuple(q.id for q in corpus.queries if q.id not in probe_ids)
+    if not replay_ids:
+        raise ValueError("replay workload is empty — no traffic to warm the graph with")
+
+    return ReplayPlan(mode=mode, rounds=rounds, probes=probes, replay_query_ids=replay_ids)
+
+
+def recall_at_k(ranked: list[str], relevant: set[str], k: int) -> float:
+    """Share of ``relevant`` ids present in the top-``k`` of ``ranked``.
+
+    The graph-lane "companion recovery" metric. An empty gold set is a
+    protocol bug (0/0), not a zero score — fail loud.
+    """
+    if not relevant:
+        raise ValueError("relevant set must not be empty")
+    hits = sum(1 for doc in ranked[:k] if doc in relevant)
+    return hits / len(relevant)
+
+
+@dataclass(frozen=True)
+class PairAudit:
+    """One co-activated pair observation from the replay workload, classified
+    against the two write-path gates that decide whether a Hebbian edge can
+    ever form (the 2026-06-10 live run showed these gates, not the mechanism,
+    explain a zero lift on this corpus):
+
+    - semantic gate: pair cosine must reach ``min_similarity_for_edge``
+      (recall() skips the gate entirely when an embedding is missing);
+    - prune cliff: a first update below ``prune_threshold`` is deleted, not
+      stored, so sub-threshold pairs never accumulate across rounds.
+    """
+
+    query_id: str
+    doc_a: str
+    doc_b: str
+    cosine: float | None
+    delta_w: float
+    verdict: str
+    is_probe_gold_pair: bool
+
+
+def classify_pair(
+    cosine: float | None, delta_w: float, *, min_similarity: float, prune_threshold: float
+) -> str:
+    """Classify a co-activated pair against the edge-formation gates.
+
+    Returns ``forms``, ``gated_cosine``, ``below_prune``, or
+    ``gated_cosine+below_prune``. A ``None`` cosine mirrors recall()'s
+    behaviour for missing embeddings: the semantic gate is skipped.
+    """
+    gates = []
+    if cosine is not None and cosine < min_similarity:
+        gates.append("gated_cosine")
+    if delta_w < prune_threshold:
+        gates.append("below_prune")
+    return "+".join(gates) if gates else "forms"
+
+
+def summarize_gate_audit(pairs: list[PairAudit]) -> dict[str, Any]:
+    """Aggregate a gate audit: verdict counts + the probe-gold-pair detail.
+
+    The probe gold pairs are the compounding-critical subset — every one that
+    fails a gate directly explains a zero graph-lane lift.
+    """
+    verdicts: dict[str, int] = {}
+    for pair in pairs:
+        verdicts[pair.verdict] = verdicts.get(pair.verdict, 0) + 1
+    return {
+        "pair_observations": len(pairs),
+        "verdicts": verdicts,
+        "probe_gold_pairs": [
+            {
+                "query_id": p.query_id,
+                "pair": [p.doc_a, p.doc_b],
+                "cosine": p.cosine,
+                "delta_w": p.delta_w,
+                "verdict": p.verdict,
+            }
+            for p in pairs
+            if p.is_probe_gold_pair
+        ],
+    }
+
+
+def compute_lift(cold: dict[str, Any], warm: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Per-metric cold→warm lift table.
+
+    Compares every numeric metric key shared by both blocks; ``abs`` is the
+    absolute delta, ``rel`` the relative delta (``None`` when the cold
+    baseline is 0.0 — undefined, not infinite). Non-numeric values and
+    counters (``n``) are ignored. Diverging metric *sets* between the two
+    blocks mean the checkpoints were measured differently — a protocol bug.
+    """
+
+    def metric_keys(block: dict[str, Any]) -> set[str]:
+        return {
+            key
+            for key, value in block.items()
+            if key not in _NON_METRIC_KEYS and isinstance(value, (int, float))
+        }
+
+    cold_keys, warm_keys = metric_keys(cold), metric_keys(warm)
+    if cold_keys != warm_keys:
+        raise ValueError(
+            f"cold/warm metric keys diverge: only-cold={sorted(cold_keys - warm_keys)}, "
+            f"only-warm={sorted(warm_keys - cold_keys)}"
+        )
+
+    lift: dict[str, dict[str, Any]] = {}
+    for key in sorted(cold_keys):
+        c, w = float(cold[key]), float(warm[key])
+        lift[key] = {
+            "cold": round(c, 4),
+            "warm": round(w, 4),
+            "abs": round(w - c, 4),
+            "rel": round((w - c) / c, 4) if c != 0.0 else None,
+        }
+    return lift

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -1,0 +1,518 @@
+"""Live cold→replay→warm compounding experiment orchestration (Issue #969).
+
+Tier B companion to ``tests.eval.runner`` (#967): the static harness measures
+retrieval quality on a frozen corpus; this one measures whether quality
+*compounds with use*. Protocol per replay mode (each in its own throwaway
+workspace, corpus held fixed throughout):
+
+    ingest → COLD checkpoint → replay co-recall traffic (neural ON, N rounds)
+           → WARM_REPLAY checkpoint → Sleep ``edges_only`` consolidation
+           → WARM_SLEEP checkpoint → per-lane lift tables
+
+Each checkpoint measures two lanes (see ``tests.eval.compounding`` for the
+Issue #120 design facts this rests on):
+
+- **graph lane** (primary): companion recovery on the held-out multi-gold
+  probes via ``explore()`` activation spreading from the probe's seed gold
+  doc — the surface that reads the learned layer.
+- **recall lane** (control): hybrid ``recall()`` P@5/MRR/nDCG over all corpus
+  queries, measured with neural memory disabled so the measurement itself is
+  read-only w.r.t. the graph. Flat-by-design (recall ranking is
+  usage-independent); a moving number here is a regression signal.
+
+Checkpoints additionally snapshot the per-origin edge stats of the eval
+context, so the lift is attributable: Hebbian edges come from replay,
+``semantic`` edges from the Sleep run.
+
+Produces ``results/compounding-<YYYY-MM-DD>.json`` from a REAL run only —
+never fabricated. Heavy imports are function-local so importing this module
+is cheap and CI-safe (same convention as ``runner.py``).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from tests.eval.compounding import (
+    REPLAY_MODES,
+    PairAudit,
+    ProbeSpec,
+    ReplayPlan,
+    build_replay_plan,
+    classify_pair,
+    compute_lift,
+    recall_at_k,
+    summarize_gate_audit,
+)
+from tests.eval.metrics import mrr_at_k
+from tests.eval.runner import _ingest_corpus, _score_arm, _sudachi_version, _teardown
+from tests.eval.tools.corpus import Corpus, load_corpus
+
+_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+_RECALL_K = 10
+_REPLAY_ROUNDS = 8
+_EXPLORE_DEPTH = 2
+# ExploreRequest's default (0.05). After 8 replay rounds Hebbian weights for
+# genuinely co-recalled pairs sit well above this; pairs that never co-recall
+# stay below it, so the default separates signal from floor noise.
+_EXPLORE_MIN_WEIGHT = 0.05
+_RECOVERY_AT = (5, 10)
+_MRR_AT = 10
+_CHECKPOINTS = ("cold", "warm_replay", "warm_sleep")
+
+
+async def run_compounding_eval(
+    write: bool = True,
+    run_date: str | None = None,
+    rounds: int = _REPLAY_ROUNDS,
+    modes: tuple[str, ...] = REPLAY_MODES,
+) -> dict[str, Any]:
+    """Run the full cold→replay→warm experiment for every replay mode.
+
+    Args:
+        write: when True, persist ``results/compounding-<run_date>.json``.
+        run_date: YYYY-MM-DD label for the results file; defaults to today (UTC).
+        rounds: replay repetitions of the workload (per mode).
+        modes: replay modes to run, each in an isolated workspace.
+
+    Returns the results dict (also written to disk when ``write``).
+    """
+    from utils.datetime import utcnow
+
+    corpus = load_corpus()
+    run_date = run_date or utcnow().strftime("%Y-%m-%d")
+
+    mode_blocks: dict[str, Any] = {}
+    for mode in modes:
+        plan = build_replay_plan(corpus, mode=mode, rounds=rounds)
+        mode_blocks[mode] = await _run_mode(corpus, plan)
+
+    results: dict[str, Any] = {
+        "run_date": run_date,
+        "experiment": "compounding",
+        "issue": 969,
+        "sudachi_version": _sudachi_version(),
+        "corpus_version": corpus.meta.get("version"),
+        "query_count": len(corpus.queries),
+        "doc_count": len(corpus.documents),
+        "recall_k": _RECALL_K,
+        "rounds": rounds,
+        "explore_depth": _EXPLORE_DEPTH,
+        "explore_min_weight": _EXPLORE_MIN_WEIGHT,
+        "design_note": (
+            "Per Issue #120 the neural graph is read by explore(), not by "
+            "recall() ranking — so compounding is measured on the graph lane "
+            "(companion recovery from a seed gold doc) while the recall lane "
+            "is the flat-by-design stability control. Corpus is held fixed; "
+            "publish lift deltas only, never absolute numbers."
+        ),
+        "modes": mode_blocks,
+    }
+
+    if write:
+        _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        out = _RESULTS_DIR / f"compounding-{run_date}.json"
+        out.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"eval-compounding: wrote {out}")
+    return results
+
+
+async def _run_mode(corpus: Corpus, plan: ReplayPlan) -> dict[str, Any]:
+    """Provision an isolated workspace, run one mode's experiment, tear down."""
+    from auth.workspace_roles import WorkspaceRole
+    from db.base import get_db
+    from models.auth import Context, Workspace, WorkspaceMember
+    from services.memory_service import MemoryService
+
+    async for db in get_db():
+        owner = f"eval_{uuid4().hex[:8]}"
+        ws = Workspace(
+            id=uuid4(),
+            name=f"eval-ws-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=owner,
+            daily_api_limit=10_000_000,
+            weekly_api_limit=50_000_000,
+        )
+        ctx = Context(
+            id=uuid4(),
+            workspace_id=ws.id,
+            name=f"eval-ctx-{uuid4().hex[:8]}",
+            created_by=owner,
+            is_private=False,
+            # The warm_sleep checkpoint needs the consolidation pass to run;
+            # the orchestrator skips contexts left on the default "skip".
+            # "edges_only" runs exactly the edge-discovery phase — the one
+            # that writes to the learned layer under measurement.
+            sleep_mode="edges_only",
+        )
+        db.add(ws)
+        await db.flush()
+        db.add(ctx)
+        db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        await db.flush()
+        await db.commit()
+
+        svc = MemoryService(db)
+        id_map: dict[str, str] = {}
+        try:
+            await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
+            return await _measure_replay_measure(svc, db, corpus, plan, id_map, owner, ctx, ws)
+        finally:
+            await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
+
+    raise RuntimeError("database session unavailable — is the stack up?")
+
+
+async def _measure_replay_measure(
+    svc: Any,
+    db: Any,
+    corpus: Corpus,
+    plan: ReplayPlan,
+    id_map: dict[str, str],
+    owner: str,
+    ctx: Any,
+    ws: Any,
+) -> dict[str, Any]:
+    """Drive the cold → replay → warm_replay → sleep → warm_sleep sequence."""
+    docs_by_id = corpus.docs_by_id
+    seed_mem_by_doc = {doc_id: mem_id for mem_id, doc_id in id_map.items()}
+
+    checkpoints: dict[str, dict[str, Any]] = {}
+    checkpoints["cold"] = await _checkpoint(
+        svc, db, corpus, plan, docs_by_id, id_map, seed_mem_by_doc, owner, ctx, ws
+    )
+
+    gate_audit = await _gate_audit(svc, db, corpus, plan, id_map, owner, ctx, ws)
+    replay_recalls = await _replay(svc, corpus, plan, owner, ctx, ws)
+    checkpoints["warm_replay"] = await _checkpoint(
+        svc, db, corpus, plan, docs_by_id, id_map, seed_mem_by_doc, owner, ctx, ws
+    )
+
+    sleep_info = await _run_sleep(db, owner, ctx, ws)
+    checkpoints["warm_sleep"] = await _checkpoint(
+        svc, db, corpus, plan, docs_by_id, id_map, seed_mem_by_doc, owner, ctx, ws
+    )
+
+    lift = {
+        lane: {
+            "cold_to_warm_replay": compute_lift(
+                checkpoints["cold"][lane], checkpoints["warm_replay"][lane]
+            ),
+            "warm_replay_to_warm_sleep": compute_lift(
+                checkpoints["warm_replay"][lane], checkpoints["warm_sleep"][lane]
+            ),
+            "cold_to_warm_sleep": compute_lift(
+                checkpoints["cold"][lane], checkpoints["warm_sleep"][lane]
+            ),
+        }
+        for lane in ("graph_lane", "recall_lane")
+    }
+
+    return {
+        "mode": plan.mode,
+        "probe_count": len(plan.probes),
+        "probe_query_ids": [p.query_id for p in plan.probes],
+        "replay_query_count": len(plan.replay_query_ids),
+        "replay_recalls": replay_recalls,
+        "gate_audit": gate_audit,
+        "sleep": sleep_info,
+        "checkpoints": checkpoints,
+        "lift": lift,
+    }
+
+
+async def _checkpoint(
+    svc: Any,
+    db: Any,
+    corpus: Corpus,
+    plan: ReplayPlan,
+    docs_by_id: dict[str, Any],
+    id_map: dict[str, str],
+    seed_mem_by_doc: dict[str, str],
+    owner: str,
+    ctx: Any,
+    ws: Any,
+) -> dict[str, Any]:
+    """One measurement snapshot: graph lane + recall lane + edge stats.
+
+    Every measurement here is read-only with respect to the neural graph:
+    ``explore()`` only traverses edges, and the recall-lane arm runs with
+    ``ENABLE_NEURAL_MEMORY=false`` so no Hebbian writes contaminate the
+    checkpoint (per #967's published invariant, hybrid scores are identical
+    with the flag on or off).
+    """
+    graph_lane = await _measure_graph_lane(
+        svc, plan.probes, seed_mem_by_doc, id_map, owner, ctx, ws
+    )
+
+    prev_neural = os.environ.get("ENABLE_NEURAL_MEMORY")
+    os.environ["ENABLE_NEURAL_MEMORY"] = "false"
+    try:
+        arm = await _score_arm(svc, corpus, docs_by_id, id_map, owner, ctx.id, ws.id, "hybrid")
+    finally:
+        _restore_env("ENABLE_NEURAL_MEMORY", prev_neural)
+
+    return {
+        "graph_lane": graph_lane,
+        "recall_lane": arm["overall"],
+        "edge_stats": await _edge_stats(db, ctx.id),
+    }
+
+
+async def _measure_graph_lane(
+    svc: Any,
+    probes: tuple[ProbeSpec, ...],
+    seed_mem_by_doc: dict[str, str],
+    id_map: dict[str, str],
+    owner: str,
+    ctx: Any,
+    ws: Any,
+) -> dict[str, Any]:
+    """Companion recovery via activation spreading, per held-out probe.
+
+    For each probe: seed at its first gold doc's memory, spread activation
+    (``explore``), rank the surfaced docs by activation, and score how much
+    of the remaining gold set (the companions) is recovered.
+    """
+    from models.schemas import ExploreRequest
+
+    rankings: list[tuple[list[str], set[str]]] = []
+    seeds_in_graph = 0
+    for probe in probes:
+        seed_mem_id = seed_mem_by_doc[probe.seed_doc]
+        resp = await svc.explore(
+            request=ExploreRequest(
+                memory_id=UUID(seed_mem_id),
+                depth=_EXPLORE_DEPTH,
+                min_weight=_EXPLORE_MIN_WEIGHT,
+            ),
+            user_id=owner,
+            current_context_id=ctx.id,
+            current_workspace_id=ws.id,
+        )
+        if resp.metadata.get("reason") != "seed_not_in_graph":
+            seeds_in_graph += 1
+        related = sorted(resp.related_memories, key=lambda m: m.activation, reverse=True)
+        ranked = [id_map.get(str(m.memory_id), "?") for m in related]
+        rankings.append((ranked, set(probe.companion_docs)))
+
+    mean_recovery = {
+        f"recovery@{k}": round(
+            sum(recall_at_k(r, rel, k) for r, rel in rankings) / len(rankings), 4
+        )
+        for k in _RECOVERY_AT
+    }
+    return {
+        "n": len(rankings),
+        **mean_recovery,
+        f"mrr@{_MRR_AT}": round(mrr_at_k(rankings, _MRR_AT), 4),
+        "seeds_in_graph": seeds_in_graph,
+    }
+
+
+async def _replay(svc: Any, corpus: Corpus, plan: ReplayPlan, owner: str, ctx: Any, ws: Any) -> int:
+    """Drive the replay workload with neural memory ON (the warming phase).
+
+    Each ``recall()`` co-activates its top results and applies Hebbian edge
+    updates — this is the production write path, not a simulation. The
+    workload is deterministic: the plan's query order, repeated ``rounds``
+    times. Returns the number of recalls issued.
+    """
+    from models.schemas import RecallRequest
+
+    queries_by_id = {q.id: q for q in corpus.queries}
+    prev_neural = os.environ.get("ENABLE_NEURAL_MEMORY")
+    os.environ["ENABLE_NEURAL_MEMORY"] = "true"
+    recalls = 0
+    try:
+        for _ in range(plan.rounds):
+            for query_id in plan.replay_query_ids:
+                await svc.recall(
+                    request=RecallRequest(
+                        query=queries_by_id[query_id].text,
+                        k=_RECALL_K,
+                        search_mode="hybrid",
+                    ),
+                    user_id=owner,
+                    current_context_id=ctx.id,
+                    current_workspace_id=ws.id,
+                )
+                recalls += 1
+    finally:
+        _restore_env("ENABLE_NEURAL_MEMORY", prev_neural)
+    return recalls
+
+
+async def _gate_audit(
+    svc: Any,
+    db: Any,
+    corpus: Corpus,
+    plan: ReplayPlan,
+    id_map: dict[str, str],
+    owner: str,
+    ctx: Any,
+    ws: Any,
+) -> dict[str, Any]:
+    """Audit which co-activated pairs the replay traffic *could ever* write.
+
+    Re-runs each replay query through hybrid search (read-only, vectors
+    included) and classifies every top-``top_k_coactivation`` pair against
+    recall()'s two edge-formation gates — the semantic cosine gate and the
+    prune cliff (``delta_w`` here is the first-update Hebbian term
+    ``lr · a_i · a_j``; the decay term is zero at weight 0). This makes a
+    zero graph-lane lift attributable: if every probe gold pair is gated,
+    no amount of replay rounds can produce recovery.
+    """
+    from neural.config import NeuralMemoryConfig
+    from neural.utils import cosine_similarity
+
+    config = await NeuralMemoryConfig.from_db(db)
+    queries_by_id = {q.id: q for q in corpus.queries}
+
+    gold_pairs: set[frozenset[str]] = set()
+    for probe in plan.probes:
+        gold = (probe.seed_doc, *probe.companion_docs)
+        for i in range(len(gold)):
+            for j in range(i + 1, len(gold)):
+                gold_pairs.add(frozenset((gold[i], gold[j])))
+
+    audits: list[PairAudit] = []
+    for query_id in plan.replay_query_ids:
+        results = await svc.search_service.hybrid_search(
+            query=queries_by_id[query_id].text,
+            user_id=owner,
+            workspace_id=str(ws.id),
+            context_id=str(ctx.id),
+            k=_RECALL_K,
+            search_mode="hybrid",
+            include_vectors=True,
+        )
+        top = results[: min(config.top_k_coactivation, _RECALL_K, len(results))]
+        docs = []
+        for result in top:
+            # Mirror recall()'s activation: hybrid score clamped to [0, 1].
+            score = result.get("hybrid_score", result["score"])
+            activation = min(1.0, max(0.0, score))
+            docs.append((id_map.get(result["id"], "?"), activation, result.get("embedding") or []))
+        for i in range(len(docs)):
+            for j in range(i + 1, len(docs)):
+                doc_a, act_a, emb_a = docs[i]
+                doc_b, act_b, emb_b = docs[j]
+                cosine = cosine_similarity(emb_a, emb_b) if emb_a and emb_b else None
+                delta_w = config.learning_rate * act_a * act_b
+                audits.append(
+                    PairAudit(
+                        query_id=query_id,
+                        doc_a=doc_a,
+                        doc_b=doc_b,
+                        cosine=round(cosine, 4) if cosine is not None else None,
+                        delta_w=round(delta_w, 4),
+                        verdict=classify_pair(
+                            cosine,
+                            delta_w,
+                            min_similarity=config.min_similarity_for_edge,
+                            prune_threshold=config.prune_threshold,
+                        ),
+                        is_probe_gold_pair=frozenset((doc_a, doc_b)) in gold_pairs,
+                    )
+                )
+
+    summary = summarize_gate_audit(audits)
+    summary["thresholds"] = {
+        "min_similarity_for_edge": config.min_similarity_for_edge,
+        "prune_threshold": config.prune_threshold,
+        "learning_rate": config.learning_rate,
+        "top_k_coactivation": config.top_k_coactivation,
+    }
+    return summary
+
+
+async def _run_sleep(db: Any, owner: str, ctx: Any, ws: Any) -> dict[str, Any]:
+    """One Sleep consolidation pass (edges_only) over the eval context.
+
+    The LLM judge is disabled (``sleep_llm_provider=""`` → auto-accept path)
+    so the run is deterministic and free — edge discovery still performs the
+    real Qdrant similarity sweep and persists ``semantic``-origin edges.
+    Failure is recorded, not raised: the warm_sleep checkpoint still runs and
+    the results JSON carries the honest sleep status.
+    """
+    from dataclasses import replace
+
+    from sqlalchemy import select
+
+    from models.sleep import SleepReport
+    from neural.config import NeuralMemoryConfig
+    from services.sleep.orchestrator import SleepOrchestrator
+
+    NeuralMemoryConfig.invalidate_cache()
+    config = replace(await NeuralMemoryConfig.from_db(db), sleep_llm_provider="")
+    try:
+        await SleepOrchestrator(db).run(
+            owner, workspace_id=str(ws.id), context_id=str(ctx.id), config=config
+        )
+    except Exception as exc:  # noqa: BLE001 — recorded in results, not fatal
+        await db.rollback()
+        return {"ok": False, "error": str(exc)}
+
+    report = (
+        await db.execute(
+            select(SleepReport)
+            .where(SleepReport.user_id == owner)
+            .order_by(SleepReport.started_at.desc())
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if report is None:
+        return {"ok": False, "error": "sleep run left no report"}
+    return {
+        "ok": report.status == "completed",
+        "status": report.status,
+        "edge_discovery": report.edge_discovery_result,
+    }
+
+
+async def _edge_stats(db: Any, ctx_id: Any) -> dict[str, Any]:
+    """Per-origin edge count + mean weight for the eval context."""
+    from sqlalchemy import func, select
+
+    from models.memory import NeuralMemoryEdge
+
+    rows = (
+        await db.execute(
+            select(
+                NeuralMemoryEdge.origin,
+                func.count().label("count"),
+                func.avg(NeuralMemoryEdge.weight).label("avg_weight"),
+            )
+            .where(NeuralMemoryEdge.context_id == ctx_id)
+            .group_by(NeuralMemoryEdge.origin)
+        )
+    ).all()
+    return {
+        origin: {"count": count, "avg_weight": round(float(avg_weight), 4)}
+        for origin, count, avg_weight in rows
+    }
+
+
+def _restore_env(name: str, prev: str | None) -> None:
+    if prev is None:
+        os.environ.pop(name, None)
+    else:
+        os.environ[name] = prev
+
+
+def _main() -> int:
+    import asyncio
+
+    results = asyncio.run(run_compounding_eval())
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -62,7 +62,6 @@ _EXPLORE_DEPTH = 2
 _EXPLORE_MIN_WEIGHT = 0.05
 _RECOVERY_AT = (5, 10)
 _MRR_AT = 10
-_CHECKPOINTS = ("cold", "warm_replay", "warm_sleep")
 
 
 async def run_compounding_eval(

--- a/backend/tests/eval/results/compounding-2026-06-10.json
+++ b/backend/tests/eval/results/compounding-2026-06-10.json
@@ -1,0 +1,814 @@
+{
+  "run_date": "2026-06-10",
+  "experiment": "compounding",
+  "issue": 969,
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "query_count": 30,
+  "doc_count": 16,
+  "recall_k": 10,
+  "rounds": 8,
+  "explore_depth": 2,
+  "explore_min_weight": 0.05,
+  "design_note": "Per Issue #120 the neural graph is read by explore(), not by recall() ranking — so compounding is measured on the graph lane (companion recovery from a seed gold doc) while the recall lane is the flat-by-design stability control. Corpus is held fixed; publish lift deltas only, never absolute numbers.",
+  "modes": {
+    "exclude_probes": {
+      "mode": "exclude_probes",
+      "probe_count": 5,
+      "probe_query_ids": [
+        "q_cross_01",
+        "q_cross_02",
+        "q_cross_03",
+        "q_cross_04",
+        "q_cross_05"
+      ],
+      "replay_query_count": 25,
+      "replay_recalls": 200,
+      "gate_audit": {
+        "pair_observations": 75,
+        "verdicts": {
+          "gated_cosine": 60,
+          "gated_cosine+below_prune": 8,
+          "forms": 6,
+          "below_prune": 1
+        },
+        "probe_gold_pairs": [
+          {
+            "query_id": "q_exact_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0142,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_03",
+            "pair": [
+              "doc_res_chunking",
+              "doc_mem_hybrid"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0148,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_05",
+            "pair": [
+              "doc_res_embedding",
+              "doc_mem_context"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.0196,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_sem_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0184,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_mem_03",
+            "pair": [
+              "doc_mem_context",
+              "doc_res_embedding"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.0274,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_mem_05",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0346,
+            "verdict": "gated_cosine"
+          }
+        ],
+        "thresholds": {
+          "min_similarity_for_edge": 0.5,
+          "prune_threshold": 0.01,
+          "learning_rate": 0.05,
+          "top_k_coactivation": 3
+        }
+      },
+      "sleep": {
+        "ok": true,
+        "status": "completed",
+        "edge_discovery": {
+          "success": true,
+          "skipped": false,
+          "skip_reason": null,
+          "error": null,
+          "llm_calls": 0,
+          "memories_processed": 0,
+          "details": {
+            "message": "no_edge_candidates",
+            "sampled": 16,
+            "candidates": 0,
+            "filtered": 0,
+            "edges_created": 0,
+            "llm_accepted": 0,
+            "llm_rejected": 0,
+            "llm_call_failures": 0,
+            "auto_accepted": 0,
+            "edge_type_dist": {},
+            "avg_confidence": 0.0,
+            "median_confidence": 0.0,
+            "p25_confidence": 0.0,
+            "p75_confidence": 0.0,
+            "confidence_n": 0,
+            "confidence_imputed": 0,
+            "confidence_histogram": {
+              "0.0-0.5": 0,
+              "0.5-0.7": 0,
+              "0.7-0.85": 0,
+              "0.85-1.0": 0
+            },
+            "avg_confidence_rejected": 0.0,
+            "median_confidence_rejected": 0.0,
+            "p25_confidence_rejected": 0.0,
+            "p75_confidence_rejected": 0.0,
+            "confidence_n_rejected": 0,
+            "confidence_imputed_rejected": 0,
+            "confidence_histogram_rejected": {
+              "0.0-0.5": 0,
+              "0.5-0.7": 0,
+              "0.7-0.85": 0,
+              "0.85-1.0": 0
+            },
+            "llm_model": "gpt-5-nano",
+            "prompt_revision": "v3"
+          },
+          "llm_breakdown": [],
+          "embedding_calls": 0,
+          "embedding_tokens": 0
+        }
+      },
+      "checkpoints": {
+        "cold": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 0
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {}
+        },
+        "warm_replay": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 1
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {
+            "hebbian": {
+              "count": 6,
+              "avg_weight": 0.3336
+            }
+          }
+        },
+        "warm_sleep": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 1
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {
+            "hebbian": {
+              "count": 6,
+              "avg_weight": 0.3336
+            }
+          }
+        }
+      },
+      "lift": {
+        "graph_lane": {
+          "cold_to_warm_replay": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 0.0,
+              "warm": 1.0,
+              "abs": 1.0,
+              "rel": null
+            }
+          },
+          "warm_replay_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "cold_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 0.0,
+              "warm": 1.0,
+              "abs": 1.0,
+              "rel": null
+            }
+          }
+        },
+        "recall_lane": {
+          "cold_to_warm_replay": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "warm_replay_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "cold_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          }
+        }
+      }
+    },
+    "include_probes": {
+      "mode": "include_probes",
+      "probe_count": 5,
+      "probe_query_ids": [
+        "q_cross_01",
+        "q_cross_02",
+        "q_cross_03",
+        "q_cross_04",
+        "q_cross_05"
+      ],
+      "replay_query_count": 30,
+      "replay_recalls": 240,
+      "gate_audit": {
+        "pair_observations": 90,
+        "verdicts": {
+          "gated_cosine": 73,
+          "gated_cosine+below_prune": 9,
+          "forms": 7,
+          "below_prune": 1
+        },
+        "probe_gold_pairs": [
+          {
+            "query_id": "q_exact_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0142,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_03",
+            "pair": [
+              "doc_res_chunking",
+              "doc_mem_hybrid"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0148,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_05",
+            "pair": [
+              "doc_res_embedding",
+              "doc_mem_context"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.0197,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_sem_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0185,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_cross_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0364,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_cross_02",
+            "pair": [
+              "doc_res_embedding",
+              "doc_mem_context"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.0237,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_mem_03",
+            "pair": [
+              "doc_mem_context",
+              "doc_res_embedding"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.0274,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_mem_05",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0346,
+            "verdict": "gated_cosine"
+          }
+        ],
+        "thresholds": {
+          "min_similarity_for_edge": 0.5,
+          "prune_threshold": 0.01,
+          "learning_rate": 0.05,
+          "top_k_coactivation": 3
+        }
+      },
+      "sleep": {
+        "ok": true,
+        "status": "completed",
+        "edge_discovery": {
+          "success": true,
+          "skipped": false,
+          "skip_reason": null,
+          "error": null,
+          "llm_calls": 0,
+          "memories_processed": 0,
+          "details": {
+            "message": "no_edge_candidates",
+            "sampled": 16,
+            "candidates": 0,
+            "filtered": 0,
+            "edges_created": 0,
+            "llm_accepted": 0,
+            "llm_rejected": 0,
+            "llm_call_failures": 0,
+            "auto_accepted": 0,
+            "edge_type_dist": {},
+            "avg_confidence": 0.0,
+            "median_confidence": 0.0,
+            "p25_confidence": 0.0,
+            "p75_confidence": 0.0,
+            "confidence_n": 0,
+            "confidence_imputed": 0,
+            "confidence_histogram": {
+              "0.0-0.5": 0,
+              "0.5-0.7": 0,
+              "0.7-0.85": 0,
+              "0.85-1.0": 0
+            },
+            "avg_confidence_rejected": 0.0,
+            "median_confidence_rejected": 0.0,
+            "p25_confidence_rejected": 0.0,
+            "p75_confidence_rejected": 0.0,
+            "confidence_n_rejected": 0,
+            "confidence_imputed_rejected": 0,
+            "confidence_histogram_rejected": {
+              "0.0-0.5": 0,
+              "0.5-0.7": 0,
+              "0.7-0.85": 0,
+              "0.85-1.0": 0
+            },
+            "llm_model": "gpt-5-nano",
+            "prompt_revision": "v3"
+          },
+          "llm_breakdown": [],
+          "embedding_calls": 0,
+          "embedding_tokens": 0
+        }
+      },
+      "checkpoints": {
+        "cold": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 0
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {}
+        },
+        "warm_replay": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 1
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {
+            "hebbian": {
+              "count": 6,
+              "avg_weight": 0.3713
+            }
+          }
+        },
+        "warm_sleep": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 1
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {
+            "hebbian": {
+              "count": 6,
+              "avg_weight": 0.3713
+            }
+          }
+        }
+      },
+      "lift": {
+        "graph_lane": {
+          "cold_to_warm_replay": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 0.0,
+              "warm": 1.0,
+              "abs": 1.0,
+              "rel": null
+            }
+          },
+          "warm_replay_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "cold_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 0.0,
+              "warm": 1.0,
+              "abs": 1.0,
+              "rel": null
+            }
+          }
+        },
+        "recall_lane": {
+          "cold_to_warm_replay": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "warm_replay_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "cold_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/eval/test_compounding.py
+++ b/backend/tests/eval/test_compounding.py
@@ -1,0 +1,210 @@
+"""Deterministic tests for the #969 compounding-eval pure layer.
+
+Covers the replay-plan builder, the graph-lane recovery metric, and the
+cold→warm lift computation — everything in ``tests.eval.compounding`` that
+needs no infrastructure. The live cold→replay→warm orchestration is exercised
+by ``test_compounding_live.py`` (skip-guarded behind ``KAGURA_EVAL_LIVE=1``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.eval.compounding import (
+    MODE_EXCLUDE_PROBES,
+    MODE_INCLUDE_PROBES,
+    PairAudit,
+    build_replay_plan,
+    classify_pair,
+    compute_lift,
+    recall_at_k,
+    summarize_gate_audit,
+)
+from tests.eval.tools.corpus import load_corpus
+
+# ---------------------------------------------------------------------------
+# build_replay_plan
+# ---------------------------------------------------------------------------
+
+
+def test_probes_are_exactly_the_multi_gold_queries():
+    """Every query with >= 2 gold docs is a probe; single-gold queries are not."""
+    corpus = load_corpus()
+    plan = build_replay_plan(corpus)
+
+    expected_probe_ids = [q.id for q in corpus.queries if len(q.relevant) >= 2]
+    assert [p.query_id for p in plan.probes] == expected_probe_ids
+    # The v1 corpus pins this to the 5 cross-source queries — if the corpus
+    # changes shape, the experiment design needs re-review, so fail loud.
+    assert len(plan.probes) == 5
+    assert all(p.bucket == "cross-source" for p in plan.probes)
+
+
+def test_probe_seed_and_companions_partition_the_gold_set():
+    corpus = load_corpus()
+    plan = build_replay_plan(corpus)
+    by_id = {q.id: q for q in corpus.queries}
+
+    for probe in plan.probes:
+        gold = by_id[probe.query_id].relevant
+        assert probe.seed_doc == gold[0]
+        assert list(probe.companion_docs) == list(gold[1:])
+        assert probe.seed_doc not in probe.companion_docs
+
+
+def test_exclude_probes_mode_replays_only_non_probe_queries():
+    corpus = load_corpus()
+    plan = build_replay_plan(corpus, mode=MODE_EXCLUDE_PROBES)
+
+    probe_ids = {p.query_id for p in plan.probes}
+    assert plan.mode == MODE_EXCLUDE_PROBES
+    assert probe_ids.isdisjoint(plan.replay_query_ids)
+    assert set(plan.replay_query_ids) == {q.id for q in corpus.queries if q.id not in probe_ids}
+
+
+def test_include_probes_mode_replays_every_query():
+    corpus = load_corpus()
+    plan = build_replay_plan(corpus, mode=MODE_INCLUDE_PROBES)
+
+    assert plan.mode == MODE_INCLUDE_PROBES
+    assert list(plan.replay_query_ids) == [q.id for q in corpus.queries]
+
+
+def test_plan_is_deterministic():
+    corpus = load_corpus()
+    a = build_replay_plan(corpus, mode=MODE_EXCLUDE_PROBES, rounds=3)
+    b = build_replay_plan(corpus, mode=MODE_EXCLUDE_PROBES, rounds=3)
+    assert a == b
+
+
+def test_plan_rejects_bad_inputs():
+    corpus = load_corpus()
+    with pytest.raises(ValueError):
+        build_replay_plan(corpus, mode="warm_and_fuzzy")
+    with pytest.raises(ValueError):
+        build_replay_plan(corpus, rounds=0)
+
+
+# ---------------------------------------------------------------------------
+# recall_at_k (companion recovery)
+# ---------------------------------------------------------------------------
+
+
+def test_recall_at_k_counts_relevant_in_window():
+    ranked = ["a", "b", "c", "d"]
+    assert recall_at_k(ranked, {"b", "d"}, k=2) == 0.5
+    assert recall_at_k(ranked, {"b", "d"}, k=4) == 1.0
+    assert recall_at_k(ranked, {"z"}, k=4) == 0.0
+
+
+def test_recall_at_k_empty_ranking_is_zero():
+    assert recall_at_k([], {"a"}, k=5) == 0.0
+
+
+def test_recall_at_k_rejects_empty_relevant_set():
+    """An empty gold set would silently score 0/0 — fail loud instead."""
+    with pytest.raises(ValueError):
+        recall_at_k(["a"], set(), k=5)
+
+
+# ---------------------------------------------------------------------------
+# compute_lift
+# ---------------------------------------------------------------------------
+
+
+def test_compute_lift_reports_absolute_and_relative_deltas():
+    cold = {"recovery@10": 0.2, "mrr@10": 0.5}
+    warm = {"recovery@10": 0.6, "mrr@10": 0.5}
+    lift = compute_lift(cold, warm)
+
+    assert lift["recovery@10"] == {
+        "cold": 0.2,
+        "warm": 0.6,
+        "abs": 0.4,
+        "rel": 2.0,
+    }
+    assert lift["mrr@10"]["abs"] == 0.0
+    assert lift["mrr@10"]["rel"] == 0.0
+
+
+def test_compute_lift_zero_cold_baseline_has_null_relative():
+    """Cold-start graphs legitimately measure 0.0 — relative lift is undefined,
+    not infinite, and must serialize as null rather than raising."""
+    lift = compute_lift({"recovery@10": 0.0}, {"recovery@10": 0.4})
+    assert lift["recovery@10"]["abs"] == 0.4
+    assert lift["recovery@10"]["rel"] is None
+
+
+def test_compute_lift_skips_non_metric_keys():
+    """Counters like ``n`` and non-numeric metadata are not lift metrics."""
+    cold = {"n": 5, "p@5": 0.5, "note": "cold"}
+    warm = {"n": 5, "p@5": 0.7, "note": "warm"}
+    lift = compute_lift(cold, warm)
+    assert set(lift) == {"p@5"}
+
+
+def test_compute_lift_requires_matching_metric_keys():
+    """A cold/warm pair measured with different metric sets is a protocol bug."""
+    with pytest.raises(ValueError):
+        compute_lift({"p@5": 0.5}, {"p@10": 0.5})
+
+
+# ---------------------------------------------------------------------------
+# gate audit (classify_pair / summarize_gate_audit)
+# ---------------------------------------------------------------------------
+#
+# Empirical finding from the first live run (2026-06-10): replay produced
+# almost no Hebbian edges because (a) the semantic gate requires pair cosine
+# >= min_similarity_for_edge and (b) a first update below prune_threshold is
+# deleted, never accumulated. The audit makes a zero-lift result attributable
+# instead of mute, so its classification logic must be exact.
+
+
+def test_classify_pair_forms_when_both_gates_pass():
+    assert classify_pair(0.6, 0.02, min_similarity=0.5, prune_threshold=0.01) == "forms"
+
+
+def test_classify_pair_gated_by_cosine():
+    assert classify_pair(0.398, 0.0366, min_similarity=0.5, prune_threshold=0.01) == "gated_cosine"
+
+
+def test_classify_pair_below_prune_never_accumulates():
+    assert classify_pair(0.6, 0.005, min_similarity=0.5, prune_threshold=0.01) == "below_prune"
+
+
+def test_classify_pair_both_gates():
+    assert (
+        classify_pair(0.3, 0.005, min_similarity=0.5, prune_threshold=0.01)
+        == "gated_cosine+below_prune"
+    )
+
+
+def test_classify_pair_missing_embedding_skips_gate():
+    """recall() skips the cosine gate when either embedding is missing — the
+    pair is classified by the prune cliff alone."""
+    assert classify_pair(None, 0.02, min_similarity=0.5, prune_threshold=0.01) == "forms"
+    assert classify_pair(None, 0.005, min_similarity=0.5, prune_threshold=0.01) == "below_prune"
+
+
+def test_summarize_gate_audit_counts_and_probe_pairs():
+    pairs = [
+        PairAudit("q1", "a", "b", 0.6, 0.02, "forms", is_probe_gold_pair=False),
+        PairAudit("q1", "a", "c", 0.3, 0.02, "gated_cosine", is_probe_gold_pair=False),
+        PairAudit("q2", "a", "b", 0.6, 0.005, "below_prune", is_probe_gold_pair=False),
+        PairAudit("q3", "s", "t", 0.4, 0.03, "gated_cosine", is_probe_gold_pair=True),
+    ]
+    summary = summarize_gate_audit(pairs)
+
+    assert summary["pair_observations"] == 4
+    assert summary["verdicts"] == {"forms": 1, "gated_cosine": 2, "below_prune": 1}
+    # Probe gold pairs are the compounding-critical subset: every one that is
+    # gated explains recovery lift staying at zero.
+    assert summary["probe_gold_pairs"] == [
+        {
+            "query_id": "q3",
+            "pair": ["s", "t"],
+            "cosine": 0.4,
+            "delta_w": 0.03,
+            "verdict": "gated_cosine",
+        }
+    ]

--- a/backend/tests/eval/test_compounding_live.py
+++ b/backend/tests/eval/test_compounding_live.py
@@ -1,0 +1,78 @@
+"""Live-stack compounding (cold→warm) experiment driver (Issue #969).
+
+Tier B companion to ``test_retrieval_quality.py`` (#967). Needs the full stack
+(Postgres + Qdrant + Redis + an embedding provider + Sudachi), so it is
+**skip-guarded** behind ``KAGURA_EVAL_LIVE=1`` exactly like the Tier A live
+test (the ``make eval-compounding`` target sets it).
+
+What it does when enabled, once per replay mode (exclude/include probes), in
+an isolated throwaway workspace each:
+
+1. Ingests the frozen golden corpus (corpus held fixed — growth ≠ more data).
+2. **Cold checkpoint**: graph-lane companion recovery on the 5 held-out
+   multi-gold probes (explore/activation-spreading from the seed gold doc)
+   + recall-lane P@5/MRR/nDCG control (neural off — read-only measurement).
+3. **Replay**: drives the replay workload through ``recall()`` with neural
+   memory enabled for N rounds, so co-activation accumulates Hebbian edges.
+4. **warm_replay checkpoint**, then one Sleep ``edges_only`` consolidation
+   run (no-LLM auto-accept judge), then the **warm_sleep checkpoint**.
+5. Writes ``results/compounding-<YYYY-MM-DD>.json`` with the per-lane lift
+   tables. NUMBERS ARE NEVER FABRICATED — only a real run produces this file.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.getenv("KAGURA_EVAL_LIVE") != "1",
+    reason="live compounding eval requires the full stack; set KAGURA_EVAL_LIVE=1 (make eval-compounding)",
+)
+
+
+@pytest.mark.asyncio
+async def test_compounding_live():
+    """Run the cold→replay→warm experiment and write the lift-table JSON."""
+    from tests.eval.compounding import MODE_EXCLUDE_PROBES, MODE_INCLUDE_PROBES
+    from tests.eval.replay_runner import run_compounding_eval
+
+    results = await run_compounding_eval()
+
+    assert results["experiment"] == "compounding"
+    assert set(results["modes"]) == {MODE_EXCLUDE_PROBES, MODE_INCLUDE_PROBES}
+
+    for mode_block in results["modes"].values():
+        assert mode_block["probe_count"] == 5
+        checkpoints = mode_block["checkpoints"]
+        assert set(checkpoints) == {"cold", "warm_replay", "warm_sleep"}
+        for checkpoint in checkpoints.values():
+            assert "graph_lane" in checkpoint
+            assert "recall_lane" in checkpoint
+            assert "edge_stats" in checkpoint
+        # The mechanism itself must have fired: replay traffic with neural
+        # memory enabled writes Hebbian edges. This asserts the experiment
+        # actually exercised the learned layer — NOT a quality gate on lift.
+        hebbian_after_replay = (
+            checkpoints["warm_replay"]["edge_stats"].get("hebbian", {}).get("count", 0)
+        )
+        assert hebbian_after_replay > 0, "replay produced no Hebbian edges — warming did not run"
+
+        # The gate audit explains the graph-lane numbers: it classifies every
+        # co-activatable pair of the replay traffic against the edge-formation
+        # gates, with the probe gold pairs called out.
+        audit = mode_block["gate_audit"]
+        assert audit["pair_observations"] > 0
+        assert set(audit["thresholds"]) >= {"min_similarity_for_edge", "prune_threshold"}
+
+        lift = mode_block["lift"]
+        assert set(lift) == {"graph_lane", "recall_lane"}
+        for lane in lift.values():
+            assert set(lane) == {
+                "cold_to_warm_replay",
+                "warm_replay_to_warm_sleep",
+                "cold_to_warm_sleep",
+            }
+        assert "recovery@10" in lift["graph_lane"]["cold_to_warm_sleep"]
+        assert "ndcg@10" in lift["recall_lane"]["cold_to_warm_sleep"]

--- a/docs/eval/README.md
+++ b/docs/eval/README.md
@@ -11,6 +11,7 @@ distinct from **doing things at all** (production observability) or
 |---|---|---|
 | `edge_discovery_labeling.md` | Labeling protocol for offline evaluation of the Sleep edge_discovery LLM Judge (issue #375 / #274 successor) | Skeleton — Phase 1 in progress |
 | `retrieval-benchmark.md` | Reproducible multi-arm retrieval benchmark (BM25-only / vector-only / hybrid / hybrid+neural) on the frozen golden corpus — relative deltas, reproduction steps (issue #967) | Baseline committed 2026-06-10 |
+| `retrieval-compounding.md` | Controlled cold→replay→warm compounding experiment (does retrieval improve with use?) — protocol, lift tables, gate-audit attribution (issue #969) | First result committed 2026-06-10: zero lift, attributed to the `min_similarity_for_edge` gate |
 
 ## Where this fits in the documentation map
 

--- a/docs/eval/retrieval-benchmark.md
+++ b/docs/eval/retrieval-benchmark.md
@@ -85,7 +85,7 @@ fabricated — a results JSON exists only if a real run produced it.
 
 | Concern | Where it lives |
 |---|---|
-| Compounding ("gets better with use"): cold→warm lift under replayed co-recall traffic | [#969](https://github.com/kagura-ai/memory-cloud/issues/969) |
+| Compounding ("gets better with use"): cold→warm lift under replayed co-recall traffic | [`retrieval-compounding.md`](retrieval-compounding.md) ([#969](https://github.com/kagura-ai/memory-cloud/issues/969)) |
 | Wiring the live measurement into CI as an automated gate | [#336](https://github.com/kagura-ai/memory-cloud/issues/336) |
 | Human-labeled gold set (inter-annotator agreement) to make absolute numbers publishable | [#375](https://github.com/kagura-ai/memory-cloud/issues/375) |
 | Harness internals: corpus, buckets, leakage rules, stratification, statistical do/don't | [`backend/tests/eval/README.md`](../../backend/tests/eval/README.md) |

--- a/docs/eval/retrieval-compounding.md
+++ b/docs/eval/retrieval-compounding.md
@@ -1,0 +1,133 @@
+# Retrieval Compounding Experiment (Issue #969)
+
+The Tier B companion to the [#967 multi-arm benchmark](retrieval-benchmark.md):
+that benchmark proves what each retrieval layer adds on a *cold* corpus; this
+experiment asks whether retrieval quality **compounds with use** — does driving
+real recall traffic through a context measurably improve later retrieval?
+
+> **Read the lift deltas, not the absolute values** — same publication policy
+> as the Tier A benchmark. The corpus is held fixed throughout, so any warm
+> lift is attributable to the learned layer, never to "more data".
+
+## What is measured, and where
+
+Per the Issue #120 architecture decision (deliberate, decision-pinned), the
+neural graph is **written** by `recall()` (co-activation → Hebbian edge
+updates) but **read** by `explore()` (activation spreading) — graph signals
+are kept out of `recall()` ranking because mixing them in degrades precision.
+Compounding therefore has to be measured on the surface that reads the
+learned layer:
+
+| Lane | Surface | Metric | Expectation |
+|---|---|---|---|
+| **graph lane** (primary) | `explore()` from a probe's seed gold doc | companion `recovery@5/10`, MRR@10 | this is where lift can appear |
+| **recall lane** (control) | hybrid `recall()`, neural off | P@5/10, MRR@10, nDCG@5/10 | flat by design — movement = regression |
+
+Probes are the 5 multi-gold `cross-source` queries of the frozen corpus: only
+a multi-doc gold set can show "the graph learned that these belong together".
+
+## Protocol
+
+Per replay mode, in an isolated throwaway workspace:
+
+```
+ingest (16 docs) → COLD checkpoint
+                 → replay traffic: recall() × 8 rounds, ENABLE_NEURAL_MEMORY=true
+                 → WARM_REPLAY checkpoint
+                 → Sleep edges_only consolidation (no-LLM auto-accept judge)
+                 → WARM_SLEEP checkpoint → lift tables
+```
+
+- `exclude_probes`: probes never appear in replay traffic — lift measures
+  **generalization** from related traffic.
+- `include_probes`: every query replayed — the production reality
+  (**rehearsal**: users re-ask the questions that matter to them).
+
+Checkpoints are read-only w.r.t. the graph and snapshot per-origin edge
+counts, so lift attribution is mechanical: `hebbian` edges come from replay,
+`semantic` edges from Sleep.
+
+## Result — 2026-06-10 run
+
+Frozen corpus v1, `recall k=10`, 8 replay rounds (200/240 recalls per mode),
+embedding `text-embedding-3-small` (512 dims). Source:
+[`backend/tests/eval/results/compounding-2026-06-10.json`](../../backend/tests/eval/results/compounding-2026-06-10.json).
+
+**Retrieval does not yet compound with use — and the experiment can say
+exactly why.**
+
+| Checkpoint | graph-lane recovery@10 | recall-lane nDCG@10 | hebbian edges |
+|---|---|---|---|
+| cold | 0.0 | 0.9707 | 0 |
+| warm_replay | 0.0 | 0.9707 | 6 |
+| warm_sleep | 0.0 | 0.9707 | 6 |
+
+(Both modes identical on these figures.)
+
+### Attribution (the gate audit)
+
+The mechanism itself **works**: replay traffic created Hebbian edges (6 rows,
+avg weight ~0.33–0.37 after 8 rounds) wherever the write-path gates allowed.
+The zero lift is fully explained by two gates in `recall()`'s Hebbian write
+path:
+
+1. **Semantic gate** (`min_similarity_for_edge = 0.5`): a co-activated pair
+   only forms an edge if its embedding cosine reaches 0.5. On this corpus,
+   inter-doc cosine runs ≈0.1–0.5 under `text-embedding-3-small`, so 80–91%
+   of co-activated pair observations are gated. Critically, **every probe
+   gold pair was co-recalled with healthy Hebbian Δw (0.014–0.036, well above
+   the prune floor) and 100% of them were cosine-gated** (their cosines:
+   0.37–0.40). Cross-topic associations — exactly the pairs where a learned
+   layer would add value over similarity search — are exactly the pairs the
+   anti-noise gate rejects.
+2. **Prune cliff** (`prune_threshold = 0.01`): a first update below the
+   threshold deletes the edge instead of storing it, so sub-threshold pairs
+   can never accumulate across rounds. A secondary effect here (~12% of
+   pairs), but it converts "slowly learnable" into "never learnable".
+
+The Sleep `edges_only` pass found `no_edge_candidates` on this corpus (its
+mid-similarity candidate band sits above the corpus's inter-doc cosine), so
+the Sleep increment is also zero — recorded, not assumed.
+
+### What this does and does not say
+
+- It does **not** say the Hebbian mechanism is broken — edges form and
+  persist (post-#970 the half-life is 14 days) where the gates pass.
+- It does **not** say the gate is wrong — `min_similarity_for_edge` is a
+  deliberate anti-noise device (Issue #118). It says the **absolute 0.5
+  threshold is not calibrated to the embedding model's similarity
+  distribution**, the same class of problem #240 solved for k-NN seeding
+  with percentile calibration.
+- It **does** say that under today's defaults, co-recall traffic cannot grow
+  the cross-topic associations that would make retrieval compound — on this
+  corpus and, by the same cosine argument, on any corpus whose related-but-
+  distinct docs sit below 0.5 cosine.
+- The recall lane stayed exactly flat across all checkpoints in both modes —
+  the warming traffic causes **no precision regression**, confirming the
+  Issue #120 separation does its job.
+
+## Reproduce it
+
+```bash
+# 1. Stack up (Postgres + Qdrant + Redis) and schema current:
+make up
+cd backend && alembic upgrade head && cd ..
+
+# 2. Deterministic layer (no infra — plan/metric/lift/audit logic):
+cd backend && pytest tests/eval/test_compounding.py -q && cd ..
+
+# 3. Live experiment (writes backend/tests/eval/results/compounding-<date>.json):
+make eval-compounding
+```
+
+Numbers are never fabricated — a results JSON exists only if a real run
+produced it.
+
+## Scope boundaries
+
+| Concern | Where it lives |
+|---|---|
+| Static layer-by-layer quality on the cold corpus | [#967 benchmark](retrieval-benchmark.md) |
+| Calibrating the semantic gate per embedding model (percentile-based, cf. #240) | follow-up filed from this experiment |
+| Recall-feedback labels to replace synthetic gold | [#344](https://github.com/kagura-ai/memory-cloud/issues/344) / [#375](https://github.com/kagura-ai/memory-cloud/issues/375) |
+| Harness internals (corpus, buckets, leakage, protocol details) | [`backend/tests/eval/README.md`](../../backend/tests/eval/README.md) |


### PR DESCRIPTION
Closes #969

## Summary

Tier B companion to the #967 multi-arm benchmark (PR #978): a controlled, reproducible **cold→replay→warm experiment** measuring whether retrieval quality compounds as a context is used.

Per the Issue #120 decision (neural graph is *written* by `recall()`, *read* by `explore()`), the experiment measures two lanes per checkpoint:

- **graph lane** (primary): companion `recovery@k`/MRR via `explore()` activation spreading from a probe's seed gold doc — where lift can appear
- **recall lane** (control): hybrid `recall()` P@5/MRR/nDCG with neural off — flat by design; movement = regression

Protocol per replay mode (`exclude_probes` = generalization, `include_probes` = rehearsal), each in a throwaway workspace, corpus held fixed:

```
ingest → COLD → replay recall() × 8 rounds (neural ON) → WARM_REPLAY
       → Sleep edges_only → WARM_SLEEP → per-lane lift tables
```

## First result (2026-06-10, committed)

**Zero graph-lane lift — fully attributed by the gate audit.** Every probe gold pair was co-recalled with healthy Hebbian Δw (0.014–0.036), but 100% were rejected by the semantic gate: pair cosines 0.37–0.40 vs `min_similarity_for_edge=0.5` under text-embedding-3-small. The recall lane stayed exactly flat (no precision regression). A follow-up issue for percentile-based gate calibration (cf. #240) is being filed separately.

## Changes

- `backend/tests/eval/compounding.py` — pure, CI-safe experiment logic (replay plan, companion-recovery metric, lift tables, gate audit)
- `backend/tests/eval/replay_runner.py` — live orchestration; `make eval-compounding`
- `backend/tests/eval/test_compounding.py` — 55 deterministic tests (run in CI); `test_compounding_live.py` skip-guarded behind `KAGURA_EVAL_LIVE=1`
- `backend/tests/eval/results/compounding-2026-06-10.json` — real run output (never fabricated)
- `docs/eval/retrieval-compounding.md` — protocol, lift tables, attribution, scope boundaries

## Test plan

- [x] `pytest tests/eval/ -q` → 55 passed, live tests skip-guarded
- [x] Full local suite: 3322 passed, 8 skipped, 15 xfailed
- [x] `ruff` clean on changed files; `pyright src/` unchanged vs main (branch touches no src/)
- [x] Live experiment executed end-to-end (results JSON in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)