### PR TITLE
fix(frontend): set fixed height on dashboard ResponsiveContainers

### DIFF
--- a/frontend/src/components/dashboard/RichMemoryOverview.tsx
+++ b/frontend/src/components/dashboard/RichMemoryOverview.tsx
@@ -208,7 +208,7 @@ export const RichMemoryOverview = forwardRef<RichMemoryOverviewRef, RichMemoryOv
           </CardHeader>
           <CardContent>
             <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height={256}>
                 <RechartsPie>
                   <Pie
                     data={scopeData}
@@ -300,7 +300,7 @@ export const RichMemoryOverview = forwardRef<RichMemoryOverviewRef, RichMemoryOv
             </CardHeader>
             <CardContent>
               <div className="h-64">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height={256}>
                   <BarChart data={topConnectionsData}>
                     <CartesianGrid strokeDasharray="3 3" />
                     <XAxis dataKey="name" />
@@ -363,7 +363,7 @@ export const RichMemoryOverview = forwardRef<RichMemoryOverviewRef, RichMemoryOv
             <CardContent>
               <div className="h-64">
                 {typeData.length > 0 ? (
-                  <ResponsiveContainer width="100%" height="100%">
+                  <ResponsiveContainer width="100%" height={256}>
                     <RechartsPie>
                       <Pie
                         data={typeData}

--- a/frontend/src/components/dashboard/UsageStats.tsx
+++ b/frontend/src/components/dashboard/UsageStats.tsx
@@ -494,7 +494,7 @@ export const UsageStats = forwardRef<UsageStatsRef, UsageStatsProps>(
           </CardHeader>
           <CardContent>
             <div className="h-64">
-              <ResponsiveContainer width="100%" height="100%">
+              <ResponsiveContainer width="100%" height={256}>
                 <LineChart data={history.daily_stats}>
                   <CartesianGrid strokeDasharray="3 3" />
                   <XAxis


### PR DESCRIPTION
## What
Switch four dashboard recharts `ResponsiveContainer`s from `height="100%"` to a fixed `height={256}` (matching their `h-64` wrapper):
- `RichMemoryOverview.tsx` (3 charts: working-vs-persistent donut, top-connections bar, type-distribution pie)
- `UsageStats.tsx` (usage-trend line)

## Why
With `height="100%"`, recharts measures the container before layout settles — and again on React StrictMode's dev double-mount — reads the height as `-1`, and spams the console:
> `The width(-1) and height(-1) of chart should be greater than 0...`

A fixed numeric height lets recharts use the value directly instead of measuring an unresolved parent. `MemoryTimelineChart` already used `height={300}` and never warned, confirming the `height="100%"` sites were the sole source.

Dev-only console hygiene — **no runtime/behavior change**, layout unchanged (wrapper was already 256px).

## Verification
- Live (preview): a fresh dashboard reload adds **0** new `width(-1)` warnings (console-buffer delta; warn-total held at 24 while all-level grew 180→204), charts still render at 653×256 / 653×300.
- `tsc --noEmit`: clean.
- dashboard vitest: 26/26 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)