### PR TITLE
fix(frontend): match official mark/wordmark proportions in image lockup

### DIFF
--- a/frontend/src/app/device/page.tsx
+++ b/frontend/src/app/device/page.tsx
@@ -263,7 +263,7 @@ function DevicePageInner() {
 
       <div className="relative w-full max-w-md px-4">
         <div className="mb-8 flex justify-center">
-          <KaguraLogo className="h-24 w-auto" variant="image" />
+          <KaguraLogo className="h-20 w-auto" variant="image" />
         </div>
 
         <Card className="overflow-hidden border-gray-200 bg-white/80 shadow-2xl backdrop-blur-xl">

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -28,13 +28,7 @@ import {
 } from "@/lib/auth/auth";
 import { safeReturnTo } from "@/lib/auth/safeReturnTo";
 import { buildOAuthRedirect } from "@/lib/auth/buildOAuthRedirect";
-import {
-  ArrowRight,
-  Info,
-  Sparkles,
-  Shield,
-  Zap,
-} from "lucide-react";
+import { ArrowRight, Info, Sparkles, Shield, Zap } from "lucide-react";
 import { ErrorBanner } from "@/components/common/ErrorBanner";
 import { KaguraLogo } from "@/components/icons/KaguraLogo";
 import { LanguageSelector } from "@/components/LanguageSelector";
@@ -265,7 +259,7 @@ function LoginContent() {
 
       <div className="relative w-full max-w-md px-4">
         <div className="mb-8 flex justify-center">
-          <KaguraLogo className="h-24 w-auto" variant="image" />
+          <KaguraLogo className="h-20 w-auto" variant="image" />
         </div>
 
         <Card className="overflow-hidden border-gray-200 bg-white/80 shadow-2xl backdrop-blur-xl">

--- a/frontend/src/components/icons/KaguraLogo.tsx
+++ b/frontend/src/components/icons/KaguraLogo.tsx
@@ -140,7 +140,7 @@ export function KaguraLogo({
     return (
       <svg
         xmlns="http://www.w3.org/2000/svg"
-        viewBox="0 0 336 120"
+        viewBox="0 0 560 120"
         className={className}
         role="img"
         aria-label="Kagura AI"
@@ -149,10 +149,10 @@ export function KaguraLogo({
           href="/brand/kagura-mark.png"
           x="6"
           y="8"
-          width="104"
+          width="108"
           height="104"
         />
-        <image href={wordmark} x="120" y="34" width="207" height="52" />
+        <image href={wordmark} x="146" y="18" width="408" height="102" />
       </svg>
     );
   }


### PR DESCRIPTION
## Problem
The `variant="image"` lockup sized the wordmark at **~0.4× the mark height**, so "Kagura AI" looked too small beside the mark — most visible in the dark sidebar (user-reported).

## Fix
Measured the official horizontal lockup (`KaguraAI_logo3`): glyph height should be **~0.81× the mark height** with a **~0.29× gap**. Re-tuned the image-variant geometry to those official proportions:
- viewBox `336×120` → `560×120`
- wordmark `<image>` enlarged + repositioned (`x146 y18 w408 h102`), mark box height unchanged

The lockup is now wider (~4.67:1, official), so:
- **Auth heroes** (login/device): `h-24` → `h-20` to stay within their `max-w-md` (416px content) container
- **Sidebar** (`w-64` = 256px): fits the wider lockup at `h-8` (~150px)

## Verification
- `tsc --noEmit`: no errors
- Lockup rendered headless on dark (sidebar) and light (auth) and checked against the official mark:wordmark ratio
- Follow-up to #1075 (which introduced the official sidebar wordmark but at the wrong size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)