### PR TITLE
test(api): guard tests/e2e from in-process collection

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 from collections.abc import AsyncGenerator
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
@@ -68,6 +69,46 @@ def pytest_configure(config: pytest.Config) -> None:
             "asyncio_default_test_loop_scope must be 'session' in pyproject.toml "
             "to match session-scoped async fixtures (async_engine, db_session)."
         )
+
+
+_E2E_DIR = Path(__file__).parent / "e2e"
+
+
+def _e2e_explicitly_requested(config: pytest.Config) -> bool:
+    """True only when the caller deliberately opted into the e2e suite.
+
+    Opt-in signals: a CLI path under ``tests/e2e`` (how ``make test-e2e``
+    invokes pytest), an ``-m e2e`` marker selection, or ``RUN_E2E=1``.
+    """
+    if os.environ.get("RUN_E2E"):
+        return True
+    markexpr = config.getoption("markexpr", default="") or ""
+    if "e2e" in markexpr:
+        return True
+    return any("e2e" in str(arg) for arg in config.invocation_params.args)
+
+
+def pytest_ignore_collect(collection_path: Path, config: pytest.Config) -> bool | None:
+    """Keep the Playwright e2e suite out of in-process unit/integration runs.
+
+    ``tests/e2e`` drives Playwright's *sync* API (``sync_playwright()`` in
+    ``tests/e2e/conftest.py``), which runs its own asyncio event loop on the
+    main thread. The rest of the suite shares a single session-scoped loop
+    (``asyncio_default_test_loop_scope = "session"``). Mixing the two in one
+    process leaves Playwright's loop current, so every ``pytest-asyncio`` test
+    collected after ``tests/e2e`` dies with
+    ``RuntimeError: Runner.run() cannot be called from a running event loop``.
+
+    The Makefile targets already pass ``--ignore=tests/e2e``, but a bare
+    ``pytest`` / ``pytest tests/`` (``testpaths = ["tests"]``) would otherwise
+    pull e2e in and produce ~1000 misleading failures. Skip the e2e subtree
+    unless it is explicitly requested (see ``_e2e_explicitly_requested``).
+    """
+    if collection_path != _E2E_DIR and _E2E_DIR not in collection_path.parents:
+        return None  # not an e2e path — defer to default collection
+    if _e2e_explicitly_requested(config):
+        return None
+    return True
 
 
 # Test database URL — default to localhost (Docker port-mapped)

--- a/backend/tests/e2e/test_memory_lifecycle.py
+++ b/backend/tests/e2e/test_memory_lifecycle.py
@@ -13,6 +13,11 @@ from fastapi.testclient import TestClient
 from api.main import app
 from auth.dependencies import get_user_from_api_key_or_session
 
+# Module lives under tests/e2e; tag every test so `-m e2e` / `-m "not e2e"`
+# selection is complete (the directory guard in tests/conftest.py is the
+# primary protection — see pytest_ignore_collect there).
+pytestmark = pytest.mark.e2e
+
 MOCK_USER = {
     "user_id": "test_user_e2e",
     "email": "test@example.com",

--- a/backend/tests/e2e/test_rate_limiting.py
+++ b/backend/tests/e2e/test_rate_limiting.py
@@ -9,6 +9,11 @@ from fastapi.testclient import TestClient
 
 from api.main import app
 
+# Module lives under tests/e2e; tag every test so `-m e2e` / `-m "not e2e"`
+# selection is complete (the directory guard in tests/conftest.py is the
+# primary protection — see pytest_ignore_collect there).
+pytestmark = pytest.mark.e2e
+
 
 @pytest.fixture
 def client():


### PR DESCRIPTION
## Problem

A bare `pytest tests/` from `backend/` produced **1012 failed / 447 errors** — but **none were real product bugs**. They were all collateral from one infrastructure interaction:

- `tests/e2e/conftest.py`'s `browser` fixture uses Playwright's **sync** API (`sync_playwright()`), which runs its own asyncio event loop on the main thread.
- The suite shares **one session-scoped loop** (`asyncio_default_test_loop_scope = "session"`).
- Once any e2e test runs, every subsequent `pytest-asyncio` test dies with `RuntimeError: Runner.run() cannot be called from a running event loop`. e2e sorts alphabetically before `integration/mcp/models/neural/services/tasks/utils` — exactly where the failures clustered.

The Makefile targets dodge this with `--ignore=tests/e2e`, but `testpaths = ["tests"]` means a plain `pytest` walks straight into the trap, and the 1000+ misleading failures hide the truth. (Coverage `--cov` was a red herring, ruled out via A/B.)

## Fix

- **`backend/tests/conftest.py`** — add `pytest_ignore_collect` that skips the `tests/e2e` subtree unless explicitly requested (a CLI path under `tests/e2e`, `-m e2e`, or `RUN_E2E=1`).
- **`test_memory_lifecycle.py`, `test_rate_limiting.py`** — add `pytestmark = pytest.mark.e2e` (the only 2 previously-unmarked e2e files) so `-m e2e` / `-m "not e2e"` selection is complete.

## Verification

| Check | Result |
|---|---|
| `pytest tests/` collection | **0** e2e items (was pulling them in) |
| `pytest tests/e2e/` / `-m e2e` collection | **34** items — `make test-e2e` untouched |
| bare `pytest tests/` | **1012 failed → 4 failed / 3811 passed** |
| residual 4 failures | `test_resource_indexer_qdrant.py` — need a live Qdrant (pre-existing infra dep, unrelated) |
| `ruff check` changed files | clean |
| `pyright src/` | clean (only `tests/` touched) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)