### PR TITLE
feat(api): context portability export — GET /contexts/{id}/export (#950)

### DIFF
--- a/backend/src/api/routes/contexts.py
+++ b/backend/src/api/routes/contexts.py
@@ -23,7 +23,7 @@ from auth.dependencies import APIKeyOrSessionUser, SessionUser, get_current_user
 from auth.workspace_roles import ContextRole, WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
-from models.schemas import RelatedTagItem
+from models.schemas import ContextExportResponse, RelatedTagItem
 from models.sleep import SleepMode
 from services.context_service import ContextService, TagSortMode
 from utils.datetime import to_utc_iso
@@ -711,6 +711,45 @@ async def get_context_stats(
 
     except NotFoundException as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+@router.get("/{context_id}/export", response_model=ContextExportResponse)
+async def export_context(
+    context_id: UUID,
+    user: APIKeyOrSessionUser,
+    service: ContextService = Depends(get_context_service),
+) -> ContextExportResponse:
+    """Export a context as portable JSON (Issue #950 — GDPR Art.20 portability).
+
+    Returns the context metadata, its search configuration, and every memory
+    visible to the caller — a private context exports only the caller's own
+    memories, a shared context exports every member's, exactly as
+    ``GET /memory/list`` scopes them. Vectors, neural edges, and sessions are
+    intentionally omitted: they are regenerated / re-learned on re-import.
+
+    This is a context-scoped portability export (anti-lock-in), not a per-user
+    Art.20 subject-access request; a created_by-filtered cross-context export
+    is a planned follow-up, as is workspace-wide export.
+
+    Raises:
+        404: context not found, or the caller lacks read access (uniform —
+            does not reveal whether the context exists in another workspace).
+        413: the context exceeds the single-export memory cap.
+    """
+    user_id = user.get("user_id") or user.get("sub")
+    if not user_id:
+        # Authenticated but the token carries no principal claim — 401, not the
+        # uniform 404 a None user_id would otherwise produce inside the
+        # workspace-read resolver. Mirrors list_memories' user_id guard.
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Unable to determine caller identity",
+        )
+    return await service.export_context(
+        user_id=user_id,
+        context_id=context_id,
+        key_workspace_id=user.get("api_key_workspace_id"),
+    )
 
 
 @router.get("/{context_id}/tags", response_model=ContextTagsResponse)

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -361,6 +361,83 @@ class ReferenceResponse(TZAwareBaseModel):
     incoming_has_more: bool = False
 
 
+class ExportedSearchConfig(BaseModel):
+    """Per-context search configuration in a portability export (Issue #950)."""
+
+    semantic_weight: float
+    bm25_weight: float
+    fetch_factor: int
+    use_rerank: bool
+    reranker_provider: str | None
+    reranker_model: str | None
+    embedding_model: str
+    embedding_dimensions: int
+
+
+class ExportedMemory(TZAwareBaseModel):
+    """A single memory in a portability export (Issue #950).
+
+    Excludes regenerable fields (vector / embedding status), DB-computed
+    columns, internal owner/workspace identifiers, and soft-delete state —
+    only the user-meaningful, portable fields are emitted. ``details`` is
+    included verbatim; note it may carry references (e.g. external blob
+    pointers) that will not resolve outside this deployment.
+    """
+
+    id: UUID
+    summary: str
+    context_summary: str | None
+    content: str
+    details: dict | None
+    type: str
+    importance: float
+    confidence: float
+    tags: list[str]
+    context: dict | None
+    scope: str
+    delivery_mode: str
+    created_at: datetime
+    updated_at: datetime | None
+    source_uri: str | None = None
+    source_type: str | None = None
+
+
+class ExportedContextMeta(TZAwareBaseModel):
+    """Context metadata block in a portability export (Issue #950)."""
+
+    id: UUID
+    name: str
+    display_name: str | None
+    description: str | None
+    summary: str | None
+    usage_guide: str | None
+    is_private: bool
+    is_public: bool
+    created_at: datetime
+    updated_at: datetime | None
+
+
+class ContextExportResponse(TZAwareBaseModel):
+    """GDPR Art.20-supporting context portability export (Issue #950).
+
+    A point-in-time JSON snapshot of a context the caller can read: its
+    metadata, search configuration, and every memory visible to the caller
+    (private context -> creator-only; shared -> all members) — the same
+    visibility model as ``GET /memory/list``. Vectors, neural edges, and
+    sessions are intentionally omitted: they are regenerated / re-learned on
+    re-import. This is a context-scoped *portability* export (anti-lock-in),
+    not a per-user Art.20 subject-access request — a created_by-filtered,
+    cross-context personal-data export is a separate follow-up.
+    """
+
+    format_version: str = "1.0"
+    exported_at: datetime
+    context: ExportedContextMeta
+    search_config: ExportedSearchConfig | None
+    memory_count: int
+    memories: list[ExportedMemory]
+
+
 class ForgetRequest(BaseModel):
     """Request schema for forget() API."""
 

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -9,7 +9,7 @@ Contexts are owned by workspaces, not individual users.
 """
 
 import re
-from typing import Any, Literal, cast, get_args
+from typing import TYPE_CHECKING, Any, Literal, cast, get_args
 from uuid import UUID
 
 from sqlalchemy import and_, delete, func, select
@@ -23,6 +23,7 @@ from models.sleep import SleepMode
 from utils.datetime import utcnow
 from utils.exceptions import (
     ConflictError,
+    ExportTooLargeError,
     FeatureNotAvailableError,
     NotFoundException,
     QuotaExceededError,
@@ -30,11 +31,20 @@ from utils.exceptions import (
 )
 from utils.logger import get_logger
 
+if TYPE_CHECKING:
+    from models.schemas import ContextExportResponse
+
 logger = get_logger(__name__)
 
 DEFAULT_CONTEXT_NAME = "default"
 DEFAULT_CONTEXT_DESCRIPTION = "Default context (auto-created)"
 CONTEXT_NAME_PATTERN = re.compile(r"^[a-z0-9_-]+$")
+
+# Issue #950: hard cap on a single context-portability export. One JSON body,
+# no pagination — this valve keeps the contract stable until a streaming /
+# workspace-wide variant lands. Sized well above any realistic closed-beta
+# context; an over-cap context raises ExportTooLargeError (413).
+EXPORT_MAX_MEMORIES = 50_000
 
 # Issue #614: list_tags sort modes — single source of truth shared by REST
 # Query type and MCP handler validation.
@@ -330,6 +340,124 @@ class ContextService:
                     raise NotFoundException(f"Context not found: {context_id}")
 
         return context
+
+    async def export_context(
+        self,
+        user_id: str,
+        context_id: UUID,
+        *,
+        key_workspace_id: UUID | None = None,
+    ) -> "ContextExportResponse":
+        """Build a portable JSON snapshot of a context the caller can read (#950).
+
+        Authorization mirrors ``GET /memory/list`` exactly: the context is
+        resolved through ``PermissionService.resolve_context_for_workspace_read``
+        (uniform 404 hides cross-workspace existence — CWE-639), and memory
+        visibility follows the same ``owner_filter`` rule — a private context
+        exports only the caller's own memories, a shared context exports every
+        member's. An export therefore never reveals more than the caller could
+        already read via ``/memory/list``. Vectors, neural edges, and sessions
+        are omitted (regenerated / re-learned on re-import).
+
+        Raises:
+            NotFoundException: context missing, or caller lacks read access.
+            ExportTooLargeError: context exceeds ``EXPORT_MAX_MEMORIES`` (413).
+        """
+        from models.config import ContextSearchConfig
+        from models.memory import Memory
+        from models.schemas import (
+            ContextExportResponse,
+            ExportedContextMeta,
+            ExportedMemory,
+            ExportedSearchConfig,
+        )
+        from services.permission_service import PermissionService
+
+        ctx = await PermissionService(self.db).resolve_context_for_workspace_read(
+            user_id=user_id,
+            context_id=context_id,
+            key_workspace_id=key_workspace_id,
+        )
+
+        # Read-parity with GET /memory/list: private context => creator-only.
+        owner_filter = user_id if ctx.is_private else None
+        mq = select(Memory).where(
+            Memory.context_id == context_id,
+            Memory.deleted_at.is_(None),
+        )
+        if owner_filter is not None:
+            mq = mq.where(Memory.user_id == owner_filter)
+        # Fetch cap+1 so an oversized context is detected in a single query,
+        # avoiding a separate COUNT round-trip on the common (small) path.
+        mq = mq.order_by(Memory.created_at).limit(EXPORT_MAX_MEMORIES + 1)
+        rows = list((await self.db.execute(mq)).scalars().all())
+        if len(rows) > EXPORT_MAX_MEMORIES:
+            # len(rows) is the cap+1 probe value, i.e. "at least EXPORT_MAX+1" —
+            # not the exact total (we deliberately avoid a second COUNT(*) on the
+            # rare over-cap path). The limit in the error message is what the
+            # caller acts on; the exact count is immaterial to the 413.
+            raise ExportTooLargeError(len(rows), EXPORT_MAX_MEMORIES)
+
+        cfg = (
+            await self.db.execute(
+                select(ContextSearchConfig).where(ContextSearchConfig.context_id == context_id)
+            )
+        ).scalar_one_or_none()
+        search_config = (
+            ExportedSearchConfig(
+                semantic_weight=float(cfg.semantic_weight),
+                bm25_weight=float(cfg.bm25_weight),
+                fetch_factor=cfg.fetch_factor,
+                use_rerank=cfg.use_rerank,
+                reranker_provider=cfg.reranker_provider,
+                reranker_model=cfg.reranker_model,
+                embedding_model=cfg.embedding_model,
+                embedding_dimensions=cfg.embedding_dimensions,
+            )
+            if cfg is not None
+            else None
+        )
+
+        memories = [
+            ExportedMemory(
+                id=m.id,
+                summary=m.summary,
+                context_summary=m.context_summary,
+                content=m.content,
+                details=m.details,
+                type=m.type,
+                importance=m.importance,
+                confidence=m.confidence,
+                tags=m.tags or [],
+                context=m.context,
+                scope=m.scope,
+                delivery_mode=m.delivery_mode,
+                created_at=m.created_at,
+                updated_at=m.updated_at,
+                source_uri=m.source_uri,
+                source_type=m.source_type,
+            )
+            for m in rows
+        ]
+
+        return ContextExportResponse(
+            exported_at=utcnow(),
+            context=ExportedContextMeta(
+                id=ctx.id,
+                name=ctx.name,
+                display_name=ctx.display_name,
+                description=ctx.description,
+                summary=ctx.summary,
+                usage_guide=ctx.usage_guide,
+                is_private=ctx.is_private,
+                is_public=ctx.is_public,
+                created_at=ctx.created_at,
+                updated_at=ctx.updated_at,
+            ),
+            search_config=search_config,
+            memory_count=len(memories),
+            memories=memories,
+        )
 
     async def get_context_by_name_for_workspace(
         self, workspace_id: UUID, name: str

--- a/backend/src/utils/exceptions.py
+++ b/backend/src/utils/exceptions.py
@@ -188,6 +188,28 @@ class ConflictError(MemoryCloudException):
         super().__init__(message, status_code=409, error_code="RES-002", **details)
 
 
+class ExportTooLargeError(MemoryCloudException):
+    """Context has more memories than a single export can return (413).
+
+    Issue #950: the context-portability export returns one JSON body with no
+    pagination. A hard cap (``memory_count`` echoed in ``details``) is the
+    zero-cost safety valve that keeps the endpoint's contract stable while a
+    streaming / paginated variant — or workspace-wide export — is deferred to
+    a follow-up. 413 (not 400/422): the request is well-formed; the *result*
+    is too large to serve in this shape.
+    """
+
+    def __init__(self, memory_count: int, limit: int) -> None:
+        super().__init__(
+            f"Context has {memory_count} memories, exceeding the single-export "
+            f"limit of {limit}. A paginated / workspace export is a planned follow-up.",
+            status_code=413,
+            error_code="EXPORT-001",
+            memory_count=memory_count,
+            limit=limit,
+        )
+
+
 class ValidationError(MemoryCloudException):
     """Validation error (422)."""
 

--- a/backend/tests/services/test_context_export.py
+++ b/backend/tests/services/test_context_export.py
@@ -1,0 +1,267 @@
+"""Tests for ContextService.export_context (Issue #950, GDPR Art.20 portability).
+
+The export's authorization + visibility mirror GET /memory/list exactly:
+resolve via PermissionService.resolve_context_for_workspace_read (uniform 404),
+then a private context exports only the caller's own memories while a shared
+context exports every member's. These tests pin that contract, the serialized
+shape, the regenerable-field exclusion, the null search-config path, and the
+single-export size cap (413).
+"""
+
+from datetime import datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from services.context_service import ContextService
+from utils.exceptions import ExportTooLargeError, NotFoundException
+
+USER = "user-1"
+
+
+def _ctx(*, is_private: bool):
+    c = MagicMock()
+    c.id = uuid4()
+    c.name = "proj"
+    c.display_name = "Proj"
+    c.description = "desc"
+    c.summary = "sum"
+    c.usage_guide = None
+    c.is_private = is_private
+    c.is_public = False
+    c.created_at = datetime(2026, 1, 1)
+    c.updated_at = None
+    return c
+
+
+def _mem(user_id: str = USER):
+    m = MagicMock()
+    m.id = uuid4()
+    m.summary = "s"
+    m.context_summary = None
+    m.content = "c"
+    m.details = {"k": "v"}
+    m.type = "note"
+    m.importance = 0.8
+    m.confidence = 0.9
+    m.tags = ["a"]
+    m.context = None
+    m.scope = "persistent"
+    m.delivery_mode = "on_recall"
+    m.created_at = datetime(2026, 1, 2)
+    m.updated_at = None
+    m.source_uri = None
+    m.source_type = None
+    m.user_id = user_id
+    return m
+
+
+def _cfg():
+    c = MagicMock()
+    c.semantic_weight = Decimal("0.60")
+    c.bm25_weight = Decimal("0.40")
+    c.fetch_factor = 3
+    c.use_rerank = False
+    c.reranker_provider = "voyage"
+    c.reranker_model = "rerank-2"
+    c.embedding_model = "text-embedding-3-small"
+    c.embedding_dimensions = 512
+    return c
+
+
+def _db_with(mem_rows, cfg):
+    """AsyncMock db: 1st execute -> memories, 2nd -> search config row."""
+    db = AsyncMock()
+    mem_res = MagicMock()
+    mem_res.scalars.return_value.all.return_value = mem_rows
+    cfg_res = MagicMock()
+    cfg_res.scalar_one_or_none.return_value = cfg
+    db.execute.side_effect = [mem_res, cfg_res]
+    return db
+
+
+def _patch_perm(ctx=None, *, raises=None):
+    perm = MagicMock()
+    perm.resolve_context_for_workspace_read = AsyncMock(return_value=ctx, side_effect=raises)
+    return patch("services.permission_service.PermissionService", return_value=perm), perm
+
+
+def _mem_where_sql(db, call_index: int = 0) -> str:
+    stmt = db.execute.call_args_list[call_index].args[0]
+    return str(stmt.whereclause.compile(compile_kwargs={"literal_binds": False}))
+
+
+@pytest.mark.asyncio
+async def test_export_private_context_is_creator_scoped_and_serializes():
+    ctx = _ctx(is_private=True)
+    db = _db_with([_mem(), _mem()], _cfg())
+    perm_patch, _ = _patch_perm(ctx)
+
+    with perm_patch:
+        out = await ContextService(db).export_context(USER, ctx.id, key_workspace_id=None)
+
+    assert out.format_version == "1.0"
+    assert out.memory_count == 2
+    assert len(out.memories) == 2
+    assert out.context.name == "proj"
+    assert out.context.is_private is True
+    assert out.memories[0].type == "note"
+    assert out.memories[0].tags == ["a"]
+    assert out.search_config is not None
+    assert out.search_config.semantic_weight == 0.6
+    assert out.search_config.embedding_dimensions == 512
+
+    # Private context => the memory query MUST carry a user_id (creator) filter
+    # alongside context_id + the soft-delete guard.
+    sql = _mem_where_sql(db, 0)
+    assert "user_id" in sql
+    assert "context_id" in sql
+    assert "deleted_at IS NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_export_shared_context_drops_user_filter():
+    ctx = _ctx(is_private=False)
+    db = _db_with([_mem("other-user")], _cfg())
+    perm_patch, _ = _patch_perm(ctx)
+
+    with perm_patch:
+        out = await ContextService(db).export_context(USER, ctx.id, key_workspace_id=None)
+
+    assert out.memory_count == 1
+    # Shared context => every member's memories; NO user_id predicate, but
+    # context_id + deleted_at guards remain.
+    sql = _mem_where_sql(db, 0)
+    assert "user_id" not in sql
+    assert "context_id" in sql
+    assert "deleted_at IS NULL" in sql
+
+
+@pytest.mark.asyncio
+async def test_export_forwards_key_workspace_id():
+    ctx = _ctx(is_private=False)
+    db = _db_with([], None)
+    perm_patch, perm = _patch_perm(ctx)
+    key_ws = uuid4()
+
+    with perm_patch:
+        await ContextService(db).export_context(USER, ctx.id, key_workspace_id=key_ws)
+
+    perm.resolve_context_for_workspace_read.assert_awaited_once_with(
+        user_id=USER, context_id=ctx.id, key_workspace_id=key_ws
+    )
+
+
+@pytest.mark.asyncio
+async def test_export_no_search_config_yields_null():
+    ctx = _ctx(is_private=False)
+    db = _db_with([_mem()], None)  # no ContextSearchConfig row
+    perm_patch, _ = _patch_perm(ctx)
+
+    with perm_patch:
+        out = await ContextService(db).export_context(USER, ctx.id)
+
+    assert out.search_config is None
+    assert out.memory_count == 1
+
+
+@pytest.mark.asyncio
+async def test_export_missing_or_forbidden_context_propagates_404():
+    cid = uuid4()
+    db = AsyncMock()
+    perm_patch, _ = _patch_perm(raises=NotFoundException("Context", str(cid)))
+
+    with perm_patch:
+        with pytest.raises(NotFoundException) as exc:
+            await ContextService(db).export_context(USER, cid)
+
+    assert exc.value.status_code == 404
+    db.execute.assert_not_called()  # never reaches the memory query
+
+
+@pytest.mark.asyncio
+async def test_export_too_large_raises_413():
+    ctx = _ctx(is_private=False)
+    # Patch the cap low so we don't have to fabricate 50k rows; the service
+    # fetches cap+1 and raises when the result exceeds the cap.
+    with patch("services.context_service.EXPORT_MAX_MEMORIES", 2):
+        db = AsyncMock()
+        mem_res = MagicMock()
+        mem_res.scalars.return_value.all.return_value = [_mem(), _mem(), _mem()]  # 3 > 2
+        db.execute.side_effect = [mem_res]
+        perm_patch, _ = _patch_perm(ctx)
+        with perm_patch:
+            with pytest.raises(ExportTooLargeError) as exc:
+                await ContextService(db).export_context(USER, ctx.id)
+
+    assert exc.value.status_code == 413
+    assert exc.value.error_code == "EXPORT-001"
+    assert exc.value.details["memory_count"] == 3
+    assert exc.value.details["limit"] == 2
+
+
+# --- Route-level delegation + identity guard (api/routes/contexts.py) ---------
+
+
+@pytest.mark.asyncio
+async def test_route_delegates_and_forwards_identity():
+    from api.routes.contexts import export_context as route_export
+
+    svc = MagicMock()
+    svc.export_context = AsyncMock(return_value="SENTINEL")
+    cid = uuid4()
+    key = uuid4()
+
+    out = await route_export(
+        context_id=cid,
+        user={"user_id": USER, "api_key_workspace_id": key},
+        service=svc,
+    )
+
+    assert out == "SENTINEL"
+    svc.export_context.assert_awaited_once_with(user_id=USER, context_id=cid, key_workspace_id=key)
+
+
+@pytest.mark.asyncio
+async def test_route_missing_identity_returns_401():
+    from fastapi import HTTPException
+
+    from api.routes.contexts import export_context as route_export
+
+    svc = MagicMock()
+    svc.export_context = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await route_export(context_id=uuid4(), user={}, service=svc)
+
+    assert exc.value.status_code == 401
+    svc.export_context.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_export_omits_regenerable_and_internal_fields():
+    """Regression guard (#950): the serialized memory must NOT carry vector /
+    embedding fields, internal owner/workspace identifiers, or soft-delete
+    state. Pins the exclusion so a future field added to ExportedMemory can't
+    silently leak these into a portability export."""
+    ctx = _ctx(is_private=False)
+    db = _db_with([_mem()], _cfg())
+    perm_patch, _ = _patch_perm(ctx)
+
+    with perm_patch:
+        out = await ContextService(db).export_context(USER, ctx.id)
+
+    dumped = out.memories[0].model_dump()
+    for forbidden in (
+        "summary_embedding_id",
+        "embedding_status",
+        "embedding_error",
+        "user_id",
+        "workspace_id",
+        "context_id",
+        "deleted_at",
+        "deleted_by",
+    ):
+        assert forbidden not in dumped, f"{forbidden} leaked into export"


### PR DESCRIPTION
Closes #950

## Summary
- New `GET /api/v1/contexts/{context_id}/export` — a portable JSON snapshot of a context (GDPR Art.20 data portability; pairs with the existing Art.17 erasure #360, reduces lock-in).
- Returns context metadata, search configuration, and every memory the caller can read. **Authorization and visibility mirror `GET /memory/list` exactly**: resolved via `PermissionService.resolve_context_for_workspace_read` (uniform 404 hides cross-workspace existence — CWE-639), then `owner_filter = user_id if is_private else None` — a private context exports only the caller's own memories, a shared context exports every member's. An export never reveals more than the caller could already read.
- Excluded (regenerated / re-learned on re-import): vector & embedding fields, DB-computed columns, internal owner/workspace identifiers, soft-delete state, neural edges, sessions.

## Implementation notes
- `ContextService.export_context()` — 2 queries, no N+1; a single `limit(cap+1)` probe detects an over-cap context in one round-trip and raises a new `ExportTooLargeError` (413, `EXPORT-001`, `EXPORT_MAX_MEMORIES = 50_000`): a zero-cost safety valve that keeps the endpoint contract stable until a streaming / workspace-wide variant lands.
- 4 new response models in `models/schemas.py` (TZAware where they carry datetimes). The new error code is additive on the #992-frozen error *shape*.
- Route guards a missing principal claim with 401; otherwise authz/not-found propagate to the global handler (404/413, canonical shape) and a workspace-scoped API key is confined via forwarded `api_key_workspace_id` (#963 parity).

## Scope (per design review)
This is a **context-scoped portability export** (anti-lock-in), **not** a formal per-user Art.20 subject-access request. Deferred as follow-ups: a `created_by`-filtered cross-context personal-data export, workspace-wide export, and MCP export.

## Tests
`tests/services/test_context_export.py` (9): private creator-only scoping, shared all-members, `key_workspace_id` forwarding, null search-config, 404 propagation, 413 over-cap, route delegation + the 401 guard, and an exclusion guard pinning that embedding/internal fields never leak. ruff clean; OpenAPI generates with the new component; existing context suites green.

## Pre-PR review summary
- gate2 mode: advisor-only (binary_gate none)
- cso: green · qa-lead: green · cto: green
- gate1: green via /claude-c-suite:ask (CLO lens)
- review provider: none (opt-in)

🤖 Generated via /gh-issue-driven:ship
