### PR TITLE
docs: update kagura-memory-ai-worker references → kagura-chat-bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,7 +101,7 @@ AUDIT_PSEUDO_SALT=kagura-erasure-v1
 AUDIT_HMAC_KEY=change-me-audit-hmac-key
 
 # -----------------------------------------------------------------------------
-# ai-worker connectors (kagura-memory-ai-worker, Spec 2026-06-02)
+# ai-worker connectors (kagura-chat-bridge, Spec 2026-06-02)
 # -----------------------------------------------------------------------------
 
 # Shared bearer token the ai-worker presents to GET /api/v1/workers/config.

--- a/backend/alembic/versions/e25_782_widen_edge_type.py
+++ b/backend/alembic/versions/e25_782_widen_edge_type.py
@@ -1,6 +1,6 @@
 """Widen the valid_edge_type CHECK to add continues_from + references_file (#782).
 
-The kagura-memory-ai-worker emits two producer-asserted structural relation
+The kagura-chat-bridge emits two producer-asserted structural relation
 types that did not exist in the post-#741 four-value ``edge_type`` set:
 
 * ``continues_from``  — chronological/narrative successor between chat memories.

--- a/backend/src/api/routes/workers.py
+++ b/backend/src/api/routes/workers.py
@@ -1,6 +1,6 @@
 """ai-worker service endpoints (Spec 2026-06-02, Plan 3).
 
-The kagura-memory-ai-worker is a Kagura-operated shared multi-tenant worker
+The kagura-chat-bridge is a Kagura-operated shared multi-tenant worker
 (Model B). It dispatches inbound platform events (e.g. Slack) by team id, then
 fetches the per-connector config from here — replacing the static
 ``connector.json`` file. Authenticated by a dedicated worker service token

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -81,7 +81,7 @@ class Settings(BaseSettings):
         default=60,
         description="Min seconds between api_keys.last_used_at writes per key (Issue #947)",
     )
-    # ai-worker (kagura-memory-ai-worker) service auth. The worker presents this
+    # ai-worker (kagura-chat-bridge) service auth. The worker presents this
     # as a Bearer token to GET /api/v1/workers/config (Spec 2026-06-02). Empty
     # disables the worker config endpoint (fail-closed). Use: openssl rand -hex 32.
     #

--- a/backend/src/mcp_server/tools/edge.py
+++ b/backend/src/mcp_server/tools/edge.py
@@ -41,7 +41,7 @@ from models.memory import (
 #   - related_to / depends_on / learned_from: LLM-emittable relation types
 #     (#374 → see `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`).
 #   - continues_from / references_file (#782): producer-asserted structural
-#     relation types emitted by the kagura-memory-ai-worker ingest pipeline.
+#     relation types emitted by the kagura-chat-bridge ingest pipeline.
 #     NOT emitted by the sleep LLM judge (excluded from
 #     `services/sleep/edge_discovery.py::LLM_EMITTABLE_EDGE_TYPES`); the MCP
 #     boundary does not separately enforce this — clients may pass them.

--- a/backend/src/models/memory.py
+++ b/backend/src/models/memory.py
@@ -521,7 +521,7 @@ EDGE_TYPE_RELATED_TO = "related_to"
 EDGE_TYPE_DEPENDS_ON = "depends_on"
 EDGE_TYPE_LEARNED_FROM = "learned_from"
 # Issue #782: producer-asserted structural relation types emitted by the
-# kagura-memory-ai-worker ingest pipeline. They live on the edge_type
+# kagura-chat-bridge ingest pipeline. They live on the edge_type
 # (relation) axis; their provenance is the ``origin`` axis (origin='declared'
 # for the worker create_edge path, pinned in mcp_server/tools/edge.py).
 #   - continues_from: chronological/narrative successor between chat memories

--- a/backend/src/services/graph_service.py
+++ b/backend/src/services/graph_service.py
@@ -53,9 +53,9 @@ class GraphService:
         - depends_on: LLM-judged dependency relationship (directed)
         - learned_from: LLM-judged learning source (directed)
         - continues_from: producer-asserted chronological/narrative successor
-          (directed; #782, emitted by kagura-memory-ai-worker)
+          (directed; #782, emitted by kagura-chat-bridge)
         - references_file: producer-asserted structural reference, chat → file
-          overview (directed; #782, emitted by kagura-memory-ai-worker)
+          overview (directed; #782, emitted by kagura-chat-bridge)
 
     Provenance lives on the ``origin`` axis (#722), independent of edge_type:
         - hebbian: runtime Hebbian co-activation trace

--- a/backend/tests/services/test_graph_service_edge_types.py
+++ b/backend/tests/services/test_graph_service_edge_types.py
@@ -12,7 +12,7 @@ values (``neural_association`` / ``related_to`` / ``depends_on`` /
 seeding to ``edge_metadata['source']``. #782 widened the set back to six by
 appending two producer-asserted structural relation types
 (``continues_from`` / ``references_file``) emitted by the
-kagura-memory-ai-worker pipeline. The drift tests in this file pin the
+kagura-chat-bridge pipeline. The drift tests in this file pin the
 current shape.
 
 Tests pin three invariants:
@@ -115,7 +115,7 @@ async def test_add_edge_accepts_producer_asserted_types(rel_type: str) -> None:
     """#782: ``add_edge`` accepts the two producer-asserted structural types.
 
     ``continues_from`` / ``references_file`` are emitted by the
-    kagura-memory-ai-worker ingest pipeline (not the LLM judge). The validator
+    kagura-chat-bridge ingest pipeline (not the LLM judge). The validator
     must accept them and forward ``edge_type`` unchanged to
     ``NeuralEdgeRepository``. Origin pinning is the caller's responsibility on
     this path (see the sibling ``test_add_edge_propagates_explicit_origin``

--- a/docs/connector-ingest-contract.md
+++ b/docs/connector-ingest-contract.md
@@ -1,7 +1,7 @@
 # Connector Ingest Contract (ai-worker → memory-cloud)
 
 This document is the **written contract** that an external worker (e.g.
-[`kagura-memory-ai-worker`](https://github.com/kagura-ai/kagura-memory-ai-worker))
+[`kagura-chat-bridge`](https://github.com/kagura-ai/kagura-chat-bridge))
 follows when it pushes chat-connector messages (Slack / Discord / Teams) into
 Kagura Memory Cloud through the **existing Resource Foundation** ingest path.
 
@@ -14,7 +14,7 @@ doc only pins down the connector-specific rules layered on top of those endpoint
 
 > **Scope.** This is the F6-c (#852) guidance deliverable of epic #755. The
 > worker-side write-path decision and its e2e/smoke verification are tracked in
-> [ai-worker#91](https://github.com/kagura-ai/kagura-memory-ai-worker/issues/91),
+> [ai-worker#91](https://github.com/kagura-ai/kagura-chat-bridge/issues/91),
 > not here.
 
 ## Prerequisites (already shipped)

--- a/docs/pii-guardrail-consumption-contract.md
+++ b/docs/pii-guardrail-consumption-contract.md
@@ -3,7 +3,7 @@
 This document is the **written contract** for `pii_guardrail_config` — the
 PII-scrubbing configuration that Kagura Memory Cloud stores on a connector and
 that an external worker (e.g.
-[`kagura-memory-ai-worker`](https://github.com/kagura-ai/kagura-memory-ai-worker))
+[`kagura-chat-bridge`](https://github.com/kagura-ai/kagura-chat-bridge))
 **consumes** in its pre-compile stage to scrub personal data **before** chat
 messages are ingested.
 
@@ -16,7 +16,7 @@ on the way in.
 > the final slice of epic #755. The worker-side pre-compile scrubbing
 > implementation, the Discord/Teams connector smoke tests, and the epic-closing
 > acceptance are tracked in
-> [ai-worker#91](https://github.com/kagura-ai/kagura-memory-ai-worker/issues/91),
+> [ai-worker#91](https://github.com/kagura-ai/kagura-chat-bridge/issues/91),
 > **not** here. This doc does not close #755.
 
 ## Responsibility split (what lives where)

--- a/docs/rfc/0001-weekly-reset-subscription-quota.md
+++ b/docs/rfc/0001-weekly-reset-subscription-quota.md
@@ -2,7 +2,7 @@
 
 - **Issue**: [#693](https://github.com/kagura-ai/memory-cloud/issues/693)
 - **Status**: Draft (Phase 3 design)
-- **Consumers**: `kagura-memory-ai-worker` (Phase 2/3)
+- **Consumers**: `kagura-chat-bridge` (Phase 2/3)
 - **Last updated**: 2026-05-20
 
 ## Summary
@@ -23,7 +23,7 @@ Builds on `Workspace` / `tier` / plan-limit concepts already documented in [docs
 
 ## Why now
 
-- `kagura-memory-ai-worker` Phase 2 needs to consume this model
+- `kagura-chat-bridge` Phase 2 needs to consume this model
 - The current ai-worker README references a "Managed tier billed by `summarization_token_volume`" — this RFC proposes replacing direct metered billing with a subscription + cap model
 - LiteLLM provides production-tested primitives (virtual keys, budgets, spend tracking, fallback) — building on it avoids reinventing infrastructure
 
@@ -92,7 +92,7 @@ The cold-start budget guardrail — cold-start backfill MUST consume ≤70% of t
 - The 70/30 split is enforced by the worker, before the LiteLLM call, using local accounting (token count × per-model unit price = USD estimate).
 - **Misattribution risk**: if cold-start exhausts more than 70% (e.g., a bug in the worker's accounting), the worker burns its own steady-state runway and degrades into 429-driven throttle for the remainder of the week. This is documented worker behavior, not a server bug, and not a refund condition.
 
-**Consumer-side ratification**: `kagura-memory-ai-worker` README MUST echo this contract from the consumer side. To be filed as a follow-up against the ai-worker repo (cross-repo edit out of scope for this PR).
+**Consumer-side ratification**: `kagura-chat-bridge` README MUST echo this contract from the consumer side. To be filed as a follow-up against the ai-worker repo (cross-repo edit out of scope for this PR).
 
 ## Usage event idempotency
 
@@ -377,7 +377,7 @@ The table's *Must resolve before* column captures the gating relationship; resol
 
 ## Related
 
-- `kagura-ai/kagura-memory-ai-worker` (consumer worker; #2 LiteLLM migration deferred pending this RFC, see savepoint memory)
+- `kagura-ai/kagura-chat-bridge` (consumer worker; #2 LiteLLM migration deferred pending this RFC, see savepoint memory)
 - [#474](https://github.com/kagura-ai/memory-cloud/issues/474) `llm_call_log` event-shaped LLM cost ledger (write target for ai-worker usage events)
 - [#472](https://github.com/kagura-ai/memory-cloud/issues/472) Cost dashboard UNION ALL of `sleep_reports` + `llm_call_log` (unified aggregation surface)
 - LiteLLM docs: https://docs.litellm.ai

--- a/terraform/single-server/Caddyfile.tpl
+++ b/terraform/single-server/Caddyfile.tpl
@@ -122,7 +122,7 @@ memory.kagura-ai.com {
 # =============================================================================
 # Extension point for sibling services (one-time, do not remove)
 # =============================================================================
-# Sibling services co-resident on this VM (e.g. kagura-memory-ai-worker's
+# Sibling services co-resident on this VM (e.g. kagura-chat-bridge's
 # webhook receiver at aw.kagura-ai.com) plug their own top-level vhost blocks
 # in here by dropping a `*.caddy` file into /opt/kagura-caddy-extra/ on the
 # host. That directory is bind-mounted read-only into the caddy container

--- a/terraform/single-server/README.md
+++ b/terraform/single-server/README.md
@@ -440,7 +440,7 @@ then flips Caddy back and reloads. Safe to run at any time after a deploy.
 ### Caddy extension point (sibling services)
 
 Other services co-resident on this VM (for example
-`kagura-memory-ai-worker`'s webhook receiver at `aw.kagura-ai.com`) can publish
+`kagura-chat-bridge`'s webhook receiver at `aw.kagura-ai.com`) can publish
 their own HTTPS vhost through this server's Caddy **without any further change
 to the memory-cloud repository**. The mechanism is a one-time extension point:
 

--- a/terraform/single-server/startup.sh
+++ b/terraform/single-server/startup.sh
@@ -93,7 +93,7 @@ install -d -m 0700 /var/lib/kagura/origin-ca
 install -d -m 0755 /var/lib/kagura/volumes
 
 # Caddy extension point for sibling services co-resident on this VM (e.g.
-# kagura-memory-ai-worker). They drop *.caddy vhost files here; the caddy
+# kagura-chat-bridge). They drop *.caddy vhost files here; the caddy
 # container bind-mounts this read-only and Caddyfile imports it. root-owned
 # 0755: world-readable so the container can read it, root-write so only an
 # operator with sudo can add vhost files. See README "Caddy extension point".


### PR DESCRIPTION
Cosmetic follow-up to the worker repo rename (`kagura-memory-ai-worker` → `kagura-chat-bridge`, now merged). Updates docstrings / comments / contract-doc titles / GitHub URLs / terraform comments to the new name.

**No functional change.** Verified unchanged:
- vhost `aw.kagura-ai.com` (separate production cutover)
- role-generic `worker` surface: `/api/v1/workers`, `workspace_connectors`, `WORKER_SERVICE_TOKEN`, edge_type CHECK values (`continues_from`/`references_file`)

14 files, name-string swaps only. Old-name references now resolve via GitHub's redirect; this is doc-accuracy polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)