### PR TITLE
feat(frontend): add Claude Code OAuth one-liner to setup guide (#988)

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { hasWorkspaceRole, WorkspaceRole } from "@/lib/auth/rbac";
+import { copyText } from "@/lib/utils/clipboard";
 import { PageHeader } from "@/components/common/PageHeader";
 import { PageContainer } from "@/components/common/PageContainer";
 import { Section } from "@/components/common/Section";
@@ -365,14 +366,15 @@ export default function WorkspaceMembersPage() {
 
   const handleCopyInviteUrl = async (url: string, token: string) => {
     try {
-      await navigator.clipboard.writeText(url);
+      // copyText degrades to an execCommand fallback before throwing (#987).
+      await copyText(url);
       setCopiedToken(token);
       setTimeout(() => setCopiedToken(null), 2000);
     } catch (error) {
       console.error("Failed to copy URL:", error);
       toast({
         title: tCommon("error"),
-        description: "Failed to copy URL to clipboard",
+        description: tCommon("copyFailedManualHint"),
         variant: "destructive",
       });
     }

--- a/frontend/src/components/api-keys/CreateAPIKeyDialog.tsx
+++ b/frontend/src/components/api-keys/CreateAPIKeyDialog.tsx
@@ -7,6 +7,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { copyText } from "@/lib/utils/clipboard";
 import {
   Dialog,
   DialogContent,
@@ -85,9 +86,17 @@ export function CreateAPIKeyDialog({
 
   const handleCopy = async () => {
     if (createdKey) {
-      await navigator.clipboard.writeText(createdKey.api_key);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      try {
+        // copyText degrades to an execCommand fallback before throwing
+        // (issue #987), so a denied async-clipboard write no longer fails
+        // silently. The key is shown in this dialog, so on hard failure the
+        // user can still select + copy it manually.
+        await copyText(createdKey.api_key);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy API key:", err);
+      }
     }
   };
 

--- a/frontend/src/components/api-keys/RegenerateAPIKeyDialog.tsx
+++ b/frontend/src/components/api-keys/RegenerateAPIKeyDialog.tsx
@@ -7,6 +7,7 @@
 
 import { useState } from "react";
 import { Button } from "@/components/ui/button";
+import { copyText } from "@/lib/utils/clipboard";
 import {
   Dialog,
   DialogContent,
@@ -75,9 +76,17 @@ export function RegenerateAPIKeyDialog({
 
   const handleCopy = async () => {
     if (regeneratedKey) {
-      await navigator.clipboard.writeText(regeneratedKey.api_key);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      try {
+        // copyText degrades to an execCommand fallback before throwing
+        // (issue #987), so a denied async-clipboard write no longer fails
+        // silently. The key is shown in this dialog, so on hard failure the
+        // user can still select + copy it manually.
+        await copyText(regeneratedKey.api_key);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy API key:", err);
+      }
     }
   };
 

--- a/frontend/src/components/common/MaskedSecretField.test.tsx
+++ b/frontend/src/components/common/MaskedSecretField.test.tsx
@@ -33,6 +33,14 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   });
+  // copyText (issue #987) falls back to execCommand when writeText rejects.
+  // Default it to "unavailable" so the failure-path tests are deterministic;
+  // the fallback-success test overrides it.
+  Object.defineProperty(document, "execCommand", {
+    value: vi.fn(() => false),
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {
@@ -45,6 +53,7 @@ const baseProps = {
   copyToastTitle: "Config copied",
   copyToastDescription: "Clipboard clears in 60 seconds — paste it now.",
   copyErrorToastTitle: "Copy failed",
+  copyErrorToastDescription: "Select the value and copy it manually.",
   showLabel: "Show key",
   hideLabel: "Hide key",
   copyLabel: "Copy to clipboard",
@@ -142,7 +151,32 @@ describe("MaskedSecretField", () => {
       expect(screen.getByText("Bearer sk-•••••••••••")).toBeInTheDocument();
     });
 
-    it("clipboard write failures fire a destructive toast with the error title (not the success title)", async () => {
+    it("succeeds via the execCommand fallback when the async write is denied (no error toast)", async () => {
+      // The async clipboard write is denied, but the legacy fallback works —
+      // the user sees a success toast, not a failure (issue #987).
+      mockWriteText.mockRejectedValueOnce(
+        new DOMException("Write permission denied", "NotAllowedError"),
+      );
+      (document.execCommand as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      render(<MaskedSecretField {...baseProps} value="kag_real_secret" />);
+      fireEvent.click(
+        screen.getByRole("button", { name: "Copy to clipboard" }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(document.execCommand).toHaveBeenCalledWith("copy");
+      expect(mockToast).toHaveBeenCalledWith({
+        title: "Config copied",
+        description: "Clipboard clears in 60 seconds — paste it now.",
+      });
+    });
+
+    it("hard copy failure fires a destructive toast AND auto-reveals the secret so it can be copied manually", async () => {
+      // writeText rejects AND the execCommand fallback is unavailable
+      // (returns false, per beforeEach) → copyText throws.
       mockWriteText.mockRejectedValueOnce(new Error("clipboard denied"));
       render(<MaskedSecretField {...baseProps} value="kag_real_secret" />);
       fireEvent.click(
@@ -150,41 +184,31 @@ describe("MaskedSecretField", () => {
       );
       await act(async () => {
         await Promise.resolve();
-      });
-
-      // The error toast must use copyErrorToastTitle, NOT copyToastTitle —
-      // otherwise a failure looks like a success at a glance.
-      expect(mockToast).toHaveBeenCalledWith({
-        title: "Copy failed",
-        description: "clipboard denied",
-        variant: "destructive",
-      });
-    });
-
-    it("non-Error rejections produce a usable description (not empty)", async () => {
-      mockWriteText.mockRejectedValueOnce("permission denied");
-      render(<MaskedSecretField {...baseProps} value="kag_real_secret" />);
-      fireEvent.click(
-        screen.getByRole("button", { name: "Copy to clipboard" }),
-      );
-      await act(async () => {
         await Promise.resolve();
       });
 
+      // Error toast uses copyErrorToastTitle + the actionable description,
+      // NOT the raw DOM exception string or the success title.
       expect(mockToast).toHaveBeenCalledWith({
         title: "Copy failed",
-        description: "permission denied",
+        description: "Select the value and copy it manually.",
         variant: "destructive",
       });
+      // CRITICAL: the secret is now revealed so the user can select + copy it
+      // manually — a one-time-reveal key must never dead-end.
+      expect(screen.getByText("Bearer kag_real_secret")).toBeInTheDocument();
     });
 
-    it("falls back to literal 'Error' title when copyErrorToastTitle is omitted", async () => {
+    it("falls back to literal 'Error' title and raw message when error strings are omitted", async () => {
       mockWriteText.mockRejectedValueOnce(new Error("oops"));
-      const { copyErrorToastTitle: _omit, ...propsWithoutErrorTitle } =
-        baseProps;
+      const {
+        copyErrorToastTitle: _omitTitle,
+        copyErrorToastDescription: _omitDesc,
+        ...propsWithoutErrorStrings
+      } = baseProps;
       render(
         <MaskedSecretField
-          {...propsWithoutErrorTitle}
+          {...propsWithoutErrorStrings}
           value="kag_real_secret"
         />,
       );
@@ -193,13 +217,19 @@ describe("MaskedSecretField", () => {
       );
       await act(async () => {
         await Promise.resolve();
+        await Promise.resolve();
       });
 
-      expect(mockToast).toHaveBeenCalledWith({
-        title: "Error",
-        description: "oops",
-        variant: "destructive",
-      });
+      // Title falls back to "Error"; description falls back to the thrown
+      // error's message (ClipboardCopyError) — a usable, non-empty string.
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Error",
+          variant: "destructive",
+        }),
+      );
+      const call = mockToast.mock.calls.at(-1)?.[0];
+      expect(call.description).toBeTruthy();
     });
   });
 

--- a/frontend/src/components/common/MaskedSecretField.tsx
+++ b/frontend/src/components/common/MaskedSecretField.tsx
@@ -74,6 +74,13 @@ export interface MaskedSecretFieldProps {
    */
   copyErrorToastTitle?: string;
   /**
+   * Toast description shown when the clipboard write fails (issue #987).
+   * Should be an actionable, i18n'd hint (e.g. "select the value and copy
+   * manually") — on failure the field auto-reveals so the user can do so.
+   * If omitted, the raw error message is used as a last-resort fallback.
+   */
+  copyErrorToastDescription?: string;
+  /**
    * Tooltip / aria-label for the Show button (revealed=false state).
    */
   showLabel: string;
@@ -105,6 +112,7 @@ export function MaskedSecretField({
   copyToastTitle,
   copyToastDescription,
   copyErrorToastTitle,
+  copyErrorToastDescription,
   showLabel,
   hideLabel,
   copyLabel,
@@ -112,7 +120,7 @@ export function MaskedSecretField({
   "data-testid": testId,
 }: MaskedSecretFieldProps) {
   const { toast } = useToast();
-  const { revealed, toggle, copy, copied, hide } = useRevealableSecret({
+  const { revealed, toggle, copy, copied, hide, show } = useRevealableSecret({
     autoClearMs,
   });
 
@@ -140,12 +148,20 @@ export function MaskedSecretField({
       // Re-throwing here would surface as an unhandled rejection because
       // this is an event handler. Surface as a destructive toast instead;
       // the consumer typically doesn't need to react to clipboard failures.
-      // Use a distinct error title (NOT the success title) so the user
-      // can distinguish success from failure at a glance, and narrow `err`
-      // safely so non-Error rejections produce a usable description.
+      //
+      // The copy failed even via copyText's execCommand fallback (issue
+      // #987). Auto-reveal the secret so the user can select and copy it
+      // manually — a one-time-reveal key must never dead-end — and prefer an
+      // actionable, i18n'd description over the raw DOM exception string.
+      // Use a distinct error title (NOT the success title) so the user can
+      // distinguish success from failure at a glance, and narrow `err` safely
+      // so non-Error rejections still produce a usable last-resort description.
+      show();
       toast({
         title: copyErrorToastTitle ?? "Error",
-        description: err instanceof Error ? err.message : String(err),
+        description:
+          copyErrorToastDescription ??
+          (err instanceof Error ? err.message : String(err)),
         variant: "destructive",
       });
     }

--- a/frontend/src/components/contexts/InstructionsTemplate.tsx
+++ b/frontend/src/components/contexts/InstructionsTemplate.tsx
@@ -11,6 +11,7 @@
 import { useState } from 'react';
 import { ChevronDown, Copy, Check } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { copyText } from '@/lib/utils/clipboard';
 import { cn } from '@/styles/design-tokens';
 import { useTranslations } from 'next-intl';
 
@@ -84,7 +85,8 @@ export function InstructionsTemplate({
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(template);
+      // copyText degrades to an execCommand fallback before throwing (#987).
+      await copyText(template);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {

--- a/frontend/src/components/contexts/SettingsTabPanel.tsx
+++ b/frontend/src/components/contexts/SettingsTabPanel.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
+import { copyText } from "@/lib/utils/clipboard";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -308,7 +309,9 @@ export function SettingsTabPanel({
                   className="shrink-0"
                   onClick={async () => {
                     try {
-                      await navigator.clipboard.writeText(context.id);
+                      // copyText degrades to an execCommand fallback before
+                      // throwing (issue #987).
+                      await copyText(context.id);
                       setIdCopied(true);
                       setTimeout(() => setIdCopied(false), 1500);
                     } catch {

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -644,6 +644,7 @@ export function APIKeysTabPanel() {
                 <MCPConfigBlock
                   apiKey={apiKeys[0] ?? null}
                   mcpUrl={workspaceScopedMcpUrl || mcpBaseUrl}
+                  mcpBaseUrl={mcpBaseUrl}
                 />
               </div>
             </CollapsibleContent>

--- a/frontend/src/components/credentials/APIKeysTabPanel.tsx
+++ b/frontend/src/components/credentials/APIKeysTabPanel.tsx
@@ -206,13 +206,16 @@ export function APIKeysTabPanel() {
   const handleCopy = async (text: string, key: string) => {
     try {
       await copyToTarget(text, key);
-    } catch (err: unknown) {
+    } catch {
       // Clipboard write failure is a user-action failure (the user clicked
       // a Copy button) — surface via destructive toast per the 3-channel
-      // error rule, not via silent console.error.
+      // error rule, not via silent console.error. copyText already tried the
+      // execCommand fallback (issue #987), so show an actionable, i18n'd hint
+      // instead of leaking the raw DOM exception string. The MCP URL is always
+      // visible in its <code> block, so the user can select + copy manually.
       toast({
         title: tCommon("error"),
-        description: err instanceof Error ? err.message : String(err),
+        description: tCommon("copyFailedManualHint"),
         variant: "destructive",
       });
     }
@@ -530,6 +533,7 @@ export function APIKeysTabPanel() {
           copyToastTitle={t("keyCopied")}
           copyToastDescription={t("keyCopiedHint")}
           copyErrorToastTitle={tCommon("error")}
+          copyErrorToastDescription={tCommon("copyFailedManualHint")}
           showLabel={t("showKey")}
           hideLabel={t("hideKey")}
           copyLabel={t("copyToClipboard")}

--- a/frontend/src/components/credentials/MCPConfigBlock.test.tsx
+++ b/frontend/src/components/credentials/MCPConfigBlock.test.tsx
@@ -21,6 +21,7 @@ import {
   MCPConfigBlock,
   CODEX_INSTALL_COMMAND,
   buildTomlConfig,
+  toBareMcpUrl,
 } from "./MCPConfigBlock";
 
 // Stable references defined OUTSIDE beforeEach so React's useCallback /
@@ -177,6 +178,34 @@ describe("MCPConfigBlock", () => {
       expect(
         screen.getByRole("button", { name: "copyClaudeOAuthCommand" }),
       ).toBeEnabled();
+    });
+
+    it("uses the explicit mcpBaseUrl prop for the command instead of stripping mcpUrl", () => {
+      // The caller passes its already-computed bare URL; the command must use
+      // it verbatim (no regex on mcpUrl), even if it differs from what
+      // stripping the workspace-scoped mcpUrl would produce.
+      render(
+        <MCPConfigBlock
+          apiKey={VISIBLE_KEY}
+          mcpUrl={MCP_URL}
+          mcpBaseUrl="https://memory.kagura-ai.com/mcp"
+        />,
+      );
+      expect(screen.getByText(OAUTH_CMD)).toBeInTheDocument();
+    });
+  });
+
+  describe("toBareMcpUrl", () => {
+    it("strips a trailing /w/<workspaceId> suffix", () => {
+      expect(toBareMcpUrl("https://memory.kagura-ai.com/mcp/w/test-ws")).toBe(
+        "https://memory.kagura-ai.com/mcp",
+      );
+    });
+
+    it("is a no-op on an already-bare /mcp URL (idempotent)", () => {
+      expect(toBareMcpUrl("http://localhost:8080/mcp")).toBe(
+        "http://localhost:8080/mcp",
+      );
     });
   });
 

--- a/frontend/src/components/credentials/MCPConfigBlock.test.tsx
+++ b/frontend/src/components/credentials/MCPConfigBlock.test.tsx
@@ -139,6 +139,47 @@ describe("MCPConfigBlock", () => {
     });
   });
 
+  describe("Claude Code OAuth one-liner (#988)", () => {
+    const OAUTH_CMD =
+      "claude mcp add --transport http kagura-memory https://memory.kagura-ai.com/mcp";
+
+    it("renders the env-derived `claude mcp add` command using the bare /mcp endpoint", () => {
+      render(<MCPConfigBlock apiKey={VISIBLE_KEY} mcpUrl={MCP_URL} />);
+      // claude-code is the default tab. The OAuth one-liner targets the bare
+      // /mcp endpoint (OAuth resolves the workspace at login), so the
+      // /w/<id> suffix from the workspace-scoped mcpUrl must be stripped.
+      expect(screen.getByText(OAUTH_CMD)).toBeInTheDocument();
+      expect(
+        screen.queryByText(/claude mcp add[^\n]*\/w\/test-ws/),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render the OAuth one-liner on the chatgpt tab", () => {
+      localStorageStore["kagura_last_mcp_client"] = "chatgpt";
+      render(<MCPConfigBlock apiKey={VISIBLE_KEY} mcpUrl={MCP_URL} />);
+      expect(screen.queryByText(/claude mcp add/)).not.toBeInTheDocument();
+    });
+
+    it("copies the OAuth command via its copy button", async () => {
+      render(<MCPConfigBlock apiKey={VISIBLE_KEY} mcpUrl={MCP_URL} />);
+      fireEvent.click(
+        screen.getByRole("button", { name: "copyClaudeOAuthCommand" }),
+      );
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(mockWriteText).toHaveBeenCalledWith(OAUTH_CMD);
+    });
+
+    it("is available even when the API-key window is closed (OAuth needs no key)", () => {
+      render(<MCPConfigBlock apiKey={HIDDEN_KEY} mcpUrl={MCP_URL} />);
+      expect(screen.getByText(OAUTH_CMD)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "copyClaudeOAuthCommand" }),
+      ).toBeEnabled();
+    });
+  });
+
   describe("client tabs", () => {
     // Note on test approach: Radix Tabs Triggers do not respond cleanly to
     // fireEvent.click in happy-dom (they rely on pointer events). Rather

--- a/frontend/src/components/credentials/MCPConfigBlock.test.tsx
+++ b/frontend/src/components/credentials/MCPConfigBlock.test.tsx
@@ -72,6 +72,13 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   });
+  // copyText (issue #987) falls back to execCommand when writeText rejects.
+  // Default it to "unavailable" so the copy-failure tests are deterministic.
+  Object.defineProperty(document, "execCommand", {
+    value: vi.fn(() => false),
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {
@@ -244,36 +251,42 @@ describe("MCPConfigBlock", () => {
       });
     });
 
-    it("clipboard write failures fire a destructive toast with the common error title (not the success title)", async () => {
+    it("hard copy failure fires a destructive toast with the actionable hint (not the success title)", async () => {
+      // writeText rejects AND the execCommand fallback is unavailable
+      // (returns false, per beforeEach) → copyText throws.
       mockWriteText.mockRejectedValueOnce(new Error("clipboard denied"));
       render(<MCPConfigBlock apiKey={VISIBLE_KEY} mcpUrl={MCP_URL} />);
       fireEvent.click(screen.getByRole("button", { name: "copyConfig" }));
       await act(async () => {
         await Promise.resolve();
+        await Promise.resolve();
       });
 
-      // Note: the test mocks useTranslations to return the key as-is,
-      // so "error" here is the tCommon namespace key (not "mcpConfigCopied").
+      // Note: the test mocks useTranslations to return the key as-is, so
+      // "error"/"copyFailedManualHint" are the tCommon namespace keys. The
+      // raw DOM exception string must NOT leak into the toast (issue #987).
       expect(mockToast).toHaveBeenCalledWith({
         title: "error",
-        description: "clipboard denied",
+        description: "copyFailedManualHint",
         variant: "destructive",
       });
     });
 
-    it("non-Error rejections produce a usable description (not empty)", async () => {
-      // Some clipboard implementations reject with strings or DOMException
-      // — verify we narrow safely instead of hitting an undefined .message.
+    it("non-Error rejections still produce the actionable hint (no crash, not empty)", async () => {
+      // Some clipboard implementations reject with strings or DOMException —
+      // copyText normalizes any failure to a typed error, so the toast shows
+      // the actionable hint rather than an undefined/empty description.
       mockWriteText.mockRejectedValueOnce("permission denied");
       render(<MCPConfigBlock apiKey={VISIBLE_KEY} mcpUrl={MCP_URL} />);
       fireEvent.click(screen.getByRole("button", { name: "copyConfig" }));
       await act(async () => {
         await Promise.resolve();
+        await Promise.resolve();
       });
 
       expect(mockToast).toHaveBeenCalledWith({
         title: "error",
-        description: "permission denied",
+        description: "copyFailedManualHint",
         variant: "destructive",
       });
     });

--- a/frontend/src/components/credentials/MCPConfigBlock.tsx
+++ b/frontend/src/components/credentials/MCPConfigBlock.tsx
@@ -337,13 +337,14 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
         title: t("mcpConfigCopied"),
         description: t("mcpConfigCopiedHint"),
       });
-    } catch (err) {
-      // Use the common error title (NOT the success title) and narrow err
-      // safely so non-Error rejections (DOMException, strings) don't
-      // produce empty descriptions.
+    } catch {
+      // Use the common error title (NOT the success title). copyText already
+      // tried the execCommand fallback (issue #987), so show an actionable
+      // hint instead of leaking the raw DOM exception string — the config
+      // snippet is visible in the <pre> block for manual copy.
       toast({
         title: tCommon("error"),
-        description: err instanceof Error ? err.message : String(err),
+        description: tCommon("copyFailedManualHint"),
         variant: "destructive",
       });
     }
@@ -358,10 +359,12 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
         title: t("mcpConfigCopied"),
         description: t("mcpConfigCopiedHint"),
       });
-    } catch (err) {
+    } catch {
+      // copyText already tried the execCommand fallback (issue #987); show an
+      // actionable hint instead of the raw DOM exception string.
       toast({
         title: tCommon("error"),
-        description: err instanceof Error ? err.message : String(err),
+        description: tCommon("copyFailedManualHint"),
         variant: "destructive",
       });
     }
@@ -387,10 +390,12 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
         title: t("codexInstallCopied"),
         description: t("mcpConfigCopiedHint"),
       });
-    } catch (err) {
+    } catch {
+      // copyText already tried the execCommand fallback (issue #987); show an
+      // actionable hint instead of the raw DOM exception string.
       toast({
         title: tCommon("error"),
-        description: err instanceof Error ? err.message : String(err),
+        description: tCommon("copyFailedManualHint"),
         variant: "destructive",
       });
     }

--- a/frontend/src/components/credentials/MCPConfigBlock.tsx
+++ b/frontend/src/components/credentials/MCPConfigBlock.tsx
@@ -68,6 +68,22 @@ const PLACEHOLDER_KEY = "YOUR_API_KEY";
 export const CODEX_INSTALL_COMMAND =
   "codex plugin install kagura-memory@kagura-memory-cloud";
 
+/**
+ * Strip the workspace-scoped `/w/<workspaceId>` suffix from an MCP URL,
+ * yielding the bare `…/mcp` endpoint the Claude Code OAuth one-liner targets
+ * (OAuth resolves the workspace at login — issue #988). Idempotent: a URL that
+ * is already bare passes through unchanged.
+ *
+ * This is the single source of the derivation. Prefer passing the bare URL
+ * directly via the `mcpBaseUrl` prop (the caller in APIKeysTabPanel already
+ * computes `baseUrl + "/mcp"`); this helper is the fallback when only the
+ * workspace-scoped URL is available, and keeps the regex in one tested place
+ * instead of inlined at each future call site.
+ */
+export function toBareMcpUrl(mcpUrl: string): string {
+  return mcpUrl.replace(/\/w\/[^/]+$/, "");
+}
+
 export interface MCPConfigBlockProps {
   /**
    * The user's API key. `null` when no key has been created yet OR the
@@ -77,6 +93,13 @@ export interface MCPConfigBlockProps {
   apiKey: MemberAPIKey | null;
   /** The MCP endpoint URL the JSON snippet should embed. */
   mcpUrl: string;
+  /**
+   * The bare `…/mcp` endpoint (no `/w/<workspaceId>` suffix) for the OAuth
+   * one-liner. Optional: when omitted it is derived from `mcpUrl` via
+   * {@link toBareMcpUrl}. The caller passes its already-computed base URL so
+   * the production path needs no regex.
+   */
+  mcpBaseUrl?: string;
 }
 
 function readStoredClient(): MCPClient {
@@ -217,7 +240,11 @@ export function buildTomlConfig(mcpUrl: string, authValue: string): string {
   ].join("\n");
 }
 
-export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
+export function MCPConfigBlock({
+  apiKey,
+  mcpUrl,
+  mcpBaseUrl,
+}: MCPConfigBlockProps) {
   const t = useTranslations("apiKeys");
   const tCommon = useTranslations("common");
   const { toast } = useToast();
@@ -326,8 +353,8 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
   // copies even when the key window is closed.
   const claudeOAuthCommand = useMemo(
     () =>
-      `claude mcp add --transport http kagura-memory ${mcpUrl.replace(/\/w\/[^/]+$/, "")}`,
-    [mcpUrl],
+      `claude mcp add --transport http kagura-memory ${mcpBaseUrl ?? toBareMcpUrl(mcpUrl)}`,
+    [mcpBaseUrl, mcpUrl],
   );
 
   // Track which Copy button the user pressed last, so the Check icon only
@@ -340,20 +367,26 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
     "json" | "toml" | "install" | "oauth" | null
   >(null);
 
-  const handleCopy = async () => {
-    if (copyJson === null) return;
+  // Single copy path for all four buttons. They differ only in the value
+  // copied, the per-target "copied" affordance (`target`), and the success
+  // title; the guard (skip when the value is null/disabled), the routing
+  // through useRevealableSecret.copy → copyText (#987 execCommand fallback,
+  // and cancellation of any prior 60s auto-clear so a pending timer can't wipe
+  // the freshly-copied value), and the destructive failure toast are identical.
+  // On hard failure copyText has already exhausted its fallback, so we surface
+  // an actionable i18n hint (the snippet stays visible in the <pre> for manual
+  // copy) rather than leaking the raw DOM exception string.
+  const runCopy = async (
+    value: string | null,
+    target: "json" | "toml" | "install" | "oauth",
+    successTitle: string,
+  ) => {
+    if (value === null) return;
     try {
-      await copy(copyJson);
-      setLastCopied("json");
-      toast({
-        title: t("mcpConfigCopied"),
-        description: t("mcpConfigCopiedHint"),
-      });
+      await copy(value);
+      setLastCopied(target);
+      toast({ title: successTitle, description: t("mcpConfigCopiedHint") });
     } catch {
-      // Use the common error title (NOT the success title). copyText already
-      // tried the execCommand fallback (issue #987), so show an actionable
-      // hint instead of leaking the raw DOM exception string — the config
-      // snippet is visible in the <pre> block for manual copy.
       toast({
         title: tCommon("error"),
         description: tCommon("copyFailedManualHint"),
@@ -362,77 +395,12 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
     }
   };
 
-  const handleTomlCopy = async () => {
-    if (copyToml === null) return;
-    try {
-      await copy(copyToml);
-      setLastCopied("toml");
-      toast({
-        title: t("mcpConfigCopied"),
-        description: t("mcpConfigCopiedHint"),
-      });
-    } catch {
-      // copyText already tried the execCommand fallback (issue #987); show an
-      // actionable hint instead of the raw DOM exception string.
-      toast({
-        title: tCommon("error"),
-        description: tCommon("copyFailedManualHint"),
-        variant: "destructive",
-      });
-    }
-  };
-
-  const handleInstallCopy = async () => {
-    // Route through useRevealableSecret.copy so the hook cancels any
-    // pending auto-clear from a prior JSON/TOML copy — otherwise that
-    // 60s timer would fire after the install command lands in the
-    // clipboard and silently wipe it before the user can paste. The
-    // install command is not a secret, but the consistent 60s auto-clear
-    // matches the other Copy buttons in this component, and the user has
-    // plenty of time to switch to a terminal and paste.
-    try {
-      await copy(CODEX_INSTALL_COMMAND);
-      setLastCopied("install");
-      // The install command routes through useRevealableSecret.copy (see
-      // comment above), so it ALSO triggers the hook's 60s clipboard
-      // auto-clear. Surface the same "clipboard clears in 60s" hint as
-      // the other Copy buttons so the user isn't surprised when their
-      // pasted command vanishes.
-      toast({
-        title: t("codexInstallCopied"),
-        description: t("mcpConfigCopiedHint"),
-      });
-    } catch {
-      // copyText already tried the execCommand fallback (issue #987); show an
-      // actionable hint instead of the raw DOM exception string.
-      toast({
-        title: tCommon("error"),
-        description: tCommon("copyFailedManualHint"),
-        variant: "destructive",
-      });
-    }
-  };
-
-  const handleOAuthCopy = async () => {
-    // Route through useRevealableSecret.copy → copyText (#987) for the shared
-    // execCommand fallback. The command is not a secret; routing through the
-    // hook keeps the per-target "copied" affordance consistent with the other
-    // buttons and lets the hook cancel any prior pending auto-clear.
-    try {
-      await copy(claudeOAuthCommand);
-      setLastCopied("oauth");
-      toast({
-        title: t("claudeOAuthCopied"),
-        description: t("mcpConfigCopiedHint"),
-      });
-    } catch {
-      toast({
-        title: tCommon("error"),
-        description: tCommon("copyFailedManualHint"),
-        variant: "destructive",
-      });
-    }
-  };
+  const handleCopy = () => runCopy(copyJson, "json", t("mcpConfigCopied"));
+  const handleTomlCopy = () => runCopy(copyToml, "toml", t("mcpConfigCopied"));
+  const handleInstallCopy = () =>
+    runCopy(CODEX_INSTALL_COMMAND, "install", t("codexInstallCopied"));
+  const handleOAuthCopy = () =>
+    runCopy(claudeOAuthCommand, "oauth", t("claudeOAuthCopied"));
 
   return (
     <div className="space-y-3" suppressHydrationWarning>

--- a/frontend/src/components/credentials/MCPConfigBlock.tsx
+++ b/frontend/src/components/credentials/MCPConfigBlock.tsx
@@ -318,6 +318,18 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
     return buildTomlConfig(mcpUrl, liveKey);
   }, [mcpUrl, liveKey]);
 
+  // Claude Code OAuth one-liner (#988). Targets the BARE /mcp endpoint —
+  // OAuth resolves the workspace at login, so the workspace-scoped
+  // `/w/<workspaceId>` suffix is stripped (if mcpUrl is already bare, the
+  // regex is a no-op). The command is env-aware via mcpUrl (localhost in dev,
+  // the production host in prod) and needs no API key, so it renders and
+  // copies even when the key window is closed.
+  const claudeOAuthCommand = useMemo(
+    () =>
+      `claude mcp add --transport http kagura-memory ${mcpUrl.replace(/\/w\/[^/]+$/, "")}`,
+    [mcpUrl],
+  );
+
   // Track which Copy button the user pressed last, so the Check icon only
   // flashes on the button they actually clicked. Without this, the shared
   // `copied` flag from useRevealableSecret causes the Codex tab's install
@@ -325,7 +337,7 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
   // (Copilot review flagged this on PR #817). The hook still owns the 2s
   // timer; this just disambiguates the visual target.
   const [lastCopied, setLastCopied] = useState<
-    "json" | "toml" | "install" | null
+    "json" | "toml" | "install" | "oauth" | null
   >(null);
 
   const handleCopy = async () => {
@@ -401,6 +413,27 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
     }
   };
 
+  const handleOAuthCopy = async () => {
+    // Route through useRevealableSecret.copy → copyText (#987) for the shared
+    // execCommand fallback. The command is not a secret; routing through the
+    // hook keeps the per-target "copied" affordance consistent with the other
+    // buttons and lets the hook cancel any prior pending auto-clear.
+    try {
+      await copy(claudeOAuthCommand);
+      setLastCopied("oauth");
+      toast({
+        title: t("claudeOAuthCopied"),
+        description: t("mcpConfigCopiedHint"),
+      });
+    } catch {
+      toast({
+        title: tCommon("error"),
+        description: tCommon("copyFailedManualHint"),
+        variant: "destructive",
+      });
+    }
+  };
+
   return (
     <div className="space-y-3" suppressHydrationWarning>
       <Tabs value={client} onValueChange={(v) => setClient(v as MCPClient)}>
@@ -416,7 +449,49 @@ export function MCPConfigBlock({ apiKey, mcpUrl }: MCPConfigBlockProps) {
             path because its UI is a static install command + a collapsible
             manual TOML — buildJsonConfig doesn't apply. */}
         {MCP_CLIENTS.filter((c) => c !== "codex").map((c) => (
-          <TabsContent key={c} value={c} className="mt-3">
+          <TabsContent key={c} value={c} className="mt-3 space-y-3">
+            {/* Issue #988: Claude Code OAuth one-liner (recommended) — no API
+                key needed; Claude Code runs the OAuth browser flow on first
+                use. Only for the claude-code client; ChatGPT does not use the
+                `claude mcp add` CLI. The existing .mcp.json JSON stays below as
+                the manual / API-key alternative. */}
+            {c === "claude-code" && (
+              <div>
+                <h4 className="text-sm font-medium mb-2">
+                  {t("claudeOAuthHeading")}
+                </h4>
+                <div className="relative">
+                  <pre className="bg-gray-900 text-gray-100 p-3 pr-12 rounded overflow-x-auto text-xs whitespace-pre-wrap break-all">
+                    {claudeOAuthCommand}
+                  </pre>
+                  <div className="absolute top-2 right-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={handleOAuthCopy}
+                      title={t("copyClaudeOAuthCommand")}
+                      aria-label={t("copyClaudeOAuthCommand")}
+                      className="text-gray-300 hover:text-white hover:bg-gray-700/50"
+                    >
+                      {copied && lastCopied === "oauth" ? (
+                        <Check className="w-4 h-4 text-green-400" />
+                      ) : (
+                        <Copy className="w-4 h-4" />
+                      )}
+                    </Button>
+                  </div>
+                </div>
+                <p className="text-xs text-blue-700 dark:text-blue-300 mt-2">
+                  💡 {t("claudeOAuthHint")}
+                </p>
+              </div>
+            )}
+            {c === "claude-code" && (
+              <p className="text-xs font-medium text-gray-600 dark:text-gray-400 pt-1">
+                {t("claudeManualConfigLabel")}
+              </p>
+            )}
             <div className="relative">
               <pre className="bg-gray-900 text-gray-100 p-3 pr-20 rounded overflow-x-auto text-xs whitespace-pre-wrap break-all">
                 {displayJson}

--- a/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
+++ b/frontend/src/components/resource-tokens/CreateResourceTokenDialog.tsx
@@ -8,6 +8,7 @@
 import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { Button } from "@/components/ui/button";
+import { copyText } from "@/lib/utils/clipboard";
 import {
   Dialog,
   DialogContent,
@@ -167,9 +168,16 @@ export function CreateResourceTokenDialog({
 
   const handleCopy = async () => {
     if (createdToken) {
-      await navigator.clipboard.writeText(createdToken.token);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
+      try {
+        // copyText degrades to an execCommand fallback before throwing
+        // (issue #987). The token is shown in this dialog, so on hard failure
+        // the user can still select + copy it manually.
+        await copyText(createdToken.token);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch (err) {
+        console.error("Failed to copy resource token:", err);
+      }
     }
   };
 

--- a/frontend/src/components/resource-tokens/ResourceTokensTable.tsx
+++ b/frontend/src/components/resource-tokens/ResourceTokensTable.tsx
@@ -7,6 +7,7 @@
 import { useTranslations } from 'next-intl';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { copyText } from '@/lib/utils/clipboard';
 import {
   Table,
   TableBody,
@@ -63,11 +64,13 @@ export function ResourceTokensTable({
 
   const handleCopyResourceId = async (tokenId: number, resourceId: string) => {
     try {
-      await navigator.clipboard.writeText(resourceId);
+      // copyText degrades to an execCommand fallback before throwing (#987).
+      // The resource ID is visible in the table, so a hard failure is benign.
+      await copyText(resourceId);
       setCopiedTokenId(tokenId);  // Track by token.id to avoid N:1 collision
       setTimeout(() => setCopiedTokenId(null), 2000);
-    } catch (err) {
-      // Silently fail
+    } catch {
+      // Silently fail — the value is visible for manual copy.
     }
   };
 

--- a/frontend/src/components/workspaces/WorkspaceIdField.test.tsx
+++ b/frontend/src/components/workspaces/WorkspaceIdField.test.tsx
@@ -41,6 +41,13 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   });
+  // copyText (issue #987) falls back to execCommand when writeText rejects.
+  // Default it to "unavailable" so the failure-path test is deterministic.
+  Object.defineProperty(document, "execCommand", {
+    value: vi.fn(() => false),
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {
@@ -70,17 +77,19 @@ describe("WorkspaceIdField", () => {
     });
   });
 
-  it("fires a destructive toast when the clipboard write fails", async () => {
+  it("fires a destructive toast with an actionable hint when both clipboard and fallback fail", async () => {
     mockWriteText.mockRejectedValueOnce(new Error("clipboard denied"));
     render(<WorkspaceIdField workspaceId={WORKSPACE_ID} />);
 
     fireEvent.click(screen.getByRole("button", { name: "copyWorkspaceId" }));
     await act(async () => {});
 
+    // copyText threw (writeText denied + execCommand unavailable) — the toast
+    // shows the actionable i18n hint, NOT the raw DOM exception string.
     expect(mockToast).toHaveBeenCalledWith({
       variant: "destructive",
       title: "error",
-      description: "clipboard denied",
+      description: "copyFailedManualHint",
     });
   });
 });

--- a/frontend/src/components/workspaces/WorkspaceIdField.tsx
+++ b/frontend/src/components/workspaces/WorkspaceIdField.tsx
@@ -36,13 +36,16 @@ export function WorkspaceIdField({ workspaceId }: WorkspaceIdFieldProps) {
         title: tCommon("success"),
         description: t("workspaceIdCopied"),
       });
-    } catch (err) {
+    } catch {
       // useCopyFeedback re-throws clipboard errors so callers can surface
       // them — frontend rule: button-driven action failures use a toast.
+      // copyText already tried the execCommand fallback (issue #987), so show
+      // an actionable hint rather than the raw DOM exception string. The ID is
+      // visible in its <code> block, so the user can select + copy it manually.
       toast({
         variant: "destructive",
         title: tCommon("error"),
-        description: err instanceof Error ? err.message : t("copyFailed"),
+        description: tCommon("copyFailedManualHint"),
       });
     }
   };

--- a/frontend/src/hooks/useCopyFeedback.test.ts
+++ b/frontend/src/hooks/useCopyFeedback.test.ts
@@ -28,6 +28,14 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   });
+  // copyText (issue #987) falls back to execCommand when writeText rejects.
+  // Default the fallback to "unavailable" so error-path tests are
+  // deterministic; individual tests override it to exercise the success path.
+  Object.defineProperty(document, "execCommand", {
+    value: vi.fn(() => false),
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {
@@ -190,17 +198,35 @@ describe("useCopyFeedback", () => {
     expect(result.current.isCopied("key-a")).toBe(false);
   });
 
-  it("propagates clipboard.writeText errors to the caller", async () => {
+  it("propagates the error to the caller when both clipboard and fallback fail", async () => {
+    // writeText rejects AND the execCommand fallback is unavailable
+    // (returns false, per beforeEach) → copyText throws ClipboardCopyError.
     mockWriteText.mockRejectedValueOnce(new Error("clipboard denied"));
     const { result } = renderHook(() => useCopyFeedback());
 
     await act(async () => {
-      await expect(result.current.copyToTarget("x", "key-a")).rejects.toThrow(
-        "clipboard denied",
-      );
+      await expect(
+        result.current.copyToTarget("x", "key-a"),
+      ).rejects.toThrow();
     });
     // The key should NOT be flagged as copied on failure
     expect(result.current.isCopied("key-a")).toBe(false);
+  });
+
+  it("succeeds via the execCommand fallback when writeText is denied", async () => {
+    // The async clipboard write is denied, but the legacy fallback works —
+    // the user-visible result is a successful copy (issue #987).
+    mockWriteText.mockRejectedValueOnce(
+      new DOMException("Write permission denied", "NotAllowedError"),
+    );
+    (document.execCommand as ReturnType<typeof vi.fn>).mockReturnValue(true);
+    const { result } = renderHook(() => useCopyFeedback());
+
+    await act(async () => {
+      await result.current.copyToTarget("x", "key-a");
+    });
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+    expect(result.current.isCopied("key-a")).toBe(true);
   });
 
   it("does not fire timers after unmount", async () => {

--- a/frontend/src/hooks/useCopyFeedback.ts
+++ b/frontend/src/hooks/useCopyFeedback.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { copyText } from "@/lib/utils/clipboard";
 
 /**
  * Default duration to show the "copied" feedback affordance after a
@@ -90,7 +91,9 @@ export function useCopyFeedback(): UseCopyFeedbackReturn {
       // Re-throws on failure so the caller can fire a destructive toast.
       // We do not attempt to recover here — the caller's error handler
       // owns the user-facing surface (toast vs inline message vs banner).
-      await navigator.clipboard.writeText(text);
+      // copyText degrades to an execCommand fallback before it throws
+      // (issue #987), so a denied async-clipboard write no longer dead-ends.
+      await copyText(text);
 
       if (!isMountedRef.current) return;
 

--- a/frontend/src/hooks/useRevealableSecret.test.ts
+++ b/frontend/src/hooks/useRevealableSecret.test.ts
@@ -27,6 +27,15 @@ beforeEach(() => {
     writable: true,
     configurable: true,
   });
+  // copyText (issue #987) falls back to execCommand when writeText rejects.
+  // Default the fallback to "unavailable" so the copy() error-path tests are
+  // deterministic. The auto-clear path is unchanged (it calls writeText("")
+  // directly, not copyText), so the auto-clear tests are unaffected.
+  Object.defineProperty(document, "execCommand", {
+    value: vi.fn(() => false),
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {
@@ -101,14 +110,27 @@ describe("useRevealableSecret", () => {
       expect(result.current.copied).toBe(false);
     });
 
-    it("propagates clipboard.writeText errors", async () => {
+    it("propagates the error when both clipboard and fallback fail", async () => {
+      // writeText rejects AND the execCommand fallback is unavailable
+      // (returns false, per beforeEach) → copyText throws.
       mockWriteText.mockRejectedValueOnce(new Error("clipboard denied"));
       const { result } = renderHook(() => useRevealableSecret());
       await act(async () => {
-        await expect(result.current.copy("x")).rejects.toThrow(
-          "clipboard denied",
-        );
+        await expect(result.current.copy("x")).rejects.toThrow();
       });
+    });
+
+    it("succeeds via the execCommand fallback when writeText is denied", async () => {
+      mockWriteText.mockRejectedValueOnce(
+        new DOMException("Write permission denied", "NotAllowedError"),
+      );
+      (document.execCommand as ReturnType<typeof vi.fn>).mockReturnValue(true);
+      const { result } = renderHook(() => useRevealableSecret());
+      await act(async () => {
+        await result.current.copy("secret-value");
+      });
+      expect(document.execCommand).toHaveBeenCalledWith("copy");
+      expect(result.current.copied).toBe(true);
     });
 
     it("preserves previous copy's copied state when a re-copy within the feedback window fails", async () => {
@@ -126,7 +148,7 @@ describe("useRevealableSecret", () => {
       });
       mockWriteText.mockRejectedValueOnce(new Error("denied"));
       await act(async () => {
-        await expect(result.current.copy("second")).rejects.toThrow("denied");
+        await expect(result.current.copy("second")).rejects.toThrow();
       });
 
       // CRITICAL: copied must STILL be true — the first copy's feedback
@@ -156,9 +178,11 @@ describe("useRevealableSecret", () => {
       });
       mockWriteText.mockRejectedValueOnce(new Error("denied"));
       await act(async () => {
-        await expect(result.current.copy("second")).rejects.toThrow("denied");
+        await expect(result.current.copy("second")).rejects.toThrow();
       });
       // 2 calls: "first" (success) + "second" (rejected). NO timer cancellation.
+      // The execCommand fallback for "second" uses a separate API, so the
+      // writeText call count is unaffected.
       expect(mockWriteText).toHaveBeenCalledTimes(2);
 
       // Wait for the ORIGINAL 60s auto-clear (30s more from now)

--- a/frontend/src/hooks/useRevealableSecret.ts
+++ b/frontend/src/hooks/useRevealableSecret.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import { copyText } from "@/lib/utils/clipboard";
 
 /**
  * Default duration to keep the "copied" UI affordance visible after a copy.
@@ -121,12 +122,10 @@ export function useRevealableSecret(
       //
       // Re-throws on failure so the caller can show a destructive toast
       // (clipboard write failure is a user-visible action failure, not
-      // a defense-in-depth background event).
-      try {
-        await navigator.clipboard.writeText(text);
-      } catch (err) {
-        throw err;
-      }
+      // a defense-in-depth background event). copyText degrades to an
+      // execCommand fallback before throwing (issue #987), so a denied
+      // async-clipboard write no longer dead-ends one-time-reveal secrets.
+      await copyText(text);
 
       if (!isMountedRef.current) return;
 

--- a/frontend/src/lib/utils/clipboard.test.ts
+++ b/frontend/src/lib/utils/clipboard.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for the copyText clipboard utility (issue #987).
+ *
+ * Contract:
+ * - Prefer the async Clipboard API (navigator.clipboard.writeText).
+ * - Fall back to the legacy document.execCommand('copy') via a hidden
+ *   textarea when the async API is missing OR rejects (e.g. NotAllowedError
+ *   "Write permission denied" when the document is not focused / insecure
+ *   origin / embedded webview).
+ * - Throw a typed ClipboardCopyError only when BOTH paths fail, so callers
+ *   can render an actionable, i18n'd message instead of a raw DOM exception.
+ * - The fallback textarea (which may transiently hold a plaintext secret) is
+ *   removed synchronously and prior focus is restored.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { copyText, ClipboardCopyError } from "./clipboard";
+
+const mockWriteText = vi.fn();
+
+function setClipboard(value: unknown) {
+  Object.defineProperty(navigator, "clipboard", {
+    value,
+    writable: true,
+    configurable: true,
+  });
+}
+
+beforeEach(() => {
+  mockWriteText.mockReset();
+  mockWriteText.mockResolvedValue(undefined);
+  setClipboard({ writeText: mockWriteText });
+  // jsdom does not implement execCommand; provide a controllable stub.
+  Object.defineProperty(document, "execCommand", {
+    value: vi.fn(() => true),
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("copyText", () => {
+  it("writes via the async Clipboard API when available", async () => {
+    await copyText("hello");
+    expect(mockWriteText).toHaveBeenCalledWith("hello");
+    expect(document.execCommand).not.toHaveBeenCalled();
+  });
+
+  it("falls back to execCommand('copy') when writeText rejects (NotAllowedError)", async () => {
+    mockWriteText.mockRejectedValueOnce(
+      new DOMException("Write permission denied", "NotAllowedError"),
+    );
+    await copyText("api-key-value");
+    expect(mockWriteText).toHaveBeenCalledWith("api-key-value");
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("falls back to execCommand when the async Clipboard API is absent", async () => {
+    setClipboard(undefined);
+    await copyText("value");
+    expect(document.execCommand).toHaveBeenCalledWith("copy");
+  });
+
+  it("throws ClipboardCopyError when both paths fail", async () => {
+    mockWriteText.mockRejectedValueOnce(new Error("denied"));
+    (document.execCommand as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    await expect(copyText("x")).rejects.toBeInstanceOf(ClipboardCopyError);
+  });
+
+  it("throws ClipboardCopyError when no copy mechanism exists at all", async () => {
+    setClipboard(undefined);
+    (document.execCommand as ReturnType<typeof vi.fn>).mockReturnValue(false);
+    await expect(copyText("x")).rejects.toBeInstanceOf(ClipboardCopyError);
+  });
+
+  it("removes the fallback textarea synchronously (no plaintext lingers in the DOM)", async () => {
+    setClipboard(undefined);
+    await copyText("super-secret");
+    expect(document.querySelector("textarea")).toBeNull();
+    // The secret must not be findable anywhere in the DOM after the copy.
+    expect(document.body.innerHTML).not.toContain("super-secret");
+  });
+
+  it("removes the fallback textarea even when execCommand throws", async () => {
+    setClipboard(undefined);
+    (document.execCommand as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("execCommand blew up");
+    });
+    await expect(copyText("secret")).rejects.toBeInstanceOf(ClipboardCopyError);
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+
+  it("restores focus to the previously focused element after the fallback", async () => {
+    setClipboard(undefined);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+
+    await copyText("value");
+
+    expect(document.activeElement).toBe(input);
+    input.remove();
+  });
+});

--- a/frontend/src/lib/utils/clipboard.ts
+++ b/frontend/src/lib/utils/clipboard.ts
@@ -1,0 +1,127 @@
+/**
+ * Clipboard copy utility with graceful degradation (issue #987).
+ *
+ * The async Clipboard API (`navigator.clipboard.writeText`) is the preferred
+ * path, but it requires a secure context AND a focused document. When the
+ * browser denies the write it throws `NotAllowedError: Failed to execute
+ * 'writeText' on 'Clipboard': Write permission denied.` — which happens when
+ * DevTools is the focused surface, the tab is backgrounded, the origin is an
+ * insecure non-localhost `http://`, or inside hardened/embedded webviews.
+ *
+ * Previously both copy hooks called `navigator.clipboard.writeText` directly
+ * with no fallback, so any denial surfaced the raw DOM exception in a toast
+ * and left the user with no way to copy — a dead end for one-time-reveal API
+ * keys. `copyText` adds a legacy `document.execCommand('copy')` fallback and a
+ * typed error so callers can render an actionable, i18n'd message.
+ */
+
+/**
+ * Thrown when `copyText` exhausts both the async Clipboard API and the legacy
+ * `execCommand` fallback (or runs where neither exists, e.g. SSR). Callers in
+ * a user-action context catch this and surface a friendly, i18n'd message;
+ * best-effort callers (clipboard auto-clear) catch and ignore it.
+ */
+export class ClipboardCopyError extends Error {
+  /** The underlying error from the primary (async clipboard) attempt, if any. */
+  readonly cause?: unknown;
+
+  constructor(message = "clipboard_copy_failed", cause?: unknown) {
+    super(message);
+    this.name = "ClipboardCopyError";
+    this.cause = cause;
+  }
+}
+
+/**
+ * Copy `text` to the clipboard, degrading gracefully across environments.
+ *
+ * Attempt order:
+ * 1. `navigator.clipboard.writeText` — preferred (secure context + focus).
+ * 2. `document.execCommand('copy')` via a hidden, off-screen `<textarea>` —
+ *    covers denial, insecure origins, and embedded webviews.
+ *
+ * Resolves on the first success. Throws {@link ClipboardCopyError} only when
+ * every available mechanism fails. The fallback textarea transiently holds
+ * `text` (which may be a plaintext secret), so it is removed synchronously in
+ * a `finally` block and prior focus/selection is restored.
+ *
+ * @param text - the string to place on the clipboard.
+ * @throws ClipboardCopyError when no mechanism succeeds.
+ */
+export async function copyText(text: string): Promise<void> {
+  // SSR / non-DOM guard: there is no clipboard or document to copy into.
+  if (typeof document === "undefined") {
+    throw new ClipboardCopyError("clipboard_unavailable");
+  }
+
+  let primaryError: unknown;
+
+  // 1. Async Clipboard API. Access via a local so a throwing property getter
+  //    (some hardened environments) degrades to the fallback instead of
+  //    crashing.
+  let clipboard: Clipboard | undefined;
+  try {
+    clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+  } catch {
+    clipboard = undefined;
+  }
+
+  if (clipboard && typeof clipboard.writeText === "function") {
+    try {
+      await clipboard.writeText(text);
+      return;
+    } catch (err) {
+      // Remember the cause, then fall through to the legacy fallback.
+      primaryError = err;
+    }
+  }
+
+  // 2. Legacy execCommand fallback.
+  if (legacyExecCommandCopy(text)) {
+    return;
+  }
+
+  throw new ClipboardCopyError("clipboard_copy_failed", primaryError);
+}
+
+/**
+ * Synchronous legacy copy via a hidden textarea + `document.execCommand('copy')`.
+ * Returns `true` on success, `false` otherwise. Never throws — any DOM
+ * exception is treated as "fallback unavailable". Restores prior focus so the
+ * user's caret position is not disturbed.
+ */
+function legacyExecCommandCopy(text: string): boolean {
+  if (typeof document.execCommand !== "function") {
+    return false;
+  }
+
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+  const textarea = document.createElement("textarea");
+
+  try {
+    textarea.value = text;
+    // Keep it out of view and out of layout/scroll, but still selectable.
+    textarea.setAttribute("readonly", "");
+    textarea.setAttribute("aria-hidden", "true");
+    textarea.tabIndex = -1;
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    textarea.style.left = "-9999px";
+    textarea.style.opacity = "0";
+
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+
+    return document.execCommand("copy") === true;
+  } catch {
+    return false;
+  } finally {
+    // Synchronous teardown — the textarea holds the (possibly secret) value
+    // and must never linger in the DOM. Restore prior focus afterwards.
+    textarea.remove();
+    if (previouslyFocused && typeof previouslyFocused.focus === "function") {
+      previouslyFocused.focus();
+    }
+  }
+}

--- a/frontend/src/lib/utils/index.ts
+++ b/frontend/src/lib/utils/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { cn } from './cn';
+export { copyText, ClipboardCopyError } from './clipboard';

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -30,6 +30,7 @@
     "loading": "Loading...",
     "error": "Error",
     "success": "Success",
+    "copyFailedManualHint": "Couldn't copy automatically. The value stays visible — select it and copy manually.",
     "confirm": "Confirm",
     "back": "Back",
     "next": "Next",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1554,6 +1554,11 @@
     "mcpConfigCopied": "Config copied",
     "mcpConfigCopiedHint": "Clipboard clears in 60 seconds — paste it now.",
     "mcpConfigHiddenCopyDisabled": "Regenerate the key to copy a working config",
+    "claudeOAuthHeading": "Add via OAuth (recommended)",
+    "claudeOAuthHint": "No API key needed — Claude Code opens the OAuth sign-in in your browser on first use.",
+    "copyClaudeOAuthCommand": "Copy command",
+    "claudeOAuthCopied": "Command copied",
+    "claudeManualConfigLabel": "Or configure manually with .mcp.json (API key):",
     "clients": {
       "claudeCode": "Claude Code",
       "chatgpt": "ChatGPT",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1554,6 +1554,11 @@
     "mcpConfigCopied": "設定をコピーしました",
     "mcpConfigCopiedHint": "クリップボードは 60 秒後に消去されます。今すぐ貼り付けてください。",
     "mcpConfigHiddenCopyDisabled": "動作する設定をコピーするにはキーを再生成してください",
+    "claudeOAuthHeading": "OAuth で追加 (推奨)",
+    "claudeOAuthHint": "API キー不要 — 初回利用時に Claude Code がブラウザで OAuth ログインを開きます。",
+    "copyClaudeOAuthCommand": "コマンドをコピー",
+    "claudeOAuthCopied": "コマンドをコピーしました",
+    "claudeManualConfigLabel": "または .mcp.json で手動設定 (API キー):",
     "clients": {
       "claudeCode": "Claude Code",
       "chatgpt": "ChatGPT",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -30,6 +30,7 @@
     "loading": "読み込み中...",
     "error": "エラー",
     "success": "成功",
+    "copyFailedManualHint": "自動でコピーできませんでした。値は表示されたままです。選択して手動でコピーしてください。",
     "confirm": "確認",
     "back": "戻る",
     "next": "次へ",


### PR DESCRIPTION
Closes #988.

> ⚠️ **Stacked on #987** ([PR #997](https://github.com/kagura-ai/memory-cloud/pull/997)). This branch contains #987's clipboard commit as a base; merge #987 first, then this branch will be rebased onto `main`. Review only the `feat`/`refactor` commits here.

## What
Adds the Claude Code OAuth one-liner to the MCP setup guide so users can connect without manually editing `.mcp.json` or pasting an API key:

```
claude mcp add --transport http kagura-memory <bare /mcp endpoint>
```

- Rendered at the top of the **Claude Code** tab only (ChatGPT does not use the `claude mcp add` CLI). The existing `.mcp.json` JSON stays below as the manual / API-key alternative.
- **Env-aware**: the endpoint is derived from `mcpUrl` (localhost in dev, the production host in prod).
- **Workspace-agnostic**: targets the **bare** `…/mcp` (OAuth resolves the workspace at login), so the `/w/<workspaceId>` suffix is stripped. Independent of the API key — renders and copies even when the key window is closed.

### Review follow-up (second commit)
- `toBareMcpUrl()` — the `/w/<id>`-stripping regex is extracted into one documented, unit-tested helper. An optional `mcpBaseUrl` prop lets `APIKeysTabPanel` (which already computes `baseUrl + "/mcp"`) pass the bare URL directly, so the **production path no longer regex-strips**; the helper is the fallback.
- `runCopy()` factory — the four near-identical copy handlers (json / toml / install / oauth) collapse into one parameterized path (guard + hook routing + failure toast were identical).

## Tests
4 OAuth render/copy tests + `toBareMcpUrl` unit tests (strip + idempotent) + explicit-`mcpBaseUrl` path. `tsc` clean; verified live in the local app (OAuth command renders the bare `http://localhost:8080/mcp`, manual JSON keeps the workspace-scoped URL).
