### PR TITLE
refactor(api): converge auth-boundary errors to canonical shape (#992)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.exc import SQLAlchemyError
@@ -335,6 +336,45 @@ async def memory_cloud_exception_handler(
             "error": exc.error_code,
             "message": exc.message,
             "details": details,
+        },
+    )
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_exception_handler(
+    request: Request, exc: RequestValidationError
+) -> JSONResponse:
+    """Map FastAPI's default 422 onto the canonical ``{error, message, details}``
+    envelope (#992 Phase 1).
+
+    Without this handler, request-body validation failures emit FastAPI's
+    default ``{"detail": [ ... ]}`` array, which (a) diverges from the
+    canonical shape that ``ValidationError`` (``VAL-001``) already produces
+    via ``memory_cloud_exception_handler``, and (b) **echoes the rejected
+    ``input``** (plus ``ctx``/``url``) — a payload-reflection / info-disclosure
+    risk on a surface that freezes at 1.0. We project each error to a trimmed
+    ``{loc, msg, type}`` and drop ``input``/``ctx``/``url`` entirely so a
+    mistyped password, token, or PII field is never reflected back.
+    """
+    errors = [
+        {
+            "loc": list(err.get("loc", [])),
+            "msg": err.get("msg", ""),
+            "type": err.get("type", ""),
+        }
+        for err in exc.errors()
+    ]
+    logger.warning(
+        "request_validation_error",
+        path=request.url.path,
+        error_count=len(errors),
+    )
+    return JSONResponse(
+        status_code=422,
+        content={
+            "error": "VAL-001",
+            "message": "Request validation failed",
+            "details": {"errors": errors},
         },
     )
 

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -37,6 +37,7 @@ from models.schemas import (
 from utils import db_transaction, get_user_id
 from utils.datetime import to_utc_iso
 from utils.exceptions import (
+    AdminProtectionError,
     AuthorizationError,
     BonusBelowZeroError,
     InsufficientReasonError,
@@ -719,10 +720,7 @@ async def update_user_role(
 
     # Prevent self-demotion
     if admin_id == user_id and request.role != "admin":
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Cannot change your own admin role",
-        )
+        raise AdminProtectionError("Cannot change your own admin role", reason="self_demotion")
 
     async with db_transaction(db, "update_user_role", "Failed to update user role"):
         result = await db.execute(select(User).where(User.user_id == user_id))
@@ -976,16 +974,15 @@ async def delete_user(
 
     # Prevent self-deletion
     if admin_id == user_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Cannot delete your own account",
-        )
+        raise AdminProtectionError("Cannot delete your own account", reason="self_deletion")
 
     # Issue #166: Check if user is a protected system admin
     service = SystemAdminService(db)
     can_delete, reason = await service.can_delete_admin(user_id)
     if not can_delete:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=reason)
+        # ``reason`` is the documented governance message (initial/last admin);
+        # the classification is already logged inside can_delete_admin.
+        raise AdminProtectionError(reason, reason="admin_protected")
 
     async with db_transaction(db, "delete_user", "Failed to delete user"):
         result = await db.execute(select(User).where(User.user_id == user_id))
@@ -1125,9 +1122,8 @@ async def admin_force_erase_user(
     admin_id = get_user_id(admin)
 
     if admin_id == user_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Cannot erase your own account via the admin path",
+        raise AdminProtectionError(
+            "Cannot erase your own account via the admin path", reason="self_erasure"
         )
 
     service = AccountErasureService(db)

--- a/backend/src/api/routes/auth.py
+++ b/backend/src/api/routes/auth.py
@@ -44,7 +44,7 @@ from services.signup_gate_service import check_signup_access
 from services.workspace_service import WorkspaceService
 from utils.datetime import utcnow
 from utils.encryption import get_encryptor
-from utils.exceptions import ConflictError
+from utils.exceptions import AuthenticationError, ConflictError, InvalidCredentialsError
 from utils.logger import get_logger
 
 # auth.py historically bound logger via stdlib ``logging.getLogger``
@@ -847,9 +847,9 @@ async def google_callback(
         raise
     except Exception as e:
         logger.error(f"OAuth2 callback failed: {e}")
-        raise HTTPException(
-            status_code=401, detail=f"OAuth2 authentication failed: {str(e)}"
-        ) from e
+        # Keep the internal exception text off the wire (already logged above);
+        # the global handler emits the canonical {error, message, details}.
+        raise AuthenticationError("OAuth2 authentication failed") from e
 
 
 @router.post("/logout")
@@ -1280,9 +1280,8 @@ async def github_callback(
         raise
     except Exception as e:
         logger.error(f"GitHub OAuth2 callback failed: {e}")
-        raise HTTPException(
-            status_code=401, detail=f"GitHub authentication failed: {str(e)}"
-        ) from e
+        # str(e) stays in the log only; the global handler emits the canonical shape.
+        raise AuthenticationError("GitHub authentication failed") from e
 
 
 # ============================================================================
@@ -1512,11 +1511,11 @@ async def password_login(
 
     if not user or not user.password_hash:
         _record_login_failure(body.login_id)
-        raise HTTPException(status_code=401, detail="Invalid credentials")
+        raise InvalidCredentialsError()
 
     if not verify_password(body.password, user.password_hash):
         _record_login_failure(body.login_id)
-        raise HTTPException(status_code=401, detail="Invalid credentials")
+        raise InvalidCredentialsError()
 
     _clear_login_failures(body.login_id)
 
@@ -1555,7 +1554,7 @@ async def mfa_verify(
 
     user_id = _session_manager._redis.get(f"mfa_pending:{body.mfa_session_token}")
     if not user_id:
-        raise HTTPException(status_code=401, detail="Invalid or expired MFA session")
+        raise AuthenticationError("Invalid or expired MFA session")
 
     async for db in get_db():
         result = await db.execute(select(User).where(User.user_id == user_id))
@@ -1563,7 +1562,7 @@ async def mfa_verify(
         break
 
     if not user or not user.totp_secret:
-        raise HTTPException(status_code=401, detail="MFA not configured")
+        raise AuthenticationError("MFA not configured")
 
     try:
         totp_secret = get_encryptor().decrypt(user.totp_secret)
@@ -1573,7 +1572,7 @@ async def mfa_verify(
     if not verify_totp(totp_secret, body.totp_code):
         # Delete MFA token on failed attempt (prevent brute-force replay)
         _session_manager._redis.delete(f"mfa_pending:{body.mfa_session_token}")
-        raise HTTPException(status_code=401, detail="Invalid TOTP code. Please login again.")
+        raise AuthenticationError("Invalid TOTP code. Please login again.")
 
     _session_manager._redis.delete(f"mfa_pending:{body.mfa_session_token}")
 

--- a/backend/src/api/routes/member_credentials.py
+++ b/backend/src/api/routes/member_credentials.py
@@ -28,6 +28,7 @@ from models.schemas import (
 )
 from services.member_credentials_service import MemberCredentialsService
 from utils.datetime import to_utc_iso, utcnow
+from utils.exceptions import AuthorizationError, NotFoundException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -70,10 +71,7 @@ async def check_permission(
     )
 
     if not can_perform:
-        raise HTTPException(
-            status_code=403,
-            detail=f"Not authorized to {action} credentials",
-        )
+        raise AuthorizationError(message=f"Not authorized to {action} credentials")
 
 
 @router.get("/{user_id}/credentials", response_model=MemberCredentialsResponse)
@@ -149,7 +147,7 @@ async def hide_api_key(
     """
     # Permission check: owner only
     if user["user_id"] != user_id:
-        raise HTTPException(status_code=403, detail="Only owner can hide API key")
+        raise AuthorizationError(message="Only owner can hide API key")
 
     # Get API key (most recent active key)
     from sqlalchemy import and_, select
@@ -180,9 +178,13 @@ async def hide_api_key(
         await db.commit()
         return {"status": "hidden", "key_id": api_key.id}
     except PermissionError as e:
-        raise HTTPException(status_code=403, detail=str(e)) from e
+        # CWE-639: keep the raw PermissionError text off the wire (log-only
+        # ``reason``); the handler emits the uniform "Insufficient permissions".
+        raise AuthorizationError(reason=str(e)) from e
     except ValueError as e:
-        raise HTTPException(status_code=404, detail=str(e)) from e
+        # Sibling of the 403 above — converted together so this handler does
+        # not emit a mixed {detail}/{error} shape (#992 Phase 1).
+        raise NotFoundException("API key") from e
 
 
 @router.post(
@@ -306,7 +308,7 @@ async def create_api_key(
     """
     # Permission check: only owner can create their own keys
     if user["user_id"] != user_id:
-        raise HTTPException(status_code=403, detail="Only owner can create API keys")
+        raise AuthorizationError(message="Only owner can create API keys")
 
     # Issue #626: Public-bound key creation gating + scope decision.
     # When ``bound_context_id`` is supplied, the key is public-bound and the
@@ -334,9 +336,8 @@ async def create_api_key(
         if ctx is None:
             raise HTTPException(status_code=404, detail="bound_context_id: context not found")
         if ctx.workspace_id != workspace_id:
-            raise HTTPException(
-                status_code=403,
-                detail="bound_context_id: context does not belong to this workspace",
+            raise AuthorizationError(
+                message="bound_context_id: context does not belong to this workspace"
             )
         if ctx.is_public is not True:
             raise HTTPException(
@@ -357,12 +358,11 @@ async def create_api_key(
         # ``created_by`` (via a separate admin action) or by recreating
         # the context.
         if ctx.created_by != user_id:
-            raise HTTPException(
-                status_code=403,
-                detail=(
+            raise AuthorizationError(
+                message=(
                     "bound_context_id: only the context creator can mint a "
                     "public-bound key against this context"
-                ),
+                )
             )
 
         # Tier gate: workspace plan must include the ``public_contexts`` feature
@@ -384,17 +384,15 @@ async def create_api_key(
         # ``has_feature`` / ``get_plan_tier`` don't see ``None`` and 500.
         plan_name = (ws.plan_name if ws is not None else None) or "free"
         if not has_feature(plan_name, "public_contexts"):
-            raise HTTPException(
-                status_code=403,
-                detail="Workspace plan does not include the public_contexts feature",
+            raise AuthorizationError(
+                message="Workspace plan does not include the public_contexts feature"
             )
         if get_plan_tier(plan_name).bound_public_calls_per_minute <= 0:
-            raise HTTPException(
-                status_code=403,
-                detail=(
+            raise AuthorizationError(
+                message=(
                     "Workspace plan does not provision a per-key quota for "
                     "public-bound API keys (bound_public_calls_per_minute=0)"
-                ),
+                )
             )
 
         # Mutual exclusion with workspace scope (#169).
@@ -560,7 +558,7 @@ async def delete_api_key_by_id(
         HTTPException: 403 if not owner, 404 if key not found.
     """
     if user["user_id"] != user_id:
-        raise HTTPException(status_code=403, detail="Only owner can delete API keys")
+        raise AuthorizationError(message="Only owner can delete API keys")
 
     from sqlalchemy import and_, select
 
@@ -583,10 +581,7 @@ async def delete_api_key_by_id(
     if api_key.workspace_id is not None:
         # Workspace-scoped key (#169) — URL workspace must match the column.
         if api_key.workspace_id != workspace_id:
-            raise HTTPException(
-                status_code=403,
-                detail="API key does not belong to this workspace",
-            )
+            raise AuthorizationError(message="API key does not belong to this workspace")
     elif api_key.bound_context_id is not None:
         # Public-bound key (#626) — the binding's workspace must match.
         ctx_row = await db.execute(select(Context).where(Context.id == api_key.bound_context_id))
@@ -596,9 +591,8 @@ async def delete_api_key_by_id(
         # key has no anchoring workspace — fall through to delete without
         # the workspace-match assertion.
         if bound_ctx is not None and bound_ctx.workspace_id != workspace_id:
-            raise HTTPException(
-                status_code=403,
-                detail="API key is bound to a context in a different workspace",
+            raise AuthorizationError(
+                message="API key is bound to a context in a different workspace"
             )
     # else: global / owner-scoped key (both columns NULL) — workspace_id in
     # the URL is purely permission scope; the owner-only check above is
@@ -669,7 +663,7 @@ async def hide_oauth_app(
     """
     # Permission check: owner only
     if user["user_id"] != user_id:
-        raise HTTPException(status_code=403, detail="Only owner can hide OAuth app")
+        raise AuthorizationError(message="Only owner can hide OAuth app")
 
     from sqlalchemy import and_, select
 
@@ -741,7 +735,7 @@ async def regenerate_oauth_secret(
     )
 
     if not can_regenerate:
-        raise HTTPException(status_code=403, detail="Not authorized to regenerate OAuth secret")
+        raise AuthorizationError(message="Not authorized to regenerate OAuth secret")
 
     import hashlib
     import secrets
@@ -831,7 +825,7 @@ async def delete_oauth_app(
     )
 
     if not can_delete:
-        raise HTTPException(status_code=403, detail="Not authorized to delete OAuth app")
+        raise AuthorizationError(message="Not authorized to delete OAuth app")
 
     # Get and delete app
     from sqlalchemy import and_, select

--- a/backend/src/api/routes/oauth.py
+++ b/backend/src/api/routes/oauth.py
@@ -43,6 +43,7 @@ from models.api_base import TZAwareBaseModel
 from models.auth import OAuth2Client, OAuth2DeviceCode, OAuth2Token, User, generate_user_code
 from models.schemas import TokenIntrospectionResponse
 from utils.datetime import to_utc_iso, utcnow
+from utils.exceptions import AuthenticationError, AuthorizationError
 from utils.logger import get_logger
 from utils.oauth_errors import rfc6749_error_response
 from utils.oauth_messages import get_oauth_messages
@@ -852,10 +853,7 @@ async def get_oauth2_client(
         # SECURITY: Check owner (Issue #93-3)
         current_user_id = get_current_user_id(request)
         if client.owner_id != current_user_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="You are not allowed to access this client",
-            )
+            raise AuthorizationError(message="You are not allowed to access this client")
 
         # Decrypt secret if visible + owner
         from utils.encryption import get_encryptor
@@ -1011,10 +1009,7 @@ async def hide_oauth2_client_secret(
         # SECURITY: Check owner
         current_user_id = get_current_user_id(request)
         if client.owner_id != current_user_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Only owner can hide OAuth2 client secret",
-            )
+            raise AuthorizationError(message="Only owner can hide OAuth2 client secret")
 
         # Hide secret
 
@@ -1081,9 +1076,8 @@ async def regenerate_oauth2_client_secret(
         # SECURITY: Check owner (Issue #93-3)
         current_user_id = get_current_user_id(request)
         if client.owner_id != current_user_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="You are not allowed to regenerate this client's secret",
+            raise AuthorizationError(
+                message="You are not allowed to regenerate this client's secret"
             )
 
         # Generate new secret
@@ -1664,7 +1658,7 @@ async def oauth_authorize_post(
 
     user = get_current_user_from_session(request)
     if not user:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+        raise AuthenticationError("Not authenticated")
 
     # Get confirm from preloaded form data
     confirm = request.state.form_data.get("confirm")
@@ -2025,10 +2019,7 @@ async def device_confirm(
     """
     user = _get_user_from_session(request)
     if not user:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Authentication required",
-        )
+        raise AuthenticationError("Authentication required")
 
     db_session = get_sync_session()
 

--- a/backend/src/api/routes/public_search.py
+++ b/backend/src/api/routes/public_search.py
@@ -22,7 +22,7 @@ from models.auth import Context, Workspace
 from services.resource_lookup import get_latest_schema
 from services.search_service import SearchService
 from utils.datetime import to_utc_iso, utcnow
-from utils.exceptions import AuthorizationError, NotFoundException, RateLimitError
+from utils.exceptions import APIKeyError, AuthorizationError, NotFoundException, RateLimitError
 from utils.logger import get_logger
 from utils.usage_logger import log_usage
 
@@ -270,16 +270,15 @@ async def _resolve_public_attribution(
     verified = await APIKeyManager(db).verify_key(api_key)
     if verified is None:
         # Authentication failure — invalid hash, revoked, or expired.
-        raise HTTPException(status_code=401, detail="Invalid or expired API key")
+        raise APIKeyError("Invalid or expired API key")
 
     if verified.bound_context_id is None:
         # Valid key (owner / workspace-scoped) without a public binding.
-        raise HTTPException(
-            status_code=403,
-            detail=(
+        raise AuthorizationError(
+            message=(
                 "API key is not bound to a public context; "
                 "use a public-bound key or omit Authorization for anonymous access"
-            ),
+            )
         )
 
     if verified.bound_context_id != context_id:
@@ -290,9 +289,13 @@ async def _resolve_public_attribution(
             requested_context_id=str(context_id),
             bound_context_id=str(verified.bound_context_id),
         )
-        raise HTTPException(
-            status_code=403,
-            detail="API key is bound to a different context (BOUND_SCOPE_VIOLATION)",
+        # Intentional override of AuthorizationError's default uniform message:
+        # the BOUND_SCOPE_VIOLATION marker is a documented client signal and
+        # leaks no resource existence (the bound_context_id stays log-only, and
+        # the handler strips details). Do NOT "normalize" this back to the
+        # default message — a test asserts this marker is visible.
+        raise AuthorizationError(
+            message="API key is bound to a different context (BOUND_SCOPE_VIOLATION)"
         )
 
     return verified
@@ -426,9 +429,8 @@ async def public_search(
 
         # Verify context belongs to user's current workspace
         if context.workspace_id != current_workspace_id:
-            raise HTTPException(
-                status_code=403,
-                detail="This public context belongs to a different workspace. Please switch workspaces or use anonymous access.",
+            raise AuthorizationError(
+                message="This public context belongs to a different workspace. Please switch workspaces or use anonymous access."
             )
 
     # 3. Rate limit dispatch by principal type.

--- a/backend/src/api/routes/workspace.py
+++ b/backend/src/api/routes/workspace.py
@@ -36,6 +36,7 @@ from models.auth import Context, User, Workspace, WorkspaceMember
 from models.auth import UsageStats as UsageStatsModel
 from models.memory import Memory
 from utils.datetime import to_utc_iso, utcnow
+from utils.exceptions import AuthenticationError
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +121,7 @@ async def get_workspace_stats(
     """
     user_id = user.get("user_id")
     if not user_id:
-        raise HTTPException(status_code=401, detail="User ID not found in session")
+        raise AuthenticationError("User ID not found in session")
 
     try:
         # Issue #65: Single JOIN replaces 2 sequential queries

--- a/backend/tests/api/test_device_unauth_audit.py
+++ b/backend/tests/api/test_device_unauth_audit.py
@@ -53,10 +53,7 @@ class TestDeviceUnauthAuditEndpoint:
         body = resp.json()
         # #992: 422s now use the canonical {error, message, details} envelope.
         assert body["error"] == "VAL-001"
-        assert any(
-            "too_long" in (err.get("type", "") or "")
-            for err in body["details"]["errors"]
-        )
+        assert any("too_long" in (err.get("type", "") or "") for err in body["details"]["errors"])
 
     def test_rejects_prefix_with_disallowed_characters(self):
         # user_code is uppercase alphanumeric (RFC 8628). Anything outside

--- a/backend/tests/api/test_device_unauth_audit.py
+++ b/backend/tests/api/test_device_unauth_audit.py
@@ -51,7 +51,12 @@ class TestDeviceUnauthAuditEndpoint:
         )
         assert resp.status_code == 422
         body = resp.json()
-        assert any("too_long" in (err.get("type", "") or "") for err in body.get("detail", []))
+        # #992: 422s now use the canonical {error, message, details} envelope.
+        assert body["error"] == "VAL-001"
+        assert any(
+            "too_long" in (err.get("type", "") or "")
+            for err in body["details"]["errors"]
+        )
 
     def test_rejects_prefix_with_disallowed_characters(self):
         # user_code is uppercase alphanumeric (RFC 8628). Anything outside

--- a/backend/tests/api/test_error_shape_phase1.py
+++ b/backend/tests/api/test_error_shape_phase1.py
@@ -1,0 +1,114 @@
+"""Issue #992 Phase 1 — auth-boundary error-shape convergence + 422 handler.
+
+Covers two things this PR introduces:
+
+1. A ``RequestValidationError`` handler that converts FastAPI's default
+   ``{"detail": [ ... ]}`` 422 body into the canonical ``{error, message,
+   details}`` envelope (matching ``ValidationError`` / ``VAL-001``), and
+   — critically — STRIPS the echoed ``input`` (and ``ctx``/``url``) so a
+   rejected payload is never reflected back on the frozen public surface
+   (CWE-639 / info-disclosure defense; gate1 CSO finding (d)).
+
+2. Auth-boundary route handlers now raise canonical ``MemoryCloudException``
+   subclasses instead of raw ``HTTPException``, so their bodies match the
+   ``{error, message, details}`` contract with status codes unchanged.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+from fastapi.exceptions import RequestValidationError
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_request_validation_handler_uses_canonical_envelope_and_strips_input():
+    from api.main import request_validation_exception_handler
+
+    # A realistic FastAPI/pydantic-v2 error entry: note the ``input`` echoes
+    # the caller's submitted secret, and ``url``/``ctx`` may carry fragments.
+    exc = RequestValidationError(
+        [
+            {
+                "type": "missing",
+                "loc": ("body", "password"),
+                "msg": "Field required",
+                "input": {"login_id": "alice", "secret": "hunter2-PLAINTEXT"},
+                "url": "https://errors.pydantic.dev/2.0/v/missing",
+                "ctx": {"foo": "bar"},
+            }
+        ]
+    )
+    req = MagicMock()
+    req.url.path = "/api/v1/auth/login"
+
+    resp = _run(request_validation_exception_handler(req, exc))
+    body = json.loads(resp.body)
+
+    assert resp.status_code == 422
+    assert body["error"] == "VAL-001"
+    assert body["message"]  # human-readable, non-empty
+    # Trimmed projection only — loc/msg/type, nothing else.
+    assert body["details"]["errors"] == [
+        {"loc": ["body", "password"], "msg": "Field required", "type": "missing"}
+    ]
+    # The submitted payload MUST NOT be echoed anywhere in the response.
+    assert "hunter2-PLAINTEXT" not in resp.body.decode()
+    assert "input" not in body["details"]["errors"][0]
+
+
+def test_request_validation_handler_handles_multiple_errors():
+    from api.main import request_validation_exception_handler
+
+    exc = RequestValidationError(
+        [
+            {"type": "missing", "loc": ("body", "a"), "msg": "Field required", "input": {}},
+            {"type": "string_type", "loc": ("body", "b"), "msg": "not a string", "input": 5},
+        ]
+    )
+    req = MagicMock()
+    req.url.path = "/x"
+
+    resp = _run(request_validation_exception_handler(req, exc))
+    body = json.loads(resp.body)
+    assert len(body["details"]["errors"]) == 2
+    assert {e["loc"][-1] for e in body["details"]["errors"]} == {"a", "b"}
+
+
+# --- auth-boundary conversions: status + error_code parity ---
+
+
+def test_invalid_credentials_error_is_401_auth002():
+    from utils.exceptions import InvalidCredentialsError
+
+    e = InvalidCredentialsError()
+    assert e.status_code == 401
+    assert e.error_code == "AUTH-002"
+    assert e.message == "Invalid credentials"
+
+
+def test_mfa_session_uses_authentication_error_401():
+    from utils.exceptions import AuthenticationError
+
+    e = AuthenticationError("Invalid or expired MFA session")
+    assert e.status_code == 401
+    assert e.error_code == "AUTH-001"
+    assert e.message == "Invalid or expired MFA session"
+
+
+def test_admin_protection_error_keeps_message_and_strips_reason():
+    # admin.py self-delete / protected-admin conversions.
+    from utils.exceptions import AdminProtectionError
+
+    e = AdminProtectionError("Cannot delete the last remaining system administrator", reason="admin_protected")
+    assert e.status_code == 403
+    assert e.error_code == "ADMIN-001"
+    assert e.message == "Cannot delete the last remaining system administrator"
+    # reason is a private classification, never serialized (CWE-639 pattern).
+    assert e.reason == "admin_protected"
+    assert "reason" not in e.details

--- a/backend/tests/api/test_error_shape_phase1.py
+++ b/backend/tests/api/test_error_shape_phase1.py
@@ -105,7 +105,9 @@ def test_admin_protection_error_keeps_message_and_strips_reason():
     # admin.py self-delete / protected-admin conversions.
     from utils.exceptions import AdminProtectionError
 
-    e = AdminProtectionError("Cannot delete the last remaining system administrator", reason="admin_protected")
+    e = AdminProtectionError(
+        "Cannot delete the last remaining system administrator", reason="admin_protected"
+    )
     assert e.status_code == 403
     assert e.error_code == "ADMIN-001"
     assert e.message == "Cannot delete the last remaining system administrator"

--- a/backend/tests/api/test_workspace.py
+++ b/backend/tests/api/test_workspace.py
@@ -22,6 +22,7 @@ from api.routes.workspace import (
 )
 from api.routes.workspaces import UpdateMemberRoleRequest, update_member_role
 from auth.workspace_roles import WorkspaceRole
+from utils.exceptions import AuthenticationError
 
 
 class TestWorkspaceStats:
@@ -59,12 +60,13 @@ class TestWorkspaceStats:
 
     @pytest.mark.asyncio
     async def test_no_user_id_returns_401(self, mock_db):
-        """Test that missing user_id returns 401."""
-        with pytest.raises(HTTPException) as exc_info:
+        """Test that missing user_id returns 401 (#992: canonical AuthenticationError)."""
+        with pytest.raises(AuthenticationError) as exc_info:
             await get_workspace_stats(user={}, db=mock_db)
 
         assert exc_info.value.status_code == 401
-        assert "User ID not found" in exc_info.value.detail
+        assert exc_info.value.error_code == "AUTH-001"
+        assert "User ID not found" in exc_info.value.message
 
     @pytest.mark.asyncio
     async def test_empty_contexts_returns_empty_stats(self, mock_db, mock_user):

--- a/docs/api-surface-1.0/error-responses.md
+++ b/docs/api-surface-1.0/error-responses.md
@@ -37,7 +37,7 @@ HTTP status comes from `exc.status_code` (per-class; see catalogue). Notable hea
 
 ### 2. REST — raw `HTTPException` (FastAPI default, NON-canonical)
 
-No custom handler is registered for `fastapi.HTTPException` / `StarletteHTTPException`. The 366 raw raise sites (see §Non-conforming) therefore produce FastAPI's default:
+No custom handler is registered for `fastapi.HTTPException` / `StarletteHTTPException`. The remaining raw raise sites (see §Non-conforming) therefore produce FastAPI's default:
 
 ```json
 { "detail": "<string or object passed as detail>" }
@@ -46,19 +46,26 @@ No custom handler is registered for `fastapi.HTTPException` / `StarletteHTTPExce
 - No `error` code. No `message`. No `details` object. SDKs cannot route on these.
 - Status code is whatever the raise site passes.
 
-### 3. REST — 422 validation (FastAPI default)
+> **#992 Phase 1 (partial, landed):** the original census counted **366** raw raise sites. Phase 1 converted **36 auth-boundary 401/403 route-level sites** (every 401/403 in `auth.py`, `oauth.py`, `public_search.py`, `workspace.py`, `member_credentials.py`, `admin.py` — single-line **and** multi-line raise forms) onto the canonical `MemoryCloudException` family, leaving **~330** raw sites. The only 401/403 deliberately left raw in those files are `oauth.py:327/341`, which carry the RFC 6750 `WWW-Authenticate: Bearer` challenge header the global handler does not emit. The dependency-layer 401/403 emitters (`auth/dependencies.py`, `auth/analysis_gates.py`, `utils/auth_helpers.py`), the non-auth statuses (400/404/422/500) in the touched files, and Phase 2's remaining route files are **not** yet migrated — see §Follow-up. #992 stays open.
 
-No `RequestValidationError` handler exists anywhere in `backend/src` (verified by grep). Pydantic/FastAPI default applies:
+### 3. REST — 422 validation (canonical, since #992 Phase 1)
+
+A `RequestValidationError` handler is registered in `backend/src/api/main.py` (`request_validation_exception_handler`, added in #992 Phase 1). Request-body validation failures now emit the canonical envelope:
 
 ```json
 {
-  "detail": [
-    { "type": "...", "loc": ["body", "field"], "msg": "...", "input": "...", "...": "..." }
-  ]
+  "error": "VAL-001",
+  "message": "Request validation failed",
+  "details": {
+    "errors": [
+      { "loc": ["body", "field"], "msg": "...", "type": "..." }
+    ]
+  }
 }
 ```
 
-- HTTP 422, no `error` code. ⚠ This is part of the public surface and diverges from both the canonical shape and `ValidationError` (`VAL-001`, 422), which **does** conform when raised from service code. Two different 422 shapes coexist.
+- HTTP 422, `error: "VAL-001"` — matches the `ValidationError` shape raised from service code, so the two 422 paths now agree.
+- The handler projects each pydantic error to a trimmed `{loc, msg, type}` and **drops `input`/`ctx`/`url`** — the rejected payload is never echoed back (CWE-639 / info-disclosure defense for the frozen surface).
 
 ### 4. MCP tool errors (in-band, JSON-in-TextContent)
 
@@ -278,7 +285,7 @@ Issue acceptance allows at most 2 sub-issues; candidates are grouped into 2 bund
 |---|---|---|
 | P1 | Rename the 3 snake_case REST codes in `api/routes/admin_sleep.py` to the `NAMESPACE-NNN` convention (e.g. `SLEEP-001/002/003`) before any SDK pins them. | §B ⚠ |
 | P1 | Resolve the `ADMIN-*` namespace collision: `ADMIN-001` (403 protection) vs `ADMIN-101/102` (400 preconditions). Either re-namespace the preconditions (e.g. `REQ-1xx`) or document the split-by-hundreds scheme as frozen. | §B ⚠ |
-| P1 | Decide the 422 story: either register a `RequestValidationError` handler that wraps FastAPI validation errors in the canonical shape (e.g. `VAL-002` with the pydantic array under `details`), or freeze the FastAPI default array as documented surface. Today two 422 shapes coexist (`VAL-001` canonical vs default array). | §Canonical 3, §Non-conforming ⚠ |
+| ✅ DONE (#992 Phase 1) | ~~Decide the 422 story~~ — **resolved**: a `RequestValidationError` handler now wraps FastAPI validation errors in the canonical envelope under `error: "VAL-001"` (`{loc, msg, type}` projection, `input` stripped). The two 422 shapes now agree. | §Canonical 3 |
 | P2 | Give Qdrant a dedicated code (the `EXT-101` gap before Redis `EXT-102` strongly suggests it was reserved for Qdrant); keep `EXT-001` as the generic fallback only. | §A ⚠ |
 | P2 | Remove the class-name fallback in `MemoryCloudException.__init__` (`error_code or self.__class__.__name__`) or make `error_code` required — the fallback can silently mint undocumented codes. | §Canonical 1 ⚠ |
 | P2 | De-duplicate MCP literals `invalid_argument`/`invalid_arguments` and `missing_fields`/`missing_required_fields`. | §Supplementary ⚠ |
@@ -288,7 +295,7 @@ Issue acceptance allows at most 2 sub-issues; candidates are grouped into 2 bund
 
 | Priority | Item | Feeds from |
 |---|---|---|
-| P1 | Migrate the auth boundary first: `auth/dependencies.py` (18), `auth/analysis_gates.py` (4), `utils/auth_helpers.py` (4) — these emit 401/403 in the non-canonical shape on every protected route, directly beside the canonical `AUTH-xxx` family. | §Non-conforming ⚠ |
+| 🟡 PARTIAL (#992 Phase 1) | Migrate the auth boundary first. **Route-level 401/403 done**: the 21 raw sites in `auth.py`, `oauth.py`, `public_search.py`, `workspace.py`, `member_credentials.py`, `admin.py` now raise the canonical `AUTH-*`/`ADMIN-001` family. **Still raw (Phase 2)**: the dependency-layer emitters `auth/dependencies.py` (18), `auth/analysis_gates.py` (4), `utils/auth_helpers.py` (4) — these run on every protected route and are the higher-frequency emitters. Note `auth/dependencies.py:505/521` deliberately carry `WWW-Authenticate: Bearer error="insufficient_scope"` (RFC 6750) and `oauth.py:329/343` carry `WWW-Authenticate: Bearer` — preserve those headers when migrating. | §Non-conforming ⚠ |
 | P1 | Retire `utils/db_helpers.py:79` (`handle_db_operation` → `HTTPException(500)`) in favor of `DatabaseError`/`InternalError`, and stop `utils/error_messages.py` documenting the raw-raise pattern. | §Non-conforming ⚠ |
-| P2 | Migrate the remaining ~340 route-level raises, largest files first (`oauth.py` 31, `member_credentials.py` 29, `contexts.py` 29, `auth.py` 24, `admin.py` 19, `resource_tokens.py` 17). Alternatively, if full migration won't land before 1.0: register a `StarletteHTTPException` handler that re-shapes `{"detail": ...}` into `{error: "HTTP-<status>", message, details: {}}` as a stopgap so the *shape* freezes even where codes don't exist yet. | §Non-conforming ⚠ |
+| P2 | Migrate the remaining ~296 route-level raises (non-auth statuses + untouched files), largest files first (`contexts.py` 29, `oauth.py` 26, `resource_tokens.py` 17, `auth.py` 17, `member_credentials.py` 15, `admin.py` 15). Alternatively, if full migration won't land before 1.0: register a `StarletteHTTPException` handler that re-shapes `{"detail": ...}` into `{error: "HTTP-<status>", message, details: {}}` as a stopgap so the *shape* freezes even where codes don't exist yet. | §Non-conforming ⚠ |
 | P2 | Propagate `error_code` through the MCP `-32603` catch-all via `error.data` (e.g. `data.error_code`) so transport-level failures stay SDK-routable. | §D ⚠ |

--- a/frontend/src/lib/api/base.test.ts
+++ b/frontend/src/lib/api/base.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { ApiError } from "./base";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ApiClient, ApiError } from "./base";
 
 describe("ApiError", () => {
   it("is an instance of Error", () => {
@@ -51,5 +51,55 @@ describe("ApiError", () => {
     const err = new ApiError({ message: "minimal", status: 0 });
     expect(err.error).toBeUndefined();
     expect(err.details).toBeUndefined();
+  });
+});
+
+describe("ApiClient error normalization (#992 canonical 422 envelope)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function mockFetchOnce(status: number, body: unknown) {
+    vi.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(JSON.stringify(body), {
+        status,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+  }
+
+  it("aliases canonical 422 details.errors -> details.detail so field consumers keep working", async () => {
+    const errors = [
+      { loc: ["body", "redirect_uris"], msg: "Field required", type: "missing" },
+    ];
+    mockFetchOnce(422, {
+      error: "VAL-001",
+      message: "Request validation failed",
+      details: { errors },
+    });
+
+    const client = new ApiClient("http://test");
+    const caught = await client.post("/x", {}).catch((e: unknown) => e);
+
+    expect(caught).toBeInstanceOf(ApiError);
+    const err = caught as ApiError;
+    expect(err.status).toBe(422);
+    expect(err.error).toBe("VAL-001");
+    const details = err.details as Record<string, unknown>;
+    // Existing field-validation consumers read details.detail as the array.
+    expect(details.detail).toEqual(errors);
+    expect(details.errors).toEqual(errors);
+  });
+
+  it("leaves a string `detail` from a raw HTTPException endpoint untouched", async () => {
+    // Not-yet-converted endpoints still emit FastAPI's { detail: "..." }.
+    mockFetchOnce(404, { detail: "API key not found" });
+
+    const client = new ApiClient("http://test");
+    const caught = await client.get("/x").catch((e: unknown) => e);
+
+    expect(caught).toBeInstanceOf(ApiError);
+    const details = (caught as ApiError).details as Record<string, unknown>;
+    expect(details.detail).toBe("API key not found");
   });
 });

--- a/frontend/src/lib/api/base.ts
+++ b/frontend/src/lib/api/base.ts
@@ -83,11 +83,31 @@ export class ApiClient {
           `HTTP ${response.status}: ${response.statusText}`;
         const errorCode = errorDetails.error;
 
+        // #992: the canonical 422 envelope is { error: "VAL-001", message,
+        // details: { errors: [{loc, msg, type}] } }. Existing field-validation
+        // consumers read `details.detail` (the legacy FastAPI array shape).
+        // Alias `errors` -> `detail` here, at the single transport choke point,
+        // so field-level messages keep rendering without every call site
+        // learning the new key. (String-`detail` errors from not-yet-converted
+        // raw-HTTPException endpoints have no `errors` key and are untouched.)
+        let details = errorDetails.details || errorDetails;
+        if (
+          details &&
+          typeof details === "object" &&
+          Array.isArray((details as { errors?: unknown }).errors) &&
+          (details as { detail?: unknown }).detail === undefined
+        ) {
+          details = {
+            ...details,
+            detail: (details as { errors: unknown[] }).errors,
+          };
+        }
+
         throw new ApiError({
           error: errorCode,
           message: errorMessage,
           status: response.status,
-          details: errorDetails.details || errorDetails,
+          details,
         });
       }
 


### PR DESCRIPTION
Part of #992 (Phase 1 — **does not close** the issue; remainder tracked in `docs/api-surface-1.0/error-responses.md`).

## Summary
- Converge **every route-level 401/403 raw `raise HTTPException`** in the six auth-boundary route files (`auth.py`, `oauth.py`, `public_search.py`, `workspace.py`, `member_credentials.py`, `admin.py`) — **36 sites**, single-line *and* multi-line forms — onto the canonical `{error, message, details}` envelope via the existing `MemoryCloudException` family. No new exception classes.
- Register a `RequestValidationError` (422) handler so request-validation failures use the same canonical shape (`error: "VAL-001"`) instead of FastAPI's `{detail: [...]}` array.
- Status codes preserved everywhere (401→401, 403→403). Messages preserved except where the raw text was an internal exception string (now log-only `reason`).

## Implementation notes
- 401 → `AuthenticationError` / `InvalidCredentialsError` / `APIKeyError`; 403 → `AuthorizationError` (handler strips `details` for CWE-639) / `AdminProtectionError` (log-only `reason`).
- **Security**: the 422 handler projects each pydantic error to a trimmed `{loc, msg, type}` and **drops `input`/`ctx`/`url`** so a rejected payload (password, token, PII) is never echoed back. The social-login 401s stop echoing `str(e)`, and the `PermissionError`→403 path routes its text to a log-only `reason`.
- **Deliberately left raw**: `oauth.py:327/341` — RFC 6750 `WWW-Authenticate: Bearer` challenge 401s the global handler cannot emit. No converted site carried that header.
- Phased boundary is **by status** (issue's own task list): non-auth statuses (400/404/422-manual/500) in the touched files, the dependency-layer emitters (`auth/dependencies.py` etc.), and the remaining route files are Phase 2. No same-status shape divergence is introduced.
- `docs/api-surface-1.0/error-responses.md` re-frozen for the 422 + auth-boundary portions (census 366 → ~330; Phase-2 follow-up rows updated).

## Pre-PR review summary
- gate2 mode: advisor-only (no binary gate configured)
- audit: skipped
- cso: green · qa-lead: yellow · cto: green
- gate1: green via /claude-c-suite:ask (CSO lens)
- review provider: none (opt-in — run `/gh-issue-driven:review` to start a review loop)

qa-lead's **yellow** is a non-blocking follow-up: add an e2e/integration test asserting a *converted* endpoint's live wire body (e.g. `POST /auth/login` bad creds → `{error:"AUTH-002"}`). The 422 input-stripping and exception-class parity are already directly tested.

## Verification
- `ruff` clean; `tests/api` + `tests/smoke` + `tests/auth` = **1114 passed**, 0 failed.
- Inner review (2 rounds, opus) converged with no remaining findings.

Full reviews saved in the plugin cache:
- `~/.claude/cache/gh-issue-driven/992-refactor-error-shape-phase1-auth-boundary.gate1.md`
- `~/.claude/cache/gh-issue-driven/992-refactor-error-shape-phase1-auth-boundary.gate2.md`

🤖 Generated via /gh-issue-driven:ship
