### PR TITLE
refactor(api): hide internal identifiers in response models (#991)

### DIFF
--- a/backend/src/api/routes/system.py
+++ b/backend/src/api/routes/system.py
@@ -243,12 +243,13 @@ async def get_system_telemetry(
                 "persistent": total_memories - working_memories,
             },
             embedding_config={
+                # provider/model/dimensions are low-sensitivity capability info
+                # (surfaced in the admin environment page). `ollama_base_url`
+                # was dropped (#991): it exposed an internal infrastructure URL
+                # to any authenticated caller and had no consumer.
                 "provider": settings.embedding_provider,
                 "model": settings.embedding_model,
                 "dimensions": settings.embedding_dimensions,
-                "ollama_base_url": settings.ollama_base_url
-                if settings.embedding_provider == "ollama"
-                else None,
             },
             neural_memory=neural_stats,
             uptime_seconds=uptime_seconds,

--- a/backend/src/api/routes/system.py
+++ b/backend/src/api/routes/system.py
@@ -1,5 +1,7 @@
 """System API routes for health check and info endpoints."""
 
+from typing import Any
+
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 from sqlalchemy import select
@@ -34,6 +36,22 @@ class TelemetryResponse(BaseModel):
     neural_memory: dict
     uptime_seconds: int
     version: str
+
+
+def _embedding_config_payload(settings: Any) -> dict[str, Any]:
+    """Public embedding capability info for the telemetry response.
+
+    Intentionally limited to ``provider`` / ``model`` / ``dimensions`` —
+    low-sensitivity capability info consumed by the admin environment page.
+    Internal infrastructure details (notably ``ollama_base_url``) are
+    deliberately excluded so they are never exposed to an authenticated,
+    non-admin caller of ``/system/telemetry`` (#991).
+    """
+    return {
+        "provider": settings.embedding_provider,
+        "model": settings.embedding_model,
+        "dimensions": settings.embedding_dimensions,
+    }
 
 
 @router.get("/health")
@@ -175,25 +193,20 @@ async def get_system_telemetry(
                         model_names = []
                         if models_resp.status_code == 200:
                             model_names = [m["name"] for m in models_resp.json().get("models", [])]
+                        # `url` intentionally omitted (#991): the internal Ollama
+                        # base URL is not exposed on this non-admin endpoint; the
+                        # frontend consumes only status + models.
                         ollama_status = ServiceStatus(
                             status="ok",
-                            details={
-                                "url": settings.ollama_base_url,
-                                "models": model_names,
-                            },
+                            details={"models": model_names},
                         )
                     else:
                         ollama_status = ServiceStatus(
                             status="error",
-                            details={
-                                "url": settings.ollama_base_url,
-                                "http_status": resp.status_code,
-                            },
+                            details={"http_status": resp.status_code},
                         )
             except Exception as e:
-                ollama_status = ServiceStatus(
-                    status="error", details={"url": settings.ollama_base_url, "error": str(e)}
-                )
+                ollama_status = ServiceStatus(status="error", details={"error": str(e)})
 
         # Memory stats (all users)
         from sqlalchemy import func
@@ -242,15 +255,7 @@ async def get_system_telemetry(
                 "working": working_memories,
                 "persistent": total_memories - working_memories,
             },
-            embedding_config={
-                # provider/model/dimensions are low-sensitivity capability info
-                # (surfaced in the admin environment page). `ollama_base_url`
-                # was dropped (#991): it exposed an internal infrastructure URL
-                # to any authenticated caller and had no consumer.
-                "provider": settings.embedding_provider,
-                "model": settings.embedding_model,
-                "dimensions": settings.embedding_dimensions,
-            },
+            embedding_config=_embedding_config_payload(settings),
             neural_memory=neural_stats,
             uptime_seconds=uptime_seconds,
             version=APP_VERSION,

--- a/backend/src/api/routes/workspace_connectors.py
+++ b/backend/src/api/routes/workspace_connectors.py
@@ -88,7 +88,11 @@ class WorkspaceConnectorSummary(TZAwareBaseModel):
 
     connector_id: UUID
     connector_type: str
-    resource_pk: UUID
+    # Public `resource_id` slug, not the internal `resource_pk` DB key (#991):
+    # the slug is the stable surface identifier; the internal PK was an
+    # information leak and is dropped before the 1.0 freeze. Resolved via a
+    # JOIN in ConnectorProvisioningService.list_connectors.
+    resource_id: str
     context_id: UUID | None = None
     config_version: int
     created_at: datetime
@@ -233,18 +237,18 @@ async def list_workspace_connectors(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="No workspace selected. Please select a workspace first.",
         )
-    connectors = await ConnectorProvisioningService(db).list_connectors(workspace_id)
+    items = await ConnectorProvisioningService(db).list_connectors(workspace_id)
     return [
         WorkspaceConnectorSummary(
-            connector_id=c.id,
-            connector_type=c.connector_type,
-            resource_pk=c.resource_pk,
-            context_id=c.context_id,
-            config_version=c.config_version,
-            created_at=c.created_at,
-            created_by=c.created_by,
+            connector_id=item.connector.id,
+            connector_type=item.connector.connector_type,
+            resource_id=item.resource_id,
+            context_id=item.connector.context_id,
+            config_version=item.connector.config_version,
+            created_at=item.connector.created_at,
+            created_by=item.connector.created_by,
         )
-        for c in connectors
+        for item in items
     ]
 
 

--- a/backend/src/services/connector_provisioning.py
+++ b/backend/src/services/connector_provisioning.py
@@ -21,7 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.resource_tokens import ResourceTokenManager
 from models.auth import Workspace
-from models.resource import ResourceSchema, ResourceToken, WorkspaceConnector
+from models.resource import Resource, ResourceSchema, ResourceToken, WorkspaceConnector
 from services.resource_lookup import resolve_resource_pk, upsert_resource
 from utils.exceptions import ConflictError, MemoryCloudException, NotFoundException, ValidationError
 from utils.logger import get_logger
@@ -67,6 +67,16 @@ class ConnectorProvisioningResult:
     # with a write-target context.
     context_id: UUID | None = None
     plaintext_kmc_api_key: str | None = None
+
+
+@dataclass(frozen=True)
+class ConnectorListItem:
+    """One connector row for the workspace list view, paired with its public
+    ``resource_id`` slug (resolved via a JOIN so the internal ``resource_pk``
+    DB key is never exposed on the surface — #991)."""
+
+    connector: WorkspaceConnector
+    resource_id: str
 
 
 @dataclass(frozen=True)
@@ -507,14 +517,23 @@ class ConnectorProvisioningService:
         # already cleared the SET LOCAL along with the rest of the transaction.
         await self.db.execute(text("SET LOCAL lock_timeout = '0'"))
 
-    async def list_connectors(self, workspace_id: UUID) -> list[WorkspaceConnector]:
-        """Return all connectors for a workspace, newest first."""
+    async def list_connectors(self, workspace_id: UUID) -> list[ConnectorListItem]:
+        """Return all connectors for a workspace, newest first.
+
+        Each row is paired with its public ``resource_id`` slug via a single
+        JOIN on ``resources`` (no per-row lookup / N+1), so the surface exposes
+        the slug instead of the internal ``resource_pk`` DB key (#991).
+        """
         result = await self.db.execute(
-            select(WorkspaceConnector)
+            select(WorkspaceConnector, Resource.resource_id)
+            .join(Resource, WorkspaceConnector.resource_pk == Resource.id)
             .where(WorkspaceConnector.workspace_id == workspace_id)
             .order_by(WorkspaceConnector.created_at.desc())
         )
-        return list(result.scalars().all())
+        return [
+            ConnectorListItem(connector=connector, resource_id=resource_id)
+            for connector, resource_id in result.all()
+        ]
 
     async def get_connector_for_dispatch(
         self, connector_type: str, external_team_id: str

--- a/backend/tests/api/test_system_telemetry.py
+++ b/backend/tests/api/test_system_telemetry.py
@@ -1,0 +1,32 @@
+"""Tests for /system/telemetry response shaping (#991).
+
+Pins the security-relevant contract that the telemetry ``embedding_config``
+payload exposes only public capability info and never the internal
+``ollama_base_url`` to an authenticated, non-admin caller.
+"""
+
+from types import SimpleNamespace
+
+from api.routes.system import _embedding_config_payload
+
+
+def test_embedding_config_payload_excludes_internal_ollama_url():
+    """embedding_config must expose only provider/model/dimensions — never the
+    internal ollama_base_url, even when the provider is ollama (#991)."""
+    settings = SimpleNamespace(
+        embedding_provider="ollama",
+        embedding_model="nomic-embed-text",
+        embedding_dimensions=768,
+        ollama_base_url="http://internal-ollama:11434",
+    )
+
+    payload = _embedding_config_payload(settings)
+
+    assert payload == {
+        "provider": "ollama",
+        "model": "nomic-embed-text",
+        "dimensions": 768,
+    }
+    # Defence in depth: the internal URL must not leak via any key or value.
+    assert "ollama_base_url" not in payload
+    assert "internal-ollama" not in str(payload)

--- a/backend/tests/api/test_workspace_connectors.py
+++ b/backend/tests/api/test_workspace_connectors.py
@@ -104,6 +104,7 @@ async def test_create_passes_normalized_pii_guardrail_config_dict_to_service():
 @pytest.mark.asyncio
 async def test_list_workspace_connectors_returns_summaries():
     from datetime import datetime
+    from types import SimpleNamespace
 
     from api.routes.workspace_connectors import list_workspace_connectors
 
@@ -114,19 +115,24 @@ async def test_list_workspace_connectors_returns_summaries():
     c = MagicMock()
     c.id = uuid4()
     c.connector_type = "slack"
-    c.resource_pk = uuid4()
     c.context_id = uuid4()
     c.config_version = 1
     c.created_at = datetime(2026, 6, 2, 0, 0, 0)
     c.created_by = "user-1"
 
+    # list_connectors now returns ConnectorListItem(connector, resource_id) so the
+    # summary exposes the public slug, not the internal resource_pk DB key (#991).
+    item = SimpleNamespace(connector=c, resource_id="my-resource-slug")
+
     with patch("api.routes.workspace_connectors.ConnectorProvisioningService") as service_cls:
-        service_cls.return_value.list_connectors = AsyncMock(return_value=[c])
+        service_cls.return_value.list_connectors = AsyncMock(return_value=[item])
         result = await list_workspace_connectors(admin, db)
 
     assert len(result) == 1
     assert result[0].connector_id == c.id
     assert result[0].connector_type == "slack"
+    assert result[0].resource_id == "my-resource-slug"
+    assert not hasattr(result[0], "resource_pk")
     service_cls.return_value.list_connectors.assert_awaited_once_with(ws_id)
 
 

--- a/backend/tests/services/test_connector_provisioning.py
+++ b/backend/tests/services/test_connector_provisioning.py
@@ -302,18 +302,24 @@ class TestConnectorIdempotencyKey:
 
 @pytest.mark.asyncio
 async def test_list_connectors_returns_workspace_scoped_rows_newest_first():
+    from services.connector_provisioning import ConnectorListItem
+
     ws_id = uuid4()
-    rows = [SimpleNamespace(id=uuid4()), SimpleNamespace(id=uuid4())]
+    conn_a, conn_b = SimpleNamespace(id=uuid4()), SimpleNamespace(id=uuid4())
+    # The JOIN yields (WorkspaceConnector, resource_id-slug) tuples (#991); the
+    # service maps each to a ConnectorListItem so the surface exposes the slug.
+    rows = [(conn_a, "slug-a"), (conn_b, "slug-b")]
 
     db = MagicMock()
-    scalars = MagicMock()
-    scalars.all.return_value = rows
     exec_result = MagicMock()
-    exec_result.scalars.return_value = scalars
+    exec_result.all.return_value = rows
     db.execute = AsyncMock(return_value=exec_result)
 
     service = ConnectorProvisioningService(db)
     result = await service.list_connectors(ws_id)
 
-    assert result == rows
+    assert result == [
+        ConnectorListItem(connector=conn_a, resource_id="slug-a"),
+        ConnectorListItem(connector=conn_b, resource_id="slug-b"),
+    ]
     db.execute.assert_awaited_once()

--- a/docs/api-surface-1.0/rest-response-models.md
+++ b/docs/api-surface-1.0/rest-response-models.md
@@ -1267,7 +1267,7 @@ Notes:
 ### TelemetryResponse (BaseModel, L28)
 > System telemetry response (endpoint is gated by APIKeyOrSessionUser, i.e. any authenticated user).
 - `services: dict[str, ServiceStatus]` — required
-- `embedding_config: dict | None` — optional ✅ **internal `ollama_base_url` dropped in #991** (it exposed an internal infrastructure URL to any authenticated caller and had no consumer). The remaining `{provider, model, dimensions}` are low-sensitivity capability info already surfaced in the admin environment page; the endpoint stays `APIKeyOrSessionUser` (non-admin consumers depend on it).
+- `embedding_config: dict | None` — optional ✅ **internal `ollama_base_url` dropped in #991** (it exposed an internal infrastructure URL to any authenticated caller and had no consumer). The remaining `{provider, model, dimensions}` are low-sensitivity capability info already surfaced in the admin environment page; the endpoint stays `APIKeyOrSessionUser` (non-admin consumers depend on it). The payload is built by `_embedding_config_payload()` and pinned by `tests/api/test_system_telemetry.py`. The same internal URL was also removed from the `services.ollama` health-check `details` (kept `status` + `models`; the frontend never read `details.url`), so the telemetry response no longer surfaces it anywhere.
 - `memory_stats: dict` — required
 - `neural_memory: dict` — required
 - `uptime_seconds: int` — required
@@ -1689,7 +1689,7 @@ Issue #622 allows at most 2 follow-up sub-issues; candidates below are grouped i
 |---|---|---|
 | `WorkspaceConnectorCreateResponse.resource_pk` (workspace_connectors.py) | ✅ DONE (#991) | Dropped — redundant with the public `resource_id` slug already on the response |
 | `WorkspaceConnectorSummary.resource_pk` (workspace_connectors.py) | ✅ DONE (#991) | Replaced `resource_pk: UUID` with the public `resource_id: str` slug, resolved via a single `Resource` JOIN in `ConnectorProvisioningService.list_connectors` (no N+1). Frontend type synced. |
-| `TelemetryResponse.embedding_config` (system.py) | ✅ DONE (#991) | Dropped the internal `ollama_base_url` field (internal infra URL, zero consumers). Kept `{provider, model, dimensions}` (low-sensitivity capability info consumed by the admin environment page). Endpoint stays `APIKeyOrSessionUser` — gating it would break the non-admin telemetry consumers. |
+| `TelemetryResponse.embedding_config` (system.py) | ✅ DONE (#991) | Dropped the internal `ollama_base_url` field (internal infra URL, zero consumers). Kept `{provider, model, dimensions}` (low-sensitivity capability info consumed by the admin environment page). Endpoint stays `APIKeyOrSessionUser` — gating it would break the non-admin telemetry consumers. The same URL was also removed from the `services.ollama` health-check `details` so it is not surfaced anywhere in the response; payload pinned by `tests/api/test_system_telemetry.py`. |
 | `ResourceEventRecord.payload` / `event_metadata` (resources.py) | P1 | Confirm raw-vs-derived boundary (#968) / classification redaction applies to the Resource Detail Data tab before freeze |
 | `OAuth2ClientResponse.plaintext_secret` (oauth.py) | P1 | Verify owner+visibility gating and `response_model_exclude` coverage on every endpoint returning this model; fix the misleading "without secret" docstring |
 | `WorkerConnectorConfig` (workers.py) | P1 | Explicitly exclude the `/workers` surface (plaintext Slack/KMC secrets) from the public 1.0 OpenAPI/freeze scope |

--- a/docs/api-surface-1.0/rest-response-models.md
+++ b/docs/api-surface-1.0/rest-response-models.md
@@ -3,7 +3,8 @@
 > Issue: #622 — pre-1.0 public API surface enumeration and freeze
 > Enumerated at commit 20ae959a2c79cacd2cf7922512ad780f540e9c60 (main HEAD, 2026-06-12)
 > Scope: all BaseModel / TZAwareBaseModel subclasses defined in backend/src/api/routes/ (46 route files, 208 model classes — 208 of 208 enumerated)
-> Re-frozen after #991: 3 duplicate class names renamed; dead `APIKey*` schemas removed from `models/schemas.py`; redundant `WorkspaceConnectorCreateResponse.resource_pk` dropped. Deferred: `WorkspaceConnectorSummary.resource_pk` (needs a Resource JOIN), `TelemetryResponse.embedding_config` gating (needs an intent decision), and the sequential-int-PK replacement (Bundle B).
+> Re-frozen after #991 (Phase 1): 3 duplicate class names renamed; dead `APIKey*` schemas removed from `models/schemas.py`; redundant `WorkspaceConnectorCreateResponse.resource_pk` dropped.
+> Re-frozen after #991 (Phase 2): `WorkspaceConnectorSummary.resource_pk` → public `resource_id` slug (via Resource JOIN); `TelemetryResponse.embedding_config.ollama_base_url` dropped (internal URL, no consumer); sequential int PKs (`APIKeyResponse.id`, `ExternalKeyResponse.id`, `ResourceTokenResponse.id`, `WorkspaceConnectorCreateResponse.token_id`) **consciously frozen** into the 1.0 contract — opaque-ID replacement deferred to #1008 (post-1.0, breaking/major). #991 is now fully resolved.
 
 Notes:
 
@@ -379,7 +380,7 @@ Notes:
 
 ### APIKeyResponse (TZAwareBaseModel, L84)
 > Response model for API key metadata.
-- `id: int` — required ⚠ sequential integer DB PK used as the public identifier (leaks row count; consider opaque id before freeze)
+- `id: int` — required ⚠ sequential integer DB PK used as the public identifier. **DECIDED (#991): frozen into the 1.0 contract** — replacement is a breaking migration (URL paths + params + DB lookups + responses); the enumeration existence-oracle is already closed (owner-scope + uniform not-found), residual exposure is row-count *magnitude* only. Opaque-ID migration tracked in #1008 (post-1.0, breaking/major).
 - `key_prefix: str` — required
 - `name: str` — required
 - `user_id: str` — required
@@ -708,7 +709,7 @@ Notes:
 
 ### ExternalKeyResponse (BaseModel, L67)
 > External API key response (masked).
-- `id: int` — required ⚠ sequential integer DB PK used as the public identifier (leaks row count; consider opaque id before freeze)
+- `id: int` — required ⚠ sequential integer DB PK used as the public identifier. **DECIDED (#991): frozen into the 1.0 contract** — replacement is a breaking migration (URL paths + params + DB lookups + responses); the enumeration existence-oracle is already closed (owner-scope + uniform not-found), residual exposure is row-count *magnitude* only. Opaque-ID migration tracked in #1008 (post-1.0, breaking/major).
 - `key_name: str` — required
 - `provider: str` — required
 - `masked_value: str` — required
@@ -1157,7 +1158,7 @@ Notes:
 
 ### ResourceTokenResponse (TZAwareBaseModel, L75)
 > Response model for resource token metadata (no plaintext).
-- `id: int` — required ⚠ sequential integer DB PK used as the public identifier (leaks row count; consider opaque id before freeze)
+- `id: int` — required ⚠ sequential integer DB PK used as the public identifier. **DECIDED (#991): frozen into the 1.0 contract** — replacement is a breaking migration (URL paths + params + DB lookups + responses); the enumeration existence-oracle is already closed (owner-scope + uniform not-found), residual exposure is row-count *magnitude* only. Opaque-ID migration tracked in #1008 (post-1.0, breaking/major).
 - `resource_id: str` — required
 - `description: str | None` — optional
 - `quota_events_per_hour: int` — required
@@ -1266,7 +1267,7 @@ Notes:
 ### TelemetryResponse (BaseModel, L28)
 > System telemetry response (endpoint is gated by APIKeyOrSessionUser, i.e. any authenticated user).
 - `services: dict[str, ServiceStatus]` — required
-- `embedding_config: dict | None` — optional ⚠ internal embedding infrastructure config exposed to any authenticated user — consider admin-only or remove before freeze
+- `embedding_config: dict | None` — optional ✅ **internal `ollama_base_url` dropped in #991** (it exposed an internal infrastructure URL to any authenticated caller and had no consumer). The remaining `{provider, model, dimensions}` are low-sensitivity capability info already surfaced in the admin environment page; the endpoint stays `APIKeyOrSessionUser` (non-admin consumers depend on it).
 - `memory_stats: dict` — required
 - `neural_memory: dict` — required
 - `uptime_seconds: int` — required
@@ -1470,7 +1471,7 @@ Notes:
 - `resource_id: str` — required
 - ~~`resource_pk: UUID`~~ — ✅ **removed in #991** (was the internal `resources.id` DB PK, redundant with the public `resource_id` slug above).
 - `context_id: UUID | None` — optional
-- `token_id: int` — required
+- `token_id: int` — required ⚠ sequential integer DB PK (ResourceToken.id) used as a public identifier. **DECIDED (#991): frozen into the 1.0 contract**; opaque-ID migration tracked in #1008 (post-1.0, breaking/major). See the `id: int` markers above for the rationale.
 - `token: str` — required ⚠ plaintext connector token (shown-once by design — verify never logged/cached downstream)
 - `kmc_api_key: str | None` — optional ⚠ plaintext KMC write key (shown-once by design)
 - `quota_events_per_hour: int` — required
@@ -1480,7 +1481,7 @@ Notes:
 > One connector row for the workspace list view.
 - `connector_id: UUID` — required
 - `connector_type: str` — required
-- `resource_pk: UUID` — required ⚠ internal DB primary key in a routine list view — should expose the public `resource_id` instead
+- `resource_id: str` — required ✅ **public slug exposed in #991** (replaced the internal `resource_pk` DB key, resolved via a `Resource` JOIN in `ConnectorProvisioningService.list_connectors`).
 - `context_id: UUID | None` — optional
 - `config_version: int` — required
 - `created_at: datetime` — required
@@ -1687,8 +1688,8 @@ Issue #622 allows at most 2 follow-up sub-issues; candidates below are grouped i
 | Candidate | Priority | Action |
 |---|---|---|
 | `WorkspaceConnectorCreateResponse.resource_pk` (workspace_connectors.py) | ✅ DONE (#991) | Dropped — redundant with the public `resource_id` slug already on the response |
-| `WorkspaceConnectorSummary.resource_pk` (workspace_connectors.py) | P1 (deferred) | NOT a pure drop — this response has no `resource_id`; substituting the public slug needs a `Resource` JOIN in `ConnectorProvisioningService.list_connectors`. Tracked for a follow-up. |
-| `TelemetryResponse.embedding_config` (system.py) | P1 (deferred) | Visible to any authenticated user (incl. an internal Ollama URL when provider=ollama). Gating the endpoint is breaking; dropping/nulling the field needs an intent decision (is embedding config intended public?). Tracked for a follow-up. |
+| `WorkspaceConnectorSummary.resource_pk` (workspace_connectors.py) | ✅ DONE (#991) | Replaced `resource_pk: UUID` with the public `resource_id: str` slug, resolved via a single `Resource` JOIN in `ConnectorProvisioningService.list_connectors` (no N+1). Frontend type synced. |
+| `TelemetryResponse.embedding_config` (system.py) | ✅ DONE (#991) | Dropped the internal `ollama_base_url` field (internal infra URL, zero consumers). Kept `{provider, model, dimensions}` (low-sensitivity capability info consumed by the admin environment page). Endpoint stays `APIKeyOrSessionUser` — gating it would break the non-admin telemetry consumers. |
 | `ResourceEventRecord.payload` / `event_metadata` (resources.py) | P1 | Confirm raw-vs-derived boundary (#968) / classification redaction applies to the Resource Detail Data tab before freeze |
 | `OAuth2ClientResponse.plaintext_secret` (oauth.py) | P1 | Verify owner+visibility gating and `response_model_exclude` coverage on every endpoint returning this model; fix the misleading "without secret" docstring |
 | `WorkerConnectorConfig` (workers.py) | P1 | Explicitly exclude the `/workers` surface (plaintext Slack/KMC secrets) from the public 1.0 OpenAPI/freeze scope |
@@ -1699,6 +1700,6 @@ Issue #622 allows at most 2 follow-up sub-issues; candidates below are grouped i
 
 | Candidate | Priority | Action |
 |---|---|---|
-| `APIKeyResponse.id`, `ExternalKeyResponse.id`, `ResourceTokenResponse.id`, `WorkspaceConnectorCreateResponse.token_id` (all `int`) | P2 | Replace sequential integer DB PKs with opaque/prefixed public identifiers before freezing the surface |
+| `APIKeyResponse.id`, `ExternalKeyResponse.id`, `ResourceTokenResponse.id`, `WorkspaceConnectorCreateResponse.token_id` (all `int`) | ✅ DECIDED (#991) → tracked #1008 | **Frozen into the 1.0 contract** rather than replaced. Replacement is a breaking migration spanning URL paths (`/{token_id}`), request params, DB lookups, and response shapes across 4 models / 3+ route files — out of scope for a pre-1.0 cleanup. The enumeration existence-oracle is already closed (owner-scope + uniform not-found); residual exposure is row-count *magnitude* only. Opaque-ID replacement deferred to #1008 (post-1.0, breaking/major). |
 | Untyped `dict` fields on freezable responses: `PublicSearchResult.metadata`, `GraphStats.top_connections`/`recent_edges`, `GraphDataResponse.stats`, `UserStats.*`, `WorkspacePlanInfo.usage`/`quotas` (workspace_plan.py), `AvailablePlanInfo.quotas`, `TelemetryResponse.memory_stats`/`neural_memory`, `SleepReportDetail.*_result`, `UserInfo.workspaces` | P2 | Type them with explicit models, or mark them explicitly non-frozen in the 1.0 contract |
 | Duplicate class names across route files | ✅ DONE (#991) | Renamed the `admin_plans.py` / `workspaces.py` copies → `AdminWorkspacePlanInfo`, `AdminUpdatePlanRequest`, `WorkspaceContextStatsResponse`; `workspace_plan.py` / `contexts.py` keep the canonical names. Also removed the dead `APIKeyCreate`/`APIKeyResponse`/`APIKeyCreateResponse` duplicates from `models/schemas.py` (zero callers; live versions are in `api_keys.py`). OpenAPI now emits distinct component names per endpoint; field JSON unchanged. |

--- a/frontend/src/lib/api/workspace-connectors.ts
+++ b/frontend/src/lib/api/workspace-connectors.ts
@@ -14,7 +14,7 @@ export type ConnectorType = "slack" | "discord" | "teams";
 export interface WorkspaceConnectorSummary {
   connector_id: string;
   connector_type: ConnectorType;
-  resource_pk: string;
+  resource_id: string;
   context_id: string | null;
   config_version: number;
   created_at: string;
@@ -40,7 +40,6 @@ export interface CreateConnectorResponse {
   connector_id: string;
   connector_type: ConnectorType;
   resource_id: string;
-  resource_pk: string;
   context_id: string | null;
   token_id: number;
   token: string;


### PR DESCRIPTION
Closes #991

## Summary
- Hide internal identifiers on the pre-1.0 REST response surface (Phase 2 of #991, part of #622).
- `WorkspaceConnectorSummary`: expose the public `resource_id` slug instead of the internal `resource_pk` DB key, resolved via a single `Resource` JOIN in `list_connectors` (no N+1). Frontend type synced; dropped the stale `CreateConnectorResponse.resource_pk` left over from Phase 1.
- `TelemetryResponse`: drop the internal `ollama_base_url` from `embedding_config` (no consumer; `/system/telemetry` is `APIKeyOrSessionUser`) and from the `services.ollama` health-check details, so the internal URL is no longer surfaced anywhere in the response. Extracted `_embedding_config_payload()` as a testable seam.
- Sequential int PKs (`APIKeyResponse.id`, `ExternalKeyResponse.id`, `ResourceTokenResponse.id`, `WorkspaceConnectorCreateResponse.token_id`) consciously frozen into the 1.0 contract; opaque-ID replacement is a breaking migration deferred to #1008 (post-1.0).

## Implementation notes
- New frozen `ConnectorListItem(connector, resource_id)` dataclass; `list_connectors` return type changed `list[WorkspaceConnector]` → `list[ConnectorListItem]`; route handler + 2 tests adapted.
- New `tests/api/test_system_telemetry.py` pins the embedding_config payload shape (excludes ollama_base_url).
- Re-froze `docs/api-surface-1.0/rest-response-models.md` (resource_id exposed, ollama URL dropped, int-PKs frozen→#1008).
- Verified: ruff check + format clean; OpenAPI 262 components (WorkspaceConnectorSummary has resource_id); 22 backend tests pass; frontend tsc clean.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: yellow (two non-blocking coverage gaps: no dedicated test for the services.ollama url removal; no integration test exercising the real connector→resource JOIN)
- cto: green
- gate1: yellow via /claude-c-suite:ask (conditions met: #1008 filed, int-PK acceptance documented, single JOIN, consumer checks, OpenAPI verified)
- review provider: none (opt-in)

🤖 Generated via /gh-issue-driven:ship
