### PR TITLE
chore(mcp): additionalProperties + drop analyze_context query no-op (#990)

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -13,7 +13,7 @@ def get_tool_definitions() -> list[dict]:
     Returns:
         List of tool definition dicts (compatible with MCP spec)
     """
-    return [
+    tools: list[dict] = [
         {
             "name": "list_my_bindings",
             "readOnly": True,
@@ -1547,10 +1547,6 @@ Requires action recording (reports created before this feature have no actions t
                         "type": "number",
                         "description": "Optional importance floor (0.0–1.0).",
                     },
-                    "query": {
-                        "type": "string",
-                        "description": "Reserved for v1.5 query-scoped runs (ignored in v1).",
-                    },
                     "model_id": {
                         "type": "integer",
                         "description": (
@@ -1922,6 +1918,18 @@ never returned. This lane is excluded from recall() by design.""",
             },
         },
     ]
+    # Pre-1.0 schema policy (#990): every tool inputSchema is strict — no
+    # undeclared top-level parameters. Applied centrally here so all 45 tools
+    # stay uniform and any new tool inherits the policy automatically. This is
+    # advisory (handlers read args defensively via ``.get`` and never
+    # Pydantic-validate), so it tightens the client-facing contract without
+    # changing server behaviour. Nested object params are unaffected — only the
+    # top-level argument object is closed.
+    for tool in tools:
+        schema = tool.get("inputSchema")
+        if isinstance(schema, dict) and schema.get("type") == "object":
+            schema.setdefault("additionalProperties", False)
+    return tools
 
 
 # ============================================================================

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1331,6 +1331,38 @@ Requires action recording (reports created before this feature have no actions t
                             "Event ingestion quota per hour for the token (1-10000, default: 1000)."
                         ),
                     },
+                    # Registration-flow params (Spec 2026-06-02). Read by the handler
+                    # (resource.py handle_setup_connector) and forwarded to
+                    # ConnectorProvisioningService — declared here so the strict
+                    # additionalProperties:false policy (#990) does not forbid them.
+                    "context_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Existing write-target context UUID for ingested events.",
+                    },
+                    "auto_create_context_name": {
+                        "type": "string",
+                        "description": (
+                            "Create a fresh private context with this name (alternative to "
+                            "context_id; max 100 chars)."
+                        ),
+                    },
+                    "llm_config": {
+                        "type": "object",
+                        "description": "BYO LLM config bundle; stored Fernet-encrypted.",
+                    },
+                    "channel_ids": {
+                        "type": "array",
+                        "description": "Ingest channel selection for the connector.",
+                    },
+                    "locale": {
+                        "type": "string",
+                        "description": "Connector locale (max 10 chars).",
+                    },
+                    "external_team_id": {
+                        "type": "string",
+                        "description": "Platform team id (worker dispatch key; max 255 chars).",
+                    },
                 },
             },
         },

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -302,7 +302,8 @@ async def handle_analyze_context(
                 types=args.get("types"),
                 tags=args.get("tags"),
                 min_importance=args.get("min_importance"),
-                query=args.get("query"),
+                # query (Reserved for v1.5) was removed from the analyze_context
+                # inputSchema in #990; AnalysisParams.query defaults to None.
                 model_id=args.get("model_id"),
                 extra={
                     "from": args.get("from"),

--- a/backend/tests/mcp_server/test_tool_schema_policy.py
+++ b/backend/tests/mcp_server/test_tool_schema_policy.py
@@ -1,0 +1,36 @@
+"""Pre-1.0 MCP tool inputSchema policy guards (#990).
+
+These pin the schema-rigor decisions made for the 1.0 freeze so they cannot
+silently regress: every tool's argument object is strict (no undeclared
+top-level params), and the reserved-for-v1.5 no-op param was removed.
+"""
+
+from mcp_server.tools._definitions import get_tool_definitions
+
+
+def test_all_object_schemas_are_strict():
+    """Every tool inputSchema forbids undeclared top-level parameters (#990).
+
+    additionalProperties is applied centrally in get_tool_definitions, so a new
+    tool that forgets it (or sets it true) is a policy regression caught here.
+    """
+    defs = get_tool_definitions()
+    offenders = [
+        d["name"]
+        for d in defs
+        if d.get("inputSchema", {}).get("type") == "object"
+        and d["inputSchema"].get("additionalProperties") is not False
+    ]
+    assert offenders == [], f"tools missing additionalProperties:false: {offenders}"
+
+
+def test_analyze_context_query_noop_removed():
+    """The reserved-for-v1.5 no-op ``query`` param is gone from the schema (#990).
+
+    Shipping a documented no-op into a frozen 1.0 surface invites silent failure
+    (clients pass it expecting an effect). It will be re-added in v1.5 when the
+    query-scoped analysis path is actually implemented.
+    """
+    defs = get_tool_definitions()
+    analyze = next(d for d in defs if d["name"] == "analyze_context")
+    assert "query" not in analyze["inputSchema"]["properties"]

--- a/docs/api-surface-1.0/mcp-input-schemas.md
+++ b/docs/api-surface-1.0/mcp-input-schemas.md
@@ -3,8 +3,9 @@
 > Issue: #622 — pre-1.0 public API surface enumeration and freeze
 > Enumerated at commit 20ae959a2c79cacd2cf7922512ad780f540e9c60 (main HEAD, 2026-06-12)
 > Source: backend/src/mcp_server/tools/_definitions.py — 45 tools, 45 of 45 enumerated
+> Re-frozen after #990 (additionalProperties:false on all 45 schemas; analyze_context `query` no-op removed; `model_id` replacement deferred to a follow-up)
 
-**Global note**: `additionalProperties` is not set on any tool's `inputSchema` (0 occurrences in the file). JSON Schema's default (`true`) therefore applies everywhere — unknown parameters are silently accepted at the schema level. For a frozen 1.0 surface this should be an explicit decision (set `additionalProperties: false` or document the permissive default). ⚠
+**Global note**: ✅ **Resolved in #990.** Every tool `inputSchema` now sets `additionalProperties: false` — undeclared top-level parameters are forbidden by the published contract. Applied centrally in `get_tool_definitions()` so all 45 tools stay uniform and any new tool inherits the policy automatically. The policy is advisory at the server (handlers read args defensively via `.get` and never Pydantic-validate), so it tightens the client-facing contract without changing server behaviour; nested object params are unaffected (only the top-level argument object is closed).
 
 ---
 
@@ -356,8 +357,8 @@ Start (or dry-run cost-preview) a broadlistening analysis run that clusters a co
   - `types` — array of string ⚠ top-level filter params (`types`, `tags`, `min_importance`) duplicate recall's `filters` object vocabulary with different shapes (`types` plural array vs filters `type` singular; `min_importance` vs filters `importance: {gte}`)
   - `tags` — array of string
   - `min_importance` — number (0.0–1.0)
-  - `query` — string ⚠ "Reserved for v1.5 query-scoped runs (ignored in v1)" — shipping a documented no-op parameter into a frozen 1.0 surface invites silent-failure confusion; remove until implemented
-  - `model_id` — integer ⚠ lock-in: an internal `llm_pricing.id` database PK exposed as the public model selector, and the description hardcodes "openai gpt-5-nano" — both the PK coupling and the vendor/model name are implementation details
+  - ~~`query`~~ — ✅ **removed in #990** (was a reserved-for-v1.5 no-op; will be re-added when the query-scoped path is implemented).
+  - `model_id` — integer ⚠ lock-in: an internal `llm_pricing.id` database PK exposed as the public model selector, hardcoding "openai gpt-5-nano" in the description. **Deferred** from #990: `model_id` is a *shared* MCP + REST contract (`api/routes/analyses.py` builds the same `AnalysisParams`; a REST Pydantic schema and 4 test files reference it), so replacing the PK with a stable `(provider, model)` identifier is a cross-surface change that needs its own focused pass — see the dedicated follow-up.
   - `dry_run` — boolean (default false)
 
 ### get_analysis
@@ -495,9 +496,9 @@ Recurring inconsistencies (each instance flagged inline above):
 - **P1** Unify time-range bounds on one pair (`from`/`to` or `from`/`until`) across recall_upcoming, analyze_context, setup_connector.
 - **P1** Add `format: "uuid"` to every UUID param (analysis bundle, file tools, feedback, set_state, get_state, run_id, file_id, memory_id in feedback).
 - **P1** forget: make the two modes explicit (`anyOf`/`oneOf` over memory_id / query) so a bare `{context_id}` call is schema-invalid — destructive tool, ambiguous input.
-- **P1** Remove analyze_context's reserved no-op `query` param (re-add in v1.5 when implemented) and replace `model_id` (internal llm_pricing PK) with a stable model identifier.
+- ✅ **DONE (#990, query)** / **DEFERRED (model_id)** — analyze_context's reserved no-op `query` param was removed (re-add in v1.5). Replacing `model_id` (internal llm_pricing PK) with a stable identifier was **deferred to a dedicated follow-up**: it is a shared MCP + REST contract (orchestrator `AnalysisParams`, `api/routes/analyses.py`, REST Pydantic schema, 4 test files), so it needs a cross-surface design pass rather than an MCP-schema-only edit.
 - **P1** Decide the `workspace_id` override on the 5 file tools: remove from public schema or document the auth model explicitly.
-- **P1** Set `additionalProperties: false` (or record the permissive default as a deliberate freeze decision) on all 45 inputSchemas.
+- ✅ **DONE (#990)** Set `additionalProperties: false` on all 45 inputSchemas (applied centrally in `get_tool_definitions()`; guarded by `tests/mcp_server/test_tool_schema_policy.py`).
 - **P1** Unify edge-type param naming/typing: `relation_types`/`edge_types`/`edge_type` → one name, one typing.
 
 ### Bundle 2 — P2: enum policy + prose-to-schema hardening (propose as sub-issue "MCP surface: enum extension policy and schema-enforced constraints")


### PR DESCRIPTION
Part of #990 (non-breaking subset) · Part of #622

> This PR addresses the **non-breaking subset** of #990 and intentionally does **not** close it — the breaking renames and the `model_id` replacement remain open (see "Deferred" below).

## Summary
Pre-1.0 MCP input-schema cleanup. Behaviour-preserving: the schema policy is advisory (handlers read args via `.get` and never Pydantic-validate), so this tightens the published client contract without changing server behaviour.

## Implementation notes
- **`additionalProperties: false` on all 45 tool inputSchemas** — applied centrally in `get_tool_definitions()` (the `return [literal]` becomes `tools = [...]; for t in tools: t["inputSchema"].setdefault("additionalProperties", False); return tools`). Uniform, new tools inherit it automatically, and `setdefault` leaves a per-tool opt-out. Applied to the **top-level argument object only** — nested object params (e.g. `remember.context`, `set_state` value, `ingest_events.events`) keep their own open schemas.
- **Remove `analyze_context.query`** — the reserved-for-v1.5 no-op param, from the inputSchema and the MCP handler's `AnalysisParams` build (`AnalysisParams.query` defaults to `None`; re-add in v1.5 when the query-scoped path lands). The shared `AnalysisParams.query` field is **kept** (the REST analysis path still uses it).
- **New `tests/mcp_server/test_tool_schema_policy.py`** pins both decisions (all object schemas strict; `analyze_context` has no `query`).
- **Re-froze** `docs/api-surface-1.0/mcp-input-schemas.md`.

### Deferred (out of scope for this MCP-schema-only PR)
- **`model_id` (internal `llm_pricing` PK → stable identifier)**: investigation found it is a **shared MCP + REST contract** — `api/routes/analyses.py` builds the same `AnalysisParams`, a REST Pydantic schema and 4 test files reference it, and `_resolve_pricing_row` is shared. Replacing the PK with a stable `(provider, model)` identifier changes the REST analysis API too, so it warrants its own focused cross-surface pass.
- **Breaking param renames** (`merge_contexts` `source_id`/`target_id`, `k`/`limit`/`cap` unification, time-range bounds, edge-type naming) remain tracked in the doc's Follow-up section.

### Verification (live dev stack)
- `tests/mcp_server/` + `test_delivery_mode_cross_module` + `test_orchestrator`: **219 passed** (21 DB-skips — the resolver this PR doesn't touch). New policy tests **2/2**. `ruff check` + introspection confirming 0/45 schemas missing `additionalProperties`. ruff format clean.

## Pre-PR review summary
- gate2 mode: advisor-only · cso: green · qa-lead: green · cto: green
- gate1: green (design settled by operator scoping decision)
- review provider: none (PR opens as draft for manual review)

🤖 Generated via /gh-issue-driven:ship
