### PR TITLE
feat(api): cap paid-tier platform embedding spend (#1033)

### DIFF
--- a/backend/src/services/embedding_service.py
+++ b/backend/src/services/embedding_service.py
@@ -234,42 +234,67 @@ class EmbeddingService:
         self,
         workspace_id: str | None,
         context_id: str | None = None,
+        disallow_env_fallback: bool = False,
     ) -> tuple[EmbeddingSpendCapService | None, Workspace | None]:
-        """Resolve the cap service + workspace and run the pre-call gate (#709).
+        """Resolve the cap service + workspace and run the pre-call gate (#709, #1033).
 
-        Returns ``(None, None)`` for skip cases:
+        Returns ``(cap_svc, cap_workspace)`` when the call should be capped, or
+        ``(None, None)`` to skip. Skip cases:
 
         - **Ollama** — no real provider cost; cap is irrelevant.
         - **Missing ``workspace_id``** — no caller scope to resolve a cap against.
-        - **No BYOK credential** — the cap is **BYOK-scoped by design** (#708
-          drain-attack mitigation). A call falling back to ``OPENAI_API_KEY`` env
-          is platform-paid; capping it would rate-limit dev/demo workspaces that
-          were never the threat model. Matches the contract asserted by
-          ``EmbeddingSpendCapExceeded`` (``utils/exceptions.py``) and the cap
-          service module docstring (``embedding_spend_cap_service.py``).
         - **Workspace row missing** — disappeared between request entry and embed.
+        - **No BYOK on the Free tier** — a no-BYOK call falls back to the
+          platform ``OPENAI_API_KEY`` env. Free / dev stays **uncapped** (#708
+          drain-attack carve-out: capping env-fallback would rate-limit the
+          dev/demo workspaces that were never the threat model).
+        - **No BYOK while ``disallow_env_fallback`` is set** — the Option A
+          shared-context read path forbids the env fallback, so this call will
+          raise ``NotFoundException`` in ``_get_client`` rather than embed on the
+          platform key. There is no platform spend to bound here, so skip (and
+          let the real not-found error surface instead of a spurious 429).
 
-        Otherwise loads the workspace ONCE and runs ``check_cap_or_raise`` so
-        the post-call ``record_spend_from_tokens`` can reuse the row without a
-        second SELECT. Raises ``EmbeddingSpendCapExceeded`` (HTTP 429,
-        ``QUOTA-002``) when the BYOK daily / monthly cap has been reached.
+        Otherwise the cap fires against the **single per-workspace per-tier
+        counter**. Issue #1033 extends *coverage* of that one counter; it does
+        NOT split it by payer:
 
-        Issue #708 loop 4: ``context_id`` mirrors ``has_byok_key``'s priority
-        so the cap gate fires only when ``_get_user_api_key`` would actually
-        select a BYOK row for THIS context — not for a key scoped to some
-        OTHER context in the same workspace. Without this parameter, a
-        workspace whose only BYOK is scoped to context_X would have the
-        cap incorrectly applied to env-fallback calls on context_Y.
+        - **BYOK present** → capped exactly as before (#709), on any tier.
+        - **No BYOK on a PAID tier (basic/pro)** → the embed runs on the
+          platform's dime, so it is now capped too — bounding total workspace
+          embedding volume against the same per-tier counter. Payer
+          **attribution** is recorded separately in ``LLMCallLog.paid_by`` (see
+          ``resolve_paid_by`` / ``cost_aggregation_service``), so the cap stays a
+          pure volume guard rather than a per-payer budget. Prerequisite guard
+          for #1030; inert until paid-tier traffic routes to the platform key,
+          but lands first so the ceiling is in place.
+
+        The workspace is loaded ONCE and reused for both ``check_cap_or_raise``
+        and the post-call ``record_spend_from_tokens`` (no second SELECT). The
+        load now also runs on the no-BYOK paid path (to read ``plan_name``);
+        since the gate only runs on a cache MISS this is at most one extra
+        indexed PK SELECT per unique text, not per call.
+
+        Issue #708 loop 4: ``context_id`` mirrors ``has_byok_key``'s priority so
+        the BYOK branch fires only when ``_get_user_api_key`` would actually
+        select a BYOK row for THIS context — not for a key scoped to some OTHER
+        context in the same workspace.
         """
         if not workspace_id or self.provider == "ollama":
             return None, None
-        if not await self.has_byok_key(workspace_id, context_id=context_id):
-            return None, None
         from services.embedding_spend_cap_service import EmbeddingSpendCapService
+
+        has_byok = await self.has_byok_key(workspace_id, context_id=context_id)
+        # No BYOK + env fallback forbidden → the call errors in ``_get_client``
+        # rather than embedding on the platform key; there is nothing to cap.
+        if not has_byok and disallow_env_fallback:
+            return None, None
 
         cap_svc = EmbeddingSpendCapService(self.db)
         cap_workspace = await cap_svc.load_workspace(workspace_id)
         if cap_workspace is None:
+            return None, None
+        # No BYOK on the Free tier → platform env-fallback stays uncapped (#708).
+        if not has_byok and cap_workspace.plan_name == "free":
             return None, None
         await cap_svc.check_cap_or_raise(cap_workspace)
         return cap_svc, cap_workspace
@@ -551,11 +576,14 @@ class EmbeddingService:
                 )
                 return vector, 0
 
-            # Issue #709: BYOK embedding spend cap gate.
-            # #708 loop 4: thread ``context_id`` so the gate's BYOK probe
-            # mirrors the same priority ``_get_user_api_key`` uses below.
+            # Issue #709/#1033: embedding spend cap gate (BYOK + paid-tier platform).
+            # #708 loop 4: thread ``context_id`` so the gate's BYOK probe mirrors
+            # ``_get_user_api_key``; ``disallow_env_fallback`` so a no-BYOK Option A
+            # read (which won't reach the platform key) isn't treated as platform-paid.
             cap_svc, cap_workspace = await self._prepare_spend_cap_gate(
-                workspace_id, context_id=context_id
+                workspace_id,
+                context_id=context_id,
+                disallow_env_fallback=disallow_env_fallback,
             )
 
             client = await self._get_client(
@@ -681,12 +709,15 @@ class EmbeddingService:
 
             # Generate embeddings only for uncached texts
             if uncached_texts:
-                # Issue #709: cap gate covers the whole batch — single check
-                # before the bulk API call.
+                # Issue #709/#1033: cap gate covers the whole batch — single
+                # check before the bulk API call (BYOK + paid-tier platform).
                 # #708 loop 4: thread ``context_id`` so the gate's BYOK probe
-                # mirrors the same priority ``_get_user_api_key`` uses below.
+                # mirrors ``_get_user_api_key``; ``disallow_env_fallback`` so a
+                # no-BYOK Option A read isn't treated as platform-paid.
                 cap_svc, cap_workspace = await self._prepare_spend_cap_gate(
-                    workspace_id, context_id=context_id
+                    workspace_id,
+                    context_id=context_id,
+                    disallow_env_fallback=disallow_env_fallback,
                 )
 
                 client = await self._get_client(

--- a/backend/tests/services/test_embedding_service.py
+++ b/backend/tests/services/test_embedding_service.py
@@ -1,6 +1,8 @@
 """Tests for EmbeddingService."""
 
+from decimal import Decimal
 from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
 
 import pytest
 
@@ -349,6 +351,121 @@ class TestContextAwareBYOKThreading:
         service.has_byok_key.assert_called_once_with(
             "00000000-0000-0000-0000-000000000001", context_id=None
         )
+
+
+class TestPlatformPaidCapGate:
+    """#1033: the embedding spend cap also covers PLATFORM-paid calls on paid
+    tiers (basic/pro). Free-tier / dev env-fallback stays uncapped (#708 intent),
+    and the BYOK path is unchanged. The gate returns ``(cap_svc, cap_workspace)``
+    and caps against the SINGLE per-tier counter — coverage is widened, the
+    counter is NOT split by payer (payer attribution lives in LLMCallLog.paid_by).
+    """
+
+    @pytest.fixture
+    def service(self):
+        return EmbeddingService(_make_mock_db())
+
+    @staticmethod
+    def _cap_ws(plan_name):
+        ws = MagicMock()
+        ws.id = uuid4()
+        ws.plan_name = plan_name
+        ws.effective_embedding_daily_cap_usd = Decimal("2.0")
+        ws.effective_embedding_monthly_cap_usd = Decimal("60.0")
+        return ws
+
+    @staticmethod
+    def _patch_cap_service(ws):
+        """Patch the lazily-imported EmbeddingSpendCapService; return (patcher, instance)."""
+        patcher = patch("services.embedding_spend_cap_service.EmbeddingSpendCapService")
+        mock_cls = patcher.start()
+        inst = mock_cls.return_value
+        inst.load_workspace = AsyncMock(return_value=ws)
+        inst.check_cap_or_raise = AsyncMock()
+        return patcher, inst
+
+    @pytest.mark.asyncio
+    async def test_paid_tier_platform_paid_is_capped(self, service):
+        """basic/pro + no BYOK (env/platform fallback) → cap fires (single counter)."""
+        service.has_byok_key = AsyncMock(return_value=False)
+        ws = self._cap_ws("basic")
+        patcher, inst = self._patch_cap_service(ws)
+        try:
+            cap_svc, cap_ws = await service._prepare_spend_cap_gate(
+                "00000000-0000-0000-0000-000000000001",
+                context_id="00000000-0000-0000-0000-000000000002",
+            )
+        finally:
+            patcher.stop()
+        assert cap_svc is inst and cap_ws is ws
+        inst.check_cap_or_raise.assert_awaited_once_with(ws)
+
+    @pytest.mark.asyncio
+    async def test_free_tier_platform_paid_stays_uncapped(self, service):
+        """free + no BYOK (env fallback) → NOT capped (#708 dev/demo carve-out)."""
+        service.has_byok_key = AsyncMock(return_value=False)
+        ws = self._cap_ws("free")
+        patcher, inst = self._patch_cap_service(ws)
+        try:
+            result = await service._prepare_spend_cap_gate("00000000-0000-0000-0000-000000000001")
+        finally:
+            patcher.stop()
+        assert result == (None, None)
+        inst.check_cap_or_raise.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_byok_path_capped_and_unchanged_on_any_tier(self, service):
+        """BYOK present → capped regardless of tier (incl. free, unchanged from #709)."""
+        service.has_byok_key = AsyncMock(return_value=True)
+        ws = self._cap_ws("free")  # a free workspace's OWN BYOK is still capped today
+        patcher, inst = self._patch_cap_service(ws)
+        try:
+            cap_svc, cap_ws = await service._prepare_spend_cap_gate(
+                "00000000-0000-0000-0000-000000000001"
+            )
+        finally:
+            patcher.stop()
+        assert cap_svc is inst and cap_ws is ws
+        inst.check_cap_or_raise.assert_awaited_once_with(ws)
+
+    @pytest.mark.asyncio
+    async def test_paid_tier_no_byok_with_disallow_env_fallback_skips(self, service):
+        """#1033/#8: no BYOK + disallow_env_fallback (Option A shared read) → skip.
+
+        The call will raise NotFoundException in _get_client rather than embed on
+        the platform key, so there's no platform spend to cap. The gate must NOT
+        load the workspace or fire the cap (which would surface a spurious 429).
+        """
+        service.has_byok_key = AsyncMock(return_value=False)
+        ws = self._cap_ws("pro")
+        patcher, inst = self._patch_cap_service(ws)
+        try:
+            result = await service._prepare_spend_cap_gate(
+                "00000000-0000-0000-0000-000000000001",
+                context_id="00000000-0000-0000-0000-000000000002",
+                disallow_env_fallback=True,
+            )
+        finally:
+            patcher.stop()
+        assert result == (None, None)
+        inst.load_workspace.assert_not_called()
+        inst.check_cap_or_raise.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ollama_provider_skips_before_byok_probe(self, service):
+        """provider='ollama' → skip immediately (no provider cost), before the BYOK probe."""
+        service.provider = "ollama"
+        service.has_byok_key = AsyncMock(return_value=True)
+        result = await service._prepare_spend_cap_gate("00000000-0000-0000-0000-000000000001")
+        assert result == (None, None)
+        service.has_byok_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_id_skips(self, service):
+        """No workspace_id → skip (returns the 2-tuple of Nones)."""
+        service.has_byok_key = AsyncMock(return_value=False)
+        result = await service._prepare_spend_cap_gate(None)
+        assert result == (None, None)
 
 
 class TestKeySourceAndPaidByDedup:


### PR DESCRIPTION
Closes #1033

## Summary
- Extend the embedding spend cap (#709) to cover **platform-paid** calls on **paid tiers** (basic/pro) — the cost-safety prerequisite for #1030 (platform-managed embeddings). Previously `_prepare_spend_cap_gate` early-returned on `not has_byok_key`, leaving env/platform calls uncapped.
- **Gate-only** change: the gate now caps BYOK (any tier, unchanged from #709) **and** no-BYOK on a paid tier, against the **single existing per-tier counter**. Free/dev env-fallback stays **uncapped** (#708 drain-attack carve-out); it also skips when `disallow_env_fallback` is set (Option A shared reads error in `_get_client` rather than embedding on the platform key).
- The cap is a **volume guard** over one per-tier counter — **not** split per payer. Payer attribution stays in `LLMCallLog.paid_by` / `cost_aggregation_service`. `EmbeddingSpendCapService` is unchanged.

## Implementation notes
- A split-counter (`:platform:` namespace) prototype was **reverted** after an xhigh `/code-review`: separate counters under-reported platform spend in the admin view (`get_current_spend`), granted a workspace **2× its tier budget**, and added TOCTOU/dead-code surface. Single counter is simpler and more correct.
- Tests: `TestPlatformPaidCapGate` (6 cases — paid+platform capped / free+platform uncapped / byok unchanged / `disallow_env_fallback` skip / ollama skip / missing-workspace skip). **53 pass · ruff clean · pyright 0**.

## Pre-PR review summary
- gate2 mode: advisor-only — **cso: green · qa-lead: green · cto: green**
- gate1: yellow via /ask (the "cap accounting ambiguous" concern was later **refuted** in review — the design is settled)
- `/code-review` (xhigh): all findings addressed (split-counter reverted; `disallow_env_fallback` + ollama-test gaps fixed)

🤖 Generated via /gh-issue-driven:ship
