### PR TITLE
fix/docs(mcp): #1054 consistency (enum/uuid) + reference() returns full memory

### DIFF
--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -372,7 +372,7 @@ Returns all 3 layers: summary, context_summary, and complete details/content.
 
 IMPORTANT: Always specify context_id to ensure you're retrieving from the intended context. Use list_contexts() to discover available context IDs.
 
-Returns: {status, memory: {memory_id, summary, context_summary, content, details, type, importance, tags, context, created_at, client}} — all three layers including the full content/details.""",
+Returns: {status, memory: {memory_id, summary, context_summary, content, details, type, scope, importance, tags, context, created_at, updated_at, client, source_uri, source_type, outgoing_links: [{memory_id, summary, type, importance, weight, created_at}], outgoing_has_more, incoming_links: [...], incoming_has_more}} — all three layers plus declared-link references and provenance. updated_at is a staleness cue (null/old means the fact may be out of date).""",
             "inputSchema": {
                 "type": "object",
                 "required": ["memory_id", "context_id"],

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1166,6 +1166,7 @@ Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fe
                     },
                     "reranker_provider": {
                         "type": "string",
+                        "enum": ["voyage", "cohere", "ollama"],
                         "description": "Reranker provider: 'voyage', 'cohere', or 'ollama' (local, no API key needed).",
                     },
                     "reranker_model": {
@@ -1637,6 +1638,7 @@ Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, 
                 "properties": {
                     "context_id": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Target context UUID (must belong to your workspace).",
                     },
                     "from": {
@@ -1697,6 +1699,7 @@ Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, 
                 "properties": {
                     "run_id": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Analysis run UUID (from analyze_context).",
                     },
                 },
@@ -1721,6 +1724,7 @@ Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, 
                 "properties": {
                     "context_id": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Target context UUID.",
                     },
                     "limit": {
@@ -1752,6 +1756,7 @@ Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, 
                 "properties": {
                     "context_id": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Target context UUID.",
                     },
                 },
@@ -1780,6 +1785,7 @@ Returns: {status, report_id, rollback_summary: {edges_deleted, merges_reversed, 
                 "properties": {
                     "run_id": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Analysis run UUID.",
                     },
                     "cluster_index": {
@@ -1963,6 +1969,7 @@ Returns: {status, feedback_id, memory_id, helpful}.""",
                 "properties": {
                     "context_id": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Target context UUID (the recalled memory's context).",
                     },
                     "memory_id": {
@@ -2003,6 +2010,7 @@ Returns: {status, key}.""",
                 "properties": {
                     "context_id": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Target context UUID (state is scoped to this context).",
                     },
                     "key": {
@@ -2035,6 +2043,7 @@ Returns: {status, key, value, found}. found is false (value null) when the key i
                 "properties": {
                     "context_id": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Target context UUID.",
                     },
                     "key": {

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -372,7 +372,7 @@ Returns all 3 layers: summary, context_summary, and complete details/content.
 
 IMPORTANT: Always specify context_id to ensure you're retrieving from the intended context. Use list_contexts() to discover available context IDs.
 
-Returns: {status, memory: {memory_id, summary, context_summary, content, details, type, scope, importance, tags, context, created_at, updated_at, client, source_uri, source_type, outgoing_links: [{memory_id, summary, type, importance, weight, created_at}], outgoing_has_more, incoming_links: [...], incoming_has_more}} — all three layers plus declared-link references and provenance. updated_at is a staleness cue (null/old means the fact may be out of date).""",
+Returns: {status, memory: {memory_id, summary, context_summary, content, details, type, scope, importance, tags, context, created_at, updated_at, client, source_uri, source_type, outgoing_links: [{memory_id, summary, type, importance, weight, created_at}], outgoing_has_more, incoming_links: [...], incoming_has_more}} — all three layers plus declared-link references and provenance. updated_at is a staleness cue (an old value means the fact may be out of date).""",
             "inputSchema": {
                 "type": "object",
                 "required": ["memory_id", "context_id"],

--- a/backend/src/mcp_server/tools/memory.py
+++ b/backend/src/mcp_server/tools/memory.py
@@ -723,6 +723,10 @@ async def handle_reference(
                     help="Use recall() to find memories you have access to.",
                 )
 
+            # Surface the FULL ReferenceResponse the service already builds: the
+            # handler previously dropped scope/updated_at (#434), source provenance
+            # (#215), and the declared-link references (#440), so an agent could not
+            # see a memory's links or staleness via reference() (#1054).
             reference_data = {
                 "memory_id": str(result.memory_id),
                 "summary": result.summary,
@@ -730,11 +734,19 @@ async def handle_reference(
                 "content": result.content,
                 "details": result.details,
                 "type": result.type,
+                "scope": result.scope,
                 "importance": result.importance,
                 "tags": result.tags,
                 "context": result.context,
-                "created_at": result.created_at.isoformat(),
+                "created_at": to_utc_iso(result.created_at),
+                "updated_at": to_utc_iso(result.updated_at),
                 "client": result.client,
+                "source_uri": result.source_uri,
+                "source_type": result.source_type,
+                "outgoing_links": [ref.model_dump(mode="json") for ref in result.outgoing_links],
+                "outgoing_has_more": result.outgoing_has_more,
+                "incoming_links": [ref.model_dump(mode="json") for ref in result.incoming_links],
+                "incoming_has_more": result.incoming_has_more,
             }
 
             await _log_tool_usage(

--- a/backend/tests/mcp_server/test_memory_reference_tool.py
+++ b/backend/tests/mcp_server/test_memory_reference_tool.py
@@ -1,0 +1,99 @@
+"""Unit test: reference() surfaces the FULL ReferenceResponse (#1054).
+
+Guards that handle_reference no longer drops scope/updated_at (#434), source
+provenance (#215), or the declared-link references (#440) — the gap a first-time
+agent hit when trying to see a memory's links/staleness via reference(). The
+service already returns these; only the MCP handler's hand-built dict omitted
+them. DB-backed service behaviour is covered elsewhere; here the service is mocked.
+"""
+
+from __future__ import annotations
+
+import json
+from contextlib import ExitStack
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from mcp_server.tools.memory import handle_reference
+from models.schemas import LinkedMemoryRef, ReferenceResponse
+
+
+def _payload(result):
+    assert len(result) == 1
+    return json.loads(result[0].text)
+
+
+def _ref_response(mem_id, link_id):
+    return ReferenceResponse(
+        memory_id=mem_id,
+        summary="seed summary",
+        context_summary="ctx",
+        content="full layer-3 content",
+        details={"k": "v"},
+        type="note",
+        scope="working",
+        importance=0.8,
+        tags=["a"],
+        context={"file_path": "x.py"},
+        created_at=datetime(2026, 6, 1, 12, 0, 0),
+        updated_at=datetime(2026, 6, 2, 9, 30, 0),
+        client="api",
+        source_uri="vault://v/note.md",
+        source_type="vault",
+        outgoing_links=[
+            LinkedMemoryRef(
+                memory_id=link_id,
+                summary="linked",
+                type="code",
+                importance=0.5,
+                weight=1.0,
+                created_at=datetime(2026, 5, 1, 0, 0, 0),
+            )
+        ],
+        outgoing_has_more=True,
+        incoming_links=[],
+        incoming_has_more=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_reference_surfaces_links_scope_provenance():
+    mem_id, link_id = uuid4(), uuid4()
+    svc = MagicMock(reference=AsyncMock(return_value=_ref_response(mem_id, link_id)))
+
+    async def gen():
+        yield AsyncMock()
+
+    with ExitStack() as stack:
+        stack.enter_context(patch("db.base.get_db", new=gen))
+        stack.enter_context(
+            patch("mcp_server.tools.memory._resolve_context_for_read", new=AsyncMock())
+        )
+        stack.enter_context(
+            patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock())
+        )
+        stack.enter_context(patch("services.memory_service.MemoryService", return_value=svc))
+        result = await handle_reference(
+            args={"memory_id": str(mem_id), "context_id": str(uuid4())},
+            user_id="u",
+            workspace_id=uuid4(),
+        )
+
+    m = _payload(result)["memory"]
+    # Layer-3 basics still present
+    assert m["memory_id"] == str(mem_id)
+    assert m["content"] == "full layer-3 content"
+    # #434: scope + updated_at (staleness cue) — previously dropped
+    assert m["scope"] == "working"
+    assert m["updated_at"].startswith("2026-06-02")
+    # #215: provenance — previously dropped
+    assert m["source_uri"] == "vault://v/note.md"
+    assert m["source_type"] == "vault"
+    # #440: declared-link references — previously dropped
+    assert m["outgoing_links"][0]["memory_id"] == str(link_id)
+    assert m["outgoing_has_more"] is True
+    assert m["incoming_links"] == []
+    assert m["incoming_has_more"] is False


### PR DESCRIPTION
The remaining substantive #1054 work (after the return-shape PRs #1055/#1056). Two commits.

## 1. Consistency (schema-only, no behavior change)
- `update_search_config.reranker_provider`: free-form string → `enum ["voyage","cohere","ollama"]` (matches the other enum'd params).
- Added `"format":"uuid"` to the 8 `context_id`/`run_id` args that lacked it (`analyze_context`, `get_analysis`, `list_analyses`, `get_active_analysis`, `get_cluster`, `feedback`, `set_state`, `get_state`) — the ~40 others already had it, so the "this is a UUID, don't fabricate" signal is now uniform across the surface.

## 2. fix: reference() returns the full memory (behavior)
The `reference()` MCP handler hand-built its response dict and **dropped fields the service already returns** in `ReferenceResponse`:
- `scope` + `updated_at` (#434) — staleness cue,
- `source_uri` + `source_type` (#215) — provenance,
- `outgoing_links` / `incoming_links` + `*_has_more` (#440) — declared-link references.

So an agent could not see a memory's links or self-assess staleness via `reference()` — found by the first-time-agent audit (#1054). Now surfaces all of them (links serialized via `model_dump(mode="json")`), and switches `created_at`/`updated_at` to `to_utc_iso()` for the Z-suffix convention the handler already uses elsewhere. Output is **additive**; the service layer is unchanged. The `reference` `Returns:` doc is updated to match. Adds a unit test asserting links/scope/provenance now appear.

## Verification
`ruff` clean; `pyright` 0 errors; new `test_memory_reference_tool.py` + `test_tool_schema_policy.py` pass (5). All UUID/enum gaps confirmed closed; no duplicate docs.

## #1054 status after this
This completes the audit's blockers (response shapes ×45, multi-mode, cross-tool UUID confusion, multi-step next-steps, enum/uuid consistency) and the `reference` subset bug. The only items left are **optional polish**: pagination `k`→`limit` rename (a breaking API change — deliberately not done) and exhaustively sprinkling `(default: X)` on every param. Recommend closing #1054 after merge unless you want those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)