### PR TITLE
docs(api): #622 pre-1.0 API surface enumeration — first pass

### DIFF
--- a/docs/api-surface-1.0/auth-surface.md
+++ b/docs/api-surface-1.0/auth-surface.md
@@ -1,0 +1,286 @@
+# Auth / OAuth / DCR Surface — pre-1.0 surface enumeration
+
+> Issue: #622 — pre-1.0 public API surface enumeration and freeze
+> Enumerated at commit 20ae959a2c79cacd2cf7922512ad780f540e9c60 (main HEAD, 2026-06-12)
+
+Sources read in full: `backend/src/auth/jwt.py`, `backend/src/auth/mcp_scopes.py`,
+`backend/src/api/routes/well_known.py`, `backend/src/auth/oauth2_bearer.py`,
+`backend/src/auth/dependencies.py` (scope-enforcement sections),
+`backend/src/auth/oauth2_server.py` (token-generation/grant sections),
+`backend/src/api/routes/oauth.py` (route decorators + DCR/token/introspect handlers),
+`backend/src/mcp_server/auth.py`. Enumeration is complete for the items below; no
+silent truncation.
+
+---
+
+## JWT claim shapes
+
+The platform issues exactly **one JWT token type**. All other credentials (OAuth2
+access/refresh tokens, API keys, resource tokens, browser sessions) are **opaque
+random strings, not JWTs** — they carry no claims; their attributes live in DB rows.
+
+### 1. Dashboard JWT access token — `auth/jwt.py:create_access_token`
+
+Signed `HS256` (default, `settings.jwt_algorithm`) with shared secret
+`settings.jwt_secret`; lifetime `settings.jwt_expire_minutes` (default 60).
+Algorithm is enforced on verify (mismatch → reject). 5 claims, all always present:
+
+| Claim | Type | Meaning | Presence |
+|---|---|---|---|
+| `sub` | string | User identifier (IdP-qualified, e.g. `google\|123`) | always |
+| `email` | string | User email | always |
+| `role` | string | App role: `admin` / `user` / `read_only` (custom claim) | always |
+| `iat` | NumericDate | Issued-at | always |
+| `exp` | NumericDate | Expiry (`iat` + `jwt_expire_minutes`) | always |
+
+No `iss`, `aud`, `jti`, `nbf`, no workspace/tenant claim, no `token_type`
+discriminator, no scope claim.
+
+⚠ **`create_access_token` / `verify_access_token` have zero production callers**
+(grep across `backend/src` excluding tests finds no import of `auth.jwt`). The
+live dashboard auth is an opaque session cookie (`auth/session.py`,
+`secrets.token_urlsafe(32)` session id resolved by SessionMiddleware). Freezing
+this JWT shape at 1.0 would freeze dead surface — decide remove-or-adopt before
+the freeze.
+
+### 2. OAuth2 access token (authorization_code / refresh_token / device_code grants)
+
+Opaque `secrets.token_urlsafe(32)` (43 chars, no prefix) — `auth/oauth2_server.py:_generate_token_with_expiry`.
+No JWT claims. Server-side row (`oauth_tokens`) holds user_id, client_id, scope,
+issued_at, expiry (3600 s for all three grants), revocation flags, and `resource`
+(RFC 8707). The externally visible "claim surface" is the RFC 7662 introspection
+response (7 fields, `models/schemas.py:TokenIntrospectionResponse`):
+
+| Field | Type | Meaning | Presence |
+|---|---|---|---|
+| `active` | bool | Token validity | always |
+| `client_id` | string | Issuing client | only when active |
+| `scope` | string | Space-separated granted scopes; may be null for legacy tokens issued without scope | conditional |
+| `exp` | int (epoch) | Expiry | only when active |
+| `iat` | int (epoch) | Issued-at | only when active |
+| `token_type` | string | Always `"Bearer"` | only when active |
+| `aud` | string | RFC 8707 resource indicator; null if not requested | conditional |
+
+### 3. OAuth2 refresh token
+
+Opaque `secrets.token_urlsafe(32)`, issued alongside every access token
+(unconditionally — see `offline_access` flag below). Long-lived, no automatic
+expiration; rotated on use (old access+refresh revoked, RFC 6819 §5.2.2.3).
+
+### 4. Device-flow token response extras (RFC 8628)
+
+`DeviceAuthorizationGrant.generate_token` returns the standard 5 token-response
+keys (`token_type`, `access_token`, `expires_in`, `scope`, `refresh_token`) **plus
+non-standard identity fields** for SDK display:
+
+| Field | Presence |
+|---|---|
+| `user_email` | conditional (when user row resolvable) |
+| `workspace_id` | conditional (user has a non-deleted current workspace) |
+| `workspace_name` | conditional (same) |
+
+Code comments mark these as point-in-time and explicitly **not security-bearing**.
+⚠ Non-standard members of an RFC 6749 token response — stability must be declared
+(or namespaced) before freeze.
+
+### 5. API keys and resource tokens (not JWTs, listed for completeness)
+
+- API key: `kagura_` + `token_urlsafe(32)` (`auth/api_keys.py`, `API_KEY_PREFIX`); SHA-256 hash stored. Variants: global, workspace-scoped, public-bound (`bound_context_id`, #626 — rejected outside `/api/v1/public/*`).
+- Resource token: `kagura_resource_` + `token_urlsafe(32)` (`auth/resource_tokens.py`); capability-typed, resource+workspace-scoped, hourly event quota.
+- Bearer disambiguation contract (`oauth2_bearer.is_oauth_bearer_token`): anything **not** starting with `kagura_` is treated as an OAuth token. The `kagura_` prefix is therefore itself frozen surface.
+
+---
+
+## well-known metadata endpoints
+
+Router: `backend/src/api/routes/well_known.py`, mounted at prefix `/.well-known`
+(`api/main.py:588`). 4 endpoints total. `base_url` = `FRONTEND_URL` env;
+`mcp_base` = `FRONTEND_URL` + `MCP_BASE_PATH` (default `/mcp`).
+
+### 1. `GET /.well-known/oauth-protected-resource/mcp`
+
+301 redirect → `/.well-known/oauth-protected-resource`. No body fields.
+
+### 2. `GET /.well-known/oauth-protected-resource` (RFC 9728) — 8 fields
+
+| Field | Value |
+|---|---|
+| `resource` | `{mcp_base}` (MCP canonical URL) |
+| `authorization_servers` | `[{base_url}]` |
+| `scopes_supported` | `ALL_ADVERTISED_SCOPES` (6 scopes, see catalogue) |
+| `bearer_methods_supported` | `["header"]` |
+| `resource_signing_alg_values_supported` | `["RS256", "HS256"]` |
+| `resource_documentation` | `{base_url}/redoc` |
+| `resource_policy_uri` | `{base_url}/docs` |
+| `mcp_sse_endpoint` | `{mcp_base}/sse` |
+
+⚠ `resource_signing_alg_values_supported` advertises RS256/HS256 but access tokens
+are opaque (never signed, and no RS256 key exists anywhere). Misleading for a
+frozen surface.
+⚠ `mcp_sse_endpoint` is a custom, non-RFC field — declare as a stable extension
+or rename before freeze.
+⚠ `resource_policy_uri` points at the Swagger UI (`/docs`), not a policy document.
+
+### 3. `GET /.well-known/openid-configuration` (OIDC Discovery) — 14 fields
+
+| Field | Value |
+|---|---|
+| `issuer` | `{base_url}` |
+| `authorization_endpoint` | `{base_url}/api/v1/oauth/authorize` |
+| `token_endpoint` | `{base_url}/api/v1/oauth/token` |
+| `revocation_endpoint` | `{base_url}/api/v1/oauth/revoke` |
+| `introspection_endpoint` | `{base_url}/api/v1/oauth/introspect` |
+| `registration_endpoint` | `{base_url}/api/v1/oauth/register` |
+| `code_challenge_methods_supported` | `["S256"]` |
+| `scopes_supported` | `ALL_ADVERTISED_SCOPES` (6) |
+| `response_types_supported` | `["code"]` |
+| `grant_types_supported` | `["authorization_code", "refresh_token"]` |
+| `token_endpoint_auth_methods_supported` | `["none", "client_secret_post", "client_secret_basic"]` |
+| `introspection_endpoint_auth_methods_supported` | `["none"]` |
+| `response_modes_supported` | `["query"]` |
+| `subject_types_supported` | `["public"]` |
+
+⚠ Missing OIDC-Discovery-REQUIRED fields `jwks_uri`, `userinfo_endpoint`,
+`id_token_signing_alg_values_supported` — and the server never issues an
+`id_token`. This is the #608 D5 "OIDC dishonesty", still open at this commit.
+⚠ `grant_types_supported` omits `urn:ietf:params:oauth:grant-type:device_code`
+although the device grant is registered and live (see endpoints section) and a
+`kagura-cli` public client is seeded for it (#624/#627). Advertised set is
+narrower than the real surface.
+
+### 4. `GET /.well-known/oauth-authorization-server` (RFC 8414) — 12 fields
+
+Identical to openid-configuration **minus** `response_modes_supported` and
+`subject_types_supported` (the other 12 fields and values match exactly).
+Same device_code omission applies.
+
+---
+
+## OAuth scope catalogue
+
+Single source of truth: `backend/src/auth/mcp_scopes.py:ALL_ADVERTISED_SCOPES`
+(6 scopes; all four metadata advertisements derive from it since #592).
+
+| Scope | Meaning | Advertised | Notes |
+|---|---|---|---|
+| `openid` | OIDC discovery compatibility only | yes (all sources) | Server issues no `id_token`; advertised so strict clients pass discovery (#608 D5, deferred) |
+| `memory:read` | Read access to memory APIs | yes | REST: method-mapped to GET/HEAD/OPTIONS on `/api/v1/*` (`auth/dependencies.py`; 403 + `WWW-Authenticate: Bearer error="insufficient_scope"` on miss) |
+| `memory:write` | Mutating access | yes | REST: POST/PUT/PATCH/DELETE; fail-closed default for unknown verbs |
+| `memory:admin` | Intended: workspace-admin operations (#608 D3) | yes | Excluded from scope hierarchy (`memory:admin` does NOT imply `memory:write`); D3 route gates pending |
+| `memory:delete` | Intended: distinct delete capability (#608 D4) | yes | D4 pending; HTTP DELETE currently maps to `memory:write` |
+| `offline_access` | RFC 6749 refresh-token request | yes | Refresh-token issuance policy under pre-1.0 review |
+
+**Enforcement matrix:** the per-scope × per-transport enforcement matrix is
+being completed as part of pre-1.0 hardening; it is tracked in the internal
+hardening ledger and this section will be re-frozen with the final matrix
+before v1.0.0-rc1.
+
+API keys and resource tokens are outside the scope system by design (role/RBAC
+and capability lanes respectively, per #608 D2).
+
+---
+
+## OAuth / DCR endpoints
+
+Router: `backend/src/api/routes/oauth.py`, `APIRouter(prefix="/oauth")` mounted
+under `/api/v1` → all paths below are `/api/v1/oauth/...`. 19 routes total
+(paths + grant types only, per enumeration scope).
+
+Semver-locked discovery-referenced endpoints:
+
+| Path | Method | Purpose |
+|---|---|---|
+| `/register` | POST | DCR (RFC 7591). Public, no auth. Provider whitelist (`chatgpt`/`claude`/`cursor` via redirect-URI/client-name detection incl. RFC 8252 loopback), 5 req/min/IP rate limit. Always forces `token_endpoint_auth_method="none"`; never returns `client_secret` (#689) |
+| `/authorize` | GET | Authorization endpoint (consent page, HTML) |
+| `/authorize` | POST | Consent decision submit |
+| `/token`, `/token/` | POST | Token endpoint (Authlib). Grants registered: `authorization_code` (PKCE S256, 10-min single-use codes), `refresh_token` (rotation), `urn:ietf:params:oauth:grant-type:device_code` (RFC 8628, #536) |
+| `/revoke` | POST | RFC 7009 revocation (access or refresh; `token_type_hint` accepted) |
+| `/introspect` | POST | RFC 7662 introspection; auth method `none` (public) |
+
+Device flow (RFC 8628):
+
+| Path | Method | Purpose |
+|---|---|---|
+| `/device/authorize` | POST | Device authorization request (device_code + user_code) |
+| `/device/verify` | POST | Verify a user_code (browser side) |
+| `/device/confirm` | POST | User confirms/denies the device grant |
+| `/device/audit-unauth` | POST | Internal frontend audit beacon (#779); `include_in_schema=False` — ⚠ should be declared non-public surface |
+
+Client-management (session-authenticated dashboard surface, not part of the
+RFC-discovery contract but same router/prefix):
+
+| Path | Methods |
+|---|---|
+| `/clients` | GET (list), POST (create, returns secret once) |
+| `/clients/{client_id}` | GET, PUT, DELETE |
+| `/clients/{client_id}/hide` | POST (hide plaintext secret) |
+| `/clients/{client_id}/regenerate-secret` | POST |
+| `/providers` | GET (list IdP providers) |
+
+⚠ `/token` is `include_in_schema=False` on the canonical path while `/token/`
+(trailing slash) is schema-visible — cosmetic OpenAPI inconsistency on the single
+most important OAuth URL.
+
+---
+
+## DCR_DEFAULT_SCOPE (#608) status
+
+Definition (`backend/src/auth/mcp_scopes.py:56-58`):
+
+```python
+DCR_DEFAULT_SCOPES = tuple(s for s in ALL_ADVERTISED_SCOPES if s != "memory:admin")
+DCR_DEFAULT_SCOPE  = " ".join(DCR_DEFAULT_SCOPES)
+# => "openid memory:read memory:write memory:delete offline_access"
+```
+
+Applied in two places: `routes/oauth.py:764` (DCR fallback when client omits
+`scope`) and `models/auth.py:530` (`OAuth2Client.scope` column default).
+`memory:admin` remains explicitly requestable via the DCR `scope` parameter and
+is still advertised in `scopes_supported`.
+
+**Verdict: the current value MATCHES the #608 (D1) narrow intent.** Issue #608
+(closed COMPLETED 2026-05-12; PR #615 merged, including the
+`e08_592_oauth_scope_canonicalize` backfill migration path) required
+narrowing-first: every newly issued DCR token must be admin-less by default
+*before* any `require_scope("memory:admin")` route gate lands, so no
+already-issued client silently gains admin. That ordering is intact.
+
+Caveats inherited from #608 that remain open at this commit:
+- D2/D3 (the `require_scope` dependency + workspace-admin route gates) are not
+  yet implemented (tracked for pre-1.0 hardening).
+- D4 (`memory:delete` semantics) and D5 (`openid`/`id_token`) remain open as
+  designed in #608.
+
+---
+
+## Follow-up candidates
+
+Grouped into 2 proposed sub-issue bundles (issue acceptance allows ≤2).
+
+### Bundle 1 (P1 — scope/metadata honesty; must settle before 1.0 freeze)
+
+- **P1** Scope-enforcement matrix completion: tracked in the internal pre-1.0
+  hardening ledger (intentionally out of scope for this public enumeration);
+  this doc re-freezes once it lands.
+- **P1** `openid` (#608 D5): drop from advertisement (Path B, no deprecation
+  needed per #608) or implement `id_token`+`jwks_uri`+`userinfo`; the current
+  OIDC discovery doc is non-conformant either way.
+- **P1** Advertise `urn:ietf:params:oauth:grant-type:device_code` in
+  `grant_types_supported` (both metadata docs) — it is live, seeded for
+  kagura-cli, and a frozen metadata doc that under-advertises grants is a
+  compat trap.
+
+### Bundle 2 (P2 — token/metadata shape cleanups; nice-to-have before freeze)
+
+- **P2** Delete or adopt the orphaned dashboard JWT module (`auth/jwt.py` — zero
+  production callers); do not freeze dead claim shapes into the 1.0 surface.
+- **P2** Remove `resource_signing_alg_values_supported` from
+  `oauth-protected-resource` (tokens are opaque; no RS256 key exists).
+- **P2** `mcp_sse_endpoint`: declare as a stable documented extension or move
+  behind a namespaced key; fix `resource_policy_uri` pointing at Swagger UI.
+- **P2** Device-flow token-response extras (`user_email`, `workspace_id`,
+  `workspace_name`): document stability tier explicitly (display-only,
+  non-security-bearing) or namespace them.
+- **P2** `/token` vs `/token/` OpenAPI visibility inconsistency; decide whether
+  `/device/audit-unauth` is public surface (recommend: documented-internal,
+  excluded from the freeze).

--- a/docs/api-surface-1.0/error-responses.md
+++ b/docs/api-surface-1.0/error-responses.md
@@ -1,0 +1,294 @@
+# Error Response Shapes — pre-1.0 surface enumeration
+
+> Issue: #622 — pre-1.0 public API surface enumeration and freeze
+> Enumerated at commit 20ae959a2c79cacd2cf7922512ad780f540e9c60 (main HEAD, 2026-06-12)
+
+Method: exhaustive `grep -rn "error_code" backend/src --include='*.py'` (all 80 occurrences triaged), full read of `backend/src/utils/exceptions.py`, the exception handlers in `backend/src/api/main.py`, the MCP transport/tool error paths, and a per-file census of raw `raise HTTPException(` sites.
+
+---
+
+## Canonical shape
+
+### 1. REST — structured errors (`MemoryCloudException` family)
+
+Emitted by `memory_cloud_exception_handler` (`backend/src/api/main.py:313-339`) for every `MemoryCloudException` subclass:
+
+```json
+{
+  "error": "<error_code>",
+  "message": "<human-readable message>",
+  "details": { "...": "..." }
+}
+```
+
+| Field | Presence | Description |
+|---|---|---|
+| `error` | always | Machine-readable error code. Set per exception class; falls back to the exception **class name** if the constructor receives `error_code=None` (`exceptions.py:39`) — no current raise site exercises the fallback, but it is live behavior. ⚠ |
+| `message` | always | Human-readable message (`exc.message`). |
+| `details` | always (may be `{}`) | The exception's `**details` kwargs. **Exception:** for `AuthorizationError` and `AdminProtectionError` the handler forcibly serializes `details: {}` (CWE-639 defense in depth, `main.py:331`) — the private `reason` attribute is log-only and never serialized. |
+
+HTTP status comes from `exc.status_code` (per-class; see catalogue). Notable headers:
+
+- `DatabaseConnectionError` paths (incl. the `SQLAlchemyError` and connection-error handlers, `main.py:342-403`) add `Retry-After: 5` and return the same 3-field body via `_database_unavailable_response` (wraps `DatabaseConnectionError` → `DB-002`, 503). The connection-error handler is registered on `ConnectionRefusedError` / `ConnectionResetError` / `ConnectionAbortedError` / `BrokenPipeError` (not base `ConnectionError`).
+- Rate-limit middleware (`backend/src/api/middleware/rate_limit.py:121-163`) returns the **same 3-field shape inline** (not via the handler): `RATE-001` 429 with `X-RateLimit-Limit/Remaining/Reset` + `Retry-After: 60`; `QUOTA-001` 429 with `Retry-After: 86400`.
+- Deprecated `/api/v1/attachments/*` returns the same 3-field shape inline as `RES-004` 410 with RFC 8594 `Sunset` / `Deprecation` / `Link` headers (`backend/src/api/routes/attachments.py:29-54`) — emitted inline precisely because the global handler does not propagate those headers.
+
+> ⚠ Note vs. intent: issues #401/#602/#603/#604 standardized on this `{error, message, details}` shape (confirmed in the #602 PR body: callers read `exc.reason` instead of `exc.detail`; frontend consumes the uniform shape). The shape is **not** `{detail, error_code}` — `detail` is the *non-conforming* FastAPI default, below.
+
+### 2. REST — raw `HTTPException` (FastAPI default, NON-canonical)
+
+No custom handler is registered for `fastapi.HTTPException` / `StarletteHTTPException`. The 366 raw raise sites (see §Non-conforming) therefore produce FastAPI's default:
+
+```json
+{ "detail": "<string or object passed as detail>" }
+```
+
+- No `error` code. No `message`. No `details` object. SDKs cannot route on these.
+- Status code is whatever the raise site passes.
+
+### 3. REST — 422 validation (FastAPI default)
+
+No `RequestValidationError` handler exists anywhere in `backend/src` (verified by grep). Pydantic/FastAPI default applies:
+
+```json
+{
+  "detail": [
+    { "type": "...", "loc": ["body", "field"], "msg": "...", "input": "...", "...": "..." }
+  ]
+}
+```
+
+- HTTP 422, no `error` code. ⚠ This is part of the public surface and diverges from both the canonical shape and `ValidationError` (`VAL-001`, 422), which **does** conform when raised from service code. Two different 422 shapes coexist.
+
+### 4. MCP tool errors (in-band, JSON-in-TextContent)
+
+`_error_response` (`backend/src/mcp_server/tools/_helpers.py:107`) — every MCP tool error is a JSON-RPC **success** carrying:
+
+```json
+{ "status": "error", "error": "<code>", "message": "<message>", "...extra fields" }
+```
+
+`MemoryCloudException` is caught in tool handlers and its `error_code`/`message`/`details` pass through verbatim (e.g. `backend/src/mcp_server/tools/resource.py:1162-1175`), so REST codes like `CONNECTOR-001` appear unchanged on the MCP surface.
+
+### 5. MCP transport — JSON-RPC protocol errors
+
+Unhandled exceptions in `tools/call` map to a JSON-RPC error object (`backend/src/mcp_server/transport.py:237-270`), HTTP 200:
+
+```json
+{
+  "jsonrpc": "2.0", "id": "<request id>",
+  "error": {
+    "code": -32xxx,
+    "message": "<message>",
+    "data": { "exception_type": "<PyClassName>", "details": "<str(e), truncated 500>" }
+  }
+}
+```
+
+| JSON-RPC code | Trigger | Site |
+|---|---|---|
+| `-32001` | `asyncio.TimeoutError` — tool execution timeout (custom) | `transport.py:246` |
+| `-32002` | `PermissionError` — permission denied (custom) | `transport.py:249` |
+| `-32602` | `ValueError` — invalid params (standard) | `transport.py:252` |
+| `-32603` | anything else — internal error (standard) | `transport.py:255` |
+
+⚠ The application `error_code` does **not** pass through this path — `MemoryCloudException` falls into the `-32603` bucket with only `exception_type` in `data`. (In practice most tool handlers catch it first, path 4 above.)
+
+### 6. MCP transport — OAuth 401 challenge (RFC 6750)
+
+Auth failure before dispatch (`transport.py:531-580`): HTTP 401, body `{"error": "<code>", "error_description": "<text>"}` plus a `WWW-Authenticate: Bearer realm=..., error=..., error_description=..., resource_metadata=...` header. Codes are deliberately restricted to the RFC 6750 §3.1 vocabulary — internal `AUTH-xxx` codes must NOT leak into the challenge:
+
+| Code | Trigger | Site |
+|---|---|---|
+| `invalid_request` | missing/malformed Bearer credentials (default) | `transport.py:543` |
+| `invalid_token` | `TokenExpiredError` / `TokenRevokedError` / `InvalidTokenError` | `transport.py:547` |
+
+---
+
+## Error code catalogue
+
+**Total: 55 distinct error code values** (54 distinct values matched by the `error_code` grep + `RES-004`, which is emitted inline as an `"error"` literal with no exception class — reserved per the comment at `exceptions.py:177-181`). **55 of 55 enumerated** below. JSON-RPC numeric codes are counted (4 values); `invalid_token` is one value with three emitting classes plus the RFC 6750 path.
+
+### A. `MemoryCloudException` hierarchy (REST canonical shape) — `backend/src/utils/exceptions.py`
+
+| Code | Exception class (file:line of code assignment) | HTTP | Meaning |
+|---|---|---|---|
+| `AUTH-001` | `AuthenticationError` — exceptions.py:54 | 401 | Authentication failed (generic). |
+| `AUTH-002` | `InvalidCredentialsError` — exceptions.py:64 | 401 | Invalid credentials. |
+| `AUTH-003` | `TokenExpiredError` — exceptions.py:71 | 401 | Token expired. |
+| `AUTH-101` | `AuthorizationError` — exceptions.py:92 | 403 | Insufficient permissions (uniform message; `details` always stripped, CWE-639). |
+| `AUTH-201` | `APIKeyError` — exceptions.py:129 | 401 | Invalid or missing API key. |
+| `AUTH-202` | `APIKeyRevokedError` — exceptions.py:139 | 401 | API key revoked. |
+| `AUTH-203` | `APIKeyExpiredError` — exceptions.py:146 | 401 | API key expired. |
+| `ADMIN-001` | `AdminProtectionError` — exceptions.py:117 | 403 | System-admin invariant blocks operation (initial/last admin); `details` always stripped. |
+| `RES-001` | `NotFoundException` — exceptions.py:159 | 404 | Resource not found. |
+| `RES-002` | `ConflictError` — exceptions.py:188 | 409 | Resource conflict. |
+| `RES-003` | `MemoryGoneError` — exceptions.py:174 | 410 | Resource soft-deleted (distinct from 404 so clients stop retrying). |
+| `RES-004` | *(no class — inline `JSONResponse`)* — api/routes/attachments.py:30 | 410 | Deprecated `/api/v1/attachments/*` retired; carries Sunset/Deprecation/Link headers. |
+| `VAL-001` | `ValidationError` — exceptions.py:195 | 422 | Service-layer validation error (shape/format). ⚠ Coexists with the non-conforming FastAPI 422. |
+| `REQ-001` | `BadRequestError` (default) — exceptions.py:217 | 400 | State-precondition failure (call sites may override the code, see ADMIN-101/102). |
+| `MEDIA-001` | `UnsupportedMediaTypeError` — exceptions.py:254 | 415 | Content-Type not in allow-list; `details.allowed` lists accepted types. |
+| `BONUS-001` | `InsufficientReasonError` — exceptions.py:283 | 400 | Slot-bonus shrink below owned count requires a reason. |
+| `BONUS-002` | `BonusBelowZeroError` — exceptions.py:301 | 400 | Resulting workspace_slot_bonus would be negative. |
+| `RATE-001` | `RateLimitError` — exceptions.py:318; also inline at api/middleware/rate_limit.py:124 | 429 | Per-minute rate limit exceeded; `Retry-After` + `X-RateLimit-*` headers on the middleware path. |
+| `QUOTA-001` | `QuotaExceededError` — exceptions.py:339; also inline at api/middleware/rate_limit.py:156 | 429 | Daily quota exceeded; `Retry-After: 86400` on the middleware path. |
+| `QUOTA-002` | `EmbeddingSpendCapExceeded` — exceptions.py:383 | 429 | BYOK embedding spend cap reached (`details.period` = daily/monthly). |
+| `FEAT-001` | `FeatureNotAvailableError` — exceptions.py:392 | 403 | Feature not available on current plan tier. |
+| `DB-001` | `DatabaseError` — exceptions.py:406 | 500 | Database operation failed. |
+| `DB-002` | `DatabaseConnectionError` — exceptions.py:416; also via `SQLAlchemyError`/connection-error handlers (api/main.py:342-403) | 503 | DB unavailable; `Retry-After: 5`. |
+| `EXT-001` | `ExternalServiceError` (default) — exceptions.py:426; inherited by `QdrantError` (exceptions.py:434-438) and direct raises in storage/factory.py:47,65, storage/r2.py:102 | 502 | Generic external-service error. ⚠ Qdrant has no dedicated code; `EXT-101` is an unexplained gap before Redis's `EXT-102`. |
+| `EXT-102` | `RedisError` — exceptions.py:445 | 502 | Redis service error. |
+| `EXT-201` | `OpenAIError` — exceptions.py:452 | 502 | OpenAI API error (direct, non-fallback-chain). |
+| `EXT-202` | `CohereError` — exceptions.py:459 | 502 | Cohere API error. |
+| `EXT-203` | `VoyageError` — exceptions.py:469 | 502 | Voyage AI reranker error. |
+| `EXT-204` | `StripeError` — exceptions.py:482 | 502 | Stripe API unexpected-shape error. |
+| `EXT-205` | `EmailDispatchError` — exceptions.py:511 (status overridden to 503 at :515) | 503 | Email-provider dispatch failed; retriable. |
+| `invalid_token` | `TokenRevokedError` — exceptions.py:526; `InvalidTokenError` — exceptions.py:535; RFC 6750 challenge — mcp_server/transport.py:547 | 401 | OAuth2 token revoked/invalid. ⚠ RFC 6750-mandated lowercase vocabulary, intentionally outside the `NAMESPACE-NNN` convention; on the REST path it surfaces in the canonical body as `"error": "invalid_token"`. |
+| `CFG-001` | `ConfigurationError` — exceptions.py:546 | 500 | Server configuration error. |
+| `INT-001` | `InternalError` — exceptions.py:553 | 500 | Internal server error (structured). |
+| `ERASURE-001` | `ErasureRequestNotFoundError` — exceptions.py:564 | 404 | No erasure request found. |
+| `ERASURE-002` | `ErasureTokenInvalidError` — exceptions.py:571 | 400 | Erasure confirmation token missing/expired/mismatched. |
+| `ERASURE-003` | `ErasureForbiddenError` — exceptions.py:583 | 403 | Erasure not permitted (e.g. password mismatch). |
+| `ERASURE-004` | `InitialAdminCannotBeErasedError` — exceptions.py:598 | 403 | Initial system admin is a protected account. |
+| `ERASURE-005` | `WorkspaceTransferRequiredError` — exceptions.py:617 | 409 | Must transfer workspace ownership before erasure. |
+| `ERASURE-006` | `ErasureAlreadyInProgressError` — exceptions.py:630 | 409 | Erasure request already pending/in progress. |
+
+### B. Service/route-level codes (raised as `MemoryCloudException`/subclass with overridden code)
+
+| Code | Call site | HTTP | Meaning |
+|---|---|---|---|
+| `CONNECTOR-001` | `MemoryCloudException` — services/connector_provisioning.py:407 | 403 | Connector seat limit reached for plan. |
+| `CONNECTOR-002` | `MemoryCloudException` — services/connector_provisioning.py:503 | 503 | Connector seat lock unavailable (PG 55P03 lock timeout); retry. |
+| `EXT-ANA-001` | `ExternalServiceError` subclass — services/analysis/llm_caller.py:83 | 502 | Entire OpenAI fallback chain exhausted (`details.upstream_provider_error=true`, `attempted_models`). |
+| `ADMIN-101` | `BadRequestError` — services/system_admin_service.py:111 | 400 | User is already a system admin. ⚠ Namespace collision: `ADMIN-001` is a 403 protection error, `ADMIN-1xx` are 400 preconditions. |
+| `ADMIN-102` | `BadRequestError` — services/system_admin_service.py:184 | 400 | User is not a system admin. ⚠ Same namespace concern. |
+| `admin_user_id_missing` | `MemoryCloudException` — api/routes/admin_sleep.py:234 | 500 | Admin user id missing from session (defensive). ⚠ snake_case, violates `NAMESPACE-NNN` convention. |
+| `sleep_run_in_progress` | `MemoryCloudException` — api/routes/admin_sleep.py:255 | 409 | A sleep run is already in progress for this user. ⚠ snake_case. |
+| `sleep_target_not_found` | `MemoryCloudException` — api/routes/admin_sleep.py:278 | 404 | No eligible contexts for sleep maintenance. ⚠ snake_case. |
+
+### C. MCP-only codes assigned via `error_code` variable — `backend/src/mcp_server/tools/resource.py`
+
+Emitted in the MCP tool envelope (`{"status":"error","error":...}`); the logged HTTP-equivalent status is shown.
+
+| Code | Call site | HTTP-equiv | Meaning |
+|---|---|---|---|
+| `resource_id_conflict` | resource.py:1026 | 409 | `resource_id` already in use in this context. |
+| `context_name_conflict` | resource.py:1029 | 409 | Context name already exists in this workspace. |
+| `conflict` | resource.py:1032 | 409 | Other uniqueness-constraint violation (sanitized). |
+
+### D. JSON-RPC protocol codes — `backend/src/mcp_server/transport.py`
+
+| Code | Site | Meaning |
+|---|---|---|
+| `-32001` | transport.py:246 | Tool execution timeout (custom). |
+| `-32002` | transport.py:249 | Permission denied (custom). |
+| `-32602` | transport.py:252 | Invalid params (standard). |
+| `-32603` | transport.py:255 | Internal error (standard; catch-all — application `error_code` is NOT propagated here ⚠). |
+
+### E. RFC 6750 challenge codes — `backend/src/mcp_server/transport.py`
+
+| Code | Site | Meaning |
+|---|---|---|
+| `invalid_request` | transport.py:543 | Missing/malformed Bearer credentials (default). |
+| `invalid_token` | transport.py:547 | Token expired/revoked/invalid (also catalogued in §A). |
+
+### Supplementary: MCP `_error_response` literal codes (outside the `error_code` grep, same `"error"` field)
+
+These 41 distinct snake_case literals are passed directly as the first argument to `_error_response(...)` across `backend/src/mcp_server/tools/*.py` and `mcp_server` dispatch — they occupy the same `"error"` field on the MCP surface and are listed for surface completeness (occurrence counts from `grep -rhoP '_error_response\(\s*"[^"]+"'`):
+
+`internal_error` (37), `validation_error` (29), `missing_fields` (20), `workspace_required` (13), `invalid_context_id_format` (5), `invalid_report_id` (3), `invalid_memory_id_format` (3), `db_error` (3), `workspace_not_found` (2), `permission_denied` (2), `not_found` (2), `invalid_arguments` (2), and one each of: `update_search_config_error`, `update_context_error`, `unknown_tool`, `setup_resource_error`, `setup_connector_error`, `service_unavailable`, `quota_exceeded`, `missing_required_fields`, `merge_contexts_error`, `list_tags_error`, `list_resource_tokens_error`, `list_my_bindings_error`, `list_analyses_error`, `invalid_search_config`, `invalid_context_id`, `invalid_argument`, `ingest_events_error`, `get_usage_error`, `get_resource_schema_error`, `get_resource_impact_error`, `get_cluster_error`, `get_analysis_error`, `get_active_analysis_error`, `describe_binding_error`, `delete_context_error`, `create_context_error`, `conflict` (also §C), `binding_not_found`, `analyze_context_error`.
+
+⚠ `invalid_argument` vs `invalid_arguments`, and `missing_fields` vs `missing_required_fields`, are accidental near-duplicates.
+
+---
+
+## Non-conforming emissions
+
+Raw `raise HTTPException(` statements bypass the canonical `{error, message, details}` shape and emit FastAPI's `{"detail": ...}` instead — no machine-routable code.
+
+**Count: 369 grep matches across 42 files; 3 matches are docstring examples only (`api/middleware/session.py:19,154`, `utils/error_messages.py:8`), leaving 366 real raise sites in 40 files.** Full per-file table (grep-match counts; the 3 docstring-only matches are marked):
+
+| Count | File |
+|---|---|
+| 31 | backend/src/api/routes/oauth.py |
+| 29 | backend/src/api/routes/member_credentials.py |
+| 29 | backend/src/api/routes/contexts.py |
+| 24 | backend/src/api/routes/auth.py |
+| 19 | backend/src/api/routes/admin.py |
+| 18 | backend/src/auth/dependencies.py |
+| 17 | backend/src/api/routes/resource_tokens.py |
+| 12 | backend/src/api/routes/workspace_connectors.py |
+| 12 | backend/src/api/routes/external_keys.py |
+| 12 | backend/src/api/routes/connectors_slack.py |
+| 11 | backend/src/api/routes/api_keys.py |
+| 10 | backend/src/api/routes/memory.py |
+| 10 | backend/src/api/routes/invitations.py |
+| 9 | backend/src/api/routes/workspace.py |
+| 9 | backend/src/api/routes/resource_ingest.py |
+| 9 | backend/src/api/routes/me_oauth.py |
+| 9 | backend/src/api/routes/admin_plans.py |
+| 8 | backend/src/plugins/billing/routes.py |
+| 8 | backend/src/api/routes/public_search.py |
+| 8 | backend/src/api/routes/analyses.py |
+| 6 | backend/src/api/routes/workspace_plan.py |
+| 6 | backend/src/api/routes/bm25_drift.py |
+| 5 | backend/src/api/routes/workspaces.py |
+| 5 | backend/src/api/routes/users.py |
+| 5 | backend/src/api/routes/neural_config.py |
+| 5 | backend/src/api/routes/cost_aggregation.py |
+| 5 | backend/src/api/routes/context_search_config.py |
+| 5 | backend/src/api/routes/config.py |
+| 4 | backend/src/utils/auth_helpers.py |
+| 4 | backend/src/auth/analysis_gates.py |
+| 4 | backend/src/api/routes/workers.py |
+| 4 | backend/src/api/routes/agent_state.py |
+| 4 | backend/src/api/routes/admin_signup_gate.py |
+| 3 | backend/src/api/routes/sleep_reports.py |
+| 2 | backend/src/api/routes/system.py |
+| 2 | backend/src/api/middleware/session.py *(docstring examples only — not emitted)* |
+| 1 | backend/src/utils/error_messages.py *(docstring example only — not emitted)* |
+| 1 | backend/src/utils/db_helpers.py |
+| 1 | backend/src/api/routes/resources.py |
+| 1 | backend/src/api/routes/me_account.py |
+| 1 | backend/src/api/routes/feedback.py |
+| 1 | backend/src/api/routes/admin_neural.py |
+
+Representative sites (4 of 366 listed; full per-file counts above):
+
+- `backend/src/utils/db_helpers.py:79` — generic `handle_db_operation` helper converts *any* exception to `HTTPException(500, detail=...)`, institutionalizing the non-canonical shape for every caller. ⚠
+- `backend/src/auth/dependencies.py` (18 sites) — auth-dependency 401/403s in `{"detail": ...}` shape, sitting beside the canonical `AUTH-xxx` family. ⚠
+- `backend/src/api/routes/oauth.py` (31 sites) — largest single-file cluster.
+- `backend/src/utils/error_messages.py` — `ErrorMessages` constants module explicitly documents the `raise HTTPException(400, ErrorMessages.X)` pattern as the recommended usage. ⚠
+
+Other non-conforming shapes (not raw HTTPException):
+
+1. **FastAPI 422** — `{"detail": [ ... ]}` array shape; no `RequestValidationError` handler exists (§Canonical shape, point 3). ⚠
+2. **MCP `-32603` catch-all** — swallows `MemoryCloudException.error_code` when a tool handler lacks its own catch (§Canonical shape, point 5). ⚠
+3. Three snake_case codes on the REST surface (`admin_user_id_missing`, `sleep_run_in_progress`, `sleep_target_not_found`) conform in *shape* but break the `NAMESPACE-NNN` code convention (§Catalogue B). ⚠
+
+---
+
+## Follow-up candidates
+
+Issue acceptance allows at most 2 sub-issues; candidates are grouped into 2 bundles accordingly.
+
+### Bundle 1 — Code-vocabulary normalization before freeze (mostly P1)
+
+| Priority | Item | Feeds from |
+|---|---|---|
+| P1 | Rename the 3 snake_case REST codes in `api/routes/admin_sleep.py` to the `NAMESPACE-NNN` convention (e.g. `SLEEP-001/002/003`) before any SDK pins them. | §B ⚠ |
+| P1 | Resolve the `ADMIN-*` namespace collision: `ADMIN-001` (403 protection) vs `ADMIN-101/102` (400 preconditions). Either re-namespace the preconditions (e.g. `REQ-1xx`) or document the split-by-hundreds scheme as frozen. | §B ⚠ |
+| P1 | Decide the 422 story: either register a `RequestValidationError` handler that wraps FastAPI validation errors in the canonical shape (e.g. `VAL-002` with the pydantic array under `details`), or freeze the FastAPI default array as documented surface. Today two 422 shapes coexist (`VAL-001` canonical vs default array). | §Canonical 3, §Non-conforming ⚠ |
+| P2 | Give Qdrant a dedicated code (the `EXT-101` gap before Redis `EXT-102` strongly suggests it was reserved for Qdrant); keep `EXT-001` as the generic fallback only. | §A ⚠ |
+| P2 | Remove the class-name fallback in `MemoryCloudException.__init__` (`error_code or self.__class__.__name__`) or make `error_code` required — the fallback can silently mint undocumented codes. | §Canonical 1 ⚠ |
+| P2 | De-duplicate MCP literals `invalid_argument`/`invalid_arguments` and `missing_fields`/`missing_required_fields`. | §Supplementary ⚠ |
+| P2 | Document (do not rename) the intentional RFC 6750 lowercase vocabulary (`invalid_token`, `invalid_request`) as a frozen exception to the convention. | §A, §E ⚠ |
+
+### Bundle 2 — Eliminate `{"detail": ...}` emissions (continuation of #401/#602/#603/#604)
+
+| Priority | Item | Feeds from |
+|---|---|---|
+| P1 | Migrate the auth boundary first: `auth/dependencies.py` (18), `auth/analysis_gates.py` (4), `utils/auth_helpers.py` (4) — these emit 401/403 in the non-canonical shape on every protected route, directly beside the canonical `AUTH-xxx` family. | §Non-conforming ⚠ |
+| P1 | Retire `utils/db_helpers.py:79` (`handle_db_operation` → `HTTPException(500)`) in favor of `DatabaseError`/`InternalError`, and stop `utils/error_messages.py` documenting the raw-raise pattern. | §Non-conforming ⚠ |
+| P2 | Migrate the remaining ~340 route-level raises, largest files first (`oauth.py` 31, `member_credentials.py` 29, `contexts.py` 29, `auth.py` 24, `admin.py` 19, `resource_tokens.py` 17). Alternatively, if full migration won't land before 1.0: register a `StarletteHTTPException` handler that re-shapes `{"detail": ...}` into `{error: "HTTP-<status>", message, details: {}}` as a stopgap so the *shape* freezes even where codes don't exist yet. | §Non-conforming ⚠ |
+| P2 | Propagate `error_code` through the MCP `-32603` catch-all via `error.data` (e.g. `data.error_code`) so transport-level failures stay SDK-routable. | §D ⚠ |

--- a/docs/api-surface-1.0/mcp-input-schemas.md
+++ b/docs/api-surface-1.0/mcp-input-schemas.md
@@ -1,0 +1,512 @@
+# MCP Tool Input Schemas — pre-1.0 surface enumeration
+
+> Issue: #622 — pre-1.0 public API surface enumeration and freeze
+> Enumerated at commit 20ae959a2c79cacd2cf7922512ad780f540e9c60 (main HEAD, 2026-06-12)
+> Source: backend/src/mcp_server/tools/_definitions.py — 45 tools, 45 of 45 enumerated
+
+**Global note**: `additionalProperties` is not set on any tool's `inputSchema` (0 occurrences in the file). JSON Schema's default (`true`) therefore applies everywhere — unknown parameters are silently accepted at the schema level. For a frozen 1.0 surface this should be an explicit decision (set `additionalProperties: false` or document the permissive default). ⚠
+
+---
+
+### list_my_bindings
+
+List the public-bound API keys you own (read-only introspection; Issue #629).
+
+- **Required**: none
+- **Optional**: none (empty `properties`)
+
+### describe_binding
+
+Describe one of your public-bound API keys by exactly one selector (read-only).
+
+- **Required**: none ⚠ schema requires nothing, but the contract is "EXACTLY ONE of key_id / context_id" — not expressible as written; a `oneOf` (or at least one required selector) would harden the 1.0 surface
+- **Optional**:
+  - `key_id` — integer (from list_my_bindings; mutually exclusive with context_id)
+  - `context_id` — string, format `uuid` (bound public context; mutually exclusive with key_id) ⚠ here `context_id` means "selector for a binding lookup", whereas in nearly every other tool it means "the context to operate in" — same name, different role
+
+### remember
+
+Store information into long-term memory with 3-layer architecture (summary / context_summary / details).
+
+- **Required**:
+  - `summary` — string (10–500 chars, per description; no `minLength`/`maxLength` constraint in schema ⚠ documented limits not schema-enforced)
+  - `content` — string
+  - `type` — string (free-form; examples: 'code', 'note', 'decision', 'bug-fix', 'feature', 'config', 'learning') ⚠ free string with magic value `'time'` (Time Memory, see recall_upcoming) not listed among the examples — enum-vs-open-vocabulary decision should be explicit before freeze
+  - `context_id` — string, format `uuid`
+- **Optional**:
+  - `context_summary` — string (max 2000 chars, description-only)
+  - `details` — object
+  - `importance` — number (0.0–1.0, default 0.5 per description; no schema `default`)
+  - `tags` — array of string
+  - `context` — object ⚠ `context` (metadata object) vs `context_id` (UUID) vs `context_summary` (string) in the same tool is a confusing namespace; `metadata` would be clearer
+  - `delivery_mode` — string, enum [`always`, `on_recall`, `on_trigger`] (default `on_recall` per description)
+  - `source_uri` — string (max 2048 chars, description-only)
+  - `source_type` — string, enum [`file`, `url`, `vault`, `api`, `manual`] ⚠ enum lock-in risk: `vault` encodes an Obsidian-specific integration; new origins (e.g. slack, notion, email) will force enum growth on a frozen surface
+  - `linked_memory_ids` — array of string (format `uuid`)
+  - `linked_source_uris` — array of string
+
+### update_memory
+
+Update a memory in-place (by memory_id) or upsert by external_id.
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**:
+  - `memory_id` — string, format `uuid` (in-place mode)
+  - `external_id` — string (upsert lookup key) ⚠ external-identity naming: `external_id` here vs `doc_id` in ingest_events vs `source_uri` in remember — three names for "stable external identifier" across the surface
+  - `summary` — string (required for upsert mode — mode-conditional requirement not expressible in current schema ⚠ "provide exactly one of memory_id / external_id" plus mode-dependent required fields are description-only contracts; consider `oneOf` before freeze)
+  - `content` — string (required for upsert mode)
+  - `type` — string (required for upsert mode)
+  - `context_summary` — string (max 2000 chars)
+  - `details` — object
+  - `importance` — number (0.0–1.0)
+  - `tags` — array of string
+  - `context` — object
+  - `delivery_mode` — string, enum [`always`, `on_recall`, `on_trigger`]
+
+### recall
+
+Hybrid search (semantic + BM25 + Neural Memory boosting) over memories; returns Layers 1–2.
+
+- **Required**: `query` — string
+- **Optional**:
+  - `k` — integer (default 5, max 100 per description) ⚠ result-size param is `k` here but `limit` in list_edges/list_tags/get_sleep_history/list_resource_tokens/list_analyses/get_cluster/list_files and `cap` in load_pinned — three names for the same concept
+  - `use_rerank` — boolean (default false)
+  - `filters` — object (free-form: type, tags, tags_match, importance gte, created/updated bounds, source_uri_prefix, source_type, trust_tier) ⚠ filter vocabulary lives only in prose; analyze_context exposes the equivalent filters (`types`, `tags`, `min_importance`, `from`/`to`) as top-level params instead — two filter styles on one surface
+  - `context_id` — string, format `uuid`
+  - `context_ids` — array of string (format `uuid`), minItems 2, maxItems 20 (overrides context_id) ⚠ singular `context_id` + plural `context_ids` with override semantics on the same tool — workable but should be a deliberate frozen pattern
+  - `search_mode` — string, enum [`hybrid`, `semantic`, `keyword`] (default hybrid) ⚠ mild lock-in: description bakes in the 60/40 weighting and BM25/Neural-Memory implementation details; enum values themselves look stable
+  - `include_explore_hints` — boolean (default false)
+- ⚠ `context_id` is optional here but required (and "IMPORTANT: always specify") on most sibling tools — for a frozen surface, recall/remember-family should agree on whether context_id is required
+
+### reference
+
+Retrieve full Layer-3 details of one memory by ID.
+
+- **Required**:
+  - `memory_id` — string, format `uuid`
+  - `context_id` — string, format `uuid`
+- **Optional**: none
+
+### recall_upcoming
+
+Deterministic time-window query over Time Memories (type='time'), soonest first.
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**:
+  - `from` — string (naive ISO lower bound) ⚠ range params are `from`/`until` here but `from`/`to` in analyze_context — upper-bound name differs across the surface
+  - `until` — string (naive ISO upper bound)
+  - `k` — integer (default 20, max 100) ⚠ same `k` name as recall but a different default (20 vs 5)
+
+### load_pinned
+
+Deterministically load the complete set of delivery_mode='always' memories for a context (counterpart to probabilistic recall).
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**: `cap` — integer (1–1000; server default if omitted) ⚠ third name for result-size (`cap` vs `k` vs `limit`)
+
+### forget
+
+Soft-delete memories by specific memory_id or by search query (top-k matches); 30-day retention.
+
+- **Required**: `context_id` — string, format `uuid` ⚠ neither `memory_id` nor `query` is required — schema permits a call with only context_id, which has no defined meaning; a `oneOf`/`anyOf` over the two modes should land before freeze (a destructive tool with an ambiguous-input hole is the worst place for it)
+- **Optional**:
+  - `memory_id` — string, format `uuid`
+  - `query` — string (bulk-delete mode) ⚠ `query` means "search to delete" here, "search to recall" in recall/feedback, and "reserved, ignored" in analyze_context
+  - `k` — integer (default 10; safety limit in query mode)
+
+### explore
+
+Graph traversal from a seed memory via activation spreading (Neural Memory).
+
+- **Required**:
+  - `memory_id` — string, format `uuid` (seed)
+  - `context_id` — string, format `uuid`
+- **Optional**:
+  - `depth` — integer (default 2, max 5)
+  - `min_weight` — number (schema `default: 0.05`, range 0.0–1.0)
+  - `relation_types` — array of string ('neural_association', 'related_to', 'depends_on', 'learned_from', 'continues_from', 'references_file') ⚠ named `relation_types` here but `edge_types` in list_edges and `edge_type` in create_edge/update_edge — same vocabulary, two names; also a string array here vs a hard enum in create_edge/update_edge
+
+### list_edges
+
+List outgoing/incoming Neural Memory graph edges for a memory.
+
+- **Required**:
+  - `memory_id` — string, format `uuid`
+  - `context_id` — string, format `uuid`
+- **Optional**:
+  - `min_weight` — number (schema `default: 0.0`) ⚠ default differs from explore's 0.05 for the same-named param (defensible — list vs traverse — but worth a deliberate call)
+  - `edge_types` — array of string (same vocabulary as explore's `relation_types` ⚠ see explore)
+  - `limit` — integer (max edges per direction)
+
+### create_edge
+
+Create a manual edge between two memories.
+
+- **Required**:
+  - `source_id` — string, format `uuid` (memory)
+  - `target_id` — string, format `uuid` (memory)
+  - `context_id` — string, format `uuid`
+- **Optional**:
+  - `edge_type` — string, enum [`neural_association`, `related_to`, `depends_on`, `learned_from`, `continues_from`, `references_file`], schema `default: "related_to"` ⚠ enum lock-in risk: `neural_association` exposes the internal Hebbian-learning mechanism as a public value (description even says "prefer 'related_to' for manual edges"); `continues_from`/`references_file` are producer-asserted types added in #782 — the set has already grown once and will again; consider an open string with server-side validation, or a documented extension policy
+  - `weight` — number (0.0–3.0, schema `default: 1.0`)
+  - `confidence` — number (0.0–1.0, schema `default: 1.0`)
+
+### update_edge
+
+Update an existing edge's weight and/or type (identified by source_id + target_id).
+
+- **Required**:
+  - `source_id` — string, format `uuid`
+  - `target_id` — string, format `uuid`
+  - `context_id` — string, format `uuid`
+- **Optional**:
+  - `weight` — number (0.0–3.0; deliberately no default — omitted = unchanged)
+  - `edge_type` — string, same 6-value enum as create_edge (⚠ same lock-in risk)
+
+### delete_edge
+
+Hard-delete an edge between two memories.
+
+- **Required**:
+  - `source_id` — string, format `uuid`
+  - `target_id` — string, format `uuid`
+  - `context_id` — string, format `uuid`
+- **Optional**: none
+- ⚠ hard delete, while forget/delete_context/delete_file are soft deletes — the asymmetry is documented but worth confirming as intentional for 1.0
+
+### get_context_info
+
+Get a context's metadata, usage guidelines, and memory-tool instructions (session-start call).
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**: `include_details` — boolean (default true per description)
+
+### list_contexts
+
+List available contexts in the workspace, most recently used first.
+
+- **Required**: none
+- **Optional**: `include_stats` — boolean (default false) ⚠ `include_stats` here vs `include_details` in get_context_info vs `include_revoked` in list_resource_tokens — the include_* family is fine, but stats/details naming for "memory-count breakdown" differs between these two sibling tools
+
+### list_tags
+
+List a context's tag vocabulary with usage counts and recency (tag-drift mitigation; Issue #614).
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**:
+  - `limit` — integer (1–500, default 50)
+  - `min_count` — integer (default 1)
+  - `sort` — string, enum [`count`, `recent`, `alpha`]
+  - `prefix` — string (case-insensitive; %/_ escaped)
+
+### create_context
+
+Create a new context (namespace) in the workspace.
+
+- **Required**: `name` — string (pattern `^[a-z0-9_-]+$` per description; ⚠ pattern is prose-only, no schema `pattern` constraint)
+- **Optional**:
+  - `display_name` — string (defaults to name)
+  - `description` — string
+  - `summary` — string (200–500 chars)
+  - `usage_guide` — string
+  - `is_private` — boolean (default true)
+  - `embedding_model` — string ⚠ enum-adjacent lock-in: free string, but the description hardcodes provider/model names ('text-embedding-3-small', 'qwen3-embedding:8b') and dimension counts — model names will churn; keep free-form and move examples to docs
+
+### update_context
+
+Update an existing context's settings (role-gated per field).
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**:
+  - `display_name` — string (max 200 chars)
+  - `description` — string (max 500 chars)
+  - `summary` — string (max 500 chars)
+  - `usage_guide` — string (max 2000 chars)
+  - `resource_id` — string (lowercase alphanumeric + underscores) ⚠ note: hyphens not allowed here per description, but setup_resource/setup_connector allow hyphens for the same identifier — conflicting validation prose for one concept
+  - `is_public` — boolean
+  - `is_locked` — boolean
+
+### delete_context
+
+Soft-delete a context and all its memories (owner-only; locked contexts must be unlocked first).
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**: none
+
+### merge_contexts
+
+Copy all memories from a source context into a target context (same embedding model, same workspace).
+
+- **Required**:
+  - `source_id` — string, format `uuid` (context) ⚠ name collision: `source_id`/`target_id` are CONTEXT UUIDs here but MEMORY UUIDs in create_edge/update_edge/delete_edge — the strongest cross-tool ambiguity on the surface; `source_context_id`/`target_context_id` would disambiguate
+  - `target_id` — string, format `uuid` (context)
+- **Optional**: `delete_source` — boolean (default false)
+
+### update_search_config
+
+Tune per-context hybrid-search weights and reranker settings.
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**:
+  - `semantic_weight` — number (0.0–1.0, default 0.6)
+  - `bm25_weight` — number (0.0–1.0, default 0.4; weights must sum to 1.0 — prose-only constraint) ⚠ `bm25_weight` exposes the algorithm name (BM25) in a frozen param name; `keyword_weight` would survive an algorithm swap
+  - `fetch_factor` — integer (1–10, default 3) ⚠ leaks retrieval-pipeline implementation into the public surface
+  - `use_rerank` — boolean
+  - `reranker_provider` — string ('voyage' | 'cohere' | 'ollama' per description) ⚠ enum lock-in risk in substance though not in schema: provider names are third-party vendors and will churn; note the inconsistency that connector_type IS a hard enum while reranker_provider is a free string — pick one policy
+  - `reranker_model` — string (provider-specific model names in description)
+
+### get_usage
+
+Get current workspace usage and quota limits (plan, memories, contexts, members, mcp_calls_per_day).
+
+- **Required**: none
+- **Optional**: none (empty `properties`)
+
+### get_sleep_history
+
+List recent Sleep Maintenance runs for a context.
+
+- **Required**: `context_id` — string, format `uuid`
+- **Optional**: `limit` — integer (schema `default: 10`, max 50)
+
+### get_sleep_report
+
+Get one Sleep Maintenance report with its full action audit log.
+
+- **Required**: `report_id` — string, format `uuid` ⚠ Sleep runs are addressed by `report_id` while analysis runs are addressed by `run_id` (get_analysis/get_cluster) — two names for "id of a background run" on one surface
+- **Optional**: none
+
+### rollback_sleep_run
+
+Reverse all recorded actions of a completed Sleep Maintenance run (destructive; marks report rolled_back).
+
+- **Required**: `report_id` — string, format `uuid` (⚠ tool is named *_sleep_run but takes report_id — run/report vocabulary is mixed even within the sleep bundle)
+- **Optional**: none
+
+### setup_resource
+
+Atomically create a public context + resource token for an ingestion pipeline (Pro plan; owner/admin).
+
+- **Required**:
+  - `name` — string (lowercase alphanumeric/hyphen/underscore, max 100 chars — prose-only)
+  - `resource_id` — string (lowercase alphanumeric/hyphen/underscore, max 255 chars, workspace-unique)
+- **Optional**:
+  - `display_name` — string
+  - `description` — string (token description)
+  - `quota_events_per_hour` — integer (1–10000, default 1000)
+
+### setup_connector
+
+Create an ai-worker chat-ingest connector (resource row + connector row + scoped token) in one operation.
+
+- **Required**:
+  - `connector_type` — string, enum [`slack`, `discord`, `teams`] ⚠ highest enum lock-in risk on the surface: a hard-frozen list of third-party chat vendors is guaranteed to grow (LINE, Mattermost, email…); every addition is a surface change — consider free string + server-side registry before freeze
+  - `resource_id` — string (lowercase alphanumeric/hyphen/underscore, max 255 chars, workspace-unique)
+- **Optional**:
+  - `display_name` — string
+  - `oauth_tokens` — object (stored Fernet-encrypted)
+  - `pii_guardrail_config` — object
+  - `litellm_virtual_key_id` — string ⚠ vendor lock-in in a param NAME: "LiteLLM" (an internal gateway choice) is baked into the frozen public surface; a neutral name (`gateway_key_id`/`virtual_key_id`) would survive a gateway swap
+  - `virtual_key_valid_until` — string (ISO 8601) ⚠ uses `*_until` while analyze_context uses `to` — see from/until/to inconsistency
+  - `quota_events_per_hour` — integer (1–10000, default 1000)
+
+### ingest_events
+
+Batch ingest resource events (upsert/delete), max 100 events per call, 100KB per payload.
+
+- **Required**:
+  - `resource_id` — string
+  - `events` — array of object (max 100 — prose-only, no `maxItems` ⚠ documented limits not schema-enforced). Each event:
+    - **Required**: `op` — string, enum [`upsert`, `delete`]; `doc_id` — string ⚠ `doc_id` vs update_memory's `external_id` — two names for "stable external document identity"
+    - **Optional**: `version` — integer (required for upsert — mode-conditional, prose-only); `payload` — object (required for upsert); `idempotency_key` — string; `importance` — number (0.0–1.0, default 0.6 ⚠ differs from remember's importance default 0.5 — deliberate?); `event_metadata` — object ⚠ remember calls the same concept `context`; pick one metadata-bag name
+- **Optional** (top level): none
+
+### get_resource_impact
+
+Get resource stats (active token count, memory count, current schema version) before schema changes.
+
+- **Required**: `resource_id` — string
+- **Optional**: none
+
+### get_resource_schema
+
+Get a resource's field schema definition (latest or a historical version).
+
+- **Required**: `resource_id` — string
+- **Optional**: `schema_version` — integer (default: latest)
+
+### list_resource_tokens
+
+List resource-token metadata for the workspace (owner/admin; no plaintext tokens).
+
+- **Required**: none (explicit `"required": []` — only tool in the file to spell it out)
+- **Optional**:
+  - `resource_id` — string (filter)
+  - `limit` — integer (1–100, default 50)
+  - `offset` — integer (default 0) ⚠ only offset-paginated tool; list_analyses/get_cluster use opaque `cursor` — two pagination models frozen side by side
+  - `include_revoked` — boolean (default true) ⚠ defaulting to INCLUDE revoked tokens is a surprising default for a list endpoint; most list tools exclude dead rows by default (list_files excludes deleted, list_contexts excludes deleted)
+
+### analyze_context
+
+Start (or dry-run cost-preview) a broadlistening analysis run that clusters a context's memories into themes.
+
+- **Required**: `context_id` — string ⚠ missing `format: "uuid"` — the analysis bundle (analyze_context, list_analyses, get_active_analysis), feedback, set_state, get_state all drop the uuid format annotation that the rest of the surface carries on context_id
+- **Optional**:
+  - `from` — string (ISO-8601 lower bound) / `to` — string (upper bound) ⚠ recall_upcoming uses `from`/`until` — unify before freeze
+  - `types` — array of string ⚠ top-level filter params (`types`, `tags`, `min_importance`) duplicate recall's `filters` object vocabulary with different shapes (`types` plural array vs filters `type` singular; `min_importance` vs filters `importance: {gte}`)
+  - `tags` — array of string
+  - `min_importance` — number (0.0–1.0)
+  - `query` — string ⚠ "Reserved for v1.5 query-scoped runs (ignored in v1)" — shipping a documented no-op parameter into a frozen 1.0 surface invites silent-failure confusion; remove until implemented
+  - `model_id` — integer ⚠ lock-in: an internal `llm_pricing.id` database PK exposed as the public model selector, and the description hardcodes "openai gpt-5-nano" — both the PK coupling and the vendor/model name are implementation details
+  - `dry_run` — boolean (default false)
+
+### get_analysis
+
+Fetch one analysis run by id (workspace-scoped; uniform run_not_found).
+
+- **Required**: `run_id` — string ⚠ no `format: "uuid"` despite being documented as a UUID; ⚠ `run_id` vs sleep tools' `report_id`
+- **Optional**: none
+
+### list_analyses
+
+List analysis runs for a context, newest first, cursor-paginated.
+
+- **Required**: `context_id` — string (⚠ no uuid format)
+- **Optional**:
+  - `limit` — integer (1–100, default 20)
+  - `cursor` — string (opaque)
+
+### get_active_analysis
+
+Return the most recent succeeded analysis run for a context.
+
+- **Required**: `context_id` — string (⚠ no uuid format)
+- **Optional**: none
+
+### get_cluster
+
+Drill into one cluster of an analysis run (label, representatives, paginated members).
+
+- **Required**:
+  - `run_id` — string (⚠ no uuid format)
+  - `cluster_index` — integer (zero-based, stable)
+- **Optional**:
+  - `limit` — integer (1–200, default 50) ⚠ max differs from list_analyses' 100 and list_files' 500 — per-tool caps are fine but should be tabulated in the freeze doc
+  - `cursor` — string (opaque)
+
+### init_file_upload
+
+Reserve quota and return a presigned PUT URL for an R2 file upload (100 MiB Phase-1 cap; sha256 dedup).
+
+- **Required**:
+  - `filename` — string
+  - `content_type` — string (MIME)
+  - `size_bytes` — integer
+  - `sha256` — string (lower-case hex; no `pattern` constraint ⚠ format prose-only)
+- **Optional**: `workspace_id` — string ⚠ "Overrides the authenticated workspace_id" appears on all 5 file tools and nowhere else on the surface. Every other tool scopes implicitly by auth (+ context_id). An auth-override parameter is both an inconsistency and a security-review item — if it's an internal/admin affordance it should not be in the frozen public schema
+
+### complete_file_upload
+
+Finalize an upload after the client PUTs bytes (verifies R2 object + sha256/size; idempotent).
+
+- **Required**:
+  - `file_id` — string ⚠ no `format: "uuid"` despite "UUID returned by init_file_upload" (same gap on all four file_id params)
+  - `sha256` — string
+- **Optional**: `workspace_id` — string (⚠ see init_file_upload)
+
+### get_file_download_url
+
+Return a short-lived presigned GET URL for an uploaded file (read-only).
+
+- **Required**: `file_id` — string (⚠ no uuid format)
+- **Optional**: `workspace_id` — string (⚠ see init_file_upload)
+
+### delete_file
+
+Soft-delete a file; quota released immediately, binary swept after 7 days.
+
+- **Required**: `file_id` — string (⚠ no uuid format)
+- **Optional**: `workspace_id` — string (⚠ see init_file_upload)
+
+### list_files
+
+List uploaded, non-deleted files in the workspace, newest first (read-only).
+
+- **Required**: none
+- **Optional**:
+  - `limit` — integer (1–500, default 50)
+  - `workspace_id` — string (⚠ see init_file_upload)
+
+### feedback
+
+Record whether a recalled memory was helpful for a query (append-only; excluded from recall; Issue #888).
+
+- **Required**:
+  - `context_id` — string (⚠ no uuid format — newest tools #888/#889 dropped the annotation)
+  - `memory_id` — string (⚠ no uuid format)
+  - `helpful` — boolean
+- **Optional**:
+  - `query` — string (max 1024 chars)
+  - `note` — string (max 2000 chars)
+
+### set_state
+
+Upsert TTL-bounded agent run-state at (context_id, key); excluded from recall (Issue #889).
+
+- **Required**:
+  - `context_id` — string (⚠ no uuid format)
+  - `key` — string (max 255 chars)
+  - `value` — untyped (any JSON value; only schema-less property on the surface — intentional, but worth an explicit note in the freeze doc)
+- **Optional**: `ttl_seconds` — integer (clamped to 2592000 = 30 days)
+
+### get_state
+
+Read one key or list all live state entries for a context (read-only).
+
+- **Required**: `context_id` — string (⚠ no uuid format)
+- **Optional**: `key` — string (omit to list all live entries)
+
+---
+
+## Cross-tool naming observations
+
+Recurring inconsistencies (each instance flagged inline above):
+
+1. **Result-size parameter — three names**: `k` (recall, recall_upcoming, forget), `limit` (list_edges, list_tags, get_sleep_history, list_resource_tokens, list_analyses, get_cluster, list_files), `cap` (load_pinned). Same concept, three frozen spellings; `k` even carries different defaults (5 vs 20 vs 10) across its three uses.
+2. **`source_id`/`target_id` overload**: memory UUIDs in create_edge/update_edge/delete_edge, context UUIDs in merge_contexts. The single most dangerous ambiguity for tool-calling LLMs and SDK users.
+3. **Time-range bounds**: `from`/`until` (recall_upcoming) vs `from`/`to` (analyze_context) vs `*_valid_until` (setup_connector).
+4. **Edge-type vocabulary — three param names and two typings**: `relation_types` (array of free string, explore) vs `edge_types` (array of free string, list_edges) vs `edge_type` (hard 6-value enum, create_edge/update_edge).
+5. **`format: "uuid"` coverage is inconsistent**: present on the core memory/context/edge tools, absent from the entire analysis bundle (`context_id`, `run_id`), all file tools (`file_id`), and the newest tools (feedback, set_state, get_state). The newer the tool, the less schema rigor — exactly the drift a freeze should stop.
+6. **Two pagination models**: `offset` (list_resource_tokens) vs opaque `cursor` (list_analyses, get_cluster); everything else is single-page `limit`-capped.
+7. **Background-run identity**: `report_id` (sleep bundle) vs `run_id` (analysis bundle); rollback_sleep_run is even named "run" while taking `report_id`.
+8. **External document identity**: `external_id` (update_memory) vs `doc_id` (ingest_events) vs `source_uri` (remember) — three lanes, three names.
+9. **Metadata bag**: `context` (remember/update_memory — clashing with `context_id` and `context_summary` in the same tool) vs `event_metadata` (ingest_events).
+10. **Filter style**: recall packs filters into one free-form `filters` object (singular `type`, `importance: {gte}`); analyze_context spreads them top-level (`types` plural, `min_importance`).
+11. **`workspace_id` override** exists only on the 5 file tools; the rest of the surface scopes by auth + context_id. Inconsistent and security-sensitive.
+12. **Constraints live in prose, not schema**: char limits (summary 10–500, context_summary 2000), `maxItems` (events ≤ 100), patterns (context name, sha256 hex), numeric ranges and most defaults are description-only; `additionalProperties` is never set. Tool-side validation cannot rely on the published schema.
+13. **Enum policy is inconsistent**: connector_type is a hard vendor enum while reranker_provider (same vendor-list shape) is a free string; edge_type is a hard enum that already grew once (#782).
+
+## Follow-up candidates
+
+### Bundle 1 — P1: naming + schema-rigor fixes that are breaking after freeze (propose as sub-issue "MCP surface: pre-freeze naming and schema unification")
+
+- **P1** Rename merge_contexts `source_id`/`target_id` → `source_context_id`/`target_context_id` (or namespace all edge params as `source_memory_id`/`target_memory_id`) — resolves the memory/context overload.
+- **P1** Unify result-size param: standardize on `limit` (or `k`) across recall, recall_upcoming, forget, load_pinned and all list_* tools; alias-and-deprecate the others before 1.0.
+- **P1** Unify time-range bounds on one pair (`from`/`to` or `from`/`until`) across recall_upcoming, analyze_context, setup_connector.
+- **P1** Add `format: "uuid"` to every UUID param (analysis bundle, file tools, feedback, set_state, get_state, run_id, file_id, memory_id in feedback).
+- **P1** forget: make the two modes explicit (`anyOf`/`oneOf` over memory_id / query) so a bare `{context_id}` call is schema-invalid — destructive tool, ambiguous input.
+- **P1** Remove analyze_context's reserved no-op `query` param (re-add in v1.5 when implemented) and replace `model_id` (internal llm_pricing PK) with a stable model identifier.
+- **P1** Decide the `workspace_id` override on the 5 file tools: remove from public schema or document the auth model explicitly.
+- **P1** Set `additionalProperties: false` (or record the permissive default as a deliberate freeze decision) on all 45 inputSchemas.
+- **P1** Unify edge-type param naming/typing: `relation_types`/`edge_types`/`edge_type` → one name, one typing.
+
+### Bundle 2 — P2: enum policy + prose-to-schema hardening (propose as sub-issue "MCP surface: enum extension policy and schema-enforced constraints")
+
+- **P2** Define an enum-extension policy before freeze: connector_type (vendor list — most likely to grow), edge_type (already grew in #782; `neural_association` leaks the algorithm), source_type (`vault` is Obsidian-specific), search_mode. Either commit to additive-enum semver rules or relax to validated strings.
+- **P2** Make reranker_provider/reranker_model and embedding_model handling consistent (currently free strings whose descriptions hardcode vendor/model names); rename `bm25_weight` → `keyword_weight` and reconsider exposing `fetch_factor`.
+- **P2** Rename setup_connector `litellm_virtual_key_id` → gateway-neutral name.
+- **P2** Unify external-identity naming (`external_id` vs `doc_id`) and metadata-bag naming (`context` vs `event_metadata`; consider `metadata` everywhere — also resolves remember's context/context_id/context_summary namespace clash).
+- **P2** Unify `report_id` vs `run_id` for background runs; align rollback_sleep_run's name with its param.
+- **P2** Move prose constraints into schema: minLength/maxLength for summary/context_summary/key/note, `maxItems: 100` on ingest_events.events, `pattern` for context name and sha256, numeric `minimum`/`maximum` for weights/importance/limits; add explicit `default` values where prose states them.
+- **P2** Converge pagination on cursor style (deprecate list_resource_tokens `offset`); flip `include_revoked` default to false for consistency with other list tools.
+- **P2** Align recall's optional `context_id` (and feedback/set_state requiredness) with the rest of the surface's "always specify context_id" contract; document the `context_id`/`context_ids` override pattern as the frozen multi-context idiom.

--- a/docs/api-surface-1.0/rest-response-models.md
+++ b/docs/api-surface-1.0/rest-response-models.md
@@ -1,0 +1,1702 @@
+# REST API Response Models — pre-1.0 surface enumeration
+
+> Issue: #622 — pre-1.0 public API surface enumeration and freeze
+> Enumerated at commit 20ae959a2c79cacd2cf7922512ad780f540e9c60 (main HEAD, 2026-06-12)
+> Scope: all BaseModel / TZAwareBaseModel subclasses defined in backend/src/api/routes/ (46 route files, 208 model classes — 208 of 208 enumerated)
+
+Notes:
+
+- 36 of the 46 route files define models; the following 10 define none locally (they reuse models from other modules or return plain dicts): `__init__.py`, `attachments.py`, `connectors_slack.py`, `context_search_config.py`, `invitations.py`, `member_credentials.py`, `resource_ingest.py`, `system_admins.py`, `users.py`, `well_known.py`.
+- Two route-file classes subclass an in-scope model rather than `BaseModel` directly and are therefore outside the 208-class grep, but are part of the response surface and noted inline for completeness: `Bm25DriftDetail(Bm25DriftSummary)` (bm25_drift.py L64, adds `context_deleted`, `top_divergent_terms`) and `SleepReportDetail(SleepReportSummary)` (sleep_reports.py L66, adds `context_deleted`, `embedding_calls_made`, `error_message`, and five `*_result: dict` fields).
+- Field convention: `field_name: type — required|optional (default ...)`. Required = no default in the model definition (Pydantic v2 semantics: `X | None` without a default is still required).
+- Request models are included for completeness and marked `(request model)`; the freeze priority per #622 is the response surface.
+
+## admin.py
+
+### UserInfo (TZAwareBaseModel, L58)
+> User information for admin view.
+- `id: str` — required
+- `email: str` — required
+- `name: str` — required
+- `picture: str | None` — optional
+- `role: str` — required
+- `created_at: datetime` — required
+- `last_login: datetime | None` — optional
+- `memory_count: int` — required
+- `is_active: bool` — required
+- `timezone: str` — optional (default `'UTC'`)
+- `auth_provider: str | None` — optional
+- `workspaces: list[dict]` — optional (default `[]`)
+- `owned_count: int` — optional (default `0`)
+- `workspace_slot_bonus: int` — optional (default `0`)
+- `base_cap: int` — optional (default `BASE_CAP`)
+- `cap: int` — optional (default `BASE_CAP`)
+
+### UserStats (BaseModel, L103)
+> Detailed statistics for a specific user.
+- `user: dict` — required
+- `memories: dict` — required
+- `api_usage: dict` — required
+
+### UserListResponse (BaseModel, L111)
+> Response for user list.
+- `users: list[UserInfo]` — required
+- `total: int` — required
+
+### RoleUpdateRequest (BaseModel, L118) (request model)
+> Request to update user role.
+- `role: str` — required
+
+### AdminErasureRequestBody (BaseModel, L1079) (request model)
+> Payload for POST /admin/users/{user_id}/erase.
+- `reason_code: AdminErasureReasonCode` — required
+- `reason_detail: str | None` — optional
+
+### ContextRecoveryRequest (BaseModel, L1217) (request model)
+> Request to recover a deleted context from Qdrant data.
+- `context_id: str` — required
+- `workspace_id: str | None` — optional
+- `context_name: str | None` — optional
+- `dry_run: bool` — optional (default `True`)
+
+### ContextRecoveryResponse (BaseModel, L1226)
+> Result of context recovery attempt.
+- `context_id: str` — required
+- `workspace_id: str` — required
+- `qdrant_points_found: int` — required
+- `memories_recovered: int` — required
+- `memories_already_existed: int` — required
+- `context_record_created: bool` — required
+- `search_config_restored: bool` — required
+- `dry_run: bool` — required
+- `errors: list[str]` — required
+
+## admin_neural.py
+
+### RecalibrateResponse (BaseModel, L43)
+> 202 response body for the admin recalibrate endpoint.
+- `accepted: bool` — required
+- `model_name: str` — required
+- `dimensions: int` — required
+
+## admin_plans.py
+
+### WorkspacePlanInfo (BaseModel, L46)
+> Workspace with plan information.
+- `id: str` — required
+- `name: str` — required
+- `plan_name: str` — required
+- `owner_user_id: str` — required
+- `owner_name: str | None` — optional
+- `owner_email: str | None` — optional
+- `total_memories: int` — required
+- `memory_limit: int` — required
+- `mcp_calls_per_day: int` — required
+- `mcp_calls_per_week: int` — required
+
+### UpdatePlanRequest (BaseModel, L64) (request model)
+> Request to update workspace plan tier.
+- `plan_name: str` — required
+- `reason: str | None` — optional
+
+### QuotaBreakdown (BaseModel, L71)
+> Quota values for a single tier (Issue #665).
+- `memory_limit: int` — required
+- `mcp_calls_per_day: int` — required
+- `max_contexts: int` — required
+- `max_members: int` — required
+- `analysis_runs_per_day: int` — required
+- `rest_calls_per_day: int` — optional (default `0`)
+- `public_calls_per_day: int` — optional (default `0`)
+- `storage_bytes_limit: int` — optional (default `0`)
+- `sleep_enabled_contexts_limit: int` — optional (default `0`)
+- `max_resource_tokens: int` — optional (default `0`)
+- `max_connectors: int` — optional (default `0`)
+
+### AddonValues (BaseModel, L97)
+> Addon bonus values.
+- `memory_bonus: int` — optional (default `0`)
+- `mcp_quota_bonus: int` — optional (default `0`)
+- `rest_quota_bonus: int` — optional (default `0`)
+- `public_quota_bonus: int` — optional (default `0`)
+- `member_bonus: int` — optional (default `0`)
+- `context_bonus: int` — optional (default `0`)
+- `analysis_bonus: int` — optional (default `0`)
+- `storage_bonus_mb: int` — optional (default `0`)
+- `sleep_contexts_bonus: int` — optional (default `0`)
+- `connector_bonus: int` — optional (default `0`)
+
+### UsageValues (BaseModel, L117)
+> Current usage values.
+- `memories: int` — required
+- `contexts: int` — required
+- `members: int` — required
+
+### SpendCapValues (BaseModel, L125)
+> BYOK embedding spend cap values (Issue #709).
+- `tier_default_daily_usd: float | None` — optional
+- `tier_default_monthly_usd: float | None` — optional
+- `override_daily_usd: float | None` — optional
+- `override_monthly_usd: float | None` — optional
+- `effective_daily_usd: float | None` — optional
+- `effective_monthly_usd: float | None` — optional
+- `current_daily_usd: float` — optional (default `0.0`)
+- `current_monthly_usd: float` — optional (default `0.0`)
+
+### WorkspaceQuotaDetail (BaseModel, L144)
+> Detailed quota breakdown for a workspace.
+- `workspace_id: str` — required
+- `workspace_name: str` — required
+- `plan_name: str` — required
+- `base: QuotaBreakdown` — required
+- `addon: AddonValues` — required
+- `effective: QuotaBreakdown` — required
+- `usage: UsageValues` — required
+- `spend_cap: SpendCapValues | None` — optional
+
+### UpdateAddonRequest (BaseModel, L157) (request model)
+> Request to update workspace addon bonuses (Issue #665).
+- `addon_memory_bonus: int | None` — optional
+- `addon_mcp_quota_bonus: int | None` — optional
+- `addon_member_bonus: int | None` — optional
+- `addon_context_bonus: int | None` — optional
+- `addon_analysis_bonus: int | None` — optional
+- `addon_rest_quota_bonus: int | None` — optional
+- `addon_public_quota_bonus: int | None` — optional
+- `addon_storage_bonus_mb: int | None` — optional
+- `addon_sleep_contexts_bonus: int | None` — optional
+- `addon_connector_bonus: int | None` — optional
+
+### UpdateSpendCapRequest (BaseModel, L194) (request model)
+> Request to update the per-workspace embedding spend cap (Issue #709).
+- `embedding_daily_cap_usd: float | None` — optional
+- `embedding_monthly_cap_usd: float | None` — optional
+
+### PlanChangeAuditEntry (BaseModel, L212)
+> Plan change audit log entry.
+- `id: int` — required
+- `workspace_id: str` — required
+- `workspace_name: str` — required
+- `old_plan: str | None` — required
+- `new_plan: str` — required
+- `changed_by: str` — required
+- `changed_at: str` — required
+- `reason: str | None` — required
+
+### AddonCacheDriftEntry (BaseModel, L225)
+> One drifted addon cache column for a workspace (Issue #799).
+- `workspace_id: str` — required
+- `workspace_name: str` — required
+- `addon_type: str` — required
+- `cache_column: str` — required
+- `cache_value: int` — required
+- `expected_value: int` — required
+
+### PlanTierInfo (BaseModel, L242)
+> Plan tier configuration served to the admin tiers comparison table.
+- `name: str` — required
+- `display_name: str` — required
+- `price_monthly: int` — required
+- `max_contexts_per_workspace: int` — required
+- `max_members_per_workspace: int` — required
+- `max_resource_tokens: int` — required
+- `memory_limit: int` — required
+- `mcp_calls_per_day: int` — required
+- `mcp_calls_per_week: int` — required
+- `rest_calls_per_day: int` — required
+- `rest_calls_per_week: int` — required
+- `public_calls_per_day: int` — required
+- `public_calls_per_week: int` — required
+- `bound_public_calls_per_minute: int` — required
+- `analysis_runs_per_day: int` — required
+- `storage_limit_bytes: int` — required
+- `sleep_enabled_contexts_limit: int` — required
+- `embedding_daily_cap_usd: float | None` — optional
+- `embedding_monthly_cap_usd: float | None` — optional
+- `allows_shared_contexts: bool` — required
+- `features: list[str]` — required
+
+## admin_signup_gate.py
+
+### SignupGateConfigResponse (BaseModel, L38)
+> Config read-model.
+- `enabled: bool` — required
+- `mode: Literal['manual', 'github_sponsors', 'both']` — required
+- `github_sponsors_grace_period_days: int` — required
+
+### SignupGateConfigUpdate (BaseModel, L53) (request model)
+- `enabled: bool` — required
+- `mode: Literal['manual']` — required
+
+### AllowlistEntryResponse (TZAwareBaseModel, L62)
+> Allowlist entry read-model.
+- `id: UUID` — required
+- `provider: str` — required
+- `subject_id: str` — required
+- `subject_label: str` — required
+- `github_user_id: str` — required
+- `github_username: str` — required
+- `source: str` — required
+- `state: str` — required
+- `added_by_user_id: str | None` — required
+- `created_at: datetime` — required
+
+### AllowlistAddRequest (BaseModel, L89) (request model)
+> Allowlist add payload (provider-aware since #655).
+- `provider: Literal['github', 'google']` — optional (default `'github'`)
+- `github_username: str | None` — optional
+- `email: str | None` — optional
+
+## admin_sleep.py
+
+### SleepRunRequest (BaseModel, L42) (request model)
+> Body for POST /admin/sleep/run.
+- `context_id: UUID | None` — optional
+
+### SleepRunResponse (BaseModel, L53)
+> 202 response for POST /admin/sleep/run.
+- `report_ids: list[UUID]` — required
+
+## agent_state.py
+
+### AgentStateSetRequest (BaseModel, L50) (request model)
+> Body for upserting an agent-state entry.
+- `value: Any` — required
+- `ttl_seconds: int | None` — optional
+
+### AgentStateKeyResponse (BaseModel, L69)
+> Envelope for a write that returns just the affected key (set / delete).
+- `key: str` — required
+
+### AgentStateValueResponse (BaseModel, L75)
+> Envelope for a single-key read.
+- `key: str` — required
+- `value: Any` — required
+
+### AgentStateListResponse (BaseModel, L82)
+> Envelope for listing all live entries in a context.
+- `states: dict[str, Any]` — required
+- `count: int` — required
+
+## analyses.py
+
+### AnalysisPreviewRequest (BaseModel, L102) (request model)
+> Pre-flight cost-estimate request body.
+- `from_dt: str | None` — optional
+- `to_dt: str | None` — optional
+- `types: list[str] | None` — optional
+- `tags: list[str] | None` — optional
+- `min_importance: float | None` — optional
+- `query: str | None` — optional
+- `model_id: int | None` — optional
+
+### AnalysisPreviewResponse (BaseModel, L149)
+> Cost-estimate output (Stage [A] from preview.py).
+- `memory_count: int` — required
+- `cluster_count_estimate: int` — required
+- `estimated_cost_cents: int` — required
+- `model_id: str` — required
+- `breakdown: dict[str, int]` — required
+
+### AnalysisStartResponse (TZAwareBaseModel, L163)
+> 202 Accepted body.
+- `run_id: UUID` — required
+- `status: str` — required
+- `started_at: datetime` — required
+
+### AnalysisRow (TZAwareBaseModel, L180)
+> One row in list / single-fetch responses.
+- `run_id: UUID` — required
+- `workspace_id: UUID` — required
+- `context_id: UUID` — required
+- `status: str` — required
+- `triggered_by: str` — required
+- `started_at: datetime` — required
+- `finished_at: datetime | None` — required
+- `input_count: int` — required
+- `cost_estimated_cents: int | None` — required
+- `cost_actual_cents: int | None` — required
+- `error: str | None` — required
+- `cancellation_reason: str | None` — required
+
+### AnalysisListResponse (BaseModel, L209)
+> Paginated list of runs.
+- `items: list[AnalysisRow]` — required
+- `next_cursor: str | None` — required
+
+### ClusterRow (BaseModel, L216)
+> One cluster within an analysis run.
+- `cluster_index: int` — required
+- `label: str` — required
+- `description: str | None` — required
+- `count: int` — required
+- `centroid_2d: list[float]` — required
+- `representative_memory_ids: list[UUID]` — required
+- `property_stats: dict[str, Any]` — required
+- `label_confidence: float` — required
+
+### ClusterListResponse (BaseModel, L244)
+> All clusters for a run, ordered by ``cluster_index``.
+- `items: list[ClusterRow]` — required
+
+### PositionRow (BaseModel, L250)
+> One ``(memory_id, x, y, cluster_index)`` row for scatter rendering.
+- `memory_id: UUID` — required
+- `x: float` — required
+- `y: float` — required
+- `cluster_index: int` — required
+
+### PositionListResponse (BaseModel, L259)
+> All scatter positions for a run, ordered by ``cluster_index``.
+- `items: list[PositionRow]` — required
+
+### AnalysisCancelResponse (TZAwareBaseModel, L265)
+> DELETE /{run_id} response — confirms the soft-cancel.
+- `run_id: UUID` — required
+- `status: str` — required
+- `cancellation_reason: str | None` — required
+- `finished_at: datetime | None` — required
+
+## api_keys.py
+
+### APIKeyCreate (BaseModel, L54) (request model)
+> Request model for creating an API key.
+- `name: str` — required
+- `expires_days: int | None` — optional
+
+### DailyStats (BaseModel, L68)
+> Daily usage statistics.
+- `date: str` — required
+- `count: int` — required
+
+### APIKeyStats (BaseModel, L75)
+> API key usage statistics.
+- `total_requests: int` — required
+- `daily_stats: list[DailyStats]` — required
+- `period_start: str` — required
+- `period_end: str` — required
+
+### APIKeyResponse (TZAwareBaseModel, L84)
+> Response model for API key metadata.
+- `id: int` — required ⚠ sequential integer DB PK used as the public identifier (leaks row count; consider opaque id before freeze)
+- `key_prefix: str` — required
+- `name: str` — required
+- `user_id: str` — required
+- `created_at: datetime` — required
+- `last_used_at: datetime | None` — optional
+- `revoked_at: datetime | None` — optional
+- `expires_at: datetime | None` — optional
+- `status: Literal['active', 'revoked', 'expired']` — required
+
+## auth.py
+
+### LoginResponse (BaseModel, L92)
+> OAuth2 login response.
+- `authorization_url: str` — required
+- `state: str` — required
+
+### CallbackResponse (BaseModel, L99)
+> OAuth2 callback response.
+- `success: bool` — required
+- `user_id: str` — required
+- `email: str` — required
+- `role: str` — required
+- `message: str` — required
+
+### ProviderInfo (BaseModel, L445)
+> OAuth provider info.
+- `name: str` — required
+
+### ProvidersResponse (BaseModel, L451)
+> Available OAuth providers.
+- `providers: list[ProviderInfo]` — required
+
+### PasswordLoginRequest (BaseModel, L1293) (request model)
+> Password login request.
+- `login_id: str` — required
+- `password: str` — required
+
+### PasswordLoginResponse (BaseModel, L1300)
+> Password login response.
+- `success: bool` — required
+- `mfa_required: bool` — optional (default `False`)
+- `mfa_session_token: str | None` — optional
+- `redirect_url: str | None` — optional
+
+### MfaVerifyRequest (BaseModel, L1309) (request model)
+> MFA verification request.
+- `mfa_session_token: str` — required
+- `totp_code: str` — required
+
+### AuthConfigResponse (BaseModel, L1316)
+> Auth configuration for frontend.
+- `password_login_enabled: bool` — required
+- `google_oauth_enabled: bool` — required
+- `github_oauth_enabled: bool` — required
+
+## bm25_drift.py
+
+### Bm25DriftSummary (TZAwareBaseModel, L50)
+> Drift log row, list-view shape (no top_divergent_terms).
+- `id: int` — required
+- `context_id: UUID` — required
+- `context_name: str | None` — optional
+- `measured_at: datetime` — required
+- `psi: float | None` — required
+- `psi_status: str` — required
+- `m_memory_points: int` — required
+- `r_resource_points: int` — required
+- `num_terms: int` — required
+
+### Bm25DriftListResponse (BaseModel, L71)
+- `rows: list[Bm25DriftSummary]` — required
+- `total: int` — required
+- `limit: int` — required
+- `offset: int` — required
+
+### Bm25DriftDetailResponse (BaseModel, L78)
+- `row: Bm25DriftDetail` — required (`Bm25DriftDetail(Bm25DriftSummary)` L64 adds `context_deleted: bool = False`, `top_divergent_terms: list[dict] | None`)
+
+### Bm25DriftRunRequest (BaseModel, L82) (request model)
+> Body for POST /admin/bm25-drift/run.
+- `context_id: UUID | None` — optional
+
+### Bm25DriftRunResponse (BaseModel, L94)
+- `scheduled_context_count: int` — required
+
+### Bm25DriftRevealRequest (BaseModel, L98) (request model)
+> Body for POST /admin/bm25-drift/{row_id}/reveal-terms.
+- `reason: str` — required (`Field(..., min_length=10)`, justification is audit-logged)
+
+### ResolvedTermEntry (BaseModel, L108)
+> Single entry from top_divergent_terms with resolved token.
+- `index: int` — required
+- `df_memory: float` — required
+- `df_global: float` — required
+- `idf_memory: float` — required
+- `idf_global: float` — required
+- `delta: float` — required
+- `token: str | None` — optional (plaintext term — admin-gated reveal endpoint with audit logging, by design)
+
+## config.py
+
+### ConfigValue (BaseModel, L28)
+> Single configuration value.
+- `key: str` — required
+- `value: Any` — required
+- `category: str` — required
+- `description: str | None` — optional
+- `is_sensitive: bool` — optional (default `False`)
+
+### ConfigListResponse (BaseModel, L38)
+> Configuration list response.
+- `configs: list[ConfigValue]` — required
+- `total: int` — required
+
+### ConfigUpdateRequest (BaseModel, L45) (request model)
+> Update configuration value.
+- `value: Any` — required
+
+### ConfigBatchRequest (BaseModel, L51) (request model)
+> Batch update configuration.
+- `updates: dict[str, Any]` — required
+
+### ConfigValidateRequest (BaseModel, L57) (request model)
+> Validate configuration.
+- `key: str` — required
+- `value: Any` — required
+
+### ConfigKeySchema (BaseModel, L64)
+> Configuration key metadata schema.
+- `key: str` — required
+- `type: str` — required
+- `category: str` — required
+- `description: str` — required
+- `default_value: Any` — required
+- `enum_values: list[str] | None` — optional
+- `enum_descriptions: dict[str, str] | None` — optional
+- `min_value: float | None` — optional
+- `max_value: float | None` — optional
+- `is_sensitive: bool` — optional (default `False`)
+- `requires_restart: bool` — optional (default `False`)
+- `impact: str | None` — optional
+- `examples: list[str] | None` — optional
+- `recommended: str | None` — optional
+- `documentation_url: str | None` — optional
+
+## contexts.py
+
+### ContextCreate (BaseModel, L108) (request model)
+> Request model for creating a context.
+- `name: str` — required
+- `display_name: str | None` — optional
+- `description: str | None` — optional
+- `summary: str | None` — optional
+- `usage_guide: str | None` — optional
+- `embedding_model: str | None` — optional
+- `is_private: bool` — optional (default `True`)
+
+### ContextUpdate (BaseModel, L151) (request model)
+> Request model for updating a context.
+- `display_name: str | None` — optional
+- `description: str | None` — optional
+- `summary: str | None` — optional
+- `usage_guide: str | None` — optional
+- `is_private: bool | None` — optional
+- `is_public: bool | None` — optional
+- `resource_id: str | None` — optional
+- `is_locked: bool | None` — optional
+- `sleep_mode: SleepMode | None` — optional
+
+### ContextResponse (TZAwareBaseModel, L198)
+> Response model for context data.
+- `id: UUID` — required
+- `name: str` — required
+- `display_name: str | None` — optional
+- `description: str | None` — optional
+- `summary: str | None` — optional
+- `usage_guide: str | None` — optional
+- `is_default: bool` — required
+- `is_private: bool` — optional (default `True`)
+- `is_public: bool` — optional (default `False`)
+- `resource_id: str | None` — optional
+- `is_locked: bool` — optional (default `False`)
+- `sleep_mode: SleepMode` — optional (default `'skip'`)
+- `created_by: str | None` — optional
+- `created_by_name: str | None` — optional
+- `created_at: datetime` — required
+- `updated_at: datetime | None` — optional
+- `use_rerank: bool | None` — optional
+- `reranker_provider: str | None` — optional
+- `embedding_model: str | None` — optional
+- `embedding_dimensions: int | None` — optional
+- `member_count: int | None` — optional
+- `memory_count: int` — optional (default `0`)
+- `last_activity_at: datetime | None` — optional
+
+### ContextListResponse (BaseModel, L253)
+> Response model for context list.
+- `contexts: list[ContextResponse]` — required
+- `total: int` — required
+
+### ContextStatsResponse (BaseModel, L261)
+> Response model for context statistics.
+- `context_id: UUID` — required
+- `context_name: str` — required
+- `memory_count: int` — required
+- `status: str` — required
+
+### ContextTagsResponse (BaseModel, L273)
+> Response model for ``GET /contexts/{context_id}/tags`` (Issue #614).
+- `context_id: UUID` — required
+- `tags: list[RelatedTagItem]` — required
+- `total: int` — required
+
+### ContextMemberResponse (BaseModel, L1107)
+> Response model for context member.
+- `user_id: str` — required
+- `user_name: str | None` — optional
+- `user_email: str | None` — optional
+- `role: str` — required
+- `added_at: str | None` — optional
+- `is_workspace_admin: bool` — optional (default `False`)
+
+### AddContextMemberRequest (BaseModel, L1131) (request model)
+> Request model for adding context member.
+- `user_id: str` — required
+- `role: str` — required
+
+### UpdateContextMemberRoleRequest (BaseModel, L1138) (request model)
+> Request model for updating context member role.
+- `role: str` — required
+
+### MemoryStatItem (BaseModel, L1560)
+> Per-memory usage statistics.
+- `id: str` — required
+- `summary: str` — required
+- `type: str` — required
+- `importance: float` — required
+- `scope: str` — required
+- `use_count: int` — required
+- `access_count: int` — required
+- `last_used_at: str | None` — required
+- `embedding_status: str` — required
+- `created_at: str` — required
+
+### MemoryUsageStatsResponse (BaseModel, L1575)
+> Response for per-memory stats endpoint.
+- `memories: list[MemoryStatItem]` — required
+- `total: int` — required
+- `sort_by: str` — required
+- `sort_order: str` — required
+
+### DuplicateMemoryInfo (BaseModel, L1665)
+> Memory info for duplicate pair display.
+- `id: str` — required
+- `summary: str` — required
+- `type: str` — required
+- `created_at: str` — required
+
+### DuplicatePair (BaseModel, L1674)
+> A pair of similar memories.
+- `memory_a: DuplicateMemoryInfo` — required
+- `memory_b: DuplicateMemoryInfo` — required
+- `similarity: float` — required
+
+### DuplicatesResponse (BaseModel, L1682)
+> Response for duplicate detection endpoint.
+- `pairs: list[DuplicatePair]` — required
+- `total_pairs: int` — required
+- `threshold: float` — required
+- `memories_scanned: int` — required
+
+## cost_aggregation.py
+
+(Admin-only routes — `require_admin` guard.)
+
+### CostBreakdownByModelResponse (TZAwareBaseModel, L59)
+> Per-model cost split inside a CostAggregationRowResponse.
+- `model: str | None` — required
+- `calls: int` — required
+- `cost_usd: float | None` — required
+- `cost_usd_byok: float | None` — required
+
+### CostBreakdownBySourceResponse (TZAwareBaseModel, L76)
+> Per-source cost split inside a CostAggregationRowResponse.
+- `source: str` — required
+- `calls: int` — required
+- `cost_usd: float | None` — required
+- `cost_usd_byok: float | None` — required
+
+### CostAggregationRowResponse (TZAwareBaseModel, L89)
+> One (period × workspace × user) row in the aggregation response.
+- `period_start: date` — required
+- `workspace_id: UUID | None` — required
+- `user_id: str` — required
+- `calls: int` — required
+- `tokens_in: int` — required
+- `tokens_out: int` — required
+- `tokens_cached_in: int` — required
+- `tokens_cache_write: int` — required
+- `embedding_tokens: int` — required
+- `cost_usd: float | None` — required
+- `cost_usd_byok: float | None` — required
+- `cost_breakdown_by_model: list[CostBreakdownByModelResponse]` — required
+- `cost_breakdown_by_source: list[CostBreakdownBySourceResponse]` — required
+
+### CostAggregationResponse (TZAwareBaseModel, L118)
+> Wrapper around the row list — keeps room for a future cursor.
+- `rows: list[CostAggregationRowResponse]` — required
+
+## external_keys.py
+
+### ExternalKeyCreate (BaseModel, L46) (request model)
+> Create external API key request.
+- `key_name: str` — required
+- `provider: str` — required
+- `value: str` — required
+- `enabled: bool` — optional (default `True`)
+
+### ExternalKeyUpdate (BaseModel, L55) (request model)
+> Update external API key request.
+- `value: str` — required
+
+### ExternalKeyToggle (BaseModel, L61) (request model)
+> Toggle enabled/disabled state (Issue #105).
+- `enabled: bool` — required
+
+### ExternalKeyResponse (BaseModel, L67)
+> External API key response (masked).
+- `id: int` — required ⚠ sequential integer DB PK used as the public identifier (leaks row count; consider opaque id before freeze)
+- `key_name: str` — required
+- `provider: str` — required
+- `masked_value: str` — required
+- `user_id: str` — required
+- `enabled: bool` — required
+- `created_at: str` — required
+- `updated_at: str` — required
+
+### ExternalKeyListResponse (BaseModel, L80)
+> External API keys list response.
+- `keys: list[ExternalKeyResponse]` — required
+- `total: int` — required
+
+## feedback.py
+
+### FeedbackRequest (BaseModel, L35) (request model)
+> Body for recording retrieval feedback.
+- `memory_id: UUID` — required
+- `helpful: bool` — required
+- `query: str | None` — optional
+- `note: str | None` — optional
+
+### FeedbackResponse (BaseModel, L52)
+- `feedback_id: UUID` — required
+- `memory_id: UUID` — required
+- `helpful: bool` — required
+
+## files.py
+
+### FileReserveRequest (BaseModel, L48) (request model)
+> Body for ``POST /api/v1/files/reserve``.
+- `workspace_id: UUID` — required
+- `filename: str` — required
+- `content_type: str` — required
+- `size_bytes: int` — required
+- `sha256: str` — required
+
+### FileReserveResponse (TZAwareBaseModel, L67)
+- `file_id: UUID` — required
+- `upload_url: str` — required
+- `expires_at: datetime` — required
+
+### FileConfirmRequest (BaseModel, L73) (request model)
+> Body for ``POST /api/v1/files/{file_id}/confirm``.
+- `sha256: str` — required
+
+### FileObjectOut (TZAwareBaseModel, L83)
+> Subset of ``FileObject`` exposed to clients.
+- `id: UUID` — required
+- `workspace_id: UUID` — required
+- `filename: str` — required
+- `content_type: str` — required
+- `size_bytes: int` — required
+- `sha256: str` — required
+- `status: str` — required
+- `created_at: datetime` — required
+- `uploaded_at: datetime | None` — optional
+
+### FileDownloadUrlOut (TZAwareBaseModel, L103)
+- `download_url: str` — required
+
+## graph.py
+
+### GraphStats (BaseModel, L33)
+> Graph statistics response.
+- `total_nodes: int` — required
+- `total_edges: int` — required
+- `avg_edge_weight: float` — required
+- `max_edge_weight: float` — required
+- `min_edge_weight: float` — required
+- `density: float` — required
+- `top_connections: list[dict]` — required
+- `recent_edges: list[dict]` — required
+
+### GraphStatsResponse (BaseModel, L46)
+> Graph stats API response.
+- `user_id: str` — required
+- `stats: GraphStats` — required
+- `last_updated: str` — required
+
+### GraphNode (BaseModel, L54)
+> Graph node for visualization.
+- `id: str` — required
+- `summary: str` — required
+- `type: str` — required
+- `importance: float` — required
+- `degree: int` — required
+- `created_at: str | None` — optional
+
+### GraphEdge (BaseModel, L65)
+> Graph edge for visualization.
+- `source: str` — required
+- `target: str` — required
+- `weight: float` — required
+- `type: str` — required
+- `created_at: str | None` — optional
+- `confidence: float | None` — optional
+
+### GraphDataResponse (BaseModel, L83)
+> Graph data for visualization.
+- `nodes: list[GraphNode]` — required
+- `edges: list[GraphEdge]` — required
+- `stats: dict` — required
+
+## mcp.py
+
+### MCPToolInfo (BaseModel, L23)
+> MCP Tool information.
+- `name: str` — required
+- `description: str` — required
+- `input_schema: dict` — required
+
+### MCPToolsResponse (BaseModel, L31)
+> MCP tools list response.
+- `tools: list[MCPToolInfo]` — required
+- `total: int` — required
+
+### MCPStatusResponse (BaseModel, L38)
+> MCP server status response.
+- `status: str` — required
+- `active_sessions: int` — required
+- `total_tools: int` — required
+- `tools_available: list[str]` — required
+- `last_activity: str | None` — required
+
+## me_account.py
+
+### ErasureRequestCreateResponse (TZAwareBaseModel, L57)
+> Returned after creating a self-service erasure request.
+- `request_id: UUID` — required
+- `status: str` — required
+- `requested_at: datetime` — required
+- `confirm_token: str | None` — optional ⚠ erasure confirmation token returned in the API body for password-auth users (by design per docstring; verify in-band token delivery is acceptable vs out-of-band before freeze)
+
+### ErasureConfirmRequest (BaseModel, L101) (request model)
+> Payload for POST /me/account/erasure-confirm.
+- `token: str` — required
+- `password: str | None` — optional
+
+### ErasureRequestStateResponse (TZAwareBaseModel, L111)
+> Read-only view of an erasure request's lifecycle state.
+- `request_id: UUID` — required
+- `status: str` — required
+- `is_self_service: bool` — required
+- `requested_at: datetime` — required
+- `confirmed_at: datetime | None` — optional
+- `scheduled_for: datetime | None` — optional
+- `started_at: datetime | None` — optional
+- `completed_at: datetime | None` — optional
+- `cancelled_at: datetime | None` — optional
+- `failure_reason: str | None` — optional
+
+### LinkProviderRequest (BaseModel, L253) (request model)
+> Body for POST /me/account/link-provider.
+- `provider: Literal['google', 'github']` — required
+
+### LinkProviderResponse (BaseModel, L259)
+> Frontend redirects ``window.location`` to ``authorization_url``.
+- `authorization_url: str` — required
+- `state: str` — required
+
+### UnlinkProviderRequest (BaseModel, L270) (request model)
+> Body for POST /me/account/unlink-provider.
+- `provider: Literal['google', 'github']` — required
+
+### UnlinkProviderResponse (BaseModel, L276)
+> Returned by POST /me/account/unlink-provider on success.
+- `status: str` — required
+
+### LinkedProvider (BaseModel, L282)
+> One linked OAuth identity, as surfaced to the profile UI.
+- `provider: str` — required
+- `linked_at: str | None` — optional
+- `last_used_at: str | None` — optional
+
+### ProvidersListResponse (BaseModel, L295)
+> All OAuth providers currently linked to the session user.
+- `providers: list[LinkedProvider]` — required
+
+## me_oauth.py
+
+### RefreshOAuthRequest (BaseModel, L169) (request model)
+> Optional ``return_to`` lets the frontend control the post-callback redirect.
+- `return_to: str | None` — optional
+
+### RefreshOAuthResponse (BaseModel, L180)
+> Frontend redirects ``window.location`` to ``authorization_url``.
+- `authorization_url: str` — required
+- `state: str` — required
+
+## memory.py
+
+### MemoryListItem (BaseModel, L443)
+> Memory list item.
+- `id: str` — required
+- `summary: str` — required
+- `type: str` — required
+- `scope: str` — required
+- `importance: float` — required
+- `created_at: str` — required
+- `updated_at: str` — required
+
+### MemoryListResponse (BaseModel, L455)
+> Memory list response.
+- `memories: list[MemoryListItem]` — required
+- `total: int` — required
+- `has_more: bool` — required
+
+## neural_config.py
+
+### NeuralConfigItem (TZAwareBaseModel, L33)
+> Neural config item response.
+- `key: str` — required
+- `value: str` — required
+- `value_type: str` — required
+- `category: str` — required
+- `description: str | None` — required
+- `min_value: float | None` — required
+- `max_value: float | None` — required
+- `updated_at: datetime` — required
+
+### NeuralConfigListResponse (BaseModel, L46)
+> List of neural config items.
+- `configs: list[NeuralConfigItem]` — required
+- `categories: list[str]` — required
+- `total: int` — required
+
+### NeuralConfigUpdateRequest (BaseModel, L54) (request model)
+> Update neural config request.
+- `value: str` — required
+
+### NeuralConfigUpdateResponse (BaseModel, L60)
+> Update neural config response.
+- `key: str` — required
+- `old_value: str` — required
+- `new_value: str` — required
+- `message: str` — required
+
+### NeuralConfigResetResponse (BaseModel, L69)
+> Reset neural config response.
+- `message: str` — required
+- `reset_count: int` — required
+
+## oauth.py
+
+### OAuth2ClientResponse (BaseModel, L107)
+> OAuth2 Client response (without secret).
+- `id: int` — required
+- `client_id: str` — required
+- `client_name: str` — required
+- `redirect_uris: list[str]` — required
+- `grant_types: list[str]` — required
+- `response_types: list[str]` — required
+- `scope: str` — required
+- `token_endpoint_auth_method: str` — required
+- `owner_id: str | None` — required
+- `provider: str` — required
+- `created_at: str` — required
+- `plaintext_secret: str | None` — optional ⚠ decrypted client secret in a response model whose docstring says "without secret" — gated by owner + visibility window in code, but verify gating and `response_model_exclude` coverage on every endpoint returning this model before freeze
+- `is_visible: bool` — required
+- `visibility_expires_at: str | None` — optional
+
+### OAuth2ClientCreateRequest (BaseModel, L148) (request model)
+> OAuth2 Client creation request.
+- `client_name: str` — required
+- `redirect_uris: list[str]` — required
+- `provider: str` — optional (default `'custom'`)
+- `grant_types: list[str]` — optional (default `['authorization_code', 'refresh_token']`)
+- `response_types: list[str]` — optional (default `['code']`)
+- `scope: str` — optional (default `DCR_DEFAULT_SCOPE`)
+- `token_endpoint_auth_method: str` — optional (default `'client_secret_post'`)
+
+### DynamicClientRegistrationRequest (BaseModel, L178) (request model)
+> Dynamic Client Registration (DCR) request for MCP clients.
+- `client_name: str` — optional (default `'MCP Client'`)
+- `redirect_uris: list[str]` — required
+- `grant_types: list[str]` — optional (default `['authorization_code', 'refresh_token']`)
+- `response_types: list[str]` — optional (default `['code']`)
+- `scope: str | None` — optional
+- `token_endpoint_auth_method: str` — optional (default `'none'`)
+
+### OAuth2ClientUpdateRequest (BaseModel, L204) (request model)
+> OAuth2 Client update request.
+- `client_name: str | None` — optional
+- `redirect_uris: list[str] | None` — optional
+- `scope: str | None` — optional
+- `token_endpoint_auth_method: str | None` — optional
+
+### OAuth2ProviderResponse (BaseModel, L223)
+> OAuth2 Provider response.
+- `name: str` — required
+- `display_name: str` — required
+- `client_id: str | None` — required
+- `authorization_url: str` — required
+- `token_url: str` — required
+- `scopes: list[str]` — required
+- `enabled: bool` — required
+- `configured: bool` — required
+
+### DeviceAuthorizationRequest (BaseModel, L241) (request model)
+> Device Authorization Request (RFC 8628 Section 3.1).
+- `client_id: str` — required
+- `scope: str | None` — optional
+
+### DeviceAuthorizationResponse (TZAwareBaseModel, L248)
+> Device Authorization Response (RFC 8628 Section 3.2).
+- `device_code: str` — required
+- `user_code: str` — required
+- `verification_uri: str` — required
+- `verification_uri_complete: str` — required
+- `expires_in: int` — required
+- `interval: int` — required
+
+### DeviceVerifyRequest (BaseModel, L259) (request model)
+> Request to look up pending device authorization by user_code.
+- `user_code: str` — required
+
+### DeviceVerifyResponse (TZAwareBaseModel, L265)
+> Pending device authorization info returned for the consent screen.
+- `user_code: str` — required
+- `client_name: str` — required
+- `scope: str | None` — required
+- `expires_at: str` — required
+- `is_authorized: bool` — required
+- `is_expired: bool` — required
+
+### DeviceConfirmRequest (BaseModel, L276) (request model)
+> User consent decision for a pending device authorization.
+- `user_code: str` — required
+- `approve: bool` — optional (default `True`)
+
+### DeviceConfirmResponse (TZAwareBaseModel, L283)
+> Result of user consent decision.
+- `status: str` — required
+- `user_code: str` — required
+
+### DeviceUnauthAuditRequest (BaseModel, L290) (request model)
+> Fire-and-forget audit payload for unauthenticated /device hits (Issue #779).
+- `user_code_prefix: str` — optional (default `''`)
+
+## public_search.py
+
+### PublicSearchRequest (BaseModel, L39) (request model)
+> Public search request.
+- `query: str` — required
+- `limit: int` — optional (default `10`)
+- `use_rerank: bool` — optional (default `False`)
+- `search_mode: str` — optional (default `'hybrid'`)
+
+### PublicSearchResult (BaseModel, L52)
+> Single search result with schema-aware formatting.
+- `memory_id: str` — required
+- `content: str` — required
+- `score: float` — required
+- `metadata: dict` — required ⚠ untyped dict on an anonymous-capable public endpoint — leak surface depends entirely on upstream classification filtering; unfreezable shape as-is
+- `highlighted: dict | None` — optional
+
+### PublicSearchResponse (BaseModel, L62)
+> Public search response.
+- `status: str` — optional (default `'success'`)
+- `query: str` — required
+- `results: list[PublicSearchResult]` — required
+- `count: int` — required
+- `context_id: str` — required
+- `resource_id: str | None` — optional
+- `schema_version: int | None` — optional
+
+## resource_indexer.py
+
+### IndexerStateMetrics (BaseModel, L50)
+> Per-run indexer metrics, flattened from the JSONB column.
+- `applied_upserts: int` — optional (default `0`)
+- `applied_deletes: int` — optional (default `0`)
+- `errors: int` — optional (default `0`)
+- `skipped_reason: IndexerSkippedReason | None` — optional
+
+### IndexerState (BaseModel, L65)
+> Indexer state snapshot for one resource/context.
+- `job_status: IndexerJobStatus` — required
+- `last_run_at: str | None` — optional
+- `next_run_at: str | None` — optional
+- `active_version: int` — required
+- `last_offset: int` — required
+- `lag_seconds: float | None` — optional
+- `metrics: IndexerStateMetrics` — required
+
+### ResourceEventItem (BaseModel, L100)
+> Single row in the recent ingest events list.
+- `id: int` — required
+- `op: Literal['upsert', 'delete']` — required
+- `doc_id: str` — required
+- `version: int | None` — optional
+- `created_at: str | None` — optional
+
+### IndexerStatusResponse (BaseModel, L116)
+> Response body for ``GET /api/v1/resources/{resource_id}/indexer-status``.
+- `resource_id: str` — required
+- `state: IndexerState | None` — optional
+- `recent_events: list[ResourceEventItem]` — optional (default `list()`)
+
+## resource_schema.py
+
+### FieldDefinition (BaseModel, L35)
+> Field metadata definition.
+- `name: str` — required
+- `type: str` — required
+- `description: str` — required
+- `classification: str` — optional (default `'public'`)
+- `index_hint: str` — optional (default `''`)
+- `unit: str | None` — optional
+- `enum_values: list[str] | None` — optional
+- `example: str | None` — optional
+- `required: bool` — optional (default `False`)
+
+### SchemaCreateRequest (BaseModel, L63) (request model)
+> Request to create a new resource schema.
+- `resource_id: str` — required
+- `field_definitions: list[FieldDefinition]` — required
+
+### SchemaResponse (BaseModel, L72)
+> Response with resource schema.
+- `resource_id: str` — required
+- `schema_version: int` — required
+- `field_definitions: list[FieldDefinition]` — required
+- `created_at: str` — required
+
+### ResourceImpactResponse (BaseModel, L81)
+> Response with resource change impact information.
+- `resource_id: str` — required
+- `token_count: int` — required
+- `memory_count: int` — required
+- `current_schema_version: int | None` — optional
+
+## resource_tokens.py
+
+### ResourceTokenCreate (BaseModel, L54) (request model)
+> Request model for creating a resource token.
+- `resource_id: str` — required
+- `description: str | None` — optional
+- `quota_events_per_hour: int` — optional (default `1000`)
+
+### ResourceTokenUpdate (BaseModel, L66) (request model)
+> Request model for updating a resource token.
+- `description: str | None` — optional
+- `quota_events_per_hour: int | None` — optional
+
+### ResourceTokenResponse (TZAwareBaseModel, L75)
+> Response model for resource token metadata (no plaintext).
+- `id: int` — required ⚠ sequential integer DB PK used as the public identifier (leaks row count; consider opaque id before freeze)
+- `resource_id: str` — required
+- `description: str | None` — optional
+- `quota_events_per_hour: int` — required
+- `created_by: str | None` — optional
+- `created_at: datetime` — required
+- `last_used_at: datetime | None` — optional
+- `is_active: bool` — required
+- `status: Literal['active', 'revoked']` — required
+
+### PaginatedResourceTokensResponse (BaseModel, L91)
+> Paginated response for resource tokens.
+- `tokens: list[ResourceTokenResponse]` — required
+- `total: int` — required
+- `limit: int` — required
+- `offset: int` — required
+
+## resources.py
+
+### ResourceListItem (BaseModel, L44)
+> Single resource entry in the workspace resource list.
+- `resource_id: str` — required
+- `context_id: str` — required
+- `context_name: str` — required
+- `context_display_name: str | None` — optional
+- `token_count: int` — required
+- `memory_count: int` — required
+- `current_schema_version: int | None` — optional
+- `created_at: str` — required
+- `updated_at: str` — required
+
+### ResourceListResponse (BaseModel, L66)
+> Workspace resource list response.
+- `resources: list[ResourceListItem]` — required
+- `total: int` — required
+
+### ResourceEventRecord (BaseModel, L260)
+> A single ingest event row for the Resource Detail Data tab.
+- `id: str` — required
+- `op: str` — required
+- `doc_id: str` — required
+- `version: int | None` — optional
+- `idempotency_key: str | None` — optional
+- `importance: float` — required
+- `created_at: str` — required
+- `payload: dict | None` — optional ⚠ raw ingest payload returned verbatim (size-capped only) — confirm raw-vs-derived boundary / classification redaction (#968) applies before 1.0
+- `event_metadata: dict | None` — optional ⚠ raw producer-supplied metadata, same raw-data-boundary concern as payload
+- `payload_bytes: int` — required
+- `payload_truncated: bool` — required
+
+### ResourceEventsResponse (BaseModel, L297)
+> Cursor-paginated resource events response.
+- `events: list[ResourceEventRecord]` — required
+- `next_cursor: str | None` — optional
+
+## sleep_reports.py
+
+### SleepReportSummary (TZAwareBaseModel, L46)
+> Sleep report summary for list view.
+- `id: UUID` — required
+- `user_id: str` — required
+- `workspace_id: UUID | None` — required
+- `context_id: UUID | None` — required
+- `context_name: str | None` — optional
+- `status: str` — required
+- `started_at: datetime` — required
+- `completed_at: datetime | None` — required
+- `memories_processed: int` — required
+- `edges_created: int` — required
+- `memories_merged: int` — required
+- `memories_promoted: int` — required
+- `memories_flagged: int` — required
+- `llm_calls_made: int` — required
+- `llm_tokens_used: int` — required
+
+### SleepActionItem (TZAwareBaseModel, L79)
+> Sleep action audit log entry.
+- `id: int` — required
+- `phase: str` — required
+- `action_type: str` — required
+- `memory_id: UUID | None` — required
+- `target_id: UUID | None` — required
+- `details: dict[str, Any] | None` — required
+- `created_at: datetime` — required
+
+### SleepReportListResponse (BaseModel, L91)
+> List of sleep reports with pagination.
+- `reports: list[SleepReportSummary]` — required
+- `total: int` — required
+- `limit: int` — required
+- `offset: int` — required
+
+### SleepReportDetailResponse (BaseModel, L100)
+> Sleep report detail with all actions.
+- `report: SleepReportDetail` — required (`SleepReportDetail(SleepReportSummary)` L66 adds `context_deleted`, `embedding_calls_made`, `error_message`, `edge_discovery_result`, `dedup_result`, `importance_result`, `consolidation_result`, `reindex_result` — five untyped `dict | None` pipeline internals)
+- `actions: list[SleepActionItem]` — required
+- `action_count: int` — required
+
+## system.py
+
+### ServiceStatus (BaseModel, L20)
+> Individual service status.
+- `status: str` — required
+- `version: str | None` — optional
+- `details: dict | None` — optional
+
+### TelemetryResponse (BaseModel, L28)
+> System telemetry response (endpoint is gated by APIKeyOrSessionUser, i.e. any authenticated user).
+- `services: dict[str, ServiceStatus]` — required
+- `embedding_config: dict | None` — optional ⚠ internal embedding infrastructure config exposed to any authenticated user — consider admin-only or remove before freeze
+- `memory_stats: dict` — required
+- `neural_memory: dict` — required
+- `uptime_seconds: int` — required
+- `version: str` — required
+
+### EmbeddingModelInfo (BaseModel, L358)
+> Individual embedding model info.
+- `name: str` — required
+- `dimensions: int` — required
+- `provider: str` — required
+- `available: bool` — required
+
+### EmbeddingModelsResponse (BaseModel, L367)
+> Response for available embedding models.
+- `models: list[EmbeddingModelInfo]` — required
+- `default_model: str` — required
+
+## usage.py
+
+### PlanLimits (BaseModel, L29)
+> Plan limits and quotas.
+- `plan_name: str` — required
+- `memory_limit: int` — required
+- `daily_total_limit: int` — required
+- `weekly_total_limit: int` — required
+- `mcp_calls_per_day: int` — optional (default `0`)
+- `mcp_calls_per_week: int` — optional (default `0`)
+- `rest_calls_per_day: int` — optional (default `0`)
+- `rest_calls_per_week: int` — optional (default `0`)
+- `public_calls_per_day: int` — optional (default `0`)
+- `public_calls_per_week: int` — optional (default `0`)
+
+### AnalysisUsage (BaseModel, L59)
+> Memory broadlistening daily quota usage (Issue #496).
+- `used_today: int` — optional (default `0`)
+- `limit_today: int` — optional (default `0`)
+- `addon_bonus: int` — optional (default `0`)
+- `remaining_today: int` — optional (default `0`)
+- `resets_at: str` — required
+
+### SleepContextsUsage (BaseModel, L81)
+> Sleep-enabled contexts quota usage (Issue #560).
+- `used: int` — optional (default `0`)
+- `limit: int` — optional (default `0`)
+- `addon_bonus: int` — optional (default `0`)
+- `remaining: int` — optional (default `0`)
+
+### WorkspacesUsage (BaseModel, L102)
+> Owned-workspace cap usage (Issue #661).
+- `used: int` — optional (default `0`)
+- `limit: int` — optional (default `0`)
+- `remaining: int` — optional (default `0`)
+
+### CurrentUsage (BaseModel, L126)
+> Current usage statistics.
+- `memory_count: int` — required
+- `api_calls_today: int` — required
+- `api_calls_this_week: int` — required
+- `mcp_calls_today: int` — optional (default `0`)
+- `mcp_calls_this_week: int` — optional (default `0`)
+- `rest_calls_today: int` — optional (default `0`)
+- `rest_calls_this_week: int` — optional (default `0`)
+- `public_calls_today: int` — optional (default `0`)
+- `public_calls_this_week: int` — optional (default `0`)
+- `analysis: AnalysisUsage | None` — optional
+- `sleep_contexts: SleepContextsUsage | None` — optional
+- `workspaces: WorkspacesUsage` — required
+
+### UsageStatus (BaseModel, L163)
+> Usage status with percentage.
+- `current: int | float` — required
+- `limit: int | float` — required
+- `percentage: float` — required
+- `is_warning: bool` — required
+- `is_critical: bool` — required
+- `is_exceeded: bool` — required
+
+### UsageCurrentResponse (BaseModel, L174)
+> Current usage vs limits response.
+- `plan: PlanLimits` — required
+- `usage: CurrentUsage` — required
+- `memory_usage: UsageStatus` — required
+- `daily_api_usage: UsageStatus` — required
+- `weekly_api_usage: UsageStatus` — required
+
+### DailyUsage (BaseModel, L184)
+> Daily usage statistics.
+- `date: str` — required
+- `count: int` — required
+
+### UsageHistoryResponse (BaseModel, L191)
+> Historical usage data.
+- `daily_stats: list[DailyUsage]` — required
+- `total_requests: int` — required
+- `period_start: str` — required
+- `period_end: str` — required
+
+### EndpointUsage (BaseModel, L200)
+> Usage by endpoint.
+- `endpoint: str` — required
+- `count: int` — required
+- `percentage: float` — required
+
+### UsageBreakdownResponse (BaseModel, L208)
+> Usage breakdown by endpoint.
+- `by_endpoint: list[EndpointUsage]` — required
+- `total_requests: int` — required
+- `period_days: int` — required
+
+## workers.py
+
+### WorkerConnectorConfig (TZAwareBaseModel, L60)
+> Per-connector config handed to the ai-worker. Contains secrets. (Endpoint is gated by `verify_worker_token` — internal worker surface, not for the public 1.0 freeze.)
+- `connector_id: UUID` — required
+- `workspace_id: UUID` — required
+- `context_id: UUID` — required
+- `platform: str` — required
+- `locale: str | None` — optional
+- `slack: dict[str, Any]` — required ⚠ contains plaintext Slack connector secrets per docstring — keep this model out of the public OpenAPI/1.0 surface
+- `kmc: dict[str, Any]` — required ⚠ contains plaintext KMC write key — same internal-surface concern
+- `resource: dict[str, Any] | None` — optional
+- `llm: dict[str, Any] | None` — optional
+- `pii_guardrail_config: dict[str, Any] | None` — optional
+
+## workspace.py
+
+### PrivateContextAggregation (BaseModel, L50)
+> Aggregated statistics for inaccessible private contexts.
+- `context_count: int` — required
+- `memory_count: int` — required
+
+### ContextStats (BaseModel, L60)
+> Statistics for a single context.
+- `context_id: str` — required
+- `context_name: str` — required
+- `created_by: str | None` — required
+- `created_by_name: str | None` — required
+- `memory_count: int` — required
+- `is_private: bool` — optional (default `False`)
+
+### WorkspaceStatsResponse (BaseModel, L74)
+> Aggregated statistics across all user's contexts.
+- `total_memories: int` — required
+- `context_count: int` — required
+- `contexts: list[ContextStats]` — required
+- `private_aggregation: PrivateContextAggregation | None` — optional
+- `plan_name: str` — required
+
+### MemberUsageEntry (BaseModel, L575)
+> Usage stats for a single workspace member.
+- `user_id: str` — required
+- `name: str | None` — required
+- `email: str | None` — required
+- `memory_count: int` — required
+- `api_calls_today: int` — required
+- `api_calls_week: int` — required
+
+### MemberUsageResponse (BaseModel, L586)
+> Per-member usage breakdown for workspace.
+- `members: list[MemberUsageEntry]` — required
+- `total_members: int` — required
+
+### FailedMemoryInfo (BaseModel, L681)
+> Info about a failed embedding memory.
+- `id: str` — required
+- `summary: str` — required
+- `embedding_error: str | None` — required
+- `created_at: str` — required
+- `updated_at: str | None` — required
+
+### EmbeddingStatusResponse (BaseModel, L691)
+> Embedding queue status response.
+- `total: int` — required
+- `by_status: dict[str, int]` — required
+- `failed_memories: list[FailedMemoryInfo]` — required
+
+## workspace_connectors.py
+
+### WorkspaceConnectorCreateRequest (BaseModel, L26) (request model)
+> Request body for provisioning an ai-worker connector.
+- `connector_type: Literal['slack', 'discord', 'teams']` — required
+- `resource_id: str` — required
+- `display_name: str | None` — optional
+- `oauth_tokens: dict[str, Any] | None` — optional
+- `pii_guardrail_config: dict[str, Any] | None` — optional
+- `litellm_virtual_key_id: str | None` — optional
+- `virtual_key_valid_until: datetime | None` — optional
+- `quota_events_per_hour: int` — optional (default `1000`)
+- `context_id: UUID | None` — optional
+- `auto_create_context_name: str | None` — optional
+- `llm_config: dict[str, Any] | None` — optional
+- `channel_ids: list[Any] | None` — optional
+- `locale: str | None` — optional
+- `external_team_id: str | None` — optional
+- `slack_install_handle: str | None` — optional
+
+### WorkspaceConnectorCreateResponse (BaseModel, L67)
+> Connector setup response. The token + KMC key are shown exactly once.
+- `connector_id: UUID` — required
+- `connector_type: str` — required
+- `resource_id: str` — required
+- `resource_pk: UUID` — required ⚠ internal DB primary key leaked alongside the public `resource_id` — hide or rename before freeze
+- `context_id: UUID | None` — optional
+- `token_id: int` — required
+- `token: str` — required ⚠ plaintext connector token (shown-once by design — verify never logged/cached downstream)
+- `kmc_api_key: str | None` — optional ⚠ plaintext KMC write key (shown-once by design)
+- `quota_events_per_hour: int` — required
+- `idempotency_key_prefix: str` — required
+
+### WorkspaceConnectorSummary (TZAwareBaseModel, L84)
+> One connector row for the workspace list view.
+- `connector_id: UUID` — required
+- `connector_type: str` — required
+- `resource_pk: UUID` — required ⚠ internal DB primary key in a routine list view — should expose the public `resource_id` instead
+- `context_id: UUID | None` — optional
+- `config_version: int` — required
+- `created_at: datetime` — required
+- `created_by: str | None` — optional
+
+### RotateKmcKeyResponse (TZAwareBaseModel, L96)
+> Response after rotating a connector's KMC write key. Shown exactly once.
+- `connector_id: UUID` — required
+- `kmc_api_key: str` — required
+- `kmc_api_key_expires_at: datetime` — required
+- `config_version: int` — required
+
+## workspace_plan.py
+
+### WorkspacePlanInfo (BaseModel, L45)
+> Workspace plan information with usage stats. (Name collides with `admin_plans.WorkspacePlanInfo` — OpenAPI schema-name ambiguity.)
+- `workspace_id: str` — required
+- `workspace_name: str` — required
+- `current_plan: str` — required
+- `plan_display_name: str` — required
+- `price_monthly: int` — required
+- `usage: dict` — required
+- `quotas: dict` — required
+- `can_upgrade: bool` — required
+- `can_downgrade: bool` — required
+
+### AvailablePlanInfo (BaseModel, L59)
+> Available plan tier information.
+- `name: str` — required
+- `display_name: str` — required
+- `price_monthly: int` — required
+- `quotas: dict` — required
+- `features: list[str]` — required
+
+### UpdatePlanRequest (BaseModel, L69) (request model)
+> Request to update workspace plan. (Name collides with `admin_plans.UpdatePlanRequest`.)
+- `plan_name: str` — required
+- `reason: str | None` — optional
+
+## workspaces.py
+
+### WorkspaceCreate (BaseModel, L38) (request model)
+> Request model for creating workspace.
+- `name: str` — required
+- `openai_api_key: str | None` — optional
+- `description: str | None` — optional
+- `default_context_name: str | None` — optional
+- `default_context_summary: str | None` — optional
+- `default_context_usage_guide: str | None` — optional
+- `default_context_embedding_model: str | None` — optional
+
+### WorkspaceUpdate (BaseModel, L58) (request model)
+> Request model for updating workspace.
+- `name: str | None` — optional
+- `description: str | None` — optional
+
+### WorkspaceResponse (BaseModel, L68)
+> Response model for workspace.
+- `id: UUID` — required
+- `name: str` — required
+- `description: str | None` — required
+- `owner_user_id: str` — required
+- `plan_name: str` — required
+- `member_count: int` — required
+- `context_count: int` — required
+- `created_at: str` — required
+- `current_user_role: str | None` — optional
+- `analyses_enabled: bool` — optional (default `False`)
+
+### CredentialsStatusInfo (BaseModel, L89)
+> Credentials status information for member.
+- `api_key_count: int` — optional (default `0`)
+- `api_key_visible: bool` — optional (default `False`)
+- `claude_app_visible: bool | None` — optional
+- `chatgpt_app_visible: bool | None` — optional
+- `custom_app_count: int` — optional (default `0`)
+
+### ContextStatsItem (TZAwareBaseModel, L99)
+> Context usage statistics item.
+- `context_id: str` — required
+- `context_name: str` — required
+- `memory_count: int` — required
+- `last_activity: datetime | None` — required
+- `member_count: int` — required
+- `api_calls_week: int` — optional (default `0`)
+- `active_users_week: int` — optional (default `0`)
+- `avg_response_time_ms: float` — optional (default `0.0`)
+
+### WorkspaceTotals (BaseModel, L115)
+> Workspace-wide totals.
+- `memory_count: int` — required
+
+### ContextStatsResponse (BaseModel, L124)
+> Response model for context statistics. (Name collides with `contexts.ContextStatsResponse` — different shape, OpenAPI schema-name ambiguity.)
+- `contexts: list[ContextStatsItem]` — required
+- `total_contexts: int` — required
+- `workspace_totals: WorkspaceTotals` — required
+
+### DailyUsageItem (BaseModel, L135)
+> Daily usage statistics item.
+- `date: str` — required
+- `api_calls: int` — required
+- `unique_users: int` — required
+
+### UserActivityItem (TZAwareBaseModel, L146)
+> User activity statistics item.
+- `user_id: str` — required
+- `user_name: str | None` — required
+- `user_email: str | None` — required
+- `api_calls: int` — required
+- `last_activity: datetime | None` — required
+
+### ContextUsageTimelineResponse (BaseModel, L159)
+> Response model for context usage timeline.
+- `context_id: str` — required
+- `context_name: str` — required
+- `daily_usage: list[DailyUsageItem]` — required
+- `total_calls: int` — required
+
+### ContextUserActivityResponse (BaseModel, L171)
+> Response model for context user activity.
+- `context_id: str` — required
+- `context_name: str` — required
+- `users: list[UserActivityItem]` — required
+- `total_users: int` — required
+
+### DailyMemoryCount (BaseModel, L183)
+> Daily memory count item for timeline.
+- `date: str` — required
+- `count: int` — required
+
+### MemoryTimelineResponse (BaseModel, L193)
+> Response model for workspace memory timeline.
+- `workspace_id: str` — required
+- `workspace_name: str` — required
+- `daily_counts: list[DailyMemoryCount]` — required
+- `memories_created_in_period: int` — required
+- `period_start: str` — required
+- `period_end: str` — required
+
+### TimelineItem (BaseModel, L207)
+> Timeline data point.
+- `date: str` — required
+- `count: int` — required
+
+### SearchTimelineItem (BaseModel, L217)
+> Search timeline data point with anonymous/authenticated split.
+- `date: str` — required
+- `total: int` — required
+- `anonymous: int` — required
+- `authenticated: int` — required
+
+### ResourceIngestStats (BaseModel, L229)
+> Resource Ingest API statistics.
+- `total_events: int` — required
+- `last_n_days: int` — required
+- `avg_per_day: float` — required
+- `active_tokens: int` — required
+- `timeline: list[TimelineItem]` — required
+
+### PublicSearchStats (BaseModel, L242)
+> Public Search API statistics.
+- `total_searches: int` — required
+- `last_n_days: int` — required
+- `anonymous: int` — required
+- `authenticated: int` — required
+- `timeline: list[SearchTimelineItem]` — required
+
+### PublicAPIStatsResponse (BaseModel, L255)
+> Response model for public API statistics.
+- `resource_ingest: ResourceIngestStats` — required
+- `public_search: PublicSearchStats` — required
+
+### WorkspaceMemberResponse (BaseModel, L265)
+> Response model for workspace member.
+- `user_id: str` — required
+- `user_name: str | None` — optional
+- `user_email: str | None` — optional
+- `role: str` — required
+- `joined_at: str | None` — required
+- `credentials_status: CredentialsStatusInfo | None` — optional
+- `last_login_at: str | None` — optional
+- `allowed_context_ids: list[str] | None` — optional
+
+### AddMemberRequest (BaseModel, L286) (request model)
+> Request model for adding member.
+- `user_id: str` — required
+- `role: str` — required
+
+### UpdateMemberRoleRequest (BaseModel, L293) (request model)
+> Request model for updating member role.
+- `role: str` — required
+
+### UpdateMemberContextAccessRequest (BaseModel, L299) (request model)
+> Request model for updating member's context access.
+- `allowed_context_ids: list[str] | None` — optional
+
+## Follow-up candidates
+
+Issue #622 allows at most 2 follow-up sub-issues; candidates below are grouped into two proposed bundles.
+
+### Bundle A — Internal-data and secret exposure hygiene (proposed sub-issue 1)
+
+| Candidate | Priority | Action |
+|---|---|---|
+| `WorkspaceConnectorCreateResponse.resource_pk`, `WorkspaceConnectorSummary.resource_pk` (workspace_connectors.py) | P1 | Hide internal DB PK; expose only the public `resource_id` |
+| `TelemetryResponse.embedding_config` (system.py) | P1 | Make admin-only or drop — internal embedding infra config currently visible to any authenticated user |
+| `ResourceEventRecord.payload` / `event_metadata` (resources.py) | P1 | Confirm raw-vs-derived boundary (#968) / classification redaction applies to the Resource Detail Data tab before freeze |
+| `OAuth2ClientResponse.plaintext_secret` (oauth.py) | P1 | Verify owner+visibility gating and `response_model_exclude` coverage on every endpoint returning this model; fix the misleading "without secret" docstring |
+| `WorkerConnectorConfig` (workers.py) | P1 | Explicitly exclude the `/workers` surface (plaintext Slack/KMC secrets) from the public 1.0 OpenAPI/freeze scope |
+| `ErasureRequestCreateResponse.confirm_token` (me_account.py) | P2 | Decide whether in-band token delivery for password-auth users is acceptable at 1.0, or move out-of-band |
+| `WorkspaceConnectorCreateResponse.token` / `kmc_api_key`, `RotateKmcKeyResponse.kmc_api_key` | P2 | Shown-once by design; audit that they are never logged/cached downstream and document the contract |
+
+### Bundle B — Identifier and shape freeze hygiene (proposed sub-issue 2)
+
+| Candidate | Priority | Action |
+|---|---|---|
+| `APIKeyResponse.id`, `ExternalKeyResponse.id`, `ResourceTokenResponse.id`, `WorkspaceConnectorCreateResponse.token_id` (all `int`) | P2 | Replace sequential integer DB PKs with opaque/prefixed public identifiers before freezing the surface |
+| Untyped `dict` fields on freezable responses: `PublicSearchResult.metadata`, `GraphStats.top_connections`/`recent_edges`, `GraphDataResponse.stats`, `UserStats.*`, `WorkspacePlanInfo.usage`/`quotas` (workspace_plan.py), `AvailablePlanInfo.quotas`, `TelemetryResponse.memory_stats`/`neural_memory`, `SleepReportDetail.*_result`, `UserInfo.workspaces` | P2 | Type them with explicit models, or mark them explicitly non-frozen in the 1.0 contract |
+| Duplicate class names across route files: `WorkspacePlanInfo` and `UpdatePlanRequest` (admin_plans.py vs workspace_plan.py), `ContextStatsResponse` (contexts.py vs workspaces.py) | P2 | Rename one of each pair to avoid OpenAPI schema-name ambiguity at freeze time |


### PR DESCRIPTION
## Summary

First-pass enumeration for #622: every surface that becomes semver-locked at v1.0.0, frozen against main `20ae959`.

| File | Coverage |
|---|---|
| `rest-response-models.md` | 208/208 response model classes across 46 route files (issue text said 38 — actual count documented) |
| `mcp-input-schemas.md` | 45/45 MCP tool input schemas + cross-tool naming observations |
| `error-responses.md` | canonical `{error, message, details}` shape + 55/55 error_codes (+41 MCP `_error_response` literals) |
| `auth-surface.md` | JWT/opaque token shapes, 4 well-known docs, 6-scope catalogue, 19 OAuth/DCR routes, DCR_DEFAULT_SCOPE (#608 D1) verification |

## Notable findings (detail in the docs' Follow-up sections)

- The canonical error shape is `{error, message, details}`, **not** the `{detail, error_code}` the issue text assumed; 366 raw `raise HTTPException` sites in 40 files bypass it (per-file census included).
- `merge_contexts` reuses `source_id`/`target_id` with different semantics than the edge tools; result-size params split across `k`/`limit`/`cap`.
- The dashboard JWT path is dead code (zero production callers) — candidate for removal before freezing claim shapes.
- DCR_DEFAULT_SCOPE matches the #608 D1 narrow intent ✓.

Scope-enforcement matrix completion is tracked in the internal hardening ledger and intentionally out of scope here; `auth-surface.md` re-freezes once it lands.

## Remaining #622 acceptance items (not in this PR)

- `/claude-c-suite:dx-lead` review of the MCP tool surface
- Re-freeze against the eventual v1.0.0-rc1 tag
- ≤2 follow-up sub-issues (filed separately)

Part of #622

🤖 Generated with [Claude Code](https://claude.com/claude-code)