### PR TITLE
chore(frontend): shrink sidebar logo to h-6, nudge wordmark down 5px

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -449,7 +449,7 @@ export function Sidebar() {
         )}
         onClick={() => setIsOpen(false)}
       >
-        <KaguraLogo className="h-8 w-auto" variant="image" surface="dark" />
+        <KaguraLogo className="h-6 w-auto" variant="image" surface="dark" />
       </Link>
 
       {/* Workspace Switcher at Top - Minimal padding */}

--- a/frontend/src/components/icons/KaguraLogo.tsx
+++ b/frontend/src/components/icons/KaguraLogo.tsx
@@ -152,7 +152,7 @@ export function KaguraLogo({
           width="108"
           height="104"
         />
-        <image href={wordmark} x="146" y="18" width="408" height="102" />
+        <image href={wordmark} x="146" y="23" width="408" height="102" />
       </svg>
     );
   }


### PR DESCRIPTION
## Summary
Visual fine-tuning of the sidebar logo (follow-up to #1076), per feedback that the official-proportion lockup read a bit large.

- **Sidebar**: `h-8` → `h-6` — ~150px → ~112px in the `w-64` sidebar (≈ the pre-#1075 footprint).
- **Wordmark vertical nudge**: image-variant `<image>` `y=18` → `y=23` (down 5px) so "Kagura AI" sits better against the mark's optical centre. Shared variant, so login/device get the same 5px shift — negligible at their size.

## Verification
- `tsc --noEmit`: no errors
- Size/position previewed at the actual sidebar width before choosing h-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)