### PR TITLE
fix(storage): GC lingering failed file_objects rows (#962)

### DIFF
--- a/backend/alembic/versions/e39_962_failed_file_gc.py
+++ b/backend/alembic/versions/e39_962_failed_file_gc.py
@@ -15,6 +15,9 @@ any lingering ``failed`` row and broadens the nightly GC to reap
    without waiting for the next orphan-sweeper tick.
 2. Widen ``idx_file_objects_soft_deleted_gc`` to cover ``failed`` so the GC scan
    stays index-backed.
+3. Add ``idx_file_objects_failed_pending_softdelete`` so the orphan sweeper's
+   recurring ``failed AND deleted_at IS NULL`` stamp (and the backfill below) is
+   an index scan, not a seq-scan, as the table grows.
 
 Revision ID: e39_962_failed_file_gc
 Revises: e38_982_edge_gate_kind
@@ -35,15 +38,24 @@ branch_labels = None
 depends_on = None
 
 _GC_INDEX = "idx_file_objects_soft_deleted_gc"
+_STAMP_INDEX = "idx_file_objects_failed_pending_softdelete"
 
 
 def upgrade() -> None:
-    """Backfill lingering failed rows + widen the GC index to cover ``failed``."""
-    # 1. One-time cleanup: route pre-existing lingering failed rows into the GC.
+    """Backfill lingering failed rows + add/widen the supporting indexes."""
+    # 1. Locator for the recurring stamp + the backfill below — create it
+    #    first so the backfill UPDATE can use it instead of a seq-scan.
+    op.create_index(
+        _STAMP_INDEX,
+        "file_objects",
+        ["id"],
+        postgresql_where=sa.text("status = 'failed' AND deleted_at IS NULL"),
+    )
+    # 2. One-time cleanup: route pre-existing lingering failed rows into the GC.
     op.execute(
         "UPDATE file_objects SET deleted_at = NOW() WHERE status = 'failed' AND deleted_at IS NULL"
     )
-    # 2. Widen the GC partial index to match the broadened sweep predicate.
+    # 3. Widen the GC partial index to match the broadened sweep predicate.
     op.drop_index(_GC_INDEX, table_name="file_objects")
     op.create_index(
         _GC_INDEX,
@@ -54,7 +66,9 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    """Restore the narrow uploaded-only index predicate (backfill is forward-only)."""
+    """Restore the narrow uploaded-only index + drop the stamp locator.
+
+    The backfill is forward-only (see module docstring)."""
     op.drop_index(_GC_INDEX, table_name="file_objects")
     op.create_index(
         _GC_INDEX,
@@ -62,3 +76,4 @@ def downgrade() -> None:
         ["deleted_at"],
         postgresql_where=sa.text("status = 'uploaded' AND deleted_at IS NOT NULL"),
     )
+    op.drop_index(_STAMP_INDEX, table_name="file_objects")

--- a/backend/alembic/versions/e39_962_failed_file_gc.py
+++ b/backend/alembic/versions/e39_962_failed_file_gc.py
@@ -1,0 +1,64 @@
+"""Route lingering ``failed`` file_objects rows into the GC (#962).
+
+Issue #962: ``file_objects`` rows in terminal ``status='failed'`` with
+``deleted_at IS NULL`` were reaped by no garbage-collection path. The orphan
+sweeper targeted only ``status='reserved'`` and the #552 nightly GC targeted
+only ``status='uploaded' AND deleted_at IS NOT NULL``, so ``failed`` rows held
+no quota and were UI-hidden but accumulated as dead rows.
+
+The application change in this PR has the orphan sweeper stamp ``deleted_at`` on
+any lingering ``failed`` row and broadens the nightly GC to reap
+``status IN ('uploaded', 'failed')``. This migration:
+
+1. One-time backfill — soft-delete pre-existing ``failed AND deleted_at IS NULL``
+   rows (Phase-1-era + pre-#552 ``confirm_upload`` failures) so the GC reaps them
+   without waiting for the next orphan-sweeper tick.
+2. Widen ``idx_file_objects_soft_deleted_gc`` to cover ``failed`` so the GC scan
+   stays index-backed.
+
+Revision ID: e39_962_failed_file_gc
+Revises: e38_982_edge_gate_kind
+
+DOWNGRADE: restores the narrow (uploaded-only) index predicate. The backfill is
+forward-only — re-NULLing ``deleted_at`` would resurrect the un-GC'able rows the
+upgrade was written to remove, so downgrade intentionally does not undo it.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e39_962_failed_file_gc"
+down_revision = "e38_982_edge_gate_kind"
+branch_labels = None
+depends_on = None
+
+_GC_INDEX = "idx_file_objects_soft_deleted_gc"
+
+
+def upgrade() -> None:
+    """Backfill lingering failed rows + widen the GC index to cover ``failed``."""
+    # 1. One-time cleanup: route pre-existing lingering failed rows into the GC.
+    op.execute(
+        "UPDATE file_objects SET deleted_at = NOW() WHERE status = 'failed' AND deleted_at IS NULL"
+    )
+    # 2. Widen the GC partial index to match the broadened sweep predicate.
+    op.drop_index(_GC_INDEX, table_name="file_objects")
+    op.create_index(
+        _GC_INDEX,
+        "file_objects",
+        ["deleted_at"],
+        postgresql_where=sa.text("status IN ('uploaded', 'failed') AND deleted_at IS NOT NULL"),
+    )
+
+
+def downgrade() -> None:
+    """Restore the narrow uploaded-only index predicate (backfill is forward-only)."""
+    op.drop_index(_GC_INDEX, table_name="file_objects")
+    op.create_index(
+        _GC_INDEX,
+        "file_objects",
+        ["deleted_at"],
+        postgresql_where=sa.text("status = 'uploaded' AND deleted_at IS NOT NULL"),
+    )

--- a/backend/src/models/file_objects.py
+++ b/backend/src/models/file_objects.py
@@ -128,14 +128,17 @@ class FileObject(Base):
             "expires_at",
             postgresql_where="status = 'reserved'",
         ),
-        # Soft-delete GC helper (Issue #552): nightly sweep of
-        # ``status='uploaded' AND deleted_at IS NOT NULL`` rows past the
-        # 7-day retention window. Partial index keeps storage proportional
-        # to actually-deleted-pending-GC rows rather than total uploads.
+        # Soft-delete GC helper (Issue #552, broadened in #962): nightly
+        # sweep of ``status IN ('uploaded', 'failed') AND deleted_at IS NOT
+        # NULL`` rows past the 7-day retention window. #962 added ``failed``:
+        # the orphan sweeper now soft-deletes lingering ``failed`` rows
+        # (which hold no quota and are UI-hidden but otherwise had no GC
+        # path) so this nightly sweep reaps them too. Partial index keeps
+        # storage proportional to actually-deleted-pending-GC rows.
         Index(
             "idx_file_objects_soft_deleted_gc",
             "deleted_at",
-            postgresql_where="status = 'uploaded' AND deleted_at IS NOT NULL",
+            postgresql_where=("status IN ('uploaded', 'failed') AND deleted_at IS NOT NULL"),
         ),
     )
 

--- a/backend/src/models/file_objects.py
+++ b/backend/src/models/file_objects.py
@@ -140,6 +140,16 @@ class FileObject(Base):
             "deleted_at",
             postgresql_where=("status IN ('uploaded', 'failed') AND deleted_at IS NOT NULL"),
         ),
+        # #962: locator for the orphan sweeper's failed-row soft-delete stamp
+        # (and the one-time backfill). Keeps that bulk ``UPDATE … WHERE
+        # status='failed' AND deleted_at IS NULL`` an index scan over the
+        # normally near-empty failed-pending set — the stamp drains the set
+        # each 15-min tick — instead of a seq-scan of the whole table.
+        Index(
+            "idx_file_objects_failed_pending_softdelete",
+            "id",
+            postgresql_where="status = 'failed' AND deleted_at IS NULL",
+        ),
     )
 
 

--- a/backend/src/tasks/file_tasks.py
+++ b/backend/src/tasks/file_tasks.py
@@ -269,12 +269,18 @@ async def sweep_soft_deleted_files() -> dict[str, int]:
                     )
                     continue
             else:
-                # No binary to delete. For an ``uploaded`` row a NULL
-                # ``storage_key`` is an invariant violation (the orphan
-                # sweeper should have transitioned it to ``failed``); for a
-                # ``failed`` row (#962) it is the normal "client reserved
-                # but never PUT" case. Either way the row is hard-deletable
-                # since there is no R2 binary to leak.
+                # No binary to delete. For a ``failed`` row (#962) a NULL
+                # ``storage_key`` is the normal "client reserved but never
+                # PUT" case. For an ``uploaded`` row it is an invariant
+                # violation (the orphan sweeper should have transitioned it
+                # to ``failed``) — keep that operator signal rather than
+                # letting #962's broadened filter swallow it silently.
+                # Either way the row is hard-deletable: no R2 binary to leak.
+                if f.status == "uploaded":
+                    logger.warning(
+                        "soft_delete_gc_uploaded_missing_storage_key",
+                        file_id=file_id,
+                    )
                 counts["hard_deleted_no_r2"] += 1
 
             # Idempotent DELETE: when multiple API replicas run the

--- a/backend/src/tasks/file_tasks.py
+++ b/backend/src/tasks/file_tasks.py
@@ -30,7 +30,7 @@ from typing import Any, cast
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.interval import IntervalTrigger
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.engine import CursorResult
 
 from db.base import get_db
@@ -67,7 +67,13 @@ async def sweep_orphan_files() -> dict[str, int]:
         ``{"swept": N, "released_bytes": N, "r2_deleted": N, "r2_failed": N}``
         — useful for the scheduler log and future ops dashboards.
     """
-    counts = {"swept": 0, "released_bytes": 0, "r2_deleted": 0, "r2_failed": 0}
+    counts = {
+        "swept": 0,
+        "released_bytes": 0,
+        "r2_deleted": 0,
+        "r2_failed": 0,
+        "failed_soft_deleted": 0,  # #962
+    }
 
     # Filter at SQL so the partial index ``idx_file_objects_reserved_expires``
     # is used; otherwise every sweeper tick loads all in-flight rows.
@@ -154,7 +160,33 @@ async def sweep_orphan_files() -> dict[str, int]:
                         error=str(exc),
                     )
 
-    if counts["swept"] > 0:
+        # #962: defensively soft-delete any lingering ``failed`` rows that
+        # never got a ``deleted_at``. Three sources land here: orphan-swept
+        # rows (this very sweep marks ``reserved -> failed`` above without a
+        # ``deleted_at``, keeping them as tracking rows for the unique-slot
+        # comment), pre-#552 ``confirm_upload`` failures, and Phase-1-era
+        # rows. They hold no quota and are UI-hidden, but had NO GC path.
+        # Stamping ``deleted_at`` routes them into the nightly
+        # ``sweep_soft_deleted_files`` (broadened to ``failed`` in #962),
+        # which deletes the R2 binary (if any) and hard-deletes the row.
+        # One bulk UPDATE so cost stays flat regardless of backlog size;
+        # the ``idx_file_objects_soft_deleted_gc`` partial index covers the
+        # subsequent GC scan.
+        stamp_result = cast(
+            CursorResult[Any],
+            await db.execute(
+                update(FileObject)
+                .where(
+                    FileObject.status == "failed",
+                    FileObject.deleted_at.is_(None),
+                )
+                .values(deleted_at=utcnow())
+            ),
+        )
+        await db.commit()
+        counts["failed_soft_deleted"] = stamp_result.rowcount or 0
+
+    if counts["swept"] > 0 or counts["failed_soft_deleted"] > 0:
         logger.info("orphan_files_swept", **counts)
     return counts
 
@@ -201,8 +233,11 @@ async def sweep_soft_deleted_files() -> dict[str, int]:
         # makes the next ``deleted_at <=`` filter cheap.
         result = await db.execute(
             select(FileObject)
+            # #962: ``failed`` joins ``uploaded`` — the orphan sweeper now
+            # stamps ``deleted_at`` on lingering failed rows, so they reach
+            # this GC the same way soft-deleted uploads do.
             .where(
-                FileObject.status == "uploaded",
+                FileObject.status.in_(("uploaded", "failed")),
                 FileObject.deleted_at.isnot(None),
                 FileObject.deleted_at <= threshold,
             )
@@ -234,10 +269,12 @@ async def sweep_soft_deleted_files() -> dict[str, int]:
                     )
                     continue
             else:
-                # ``storage_key IS NULL`` on an ``uploaded`` row is an
-                # invariant violation — the orphan sweeper should have
-                # transitioned it to ``failed`` already. Hard-deletable
-                # since there's no binary to leak.
+                # No binary to delete. For an ``uploaded`` row a NULL
+                # ``storage_key`` is an invariant violation (the orphan
+                # sweeper should have transitioned it to ``failed``); for a
+                # ``failed`` row (#962) it is the normal "client reserved
+                # but never PUT" case. Either way the row is hard-deletable
+                # since there is no R2 binary to leak.
                 counts["hard_deleted_no_r2"] += 1
 
             # Idempotent DELETE: when multiple API replicas run the

--- a/backend/tests/tasks/test_file_tasks.py
+++ b/backend/tests/tasks/test_file_tasks.py
@@ -298,6 +298,44 @@ class TestSweepSoftDeletedFiles:
         assert "'uploaded'" in compiled and "'failed'" in compiled
 
     @pytest.mark.asyncio
+    async def test_gc_warns_on_uploaded_row_missing_storage_key(self):
+        """#962: broadening the filter to ``failed`` must NOT swallow the
+        ``uploaded`` + NULL storage_key anomaly — that is a real invariant
+        violation and still warrants an operator warning."""
+        bad = _make_file(
+            status="uploaded",
+            deleted_at=utcnow() - timedelta(days=8),
+            storage_key=None,
+        )
+        get_db_patch, _ = _patch_get_db([bad])
+        fake_storage = MagicMock()
+        fake_storage.delete_object = AsyncMock()
+        with get_db_patch, _patch_storage(fake_storage):
+            with patch.object(file_tasks.logger, "warning") as warn:
+                counts = await file_tasks.sweep_soft_deleted_files()
+        assert counts["hard_deleted_no_r2"] == 1
+        warn.assert_called_once()
+        assert warn.call_args.args[0] == "soft_delete_gc_uploaded_missing_storage_key"
+
+    @pytest.mark.asyncio
+    async def test_failed_row_missing_storage_key_does_not_warn(self):
+        """The same NULL storage_key on a ``failed`` row is normal (never
+        PUT) — no warning."""
+        ok = _make_file(
+            status="failed",
+            deleted_at=utcnow() - timedelta(days=8),
+            storage_key=None,
+        )
+        get_db_patch, _ = _patch_get_db([ok])
+        fake_storage = MagicMock()
+        fake_storage.delete_object = AsyncMock()
+        with get_db_patch, _patch_storage(fake_storage):
+            with patch.object(file_tasks.logger, "warning") as warn:
+                counts = await file_tasks.sweep_soft_deleted_files()
+        assert counts["hard_deleted_no_r2"] == 1
+        warn.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_lost_race_with_other_replica_is_no_op(self):
         """Multi-replica scenario: another sweeper already deleted the
         row. ``DELETE … WHERE id=… AND deleted_at IS NOT NULL`` returns

--- a/backend/tests/tasks/test_file_tasks.py
+++ b/backend/tests/tasks/test_file_tasks.py
@@ -40,16 +40,19 @@ def _make_file(
     return file
 
 
-def _patch_get_db(rows, *, delete_rowcount: int = 1):
+def _patch_get_db(rows, *, delete_rowcount: int = 1, stamp_rowcount: int = 0):
     """``async for db in get_db()`` yields one mock that returns ``rows``.
 
-    The mock ``db.execute`` is sequence-aware: the first call returns
-    the SELECT result (the candidate ``rows``); subsequent calls
-    (per-row DELETE in the GC sweep) return a result whose
-    ``rowcount`` is ``delete_rowcount``. Tests that need to simulate
-    a lost-race (another replica beat us to the row) can pass
-    ``delete_rowcount=0``.
+    The mock ``db.execute`` is **statement-type aware** (robust to call
+    ordering): a ``Select`` returns the candidate ``rows``; a ``Delete``
+    (per-row hard-delete in the GC sweep) returns ``delete_rowcount``; an
+    ``Update`` (#962 orphan-sweep failed-row soft-delete stamp) returns
+    ``stamp_rowcount``. Tests simulating a lost race pass
+    ``delete_rowcount=0``; tests exercising the failed-row stamp pass
+    ``stamp_rowcount=N``.
     """
+    from sqlalchemy import Delete, Select, Update
+
     db = MagicMock()
     db.commit = AsyncMock()
     db.delete = AsyncMock()  # legacy compat: orphan sweeper does not use it
@@ -60,11 +63,17 @@ def _patch_get_db(rows, *, delete_rowcount: int = 1):
     delete_result = MagicMock()
     delete_result.rowcount = delete_rowcount
 
-    call_state = {"n": 0}
+    stamp_result = MagicMock()
+    stamp_result.rowcount = stamp_rowcount
 
-    async def _execute(*_args, **_kwargs):
-        call_state["n"] += 1
-        return list_result if call_state["n"] == 1 else delete_result
+    async def _execute(stmt, *_args, **_kwargs):
+        if isinstance(stmt, Select):
+            return list_result
+        if isinstance(stmt, Update):
+            return stamp_result
+        if isinstance(stmt, Delete):
+            return delete_result
+        return delete_result
 
     db.execute = AsyncMock(side_effect=_execute)
 
@@ -102,8 +111,15 @@ class TestSweepOrphanFiles:
         get_db_patch, db = _patch_get_db(rows)
         with get_db_patch, _patch_release(), _patch_storage(None):
             counts = await file_tasks.sweep_orphan_files()
-        assert counts == {"swept": 0, "released_bytes": 0, "r2_deleted": 0, "r2_failed": 0}
-        db.commit.assert_awaited_once()
+        assert counts == {
+            "swept": 0,
+            "released_bytes": 0,
+            "r2_deleted": 0,
+            "r2_failed": 0,
+            "failed_soft_deleted": 0,
+        }
+        # Two commits: the orphan-reap commit + the #962 failed-row stamp commit.
+        assert db.commit.await_count == 2
 
     @pytest.mark.asyncio
     async def test_skips_rows_within_grace(self):
@@ -136,7 +152,8 @@ class TestSweepOrphanFiles:
         assert old.status == "failed"
         release.assert_awaited_once()
         fake_storage.delete_object.assert_awaited_once_with("ws/aa/key")
-        db.commit.assert_awaited_once()
+        # Orphan-reap commit + the #962 failed-row stamp commit.
+        assert db.commit.await_count == 2
 
     @pytest.mark.asyncio
     async def test_r2_delete_failure_is_swallowed(self):
@@ -172,6 +189,32 @@ class TestSweepOrphanFiles:
         assert counts["r2_failed"] == 0
         assert old.status == "failed"
         release.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_stamps_lingering_failed_rows(self):
+        """#962: ``failed AND deleted_at IS NULL`` rows (orphan-swept
+        tracking rows, pre-#552 confirm_upload failures, Phase-1-era) get a
+        ``deleted_at`` via the bulk stamp so the nightly GC can reap them.
+        No reserved orphans here — only the stamp runs."""
+        get_db_patch, db = _patch_get_db([], stamp_rowcount=3)
+        with get_db_patch, _patch_release() as release, _patch_storage(None):
+            counts = await file_tasks.sweep_orphan_files()
+        assert counts["failed_soft_deleted"] == 3
+        assert counts["swept"] == 0
+        release.assert_not_awaited()  # stamp releases no quota (failed rows hold none)
+        # Orphan-reap commit + the stamp commit.
+        assert db.commit.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_stamp_issues_an_update(self):
+        """The stamp is a single bulk ``UPDATE`` over failed+NULL rows."""
+        from sqlalchemy import Update
+
+        get_db_patch, db = _patch_get_db([], stamp_rowcount=1)
+        with get_db_patch, _patch_release(), _patch_storage(None):
+            await file_tasks.sweep_orphan_files()
+        stmts = [c.args[0] for c in db.execute.await_args_list]
+        assert any(isinstance(s, Update) for s in stmts), "expected a bulk UPDATE stamp"
 
 
 class TestSweepSoftDeletedFiles:
@@ -222,6 +265,37 @@ class TestSweepSoftDeletedFiles:
         # 2 db.execute calls: 1 SELECT + 1 DELETE (per-row).
         assert db.execute.await_count == 2
         db.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_gc_reaps_failed_status_rows(self):
+        """#962: the GC now reaps ``status='failed'`` rows (stamped by the
+        orphan sweeper), not just ``uploaded``. A failed row's NULL
+        ``storage_key`` is the normal "reserved but never PUT" case → hard
+        delete with no R2 op."""
+        old = _make_file(
+            status="failed",
+            deleted_at=utcnow() - timedelta(days=8),
+            storage_key=None,
+        )
+        get_db_patch, db = _patch_get_db([old])
+        fake_storage = MagicMock()
+        fake_storage.delete_object = AsyncMock()
+        with get_db_patch, _patch_storage(fake_storage):
+            counts = await file_tasks.sweep_soft_deleted_files()
+
+        assert counts["swept"] == 1
+        assert counts["hard_deleted_no_r2"] == 1
+        assert counts["r2_deleted"] == 0
+        fake_storage.delete_object.assert_not_awaited()
+        # SELECT + per-row DELETE.
+        assert db.execute.await_count == 2
+        db.commit.assert_awaited_once()
+
+        # Rigor: confirm the candidate SELECT actually widened to include
+        # 'failed' (not merely that a failed row, once selected, is handled).
+        select_stmt = db.execute.await_args_list[0].args[0]
+        compiled = str(select_stmt.compile(compile_kwargs={"literal_binds": True}))
+        assert "'uploaded'" in compiled and "'failed'" in compiled
 
     @pytest.mark.asyncio
     async def test_lost_race_with_other_replica_is_no_op(self):


### PR DESCRIPTION
Closes #962. Milestone: v0.34.0.

## Problem

`file_objects` rows in terminal `status='failed'` with `deleted_at IS NULL` had **no GC path**: the orphan sweeper targets only `status='reserved'`, and the #552 nightly GC only `status='uploaded' AND deleted_at IS NOT NULL`. They hold no quota and are UI-hidden but accumulate as dead rows. Note the orphan sweeper itself marks `reserved → failed` *without* a `deleted_at` (keeping the row as a tracking row), so this affected **ongoing** failures, not just the Phase-1-era prod rows the issue lists.

## Fix

Took the issue's *"extend the orphan sweeper's filter"* option — robust against **all** failure paths (present and future) with no per-path audit:

- **`sweep_orphan_files`** — one bulk `UPDATE` stamps `deleted_at` on every lingering `failed AND deleted_at IS NULL` row each 15-min beat, routing them into the nightly GC (new `failed_soft_deleted` counter).
- **`sweep_soft_deleted_files`** — candidate filter widened to `status IN ('uploaded','failed')`; stamped failed rows are reaped (R2 delete if any + hard delete). For a `failed` row a NULL `storage_key` is the normal "reserved but never PUT" case, not an invariant violation (comment updated).
- **`idx_file_objects_soft_deleted_gc`** — partial-index predicate widened to match.
- **Migration `e39_962_failed_file_gc`** — one-time backfill of existing `failed AND deleted_at IS NULL` rows + index re-create. Backfill is forward-only; downgrade restores the narrow index.

## Tests

`tests/tasks/test_file_tasks.py` (16 pass): orphan-sweep stamp (count + that an `UPDATE` is issued), GC reaping `failed` rows **including a compiled-SELECT assertion** that the filter genuinely widened, plus existing orphan tests updated for the extra stamp commit. ruff clean; single alembic head. The migration apply is exercised by the `backend-integration` CI lane (path-triggers on `alembic/versions/**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)