### PR TITLE
chore: v0.34.1 review follow-ups — /internal edge hardening + cleanup

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -662,7 +662,9 @@ app.include_router(workspace_connectors.router, prefix="/api/v1")
 app.include_router(workers.router, prefix="/api/v1")
 # Issue #954: internal billing entitlement push. Mounted WITHOUT /api/v1 — it
 # lives under /internal so it stays off the public API surface (#622) and is
-# blocked at the edge; reachable only over the internal network.
+# blocked at the edge (Caddyfile.tpl `handle /internal*` -> 404, enforced every
+# deploy by deploy.sh `verify_internal_blocked`); reachable only over the
+# internal Docker network, with BILLING_SERVICE_TOKEN as the in-app control.
 app.include_router(internal_billing.router)
 app.include_router(connectors_slack.router, prefix="/api/v1")
 

--- a/backend/src/api/routes/internal_billing.py
+++ b/backend/src/api/routes/internal_billing.py
@@ -22,10 +22,18 @@ Design decisions (documented for the cross-repo contract; see #954):
   membership/context cleanup is handled by the interactive flow or a
   reconciliation job (kagura-billing#5), not here.
 - **Idempotent.** PUT sets absolute values; re-delivery (reconciliation) yields
-  the same state and 200, never a "already on this plan" 400.
+  the same state and 200, never a "already on this plan" 400. Addons are an
+  *absolute, partial* update: omitted dimensions are left unchanged. The billing
+  service therefore owns re-baselining addons on a tier change — on a downgrade
+  it must push the new ``plan_name`` AND the addon values for the new tier
+  (e.g. ``addons:{...:0}``); this endpoint will not zero a prior tier's addon
+  bonus on its own (it has no notion of which addons "belong" to a tier).
 - **Internal-only.** Mounted under ``/internal`` (NOT ``/api/v1``) so it stays
-  off the public surface (#622 freeze) and is easy to block at the edge. Reach
-  it only over the internal network.
+  off the public surface (#622 freeze). It is also blocked at the edge:
+  ``terraform/single-server/Caddyfile.tpl`` has a ``handle /internal* {respond
+  404}`` block and ``deploy.sh`` fails the deploy via ``verify_internal_blocked``
+  if that block is ever missing. Reach it only over the internal Docker network;
+  the ``BILLING_SERVICE_TOKEN`` bearer is the in-app control on top of that.
 """
 
 from __future__ import annotations

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import hashlib
+import math
 import statistics
 from datetime import datetime
 from uuid import UUID, uuid4
@@ -1313,8 +1314,6 @@ class MemoryService:
         Does NOT touch ranking; purely a derived annotation. ``scores`` /
         ``semantic_scores`` may be in any order — sorted descending internally.
         """
-        import statistics
-
         sem = sorted((semantic_scores or []), reverse=True)
         if sem:
             return MemoryService._confidence_from_semantic(
@@ -1491,8 +1490,6 @@ class MemoryService:
         semantic relevance dominant: this only reorders the already
         relevance-filtered candidate pool, it never pulls in new hits.
         """
-        import math
-
         adopt = min(1.0, math.log1p(max(0, reference_count)) / math.log1p(adopt_norm))
         fb = math.tanh(net_helpful / feedback_norm)
         usage = importance * (adopt_weight * adopt + feedback_weight * fb)

--- a/backend/tests/api/test_internal_billing_plan.py
+++ b/backend/tests/api/test_internal_billing_plan.py
@@ -8,9 +8,10 @@ tests/integration/test_internal_billing_plan_db.py.
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
+import pytest
 from fastapi.testclient import TestClient
 
 from api.main import app
@@ -41,142 +42,113 @@ def _make_ws():
     return ws
 
 
-def _client(workspace=None):
-    async def mock_db():
-        db = MagicMock()
-        exec_result = MagicMock()
-        exec_result.scalar_one_or_none.return_value = workspace
-        db.execute = AsyncMock(return_value=exec_result)
-        db.commit = AsyncMock()
-        yield db
+@pytest.fixture
+def billing(monkeypatch):
+    """Harness for the internal billing endpoint.
 
-    app.dependency_overrides[get_db] = mock_db
-    return TestClient(app, raise_server_exceptions=False)
+    Replaces the per-test ``_settings``/``try-finally``/``_teardown`` boilerplate:
+    - ``monkeypatch`` patches the token the auth dependency reads and auto-undoes
+      it at teardown (no manual ``patcher.stop()``).
+    - ``app.dependency_overrides`` is cleared after every test (no manual
+      ``_teardown()``), so a failing test can't leak an override into later ones.
 
+    Usage: ``billing.token = "..."`` sets the configured service token (default
+    ``"secret"``); ``billing.client(ws)`` returns a TestClient whose mocked DB
+    resolves the workspace lookup to ``ws`` (pass ``None`` for the 404 path).
+    """
+    mock_settings = MagicMock()
+    mock_settings.billing_service_token = "secret"
+    monkeypatch.setattr("api.routes.internal_billing.get_settings", lambda: mock_settings)
 
-def _settings(token: str):
-    """Patch the token the auth dependency reads."""
-    patcher = patch("api.routes.internal_billing.get_settings")
-    mock = patcher.start()
-    mock.return_value.billing_service_token = token
-    return patcher
+    class _Harness:
+        @property
+        def token(self) -> str:
+            return mock_settings.billing_service_token
 
+        @token.setter
+        def token(self, value: str) -> None:
+            mock_settings.billing_service_token = value
 
-def _teardown():
+        def client(self, workspace=None) -> TestClient:
+            async def mock_db():
+                db = MagicMock()
+                exec_result = MagicMock()
+                exec_result.scalar_one_or_none.return_value = workspace
+                db.execute = AsyncMock(return_value=exec_result)
+                db.commit = AsyncMock()
+                yield db
+
+            app.dependency_overrides[get_db] = mock_db
+            return TestClient(app, raise_server_exceptions=False)
+
+    yield _Harness()
     app.dependency_overrides.clear()
 
 
-def test_unset_token_returns_503():
-    p = _settings("")
-    client = _client(_make_ws())
-    try:
-        resp = client.put(_PATH, json={"plan_name": "pro"}, headers={"Authorization": "Bearer x"})
-    finally:
-        p.stop()
-        _teardown()
+def test_unset_token_returns_503(billing):
+    billing.token = ""
+    resp = billing.client(_make_ws()).put(
+        _PATH, json={"plan_name": "pro"}, headers={"Authorization": "Bearer x"}
+    )
     assert resp.status_code == 503
 
 
-def test_missing_authorization_returns_401():
-    p = _settings("secret")
-    client = _client(_make_ws())
-    try:
-        resp = client.put(_PATH, json={"plan_name": "pro"})
-    finally:
-        p.stop()
-        _teardown()
+def test_missing_authorization_returns_401(billing):
+    resp = billing.client(_make_ws()).put(_PATH, json={"plan_name": "pro"})
     assert resp.status_code == 401
 
 
-def test_invalid_token_returns_401():
-    p = _settings("secret")
-    client = _client(_make_ws())
-    try:
-        resp = client.put(
-            _PATH, json={"plan_name": "pro"}, headers={"Authorization": "Bearer wrong"}
-        )
-    finally:
-        p.stop()
-        _teardown()
+def test_invalid_token_returns_401(billing):
+    resp = billing.client(_make_ws()).put(
+        _PATH, json={"plan_name": "pro"}, headers={"Authorization": "Bearer wrong"}
+    )
     assert resp.status_code == 401
 
 
-def test_invalid_plan_returns_422():
+def test_invalid_plan_returns_422(billing):
     # Canonical ValidationError (VAL-001 / 422), not a raw HTTPException.
-    p = _settings("secret")
-    client = _client(_make_ws())
-    try:
-        resp = client.put(
-            _PATH,
-            json={"plan_name": "enterprise"},
-            headers={"Authorization": "Bearer secret"},
-        )
-    finally:
-        p.stop()
-        _teardown()
+    resp = billing.client(_make_ws()).put(
+        _PATH, json={"plan_name": "enterprise"}, headers={"Authorization": "Bearer secret"}
+    )
     assert resp.status_code == 422
 
 
-def test_unknown_addon_returns_422():
-    p = _settings("secret")
-    client = _client(_make_ws())
-    try:
-        resp = client.put(
-            _PATH,
-            json={"plan_name": "pro", "addons": {"bogus": 1}},
-            headers={"Authorization": "Bearer secret"},
-        )
-    finally:
-        p.stop()
-        _teardown()
+def test_unknown_addon_returns_422(billing):
+    resp = billing.client(_make_ws()).put(
+        _PATH,
+        json={"plan_name": "pro", "addons": {"bogus": 1}},
+        headers={"Authorization": "Bearer secret"},
+    )
     assert resp.status_code == 422
 
 
-def test_negative_addon_returns_422():
-    p = _settings("secret")
-    client = _client(_make_ws())
-    try:
-        resp = client.put(
-            _PATH,
-            json={"plan_name": "pro", "addons": {"memory": -5}},
-            headers={"Authorization": "Bearer secret"},
-        )
-    finally:
-        p.stop()
-        _teardown()
+def test_negative_addon_returns_422(billing):
+    resp = billing.client(_make_ws()).put(
+        _PATH,
+        json={"plan_name": "pro", "addons": {"memory": -5}},
+        headers={"Authorization": "Bearer secret"},
+    )
     assert resp.status_code == 422
 
 
-def test_workspace_not_found_returns_404():
-    p = _settings("secret")
-    client = _client(workspace=None)
-    try:
-        resp = client.put(
-            _PATH, json={"plan_name": "pro"}, headers={"Authorization": "Bearer secret"}
-        )
-    finally:
-        p.stop()
-        _teardown()
+def test_workspace_not_found_returns_404(billing):
+    resp = billing.client(workspace=None).put(
+        _PATH, json={"plan_name": "pro"}, headers={"Authorization": "Bearer secret"}
+    )
     assert resp.status_code == 404
 
 
-def test_sets_plan_and_addons():
-    p = _settings("secret")
+def test_sets_plan_and_addons(billing):
     ws = _make_ws()
-    client = _client(ws)
-    try:
-        resp = client.put(
-            _PATH,
-            json={
-                "plan_name": "pro",
-                "status": "active",
-                "addons": {"sleep_contexts": 2, "storage_mb": 1024},
-            },
-            headers={"Authorization": "Bearer secret"},
-        )
-    finally:
-        p.stop()
-        _teardown()
+    resp = billing.client(ws).put(
+        _PATH,
+        json={
+            "plan_name": "pro",
+            "status": "active",
+            "addons": {"sleep_contexts": 2, "storage_mb": 1024},
+        },
+        headers={"Authorization": "Bearer secret"},
+    )
     assert resp.status_code == 200
     body = resp.json()
     assert body["plan_name"] == "pro"

--- a/terraform/single-server/Caddyfile.tpl
+++ b/terraform/single-server/Caddyfile.tpl
@@ -46,6 +46,17 @@ memory.kagura-ai.com {
 		respond 404
 	}
 
+	# /internal/* is the billing-service entitlement-push surface (#954): it
+	# writes plan tier + addon quota, authenticated only by BILLING_SERVICE_TOKEN.
+	# Like /api/v1/workers/*, it is reachable only over the internal Docker
+	# network and must never be served through public ingress — block it at the
+	# edge as defense-in-depth on top of the token. 404 (not 403) so the path is
+	# not confirmed. deploy.sh `verify_internal_blocked` fails the deploy if this
+	# block ever goes missing.
+	handle /internal* {
+		respond 404
+	}
+
 	# -------------------------------------------------------------------------
 	# Backend API (FastAPI on :8080) — blue-green upstream
 	# -------------------------------------------------------------------------

--- a/terraform/single-server/scripts/deploy.sh
+++ b/terraform/single-server/scripts/deploy.sh
@@ -39,8 +39,8 @@ READINESS_INTERVAL=2                            # seconds between checks
 DRAIN_TIMEOUT="${DRAIN_TIMEOUT:-30}"            # seconds to drain old container
 WEB_READINESS_TIMEOUT="${WEB_READINESS_TIMEOUT:-30}"  # seconds to wait for kagura-web /api/health
 WEB_READINESS_INTERVAL="${WEB_READINESS_INTERVAL:-2}" # seconds between web checks
-WORKERS_GATE_TIMEOUT="${WORKERS_GATE_TIMEOUT:-30}"    # seconds to wait for /api/v1/workers/* to be blocked at Caddy
-WORKERS_GATE_INTERVAL="${WORKERS_GATE_INTERVAL:-2}"   # seconds between security-gate checks
+WORKERS_GATE_TIMEOUT="${WORKERS_GATE_TIMEOUT:-30}"    # seconds to wait for an edge-blocked path (/api/v1/workers/*, /internal/*) to 404 at Caddy
+WORKERS_GATE_INTERVAL="${WORKERS_GATE_INTERVAL:-2}"   # seconds between security-gate checks (shared by the workers + internal gates)
 
 # curl indirection: the security-gate probe runs through "$CURL" so the bats
 # suite can inject a stub (tests/deploy_verify_workers_blocked.bats). Production
@@ -132,6 +132,7 @@ cmd_rollback() {
     generate_caddyfile "api-${inactive}"
     reload_caddy
     verify_workers_blocked
+    verify_internal_blocked
 
     DEPLOY_STAGE="rollback complete (active: ${inactive})"
     log "Rollback complete. Active: $inactive"
@@ -179,6 +180,7 @@ cmd_deploy() {
     generate_caddyfile "api-${inactive}"
     reload_caddy
     verify_workers_blocked
+    verify_internal_blocked
 
     # Step 7: Drain and stop old container
     # Disable restart policy first — otherwise `restart: always` revives
@@ -339,12 +341,18 @@ reload_caddy() {
     log "  Caddy restarted"
 }
 
-verify_workers_blocked() {
-    # Security gate: /api/v1/workers/* must return 404 via Caddy after every
-    # config reload. The route carries decrypted connector secrets and is
-    # intended for the co-resident ai-worker on the internal Docker network
-    # only. Use -k (insecure) because the Cloudflare Origin CA cert is not
+_verify_path_blocked() {
+    # Shared edge-block security gate (used by verify_workers_blocked and
+    # verify_internal_blocked). Asserts that an internal-only path returns 404
+    # via Caddy after every config reload — i.e. it is NOT served through public
+    # ingress. Use -k (insecure) because the Cloudflare Origin CA cert is not
     # trusted by the system CA bundle, but we only care about the HTTP status.
+    #
+    #   $1 label      — human label for logs/errors (e.g. "/internal/*")
+    #   $2 probe_path — the absolute path to GET (must yield non-404 if the route
+    #                   WERE proxied to the API, so blocked=404 is distinguishable
+    #                   from exposed; for /internal we probe the real PUT route
+    #                   with GET so an exposed API answers 405, not 404).
     #
     # Domain is extracted from CADDYFILE_TPL so this stays in sync with the
     # configured site block without manual updates here.
@@ -362,7 +370,8 @@ verify_workers_blocked() {
     # Caddy is still starting) and `set -e` kills the script *silently* on the
     # first attempt — the original #986 bug, where the retry loop and the
     # ${http_status:-000} fallback below were both dead code.
-    log "  Security gate: verifying /api/v1/workers/* is blocked at Caddy (timeout: ${WORKERS_GATE_TIMEOUT}s)..."
+    local label="$1" probe_path="$2"
+    log "  Security gate: verifying ${label} is blocked at Caddy (timeout: ${WORKERS_GATE_TIMEOUT}s)..."
     local domain http_status start_time
     http_status=000
     domain=$(awk '/^[a-zA-Z]/ { gsub(/ *\{.*/, ""); print; exit }' "$CADDYFILE_TPL")
@@ -375,18 +384,33 @@ verify_workers_blocked() {
         http_status=$("$CURL" -sk -o /dev/null -w "%{http_code}" \
             --max-time 5 \
             --resolve "${domain}:443:127.0.0.1" \
-            "https://${domain}/api/v1/workers/config" 2>/dev/null || true)
+            "https://${domain}${probe_path}" 2>/dev/null || true)
         http_status=${http_status:-000}
         if [ "$http_status" = "404" ]; then
-            log "  /api/v1/workers/* is correctly blocked (HTTP 404, $((SECONDS - start_time))s)"
+            log "  ${label} is correctly blocked (HTTP 404, $((SECONDS - start_time))s)"
             return 0
         fi
         sleep "$WORKERS_GATE_INTERVAL"
     done
-    error "/api/v1/workers/* is NOT blocked by Caddy (HTTP ${http_status}, expected 404) after ${WORKERS_GATE_TIMEOUT}s.
-  Aborting before any further steps — the workers route is exposed and must be fixed before this deploy/rollback can complete.
-  Check Caddyfile: the 'handle /api/v1/workers*' block must appear BEFORE 'handle /api/*'.
+    error "${label} is NOT blocked by Caddy (HTTP ${http_status}, expected 404) after ${WORKERS_GATE_TIMEOUT}s.
+  Aborting before any further steps — the route is exposed and must be fixed before this deploy/rollback can complete.
+  Check Caddyfile: the 'handle ${label}' block must appear BEFORE 'handle /api/*' / the catch-all.
   Regenerate and redeploy: $0 --generate-caddyfile && dc restart caddy"
+}
+
+verify_workers_blocked() {
+    # /api/v1/workers/* carries decrypted connector secrets and is intended for
+    # the co-resident ai-worker on the internal Docker network only.
+    _verify_path_blocked "/api/v1/workers/*" "/api/v1/workers/config"
+}
+
+verify_internal_blocked() {
+    # /internal/* is the billing entitlement-push surface (#954): it writes plan
+    # tier + addon quota, authenticated only by BILLING_SERVICE_TOKEN. Block it
+    # at the edge as defense-in-depth on top of the token. We GET the real PUT
+    # route so an *exposed* API answers 405 (method not allowed, route exists),
+    # never a 404 — keeping blocked(404) distinguishable from exposed.
+    _verify_path_blocked "/internal/*" "/internal/workspaces/probe/plan"
 }
 
 cmd_generate_caddyfile() {
@@ -472,8 +496,8 @@ main() {
             echo "  DRAIN_TIMEOUT          Seconds to drain old API container (default: 30)"
             echo "  WEB_READINESS_TIMEOUT  Seconds to wait for web /api/health (default: 30)"
             echo "  WEB_READINESS_INTERVAL Seconds between web health checks (default: 2)"
-            echo "  WORKERS_GATE_TIMEOUT   Seconds to wait for /api/v1/workers/* to be blocked at Caddy (default: 30)"
-            echo "  WORKERS_GATE_INTERVAL  Seconds between security-gate checks (default: 2)"
+            echo "  WORKERS_GATE_TIMEOUT   Seconds to wait for an edge-blocked path (/api/v1/workers/*, /internal/*) to 404 at Caddy (default: 30)"
+            echo "  WORKERS_GATE_INTERVAL  Seconds between security-gate checks; shared by the workers + internal gates (default: 2)"
             ;;
         "")
             cmd_deploy

--- a/terraform/single-server/scripts/tests/deploy_verify_internal_blocked.bats
+++ b/terraform/single-server/scripts/tests/deploy_verify_internal_blocked.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Regression suite for deploy.sh `verify_internal_blocked` — the edge-block
+# security gate for /internal/* (the #954 billing entitlement-push surface).
+# It shares the proven `_verify_path_blocked` loop with verify_workers_blocked
+# (see deploy_verify_workers_blocked.bats for the #986 fail-closed details);
+# these tests pin that the /internal gate is wired to the same 404 contract and
+# stays fail-CLOSED, so a missing `handle /internal*` Caddy block aborts the
+# deploy instead of silently shipping an exposed entitlement-write endpoint.
+#
+# Same harness as the workers suite: the script is sourced and the probe is
+# driven through an injected `$CURL` stub fed by a per-attempt sequence file.
+# No network, no docker.
+# =============================================================================
+
+mock_curl() {
+    local n line
+    n=$(( $(cat "$SEQ_IDX") + 1 ))
+    echo "$n" > "$SEQ_IDX"
+    line=$(sed -n "${n}p" "$SEQ_FILE")
+    if [ -z "$line" ]; then line=$(tail -n 1 "$SEQ_FILE"); fi
+    if [ "$line" = "FAIL" ]; then
+        return 7
+    fi
+    printf '%s' "$line"
+}
+
+setup() {
+    export SEQ_FILE="$BATS_TEST_TMPDIR/seq"
+    export SEQ_IDX="$BATS_TEST_TMPDIR/idx"
+    export -f mock_curl
+
+    export CADDYFILE_TPL="$BATS_TEST_TMPDIR/Caddyfile.tpl"
+    printf 'memory.example.test {\n    reverse_proxy api:8000\n}\n' > "$CADDYFILE_TPL"
+
+    export CURL=mock_curl
+    source "$BATS_TEST_DIRNAME/../deploy.sh"
+    set +u
+
+    WORKERS_GATE_TIMEOUT=10
+    WORKERS_GATE_INTERVAL=1
+}
+
+@test "internal 000 -> 404: first probe connection-refused, retry sees 404 -> returns 0" {
+    printf 'FAIL\n404\n' > "$SEQ_FILE"; echo 0 > "$SEQ_IDX"
+
+    run verify_internal_blocked
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"/internal/*"* ]]
+    [[ "$output" == *"correctly blocked (HTTP 404"* ]]
+}
+
+@test "internal timeout: exposed API answers a stable 405 (GET on PUT route), never 404 -> aborts loudly, fail-closed" {
+    printf '405\n' > "$SEQ_FILE"; echo 0 > "$SEQ_IDX"
+    WORKERS_GATE_TIMEOUT=1
+
+    run verify_internal_blocked
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"/internal/*"* ]]
+    [[ "$output" == *"NOT blocked"* ]]
+    [[ "$output" == *"expected 404"* ]]
+    [[ "$output" != *"correctly blocked"* ]]
+}
+
+@test "internal set -e safety: a connection-refused probe does NOT silently kill the caller (#986 guard)" {
+    printf 'FAIL\n404\n' > "$SEQ_FILE"; echo 0 > "$SEQ_IDX"
+
+    run bash -c '
+        set -euo pipefail
+        source "'"$BATS_TEST_DIRNAME"'/../deploy.sh"
+        WORKERS_GATE_TIMEOUT=10 WORKERS_GATE_INTERVAL=1
+        verify_internal_blocked >/dev/null 2>&1
+        echo "STEP7_REACHED"
+    '
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"STEP7_REACHED"* ]]
+}


### PR DESCRIPTION
Non-blocking follow-ups from the v0.34.0/v0.34.1 max-effort code review. (Findings #1/#2 shipped in v0.34.1 / #1060; finding #4 was investigated and **intentionally not changed** — see below.)

## 🟠 #3 — block `/internal` at the Caddy edge (defense-in-depth)
The `/internal` billing entitlement-push surface (#954) writes plan tier + addon quota, guarded only by `BILLING_SERVICE_TOKEN`. The code *claimed* it was "blocked at the edge" but there was no Caddy block and no deploy-time regression gate (unlike `/api/v1/workers/*`).
- `Caddyfile.tpl`: `handle /internal* { respond 404 }` (mirrors workers; 404 not 403).
- `deploy.sh`: extracted the proven probe loop into `_verify_path_blocked` (preserves the #986 fail-closed `|| true` / `${http_status:-000}` semantics verbatim), added `verify_internal_blocked`, wired into both `cmd_deploy` (Step 6) and `cmd_rollback`. Internal probe GETs the real PUT route so an exposed API answers **405**, keeping blocked(404) distinguishable.
- `deploy_verify_internal_blocked.bats`: mirrors the workers regression suite (CI `shell` job auto-discovers it).
- Comments in `internal_billing.py` / `main.py` now describe the real mechanism.

## 🔵 #6 — document billing addon re-baseline ownership
Addons are an absolute *partial* update, so a tier downgrade that omits `addons` leaves a prior tier's bonus in place. Documented that re-baselining on a tier change is the billing service's responsibility (this endpoint has no notion of which addons "belong" to a tier).

## 🔵 #7 — dedupe internal_billing test boilerplate
8 tests hand-rolled the same settings-patch + `try/finally` teardown → replaced with a `billing` fixture (monkeypatch auto-undo + `dependency_overrides` cleared every test). Assertions unchanged.

## 🔵 #5 — hoist redundant imports
`import statistics` was duplicated and `import math` was function-local in `memory_service.py` → hoisted to module top. No behaviour change.

## ⏭️ #4 — investigated, not changed
The reinforce config `get_by_context` SELECT is **not** cleanly removable: `recall()` only loads the search config inside the `is_shared_context_read` branch (conditional), so it isn't reliably available at the reinforce call site, and there's no cheaper signal than the config row itself to gate on. It's one indexed lookup inherent to a per-context gated feature — not worth coupling the code for.

## Verification
- `ruff check` / `ruff format --check`: clean · `pyright`: 0 errors
- `pytest`: 72 passed (refactored billing suite + memory_service confidence/reinforce + merge regression)
- `bash -n deploy.sh`: OK (shellcheck + bats run in CI `shell` job)

Note: #3's Caddy block + gate take effect on the **next deploy** (a v0.34.2 release/deploy can follow this merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)