### PR TITLE
fix: hotfix v0.32.1 — recall context scoping (#1036) + auth error-banner contrast

### DIFF
--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -212,11 +212,17 @@ async def recall(
 
     # Issue #82: Pass current context ID for context-based collection
     # Issue #146: Pass current workspace ID for workspace-scoped API keys
-    # Issue #246: current_context_id removed - use None
+    # Issue #1036: scope recall to the requested context. The endpoint used to
+    # hardcode current_context_id=None (a leftover from #246), but
+    # MemoryService.recall() still requires a context, so every recall 500'd.
+    # Forward filters.context_id, mirroring how /remember resolves
+    # request.context["context_id"]. No filter → None (the service guard then
+    # rejects it, same as before — see test_recall_no_workspace).
+    context_id = request.filters.get("context_id") if request.filters else None
     result = await memory_service.recall(
         request,
         user_id=user["user_id"],
-        current_context_id=None,  # Issue #246: current_context_id removed
+        current_context_id=context_id,
         current_workspace_id=user.get("current_workspace_id"),  # NEW: Issue #146
     )
 

--- a/backend/src/api/routes/memory.py
+++ b/backend/src/api/routes/memory.py
@@ -219,12 +219,18 @@ async def recall(
     # request.context["context_id"]. No filter → None (the service guard then
     # rejects it, same as before — see test_recall_no_workspace).
     context_id = request.filters.get("context_id") if request.filters else None
-    result = await memory_service.recall(
-        request,
-        user_id=user["user_id"],
-        current_context_id=context_id,
-        current_workspace_id=user.get("current_workspace_id"),  # NEW: Issue #146
-    )
+    try:
+        result = await memory_service.recall(
+            request,
+            user_id=user["user_id"],
+            current_context_id=context_id,
+            current_workspace_id=user.get("current_workspace_id"),  # NEW: Issue #146
+        )
+    except ValueError as e:
+        # Mirror /remember: MemoryService.recall raises ValueError for bad
+        # requests (missing context, or a non-UUID context_id that fails to
+        # parse downstream). Map to 422 rather than letting it surface as 500.
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)) from e
 
     return result
 

--- a/backend/tests/api/test_memory_recall_route.py
+++ b/backend/tests/api/test_memory_recall_route.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from fastapi import HTTPException
 
 from api.routes.memory import recall
 from models.schemas import RecallRequest, RecallResponse
@@ -48,3 +49,19 @@ async def test_recall_route_forwards_none_when_no_filters():
 
     kwargs = svc.recall.await_args.kwargs
     assert kwargs["current_context_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_recall_route_maps_value_error_to_422():
+    """A bad request (missing context, or a non-UUID context_id that fails to
+    parse downstream) surfaces as 422, not an unhandled 500 — mirroring
+    /remember and /pinned."""
+    svc = AsyncMock()
+    svc.recall = AsyncMock(
+        side_effect=ValueError("recall() requires current_workspace_id and current_context_id")
+    )
+    req = RecallRequest(query="test", k=5, filters={"context_id": "not-a-uuid"})
+
+    with pytest.raises(HTTPException) as exc:
+        await recall(request=req, user=MOCK_USER, memory_service=svc)
+    assert exc.value.status_code == 422

--- a/backend/tests/api/test_memory_recall_route.py
+++ b/backend/tests/api/test_memory_recall_route.py
@@ -1,0 +1,50 @@
+"""Route tests for POST /memory/recall (#1036).
+
+Direct-call convention (like test_memory_pinned_route.py): invoke the handler
+with a mocked MemoryService and assert argument plumbing.
+
+Regression guard for #1036: the route used to hardcode current_context_id=None
+while MemoryService.recall() requires a context, so every recall 500'd. The
+route must forward filters["context_id"] as current_context_id.
+"""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from api.routes.memory import recall
+from models.schemas import RecallRequest, RecallResponse
+
+MOCK_USER = {"user_id": "u1", "current_workspace_id": uuid4()}
+
+
+@pytest.mark.asyncio
+async def test_recall_route_forwards_context_id_from_filters():
+    """#1036: filters.context_id must reach the service as current_context_id."""
+    svc = AsyncMock()
+    svc.recall = AsyncMock(return_value=RecallResponse(results=[]))
+    ctx = uuid4()
+    req = RecallRequest(query="how does recall work?", k=3, filters={"context_id": str(ctx)})
+
+    await recall(request=req, user=MOCK_USER, memory_service=svc)
+
+    svc.recall.assert_awaited_once()
+    kwargs = svc.recall.await_args.kwargs
+    # Mirrors /remember: the raw string from the filter is forwarded as-is.
+    assert kwargs["current_context_id"] == str(ctx)
+    assert kwargs["current_workspace_id"] == MOCK_USER["current_workspace_id"]
+
+
+@pytest.mark.asyncio
+async def test_recall_route_forwards_none_when_no_filters():
+    """No filters → current_context_id=None (the service guard then rejects it,
+    same contract as before — see test_recall_no_workspace)."""
+    svc = AsyncMock()
+    svc.recall = AsyncMock(return_value=RecallResponse(results=[]))
+    req = RecallRequest(query="test", k=5)
+
+    await recall(request=req, user=MOCK_USER, memory_service=svc)
+
+    kwargs = svc.recall.await_args.kwargs
+    assert kwargs["current_context_id"] is None

--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -21,7 +21,7 @@ import { useTranslations } from "next-intl";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import { Alert, AlertDescription } from "@/components/ui/alert";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
@@ -35,7 +35,7 @@ import {
   type DeviceVerifyResponse,
 } from "@/lib/auth/auth";
 import { useAuth } from "@/contexts/AuthContext";
-import { AlertCircle, CheckCircle2, XCircle, Monitor } from "lucide-react";
+import { CheckCircle2, XCircle, Monitor } from "lucide-react";
 
 type Phase =
   | "input"
@@ -335,13 +335,7 @@ function DevicePageInner() {
                 )}
 
                 {phase === "error" && error && (
-                  <Alert
-                    variant="destructive"
-                    className="border-red-200 bg-red-50 text-left"
-                  >
-                    <AlertCircle className="h-4 w-4" />
-                    <AlertDescription>{error}</AlertDescription>
-                  </Alert>
+                  <ErrorBanner error={error} lightSurface className="!mb-0" />
                 )}
 
                 {phase === "error" && (
@@ -415,13 +409,7 @@ function DevicePageInner() {
 
             {phase === "error" && error && deviceInfo && (
               <div className="text-center space-y-4">
-                <Alert
-                  variant="destructive"
-                  className="border-red-200 bg-red-50 text-left"
-                >
-                  <AlertCircle className="h-4 w-4" />
-                  <AlertDescription>{error}</AlertDescription>
-                </Alert>
+                <ErrorBanner error={error} lightSurface className="!mb-0" />
                 <div className="flex gap-3 justify-center">
                   <Button variant="outline" onClick={resetToInput}>
                     {t("device.backToVerify")}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -30,12 +30,12 @@ import { safeReturnTo } from "@/lib/auth/safeReturnTo";
 import { buildOAuthRedirect } from "@/lib/auth/buildOAuthRedirect";
 import {
   ArrowRight,
-  AlertCircle,
   Info,
   Sparkles,
   Shield,
   Zap,
 } from "lucide-react";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { KaguraLogo } from "@/components/icons/KaguraLogo";
 import { LanguageSelector } from "@/components/LanguageSelector";
 
@@ -296,16 +296,10 @@ function LoginContent() {
               </Alert>
             )}
 
-            {/* Error */}
-            {error && (
-              <Alert
-                variant="destructive"
-                className="mb-6 border-red-200 bg-red-50"
-              >
-                <AlertCircle className="h-4 w-4" />
-                <AlertDescription>{error}</AlertDescription>
-              </Alert>
-            )}
+            {/* Error — auth card is always-light (#1029), so pin the light red
+                ramp; the theme-adaptive default would render faint red-300 text
+                on the white card in dark mode. */}
+            <ErrorBanner error={error} lightSurface />
 
             {mfaRequired ? (
               /* MFA Form */

--- a/frontend/src/components/common/ErrorBanner.tsx
+++ b/frontend/src/components/common/ErrorBanner.tsx
@@ -9,24 +9,46 @@ import { AlertTriangle } from 'lucide-react';
 interface ErrorBannerProps {
   error: string | null;
   className?: string;
+  /**
+   * Pin the light red ramp regardless of the global theme. Use on always-light
+   * surfaces: the auth pages (#1029) render a white card even when the app
+   * theme is dark, so the theme-adaptive `dark:` variants below would paint
+   * faint red-300 text on the white card. Default (false) keeps the
+   * theme-adaptive behavior every other consumer relies on.
+   */
+  lightSurface?: boolean;
 }
 
-export function ErrorBanner({ error, className = '' }: ErrorBannerProps) {
+export function ErrorBanner({
+  error,
+  className = '',
+  lightSurface = false,
+}: ErrorBannerProps) {
   if (!error) return null;
+
+  const container = lightSurface
+    ? 'border-red-200 bg-red-50'
+    : 'border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-900/20';
+  const iconColor = lightSurface
+    ? 'text-red-600'
+    : 'text-red-600 dark:text-red-400';
+  const textColor = lightSurface
+    ? 'text-red-800'
+    : 'text-red-800 dark:text-red-300';
 
   return (
     <div
-      className={`rounded-lg border border-red-200 dark:border-red-900 bg-red-50 dark:bg-red-900/20 p-4 mb-6 ${className}`}
+      className={`rounded-lg border ${container} p-4 mb-6 ${className}`}
       role="alert"
       aria-live="assertive"
       aria-atomic="true"
     >
       <div className="flex items-center gap-2">
         <AlertTriangle
-          className="h-5 w-5 text-red-600 dark:text-red-400 flex-shrink-0"
+          className={`h-5 w-5 ${iconColor} flex-shrink-0`}
           aria-hidden="true"
         />
-        <p className="text-sm text-red-800 dark:text-red-300">{error}</p>
+        <p className={`text-sm ${textColor}`}>{error}</p>
       </div>
     </div>
   );


### PR DESCRIPTION
Hotfix bundling two verified bug fixes. Reviewed via /code-review (high effort) — one finding surfaced and addressed (recall ValueError→422); all other angles clean.

## 1. `POST /memory/recall` always 500'd — Closes #1036
The route hardcoded `current_context_id=None` (a #246 leftover) while `MemoryService.recall()` still requires a context, so the guard tripped on **every** request → 500. This broke the first-run onboarding's recall 'value moment' and any in-app REST recall.
- Forward `request.filters['context_id']` as `current_context_id` (mirrors how /remember resolves `request.context['context_id']`).
- Map `ValueError` → **422** (mirroring /remember & /pinned) so a missing/non-UUID context is a clean client error, not an unhandled 500.
- Verified end-to-end: onboarding recall now returns a 100%-match hit.

## 2. Auth error banner unreadable in dark global theme
Login/device error text rendered faint red-300 with a misaligned icon when the OS/app theme is dark, because the auth card is always-light (#1029) but the shadcn Alert flipped to its `dark:` ramp on the GLOBAL theme.
- Render these errors via `ErrorBanner` (flex items-center → centered) with a new backward-compatible `lightSurface` prop that pins the light red ramp. Default unchanged for all other consumers.
- Verified in dark theme: text now red-800 (rgb(153,27,27)), icon static & centered.

## Tests
- backend: `tests/api/test_memory_recall_route.py` (3 passed) — forwards context_id, None when no filters, ValueError→422. `test_recall_no_workspace` contract preserved. ruff clean.
- frontend: 53 login/device/common vitest pass.

## Notes
- Version bump to v0.32.1 + tag handled as a separate release step (mirroring the `chore(release): v0.32.0` pattern).
- Dead-code cleanup (KaguraLogoBgWhite) intentionally NOT in this hotfix — it's a refactor, will go as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)