### PR TITLE
test(frontend): fix admin plans quota fixture for connector addon

### DIFF
--- a/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
+++ b/frontend/src/app/(authenticated)/admin/plans/page.test.tsx
@@ -167,6 +167,7 @@ const QUOTA_DETAIL_PRO = {
     public_calls_per_day: 1_000,
     storage_bytes_limit: 10 * 1024 ** 3,
     sleep_enabled_contexts_limit: 3,
+    max_connectors: 10,
     max_resource_tokens: 30,
   },
   addon: {
@@ -179,6 +180,7 @@ const QUOTA_DETAIL_PRO = {
     analysis_bonus: 0,
     storage_bonus_mb: 0,
     sleep_contexts_bonus: 0,
+    connector_bonus: 0,
   },
   effective: {
     memory_limit: 110_000,
@@ -190,6 +192,7 @@ const QUOTA_DETAIL_PRO = {
     public_calls_per_day: 1_000,
     storage_bytes_limit: 10 * 1024 ** 3,
     sleep_enabled_contexts_limit: 3,
+    max_connectors: 10,
     max_resource_tokens: 30,
   },
   usage: { memories: 50_000, contexts: 5, members: 3 },
@@ -337,12 +340,12 @@ describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
     await screen.findByText("admin.plans.addonDialog.title");
   }
 
-  it("renders all 9 addon inputs with values pre-populated from quota detail", async () => {
+  it("renders all 10 addon inputs with values pre-populated from quota detail", async () => {
     await openAddonDialog();
 
     // Every ADDON_TYPES entry has a stable input id of "addon-<key>".
-    // The 9 keys in render order are memory / mcp / rest / public /
-    // members / contexts / analysis / storage / sleep.
+    // The 10 keys in render order are memory / mcp / rest / public /
+    // members / contexts / analysis / storage / sleep / connector.
     const expectedIds = [
       "addon-memory",
       "addon-mcp",
@@ -353,6 +356,7 @@ describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
       "addon-analysis",
       "addon-storage",
       "addon-sleep",
+      "addon-connector",
     ];
     for (const id of expectedIds) {
       const input = document.getElementById(id) as HTMLInputElement | null;
@@ -367,7 +371,7 @@ describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
     expect(memoryInput.value).toBe("10000");
   });
 
-  it("submits all 9 fields to updateWorkspaceAddons on save", async () => {
+  it("submits all 10 fields to updateWorkspaceAddons on save", async () => {
     await openAddonDialog();
 
     // Mutate one input so the request body is verifiable against a
@@ -380,7 +384,7 @@ describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
     const saveButton = screen.getByText("admin.plans.addonDialog.save");
     fireEvent.click(saveButton);
 
-    // The PUT body must include all 9 addon_* fields so the backend's
+    // The PUT body must include all 10 addon_* fields so the backend's
     // no-touch contract (#665 review-fix #2) treats the request as
     // "send absolute values, no implicit deletes". The dialog is a
     // full-form submission, not a delta.
@@ -397,6 +401,7 @@ describe("AdminPlansPage — workspaces tab addon dialog (Issue #663)", () => {
       addon_analysis_bonus: 0,
       addon_storage_bonus_mb: 0,
       addon_sleep_contexts_bonus: 0,
+      addon_connector_bonus: 0,
     });
   });
 


### PR DESCRIPTION
## What

Repairs 6 failing tests in `frontend/src/app/(authenticated)/admin/plans/page.test.tsx` (they fail on `main`, independent of any feature work).

## Root cause

Test-fixture drift. `ADDON_TYPES` gained a 10th entry — `connector` (`baseField: max_connectors`, `addonField: connector_bonus`, `updateField: addon_connector_bonus`) — but the `QUOTA_DETAIL_PRO` mock was never updated. In the quota detail panel's `ADDON_TYPES.map`, `quotaDetail.base.max_connectors` was `undefined`, so `formatQuotaValue()` called `.toLocaleString()` on `undefined` and threw, crashing every test that renders the panel:

```
TypeError: Cannot read properties of undefined (reading 'toLocaleString')
  at formatQuotaValue (_addon-types.ts:323)
  from page.tsx:575 (ADDON_TYPES.map)
```

## Fix (test file only — no production change)

Production code is correct: `baseField`/`addonField` are typed `keyof QuotaBreakdown` / `keyof WorkspaceQuotaDetail["addon"]`, so real data guarantees the field. The fix is the fixture, not a null-guard in `formatQuotaValue` (a guard would only mask future drift).

- Add `max_connectors` to `QUOTA_DETAIL_PRO.base` / `.effective` and `connector_bonus` to `.addon`
- "renders all 9 → 10 addon inputs" — add `addon-connector`
- "submits all 9 → 10 fields" — add `addon_connector_bonus`

## Verification

`npx vitest run "src/app/(authenticated)/admin/plans/page.test.tsx"` → **13 passed**; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)