### PR TITLE
feat(api): codify raw-vs-derived data boundary + CI guard (#968)

### DIFF
--- a/.claude/commands/self-review.md
+++ b/.claude/commands/self-review.md
@@ -84,13 +84,21 @@ git diff main...HEAD | grep -ni 'api_key\s*=\s*"\|password\s*=\s*"\|secret\s*=\s
 - Enum value removed (existing DB data may reference it)?
 - New env vars added → `.env.example` updated?
 
-### 8. Performance
+### 8. Derived-layer boundary (if storage/export/Sleep/edges changed)
+
+See `docs/derived-layer-boundary.md` — raw memories are exportable; the derived/learned layer is the moat.
+
+- **(a) No leakage**: derived signal (edge weights/origins, calibration values, Sleep results, computed clusters/hubs) does NOT move onto the raw-export surface
+- **(b) Genuine accrual**: new derived state genuinely compounds with use (strengthened/recalibrated/consolidated over time), not a static cache of raw data
+- New tables classified in `backend/src/models/data_boundary.py`? New export-shaped schemas added to `EXPORT_SURFACE_SCHEMA_NAMES`?
+
+### 9. Performance
 
 - Large datasets in arrays? (stream/paginate instead)
 - External API calls inside loops?
 - New blocking work on startup or per-request hot path?
 
-### 9. Frontend (if changed)
+### 10. Frontend (if changed)
 
 - **Dark mode**: `dark:` prefixes on new elements?
 - **i18n**: `useTranslations()` not hardcoded strings?
@@ -98,7 +106,7 @@ git diff main...HEAD | grep -ni 'api_key\s*=\s*"\|password\s*=\s*"\|secret\s*=\s
 - **Loading/Error states**: data fetching has spinner and error display?
 - **Accessibility**: interactive elements have `aria-label`?
 
-### 10. Standards
+### 11. Standards
 
 ```bash
 git diff main...HEAD | grep -n '^\+.*\(print(\|console\.log\)'
@@ -107,19 +115,19 @@ git diff main...HEAD | grep -n '^\+.*\(print(\|console\.log\)'
 - Backend: snake_case, type hints, structlog logger
 - Frontend: PascalCase, no `any` type
 
-### 11. Dependencies (if changed)
+### 12. Dependencies (if changed)
 
 - License compatibility (MIT/Apache OK, GPL needs review)
 - Actively maintained? (last release < 1 year)
 - Version pinned appropriately?
 
-### 12. Testing
+### 13. Testing
 
 - Sufficient coverage for new code?
 - Edge cases covered?
 - Existing tests pass? (`make test-unit`)
 
-### 13. Excessive changes
+### 14. Excessive changes
 
 - Changes minimal and focused?
 - No "while I'm here" refactoring of unrelated code?
@@ -150,6 +158,7 @@ git diff main...HEAD | grep -n '^\+.*\(print(\|console\.log\)'
 | DB & Migrations | ✅ / ⚠️ / ❌ |
 | Integration paths | ✅ / ⚠️ / ❌ |
 | Breaking changes | ✅ / ⚠️ / ❌ |
+| Derived-layer boundary | ✅ / ⚠️ / ❌ / N/A |
 | Performance | ✅ / ⚠️ / ❌ |
 | Frontend | ✅ / ⚠️ / ❌ / N/A |
 | Standards | ✅ / ⚠️ / ❌ |

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -1,0 +1,146 @@
+"""Raw-vs-derived data boundary registry (Issue #968, moat lever M2).
+
+The rule: **raw memories are exportable; the derived/learned layer is the
+moat and is what compounds with use.** Raw artifacts (user-authored text,
+tags, provenance) must be fully portable — GDPR/JSON export (#950) covers
+them. Derived artifacts (Hebbian edge weights, embedding calibration,
+Sleep-consolidated structure) are platform-learned and must never move onto
+the raw-export surface.
+
+This module is the machine-readable half of that rule; the prose half lives
+in ``docs/derived-layer-boundary.md``. ``tests/test_derived_layer_boundary.py``
+enforces both: every ORM table must appear in exactly one of the three sets
+below, and the export-surface schemas must never grow a derived-only field.
+
+When you add a table, classify it here deliberately:
+
+- ``RAW_EXPORTABLE_TABLES`` — user-authored or user-ingested content and its
+  provenance. The user can take this with them; losing it loses nothing the
+  platform learned.
+- ``DERIVED_MOAT_TABLES`` — structure the platform computed or learned from
+  usage. Cannot be reconstructed from a raw export; accrues value with use.
+- ``OPERATIONAL_TABLES`` — platform plumbing (auth, billing, quotas, audit,
+  infra state). Neither raw content nor learned structure; governed by its
+  own regimes (auth/security, GDPR erasure, cost accounting).
+"""
+
+from __future__ import annotations
+
+RAW_EXPORTABLE_TABLES: frozenset[str] = frozenset(
+    {
+        "memories",  # L1/L2/L3 text, tags, importance, source provenance
+        "attachments",  # user file metadata (blobs in R2)
+        "file_objects",  # R2 object records for user uploads (#485)
+        "agent_states",  # user-set key/value run state (#889)
+        "contexts",  # user-authored container name/description
+        "resources",  # connected source-of-truth resources
+        "resource_events",  # ingested raw source events
+        "resource_schemas",  # user-registered resource schemas
+    }
+)
+
+DERIVED_MOAT_TABLES: frozenset[str] = frozenset(
+    {
+        "neural_memory_edges",  # Hebbian/semantic edge weights + origin
+        "graph_memory",  # legacy NetworkX graph JSON storage
+        "embedding_calibrations",  # similarity percentile calibration (p25–p99)
+        "neural_config",  # neural tuning parameters
+        "sleep_reports",  # Sleep consolidation phase results
+        "sleep_actions",  # individual consolidation decisions
+        "hub_tag_cache",  # computed tag co-occurrence hubs
+        "memory_analyses",  # Broadlistening analysis runs
+        "memory_analysis_assignments",  # memory→cluster assignments
+        "memory_analysis_clusters",  # computed cluster structure
+        "retrieval_feedback",  # learning signal (content-reuse policy: feedback only)
+        "bm25_idf_drift_log",  # corpus-derived index statistics
+    }
+)
+
+OPERATIONAL_TABLES: frozenset[str] = frozenset(
+    {
+        "users",
+        "user_oauth_providers",
+        "oauth_authorization_codes",
+        "oauth_clients",
+        "oauth_device_codes",
+        "oauth_tokens",
+        "api_keys",
+        "external_api_keys",
+        "workspaces",
+        "workspace_members",
+        "workspace_invitations",
+        "workspace_addons",
+        "workspace_connectors",
+        "workspace_storage_usage",
+        "context_members",
+        "context_search_configs",
+        "plan_changes",
+        "usage_stats",
+        "audit_logs",
+        "erasure_requests",
+        "signup_allowlist",
+        "signup_gate_config",
+        "config_overrides",
+        "llm_call_log",
+        "llm_pricing",
+        "mcp_tool_descriptions",
+        "indexer_state",
+        "resource_tokens",
+        "sleep_report_llm_usage",  # cost telemetry, not consolidation output
+    }
+)
+
+# Field names that exist only on derived-layer artifacts. They must never
+# appear on an export-surface schema — exporting them would leak the learned
+# structure (edge weights/decay behavior, calibration thresholds, Sleep
+# decisions) into the portable layer.
+DERIVED_ONLY_FIELD_NAMES: frozenset[str] = frozenset(
+    {
+        "weight",  # edge co-activation strength (see exception below)
+        "activation",  # spreading-activation strength (serving-only)
+        "origin",  # hebbian/semantic/declared discriminator → leaks decay rules
+        "edge_metadata",
+        "p25",
+        "p50",
+        "p75",
+        "p90",
+        "p95",
+        "p99",
+        "edge_discovery_result",
+        "dedup_result",
+        "importance_result",
+        "consolidation_result",
+        "reindex_result",
+        "hub_tags",
+        "threshold_used",
+    }
+)
+
+# Pydantic schemas in models/schemas.py that form the raw-export surface:
+# the user-facing memory read/write shapes a portability export (#950) would
+# be built from. The serving surfaces (explore()'s RelatedMemoryResponse,
+# ExploreResponse) are deliberately NOT listed — derived signal is allowed
+# to annotate per-query serving responses; it is bulk export that is banned.
+# See docs/derived-layer-boundary.md.
+EXPORT_SURFACE_SCHEMA_NAMES: frozenset[str] = frozenset(
+    {
+        "MemoryResponse",
+        "RecallResponse",
+        "ReferenceResponse",
+        "LinkedMemoryRef",
+        "PinnedMemoryItem",
+        "RelatedTagItem",
+        "RememberResponse",
+        "UpdateMemoryResponse",
+    }
+)
+
+# Documented exceptions to the derived-field ban, schema name → field names.
+# LinkedMemoryRef.weight: reference() surfaces declared (user-authored) links
+# only, and the user set the initial weight at create_edge. The live value
+# can carry a Hebbian-strengthened component (the edge row is shared per
+# ordered pair), which is accepted for declared links — but new export
+# surfaces must not copy this exception without the same justification.
+EXPORT_SURFACE_FIELD_EXCEPTIONS: dict[str, frozenset[str]] = {
+    "LinkedMemoryRef": frozenset({"weight"}),
+}

--- a/backend/tests/test_derived_layer_boundary.py
+++ b/backend/tests/test_derived_layer_boundary.py
@@ -1,0 +1,155 @@
+"""Executable guard for the raw-vs-derived data boundary (Issue #968).
+
+Moat lever M2: raw memories (user-authored text, tags, provenance) are
+exportable; the derived/learned layer (Hebbian edge weights, embedding
+calibration, Sleep-consolidated structure) is the moat and must never leak
+into the raw-export surface.
+
+The boundary itself lives in three places, and this module pins all of them:
+
+1. ``models.data_boundary`` — the machine-readable classification registry.
+   Every ORM table must be classified into exactly one bucket (raw /
+   derived / operational), so any NEW table fails this suite until its
+   author makes the boundary call explicitly.
+2. ``docs/derived-layer-boundary.md`` — the design doc stating the rule and
+   enumerating the boundary-relevant artifacts. The doc-drift tests keep it
+   in sync with the registry.
+3. ``.claude/commands/self-review.md`` — the feature-review checklist item
+   that asks the two boundary questions on every storage/export/Sleep/edge
+   change.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Import every model module so Base.metadata is fully populated. Mirrors the
+# explicit-import pattern in conftest.py / models/__init__.py (#531): the
+# package __init__ alone does not register memories/auth/hub_tag/etc.
+import models  # noqa: F401
+import models.auth  # noqa: F401
+import models.bm25_drift  # noqa: F401
+import models.config  # noqa: F401
+import models.erasure  # noqa: F401
+import models.hub_tag  # noqa: F401
+import models.memory  # noqa: F401
+import models.neural  # noqa: F401
+import models.resource  # noqa: F401
+import models.signup_gate  # noqa: F401
+from db.base import Base
+from models import schemas
+from models.data_boundary import (
+    DERIVED_MOAT_TABLES,
+    DERIVED_ONLY_FIELD_NAMES,
+    EXPORT_SURFACE_FIELD_EXCEPTIONS,
+    EXPORT_SURFACE_SCHEMA_NAMES,
+    OPERATIONAL_TABLES,
+    RAW_EXPORTABLE_TABLES,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DESIGN_DOC = REPO_ROOT / "docs" / "derived-layer-boundary.md"
+SELF_REVIEW_CHECKLIST = REPO_ROOT / ".claude" / "commands" / "self-review.md"
+
+
+class TestTableClassification:
+    """Every ORM table must carry an explicit boundary classification."""
+
+    def test_every_table_is_classified(self) -> None:
+        actual = set(Base.metadata.tables.keys())
+        classified = RAW_EXPORTABLE_TABLES | DERIVED_MOAT_TABLES | OPERATIONAL_TABLES
+
+        unclassified = actual - classified
+        assert not unclassified, (
+            f"Tables missing a boundary classification in models/data_boundary.py: "
+            f"{sorted(unclassified)}. For each new table decide: is it raw "
+            f"user-authored content (RAW_EXPORTABLE_TABLES), learned/derived "
+            f"structure (DERIVED_MOAT_TABLES), or platform plumbing "
+            f"(OPERATIONAL_TABLES)? See docs/derived-layer-boundary.md."
+        )
+
+        stale = classified - actual
+        assert not stale, (
+            f"models/data_boundary.py classifies tables that no longer exist: "
+            f"{sorted(stale)}. Remove them from the registry (and from "
+            f"docs/derived-layer-boundary.md)."
+        )
+
+    def test_classifications_are_disjoint(self) -> None:
+        assert not RAW_EXPORTABLE_TABLES & DERIVED_MOAT_TABLES
+        assert not RAW_EXPORTABLE_TABLES & OPERATIONAL_TABLES
+        assert not DERIVED_MOAT_TABLES & OPERATIONAL_TABLES
+
+
+class TestExportSurface:
+    """Derived-only signal must never appear on user-facing memory schemas."""
+
+    def test_export_surface_schemas_exist(self) -> None:
+        missing = [name for name in EXPORT_SURFACE_SCHEMA_NAMES if not hasattr(schemas, name)]
+        assert not missing, (
+            f"EXPORT_SURFACE_SCHEMA_NAMES references schemas that do not exist "
+            f"in models/schemas.py: {missing}"
+        )
+
+    def test_no_derived_fields_on_export_schemas(self) -> None:
+        leaks: dict[str, list[str]] = {}
+        for name in EXPORT_SURFACE_SCHEMA_NAMES:
+            schema_cls = getattr(schemas, name)
+            allowed = EXPORT_SURFACE_FIELD_EXCEPTIONS.get(name, frozenset())
+            leaked = sorted((set(schema_cls.model_fields) & DERIVED_ONLY_FIELD_NAMES) - allowed)
+            if leaked:
+                leaks[name] = leaked
+        assert not leaks, (
+            f"Derived-layer fields leaked onto the raw-export surface: {leaks}. "
+            f"Edge weight/origin, calibration percentiles, and Sleep "
+            f"consolidation results are the moat — they must not be exported. "
+            f"See docs/derived-layer-boundary.md."
+        )
+
+
+class TestDesignDoc:
+    """docs/derived-layer-boundary.md must exist and stay in sync."""
+
+    def test_doc_exists(self) -> None:
+        assert DESIGN_DOC.is_file(), (
+            "docs/derived-layer-boundary.md is missing — it is the canonical "
+            "statement of the raw-vs-derived boundary (Issue #968)."
+        )
+
+    def test_doc_states_the_rule(self) -> None:
+        text = DESIGN_DOC.read_text(encoding="utf-8").lower()
+        for keyword in ("raw", "exportable", "derived", "moat", "compound"):
+            assert keyword in text, (
+                f"Design doc no longer states the boundary rule (missing keyword {keyword!r})."
+            )
+
+    def test_doc_enumerates_boundary_tables(self) -> None:
+        """Every raw and derived table must be named in the doc (drift guard).
+
+        Operational tables are exempt — they are listed only in the registry.
+        """
+        text = DESIGN_DOC.read_text(encoding="utf-8")
+        missing = [
+            t for t in sorted(RAW_EXPORTABLE_TABLES | DERIVED_MOAT_TABLES) if f"`{t}`" not in text
+        ]
+        assert not missing, (
+            f"Boundary-relevant tables not documented in "
+            f"docs/derived-layer-boundary.md: {missing}. When classifying a "
+            f"table as raw or derived, add it to the doc's enumeration."
+        )
+
+
+class TestFeatureReviewChecklist:
+    """self-review must ask the two boundary questions (Issue #968 item 2)."""
+
+    def test_checklist_has_boundary_section(self) -> None:
+        text = SELF_REVIEW_CHECKLIST.read_text(encoding="utf-8")
+        assert "derived-layer-boundary" in text, (
+            ".claude/commands/self-review.md lost the derived-layer boundary "
+            "checklist item (must reference docs/derived-layer-boundary.md)."
+        )
+        # The two mandated questions: (a) no derived signal on the raw-export
+        # surface, (b) derived signal genuinely accrues with use.
+        lowered = text.lower()
+        assert "export" in lowered and "derived" in lowered
+        assert "accrue" in lowered or "compound" in lowered

--- a/backend/tests/test_derived_layer_boundary.py
+++ b/backend/tests/test_derived_layer_boundary.py
@@ -23,19 +23,28 @@ from __future__ import annotations
 
 from pathlib import Path
 
-# Import every model module so Base.metadata is fully populated. Mirrors the
-# explicit-import pattern in conftest.py / models/__init__.py (#531): the
-# package __init__ alone does not register memories/auth/hub_tag/etc.
+# Import every model module so Base.metadata is fully populated, without
+# relying on the side-effect imports inside models/__init__.py (#531). The
+# explicit list keeps this guard self-sufficient: a table only escapes
+# classification if its module is imported nowhere at all. Same canonical
+# module set as tests/test_schema_drift.py's _MODEL_MODULES.
 import models  # noqa: F401
+import models.agent_state  # noqa: F401
+import models.analysis  # noqa: F401
 import models.auth  # noqa: F401
 import models.bm25_drift  # noqa: F401
 import models.config  # noqa: F401
 import models.erasure  # noqa: F401
+import models.file_objects  # noqa: F401
 import models.hub_tag  # noqa: F401
+import models.llm_call_log  # noqa: F401
+import models.llm_pricing  # noqa: F401
 import models.memory  # noqa: F401
 import models.neural  # noqa: F401
 import models.resource  # noqa: F401
+import models.retrieval_feedback  # noqa: F401
 import models.signup_gate  # noqa: F401
+import models.sleep  # noqa: F401
 from db.base import Base
 from models import schemas
 from models.data_boundary import (

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@
 
 - [Architecture](architecture.md) — System design, data flow, and tech stack (incl. **LLM Knowledge Base 5-layer mapping**)
 - [API Reference](api-reference.md) — REST API endpoints, authentication, request/response examples
+- [Derived-Layer Boundary](derived-layer-boundary.md) — Design rule: raw memories are exportable, the derived/learned layer is the moat (table classification + feature-review checklist)
 
 ## Guides
 

--- a/docs/derived-layer-boundary.md
+++ b/docs/derived-layer-boundary.md
@@ -113,7 +113,7 @@ justification (registered in `EXPORT_SURFACE_FIELD_EXCEPTIONS`).
 ## Feature-review checklist
 
 For any feature touching **storage, export, Sleep, or edges**, answer both
-in the PR (also wired into `.claude/commands/self-review.md`, step 7):
+in the PR (also wired into `.claude/commands/self-review.md`, step 8):
 
 - [ ] **(a) No leakage** — the change does not move derived signal
   (edge weights/origins, calibration values, Sleep results, computed

--- a/docs/derived-layer-boundary.md
+++ b/docs/derived-layer-boundary.md
@@ -1,0 +1,132 @@
+# Derived-Layer Boundary: raw is exportable, derived is the moat
+
+- **Issue**: [#968](https://github.com/kagura-ai/memory-cloud/issues/968) (moat lever M2)
+- **Status**: Adopted
+- **Enforced by**: `backend/src/models/data_boundary.py` + `backend/tests/test_derived_layer_boundary.py`
+- **Last updated**: 2026-06-11
+
+## The rule
+
+> **Raw memories are exportable; the derived/learned layer is the moat and is
+> what compounds with use.**
+
+Raw memories are commodity text. Users own them, and they are (rightly)
+portable via the GDPR/JSON export work (#950). The defensible asset is the
+**derived layer**: per-context Hebbian edge weights, embedding/importance
+calibration, neural co-recall tuning, and Sleep-consolidated structure. That
+layer cannot be reproduced by exporting raw text, and it gets better the
+longer a context is used.
+
+Every feature touching storage, export, Sleep, or edges must keep these two
+properties simultaneously true:
+
+1. **No leakage**: derived signal never moves onto the raw-export surface.
+2. **Genuine accrual**: derived signal actually compounds with use — a
+   "derived" artifact that is a pure function of the raw data at rest is not
+   a moat, it is a cache.
+
+## Layer definitions
+
+| Layer | Definition | Portability |
+|-------|------------|-------------|
+| **Raw** | Content the user authored or ingested, plus its provenance. Recomputable by nobody — it *is* the user's data. | Fully exportable (#950). Erasable under GDPR (#360). |
+| **Derived** | Structure the platform computed or learned **from usage**: co-activation, recall patterns, consolidation decisions, calibration. | Never exported. Erased with the account, but not portable. |
+| **Operational** | Platform plumbing: auth, billing, quotas, audit, infra state. | Neither; governed by its own regimes (security, GDPR erasure, cost accounting). |
+
+The machine-readable classification of **every** database table lives in
+`backend/src/models/data_boundary.py`. A CI guard
+(`backend/tests/test_derived_layer_boundary.py`) fails when a new table is
+added without a classification, so the boundary decision is forced at
+feature-development time, not discovered at export time.
+
+## Artifact enumeration
+
+### Raw (exportable)
+
+| Table | What it holds |
+|-------|---------------|
+| `memories` | L1 `summary`, L2 `context_summary`, L3 `content`/`details`, `tags`, `type`, `scope`, user-set `importance`/`confidence`, provenance (`source`, `source_type`, `source_uri`), timestamps |
+| `attachments` | User file metadata (filename, content type, size) |
+| `file_objects` | R2 object records for user uploads (#485) |
+| `agent_states` | User-set key/value run state (#889) |
+| `contexts` | User-authored container name/description |
+| `resources` | Connected source-of-truth resources |
+| `resource_events` | Ingested raw source events |
+| `resource_schemas` | User-registered resource schemas |
+
+Also raw: **declared edges** — links the user explicitly created via
+`create_edge` (rows in `neural_memory_edges` with `origin='declared'`). The
+link topology and its user-set initial weight are user-authored data.
+
+### Derived (the moat — never exported)
+
+| Table | What it holds | Why it compounds |
+|-------|---------------|------------------|
+| `neural_memory_edges` | Hebbian (`origin='hebbian'`) and semantic (`origin='semantic'`) edge `weight`, `origin`, `confidence`, `edge_metadata` | Strengthened by co-recall, decayed nightly; encodes how *this* context is actually used |
+| `graph_memory` | Legacy NetworkX graph JSON | Same learned graph, earlier storage format |
+| `embedding_calibrations` | Top-k similarity percentiles (`p25`–`p99`), sample size, TTL | Recalibrated as the corpus grows; tunes seeding thresholds per workspace |
+| `neural_config` | Neural tuning parameters | Operator/learned tuning of the learning loop itself |
+| `sleep_reports` | Per-phase Sleep results (`edge_discovery_result`, `dedup_result`, `importance_result`, `consolidation_result`, `reindex_result`) | Consolidation history; each run builds on prior structure |
+| `sleep_actions` | Individual consolidation decisions (merges, promotions, flags) | Same |
+| `hub_tag_cache` | Computed tag co-occurrence hubs (`hub_tags`, `threshold_used`) | Recomputed nightly from observed tag usage |
+| `memory_analyses` / `memory_analysis_assignments` / `memory_analysis_clusters` | Broadlistening cluster structure | Computed structure over the corpus |
+| `retrieval_feedback` | Recall feedback signal (#888) | The only sanctioned learning input under the content-reuse policy |
+| `bm25_idf_drift_log` | Corpus-derived index statistics | Tracks how the lexical index adapts to the corpus |
+
+Ephemeral derived state also exists outside the DB: Redis
+`co_activations:{user_id}` keys (in-flight Hebbian co-activation sums). Same
+rule applies — serving-only, never exported.
+
+### Why exporting derived fields leaks the moat
+
+- `weight` + `origin` together let a client replay the Hebbian decay schedule
+  and reconstruct the learned graph offline.
+- Calibration percentiles (`p25`–`p99`) reverse-engineer the similarity
+  thresholds that make seeding precise per-corpus.
+- Sleep phase results expose consolidation decisions (what was merged,
+  promoted, re-weighted) — the distilled output of the maintenance loop.
+
+## Export surface vs serving surface
+
+Derived signal is *supposed* to act on every query — that is its value. The
+ban is on **bulk portability**, not on serving:
+
+- **Export surface** (raw): `MemoryResponse`, `RecallResponse`,
+  `ReferenceResponse`, `LinkedMemoryRef`, `PinnedMemoryItem`,
+  `RelatedTagItem`, `RememberResponse`, `UpdateMemoryResponse` — and any
+  future #950 export format. These must never grow a derived-only field.
+  Enforced by `test_no_derived_fields_on_export_schemas`.
+- **Serving surface** (derived-annotated): `explore()`'s
+  `RelatedMemoryResponse` exposes per-query `activation` and `weight`;
+  `recall()` exposes a transient `score`. These are query-scoped, ranked
+  annotations — acceptable. A new endpoint that returns derived values
+  *in bulk* (e.g. "list all edges with weights") is an export in disguise
+  and crosses the boundary.
+
+**Documented exception**: `LinkedMemoryRef.weight`. `reference()` surfaces
+declared (user-authored) links only, and the user set the initial weight at
+`create_edge`. Because edge rows are unique per ordered pair, the live value
+can carry a Hebbian-strengthened component; this is accepted for declared
+links. New surfaces must not copy this exception without the same
+justification (registered in `EXPORT_SURFACE_FIELD_EXCEPTIONS`).
+
+## Feature-review checklist
+
+For any feature touching **storage, export, Sleep, or edges**, answer both
+in the PR (also wired into `.claude/commands/self-review.md`, step 7):
+
+- [ ] **(a) No leakage** — the change does not move derived signal
+  (edge weights/origins, calibration values, Sleep results, computed
+  clusters/hubs) onto the raw-export surface. New tables are classified in
+  `backend/src/models/data_boundary.py`; new export-shaped schemas are added
+  to `EXPORT_SURFACE_SCHEMA_NAMES` so the leak guard covers them.
+- [ ] **(b) Genuine accrual** — if the change adds derived state, that state
+  actually compounds with use (strengthened/recalibrated/consolidated by
+  usage over time), rather than being a static cache of the raw data.
+
+## Why now
+
+Pre-1.0 API freeze (#622) and export (#950) are both in flight. This boundary
+is set deliberately before either solidifies, so export ships maximally
+portable raw data without ever shipping the learned layer, and so new
+derived features are designed to compound rather than to cache.


### PR DESCRIPTION
## Summary

Implements moat lever M2 (#968): makes the implicit "raw memories are exportable; the derived/learned layer is the moat" rule explicit, machine-readable, and CI-enforced — before the pre-1.0 API freeze (#622) and export (#950) solidify.

- **`docs/derived-layer-boundary.md`** — the design rule, full raw/derived/operational artifact enumeration (every table named), the export-surface vs serving-surface distinction (explore()'s per-query `activation`/`weight` annotations are serving, not export), and the documented `LinkedMemoryRef.weight` exception for declared links.
- **`backend/src/models/data_boundary.py`** — classification registry: `RAW_EXPORTABLE_TABLES` / `DERIVED_MOAT_TABLES` / `OPERATIONAL_TABLES`, `DERIVED_ONLY_FIELD_NAMES`, `EXPORT_SURFACE_SCHEMA_NAMES`, `EXPORT_SURFACE_FIELD_EXCEPTIONS`.
- **`backend/tests/test_derived_layer_boundary.py`** — executable guard (8 tests, TDD-first):
  - every ORM table must be classified in exactly one bucket → a **new table fails CI until its author makes the boundary call**;
  - export-surface schemas can never grow a derived-only field (edge `weight`/`origin`, calibration `p25`–`p99`, Sleep phase results, hub-tag fields);
  - doc and self-review checklist are drift-pinned to the registry.
- **`.claude/commands/self-review.md` step 8** — the feature-review checklist item: for storage/export/Sleep/edges changes, confirm **(a)** no derived signal moves onto the raw-export surface and **(b)** new derived state genuinely accrues with use.

## Verification

- `pytest --ignore=tests/e2e --ignore=tests/integration`: **3330 passed, 8 skipped, 15 xfailed**
- `make lint`: clean
- New suite red→green via TDD (registry, doc, checklist each written against a failing assertion)

Closes #968

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask
- review provider: code-review

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/968-feat-moat-design-codify-the-derived-layer-moa.gate1.md
- ~/.claude/cache/gh-issue-driven/968-feat-moat-design-codify-the-derived-layer-moa.gate2.md

🤖 Generated via /gh-issue-driven:ship
