### PR TITLE
test(infra): verify_workers_blocked bats + CI shellcheck (#1000)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,25 @@ jobs:
       - name: Models no-Column guard
         run: make lint-models-no-column
 
+  # Shell-script quality gate for the blue-green deploy script. shellcheck
+  # catches the `set -e` / quoting bug class behind #986 (a bare
+  # `var=$(curl ...)` dying silently); the bats suite pins the three
+  # verify_workers_blocked branches so that regression cannot return (#1000).
+  shell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # shellcheck is preinstalled on ubuntu-latest; bats is not.
+      - name: Install bats
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq bats
+
+      - name: ShellCheck deploy.sh
+        run: shellcheck terraform/single-server/scripts/deploy.sh
+
+      - name: Bats — verify_workers_blocked regression suite
+        run: bats terraform/single-server/scripts/tests/
+
   backend-unit:
     runs-on: ubuntu-latest
     services:

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -29,7 +29,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 COMPOSE_FILE="$PROJECT_DIR/docker-compose.prod.yml"
-CADDYFILE_TPL="$PROJECT_DIR/Caddyfile.tpl"
+CADDYFILE_TPL="${CADDYFILE_TPL:-$PROJECT_DIR/Caddyfile.tpl}"
 CADDYFILE="$PROJECT_DIR/Caddyfile"
 MARKER_FILE="/opt/kagura-memory/active-color"
 ENV_FILE="$PROJECT_DIR/.env.prod"
@@ -41,6 +41,11 @@ WEB_READINESS_TIMEOUT="${WEB_READINESS_TIMEOUT:-30}"  # seconds to wait for kagu
 WEB_READINESS_INTERVAL="${WEB_READINESS_INTERVAL:-2}" # seconds between web checks
 WORKERS_GATE_TIMEOUT="${WORKERS_GATE_TIMEOUT:-30}"    # seconds to wait for /api/v1/workers/* to be blocked at Caddy
 WORKERS_GATE_INTERVAL="${WORKERS_GATE_INTERVAL:-2}"   # seconds between security-gate checks
+
+# curl indirection: the security-gate probe runs through "$CURL" so the bats
+# suite can inject a stub (tests/deploy_verify_workers_blocked.bats). Production
+# leaves it unset and resolves to the real curl — behaviour is unchanged.
+CURL="${CURL:-curl}"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -314,6 +319,9 @@ generate_caddyfile() {
     # file into the caddy container. mv changes the inode, so the container
     # would keep seeing the old file. cp overwrites in-place, preserving
     # the inode that Docker tracks.
+    # shellcheck disable=SC2016  # the single-quoted '${API_UPSTREAM}' is the
+    # var-list ARGUMENT to envsubst (it must stay literal so envsubst knows
+    # which placeholder to expand) — it is intentionally NOT a shell expansion.
     if ! API_UPSTREAM="$upstream" envsubst '${API_UPSTREAM}' < "$CADDYFILE_TPL" > "$CADDYFILE.tmp"; then
         rm -f "$CADDYFILE.tmp"
         error "envsubst failed — Caddyfile not updated"
@@ -364,7 +372,7 @@ verify_workers_blocked() {
         # Caddy selects the correct vhost. A plain -H "Host:" with 127.0.0.1
         # in the URL leaves SNI as "127.0.0.1" and Caddy may not match the
         # site block.
-        http_status=$(curl -sk -o /dev/null -w "%{http_code}" \
+        http_status=$("$CURL" -sk -o /dev/null -w "%{http_code}" \
             --max-time 5 \
             --resolve "${domain}:443:127.0.0.1" \
             "https://${domain}/api/v1/workers/config" 2>/dev/null || true)
@@ -405,67 +413,77 @@ cmd_generate_caddyfile() {
 # ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
-cd "$PROJECT_DIR"
+# Wrapped in main() + guarded by the BASH_SOURCE check so the bats suite can
+# `source` this script to unit-test individual functions (e.g.
+# verify_workers_blocked) WITHOUT running a real deploy. When executed
+# directly, $0 == ${BASH_SOURCE[0]} and main runs exactly as before.
+main() {
+    cd "$PROJECT_DIR"
 
-# Final-status line on every exit path (#986). Installed before prerequisite
-# validation so even an early set -e death reports where it aborted.
-trap 'on_exit $?' EXIT
+    # Final-status line on every exit path (#986). Installed before prerequisite
+    # validation so even an early set -e death reports where it aborted.
+    trap 'on_exit $?' EXIT
 
-# Validate prerequisites
-command -v envsubst > /dev/null 2>&1 || error "envsubst not found. Install: apt-get install gettext-base"
-[ -f "$COMPOSE_FILE" ] || error "docker-compose.prod.yml not found at $COMPOSE_FILE"
-[ -f "$ENV_FILE" ] || error ".env.prod not found at $ENV_FILE"
-# Note: `timeout` (coreutils) is also required, but only by --web — it is
-# validated inside cmd_deploy_web so other deploy paths remain usable on
-# environments without it.
+    # Validate prerequisites
+    command -v envsubst > /dev/null 2>&1 || error "envsubst not found. Install: apt-get install gettext-base"
+    [ -f "$COMPOSE_FILE" ] || error "docker-compose.prod.yml not found at $COMPOSE_FILE"
+    [ -f "$ENV_FILE" ] || error ".env.prod not found at $ENV_FILE"
+    # Note: `timeout` (coreutils) is also required, but only by --web — it is
+    # validated inside cmd_deploy_web so other deploy paths remain usable on
+    # environments without it.
 
-# Validate tunable env vars (timeouts + intervals) are non-negative integers
-[[ "$READINESS_TIMEOUT" =~ ^[0-9]+$ ]] || error "READINESS_TIMEOUT must be an integer (got: $READINESS_TIMEOUT)"
-[[ "$DRAIN_TIMEOUT" =~ ^[0-9]+$ ]] || error "DRAIN_TIMEOUT must be an integer (got: $DRAIN_TIMEOUT)"
-[[ "$WEB_READINESS_TIMEOUT" =~ ^[0-9]+$ ]] || error "WEB_READINESS_TIMEOUT must be an integer (got: $WEB_READINESS_TIMEOUT)"
-[[ "$WEB_READINESS_INTERVAL" =~ ^[1-9][0-9]*$ ]] || error "WEB_READINESS_INTERVAL must be a positive integer >= 1 (got: $WEB_READINESS_INTERVAL); 0 would busy-loop the smoke check"
-[[ "$WORKERS_GATE_TIMEOUT" =~ ^[0-9]+$ ]] || error "WORKERS_GATE_TIMEOUT must be an integer (got: $WORKERS_GATE_TIMEOUT)"
-[[ "$WORKERS_GATE_INTERVAL" =~ ^[1-9][0-9]*$ ]] || error "WORKERS_GATE_INTERVAL must be a positive integer >= 1 (got: $WORKERS_GATE_INTERVAL); 0 would busy-loop the security gate"
+    # Validate tunable env vars (timeouts + intervals) are non-negative integers
+    [[ "$READINESS_TIMEOUT" =~ ^[0-9]+$ ]] || error "READINESS_TIMEOUT must be an integer (got: $READINESS_TIMEOUT)"
+    [[ "$DRAIN_TIMEOUT" =~ ^[0-9]+$ ]] || error "DRAIN_TIMEOUT must be an integer (got: $DRAIN_TIMEOUT)"
+    [[ "$WEB_READINESS_TIMEOUT" =~ ^[0-9]+$ ]] || error "WEB_READINESS_TIMEOUT must be an integer (got: $WEB_READINESS_TIMEOUT)"
+    [[ "$WEB_READINESS_INTERVAL" =~ ^[1-9][0-9]*$ ]] || error "WEB_READINESS_INTERVAL must be a positive integer >= 1 (got: $WEB_READINESS_INTERVAL); 0 would busy-loop the smoke check"
+    [[ "$WORKERS_GATE_TIMEOUT" =~ ^[0-9]+$ ]] || error "WORKERS_GATE_TIMEOUT must be an integer (got: $WORKERS_GATE_TIMEOUT)"
+    [[ "$WORKERS_GATE_INTERVAL" =~ ^[1-9][0-9]*$ ]] || error "WORKERS_GATE_INTERVAL must be a positive integer >= 1 (got: $WORKERS_GATE_INTERVAL); 0 would busy-loop the security gate"
 
-# Ensure marker directory exists
-mkdir -p "$(dirname "$MARKER_FILE")"
+    # Ensure marker directory exists
+    mkdir -p "$(dirname "$MARKER_FILE")"
 
-case "${1:-}" in
-    --rollback)
-        cmd_rollback
-        ;;
-    --status)
-        DEPLOY_STAGE="readonly"
-        cmd_status
-        ;;
-    --web)
-        cmd_deploy_web
-        ;;
-    --generate-caddyfile)
-        cmd_generate_caddyfile
-        ;;
-    --help|-h)
-        DEPLOY_STAGE="readonly"
-        echo "Usage: $0 [--rollback|--status|--web|--generate-caddyfile|--help]"
-        echo ""
-        echo "  (no args)             Deploy to the inactive API color (zero-downtime blue-green)"
-        echo "  --rollback            Switch back to the previous API color"
-        echo "  --status              Show current active API color and container states"
-        echo "  --web                 Rebuild + restart kagura-web in place"
-        echo "  --generate-caddyfile  Render ./Caddyfile from Caddyfile.tpl (bootstrap; no deploy)"
-        echo ""
-        echo "Environment variables:"
-        echo "  READINESS_TIMEOUT      Seconds to wait for API /readiness (default: 60)"
-        echo "  DRAIN_TIMEOUT          Seconds to drain old API container (default: 30)"
-        echo "  WEB_READINESS_TIMEOUT  Seconds to wait for web /api/health (default: 30)"
-        echo "  WEB_READINESS_INTERVAL Seconds between web health checks (default: 2)"
-        echo "  WORKERS_GATE_TIMEOUT   Seconds to wait for /api/v1/workers/* to be blocked at Caddy (default: 30)"
-        echo "  WORKERS_GATE_INTERVAL  Seconds between security-gate checks (default: 2)"
-        ;;
-    "")
-        cmd_deploy
-        ;;
-    *)
-        error "Unknown argument: $1 (try --help)"
-        ;;
-esac
+    case "${1:-}" in
+        --rollback)
+            cmd_rollback
+            ;;
+        --status)
+            DEPLOY_STAGE="readonly"
+            cmd_status
+            ;;
+        --web)
+            cmd_deploy_web
+            ;;
+        --generate-caddyfile)
+            cmd_generate_caddyfile
+            ;;
+        --help|-h)
+            DEPLOY_STAGE="readonly"
+            echo "Usage: $0 [--rollback|--status|--web|--generate-caddyfile|--help]"
+            echo ""
+            echo "  (no args)             Deploy to the inactive API color (zero-downtime blue-green)"
+            echo "  --rollback            Switch back to the previous API color"
+            echo "  --status              Show current active API color and container states"
+            echo "  --web                 Rebuild + restart kagura-web in place"
+            echo "  --generate-caddyfile  Render ./Caddyfile from Caddyfile.tpl (bootstrap; no deploy)"
+            echo ""
+            echo "Environment variables:"
+            echo "  READINESS_TIMEOUT      Seconds to wait for API /readiness (default: 60)"
+            echo "  DRAIN_TIMEOUT          Seconds to drain old API container (default: 30)"
+            echo "  WEB_READINESS_TIMEOUT  Seconds to wait for web /api/health (default: 30)"
+            echo "  WEB_READINESS_INTERVAL Seconds between web health checks (default: 2)"
+            echo "  WORKERS_GATE_TIMEOUT   Seconds to wait for /api/v1/workers/* to be blocked at Caddy (default: 30)"
+            echo "  WORKERS_GATE_INTERVAL  Seconds between security-gate checks (default: 2)"
+            ;;
+        "")
+            cmd_deploy
+            ;;
+        *)
+            error "Unknown argument: $1 (try --help)"
+            ;;
+    esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi

--- a/terraform/single-server/scripts/tests/deploy_verify_workers_blocked.bats
+++ b/terraform/single-server/scripts/tests/deploy_verify_workers_blocked.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Regression suite for deploy.sh `verify_workers_blocked` — the #986 security
+# gate. The bare `http_status=$(curl ...)` assignment died silently under
+# `set -euo pipefail` on a connection-refused probe (curl exit 7), skipping
+# Step 7 (drain old color). These tests pin all three branches so the bug
+# cannot return. See issue #1000 (follow-up to #986).
+#
+# The script is sourced (it guards its entrypoint with a BASH_SOURCE check),
+# and the security-gate probe is driven through an injected `$CURL` stub whose
+# per-attempt responses come from a sequence file. No network, no docker.
+# =============================================================================
+
+# Stub for the curl indirection in verify_workers_blocked. Behaviour is driven
+# by $SEQ_FILE (one token per probe attempt) and a $SEQ_IDX counter file:
+#   FAIL  -> exit 7 with NO stdout (connection refused, the #986 trigger)
+#   NNN   -> print the HTTP status code NNN on stdout (exit 0)
+# Tokens past end-of-file repeat the last line (a "stable" response).
+mock_curl() {
+    local n line
+    n=$(( $(cat "$SEQ_IDX") + 1 ))
+    echo "$n" > "$SEQ_IDX"
+    line=$(sed -n "${n}p" "$SEQ_FILE")
+    if [ -z "$line" ]; then line=$(tail -n 1 "$SEQ_FILE"); fi
+    if [ "$line" = "FAIL" ]; then
+        return 7
+    fi
+    printf '%s' "$line"
+}
+
+setup() {
+    # Exported so the third test's fresh `bash -c` child (which re-sources the
+    # script) inherits the stub and its sequence state via the environment.
+    export SEQ_FILE="$BATS_TEST_TMPDIR/seq"
+    export SEQ_IDX="$BATS_TEST_TMPDIR/idx"
+    export -f mock_curl
+
+    # Minimal Caddyfile.tpl fixture so verify_workers_blocked's awk domain
+    # extraction has a real file (the domain value is irrelevant — curl is
+    # stubbed — but the extraction must not fail under `set -e`).
+    export CADDYFILE_TPL="$BATS_TEST_TMPDIR/Caddyfile.tpl"
+    printf 'memory.example.test {\n    reverse_proxy api:8000\n}\n' > "$CADDYFILE_TPL"
+
+    # Source the script under test. Drop ONLY nounset afterward: the sourced
+    # `set -u` would trip bats' own internal unset-var references, but we must
+    # KEEP errexit on — bats relies on it to fail a test when an assertion
+    # (`[ ... ]`) returns non-zero. Turning errexit off here would silently make
+    # every assertion a no-op (a false-green). `run`/`run bash -c` capture
+    # status without tripping errexit, so the assertions stay meaningful.
+    # Exported so the script's own `CURL="${CURL:-curl}"` keeps our stub when
+    # the third test re-sources it in a child process.
+    export CURL=mock_curl
+    source "$BATS_TEST_DIRNAME/../deploy.sh"
+    set +u
+
+    # Generous, deterministic gate window. The window is wall-clock (`SECONDS`,
+    # integer) so it must comfortably fit two probes plus one interval despite
+    # subprocess-spawn overhead — TIMEOUT=10/INTERVAL=1 gives ~10 retries of
+    # headroom while the cases only need two.
+    WORKERS_GATE_TIMEOUT=10
+    WORKERS_GATE_INTERVAL=1
+}
+
+@test "000 -> 404: first probe connection-refused, retry sees 404 -> returns 0 (the #986 race)" {
+    printf 'FAIL\n404\n' > "$SEQ_FILE"; echo 0 > "$SEQ_IDX"
+
+    run verify_workers_blocked
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"correctly blocked (HTTP 404"* ]]
+}
+
+@test "timeout: stable 200, never 404 -> aborts loudly, fail-closed (old color NOT drained)" {
+    printf '200\n' > "$SEQ_FILE"; echo 0 > "$SEQ_IDX"
+    WORKERS_GATE_TIMEOUT=1   # one probe, then deadline — keeps the test ~1s
+
+    run verify_workers_blocked
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"NOT blocked"* ]]
+    [[ "$output" == *"expected 404"* ]]
+    [[ "$output" != *"correctly blocked"* ]]
+}
+
+@test "set -e safety: a connection-refused probe does NOT silently kill the caller (regression guard for #986)" {
+    printf 'FAIL\n404\n' > "$SEQ_FILE"; echo 0 > "$SEQ_IDX"
+
+    # Reproduce cmd_deploy's call site in a FRESH bash under real
+    # `set -euo pipefail`. bats neutralises errexit inside its own test shell
+    # (even inside a command-substitution subshell), so the #986 silent death
+    # can only be observed faithfully in a child process bats does not manage.
+    # Before the fix, the curl exit 7 killed this child before "STEP7_REACHED".
+    run bash -c '
+        set -euo pipefail
+        source "'"$BATS_TEST_DIRNAME"'/../deploy.sh"
+        WORKERS_GATE_TIMEOUT=10 WORKERS_GATE_INTERVAL=1
+        verify_workers_blocked >/dev/null 2>&1
+        echo "STEP7_REACHED"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STEP7_REACHED"* ]]
+}


### PR DESCRIPTION
Closes #1000

## Summary
- Closes the test gap #986's security-gate fix shipped with: `deploy.sh` had no harness and could only be proven by the next prod deploy.
- Adds a `bats` regression suite pinning all three `verify_workers_blocked` branches, and a CI `shell` job running `shellcheck` + `bats` on every PR.
- Behaviour-preserving refactor only — no change to the deploy/rollback/web/status paths.

## Implementation notes
- **deploy.sh testability seam:** the entrypoint (`cd`, `trap … EXIT`, prereq + env-var validation, marker `mkdir`, `case` dispatch) is wrapped verbatim into `main()` and guarded by `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then main "$@"; fi`, so bats can `source` the script without running a deploy. The EXIT trap stays process-global, so the #986 final-status reporting is unchanged. `$CURL` and `$CADDYFILE_TPL` are made env-injectable (`${CURL:-curl}`); production resolves both to their prior defaults when unset.
- **bats suite** (`terraform/single-server/scripts/tests/deploy_verify_workers_blocked.bats`), 3 cases:
  1. `000 -> 404` retry race — first probe connection-refused (curl exit 7), retry sees 404 → returns 0 (the exact #986 scenario).
  2. timeout — stable `200`, never 404 → aborts loudly, **fail-closed** (old color NOT drained).
  3. `set -e` safety — the regression guard, run in a **fresh `bash -c` under real `set -euo pipefail`** because bats neutralises errexit in its own shell (a `run`-based test would be a false-green that never exercises the bug).
- **CI:** new `shell` job. `shellcheck` is preinstalled on `ubuntu-latest`; `bats` installed via apt. One documented `# shellcheck disable=SC2016` for envsubst's intentional single-quoted var-list argument.

### Verified locally with the real CI tools (Docker)
- `koalaman/shellcheck:stable` on `deploy.sh`: **green** (exit 0).
- `bats/bats:latest` on the fixed script: **3/3 ok**.
- `bats` on a deliberately-broken copy (load-bearing `|| true` reverted): **case 3 fails** (`[ "$status" -eq 0 ]' failed`, exit 1) — proving the regression guard actually guards.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: green via /ask (QA Lead lens)
- review provider: none (PR opens as draft for manual review)

Full reviews are saved in the plugin cache:
- ~/.claude/cache/gh-issue-driven/1000-test-deploy-sh-regression-coverage-shellcheck.gate1.md
- ~/.claude/cache/gh-issue-driven/1000-test-deploy-sh-regression-coverage-shellcheck.gate2.md

🤖 Generated via /gh-issue-driven:ship
