### PR TITLE
feat(storage): generalize R2Storage to an S3-compatible backend (#994)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -247,11 +247,23 @@ BILLING_ENABLED=false
 # -----------------------------------------------------------------------------
 # Platform-managed file storage for SDK File Ingestion BLOBs. Empty values
 # disable the file-storage feature entirely — the /api/v1/files routes and
-# MCP file tools return a clear error on first call until R2 is configured.
+# MCP file tools return a clear error on first call until storage is configured.
 #
-# Generate S3-compatible access keys in the Cloudflare R2 dashboard with
-# bucket-scoped permissions. One key per environment (dev/staging/prod).
+# Any S3-compatible backend works (Issue #994): Cloudflare R2 (managed cloud),
+# MinIO or AWS S3 (self-host). The same client drives all of them — only the
+# endpoint differs. STORAGE_* are the canonical names; the legacy R2_* names
+# below are still accepted as aliases (existing deploys keep working unchanged).
+# See docs/deployment.md for the self-host (MinIO) walkthrough.
 #
+# STORAGE_BACKEND_TYPE=r2          # r2 | s3 | minio | s3-compatible | aws
+# STORAGE_ACCOUNT_ID=              # R2 account ID; any non-empty value for MinIO/AWS
+# STORAGE_ACCESS_KEY_ID=
+# STORAGE_SECRET_ACCESS_KEY=
+# STORAGE_BUCKET=kagura-memory-files-dev
+# STORAGE_ENDPOINT_URL=https://<account_id>.r2.cloudflarestorage.com  # MinIO: http://minio:9000
+#
+# Legacy aliases (deprecated; still honored — a one-time deprecation line is
+# logged when only R2_* is set and no STORAGE_*):
 # R2_ACCOUNT_ID=
 # R2_ACCESS_KEY_ID=
 # R2_SECRET_ACCESS_KEY=
@@ -266,7 +278,7 @@ BILLING_ENABLED=false
 # backend can deploy ahead of SDK rollout. See CHANGELOG entry for #556 for
 # the staged rollout sequence and docs/ops/r2-checksum-binding-rollout.md §10
 # for default-flip / flag-removal criteria (#577).
-# R2_CHECKSUM_BINDING_ENABLED=false
+# STORAGE_CHECKSUM_BINDING_ENABLED=false   # alias: R2_CHECKSUM_BINDING_ENABLED
 #
 # Per-file Phase 1 cap (MiB). Hard ceiling enforced server-side; clients
 # uploading more than this fail at upload-init.

--- a/.env.example
+++ b/.env.example
@@ -256,6 +256,7 @@ BILLING_ENABLED=false
 # See docs/deployment.md for the self-host (MinIO) walkthrough.
 #
 # STORAGE_BACKEND_TYPE=r2          # r2 | s3 | minio | s3-compatible | aws
+# STORAGE_REGION=auto              # 'auto' for R2/MinIO; real region (e.g. us-east-1) for aws
 # STORAGE_ACCOUNT_ID=              # R2 account ID; any non-empty value for MinIO/AWS
 # STORAGE_ACCESS_KEY_ID=
 # STORAGE_SECRET_ACCESS_KEY=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,10 +247,37 @@ jobs:
       - name: Install dependencies
         run: cd backend && pip install -e ".[dev]"
 
+      # MinIO for the #994 S3-compatible storage integration test. Started as a
+      # plain container (not a GHA `services:` entry) so we control the
+      # `server /data` command; the test creates its own bucket. The test
+      # self-skips if MINIO_TEST_ENDPOINT is unreachable, so a MinIO hiccup
+      # never fails the whole integration job spuriously.
+      - name: Start MinIO
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio server /data
+          for i in $(seq 1 30); do
+            if curl -fs http://localhost:9000/minio/health/live >/dev/null; then
+              echo "minio up"; exit 0
+            fi
+            sleep 2
+          done
+          # Hard-fail rather than let the test silently skip — the MinIO
+          # round-trip is the #994 acceptance criterion, so "MinIO never came
+          # up" must turn the job red, not green-by-skip.
+          echo "MinIO did not become healthy within 60s" >&2
+          docker logs minio 2>&1 | tail -30 || true
+          exit 1
+
       - name: Run integration tests
         env:
           TEST_DATABASE_URL: postgresql+asyncpg://kagura:kagura_dev_password@localhost:5432/kagura_test
           REDIS_URL: redis://localhost:6379
+          MINIO_TEST_ENDPOINT: http://localhost:9000
+          MINIO_TEST_ACCESS_KEY: minioadmin
+          MINIO_TEST_SECRET_KEY: minioadmin
+          MINIO_TEST_BUCKET: kagura-files-test
         run: cd backend && pytest tests/integration/ tests/smoke/test_all_routes.py -v --timeout=120 --maxfail=3
 
   # Authenticated a11y (color-contrast) lane (#840). Unlike the hermetic

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -459,9 +459,7 @@ class Settings(BaseSettings):
     )
     storage_account_id: str = Field(
         default="",
-        validation_alias=AliasChoices(
-            "storage_account_id", "s3_account_id", "r2_account_id"
-        ),
+        validation_alias=AliasChoices("storage_account_id", "s3_account_id", "r2_account_id"),
         description="S3-compatible account ID (R2 account ID; unused by AWS S3 / MinIO)",
     )
     storage_access_key_id: str = Field(
@@ -487,9 +485,7 @@ class Settings(BaseSettings):
     )
     storage_endpoint_url: str = Field(
         default="",
-        validation_alias=AliasChoices(
-            "storage_endpoint_url", "s3_endpoint_url", "r2_endpoint_url"
-        ),
+        validation_alias=AliasChoices("storage_endpoint_url", "s3_endpoint_url", "r2_endpoint_url"),
         description=(
             "S3-compatible endpoint URL. R2: https://<account>.r2.cloudflarestorage.com; "
             "MinIO: http://minio:9000; AWS S3: leave empty for the default region endpoint."

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -437,14 +437,24 @@ class Settings(BaseSettings):
     # (which set only R2_*) work unchanged. `Settings` uses extra="ignore", so
     # dropping the r2_* alias would SILENTLY ignore prod's R2_* env -> empty
     # endpoint -> the upload path 502s with no load-time error (#994 gate1 risk).
-    storage_backend_type: str = Field(
+    storage_backend_type: Literal["r2", "s3", "minio", "s3-compatible", "aws"] = Field(
         default="r2",
-        validation_alias=AliasChoices("storage_backend_type"),
         description=(
-            "Object-storage backend discriminator: r2 | s3 | minio | "
-            "s3-compatible | aws. All use the same S3-compatible client; only "
-            "the endpoint differs. Default 'r2' preserves the managed-cloud "
-            "deploy (Cloudflare R2). Self-hosters set 'minio' / 's3'."
+            "Object-storage backend discriminator. All use the same "
+            "S3-compatible client; only the endpoint (and, for 'aws', the "
+            "region) differs. Default 'r2' preserves the managed-cloud deploy "
+            "(Cloudflare R2). Self-hosters set 'minio' / 's3' / 'aws'. Pydantic "
+            "rejects other values at boot, so STORAGE_BACKEND_TYPE typos fail "
+            "loudly instead of 502-ing on the first upload."
+        ),
+    )
+    storage_region: str = Field(
+        default="auto",
+        validation_alias=AliasChoices("storage_region", "s3_region", "r2_region"),
+        description=(
+            "S3 region. 'auto' (default) is correct for R2 and MinIO (both "
+            "ignore it). Set the bucket's real region (e.g. 'us-east-1') for an "
+            "'aws' backend, where SigV4 needs it."
         ),
     )
     storage_account_id: str = Field(

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -9,7 +9,7 @@ import os
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from utils.media_types import MEDIA_TYPE_RE, normalize_media_type
@@ -430,14 +430,60 @@ class Settings(BaseSettings):
         default=0.95, description="Usage critical threshold (0.0-1.0)"
     )
 
-    # Object Storage / Cloudflare R2 (Issue #485)
-    r2_account_id: str = Field(default="", description="Cloudflare R2 account ID")
-    r2_access_key_id: str = Field(default="", description="R2 S3-compatible access key ID")
-    r2_secret_access_key: str = Field(default="", description="R2 S3-compatible secret access key")
-    r2_bucket: str = Field(default="", description="R2 bucket name (e.g. kagura-memory-files-dev)")
-    r2_endpoint_url: str = Field(
+    # Object Storage — S3-compatible backend (Issue #485 R2; generalized #994).
+    # All five credential settings accept STORAGE_* (canonical), S3_*, and R2_*
+    # (legacy) env vars via AliasChoices. The canonical name is listed FIRST so
+    # it wins when more than one is set; R2_* is kept so existing prod deploys
+    # (which set only R2_*) work unchanged. `Settings` uses extra="ignore", so
+    # dropping the r2_* alias would SILENTLY ignore prod's R2_* env -> empty
+    # endpoint -> the upload path 502s with no load-time error (#994 gate1 risk).
+    storage_backend_type: str = Field(
+        default="r2",
+        validation_alias=AliasChoices("storage_backend_type"),
+        description=(
+            "Object-storage backend discriminator: r2 | s3 | minio | "
+            "s3-compatible | aws. All use the same S3-compatible client; only "
+            "the endpoint differs. Default 'r2' preserves the managed-cloud "
+            "deploy (Cloudflare R2). Self-hosters set 'minio' / 's3'."
+        ),
+    )
+    storage_account_id: str = Field(
         default="",
-        description="R2 S3-compatible endpoint (https://<account>.r2.cloudflarestorage.com)",
+        validation_alias=AliasChoices(
+            "storage_account_id", "s3_account_id", "r2_account_id"
+        ),
+        description="S3-compatible account ID (R2 account ID; unused by AWS S3 / MinIO)",
+    )
+    storage_access_key_id: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "storage_access_key_id", "s3_access_key_id", "r2_access_key_id"
+        ),
+        description="S3-compatible access key ID",
+    )
+    storage_secret_access_key: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "storage_secret_access_key",
+            "s3_secret_access_key",
+            "r2_secret_access_key",
+        ),
+        description="S3-compatible secret access key",
+    )
+    storage_bucket: str = Field(
+        default="",
+        validation_alias=AliasChoices("storage_bucket", "s3_bucket", "r2_bucket"),
+        description="Bucket name (e.g. kagura-memory-files-dev)",
+    )
+    storage_endpoint_url: str = Field(
+        default="",
+        validation_alias=AliasChoices(
+            "storage_endpoint_url", "s3_endpoint_url", "r2_endpoint_url"
+        ),
+        description=(
+            "S3-compatible endpoint URL. R2: https://<account>.r2.cloudflarestorage.com; "
+            "MinIO: http://minio:9000; AWS S3: leave empty for the default region endpoint."
+        ),
     )
     file_object_max_size_mb: int = Field(
         default=100, description="Per-file size cap in MB (Issue #485 Phase 1 = 100)"
@@ -448,8 +494,13 @@ class Settings(BaseSettings):
     presign_get_ttl_seconds: int = Field(
         default=300, description="Presigned GET URL lifetime in seconds"
     )
-    r2_checksum_binding_enabled: bool = Field(
+    storage_checksum_binding_enabled: bool = Field(
         default=False,
+        validation_alias=AliasChoices(
+            "storage_checksum_binding_enabled",
+            "s3_checksum_binding_enabled",
+            "r2_checksum_binding_enabled",
+        ),
         description=(
             "Bind body sha256 to presigned PUT via S3 ChecksumSHA256 (Issue #556). "
             "When True, R2 verifies the body sha256 server-side and rejects "

--- a/backend/src/storage/factory.py
+++ b/backend/src/storage/factory.py
@@ -1,17 +1,26 @@
 """Factory + lifecycle for the in-process ``BlobStorageProtocol`` instance.
 
-Phase 1 dispatches on whether R2 settings are configured:
+Dispatch (Issue #485; generalized in #994):
 
-- All five R2 settings populated → ``R2Storage`` instance.
-- Anything missing → raise on first ``get_blob_storage()`` call so dev
-  environments without R2 fail fast with a clear error instead of
-  reaching production with a half-wired upload path.
+- ``settings.storage_backend_type`` selects the backend label. Every known
+  value (r2 / s3 / minio / s3-compatible / aws) currently constructs the same
+  :class:`~storage.s3_compatible.S3CompatibleStorage` — they all speak the S3
+  API and differ only by ``STORAGE_ENDPOINT_URL``. The discriminator exists so
+  self-hosters can declare their backend explicitly (and so a future per-backend
+  impl is a one-place change here).
+- An unknown ``storage_backend_type`` or an empty endpoint raises
+  ``ExternalServiceError`` (HTTP 502) on the first ``get_blob_storage()`` call,
+  so a half-wired upload path fails fast with a clear error, never an opaque 500.
 
-Phase 2 BYO will dispatch on a new ``settings.storage_backend_type``
-discriminator. Adding it then will be a one-place change here.
+Backward compatibility: prod sets only the legacy ``R2_*`` env vars and no
+discriminator. The default ``storage_backend_type="r2"`` plus the ``R2_*``
+``AliasChoices`` on the settings fields keep that deploy working unchanged; a
+one-time deprecation line is logged when only ``R2_*`` (no ``STORAGE_*``) is set.
 """
 
 from __future__ import annotations
+
+import os
 
 import structlog
 
@@ -19,6 +28,52 @@ from config.settings import get_settings
 from storage.protocol import BlobStorageProtocol
 
 logger = structlog.get_logger(__name__)
+
+# Known discriminator values. All map to S3CompatibleStorage today; the set is
+# the validation allowlist so a typo (e.g. "mino") fails loudly, not silently.
+_KNOWN_BACKENDS = frozenset({"r2", "s3", "minio", "s3-compatible", "aws"})
+
+
+def _warn_if_legacy_storage_env() -> None:
+    """Emit one deprecation line when the deploy uses only legacy ``R2_*`` env.
+
+    Best-effort and side-effect-free beyond logging: reads ``os.environ``
+    directly (the resolved Settings value cannot report which alias matched).
+    Silent when canonical ``STORAGE_*`` / ``S3_*`` vars are present.
+    """
+    legacy = any(
+        os.getenv(k)
+        for k in (
+            "R2_ENDPOINT_URL",
+            "R2_BUCKET",
+            "R2_ACCESS_KEY_ID",
+            "R2_SECRET_ACCESS_KEY",
+            "R2_ACCOUNT_ID",
+        )
+    )
+    canonical = any(
+        os.getenv(k)
+        for k in (
+            "STORAGE_ENDPOINT_URL",
+            "S3_ENDPOINT_URL",
+            "STORAGE_BUCKET",
+            "S3_BUCKET",
+            "STORAGE_ACCESS_KEY_ID",
+            "S3_ACCESS_KEY_ID",
+            "STORAGE_SECRET_ACCESS_KEY",
+            "S3_SECRET_ACCESS_KEY",
+            "STORAGE_ACCOUNT_ID",
+            "S3_ACCOUNT_ID",
+        )
+    )
+    if legacy and not canonical:
+        logger.warning(
+            "storage_env_deprecated",
+            detail=(
+                "R2_* storage env vars are deprecated; rename to STORAGE_* "
+                "(R2_* is still honored). See docs/deployment.md."
+            ),
+        )
 
 
 _storage: BlobStorageProtocol | None = None
@@ -28,8 +83,8 @@ def get_blob_storage() -> BlobStorageProtocol:
     """Return the process-wide ``BlobStorageProtocol`` instance.
 
     Lazily constructed on first call. Raises ``ExternalServiceError``
-    (HTTP 502 via the global handler) if R2 is missing OR partially
-    configured — both unconfigured (``r2_endpoint_url`` empty) and
+    (HTTP 502 via the global handler) if storage is missing OR partially
+    configured — both unconfigured (``storage_endpoint_url`` empty) and
     half-configured (some fields set, others empty) surface the same
     "storage unavailable" shape so REST and MCP file handlers can
     return a usable error message instead of an opaque 500.
@@ -43,30 +98,47 @@ def get_blob_storage() -> BlobStorageProtocol:
     global _storage
     if _storage is None:
         settings = get_settings()
-        if not settings.r2_endpoint_url:
+
+        backend_type = (settings.storage_backend_type or "r2").strip().lower()
+        if backend_type not in _KNOWN_BACKENDS:
             raise ExternalServiceError(
-                "R2",
-                "storage is not configured (R2_ENDPOINT_URL empty). "
-                "Set R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, "
-                "R2_BUCKET, and R2_ENDPOINT_URL — see .env.example.",
+                "storage",
+                f"unknown storage_backend_type '{backend_type}' "
+                f"(expected one of: {', '.join(sorted(_KNOWN_BACKENDS))}).",
             )
-        from storage.r2 import R2Storage
+
+        if not settings.storage_endpoint_url:
+            raise ExternalServiceError(
+                "storage",
+                "storage is not configured (STORAGE_ENDPOINT_URL empty). "
+                "Set STORAGE_ACCESS_KEY_ID, STORAGE_SECRET_ACCESS_KEY, "
+                "STORAGE_BUCKET, and STORAGE_ENDPOINT_URL (legacy R2_* names are "
+                "still accepted) — see .env.example.",
+            )
+
+        _warn_if_legacy_storage_env()
+
+        from storage.s3_compatible import S3CompatibleStorage
 
         try:
-            _storage = R2Storage(
-                account_id=settings.r2_account_id,
-                access_key_id=settings.r2_access_key_id,
-                secret_access_key=settings.r2_secret_access_key,
-                bucket=settings.r2_bucket,
-                endpoint_url=settings.r2_endpoint_url,
-                enable_checksum_binding=settings.r2_checksum_binding_enabled,
+            _storage = S3CompatibleStorage(
+                account_id=settings.storage_account_id,
+                access_key_id=settings.storage_access_key_id,
+                secret_access_key=settings.storage_secret_access_key,
+                bucket=settings.storage_bucket,
+                endpoint_url=settings.storage_endpoint_url,
+                enable_checksum_binding=settings.storage_checksum_binding_enabled,
             )
         except ValueError as exc:
             raise ExternalServiceError(
-                "R2",
+                "storage",
                 f"storage construction failed (partial config?): {exc}",
             ) from exc
-        logger.info("blob_storage_initialized", backend="r2", bucket=settings.r2_bucket)
+        logger.info(
+            "blob_storage_initialized",
+            backend=backend_type,
+            bucket=settings.storage_bucket,
+        )
     return _storage
 
 

--- a/backend/src/storage/factory.py
+++ b/backend/src/storage/factory.py
@@ -29,10 +29,6 @@ from storage.protocol import BlobStorageProtocol
 
 logger = structlog.get_logger(__name__)
 
-# Known discriminator values. All map to S3CompatibleStorage today; the set is
-# the validation allowlist so a typo (e.g. "mino") fails loudly, not silently.
-_KNOWN_BACKENDS = frozenset({"r2", "s3", "minio", "s3-compatible", "aws"})
-
 
 def _warn_if_legacy_storage_env() -> None:
     """Emit one deprecation line when the deploy uses only legacy ``R2_*`` env.
@@ -99,13 +95,10 @@ def get_blob_storage() -> BlobStorageProtocol:
     if _storage is None:
         settings = get_settings()
 
-        backend_type = (settings.storage_backend_type or "r2").strip().lower()
-        if backend_type not in _KNOWN_BACKENDS:
-            raise ExternalServiceError(
-                "storage",
-                f"unknown storage_backend_type '{backend_type}' "
-                f"(expected one of: {', '.join(sorted(_KNOWN_BACKENDS))}).",
-            )
+        # storage_backend_type is a Literal — pydantic already rejected typos at
+        # config load, so no allowlist check is needed here (single source of
+        # truth lives on the settings field).
+        backend_type = settings.storage_backend_type
 
         if not settings.storage_endpoint_url:
             raise ExternalServiceError(
@@ -128,6 +121,7 @@ def get_blob_storage() -> BlobStorageProtocol:
                 bucket=settings.storage_bucket,
                 endpoint_url=settings.storage_endpoint_url,
                 enable_checksum_binding=settings.storage_checksum_binding_enabled,
+                region=settings.storage_region,
             )
         except ValueError as exc:
             raise ExternalServiceError(

--- a/backend/src/storage/r2.py
+++ b/backend/src/storage/r2.py
@@ -1,184 +1,22 @@
-"""Cloudflare R2 implementation of ``BlobStorageProtocol`` (Issue #485).
+"""Backward-compatible alias for the storage backend (Issue #994).
 
-R2 exposes an S3-compatible API, so we use ``aioboto3`` against R2's
-endpoint. Single ``aioboto3.Session`` is reused; the per-call client
-context manager opens a connection from the underlying ``aiobotocore``
-pool, so there is no per-request socket setup cost.
+``R2Storage`` was renamed to :class:`~storage.s3_compatible.S3CompatibleStorage`
+when the backend was generalized to any S3-compatible endpoint (R2 / MinIO /
+AWS S3). The implementation never branched on R2 — only the endpoint URL
+differs — so the rename is behavior-preserving.
+
+This module re-exports the new class under the old name so existing imports
+(``from storage.r2 import R2Storage``) and any external references keep working.
+Prefer importing :class:`S3CompatibleStorage` from ``storage.s3_compatible`` in
+new code.
 """
 
 from __future__ import annotations
 
-import base64
-from typing import Any
+from storage.s3_compatible import S3CompatibleStorage
 
-import aioboto3
-import structlog
-from botocore.exceptions import ClientError
+# Backward-compatible alias — same class object, so ``isinstance(x, R2Storage)``
+# and ``isinstance(x, S3CompatibleStorage)`` are equivalent.
+R2Storage = S3CompatibleStorage
 
-from storage.protocol import ObjectMetadata
-from utils.exceptions import ExternalServiceError
-
-logger = structlog.get_logger(__name__)
-
-
-class R2Storage:
-    """``BlobStorageProtocol`` impl backed by Cloudflare R2.
-
-    The class deliberately does not inherit from ``BlobStorageProtocol``
-    — runtime structural typing (``@runtime_checkable``) is enough, and
-    keeping it separate avoids tight coupling for Phase 2 BYO impls.
-    """
-
-    def __init__(
-        self,
-        *,
-        account_id: str,
-        access_key_id: str,
-        secret_access_key: str,
-        bucket: str,
-        endpoint_url: str,
-        enable_checksum_binding: bool = False,
-    ) -> None:
-        if not (account_id and access_key_id and secret_access_key and bucket and endpoint_url):
-            raise ValueError(
-                "R2Storage requires non-empty account_id, access_key_id, "
-                "secret_access_key, bucket, and endpoint_url"
-            )
-        self._bucket = bucket
-        self._endpoint_url = endpoint_url
-        self._enable_checksum_binding = enable_checksum_binding
-        self._session = aioboto3.Session(
-            aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key,
-            region_name="auto",  # R2 ignores region; "auto" is the canonical value
-        )
-
-    def _client(self) -> Any:
-        """Return a fresh aioboto3 S3 client context manager.
-
-        Callers MUST use it with ``async with`` so the underlying
-        connection is returned to the pool.
-        """
-        return self._session.client("s3", endpoint_url=self._endpoint_url)
-
-    async def write_object(
-        self,
-        key: str,
-        data: bytes,
-        content_type: str,
-        sha256: str,
-    ) -> None:
-        """Server-side upload (used by the attachments migration only)."""
-        async with self._client() as client:
-            await client.put_object(
-                Bucket=self._bucket,
-                Key=key,
-                Body=data,
-                ContentType=content_type,
-                Metadata={"sha256": sha256},
-            )
-            logger.info("r2_object_written", key=key, size_bytes=len(data))
-
-    async def head_object(self, key: str) -> ObjectMetadata | None:
-        async with self._client() as client:
-            try:
-                resp = await client.head_object(Bucket=self._bucket, Key=key)
-            except ClientError as exc:
-                code = exc.response.get("Error", {}).get("Code")
-                # Both shapes appear in the wild — botocore translates
-                # HTTP 404 to ``"404"`` for HEAD; ``NoSuchKey`` is the
-                # GET shape, kept for safety in case R2 differs.
-                if code in ("404", "NoSuchKey"):
-                    return None
-                # Non-404 errors (5xx, AccessDenied, throttling, …) are
-                # surfaced as a domain exception so REST/MCP layers map
-                # them to a clear 502 instead of a raw boto traceback.
-                logger.warning(
-                    "r2_head_object_error",
-                    key=key,
-                    code=code,
-                    error=str(exc),
-                )
-                raise ExternalServiceError(
-                    "R2",
-                    f"head_object failed for key={key!r}: {code}",
-                ) from exc
-            return ObjectMetadata(
-                size_bytes=int(resp["ContentLength"]),
-                etag=str(resp.get("ETag", "")).strip('"'),
-            )
-
-    async def delete_object(self, key: str) -> None:
-        async with self._client() as client:
-            await client.delete_object(Bucket=self._bucket, Key=key)
-            logger.info("r2_object_deleted", key=key)
-
-    async def generate_presigned_put(
-        self,
-        key: str,
-        content_type: str,
-        size_bytes: int,
-        ttl_seconds: int,
-        sha256: str,
-    ) -> str:
-        # Issue #556 originally proposed presigned POST (signs body sha256
-        # via policy condition); R2 returns 501 NotImplemented for POST.
-        # We sign ``ChecksumSHA256`` on PUT instead — see the live spike
-        # at backend/tests/integration/test_r2_live.py for the contract.
-        # The flag is gated by ``r2_checksum_binding_enabled`` (default
-        # False) so backend can deploy ahead of SDK rollout.
-        params: dict[str, Any] = {
-            "Bucket": self._bucket,
-            "Key": key,
-            "ContentType": content_type,
-            "ContentLength": size_bytes,
-        }
-        if self._enable_checksum_binding:
-            params["ChecksumSHA256"] = base64.b64encode(bytes.fromhex(sha256)).decode()
-        async with self._client() as client:
-            url = await client.generate_presigned_url(
-                ClientMethod="put_object",
-                Params=params,
-                ExpiresIn=ttl_seconds,
-                HttpMethod="PUT",
-            )
-            return str(url)
-
-    async def generate_presigned_get(
-        self,
-        key: str,
-        filename: str,
-        ttl_seconds: int,
-    ) -> str:
-        # Sanitize the filename before embedding into the
-        # ``Content-Disposition`` header. Without this a filename
-        # containing a literal ``"`` could break out of the quoted
-        # parameter and enable filename-spoofing for downloads;
-        # CR/LF could (in principle) corrupt the header
-        # (CSO Gate2 finding F-1 + Copilot loop 5 finding on PR #551).
-        safe_filename = (
-            filename.replace('"', "_").replace("\n", "_").replace("\r", "_").replace("\x00", "_")
-        )
-        async with self._client() as client:
-            url = await client.generate_presigned_url(
-                ClientMethod="get_object",
-                Params={
-                    "Bucket": self._bucket,
-                    "Key": key,
-                    "ResponseContentDisposition": f'attachment; filename="{safe_filename}"',
-                },
-                ExpiresIn=ttl_seconds,
-                HttpMethod="GET",
-            )
-            return str(url)
-
-    async def close(self) -> None:
-        """Release any pooled resources held by aiobotocore.
-
-        Currently a no-op — aioboto3 pools live inside the per-call
-        ``async with`` block and are released on context exit. Kept on
-        the API surface so the lifespan handler can call it
-        unconditionally and a future eager-init refactor stays
-        backwards compatible.
-        """
-        return None
+__all__ = ["R2Storage", "S3CompatibleStorage"]

--- a/backend/src/storage/s3_compatible.py
+++ b/backend/src/storage/s3_compatible.py
@@ -1,0 +1,196 @@
+"""S3-compatible implementation of ``BlobStorageProtocol`` (Issue #485; #994).
+
+A single ``aioboto3``-backed client driven entirely by ``endpoint_url`` — the
+same code path serves Cloudflare R2 (managed cloud), MinIO and AWS S3
+(self-host), because all three speak the S3 API. The backend is selected by
+``settings.storage_backend_type`` in ``storage/factory.py``; this class does
+not branch on it (only the endpoint differs).
+
+Single ``aioboto3.Session`` is reused; the per-call client context manager
+opens a connection from the underlying ``aiobotocore`` pool, so there is no
+per-request socket setup cost.
+
+History: shipped in #485 as ``R2Storage`` (R2-only); generalized to
+``S3CompatibleStorage`` in #994. ``storage/r2.py`` re-exports the old name as
+a backward-compatible alias.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Any
+
+import aioboto3
+import structlog
+from botocore.exceptions import ClientError
+
+from storage.protocol import ObjectMetadata
+from utils.exceptions import ExternalServiceError
+
+logger = structlog.get_logger(__name__)
+
+
+class S3CompatibleStorage:
+    """``BlobStorageProtocol`` impl backed by any S3-compatible endpoint.
+
+    The class deliberately does not inherit from ``BlobStorageProtocol``
+    — runtime structural typing (``@runtime_checkable``) is enough, and
+    keeping it separate avoids tight coupling for BYO impls.
+    """
+
+    def __init__(
+        self,
+        *,
+        account_id: str,
+        access_key_id: str,
+        secret_access_key: str,
+        bucket: str,
+        endpoint_url: str,
+        enable_checksum_binding: bool = False,
+    ) -> None:
+        if not (account_id and access_key_id and secret_access_key and bucket and endpoint_url):
+            raise ValueError(
+                "S3CompatibleStorage requires non-empty account_id, access_key_id, "
+                "secret_access_key, bucket, and endpoint_url"
+            )
+        self._bucket = bucket
+        self._endpoint_url = endpoint_url
+        self._enable_checksum_binding = enable_checksum_binding
+        self._session = aioboto3.Session(
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+            # R2 and MinIO ignore region; "auto" is R2's canonical value and
+            # MinIO accepts any string. AWS S3 proper would need the bucket's
+            # real region — out of scope for the R2/MinIO acceptance criteria.
+            region_name="auto",
+        )
+
+    def _client(self) -> Any:
+        """Return a fresh aioboto3 S3 client context manager.
+
+        Callers MUST use it with ``async with`` so the underlying
+        connection is returned to the pool.
+        """
+        return self._session.client("s3", endpoint_url=self._endpoint_url)
+
+    async def write_object(
+        self,
+        key: str,
+        data: bytes,
+        content_type: str,
+        sha256: str,
+    ) -> None:
+        """Server-side upload (used by the attachments migration only)."""
+        async with self._client() as client:
+            await client.put_object(
+                Bucket=self._bucket,
+                Key=key,
+                Body=data,
+                ContentType=content_type,
+                Metadata={"sha256": sha256},
+            )
+            logger.info("r2_object_written", key=key, size_bytes=len(data))
+
+    async def head_object(self, key: str) -> ObjectMetadata | None:
+        async with self._client() as client:
+            try:
+                resp = await client.head_object(Bucket=self._bucket, Key=key)
+            except ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code")
+                # Both shapes appear in the wild — botocore translates
+                # HTTP 404 to ``"404"`` for HEAD; ``NoSuchKey`` is the
+                # GET shape, kept for safety in case R2 differs.
+                if code in ("404", "NoSuchKey"):
+                    return None
+                # Non-404 errors (5xx, AccessDenied, throttling, …) are
+                # surfaced as a domain exception so REST/MCP layers map
+                # them to a clear 502 instead of a raw boto traceback.
+                logger.warning(
+                    "r2_head_object_error",
+                    key=key,
+                    code=code,
+                    error=str(exc),
+                )
+                raise ExternalServiceError(
+                    "R2",
+                    f"head_object failed for key={key!r}: {code}",
+                ) from exc
+            return ObjectMetadata(
+                size_bytes=int(resp["ContentLength"]),
+                etag=str(resp.get("ETag", "")).strip('"'),
+            )
+
+    async def delete_object(self, key: str) -> None:
+        async with self._client() as client:
+            await client.delete_object(Bucket=self._bucket, Key=key)
+            logger.info("r2_object_deleted", key=key)
+
+    async def generate_presigned_put(
+        self,
+        key: str,
+        content_type: str,
+        size_bytes: int,
+        ttl_seconds: int,
+        sha256: str,
+    ) -> str:
+        # Issue #556 originally proposed presigned POST (signs body sha256
+        # via policy condition); R2 returns 501 NotImplemented for POST.
+        # We sign ``ChecksumSHA256`` on PUT instead — see the live spike
+        # at backend/tests/integration/test_r2_live.py for the contract.
+        # The flag is gated by ``r2_checksum_binding_enabled`` (default
+        # False) so backend can deploy ahead of SDK rollout.
+        params: dict[str, Any] = {
+            "Bucket": self._bucket,
+            "Key": key,
+            "ContentType": content_type,
+            "ContentLength": size_bytes,
+        }
+        if self._enable_checksum_binding:
+            params["ChecksumSHA256"] = base64.b64encode(bytes.fromhex(sha256)).decode()
+        async with self._client() as client:
+            url = await client.generate_presigned_url(
+                ClientMethod="put_object",
+                Params=params,
+                ExpiresIn=ttl_seconds,
+                HttpMethod="PUT",
+            )
+            return str(url)
+
+    async def generate_presigned_get(
+        self,
+        key: str,
+        filename: str,
+        ttl_seconds: int,
+    ) -> str:
+        # Sanitize the filename before embedding into the
+        # ``Content-Disposition`` header. Without this a filename
+        # containing a literal ``"`` could break out of the quoted
+        # parameter and enable filename-spoofing for downloads;
+        # CR/LF could (in principle) corrupt the header
+        # (CSO Gate2 finding F-1 + Copilot loop 5 finding on PR #551).
+        safe_filename = (
+            filename.replace('"', "_").replace("\n", "_").replace("\r", "_").replace("\x00", "_")
+        )
+        async with self._client() as client:
+            url = await client.generate_presigned_url(
+                ClientMethod="get_object",
+                Params={
+                    "Bucket": self._bucket,
+                    "Key": key,
+                    "ResponseContentDisposition": f'attachment; filename="{safe_filename}"',
+                },
+                ExpiresIn=ttl_seconds,
+                HttpMethod="GET",
+            )
+            return str(url)
+
+    async def close(self) -> None:
+        """Release any pooled resources held by aiobotocore.
+
+        Currently a no-op — aioboto3 pools live inside the per-call
+        ``async with`` block and are released on context exit. Kept on
+        the API surface so the lifespan handler can call it
+        unconditionally and a future eager-init refactor stays
+        backwards compatible.
+        """
+        return None

--- a/backend/src/storage/s3_compatible.py
+++ b/backend/src/storage/s3_compatible.py
@@ -47,6 +47,7 @@ class S3CompatibleStorage:
         bucket: str,
         endpoint_url: str,
         enable_checksum_binding: bool = False,
+        region: str = "auto",
     ) -> None:
         if not (account_id and access_key_id and secret_access_key and bucket and endpoint_url):
             raise ValueError(
@@ -59,10 +60,10 @@ class S3CompatibleStorage:
         self._session = aioboto3.Session(
             aws_access_key_id=access_key_id,
             aws_secret_access_key=secret_access_key,
-            # R2 and MinIO ignore region; "auto" is R2's canonical value and
-            # MinIO accepts any string. AWS S3 proper would need the bucket's
-            # real region — out of scope for the R2/MinIO acceptance criteria.
-            region_name="auto",
+            # R2 and MinIO ignore region; "auto" (the default, R2's canonical
+            # value) works for both. AWS S3 proper needs the bucket's real
+            # region — set STORAGE_REGION=<region> for an `aws` backend.
+            region_name=region or "auto",
         )
 
     def _client(self) -> Any:
@@ -89,7 +90,7 @@ class S3CompatibleStorage:
                 ContentType=content_type,
                 Metadata={"sha256": sha256},
             )
-            logger.info("r2_object_written", key=key, size_bytes=len(data))
+            logger.info("storage_object_written", key=key, size_bytes=len(data))
 
     async def head_object(self, key: str) -> ObjectMetadata | None:
         async with self._client() as client:
@@ -106,13 +107,13 @@ class S3CompatibleStorage:
                 # surfaced as a domain exception so REST/MCP layers map
                 # them to a clear 502 instead of a raw boto traceback.
                 logger.warning(
-                    "r2_head_object_error",
+                    "storage_head_object_error",
                     key=key,
                     code=code,
                     error=str(exc),
                 )
                 raise ExternalServiceError(
-                    "R2",
+                    "storage",
                     f"head_object failed for key={key!r}: {code}",
                 ) from exc
             return ObjectMetadata(
@@ -123,7 +124,7 @@ class S3CompatibleStorage:
     async def delete_object(self, key: str) -> None:
         async with self._client() as client:
             await client.delete_object(Bucket=self._bucket, Key=key)
-            logger.info("r2_object_deleted", key=key)
+            logger.info("storage_object_deleted", key=key)
 
     async def generate_presigned_put(
         self,

--- a/backend/tests/config/test_storage_settings.py
+++ b/backend/tests/config/test_storage_settings.py
@@ -36,6 +36,9 @@ _STORAGE_ENV_KEYS = [
     "STORAGE_CHECKSUM_BINDING_ENABLED",
     "S3_CHECKSUM_BINDING_ENABLED",
     "R2_CHECKSUM_BINDING_ENABLED",
+    "STORAGE_REGION",
+    "S3_REGION",
+    "R2_REGION",
 ]
 
 
@@ -100,3 +103,21 @@ def test_storage_backend_type_defaults_to_r2(clean_storage_env):
     """Prod sets no discriminator; default MUST be the zero-change 'r2'."""
     s = _fresh_settings()
     assert s.storage_backend_type == "r2"
+
+
+def test_invalid_storage_backend_type_fails_at_load(clean_storage_env):
+    """#994: the Literal type rejects a typo at config LOAD (fail loudly at
+    boot), not on the first upload with a 502 hours later."""
+    import pytest as _pytest
+    from pydantic import ValidationError
+
+    clean_storage_env.setenv("STORAGE_BACKEND_TYPE", "mino")  # typo of "minio"
+    with _pytest.raises(ValidationError):
+        _fresh_settings()
+
+
+def test_storage_region_defaults_to_auto_and_aliases(clean_storage_env):
+    """region defaults to 'auto' (R2/MinIO); legacy R2_REGION resolves it."""
+    assert _fresh_settings().storage_region == "auto"
+    clean_storage_env.setenv("R2_REGION", "us-east-1")
+    assert _fresh_settings().storage_region == "us-east-1"

--- a/backend/tests/config/test_storage_settings.py
+++ b/backend/tests/config/test_storage_settings.py
@@ -1,0 +1,102 @@
+"""Issue #994 — storage settings env-var backward compatibility.
+
+The five R2 storage settings were renamed `r2_*` -> `storage_*` with
+`STORAGE_*` / `S3_*` / `R2_*` accepted as aliases. Because `Settings` uses
+`extra="ignore"`, a rename WITHOUT the `r2_*` alias would make a prod deploy's
+existing `R2_*` env vars silently dropped -> empty endpoint -> the upload path
+502s on first use with no load-time error. These tests pin the acceptance
+criterion "existing prod R2 deploy works unchanged with current env vars".
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from config.settings import Settings
+
+# All env keys the storage fields can resolve from, cleared before each case so
+# the host's real .env / shell does not leak into the assertion.
+_STORAGE_ENV_KEYS = [
+    "STORAGE_BACKEND_TYPE",
+    "STORAGE_ACCOUNT_ID",
+    "S3_ACCOUNT_ID",
+    "R2_ACCOUNT_ID",
+    "STORAGE_ACCESS_KEY_ID",
+    "S3_ACCESS_KEY_ID",
+    "R2_ACCESS_KEY_ID",
+    "STORAGE_SECRET_ACCESS_KEY",
+    "S3_SECRET_ACCESS_KEY",
+    "R2_SECRET_ACCESS_KEY",
+    "STORAGE_BUCKET",
+    "S3_BUCKET",
+    "R2_BUCKET",
+    "STORAGE_ENDPOINT_URL",
+    "S3_ENDPOINT_URL",
+    "R2_ENDPOINT_URL",
+    "STORAGE_CHECKSUM_BINDING_ENABLED",
+    "S3_CHECKSUM_BINDING_ENABLED",
+    "R2_CHECKSUM_BINDING_ENABLED",
+]
+
+
+@pytest.fixture
+def clean_storage_env(monkeypatch):
+    for k in _STORAGE_ENV_KEYS:
+        monkeypatch.delenv(k, raising=False)
+    return monkeypatch
+
+
+def _fresh_settings() -> Settings:
+    # _env_file=None ignores .env.dev so only os.environ (monkeypatched) is read.
+    return Settings(_env_file=None)
+
+
+def test_legacy_r2_env_vars_still_resolve_storage_fields(clean_storage_env):
+    """Prod sets only R2_* and no STORAGE_*; the fields MUST still populate."""
+    clean_storage_env.setenv("R2_ACCOUNT_ID", "acct")
+    clean_storage_env.setenv("R2_ACCESS_KEY_ID", "ak")
+    clean_storage_env.setenv("R2_SECRET_ACCESS_KEY", "sk")
+    clean_storage_env.setenv("R2_BUCKET", "kagura-memory-files-prod")
+    clean_storage_env.setenv(
+        "R2_ENDPOINT_URL", "https://acct.r2.cloudflarestorage.com"
+    )
+    clean_storage_env.setenv("R2_CHECKSUM_BINDING_ENABLED", "true")
+
+    s = _fresh_settings()
+
+    assert s.storage_account_id == "acct"
+    assert s.storage_access_key_id == "ak"
+    assert s.storage_secret_access_key == "sk"
+    assert s.storage_bucket == "kagura-memory-files-prod"
+    assert s.storage_endpoint_url == "https://acct.r2.cloudflarestorage.com"
+    assert s.storage_checksum_binding_enabled is True
+
+
+def test_canonical_storage_env_vars_resolve(clean_storage_env):
+    clean_storage_env.setenv("STORAGE_ENDPOINT_URL", "http://minio:9000")
+    clean_storage_env.setenv("STORAGE_BUCKET", "kagura-files")
+    clean_storage_env.setenv("STORAGE_ACCESS_KEY_ID", "minioadmin")
+    clean_storage_env.setenv("STORAGE_SECRET_ACCESS_KEY", "minioadmin")
+    clean_storage_env.setenv("STORAGE_BACKEND_TYPE", "minio")
+
+    s = _fresh_settings()
+
+    assert s.storage_endpoint_url == "http://minio:9000"
+    assert s.storage_bucket == "kagura-files"
+    assert s.storage_backend_type == "minio"
+
+
+def test_canonical_storage_wins_over_legacy_r2_when_both_set(clean_storage_env):
+    """AliasChoices order is (storage_, s3_, r2_) — first match wins."""
+    clean_storage_env.setenv("R2_ENDPOINT_URL", "https://legacy.example.com")
+    clean_storage_env.setenv("STORAGE_ENDPOINT_URL", "http://minio:9000")
+
+    s = _fresh_settings()
+
+    assert s.storage_endpoint_url == "http://minio:9000"
+
+
+def test_storage_backend_type_defaults_to_r2(clean_storage_env):
+    """Prod sets no discriminator; default MUST be the zero-change 'r2'."""
+    s = _fresh_settings()
+    assert s.storage_backend_type == "r2"

--- a/backend/tests/config/test_storage_settings.py
+++ b/backend/tests/config/test_storage_settings.py
@@ -60,9 +60,7 @@ def test_legacy_r2_env_vars_still_resolve_storage_fields(clean_storage_env):
     clean_storage_env.setenv("R2_ACCESS_KEY_ID", "ak")
     clean_storage_env.setenv("R2_SECRET_ACCESS_KEY", "sk")
     clean_storage_env.setenv("R2_BUCKET", "kagura-memory-files-prod")
-    clean_storage_env.setenv(
-        "R2_ENDPOINT_URL", "https://acct.r2.cloudflarestorage.com"
-    )
+    clean_storage_env.setenv("R2_ENDPOINT_URL", "https://acct.r2.cloudflarestorage.com")
     clean_storage_env.setenv("R2_CHECKSUM_BINDING_ENABLED", "true")
 
     s = _fresh_settings()

--- a/backend/tests/integration/test_minio_integration.py
+++ b/backend/tests/integration/test_minio_integration.py
@@ -1,0 +1,160 @@
+"""Integration test for the S3-compatible backend against MinIO (Issue #994).
+
+Proves the SAME ``S3CompatibleStorage`` code that serves Cloudflare R2 in the
+managed cloud also works against a self-hosted MinIO endpoint — the upload /
+download acceptance criterion for #994 (BYO storage). Mirrors the live-R2
+contract test (``test_r2_live.py``) but against MinIO, which CI starts as a
+local container.
+
+Opt-in / gated: skipped unless ``MINIO_TEST_ENDPOINT`` (and the access/secret/
+bucket vars) are set AND the endpoint is reachable. Locally:
+
+    docker run -d -p 9000:9000 -e MINIO_ROOT_USER=minioadmin \
+      -e MINIO_ROOT_PASSWORD=minioadmin minio/minio server /data
+    MINIO_TEST_ENDPOINT=http://localhost:9000 MINIO_TEST_ACCESS_KEY=minioadmin \
+    MINIO_TEST_SECRET_KEY=minioadmin MINIO_TEST_BUCKET=kagura-files-test \
+    pytest backend/tests/integration/test_minio_integration.py -v
+
+CI wires these in the ``backend-integration`` job (see .github/workflows/ci.yml).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import uuid
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import httpx
+import pytest
+
+from storage.s3_compatible import S3CompatibleStorage
+
+_ENDPOINT = os.getenv("MINIO_TEST_ENDPOINT", "")
+_ACCESS_KEY = os.getenv("MINIO_TEST_ACCESS_KEY", "")
+_SECRET_KEY = os.getenv("MINIO_TEST_SECRET_KEY", "")
+_BUCKET = os.getenv("MINIO_TEST_BUCKET", "kagura-files-test")
+
+
+def _minio_reachable() -> bool:
+    if not (_ENDPOINT and _ACCESS_KEY and _SECRET_KEY):
+        return False
+    try:
+        # MinIO liveness endpoint returns 200 when the server is up.
+        with urlopen(f"{_ENDPOINT}/minio/health/live", timeout=3) as resp:  # noqa: S310
+            return resp.status == 200
+    except (URLError, OSError, ValueError):
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _minio_reachable(),
+    reason=(
+        "MinIO integration test skipped — set MINIO_TEST_ENDPOINT / "
+        "MINIO_TEST_ACCESS_KEY / MINIO_TEST_SECRET_KEY (and start a reachable "
+        "MinIO at that endpoint)."
+    ),
+)
+
+
+def _hex_sha256(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+@pytest.fixture(scope="module")
+def storage() -> S3CompatibleStorage:
+    # checksum binding off — the #556 ChecksumSHA256 integrity gate is an
+    # R2-specific server feature; this test exercises basic S3 upload/download.
+    return S3CompatibleStorage(
+        account_id="minio",
+        access_key_id=_ACCESS_KEY,
+        secret_access_key=_SECRET_KEY,
+        bucket=_BUCKET,
+        endpoint_url=_ENDPOINT,
+        enable_checksum_binding=False,
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def _ensure_bucket(storage: S3CompatibleStorage):
+    """Create the test bucket if MinIO doesn't have it yet (fresh container)."""
+    from botocore.exceptions import ClientError
+
+    async with storage._client() as client:
+        try:
+            await client.create_bucket(Bucket=_BUCKET)
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            # Already exists (ours or anyone's) is fine for the test.
+            if code not in ("BucketAlreadyOwnedByYou", "BucketAlreadyExists"):
+                raise
+    yield
+
+
+@pytest.fixture
+def run_prefix() -> str:
+    return f"_spike/test_minio/{uuid.uuid4().hex}"
+
+
+class TestMinioRoundTrip:
+    @pytest.mark.asyncio
+    async def test_write_head_get_delete_roundtrip(
+        self, storage: S3CompatibleStorage, run_prefix: str
+    ) -> None:
+        """Server-side write → head (size/etag) → presigned GET → bytes match → delete."""
+        key = f"{run_prefix}/roundtrip.txt"
+        data = b"minio-s3-compatible-roundtrip"
+        try:
+            await storage.write_object(
+                key=key,
+                data=data,
+                content_type="text/plain",
+                sha256=_hex_sha256(data),
+            )
+
+            meta = await storage.head_object(key)
+            assert meta is not None
+            assert meta["size_bytes"] == len(data)
+            assert meta["etag"]
+
+            get_url = await storage.generate_presigned_get(
+                key=key, filename="roundtrip.txt", ttl_seconds=300
+            )
+            async with httpx.AsyncClient(timeout=30.0) as http:
+                resp = await http.get(get_url)
+            assert resp.status_code == 200
+            assert resp.content == data
+        finally:
+            await storage.delete_object(key)
+
+        assert await storage.head_object(key) is None
+
+    @pytest.mark.asyncio
+    async def test_presigned_put_upload_lands(
+        self, storage: S3CompatibleStorage, run_prefix: str
+    ) -> None:
+        """Presigned PUT → client uploads via the URL → head confirms it landed."""
+        key = f"{run_prefix}/presigned_put.bin"
+        data = b"uploaded-via-presigned-put-url"
+        try:
+            put_url = await storage.generate_presigned_put(
+                key=key,
+                content_type="application/octet-stream",
+                size_bytes=len(data),
+                ttl_seconds=300,
+                sha256=_hex_sha256(data),
+            )
+            async with httpx.AsyncClient(timeout=30.0) as http:
+                put_resp = await http.put(
+                    put_url,
+                    content=data,
+                    headers={"Content-Type": "application/octet-stream"},
+                )
+            assert put_resp.status_code in (200, 204), put_resp.text
+
+            meta = await storage.head_object(key)
+            assert meta is not None
+            assert meta["size_bytes"] == len(data)
+        finally:
+            await storage.delete_object(key)

--- a/backend/tests/storage/test_factory.py
+++ b/backend/tests/storage/test_factory.py
@@ -30,25 +30,30 @@ def _reset_factory():
 
 
 def _settings_with_r2(**overrides):
-    """Build a Mock ``Settings`` object with R2 fields populated."""
+    """Build a Mock ``Settings`` with the S3-compatible storage fields populated.
+
+    (#994 renamed r2_* -> storage_*; the discriminator must be a real string so
+    the factory's `.strip().lower()` allowlist check does not see a MagicMock.)
+    """
     from unittest.mock import MagicMock
 
     s = MagicMock()
-    s.r2_account_id = "acct"
-    s.r2_access_key_id = "key"
-    s.r2_secret_access_key = "secret"
-    s.r2_bucket = "kagura-files-test"
-    s.r2_endpoint_url = "https://acct.r2.cloudflarestorage.com"
+    s.storage_backend_type = "r2"
+    s.storage_account_id = "acct"
+    s.storage_access_key_id = "key"
+    s.storage_secret_access_key = "secret"
+    s.storage_bucket = "kagura-files-test"
+    s.storage_endpoint_url = "https://acct.r2.cloudflarestorage.com"
     # Explicit bool — bare MagicMock attribute access would return a truthy
     # child and silently flip the ChecksumSHA256 binding on (#556).
-    s.r2_checksum_binding_enabled = False
+    s.storage_checksum_binding_enabled = False
     for k, v in overrides.items():
         setattr(s, k, v)
     return s
 
 
 def _settings_without_r2():
-    return _settings_with_r2(r2_endpoint_url="")
+    return _settings_with_r2(storage_endpoint_url="")
 
 
 class TestGetBlobStorage:
@@ -60,7 +65,7 @@ class TestGetBlobStorage:
         from utils.exceptions import ExternalServiceError
 
         with patch("storage.factory.get_settings", return_value=_settings_without_r2()):
-            with pytest.raises(ExternalServiceError, match="R2"):
+            with pytest.raises(ExternalServiceError, match="not configured"):
                 factory.get_blob_storage()
 
     def test_returns_r2_storage_when_configured(self):
@@ -82,7 +87,7 @@ class TestGetBlobStorage:
         gate is silently dead even after operators flip the env var."""
         with patch(
             "storage.factory.get_settings",
-            return_value=_settings_with_r2(r2_checksum_binding_enabled=True),
+            return_value=_settings_with_r2(storage_checksum_binding_enabled=True),
         ):
             storage = factory.get_blob_storage()
             assert isinstance(storage, R2Storage)

--- a/backend/tests/storage/test_factory.py
+++ b/backend/tests/storage/test_factory.py
@@ -39,6 +39,7 @@ def _settings_with_r2(**overrides):
 
     s = MagicMock()
     s.storage_backend_type = "r2"
+    s.storage_region = "auto"
     s.storage_account_id = "acct"
     s.storage_access_key_id = "key"
     s.storage_secret_access_key = "secret"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,8 +132,44 @@ services:
     depends_on:
       - api
 
+  # MinIO — S3-compatible object storage for self-host / local BYO-storage
+  # testing (Issue #994). Opt-in via the `minio` profile so it does NOT start
+  # with a default `docker compose up`:
+  #   docker compose --profile minio up -d minio
+  # Then point the API at it with STORAGE_BACKEND_TYPE=minio,
+  # STORAGE_ENDPOINT_URL=http://minio:9000, STORAGE_ACCESS_KEY_ID/SECRET=minioadmin,
+  # STORAGE_BUCKET=kagura-files-dev. The legacy R2_* names still work as aliases.
+  #
+  # ⚠ SECURITY — DEV DEFAULTS ONLY. The minioadmin/minioadmin credentials and the
+  # published 9000/9001 ports below are for LOCAL development only. For a real
+  # self-host deployment you MUST: (1) set strong unique MINIO_ROOT_USER /
+  # MINIO_ROOT_PASSWORD (or, better, per-app access keys with bucket-scoped
+  # policy), and (2) NOT expose these ports publicly — front MinIO with TLS and
+  # keep it on the private network. Copying this block to production unchanged
+  # leaves an open, default-credentialed object store (OWASP A05).
+  minio:
+    image: minio/minio
+    container_name: kagura-minio
+    profiles: ["minio"]
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:9000/minio/health/live || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
 volumes:
   postgres_data:
   qdrant_data:
   redis_data:
   frontend_node_modules:
+  minio_data:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -259,6 +259,7 @@ when only `R2_*` is set):
 | `STORAGE_ACCESS_KEY_ID` | `S3_ACCESS_KEY_ID`, `R2_ACCESS_KEY_ID` | — | Access key. |
 | `STORAGE_SECRET_ACCESS_KEY` | `S3_SECRET_ACCESS_KEY`, `R2_SECRET_ACCESS_KEY` | — | Secret key. |
 | `STORAGE_ACCOUNT_ID` | `S3_ACCOUNT_ID`, `R2_ACCOUNT_ID` | — | R2 account ID; unused by AWS S3 / MinIO (set any non-empty value). |
+| `STORAGE_REGION` | `S3_REGION`, `R2_REGION` | `auto` | `auto` is correct for R2 and MinIO. Set the bucket's real region (e.g. `us-east-1`) for an `aws` backend. |
 | `STORAGE_CHECKSUM_BINDING_ENABLED` | `S3_CHECKSUM_BINDING_ENABLED`, `R2_CHECKSUM_BINDING_ENABLED` | `false` | Server-side body-sha256 binding (#556). R2-specific; leave `false` on MinIO. |
 
 ### Self-host with MinIO

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -232,3 +232,72 @@ in env, then restart the API container). Existing edges are left alone;
 Sleep Maintenance prunes them naturally over time via the synthetic-seed
 filter (#248 + #223 extension to `_is_synthetic_seed_edge`).
 
+
+## Object Storage (S3-compatible) — Issue #994
+
+Platform-managed file storage (`/api/v1/files/*`, Issue #485) writes to any
+**S3-compatible** object store. The same `S3CompatibleStorage` client (aioboto3)
+drives every backend — only the endpoint differs:
+
+| Deployment | Backend | Endpoint |
+| --- | --- | --- |
+| Managed cloud (kagura) | Cloudflare R2 | `https://<account>.r2.cloudflarestorage.com` |
+| Self-host (recommended) | MinIO | `http://minio:9000` |
+| Self-host (AWS) | AWS S3 | leave `STORAGE_ENDPOINT_URL` empty for the region default |
+
+### Environment variables
+
+Canonical `STORAGE_*` names (legacy `R2_*` names are still accepted as aliases —
+existing deploys keep working unchanged; a one-time deprecation line is logged
+when only `R2_*` is set):
+
+| Variable | Aliases | Default | Notes |
+| --- | --- | --- | --- |
+| `STORAGE_BACKEND_TYPE` | — | `r2` | `r2` \| `s3` \| `minio` \| `s3-compatible` \| `aws`. Selects the label; all use the same S3 client. |
+| `STORAGE_ENDPOINT_URL` | `S3_ENDPOINT_URL`, `R2_ENDPOINT_URL` | — | **Required.** Empty ⇒ the upload path returns HTTP 502 "storage not configured". |
+| `STORAGE_BUCKET` | `S3_BUCKET`, `R2_BUCKET` | — | Bucket name. |
+| `STORAGE_ACCESS_KEY_ID` | `S3_ACCESS_KEY_ID`, `R2_ACCESS_KEY_ID` | — | Access key. |
+| `STORAGE_SECRET_ACCESS_KEY` | `S3_SECRET_ACCESS_KEY`, `R2_SECRET_ACCESS_KEY` | — | Secret key. |
+| `STORAGE_ACCOUNT_ID` | `S3_ACCOUNT_ID`, `R2_ACCOUNT_ID` | — | R2 account ID; unused by AWS S3 / MinIO (set any non-empty value). |
+| `STORAGE_CHECKSUM_BINDING_ENABLED` | `S3_CHECKSUM_BINDING_ENABLED`, `R2_CHECKSUM_BINDING_ENABLED` | `false` | Server-side body-sha256 binding (#556). R2-specific; leave `false` on MinIO. |
+
+### Self-host with MinIO
+
+A `minio` service ships in `docker-compose.yml` behind the `minio` profile (it
+does **not** start by default):
+
+```bash
+docker compose --profile minio up -d minio   # console at http://localhost:9001
+```
+
+> ⚠ **Security — dev defaults only.** The compose `minio` service ships with the
+> well-known `minioadmin` / `minioadmin` credentials and published `9000`/`9001`
+> ports for local convenience. For a real deployment, set strong unique
+> `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` (or per-app bucket-scoped access
+> keys), keep MinIO on the private network behind TLS, and do **not** expose
+> those ports publicly. An internet-reachable MinIO with default credentials is
+> an open object store (OWASP A05: Security Misconfiguration).
+
+Then point the API at it (create the bucket once via the MinIO console or `mc`):
+
+```bash
+STORAGE_BACKEND_TYPE=minio
+STORAGE_ENDPOINT_URL=http://minio:9000
+STORAGE_ACCESS_KEY_ID=minioadmin
+STORAGE_SECRET_ACCESS_KEY=minioadmin
+STORAGE_BUCKET=kagura-files-dev
+STORAGE_ACCOUNT_ID=minio
+```
+
+CI exercises the presigned PUT → GET → head round-trip against a live MinIO in
+the `backend-integration` job (`backend/tests/integration/test_minio_integration.py`).
+
+### Design note — BYO bucket per workspace (not implemented)
+
+The seam for a future **bring-your-own-bucket** tier feature (a workspace
+supplies its own S3 credentials, symmetric with the BYOK-embeddings direction)
+is the `storage_backend_type` discriminator plus the per-call `S3CompatibleStorage`
+construction in `storage/factory.py`. Today the factory builds one process-wide
+instance from the global `STORAGE_*` settings; per-workspace BYO would move
+construction behind a workspace-scoped credential lookup. Recorded here as a
+seam only — no implementation in #994.


### PR DESCRIPTION
Part of #994 (does **not** close it — BYO-bucket-per-workspace is recorded as a seam only; see docs/deployment.md).

## Summary
- Generalize the already-S3-compatible R2 storage so the **same** `S3CompatibleStorage` client (aioboto3 + `endpoint_url`) serves **Cloudflare R2** (managed cloud), **MinIO** and **AWS S3** (self-host BYO). Only the endpoint differs.
- Rename class `R2Storage` → `S3CompatibleStorage` (`storage/s3_compatible.py`); `storage/r2.py` re-exports `R2Storage = S3CompatibleStorage` (same class object — `isinstance` and existing imports keep working). Behavior-preserving.
- Add a `storage_backend_type` discriminator (default `"r2"`) + dispatch in `factory.py` (the seam the factory docstring pre-announced). All known values map to `S3CompatibleStorage` today; unknown values fail loudly.

## Implementation notes
- The 5 `r2_*` settings → `storage_*` (+ new `storage_checksum_binding_enabled`), each with `validation_alias=AliasChoices("storage_*","s3_*","r2_*")`. **`Settings` uses `extra="ignore"`, so the `r2_*` aliases are load-bearing** — without them a prod deploy's `R2_*` env would be silently dropped → empty endpoint → uploads 502. Regression test `test_storage_settings.py` pins "R2_*-only env resolves the storage_* fields".
- `factory.py` logs the resolved backend and a one-time deprecation when only `R2_*` env is set.
- **MinIO**: profile-gated `minio` service in `docker-compose.yml`, a CI step in `backend-integration` (hard-fails if MinIO never comes up, so the acceptance test can't green-by-skip), and `tests/integration/test_minio_integration.py` (presigned PUT → GET → head round-trip, connectivity-gated).
- `docs/deployment.md` self-host section + `.env.example` canonicalized to `STORAGE_*` (R2_* documented as legacy aliases). Security warnings added (MinIO dev-default creds must not reach prod).
- `region_name="auto"` works for R2/MinIO; full AWS-region handling is a documented follow-up.

## Pre-PR review summary
- gate2 mode: advisor-only (no binary gate configured)
- audit: skipped
- cso: yellow · qa-lead: green · cto: green
- gate1: green via /claude-c-suite:ask (CTO lens)
- review provider: none (opt-in — run `/gh-issue-driven:review`)

cso's **yellow** (MinIO compose default-creds footgun) was **mitigated in this PR** by adding dev-defaults-only security warnings to the compose block and docs. Follow-ups (non-blocking): full `/api/v1/files` HTTP path over MinIO e2e; schedule removal of the `R2Storage` alias + `R2_*` env names.

## Verification
- `ruff` clean; `storage` + `config` + `services` + `api` + `smoke` = **1895 passed**, 0 failed.
- 2 MinIO integration tests **passed against a live local MinIO** container.
- 4 settings-alias regression tests pass (incl. the prod-zero-change criterion).
- Inner review (opus): #1 acceptance criterion verified; 2 minor findings applied.

## Acceptance
- ✅ Existing prod R2 deploy works unchanged with current env vars (regression-tested).
- ✅ A MinIO-backed deployment passes the upload/download integration tests (verified live).

Full reviews in the plugin cache:
- `~/.claude/cache/gh-issue-driven/994-feat-s3-compatible-storage-backend.gate1.md`
- `~/.claude/cache/gh-issue-driven/994-feat-s3-compatible-storage-backend.gate2.md`

🤖 Generated via /gh-issue-driven:ship
