### PR TITLE
fix(frontend): surface in-dialog clipboard-copy failures (#987 follow-up)

### DIFF
--- a/frontend/src/components/api-keys/CreateAPIKeyDialog.tsx
+++ b/frontend/src/components/api-keys/CreateAPIKeyDialog.tsx
@@ -52,6 +52,10 @@ export function CreateAPIKeyDialog({
     null,
   );
   const [copied, setCopied] = useState(false);
+  // True when copyText exhausted both clipboard paths (#987). Surfaces an
+  // in-dialog hint AND un-gates the Done button so a denied clipboard can't
+  // trap the user behind "Copy the key first" with no way to proceed.
+  const [copyFailed, setCopyFailed] = useState(false);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -93,9 +97,11 @@ export function CreateAPIKeyDialog({
         // user can still select + copy it manually.
         await copyText(createdKey.api_key);
         setCopied(true);
+        setCopyFailed(false);
         setTimeout(() => setCopied(false), 2000);
       } catch (err) {
         console.error("Failed to copy API key:", err);
+        setCopyFailed(true);
       }
     }
   };
@@ -106,6 +112,7 @@ export function CreateAPIKeyDialog({
     setError(null);
     setCreatedKey(null);
     setCopied(false);
+    setCopyFailed(false);
     onClose();
   };
 
@@ -170,6 +177,15 @@ export function CreateAPIKeyDialog({
                     )}
                   </Button>
                 </div>
+                {copyFailed && (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription>
+                      Couldn&apos;t copy automatically. The key stays visible
+                      above — select it and copy it manually.
+                    </AlertDescription>
+                  </Alert>
+                )}
               </div>
 
               {/* Key Prefix */}
@@ -200,8 +216,12 @@ export function CreateAPIKeyDialog({
           </div>
 
           <DialogFooter>
-            <Button onClick={handleDone} className="w-full" disabled={!copied}>
-              {copied ? "Done" : "Copy the key first"}
+            <Button
+              onClick={handleDone}
+              className="w-full"
+              disabled={!copied && !copyFailed}
+            >
+              {copied || copyFailed ? "Done" : "Copy the key first"}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/frontend/src/components/api-keys/RegenerateAPIKeyDialog.tsx
+++ b/frontend/src/components/api-keys/RegenerateAPIKeyDialog.tsx
@@ -52,6 +52,9 @@ export function RegenerateAPIKeyDialog({
   const [regeneratedKey, setRegeneratedKey] =
     useState<APIKeyCreateResponse | null>(null);
   const [copied, setCopied] = useState(false);
+  // True when copyText exhausted both clipboard paths (#987) — surfaces an
+  // in-dialog hint so a denied clipboard doesn't fail silently.
+  const [copyFailed, setCopyFailed] = useState(false);
 
   const handleRegenerate = async () => {
     try {
@@ -83,9 +86,11 @@ export function RegenerateAPIKeyDialog({
         // user can still select + copy it manually.
         await copyText(regeneratedKey.api_key);
         setCopied(true);
+        setCopyFailed(false);
         setTimeout(() => setCopied(false), 2000);
       } catch (err) {
         console.error("Failed to copy API key:", err);
+        setCopyFailed(true);
       }
     }
   };
@@ -94,6 +99,7 @@ export function RegenerateAPIKeyDialog({
     setError(null);
     setRegeneratedKey(null);
     setCopied(false);
+    setCopyFailed(false);
     onClose();
   };
 
@@ -153,6 +159,15 @@ export function RegenerateAPIKeyDialog({
                   )}
                 </Button>
               </div>
+              {copyFailed && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>
+                    Couldn&apos;t copy automatically. The key stays visible
+                    above — select it and copy it manually.
+                  </AlertDescription>
+                </Alert>
+              )}
             </div>
 
             <div className="space-y-2">

--- a/frontend/src/components/contexts/SettingsTabPanel.tsx
+++ b/frontend/src/components/contexts/SettingsTabPanel.tsx
@@ -315,8 +315,13 @@ export function SettingsTabPanel({
                       setIdCopied(true);
                       setTimeout(() => setIdCopied(false), 1500);
                     } catch {
+                      // copyText already exhausted its execCommand fallback
+                      // (#987); surface the shared actionable hint (the ID
+                      // stays visible for manual copy) instead of a bare
+                      // "copy failed" title, matching the other copy sites.
                       toast({
-                        title: t("copyFailed"),
+                        title: tCommon("error"),
+                        description: tCommon("copyFailedManualHint"),
                         variant: "destructive",
                       });
                     }

--- a/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
+++ b/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
@@ -67,6 +67,7 @@ export function CreateResourceTokenDialog({
   initialResourceId,
 }: CreateResourceTokenDialogProps) {
   const t = useTranslations("resourceTokens");
+  const tCommon = useTranslations("common");
   const { currentWorkspace } = useWorkspace();
   const planName = (currentWorkspace?.plan_name ||
     "free") as keyof typeof QUOTA_CONFIG;
@@ -97,6 +98,9 @@ export function CreateResourceTokenDialog({
   const [createdToken, setCreatedToken] =
     useState<ResourceTokenCreateResponse | null>(null);
   const [copied, setCopied] = useState(false);
+  // True when copyText exhausted both clipboard paths (#987) — surfaces an
+  // in-dialog hint so a denied clipboard doesn't fail silently.
+  const [copyFailed, setCopyFailed] = useState(false);
 
   // Load contexts with resource_id when dialog opens
   useEffect(() => {
@@ -174,9 +178,11 @@ export function CreateResourceTokenDialog({
         // the user can still select + copy it manually.
         await copyText(createdToken.token);
         setCopied(true);
+        setCopyFailed(false);
         setTimeout(() => setCopied(false), 2000);
       } catch (err) {
         console.error("Failed to copy resource token:", err);
+        setCopyFailed(true);
       }
     }
   };
@@ -188,6 +194,7 @@ export function CreateResourceTokenDialog({
     setError(null);
     setCreatedToken(null);
     setCopied(false);
+    setCopyFailed(false);
     onClose();
   };
 
@@ -263,6 +270,14 @@ export function CreateResourceTokenDialog({
                     )}
                   </Button>
                 </div>
+                {copyFailed && (
+                  <Alert variant="destructive">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription>
+                      {tCommon("copyFailedManualHint")}
+                    </AlertDescription>
+                  </Alert>
+                )}
               </div>
 
               {/* Quota */}


### PR DESCRIPTION
Closes #987.

> ℹ️ **Scope note:** the core `copyText` fallback for #987 already landed on `main` as the stacked base of #988 ([#998](https://github.com/kagura-ai/memory-cloud/pull/998)). #998 was merged first, so this branch has been rebased onto `main` and now carries **only the review-follow-up** that completes #987 — the in-dialog failure surfaces. (The `clipboard.ts` util, both hooks, and the ~9 call-site conversions are already in `main`.)

## What this PR adds

Review follow-up on the clipboard fix: the one-time secret dialogs swallowed a hard copy failure with `console.error` only, so a denied clipboard gave the user no feedback. `CreateAPIKeyDialog` was the worst case — its Done button is gated on the `copied` flag, so a silent failure trapped the user behind "Copy the key first" with no way out.

- **CreateAPIKeyDialog / RegenerateAPIKeyDialog / CreateResourceTokenDialog** — add a `copyFailed` state that renders an in-dialog `<Alert variant="destructive">` (per `frontend.md`: dialog-body errors use `Alert`, not a toast hidden behind the modal). `CreateAPIKeyDialog` also un-gates Done on failure so the visible-but-unclipboardable key is not a dead end.
- **SettingsTabPanel** — align the context-ID copy-failure toast to the shared actionable shape (`tCommon` error + `copyFailedManualHint`).

## Tests
`tsc` clean against current `main`; dialog files are render-only changes (no test files). The `copyText` util's own tests live with the base change already in `main`.
