### PR TITLE
docs(readme): sync brand logo to SDK vector flower mark

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://www.kagura-ai.com/ja/">
-    <img src="docs/assets/kagura-logo.png" alt="Kagura Memory Cloud" width="240">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="docs/assets/kagura-logo-dark.svg">
+      <img src="docs/assets/kagura-logo.svg" alt="Kagura Memory Cloud" width="320">
+    </picture>
   </a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <p align="center">
   <a href="https://www.kagura-ai.com">
-    <img src="docs/assets/kagura-logo.png" alt="Kagura Memory Cloud" width="240">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="docs/assets/kagura-logo-dark.svg">
+      <img src="docs/assets/kagura-logo.svg" alt="Kagura Memory Cloud" width="320">
+    </picture>
   </a>
 </p>
 

--- a/docs/assets/kagura-logo-dark.svg
+++ b/docs/assets/kagura-logo-dark.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 440 120" role="img" aria-label="Kagura AI">
+  <title>Kagura AI</title>
+  <defs>
+    <linearGradient id="kg-tokiwa" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#3f9168"/><stop offset="1" stop-color="#00664b"/></linearGradient>
+    <linearGradient id="kg-shu" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#f3893a"/><stop offset="1" stop-color="#eb6100"/></linearGradient>
+    <linearGradient id="kg-ukon" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#fdc659"/><stop offset="1" stop-color="#faa916"/></linearGradient>
+    <linearGradient id="kg-gofun" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#f2f1cf"/><stop offset="1" stop-color="#dcdf9a"/></linearGradient>
+    <linearGradient id="kg-kodai" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#9c79ae"/><stop offset="1" stop-color="#70477c"/></linearGradient>
+  </defs>
+  <g transform="translate(12 10) scale(0.5)">
+    <circle cx="100" cy="42" r="38" fill="url(#kg-tokiwa)"/>
+    <circle cx="155" cy="82" r="38" fill="url(#kg-shu)"/>
+    <circle cx="134" cy="147" r="38" fill="url(#kg-ukon)"/>
+    <circle cx="66" cy="147" r="38" fill="url(#kg-gofun)"/>
+    <circle cx="45" cy="82" r="38" fill="url(#kg-kodai)"/>
+    <g stroke="#fffffb" stroke-width="9" stroke-linecap="round" fill="#fffffb">
+      <line x1="100" y1="58" x2="100" y2="82"/>
+      <line x1="139.8" y1="87" x2="117" y2="94.4"/>
+      <line x1="124.6" y1="134" x2="110.6" y2="114.6"/>
+      <line x1="75.4" y1="134" x2="89.4" y2="114.6"/>
+      <line x1="60.2" y1="87" x2="83" y2="94.4"/>
+      <circle cx="100" cy="58" r="8" stroke="none"/>
+      <circle cx="139.8" cy="87" r="8" stroke="none"/>
+      <circle cx="124.6" cy="134" r="8" stroke="none"/>
+      <circle cx="75.4" cy="134" r="8" stroke="none"/>
+      <circle cx="60.2" cy="87" r="8" stroke="none"/>
+    </g>
+  </g>
+  <text x="132" y="78" font-family="'Noto Sans JP', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.5"><tspan fill="#f0f6fc">Kagura</tspan><tspan fill="#faa916"> AI</tspan></text>
+</svg>

--- a/docs/assets/kagura-logo.svg
+++ b/docs/assets/kagura-logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 440 120" role="img" aria-label="Kagura AI">
+  <title>Kagura AI</title>
+  <defs>
+    <linearGradient id="kg-tokiwa" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#3f9168"/><stop offset="1" stop-color="#00664b"/></linearGradient>
+    <linearGradient id="kg-shu" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#f3893a"/><stop offset="1" stop-color="#eb6100"/></linearGradient>
+    <linearGradient id="kg-ukon" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#fdc659"/><stop offset="1" stop-color="#faa916"/></linearGradient>
+    <linearGradient id="kg-gofun" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#f2f1cf"/><stop offset="1" stop-color="#dcdf9a"/></linearGradient>
+    <linearGradient id="kg-kodai" x1="0" y1="0" x2="1" y2="1"><stop offset="0" stop-color="#9c79ae"/><stop offset="1" stop-color="#70477c"/></linearGradient>
+  </defs>
+  <g transform="translate(12 10) scale(0.5)">
+    <circle cx="100" cy="42" r="38" fill="url(#kg-tokiwa)"/>
+    <circle cx="155" cy="82" r="38" fill="url(#kg-shu)"/>
+    <circle cx="134" cy="147" r="38" fill="url(#kg-ukon)"/>
+    <circle cx="66" cy="147" r="38" fill="url(#kg-gofun)"/>
+    <circle cx="45" cy="82" r="38" fill="url(#kg-kodai)"/>
+    <g stroke="#fffffb" stroke-width="9" stroke-linecap="round" fill="#fffffb">
+      <line x1="100" y1="58" x2="100" y2="82"/>
+      <line x1="139.8" y1="87" x2="117" y2="94.4"/>
+      <line x1="124.6" y1="134" x2="110.6" y2="114.6"/>
+      <line x1="75.4" y1="134" x2="89.4" y2="114.6"/>
+      <line x1="60.2" y1="87" x2="83" y2="94.4"/>
+      <circle cx="100" cy="58" r="8" stroke="none"/>
+      <circle cx="139.8" cy="87" r="8" stroke="none"/>
+      <circle cx="124.6" cy="134" r="8" stroke="none"/>
+      <circle cx="75.4" cy="134" r="8" stroke="none"/>
+      <circle cx="60.2" cy="87" r="8" stroke="none"/>
+    </g>
+  </g>
+  <text x="132" y="78" font-family="'Noto Sans JP', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="56" font-weight="700" letter-spacing="-1.5"><tspan fill="#1f2328">Kagura</tspan><tspan fill="#faa916"> AI</tspan></text>
+</svg>


### PR DESCRIPTION
Replace the raster flower PNG in `README.md` / `README.ja.md` with the SDK's current vector brand logo (5-petal mark + "Kagura AI"), copied byte-for-byte from [`kagura-memory-python-sdk`](https://github.com/kagura-ai/kagura-memory-python-sdk) `origin/main`.

## Changes
- Add `docs/assets/kagura-logo.svg` (light: "Kagura" `#1f2328`) and `docs/assets/kagura-logo-dark.svg` (dark: "Kagura" `#f0f6fc`)
- Switch both READMEs to a `<picture>` element with `prefers-color-scheme` (width 320), matching the SDK README header
- Frontend, SDK, and memory-cloud README now share one vector logo

## Notes
- Old `docs/assets/kagura-logo.png` is left in place (no longer referenced by `*.md`); can be removed in a follow-up after confirming no og:image use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
