### PR TITLE
fix: merge_contexts use_count crash + recall context_id schema (v0.34.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.34.0"
+version = "0.34.1"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.34.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.34.1"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.34.0"
+APP_VERSION = "0.34.1"
 
 # ============================================================================
 # Memory Content Limits

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -313,7 +313,16 @@ Search modes: Use search_mode to control the search strategy.
 Returns: {status, results: [{memory_id, summary, context_summary, type, importance, scope, score, tags, created_at, updated_at}], count, related_tags, context_id, context_name, context_display_name, context_is_private, context_is_locked, confidence (see above), explore_hints (only when include_explore_hints=true)}. results carry Layers 1-2 only — call reference(memory_id) for full Layer-3 content.""",
             "inputSchema": {
                 "type": "object",
-                "required": ["query", "context_id"],
+                # ``query`` is the only unconditional requirement. The handler
+                # accepts EITHER ``context_id`` OR ``context_ids`` (cross-context
+                # recall via ``context_ids`` alone is valid — see handle_recall),
+                # so ``context_id`` is intentionally NOT in ``required``: listing it
+                # would make a schema-validating client reject a legitimate
+                # ``context_ids``-only call. This "exactly one of" pair is a
+                # description-only contract enforced at the handler, matching the
+                # convention used for forget(memory_id/query) and
+                # describe_binding(key_id/context_id).
+                "required": ["query"],
                 "properties": {
                     "query": {
                         "type": "string",
@@ -334,7 +343,7 @@ Returns: {status, results: [{memory_id, summary, context_summary, type, importan
                     "context_id": {
                         "type": "string",
                         "format": "uuid",
-                        "description": "Target context UUID (e.g. '550e8400-e29b-41d4-a716-446655440000'). MUST be a valid UUID from list_contexts(). Do NOT guess or fabricate IDs. For cross-context search, use context_ids instead.",
+                        "description": "Target context UUID (e.g. '550e8400-e29b-41d4-a716-446655440000'). MUST be a valid UUID from list_contexts(). Do NOT guess or fabricate IDs. Provide EITHER context_id OR context_ids (at least one is required). For cross-context search, use context_ids instead.",
                     },
                     "context_ids": {
                         "type": "array",

--- a/backend/src/services/context_service.py
+++ b/backend/src/services/context_service.py
@@ -940,7 +940,6 @@ class ContextService:
                 scope=mem.scope,
                 long_term=mem.long_term,
                 promoted_at=mem.promoted_at,
-                use_count=0,
                 access_count=0,
                 client=mem.client,
                 client_version=mem.client_version,

--- a/backend/tests/services/test_context_merge_use_count.py
+++ b/backend/tests/services/test_context_merge_use_count.py
@@ -1,0 +1,96 @@
+"""Regression: merge_contexts must not copy memories via dropped columns.
+
+v0.34.0 review finding (#1046 fallout): ``ContextService.merge_contexts``
+constructed each copied memory as ``Memory(..., use_count=0, ...)``, but #1046
+dropped ``use_count`` from the ``Memory`` ORM model. The copy loop therefore
+raised ``TypeError: 'use_count' is an invalid keyword argument for Memory`` for
+any merge of a context that actually holds memories.
+
+It shipped because every existing ``merge_contexts`` test mocks the service or
+exercises only the empty-source early-return — the memory-copy loop had zero
+coverage. This test drives the REAL copy loop with a REAL ``Memory`` model (DB,
+Qdrant and permission checks mocked), so a future column drift in the copy
+field-set fails here instead of in production.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from models.memory import Memory
+from services.context_service import ContextService
+from utils.datetime import utcnow
+
+
+def _source_memory(user_id: str, source_context_id) -> Memory:
+    """A real (transient) Memory the copy loop will read its fields from."""
+    return Memory(
+        id=uuid4(),
+        user_id=user_id,
+        workspace_id=uuid4(),
+        context_id=source_context_id,
+        summary="copied summary",
+        context_summary="why it matters",
+        content="full content",
+        context={"context_id": str(source_context_id)},
+        details=None,
+        type="note",
+        importance=0.6,
+        confidence=0.9,
+        tags=["a", "b"],
+        scope="persistent",
+        long_term=True,
+        promoted_at=None,
+        client="test",
+        client_version="1",
+        source="manual",
+        created_at=utcnow(),
+        embedding_status="success",
+    )
+
+
+@pytest.mark.asyncio
+async def test_merge_contexts_copies_memory_without_dropped_use_count():
+    user_id = "user-merge"
+    source_id = uuid4()
+    target_id = uuid4()
+    workspace_id = uuid4()
+
+    source_ctx = MagicMock(id=source_id, workspace_id=workspace_id, is_locked=False)
+    target_ctx = MagicMock(id=target_id, workspace_id=workspace_id, is_locked=False)
+
+    mock_db = AsyncMock()
+    # First execute() = embedding-config query (none → both use settings defaults,
+    # so the same-model check passes); second = source-memory query.
+    cfg_result = MagicMock()
+    cfg_result.scalars.return_value.all.return_value = []
+    mem_result = MagicMock()
+    mem_result.scalars.return_value.all.return_value = [_source_memory(user_id, source_id)]
+    mock_db.execute.side_effect = [cfg_result, mem_result]
+    mock_db.add = MagicMock()  # synchronous in SQLAlchemy
+
+    service = ContextService(mock_db)
+
+    with (
+        patch.object(
+            service, "get_context", new_callable=AsyncMock, side_effect=[source_ctx, target_ctx]
+        ),
+        patch("services.permission_service.PermissionService") as PermSvc,
+        patch("db.qdrant.copy_context_points", new_callable=AsyncMock, return_value=1),
+        patch("db.qdrant.get_collection_name", return_value="collection"),
+    ):
+        PermSvc.return_value.check_context_owner = AsyncMock()
+        result = await service.merge_contexts(user_id, source_id, target_id)
+
+    assert result["merged"] == 1
+    # The copy loop built and added exactly one new Memory (no TypeError on the
+    # dropped column), retargeted to the destination context with stats reset.
+    mock_db.add.assert_called_once()
+    new_mem = mock_db.add.call_args.args[0]
+    assert isinstance(new_mem, Memory)
+    assert new_mem.context_id == target_id
+    assert new_mem.access_count == 0
+    assert not hasattr(new_mem, "use_count")

--- a/docs/api-surface-1.0/mcp-input-schemas.md
+++ b/docs/api-surface-1.0/mcp-input-schemas.md
@@ -69,15 +69,15 @@ Update a memory in-place (by memory_id) or upsert by external_id.
 
 Hybrid search (semantic + BM25 + Neural Memory boosting) over memories; returns Layers 1–2.
 
-- **Required**: `query` — string; `context_id` — string, format `uuid` ✅ **DECIDED (#1054): `context_id` is now required** (recall is context-scoped — the handler always required it; the schema's `required` array now matches, was previously listed under Optional here)
+- **Required**: `query` — string. ✅ **CORRECTED (v0.34.0 review): `context_id` is NOT unconditionally required.** The handler requires *either* `context_id` *or* `context_ids` (`if "context_id" not in args and "context_ids" not in args: error`), so cross-context recall via `context_ids` alone is a valid call. #1054 had added `context_id` to the schema's `required` array on the false premise that "the handler always required it" — that rejected legitimate `context_ids`-only calls at any schema-validating client/gateway, and has been reverted (`required: ["query"]`). The `context_id`/`context_ids` pair is a description-only "exactly one of" contract — left out of `required`, enforced at the handler — the same convention as `forget(memory_id/query)` and `describe_binding(key_id/context_id)`.
 - **Optional**:
   - `k` — integer (default 5, max 100 per description) ✅ **DECIDED (#990): the `k`/`limit`/`cap` trio is consciously frozen as three distinct conventions, not unified.** `k` = the top-k count for a *relevance-ranked* result set (recall/get_sleep_history — established ML term); `limit` = pagination size for a *flat list* (the list_* family); `cap` = the ceiling for *pinned-memory load* (load_pinned). Unifying to one name spans ~8 tools (breaking) and would erase the relevance-vs-pagination signal `k` carries — net DX loss. Frozen as-is.
   - `use_rerank` — boolean (default false)
   - `filters` — object (free-form: type, tags, tags_match, importance gte, created/updated bounds, source_uri_prefix, source_type, trust_tier) ⚠ filter vocabulary lives only in prose; analyze_context exposes the equivalent filters (`types`, `tags`, `min_importance`, `from`/`to`) as top-level params instead — two filter styles on one surface
-  - `context_ids` — array of string (format `uuid`), minItems 2, maxItems 20 (cross-context recall; supplements the now-required `context_id`) ⚠ singular required `context_id` + plural optional `context_ids` on the same tool — workable but should be a deliberate frozen pattern
+  - `context_ids` — array of string (format `uuid`), minItems 2, maxItems 20 (cross-context recall; an ALTERNATIVE to `context_id` — `context_ids` overrides `context_id` when both are given, and is sufficient on its own). The deliberate frozen pattern: singular `context_id` and plural `context_ids` are the two arms of one "exactly one of" selector, neither in `required`.
   - `search_mode` — string, enum [`hybrid`, `semantic`, `keyword`] (default hybrid) ⚠ mild lock-in: description bakes in the 60/40 weighting and BM25/Neural-Memory implementation details; enum values themselves look stable
   - `include_explore_hints` — boolean (default false)
-- ⚠ `context_id` is optional here but required (and "IMPORTANT: always specify") on most sibling tools — for a frozen surface, recall/remember-family should agree on whether context_id is required
+- ✅ `context_id` is not in `required` here (because `context_ids` can stand in) while it IS required on the remember-family (which has no plural form). This asymmetry is intentional and frozen: recall is the only tool with a cross-context (`context_ids`) mode. The prose still says "IMPORTANT: always specify context_id" as the single-context happy-path guidance for agents.
 
 ### reference
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
Two correctness fixes found in the v0.34.0 max-effort code review, plus the v0.34.1 patch bump.

## 🔴 Fix #1 — `merge_contexts` 500 crash (live regression since v0.34.0)
`#1046` dropped the dead `use_count` column from the `Memory` ORM model, but `ContextService.merge_contexts` still built each copied memory as `Memory(..., use_count=0, ...)`. Merging any context that holds ≥1 memory raised `TypeError: 'use_count' is an invalid keyword argument for Memory` at object construction.

- Why it shipped: every `merge_contexts` test mocks the service or hits only the empty-source early-return — the memory-copy loop had **zero** coverage.
- Fix: remove the `use_count=0` kwarg (`access_count=0` already resets surfacing stats).
- Regression test `tests/services/test_context_merge_use_count.py` drives the **real** copy loop with a **real** `Memory` model (DB/Qdrant/permission mocked), runs in the fast `backend-unit` lane. Verified `Memory(use_count=0)` raises the exact `TypeError` pre-fix (test has teeth).

## 🟠 Fix #2 — `recall` schema over-restricts `context_id`
`handle_recall` accepts **either** `context_id` **or** `context_ids` (cross-context recall via `context_ids` alone is a first-class, documented path). #1054 added `context_id` to the recall `inputSchema.required` array on the false premise that "the handler always required it" — any schema-validating client/gateway would then reject a legitimate `{query, context_ids:[...]}` call. This is on the #622 pre-1.0 frozen surface.

- `_definitions.py`: recall `required` → `["query"]`; the `context_id`/`context_ids` pair is a description-only "exactly one of" contract enforced at the handler (same convention as `forget`, `describe_binding`).
- `docs/api-surface-1.0/mcp-input-schemas.md`: corrected the recorded #1054 decision + resolved two stale ⚠ notes.

## Verification (in `kagura-api` container)
- `ruff check` / `ruff format --check`: clean
- `pyright`: 0 errors
- Tests: new + existing context tools 11 passed; recall/schema 21 passed; schema-policy 4 passed
- Runtime: `recall required: ['query']` with both properties present

🤖 Generated with [Claude Code](https://claude.com/claude-code)