### PR TITLE
fix(storage): reject extension/declared-MIME mismatch on upload reserve (#961)

### DIFF
--- a/backend/src/services/file_storage_service.py
+++ b/backend/src/services/file_storage_service.py
@@ -30,6 +30,7 @@ swept by the orphan task (Commit 8) — the sweeper calls
 
 from __future__ import annotations
 
+import mimetypes
 import re
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -61,6 +62,14 @@ from utils.media_types import MEDIA_TYPE_RE, normalize_media_type
 # accept a 64-char input with embedded whitespace, decoding to fewer
 # than 32 bytes (exact length depends on how many non-hex chars are present).
 _SHA256_HEX_RE = re.compile(SHA256_HEX_PATTERN)
+
+# Issue #961: extension→MIME resolver for the content_type consistency check.
+# A private ``MimeTypes`` instance is seeded ONLY from Python's compiled-in
+# table — it does not read the host's ``/etc/mime.types`` — so the
+# security-relevant mapping (e.g. ``.svg`` → ``image/svg+xml``) is identical
+# across every deploy environment and does not probe the filesystem on the
+# request path. Built once at import; ``guess_type`` is read-only thereafter.
+_MIME = mimetypes.MimeTypes()
 
 logger = get_logger(__name__)
 
@@ -236,6 +245,34 @@ class FileStorageService:
             raise UnsupportedMediaTypeError(
                 content_type=content_type,
                 allowed=allowed,
+            )
+
+        # Issue #961: the allow-list above only validates the *declared*
+        # content_type. A disallowed payload can slip in mislabeled — an
+        # ``.svg`` declared ``text/plain`` lands as text/plain (allowed) yet
+        # carries inline-script SVG (stored-XSS once served). Derive the MIME
+        # the filename *extension* implies and reject any inconsistency, so a
+        # declared value can no longer launder a disallowed (or simply
+        # mismatched) type past the allow-list. ``guess_type`` lower-cases the
+        # extension, so ``.SVG`` resolves like ``.svg``. When the extension is
+        # unknown to Python's mimetypes registry (``.md``, ``.webp`` → None) or
+        # absent, the inferred value is None and this layer is skipped — the
+        # declared allow-list remains the governing check, avoiding
+        # false-positives on extensions mimetypes does not know. NOTE: as the
+        # operator widens ALLOWED_FILE_CONTENT_TYPES, a declared value that is
+        # allowed but differs from the extension's canonical MIME (e.g. an
+        # ``.xml`` declared ``application/xml`` when mimetypes infers
+        # ``text/xml``) will also be rejected here — intended strictness, but
+        # worth knowing when curating the allow-list. This runs at the shared
+        # service chokepoint, so REST (POST /files/reserve) and MCP
+        # (handle_init_file_upload) inherit it identically (#553 parity).
+        guessed_raw, _ = _MIME.guess_type(filename)
+        inferred = normalize_media_type(guessed_raw) if guessed_raw else None
+        if inferred is not None and inferred != base_content_type:
+            raise UnsupportedMediaTypeError(
+                content_type=content_type,
+                allowed=allowed,
+                inferred_content_type=inferred,
             )
 
         workspace = await self._load_workspace(workspace_id)

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -246,14 +246,35 @@ class UnsupportedMediaTypeError(MemoryCloudException):
     render a precise rejection message without a separate API call.
     """
 
-    def __init__(self, content_type: str, allowed: set[str] | list[str]) -> None:
-        message = f"Content type '{content_type}' not allowed"
+    def __init__(
+        self,
+        content_type: str,
+        allowed: set[str] | list[str],
+        inferred_content_type: str | None = None,
+    ) -> None:
+        # Issue #961: when ``inferred_content_type`` is supplied, the rejection
+        # is an extension/declared-MIME *mismatch* (the declared value passed
+        # the allow-list, but the filename extension implies a different — and
+        # possibly disallowed — type, e.g. an .svg declared text/plain). Echo
+        # both values so the caller sees why. When omitted, behaviour is
+        # unchanged: a plain allow-list rejection of the declared type.
+        details: dict[str, object] = {
+            "content_type": content_type,
+            "allowed": sorted(allowed),
+        }
+        if inferred_content_type is not None:
+            message = (
+                f"Content type '{content_type}' does not match the filename "
+                f"extension (which implies '{inferred_content_type}')"
+            )
+            details["inferred_content_type"] = inferred_content_type
+        else:
+            message = f"Content type '{content_type}' not allowed"
         super().__init__(
             message,
             status_code=415,
             error_code="MEDIA-001",
-            content_type=content_type,
-            allowed=sorted(allowed),
+            **details,
         )
 
 

--- a/backend/tests/services/test_file_storage_service.py
+++ b/backend/tests/services/test_file_storage_service.py
@@ -138,7 +138,7 @@ class TestReserveUpload:
             out = await service.reserve_upload(
                 workspace_id=workspace_id,
                 created_by="user-1",
-                filename="test.bin",
+                filename="report.pdf",
                 content_type="application/pdf",
                 size_bytes=1024,
                 sha256=VALID_SHA,
@@ -736,3 +736,144 @@ class TestListFiles:
 
         out = await service.list_files(workspace_id=workspace_id, limit=10)
         assert len(out) == 2
+
+
+class TestReserveUploadExtensionConsistency:
+    """Issue #961: the declared content_type alone can launder a disallowed
+    payload past the allow-list (an .svg declared text/plain → stored-XSS once
+    served). ``reserve_upload`` now also derives the MIME implied by the
+    filename extension and rejects (415) any inconsistency. The check lives in
+    the shared service chokepoint, so both REST (POST /files/reserve) and MCP
+    (handle_init_file_upload) inherit it.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _canonical_allowlist(self, monkeypatch):
+        from config.settings import get_settings
+
+        monkeypatch.setattr(
+            get_settings(),
+            "allowed_file_content_types",
+            "image/png,image/jpeg,image/gif,application/pdf,"
+            "text/plain,text/markdown,text/csv,application/json",
+        )
+
+    @pytest.mark.asyncio
+    async def test_svg_declared_as_text_plain_rejected_415(self, service, db, workspace_id):
+        """The headline bypass: .svg (→ image/svg+xml, NOT allowed) declared as
+        text/plain (allowed) must be rejected, not stored mislabeled."""
+        with pytest.raises(UnsupportedMediaTypeError) as exc_info:
+            await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="2026-06-08-diagram.svg",
+                content_type="text/plain",
+                size_bytes=1024,
+                sha256=VALID_SHA,
+            )
+        err = exc_info.value
+        assert err.status_code == 415
+        assert err.error_code == "MEDIA-001"
+        # Both the declared and the inferred value are echoed (#961 acceptance).
+        assert err.details["content_type"] == "text/plain"
+        assert err.details["inferred_content_type"] == "image/svg+xml"
+        # Rejection happens before workspace load — no DB execute, no R2 reserve.
+        db.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_declared_extension_mismatch_among_allowed_rejected(
+        self, service, db, workspace_id
+    ):
+        """A .png (→ image/png, allowed) declared as text/plain (allowed) is
+        still a mismatch — the declared value does not match the extension."""
+        with pytest.raises(UnsupportedMediaTypeError) as exc_info:
+            await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="photo.png",
+                content_type="text/plain",
+                size_bytes=1024,
+                sha256=VALID_SHA,
+            )
+        err = exc_info.value
+        assert err.status_code == 415
+        assert err.details["content_type"] == "text/plain"
+        assert err.details["inferred_content_type"] == "image/png"
+
+    @pytest.mark.asyncio
+    async def test_uppercase_extension_is_normalized(self, service, db, workspace_id):
+        """Extension matching is case-insensitive (.SVG resolves like .svg)."""
+        with pytest.raises(UnsupportedMediaTypeError) as exc_info:
+            await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="EVIL.SVG",
+                content_type="image/png",
+                size_bytes=1024,
+                sha256=VALID_SHA,
+            )
+        # Pin the reason: it must be the extension-consistency layer (.SVG →
+        # image/svg+xml), not an unrelated rejection that happens to also 415.
+        assert exc_info.value.details["inferred_content_type"] == "image/svg+xml"
+
+    @pytest.mark.asyncio
+    async def test_matching_extension_passes(self, service, db, workspace_id):
+        """.png declared image/png — extension and declared agree → allowed."""
+        ws = _make_workspace(workspace_id)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=ws)
+        db.execute.return_value = result
+
+        with _patch_quota_reserve(succeed=True):
+            out = await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="photo.png",
+                content_type="image/png",
+                size_bytes=1024,
+                sha256=VALID_SHA,
+            )
+        assert isinstance(out, ReserveResult)
+
+    @pytest.mark.asyncio
+    async def test_unknown_extension_falls_back_to_declared_allowlist(
+        self, service, db, workspace_id
+    ):
+        """.md → mimetypes returns None: the consistency layer is skipped and
+        the declared allow-list governs. Guards against false-positives on
+        extensions Python's mimetypes registry does not know (.md, .webp)."""
+        ws = _make_workspace(workspace_id)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=ws)
+        db.execute.return_value = result
+
+        with _patch_quota_reserve(succeed=True):
+            out = await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="notes.md",
+                content_type="text/markdown",
+                size_bytes=1024,
+                sha256=VALID_SHA,
+            )
+        assert isinstance(out, ReserveResult)
+
+    @pytest.mark.asyncio
+    async def test_no_extension_falls_back_to_declared_allowlist(self, service, db, workspace_id):
+        """A filename with no extension → None inferred → declared allow-list
+        governs (e.g. an uploaded "README" declared text/plain)."""
+        ws = _make_workspace(workspace_id)
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=ws)
+        db.execute.return_value = result
+
+        with _patch_quota_reserve(succeed=True):
+            out = await service.reserve_upload(
+                workspace_id=workspace_id,
+                created_by="u",
+                filename="README",
+                content_type="text/plain",
+                size_bytes=1024,
+                sha256=VALID_SHA,
+            )
+        assert isinstance(out, ReserveResult)


### PR DESCRIPTION
Closes #961

## Summary
- The file-upload content_type allow-list (#553) validated only the client-DECLARED MIME, never the filename extension — a disallowed payload could enter mislabeled (prod: a `.svg` declared `text/plain`; `image/svg+xml` is deliberately excluded for stored-XSS reasons).
- Add an extension-consistency layer in `FileStorageService.reserve_upload` (the shared chokepoint both REST `POST /files/reserve` and MCP `handle_init_file_upload` call → automatic parity): derive the MIME the filename extension implies and reject (415) when it differs from the declared (already allow-listed) type.

## Implementation notes
- Extension→MIME resolution uses a module-private `mimetypes.MimeTypes()` seeded only from Python's compiled-in table (not the host `/etc/mime.types`), so the security check is deterministic across deploy environments and does no request-path filesystem I/O.
- Unknown / extension-less filenames infer `None` and skip the layer (declared allow-list still governs) — no false-positives on extensions mimetypes does not know (`.md`, `.webp`).
- `UnsupportedMediaTypeError` gains an optional `inferred_content_type`, so the 415 echoes both declared + inferred (error_code stays `MEDIA-001`; additive/backward-compatible on the #992-frozen error shape).

## Known limitation (accepted at design review)
A double-extension whose final component is benign (`evil.svg.txt` → `text/plain`) is stored and served as the declared, allow-listed, inert type, so it is not an active-content XSS vector. Byte-level sniffing (needs an R2 GET-back at confirm — the server never sees the bytes in the 3-step presigned PUT) is deferred to ClamAV (#565), gated on public signup.

## Tests
New `TestReserveUploadExtensionConsistency`: `.svg`-as-`text/plain` rejected (inferred echoed), allowed-type mismatch, uppercase `.SVG`, matching extension passes, unknown/no-extension fall back to the declared allow-list. 78 passed across service + REST + MCP suites; ruff clean.

## Pre-PR review summary
- gate2 mode: advisor-only (binary_gate none)
- cso: green · qa-lead: green · cto: green
- gate1: green via /claude-c-suite:ask (CSO lens)
- review provider: none (opt-in)

🤖 Generated via /gh-issue-driven:ship
