### PR TITLE
feat(api): per-model calibration of min_similarity_for_edge (#982)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -257,6 +257,7 @@ next-env.d.ts
 .claude/settings.local.json
 .claude/scheduled_tasks.lock
 .claude/worktrees/
+.claude/launch.json
 *.bak.*
 backend/=*
 backend/uv.lock

--- a/backend/alembic/versions/e38_982_edge_gate_kind.py
+++ b/backend/alembic/versions/e38_982_edge_gate_kind.py
@@ -1,0 +1,116 @@
+"""Add ``kind`` to embedding_calibrations for edge-gate calibration (#982).
+
+Issue #982 (follow-up to #969): calibrate ``min_similarity_for_edge`` (the
+co-activation / Hebbian semantic gate, #118) per embedding model instead of
+the absolute 0.5 default that the #969 compounding experiment showed rejects
+genuine cross-topic pairs (cosines 0.37-0.40 under text-embedding-3-small).
+
+The edge gate is calibrated against the RANDOM-PAIR cosine distribution, which
+is a different population from the top-k neighbor distribution that #406 stores
+for knn-seed calibration. Rather than a parallel table, we tag rows with a
+``kind`` so a single ``(model_name, dimensions)`` pair can hold one row of each
+distribution:
+
+- ``knn_seed``  = top-k neighbor distribution (#406, pre-existing rows)
+- ``edge_gate`` = random-pair distribution (this issue)
+
+Changes:
+
+1. Add ``kind VARCHAR(16) NOT NULL DEFAULT 'knn_seed'``. The default backfills
+   every pre-#982 row to ``knn_seed``, preserving their meaning — the runtime
+   ``resolve_knn_threshold`` now filters ``kind = 'knn_seed'``.
+2. Swap both partial-unique indexes to include ``kind`` so knn_seed and
+   edge_gate rows coexist for the same ``(model, dims[, context_id])``.
+
+Revision ID: e38_982_edge_gate_kind
+Revises: e37_517_user_oauth_providers
+
+DOWNGRADE WARNING: downgrade DELETEs all ``edge_gate`` rows before restoring the
+``kind``-less unique indexes (otherwise a knn_seed + edge_gate pair for the same
+(model, dims, NULL) would violate uniqueness). Those rows are recomputable by
+the calibration job, so the loss is benign.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e38_982_edge_gate_kind"
+down_revision = "e37_517_user_oauth_providers"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add ``kind`` (backfilled to knn_seed) and widen the unique indexes."""
+    # 1. Add kind. NOT NULL + server_default backfills existing rows in one
+    #    statement (Postgres applies the default to pre-existing rows).
+    op.add_column(
+        "embedding_calibrations",
+        sa.Column(
+            "kind",
+            sa.String(16),
+            nullable=False,
+            server_default="knn_seed",
+        ),
+    )
+
+    # 2. Swap both partial-unique indexes to include kind so each (model, dims)
+    #    can hold one knn_seed row and one edge_gate row.
+    op.drop_index(
+        "uq_calibration_model_dims_global",
+        table_name="embedding_calibrations",
+    )
+    op.drop_index(
+        "uq_calibration_model_dims_nonnull",
+        table_name="embedding_calibrations",
+    )
+    op.create_index(
+        "uq_calibration_model_dims_global",
+        "embedding_calibrations",
+        ["model_name", "dimensions", "kind"],
+        unique=True,
+        postgresql_where=sa.text("context_id IS NULL"),
+    )
+    op.create_index(
+        "uq_calibration_model_dims_nonnull",
+        "embedding_calibrations",
+        ["model_name", "dimensions", "context_id", "kind"],
+        unique=True,
+        postgresql_where=sa.text("context_id IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Restore the kind-less indexes and drop the column.
+
+    Deletes ``edge_gate`` rows first so the restored ``(model, dims)`` global
+    uniqueness (which ignores kind) cannot be violated by a knn_seed/edge_gate
+    pair. Those rows are recomputable by the calibration job.
+    """
+    op.execute("DELETE FROM embedding_calibrations WHERE kind = 'edge_gate'")
+
+    op.drop_index(
+        "uq_calibration_model_dims_nonnull",
+        table_name="embedding_calibrations",
+    )
+    op.drop_index(
+        "uq_calibration_model_dims_global",
+        table_name="embedding_calibrations",
+    )
+    op.create_index(
+        "uq_calibration_model_dims_global",
+        "embedding_calibrations",
+        ["model_name", "dimensions"],
+        unique=True,
+        postgresql_where=sa.text("context_id IS NULL"),
+    )
+    op.create_index(
+        "uq_calibration_model_dims_nonnull",
+        "embedding_calibrations",
+        ["model_name", "dimensions", "context_id"],
+        unique=True,
+        postgresql_where=sa.text("context_id IS NOT NULL"),
+    )
+    op.drop_column("embedding_calibrations", "kind")

--- a/backend/src/models/neural.py
+++ b/backend/src/models/neural.py
@@ -112,6 +112,13 @@ class NeuralConfig(Base):
             return False, f"Invalid {self.value_type} value: {e}"
 
 
+# Calibration distribution kinds (#982). Centralized so query filters and row
+# writes share one source of truth — a typo in a partial-index ``kind`` filter
+# returns zero rows silently rather than raising, so the literal must not drift.
+CALIBRATION_KIND_KNN_SEED = "knn_seed"  # top-k neighbor cosine distribution (#406)
+CALIBRATION_KIND_EDGE_GATE = "edge_gate"  # random-pair cosine distribution (#982)
+
+
 class EmbeddingCalibration(Base):
     """Per-model percentile calibration of top-k neighbor cosine similarity.
 
@@ -167,6 +174,19 @@ class EmbeddingCalibration(Base):
         ForeignKey("contexts.id", ondelete="CASCADE"),
         nullable=True,
     )
+    # Distinguishes which cosine distribution this row summarizes (#982):
+    #   "knn_seed"  = top-k neighbor distribution (#406, original use)
+    #   "edge_gate" = random-pair distribution for the co-activation/Hebbian
+    #                 semantic gate (min_similarity_for_edge calibration)
+    # These are different populations, so a (model, dims) pair may have one row
+    # of each kind — the unique indexes below include ``kind`` to allow that.
+    # Default + migration backfill is "knn_seed" so pre-#982 rows keep meaning.
+    kind: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        server_default=CALIBRATION_KIND_KNN_SEED,
+        default=CALIBRATION_KIND_KNN_SEED,
+    )
 
     p25: Mapped[float] = mapped_column(Float, nullable=False)
     p50: Mapped[float] = mapped_column(Float, nullable=False)
@@ -203,6 +223,7 @@ class EmbeddingCalibration(Base):
             "uq_calibration_model_dims_global",
             "model_name",
             "dimensions",
+            "kind",
             unique=True,
             postgresql_where=expression.text("context_id IS NULL"),
         ),
@@ -211,6 +232,7 @@ class EmbeddingCalibration(Base):
             "model_name",
             "dimensions",
             "context_id",
+            "kind",
             unique=True,
             postgresql_where=expression.text("context_id IS NOT NULL"),
         ),

--- a/backend/src/neural/calibration.py
+++ b/backend/src/neural/calibration.py
@@ -31,7 +31,11 @@ from uuid import UUID
 
 from sqlalchemy import select
 
-from models.neural import EmbeddingCalibration
+from models.neural import (
+    CALIBRATION_KIND_EDGE_GATE,
+    CALIBRATION_KIND_KNN_SEED,
+    EmbeddingCalibration,
+)
 from utils.logger import get_logger
 
 if TYPE_CHECKING:
@@ -82,16 +86,12 @@ async def resolve_knn_threshold(
 
     # Step 2: model-global calibration (context_id IS NULL).
     # TODO(v2): try context_id first, fall through to NULL on miss.
-    stmt = (
-        select(EmbeddingCalibration)
-        .where(
-            EmbeddingCalibration.model_name == model_name,
-            EmbeddingCalibration.dimensions == dimensions,
-            EmbeddingCalibration.context_id.is_(None),
-        )
-        .limit(1)
+    # Filter kind=knn_seed (#982): once edge_gate rows share the
+    # (model, dims, NULL) space, an unfiltered limit(1) could return the
+    # wrong distribution non-deterministically.
+    calibration = await _fetch_global_calibration(
+        db, model_name, dimensions, CALIBRATION_KIND_KNN_SEED
     )
-    calibration = (await db.execute(stmt)).scalar_one_or_none()
 
     if calibration is not None:
         if calibration.is_expired():
@@ -135,6 +135,87 @@ async def resolve_knn_threshold(
         dimensions=dimensions,
     )
     return None
+
+
+async def _fetch_global_calibration(
+    db: AsyncSession,
+    model_name: str,
+    dimensions: int,
+    kind: str,
+) -> EmbeddingCalibration | None:
+    """Fetch the model-global (``context_id IS NULL``) calibration row.
+
+    Shared by ``resolve_knn_threshold`` and ``resolve_edge_threshold`` so the
+    select boilerplate and the ``kind`` filter live in one place (the two
+    callers differ only in which ``kind`` they request and how they treat a
+    miss). TODO(v2): try a per-context row first, fall through to NULL.
+    """
+    stmt = (
+        select(EmbeddingCalibration)
+        .where(
+            EmbeddingCalibration.model_name == model_name,
+            EmbeddingCalibration.dimensions == dimensions,
+            EmbeddingCalibration.context_id.is_(None),
+            EmbeddingCalibration.kind == kind,
+        )
+        .limit(1)
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def resolve_edge_threshold(
+    db: AsyncSession,
+    config: NeuralMemoryConfig,
+    model_name: str,
+    dimensions: int,
+    context_id: UUID | None = None,  # noqa: ARG001 — TODO(v2): per-context lookup
+) -> float:
+    """Resolve the runtime semantic-gate threshold for edge formation (#982).
+
+    The co-activation tracker and Hebbian learner gate pair edges on cosine
+    similarity (Issue #118, anti-noise). The #969 compounding experiment found
+    the absolute 0.5 default rejects genuine cross-topic pairs (cosines
+    0.37-0.40 under text-embedding-3-small), so this resolves a per-(model,
+    dimensions) threshold from the RANDOM-PAIR cosine distribution instead.
+
+    Unlike ``resolve_knn_threshold`` (which returns ``None`` to DISABLE seeding
+    when uncalibrated), the edge gate must ALWAYS stay active — so the fallback
+    is the absolute ``config.min_similarity_for_edge``, never ``None``.
+
+    Step 1  ``edge_gate`` calibration row for ``(model, dimensions)``
+            (``context_id IS NULL``) → ``max(percentile(p), floor)`` where
+            ``p = config.min_similarity_for_edge_percentile`` and
+            ``floor = config.min_similarity_for_edge_floor``. An expired row is
+            still served (fail-open) — a stale threshold beats stalling recall.
+            NOTE: unlike the knn-seed path, there is no lazy-TTL enqueue here
+            yet because the edge_gate measurement + recalibration job is not
+            wired (the random-pair distribution writer lands in #982 Increment
+            5). Until then an expired edge_gate row is served until manually
+            recalibrated. TODO(#982): add the edge_gate recalibration trigger.
+    Step 2  no row → ``config.min_similarity_for_edge`` (pre-#982 behavior).
+
+    Args:
+        db: AsyncSession for the calibration table lookup.
+        config: Resolved ``NeuralMemoryConfig`` (already loaded from DB).
+        model_name: Embedding model name (e.g. ``text-embedding-3-small``).
+        dimensions: Vector dimensionality (e.g. 512, 4096).
+        context_id: Reserved for D5 v2 per-context calibration. Currently
+            ignored (model-global lookup only).
+
+    Returns:
+        Similarity threshold in ``[0.0, 1.0]``. Always a float (the gate is
+        never disabled).
+    """
+    calibration = await _fetch_global_calibration(
+        db, model_name, dimensions, CALIBRATION_KIND_EDGE_GATE
+    )
+
+    if calibration is not None:
+        percentile_value = calibration.percentile(config.min_similarity_for_edge_percentile)
+        return max(percentile_value, config.min_similarity_for_edge_floor)
+
+    # Step 2: uncalibrated → absolute fallback keeps the anti-noise gate active.
+    return config.min_similarity_for_edge
 
 
 async def _enqueue_lazy_recalibration(

--- a/backend/src/neural/co_activation.py
+++ b/backend/src/neural/co_activation.py
@@ -55,6 +55,7 @@ class CoActivationTracker:
         activations: list[ActivationState],
         session_id: str | None = None,
         embeddings: dict[str, list[float]] | None = None,
+        similarity_threshold: float | None = None,
     ) -> list[CoActivationRecord]:
         """Record an activation event and detect co-activations.
 
@@ -63,8 +64,12 @@ class CoActivationTracker:
             activations: List of activated nodes in this retrieval
             session_id: Optional session ID for grouping
             embeddings: Map of node_id -> embedding for semantic gating.
-                When provided, only pairs with cosine similarity >=
-                config.min_similarity_for_edge will create edges.
+                When provided, only pairs with cosine similarity >= the
+                effective threshold will create edges.
+            similarity_threshold: Per-call semantic-gate override (#982). When
+                not None, takes precedence over ``config.min_similarity_for_edge``
+                — the caller resolves the calibrated edge-gate threshold (DB-
+                aware) and passes it in. ``None`` falls back to the config value.
 
         Returns:
             List of co-activation records updated/created in this event
@@ -92,7 +97,9 @@ class CoActivationTracker:
         self._activation_history[user_id].append((timestamp, activated_ids))
 
         # Detect co-activations within the time window
-        co_activated_pairs = self._find_co_activations_in_window(user_id, timestamp)
+        co_activated_pairs = self._find_co_activations_in_window(
+            user_id, timestamp, similarity_threshold
+        )
 
         # Update co-activation records
         updated_records = []
@@ -198,16 +205,22 @@ class CoActivationTracker:
         ]
 
     def _find_co_activations_in_window(
-        self, user_id: str, current_time: datetime
+        self,
+        user_id: str,
+        current_time: datetime,
+        similarity_threshold: float | None = None,
     ) -> list[tuple[str, str, float, float]]:
         """Find all co-activated pairs within the time window.
 
-        Applies semantic gating: pairs with cosine similarity below
-        config.min_similarity_for_edge are skipped to prevent noise edges.
+        Applies semantic gating: pairs with cosine similarity below the
+        effective threshold are skipped to prevent noise edges. The effective
+        threshold is ``similarity_threshold`` when provided (#982 calibrated
+        value), else ``config.min_similarity_for_edge``.
 
         Args:
             user_id: User ID
             current_time: Current timestamp
+            similarity_threshold: Per-call gate override; ``None`` → config.
 
         Returns:
             List of (node_1, node_2, activation_1, activation_2) tuples
@@ -230,7 +243,11 @@ class CoActivationTracker:
         # Find pairs of nodes that were both activated
         co_activated_pairs = []
         node_ids = list(all_activated.keys())
-        threshold = self.config.min_similarity_for_edge
+        threshold = (
+            similarity_threshold
+            if similarity_threshold is not None
+            else self.config.min_similarity_for_edge
+        )
         skipped = 0
 
         for i, node_1 in enumerate(node_ids):

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -136,7 +136,19 @@ class NeuralMemoryConfig:
     track_co_activation: bool = True
     co_activation_window: int = 300  # 5 minutes
     min_co_activation_count: int = 2
-    min_similarity_for_edge: float = 0.5  # Semantic gating threshold
+    min_similarity_for_edge: float = 0.5  # Semantic gating threshold (absolute fallback)
+    # Edge-gate percentile calibration (#982, follow-up to #969). When an
+    # ``edge_gate`` ``embedding_calibrations`` row exists for (model, dims),
+    # the runtime gate is ``max(percentile(min_similarity_for_edge_percentile),
+    # min_similarity_for_edge_floor)`` over the RANDOM-PAIR cosine distribution;
+    # otherwise the absolute ``min_similarity_for_edge`` above is used unchanged
+    # (current behavior). The percentile is high because the random-pair upper
+    # tail is where genuine cross-topic associations begin to separate from
+    # noise — the #118 anti-noise gate, recalibrated to the model's similarity
+    # distribution per the #969 zero-lift finding (absolute 0.5 rejected real
+    # cross-topic pairs at cosine 0.37-0.40 under text-embedding-3-small).
+    min_similarity_for_edge_percentile: float = 95.0
+    min_similarity_for_edge_floor: float = 0.3
     max_assoc_score: float = 0.5  # Cap graph association score per node
     top_k_coactivation: int = 3  # Only co-activate top-k results
 
@@ -267,6 +279,16 @@ class NeuralMemoryConfig:
         if not (0.0 <= self.min_similarity_for_edge <= 1.0):
             raise ValueError(
                 f"min_similarity_for_edge must be in [0, 1], got {self.min_similarity_for_edge}"
+            )
+        if not (0.0 < self.min_similarity_for_edge_percentile < 100.0):
+            raise ValueError(
+                "min_similarity_for_edge_percentile must be in (0, 100), got "
+                f"{self.min_similarity_for_edge_percentile}"
+            )
+        if not (0.0 <= self.min_similarity_for_edge_floor <= 1.0):
+            raise ValueError(
+                "min_similarity_for_edge_floor must be in [0, 1], got "
+                f"{self.min_similarity_for_edge_floor}"
             )
         if not self.max_assoc_score > 0:
             raise ValueError(f"max_assoc_score must be positive, got {self.max_assoc_score}")
@@ -462,6 +484,10 @@ class NeuralMemoryConfig:
             co_activation_window=get_int("CO_ACTIVATION_WINDOW", 300),
             min_co_activation_count=get_int("MIN_CO_ACTIVATION_COUNT", 2),
             min_similarity_for_edge=get_float("MIN_SIMILARITY_FOR_EDGE", 0.5),
+            min_similarity_for_edge_percentile=get_float(
+                "MIN_SIMILARITY_FOR_EDGE_PERCENTILE", 95.0
+            ),
+            min_similarity_for_edge_floor=get_float("MIN_SIMILARITY_FOR_EDGE_FLOOR", 0.3),
             max_assoc_score=get_float("MAX_ASSOC_SCORE", 0.5),
             top_k_coactivation=get_int("TOP_K_COACTIVATION", 3),
             # Forgetting/Decay
@@ -574,6 +600,13 @@ class NeuralMemoryConfig:
             ),
             min_similarity_for_edge=configs.get(
                 "min_similarity_for_edge", base_config.min_similarity_for_edge
+            ),
+            min_similarity_for_edge_percentile=configs.get(
+                "min_similarity_for_edge_percentile",
+                base_config.min_similarity_for_edge_percentile,
+            ),
+            min_similarity_for_edge_floor=configs.get(
+                "min_similarity_for_edge_floor", base_config.min_similarity_for_edge_floor
             ),
             max_assoc_score=configs.get("max_assoc_score", base_config.max_assoc_score),
             top_k_coactivation=configs.get("top_k_coactivation", base_config.top_k_coactivation),

--- a/backend/src/neural/hebbian.py
+++ b/backend/src/neural/hebbian.py
@@ -58,19 +58,28 @@ class HebbianLearner:
         user_id: str,
         activations: list[ActivationState],
         nodes: dict[str, NeuralMemoryNode],
+        similarity_threshold: float | None = None,
     ) -> None:
         """Queue Hebbian updates for co-activated nodes.
 
         Applies semantic gating (Issue #118): pairs with cosine similarity
-        below config.min_similarity_for_edge are skipped to prevent noise
-        edges from accumulating.
+        below the effective threshold are skipped to prevent noise edges from
+        accumulating. The effective threshold is ``similarity_threshold`` when
+        provided (#982 calibrated edge-gate value), else
+        ``config.min_similarity_for_edge``.
 
         Args:
             user_id: User ID (for sharding)
             activations: List of activated nodes in this retrieval
             nodes: Map of node_id -> NeuralMemoryNode (for confidence scores)
+            similarity_threshold: Per-call semantic-gate override (#982);
+                ``None`` falls back to ``config.min_similarity_for_edge``.
         """
-        threshold = self.config.min_similarity_for_edge
+        threshold = (
+            similarity_threshold
+            if similarity_threshold is not None
+            else self.config.min_similarity_for_edge
+        )
         skipped = 0
 
         for i, act_i in enumerate(activations):

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1651,9 +1651,9 @@ class MemoryService:
                             ContextSearchConfigRepository,
                         )
 
-                        ctx_search_cfg = await ContextSearchConfigRepository(
-                            self.db
-                        ).create_or_get(current_context_id)
+                        ctx_search_cfg = await ContextSearchConfigRepository(self.db).create_or_get(
+                            current_context_id
+                        )
                         edge_threshold = await resolve_edge_threshold(
                             db=self.db,
                             config=config,

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1645,21 +1645,32 @@ class MemoryService:
                 edge_threshold: float | None = None
                 edge_dims = next((len(e) for e in embedding_map.values() if e), None)
                 if edge_dims and current_context_id is not None:
-                    try:
-                        from neural.calibration import resolve_edge_threshold
-                        from repositories.config_repository import (
-                            ContextSearchConfigRepository,
-                        )
+                    # Resolve in an ISOLATED session: a transient DB error here
+                    # must not abort the recall's own transaction (which still
+                    # has the neural graph writes below to commit). The lookup
+                    # is READ-ONLY (get_by_context, never create_or_get) so the
+                    # recall hot path never writes a config row. Missing config
+                    # or any failure leaves edge_threshold=None → the gate falls
+                    # back to the absolute config value in the gating calls.
+                    from db.base import get_db
+                    from neural.calibration import resolve_edge_threshold
+                    from repositories.config_repository import (
+                        ContextSearchConfigRepository,
+                    )
 
-                        ctx_search_cfg = await ContextSearchConfigRepository(self.db).create_or_get(
-                            current_context_id
-                        )
-                        edge_threshold = await resolve_edge_threshold(
-                            db=self.db,
-                            config=config,
-                            model_name=ctx_search_cfg.embedding_model,
-                            dimensions=edge_dims,
-                        )
+                    try:
+                        async for edge_db in get_db():
+                            ctx_search_cfg = await ContextSearchConfigRepository(
+                                edge_db
+                            ).get_by_context(current_context_id)
+                            if ctx_search_cfg is not None:
+                                edge_threshold = await resolve_edge_threshold(
+                                    db=edge_db,
+                                    config=config,
+                                    model_name=ctx_search_cfg.embedding_model,
+                                    dimensions=edge_dims,
+                                )
+                            break
                     except Exception:  # noqa: BLE001 — best-effort; never break recall
                         logger.debug("edge_threshold_resolve_failed", exc_info=True)
                         edge_threshold = None

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1635,8 +1635,40 @@ class MemoryService:
                 embedding_map = {
                     nid: node.embedding for nid, node in nodes_dict.items() if node.embedding
                 }
+                # Resolve the calibrated edge-gate threshold (#982). The gate is
+                # keyed on the context's embedding (model, dimensions); both the
+                # co-activation tracker and the Hebbian learner use the same
+                # resolved value so they agree on which pairs may form edges.
+                # Best-effort: on any failure (or no edge_gate calibration row)
+                # this stays None and the gate falls back to the config absolute
+                # ``min_similarity_for_edge`` inside record_activation/queue_update.
+                edge_threshold: float | None = None
+                edge_dims = next((len(e) for e in embedding_map.values() if e), None)
+                if edge_dims and current_context_id is not None:
+                    try:
+                        from neural.calibration import resolve_edge_threshold
+                        from repositories.config_repository import (
+                            ContextSearchConfigRepository,
+                        )
+
+                        ctx_search_cfg = await ContextSearchConfigRepository(
+                            self.db
+                        ).create_or_get(current_context_id)
+                        edge_threshold = await resolve_edge_threshold(
+                            db=self.db,
+                            config=config,
+                            model_name=ctx_search_cfg.embedding_model,
+                            dimensions=edge_dims,
+                        )
+                    except Exception:  # noqa: BLE001 — best-effort; never break recall
+                        logger.debug("edge_threshold_resolve_failed", exc_info=True)
+                        edge_threshold = None
+
                 co_activation_tracker.record_activation(
-                    user_id, activated_nodes, embeddings=embedding_map
+                    user_id,
+                    activated_nodes,
+                    embeddings=embedding_map,
+                    similarity_threshold=edge_threshold,
                 )
                 await co_activation_tracker.save_to_redis(user_id)
 
@@ -1659,8 +1691,10 @@ class MemoryService:
                         )
                         nodes_added += 1
 
-                # Hebbian updates
-                await hebbian_learner.queue_update(user_id, activated_nodes, nodes_dict)
+                # Hebbian updates (same calibrated gate as co-activation above)
+                await hebbian_learner.queue_update(
+                    user_id, activated_nodes, nodes_dict, similarity_threshold=edge_threshold
+                )
                 edges_updated = await hebbian_learner.apply_updates(user_id)
 
                 logger.info(

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -49,7 +49,11 @@ from db.qdrant import get_qdrant_client
 from db.redis import get_redis_client
 from models.config import ContextSearchConfig
 from models.memory import Memory
-from models.neural import EmbeddingCalibration
+from models.neural import (
+    CALIBRATION_KIND_EDGE_GATE,
+    CALIBRATION_KIND_KNN_SEED,
+    EmbeddingCalibration,
+)
 from neural.config import NeuralMemoryConfig
 from utils.logger import get_logger
 
@@ -119,6 +123,17 @@ BOOTSTRAP_MIN_OBSERVATIONS = 10_000
 # script produced.
 SAMPLE_MEMORIES = 200
 SAMPLE_TOP_K = 50
+# Random-pair sampling for the edge_gate (random-pair) distribution (#982).
+# measure_random_pair caps the count at len(vectors)//2 (unique, non-repeating
+# pairs), so with SAMPLE_MEMORIES=200 the effective count is ~100. A generous
+# request value lets a larger future sample tighten the upper-tail estimate
+# without a code change; the real count is logged per run.
+SAMPLE_RANDOM_PAIRS = 5000
+# Minimum random-pair observations before an edge_gate row is written. Below
+# this the upper-tail percentile (p95 default) is too noisy to trust, so the
+# row is skipped and resolve_edge_threshold falls back to the absolute config
+# value (anti-noise gate stays active at its safe default).
+EDGE_GATE_MIN_PAIR_OBSERVATIONS = 30
 
 # In-process bootstrap-count throttle. ``maybe_trigger_bootstrap`` fires on
 # every ``remember()`` that hits D4 step 3 (pre-calibration phase), and each
@@ -285,17 +300,74 @@ async def _release_dedup_lock(key: str, token: str) -> None:
         )
 
 
+async def _upsert_calibration(
+    db: AsyncSession,
+    model_name: str,
+    dimensions: int,
+    context_id: UUID | None,
+    *,
+    kind: str,
+    percentiles: dict[str, float],
+    observations: int,
+    now: datetime,
+    valid_until: datetime,
+) -> EmbeddingCalibration:
+    """Kind-scoped delete-then-insert of one calibration row.
+
+    The partial unique indexes are keyed on (model, dims, [context_id,] kind)
+    since #982, so the DELETE MUST include ``kind`` — otherwise recalibrating
+    one kind wipes the sibling kind's row for the same key. Does NOT commit;
+    the caller commits once so both kinds land atomically (or neither).
+
+    Delete-then-insert is simpler than ON CONFLICT because the partial indexes
+    don't participate in INSERT ... ON CONFLICT.
+    """
+    del_stmt = delete(EmbeddingCalibration).where(
+        EmbeddingCalibration.model_name == model_name,
+        EmbeddingCalibration.dimensions == dimensions,
+        EmbeddingCalibration.kind == kind,
+    )
+    if context_id is None:
+        del_stmt = del_stmt.where(EmbeddingCalibration.context_id.is_(None))
+    else:
+        del_stmt = del_stmt.where(EmbeddingCalibration.context_id == context_id)
+    await db.execute(del_stmt)
+
+    row = EmbeddingCalibration(
+        model_name=model_name,
+        dimensions=dimensions,
+        context_id=context_id,
+        kind=kind,
+        p25=percentiles["p25"],
+        p50=percentiles["p50"],
+        p75=percentiles["p75"],
+        p90=percentiles["p90"],
+        p95=percentiles["p95"],
+        p99=percentiles["p99"],
+        sample_size=observations,
+        sampled_at=now,
+        valid_until=valid_until,
+    )
+    db.add(row)
+    return row
+
+
 async def compute_calibration(
     db: AsyncSession,
     model_name: str,
     dimensions: int,
     context_id: UUID | None,
 ) -> EmbeddingCalibration | None:
-    """Measure percentiles + upsert the calibration row.
+    """Measure percentiles + upsert the calibration rows for this key.
 
-    Returns the upserted ``EmbeddingCalibration`` instance on success, or
-    ``None`` if the D3 gate fails (insufficient sample) — the fallback
-    chain keeps step 3 (disabled) in that case until the context grows.
+    Samples once and writes BOTH calibration kinds (#982): the ``knn_seed``
+    top-k neighbor distribution and the ``edge_gate`` random-pair distribution.
+    Returns the upserted ``knn_seed`` ``EmbeddingCalibration`` instance on
+    success, or ``None`` if the D3 gate fails (insufficient sample) — the
+    fallback chain keeps step 3 (disabled) in that case until the context
+    grows. The ``edge_gate`` row is best-effort: it is skipped (leaving the
+    semantic gate on its absolute fallback) when too few random pairs are
+    available, without failing the run.
 
     The model-global case picks the largest context using this ``(model,
     dimensions)`` pair as the sampling source. This is a v1 simplification
@@ -316,6 +388,7 @@ async def compute_calibration(
     compute_percentiles = _script_module.compute_percentiles
     fetch_vectors = _script_module.fetch_vectors
     measure_top_k = _script_module.measure_top_k
+    measure_random_pair = _script_module.measure_random_pair
     sample_memories = _script_module.sample_memories
 
     sample_context_id = context_id
@@ -390,36 +463,52 @@ async def compute_calibration(
     now = datetime.now(UTC)
     valid_until = now + timedelta(days=config.calibration_ttl_days)
 
-    # Upsert: delete any existing row for this key, then insert fresh. Two
-    # partial unique indexes (one for NULL context_id, one for non-NULL)
-    # enforce at-most-one row per key from the DB side; the explicit
-    # delete-then-insert is simpler than an ON CONFLICT dance because the
-    # partial indexes don't participate in INSERT ... ON CONFLICT.
-    del_stmt = delete(EmbeddingCalibration).where(
-        EmbeddingCalibration.model_name == model_name,
-        EmbeddingCalibration.dimensions == dimensions,
-    )
-    if context_id is None:
-        del_stmt = del_stmt.where(EmbeddingCalibration.context_id.is_(None))
-    else:
-        del_stmt = del_stmt.where(EmbeddingCalibration.context_id == context_id)
-    await db.execute(del_stmt)
-
-    row = EmbeddingCalibration(
-        model_name=model_name,
-        dimensions=dimensions,
-        context_id=context_id,
-        p25=percentiles["p25"],
-        p50=percentiles["p50"],
-        p75=percentiles["p75"],
-        p90=percentiles["p90"],
-        p95=percentiles["p95"],
-        p99=percentiles["p99"],
-        sample_size=observations,
-        sampled_at=now,
+    # Upsert the knn_seed (top-k neighbor) row. Both kinds are written from
+    # this single sample so every trigger (bootstrap / scheduled / lazy-TTL)
+    # keeps them in lock-step without a second sampling pass.
+    knn_row = await _upsert_calibration(
+        db,
+        model_name,
+        dimensions,
+        context_id,
+        kind=CALIBRATION_KIND_KNN_SEED,
+        percentiles=percentiles,
+        observations=observations,
+        now=now,
         valid_until=valid_until,
     )
-    db.add(row)
+
+    # Upsert the edge_gate (random-pair) row (#982). The semantic gate must be
+    # calibrated to the RANDOM-PAIR distribution — a different population from
+    # the top-k neighbors above — so unrelated pairs are rejected while genuine
+    # cross-topic associations clear the bar. Reuse the already-fetched vectors;
+    # random pairs need no extra Qdrant round-trip. Skip (leaving the runtime on
+    # its absolute fallback) when too few pairs to estimate the upper tail.
+    pair_scores = measure_random_pair(vectors, SAMPLE_RANDOM_PAIRS)
+    pair_observations = len(pair_scores)
+    pair_percentiles = compute_percentiles(pair_scores)
+    if pair_percentiles and pair_observations >= EDGE_GATE_MIN_PAIR_OBSERVATIONS:
+        await _upsert_calibration(
+            db,
+            model_name,
+            dimensions,
+            context_id,
+            kind=CALIBRATION_KIND_EDGE_GATE,
+            percentiles=pair_percentiles,
+            observations=pair_observations,
+            now=now,
+            valid_until=valid_until,
+        )
+    else:
+        logger.warning(
+            "edge_calibration_skipped_insufficient_pairs",
+            model=model_name,
+            dimensions=dimensions,
+            context_id=str(context_id) if context_id else None,
+            pair_observations=pair_observations,
+            min_required=EDGE_GATE_MIN_PAIR_OBSERVATIONS,
+        )
+
     await db.commit()
 
     logger.info(
@@ -427,11 +516,13 @@ async def compute_calibration(
         model=model_name,
         dimensions=dimensions,
         context_id=str(context_id) if context_id else None,
-        p90=percentiles["p90"],
-        sample_size=observations,
+        knn_p90=percentiles["p90"],
+        knn_sample_size=observations,
+        edge_p95=pair_percentiles.get("p95") if pair_percentiles else None,
+        edge_pair_observations=pair_observations,
         valid_until=valid_until.isoformat(),
     )
-    return row
+    return knn_row
 
 
 async def _pick_largest_context_for_model(

--- a/backend/src/tasks/neural_calibration.py
+++ b/backend/src/tasks/neural_calibration.py
@@ -300,6 +300,32 @@ async def _release_dedup_lock(key: str, token: str) -> None:
         )
 
 
+async def _delete_calibration(
+    db: AsyncSession,
+    model_name: str,
+    dimensions: int,
+    context_id: UUID | None,
+    *,
+    kind: str,
+) -> None:
+    """Kind-scoped delete of the calibration row for one key (no commit).
+
+    The partial unique indexes are keyed on (model, dims, [context_id,] kind)
+    since #982, so the DELETE MUST include ``kind`` — otherwise it would wipe
+    the sibling kind's row for the same key.
+    """
+    del_stmt = delete(EmbeddingCalibration).where(
+        EmbeddingCalibration.model_name == model_name,
+        EmbeddingCalibration.dimensions == dimensions,
+        EmbeddingCalibration.kind == kind,
+    )
+    if context_id is None:
+        del_stmt = del_stmt.where(EmbeddingCalibration.context_id.is_(None))
+    else:
+        del_stmt = del_stmt.where(EmbeddingCalibration.context_id == context_id)
+    await db.execute(del_stmt)
+
+
 async def _upsert_calibration(
     db: AsyncSession,
     model_name: str,
@@ -314,24 +340,11 @@ async def _upsert_calibration(
 ) -> EmbeddingCalibration:
     """Kind-scoped delete-then-insert of one calibration row.
 
-    The partial unique indexes are keyed on (model, dims, [context_id,] kind)
-    since #982, so the DELETE MUST include ``kind`` — otherwise recalibrating
-    one kind wipes the sibling kind's row for the same key. Does NOT commit;
-    the caller commits once so both kinds land atomically (or neither).
-
-    Delete-then-insert is simpler than ON CONFLICT because the partial indexes
-    don't participate in INSERT ... ON CONFLICT.
+    Does NOT commit; the caller commits once so both kinds land atomically
+    (or neither). Delete-then-insert is simpler than ON CONFLICT because the
+    partial indexes don't participate in INSERT ... ON CONFLICT.
     """
-    del_stmt = delete(EmbeddingCalibration).where(
-        EmbeddingCalibration.model_name == model_name,
-        EmbeddingCalibration.dimensions == dimensions,
-        EmbeddingCalibration.kind == kind,
-    )
-    if context_id is None:
-        del_stmt = del_stmt.where(EmbeddingCalibration.context_id.is_(None))
-    else:
-        del_stmt = del_stmt.where(EmbeddingCalibration.context_id == context_id)
-    await db.execute(del_stmt)
+    await _delete_calibration(db, model_name, dimensions, context_id, kind=kind)
 
     row = EmbeddingCalibration(
         model_name=model_name,
@@ -500,6 +513,13 @@ async def compute_calibration(
             valid_until=valid_until,
         )
     else:
+        # Too few pairs for a trustworthy upper tail. Delete any prior edge_gate
+        # row so resolve_edge_threshold genuinely falls back to the absolute
+        # config value (the documented contract) instead of serving a stale
+        # (possibly expired, fail-open) threshold from an earlier run.
+        await _delete_calibration(
+            db, model_name, dimensions, context_id, kind=CALIBRATION_KIND_EDGE_GATE
+        )
         logger.warning(
             "edge_calibration_skipped_insufficient_pairs",
             model=model_name,

--- a/backend/tests/eval/compounding.py
+++ b/backend/tests/eval/compounding.py
@@ -169,13 +169,46 @@ def summarize_gate_audit(pairs: list[PairAudit]) -> dict[str, Any]:
 
     The probe gold pairs are the compounding-critical subset — every one that
     fails a gate directly explains a zero graph-lane lift.
+
+    Also reports the **noise side** of edge formation (#982 / Gate1): lowering
+    the semantic gate to admit genuine cross-topic gold pairs must not blow up
+    spurious edges between unrelated (non-gold) pairs. ``edge_precision`` is the
+    fraction of *formed* edges that are gold; ``non_gold_form_rate`` is the
+    fraction of *non-gold* pairs that formed an edge (the false-edge rate the
+    #118 gate exists to suppress). Pairing this with the recovery@k recall
+    metric is what proves a recalibration helped rather than just added noise.
     """
     verdicts: dict[str, int] = {}
+    formed_gold = 0
+    formed_non_gold = 0
+    non_gold_pair_count = 0
     for pair in pairs:
         verdicts[pair.verdict] = verdicts.get(pair.verdict, 0) + 1
+        formed = pair.verdict == "forms"
+        if pair.is_probe_gold_pair:
+            if formed:
+                formed_gold += 1
+        else:
+            non_gold_pair_count += 1
+            if formed:
+                formed_non_gold += 1
+
+    formed_total = formed_gold + formed_non_gold
     return {
         "pair_observations": len(pairs),
         "verdicts": verdicts,
+        # Recall side: did gold companion pairs form edges?
+        "formed_total": formed_total,
+        "formed_gold": formed_gold,
+        # Noise side: did unrelated pairs form edges? (#982 / Gate1 guard)
+        "formed_non_gold": formed_non_gold,
+        "non_gold_pair_count": non_gold_pair_count,
+        # precision of the formed-edge set; None when no edge formed (no lie).
+        "edge_precision": (formed_gold / formed_total) if formed_total else None,
+        # false-edge rate; None when there were no non-gold pairs to form from.
+        "non_gold_form_rate": (
+            formed_non_gold / non_gold_pair_count if non_gold_pair_count else None
+        ),
         "probe_gold_pairs": [
             {
                 "query_id": p.query_id,

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -186,16 +186,31 @@ async def _measure_replay_measure(
         svc, db, corpus, plan, docs_by_id, id_map, seed_mem_by_doc, owner, ctx, ws
     )
 
-    gate_audit = await _gate_audit(svc, db, corpus, plan, id_map, owner, ctx, ws)
-    replay_recalls = await _replay(svc, corpus, plan, owner, ctx, ws)
-    checkpoints["warm_replay"] = await _checkpoint(
-        svc, db, corpus, plan, docs_by_id, id_map, seed_mem_by_doc, owner, ctx, ws
-    )
+    # #982 demonstration: calibrate the edge_gate threshold from THIS corpus's
+    # non-gold pairwise cosine distribution and seed a (transient, model-global)
+    # edge_gate calibration row so the replay path's resolve_edge_threshold
+    # returns the calibrated value instead of the absolute 0.5 — exactly the
+    # production path. The row is deleted in the finally below; it is model-
+    # global (v1 resolve ignores context_id) so it briefly affects any
+    # concurrent recall on the same (model, dims). Acceptable for a local
+    # verification run with guaranteed cleanup.
+    edge_calibration = await _seed_edge_calibration(db, plan, id_map, ctx)
+    try:
+        gate_audit = await _gate_audit(svc, db, corpus, plan, id_map, owner, ctx, ws)
+        replay_recalls = await _replay(svc, corpus, plan, owner, ctx, ws)
+        checkpoints["warm_replay"] = await _checkpoint(
+            svc, db, corpus, plan, docs_by_id, id_map, seed_mem_by_doc, owner, ctx, ws
+        )
 
-    sleep_info = await _run_sleep(db, owner, ctx, ws)
-    checkpoints["warm_sleep"] = await _checkpoint(
-        svc, db, corpus, plan, docs_by_id, id_map, seed_mem_by_doc, owner, ctx, ws
-    )
+        sleep_info = await _run_sleep(db, owner, ctx, ws)
+        checkpoints["warm_sleep"] = await _checkpoint(
+            svc, db, corpus, plan, docs_by_id, id_map, seed_mem_by_doc, owner, ctx, ws
+        )
+    finally:
+        if edge_calibration.get("seeded"):
+            await _delete_edge_calibration(
+                db, edge_calibration["model"], edge_calibration["dimensions"]
+            )
 
     lift = {
         lane: {
@@ -218,6 +233,7 @@ async def _measure_replay_measure(
         "probe_query_ids": [p.query_id for p in plan.probes],
         "replay_query_count": len(plan.replay_query_ids),
         "replay_recalls": replay_recalls,
+        "edge_calibration": edge_calibration,
         "gate_audit": gate_audit,
         "sleep": sleep_info,
         "checkpoints": checkpoints,
@@ -347,6 +363,113 @@ async def _replay(svc: Any, corpus: Corpus, plan: ReplayPlan, owner: str, ctx: A
     return recalls
 
 
+def _gold_pairs_from_plan(plan: ReplayPlan) -> set[frozenset[str]]:
+    """All within-gold-set doc pairs across every probe (the companions a
+    learned layer should associate)."""
+    gold_pairs: set[frozenset[str]] = set()
+    for probe in plan.probes:
+        gold = (probe.seed_doc, *probe.companion_docs)
+        for i in range(len(gold)):
+            for j in range(i + 1, len(gold)):
+                gold_pairs.add(frozenset((gold[i], gold[j])))
+    return gold_pairs
+
+
+async def _seed_edge_calibration(
+    db: Any, plan: ReplayPlan, id_map: dict[str, str], ctx: Any
+) -> dict[str, Any]:
+    """Calibrate the edge_gate threshold from this corpus and seed a row (#982).
+
+    Measures the NON-GOLD pairwise cosine distribution over the corpus vectors
+    (the noise population the #118 gate suppresses) and writes a model-global
+    ``edge_gate`` calibration row so ``resolve_edge_threshold`` returns
+    ``max(percentile, floor)`` for the replay instead of the absolute 0.5. With
+    a small fixed fixture the full pairwise distribution is the right estimate
+    (random sampling would yield too few pairs). Returns a diagnostic block;
+    the caller deletes the row afterward.
+    """
+    from datetime import timedelta
+    from uuid import UUID
+
+    from db.qdrant import get_qdrant_client
+    from models.neural import CALIBRATION_KIND_EDGE_GATE
+    from neural.calibration import resolve_edge_threshold
+    from neural.config import NeuralMemoryConfig
+    from neural.utils import cosine_similarity
+    from tasks.neural_calibration import _load_measure_script, _upsert_calibration
+    from utils.datetime import utcnow
+
+    script = _load_measure_script()
+    model_name, dims, collection = await script.resolve_embedding_model(db, ctx.id)
+    qdrant = get_qdrant_client()
+    vecs_by_mem = await script.fetch_vectors(qdrant, collection, [UUID(m) for m in id_map])
+    doc_vec = {id_map[m]: v for m, v in vecs_by_mem.items() if m in id_map}
+
+    gold_pairs = _gold_pairs_from_plan(plan)
+    doc_ids = list(doc_vec)
+    non_gold_cos: list[float] = []
+    gold_cos: list[float] = []
+    for i in range(len(doc_ids)):
+        for j in range(i + 1, len(doc_ids)):
+            a, b = doc_ids[i], doc_ids[j]
+            cos = cosine_similarity(doc_vec[a], doc_vec[b])
+            if frozenset((a, b)) in gold_pairs:
+                gold_cos.append(round(cos, 4))
+            else:
+                non_gold_cos.append(cos)
+
+    percentiles = script.compute_percentiles(non_gold_cos)
+    if not percentiles or not non_gold_cos:
+        return {"seeded": False, "reason": "no_non_gold_pairs", "model": model_name,
+                "dimensions": dims}
+
+    config = await NeuralMemoryConfig.from_db(db)
+    now = utcnow()
+    await _upsert_calibration(
+        db, model_name, dims, None,
+        kind=CALIBRATION_KIND_EDGE_GATE,
+        percentiles=percentiles,
+        observations=len(non_gold_cos),
+        now=now,
+        valid_until=now + timedelta(days=config.calibration_ttl_days),
+    )
+    await db.commit()
+
+    # The exact runtime value the replay will apply (reads the row we just wrote).
+    resolved = await resolve_edge_threshold(
+        db=db, config=config, model_name=model_name, dimensions=dims
+    )
+    return {
+        "seeded": True,
+        "model": model_name,
+        "dimensions": dims,
+        "non_gold_observations": len(non_gold_cos),
+        "non_gold_percentiles": {k: round(v, 4) for k, v in percentiles.items()},
+        "percentile_used": config.min_similarity_for_edge_percentile,
+        "floor": config.min_similarity_for_edge_floor,
+        "absolute_fallback": config.min_similarity_for_edge,
+        "resolved_threshold": round(resolved, 4),
+        "gold_pair_cosines": sorted(gold_cos),
+    }
+
+
+async def _delete_edge_calibration(db: Any, model_name: str, dimensions: int) -> None:
+    """Remove the transient model-global edge_gate row seeded for the demo."""
+    from sqlalchemy import delete as sa_delete
+
+    from models.neural import CALIBRATION_KIND_EDGE_GATE, EmbeddingCalibration
+
+    await db.execute(
+        sa_delete(EmbeddingCalibration).where(
+            EmbeddingCalibration.model_name == model_name,
+            EmbeddingCalibration.dimensions == dimensions,
+            EmbeddingCalibration.context_id.is_(None),
+            EmbeddingCalibration.kind == CALIBRATION_KIND_EDGE_GATE,
+        )
+    )
+    await db.commit()
+
+
 async def _gate_audit(
     svc: Any,
     db: Any,
@@ -367,20 +490,22 @@ async def _gate_audit(
     zero graph-lane lift attributable: if every probe gold pair is gated,
     no amount of replay rounds can produce recovery.
     """
+    from neural.calibration import resolve_edge_threshold
     from neural.config import NeuralMemoryConfig
     from neural.utils import cosine_similarity
+    from repositories.config_repository import ContextSearchConfigRepository
 
     config = await NeuralMemoryConfig.from_db(db)
     queries_by_id = {q.id: q for q in corpus.queries}
 
-    gold_pairs: set[frozenset[str]] = set()
-    for probe in plan.probes:
-        gold = (probe.seed_doc, *probe.companion_docs)
-        for i in range(len(gold)):
-            for j in range(i + 1, len(gold)):
-                gold_pairs.add(frozenset((gold[i], gold[j])))
+    gold_pairs = _gold_pairs_from_plan(plan)
 
-    audits: list[PairAudit] = []
+    # Pass 1: collect raw pair candidates and capture the embedding dimension.
+    # We classify in a second pass so the cosine gate uses the SAME calibrated
+    # edge-gate threshold the live replay path applied (#982) — auditing against
+    # the absolute config value would mislabel pairs the calibrated gate formed.
+    raw_pairs: list[tuple[str, str, str, float | None, float, bool]] = []
+    dims: int | None = None
     for query_id in plan.replay_query_ids:
         results = await svc.search_service.hybrid_search(
             query=queries_by_id[query_id].text,
@@ -402,28 +527,58 @@ async def _gate_audit(
             for j in range(i + 1, len(docs)):
                 doc_a, act_a, emb_a = docs[i]
                 doc_b, act_b, emb_b = docs[j]
+                if dims is None and emb_a:
+                    dims = len(emb_a)
                 cosine = cosine_similarity(emb_a, emb_b) if emb_a and emb_b else None
                 delta_w = config.learning_rate * act_a * act_b
-                audits.append(
-                    PairAudit(
-                        query_id=query_id,
-                        doc_a=doc_a,
-                        doc_b=doc_b,
-                        cosine=round(cosine, 4) if cosine is not None else None,
-                        delta_w=round(delta_w, 4),
-                        verdict=classify_pair(
-                            cosine,
-                            delta_w,
-                            min_similarity=config.min_similarity_for_edge,
-                            prune_threshold=config.prune_threshold,
-                        ),
-                        is_probe_gold_pair=frozenset((doc_a, doc_b)) in gold_pairs,
+                raw_pairs.append(
+                    (
+                        query_id,
+                        doc_a,
+                        doc_b,
+                        cosine,
+                        delta_w,
+                        frozenset((doc_a, doc_b)) in gold_pairs,
                     )
                 )
 
+    # Resolve the calibrated edge-gate threshold (#982). Falls back to the
+    # absolute config value when no edge_gate calibration row exists for this
+    # (model, dims) — exactly mirroring resolve_edge_threshold's contract and
+    # the gate the live replay applied.
+    edge_threshold = config.min_similarity_for_edge
+    if dims is not None:
+        ctx_cfg = await ContextSearchConfigRepository(db).create_or_get(ctx.id)
+        edge_threshold = await resolve_edge_threshold(
+            db=db, config=config, model_name=ctx_cfg.embedding_model, dimensions=dims
+        )
+
+    # Pass 2: classify against the resolved threshold.
+    audits = [
+        PairAudit(
+            query_id=query_id,
+            doc_a=doc_a,
+            doc_b=doc_b,
+            cosine=round(cosine, 4) if cosine is not None else None,
+            delta_w=round(delta_w, 4),
+            verdict=classify_pair(
+                cosine,
+                delta_w,
+                min_similarity=edge_threshold,
+                prune_threshold=config.prune_threshold,
+            ),
+            is_probe_gold_pair=is_gold,
+        )
+        for (query_id, doc_a, doc_b, cosine, delta_w, is_gold) in raw_pairs
+    ]
+
     summary = summarize_gate_audit(audits)
     summary["thresholds"] = {
-        "min_similarity_for_edge": config.min_similarity_for_edge,
+        # The value actually applied to classification (calibrated when an
+        # edge_gate row exists, else the absolute fallback).
+        "min_similarity_for_edge": edge_threshold,
+        # Kept for reference so a report shows whether calibration was in effect.
+        "min_similarity_for_edge_absolute": config.min_similarity_for_edge,
         "prune_threshold": config.prune_threshold,
         "learning_rate": config.learning_rate,
         "top_k_coactivation": config.top_k_coactivation,

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -194,8 +194,13 @@ async def _measure_replay_measure(
     # global (v1 resolve ignores context_id) so it briefly affects any
     # concurrent recall on the same (model, dims). Acceptable for a local
     # verification run with guaranteed cleanup.
-    edge_calibration = await _seed_edge_calibration(db, plan, id_map, ctx)
+    # Seed INSIDE the try so its commit is always paired with the finally
+    # cleanup — _seed_edge_calibration guarantees that once it commits the row
+    # it returns seeded=True + model/dimensions even if its post-commit
+    # diagnostic raises, so the finally can always delete the transient row.
+    edge_calibration: dict[str, Any] = {"seeded": False}
     try:
+        edge_calibration = await _seed_edge_calibration(db, plan, id_map, ctx)
         gate_audit = await _gate_audit(svc, db, corpus, plan, id_map, owner, ctx, ws)
         replay_recalls = await _replay(svc, corpus, plan, owner, ctx, ws)
         checkpoints["warm_replay"] = await _checkpoint(
@@ -442,11 +447,11 @@ async def _seed_edge_calibration(
     )
     await db.commit()
 
-    # The exact runtime value the replay will apply (reads the row we just wrote).
-    resolved = await resolve_edge_threshold(
-        db=db, config=config, model_name=model_name, dimensions=dims
-    )
-    return {
+    # Past the commit the row EXISTS, so the result must always carry seeded +
+    # model + dimensions for the caller's finally cleanup. The diagnostic
+    # resolve below is non-essential — guard it so a failure there can never
+    # strand the committed transient row (the leak this guards against).
+    result: dict[str, Any] = {
         "seeded": True,
         "model": model_name,
         "dimensions": dims,
@@ -455,9 +460,18 @@ async def _seed_edge_calibration(
         "percentile_used": config.min_similarity_for_edge_percentile,
         "floor": config.min_similarity_for_edge_floor,
         "absolute_fallback": config.min_similarity_for_edge,
-        "resolved_threshold": round(resolved, 4),
+        "resolved_threshold": None,
         "gold_pair_cosines": sorted(gold_cos),
     }
+    try:
+        # The exact runtime value the replay will apply (reads the row just written).
+        resolved = await resolve_edge_threshold(
+            db=db, config=config, model_name=model_name, dimensions=dims
+        )
+        result["resolved_threshold"] = round(resolved, 4)
+    except Exception:  # noqa: BLE001 — diagnostic only; row stays cleanable
+        pass
+    return result
 
 
 async def _delete_edge_calibration(db: Any, model_name: str, dimensions: int) -> None:

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -420,13 +420,20 @@ async def _seed_edge_calibration(
 
     percentiles = script.compute_percentiles(non_gold_cos)
     if not percentiles or not non_gold_cos:
-        return {"seeded": False, "reason": "no_non_gold_pairs", "model": model_name,
-                "dimensions": dims}
+        return {
+            "seeded": False,
+            "reason": "no_non_gold_pairs",
+            "model": model_name,
+            "dimensions": dims,
+        }
 
     config = await NeuralMemoryConfig.from_db(db)
     now = utcnow()
     await _upsert_calibration(
-        db, model_name, dims, None,
+        db,
+        model_name,
+        dims,
+        None,
         kind=CALIBRATION_KIND_EDGE_GATE,
         percentiles=percentiles,
         observations=len(non_gold_cos),

--- a/backend/tests/eval/results/compounding-2026-06-11.json
+++ b/backend/tests/eval/results/compounding-2026-06-11.json
@@ -1,0 +1,898 @@
+{
+  "run_date": "2026-06-11",
+  "experiment": "compounding",
+  "issue": 969,
+  "sudachi_version": "20260428",
+  "corpus_version": 1,
+  "query_count": 30,
+  "doc_count": 16,
+  "recall_k": 10,
+  "rounds": 8,
+  "explore_depth": 2,
+  "explore_min_weight": 0.05,
+  "design_note": "Per Issue #120 the neural graph is read by explore(), not by recall() ranking — so compounding is measured on the graph lane (companion recovery from a seed gold doc) while the recall lane is the flat-by-design stability control. Corpus is held fixed; publish lift deltas only, never absolute numbers.",
+  "modes": {
+    "exclude_probes": {
+      "mode": "exclude_probes",
+      "probe_count": 5,
+      "probe_query_ids": [
+        "q_cross_01",
+        "q_cross_02",
+        "q_cross_03",
+        "q_cross_04",
+        "q_cross_05"
+      ],
+      "replay_query_count": 25,
+      "replay_recalls": 200,
+      "edge_calibration": {
+        "seeded": true,
+        "model": "text-embedding-3-small",
+        "dimensions": 512,
+        "non_gold_observations": 115,
+        "non_gold_percentiles": {
+          "p25": 0.1753,
+          "p50": 0.2406,
+          "p75": 0.2915,
+          "p90": 0.3867,
+          "p95": 0.4466,
+          "p99": 0.5415
+        },
+        "percentile_used": 95.0,
+        "floor": 0.3,
+        "absolute_fallback": 0.5,
+        "resolved_threshold": 0.4466,
+        "gold_pair_cosines": [
+          0.2298,
+          0.3448,
+          0.3693,
+          0.393,
+          0.3983
+        ]
+      },
+      "gate_audit": {
+        "pair_observations": 75,
+        "verdicts": {
+          "gated_cosine": 57,
+          "gated_cosine+below_prune": 7,
+          "forms": 10,
+          "below_prune": 1
+        },
+        "formed_total": 10,
+        "formed_gold": 0,
+        "formed_non_gold": 10,
+        "non_gold_pair_count": 68,
+        "edge_precision": 0.0,
+        "non_gold_form_rate": 0.14705882352941177,
+        "probe_gold_pairs": [
+          {
+            "query_id": "q_exact_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0142,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_02",
+            "pair": [
+              "doc_mem_trust",
+              "doc_res_apikey"
+            ],
+            "cosine": 0.393,
+            "delta_w": 0.0183,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_03",
+            "pair": [
+              "doc_res_chunking",
+              "doc_mem_hybrid"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.015,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_05",
+            "pair": [
+              "doc_res_embedding",
+              "doc_mem_context"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.019,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_res_04",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0192,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_mem_03",
+            "pair": [
+              "doc_mem_context",
+              "doc_res_embedding"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.028,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_mem_05",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.035,
+            "verdict": "gated_cosine"
+          }
+        ],
+        "thresholds": {
+          "min_similarity_for_edge": 0.4465963907175252,
+          "min_similarity_for_edge_absolute": 0.5,
+          "prune_threshold": 0.01,
+          "learning_rate": 0.05,
+          "top_k_coactivation": 3
+        }
+      },
+      "sleep": {
+        "ok": true,
+        "status": "completed",
+        "edge_discovery": {
+          "success": true,
+          "skipped": false,
+          "skip_reason": null,
+          "error": null,
+          "llm_calls": 0,
+          "memories_processed": 0,
+          "details": {
+            "message": "no_edge_candidates",
+            "sampled": 16,
+            "candidates": 0,
+            "filtered": 0,
+            "edges_created": 0,
+            "llm_accepted": 0,
+            "llm_rejected": 0,
+            "llm_call_failures": 0,
+            "auto_accepted": 0,
+            "edge_type_dist": {},
+            "avg_confidence": 0.0,
+            "median_confidence": 0.0,
+            "p25_confidence": 0.0,
+            "p75_confidence": 0.0,
+            "confidence_n": 0,
+            "confidence_imputed": 0,
+            "confidence_histogram": {
+              "0.0-0.5": 0,
+              "0.5-0.7": 0,
+              "0.7-0.85": 0,
+              "0.85-1.0": 0
+            },
+            "avg_confidence_rejected": 0.0,
+            "median_confidence_rejected": 0.0,
+            "p25_confidence_rejected": 0.0,
+            "p75_confidence_rejected": 0.0,
+            "confidence_n_rejected": 0,
+            "confidence_imputed_rejected": 0,
+            "confidence_histogram_rejected": {
+              "0.0-0.5": 0,
+              "0.5-0.7": 0,
+              "0.7-0.85": 0,
+              "0.85-1.0": 0
+            },
+            "llm_model": "gpt-4o-mini",
+            "prompt_revision": "v3"
+          },
+          "llm_breakdown": [],
+          "embedding_calls": 0,
+          "embedding_tokens": 0
+        }
+      },
+      "checkpoints": {
+        "cold": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 0
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {}
+        },
+        "warm_replay": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 2
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {
+            "hebbian": {
+              "count": 10,
+              "avg_weight": 0.3474
+            }
+          }
+        },
+        "warm_sleep": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 2
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {
+            "hebbian": {
+              "count": 10,
+              "avg_weight": 0.3474
+            }
+          }
+        }
+      },
+      "lift": {
+        "graph_lane": {
+          "cold_to_warm_replay": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 0.0,
+              "warm": 2.0,
+              "abs": 2.0,
+              "rel": null
+            }
+          },
+          "warm_replay_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 2.0,
+              "warm": 2.0,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "cold_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 0.0,
+              "warm": 2.0,
+              "abs": 2.0,
+              "rel": null
+            }
+          }
+        },
+        "recall_lane": {
+          "cold_to_warm_replay": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "warm_replay_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "cold_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          }
+        }
+      }
+    },
+    "include_probes": {
+      "mode": "include_probes",
+      "probe_count": 5,
+      "probe_query_ids": [
+        "q_cross_01",
+        "q_cross_02",
+        "q_cross_03",
+        "q_cross_04",
+        "q_cross_05"
+      ],
+      "replay_query_count": 30,
+      "replay_recalls": 240,
+      "edge_calibration": {
+        "seeded": true,
+        "model": "text-embedding-3-small",
+        "dimensions": 512,
+        "non_gold_observations": 115,
+        "non_gold_percentiles": {
+          "p25": 0.1753,
+          "p50": 0.2406,
+          "p75": 0.2915,
+          "p90": 0.3867,
+          "p95": 0.4466,
+          "p99": 0.5415
+        },
+        "percentile_used": 95.0,
+        "floor": 0.3,
+        "absolute_fallback": 0.5,
+        "resolved_threshold": 0.4466,
+        "gold_pair_cosines": [
+          0.2298,
+          0.3448,
+          0.3693,
+          0.393,
+          0.3983
+        ]
+      },
+      "gate_audit": {
+        "pair_observations": 90,
+        "verdicts": {
+          "gated_cosine": 70,
+          "gated_cosine+below_prune": 8,
+          "forms": 11,
+          "below_prune": 1
+        },
+        "formed_total": 11,
+        "formed_gold": 0,
+        "formed_non_gold": 11,
+        "non_gold_pair_count": 81,
+        "edge_precision": 0.0,
+        "non_gold_form_rate": 0.13580246913580246,
+        "probe_gold_pairs": [
+          {
+            "query_id": "q_exact_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0142,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_02",
+            "pair": [
+              "doc_mem_trust",
+              "doc_res_apikey"
+            ],
+            "cosine": 0.393,
+            "delta_w": 0.0183,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_03",
+            "pair": [
+              "doc_res_chunking",
+              "doc_mem_hybrid"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.015,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_exact_05",
+            "pair": [
+              "doc_res_embedding",
+              "doc_mem_context"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.019,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_cross_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0364,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_cross_02",
+            "pair": [
+              "doc_res_embedding",
+              "doc_mem_context"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.0221,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_res_04",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0192,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_mem_03",
+            "pair": [
+              "doc_mem_context",
+              "doc_res_embedding"
+            ],
+            "cosine": 0.3693,
+            "delta_w": 0.028,
+            "verdict": "gated_cosine"
+          },
+          {
+            "query_id": "q_mem_05",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.035,
+            "verdict": "gated_cosine"
+          }
+        ],
+        "thresholds": {
+          "min_similarity_for_edge": 0.4465963907175252,
+          "min_similarity_for_edge_absolute": 0.5,
+          "prune_threshold": 0.01,
+          "learning_rate": 0.05,
+          "top_k_coactivation": 3
+        }
+      },
+      "sleep": {
+        "ok": true,
+        "status": "completed",
+        "edge_discovery": {
+          "success": true,
+          "skipped": false,
+          "skip_reason": null,
+          "error": null,
+          "llm_calls": 0,
+          "memories_processed": 0,
+          "details": {
+            "message": "no_edge_candidates",
+            "sampled": 16,
+            "candidates": 0,
+            "filtered": 0,
+            "edges_created": 0,
+            "llm_accepted": 0,
+            "llm_rejected": 0,
+            "llm_call_failures": 0,
+            "auto_accepted": 0,
+            "edge_type_dist": {},
+            "avg_confidence": 0.0,
+            "median_confidence": 0.0,
+            "p25_confidence": 0.0,
+            "p75_confidence": 0.0,
+            "confidence_n": 0,
+            "confidence_imputed": 0,
+            "confidence_histogram": {
+              "0.0-0.5": 0,
+              "0.5-0.7": 0,
+              "0.7-0.85": 0,
+              "0.85-1.0": 0
+            },
+            "avg_confidence_rejected": 0.0,
+            "median_confidence_rejected": 0.0,
+            "p25_confidence_rejected": 0.0,
+            "p75_confidence_rejected": 0.0,
+            "confidence_n_rejected": 0,
+            "confidence_imputed_rejected": 0,
+            "confidence_histogram_rejected": {
+              "0.0-0.5": 0,
+              "0.5-0.7": 0,
+              "0.7-0.85": 0,
+              "0.85-1.0": 0
+            },
+            "llm_model": "gpt-4o-mini",
+            "prompt_revision": "v3"
+          },
+          "llm_breakdown": [],
+          "embedding_calls": 0,
+          "embedding_tokens": 0
+        }
+      },
+      "checkpoints": {
+        "cold": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 0
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {}
+        },
+        "warm_replay": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 2
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {
+            "hebbian": {
+              "count": 10,
+              "avg_weight": 0.3701
+            }
+          }
+        },
+        "warm_sleep": {
+          "graph_lane": {
+            "n": 5,
+            "recovery@5": 0.0,
+            "recovery@10": 0.0,
+            "mrr@10": 0.0,
+            "seeds_in_graph": 2
+          },
+          "recall_lane": {
+            "n": 30,
+            "p@5": 0.2133,
+            "p@10": 0.1133,
+            "mrr@10": 1.0,
+            "ndcg@5": 0.9586,
+            "ndcg@10": 0.9707
+          },
+          "edge_stats": {
+            "hebbian": {
+              "count": 10,
+              "avg_weight": 0.3701
+            }
+          }
+        }
+      },
+      "lift": {
+        "graph_lane": {
+          "cold_to_warm_replay": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 0.0,
+              "warm": 2.0,
+              "abs": 2.0,
+              "rel": null
+            }
+          },
+          "warm_replay_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 2.0,
+              "warm": 2.0,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "cold_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@10": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "recovery@5": {
+              "cold": 0.0,
+              "warm": 0.0,
+              "abs": 0.0,
+              "rel": null
+            },
+            "seeds_in_graph": {
+              "cold": 0.0,
+              "warm": 2.0,
+              "abs": 2.0,
+              "rel": null
+            }
+          }
+        },
+        "recall_lane": {
+          "cold_to_warm_replay": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "warm_replay_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          },
+          "cold_to_warm_sleep": {
+            "mrr@10": {
+              "cold": 1.0,
+              "warm": 1.0,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@10": {
+              "cold": 0.9707,
+              "warm": 0.9707,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "ndcg@5": {
+              "cold": 0.9586,
+              "warm": 0.9586,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@10": {
+              "cold": 0.1133,
+              "warm": 0.1133,
+              "abs": 0.0,
+              "rel": 0.0
+            },
+            "p@5": {
+              "cold": 0.2133,
+              "warm": 0.2133,
+              "abs": 0.0,
+              "rel": 0.0
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/backend/tests/eval/test_compounding.py
+++ b/backend/tests/eval/test_compounding.py
@@ -208,3 +208,42 @@ def test_summarize_gate_audit_counts_and_probe_pairs():
             "verdict": "gated_cosine",
         }
     ]
+
+
+def test_summarize_gate_audit_reports_noise_side_metrics():
+    """#982 / Gate1: lowering the gate must not blow up non-gold (noise) edges.
+
+    The audit reports the precision side alongside the recall side: how many
+    formed edges are gold vs noise, and what fraction of non-gold pairs formed.
+    """
+    pairs = [
+        PairAudit("q1", "a", "b", 0.6, 0.02, "forms", is_probe_gold_pair=True),
+        PairAudit("q1", "a", "c", 0.6, 0.02, "forms", is_probe_gold_pair=False),
+        PairAudit("q2", "a", "d", 0.3, 0.02, "gated_cosine", is_probe_gold_pair=False),
+        PairAudit("q3", "s", "t", 0.4, 0.03, "gated_cosine", is_probe_gold_pair=True),
+    ]
+    summary = summarize_gate_audit(pairs)
+
+    assert summary["formed_total"] == 2
+    assert summary["formed_gold"] == 1
+    assert summary["formed_non_gold"] == 1
+    # precision of the formed-edge set w.r.t. gold pairs
+    assert summary["edge_precision"] == pytest.approx(0.5)
+    # non-gold pairs observed = a-c (formed) + a-d (gated) = 2; one formed
+    assert summary["non_gold_pair_count"] == 2
+    assert summary["non_gold_form_rate"] == pytest.approx(0.5)
+
+
+def test_summarize_gate_audit_edge_precision_none_when_nothing_forms():
+    """No formed edge → edge_precision is None (not a divide-by-zero / 0.0 lie)."""
+    pairs = [
+        PairAudit("q", "a", "b", 0.3, 0.02, "gated_cosine", is_probe_gold_pair=False),
+        PairAudit("q", "s", "t", 0.3, 0.02, "gated_cosine", is_probe_gold_pair=True),
+    ]
+    summary = summarize_gate_audit(pairs)
+
+    assert summary["formed_total"] == 0
+    assert summary["edge_precision"] is None
+    # one non-gold pair observed, none formed → 0.0 (defined: 0/1)
+    assert summary["non_gold_pair_count"] == 1
+    assert summary["non_gold_form_rate"] == pytest.approx(0.0)

--- a/backend/tests/eval/test_compounding_live.py
+++ b/backend/tests/eval/test_compounding_live.py
@@ -65,6 +65,18 @@ async def test_compounding_live():
         audit = mode_block["gate_audit"]
         assert audit["pair_observations"] > 0
         assert set(audit["thresholds"]) >= {"min_similarity_for_edge", "prune_threshold"}
+        # #982 / Gate1: the success criterion measures the NOISE side too, not
+        # just recovery. A recalibration that lifts recovery@10 by also forming
+        # spurious non-gold edges is a regression, not a win — these keys make
+        # edge precision / false-edge rate visible in every run's report.
+        assert {
+            "formed_total",
+            "formed_gold",
+            "formed_non_gold",
+            "non_gold_pair_count",
+            "edge_precision",
+            "non_gold_form_rate",
+        } <= set(audit)
 
         lift = mode_block["lift"]
         assert set(lift) == {"graph_lane", "recall_lane"}

--- a/backend/tests/neural/test_calibration.py
+++ b/backend/tests/neural/test_calibration.py
@@ -14,7 +14,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from models.neural import EmbeddingCalibration
-from neural.calibration import resolve_knn_threshold
+from neural.calibration import resolve_edge_threshold, resolve_knn_threshold
 from neural.config import NeuralMemoryConfig
 
 
@@ -40,11 +40,17 @@ def _make_config(
 def _make_calibration(
     p90: float = 0.6322,
     expired: bool = False,
+    kind: str = "knn_seed",
+    p25: float = 0.40,
+    p50: float = 0.50,
+    p75: float = 0.55,
 ) -> EmbeddingCalibration:
     """Build a calibration row with the given p90 and expiry state.
 
-    Other percentiles are placeholder values that keep the row valid
-    (ascending p25→p99) but are not read by the p90-only resolve path.
+    Other percentiles default to placeholder values that keep the row
+    valid (ascending p25→p99). ``kind`` distinguishes the knn-seed
+    (top-k neighbor) distribution from the edge-gate (random-pair)
+    distribution (#982).
     """
     now = datetime.now(UTC)
     valid_until = now - timedelta(minutes=1) if expired else now + timedelta(days=30)
@@ -52,9 +58,10 @@ def _make_calibration(
         model_name="text-embedding-3-small",
         dimensions=512,
         context_id=None,
-        p25=0.40,
-        p50=0.50,
-        p75=0.55,
+        kind=kind,
+        p25=p25,
+        p50=p50,
+        p75=p75,
         p90=p90,
         p95=min(p90 + 0.05, 1.0),
         p99=min(p90 + 0.12, 1.0),
@@ -163,6 +170,68 @@ class TestResolveKnnThresholdDisabled:
         db = _mock_db(calibration_result=None)
         result = await resolve_knn_threshold(db, cfg, "qwen3-embedding:8b", 4096)
         assert result is None
+
+
+class TestEmbeddingCalibrationKind:
+    """``kind`` column (#982) distinguishes knn_seed vs edge_gate rows."""
+
+    def test_kind_attribute_round_trips(self):
+        row = _make_calibration(kind="edge_gate")
+        assert row.kind == "edge_gate"
+
+
+def _make_edge_config(
+    absolute: float = 0.5,
+    percentile: float = 95.0,
+    floor: float = 0.3,
+) -> NeuralMemoryConfig:
+    """Config with the three edge-gate calibration fields set (#982)."""
+    cfg = NeuralMemoryConfig.from_env()
+    cfg.min_similarity_for_edge = absolute
+    cfg.min_similarity_for_edge_percentile = percentile
+    cfg.min_similarity_for_edge_floor = floor
+    return cfg
+
+
+class TestResolveEdgeThresholdCalibrationPath:
+    """#982 Step 1: edge_gate calibration row → ``max(percentile(p), floor)``."""
+
+    @pytest.mark.asyncio
+    async def test_percentile_above_floor_returned(self):
+        cfg = _make_edge_config(percentile=95.0, floor=0.3)
+        # p90=0.40 → p95=0.45 (per _make_calibration); percentile(95)=0.45 > floor.
+        db = _mock_db(_make_calibration(p90=0.40, kind="edge_gate"))
+        result = await resolve_edge_threshold(db, cfg, "text-embedding-3-small", 512)
+        assert result == pytest.approx(0.45)
+
+    @pytest.mark.asyncio
+    async def test_percentile_below_floor_returns_floor(self):
+        cfg = _make_edge_config(percentile=95.0, floor=0.4)
+        # p90=0.10 → p95=0.15 < floor 0.4 → floor wins.
+        db = _mock_db(_make_calibration(p90=0.10, p25=0.05, p50=0.08, p75=0.09, kind="edge_gate"))
+        result = await resolve_edge_threshold(db, cfg, "text-embedding-3-small", 512)
+        assert result == 0.4
+
+
+class TestResolveEdgeThresholdFallback:
+    """#982 Step 2: no calibration row → absolute fallback (gate stays active)."""
+
+    @pytest.mark.asyncio
+    async def test_no_calibration_returns_absolute(self):
+        cfg = _make_edge_config(absolute=0.5)
+        db = _mock_db(calibration_result=None)
+        result = await resolve_edge_threshold(db, cfg, "text-embedding-3-small", 512)
+        # Unlike knn-seed (which returns None to disable), the edge gate MUST
+        # stay active — the absolute value is the anti-noise fallback (#118).
+        assert result == 0.5
+
+    @pytest.mark.asyncio
+    async def test_expired_row_still_served(self):
+        """Fail-open on stale calibration: serve the stored value anyway."""
+        cfg = _make_edge_config(percentile=95.0, floor=0.3)
+        db = _mock_db(_make_calibration(p90=0.40, expired=True, kind="edge_gate"))
+        result = await resolve_edge_threshold(db, cfg, "text-embedding-3-small", 512)
+        assert result == pytest.approx(0.45)
 
 
 class TestEmbeddingCalibrationPercentile:

--- a/backend/tests/neural/test_co_activation.py
+++ b/backend/tests/neural/test_co_activation.py
@@ -436,6 +436,68 @@ class TestSemanticGating:
         records = tracker.record_activation("user1", activations, embeddings=embeddings)
         assert len(records) == 1
 
+    def test_similarity_threshold_override_admits_pair_config_would_gate(self):
+        """Per-call override (#982) takes precedence over config.min_similarity_for_edge.
+
+        config gate is high (0.9) so the 0.6-cosine pair would be rejected by
+        the fallback, but a 0.3 override (the calibrated edge_gate value)
+        admits it.
+        """
+        config = NeuralMemoryConfig(
+            track_co_activation=True, co_activation_window=60, min_similarity_for_edge=0.9
+        )
+        tracker = CoActivationTracker(config)
+        emb_a = self._make_embedding([1.0, 0.0, 0.0])
+        emb_b = self._make_embedding([0.6, 0.8, 0.0])  # cosine 0.6 with emb_a
+        activations = [
+            ActivationState(node_id="a", activation=1.0),
+            ActivationState(node_id="b", activation=0.8),
+        ]
+        records = tracker.record_activation(
+            "user1",
+            activations,
+            embeddings={"a": emb_a, "b": emb_b},
+            similarity_threshold=0.3,
+        )
+        assert len(records) == 1
+
+    def test_similarity_threshold_override_gates_pair_config_would_admit(self):
+        """A high override gates a pair that the low config value would admit."""
+        config = NeuralMemoryConfig(
+            track_co_activation=True, co_activation_window=60, min_similarity_for_edge=0.1
+        )
+        tracker = CoActivationTracker(config)
+        emb_a = self._make_embedding([1.0, 0.0, 0.0])
+        emb_b = self._make_embedding([0.6, 0.8, 0.0])  # cosine 0.6 with emb_a
+        activations = [
+            ActivationState(node_id="a", activation=1.0),
+            ActivationState(node_id="b", activation=0.8),
+        ]
+        records = tracker.record_activation(
+            "user1",
+            activations,
+            embeddings={"a": emb_a, "b": emb_b},
+            similarity_threshold=0.8,
+        )
+        assert len(records) == 0
+
+    def test_none_similarity_threshold_falls_back_to_config(self, tracker):
+        """similarity_threshold=None → use config.min_similarity_for_edge (0.5 fixture)."""
+        emb_a = self._make_embedding([1.0, 0.0, 0.0])
+        emb_b = self._make_embedding([0.6, 0.8, 0.0])  # cosine 0.6 > 0.5 fixture
+        activations = [
+            ActivationState(node_id="a", activation=1.0),
+            ActivationState(node_id="b", activation=0.8),
+        ]
+        records = tracker.record_activation(
+            "user1",
+            activations,
+            embeddings={"a": emb_a, "b": emb_b},
+            similarity_threshold=None,
+        )
+        # 0.6 >= config 0.5 → pair forms (override absent).
+        assert len(records) == 1
+
     def test_dissimilar_pairs_blocked(self, tracker):
         """Pairs with low similarity should NOT create co-activation edges."""
         # Two dissimilar embeddings (cosine sim < 0.5)

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -63,6 +63,50 @@ class TestNeuralMemoryConfig:
         assert config.gradient_clipping >= 0
 
 
+class TestEdgeGateCalibrationConfig:
+    """Edge-gate percentile calibration config fields (Issue #982).
+
+    ``min_similarity_for_edge`` becomes the absolute fallback when no
+    calibration row exists; the percentile + floor drive the calibration
+    path (random-pair baseline distribution).
+    """
+
+    def test_edge_calibration_defaults(self):
+        """Defaults: high percentile (random-pair upper tail) + floor."""
+        config = NeuralMemoryConfig()
+        assert config.min_similarity_for_edge_percentile == 95.0
+        assert config.min_similarity_for_edge_floor == 0.3
+        # Absolute fallback unchanged from prior behavior.
+        assert config.min_similarity_for_edge == 0.5
+
+    def test_edge_calibration_custom_values(self):
+        config = NeuralMemoryConfig(
+            min_similarity_for_edge_percentile=99.0,
+            min_similarity_for_edge_floor=0.25,
+        )
+        assert config.min_similarity_for_edge_percentile == 99.0
+        assert config.min_similarity_for_edge_floor == 0.25
+
+    def test_edge_percentile_must_be_in_open_unit_interval(self):
+        with pytest.raises(ValueError, match="min_similarity_for_edge_percentile"):
+            NeuralMemoryConfig(min_similarity_for_edge_percentile=0.0)
+        with pytest.raises(ValueError, match="min_similarity_for_edge_percentile"):
+            NeuralMemoryConfig(min_similarity_for_edge_percentile=100.0)
+
+    def test_edge_floor_must_be_in_unit_interval(self):
+        with pytest.raises(ValueError, match="min_similarity_for_edge_floor"):
+            NeuralMemoryConfig(min_similarity_for_edge_floor=1.5)
+        with pytest.raises(ValueError, match="min_similarity_for_edge_floor"):
+            NeuralMemoryConfig(min_similarity_for_edge_floor=-0.1)
+
+    def test_edge_calibration_from_env(self, monkeypatch):
+        monkeypatch.setenv("MIN_SIMILARITY_FOR_EDGE_PERCENTILE", "97.5")
+        monkeypatch.setenv("MIN_SIMILARITY_FOR_EDGE_FLOOR", "0.35")
+        config = NeuralMemoryConfig.from_env()
+        assert config.min_similarity_for_edge_percentile == 97.5
+        assert config.min_similarity_for_edge_floor == 0.35
+
+
 class TestSleepMaintenanceConfig:
     """Test Sleep Maintenance configuration fields (Issue #101)."""
 

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -313,14 +313,26 @@ class TestHebbianLearner:
         def _nodes():
             return {
                 "a": NeuralMemoryNode(
-                    id="a", user_id="u", kind=MemoryKind.FACT, text="A",
-                    embedding=emb_a, created_at=datetime.utcnow(),
-                    use_count=0, importance=0.5, confidence=1.0,
+                    id="a",
+                    user_id="u",
+                    kind=MemoryKind.FACT,
+                    text="A",
+                    embedding=emb_a,
+                    created_at=datetime.utcnow(),
+                    use_count=0,
+                    importance=0.5,
+                    confidence=1.0,
                 ),
                 "b": NeuralMemoryNode(
-                    id="b", user_id="u", kind=MemoryKind.FACT, text="B",
-                    embedding=emb_b, created_at=datetime.utcnow(),
-                    use_count=0, importance=0.5, confidence=1.0,
+                    id="b",
+                    user_id="u",
+                    kind=MemoryKind.FACT,
+                    text="B",
+                    embedding=emb_b,
+                    created_at=datetime.utcnow(),
+                    use_count=0,
+                    importance=0.5,
+                    confidence=1.0,
                 ),
             }
 
@@ -334,9 +346,7 @@ class TestHebbianLearner:
             learning_rate=0.1, gradient_clipping=1.0, min_similarity_for_edge=0.9
         )
         admit_learner = HebbianLearner(mock_graph, admit_cfg)
-        await admit_learner.queue_update(
-            "u", activations, _nodes(), similarity_threshold=0.3
-        )
+        await admit_learner.queue_update("u", activations, _nodes(), similarity_threshold=0.3)
         assert len(admit_learner._update_queue["u"]) == 2
 
         # config 0.1 would admit; override 0.8 gates → no updates.
@@ -344,9 +354,7 @@ class TestHebbianLearner:
             learning_rate=0.1, gradient_clipping=1.0, min_similarity_for_edge=0.1
         )
         gate_learner = HebbianLearner(mock_graph, gate_cfg)
-        await gate_learner.queue_update(
-            "u", activations, _nodes(), similarity_threshold=0.8
-        )
+        await gate_learner.queue_update("u", activations, _nodes(), similarity_threshold=0.8)
         assert len(gate_learner._update_queue.get("u", [])) == 0
 
     @pytest.mark.asyncio

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -295,6 +295,61 @@ class TestHebbianLearner:
         assert len(learner._update_queue["u"]) == 2  # Bidirectional
 
     @pytest.mark.asyncio
+    async def test_similarity_threshold_override_precedence(self, mock_graph):
+        """Per-call similarity_threshold (#982) overrides config.min_similarity_for_edge.
+
+        Two embeddings with cosine 0.6. With config gate 0.9 the pair would be
+        gated, but a 0.3 override (calibrated edge_gate value) admits it; with
+        config gate 0.1 a 0.8 override gates it. Proves the override wins in
+        both directions.
+        """
+        import numpy as np
+
+        emb_a = [1.0, 0.0, 0.0] + [0.0] * 5
+        emb_b = [0.6, 0.8, 0.0] + [0.0] * 5  # cosine 0.6 with emb_a
+        emb_a = (np.array(emb_a) / np.linalg.norm(emb_a)).tolist()
+        emb_b = (np.array(emb_b) / np.linalg.norm(emb_b)).tolist()
+
+        def _nodes():
+            return {
+                "a": NeuralMemoryNode(
+                    id="a", user_id="u", kind=MemoryKind.FACT, text="A",
+                    embedding=emb_a, created_at=datetime.utcnow(),
+                    use_count=0, importance=0.5, confidence=1.0,
+                ),
+                "b": NeuralMemoryNode(
+                    id="b", user_id="u", kind=MemoryKind.FACT, text="B",
+                    embedding=emb_b, created_at=datetime.utcnow(),
+                    use_count=0, importance=0.5, confidence=1.0,
+                ),
+            }
+
+        activations = [
+            ActivationState(node_id="a", activation=0.9),
+            ActivationState(node_id="b", activation=0.8),
+        ]
+
+        # config 0.9 would gate; override 0.3 admits → 2 bidirectional updates.
+        admit_cfg = NeuralMemoryConfig(
+            learning_rate=0.1, gradient_clipping=1.0, min_similarity_for_edge=0.9
+        )
+        admit_learner = HebbianLearner(mock_graph, admit_cfg)
+        await admit_learner.queue_update(
+            "u", activations, _nodes(), similarity_threshold=0.3
+        )
+        assert len(admit_learner._update_queue["u"]) == 2
+
+        # config 0.1 would admit; override 0.8 gates → no updates.
+        gate_cfg = NeuralMemoryConfig(
+            learning_rate=0.1, gradient_clipping=1.0, min_similarity_for_edge=0.1
+        )
+        gate_learner = HebbianLearner(mock_graph, gate_cfg)
+        await gate_learner.queue_update(
+            "u", activations, _nodes(), similarity_threshold=0.8
+        )
+        assert len(gate_learner._update_queue.get("u", [])) == 0
+
+    @pytest.mark.asyncio
     async def test_prune_weak_edges_excludes_semantic_origin(self, mock_graph):
         """#724: the per-node top-M pruner only considers hebbian edges.
 

--- a/backend/tests/tasks/test_neural_calibration.py
+++ b/backend/tests/tasks/test_neural_calibration.py
@@ -1,0 +1,73 @@
+"""Unit tests for the calibration upsert helper (#982).
+
+``compute_calibration`` itself is integration-tested (it drives Qdrant + the
+measurement script + DB); these cover the extracted ``_upsert_calibration``
+helper in isolation — specifically the kind-scoping that keeps a knn_seed
+recalibration from wiping the coexisting edge_gate row.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.neural import (
+    CALIBRATION_KIND_EDGE_GATE,
+    CALIBRATION_KIND_KNN_SEED,
+)
+from tasks.neural_calibration import _upsert_calibration
+
+_PCTS = {"p25": 0.10, "p50": 0.15, "p75": 0.20, "p90": 0.25, "p95": 0.30, "p99": 0.40}
+
+
+def _mock_db() -> AsyncMock:
+    db = AsyncMock()
+    db.add = MagicMock()  # sync method
+    return db
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", [CALIBRATION_KIND_KNN_SEED, CALIBRATION_KIND_EDGE_GATE])
+async def test_upsert_builds_row_with_requested_kind(kind):
+    db = _mock_db()
+    now = datetime.now(UTC)
+    row = await _upsert_calibration(
+        db,
+        "text-embedding-3-small",
+        512,
+        None,
+        kind=kind,
+        percentiles=_PCTS,
+        observations=100,
+        now=now,
+        valid_until=now + timedelta(days=30),
+    )
+    # A (kind-scoped) delete is issued, then the fresh row is added.
+    db.execute.assert_awaited_once()
+    db.add.assert_called_once()
+    assert row.kind == kind
+    assert row.p95 == 0.30
+    assert row.sample_size == 100
+    assert row.model_name == "text-embedding-3-small"
+    assert row.dimensions == 512
+
+
+@pytest.mark.asyncio
+async def test_upsert_does_not_commit():
+    """Helper must NOT commit — the caller commits once so both kinds are atomic."""
+    db = _mock_db()
+    now = datetime.now(UTC)
+    await _upsert_calibration(
+        db,
+        "m",
+        512,
+        None,
+        kind=CALIBRATION_KIND_EDGE_GATE,
+        percentiles=_PCTS,
+        observations=50,
+        now=now,
+        valid_until=now + timedelta(days=30),
+    )
+    db.commit.assert_not_called()

--- a/backend/tests/tasks/test_neural_calibration.py
+++ b/backend/tests/tasks/test_neural_calibration.py
@@ -17,7 +17,7 @@ from models.neural import (
     CALIBRATION_KIND_EDGE_GATE,
     CALIBRATION_KIND_KNN_SEED,
 )
-from tasks.neural_calibration import _upsert_calibration
+from tasks.neural_calibration import _delete_calibration, _upsert_calibration
 
 _PCTS = {"p25": 0.10, "p50": 0.15, "p75": 0.20, "p90": 0.25, "p95": 0.30, "p99": 0.40}
 
@@ -70,4 +70,17 @@ async def test_upsert_does_not_commit():
         now=now,
         valid_until=now + timedelta(days=30),
     )
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_calibration_issues_delete_without_commit():
+    """#982: skipping an edge_gate upsert must delete any stale row (so the
+    runtime falls back to the absolute config value), without committing —
+    the caller owns the commit."""
+    db = _mock_db()
+    await _delete_calibration(
+        db, "text-embedding-3-small", 512, None, kind=CALIBRATION_KIND_EDGE_GATE
+    )
+    db.execute.assert_awaited_once()
     db.commit.assert_not_called()


### PR DESCRIPTION
## Summary

Calibrates the co-activation / Hebbian semantic gate (`min_similarity_for_edge`, #118) **per embedding model** instead of the absolute `0.5` default. Closes #982 (follow-up to the #969 compounding experiment).

The #969 experiment found **zero graph-lane lift**: cross-topic gold pairs were co-recalled with healthy Hebbian Δw but 100% rejected by the absolute cosine gate (their pair cosines are 0.37–0.40 under `text-embedding-3-small`). The fix calibrates the gate against the **random-pair cosine distribution** — a different population from the top-k neighbor distribution #240/#406 store for knn-seed.

## What changed

- **config** — `min_similarity_for_edge_percentile` (95.0) + `_floor` (0.3); the absolute `min_similarity_for_edge` is now the no-calibration fallback.
- **`resolve_edge_threshold`** — `edge_gate` calibration row → `max(percentile, floor)`, else absolute fallback (never disables the gate, unlike knn-seed). Shares the row lookup with `resolve_knn_threshold`, which now filters `kind='knn_seed'`.
- **`EmbeddingCalibration.kind`** column (`knn_seed` | `edge_gate`) + migration `e38_982_edge_gate_kind` (backfills `knn_seed`, widens the partial-unique indexes). Up/down round-trip verified.
- **`compute_calibration`** writes **both** kinds from one sample via a kind-scoped `_upsert_calibration` helper. The kind scope also fixes a latent upsert bug surfaced in self-review: once `edge_gate` rows coexist, the un-scoped DELETE would have wiped the sibling row.
- **wiring** — the recall path resolves the threshold and injects the **same value** into both the co-activation tracker and the Hebbian learner.

## Verification

- ✅ ruff clean, pyright 0 errors, **175 neural/eval/task unit tests** green, migration up/down round-trips.
- ✅ **Gate1-required noise-side guard**: `summarize_gate_audit` now reports `edge_precision` / `non_gold_form_rate` / `formed_(gold|non_gold)`, and the gate audit classifies against the *resolved* (calibrated) threshold.
- ✅ **End-to-end demonstrated** via `make eval-compounding` (self-calibrates from the corpus's non-gold pairwise distribution): probe gold pairs flip `gated_cosine → forms` and **`recovery@10` lifts 0 → 0.6** — the first demonstrated compounding — with the precision cost made measurable (`non_gold_form_rate` 0.147 → 0.47 at threshold 0.3).

## Honest finding (→ #983)

The eval also proved a **1-D cosine threshold has a structural limit** on this corpus: the cross-topic gold pairs (0.23–0.40) overlap the noise distribution (p50=0.24, p90=0.39), so any threshold trades recall against noise. The global percentile default stays at p95 (no overfitting to the toy fixture); the value of this PR is making the tradeoff *measurable*. The deeper fix — a **2-D gate (co-activation count × cosine)** that admits low-cosine pairs on repeated co-recall evidence — is tracked in #983.

## Gate1

`yellow` (via /ceo) — the one condition (add a noise-side guard to the eval criterion) is **addressed** in this PR.

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)
