### PR TITLE
ci(infra): run PR review only on ready_for_review; drop /review comment trigger

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -5,16 +5,10 @@ on:
     types: [ready_for_review]  # Only when draft is unmarked (saves API tokens)
     branches:
       - main
-  issue_comment:
-    types: [created]  # Manual trigger with /review command
 
 jobs:
   # Claude Code Review (AI-powered code review)
   claude-review:
-    # Run on ready_for_review OR /review comment
-    if: |
-      github.event_name == 'pull_request' ||
-      (github.event.issue.pull_request && contains(github.event.comment.body, '/review'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,56 +17,15 @@ jobs:
       id-token: write
 
     steps:
-      # 1. Check permissions (Organization members only)
-      - name: Check permissions
-        id: check
-        run: |
-          AUTHOR="${{ github.event.comment.user.login }}"
-          if gh api orgs/${{ github.repository_owner }}/members/$AUTHOR &>/dev/null; then
-            echo "authorized=true" >> $GITHUB_OUTPUT
-          else
-            echo "authorized=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # 2. Post unauthorized message if user is not an org member
-      - name: Post unauthorized message
-        if: steps.check.outputs.authorized != 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '❌ The `/review` command is restricted to organization members.'
-            })
-
-      # 3. Add reaction to indicate review has started
-      - name: Add reaction
-        if: steps.check.outputs.authorized == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'eyes'
-            })
-
-      # 4. Checkout PR head
+      # 1. Checkout PR head
       - name: Checkout PR
-        if: steps.check.outputs.authorized == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      # 5. Run Claude Code Review
+      # 2. Run Claude Code Review
       - name: Run Claude Code Review
-        if: steps.check.outputs.authorized == 'true'
         id: claude-review
         uses: anthropics/claude-code-action@beta
         with:
@@ -98,38 +51,8 @@ jobs:
 
           use_sticky_comment: true
 
-      # 6. Add success reaction
-      - name: Add success reaction
-        if: steps.check.outputs.authorized == 'true' && success()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: '+1'
-            })
-
-      # 7. Add failure reaction
-      - name: Add failure reaction
-        if: steps.check.outputs.authorized == 'true' && failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: '-1'
-            })
-
   # Automated Quality Checks (lint, type, test)
   quality-checks:
-    # Run on ready_for_review OR /review comment
-    if: |
-      github.event_name == 'pull_request' ||
-      (github.event.issue.pull_request && contains(github.event.comment.body, '/review'))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -137,105 +60,58 @@ jobs:
       issues: write
 
     steps:
-      # 1. Check permissions (Organization members only)
-      - name: Check permissions
-        id: check
-        run: |
-          AUTHOR="${{ github.event.comment.user.login }}"
-          if gh api orgs/${{ github.repository_owner }}/members/$AUTHOR &>/dev/null; then
-            echo "authorized=true" >> $GITHUB_OUTPUT
-          else
-            echo "authorized=false" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      # 2. Post unauthorized message if user is not an org member
-      - name: Post unauthorized message
-        if: steps.check.outputs.authorized != 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '❌ The `/review` command is restricted to organization members.'
-            })
-
-      # 3. Add reaction to indicate checks have started
-      - name: Add reaction
-        if: steps.check.outputs.authorized == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: 'rocket'
-            })
-
-      # 4. Checkout PR head
+      # 1. Checkout PR head
       - name: Checkout PR
-        if: steps.check.outputs.authorized == 'true'
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || format('refs/pull/{0}/head', github.event.issue.number) }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
-      # 5. Setup Python
+      # 2. Setup Python
       - name: Setup Python 3.11
-        if: steps.check.outputs.authorized == 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: backend/pyproject.toml
 
-      # 6. Install dependencies
+      # 3. Install dependencies
       - name: Install Backend Dependencies
-        if: steps.check.outputs.authorized == 'true'
         run: |
           cd backend
           pip install --upgrade pip
           pip install -e .
           pip install ruff pyright pytest pytest-cov pytest-asyncio
 
-      # 7. Lint check
+      # 4. Lint check
       - name: Lint Check (ruff)
-        if: steps.check.outputs.authorized == 'true'
         id: lint
         run: |
           cd backend
           ruff check src/
         continue-on-error: true  # Allow existing code quality issues (will fix in #64-#80)
 
-      # 8. Format check
+      # 5. Format check
       - name: Format Check (ruff)
-        if: steps.check.outputs.authorized == 'true'
         id: format
         run: |
           cd backend
           ruff format --check src/
         continue-on-error: true  # Allow existing formatting issues
 
-      # 8b. Models no-Column guard (#596 / epic #370)
+      # 5b. Models no-Column guard (#596 / epic #370)
       - name: Models no-Column guard
-        if: steps.check.outputs.authorized == 'true'
         id: no_column_guard
         run: make lint-models-no-column
 
-      # 9. Type check
+      # 6. Type check
       - name: Type Check (pyright)
-        if: steps.check.outputs.authorized == 'true'
         id: type
         run: |
           cd backend
           pyright src/
 
-      # 10. Run tests
+      # 7. Run tests
       - name: Run Tests
-        if: steps.check.outputs.authorized == 'true'
         id: tests
         run: |
           cd backend
@@ -249,9 +125,8 @@ jobs:
           API_KEY_SECRET: test-secret-32-bytes-long-string
           JWT_SECRET: test-jwt-secret-32-bytes-long
 
-      # 11. Check type coverage
+      # 8. Check type coverage
       - name: Check Type Coverage
-        if: steps.check.outputs.authorized == 'true'
         id: coverage
         run: |
           cd backend
@@ -272,9 +147,9 @@ jobs:
           sys.exit(0 if pct >= 80 else 1)
           "
 
-      # 12. Comment PR status
+      # 9. Comment PR status
       - name: Comment PR Status
-        if: steps.check.outputs.authorized == 'true' && always()
+        if: always()
         uses: actions/github-script@v7
         with:
           script: |
@@ -296,29 +171,3 @@ jobs:
               repo: context.repo.repo,
               body: message
             });
-
-      # 13. Add success reaction
-      - name: Add success reaction
-        if: steps.check.outputs.authorized == 'true' && success()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: '+1'
-            })
-
-      # 14. Add failure reaction
-      - name: Add failure reaction
-        if: steps.check.outputs.authorized == 'true' && failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: context.payload.comment.id,
-              content: '-1'
-            })


### PR DESCRIPTION
Removes the `issue_comment` (`/review`) trigger and the org-member permission-check machinery (reactions, unauthorized-comment, comment-context checkouts) from both the `claude-review` and `quality-checks` jobs. Review now runs solely on `pull_request: ready_for_review`.

No security regression — the org-member gate existed only to guard the comment-triggered path, which is removed in the same change. Checkout ref simplified to `github.event.pull_request.head.sha`.

This change was found uncommitted in the working tree (not authored in this session) and committed at the maintainer's request after verifying it is coherent and YAML-valid.

⚠️ Makes the "Comment `/review` on the PR" instruction in CLAUDE.md / README stale — that trigger path no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)