### PR TITLE
chore(release): v0.34.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.32.2",
+  "version": "0.34.0",
   "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.32.2"
+version = "0.34.0"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.32.2"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.34.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.32.2"
+APP_VERSION = "0.34.0"
 
 # ============================================================================
 # Memory Content Limits

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.32.2",
+  "version": "0.34.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.32.2",
+      "version": "0.34.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.32.2",
+  "version": "0.34.0",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.32.2",
+  "version": "0.34.0",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
Version bump **0.32.2 → 0.34.0** across all 7 canonical locations (`backend/pyproject.toml`, `backend/src/config/constants.py` `APP_VERSION`, `backend/src/__init__.py`, `frontend/package.json` + `package-lock.json`, `.claude-plugin/plugin.json`, `plugins/kagura-memory/.codex-plugin/plugin.json`).

Single release covering both milestones (which landed together via #1051) plus the post-milestone work merged since:

**v0.33.0 + v0.34.0 milestones (#1051):** #1046 reference_count adoption signal · #1047 recency/staleness + recall confidence · #1048 reinforce ranking · #1049 consolidation adoption gate · #1030 managed embeddings · #954 internal billing plan endpoint · #995 quota test matrix · #1033 paid-tier embedding spend cap.

**Post-milestone:** #1052 recall confidence absence detection (prominence) · #1054 MCP tool return-shape docs (all 45) + `reference()` full output + reranker_provider enum + uniform format:uuid · #622 AC4 API-surface dx-lead review.

⚠ **Behavior changes shipping in this release** (all reviewed + CI-green): recall MCP tool now **requires `context_id`**; `reference()` now returns scope/updated_at/source/declared-links; `reranker_provider` is now a hard enum. Default-OFF flags (reinforce, consolidation adoption-delete, managed-embedding fallback) remain off.

Docs-only/version-only changes in this PR; the feature work is already on main. After merge: tag `v0.34.0` + GitHub release, then deploy to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)