### PR TITLE
chore(api): dedupe response-model names + drop redundant resource_pk (#991)

### DIFF
--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -43,7 +43,7 @@ router = APIRouter(prefix="/admin/plans", tags=["admin-plans"])
 # ============================================================================
 
 
-class WorkspacePlanInfo(BaseModel):
+class AdminWorkspacePlanInfo(BaseModel):
     """Workspace with plan information.
 
     Issue #276: Slug removed.
@@ -61,7 +61,7 @@ class WorkspacePlanInfo(BaseModel):
     mcp_calls_per_week: int
 
 
-class UpdatePlanRequest(BaseModel):
+class AdminUpdatePlanRequest(BaseModel):
     """Request to update workspace plan tier."""
 
     plan_name: str = Field(..., pattern=r"^(free|basic|pro)$")
@@ -282,7 +282,7 @@ require_admin = auth_require_admin
 # ============================================================================
 
 
-@router.get("/workspaces", response_model=list[WorkspacePlanInfo])
+@router.get("/workspaces", response_model=list[AdminWorkspacePlanInfo])
 async def list_workspaces_with_plans(
     admin_user: dict = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
@@ -344,7 +344,7 @@ async def list_workspaces_with_plans(
 
             owner = users.get(workspace.owner_user_id)
             workspace_infos.append(
-                WorkspacePlanInfo(
+                AdminWorkspacePlanInfo(
                     id=str(workspace.id),
                     name=workspace.name,
                     plan_name=workspace.plan_name,
@@ -401,7 +401,7 @@ async def list_plan_tiers(
 @router.put("/workspaces/{workspace_id}/plan")
 async def update_workspace_plan(
     workspace_id: str,
-    request: UpdatePlanRequest,
+    request: AdminUpdatePlanRequest,
     admin_user: dict = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ):

--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -70,7 +70,9 @@ class WorkspaceConnectorCreateResponse(BaseModel):
     connector_id: UUID
     connector_type: str
     resource_id: str
-    resource_pk: UUID
+    # resource_pk (internal resources.id DB PK) intentionally not exposed (#991):
+    # the public `resource_id` slug above is the stable identifier; the internal
+    # PK was redundant on this response and is dropped before the 1.0 freeze.
     context_id: UUID | None = None
     token_id: int
     token: str = Field(..., description="Plaintext resource token; save immediately")
@@ -210,7 +212,6 @@ async def create_workspace_connector(
         connector_id=result.connector.id,
         connector_type=result.connector.connector_type,
         resource_id=result.resource_id,
-        resource_pk=result.resource_pk,
         context_id=result.context_id,
         token_id=result.token.id,
         token=result.plaintext_token,

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -121,7 +121,7 @@ class WorkspaceTotals(BaseModel):
     memory_count: int
 
 
-class ContextStatsResponse(BaseModel):
+class WorkspaceContextStatsResponse(BaseModel):
     """Response model for context statistics.
 
     Issue #249: GET /api/v1/workspaces/{workspace_id}/contexts/stats
@@ -884,12 +884,12 @@ async def get_workspace_stats(
     return stats
 
 
-@router.get("/{workspace_id}/contexts/stats", response_model=ContextStatsResponse)
+@router.get("/{workspace_id}/contexts/stats", response_model=WorkspaceContextStatsResponse)
 async def get_context_stats(
     workspace_id: UUID,
     request: Request,
     db: AsyncSession = Depends(get_db),
-) -> ContextStatsResponse:
+) -> WorkspaceContextStatsResponse:
     """Get per-context usage statistics.
 
     Issue #249: Context usage overview for workspace page.
@@ -902,7 +902,7 @@ async def get_context_stats(
         - Only shows contexts user has access to (RBAC)
 
     Returns:
-        ContextStatsResponse with per-context stats and totals
+        WorkspaceContextStatsResponse with per-context stats and totals
     """
     user = await get_current_user(request)
     workspace_service = WorkspaceService(db)
@@ -916,7 +916,7 @@ async def get_context_stats(
 
     stats = await workspace_service.get_context_stats(workspace_id)
 
-    return ContextStatsResponse(**stats)
+    return WorkspaceContextStatsResponse(**stats)
 
 
 @router.get(

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -648,33 +648,11 @@ class UpdateUserProfileRequest(BaseModel):
     locale: str | None = Field(None, pattern="^(en|ja)$", description="UI language (en, ja)")
 
 
-class APIKeyCreate(BaseModel):
-    """Request schema for API key creation."""
-
-    name: str = Field(..., min_length=1, max_length=100)
-    expires_in_days: int | None = Field(None, ge=1, le=365, description="有効期限（日数）")
-
-
-class APIKeyResponse(TZAwareBaseModel):
-    """Response schema for API key."""
-
-    id: int
-    key_prefix: str
-    name: str
-    created_at: datetime
-    last_used_at: datetime | None
-    revoked_at: datetime | None
-    expires_at: datetime | None
-
-    class Config:
-        from_attributes = True
-
-
-class APIKeyCreateResponse(BaseModel):
-    """Response schema for API key creation (includes plaintext key once)."""
-
-    key: str = Field(..., description="API key (show once, never stored in plaintext)")
-    key_info: APIKeyResponse
+# NOTE (#991): the dead APIKeyCreate / APIKeyResponse / APIKeyCreateResponse
+# schemas that used to live here were removed. They had zero callers — the live
+# API-key request/response models are defined in api/routes/api_keys.py — and
+# their duplicate class names produced ambiguous OpenAPI component names. The
+# `MemberAPIKeyResponse` below is a distinct, live model and is unaffected.
 
 
 class ExternalAPIKeyCreate(BaseModel):

--- a/backend/tests/api/test_workspace_connectors.py
+++ b/backend/tests/api/test_workspace_connectors.py
@@ -81,7 +81,6 @@ async def test_create_passes_normalized_pii_guardrail_config_dict_to_service():
     result.connector.id = uuid4()
     result.connector.connector_type = "slack"
     result.resource_id = "slack_general"
-    result.resource_pk = uuid4()
     result.context_id = None
     result.plaintext_kmc_api_key = None
     result.token.id = 1

--- a/backend/tests/integration/test_admin_plans_soft_delete_filter.py
+++ b/backend/tests/integration/test_admin_plans_soft_delete_filter.py
@@ -35,7 +35,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin_plans import (
     UpdateAddonRequest,
-    UpdatePlanRequest,
+    AdminUpdatePlanRequest,
     UpdateSpendCapRequest,
     get_plan_change_audit,
     get_workspace_quotas,
@@ -74,7 +74,7 @@ class TestUpdateWorkspacePlan:
         with pytest.raises(HTTPException) as exc_info:
             await update_workspace_plan(
                 workspace_id=soft_deleted_workspace["workspace_id"],
-                request=UpdatePlanRequest(plan_name="basic", reason="test"),
+                request=AdminUpdatePlanRequest(plan_name="basic", reason="test"),
                 admin_user=mock_admin(),
                 db=db_session,
             )

--- a/backend/tests/integration/test_admin_plans_soft_delete_filter.py
+++ b/backend/tests/integration/test_admin_plans_soft_delete_filter.py
@@ -34,8 +34,8 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from api.routes.admin_plans import (
-    UpdateAddonRequest,
     AdminUpdatePlanRequest,
+    UpdateAddonRequest,
     UpdateSpendCapRequest,
     get_plan_change_audit,
     get_workspace_quotas,

--- a/docs/api-surface-1.0/rest-response-models.md
+++ b/docs/api-surface-1.0/rest-response-models.md
@@ -3,6 +3,7 @@
 > Issue: #622 — pre-1.0 public API surface enumeration and freeze
 > Enumerated at commit 20ae959a2c79cacd2cf7922512ad780f540e9c60 (main HEAD, 2026-06-12)
 > Scope: all BaseModel / TZAwareBaseModel subclasses defined in backend/src/api/routes/ (46 route files, 208 model classes — 208 of 208 enumerated)
+> Re-frozen after #991: 3 duplicate class names renamed; dead `APIKey*` schemas removed from `models/schemas.py`; redundant `WorkspaceConnectorCreateResponse.resource_pk` dropped. Deferred: `WorkspaceConnectorSummary.resource_pk` (needs a Resource JOIN), `TelemetryResponse.embedding_config` gating (needs an intent decision), and the sequential-int-PK replacement (Bundle B).
 
 Notes:
 
@@ -1467,7 +1468,7 @@ Notes:
 - `connector_id: UUID` — required
 - `connector_type: str` — required
 - `resource_id: str` — required
-- `resource_pk: UUID` — required ⚠ internal DB primary key leaked alongside the public `resource_id` — hide or rename before freeze
+- ~~`resource_pk: UUID`~~ — ✅ **removed in #991** (was the internal `resources.id` DB PK, redundant with the public `resource_id` slug above).
 - `context_id: UUID | None` — optional
 - `token_id: int` — required
 - `token: str` — required ⚠ plaintext connector token (shown-once by design — verify never logged/cached downstream)
@@ -1495,7 +1496,7 @@ Notes:
 ## workspace_plan.py
 
 ### WorkspacePlanInfo (BaseModel, L45)
-> Workspace plan information with usage stats. (Name collides with `admin_plans.WorkspacePlanInfo` — OpenAPI schema-name ambiguity.)
+> Workspace plan information with usage stats. (Collision resolved in #991 — the `admin_plans.py` copy was renamed `AdminWorkspacePlanInfo`; this `workspace_plan.py` model keeps the canonical name.)
 - `workspace_id: str` — required
 - `workspace_name: str` — required
 - `current_plan: str` — required
@@ -1515,7 +1516,7 @@ Notes:
 - `features: list[str]` — required
 
 ### UpdatePlanRequest (BaseModel, L69) (request model)
-> Request to update workspace plan. (Name collides with `admin_plans.UpdatePlanRequest`.)
+> Request to update workspace plan. (Collision resolved in #991 — the `admin_plans.py` copy was renamed `AdminUpdatePlanRequest`; this `workspace_plan.py` model keeps the canonical name.)
 - `plan_name: str` — required
 - `reason: str | None` — optional
 
@@ -1573,7 +1574,7 @@ Notes:
 - `memory_count: int` — required
 
 ### ContextStatsResponse (BaseModel, L124)
-> Response model for context statistics. (Name collides with `contexts.ContextStatsResponse` — different shape, OpenAPI schema-name ambiguity.)
+> Response model for context statistics. (Collision resolved in #991 — this `workspaces.py` model was renamed `WorkspaceContextStatsResponse`; the differently-shaped `contexts.py` model keeps the canonical name.)
 - `contexts: list[ContextStatsItem]` — required
 - `total_contexts: int` — required
 - `workspace_totals: WorkspaceTotals` — required
@@ -1685,8 +1686,9 @@ Issue #622 allows at most 2 follow-up sub-issues; candidates below are grouped i
 
 | Candidate | Priority | Action |
 |---|---|---|
-| `WorkspaceConnectorCreateResponse.resource_pk`, `WorkspaceConnectorSummary.resource_pk` (workspace_connectors.py) | P1 | Hide internal DB PK; expose only the public `resource_id` |
-| `TelemetryResponse.embedding_config` (system.py) | P1 | Make admin-only or drop — internal embedding infra config currently visible to any authenticated user |
+| `WorkspaceConnectorCreateResponse.resource_pk` (workspace_connectors.py) | ✅ DONE (#991) | Dropped — redundant with the public `resource_id` slug already on the response |
+| `WorkspaceConnectorSummary.resource_pk` (workspace_connectors.py) | P1 (deferred) | NOT a pure drop — this response has no `resource_id`; substituting the public slug needs a `Resource` JOIN in `ConnectorProvisioningService.list_connectors`. Tracked for a follow-up. |
+| `TelemetryResponse.embedding_config` (system.py) | P1 (deferred) | Visible to any authenticated user (incl. an internal Ollama URL when provider=ollama). Gating the endpoint is breaking; dropping/nulling the field needs an intent decision (is embedding config intended public?). Tracked for a follow-up. |
 | `ResourceEventRecord.payload` / `event_metadata` (resources.py) | P1 | Confirm raw-vs-derived boundary (#968) / classification redaction applies to the Resource Detail Data tab before freeze |
 | `OAuth2ClientResponse.plaintext_secret` (oauth.py) | P1 | Verify owner+visibility gating and `response_model_exclude` coverage on every endpoint returning this model; fix the misleading "without secret" docstring |
 | `WorkerConnectorConfig` (workers.py) | P1 | Explicitly exclude the `/workers` surface (plaintext Slack/KMC secrets) from the public 1.0 OpenAPI/freeze scope |
@@ -1699,4 +1701,4 @@ Issue #622 allows at most 2 follow-up sub-issues; candidates below are grouped i
 |---|---|---|
 | `APIKeyResponse.id`, `ExternalKeyResponse.id`, `ResourceTokenResponse.id`, `WorkspaceConnectorCreateResponse.token_id` (all `int`) | P2 | Replace sequential integer DB PKs with opaque/prefixed public identifiers before freezing the surface |
 | Untyped `dict` fields on freezable responses: `PublicSearchResult.metadata`, `GraphStats.top_connections`/`recent_edges`, `GraphDataResponse.stats`, `UserStats.*`, `WorkspacePlanInfo.usage`/`quotas` (workspace_plan.py), `AvailablePlanInfo.quotas`, `TelemetryResponse.memory_stats`/`neural_memory`, `SleepReportDetail.*_result`, `UserInfo.workspaces` | P2 | Type them with explicit models, or mark them explicitly non-frozen in the 1.0 contract |
-| Duplicate class names across route files: `WorkspacePlanInfo` and `UpdatePlanRequest` (admin_plans.py vs workspace_plan.py), `ContextStatsResponse` (contexts.py vs workspaces.py) | P2 | Rename one of each pair to avoid OpenAPI schema-name ambiguity at freeze time |
+| Duplicate class names across route files | ✅ DONE (#991) | Renamed the `admin_plans.py` / `workspaces.py` copies → `AdminWorkspacePlanInfo`, `AdminUpdatePlanRequest`, `WorkspaceContextStatsResponse`; `workspace_plan.py` / `contexts.py` keep the canonical names. Also removed the dead `APIKeyCreate`/`APIKeyResponse`/`APIKeyCreateResponse` duplicates from `models/schemas.py` (zero callers; live versions are in `api_keys.py`). OpenAPI now emits distinct component names per endpoint; field JSON unchanged. |


### PR DESCRIPTION
Part of #991 (non-breaking subset) · Part of #622

> Addresses the **non-breaking subset** of #991 and intentionally does **not** close it — the field-gating/decision items remain open (see "Deferred").

## Summary
Pre-1.0 REST response-model cleanup. Behaviour-preserving: the renames change only OpenAPI component names (no field JSON), and the only dropped field was a redundant internal PK.

## Implementation notes
- **Dedupe the 3 duplicate OpenAPI component names** (the issue's "3 duplicated names"): rename the `admin_plans.py` / `workspaces.py` copies → `AdminWorkspacePlanInfo`, `AdminUpdatePlanRequest`, `WorkspaceContextStatsResponse`. The `workspace_plan.py` / `contexts.py` models keep the canonical names. No cross-file imports of these classes; no test asserts them by name. OpenAPI now emits **distinct components per endpoint** (verified: both `AdminWorkspacePlanInfo` and `WorkspacePlanInfo` present, etc.); field JSON per endpoint unchanged.
- **Remove the dead `APIKeyCreate` / `APIKeyResponse` / `APIKeyCreateResponse`** from `models/schemas.py` — zero callers (the live API-key models are in `api/routes/api_keys.py`), and their duplicate names were latent OpenAPI collisions. Left a `# NOTE` explaining the removal. `MemberAPIKeyResponse` (distinct, live) is untouched.
- **Drop the redundant `resource_pk`** (internal `resources.id` DB PK) from `WorkspaceConnectorCreateResponse` — the public `resource_id` slug is already on the same response.
- **Re-froze** `docs/api-surface-1.0/rest-response-models.md`.

### Deferred (tracked in the doc Follow-up)
- **`WorkspaceConnectorSummary.resource_pk`** — NOT a pure drop; that response has no `resource_id`, so exposing the public slug needs a `Resource` JOIN in `ConnectorProvisioningService.list_connectors`.
- **`TelemetryResponse.embedding_config`** visible to non-admins — gating the endpoint is breaking; dropping/nulling the field needs an intent decision. (gate2/CSO: low severity — authenticated-only, non-secret config; the follow-up should redact `ollama_base_url` if it can embed credentials.)
- **Sequential int-PK → opaque-ID** replacement (Bundle B).

### Verification (live dev stack)
- `app.openapi()` generates with the renamed pairs as **distinct components** (262 total).
- `tests/api/test_workspace_connectors.py` (33) + `test_schema_serializers.py` + plan/workspace suites: **green** (33 + 35 passed, 12 DB/intentional skips). `ruff` clean.

## Pre-PR review summary
- gate2 mode: advisor-only · cso: green · qa-lead: green · cto: green
- gate1: green (design settled by operator scoping decision)
- review provider: none (PR opens as draft for manual review)
- gate2 follow-up suggestion: a regression guard asserting no two response models share an OpenAPI component name.

🤖 Generated via /gh-issue-driven:ship
