### PR TITLE
docs(api): #622 AC4 dx-lead review + enumeration drift refresh

### DIFF
--- a/backend/tests/mcp_server/test_memory_reference_tool.py
+++ b/backend/tests/mcp_server/test_memory_reference_tool.py
@@ -72,9 +72,7 @@ async def test_reference_surfaces_links_scope_provenance():
         stack.enter_context(
             patch("mcp_server.tools.memory._resolve_context_for_read", new=AsyncMock())
         )
-        stack.enter_context(
-            patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock())
-        )
+        stack.enter_context(patch("mcp_server.tools.memory._log_tool_usage", new=AsyncMock()))
         stack.enter_context(patch("services.memory_service.MemoryService", return_value=svc))
         result = await handle_reference(
             args={"memory_id": str(mem_id), "context_id": str(uuid4())},

--- a/docs/api-surface-1.0/dx-lead-review.md
+++ b/docs/api-surface-1.0/dx-lead-review.md
@@ -1,0 +1,94 @@
+# DX Lead review — MCP tool surface (issue #622 AC4)
+
+> Reviewed at `main` HEAD on 2026-06-20, after the #1054 first-time-agent
+> usability work landed (all 45 MCP tools document return shapes; `reference()`
+> returns the full memory; `reranker_provider` enum; `format:uuid` uniform).
+>
+> Scope: the **SDK-consumer / external-integrator** perspective — what becomes
+> SEMVER-LOCKED at v1.0.0 (tool names, parameter names, required-vs-optional,
+> enum values, same-name-different-role hazards). Agent-usability was covered in
+> #1054 and is **not** re-litigated here.
+
+The #1054 audit already addressed: response-shape documentation for all 45
+tools, the `reference()` subset bug, `reranker_provider` enum, `format:uuid`
+uniformity, and the multi-mode prose notes (`update_memory`, `forget`). This
+review covers what remains for the **freeze**.
+
+## Remaining lock-in risks, ranked
+
+### 🔴 1. MCP tool OUTPUT shapes are not enumerated or frozen — biggest gap
+The freeze covers input schemas (`mcp-input-schemas.md`) + REST response models
+(`rest-response-models.md`), but the **45 MCP tool return shapes are equally
+semver-locked at 1.0 and are not enumerated/frozen anywhere.** Evidence that
+this is not theoretical: in the same session that wrote this review, `reference()`
+was found to silently drop fields and `RecallConfidence` gained `prominence` —
+exactly the drift the freeze exists to catch, on the un-enumerated output side.
+
+- **Before freeze**: add `docs/api-surface-1.0/mcp-output-shapes.md` (the #1054
+  work already produced every shape from each handler's success path — low cost
+  to formalize).
+- **Cost of NOT doing it**: output drift is invisible; a post-1.0 output change
+  an SDK depends on is a silent breaking change with no guard.
+
+### 🟠 2. Edge tools' `source_id`/`target_id` are MEMORY UUIDs, not named so
+`create_edge` / `update_edge` / `delete_edge` take `source_id` / `target_id` =
+**memory** UUIDs, while `merge_contexts` takes `source_context_id` /
+`target_context_id` = **context** UUIDs. An SDK author reading `source_id`
+reasonably assumes a generic id; the memory-vs-context distinction is
+description-only.
+
+- **Decide before freeze**: rename to `source_memory_id` / `target_memory_id`
+  (clear, symmetric with `*_context_id`) OR accept and rely on docs.
+- **Cost post-1.0**: rename = MAJOR bump across 3 tools + the SDK. **Pre-1.0
+  rename is free — decide now.**
+
+### 🟠 3. `details` is polymorphic across the surface
+`remember` input `details` = object (Layer-3 JSONB); `recall_upcoming` output
+`details` = string. Same field name, different type → SDK type generation
+collides; consumers are surprised.
+
+- **Decide before freeze**: rename the output (e.g. `detail_text`) or document
+  the divergence as intentional. **Cost post-1.0**: type change/rename = MAJOR.
+
+### 🟡 4. Convert remaining `⚠` items in `mcp-input-schemas.md` to explicit decisions
+`type` free-string with the magic `'time'` value (enum-vs-open-vocabulary);
+`describe_binding.context_id` as a binding *selector* (same name, different role);
+the `oneOf`-not-expressible contracts (`update_memory` memory_id/external_id,
+`forget` memory_id/query, `describe_binding` key_id/context_id). These carry `⚠`
+today. **Do not leave any `⚠` unresolved at rc1** — for each, either freeze with a
+rationale (`✅ DECIDED`) or fix.
+
+### 🟡 5. The enumeration docs themselves have drifted (and were incomplete)
+`rest-response-models.md` **omits every `schemas.py`-defined response model the
+routes return** — `RememberResponse`, `RecallResponse`, `RecallConfidence`
+(incl. the new `prominence` field), `ReferenceResponse`. The enumeration captured
+only models defined *inside* the route files, missing the imported `schemas.py`
+ones — i.e. the **core memory API responses are unenumerated.** A freeze run now
+would lock an incomplete/stale snapshot.
+
+- **Before freeze**: re-enumerate including `models/schemas.py` response models.
+- The cheap input-schema drift (`recall` now requires `context_id`;
+  `reranker_provider` now an enum) is fixed inline in this PR; the response-model
+  re-enumeration is deferred to the rc1 freeze (see #6).
+
+### 🔵 6. (Altitude) The "freeze" has no teeth — it should be an executable guard
+The current freeze is **docs-only**; nothing fails CI when the surface drifts,
+which is precisely why #1/#5 slipped in. The real freeze deliverable should be a
+**snapshot test**: serialize the OpenAPI spec + the MCP input/output schemas to
+committed fixtures and fail CI on any diff (review-gated updates). This both
+*performs* the freeze and *keeps it honest*. Recommend upgrading AC2 from "freeze
+docs against the rc1 tag" to "add the snapshot guard + freeze its fixtures at rc1".
+
+## rc1 freeze checklist (carried on #622, due before v1.0.0-rc1)
+
+- [ ] Add `mcp-output-shapes.md` (output enumeration) — finding #1
+- [ ] Decide & apply: `source_id`/`target_id` → `source_memory_id`/`target_memory_id`? — finding #2
+- [ ] Decide & apply: `recall_upcoming.details` polymorphism — finding #3
+- [ ] Convert all remaining `⚠` to `✅ DECIDED` or fix — finding #4
+- [ ] Re-enumerate `rest-response-models.md` incl. `schemas.py` response models — finding #5
+- [ ] Add the OpenAPI + MCP-schema snapshot test; freeze fixtures against the rc1 tag — finding #6
+- [ ] Link each enumeration file to the v1.0.0-rc1 commit (original AC2)
+
+Findings #2 and #3 are the only ones that want a **pre-rc1 code decision** (renames
+are free now, MAJOR later); the rest are enumeration/tooling that belong in the
+rc1 freeze pass.

--- a/docs/api-surface-1.0/mcp-input-schemas.md
+++ b/docs/api-surface-1.0/mcp-input-schemas.md
@@ -69,13 +69,12 @@ Update a memory in-place (by memory_id) or upsert by external_id.
 
 Hybrid search (semantic + BM25 + Neural Memory boosting) over memories; returns Layers 1–2.
 
-- **Required**: `query` — string
+- **Required**: `query` — string; `context_id` — string, format `uuid` ✅ **DECIDED (#1054): `context_id` is now required** (recall is context-scoped — the handler always required it; the schema's `required` array now matches, was previously listed under Optional here)
 - **Optional**:
   - `k` — integer (default 5, max 100 per description) ✅ **DECIDED (#990): the `k`/`limit`/`cap` trio is consciously frozen as three distinct conventions, not unified.** `k` = the top-k count for a *relevance-ranked* result set (recall/get_sleep_history — established ML term); `limit` = pagination size for a *flat list* (the list_* family); `cap` = the ceiling for *pinned-memory load* (load_pinned). Unifying to one name spans ~8 tools (breaking) and would erase the relevance-vs-pagination signal `k` carries — net DX loss. Frozen as-is.
   - `use_rerank` — boolean (default false)
   - `filters` — object (free-form: type, tags, tags_match, importance gte, created/updated bounds, source_uri_prefix, source_type, trust_tier) ⚠ filter vocabulary lives only in prose; analyze_context exposes the equivalent filters (`types`, `tags`, `min_importance`, `from`/`to`) as top-level params instead — two filter styles on one surface
-  - `context_id` — string, format `uuid`
-  - `context_ids` — array of string (format `uuid`), minItems 2, maxItems 20 (overrides context_id) ⚠ singular `context_id` + plural `context_ids` with override semantics on the same tool — workable but should be a deliberate frozen pattern
+  - `context_ids` — array of string (format `uuid`), minItems 2, maxItems 20 (cross-context recall; supplements the now-required `context_id`) ⚠ singular required `context_id` + plural optional `context_ids` on the same tool — workable but should be a deliberate frozen pattern
   - `search_mode` — string, enum [`hybrid`, `semantic`, `keyword`] (default hybrid) ⚠ mild lock-in: description bakes in the 60/40 weighting and BM25/Neural-Memory implementation details; enum values themselves look stable
   - `include_explore_hints` — boolean (default false)
 - ⚠ `context_id` is optional here but required (and "IMPORTANT: always specify") on most sibling tools — for a frozen surface, recall/remember-family should agree on whether context_id is required
@@ -253,7 +252,7 @@ Tune per-context hybrid-search weights and reranker settings.
   - `bm25_weight` — number (0.0–1.0, default 0.4; weights must sum to 1.0 — prose-only constraint) ⚠ `bm25_weight` exposes the algorithm name (BM25) in a frozen param name; `keyword_weight` would survive an algorithm swap
   - `fetch_factor` — integer (1–10, default 3) ⚠ leaks retrieval-pipeline implementation into the public surface
   - `use_rerank` — boolean
-  - `reranker_provider` — string ('voyage' | 'cohere' | 'ollama' per description) ⚠ enum lock-in risk in substance though not in schema: provider names are third-party vendors and will churn; note the inconsistency that connector_type IS a hard enum while reranker_provider is a free string — pick one policy
+  - `reranker_provider` — string, enum [`voyage`, `cohere`, `ollama`] ✅ **DECIDED (#1054): now a hard enum** (was a free string; matches the DB CHECK constraint and aligns with connector_type's enum policy). Widening the enum later (adding a provider) is non-breaking; removing a value is a MAJOR bump.
   - `reranker_model` — string (provider-specific model names in description)
 
 ### get_usage
@@ -485,7 +484,7 @@ Recurring inconsistencies (each instance flagged inline above):
 10. **Filter style**: recall packs filters into one free-form `filters` object (singular `type`, `importance: {gte}`); analyze_context spreads them top-level (`types` plural, `min_importance`).
 11. **`workspace_id` override** exists only on the 5 file tools; the rest of the surface scopes by auth + context_id. Inconsistent and security-sensitive.
 12. **Constraints live in prose, not schema**: char limits (summary 10–500, context_summary 2000), `maxItems` (events ≤ 100), patterns (context name, sha256 hex), numeric ranges and most defaults are description-only. (`additionalProperties` ✅ now set to `false` on all 45 schemas in #990 Phase 1 — the rest of the prose-only constraints remain a P2 hardening item.) Tool-side validation still cannot fully rely on the published schema.
-13. **Enum policy is inconsistent**: connector_type is a hard vendor enum while reranker_provider (same vendor-list shape) is a free string; edge_type is a hard enum that already grew once (#782).
+13. **Enum policy** ✅ **RESOLVED (#1054)**: reranker_provider is now a hard enum [`voyage`,`cohere`,`ollama`], matching connector_type — the free-string inconsistency is gone. edge_type remains a hard enum that already grew once (#782); enum *widening* is non-breaking, so growth is fine.
 
 ## Follow-up candidates
 

--- a/docs/api-surface-1.0/rest-response-models.md
+++ b/docs/api-surface-1.0/rest-response-models.md
@@ -12,6 +12,7 @@ Notes:
 - Two route-file classes subclass an in-scope model rather than `BaseModel` directly and are therefore outside the 208-class grep, but are part of the response surface and noted inline for completeness: `Bm25DriftDetail(Bm25DriftSummary)` (bm25_drift.py L64, adds `context_deleted`, `top_divergent_terms`) and `SleepReportDetail(SleepReportSummary)` (sleep_reports.py L66, adds `context_deleted`, `embedding_calls_made`, `error_message`, and five `*_result: dict` fields).
 - Field convention: `field_name: type — required|optional (default ...)`. Required = no default in the model definition (Pydantic v2 semantics: `X | None` without a default is still required).
 - Request models are included for completeness and marked `(request model)`; the freeze priority per #622 is the response surface.
+- **⚠ Known gap (to close at rc1 — see `dx-lead-review.md` finding #5):** this enumeration covers only models *defined in* `backend/src/api/routes/`. Response models *defined in* `models/schemas.py` but *returned by* routes via `response_model=` are part of the frozen surface yet **not enumerated here** — notably the core memory API: `RememberResponse`, `RecallResponse`, `RecallConfidence` (incl. the `prominence` field added in #1052), and `ReferenceResponse`. The rc1 re-enumeration must include `models/schemas.py` response models (ideally via the snapshot guard in `dx-lead-review.md` finding #6).
 
 ## admin.py
 


### PR DESCRIPTION
Advances #622 (pre-1.0 API surface enumeration & freeze) on the **actionable-now** items. The freeze itself (AC2) is gated to the **v1.0.0-rc1** tag (~Sept), so this PR does the parts that are ripe and records the rest as the rc1 checklist. (#622 was moved v0.33.0 → v1.0.0, matching its hard gate; v0.33.0 is now open=0.)

## What

- **AC4 — `/claude-c-suite:dx-lead` review** → `docs/api-surface-1.0/dx-lead-review.md`. SDK-consumer view of the MCP tool surface, ranked, with the concrete post-1.0 cost of each change and an rc1 freeze checklist. Headline findings:
  1. 🔴 **MCP tool OUTPUT shapes aren't enumerated/frozen** — input schemas + REST models are, but the 45 return shapes (just documented in #1054) are equally semver-locked and unguarded. (This session's `reference()` drop + `RecallConfidence.prominence` add are proof drift slips here.)
  2. 🟠 edge `source_id`/`target_id` are **MEMORY** uuids but unnamed as such (vs `merge_contexts`' `*_context_id`) — **pre-1.0 rename is free, MAJOR later**; decide now.
  3. 🟠 `details` polymorphism (object input vs string output).
  4. 🟡 convert remaining `⚠` to explicit decisions before rc1.
  5. 🟡 `rest-response-models.md` omits `schemas.py` response models.
  6. 🔵 (altitude) the freeze should be an **executable snapshot test**, not docs-only — that's why drift slipped.
- **Refresh the input-schema enumeration** for #1054 surface changes: `recall` now requires `context_id`; `reranker_provider` is now a hard enum (resolves the prior free-string inconsistency finding).
- **Flag the response-model gap**: `rest-response-models.md` enumerated only route-file-local models, so the core memory API responses defined in `models/schemas.py` (`RememberResponse`, `RecallResponse`, `RecallConfidence` incl. `prominence`, `ReferenceResponse`) are unenumerated — noted for the rc1 re-enumeration.

## Why not more

The freeze (link files to the rc1 commit), the output-shapes enumeration, the snapshot test, and the rename decisions (#2/#3) belong to the **rc1 freeze pass** (the checklist in `dx-lead-review.md`). Hand-patching the 1705-line frozen enumeration now would re-drift immediately — finding #6 is that the freeze needs a snapshot guard, not more hand-maintained markdown.

Docs-only; no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)