### PR TITLE
refactor(mcp): disambiguate merge_contexts params + hide internal model_id (#990)

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1041,14 +1041,21 @@ Use cases:
 Requires owner access to both contexts. Same workspace required.""",
             "inputSchema": {
                 "type": "object",
-                "required": ["source_id", "target_id"],
+                # #990: renamed source_id/target_id → source_context_id/
+                # target_context_id. These are CONTEXT UUIDs, but the edge tools
+                # (create_edge/update_edge/delete_edge) use source_id/target_id
+                # for MEMORY UUIDs — the shared names were the strongest
+                # cross-tool ambiguity on the surface. The handler still accepts
+                # the old names for one release as a deprecated alias
+                # (kagura-memory-python-sdk#196 tracks the SDK update).
+                "required": ["source_context_id", "target_context_id"],
                 "properties": {
-                    "source_id": {
+                    "source_context_id": {
                         "type": "string",
                         "format": "uuid",
                         "description": "Source context UUID to copy memories FROM. MUST be a valid UUID from list_contexts().",
                     },
-                    "target_id": {
+                    "target_context_id": {
                         "type": "string",
                         "format": "uuid",
                         "description": "Target context UUID to copy memories INTO. MUST be a valid UUID from list_contexts().",
@@ -1579,13 +1586,13 @@ Requires action recording (reports created before this feature have no actions t
                         "type": "number",
                         "description": "Optional importance floor (0.0–1.0).",
                     },
-                    "model_id": {
-                        "type": "integer",
-                        "description": (
-                            "Optional ``llm_pricing.id`` override. v1 default = "
-                            "openai gpt-5-nano (resolved server-side)."
-                        ),
-                    },
+                    # model_id (an internal ``llm_pricing.id`` integer PK) was
+                    # removed from the public MCP surface in #990: it leaked an
+                    # internal DB key and was unusable without it. The run always
+                    # uses the server-default model. A stable, per-workspace
+                    # model selector is planned for v1.5
+                    # (Workspace.analysis_default_model_id; see
+                    # services/analysis/orchestrator.py).
                     "dry_run": {
                         "type": "boolean",
                         "description": (

--- a/backend/src/mcp_server/tools/analysis.py
+++ b/backend/src/mcp_server/tools/analysis.py
@@ -304,7 +304,11 @@ async def handle_analyze_context(
                 min_importance=args.get("min_importance"),
                 # query (Reserved for v1.5) was removed from the analyze_context
                 # inputSchema in #990; AnalysisParams.query defaults to None.
-                model_id=args.get("model_id"),
+                # model_id (internal llm_pricing.id PK) was also removed from the
+                # public MCP surface in #990 — the run always uses the
+                # server-default model (AnalysisParams.model_id defaults to None
+                # → _resolve_pricing_row's default path). A stable per-workspace
+                # model selector is planned for v1.5.
                 extra={
                     "from": args.get("from"),
                     "to": args.get("to"),

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -732,8 +732,23 @@ async def handle_merge_contexts(
     args: dict[str, Any], user_id: str, workspace_id: UUID | None
 ) -> list[TextContent]:
     """Merge memories from source context into target context (Issue #90)."""
-    if "source_id" not in args or "target_id" not in args:
-        return _error_response("missing_fields", "Missing required fields: source_id and target_id")
+    # #990: params renamed source_id/target_id → source_context_id/
+    # target_context_id (they are CONTEXT UUIDs; edge tools use source_id/
+    # target_id for MEMORY UUIDs). Accept the old names for one release as a
+    # deprecated alias so the current SDK (kagura-memory-python-sdk#196) keeps
+    # working until it updates; the schema advertises only the new names.
+    source_raw = args.get("source_context_id", args.get("source_id"))
+    target_raw = args.get("target_context_id", args.get("target_id"))
+    if source_raw is None or target_raw is None:
+        return _error_response(
+            "missing_fields",
+            "Missing required fields: source_context_id and target_context_id",
+        )
+    if "source_id" in args or "target_id" in args:
+        logger.warning(
+            "merge_contexts called with deprecated params source_id/target_id; "
+            "use source_context_id/target_context_id (#990)"
+        )
 
     from db.base import get_db
 
@@ -742,8 +757,8 @@ async def handle_merge_contexts(
         try:
             from services.context_service import ContextService
 
-            source_id = _resolve_context_id(args["source_id"])
-            target_id = _resolve_context_id(args["target_id"])
+            source_id = _resolve_context_id(source_raw)
+            target_id = _resolve_context_id(target_raw)
             delete_source_raw = args.get("delete_source", False)
             if isinstance(delete_source_raw, str):
                 delete_source = delete_source_raw.lower() == "true"

--- a/backend/src/mcp_server/tools/context.py
+++ b/backend/src/mcp_server/tools/context.py
@@ -827,7 +827,11 @@ async def handle_merge_contexts(
                 "merge_contexts",
                 start_time,
                 500,
-                args.get("source_id"),
+                # source_raw (the raw input) is always bound after the
+                # missing-fields check and is correct for either param name
+                # (#990); args.get("source_id") would be None for the new
+                # canonical source_context_id calls, losing the audit trail.
+                source_raw,
                 workspace_id,
             )
             logger.error("merge_contexts_failed", exc_info=True)

--- a/backend/tests/mcp_server/test_context_tools.py
+++ b/backend/tests/mcp_server/test_context_tools.py
@@ -202,7 +202,10 @@ class TestHandleMergeContextsWorkspaceBoundary:
             ),
         ):
             result = await handle_merge_contexts(
-                args={"source_id": str(source_id), "target_id": str(target_id)},
+                args={
+                    "source_context_id": str(source_id),
+                    "target_context_id": str(target_id),
+                },
                 user_id=user_id,
                 workspace_id=workspace_id,
             )
@@ -249,7 +252,10 @@ class TestHandleMergeContextsWorkspaceBoundary:
             ),
         ):
             result = await handle_merge_contexts(
-                args={"source_id": str(source_id), "target_id": str(target_id)},
+                args={
+                    "source_context_id": str(source_id),
+                    "target_context_id": str(target_id),
+                },
                 user_id=user_id,
                 workspace_id=workspace_id,
             )
@@ -293,7 +299,10 @@ class TestHandleMergeContextsWorkspaceBoundary:
             ),
         ):
             result = await handle_merge_contexts(
-                args={"source_id": str(source_id), "target_id": str(target_id)},
+                args={
+                    "source_context_id": str(source_id),
+                    "target_context_id": str(target_id),
+                },
                 user_id=user_id,
                 workspace_id=workspace_id,
             )
@@ -302,6 +311,51 @@ class TestHandleMergeContextsWorkspaceBoundary:
         assert payload["status"] == "success"
         assert payload["merged"] == 3
         mock_service.merge_contexts.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_deprecated_source_id_alias_still_merges(
+        self, user_id, workspace_id, source_id, target_id
+    ):
+        """#990: the renamed params advertise source_context_id/target_context_id,
+        but the handler still accepts the old source_id/target_id for one release
+        (deprecated alias) so the current SDK keeps working."""
+        mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
+        mock_db.commit = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        shared_ws = uuid4()
+        resolve = AsyncMock(side_effect=[self._ctx(shared_ws), self._ctx(shared_ws)])
+        mock_service = MagicMock()
+        mock_service.merge_contexts = AsyncMock(return_value={"merged": 1, "source_deleted": False})
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch("mcp_server.tools.context._resolve_context_for_read", new=resolve),
+            patch("services.context_service.ContextService", return_value=mock_service),
+            patch("mcp_server.tools.context._log_tool_usage", new_callable=AsyncMock),
+        ):
+            result = await handle_merge_contexts(
+                args={"source_id": str(source_id), "target_id": str(target_id)},
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "success"
+        mock_service.merge_contexts.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_missing_both_param_names_errors(self, user_id, workspace_id):
+        """Neither new nor old source/target keys → missing_fields with the new
+        canonical field names in the message (#990)."""
+        result = await handle_merge_contexts(args={}, user_id=user_id, workspace_id=workspace_id)
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "missing_fields"
+        assert "source_context_id" in payload["message"]
 
 
 class TestHandleUpdateContextErrorSurface:

--- a/backend/tests/mcp_server/test_context_tools.py
+++ b/backend/tests/mcp_server/test_context_tools.py
@@ -357,6 +357,49 @@ class TestHandleMergeContextsWorkspaceBoundary:
         assert payload["error"] == "missing_fields"
         assert "source_context_id" in payload["message"]
 
+    @pytest.mark.asyncio
+    async def test_failure_path_logs_canonical_source_id(
+        self, user_id, workspace_id, source_id, target_id
+    ):
+        """#990 regression: the 500-error usage log must record the source
+        context id even for the new canonical source_context_id name. A naive
+        args.get("source_id") would log None on the failure path, losing the
+        audit trail for exactly the calls the rename standardizes on."""
+        mock_db = AsyncMock()
+        mock_db.rollback = AsyncMock()
+
+        async def mock_get_db():
+            yield mock_db
+
+        shared_ws = uuid4()
+        resolve = AsyncMock(side_effect=[self._ctx(shared_ws), self._ctx(shared_ws)])
+        mock_service = MagicMock()
+        mock_service.merge_contexts = AsyncMock(side_effect=RuntimeError("boom"))
+        log_mock = AsyncMock()
+
+        with (
+            patch("db.base.get_db", new=mock_get_db),
+            patch("mcp_server.tools.context._resolve_context_for_read", new=resolve),
+            patch("services.context_service.ContextService", return_value=mock_service),
+            patch("mcp_server.tools.context._log_tool_usage", new=log_mock),
+        ):
+            result = await handle_merge_contexts(
+                args={
+                    "source_context_id": str(source_id),
+                    "target_context_id": str(target_id),
+                },
+                user_id=user_id,
+                workspace_id=workspace_id,
+            )
+
+        payload = json.loads(result[0].text)
+        assert payload["status"] == "error"
+        assert payload["error"] == "merge_contexts_error"
+        # resource_id is the 6th positional arg of _log_tool_usage; must be the
+        # canonical source id, never None.
+        log_mock.assert_awaited_once()
+        assert log_mock.await_args.args[5] == str(source_id)
+
 
 class TestHandleUpdateContextErrorSurface:
     """Pins the domain-exception envelope contract for handle_update_context

--- a/backend/tests/mcp_server/test_tool_schema_policy.py
+++ b/backend/tests/mcp_server/test_tool_schema_policy.py
@@ -34,3 +34,30 @@ def test_analyze_context_query_noop_removed():
     defs = get_tool_definitions()
     analyze = next(d for d in defs if d["name"] == "analyze_context")
     assert "query" not in analyze["inputSchema"]["properties"]
+
+
+def test_analyze_context_internal_model_id_pk_removed():
+    """The internal ``model_id`` (llm_pricing.id int PK) is gone from the schema (#990).
+
+    It leaked an internal DB key and was unusable without knowing it; the run
+    always uses the server-default model. A stable per-workspace model selector
+    is planned for v1.5.
+    """
+    defs = get_tool_definitions()
+    analyze = next(d for d in defs if d["name"] == "analyze_context")
+    assert "model_id" not in analyze["inputSchema"]["properties"]
+
+
+def test_merge_contexts_uses_context_scoped_param_names():
+    """merge_contexts advertises source_context_id/target_context_id, not the
+    bare source_id/target_id that the edge tools use for MEMORY UUIDs (#990).
+
+    The shared names were the strongest cross-tool ambiguity on the surface;
+    the handler still accepts the old names for one release as a deprecated alias.
+    """
+    defs = get_tool_definitions()
+    merge = next(d for d in defs if d["name"] == "merge_contexts")
+    props = merge["inputSchema"]["properties"]
+    assert "source_context_id" in props and "target_context_id" in props
+    assert "source_id" not in props and "target_id" not in props
+    assert merge["inputSchema"]["required"] == ["source_context_id", "target_context_id"]

--- a/claude-skills/smoke-test.md
+++ b/claude-skills/smoke-test.md
@@ -252,7 +252,7 @@ Create a second temporary context, then test merge and usage:
 create_context(name="smoke-test-merge-{unix_timestamp}", description="Merge target for smoke test.")
 -> Save returned context_id as merge_target_id
 
-merge_contexts(source_id=<context_id>, target_id=<merge_target_id>)
+merge_contexts(source_context_id=<context_id>, target_context_id=<merge_target_id>)
 -> Verify: success response with merged memory count
 
 get_usage()

--- a/docs/api-surface-1.0/mcp-input-schemas.md
+++ b/docs/api-surface-1.0/mcp-input-schemas.md
@@ -3,7 +3,8 @@
 > Issue: #622 — pre-1.0 public API surface enumeration and freeze
 > Enumerated at commit 20ae959a2c79cacd2cf7922512ad780f540e9c60 (main HEAD, 2026-06-12)
 > Source: backend/src/mcp_server/tools/_definitions.py — 45 tools, 45 of 45 enumerated
-> Re-frozen after #990 (additionalProperties:false on all 45 schemas; analyze_context `query` no-op removed; `model_id` replacement deferred to a follow-up)
+> Re-frozen after #990 (Phase 1): additionalProperties:false on all 45 schemas; analyze_context `query` no-op removed.
+> Re-frozen after #990 (Phase 2): merge_contexts `source_id`/`target_id` → `source_context_id`/`target_context_id` (handler keeps the old names for one release as a deprecated alias; kagura-memory-python-sdk#196 tracks the SDK); analyze_context's internal `model_id` (llm_pricing.id int PK) **removed** from the public MCP surface (run uses server-default model); `k`/`limit`/`cap` result-size trio **consciously frozen** as three distinct conventions (see below). The cross-surface stable-model-identifier replacement (REST + MCP) stays deferred to the v1.5 per-workspace model selection. #990 is now resolved on the MCP surface.
 
 **Global note**: ✅ **Resolved in #990.** Every tool `inputSchema` now sets `additionalProperties: false` — undeclared top-level parameters are forbidden by the published contract. Applied centrally in `get_tool_definitions()` so all 45 tools stay uniform and any new tool inherits the policy automatically. The policy is advisory at the server (handlers read args defensively via `.get` and never Pydantic-validate), so it tightens the client-facing contract without changing server behaviour; nested object params are unaffected (only the top-level argument object is closed).
 
@@ -70,7 +71,7 @@ Hybrid search (semantic + BM25 + Neural Memory boosting) over memories; returns 
 
 - **Required**: `query` — string
 - **Optional**:
-  - `k` — integer (default 5, max 100 per description) ⚠ result-size param is `k` here but `limit` in list_edges/list_tags/get_sleep_history/list_resource_tokens/list_analyses/get_cluster/list_files and `cap` in load_pinned — three names for the same concept
+  - `k` — integer (default 5, max 100 per description) ✅ **DECIDED (#990): the `k`/`limit`/`cap` trio is consciously frozen as three distinct conventions, not unified.** `k` = the top-k count for a *relevance-ranked* result set (recall/get_sleep_history — established ML term); `limit` = pagination size for a *flat list* (the list_* family); `cap` = the ceiling for *pinned-memory load* (load_pinned). Unifying to one name spans ~8 tools (breaking) and would erase the relevance-vs-pagination signal `k` carries — net DX loss. Frozen as-is.
   - `use_rerank` — boolean (default false)
   - `filters` — object (free-form: type, tags, tags_match, importance gte, created/updated bounds, source_uri_prefix, source_type, trust_tier) ⚠ filter vocabulary lives only in prose; analyze_context exposes the equivalent filters (`types`, `tags`, `min_importance`, `from`/`to`) as top-level params instead — two filter styles on one surface
   - `context_id` — string, format `uuid`
@@ -103,7 +104,7 @@ Deterministic time-window query over Time Memories (type='time'), soonest first.
 Deterministically load the complete set of delivery_mode='always' memories for a context (counterpart to probabilistic recall).
 
 - **Required**: `context_id` — string, format `uuid`
-- **Optional**: `cap` — integer (1–1000; server default if omitted) ⚠ third name for result-size (`cap` vs `k` vs `limit`)
+- **Optional**: `cap` — integer (1–1000; server default if omitted) ✅ **frozen (#990)** as the pinned-memory-load ceiling — distinct from `k` (relevance top-k) and `limit` (list pagination); see the recall `k` note for the rationale.
 
 ### forget
 
@@ -239,7 +240,7 @@ Soft-delete a context and all its memories (owner-only; locked contexts must be 
 Copy all memories from a source context into a target context (same embedding model, same workspace).
 
 - **Required**:
-  - `source_id` — string, format `uuid` (context) ⚠ name collision: `source_id`/`target_id` are CONTEXT UUIDs here but MEMORY UUIDs in create_edge/update_edge/delete_edge — the strongest cross-tool ambiguity on the surface; `source_context_id`/`target_context_id` would disambiguate
+  - `source_context_id` / `target_context_id` — string, format `uuid` (context) ✅ **renamed in #990** from `source_id`/`target_id` to remove the collision with the edge tools (which use those names for MEMORY UUIDs — this was the strongest cross-tool ambiguity on the surface). The handler still accepts the old `source_id`/`target_id` for one release as a deprecated alias (logs a warning); kagura-memory-python-sdk#196 tracks updating the SDK before the alias is removed.
   - `target_id` — string, format `uuid` (context)
 - **Optional**: `delete_source` — boolean (default false)
 
@@ -358,7 +359,7 @@ Start (or dry-run cost-preview) a broadlistening analysis run that clusters a co
   - `tags` — array of string
   - `min_importance` — number (0.0–1.0)
   - ~~`query`~~ — ✅ **removed in #990** (was a reserved-for-v1.5 no-op; will be re-added when the query-scoped path is implemented).
-  - `model_id` — integer ⚠ lock-in: an internal `llm_pricing.id` database PK exposed as the public model selector, hardcoding "openai gpt-5-nano" in the description. **Deferred** from #990: `model_id` is a *shared* MCP + REST contract (`api/routes/analyses.py` builds the same `AnalysisParams`; a REST Pydantic schema and 4 test files reference it), so replacing the PK with a stable `(provider, model)` identifier is a cross-surface change that needs its own focused pass — see the dedicated follow-up.
+  - ~~`model_id` — integer~~ ✅ **removed from the public MCP surface in #990** — it exposed an internal `llm_pricing.id` DB PK and was unusable without knowing it; analyze_context now always uses the server-default model (`AnalysisParams.model_id` defaults to None → orchestrator's default-row path). **Note:** the *REST* `model_id` (int) on `api/routes/analyses.py` is unchanged (out of #990's MCP scope), and the **stable `(provider, model)` identifier replacement** is part of the v1.5 per-workspace model-selection redesign (`Workspace.analysis_default_model_id`) — a cross-surface change, not an MCP-schema-only edit.
   - `dry_run` — boolean (default false)
 
 ### get_analysis
@@ -491,12 +492,12 @@ Recurring inconsistencies (each instance flagged inline above):
 
 ### Bundle 1 — P1: naming + schema-rigor fixes that are breaking after freeze (propose as sub-issue "MCP surface: pre-freeze naming and schema unification")
 
-- **P1** Rename merge_contexts `source_id`/`target_id` → `source_context_id`/`target_context_id` (or namespace all edge params as `source_memory_id`/`target_memory_id`) — resolves the memory/context overload.
-- **P1** Unify result-size param: standardize on `limit` (or `k`) across recall, recall_upcoming, forget, load_pinned and all list_* tools; alias-and-deprecate the others before 1.0.
+- ✅ **DONE (#990)** Renamed merge_contexts `source_id`/`target_id` → `source_context_id`/`target_context_id`, resolving the memory/context overload. Old names accepted for one release as a deprecated handler alias (kagura-memory-python-sdk#196 tracks the SDK).
+- ✅ **DECIDED (#990): do NOT unify the result-size param.** `k` (relevance top-k), `limit` (list pagination), `cap` (pin-load ceiling) are kept as three distinct conventions — unifying spans ~8 tools (breaking) and erases the semantic signal `k` carries. Frozen and documented as deliberate (see the recall `k` note).
 - **P1** Unify time-range bounds on one pair (`from`/`to` or `from`/`until`) across recall_upcoming, analyze_context, setup_connector.
 - **P1** Add `format: "uuid"` to every UUID param (analysis bundle, file tools, feedback, set_state, get_state, run_id, file_id, memory_id in feedback).
 - **P1** forget: make the two modes explicit (`anyOf`/`oneOf` over memory_id / query) so a bare `{context_id}` call is schema-invalid — destructive tool, ambiguous input.
-- ✅ **DONE (#990, query)** / **DEFERRED (model_id)** — analyze_context's reserved no-op `query` param was removed (re-add in v1.5). Replacing `model_id` (internal llm_pricing PK) with a stable identifier was **deferred to a dedicated follow-up**: it is a shared MCP + REST contract (orchestrator `AnalysisParams`, `api/routes/analyses.py`, REST Pydantic schema, 4 test files), so it needs a cross-surface design pass rather than an MCP-schema-only edit.
+- ✅ **DONE (#990)** — analyze_context's reserved no-op `query` param was removed (Phase 1; re-add in v1.5), and the internal `model_id` (llm_pricing.id int PK) was **removed from the public MCP surface** (Phase 2 — run uses the server-default model). The **stable `(provider, model)` identifier replacement** is a shared MCP + REST contract (orchestrator `AnalysisParams`, `api/routes/analyses.py`, REST Pydantic schema) and stays deferred to the **v1.5 per-workspace model-selection** redesign — a cross-surface pass, not an MCP-schema-only edit. The REST `model_id` (int) is unchanged for now (out of #990's MCP scope).
 - **P1** Decide the `workspace_id` override on the 5 file tools: remove from public schema or document the auth model explicitly.
 - ✅ **DONE (#990)** Set `additionalProperties: false` on all 45 inputSchemas (applied centrally in `get_tool_definitions()`; guarded by `tests/mcp_server/test_tool_schema_policy.py`).
 - **P1** Unify edge-type param naming/typing: `relation_types`/`edge_types`/`edge_type` → one name, one typing.

--- a/docs/api-surface-1.0/mcp-input-schemas.md
+++ b/docs/api-surface-1.0/mcp-input-schemas.md
@@ -241,7 +241,6 @@ Copy all memories from a source context into a target context (same embedding mo
 
 - **Required**:
   - `source_context_id` / `target_context_id` — string, format `uuid` (context) ✅ **renamed in #990** from `source_id`/`target_id` to remove the collision with the edge tools (which use those names for MEMORY UUIDs — this was the strongest cross-tool ambiguity on the surface). The handler still accepts the old `source_id`/`target_id` for one release as a deprecated alias (logs a warning); kagura-memory-python-sdk#196 tracks updating the SDK before the alias is removed.
-  - `target_id` — string, format `uuid` (context)
 - **Optional**: `delete_source` — boolean (default false)
 
 ### update_search_config
@@ -474,8 +473,8 @@ Read one key or list all live state entries for a context (read-only).
 
 Recurring inconsistencies (each instance flagged inline above):
 
-1. **Result-size parameter — three names**: `k` (recall, recall_upcoming, forget), `limit` (list_edges, list_tags, get_sleep_history, list_resource_tokens, list_analyses, get_cluster, list_files), `cap` (load_pinned). Same concept, three frozen spellings; `k` even carries different defaults (5 vs 20 vs 10) across its three uses.
-2. **`source_id`/`target_id` overload**: memory UUIDs in create_edge/update_edge/delete_edge, context UUIDs in merge_contexts. The single most dangerous ambiguity for tool-calling LLMs and SDK users.
+1. **Result-size parameter — three names** ✅ **RESOLVED (#990): consciously frozen as three distinct conventions, not unified** — `k` (relevance top-k: recall, recall_upcoming, forget), `limit` (list pagination: list_edges, list_tags, get_sleep_history, list_resource_tokens, list_analyses, get_cluster, list_files), `cap` (pin-load ceiling: load_pinned). The differing `k` defaults (5 vs 20 vs 10) are per-tool intent, not drift. See the recall `k` note for the rationale.
+2. **`source_id`/`target_id` overload** ✅ **RESOLVED (#990): merge_contexts renamed to `source_context_id`/`target_context_id`** (old names kept one release as a deprecated handler alias; kagura-memory-python-sdk#196 tracks the SDK). The edge tools keep `source_id`/`target_id` for MEMORY UUIDs — no longer ambiguous.
 3. **Time-range bounds**: `from`/`until` (recall_upcoming) vs `from`/`to` (analyze_context) vs `*_valid_until` (setup_connector).
 4. **Edge-type vocabulary — three param names and two typings**: `relation_types` (array of free string, explore) vs `edge_types` (array of free string, list_edges) vs `edge_type` (hard 6-value enum, create_edge/update_edge).
 5. **`format: "uuid"` coverage is inconsistent**: present on the core memory/context/edge tools, absent from the entire analysis bundle (`context_id`, `run_id`), all file tools (`file_id`), and the newest tools (feedback, set_state, get_state). The newer the tool, the less schema rigor — exactly the drift a freeze should stop.
@@ -485,7 +484,7 @@ Recurring inconsistencies (each instance flagged inline above):
 9. **Metadata bag**: `context` (remember/update_memory — clashing with `context_id` and `context_summary` in the same tool) vs `event_metadata` (ingest_events).
 10. **Filter style**: recall packs filters into one free-form `filters` object (singular `type`, `importance: {gte}`); analyze_context spreads them top-level (`types` plural, `min_importance`).
 11. **`workspace_id` override** exists only on the 5 file tools; the rest of the surface scopes by auth + context_id. Inconsistent and security-sensitive.
-12. **Constraints live in prose, not schema**: char limits (summary 10–500, context_summary 2000), `maxItems` (events ≤ 100), patterns (context name, sha256 hex), numeric ranges and most defaults are description-only; `additionalProperties` is never set. Tool-side validation cannot rely on the published schema.
+12. **Constraints live in prose, not schema**: char limits (summary 10–500, context_summary 2000), `maxItems` (events ≤ 100), patterns (context name, sha256 hex), numeric ranges and most defaults are description-only. (`additionalProperties` ✅ now set to `false` on all 45 schemas in #990 Phase 1 — the rest of the prose-only constraints remain a P2 hardening item.) Tool-side validation still cannot fully rely on the published schema.
 13. **Enum policy is inconsistent**: connector_type is a hard vendor enum while reranker_provider (same vendor-list shape) is a free string; edge_type is a hard enum that already grew once (#782).
 
 ## Follow-up candidates


### PR DESCRIPTION
Closes #990

## Summary
- Pre-1.0 MCP input-schema cleanup, Phase 2 (part of #622).
- `merge_contexts`: rename `source_id`/`target_id` → `source_context_id`/`target_context_id` so they no longer collide with the edge tools (which use the bare names for MEMORY UUIDs — the strongest cross-tool ambiguity on the surface). The handler accepts the old names for one release as a deprecated alias (logs a warning); kagura-memory-python-sdk#196 tracks updating the SDK before the alias is removed.
- `analyze_context`: remove the internal `model_id` (an `llm_pricing.id` int PK) from the public schema — it leaked a DB key and was unusable without it; the run always uses the server-default model.
- `k`/`limit`/`cap` result-size params: consciously frozen as three distinct conventions (relevance top-k / list pagination / pin-load cap), not unified.

## Implementation notes
- New schema-policy regression guards (`test_tool_schema_policy.py`): model_id absent from analyze_context; merge_contexts required == `[source_context_id, target_context_id]`.
- Deprecated-alias + missing-fields + failure-path-audit-log tests added/updated.
- Fixed an inner-review finding: the merge 500-error path logged `args.get("source_id")` (None for canonical-name calls); now logs the resolved source id.
- The orchestrator's int-PK resolution path is intentionally kept (the REST `model_id` still uses it). The REST `model_id` (int) + the stable `(provider, model)` identifier replacement are deferred to the v1.5 per-workspace model-selection redesign (cross-surface, out of #990's MCP scope).
- Re-froze `docs/api-surface-1.0/mcp-input-schemas.md`; marked the now-resolved recurring-inconsistency catalog items.
- Verified: ruff check + format clean; 221 mcp_server tests pass.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green
- qa-lead: yellow (one non-blocking note: the failure-path test asserts a positional arg index; orchestrator int-path is DB-gated, passes in CI)
- cto: green
- gate1: yellow via /claude-c-suite:ask (DX Lead lens; conditions met: model_id hidden not frozen-as-int, SDK parity #196 filed, merge rename justified)
- review provider: none (opt-in)

🤖 Generated via /gh-issue-driven:ship
