### PR TITLE
feat(api): auto-requeue transiently failed embeddings in the sweep (#979)

### DIFF
--- a/backend/alembic/versions/e40_979_embedding_retry_count.py
+++ b/backend/alembic/versions/e40_979_embedding_retry_count.py
@@ -25,8 +25,11 @@ branch_labels = None
 depends_on = None
 
 
+_SWEEP_INDEX = "idx_memories_embedding_unsettled"
+
+
 def upgrade() -> None:
-    """Add embedding_retry_count (backfilled to 0 via server default)."""
+    """Add embedding_retry_count + the embedding-sweep partial index."""
     op.add_column(
         "memories",
         sa.Column(
@@ -36,7 +39,16 @@ def upgrade() -> None:
             server_default="0",
         ),
     )
+    # Partial index for the 30s embedding sweep (#979): scan only the
+    # not-yet-settled rows instead of the whole (mostly 'success') table.
+    op.create_index(
+        _SWEEP_INDEX,
+        "memories",
+        ["embedding_status"],
+        postgresql_where=sa.text("embedding_status <> 'success'"),
+    )
 
 
 def downgrade() -> None:
+    op.drop_index(_SWEEP_INDEX, table_name="memories")
     op.drop_column("memories", "embedding_retry_count")

--- a/backend/alembic/versions/e40_979_embedding_retry_count.py
+++ b/backend/alembic/versions/e40_979_embedding_retry_count.py
@@ -1,0 +1,42 @@
+"""Add ``embedding_retry_count`` for bounded auto-requeue of failed embeddings (#979).
+
+Issue #979: the periodic embedding sweep only requeued ``pending`` and stale
+``processing`` rows — never ``failed``. A transient embedding/Qdrant blip left a
+memory ``failed`` permanently (unsearchable) until an admin manually triggered
+the retry endpoint. This column lets the sweep auto-requeue ``failed`` rows,
+bounded by a retry counter so a permanently-poison row cannot loop forever.
+
+Adds ``embedding_retry_count INTEGER NOT NULL DEFAULT 0``. The server default
+backfills every existing row to 0 in one statement (so prior ``failed`` rows
+get a fresh auto-retry budget on first sweep after deploy).
+
+Revision ID: e40_979_embedding_retry_count
+Revises: e39_962_failed_file_gc
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e40_979_embedding_retry_count"
+down_revision = "e39_962_failed_file_gc"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add embedding_retry_count (backfilled to 0 via server default)."""
+    op.add_column(
+        "memories",
+        sa.Column(
+            "embedding_retry_count",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("memories", "embedding_retry_count")

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -1188,7 +1188,12 @@ async def retry_failed_embeddings(
         conditions.append(Memory.workspace_id == workspace_id)
 
     stmt = (
-        update(Memory).where(*conditions).values(embedding_status="pending", embedding_error=None)
+        update(Memory)
+        .where(*conditions)
+        # #979: reset the auto-retry budget too — this manual endpoint is the
+        # override for rows that exhausted MAX_EMBEDDING_RETRIES, so a fresh
+        # admin retry must let the sweep pick them up again.
+        .values(embedding_status="pending", embedding_error=None, embedding_retry_count=0)
     )
     result = cast(CursorResult[Any], await db.execute(stmt))
     await db.commit()

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -151,3 +151,12 @@ CONTEXT_CACHE_TTL_SECONDS = 60 * 60  # 3600 seconds
 
 # Redis cache TTL for workspace metadata (1 hour)
 ORG_CACHE_TTL_SECONDS = 60 * 60  # 3600 seconds
+
+# Embedding auto-requeue (#979): the periodic sweep re-claims memories stuck in
+# embedding_status='failed' so a transient embedding/Qdrant blip self-heals
+# instead of needing the manual admin retry endpoint. Bounded by a retry counter
+# so a permanently-poison row (bad input, oversized text) cannot loop forever.
+MAX_EMBEDDING_RETRIES = 3
+# Backoff before a failed embedding is eligible for auto-retry — gives a
+# transient condition time to clear and spaces retries across sweep ticks.
+EMBEDDING_RETRY_BACKOFF_SECONDS = 60

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -345,6 +345,16 @@ class Memory(Base):
             postgresql_using="gin",
             postgresql_ops={"summary": "gin_trgm_ops"},
         ),
+        # Issue #979 partial index for the embedding sweep (migration e40).
+        # The sweep runs every 30s over not-yet-settled rows (pending /
+        # processing / failed); the partial predicate keeps it scanning only
+        # that normally-tiny set instead of the whole (mostly 'success')
+        # memories table as it grows.
+        Index(
+            "idx_memories_embedding_unsettled",
+            "embedding_status",
+            postgresql_where=text("embedding_status <> 'success'"),
+        ),
         # Issue #619 compound partial B-tree on (workspace_id, context_id),
         # accelerating the scope scan used by aggregate_tags, get_context_stats,
         # and _refresh_hub_tag_cache (migration e29_619_memories_ws_ctx_idx).

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -148,9 +148,16 @@ class Memory(Base):
     )
 
     # Issue #122: Embedding status tracking for transaction integrity
-    # Values: 'pending', 'success', 'failed'
+    # Values: 'pending', 'processing', 'success', 'failed'
     embedding_status: Mapped[str] = mapped_column(String(20), nullable=False, default="pending")
     embedding_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Issue #979: bounded auto-requeue of transiently-failed embeddings. The
+    # sweep re-claims `failed` rows while this is below MAX_EMBEDDING_RETRIES,
+    # incrementing it per retry; a poison row exhausts its budget and stops.
+    # The manual admin retry endpoint resets this to 0.
+    embedding_retry_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0", default=0
+    )
 
     # Layer 2: 文脈説明
     context_summary: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -3066,8 +3066,9 @@ async def process_pending_embedding(memory_id: UUID) -> None:
 
     from datetime import timedelta
 
-    from sqlalchemy import and_, or_, select, update
+    from sqlalchemy import and_, case, or_, select, update
 
+    from config.constants import EMBEDDING_RETRY_BACKOFF_SECONDS, MAX_EMBEDDING_RETRIES
     from db.base import get_db
     from models.memory import Memory
     from services.context_routing import resolve_context_routing
@@ -3083,6 +3084,11 @@ async def process_pending_embedding(memory_id: UUID) -> None:
             from utils.datetime import utcnow as _utcnow
 
             stale_cutoff = _utcnow() - timedelta(seconds=60)
+            # #979: a `failed` row is eligible for auto-retry once its backoff
+            # has elapsed and it still has retry budget left. The counter is
+            # incremented only when we claim a `failed` row (CASE below), so the
+            # initial pending->processing claim does not consume budget.
+            retry_cutoff = _utcnow() - timedelta(seconds=EMBEDDING_RETRY_BACKOFF_SECONDS)
             result = await db.execute(
                 update(Memory)
                 .where(
@@ -3094,14 +3100,32 @@ async def process_pending_embedding(memory_id: UUID) -> None:
                             Memory.embedding_status == "processing",
                             Memory.updated_at < stale_cutoff,
                         ),
+                        and_(
+                            Memory.embedding_status == "failed",
+                            Memory.embedding_retry_count < MAX_EMBEDDING_RETRIES,
+                            Memory.updated_at < retry_cutoff,
+                        ),
                     ),
                 )
-                .values(embedding_status="processing", updated_at=_utcnow())
+                .values(
+                    embedding_status="processing",
+                    updated_at=_utcnow(),
+                    # Count only retries of a previously-failed row. The CASE
+                    # reads the pre-UPDATE status, so pending/stale-processing
+                    # claims leave the counter untouched.
+                    embedding_retry_count=case(
+                        (
+                            Memory.embedding_status == "failed",
+                            Memory.embedding_retry_count + 1,
+                        ),
+                        else_=Memory.embedding_retry_count,
+                    ),
+                )
                 .returning(Memory.id)
             )
             claimed = result.scalar_one_or_none()
             if not claimed:
-                return  # Already claimed, not pending, or soft-deleted
+                return  # Already claimed, not eligible, exhausted, or soft-deleted
 
             await db.commit()
 
@@ -3176,9 +3200,12 @@ async def process_pending_embedding(memory_id: UUID) -> None:
                 collection_name=collection,
             )
 
-            # Mark success
+            # Mark success. Clear any prior embedding_error (#979): a retry that
+            # finally succeeds should not leave a stale failure message behind.
             await db.execute(
-                update(Memory).where(Memory.id == memory_id).values(embedding_status="success")
+                update(Memory)
+                .where(Memory.id == memory_id)
+                .values(embedding_status="success", embedding_error=None)
             )
             await db.commit()
 

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import hashlib
+from datetime import datetime
 from uuid import UUID, uuid4
 
 from sqlalchemy import and_, or_, select
@@ -3056,6 +3057,34 @@ async def _create_tag_cooccurrence_seed_edges(
         )
 
 
+def embedding_retry_eligible_clause(now: datetime):
+    """SQLAlchemy clause: a ``failed`` embedding eligible for #979 auto-requeue.
+
+    Eligible when it still has retry budget (``embedding_retry_count <
+    MAX_EMBEDDING_RETRIES``) and its backoff has elapsed. The backoff is
+    measured from ``updated_at`` (the failure ``UPDATE``'s ``onupdate`` stamps
+    it to the failure time); a NULL ``updated_at`` is treated as immediately
+    eligible so a row can never get permanently stuck ``failed`` — the exact
+    state #979 exists to prevent.
+
+    Shared by the sweep prefilter (``tasks/embedding_tasks.py``) and the atomic
+    claim in ``process_pending_embedding`` so the two gates cannot drift.
+    """
+    from datetime import timedelta
+
+    from sqlalchemy import and_, or_
+
+    from config.constants import EMBEDDING_RETRY_BACKOFF_SECONDS, MAX_EMBEDDING_RETRIES
+    from models.memory import Memory
+
+    retry_cutoff = now - timedelta(seconds=EMBEDDING_RETRY_BACKOFF_SECONDS)
+    return and_(
+        Memory.embedding_status == "failed",
+        Memory.embedding_retry_count < MAX_EMBEDDING_RETRIES,
+        or_(Memory.updated_at.is_(None), Memory.updated_at < retry_cutoff),
+    )
+
+
 async def process_pending_embedding(memory_id: UUID) -> None:
     """Process embedding generation + Qdrant upsert for a pending memory.
 
@@ -3068,7 +3097,6 @@ async def process_pending_embedding(memory_id: UUID) -> None:
 
     from sqlalchemy import and_, case, or_, select, update
 
-    from config.constants import EMBEDDING_RETRY_BACKOFF_SECONDS, MAX_EMBEDDING_RETRIES
     from db.base import get_db
     from models.memory import Memory
     from services.context_routing import resolve_context_routing
@@ -3083,12 +3111,13 @@ async def process_pending_embedding(memory_id: UUID) -> None:
             # Stale processing: updated_at older than 60s (crash recovery)
             from utils.datetime import utcnow as _utcnow
 
-            stale_cutoff = _utcnow() - timedelta(seconds=60)
-            # #979: a `failed` row is eligible for auto-retry once its backoff
-            # has elapsed and it still has retry budget left. The counter is
-            # incremented only when we claim a `failed` row (CASE below), so the
-            # initial pending->processing claim does not consume budget.
-            retry_cutoff = _utcnow() - timedelta(seconds=EMBEDDING_RETRY_BACKOFF_SECONDS)
+            now = _utcnow()
+            stale_cutoff = now - timedelta(seconds=60)
+            # #979: a `failed` row is also eligible for auto-retry once its
+            # backoff has elapsed and it still has retry budget. The shared
+            # clause keeps this gate byte-identical to the sweep prefilter. The
+            # counter is incremented only when we claim a `failed` row (CASE
+            # below), so the initial pending->processing claim spends no budget.
             result = await db.execute(
                 update(Memory)
                 .where(
@@ -3100,16 +3129,12 @@ async def process_pending_embedding(memory_id: UUID) -> None:
                             Memory.embedding_status == "processing",
                             Memory.updated_at < stale_cutoff,
                         ),
-                        and_(
-                            Memory.embedding_status == "failed",
-                            Memory.embedding_retry_count < MAX_EMBEDDING_RETRIES,
-                            Memory.updated_at < retry_cutoff,
-                        ),
+                        embedding_retry_eligible_clause(now),
                     ),
                 )
                 .values(
                     embedding_status="processing",
-                    updated_at=_utcnow(),
+                    updated_at=now,
                     # Count only retries of a previously-failed row. The CASE
                     # reads the pre-UPDATE status, so pending/stale-processing
                     # claims leave the counter untouched.
@@ -3200,12 +3225,18 @@ async def process_pending_embedding(memory_id: UUID) -> None:
                 collection_name=collection,
             )
 
-            # Mark success. Clear any prior embedding_error (#979): a retry that
-            # finally succeeds should not leave a stale failure message behind.
+            # Mark success. Clear the prior embedding_error AND reset
+            # embedding_retry_count (#979): the retry budget is per
+            # failure-episode, not a lifetime tally — a later, unrelated
+            # failure must get the full MAX_EMBEDDING_RETRIES budget again.
             await db.execute(
                 update(Memory)
                 .where(Memory.id == memory_id)
-                .values(embedding_status="success", embedding_error=None)
+                .values(
+                    embedding_status="success",
+                    embedding_error=None,
+                    embedding_retry_count=0,
+                )
             )
             await db.commit()
 

--- a/backend/src/tasks/embedding_tasks.py
+++ b/backend/src/tasks/embedding_tasks.py
@@ -16,14 +16,19 @@ logger = get_logger(__name__)
 
 
 async def sweep_pending_embeddings() -> None:
-    """Find and process memories stuck in pending/processing status.
+    """Find and process memories stuck in pending/processing/failed status.
 
     - pending older than 10s: create_task likely failed or never fired
     - processing older than 60s: worker crashed mid-processing (stale)
-    process_pending_embedding() handles both cases via its claim logic.
+    - failed past the retry backoff with budget left (#979): a transient
+      embedding/Qdrant blip self-heals instead of needing the manual admin
+      retry endpoint, bounded by MAX_EMBEDDING_RETRIES so a poison row stops.
+    process_pending_embedding() re-checks each gate atomically in its claim,
+    so this SELECT is only a candidate prefilter (no double-increment race).
     """
     from sqlalchemy import and_, or_
 
+    from config.constants import EMBEDDING_RETRY_BACKOFF_SECONDS, MAX_EMBEDDING_RETRIES
     from db.base import get_db
     from models.memory import Memory
     from services.memory_service import process_pending_embedding
@@ -34,6 +39,7 @@ async def sweep_pending_embeddings() -> None:
             now = utcnow()
             pending_cutoff = now - timedelta(seconds=10)
             stale_cutoff = now - timedelta(seconds=60)
+            retry_cutoff = now - timedelta(seconds=EMBEDDING_RETRY_BACKOFF_SECONDS)
             result = await db.execute(
                 select(Memory.id)
                 .where(
@@ -46,6 +52,11 @@ async def sweep_pending_embeddings() -> None:
                         and_(
                             Memory.embedding_status == "processing",
                             Memory.updated_at < stale_cutoff,
+                        ),
+                        and_(
+                            Memory.embedding_status == "failed",
+                            Memory.embedding_retry_count < MAX_EMBEDDING_RETRIES,
+                            Memory.updated_at < retry_cutoff,
                         ),
                     ),
                 )

--- a/backend/src/tasks/embedding_tasks.py
+++ b/backend/src/tasks/embedding_tasks.py
@@ -26,12 +26,14 @@ async def sweep_pending_embeddings() -> None:
     process_pending_embedding() re-checks each gate atomically in its claim,
     so this SELECT is only a candidate prefilter (no double-increment race).
     """
-    from sqlalchemy import and_, or_
+    from sqlalchemy import and_, case, or_
 
-    from config.constants import EMBEDDING_RETRY_BACKOFF_SECONDS, MAX_EMBEDDING_RETRIES
     from db.base import get_db
     from models.memory import Memory
-    from services.memory_service import process_pending_embedding
+    from services.memory_service import (
+        embedding_retry_eligible_clause,
+        process_pending_embedding,
+    )
     from utils.datetime import utcnow
 
     async for db in get_db():
@@ -39,7 +41,6 @@ async def sweep_pending_embeddings() -> None:
             now = utcnow()
             pending_cutoff = now - timedelta(seconds=10)
             stale_cutoff = now - timedelta(seconds=60)
-            retry_cutoff = now - timedelta(seconds=EMBEDDING_RETRY_BACKOFF_SECONDS)
             result = await db.execute(
                 select(Memory.id)
                 .where(
@@ -53,12 +54,16 @@ async def sweep_pending_embeddings() -> None:
                             Memory.embedding_status == "processing",
                             Memory.updated_at < stale_cutoff,
                         ),
-                        and_(
-                            Memory.embedding_status == "failed",
-                            Memory.embedding_retry_count < MAX_EMBEDDING_RETRIES,
-                            Memory.updated_at < retry_cutoff,
-                        ),
+                        # #979: shared with the claim gate so they cannot drift.
+                        embedding_retry_eligible_clause(now),
                     ),
+                )
+                # #979: process genuinely-pending/processing rows before failed
+                # retries so a backlog of failed rows can't starve the limit(20)
+                # budget and delay brand-new memories' first embedding.
+                .order_by(
+                    case((Memory.embedding_status == "failed", 1), else_=0),
+                    Memory.created_at,
                 )
                 .limit(20)
             )

--- a/backend/tests/eval/runner.py
+++ b/backend/tests/eval/runner.py
@@ -149,7 +149,10 @@ async def _reset_embedding_to_pending(svc: Any, memory_id: UUID) -> None:
     await svc.db.execute(
         update(Memory)
         .where(Memory.id == memory_id)
-        .values(embedding_status="pending", embedding_error=None)
+        # #979: reset the auto-retry budget too (parity with the admin retry
+        # endpoint) so a doc that exhausted MAX_EMBEDDING_RETRIES during ingest
+        # can be driven again by the harness instead of staying stuck.
+        .values(embedding_status="pending", embedding_error=None, embedding_retry_count=0)
     )
     await svc.db.commit()
 

--- a/backend/tests/services/test_embedding_retry_claim.py
+++ b/backend/tests/services/test_embedding_retry_claim.py
@@ -1,0 +1,81 @@
+"""Tests for process_pending_embedding's failed-row claim gate (#979).
+
+The claim is the authoritative, atomic gate that decides whether a memory is
+(re)processed and increments the retry counter. Exercising the full embedding
+pipeline needs a real DB + Qdrant + embedding provider, so here we make the
+claim "not claimed" (returning None) to force the early return after the claim,
+then statically assert the compiled claim statement carries the #979 gate:
+``failed AND embedding_retry_count < MAX`` plus a CASE that increments the
+counter only for previously-failed rows.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+
+@pytest.mark.asyncio
+async def test_claim_gate_includes_failed_with_retry_budget_and_increments():
+    from services import memory_service
+
+    captured: list = []
+    claim_result = MagicMock()
+    claim_result.scalar_one_or_none = MagicMock(return_value=None)  # not claimed -> early return
+
+    db = MagicMock()
+
+    async def _execute(stmt, *_a, **_k):
+        captured.append(stmt)
+        return claim_result
+
+    db.execute = AsyncMock(side_effect=_execute)
+    db.commit = AsyncMock()
+
+    async def _aiter():
+        yield db
+
+    with patch("db.base.get_db", return_value=_aiter()):
+        await memory_service.process_pending_embedding(uuid4())
+
+    # Only the claim UPDATE ran (claim returned None -> early return).
+    assert len(captured) == 1
+    sql = str(
+        captured[0].compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+    ).upper()
+
+    # The claim is widened to failed rows under the retry gate...
+    assert "'FAILED'" in sql
+    assert "EMBEDDING_RETRY_COUNT" in sql
+    assert "< 3" in sql  # MAX_EMBEDDING_RETRIES default
+    # ...and increments the counter via a CASE (only for failed rows).
+    assert "CASE" in sql
+    # existing branches preserved
+    assert "'PENDING'" in sql
+    assert "'PROCESSING'" in sql
+
+
+@pytest.mark.asyncio
+async def test_claim_returns_early_when_not_claimable():
+    """A row that the claim WHERE doesn't match (exhausted budget, wrong
+    status, soft-deleted, or already claimed) yields scalar None -> the
+    function returns without touching the embedding pipeline (no commit)."""
+    from services import memory_service
+
+    claim_result = MagicMock()
+    claim_result.scalar_one_or_none = MagicMock(return_value=None)
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=claim_result)
+    db.commit = AsyncMock()
+
+    async def _aiter():
+        yield db
+
+    with patch("db.base.get_db", return_value=_aiter()):
+        await memory_service.process_pending_embedding(uuid4())
+
+    db.commit.assert_not_awaited()  # never got past the claim

--- a/backend/tests/services/test_embedding_retry_claim.py
+++ b/backend/tests/services/test_embedding_retry_claim.py
@@ -53,9 +53,28 @@ async def test_claim_gate_includes_failed_with_retry_budget_and_increments():
     assert "< 3" in sql  # MAX_EMBEDDING_RETRIES default
     # ...and increments the counter via a CASE (only for failed rows).
     assert "CASE" in sql
+    # NULL-safe backoff: a failed row with NULL updated_at is still eligible
+    # (never permanently stuck — the state #979 exists to prevent).
+    assert "IS NULL" in sql
     # existing branches preserved
     assert "'PENDING'" in sql
     assert "'PROCESSING'" in sql
+
+
+def test_retry_eligibility_clause_is_bounded_and_null_safe():
+    """The shared clause (used by both the claim and the sweep prefilter) gates
+    on retry budget and is NULL-safe on the backoff timestamp."""
+    from datetime import UTC, datetime
+
+    from services.memory_service import embedding_retry_eligible_clause
+
+    clause = embedding_retry_eligible_clause(datetime(2026, 6, 15, tzinfo=UTC))
+    sql = str(
+        clause.compile(dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True})
+    ).upper()
+    assert "'FAILED'" in sql
+    assert "EMBEDDING_RETRY_COUNT < 3" in sql  # bounded by MAX_EMBEDDING_RETRIES
+    assert "IS NULL" in sql  # NULL updated_at -> eligible, never stuck
 
 
 @pytest.mark.asyncio

--- a/backend/tests/tasks/test_embedding_tasks.py
+++ b/backend/tests/tasks/test_embedding_tasks.py
@@ -91,6 +91,39 @@ class TestSweepPendingEmbeddings:
         assert "LIMIT" in compiled.upper()
 
     @pytest.mark.asyncio
+    async def test_select_includes_failed_retry_gate(self):
+        """#979: the prefilter now also picks ``failed`` rows gated by the
+        retry counter, without dropping the pending/processing branches.
+        (The authoritative gate is re-checked in the claim — see
+        tests/services/test_embedding_retry_claim.py.)"""
+        mock_db = MagicMock()
+        mock_result = MagicMock()
+        mock_result.all.return_value = []
+        captured_stmt = None
+
+        async def capture_execute(stmt):
+            nonlocal captured_stmt
+            captured_stmt = stmt
+            return mock_result
+
+        mock_db.execute = AsyncMock(side_effect=capture_execute)
+
+        with patch("db.base.get_db", mock_get_db_factory(mock_db)):
+            await sweep_pending_embeddings()
+
+        from sqlalchemy.dialects import postgresql
+
+        sql = str(
+            captured_stmt.compile(
+                dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+            )
+        )
+        assert "'failed'" in sql
+        assert "embedding_retry_count" in sql
+        assert "'pending'" in sql  # existing branch preserved
+        assert "'processing'" in sql  # existing branch preserved
+
+    @pytest.mark.asyncio
     async def test_exception_during_sweep_is_logged(self):
         """Errors inside the sweep are caught and logged, not re-raised."""
         mock_db = MagicMock()


### PR DESCRIPTION
Closes #979. Milestone: v0.34.0.

## Problem

The embedding sweep (`tasks/embedding_tasks.py`) only requeued `pending` (>10s) and stale `processing` (>60s) rows — never `failed`. A transient embedding/Qdrant blip (e.g. a client-side Qdrant-upsert timeout, observed on WSL2 during #967) left a memory `embedding_status='failed'` **permanently** and unsearchable, recoverable only via the manual admin endpoint. Users had no signal and no self-service path.

## Fix — bounded auto-requeue

- **New `Memory.embedding_retry_count`** column (migration `e40_979`, chained off `e39`; `server_default 0` backfills existing rows, so prior failures get a fresh budget on first sweep after deploy).
- **Sweep + `process_pending_embedding` claim** now also accept `failed AND embedding_retry_count < MAX_EMBEDDING_RETRIES (3) AND updated_at < now − EMBEDDING_RETRY_BACKOFF_SECONDS (60s)`. The claim increments the counter **only for failed rows** (a `CASE` on the pre-`UPDATE` status), so the initial `pending→processing` claim spends no budget. The sweep `SELECT` is only a candidate prefilter; the claim re-checks the gate **atomically** → no double-increment race.
- A retry that finally **succeeds clears the stale `embedding_error`**.
- The **manual admin retry endpoint** now also resets `embedding_retry_count = 0` — it's the override for rows that exhausted their auto-retry budget.

Poison rows (bad input, oversized text) exhaust `MAX_EMBEDDING_RETRIES` and stop; transient failures self-heal within a sweep tick or two.

## Tests

Statement-capture (no DB/Qdrant needed): the sweep prefilter now includes the failed-retry gate (pending/processing preserved); the claim statement carries `'failed'`, `embedding_retry_count < 3`, and the incrementing `CASE`; an unclaimable row returns early without touching the pipeline. **26 related tests pass** (incl. async-remember + knn-seeding regressions); ruff clean; single alembic head. Migration apply is exercised by the `backend-integration` CI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)