### PR TITLE
chore(release): v0.34.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.34.1"
+version = "0.34.2"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.34.1"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.34.2"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.34.1"
+APP_VERSION = "0.34.2"
 
 # ============================================================================
 # Memory Content Limits

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.34.1",
+      "version": "0.34.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.34.1",
+  "version": "0.34.2",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
Patch release to activate the v0.34.1 code-review follow-ups merged in #1061 — chiefly the `/internal` edge-block hardening (#3), which only takes effect on a deploy.

Contents since v0.34.1:
- 🟠 `/internal` blocked at the Caddy edge + `verify_internal_blocked` deploy gate (defense-in-depth for the #954 billing endpoint)
- 🔵 billing addon re-baseline doc note, internal_billing test fixture refactor, redundant-import cleanup

No schema migrations. Version bump only in this PR (the changes themselves landed in #1061).

🤖 Generated with [Claude Code](https://claude.com/claude-code)