### PR TITLE
refactor(api): freeze the error-response shape via a global handler (#992)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -394,15 +394,26 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException) 
     ``VAL-``/``REQ-`` codes), and ``exc.headers`` is passed through so RFC 6750
     ``WWW-Authenticate`` challenges (Bearer / insufficient_scope) survive.
 
-    Shape-only: it does NOT apply the CWE-639 deny-class ``details`` strip that
-    ``memory_cloud_exception_handler`` does, because a raw ``HTTPException``
-    carries no structured ``details`` — only a string ``detail`` (→ ``message``).
-    The remaining raw 403 detail strings were audited for forensic leakage in
-    the #992 review; the one cross-workspace existence-oracle smell is tracked
-    in #1011.
+    A string ``detail`` becomes ``message`` with empty ``details``; a structured
+    (dict/list) ``detail`` is preserved verbatim under ``details.detail`` (the
+    only such sites are the external-keys conflict payloads) with a generic
+    ``message``. Shape-only: it does NOT apply the CWE-639 deny-class ``details``
+    strip that ``memory_cloud_exception_handler`` does. The remaining raw 403
+    detail strings were audited for forensic leakage in the #992 review; the one
+    cross-workspace existence-oracle smell is tracked in #1011.
     """
     detail = exc.detail
-    message = detail if isinstance(detail, str) else "Request failed"
+    if isinstance(detail, str):
+        message = detail
+        details: dict = {}
+    else:
+        # Structured (dict/list) detail — e.g. the external-keys reranker /
+        # embeddings conflict payloads (external_keys.py). Preserve it under
+        # ``details.detail`` so consumers that branch on the structured object
+        # keep working; ``message`` stays generic since there is no single
+        # human string.
+        message = "Request failed"
+        details = {"detail": detail}
     logger.warning(
         "http_exception",
         status_code=exc.status_code,
@@ -413,7 +424,7 @@ async def http_exception_handler(request: Request, exc: StarletteHTTPException) 
         content={
             "error": f"HTTP-{exc.status_code}",
             "message": message,
-            "details": {},
+            "details": details,
         },
         headers=getattr(exc, "headers", None),
     )

--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -13,6 +13,7 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.exc import SQLAlchemyError
+from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.base import BaseHTTPMiddleware
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -376,6 +377,45 @@ async def request_validation_exception_handler(
             "message": "Request validation failed",
             "details": {"errors": errors},
         },
+    )
+
+
+@app.exception_handler(StarletteHTTPException)
+async def http_exception_handler(request: Request, exc: StarletteHTTPException) -> JSONResponse:
+    """Reshape FastAPI/Starlette's default ``{"detail": ...}`` into the canonical
+    ``{error, message, details}`` envelope (#992 Phase 2 stopgap).
+
+    The ~330 route-level ``raise HTTPException`` sites not yet assigned a
+    semantic ``NAMESPACE-NNN`` code still emit FastAPI's default shape. This
+    handler freezes the error *shape* across all of them in one place so the
+    1.0 contract exposes a single envelope; per-site semantic-code assignment
+    is a post-1.0 improvement. ``error`` carries the reserved ``HTTP-<status>``
+    placeholder namespace (distinct from the semantic ``AUTH-``/``ADMIN-``/
+    ``VAL-``/``REQ-`` codes), and ``exc.headers`` is passed through so RFC 6750
+    ``WWW-Authenticate`` challenges (Bearer / insufficient_scope) survive.
+
+    Shape-only: it does NOT apply the CWE-639 deny-class ``details`` strip that
+    ``memory_cloud_exception_handler`` does, because a raw ``HTTPException``
+    carries no structured ``details`` — only a string ``detail`` (→ ``message``).
+    The remaining raw 403 detail strings were audited for forensic leakage in
+    the #992 review; the one cross-workspace existence-oracle smell is tracked
+    in #1011.
+    """
+    detail = exc.detail
+    message = detail if isinstance(detail, str) else "Request failed"
+    logger.warning(
+        "http_exception",
+        status_code=exc.status_code,
+        path=request.url.path,
+    )
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={
+            "error": f"HTTP-{exc.status_code}",
+            "message": message,
+            "details": {},
+        },
+        headers=getattr(exc, "headers", None),
     )
 
 

--- a/backend/src/api/routes/admin_sleep.py
+++ b/backend/src/api/routes/admin_sleep.py
@@ -183,7 +183,7 @@ def _log_background_task_result(task: asyncio.Task[Any]) -> None:
             "content": {
                 "application/json": {
                     "example": {
-                        "error": "sleep_run_in_progress",
+                        "error": "SLEEP-002",
                         "message": "A sleep run is already in progress for this user.",
                         "details": {
                             "running_report_id": "00000000-0000-0000-0000-000000000000",
@@ -213,10 +213,10 @@ async def trigger_sleep_run(
         background; poll ``GET /admin/sleep-reports/{id}`` for progress.
 
     Raises:
-        409 ``sleep_run_in_progress`` if this user already has a sleep run
+        409 ``SLEEP-002`` if this user already has a sleep run
         with ``status='running'`` — the response body includes
         ``running_report_id`` and ``started_at`` so the UI can link to it.
-        404 ``sleep_target_not_found`` if no eligible contexts match.
+        404 ``SLEEP-003`` if no eligible contexts match.
 
     Phase 1 limitation:
         The 409 guard is best-effort under concurrent requests. Two
@@ -231,7 +231,7 @@ async def trigger_sleep_run(
         raise MemoryCloudException(
             message="Admin user id missing from session.",
             status_code=500,
-            error_code="admin_user_id_missing",
+            error_code="SLEEP-001",
         )
 
     # ---- Concurrency guard --------------------------------------------------
@@ -252,7 +252,7 @@ async def trigger_sleep_run(
         raise MemoryCloudException(
             message="A sleep run is already in progress for this user.",
             status_code=409,
-            error_code="sleep_run_in_progress",
+            error_code="SLEEP-002",
             running_report_id=str(running_report_id),
             started_at=to_utc_iso(started_at),
         )
@@ -275,7 +275,7 @@ async def trigger_sleep_run(
         raise MemoryCloudException(
             message=("No eligible contexts found for this admin to run sleep maintenance on."),
             status_code=404,
-            error_code="sleep_target_not_found",
+            error_code="SLEEP-003",
             context_id=str(request.context_id) if request.context_id else None,
         )
 

--- a/backend/src/services/system_admin_service.py
+++ b/backend/src/services/system_admin_service.py
@@ -82,7 +82,7 @@ class SystemAdminService:
 
         Raises:
             NotFoundException: 404 if user not found.
-            BadRequestError: 400 (``ADMIN-101``) if user is already a system admin.
+            BadRequestError: 400 (``REQ-101``) if user is already a system admin.
 
         Example:
             >>> user = await service.promote_to_system_admin(
@@ -108,7 +108,7 @@ class SystemAdminService:
             )
             raise BadRequestError(
                 "User is already a system admin",
-                error_code="ADMIN-101",
+                error_code="REQ-101",
             )
 
         # Update role
@@ -157,7 +157,7 @@ class SystemAdminService:
 
         Raises:
             NotFoundException: 404 if user not found.
-            BadRequestError: 400 (``ADMIN-102``) if user is not a system admin.
+            BadRequestError: 400 (``REQ-102``) if user is not a system admin.
             AdminProtectionError: 403 if the target is the initial admin or
                 the last remaining admin.
 
@@ -181,7 +181,7 @@ class SystemAdminService:
             logger.warning("demote_system_admin_failed", user_email=user.email, reason="not_admin")
             raise BadRequestError(
                 "User is not a system admin",
-                error_code="ADMIN-102",
+                error_code="REQ-102",
             )
 
         # Protection 1: Cannot demote initial admin

--- a/backend/tests/api/test_admin_neural.py
+++ b/backend/tests/api/test_admin_neural.py
@@ -83,7 +83,7 @@ class TestInputValidation:
         )
         # Defensive handler-level check → 400.
         assert response.status_code == 400
-        assert response.json()["detail"] == "invalid_model_name"
+        assert response.json()["message"] == "invalid_model_name"
 
     def test_model_with_backslash_rejected(self, admin_client):
         response = admin_client.post(

--- a/backend/tests/api/test_admin_plans_spend_cap.py
+++ b/backend/tests/api/test_admin_plans_spend_cap.py
@@ -142,7 +142,7 @@ class TestSpendCapEndpointNotFound:
             json={"embedding_daily_cap_usd": 1.0, "embedding_monthly_cap_usd": 30.0},
         )
         assert resp.status_code == 404
-        assert resp.json()["detail"] == "Workspace not found"
+        assert resp.json()["message"] == "Workspace not found"
 
 
 class TestSpendCapEndpointTierBounded:
@@ -157,7 +157,7 @@ class TestSpendCapEndpointTierBounded:
             json={"embedding_daily_cap_usd": 20.0, "embedding_monthly_cap_usd": None},
         )
         assert resp.status_code == 400
-        detail = resp.json()["detail"]
+        detail = resp.json()["message"]
         assert "embedding_daily_cap_usd" in detail
         assert "tier default" in detail
         # Rejection must happen before any commit.
@@ -175,7 +175,7 @@ class TestSpendCapEndpointTierBounded:
             },
         )
         assert resp.status_code == 400
-        detail = resp.json()["detail"]
+        detail = resp.json()["message"]
         assert "embedding_monthly_cap_usd" in detail
         db.commit.assert_not_called()
 

--- a/backend/tests/api/test_admin_signup_gate.py
+++ b/backend/tests/api/test_admin_signup_gate.py
@@ -175,7 +175,7 @@ class TestAddToAllowlist:
             json={"github_username": "ghost"},
         )
         assert response.status_code == 404
-        assert "not found" in response.json()["detail"].lower()
+        assert "not found" in response.json()["message"].lower()
 
     def test_409_on_duplicate(self, client, monkeypatch):
         monkeypatch.setattr(
@@ -203,7 +203,7 @@ class TestAddToAllowlist:
             json={"github_username": "octocat"},
         )
         assert resp.status_code == 502
-        assert "GitHub" in resp.json()["detail"]
+        assert "GitHub" in resp.json()["message"]
 
     def test_422_on_empty_username(self, client):
         resp = client.post(

--- a/backend/tests/api/test_admin_sleep_trigger.py
+++ b/backend/tests/api/test_admin_sleep_trigger.py
@@ -157,7 +157,7 @@ class TestTriggerSleepRun:
 
         assert response.status_code == 409, response.text
         body = response.json()
-        assert body["error"] == "sleep_run_in_progress"
+        assert body["error"] == "SLEEP-002"
         assert "already in progress" in body["message"].lower()
         assert body["details"]["running_report_id"] == str(running_id)
         # to_utc_iso renders with a trailing Z.
@@ -185,6 +185,6 @@ class TestTriggerSleepRun:
 
         assert response.status_code == 404, response.text
         body = response.json()
-        assert body["error"] == "sleep_target_not_found"
+        assert body["error"] == "SLEEP-003"
         assert no_background_tasks == []
         mock_db.commit.assert_not_awaited()

--- a/backend/tests/api/test_context_members_rbac.py
+++ b/backend/tests/api/test_context_members_rbac.py
@@ -99,7 +99,7 @@ class TestSelfRemovalGuard:
             response = client.delete(f"/api/v1/contexts/{CONTEXT_ID}/members/{OWNER_USER_ID}")
 
         assert response.status_code == 400
-        assert "yourself" in response.json()["detail"].lower()
+        assert "yourself" in response.json()["message"].lower()
 
     def test_workspace_admin_cannot_remove_self(self, client):
         """check_context_owner promotes workspace admin to owner — guard must still fire."""
@@ -116,7 +116,7 @@ class TestSelfRemovalGuard:
             response = client.delete(f"/api/v1/contexts/{CONTEXT_ID}/members/{ADMIN_USER_ID}")
 
         assert response.status_code == 400
-        assert "yourself" in response.json()["detail"].lower()
+        assert "yourself" in response.json()["message"].lower()
 
     def test_owner_can_remove_another_user_reaches_member_lookup(self, client):
         """Removing someone else passes the self-removal guard (goes on to member lookup)."""
@@ -207,7 +207,7 @@ class TestLastOwnerDemotionGuard:
                     json={"role": "editor"},
                 )
             assert response.status_code == 400
-            assert "last" in response.json()["detail"].lower()
+            assert "last" in response.json()["message"].lower()
         finally:
             app.dependency_overrides.clear()
 
@@ -326,7 +326,7 @@ class TestWorkspaceExternalUserGuard:
                     json={"user_id": "outsider", "role": "editor"},
                 )
             assert response.status_code == 400
-            assert "workspace" in response.json()["detail"].lower()
+            assert "workspace" in response.json()["message"].lower()
         finally:
             app.dependency_overrides.clear()
 
@@ -359,7 +359,7 @@ class TestWorkspaceExternalUserGuard:
                     json={"user_id": "anyone", "role": "editor"},
                 )
             assert response.status_code == 400
-            assert "private" in response.json()["detail"].lower()
+            assert "private" in response.json()["message"].lower()
         finally:
             app.dependency_overrides.clear()
 
@@ -455,7 +455,7 @@ class TestAddMemberHappyPath:
                     json={"user_id": MEMBER_USER_ID, "role": "editor"},
                 )
             assert response.status_code == 400
-            assert "already" in response.json()["detail"].lower()
+            assert "already" in response.json()["message"].lower()
         finally:
             app.dependency_overrides.clear()
 
@@ -489,7 +489,7 @@ class TestRemoveMemberHappyPath:
             ):
                 response = client.delete(f"/api/v1/contexts/{CONTEXT_ID}/members/{OTHER_USER_ID}")
             assert response.status_code == 400
-            assert "owner" in response.json()["detail"].lower()
+            assert "owner" in response.json()["message"].lower()
         finally:
             app.dependency_overrides.clear()
 

--- a/backend/tests/api/test_cost_aggregation_routes.py
+++ b/backend/tests/api/test_cost_aggregation_routes.py
@@ -227,7 +227,7 @@ class TestAdminRoute:
             "/api/v1/admin/cost-aggregation?period=hour&from=2026-04-01&to=2026-04-07"
         )
         assert response.status_code == 400
-        assert "Invalid period" in response.json()["detail"]
+        assert "Invalid period" in response.json()["message"]
 
     def test_invalid_source_returns_400(self, client):
         _install_admin_overrides(client, [])
@@ -235,7 +235,7 @@ class TestAdminRoute:
             "/api/v1/admin/cost-aggregation?period=day&from=2026-04-01&to=2026-04-07&source=manual"
         )
         assert response.status_code == 400
-        assert "Invalid source" in response.json()["detail"]
+        assert "Invalid source" in response.json()["message"]
 
     def test_invalid_paid_by_returns_400(self, client):
         _install_admin_overrides(client, [])
@@ -243,7 +243,7 @@ class TestAdminRoute:
             "/api/v1/admin/cost-aggregation?period=day&from=2026-04-01&to=2026-04-07&paid_by=user"
         )
         assert response.status_code == 400
-        assert "Invalid paid_by" in response.json()["detail"]
+        assert "Invalid paid_by" in response.json()["message"]
 
     def test_inverted_window_returns_400(self, client):
         _install_admin_overrides(client, [])
@@ -261,7 +261,7 @@ class TestAdminRoute:
             "/api/v1/admin/cost-aggregation?period=day&from=2026-01-01&to=2027-01-01"
         )
         assert response.status_code == 400
-        assert "exceeds" in response.json()["detail"]
+        assert "exceeds" in response.json()["message"]
         assert mock_aggregate.await_count == 0  # rejected before SQL
 
     def test_window_at_cap_boundary_returns_200(self, client):
@@ -383,7 +383,7 @@ class TestWorkspaceRoute:
             "?period=day&from=2026-04-01&to=2026-04-07&source=manual"
         )
         assert response.status_code == 400
-        assert "Invalid source" in response.json()["detail"]
+        assert "Invalid source" in response.json()["message"]
 
     def test_invalid_paid_by_returns_400(self, client):
         _install_workspace_overrides(client, [], user=_regular_user())
@@ -392,7 +392,7 @@ class TestWorkspaceRoute:
             "?period=day&from=2026-04-01&to=2026-04-07&paid_by=user"
         )
         assert response.status_code == 400
-        assert "Invalid paid_by" in response.json()["detail"]
+        assert "Invalid paid_by" in response.json()["message"]
 
     def test_window_exceeding_cap_returns_400(self, client):
         # Same defense-in-depth cap on the workspace-scoped route (#528).
@@ -403,7 +403,7 @@ class TestWorkspaceRoute:
             "?period=day&from=2026-01-01&to=2027-01-01"
         )
         assert response.status_code == 400
-        assert "exceeds" in response.json()["detail"]
+        assert "exceeds" in response.json()["message"]
         assert mock_aggregate.await_count == 0  # rejected before SQL
 
 

--- a/backend/tests/api/test_device_code_endpoints.py
+++ b/backend/tests/api/test_device_code_endpoints.py
@@ -97,7 +97,7 @@ class TestDeviceAuthorizeEndpoint:
             )
 
         assert resp.status_code == 400
-        assert "Unknown client_id" in resp.json()["detail"]
+        assert "Unknown client_id" in resp.json()["message"]
 
     def test_authorize_scope_intersection(self, test_oauth_client):
         with patch("api.routes.oauth.get_sync_session") as mock_session_fn:
@@ -326,7 +326,7 @@ class TestDeviceConfirmEndpoint:
                 )
 
         assert resp.status_code == 404
-        assert "expired" in resp.json()["detail"].lower()
+        assert "expired" in resp.json()["message"].lower()
 
     def test_confirm_already_processed(self, test_device_code):
         test_device_code.authorized_at = utcnow() - timedelta(seconds=30)

--- a/backend/tests/api/test_error_shape_phase1.py
+++ b/backend/tests/api/test_error_shape_phase1.py
@@ -110,22 +110,26 @@ def test_http_exception_handler_reshapes_to_canonical_and_preserves_headers():
     assert resp.headers["WWW-Authenticate"] == 'Bearer error="insufficient_scope"'
 
 
-def test_http_exception_handler_handles_non_string_detail():
+def test_http_exception_handler_preserves_structured_dict_detail():
     from starlette.exceptions import HTTPException as StarletteHTTPException
 
     from api.main import http_exception_handler
 
+    # external_keys.py raises dict-detail HTTPExceptions for conflict payloads;
+    # the handler must preserve the object under details.detail (not drop it),
+    # so the frontend consumer branching on detail.error keeps working.
     req = MagicMock()
-    req.url.path = "/x"
-    exc = StarletteHTTPException(status_code=404, detail={"weird": "dict"})
+    req.url.path = "/api/v1/external-keys"
+    payload = {"error": "reranker_provider_conflict", "conflicting_provider": "cohere"}
+    exc = StarletteHTTPException(status_code=409, detail=payload)
 
     resp = _run(http_exception_handler(req, exc))
     body = json.loads(resp.body)
 
-    assert resp.status_code == 404
-    assert body["error"] == "HTTP-404"
-    assert body["message"] == "Request failed"  # non-string detail → generic
-    assert body["details"] == {}
+    assert resp.status_code == 409
+    assert body["error"] == "HTTP-409"
+    assert body["message"] == "Request failed"  # no single human string for a dict
+    assert body["details"]["detail"] == payload  # structured detail preserved
 
 
 # --- auth-boundary conversions: status + error_code parity ---

--- a/backend/tests/api/test_error_shape_phase1.py
+++ b/backend/tests/api/test_error_shape_phase1.py
@@ -80,6 +80,54 @@ def test_request_validation_handler_handles_multiple_errors():
     assert {e["loc"][-1] for e in body["details"]["errors"]} == {"a", "b"}
 
 
+# --- #992 Phase 2: global StarletteHTTPException stopgap handler ---
+
+
+def test_http_exception_handler_reshapes_to_canonical_and_preserves_headers():
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    from api.main import http_exception_handler
+
+    req = MagicMock()
+    req.url.path = "/api/v1/whatever"
+    exc = StarletteHTTPException(
+        status_code=403,
+        detail="Insufficient scope",
+        headers={"WWW-Authenticate": 'Bearer error="insufficient_scope"'},
+    )
+
+    resp = _run(http_exception_handler(req, exc))
+    body = json.loads(resp.body)
+
+    assert resp.status_code == 403
+    # Canonical envelope with the reserved HTTP-<status> placeholder code.
+    assert body == {
+        "error": "HTTP-403",
+        "message": "Insufficient scope",
+        "details": {},
+    }
+    # RFC 6750 challenge header must survive the reshape.
+    assert resp.headers["WWW-Authenticate"] == 'Bearer error="insufficient_scope"'
+
+
+def test_http_exception_handler_handles_non_string_detail():
+    from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    from api.main import http_exception_handler
+
+    req = MagicMock()
+    req.url.path = "/x"
+    exc = StarletteHTTPException(status_code=404, detail={"weird": "dict"})
+
+    resp = _run(http_exception_handler(req, exc))
+    body = json.loads(resp.body)
+
+    assert resp.status_code == 404
+    assert body["error"] == "HTTP-404"
+    assert body["message"] == "Request failed"  # non-string detail → generic
+    assert body["details"] == {}
+
+
 # --- auth-boundary conversions: status + error_code parity ---
 
 

--- a/backend/tests/api/test_raw_httpexception_guard.py
+++ b/backend/tests/api/test_raw_httpexception_guard.py
@@ -1,0 +1,39 @@
+"""Ratchet guard against re-introducing raw ``raise HTTPException`` in routes (#992).
+
+#992 Phase 2 froze the error *shape* via the global ``StarletteHTTPException``
+handler (``api/main.py``), but the remaining raw ``raise HTTPException`` sites
+still emit the placeholder ``HTTP-<status>`` code instead of a semantic
+``NAMESPACE-NNN`` one. This ratchet stops the count from GROWING: a new error
+path must raise a canonical ``MemoryCloudException`` subclass
+(``utils/exceptions.py``), not a raw ``HTTPException``.
+
+The baseline may only ever **decrease** as sites are converted (a post-1.0
+gradual improvement). If you legitimately lower it, update ``BASELINE`` to the
+new count. ruff cannot easily ban a specific call inside a path, so this
+test-based ratchet is the interim mechanism.
+"""
+
+import re
+from pathlib import Path
+
+# Count of raw ``raise HTTPException`` in src/api/routes/ at the #992 Phase 2
+# freeze. RATCHET: may go DOWN (conversions), must never go UP.
+BASELINE = 296
+
+_ROUTES = Path(__file__).resolve().parents[2] / "src" / "api" / "routes"
+_PATTERN = re.compile(r"raise\s+HTTPException")
+
+
+def test_raw_httpexception_count_does_not_grow():
+    per_file: dict[str, int] = {}
+    total = 0
+    for path in sorted(_ROUTES.rglob("*.py")):
+        n = len(_PATTERN.findall(path.read_text(encoding="utf-8")))
+        if n:
+            per_file[path.name] = n
+            total += n
+    assert total <= BASELINE, (
+        f"raw `raise HTTPException` count rose to {total} (baseline {BASELINE}). "
+        "New error paths must raise a canonical MemoryCloudException subclass "
+        f"(utils/exceptions.py), not a raw HTTPException. Per-file: {per_file}"
+    )

--- a/backend/tests/api/test_resource_indexer_api.py
+++ b/backend/tests/api/test_resource_indexer_api.py
@@ -241,7 +241,14 @@ class TestIsolation:
             resp = client_workspace_a.get("/api/v1/resources/does-not-exist/indexer-status")
 
         assert resp.status_code == 404
-        assert resp.json() == {"detail": "Resource not found"}
+        # #992 Phase 2: raw HTTPException is reshaped to the canonical envelope
+        # by the global StarletteHTTPException handler (HTTP-<status> placeholder
+        # code; detail string → message; empty details).
+        assert resp.json() == {
+            "error": "HTTP-404",
+            "message": "Resource not found",
+            "details": {},
+        }
 
     def test_slug_in_other_workspace_returns_404_with_identical_body(self, client_workspace_a):
         """Cross-tenant existence must not leak.

--- a/backend/tests/api/test_sleep_reports_admin.py
+++ b/backend/tests/api/test_sleep_reports_admin.py
@@ -169,7 +169,7 @@ class TestListSleepReports:
 
         response = client.get("/api/v1/admin/sleep-reports?status=bogus")
         assert response.status_code == 400
-        assert "Invalid status" in response.json()["detail"]
+        assert "Invalid status" in response.json()["message"]
 
     def test_respects_limit_and_offset(self, client):
         mock_db = AsyncMock()
@@ -421,7 +421,7 @@ class TestGetSleepReportDetail:
 
         response = client.get(f"/api/v1/admin/sleep-reports/{uuid4()}")
         assert response.status_code == 404
-        assert "not found" in response.json()["detail"].lower()
+        assert "not found" in response.json()["message"].lower()
 
     def test_invalid_uuid_returns_422(self, client):
         mock_db = AsyncMock()

--- a/backend/tests/api/test_sleep_reports_workspace.py
+++ b/backend/tests/api/test_sleep_reports_workspace.py
@@ -190,7 +190,7 @@ class TestWorkspaceListSleepReports:
 
         response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/sleep-reports?status=bogus")
         assert response.status_code == 400
-        assert "Invalid status" in response.json()["detail"]
+        assert "Invalid status" in response.json()["message"]
 
     def test_filters_by_status(self, client):
         reports = [_make_mock_report(status="failed")]
@@ -273,7 +273,7 @@ class TestWorkspaceGetSleepReportDetail:
 
         response = client.get(f"/api/v1/workspaces/{_WORKSPACE_ID}/sleep-reports/{report.id}")
         assert response.status_code == 404
-        assert "not found" in response.json()["detail"].lower()
+        assert "not found" in response.json()["message"].lower()
 
     def test_not_found_returns_404(self, client):
         mock_db = AsyncMock()

--- a/backend/tests/auth/test_oauth_bearer_rest.py
+++ b/backend/tests/auth/test_oauth_bearer_rest.py
@@ -243,7 +243,11 @@ class TestRequireSessionAuthRejectsOAuth:
         assert resp.status_code == 403
         # Message must mention both kinds so SDK error surfaces don't
         # mislead users into thinking only API keys are blocked.
-        assert "OAuth" in resp.json()["message"] or "Bearer" in resp.json()["message"]
+        # NOTE: this test mounts `require_session_auth` on a bare FastAPI() app
+        # (no app-level handlers), so the raw `{detail}` shape applies here —
+        # the #992 global StarletteHTTPException reshape only runs on the real
+        # api.main.app, not on these isolated dependency-unit harnesses.
+        assert "OAuth" in resp.json()["detail"] or "Bearer" in resp.json()["detail"]
 
     def test_kagura_api_key_still_rejected_with_403(self, app_with_session_only_route):
         client = TestClient(app_with_session_only_route)

--- a/backend/tests/auth/test_oauth_bearer_rest.py
+++ b/backend/tests/auth/test_oauth_bearer_rest.py
@@ -243,7 +243,7 @@ class TestRequireSessionAuthRejectsOAuth:
         assert resp.status_code == 403
         # Message must mention both kinds so SDK error surfaces don't
         # mislead users into thinking only API keys are blocked.
-        assert "OAuth" in resp.json()["detail"] or "Bearer" in resp.json()["detail"]
+        assert "OAuth" in resp.json()["message"] or "Bearer" in resp.json()["message"]
 
     def test_kagura_api_key_still_rejected_with_403(self, app_with_session_only_route):
         client = TestClient(app_with_session_only_route)

--- a/backend/tests/services/test_system_admin_service.py
+++ b/backend/tests/services/test_system_admin_service.py
@@ -174,7 +174,7 @@ class TestPromoteToSystemAdmin:
         with pytest.raises(BadRequestError) as exc:
             await service.promote_to_system_admin(fixture_admin.user_id, "promoter@example.com")
         assert exc.value.status_code == 400
-        assert exc.value.error_code == "ADMIN-101"
+        assert exc.value.error_code == "REQ-101"
         assert "already a system admin" in exc.value.message
 
 
@@ -219,7 +219,7 @@ class TestDemoteSystemAdmin:
         with pytest.raises(BadRequestError) as exc:
             await service.demote_system_admin(fixture_regular.user_id, "demoter@example.com")
         assert exc.value.status_code == 400
-        assert exc.value.error_code == "ADMIN-102"
+        assert exc.value.error_code == "REQ-102"
         assert "not a system admin" in exc.value.message
 
     @pytest.mark.asyncio

--- a/backend/tests/utils/test_exceptions.py
+++ b/backend/tests/utils/test_exceptions.py
@@ -186,9 +186,9 @@ class TestResourceErrors:
     def test_bad_request_error_custom_code(self):
         """Call sites override ``error_code`` so SDKs can route on a stable
         identifier without parsing the free-form message."""
-        exc = BadRequestError("User is already a system admin", error_code="ADMIN-101")
+        exc = BadRequestError("User is already a system admin", error_code="REQ-101")
         assert exc.status_code == 400
-        assert exc.error_code == "ADMIN-101"
+        assert exc.error_code == "REQ-101"
 
     def test_bad_request_error_details_passthrough(self):
         """Unlike AdminProtectionError, BadRequestError forwards ``**details``

--- a/docs/api-surface-1.0/error-responses.md
+++ b/docs/api-surface-1.0/error-responses.md
@@ -134,7 +134,7 @@ Auth failure before dispatch (`transport.py:531-580`): HTTP 401, body `{"error":
 | `RES-003` | `MemoryGoneError` — exceptions.py:174 | 410 | Resource soft-deleted (distinct from 404 so clients stop retrying). |
 | `RES-004` | *(no class — inline `JSONResponse`)* — api/routes/attachments.py:30 | 410 | Deprecated `/api/v1/attachments/*` retired; carries Sunset/Deprecation/Link headers. |
 | `VAL-001` | `ValidationError` — exceptions.py:195 | 422 | Service-layer validation error (shape/format). ⚠ Coexists with the non-conforming FastAPI 422. |
-| `REQ-001` | `BadRequestError` (default) — exceptions.py:217 | 400 | State-precondition failure (call sites may override the code, see ADMIN-101/102). |
+| `REQ-001` | `BadRequestError` (default) — exceptions.py:217 | 400 | State-precondition failure (call sites may override the code, e.g. `REQ-101`/`REQ-102`). |
 | `MEDIA-001` | `UnsupportedMediaTypeError` — exceptions.py:254 | 415 | Content-Type not in allow-list; `details.allowed` lists accepted types. |
 | `BONUS-001` | `InsufficientReasonError` — exceptions.py:283 | 400 | Slot-bonus shrink below owned count requires a reason. |
 | `BONUS-002` | `BonusBelowZeroError` — exceptions.py:301 | 400 | Resulting workspace_slot_bonus would be negative. |
@@ -272,7 +272,7 @@ Other non-conforming shapes (not raw HTTPException):
 
 1. **FastAPI 422** — `{"detail": [ ... ]}` array shape; no `RequestValidationError` handler exists (§Canonical shape, point 3). ⚠
 2. **MCP `-32603` catch-all** — swallows `MemoryCloudException.error_code` when a tool handler lacks its own catch (§Canonical shape, point 5). ⚠
-3. Three snake_case codes on the REST surface (`admin_user_id_missing`, `sleep_run_in_progress`, `sleep_target_not_found`) conform in *shape* but break the `NAMESPACE-NNN` code convention (§Catalogue B). ⚠
+3. ✅ **RESOLVED (#992 Phase 2)**: the three REST snake_case codes were renamed to `SLEEP-001/002/003` (§Catalogue B); the REST surface now uses `NAMESPACE-NNN` uniformly. (The 41 MCP `_error_response` snake_case literals at the section above are a separate MCP-surface concern, out of #992's REST scope.)
 
 ---
 

--- a/docs/api-surface-1.0/error-responses.md
+++ b/docs/api-surface-1.0/error-responses.md
@@ -35,18 +35,19 @@ HTTP status comes from `exc.status_code` (per-class; see catalogue). Notable hea
 
 > ⚠ Note vs. intent: issues #401/#602/#603/#604 standardized on this `{error, message, details}` shape (confirmed in the #602 PR body: callers read `exc.reason` instead of `exc.detail`; frontend consumes the uniform shape). The shape is **not** `{detail, error_code}` — `detail` is the *non-conforming* FastAPI default, below.
 
-### 2. REST — raw `HTTPException` (FastAPI default, NON-canonical)
+### 2. REST — raw `HTTPException` → canonical via the global handler (since #992 Phase 2)
 
-No custom handler is registered for `fastapi.HTTPException` / `StarletteHTTPException`. The remaining raw raise sites (see §Non-conforming) therefore produce FastAPI's default:
+Since #992 Phase 2 a global `StarletteHTTPException` handler (`api/main.py`) reshapes every raw `raise HTTPException` into the canonical envelope, so the **shape is frozen across the whole surface** even where a semantic code has not yet been assigned:
 
 ```json
-{ "detail": "<string or object passed as detail>" }
+{ "error": "HTTP-<status>", "message": "<the detail string>", "details": {} }
 ```
 
-- No `error` code. No `message`. No `details` object. SDKs cannot route on these.
-- Status code is whatever the raise site passes.
+- `error` carries the reserved `HTTP-<status>` placeholder namespace (e.g. `HTTP-404`), distinct from the semantic `AUTH-`/`ADMIN-`/`VAL-`/`REQ-` codes. SDKs route on the shape uniformly today; per-site semantic codes are a post-1.0 improvement.
+- `exc.headers` is passed through, so RFC 6750 `WWW-Authenticate: Bearer` challenges survive (`oauth.py`, `auth/dependencies.py`).
+- Shape-only: the handler does NOT apply the CWE-639 deny-class `details` strip (a raw `HTTPException` carries no structured `details` — only a string `detail` → `message`). The remaining raw 403 detail strings were audited for forensic leakage in the #992 review; the one cross-workspace existence-oracle smell is tracked in **#1011**.
 
-> **#992 Phase 1 (partial, landed):** the original census counted **366** raw raise sites. Phase 1 converted **36 auth-boundary 401/403 route-level sites** (every 401/403 in `auth.py`, `oauth.py`, `public_search.py`, `workspace.py`, `member_credentials.py`, `admin.py` — single-line **and** multi-line raise forms) onto the canonical `MemoryCloudException` family, leaving **~330** raw sites. The only 401/403 deliberately left raw in those files are `oauth.py:327/341`, which carry the RFC 6750 `WWW-Authenticate: Bearer` challenge header the global handler does not emit. The dependency-layer 401/403 emitters (`auth/dependencies.py`, `auth/analysis_gates.py`, `utils/auth_helpers.py`), the non-auth statuses (400/404/422/500) in the touched files, and Phase 2's remaining route files are **not** yet migrated — see §Follow-up. #992 stays open.
+> **#992 (resolved on the REST surface):** the original census counted **366** raw raise sites. **Phase 1** converted 36 auth-boundary 401/403 route-level sites onto the canonical `MemoryCloudException` family (single-line **and** multi-line forms; `oauth.py:327/341` left raw for their RFC 6750 `WWW-Authenticate` header) and added the 422 `RequestValidationError` handler. **Phase 2** froze the *shape* of the remaining **~296** raw sites in one place via the global `StarletteHTTPException` stopgap handler above — the two-shapes-coexisting problem is gone. Assigning each placeholder `HTTP-<status>` a semantic `NAMESPACE-NNN` code is a gradual post-1.0 improvement, ratchet-guarded by `tests/api/test_raw_httpexception_guard.py` so the raw count cannot grow.
 
 ### 3. REST — 422 validation (canonical, since #992 Phase 1)
 
@@ -167,11 +168,11 @@ Auth failure before dispatch (`transport.py:531-580`): HTTP 401, body `{"error":
 | `CONNECTOR-001` | `MemoryCloudException` — services/connector_provisioning.py:407 | 403 | Connector seat limit reached for plan. |
 | `CONNECTOR-002` | `MemoryCloudException` — services/connector_provisioning.py:503 | 503 | Connector seat lock unavailable (PG 55P03 lock timeout); retry. |
 | `EXT-ANA-001` | `ExternalServiceError` subclass — services/analysis/llm_caller.py:83 | 502 | Entire OpenAI fallback chain exhausted (`details.upstream_provider_error=true`, `attempted_models`). |
-| `ADMIN-101` | `BadRequestError` — services/system_admin_service.py:111 | 400 | User is already a system admin. ⚠ Namespace collision: `ADMIN-001` is a 403 protection error, `ADMIN-1xx` are 400 preconditions. |
-| `ADMIN-102` | `BadRequestError` — services/system_admin_service.py:184 | 400 | User is not a system admin. ⚠ Same namespace concern. |
-| `admin_user_id_missing` | `MemoryCloudException` — api/routes/admin_sleep.py:234 | 500 | Admin user id missing from session (defensive). ⚠ snake_case, violates `NAMESPACE-NNN` convention. |
-| `sleep_run_in_progress` | `MemoryCloudException` — api/routes/admin_sleep.py:255 | 409 | A sleep run is already in progress for this user. ⚠ snake_case. |
-| `sleep_target_not_found` | `MemoryCloudException` — api/routes/admin_sleep.py:278 | 404 | No eligible contexts for sleep maintenance. ⚠ snake_case. |
+| `REQ-101` | `BadRequestError` — services/system_admin_service.py:111 | 400 | User is already a system admin. ✅ **#992 Phase 2**: re-namespaced from `ADMIN-101` to the `REQ-*` (BadRequestError) family — resolves the `ADMIN-001` (403 protection) vs `ADMIN-1xx` (400 precondition) collision; `ADMIN-*` now uniformly means admin-protection. |
+| `REQ-102` | `BadRequestError` — services/system_admin_service.py:184 | 400 | User is not a system admin. ✅ **#992 Phase 2**: re-namespaced from `ADMIN-102` → `REQ-102` (same rationale). |
+| `SLEEP-001` | `MemoryCloudException` — api/routes/admin_sleep.py:234 | 500 | Admin user id missing from session (defensive). ✅ **#992 Phase 2**: renamed from snake_case `admin_user_id_missing` to the `NAMESPACE-NNN` convention. |
+| `SLEEP-002` | `MemoryCloudException` — api/routes/admin_sleep.py:255 | 409 | A sleep run is already in progress for this user. ✅ **#992 Phase 2**: renamed from `sleep_run_in_progress`. |
+| `SLEEP-003` | `MemoryCloudException` — api/routes/admin_sleep.py:278 | 404 | No eligible contexts for sleep maintenance. ✅ **#992 Phase 2**: renamed from `sleep_target_not_found`. |
 
 ### C. MCP-only codes assigned via `error_code` variable — `backend/src/mcp_server/tools/resource.py`
 
@@ -283,8 +284,8 @@ Issue acceptance allows at most 2 sub-issues; candidates are grouped into 2 bund
 
 | Priority | Item | Feeds from |
 |---|---|---|
-| P1 | Rename the 3 snake_case REST codes in `api/routes/admin_sleep.py` to the `NAMESPACE-NNN` convention (e.g. `SLEEP-001/002/003`) before any SDK pins them. | §B ⚠ |
-| P1 | Resolve the `ADMIN-*` namespace collision: `ADMIN-001` (403 protection) vs `ADMIN-101/102` (400 preconditions). Either re-namespace the preconditions (e.g. `REQ-1xx`) or document the split-by-hundreds scheme as frozen. | §B ⚠ |
+| ✅ DONE (#992 Phase 2) | Renamed the 3 snake_case REST codes in `api/routes/admin_sleep.py` → `SLEEP-001/002/003` (tests + OpenAPI example + the frontend mock updated). | §B |
+| ✅ DONE (#992 Phase 2) | Resolved the `ADMIN-*` collision by re-namespacing the 400 preconditions `ADMIN-101/102` → `REQ-101/102` (the BadRequestError family). `ADMIN-*` now uniformly means admin-protection (403). | §B |
 | ✅ DONE (#992 Phase 1) | ~~Decide the 422 story~~ — **resolved**: a `RequestValidationError` handler now wraps FastAPI validation errors in the canonical envelope under `error: "VAL-001"` (`{loc, msg, type}` projection, `input` stripped). The two 422 shapes now agree. | §Canonical 3 |
 | P2 | Give Qdrant a dedicated code (the `EXT-101` gap before Redis `EXT-102` strongly suggests it was reserved for Qdrant); keep `EXT-001` as the generic fallback only. | §A ⚠ |
 | P2 | Remove the class-name fallback in `MemoryCloudException.__init__` (`error_code or self.__class__.__name__`) or make `error_code` required — the fallback can silently mint undocumented codes. | §Canonical 1 ⚠ |
@@ -295,7 +296,7 @@ Issue acceptance allows at most 2 sub-issues; candidates are grouped into 2 bund
 
 | Priority | Item | Feeds from |
 |---|---|---|
-| 🟡 PARTIAL (#992 Phase 1) | Migrate the auth boundary first. **Route-level 401/403 done**: the 21 raw sites in `auth.py`, `oauth.py`, `public_search.py`, `workspace.py`, `member_credentials.py`, `admin.py` now raise the canonical `AUTH-*`/`ADMIN-001` family. **Still raw (Phase 2)**: the dependency-layer emitters `auth/dependencies.py` (18), `auth/analysis_gates.py` (4), `utils/auth_helpers.py` (4) — these run on every protected route and are the higher-frequency emitters. Note `auth/dependencies.py:505/521` deliberately carry `WWW-Authenticate: Bearer error="insufficient_scope"` (RFC 6750) and `oauth.py:329/343` carry `WWW-Authenticate: Bearer` — preserve those headers when migrating. | §Non-conforming ⚠ |
+| ✅ SHAPE DONE (#992 Phase 1+2) | **Route-level 401/403 (Phase 1)**: the 21 raw sites in `auth.py`, `oauth.py`, `public_search.py`, `workspace.py`, `member_credentials.py`, `admin.py` raise the canonical `AUTH-*`/`ADMIN-001` family with semantic codes. **Dependency-layer emitters** `auth/dependencies.py`, `auth/analysis_gates.py`, `utils/auth_helpers.py` are still raw `HTTPException` but their **shape is now canonical** via the Phase 2 global handler (placeholder `HTTP-<status>` code); their `WWW-Authenticate: Bearer` headers (`auth/dependencies.py:505/521`, `oauth.py` Bearer challenges) are preserved by the handler's `exc.headers` passthrough. Assigning these dependency-layer emitters semantic `AUTH-*` codes is the post-1.0 gradual follow-up. | §Non-conforming |
 | P1 | Retire `utils/db_helpers.py:79` (`handle_db_operation` → `HTTPException(500)`) in favor of `DatabaseError`/`InternalError`, and stop `utils/error_messages.py` documenting the raw-raise pattern. | §Non-conforming ⚠ |
-| P2 | Migrate the remaining ~296 route-level raises (non-auth statuses + untouched files), largest files first (`contexts.py` 29, `oauth.py` 26, `resource_tokens.py` 17, `auth.py` 17, `member_credentials.py` 15, `admin.py` 15). Alternatively, if full migration won't land before 1.0: register a `StarletteHTTPException` handler that re-shapes `{"detail": ...}` into `{error: "HTTP-<status>", message, details: {}}` as a stopgap so the *shape* freezes even where codes don't exist yet. | §Non-conforming ⚠ |
+| ✅ DONE (#992 Phase 2) | Registered the global `StarletteHTTPException` stopgap handler that re-shapes `{"detail": ...}` → `{error: "HTTP-<status>", message, details: {}}`, freezing the *shape* of all ~296 remaining raw raises in one place (the chosen alternative — full per-site migration was out of scope for the pre-1.0 window). Assigning each placeholder `HTTP-<status>` a semantic `NAMESPACE-NNN` code (largest files first: `contexts.py` 29, `oauth.py` 26, `resource_tokens.py` 17, `auth.py` 17, `member_credentials.py` 15, `admin.py` 15) is the post-1.0 gradual follow-up, ratchet-guarded by `tests/api/test_raw_httpexception_guard.py`. | §Non-conforming |
 | P2 | Propagate `error_code` through the MCP `-32603` catch-all via `error.data` (e.g. `data.error_code`) so transport-level failures stay SDK-routable. | §D ⚠ |

--- a/frontend/src/app/(authenticated)/admin/sleep-reports/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/sleep-reports/page.test.tsx
@@ -201,7 +201,7 @@ describe("AdminSleepReportsPage — Run Now button", () => {
     mockPost.mockRejectedValueOnce(
       new ApiError({
         status: 409,
-        error: "sleep_run_in_progress",
+        error: "SLEEP-002",
         message: "A sleep run is already in progress for this user.",
         details: {
           running_report_id: runningReportId,

--- a/frontend/src/lib/api/base.test.ts
+++ b/frontend/src/lib/api/base.test.ts
@@ -124,4 +124,42 @@ describe("ApiClient error normalization (#992 canonical 422 envelope)", () => {
     // String (not array) so consumers calling details.detail.includes(...) work.
     expect(details.detail).toBe("Resource not found");
   });
+
+  it("preserves a reshaped dict detail under details.detail (#992 Phase 2)", async () => {
+    // Dict-detail HTTPExceptions (external-keys conflicts) are reshaped to
+    // { error: "HTTP-409", message: "Request failed", details: { detail: {...} } }.
+    // Consumers branching on details.detail.error must still see the object —
+    // the HTTP-* message alias must NOT overwrite it.
+    const payload = { error: "reranker_provider_conflict", conflicting_provider: "cohere" };
+    mockFetchOnce(409, {
+      error: "HTTP-409",
+      message: "Request failed",
+      details: { detail: payload },
+    });
+
+    const client = new ApiClient("http://test");
+    const caught = await client.post("/x", {}).catch((e: unknown) => e);
+
+    expect(caught).toBeInstanceOf(ApiError);
+    const details = (caught as ApiError).details as Record<string, unknown>;
+    expect(details.detail).toEqual(payload);
+  });
+
+  it("does not inject a synthetic detail into a canonical (non-HTTP) error body", async () => {
+    // The message->detail alias is scoped to the reshaped HTTP-* placeholder
+    // code, so a semantic MemoryCloudException body keeps its authoritative
+    // details untouched (no fabricated `detail` key).
+    mockFetchOnce(429, {
+      error: "RES-001",
+      message: "Resource limit exceeded",
+      details: { limit: 100 },
+    });
+
+    const client = new ApiClient("http://test");
+    const caught = await client.get("/x").catch((e: unknown) => e);
+
+    const details = (caught as ApiError).details as Record<string, unknown>;
+    expect(details).toEqual({ limit: 100 });
+    expect(details.detail).toBeUndefined();
+  });
 });

--- a/frontend/src/lib/api/base.test.ts
+++ b/frontend/src/lib/api/base.test.ts
@@ -102,4 +102,26 @@ describe("ApiClient error normalization (#992 canonical 422 envelope)", () => {
     const details = (caught as ApiError).details as Record<string, unknown>;
     expect(details.detail).toBe("API key not found");
   });
+
+  it("aliases the reshaped HTTP-<status> message back to details.detail (#992 Phase 2)", async () => {
+    // The global StarletteHTTPException handler reshapes raw {detail} errors
+    // into { error: "HTTP-404", message, details: {} }. Consumers reading
+    // details.detail must still get the human message string.
+    mockFetchOnce(404, {
+      error: "HTTP-404",
+      message: "Resource not found",
+      details: {},
+    });
+
+    const client = new ApiClient("http://test");
+    const caught = await client.get("/x").catch((e: unknown) => e);
+
+    expect(caught).toBeInstanceOf(ApiError);
+    const err = caught as ApiError;
+    expect(err.error).toBe("HTTP-404");
+    expect(err.message).toBe("Resource not found");
+    const details = err.details as Record<string, unknown>;
+    // String (not array) so consumers calling details.detail.includes(...) work.
+    expect(details.detail).toBe("Resource not found");
+  });
 });

--- a/frontend/src/lib/api/base.ts
+++ b/frontend/src/lib/api/base.ts
@@ -103,18 +103,23 @@ export class ApiClient {
           };
         }
 
-        // #992 Phase 2: the global StarletteHTTPException handler reshapes raw
-        // `{ detail: "msg" }` errors into { error: "HTTP-<status>", message,
+        // #992 Phase 2: the global StarletteHTTPException handler reshapes a raw
+        // string-`detail` error into { error: "HTTP-<status>", message,
         // details: {} }. Consumers that read `apiError.details.detail` (the
         // legacy string) for non-422 errors would otherwise see `undefined`.
         // Alias `detail` back to the top-level message string here, at the same
-        // transport choke point, so those call sites keep rendering. Only fires
-        // when details has neither `detail` nor `errors` and a string message
-        // exists — leaving the 422 array alias and string-detail passthrough
-        // untouched.
+        // transport choke point, so those call sites keep rendering. Scoped to
+        // the reshaped `HTTP-*` placeholder code ONLY, so it never injects a
+        // synthetic `detail` into a canonical MemoryCloudException body (whose
+        // `error` is a semantic code and whose `details` are authoritative).
+        // Dict-`detail` reshaped errors already carry `details.detail` (the
+        // handler preserves the object), so this guard's `detail === undefined`
+        // check leaves them untouched.
         if (
           details &&
           typeof details === "object" &&
+          typeof errorCode === "string" &&
+          errorCode.startsWith("HTTP-") &&
           (details as { detail?: unknown }).detail === undefined &&
           (details as { errors?: unknown }).errors === undefined &&
           typeof errorDetails.message === "string" &&

--- a/frontend/src/lib/api/base.ts
+++ b/frontend/src/lib/api/base.ts
@@ -103,6 +103,26 @@ export class ApiClient {
           };
         }
 
+        // #992 Phase 2: the global StarletteHTTPException handler reshapes raw
+        // `{ detail: "msg" }` errors into { error: "HTTP-<status>", message,
+        // details: {} }. Consumers that read `apiError.details.detail` (the
+        // legacy string) for non-422 errors would otherwise see `undefined`.
+        // Alias `detail` back to the top-level message string here, at the same
+        // transport choke point, so those call sites keep rendering. Only fires
+        // when details has neither `detail` nor `errors` and a string message
+        // exists — leaving the 422 array alias and string-detail passthrough
+        // untouched.
+        if (
+          details &&
+          typeof details === "object" &&
+          (details as { detail?: unknown }).detail === undefined &&
+          (details as { errors?: unknown }).errors === undefined &&
+          typeof errorDetails.message === "string" &&
+          errorDetails.message.length > 0
+        ) {
+          details = { ...details, detail: errorDetails.message };
+        }
+
         throw new ApiError({
           error: errorCode,
           message: errorMessage,


### PR DESCRIPTION
Closes #992

## Summary
- Phase 2 of the canonical-error-shape convergence (part of #622). Freezes the REST error **shape** across the whole surface so the 1.0 contract exposes a single envelope.
- **Global `StarletteHTTPException` handler** (`api/main.py`) reshapes FastAPI's default `{"detail": ...}` into the canonical `{error: "HTTP-<status>", message, details}` for all ~296 remaining raw `raise HTTPException` sites — one choke point instead of converting 296 call sites. `exc.headers` is passed through so RFC 6750 `WWW-Authenticate` challenges survive. A string `detail` → `message`; a structured (dict/list) `detail` is preserved under `details.detail` (the external-keys conflict payloads).
- Renamed the 3 snake_case REST codes → `SLEEP-001/002/003`; resolved the `ADMIN-*` namespace collision by re-namespacing the 400 preconditions `ADMIN-101/102` → `REQ-101/102` (`ADMIN-*` now uniformly means admin-protection 403).
- Added a ratchet guard test so the raw `HTTPException` count in `routes/` can't grow (`BASELINE=296`); per-site semantic-code assignment is the post-1.0 follow-up.

## Implementation notes
- Frontend `base.ts`: alias the reshaped top-level `message` back to `details.detail`, **scoped to the `HTTP-*` placeholder code** so canonical `MemoryCloudException` bodies are never injected with a synthetic `detail` (the #1006 cross-stack lesson). Updated ~28 backend `["detail"]` assertions → `["message"]` + one exact-dict in `test_resource_indexer_api.py`.
- Handler unit tests (string detail → message + header passthrough; dict detail → `details.detail` preserved; non-string → generic message) + frontend `base.test.ts` (HTTP-404 string alias, HTTP-409 dict preserve, canonical RES-001 untouched).
- Re-froze `error-responses.md`.
- Verified: 722 tests/api pass; ruff check + format clean; OpenAPI 262 components; frontend tsc clean.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- cso: green | qa-lead: yellow (non-blocking: external_keys response-body integration test + ratchet net-zero edge — both follow-ups) | cto: green
- gate1: yellow via /claude-c-suite:ask (CTO lens) + CSO precision check (raw-403 CWE-639 → only the pre-existing #1011 oracle, filed); inner /code-review caught + fixed the dict-detail drop and scoped the base.ts alias.
- review provider: none (opt-in)

The pre-existing cross-workspace existence-oracle in `memory.py` (surfaced in review) is tracked separately in #1011.

🤖 Generated via /gh-issue-driven:ship
