### PR TITLE
chore(release): v0.35.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.34.2",
+  "version": "0.35.0",
   "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.34.2"
+version = "0.35.0"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.34.2"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.35.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.34.2"
+APP_VERSION = "0.35.0"
 
 # ============================================================================
 # Memory Content Limits

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.34.2",
+  "version": "0.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.34.2",
+      "version": "0.35.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.34.2",
+  "version": "0.35.0",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.34.2",
+  "version": "0.35.0",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
## v0.35.0 — Read-only external views

Version bump 0.34.2 → 0.35.0 across the 7 canonical version files.

This release ships the **v0.35.0 milestone** (#67) — *let external dashboards observe memory/agent state read-only, without inverting the trust boundary*:

- **#1027** ([#1066](https://github.com/kagura-ai/memory-cloud/pull/1066)) — context-scoped, read-only, TTL-bounded **share key** for memory recall. `POST /api/v1/share/recall` (share-key auth, confined to the bound context); mint/list/revoke under `/config/share-keys` (session auth).
- **#1064** ([#1067](https://github.com/kagura-ai/memory-cloud/pull/1067)) — read-only **agent session-state observation view** (`GET /api/v1/share/sessions`) driven by the #1027 share key, confined to the bound context.

### Migration
- `e43_1027_share_keys` — new `share_keys` table. Applied automatically by the blue-green deploy (`alembic upgrade head`).

After merge: tag `v0.35.0` + GitHub release, then deploy to apply the migration in production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
