### PR TITLE
fix(api): uniform 404 for cross-workspace context probes (#1011)

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -31,7 +31,6 @@ from models.schemas import (
     RememberRequest,
     RememberResponse,
 )
-from services.context_service import ContextService
 from services.memory_service import MemoryService
 from services.permission_service import PermissionService
 from utils.datetime import to_utc_iso, utcnow
@@ -58,18 +57,6 @@ async def get_memory_service(db: AsyncSession = Depends(get_db)) -> MemoryServic
         MemoryService instance
     """
     return MemoryService(db)
-
-
-async def get_context_service(db: AsyncSession = Depends(get_db)) -> ContextService:
-    """Get ContextService instance.
-
-    Args:
-        db: Database session
-
-    Returns:
-        ContextService instance
-    """
-    return ContextService(db)
 
 
 MemoryServiceDep = Annotated[MemoryService, Depends(get_memory_service)]
@@ -467,7 +454,6 @@ async def get_memory_stats(
         None, description="Optional context ID (defaults to current context)"
     ),
     memory_service: MemoryService = Depends(get_memory_service),
-    context_service: ContextService = Depends(get_context_service),
     db: AsyncSession = Depends(get_db),
 ):
     """Get memory statistics for the authenticated user's context.
@@ -478,7 +464,6 @@ async def get_memory_stats(
         user: Authenticated user
         context_id: Optional context ID (defaults to current context)
         memory_service: Memory service instance
-        context_service: Context service instance
 
     Returns:
         Memory statistics for specified or current context including counts, types, and storage
@@ -503,68 +488,35 @@ async def get_memory_stats(
     is_shared = False
 
     if target_context_id:
-        try:
-            from sqlalchemy import select
+        from models.auth import Workspace
 
-            from models.auth import Context, Workspace
-            from utils.exceptions import NotFoundException
+        # SECURITY (#1011 / #383): resolve through the workspace-read chokepoint
+        # so a cross-workspace probe yields a uniform 404 (context_not_found)
+        # instead of a 403 that confirms the context exists in another workspace
+        # (CWE-639 / OWASP A01). Mirrors GET /memory/list below and the graph
+        # routes; a member of the context's OWNING workspace can read its stats
+        # regardless of which workspace is currently active.
+        context = await PermissionService(db).resolve_context_for_workspace_read(
+            user_id=user_id,
+            context_id=target_context_id,
+            key_workspace_id=user.get("api_key_workspace_id"),
+        )
+        target_workspace_id = str(context.workspace_id)
 
-            # SECURITY: Verify context belongs to current workspace (ALWAYS)
-            # Issue #271 Code Review H-3: Make validation mandatory (not conditional)
-            current_workspace_id = user.get("current_workspace_id")
-
-            # Get context directly to verify workspace ownership
-            context_result = await db.execute(
-                select(Context).where(Context.id == target_context_id)
-            )
-            context_obj = context_result.scalar_one_or_none()
-
-            if context_obj and current_workspace_id:
-                # Verify context belongs to current workspace
-                if context_obj.workspace_id != current_workspace_id:
-                    from fastapi import HTTPException, status
-
-                    raise HTTPException(
-                        status_code=status.HTTP_403_FORBIDDEN,
-                        detail="This context belongs to a different workspace. Please switch workspaces first.",
-                    )
-            elif context_obj and not current_workspace_id:
-                # User has no current_workspace_id but accessing a specific context
-                # This is suspicious - require workspace selection
-                from fastapi import HTTPException, status
-
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="No workspace selected. Please select an workspace to view context statistics.",
-                )
-
-            context = await context_service.get_context(user_id, target_context_id)
-            target_workspace_id = str(context.workspace_id)
-
-            # Check if user is workspace owner
-            workspace_result = await db.execute(
-                select(Workspace).where(Workspace.id == user.get("current_workspace_id"))
-            )
-            workspace = workspace_result.scalar_one_or_none()
-            is_workspace_owner = workspace and workspace.owner_user_id == user_id
-
-            # Owner sees all memories (treat as shared), or context is actually shared
-            is_shared = is_workspace_owner or not context.is_private
-            logger.info(
-                f"Context privacy check: context_id={target_context_id}, is_private={context.is_private}, is_workspace_owner={is_workspace_owner}, is_shared={is_shared}"
-            )
-        except NotFoundException:
-            # Context not found - default to private (user_id filter)
-            logger.warning(f"Context not found: {target_context_id}. Defaulting to private stats")
-        except (ConnectionError, OSError) as e:
-            # Database/network connectivity issues - critical, re-raise
-            logger.error(f"Database connectivity issue while checking context privacy: {e}")
-            raise
-        except Exception as e:
-            # Other unexpected errors - log and default to safe behavior
-            logger.warning(
-                f"Unexpected error checking context privacy: {e}. Defaulting to private stats"
-            )
+        # Workspace owner sees all memories (treated as shared); otherwise a
+        # non-private (shared) context is visible to every member. Anchored to
+        # the context's OWNING workspace, not the caller's current workspace.
+        workspace_result = await db.execute(
+            select(Workspace).where(Workspace.id == context.workspace_id)
+        )
+        workspace = workspace_result.scalar_one_or_none()
+        is_workspace_owner = bool(workspace and workspace.owner_user_id == user_id)
+        is_shared = is_workspace_owner or not context.is_private
+        logger.info(
+            f"Context privacy check: context_id={target_context_id}, "
+            f"is_private={context.is_private}, is_workspace_owner={is_workspace_owner}, "
+            f"is_shared={is_shared}"
+        )
 
     # Call service layer (24h window for REST API)
     result = await memory_service.get_stats(
@@ -860,7 +812,6 @@ async def get_access_patterns(
         None, description="Optional context ID (defaults to current context)"
     ),
     db: AsyncSession = Depends(get_db),
-    context_service: ContextService = Depends(get_context_service),
     days: int = 30,
 ) -> dict[str, Any]:
     """Get memory access patterns and analytics for specified or current context.
@@ -873,7 +824,6 @@ async def get_access_patterns(
         user: Authenticated user
         context_id: Optional context ID (defaults to current context)
         db: Database session
-        context_service: Context service instance
         days: Number of days to analyze (default: 30)
 
     Returns:
@@ -891,7 +841,14 @@ async def get_access_patterns(
         # Single Collection Migration: Get workspace_id and context_id for filtering
         target_workspace_id = None
         if target_context_id:
-            context = await context_service.get_context(user_id, target_context_id)
+            # SECURITY (#1011 / #383 / #963): resolve via the shared
+            # workspace-read chokepoint for uniform-404 disclosure AND API-key
+            # workspace confinement — parity with /memory/stats and /memory/list.
+            context = await PermissionService(db).resolve_context_for_workspace_read(
+                user_id=user_id,
+                context_id=target_context_id,
+                key_workspace_id=user.get("api_key_workspace_id"),
+            )
             target_workspace_id = context.workspace_id
 
         cutoff = utcnow() - timedelta(days=days)
@@ -945,6 +902,10 @@ async def get_access_patterns(
             "analysis_days": days,
         }
 
+    except (MemoryCloudException, HTTPException):
+        # Uniform-404 authz denials (#1011) and explicit HTTP errors must
+        # surface as-is, not be masked as a generic 500.
+        raise
     except Exception as e:
         logger.error("access_patterns_failed", error=str(e))
         raise HTTPException(

--- a/backend/tests/api/test_memory_stats_cross_workspace.py
+++ b/backend/tests/api/test_memory_stats_cross_workspace.py
@@ -1,0 +1,286 @@
+"""Regression tests for GET /memory/stats cross-workspace disclosure (Issue #1011).
+
+``memory.py`` previously raised a raw ``403`` ("This context belongs to a
+different workspace. Please switch workspaces first.") whenever the requested
+``context_id`` lived in a workspace other than the caller's *current* one. That
+403 distinguished "exists elsewhere" from "not found" — a cross-workspace
+existence oracle (CWE-639 / OWASP A01).
+
+The fix routes resolution through
+``PermissionService.resolve_context_for_workspace_read``, which returns a
+uniform ``404`` (``NotFoundException``) on not-found / non-member /
+private-non-creator — identical to the sibling ``GET /memory/list`` route
+(``test_memory_list.py``) and the graph routes. A member of the context's
+*owning* workspace can read its stats regardless of which workspace is
+currently active (no "switch workspaces" dance), while a non-member can no
+longer tell whether the context exists at all.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from api.routes.memory import get_access_patterns, get_memory_stats
+from utils.exceptions import NotFoundException
+
+MOCK_USER = {"user_id": "test_user_123"}
+
+
+def _stats_result(total: int = 0):
+    r = MagicMock()
+    r.total_count = total
+    return r
+
+
+def _db_with_workspace(owner_user_id: str | None):
+    """AsyncMock db whose single .execute() returns a Workspace owner-check row."""
+    db = AsyncMock()
+    ws = MagicMock()
+    ws.owner_user_id = owner_user_id
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = ws
+    db.execute.return_value = result
+    return db
+
+
+def _ctx(workspace_id, *, is_private: bool):
+    ctx = MagicMock()
+    ctx.workspace_id = workspace_id
+    ctx.is_private = is_private
+    return ctx
+
+
+@pytest.mark.asyncio
+async def test_stats_cross_workspace_probe_returns_uniform_404():
+    """A context the caller cannot read surfaces as NotFoundException (uniform
+    404), NOT a 403 that confirms it exists in another workspace (CWE-639)."""
+    context_id = uuid4()
+    mock_db = AsyncMock()  # must not be reached for the Workspace query
+    memory_service = MagicMock()
+    memory_service.get_stats = AsyncMock(return_value=_stats_result())
+
+    perm = MagicMock()
+    perm.resolve_context_for_workspace_read = AsyncMock(
+        side_effect=NotFoundException("Context", str(context_id))
+    )
+
+    with patch("api.routes.memory.PermissionService", return_value=perm):
+        with pytest.raises(NotFoundException) as exc:
+            await get_memory_stats(
+                user=MOCK_USER,
+                context_id=context_id,
+                memory_service=memory_service,
+                db=mock_db,
+            )
+
+    assert exc.value.status_code == 404
+    # A forbidden probe must not silently fall through to "private stats".
+    memory_service.get_stats.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_stats_no_context_id_skips_permission_check():
+    """Without context_id the permission chokepoint is not consulted and stats
+    run unscoped (legacy behavior, no regression)."""
+    mock_db = AsyncMock()
+    memory_service = MagicMock()
+    memory_service.get_stats = AsyncMock(return_value=_stats_result(3))
+
+    with patch("api.routes.memory.PermissionService") as perm_cls:
+        result = await get_memory_stats(
+            user=MOCK_USER,
+            context_id=None,
+            memory_service=memory_service,
+            db=mock_db,
+        )
+
+    perm_cls.assert_not_called()
+    assert result.total_count == 3
+    memory_service.get_stats.assert_awaited_once_with(
+        user_id="test_user_123",
+        workspace_id=None,
+        context_id=None,
+        include_details=True,
+        time_window_hours=24,
+        is_shared_context=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stats_shared_context_aggregates_across_members():
+    """Non-private (shared) context → is_shared_context=True so every member's
+    memories are counted, scoped to the context's OWNING workspace."""
+    context_id = uuid4()
+    ws_id = uuid4()
+    mock_db = _db_with_workspace(owner_user_id="someone_else")  # caller is not owner
+    memory_service = MagicMock()
+    memory_service.get_stats = AsyncMock(return_value=_stats_result(7))
+
+    perm = MagicMock()
+    perm.resolve_context_for_workspace_read = AsyncMock(return_value=_ctx(ws_id, is_private=False))
+
+    with patch("api.routes.memory.PermissionService", return_value=perm) as perm_cls:
+        await get_memory_stats(
+            user=MOCK_USER,
+            context_id=context_id,
+            memory_service=memory_service,
+            db=mock_db,
+        )
+
+    perm_cls.assert_called_once_with(mock_db)
+    perm.resolve_context_for_workspace_read.assert_awaited_once_with(
+        user_id="test_user_123", context_id=context_id, key_workspace_id=None
+    )
+    memory_service.get_stats.assert_awaited_once_with(
+        user_id="test_user_123",
+        workspace_id=str(ws_id),
+        context_id=str(context_id),
+        include_details=True,
+        time_window_hours=24,
+        is_shared_context=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stats_owner_sees_private_context_as_shared():
+    """Workspace owner sees all memories even in a private context
+    (is_shared_context=True), anchored to the owning workspace."""
+    context_id = uuid4()
+    ws_id = uuid4()
+    mock_db = _db_with_workspace(owner_user_id="test_user_123")  # caller IS owner
+    memory_service = MagicMock()
+    memory_service.get_stats = AsyncMock(return_value=_stats_result(2))
+
+    perm = MagicMock()
+    perm.resolve_context_for_workspace_read = AsyncMock(return_value=_ctx(ws_id, is_private=True))
+
+    with patch("api.routes.memory.PermissionService", return_value=perm):
+        await get_memory_stats(
+            user=MOCK_USER,
+            context_id=context_id,
+            memory_service=memory_service,
+            db=mock_db,
+        )
+
+    _, kwargs = memory_service.get_stats.await_args
+    assert kwargs["is_shared_context"] is True
+
+
+@pytest.mark.asyncio
+async def test_stats_non_owner_private_context_is_creator_scoped():
+    """Non-owner viewing a private context → is_shared_context=False (creator
+    scoping preserved)."""
+    context_id = uuid4()
+    ws_id = uuid4()
+    mock_db = _db_with_workspace(owner_user_id="someone_else")
+    memory_service = MagicMock()
+    memory_service.get_stats = AsyncMock(return_value=_stats_result(1))
+
+    perm = MagicMock()
+    perm.resolve_context_for_workspace_read = AsyncMock(return_value=_ctx(ws_id, is_private=True))
+
+    with patch("api.routes.memory.PermissionService", return_value=perm):
+        await get_memory_stats(
+            user=MOCK_USER,
+            context_id=context_id,
+            memory_service=memory_service,
+            db=mock_db,
+        )
+
+    _, kwargs = memory_service.get_stats.await_args
+    assert kwargs["is_shared_context"] is False
+
+
+@pytest.mark.asyncio
+async def test_stats_forwards_api_key_workspace_scope():
+    """Issue #963 parity: a workspace-scoped API key forwards its scope as
+    key_workspace_id so /memory/stats is confined like /memory/list."""
+    context_id = uuid4()
+    ws_id = uuid4()
+    key_ws = uuid4()
+    mock_db = _db_with_workspace(owner_user_id="someone_else")
+    memory_service = MagicMock()
+    memory_service.get_stats = AsyncMock(return_value=_stats_result())
+
+    perm = MagicMock()
+    perm.resolve_context_for_workspace_read = AsyncMock(return_value=_ctx(ws_id, is_private=False))
+
+    with patch("api.routes.memory.PermissionService", return_value=perm):
+        await get_memory_stats(
+            user={"user_id": "test_user_123", "api_key_workspace_id": key_ws},
+            context_id=context_id,
+            memory_service=memory_service,
+            db=mock_db,
+        )
+
+    perm.resolve_context_for_workspace_read.assert_awaited_once_with(
+        user_id="test_user_123", context_id=context_id, key_workspace_id=key_ws
+    )
+
+
+# --- GET /access-patterns: the sibling route converged in the same fix -------
+
+
+def _db_for_access_patterns():
+    """AsyncMock db answering the 3 analytics queries with empty results."""
+    db = AsyncMock()
+    most = MagicMock()
+    most.scalars.return_value.all.return_value = []
+    typed = MagicMock()
+    typed.all.return_value = []
+    recent = MagicMock()
+    recent.scalar.return_value = 0
+    db.execute.side_effect = [most, typed, recent]
+    return db
+
+
+@pytest.mark.asyncio
+async def test_access_patterns_cross_workspace_probe_returns_uniform_404():
+    """The /access-patterns sibling must also surface a forbidden/cross-workspace
+    probe as a uniform 404 — and NOT have the helper's NotFoundException masked
+    as a 500 by the route's broad ``except Exception`` handler."""
+    context_id = uuid4()
+    mock_db = AsyncMock()
+
+    perm = MagicMock()
+    perm.resolve_context_for_workspace_read = AsyncMock(
+        side_effect=NotFoundException("Context", str(context_id))
+    )
+
+    with patch("api.routes.memory.PermissionService", return_value=perm):
+        with pytest.raises(NotFoundException) as exc:
+            await get_access_patterns(
+                user=MOCK_USER,
+                context_id=context_id,
+                db=mock_db,
+                days=30,
+            )
+
+    # 404 (uniform not-found), not 500 (which the broad except would have produced).
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_access_patterns_forwards_api_key_workspace_scope():
+    """Issue #963 parity: /access-patterns confines a workspace-scoped API key
+    via key_workspace_id, like /stats and /list."""
+    context_id = uuid4()
+    ws_id = uuid4()
+    key_ws = uuid4()
+    mock_db = _db_for_access_patterns()
+
+    perm = MagicMock()
+    perm.resolve_context_for_workspace_read = AsyncMock(return_value=_ctx(ws_id, is_private=False))
+
+    with patch("api.routes.memory.PermissionService", return_value=perm):
+        await get_access_patterns(
+            user={"user_id": "test_user_123", "api_key_workspace_id": key_ws},
+            context_id=context_id,
+            db=mock_db,
+            days=30,
+        )
+
+    perm.resolve_context_for_workspace_read.assert_awaited_once_with(
+        user_id="test_user_123", context_id=context_id, key_workspace_id=key_ws
+    )


### PR DESCRIPTION
Closes #1011

## Summary
- `GET /memory/stats` raised a raw 403 ("This context belongs to a different workspace…") that distinguished "exists in another workspace" from "not found" — a cross-workspace existence oracle (CWE-639 / OWASP A01).
- Route both `/memory/stats` and the sibling `/access-patterns` through `PermissionService.resolve_context_for_workspace_read` → uniform 404 on not-found / non-member / private-non-creator, plus #963 API-key workspace confinement. This matches `GET /memory/list` (memory.py:678) and the graph routes.
- A member of the context's *owning* workspace can now read its stats regardless of which workspace is currently active (no "switch workspaces" dance); a non-member can no longer tell whether the context exists.

## Implementation notes
- `/memory/stats`: removed the bespoke `select(Context)` + explicit 403/400 block and the broad try/except that swallowed `NotFoundException` → "default to private stats" (fail-open). `NotFoundException` now propagates → uniform 404 via the global handler. `is_workspace_owner` is now computed against the context's **owning** workspace, not the caller's current one.
- `/access-patterns`: switched to the same helper for parity, and added `except (MemoryCloudException, HTTPException): raise` before its broad `except Exception → 500` so an authz/not-found denial is not masked as a 500 (a 500-on-forbidden vs 200-on-allowed is itself an oracle).
- Removed the now-dead `context_service` DI param, the `get_context_service` factory, and the `ContextService` import (zero remaining callers in memory.py).
- **Audit (issue task 2):** the other "different workspace" sites (`resource_tokens`, `public_search`, `member_credentials`) operate on caller-owned resources or anonymous paths and are not context-existence oracles; `context_service.get_context` already enforces uniform 404.

## Behavior change (release note)
Cross-workspace / non-member probes to `GET /memory/stats` and `GET /memory/access-patterns` now return a uniform **404 context_not_found** instead of a **403** with a "switch workspaces" hint.

## Tests
New `backend/tests/api/test_memory_stats_cross_workspace.py` (8 tests, green): cross-workspace probe → 404 propagates (`get_stats` not awaited); shared/owner/private `is_shared_context` matrix; #963 `key_workspace_id` forwarding; `/access-patterns` 404-not-masked-as-500. Full run 27 passed (8 new + 19 sibling `test_memory_list.py`), ruff clean.

## Pre-PR review summary
- gate2 mode: advisor-only (binary_gate none)
- cso: green · qa-lead: green · cto: green
- gate1: green via /claude-c-suite:ask (CSO lens)
- review provider: none (opt-in — run /gh-issue-driven:review)

🤖 Generated via /gh-issue-driven:ship
