### PR TITLE
feat(api): 2D edge gate — co-activation evidence x cosine (#983)

### DIFF
--- a/backend/src/neural/co_activation.py
+++ b/backend/src/neural/co_activation.py
@@ -57,6 +57,7 @@ class CoActivationTracker:
         embeddings: dict[str, list[float]] | None = None,
         similarity_threshold: float | None = None,
         floor_threshold: float | None = None,
+        event_key: str | None = None,
     ) -> list[CoActivationRecord]:
         """Record an activation event and detect co-activations.
 
@@ -78,6 +79,10 @@ class CoActivationTracker:
                 outright. Edge materialization for band pairs is decided
                 downstream by ``HebbianLearner.queue_update`` via the
                 repetition requirement. ``None`` keeps the 1-D gate.
+            event_key: Stable fingerprint of the triggering query (#983).
+                Evidence is counted once per distinct key so replaying the
+                same query cannot inflate it; ``None`` falls back to
+                per-event counting.
 
         Returns:
             List of co-activation records updated/created in this event
@@ -119,6 +124,7 @@ class CoActivationTracker:
                 activation_1=act_1,
                 activation_2=act_2,
                 same_event=same_event,
+                event_key=event_key,
             )
             updated_records.append(record)
 
@@ -318,6 +324,7 @@ class CoActivationTracker:
         activation_1: float,
         activation_2: float,
         same_event: bool = False,
+        event_key: str | None = None,
     ) -> CoActivationRecord:
         """Update or create a co-activation record.
 
@@ -329,6 +336,7 @@ class CoActivationTracker:
             activation_2: Activation strength of node 2
             same_event: True when both nodes appeared in the same activation
                 event (#983 repetition evidence)
+            event_key: Distinct-query fingerprint for evidence dedup (#983)
 
         Returns:
             Updated/created CoActivationRecord
@@ -343,7 +351,7 @@ class CoActivationTracker:
         if key in self._co_activation_records[user_id]:
             # Update existing record
             record = self._co_activation_records[user_id][key]
-            record.update(activation_1, activation_2, same_event=same_event)
+            record.update(activation_1, activation_2, same_event=same_event, event_key=event_key)
         else:
             # Create new record
             record = CoActivationRecord(
@@ -353,6 +361,7 @@ class CoActivationTracker:
                 total_activation_product=activation_1 * activation_2,
                 user_id=user_id,
                 same_event_count=1 if same_event else 0,
+                evidence_keys={event_key} if (same_event and event_key) else set(),
             )
             self._co_activation_records[user_id][key] = record
 
@@ -432,6 +441,7 @@ class CoActivationTracker:
             record_dict = {
                 "count": record.count,
                 "same_event_count": record.same_event_count,
+                "evidence_keys": sorted(record.evidence_keys),
                 "total_activation_product": record.total_activation_product,
                 "first_seen": record.first_seen.isoformat(),
                 "last_seen": record.last_co_activation.isoformat(),
@@ -476,6 +486,7 @@ class CoActivationTracker:
                 user_id=user_id,
                 # Pre-#983 records have no same_event_count — default to 0.
                 same_event_count=record_dict.get("same_event_count", 0),
+                evidence_keys=set(record_dict.get("evidence_keys", [])),
             )
 
             # Restore timestamps

--- a/backend/src/neural/co_activation.py
+++ b/backend/src/neural/co_activation.py
@@ -56,6 +56,7 @@ class CoActivationTracker:
         session_id: str | None = None,
         embeddings: dict[str, list[float]] | None = None,
         similarity_threshold: float | None = None,
+        floor_threshold: float | None = None,
     ) -> list[CoActivationRecord]:
         """Record an activation event and detect co-activations.
 
@@ -70,6 +71,13 @@ class CoActivationTracker:
                 not None, takes precedence over ``config.min_similarity_for_edge``
                 — the caller resolves the calibrated edge-gate threshold (DB-
                 aware) and passes it in. ``None`` falls back to the config value.
+            floor_threshold: 2D edge gate (#983). When not None, lowers the
+                *recording* gate to this value so pairs in the
+                [floor, threshold) cosine band accumulate co-activation
+                evidence (``same_event_count``) instead of being rejected
+                outright. Edge materialization for band pairs is decided
+                downstream by ``HebbianLearner.queue_update`` via the
+                repetition requirement. ``None`` keeps the 1-D gate.
 
         Returns:
             List of co-activation records updated/created in this event
@@ -98,18 +106,19 @@ class CoActivationTracker:
 
         # Detect co-activations within the time window
         co_activated_pairs = self._find_co_activations_in_window(
-            user_id, timestamp, similarity_threshold
+            user_id, timestamp, similarity_threshold, floor_threshold, activated_ids
         )
 
         # Update co-activation records
         updated_records = []
-        for node_1, node_2, act_1, act_2 in co_activated_pairs:
+        for node_1, node_2, act_1, act_2, same_event in co_activated_pairs:
             record = self._update_co_activation_record(
                 user_id=user_id,
                 node_1=node_1,
                 node_2=node_2,
                 activation_1=act_1,
                 activation_2=act_2,
+                same_event=same_event,
             )
             updated_records.append(record)
 
@@ -209,21 +218,37 @@ class CoActivationTracker:
         user_id: str,
         current_time: datetime,
         similarity_threshold: float | None = None,
-    ) -> list[tuple[str, str, float, float]]:
+        floor_threshold: float | None = None,
+        current_ids: set[str] | None = None,
+    ) -> list[tuple[str, str, float, float, bool]]:
         """Find all co-activated pairs within the time window.
 
         Applies semantic gating: pairs with cosine similarity below the
-        effective threshold are skipped to prevent noise edges. The effective
-        threshold is ``similarity_threshold`` when provided (#982 calibrated
-        value), else ``config.min_similarity_for_edge``.
+        effective *recording* gate are skipped to prevent noise edges. The
+        recording gate is ``floor_threshold`` when provided (#983 — band
+        pairs accumulate evidence), else ``similarity_threshold`` (#982
+        calibrated value), else ``config.min_similarity_for_edge``.
+
+        Only pairs involving at least one node from the *current* activation
+        event are returned (#983 count-inflation fix): two nodes merely
+        lingering in the window from earlier events are not co-firing now,
+        so re-counting them every event inflated ``count`` without new
+        evidence.
 
         Args:
             user_id: User ID
             current_time: Current timestamp
             similarity_threshold: Per-call gate override; ``None`` → config.
+            floor_threshold: Recording-gate floor for the 2D edge gate
+                (#983); ``None`` keeps the 1-D gate.
+            current_ids: Node IDs of the current activation event. ``None``
+                treats every window node as current (legacy behavior, used
+                only by direct callers without event context).
 
         Returns:
-            List of (node_1, node_2, activation_1, activation_2) tuples
+            List of (node_1, node_2, activation_1, activation_2, same_event)
+            tuples, where ``same_event`` is True when both nodes are in the
+            current activation event (repetition evidence, #983).
         """
         # Get all activated nodes in the window
         window_seconds = self.config.co_activation_window
@@ -248,17 +273,26 @@ class CoActivationTracker:
             if similarity_threshold is not None
             else self.config.min_similarity_for_edge
         )
+        # The recording gate admits the [floor, threshold) band so evidence
+        # can accumulate; edge materialization stays gated downstream.
+        record_gate = floor_threshold if floor_threshold is not None else threshold
+        if current_ids is None:
+            current_ids = set(node_ids)
         skipped = 0
 
         for i, node_1 in enumerate(node_ids):
             for node_2 in node_ids[i + 1 :]:  # Avoid duplicates
-                # Semantic gating: skip pairs below similarity threshold
+                # Count-inflation fix (#983): skip pairs with no current node.
+                if node_1 not in current_ids and node_2 not in current_ids:
+                    continue
+
+                # Semantic gating: skip pairs below the recording gate
                 emb_1 = all_embeddings.get(node_1)
                 emb_2 = all_embeddings.get(node_2)
 
                 if emb_1 and emb_2:
                     sim = cosine_similarity(emb_1, emb_2)
-                    if sim < threshold:
+                    if sim < record_gate:
                         skipped += 1
                         continue
 
@@ -266,11 +300,12 @@ class CoActivationTracker:
                 avg_act_1 = sum(all_activated[node_1]) / len(all_activated[node_1])
                 avg_act_2 = sum(all_activated[node_2]) / len(all_activated[node_2])
 
-                co_activated_pairs.append((node_1, node_2, avg_act_1, avg_act_2))
+                same_event = node_1 in current_ids and node_2 in current_ids
+                co_activated_pairs.append((node_1, node_2, avg_act_1, avg_act_2, same_event))
 
         if skipped > 0:
             logger.debug(
-                "semantic_gating_skipped", extra={"skipped": skipped, "threshold": threshold}
+                "semantic_gating_skipped", extra={"skipped": skipped, "threshold": record_gate}
             )
 
         return co_activated_pairs
@@ -282,6 +317,7 @@ class CoActivationTracker:
         node_2: str,
         activation_1: float,
         activation_2: float,
+        same_event: bool = False,
     ) -> CoActivationRecord:
         """Update or create a co-activation record.
 
@@ -291,6 +327,8 @@ class CoActivationTracker:
             node_2: Second node ID
             activation_1: Activation strength of node 1
             activation_2: Activation strength of node 2
+            same_event: True when both nodes appeared in the same activation
+                event (#983 repetition evidence)
 
         Returns:
             Updated/created CoActivationRecord
@@ -305,7 +343,7 @@ class CoActivationTracker:
         if key in self._co_activation_records[user_id]:
             # Update existing record
             record = self._co_activation_records[user_id][key]
-            record.update(activation_1, activation_2)
+            record.update(activation_1, activation_2, same_event=same_event)
         else:
             # Create new record
             record = CoActivationRecord(
@@ -314,6 +352,7 @@ class CoActivationTracker:
                 count=1,
                 total_activation_product=activation_1 * activation_2,
                 user_id=user_id,
+                same_event_count=1 if same_event else 0,
             )
             self._co_activation_records[user_id][key] = record
 
@@ -392,6 +431,7 @@ class CoActivationTracker:
         for (node_1, node_2), record in self._co_activation_records[user_id].items():
             record_dict = {
                 "count": record.count,
+                "same_event_count": record.same_event_count,
                 "total_activation_product": record.total_activation_product,
                 "first_seen": record.first_seen.isoformat(),
                 "last_seen": record.last_co_activation.isoformat(),
@@ -434,6 +474,8 @@ class CoActivationTracker:
                 count=record_dict["count"],
                 total_activation_product=record_dict["total_activation_product"],
                 user_id=user_id,
+                # Pre-#983 records have no same_event_count — default to 0.
+                same_event_count=record_dict.get("same_event_count", 0),
             )
 
             # Restore timestamps

--- a/backend/src/neural/co_activation.py
+++ b/backend/src/neural/co_activation.py
@@ -442,6 +442,7 @@ class CoActivationTracker:
                 "count": record.count,
                 "same_event_count": record.same_event_count,
                 "evidence_keys": sorted(record.evidence_keys),
+                "pending_weight": record.pending_weight,
                 "total_activation_product": record.total_activation_product,
                 "first_seen": record.first_seen.isoformat(),
                 "last_seen": record.last_co_activation.isoformat(),
@@ -487,6 +488,7 @@ class CoActivationTracker:
                 # Pre-#983 records have no same_event_count — default to 0.
                 same_event_count=record_dict.get("same_event_count", 0),
                 evidence_keys=set(record_dict.get("evidence_keys", [])),
+                pending_weight=record_dict.get("pending_weight", 0.0),
             )
 
             # Restore timestamps

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -149,6 +149,17 @@ class NeuralMemoryConfig:
     # cross-topic pairs at cosine 0.37-0.40 under text-embedding-3-small).
     min_similarity_for_edge_percentile: float = 95.0
     min_similarity_for_edge_floor: float = 0.3
+    # 2D edge gate (#983): second gate axis = repetition. Pairs whose cosine
+    # falls in the [floor, calibrated-threshold) band are not rejected
+    # outright — they form an edge once their co-activation count reaches
+    # ``min_co_activation_count``. Genuine cross-topic associations are
+    # co-recalled repeatedly across different queries; noise pairs co-occur
+    # once by ranking accident (#982 eval finding: the two distributions
+    # overlap on cosine alone). Disable to restore the pure 1-D gate.
+    # NOTE: co-activation counts are tracked in process memory only — they
+    # reset on restart and are not shared across workers. Accepted and
+    # documented as a known limitation (#983); persistence is a follow-up.
+    edge_gate_repetition_enabled: bool = True
     max_assoc_score: float = 0.5  # Cap graph association score per node
     top_k_coactivation: int = 3  # Only co-activate top-k results
 
@@ -481,6 +492,7 @@ class NeuralMemoryConfig:
             importance_ema_alpha=get_float("IMPORTANCE_EMA_ALPHA", 0.3),
             # Co-Activation
             track_co_activation=get_bool("TRACK_CO_ACTIVATION", True),
+            edge_gate_repetition_enabled=get_bool("EDGE_GATE_REPETITION_ENABLED", True),
             co_activation_window=get_int("CO_ACTIVATION_WINDOW", 300),
             min_co_activation_count=get_int("MIN_CO_ACTIVATION_COUNT", 2),
             min_similarity_for_edge=get_float("MIN_SIMILARITY_FOR_EDGE", 0.5),
@@ -592,6 +604,7 @@ class NeuralMemoryConfig:
             ),
             # Co-Activation (env-only, not in DB)
             track_co_activation=base_config.track_co_activation,
+            edge_gate_repetition_enabled=base_config.edge_gate_repetition_enabled,
             co_activation_window=configs.get(
                 "co_activation_window", base_config.co_activation_window
             ),

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -300,6 +300,17 @@ class NeuralMemoryConfig:
             raise ValueError(
                 f"edge_gate_min_evidence must be positive, got {self.edge_gate_min_evidence}"
             )
+        # The repetition evidence counter (CoActivationRecord.same_event_count)
+        # saturates at the per-record evidence_keys cap; a requirement above it
+        # would make the 2D band gate silently unsatisfiable (#983).
+        from .models import CoActivationRecord
+
+        _evidence_cap = CoActivationRecord._EVIDENCE_KEYS_CAP
+        if self.edge_gate_min_evidence > _evidence_cap:
+            raise ValueError(
+                f"edge_gate_min_evidence ({self.edge_gate_min_evidence}) must not exceed the "
+                f"evidence_keys cap ({_evidence_cap}); above it the 2D band gate can never form"
+            )
         if not (0.0 <= self.min_similarity_for_edge <= 1.0):
             raise ValueError(
                 f"min_similarity_for_edge must be in [0, 1], got {self.min_similarity_for_edge}"

--- a/backend/src/neural/config.py
+++ b/backend/src/neural/config.py
@@ -156,10 +156,19 @@ class NeuralMemoryConfig:
     # co-recalled repeatedly across different queries; noise pairs co-occur
     # once by ranking accident (#982 eval finding: the two distributions
     # overlap on cosine alone). Disable to restore the pure 1-D gate.
-    # NOTE: co-activation counts are tracked in process memory only — they
-    # reset on restart and are not shared across workers. Accepted and
-    # documented as a known limitation (#983); persistence is a follow-up.
+    # NOTE: evidence counts live in the in-process CoActivationTracker and
+    # round-trip Redis with a 7-day TTL (#84 Phase 2C), so they survive
+    # restarts; cross-worker sharing is last-writer-wins (documented #983
+    # limitation).
     edge_gate_repetition_enabled: bool = True
+    # Distinct-query co-recall count required before a band pair forms.
+    # Default 4 from the measured #983 tradeoff curve (eval corpus,
+    # text-embedding-3-small/512d): evidence >= 4 keeps recovery@10 lift > 0
+    # while non_gold_form_rate returns to the p95 random-pair baseline
+    # (0.149 vs 0.147); evidence >= 2 doubles recovery (0.4) but triples the
+    # noise rate (0.43). Deployments that prefer recall over precision can
+    # lower this (the graph-lane blast radius is bounded by #120).
+    edge_gate_min_evidence: int = 4
     max_assoc_score: float = 0.5  # Cap graph association score per node
     top_k_coactivation: int = 3  # Only co-activate top-k results
 
@@ -286,6 +295,10 @@ class NeuralMemoryConfig:
         if not self.min_co_activation_count > 0:
             raise ValueError(
                 f"min_co_activation_count must be positive, got {self.min_co_activation_count}"
+            )
+        if not self.edge_gate_min_evidence > 0:
+            raise ValueError(
+                f"edge_gate_min_evidence must be positive, got {self.edge_gate_min_evidence}"
             )
         if not (0.0 <= self.min_similarity_for_edge <= 1.0):
             raise ValueError(
@@ -493,6 +506,7 @@ class NeuralMemoryConfig:
             # Co-Activation
             track_co_activation=get_bool("TRACK_CO_ACTIVATION", True),
             edge_gate_repetition_enabled=get_bool("EDGE_GATE_REPETITION_ENABLED", True),
+            edge_gate_min_evidence=get_int("EDGE_GATE_MIN_EVIDENCE", 4),
             co_activation_window=get_int("CO_ACTIVATION_WINDOW", 300),
             min_co_activation_count=get_int("MIN_CO_ACTIVATION_COUNT", 2),
             min_similarity_for_edge=get_float("MIN_SIMILARITY_FOR_EDGE", 0.5),
@@ -605,6 +619,9 @@ class NeuralMemoryConfig:
             # Co-Activation (env-only, not in DB)
             track_co_activation=base_config.track_co_activation,
             edge_gate_repetition_enabled=base_config.edge_gate_repetition_enabled,
+            edge_gate_min_evidence=configs.get(
+                "edge_gate_min_evidence", base_config.edge_gate_min_evidence
+            ),
             co_activation_window=configs.get(
                 "co_activation_window", base_config.co_activation_window
             ),

--- a/backend/src/neural/hebbian.py
+++ b/backend/src/neural/hebbian.py
@@ -52,6 +52,11 @@ class HebbianLearner:
         self.graph = graph
         self.config = config
         self._update_queue: dict[str, list[HebbianUpdate]] = defaultdict(list)
+        # #983 prune-cliff fix: sub-threshold weight accumulated for edges
+        # that do not exist yet, keyed (src_id, dst_id) per user. In-process
+        # only (same volatility contract as CoActivationTracker records);
+        # entries are popped when the edge materializes.
+        self._pending_weights: dict[str, dict[tuple[str, str], float]] = defaultdict(dict)
 
     async def queue_update(
         self,
@@ -320,19 +325,31 @@ class HebbianLearner:
         Returns:
             New weight value, or None if update failed
         """
+        pair_key = (src_id, dst_id)
+        # #983: fold in any pending sub-threshold weight from earlier
+        # co-recalls of this not-yet-materialized edge.
+        pending = self._pending_weights[user_id].pop(pair_key, 0.0)
         current_weight = await self._get_current_weight(user_id, src_id, dst_id)
-        new_weight = current_weight + delta_w
+        new_weight = current_weight + pending + delta_w
 
         # Clip to [0, weight_max]
         new_weight = max(0.0, min(new_weight, self.config.weight_max))
 
         # Prune if below threshold
         if new_weight < self.config.prune_threshold:
-            # Remove edge
             try:
                 if await self.graph.has_edge(src_id, dst_id):
+                    # Existing edge decayed below threshold — prune. The #983
+                    # cliff fix applies only to not-yet-materialized edges;
+                    # decay-side pruning is unchanged.
                     await self.graph.remove_edge(src_id, dst_id)
                     logger.debug(f"Pruned edge ({src_id}, {dst_id}) (weight={new_weight:.4f})")
+                elif new_weight > 0.0:
+                    # #983 prune-cliff fix: the edge does not exist yet, so a
+                    # sub-threshold first update used to be dropped — making
+                    # accumulation across repeated co-recalls impossible
+                    # (~12% of observed pairs in the #969 audit). Stash it.
+                    self._pending_weights[user_id][pair_key] = new_weight
                 return 0.0
             except Exception as e:
                 logger.error(f"Failed to remove edge ({src_id}, {dst_id}): {e}")

--- a/backend/src/neural/hebbian.py
+++ b/backend/src/neural/hebbian.py
@@ -20,6 +20,7 @@ References:
 
 import logging
 from collections import defaultdict
+from typing import TYPE_CHECKING
 
 from models.memory import EDGE_ORIGIN_HEBBIAN
 from src.services.graph_service import GraphService as GraphMemory
@@ -27,6 +28,9 @@ from src.services.graph_service import GraphService as GraphMemory
 from .config import NeuralMemoryConfig
 from .models import ActivationState, HebbianUpdate, NeuralMemoryNode
 from .utils import cosine_similarity
+
+if TYPE_CHECKING:
+    from .co_activation import CoActivationTracker
 
 logger = logging.getLogger(__name__)
 
@@ -42,21 +46,25 @@ class HebbianLearner:
         self,
         graph: GraphMemory,
         config: NeuralMemoryConfig,
+        co_activation_tracker: "CoActivationTracker | None" = None,
     ) -> None:
         """Initialize Hebbian learner.
 
         Args:
             graph: Graph memory instance to update
             config: Neural memory configuration
+            co_activation_tracker: Tracker whose CoActivationRecords carry the
+                #983 prune-cliff ``pending_weight``. Required for sub-threshold
+                accumulation to survive a recall — the learner is rebuilt per
+                recall, so the pending weight must live on the (Redis-persisted)
+                record, not on the learner. When ``None``, sub-threshold first
+                updates are dropped (pre-#983 behavior) rather than stashed in
+                volatile per-instance state that never persists.
         """
         self.graph = graph
         self.config = config
+        self.co_activation_tracker = co_activation_tracker
         self._update_queue: dict[str, list[HebbianUpdate]] = defaultdict(list)
-        # #983 prune-cliff fix: sub-threshold weight accumulated for edges
-        # that do not exist yet, keyed (src_id, dst_id) per user. In-process
-        # only (same volatility contract as CoActivationTracker records);
-        # entries are popped when the edge materializes.
-        self._pending_weights: dict[str, dict[tuple[str, str], float]] = defaultdict(dict)
 
     async def queue_update(
         self,
@@ -210,10 +218,31 @@ class HebbianLearner:
         if self.config.gradient_clipping > 0:
             edge_deltas = self._clip_gradients(edge_deltas)
 
+        # #983: snapshot the cliff pending_weight for each directed edge BEFORE
+        # the pass. The queue holds both (a,b) and (b,a) for every pair; reading
+        # pending live would let the second direction see the first's write and
+        # double-count. Snapshotting makes both directions read the same value
+        # and (because the writeback is the same for both) stay consistent.
+        pending_snapshot: dict[tuple[str, str], float] = {}
+        if self.co_activation_tracker is not None:
+            for src_id, dst_id in edge_deltas:
+                record = self.co_activation_tracker.get_co_activation_record(
+                    user_id, src_id, dst_id
+                )
+                pending_snapshot[(src_id, dst_id)] = (
+                    record.pending_weight if record is not None else 0.0
+                )
+
         # Apply updates to graph (Issue #84: async SQL operations)
         edges_updated = 0
         for (src_id, dst_id), delta_w in edge_deltas.items():
-            new_weight = await self._apply_update_to_edge(user_id, src_id, dst_id, delta_w)
+            new_weight = await self._apply_update_to_edge(
+                user_id,
+                src_id,
+                dst_id,
+                delta_w,
+                pending=pending_snapshot.get((src_id, dst_id), 0.0),
+            )
             if new_weight is not None:
                 edges_updated += 1
 
@@ -310,7 +339,12 @@ class HebbianLearner:
         return 0.0
 
     async def _apply_update_to_edge(
-        self, user_id: str, src_id: str, dst_id: str, delta_w: float
+        self,
+        user_id: str,
+        src_id: str,
+        dst_id: str,
+        delta_w: float,
+        pending: float | None = None,
     ) -> float | None:
         """Apply weight update to graph edge.
 
@@ -319,14 +353,24 @@ class HebbianLearner:
             src_id: Source node ID
             dst_id: Destination node ID
             delta_w: Weight delta to apply
+            pending: Snapshotted #983 cliff pending_weight for this directed
+                edge. ``None`` (direct callers) reads it live from the
+                co-activation record; ``apply_updates`` passes a pre-pass
+                snapshot so the two directions of a pair don't double-count.
 
         Returns:
             New weight value, or None if update failed
         """
-        pair_key = (src_id, dst_id)
-        # #983: fold in any pending sub-threshold weight from earlier
-        # co-recalls of this not-yet-materialized edge.
-        pending = self._pending_weights[user_id].pop(pair_key, 0.0)
+        # #983: the cliff pending_weight rides the co-activation record so it
+        # survives the recall (the learner is rebuilt per recall). No record
+        # (or no tracker) → no accumulation, falling back to pre-#983 pruning.
+        record = (
+            self.co_activation_tracker.get_co_activation_record(user_id, src_id, dst_id)
+            if self.co_activation_tracker is not None
+            else None
+        )
+        if pending is None:
+            pending = record.pending_weight if record is not None else 0.0
         current_weight = await self._get_current_weight(user_id, src_id, dst_id)
         new_weight = current_weight + pending + delta_w
 
@@ -342,12 +386,15 @@ class HebbianLearner:
                     # decay-side pruning is unchanged.
                     await self.graph.remove_edge(src_id, dst_id)
                     logger.debug(f"Pruned edge ({src_id}, {dst_id}) (weight={new_weight:.4f})")
-                elif new_weight > 0.0:
+                    if record is not None:
+                        record.pending_weight = 0.0
+                elif new_weight > 0.0 and record is not None:
                     # #983 prune-cliff fix: the edge does not exist yet, so a
                     # sub-threshold first update used to be dropped — making
                     # accumulation across repeated co-recalls impossible
-                    # (~12% of observed pairs in the #969 audit). Stash it.
-                    self._pending_weights[user_id][pair_key] = new_weight
+                    # (~12% of observed pairs in the #969 audit). Stash it on
+                    # the record so it persists to the next recall.
+                    record.pending_weight = new_weight
                 return 0.0
             except Exception as e:
                 logger.error(f"Failed to remove edge ({src_id}, {dst_id}): {e}")
@@ -379,6 +426,11 @@ class HebbianLearner:
                     },
                     confidence=1.0,
                 )
+
+            # #983: the edge materialized — any accumulated cliff pending is
+            # now folded into the edge weight, so clear it.
+            if record is not None and record.pending_weight:
+                record.pending_weight = 0.0
 
             logger.debug(
                 f"Updated edge ({src_id}, {dst_id}): "

--- a/backend/src/neural/hebbian.py
+++ b/backend/src/neural/hebbian.py
@@ -59,6 +59,8 @@ class HebbianLearner:
         activations: list[ActivationState],
         nodes: dict[str, NeuralMemoryNode],
         similarity_threshold: float | None = None,
+        floor_threshold: float | None = None,
+        co_activation_counts: dict[tuple[str, str], int] | None = None,
     ) -> None:
         """Queue Hebbian updates for co-activated nodes.
 
@@ -68,19 +70,39 @@ class HebbianLearner:
         provided (#982 calibrated edge-gate value), else
         ``config.min_similarity_for_edge``.
 
+        2D edge gate (#983): when ``floor_threshold`` and
+        ``co_activation_counts`` are provided (and
+        ``config.edge_gate_repetition_enabled``), pairs in the
+        [floor, threshold) cosine band are admitted once their repetition
+        evidence reaches ``config.min_co_activation_count`` — genuine
+        cross-topic associations are co-recalled repeatedly across queries,
+        noise pairs co-occur once by ranking accident. Below the floor stays
+        a hard reject.
+
         Args:
             user_id: User ID (for sharding)
             activations: List of activated nodes in this retrieval
             nodes: Map of node_id -> NeuralMemoryNode (for confidence scores)
             similarity_threshold: Per-call semantic-gate override (#982);
                 ``None`` falls back to ``config.min_similarity_for_edge``.
+            floor_threshold: Lower bound of the repetition band (#983);
+                ``None`` disables the repetition axis for this call.
+            co_activation_counts: Map of ``(node_id_1, node_id_2)`` — ordered
+                ``min, max`` — to same-event co-recall counts from the
+                ``CoActivationTracker`` (#983).
         """
         threshold = (
             similarity_threshold
             if similarity_threshold is not None
             else self.config.min_similarity_for_edge
         )
+        repetition_active = (
+            self.config.edge_gate_repetition_enabled
+            and floor_threshold is not None
+            and co_activation_counts is not None
+        )
         skipped = 0
+        admitted_by_repetition = 0
 
         for i, act_i in enumerate(activations):
             for act_j in activations[i + 1 :]:  # Avoid duplicates
@@ -90,12 +112,24 @@ class HebbianLearner:
                 if not node_i or not node_j:
                     continue
 
-                # Semantic gating: skip pairs below similarity threshold
+                # Semantic gating: skip pairs below similarity threshold,
+                # unless the repetition axis (#983) admits a band pair.
                 if node_i.embedding and node_j.embedding:
                     sim = cosine_similarity(node_i.embedding, node_j.embedding)
                     if sim < threshold:
-                        skipped += 1
-                        continue
+                        pair_key = (
+                            (act_i.node_id, act_j.node_id)
+                            if act_i.node_id < act_j.node_id
+                            else (act_j.node_id, act_i.node_id)
+                        )
+                        in_band = repetition_active and sim >= floor_threshold
+                        evidence = (
+                            co_activation_counts.get(pair_key, 0) if repetition_active else 0
+                        )
+                        if not (in_band and evidence >= self.config.min_co_activation_count):
+                            skipped += 1
+                            continue
+                        admitted_by_repetition += 1
 
                 # Get current weight (Issue #84: async)
                 current_weight = await self._get_current_weight(
@@ -132,6 +166,16 @@ class HebbianLearner:
         if skipped > 0:
             logger.debug(
                 "hebbian_semantic_gating", extra={"skipped": skipped, "threshold": threshold}
+            )
+
+        if admitted_by_repetition > 0:
+            logger.debug(
+                "hebbian_repetition_admitted",
+                extra={
+                    "admitted": admitted_by_repetition,
+                    "floor": floor_threshold,
+                    "min_count": self.config.min_co_activation_count,
+                },
             )
 
         logger.debug(

--- a/backend/src/neural/hebbian.py
+++ b/backend/src/neural/hebbian.py
@@ -128,9 +128,7 @@ class HebbianLearner:
                             else (act_j.node_id, act_i.node_id)
                         )
                         in_band = repetition_active and sim >= floor_threshold
-                        evidence = (
-                            co_activation_counts.get(pair_key, 0) if repetition_active else 0
-                        )
+                        evidence = co_activation_counts.get(pair_key, 0) if repetition_active else 0
                         if not (in_band and evidence >= self.config.edge_gate_min_evidence):
                             skipped += 1
                             continue

--- a/backend/src/neural/hebbian.py
+++ b/backend/src/neural/hebbian.py
@@ -79,10 +79,10 @@ class HebbianLearner:
         ``co_activation_counts`` are provided (and
         ``config.edge_gate_repetition_enabled``), pairs in the
         [floor, threshold) cosine band are admitted once their repetition
-        evidence reaches ``config.min_co_activation_count`` — genuine
-        cross-topic associations are co-recalled repeatedly across queries,
-        noise pairs co-occur once by ranking accident. Below the floor stays
-        a hard reject.
+        evidence reaches ``config.edge_gate_min_evidence`` — genuine
+        cross-topic associations are co-recalled repeatedly across distinct
+        queries, noise pairs co-occur in few. Below the floor stays a hard
+        reject.
 
         Args:
             user_id: User ID (for sharding)
@@ -131,7 +131,7 @@ class HebbianLearner:
                         evidence = (
                             co_activation_counts.get(pair_key, 0) if repetition_active else 0
                         )
-                        if not (in_band and evidence >= self.config.min_co_activation_count):
+                        if not (in_band and evidence >= self.config.edge_gate_min_evidence):
                             skipped += 1
                             continue
                         admitted_by_repetition += 1
@@ -179,7 +179,7 @@ class HebbianLearner:
                 extra={
                     "admitted": admitted_by_repetition,
                     "floor": floor_threshold,
-                    "min_count": self.config.min_co_activation_count,
+                    "min_evidence": self.config.edge_gate_min_evidence,
                 },
             )
 

--- a/backend/src/neural/models.py
+++ b/backend/src/neural/models.py
@@ -131,6 +131,11 @@ class CoActivationRecord:
         total_activation_product: Sum of (a_i * a_j) across all co-activations
         user_id: Owner (for sharding)
         first_seen: Timestamp of first co-activation (Issue #84 Phase 2C)
+        same_event_count: Number of activation events in which BOTH nodes
+            appeared together (#983). This is the repetition-evidence counter
+            the 2D edge gate consults — window-based cross-event co-occurrence
+            increments ``count`` but not this field, so a node lingering in
+            the time window cannot inflate the evidence.
     """
 
     node_id_1: str
@@ -140,6 +145,7 @@ class CoActivationRecord:
     total_activation_product: float = 0.0
     user_id: str = ""
     first_seen: datetime = field(default_factory=utcnow)  # Issue #84 Phase 2C
+    same_event_count: int = 0  # Issue #983: joint same-event recalls
 
     def __post_init__(self) -> None:
         """Ensure node IDs are ordered."""
@@ -147,14 +153,18 @@ class CoActivationRecord:
             # Swap to maintain ordering
             self.node_id_1, self.node_id_2 = self.node_id_2, self.node_id_1
 
-    def update(self, activation_1: float, activation_2: float) -> None:
+    def update(self, activation_1: float, activation_2: float, same_event: bool = False) -> None:
         """Update co-activation statistics.
 
         Args:
             activation_1: Activation strength of node 1
             activation_2: Activation strength of node 2
+            same_event: True when both nodes appeared in the same activation
+                event (#983) — increments the repetition-evidence counter
         """
         self.count += 1
+        if same_event:
+            self.same_event_count += 1
         self.total_activation_product += activation_1 * activation_2
         self.last_co_activation = utcnow()  # Issue #84 Phase 2C
 

--- a/backend/src/neural/models.py
+++ b/backend/src/neural/models.py
@@ -136,6 +136,12 @@ class CoActivationRecord:
             the 2D edge gate consults — window-based cross-event co-occurrence
             increments ``count`` but not this field, so a node lingering in
             the time window cannot inflate the evidence.
+        evidence_keys: Distinct event keys (query fingerprints) that produced
+            same-event evidence (#983). When a key is supplied, repeating the
+            SAME query cannot inflate ``same_event_count`` — one ranking
+            accident replayed N times is still one observation. Capped at
+            ``_EVIDENCE_KEYS_CAP`` (evidence saturates far above the gate's
+            ``min_co_activation_count`` requirement).
     """
 
     node_id_1: str
@@ -146,6 +152,9 @@ class CoActivationRecord:
     user_id: str = ""
     first_seen: datetime = field(default_factory=utcnow)  # Issue #84 Phase 2C
     same_event_count: int = 0  # Issue #983: joint same-event recalls
+    evidence_keys: set[str] = field(default_factory=set)  # Issue #983
+
+    _EVIDENCE_KEYS_CAP = 16
 
     def __post_init__(self) -> None:
         """Ensure node IDs are ordered."""
@@ -153,7 +162,13 @@ class CoActivationRecord:
             # Swap to maintain ordering
             self.node_id_1, self.node_id_2 = self.node_id_2, self.node_id_1
 
-    def update(self, activation_1: float, activation_2: float, same_event: bool = False) -> None:
+    def update(
+        self,
+        activation_1: float,
+        activation_2: float,
+        same_event: bool = False,
+        event_key: str | None = None,
+    ) -> None:
         """Update co-activation statistics.
 
         Args:
@@ -161,10 +176,20 @@ class CoActivationRecord:
             activation_2: Activation strength of node 2
             same_event: True when both nodes appeared in the same activation
                 event (#983) — increments the repetition-evidence counter
+            event_key: Stable fingerprint of the triggering query (#983).
+                When provided, evidence is counted once per DISTINCT key;
+                ``None`` falls back to per-event counting (legacy callers).
         """
         self.count += 1
         if same_event:
-            self.same_event_count += 1
+            if event_key is None:
+                self.same_event_count += 1
+            elif (
+                event_key not in self.evidence_keys
+                and len(self.evidence_keys) < self._EVIDENCE_KEYS_CAP
+            ):
+                self.same_event_count += 1
+                self.evidence_keys.add(event_key)
         self.total_activation_product += activation_1 * activation_2
         self.last_co_activation = utcnow()  # Issue #84 Phase 2C
 

--- a/backend/src/neural/models.py
+++ b/backend/src/neural/models.py
@@ -141,7 +141,13 @@ class CoActivationRecord:
             SAME query cannot inflate ``same_event_count`` — one ranking
             accident replayed N times is still one observation. Capped at
             ``_EVIDENCE_KEYS_CAP`` (evidence saturates far above the gate's
-            ``min_co_activation_count`` requirement).
+            ``edge_gate_min_evidence`` requirement, which config validation
+            keeps <= the cap).
+        pending_weight: Sub-threshold Hebbian weight accumulated for a pair
+            whose edge has not yet materialized (#983 prune-cliff fix). Stored
+            here (rather than on the per-recall HebbianLearner) so it rides
+            this record's Redis persistence and GDPR ``clear_user_data`` path
+            instead of evaporating when the recall handler returns.
     """
 
     node_id_1: str
@@ -153,6 +159,7 @@ class CoActivationRecord:
     first_seen: datetime = field(default_factory=utcnow)  # Issue #84 Phase 2C
     same_event_count: int = 0  # Issue #983: joint same-event recalls
     evidence_keys: set[str] = field(default_factory=set)  # Issue #983
+    pending_weight: float = 0.0  # Issue #983: prune-cliff accumulation
 
     _EVIDENCE_KEYS_CAP = 16
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1675,11 +1675,31 @@ class MemoryService:
                         logger.debug("edge_threshold_resolve_failed", exc_info=True)
                         edge_threshold = None
 
-                co_activation_tracker.record_activation(
+                # 2D edge gate (#983): when enabled, lower the recording gate
+                # to the floor so band pairs accumulate same-event evidence,
+                # and hand those counts to the Hebbian gate below. The floor
+                # is clamped to the effective threshold so it can only widen
+                # the band downward, never tighten the 1-D gate.
+                edge_floor: float | None = None
+                if config.edge_gate_repetition_enabled:
+                    effective_threshold = (
+                        edge_threshold
+                        if edge_threshold is not None
+                        else config.min_similarity_for_edge
+                    )
+                    edge_floor = min(config.min_similarity_for_edge_floor, effective_threshold)
+
+                updated_records = co_activation_tracker.record_activation(
                     user_id,
                     activated_nodes,
                     embeddings=embedding_map,
                     similarity_threshold=edge_threshold,
+                    floor_threshold=edge_floor,
+                )
+                co_activation_counts = (
+                    {(r.node_id_1, r.node_id_2): r.same_event_count for r in updated_records}
+                    if edge_floor is not None
+                    else None
                 )
                 await co_activation_tracker.save_to_redis(user_id)
 
@@ -1702,9 +1722,15 @@ class MemoryService:
                         )
                         nodes_added += 1
 
-                # Hebbian updates (same calibrated gate as co-activation above)
+                # Hebbian updates (same calibrated gate as co-activation above;
+                # band pairs may be admitted by repetition evidence, #983)
                 await hebbian_learner.queue_update(
-                    user_id, activated_nodes, nodes_dict, similarity_threshold=edge_threshold
+                    user_id,
+                    activated_nodes,
+                    nodes_dict,
+                    similarity_threshold=edge_threshold,
+                    floor_threshold=edge_floor,
+                    co_activation_counts=co_activation_counts,
                 )
                 edges_updated = await hebbian_learner.apply_updates(user_id)
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import functools
+import hashlib
 from uuid import UUID, uuid4
 
 from sqlalchemy import and_, or_, select
@@ -1689,12 +1690,18 @@ class MemoryService:
                     )
                     edge_floor = min(config.min_similarity_for_edge_floor, effective_threshold)
 
+                # Distinct-query evidence dedup (#983): the same query
+                # replayed N times re-produces its top-k — one ranking
+                # accident is one observation, however often it repeats.
+                query_event_key = hashlib.sha256(request.query.encode("utf-8")).hexdigest()[:16]
+
                 updated_records = co_activation_tracker.record_activation(
                     user_id,
                     activated_nodes,
                     embeddings=embedding_map,
                     similarity_threshold=edge_threshold,
                     floor_threshold=edge_floor,
+                    event_key=query_event_key,
                 )
                 co_activation_counts = (
                     {(r.node_id_1, r.node_id_2): r.same_event_count for r in updated_records}

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1592,9 +1592,11 @@ class MemoryService:
                     context_id=str(current_context_id) if current_context_id else None,
                 )
 
-                hebbian_learner = HebbianLearner(graph_service, config)
                 co_activation_tracker = CoActivationTracker(config)
                 await co_activation_tracker.load_from_redis(user_id)
+                # #983: the learner reads/writes the cliff pending_weight on the
+                # tracker's records so it survives this per-recall instance.
+                hebbian_learner = HebbianLearner(graph_service, config, co_activation_tracker)
 
                 # Only co-activate top-k results for higher-quality edges
                 coactivation_k = min(config.top_k_coactivation, request.k, len(search_results))
@@ -1708,7 +1710,9 @@ class MemoryService:
                     if edge_floor is not None
                     else None
                 )
-                await co_activation_tracker.save_to_redis(user_id)
+                # NOTE: save_to_redis is deferred until AFTER apply_updates so
+                # the persisted records also capture the cliff pending_weight
+                # the Hebbian pass writes (#983).
 
                 # Add nodes to graph
                 nodes_added = 0
@@ -1740,6 +1744,11 @@ class MemoryService:
                     co_activation_counts=co_activation_counts,
                 )
                 edges_updated = await hebbian_learner.apply_updates(user_id)
+
+                # #983: persist co-activation records now — this captures both
+                # the same-event evidence (record_activation) and the cliff
+                # pending_weight (apply_updates) in a single round-trip.
+                await co_activation_tracker.save_to_redis(user_id)
 
                 logger.info(
                     "graph_updated",

--- a/backend/tests/eval/compounding.py
+++ b/backend/tests/eval/compounding.py
@@ -148,20 +148,42 @@ class PairAudit:
 
 
 def classify_pair(
-    cosine: float | None, delta_w: float, *, min_similarity: float, prune_threshold: float
+    cosine: float | None,
+    delta_w: float,
+    *,
+    min_similarity: float,
+    prune_threshold: float,
+    floor: float | None = None,
+    evidence_count: int = 0,
+    min_evidence: int = 2,
 ) -> str:
     """Classify a co-activated pair against the edge-formation gates.
 
-    Returns ``forms``, ``gated_cosine``, ``below_prune``, or
-    ``gated_cosine+below_prune``. A ``None`` cosine mirrors recall()'s
-    behaviour for missing embeddings: the semantic gate is skipped.
+    Returns ``forms``, ``forms_repetition``, ``gated_cosine``,
+    ``below_prune``, or ``gated_cosine+below_prune``. A ``None`` cosine
+    mirrors recall()'s behaviour for missing embeddings: the semantic gate
+    is skipped.
+
+    2D edge gate (#983): when ``floor`` is provided, a pair whose cosine
+    falls in ``[floor, min_similarity)`` clears the semantic gate via the
+    repetition axis once ``evidence_count`` (distinct-query co-recalls)
+    reaches ``min_evidence`` — verdict ``forms_repetition``. The repetition
+    axis clears the cosine gate only; the prune cliff classifies
+    independently (a sub-prune first delta accumulates at runtime).
     """
     gates = []
+    repetition_admitted = False
     if cosine is not None and cosine < min_similarity:
-        gates.append("gated_cosine")
+        in_band = floor is not None and cosine >= floor
+        if in_band and evidence_count >= min_evidence:
+            repetition_admitted = True
+        else:
+            gates.append("gated_cosine")
     if delta_w < prune_threshold:
         gates.append("below_prune")
-    return "+".join(gates) if gates else "forms"
+    if gates:
+        return "+".join(gates)
+    return "forms_repetition" if repetition_admitted else "forms"
 
 
 def summarize_gate_audit(pairs: list[PairAudit]) -> dict[str, Any]:
@@ -184,7 +206,7 @@ def summarize_gate_audit(pairs: list[PairAudit]) -> dict[str, Any]:
     non_gold_pair_count = 0
     for pair in pairs:
         verdicts[pair.verdict] = verdicts.get(pair.verdict, 0) + 1
-        formed = pair.verdict == "forms"
+        formed = pair.verdict in ("forms", "forms_repetition")
         if pair.is_probe_gold_pair:
             if formed:
                 formed_gold += 1

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -526,6 +526,10 @@ async def _gate_audit(
     # edge-gate threshold the live replay path applied (#982) — auditing against
     # the absolute config value would mislabel pairs the calibrated gate formed.
     raw_pairs: list[tuple[str, str, str, float | None, float, bool]] = []
+    # #983: distinct replay queries that co-recalled each pair — mirrors the
+    # runtime's event_key dedup (replaying one query N times is still one
+    # observation; only co-recall across DIFFERENT queries is evidence).
+    pair_evidence: dict[frozenset[str], set[str]] = {}
     dims: int | None = None
     for query_id in plan.replay_query_ids:
         results = await svc.search_service.hybrid_search(
@@ -552,6 +556,8 @@ async def _gate_audit(
                     dims = len(emb_a)
                 cosine = cosine_similarity(emb_a, emb_b) if emb_a and emb_b else None
                 delta_w = config.learning_rate * act_a * act_b
+                pair_set = frozenset((doc_a, doc_b))
+                pair_evidence.setdefault(pair_set, set()).add(query_id)
                 raw_pairs.append(
                     (
                         query_id,
@@ -559,7 +565,7 @@ async def _gate_audit(
                         doc_b,
                         cosine,
                         delta_w,
-                        frozenset((doc_a, doc_b)) in gold_pairs,
+                        pair_set in gold_pairs,
                     )
                 )
 
@@ -574,7 +580,13 @@ async def _gate_audit(
             db=db, config=config, model_name=ctx_cfg.embedding_model, dimensions=dims
         )
 
-    # Pass 2: classify against the resolved threshold.
+    # 2D edge gate (#983): mirror the runtime's floor clamp — the repetition
+    # band can only widen the gate downward, never tighten it.
+    edge_floor: float | None = None
+    if config.edge_gate_repetition_enabled:
+        edge_floor = min(config.min_similarity_for_edge_floor, edge_threshold)
+
+    # Pass 2: classify against the resolved threshold (+ repetition evidence).
     audits = [
         PairAudit(
             query_id=query_id,
@@ -587,6 +599,9 @@ async def _gate_audit(
                 delta_w,
                 min_similarity=edge_threshold,
                 prune_threshold=config.prune_threshold,
+                floor=edge_floor,
+                evidence_count=len(pair_evidence.get(frozenset((doc_a, doc_b)), set())),
+                min_evidence=config.min_co_activation_count,
             ),
             is_probe_gold_pair=is_gold,
         )
@@ -600,6 +615,10 @@ async def _gate_audit(
         "min_similarity_for_edge": edge_threshold,
         # Kept for reference so a report shows whether calibration was in effect.
         "min_similarity_for_edge_absolute": config.min_similarity_for_edge,
+        # 2D edge gate (#983): the repetition band and its count requirement.
+        "edge_gate_repetition_enabled": config.edge_gate_repetition_enabled,
+        "min_similarity_for_edge_floor": edge_floor,
+        "min_co_activation_count": config.min_co_activation_count,
         "prune_threshold": config.prune_threshold,
         "learning_rate": config.learning_rate,
         "top_k_coactivation": config.top_k_coactivation,

--- a/backend/tests/eval/replay_runner.py
+++ b/backend/tests/eval/replay_runner.py
@@ -601,7 +601,7 @@ async def _gate_audit(
                 prune_threshold=config.prune_threshold,
                 floor=edge_floor,
                 evidence_count=len(pair_evidence.get(frozenset((doc_a, doc_b)), set())),
-                min_evidence=config.min_co_activation_count,
+                min_evidence=config.edge_gate_min_evidence,
             ),
             is_probe_gold_pair=is_gold,
         )
@@ -609,16 +609,47 @@ async def _gate_audit(
     ]
 
     summary = summarize_gate_audit(audits)
+
+    # #983 diagnostic: distinct-query evidence distribution for UNIQUE band
+    # pairs (floor <= cosine < threshold), split gold vs non-gold. This is
+    # the data that justifies the min-evidence requirement: pick the count
+    # where gold pairs survive and one-accident noise dies.
+    if edge_floor is not None:
+        seen_pairs: set[frozenset[str]] = set()
+        band_detail: list[dict[str, Any]] = []
+        for _query_id, doc_a, doc_b, cosine, _delta_w, is_gold in raw_pairs:
+            pair_set = frozenset((doc_a, doc_b))
+            if pair_set in seen_pairs or cosine is None:
+                continue
+            seen_pairs.add(pair_set)
+            if edge_floor <= cosine < edge_threshold:
+                band_detail.append(
+                    {
+                        "pair": sorted(pair_set),
+                        "cosine": round(cosine, 4),
+                        "evidence": len(pair_evidence.get(pair_set, set())),
+                        "is_probe_gold_pair": is_gold,
+                    }
+                )
+        hist: dict[str, dict[int, int]] = {"gold": {}, "non_gold": {}}
+        for entry in band_detail:
+            side = "gold" if entry["is_probe_gold_pair"] else "non_gold"
+            hist[side][entry["evidence"]] = hist[side].get(entry["evidence"], 0) + 1
+        summary["band_evidence"] = {
+            "histogram": {k: dict(sorted(v.items())) for k, v in hist.items()},
+            "pairs": sorted(band_detail, key=lambda e: (-e["evidence"], e["pair"])),
+        }
+
     summary["thresholds"] = {
         # The value actually applied to classification (calibrated when an
         # edge_gate row exists, else the absolute fallback).
         "min_similarity_for_edge": edge_threshold,
         # Kept for reference so a report shows whether calibration was in effect.
         "min_similarity_for_edge_absolute": config.min_similarity_for_edge,
-        # 2D edge gate (#983): the repetition band and its count requirement.
+        # 2D edge gate (#983): the repetition band and its evidence requirement.
         "edge_gate_repetition_enabled": config.edge_gate_repetition_enabled,
         "min_similarity_for_edge_floor": edge_floor,
-        "min_co_activation_count": config.min_co_activation_count,
+        "edge_gate_min_evidence": config.edge_gate_min_evidence,
         "prune_threshold": config.prune_threshold,
         "learning_rate": config.learning_rate,
         "top_k_coactivation": config.top_k_coactivation,

--- a/backend/tests/eval/results/compounding-2026-06-11-983-evidence2.json
+++ b/backend/tests/eval/results/compounding-2026-06-11-983-evidence2.json
@@ -52,18 +52,18 @@
       "gate_audit": {
         "pair_observations": 75,
         "verdicts": {
-          "forms_repetition": 8,
-          "gated_cosine+below_prune": 8,
+          "forms_repetition": 25,
+          "gated_cosine+below_prune": 7,
           "forms": 10,
-          "gated_cosine": 48,
+          "gated_cosine": 32,
           "below_prune": 1
         },
-        "formed_total": 18,
-        "formed_gold": 4,
-        "formed_non_gold": 14,
+        "formed_total": 35,
+        "formed_gold": 6,
+        "formed_non_gold": 29,
         "non_gold_pair_count": 68,
-        "edge_precision": 0.2222222222222222,
-        "non_gold_form_rate": 0.20588235294117646,
+        "edge_precision": 0.17142857142857143,
+        "non_gold_form_rate": 0.4264705882352941,
         "probe_gold_pairs": [
           {
             "query_id": "q_exact_01",
@@ -92,7 +92,7 @@
               "doc_mem_hybrid"
             ],
             "cosine": 0.3983,
-            "delta_w": 0.0149,
+            "delta_w": 0.015,
             "verdict": "forms_repetition"
           },
           {
@@ -102,17 +102,17 @@
               "doc_mem_context"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0194,
-            "verdict": "gated_cosine"
+            "delta_w": 0.0192,
+            "verdict": "forms_repetition"
           },
           {
-            "query_id": "q_sem_01",
+            "query_id": "q_res_04",
             "pair": [
               "doc_mem_hybrid",
               "doc_res_chunking"
             ],
             "cosine": 0.3983,
-            "delta_w": 0.0189,
+            "delta_w": 0.019,
             "verdict": "forms_repetition"
           },
           {
@@ -122,8 +122,8 @@
               "doc_res_embedding"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0276,
-            "verdict": "gated_cosine"
+            "delta_w": 0.0278,
+            "verdict": "forms_repetition"
           },
           {
             "query_id": "q_mem_05",
@@ -154,20 +154,29 @@
             {
               "pair": [
                 "doc_mem_hybrid",
-                "doc_mem_rerank"
+                "doc_res_chunking"
               ],
-              "cosine": 0.3795,
+              "cosine": 0.3983,
+              "evidence": 4,
+              "is_probe_gold_pair": true
+            },
+            {
+              "pair": [
+                "doc_res_embedding",
+                "doc_res_quota"
+              ],
+              "cosine": 0.3006,
               "evidence": 4,
               "is_probe_gold_pair": false
             },
             {
               "pair": [
                 "doc_mem_hybrid",
-                "doc_res_chunking"
+                "doc_mem_rerank"
               ],
-              "cosine": 0.3983,
-              "evidence": 4,
-              "is_probe_gold_pair": true
+              "cosine": 0.3795,
+              "evidence": 3,
+              "is_probe_gold_pair": false
             },
             {
               "pair": [
@@ -184,15 +193,6 @@
                 "doc_res_deploy"
               ],
               "cosine": 0.3418,
-              "evidence": 3,
-              "is_probe_gold_pair": false
-            },
-            {
-              "pair": [
-                "doc_res_embedding",
-                "doc_res_quota"
-              ],
-              "cosine": 0.3006,
               "evidence": 3,
               "is_probe_gold_pair": false
             },
@@ -284,7 +284,7 @@
           "min_similarity_for_edge_absolute": 0.5,
           "edge_gate_repetition_enabled": true,
           "min_similarity_for_edge_floor": 0.3,
-          "edge_gate_min_evidence": 4,
+          "min_co_activation_count": 2,
           "prune_threshold": 0.01,
           "learning_rate": 0.05,
           "top_k_coactivation": 3
@@ -365,10 +365,10 @@
         "warm_replay": {
           "graph_lane": {
             "n": 5,
-            "recovery@5": 0.2,
-            "recovery@10": 0.2,
-            "mrr@10": 0.2,
-            "seeds_in_graph": 2
+            "recovery@5": 0.4,
+            "recovery@10": 0.4,
+            "mrr@10": 0.3,
+            "seeds_in_graph": 5
           },
           "recall_lane": {
             "n": 30,
@@ -380,18 +380,18 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 14,
-              "avg_weight": 0.3989
+              "count": 28,
+              "avg_weight": 0.4176
             }
           }
         },
         "warm_sleep": {
           "graph_lane": {
             "n": 5,
-            "recovery@5": 0.2,
-            "recovery@10": 0.2,
-            "mrr@10": 0.2,
-            "seeds_in_graph": 2
+            "recovery@5": 0.4,
+            "recovery@10": 0.4,
+            "mrr@10": 0.3,
+            "seeds_in_graph": 5
           },
           "recall_lane": {
             "n": 30,
@@ -403,8 +403,8 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 14,
-              "avg_weight": 0.3989
+              "count": 28,
+              "avg_weight": 0.4176
             }
           }
         }
@@ -414,51 +414,51 @@
           "cold_to_warm_replay": {
             "mrr@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.3,
+              "abs": 0.3,
               "rel": null
             },
             "recovery@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "recovery@5": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "seeds_in_graph": {
               "cold": 0.0,
-              "warm": 2.0,
-              "abs": 2.0,
+              "warm": 5.0,
+              "abs": 5.0,
               "rel": null
             }
           },
           "warm_replay_to_warm_sleep": {
             "mrr@10": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.3,
+              "warm": 0.3,
               "abs": 0.0,
               "rel": 0.0
             },
             "recovery@10": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.4,
+              "warm": 0.4,
               "abs": 0.0,
               "rel": 0.0
             },
             "recovery@5": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.4,
+              "warm": 0.4,
               "abs": 0.0,
               "rel": 0.0
             },
             "seeds_in_graph": {
-              "cold": 2.0,
-              "warm": 2.0,
+              "cold": 5.0,
+              "warm": 5.0,
               "abs": 0.0,
               "rel": 0.0
             }
@@ -466,26 +466,26 @@
           "cold_to_warm_sleep": {
             "mrr@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.3,
+              "abs": 0.3,
               "rel": null
             },
             "recovery@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "recovery@5": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "seeds_in_graph": {
               "cold": 0.0,
-              "warm": 2.0,
-              "abs": 2.0,
+              "warm": 5.0,
+              "abs": 5.0,
               "rel": null
             }
           }
@@ -630,18 +630,18 @@
       "gate_audit": {
         "pair_observations": 90,
         "verdicts": {
-          "forms_repetition": 13,
-          "gated_cosine+below_prune": 9,
+          "forms_repetition": 28,
+          "gated_cosine+below_prune": 8,
           "forms": 11,
-          "gated_cosine": 56,
+          "gated_cosine": 42,
           "below_prune": 1
         },
-        "formed_total": 24,
-        "formed_gold": 5,
-        "formed_non_gold": 19,
+        "formed_total": 39,
+        "formed_gold": 8,
+        "formed_non_gold": 31,
         "non_gold_pair_count": 81,
-        "edge_precision": 0.20833333333333334,
-        "non_gold_form_rate": 0.2345679012345679,
+        "edge_precision": 0.20512820512820512,
+        "non_gold_form_rate": 0.38271604938271603,
         "probe_gold_pairs": [
           {
             "query_id": "q_exact_01",
@@ -670,7 +670,7 @@
               "doc_mem_hybrid"
             ],
             "cosine": 0.3983,
-            "delta_w": 0.0149,
+            "delta_w": 0.015,
             "verdict": "forms_repetition"
           },
           {
@@ -680,17 +680,7 @@
               "doc_mem_context"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0194,
-            "verdict": "gated_cosine"
-          },
-          {
-            "query_id": "q_sem_01",
-            "pair": [
-              "doc_mem_hybrid",
-              "doc_res_chunking"
-            ],
-            "cosine": 0.3983,
-            "delta_w": 0.0189,
+            "delta_w": 0.0192,
             "verdict": "forms_repetition"
           },
           {
@@ -710,8 +700,18 @@
               "doc_mem_context"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0231,
-            "verdict": "gated_cosine"
+            "delta_w": 0.0227,
+            "verdict": "forms_repetition"
+          },
+          {
+            "query_id": "q_res_04",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.019,
+            "verdict": "forms_repetition"
           },
           {
             "query_id": "q_mem_03",
@@ -720,8 +720,8 @@
               "doc_res_embedding"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0276,
-            "verdict": "gated_cosine"
+            "delta_w": 0.0277,
+            "verdict": "forms_repetition"
           },
           {
             "query_id": "q_mem_05",
@@ -760,19 +760,19 @@
             },
             {
               "pair": [
-                "doc_mem_hybrid",
-                "doc_mem_rerank"
+                "doc_mem_sleep",
+                "doc_res_deploy"
               ],
-              "cosine": 0.3795,
+              "cosine": 0.3418,
               "evidence": 4,
               "is_probe_gold_pair": false
             },
             {
               "pair": [
-                "doc_mem_sleep",
-                "doc_res_deploy"
+                "doc_res_embedding",
+                "doc_res_quota"
               ],
-              "cosine": 0.3418,
+              "cosine": 0.3006,
               "evidence": 4,
               "is_probe_gold_pair": false
             },
@@ -787,19 +787,19 @@
             },
             {
               "pair": [
-                "doc_mem_jp_neural",
-                "doc_res_jp_chunk"
+                "doc_mem_hybrid",
+                "doc_mem_rerank"
               ],
-              "cosine": 0.402,
+              "cosine": 0.3795,
               "evidence": 3,
               "is_probe_gold_pair": false
             },
             {
               "pair": [
-                "doc_res_embedding",
-                "doc_res_quota"
+                "doc_mem_jp_neural",
+                "doc_res_jp_chunk"
               ],
-              "cosine": 0.3006,
+              "cosine": 0.402,
               "evidence": 3,
               "is_probe_gold_pair": false
             },
@@ -900,7 +900,7 @@
           "min_similarity_for_edge_absolute": 0.5,
           "edge_gate_repetition_enabled": true,
           "min_similarity_for_edge_floor": 0.3,
-          "edge_gate_min_evidence": 4,
+          "min_co_activation_count": 2,
           "prune_threshold": 0.01,
           "learning_rate": 0.05,
           "top_k_coactivation": 3
@@ -981,10 +981,10 @@
         "warm_replay": {
           "graph_lane": {
             "n": 5,
-            "recovery@5": 0.2,
-            "recovery@10": 0.2,
-            "mrr@10": 0.2,
-            "seeds_in_graph": 4
+            "recovery@5": 0.4,
+            "recovery@10": 0.4,
+            "mrr@10": 0.3,
+            "seeds_in_graph": 5
           },
           "recall_lane": {
             "n": 30,
@@ -996,18 +996,18 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 16,
-              "avg_weight": 0.4844
+              "count": 28,
+              "avg_weight": 0.4598
             }
           }
         },
         "warm_sleep": {
           "graph_lane": {
             "n": 5,
-            "recovery@5": 0.2,
-            "recovery@10": 0.2,
-            "mrr@10": 0.2,
-            "seeds_in_graph": 4
+            "recovery@5": 0.4,
+            "recovery@10": 0.4,
+            "mrr@10": 0.3,
+            "seeds_in_graph": 5
           },
           "recall_lane": {
             "n": 30,
@@ -1019,8 +1019,8 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 16,
-              "avg_weight": 0.4844
+              "count": 28,
+              "avg_weight": 0.4598
             }
           }
         }
@@ -1030,51 +1030,51 @@
           "cold_to_warm_replay": {
             "mrr@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.3,
+              "abs": 0.3,
               "rel": null
             },
             "recovery@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "recovery@5": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "seeds_in_graph": {
               "cold": 0.0,
-              "warm": 4.0,
-              "abs": 4.0,
+              "warm": 5.0,
+              "abs": 5.0,
               "rel": null
             }
           },
           "warm_replay_to_warm_sleep": {
             "mrr@10": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.3,
+              "warm": 0.3,
               "abs": 0.0,
               "rel": 0.0
             },
             "recovery@10": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.4,
+              "warm": 0.4,
               "abs": 0.0,
               "rel": 0.0
             },
             "recovery@5": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.4,
+              "warm": 0.4,
               "abs": 0.0,
               "rel": 0.0
             },
             "seeds_in_graph": {
-              "cold": 4.0,
-              "warm": 4.0,
+              "cold": 5.0,
+              "warm": 5.0,
               "abs": 0.0,
               "rel": 0.0
             }
@@ -1082,26 +1082,26 @@
           "cold_to_warm_sleep": {
             "mrr@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.3,
+              "abs": 0.3,
               "rel": null
             },
             "recovery@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "recovery@5": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "seeds_in_graph": {
               "cold": 0.0,
-              "warm": 4.0,
-              "abs": 4.0,
+              "warm": 5.0,
+              "abs": 5.0,
               "rel": null
             }
           }

--- a/backend/tests/eval/results/compounding-2026-06-11-983-evidence3.json
+++ b/backend/tests/eval/results/compounding-2026-06-11-983-evidence3.json
@@ -52,18 +52,18 @@
       "gate_audit": {
         "pair_observations": 75,
         "verdicts": {
-          "forms_repetition": 8,
-          "gated_cosine+below_prune": 8,
+          "forms_repetition": 17,
+          "gated_cosine+below_prune": 7,
           "forms": 10,
-          "gated_cosine": 48,
+          "gated_cosine": 40,
           "below_prune": 1
         },
-        "formed_total": 18,
-        "formed_gold": 4,
-        "formed_non_gold": 14,
-        "non_gold_pair_count": 68,
-        "edge_precision": 0.2222222222222222,
-        "non_gold_form_rate": 0.20588235294117646,
+        "formed_total": 27,
+        "formed_gold": 5,
+        "formed_non_gold": 22,
+        "non_gold_pair_count": 67,
+        "edge_precision": 0.18518518518518517,
+        "non_gold_form_rate": 0.3283582089552239,
         "probe_gold_pairs": [
           {
             "query_id": "q_exact_01",
@@ -102,11 +102,21 @@
               "doc_mem_context"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0194,
+            "delta_w": 0.0193,
             "verdict": "gated_cosine"
           },
           {
             "query_id": "q_sem_01",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0189,
+            "verdict": "forms_repetition"
+          },
+          {
+            "query_id": "q_res_04",
             "pair": [
               "doc_mem_hybrid",
               "doc_res_chunking"
@@ -141,33 +151,32 @@
             "gold": {
               "1": 1,
               "2": 1,
-              "4": 1
+              "5": 1
             },
             "non_gold": {
               "1": 4,
               "2": 3,
-              "3": 3,
-              "4": 1
+              "3": 4
             }
           },
           "pairs": [
             {
               "pair": [
                 "doc_mem_hybrid",
-                "doc_mem_rerank"
+                "doc_res_chunking"
               ],
-              "cosine": 0.3795,
-              "evidence": 4,
-              "is_probe_gold_pair": false
+              "cosine": 0.3983,
+              "evidence": 5,
+              "is_probe_gold_pair": true
             },
             {
               "pair": [
                 "doc_mem_hybrid",
-                "doc_res_chunking"
+                "doc_mem_rerank"
               ],
-              "cosine": 0.3983,
-              "evidence": 4,
-              "is_probe_gold_pair": true
+              "cosine": 0.3795,
+              "evidence": 3,
+              "is_probe_gold_pair": false
             },
             {
               "pair": [
@@ -284,7 +293,7 @@
           "min_similarity_for_edge_absolute": 0.5,
           "edge_gate_repetition_enabled": true,
           "min_similarity_for_edge_floor": 0.3,
-          "edge_gate_min_evidence": 4,
+          "min_co_activation_count": 3,
           "prune_threshold": 0.01,
           "learning_rate": 0.05,
           "top_k_coactivation": 3
@@ -368,7 +377,7 @@
             "recovery@5": 0.2,
             "recovery@10": 0.2,
             "mrr@10": 0.2,
-            "seeds_in_graph": 2
+            "seeds_in_graph": 5
           },
           "recall_lane": {
             "n": 30,
@@ -380,8 +389,8 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 14,
-              "avg_weight": 0.3989
+              "count": 20,
+              "avg_weight": 0.4347
             }
           }
         },
@@ -391,7 +400,7 @@
             "recovery@5": 0.2,
             "recovery@10": 0.2,
             "mrr@10": 0.2,
-            "seeds_in_graph": 2
+            "seeds_in_graph": 5
           },
           "recall_lane": {
             "n": 30,
@@ -403,8 +412,8 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 14,
-              "avg_weight": 0.3989
+              "count": 20,
+              "avg_weight": 0.4347
             }
           }
         }
@@ -432,8 +441,8 @@
             },
             "seeds_in_graph": {
               "cold": 0.0,
-              "warm": 2.0,
-              "abs": 2.0,
+              "warm": 5.0,
+              "abs": 5.0,
               "rel": null
             }
           },
@@ -457,8 +466,8 @@
               "rel": 0.0
             },
             "seeds_in_graph": {
-              "cold": 2.0,
-              "warm": 2.0,
+              "cold": 5.0,
+              "warm": 5.0,
               "abs": 0.0,
               "rel": 0.0
             }
@@ -484,8 +493,8 @@
             },
             "seeds_in_graph": {
               "cold": 0.0,
-              "warm": 2.0,
-              "abs": 2.0,
+              "warm": 5.0,
+              "abs": 5.0,
               "rel": null
             }
           }
@@ -630,18 +639,18 @@
       "gate_audit": {
         "pair_observations": 90,
         "verdicts": {
-          "forms_repetition": 13,
-          "gated_cosine+below_prune": 9,
+          "forms_repetition": 22,
+          "gated_cosine+below_prune": 8,
           "forms": 11,
-          "gated_cosine": 56,
+          "gated_cosine": 48,
           "below_prune": 1
         },
-        "formed_total": 24,
-        "formed_gold": 5,
-        "formed_non_gold": 19,
-        "non_gold_pair_count": 81,
-        "edge_precision": 0.20833333333333334,
-        "non_gold_form_rate": 0.2345679012345679,
+        "formed_total": 33,
+        "formed_gold": 9,
+        "formed_non_gold": 24,
+        "non_gold_pair_count": 80,
+        "edge_precision": 0.2727272727272727,
+        "non_gold_form_rate": 0.3,
         "probe_gold_pairs": [
           {
             "query_id": "q_exact_01",
@@ -680,8 +689,8 @@
               "doc_mem_context"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0194,
-            "verdict": "gated_cosine"
+            "delta_w": 0.0193,
+            "verdict": "forms_repetition"
           },
           {
             "query_id": "q_sem_01",
@@ -710,8 +719,18 @@
               "doc_mem_context"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0231,
-            "verdict": "gated_cosine"
+            "delta_w": 0.023,
+            "verdict": "forms_repetition"
+          },
+          {
+            "query_id": "q_res_04",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0189,
+            "verdict": "forms_repetition"
           },
           {
             "query_id": "q_mem_03",
@@ -721,7 +740,7 @@
             ],
             "cosine": 0.3693,
             "delta_w": 0.0276,
-            "verdict": "gated_cosine"
+            "verdict": "forms_repetition"
           },
           {
             "query_id": "q_mem_05",
@@ -739,13 +758,13 @@
             "gold": {
               "1": 1,
               "3": 1,
-              "5": 1
+              "6": 1
             },
             "non_gold": {
               "1": 6,
               "2": 3,
-              "3": 2,
-              "4": 2
+              "3": 3,
+              "4": 1
             }
           },
           "pairs": [
@@ -755,17 +774,8 @@
                 "doc_res_chunking"
               ],
               "cosine": 0.3983,
-              "evidence": 5,
+              "evidence": 6,
               "is_probe_gold_pair": true
-            },
-            {
-              "pair": [
-                "doc_mem_hybrid",
-                "doc_mem_rerank"
-              ],
-              "cosine": 0.3795,
-              "evidence": 4,
-              "is_probe_gold_pair": false
             },
             {
               "pair": [
@@ -784,6 +794,15 @@
               "cosine": 0.3693,
               "evidence": 3,
               "is_probe_gold_pair": true
+            },
+            {
+              "pair": [
+                "doc_mem_hybrid",
+                "doc_mem_rerank"
+              ],
+              "cosine": 0.3795,
+              "evidence": 3,
+              "is_probe_gold_pair": false
             },
             {
               "pair": [
@@ -900,7 +919,7 @@
           "min_similarity_for_edge_absolute": 0.5,
           "edge_gate_repetition_enabled": true,
           "min_similarity_for_edge_floor": 0.3,
-          "edge_gate_min_evidence": 4,
+          "min_co_activation_count": 3,
           "prune_threshold": 0.01,
           "learning_rate": 0.05,
           "top_k_coactivation": 3
@@ -981,10 +1000,10 @@
         "warm_replay": {
           "graph_lane": {
             "n": 5,
-            "recovery@5": 0.2,
-            "recovery@10": 0.2,
-            "mrr@10": 0.2,
-            "seeds_in_graph": 4
+            "recovery@5": 0.4,
+            "recovery@10": 0.4,
+            "mrr@10": 0.4,
+            "seeds_in_graph": 5
           },
           "recall_lane": {
             "n": 30,
@@ -996,18 +1015,18 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 16,
-              "avg_weight": 0.4844
+              "count": 22,
+              "avg_weight": 0.4768
             }
           }
         },
         "warm_sleep": {
           "graph_lane": {
             "n": 5,
-            "recovery@5": 0.2,
-            "recovery@10": 0.2,
-            "mrr@10": 0.2,
-            "seeds_in_graph": 4
+            "recovery@5": 0.4,
+            "recovery@10": 0.4,
+            "mrr@10": 0.4,
+            "seeds_in_graph": 5
           },
           "recall_lane": {
             "n": 30,
@@ -1019,8 +1038,8 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 16,
-              "avg_weight": 0.4844
+              "count": 22,
+              "avg_weight": 0.4768
             }
           }
         }
@@ -1030,51 +1049,51 @@
           "cold_to_warm_replay": {
             "mrr@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "recovery@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "recovery@5": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "seeds_in_graph": {
               "cold": 0.0,
-              "warm": 4.0,
-              "abs": 4.0,
+              "warm": 5.0,
+              "abs": 5.0,
               "rel": null
             }
           },
           "warm_replay_to_warm_sleep": {
             "mrr@10": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.4,
+              "warm": 0.4,
               "abs": 0.0,
               "rel": 0.0
             },
             "recovery@10": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.4,
+              "warm": 0.4,
               "abs": 0.0,
               "rel": 0.0
             },
             "recovery@5": {
-              "cold": 0.2,
-              "warm": 0.2,
+              "cold": 0.4,
+              "warm": 0.4,
               "abs": 0.0,
               "rel": 0.0
             },
             "seeds_in_graph": {
-              "cold": 4.0,
-              "warm": 4.0,
+              "cold": 5.0,
+              "warm": 5.0,
               "abs": 0.0,
               "rel": 0.0
             }
@@ -1082,26 +1101,26 @@
           "cold_to_warm_sleep": {
             "mrr@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "recovery@10": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "recovery@5": {
               "cold": 0.0,
-              "warm": 0.2,
-              "abs": 0.2,
+              "warm": 0.4,
+              "abs": 0.4,
               "rel": null
             },
             "seeds_in_graph": {
               "cold": 0.0,
-              "warm": 4.0,
-              "abs": 4.0,
+              "warm": 5.0,
+              "abs": 5.0,
               "rel": null
             }
           }

--- a/backend/tests/eval/results/compounding-2026-06-11-983-evidence4.json
+++ b/backend/tests/eval/results/compounding-2026-06-11-983-evidence4.json
@@ -52,18 +52,18 @@
       "gate_audit": {
         "pair_observations": 75,
         "verdicts": {
-          "forms_repetition": 8,
-          "gated_cosine+below_prune": 8,
+          "gated_cosine": 52,
+          "forms_repetition": 5,
+          "gated_cosine+below_prune": 7,
           "forms": 10,
-          "gated_cosine": 48,
           "below_prune": 1
         },
-        "formed_total": 18,
-        "formed_gold": 4,
-        "formed_non_gold": 14,
-        "non_gold_pair_count": 68,
-        "edge_precision": 0.2222222222222222,
-        "non_gold_form_rate": 0.20588235294117646,
+        "formed_total": 15,
+        "formed_gold": 5,
+        "formed_non_gold": 10,
+        "non_gold_pair_count": 67,
+        "edge_precision": 0.3333333333333333,
+        "non_gold_form_rate": 0.14925373134328357,
         "probe_gold_pairs": [
           {
             "query_id": "q_exact_01",
@@ -116,6 +116,16 @@
             "verdict": "forms_repetition"
           },
           {
+            "query_id": "q_res_04",
+            "pair": [
+              "doc_mem_hybrid",
+              "doc_res_chunking"
+            ],
+            "cosine": 0.3983,
+            "delta_w": 0.0189,
+            "verdict": "forms_repetition"
+          },
+          {
             "query_id": "q_mem_03",
             "pair": [
               "doc_mem_context",
@@ -141,33 +151,32 @@
             "gold": {
               "1": 1,
               "2": 1,
-              "4": 1
+              "5": 1
             },
             "non_gold": {
               "1": 4,
               "2": 3,
-              "3": 3,
-              "4": 1
+              "3": 4
             }
           },
           "pairs": [
             {
               "pair": [
                 "doc_mem_hybrid",
-                "doc_mem_rerank"
+                "doc_res_chunking"
               ],
-              "cosine": 0.3795,
-              "evidence": 4,
-              "is_probe_gold_pair": false
+              "cosine": 0.3983,
+              "evidence": 5,
+              "is_probe_gold_pair": true
             },
             {
               "pair": [
                 "doc_mem_hybrid",
-                "doc_res_chunking"
+                "doc_mem_rerank"
               ],
-              "cosine": 0.3983,
-              "evidence": 4,
-              "is_probe_gold_pair": true
+              "cosine": 0.3795,
+              "evidence": 3,
+              "is_probe_gold_pair": false
             },
             {
               "pair": [
@@ -284,7 +293,7 @@
           "min_similarity_for_edge_absolute": 0.5,
           "edge_gate_repetition_enabled": true,
           "min_similarity_for_edge_floor": 0.3,
-          "edge_gate_min_evidence": 4,
+          "min_co_activation_count": 4,
           "prune_threshold": 0.01,
           "learning_rate": 0.05,
           "top_k_coactivation": 3
@@ -380,8 +389,8 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 14,
-              "avg_weight": 0.3989
+              "count": 12,
+              "avg_weight": 0.398
             }
           }
         },
@@ -403,8 +412,8 @@
           },
           "edge_stats": {
             "hebbian": {
-              "count": 14,
-              "avg_weight": 0.3989
+              "count": 12,
+              "avg_weight": 0.398
             }
           }
         }
@@ -900,7 +909,7 @@
           "min_similarity_for_edge_absolute": 0.5,
           "edge_gate_repetition_enabled": true,
           "min_similarity_for_edge_floor": 0.3,
-          "edge_gate_min_evidence": 4,
+          "min_co_activation_count": 4,
           "prune_threshold": 0.01,
           "learning_rate": 0.05,
           "top_k_coactivation": 3
@@ -997,7 +1006,7 @@
           "edge_stats": {
             "hebbian": {
               "count": 16,
-              "avg_weight": 0.4844
+              "avg_weight": 0.4841
             }
           }
         },
@@ -1020,7 +1029,7 @@
           "edge_stats": {
             "hebbian": {
               "count": 16,
-              "avg_weight": 0.4844
+              "avg_weight": 0.4841
             }
           }
         }

--- a/backend/tests/eval/results/compounding-2026-06-11.json
+++ b/backend/tests/eval/results/compounding-2026-06-11.json
@@ -122,7 +122,7 @@
               "doc_res_embedding"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0276,
+            "delta_w": 0.0275,
             "verdict": "gated_cosine"
           },
           {
@@ -381,7 +381,7 @@
           "edge_stats": {
             "hebbian": {
               "count": 14,
-              "avg_weight": 0.3989
+              "avg_weight": 0.3991
             }
           }
         },
@@ -404,7 +404,7 @@
           "edge_stats": {
             "hebbian": {
               "count": 14,
-              "avg_weight": 0.3989
+              "avg_weight": 0.3991
             }
           }
         }
@@ -680,7 +680,7 @@
               "doc_mem_context"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0194,
+            "delta_w": 0.0195,
             "verdict": "gated_cosine"
           },
           {
@@ -700,7 +700,7 @@
               "doc_res_chunking"
             ],
             "cosine": 0.3983,
-            "delta_w": 0.0363,
+            "delta_w": 0.0362,
             "verdict": "forms_repetition"
           },
           {
@@ -710,7 +710,7 @@
               "doc_mem_context"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0231,
+            "delta_w": 0.0232,
             "verdict": "gated_cosine"
           },
           {
@@ -720,7 +720,7 @@
               "doc_res_embedding"
             ],
             "cosine": 0.3693,
-            "delta_w": 0.0276,
+            "delta_w": 0.0275,
             "verdict": "gated_cosine"
           },
           {
@@ -997,7 +997,7 @@
           "edge_stats": {
             "hebbian": {
               "count": 16,
-              "avg_weight": 0.4844
+              "avg_weight": 0.4846
             }
           }
         },
@@ -1020,7 +1020,7 @@
           "edge_stats": {
             "hebbian": {
               "count": 16,
-              "avg_weight": 0.4844
+              "avg_weight": 0.4846
             }
           }
         }

--- a/backend/tests/eval/test_compounding.py
+++ b/backend/tests/eval/test_compounding.py
@@ -186,6 +186,92 @@ def test_classify_pair_missing_embedding_skips_gate():
     assert classify_pair(None, 0.005, min_similarity=0.5, prune_threshold=0.01) == "below_prune"
 
 
+def test_classify_pair_repetition_admits_band_pair_with_evidence():
+    """#983: cosine in [floor, threshold) + enough distinct-query evidence
+    → the pair forms via the repetition axis."""
+    verdict = classify_pair(
+        0.35,
+        0.02,
+        min_similarity=0.45,
+        prune_threshold=0.01,
+        floor=0.3,
+        evidence_count=2,
+        min_evidence=2,
+    )
+    assert verdict == "forms_repetition"
+
+
+def test_classify_pair_band_pair_without_evidence_stays_gated():
+    verdict = classify_pair(
+        0.35,
+        0.02,
+        min_similarity=0.45,
+        prune_threshold=0.01,
+        floor=0.3,
+        evidence_count=1,
+        min_evidence=2,
+    )
+    assert verdict == "gated_cosine"
+
+
+def test_classify_pair_below_floor_rejected_despite_evidence():
+    verdict = classify_pair(
+        0.2,
+        0.02,
+        min_similarity=0.45,
+        prune_threshold=0.01,
+        floor=0.3,
+        evidence_count=5,
+        min_evidence=2,
+    )
+    assert verdict == "gated_cosine"
+
+
+def test_classify_pair_repetition_with_subprune_delta():
+    """The repetition axis clears the cosine gate only — a sub-prune first
+    delta still classifies below_prune (it accumulates at runtime, #983)."""
+    verdict = classify_pair(
+        0.35,
+        0.005,
+        min_similarity=0.45,
+        prune_threshold=0.01,
+        floor=0.3,
+        evidence_count=2,
+        min_evidence=2,
+    )
+    assert verdict == "below_prune"
+
+
+def test_classify_pair_no_floor_keeps_1d_behavior():
+    """floor=None (repetition disabled) → identical to the #982 classifier."""
+    verdict = classify_pair(
+        0.35,
+        0.02,
+        min_similarity=0.45,
+        prune_threshold=0.01,
+        evidence_count=10,
+        min_evidence=2,
+    )
+    assert verdict == "gated_cosine"
+
+
+def test_summarize_gate_audit_counts_forms_repetition_as_formed():
+    """#983: repetition-formed edges count toward both the recall side and
+    the noise side of the audit."""
+    pairs = [
+        PairAudit("q1", "s", "t", 0.35, 0.02, "forms_repetition", is_probe_gold_pair=True),
+        PairAudit("q1", "a", "c", 0.35, 0.02, "forms_repetition", is_probe_gold_pair=False),
+        PairAudit("q2", "a", "d", 0.35, 0.02, "gated_cosine", is_probe_gold_pair=False),
+    ]
+    summary = summarize_gate_audit(pairs)
+
+    assert summary["formed_total"] == 2
+    assert summary["formed_gold"] == 1
+    assert summary["formed_non_gold"] == 1
+    assert summary["edge_precision"] == pytest.approx(0.5)
+    assert summary["non_gold_form_rate"] == pytest.approx(0.5)
+
+
 def test_summarize_gate_audit_counts_and_probe_pairs():
     pairs = [
         PairAudit("q1", "a", "b", 0.6, 0.02, "forms", is_probe_gold_pair=False),

--- a/backend/tests/neural/test_co_activation.py
+++ b/backend/tests/neural/test_co_activation.py
@@ -682,3 +682,55 @@ class TestRepetitionEvidence:
         assert record is not None
         assert record.count == 1
         assert record.same_event_count == 1
+
+    def test_repeated_query_does_not_inflate_evidence(self, tracker):
+        """Same query (same event_key) replayed N times → evidence stays 1.
+
+        This is the distinct-query-context requirement: a noise pair inside
+        one query's top-k re-co-occurs every time that query is repeated
+        (eval replay rounds, production rehearsal) — repetition of ONE
+        ranking accident is not independent evidence."""
+        for _ in range(3):
+            tracker.record_activation(
+                "user1",
+                self._activations("a", "b"),
+                embeddings=self._band_pair(),
+                similarity_threshold=0.45,
+                floor_threshold=0.3,
+                event_key="query-1",
+            )
+        record = tracker.get_co_activation_record("user1", "a", "b")
+        assert record is not None
+        assert record.same_event_count == 1
+
+    def test_distinct_queries_accumulate_evidence(self, tracker):
+        """Different queries co-recalling the same pair → evidence grows.
+
+        Genuine cross-topic associations surface in the top-k of *different*
+        queries; that is the signal the 2D gate trusts."""
+        for key in ("query-1", "query-2", "query-3"):
+            tracker.record_activation(
+                "user1",
+                self._activations("a", "b"),
+                embeddings=self._band_pair(),
+                similarity_threshold=0.45,
+                floor_threshold=0.3,
+                event_key=key,
+            )
+        record = tracker.get_co_activation_record("user1", "a", "b")
+        assert record is not None
+        assert record.same_event_count == 3
+
+    def test_no_event_key_falls_back_to_per_event_counting(self, tracker):
+        """event_key=None (legacy callers) → every joint event counts."""
+        for _ in range(2):
+            tracker.record_activation(
+                "user1",
+                self._activations("a", "b"),
+                embeddings=self._band_pair(),
+                similarity_threshold=0.45,
+                floor_threshold=0.3,
+            )
+        record = tracker.get_co_activation_record("user1", "a", "b")
+        assert record is not None
+        assert record.same_event_count == 2

--- a/backend/tests/neural/test_co_activation.py
+++ b/backend/tests/neural/test_co_activation.py
@@ -561,3 +561,124 @@ class TestSemanticGating:
 
         records = tracker.record_activation("user1", activations, embeddings=embeddings)
         assert len(records) == 1
+
+
+class TestRepetitionEvidence:
+    """2D edge gate evidence accumulation (Issue #983).
+
+    ``floor_threshold`` lowers the *recording* gate so pairs in the
+    [floor, threshold) cosine band accumulate co-activation evidence
+    instead of being rejected outright. ``same_event_count`` counts only
+    joint appearances in the same activation event (= same query top-k),
+    which is the repetition signal the 2D gate consults — window-based
+    cross-event co-occurrence stays in ``count`` but is NOT evidence.
+    """
+
+    @pytest.fixture
+    def tracker(self):
+        config = NeuralMemoryConfig(
+            track_co_activation=True,
+            co_activation_window=60,
+            min_co_activation_count=2,
+            min_similarity_for_edge=0.5,
+        )
+        return CoActivationTracker(config)
+
+    def _make_embedding(self, values: list[float]) -> list[float]:
+        import numpy as np
+
+        emb = values + [0.0] * (8 - len(values))
+        norm = np.linalg.norm(emb)
+        return (np.array(emb) / norm).tolist() if norm > 0 else emb
+
+    def _band_pair(self):
+        """Embeddings with cosine ≈ 0.35 — inside the [0.3, 0.45) band."""
+        emb_a = self._make_embedding([1.0, 0.0, 0.0])
+        emb_b = self._make_embedding([0.35, 0.9367, 0.0])
+        return {"a": emb_a, "b": emb_b}
+
+    def _activations(self, *node_ids: str) -> list[ActivationState]:
+        return [ActivationState(node_id=n, activation=1.0) for n in node_ids]
+
+    def test_floor_threshold_records_band_pair(self, tracker):
+        """Cosine in [floor, threshold) → record IS created (evidence accumulates)."""
+        records = tracker.record_activation(
+            "user1",
+            self._activations("a", "b"),
+            embeddings=self._band_pair(),
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+        )
+        assert len(records) == 1
+        assert records[0].same_event_count == 1
+
+    def test_below_floor_still_rejected(self, tracker):
+        """Cosine below the floor → no record (hard reject, unchanged)."""
+        emb_a = self._make_embedding([1.0, 0.0, 0.0])
+        emb_c = self._make_embedding([0.1, 0.995, 0.0])  # cosine ≈ 0.1 < 0.3
+        records = tracker.record_activation(
+            "user1",
+            self._activations("a", "c"),
+            embeddings={"a": emb_a, "c": emb_c},
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+        )
+        assert len(records) == 0
+
+    def test_no_floor_keeps_threshold_gate(self, tracker):
+        """floor_threshold=None → band pair is rejected as before (rollback path)."""
+        records = tracker.record_activation(
+            "user1",
+            self._activations("a", "b"),
+            embeddings=self._band_pair(),
+            similarity_threshold=0.45,
+            floor_threshold=None,
+        )
+        assert len(records) == 0
+
+    def test_same_event_count_accumulates_across_joint_recalls(self, tracker):
+        """Both nodes in the same event twice → same_event_count == 2."""
+        for _ in range(2):
+            tracker.record_activation(
+                "user1",
+                self._activations("a", "b"),
+                embeddings=self._band_pair(),
+                similarity_threshold=0.45,
+                floor_threshold=0.3,
+            )
+        record = tracker.get_co_activation_record("user1", "a", "b")
+        assert record is not None
+        assert record.same_event_count == 2
+
+    def test_window_co_occurrence_is_not_same_event_evidence(self, tracker):
+        """Event {a,b} then event {a,c}: (a,b) window count grows but
+        same_event_count stays 1 — b was not re-recalled, so no new evidence."""
+        embeddings = self._band_pair()
+        tracker.record_activation(
+            "user1",
+            self._activations("a", "b"),
+            embeddings=embeddings,
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+        )
+        tracker.record_activation(
+            "user1",
+            self._activations("a"),
+            embeddings=embeddings,
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+        )
+        record = tracker.get_co_activation_record("user1", "a", "b")
+        assert record is not None
+        assert record.count == 2  # window co-occurrence still tracked
+        assert record.same_event_count == 1  # but not counted as evidence
+
+    def test_stale_pair_not_recounted_by_unrelated_event(self, tracker):
+        """Event {a,b} then unrelated event {x,y}: (a,b) must not be re-counted
+        just because both linger in the window (count-inflation fix)."""
+        tracker.record_activation("user1", self._activations("a", "b"))
+        tracker.record_activation("user1", self._activations("x", "y"))
+        record = tracker.get_co_activation_record("user1", "a", "b")
+        assert record is not None
+        assert record.count == 1
+        assert record.same_event_count == 1

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -112,9 +112,9 @@ class TestEdgeGateRepetitionConfig:
 
     ``edge_gate_repetition_enabled`` is the rollback switch for the second
     gate axis: pairs in the [floor, calibrated-threshold) cosine band may
-    form edges once their co-activation count reaches
-    ``min_co_activation_count`` (the existing knob, previously unconsulted
-    on the edge-formation path).
+    form edges once their distinct-query co-recall evidence reaches
+    ``edge_gate_min_evidence`` (a dedicated knob — ``min_co_activation_count``
+    keeps its legacy default for the other consumers).
     """
 
     def test_repetition_gate_default_enabled(self):

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -140,6 +140,18 @@ class TestEdgeGateRepetitionConfig:
         with pytest.raises(ValueError, match="edge_gate_min_evidence"):
             NeuralMemoryConfig(edge_gate_min_evidence=0)
 
+    def test_min_evidence_cannot_exceed_evidence_keys_cap(self):
+        """A min_evidence above the per-record evidence_keys cap would make the
+        2D band gate silently unsatisfiable (same_event_count saturates at the
+        cap), so config construction must reject it."""
+        from neural.models import CoActivationRecord
+
+        cap = CoActivationRecord._EVIDENCE_KEYS_CAP
+        # At the cap is allowed; one above is rejected.
+        NeuralMemoryConfig(edge_gate_min_evidence=cap)
+        with pytest.raises(ValueError, match="edge_gate_min_evidence"):
+            NeuralMemoryConfig(edge_gate_min_evidence=cap + 1)
+
 
 class TestSleepMaintenanceConfig:
     """Test Sleep Maintenance configuration fields (Issue #101)."""

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -120,8 +120,10 @@ class TestEdgeGateRepetitionConfig:
     def test_repetition_gate_default_enabled(self):
         config = NeuralMemoryConfig()
         assert config.edge_gate_repetition_enabled is True
-        # The repetition axis reuses the existing count knob.
-        assert config.min_co_activation_count == 2
+        # Default 4 from the measured #983 tradeoff curve: evidence >= 4 is
+        # the point where recovery@10 lift stays > 0 while the noise-side
+        # non_gold_form_rate returns to the p95 baseline.
+        assert config.edge_gate_min_evidence == 4
 
     def test_repetition_gate_can_be_disabled(self):
         config = NeuralMemoryConfig(edge_gate_repetition_enabled=False)
@@ -129,8 +131,14 @@ class TestEdgeGateRepetitionConfig:
 
     def test_repetition_gate_from_env(self, monkeypatch):
         monkeypatch.setenv("EDGE_GATE_REPETITION_ENABLED", "false")
+        monkeypatch.setenv("EDGE_GATE_MIN_EVIDENCE", "2")
         config = NeuralMemoryConfig.from_env()
         assert config.edge_gate_repetition_enabled is False
+        assert config.edge_gate_min_evidence == 2
+
+    def test_min_evidence_must_be_positive(self):
+        with pytest.raises(ValueError, match="edge_gate_min_evidence"):
+            NeuralMemoryConfig(edge_gate_min_evidence=0)
 
 
 class TestSleepMaintenanceConfig:

--- a/backend/tests/neural/test_config.py
+++ b/backend/tests/neural/test_config.py
@@ -107,6 +107,32 @@ class TestEdgeGateCalibrationConfig:
         assert config.min_similarity_for_edge_floor == 0.35
 
 
+class TestEdgeGateRepetitionConfig:
+    """2D edge gate repetition axis (Issue #983).
+
+    ``edge_gate_repetition_enabled`` is the rollback switch for the second
+    gate axis: pairs in the [floor, calibrated-threshold) cosine band may
+    form edges once their co-activation count reaches
+    ``min_co_activation_count`` (the existing knob, previously unconsulted
+    on the edge-formation path).
+    """
+
+    def test_repetition_gate_default_enabled(self):
+        config = NeuralMemoryConfig()
+        assert config.edge_gate_repetition_enabled is True
+        # The repetition axis reuses the existing count knob.
+        assert config.min_co_activation_count == 2
+
+    def test_repetition_gate_can_be_disabled(self):
+        config = NeuralMemoryConfig(edge_gate_repetition_enabled=False)
+        assert config.edge_gate_repetition_enabled is False
+
+    def test_repetition_gate_from_env(self, monkeypatch):
+        monkeypatch.setenv("EDGE_GATE_REPETITION_ENABLED", "false")
+        config = NeuralMemoryConfig.from_env()
+        assert config.edge_gate_repetition_enabled is False
+
+
 class TestSleepMaintenanceConfig:
     """Test Sleep Maintenance configuration fields (Issue #101)."""
 

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -415,7 +415,7 @@ class TestHebbianLearner:
 
     @pytest.mark.asyncio
     async def test_2d_gate_band_pair_with_evidence_is_admitted(self, mock_graph):
-        """#983: cosine in [floor, threshold) + count >= min_co_activation_count
+        """#983: cosine in [floor, threshold) + count >= edge_gate_min_evidence
         → the pair forms an edge via the repetition axis."""
         learner = HebbianLearner(mock_graph, _band_config())
         await learner.queue_update(

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -510,9 +510,7 @@ class TestHebbianLearner:
         """#983 prune-cliff fix: a first Δw below prune_threshold must be
         accumulated as pending weight, not silently dropped — ~12% of
         observed pairs in the #969 audit could never accumulate."""
-        config = NeuralMemoryConfig(
-            learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05
-        )
+        config = NeuralMemoryConfig(learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05)
         mock_graph.get_edge = AsyncMock(return_value=None)
         mock_graph.has_edge = AsyncMock(return_value=False)
         mock_graph.add_edge = AsyncMock()
@@ -529,9 +527,7 @@ class TestHebbianLearner:
     async def test_cliff_accumulated_pending_materializes_edge(self, mock_graph):
         """#983: once pending + Δw crosses prune_threshold the edge is
         created with the accumulated weight, and the stash is cleared."""
-        config = NeuralMemoryConfig(
-            learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05
-        )
+        config = NeuralMemoryConfig(learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05)
         mock_graph.get_edge = AsyncMock(return_value=None)
         mock_graph.has_edge = AsyncMock(return_value=False)
         mock_graph.add_edge = AsyncMock()
@@ -550,9 +546,7 @@ class TestHebbianLearner:
         """#983 scope boundary: decay-driven pruning of REAL edges is
         unchanged — the cliff fix applies only to not-yet-materialized
         edges."""
-        config = NeuralMemoryConfig(
-            learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05
-        )
+        config = NeuralMemoryConfig(learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05)
         mock_graph.get_edge = AsyncMock(return_value={"weight": 0.04})
         mock_graph.has_edge = AsyncMock(return_value=True)
         mock_graph.add_edge = AsyncMock()

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -53,6 +53,22 @@ def _band_activations() -> list[ActivationState]:
     ]
 
 
+def _tracker_with_record(config, pair: tuple[str, str] = ("a", "b")):
+    """A CoActivationTracker pre-seeded with a record for ``pair`` so the
+    Hebbian learner has somewhere to ride pending weight (#983). In production
+    every queued pair already has a record from the same recall's
+    record_activation; tests seed it directly."""
+    from neural.co_activation import CoActivationTracker
+    from neural.models import CoActivationRecord
+
+    tracker = CoActivationTracker(config)
+    n1, n2 = sorted(pair)
+    tracker._co_activation_records["u"][(n1, n2)] = CoActivationRecord(
+        node_id_1=n1, node_id_2=n2, user_id="u"
+    )
+    return tracker
+
+
 class TestHebbianLearner:
     """Test Hebbian learning algorithm."""
 
@@ -508,20 +524,22 @@ class TestHebbianLearner:
     @pytest.mark.asyncio
     async def test_cliff_subthreshold_first_update_is_stashed_not_dropped(self, mock_graph):
         """#983 prune-cliff fix: a first Δw below prune_threshold must be
-        accumulated as pending weight, not silently dropped — ~12% of
-        observed pairs in the #969 audit could never accumulate."""
+        accumulated as pending weight on the (Redis-persisted) co-activation
+        record, not silently dropped — ~12% of observed pairs in the #969
+        audit could never accumulate."""
         config = NeuralMemoryConfig(learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05)
         mock_graph.get_edge = AsyncMock(return_value=None)
         mock_graph.has_edge = AsyncMock(return_value=False)
         mock_graph.add_edge = AsyncMock()
-        learner = HebbianLearner(mock_graph, config)
+        tracker = _tracker_with_record(config)
+        learner = HebbianLearner(mock_graph, config, tracker)
 
         result = await learner._apply_update_to_edge("u", "a", "b", 0.03)
 
         assert result == 0.0  # no edge yet (counting semantics unchanged)
         mock_graph.add_edge.assert_not_called()
         mock_graph.remove_edge.assert_not_called()
-        assert learner._pending_weights["u"][("a", "b")] == pytest.approx(0.03)
+        assert tracker.get_co_activation_record("u", "a", "b").pending_weight == pytest.approx(0.03)
 
     @pytest.mark.asyncio
     async def test_cliff_accumulated_pending_materializes_edge(self, mock_graph):
@@ -531,7 +549,8 @@ class TestHebbianLearner:
         mock_graph.get_edge = AsyncMock(return_value=None)
         mock_graph.has_edge = AsyncMock(return_value=False)
         mock_graph.add_edge = AsyncMock()
-        learner = HebbianLearner(mock_graph, config)
+        tracker = _tracker_with_record(config)
+        learner = HebbianLearner(mock_graph, config, tracker)
 
         await learner._apply_update_to_edge("u", "a", "b", 0.03)
         result = await learner._apply_update_to_edge("u", "a", "b", 0.03)
@@ -539,7 +558,60 @@ class TestHebbianLearner:
         assert result == pytest.approx(0.06)
         mock_graph.add_edge.assert_called_once()
         assert mock_graph.add_edge.call_args.kwargs["weight"] == pytest.approx(0.06)
-        assert ("a", "b") not in learner._pending_weights["u"]
+        assert tracker.get_co_activation_record("u", "a", "b").pending_weight == 0.0
+
+    @pytest.mark.asyncio
+    async def test_cliff_no_tracker_drops_subthreshold_first_update(self, mock_graph):
+        """#983: without a co-activation tracker the learner cannot persist
+        pending weight, so it falls back to the pre-#983 behavior (drop the
+        sub-threshold first update) rather than silently stashing it in a
+        volatile per-instance dict that never survives the recall."""
+        config = NeuralMemoryConfig(learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05)
+        mock_graph.get_edge = AsyncMock(return_value=None)
+        mock_graph.has_edge = AsyncMock(return_value=False)
+        mock_graph.add_edge = AsyncMock()
+        learner = HebbianLearner(mock_graph, config)  # no tracker
+
+        first = await learner._apply_update_to_edge("u", "a", "b", 0.03)
+        second = await learner._apply_update_to_edge("u", "a", "b", 0.03)
+
+        assert first == 0.0 and second == 0.0
+        mock_graph.add_edge.assert_not_called()  # never accumulates → never materializes
+
+    @pytest.mark.asyncio
+    async def test_cliff_bidirectional_pass_does_not_double_count(self, mock_graph):
+        """#983 regression: apply_updates issues both (a,b) and (b,a); the
+        pending read must be snapshotted before the pass so the second
+        direction does not see the first direction's write and double-count."""
+        config = NeuralMemoryConfig(learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05)
+        mock_graph.get_edge = AsyncMock(return_value=None)
+        mock_graph.has_edge = AsyncMock(return_value=False)
+        mock_graph.add_edge = AsyncMock()
+        tracker = _tracker_with_record(config)
+        learner = HebbianLearner(mock_graph, config, tracker)
+
+        # High-similarity embeddings so the pair passes the cosine gate and is
+        # queued; tiny activations so Δw = 0.1 * 0.1 * 0.1 = 0.001 < prune 0.05.
+        nodes = _band_nodes()
+        import numpy as np
+
+        emb = (np.array([1.0, 0.9, 0.1] + [0.0] * 5)).tolist()
+        emb = (np.array(emb) / np.linalg.norm(emb)).tolist()
+        nodes["a"].embedding = emb
+        nodes["b"].embedding = emb  # cosine 1.0 → passes gate
+        activations = [
+            ActivationState(node_id="a", activation=0.1),
+            ActivationState(node_id="b", activation=0.1),
+        ]
+        await learner.queue_update("u", activations, nodes)
+        await learner.apply_updates("u")
+
+        # Both directions saw snapshot pending=0 → each stashes 0.001, not 0.002,
+        # and neither materializes.
+        mock_graph.add_edge.assert_not_called()
+        assert tracker.get_co_activation_record("u", "a", "b").pending_weight == pytest.approx(
+            0.001
+        )
 
     @pytest.mark.asyncio
     async def test_cliff_existing_edge_below_threshold_still_pruned(self, mock_graph):
@@ -550,13 +622,14 @@ class TestHebbianLearner:
         mock_graph.get_edge = AsyncMock(return_value={"weight": 0.04})
         mock_graph.has_edge = AsyncMock(return_value=True)
         mock_graph.add_edge = AsyncMock()
-        learner = HebbianLearner(mock_graph, config)
+        tracker = _tracker_with_record(config)
+        learner = HebbianLearner(mock_graph, config, tracker)
 
         result = await learner._apply_update_to_edge("u", "a", "b", -0.02)
 
         assert result == 0.0
         mock_graph.remove_edge.assert_called_once()
-        assert ("a", "b") not in learner._pending_weights["u"]
+        assert tracker.get_co_activation_record("u", "a", "b").pending_weight == 0.0
 
     @pytest.mark.asyncio
     async def test_prune_weak_edges_excludes_semantic_origin(self, mock_graph):

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -13,6 +13,46 @@ from neural.hebbian import HebbianLearner
 from neural.models import ActivationState, MemoryKind, NeuralMemoryNode
 
 
+def _band_config(repetition_enabled: bool = True) -> NeuralMemoryConfig:
+    """Config for the 2D edge gate tests (#983)."""
+    return NeuralMemoryConfig(
+        learning_rate=0.1,
+        gradient_clipping=1.0,
+        min_similarity_for_edge=0.5,
+        min_co_activation_count=2,
+        edge_gate_repetition_enabled=repetition_enabled,
+    )
+
+
+def _band_nodes() -> dict[str, NeuralMemoryNode]:
+    """Two nodes whose embeddings sit in the [0.3, 0.45) cosine band (≈0.35)."""
+    import numpy as np
+
+    emb_a = [1.0, 0.0, 0.0] + [0.0] * 5
+    emb_b = [0.35, 0.9367, 0.0] + [0.0] * 5  # cosine ≈ 0.35 with emb_a
+    emb_a = (np.array(emb_a) / np.linalg.norm(emb_a)).tolist()
+    emb_b = (np.array(emb_b) / np.linalg.norm(emb_b)).tolist()
+    common = {
+        "user_id": "u",
+        "kind": MemoryKind.FACT,
+        "created_at": datetime.utcnow(),
+        "use_count": 0,
+        "importance": 0.5,
+        "confidence": 1.0,
+    }
+    return {
+        "a": NeuralMemoryNode(id="a", text="A", embedding=emb_a, **common),
+        "b": NeuralMemoryNode(id="b", text="B", embedding=emb_b, **common),
+    }
+
+
+def _band_activations() -> list[ActivationState]:
+    return [
+        ActivationState(node_id="a", activation=0.9),
+        ActivationState(node_id="b", activation=0.8),
+    ]
+
+
 class TestHebbianLearner:
     """Test Hebbian learning algorithm."""
 
@@ -356,6 +396,114 @@ class TestHebbianLearner:
         gate_learner = HebbianLearner(mock_graph, gate_cfg)
         await gate_learner.queue_update("u", activations, _nodes(), similarity_threshold=0.8)
         assert len(gate_learner._update_queue.get("u", [])) == 0
+
+    @pytest.mark.asyncio
+    async def test_2d_gate_band_pair_with_evidence_is_admitted(self, mock_graph):
+        """#983: cosine in [floor, threshold) + count >= min_co_activation_count
+        → the pair forms an edge via the repetition axis."""
+        learner = HebbianLearner(mock_graph, _band_config())
+        await learner.queue_update(
+            "u",
+            _band_activations(),
+            _band_nodes(),
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+            co_activation_counts={("a", "b"): 2},
+        )
+        assert len(learner._update_queue["u"]) == 2  # bidirectional
+
+    @pytest.mark.asyncio
+    async def test_2d_gate_band_pair_without_evidence_is_skipped(self, mock_graph):
+        """#983: a band pair seen only once is still gated (noise default)."""
+        learner = HebbianLearner(mock_graph, _band_config())
+        await learner.queue_update(
+            "u",
+            _band_activations(),
+            _band_nodes(),
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+            co_activation_counts={("a", "b"): 1},
+        )
+        assert len(learner._update_queue.get("u", [])) == 0
+
+    @pytest.mark.asyncio
+    async def test_2d_gate_disabled_restores_1d_behavior(self, mock_graph):
+        """#983 rollback switch: repetition disabled → band pair gated even
+        with abundant evidence."""
+        learner = HebbianLearner(mock_graph, _band_config(repetition_enabled=False))
+        await learner.queue_update(
+            "u",
+            _band_activations(),
+            _band_nodes(),
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+            co_activation_counts={("a", "b"): 10},
+        )
+        assert len(learner._update_queue.get("u", [])) == 0
+
+    @pytest.mark.asyncio
+    async def test_2d_gate_below_floor_rejected_despite_evidence(self, mock_graph):
+        """#983: the floor stays a hard reject — repetition cannot admit
+        pairs below it."""
+        import numpy as np
+
+        emb_a = (np.array([1.0, 0.0, 0.0] + [0.0] * 5)).tolist()
+        emb_c = [0.1, 0.995, 0.0] + [0.0] * 5  # cosine ≈ 0.1 < floor 0.3
+        emb_c = (np.array(emb_c) / np.linalg.norm(emb_c)).tolist()
+        nodes = _band_nodes()
+        nodes["b"].embedding = emb_c
+        nodes["a"].embedding = emb_a
+
+        learner = HebbianLearner(mock_graph, _band_config())
+        await learner.queue_update(
+            "u",
+            _band_activations(),
+            nodes,
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+            co_activation_counts={("a", "b"): 10},
+        )
+        assert len(learner._update_queue.get("u", [])) == 0
+
+    @pytest.mark.asyncio
+    async def test_2d_gate_above_threshold_needs_no_evidence(self, mock_graph):
+        """#983: pairs at/above the calibrated threshold form immediately —
+        the repetition axis only governs the band."""
+        import numpy as np
+
+        emb_a = [1.0, 0.0, 0.0] + [0.0] * 5
+        emb_b = [0.6, 0.8, 0.0] + [0.0] * 5  # cosine 0.6 >= 0.45
+        nodes = _band_nodes()
+        nodes["a"].embedding = (np.array(emb_a) / np.linalg.norm(emb_a)).tolist()
+        nodes["b"].embedding = (np.array(emb_b) / np.linalg.norm(emb_b)).tolist()
+
+        learner = HebbianLearner(mock_graph, _band_config())
+        await learner.queue_update(
+            "u",
+            _band_activations(),
+            nodes,
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+            co_activation_counts={},  # no evidence anywhere
+        )
+        assert len(learner._update_queue["u"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_2d_gate_counts_key_is_order_normalized(self, mock_graph):
+        """#983: count lookup must normalize the pair key (min, max) so the
+        caller's record ordering always matches."""
+        learner = HebbianLearner(mock_graph, _band_config())
+        # Activations listed b-first → naive (i, j) key would be ("b", "a").
+        activations = list(reversed(_band_activations()))
+        await learner.queue_update(
+            "u",
+            activations,
+            _band_nodes(),
+            similarity_threshold=0.45,
+            floor_threshold=0.3,
+            co_activation_counts={("a", "b"): 2},
+        )
+        assert len(learner._update_queue["u"]) == 2
 
     @pytest.mark.asyncio
     async def test_prune_weak_edges_excludes_semantic_origin(self, mock_graph):

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -506,6 +506,65 @@ class TestHebbianLearner:
         assert len(learner._update_queue["u"]) == 2
 
     @pytest.mark.asyncio
+    async def test_cliff_subthreshold_first_update_is_stashed_not_dropped(self, mock_graph):
+        """#983 prune-cliff fix: a first Δw below prune_threshold must be
+        accumulated as pending weight, not silently dropped — ~12% of
+        observed pairs in the #969 audit could never accumulate."""
+        config = NeuralMemoryConfig(
+            learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05
+        )
+        mock_graph.get_edge = AsyncMock(return_value=None)
+        mock_graph.has_edge = AsyncMock(return_value=False)
+        mock_graph.add_edge = AsyncMock()
+        learner = HebbianLearner(mock_graph, config)
+
+        result = await learner._apply_update_to_edge("u", "a", "b", 0.03)
+
+        assert result == 0.0  # no edge yet (counting semantics unchanged)
+        mock_graph.add_edge.assert_not_called()
+        mock_graph.remove_edge.assert_not_called()
+        assert learner._pending_weights["u"][("a", "b")] == pytest.approx(0.03)
+
+    @pytest.mark.asyncio
+    async def test_cliff_accumulated_pending_materializes_edge(self, mock_graph):
+        """#983: once pending + Δw crosses prune_threshold the edge is
+        created with the accumulated weight, and the stash is cleared."""
+        config = NeuralMemoryConfig(
+            learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05
+        )
+        mock_graph.get_edge = AsyncMock(return_value=None)
+        mock_graph.has_edge = AsyncMock(return_value=False)
+        mock_graph.add_edge = AsyncMock()
+        learner = HebbianLearner(mock_graph, config)
+
+        await learner._apply_update_to_edge("u", "a", "b", 0.03)
+        result = await learner._apply_update_to_edge("u", "a", "b", 0.03)
+
+        assert result == pytest.approx(0.06)
+        mock_graph.add_edge.assert_called_once()
+        assert mock_graph.add_edge.call_args.kwargs["weight"] == pytest.approx(0.06)
+        assert ("a", "b") not in learner._pending_weights["u"]
+
+    @pytest.mark.asyncio
+    async def test_cliff_existing_edge_below_threshold_still_pruned(self, mock_graph):
+        """#983 scope boundary: decay-driven pruning of REAL edges is
+        unchanged — the cliff fix applies only to not-yet-materialized
+        edges."""
+        config = NeuralMemoryConfig(
+            learning_rate=0.1, gradient_clipping=1.0, prune_threshold=0.05
+        )
+        mock_graph.get_edge = AsyncMock(return_value={"weight": 0.04})
+        mock_graph.has_edge = AsyncMock(return_value=True)
+        mock_graph.add_edge = AsyncMock()
+        learner = HebbianLearner(mock_graph, config)
+
+        result = await learner._apply_update_to_edge("u", "a", "b", -0.02)
+
+        assert result == 0.0
+        mock_graph.remove_edge.assert_called_once()
+        assert ("a", "b") not in learner._pending_weights["u"]
+
+    @pytest.mark.asyncio
     async def test_prune_weak_edges_excludes_semantic_origin(self, mock_graph):
         """#724: the per-node top-M pruner only considers hebbian edges.
 

--- a/backend/tests/neural/test_hebbian.py
+++ b/backend/tests/neural/test_hebbian.py
@@ -19,7 +19,7 @@ def _band_config(repetition_enabled: bool = True) -> NeuralMemoryConfig:
         learning_rate=0.1,
         gradient_clipping=1.0,
         min_similarity_for_edge=0.5,
-        min_co_activation_count=2,
+        edge_gate_min_evidence=2,
         edge_gate_repetition_enabled=repetition_enabled,
     )
 


### PR DESCRIPTION
Closes #983

## Summary

Adds **repetition as the second edge-gate axis**: pairs whose cosine falls in the `[floor, calibrated-threshold)` band are no longer rejected outright — they form a Hebbian edge once they have been co-recalled by enough **distinct queries** (`edge_gate_min_evidence`, default 4). Also fixes the `prune_threshold` first-update cliff so sub-threshold Δw accumulates instead of being dropped.

Follow-up to #982 (1-D percentile calibration), which proved a static cosine gate cannot separate cross-topic gold pairs from noise on this signal.

## Results (`make eval-compounding`, self-calibrating, noise-side guard)

| `edge_gate_min_evidence` | recovery@10 lift (exclude_probes) | non_gold_form_rate | edge_precision |
|---|---|---|---|
| 2 (issue's initial sketch) | 0 → **0.4** | 0.426 | 0.171 |
| 3 | 0 → 0.2 | 0.328 | 0.185 |
| **4 (default)** | 0 → **0.2** | **0.149–0.206** | 0.222–0.333 |

- **AC met at the default**: recovery@10 lift > 0 with `non_gold_form_rate` ≈ the p95 baseline (0.147). Run-to-run variance is ±0.05 (corpus re-embedded per run).
- **Recall lane stays perfectly flat** (P@5/MRR/nDCG unchanged cold→warm) — the #120 guarantee holds.
- First compounding demonstrated at **default config** (no manual threshold lowering, unlike the #982 demo).
- Tradeoff-curve runs are committed: `results/compounding-2026-06-11-983-evidence{2,3,4}.json`.

## Key empirical finding

The issue hypothesized "noise pairs co-occur once by ranking accident" — **empirically false on this corpus**: same-bucket non-gold pairs are co-recalled by 2–4 distinct related queries (band evidence histogram, unique pairs: gold {1:1, 2:1, 4:1} vs non-gold {1:4, 2:3, 3:3, 4:1}). Evidence ≥ 4 is where separation happens, hence the default. The distinct-query dedup (issue's "optional" item 3) turned out to be **required**: raw event counting would let an 8-round replay (or production rehearsal of one query) inflate every noise pair past any count requirement.

## Implementation

1. **Config**: `edge_gate_repetition_enabled` (rollback switch) + `edge_gate_min_evidence` (dedicated knob — `min_co_activation_count` keeps its legacy default for existing consumers). Env + DB-overridable; validated `0 < min_evidence <= evidence_keys cap (16)` so the gate can never be silently unsatisfiable.
2. **Tracker** (`CoActivationTracker`): recording gate lowered to the floor so band pairs accumulate evidence. `CoActivationRecord` gains `same_event_count` (both nodes in the same activation event) + `evidence_keys` (distinct query fingerprints, sha256 of query text). Count-inflation fixes: stale window pairs no longer re-counted every event; same query replayed N times = 1 observation.
3. **Hebbian gate** (`queue_update`): `sim >= T` forms immediately (unchanged); `floor <= sim < T` requires `evidence >= edge_gate_min_evidence`; `< floor` stays a hard reject.
4. **Prune-cliff fix**: sub-threshold first updates accumulate as `pending_weight` **on the co-activation record** and materialize when the accumulated weight crosses `prune_threshold`. Decay-side pruning of existing edges is unchanged (scope boundary).
5. **Eval**: gate audit gains `forms_repetition` verdict, per-pair distinct-query evidence, and a band-evidence histogram diagnostic.

## Review (pre-PR)

A high-effort `/code-review` pass found one real bug, fixed in dcdcc1b: the cliff fix was initially a **production no-op** — `HebbianLearner` is rebuilt per recall and its private pending dict never persisted. Fix: `pending_weight` rides `CoActivationRecord`, inheriting the tracker's Redis round-trip (7-day TTL) and GDPR `clear_user_data` for free; pending is snapshotted before `apply_updates` so the two directed updates of a pair cannot double-count (regression-tested).

## Verification notes (honest scope)

- **AC #1/#3 (2D gate + eval)**: demonstrated end-to-end by the live eval (table above).
- **AC #2 (prune cliff)**: proven by unit tests; **neutral in the eval** — all probe gold pairs have first Δw 0.014–0.036 > prune_threshold 0.01, so the cliff path doesn't affect recovery on this corpus (it affects the ~12% below-prune tail of non-gold observations). No regression: eval numbers identical before/after the fix.
- Known limitation (documented in code): evidence/pending are per-process with Redis persistence; cross-worker sharing is last-writer-wins.
- `tests/neural/`, `tests/services/`, `tests/tasks/`, `tests/eval/`: **1154 passed**. CI-parity lint (ruff check / format / models-no-column) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
