### PR TITLE
feat(neural): eval-gated reinforce rollout — telemetry + gate (#1069)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -168,6 +168,13 @@ eval-compounding:
 	@echo "Writes backend/tests/eval/results/compounding-<date>.json — real run only, never fabricated."
 	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.replay_runner
 
+.PHONY: eval-reinforce
+eval-reinforce:
+	@echo "Running live reinforce ON-vs-OFF rollout gate (Issue #1069, needs the stack: make up)..."
+	@echo "Writes backend/tests/eval/results/reinforce-<date>.json — real run only, never fabricated."
+	@echo "Exit code is non-zero if the rollout gate FAILS (do not enable reinforce in prod)."
+	cd $(BACKEND_DIR) && KAGURA_EVAL_LIVE=1 PYTHONPATH=src:. python -m tests.eval.reinforce_runner
+
 .PHONY: test-cov
 test-cov:
 	@echo "Running tests with coverage in Docker..."

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1497,11 +1497,49 @@ class MemoryService:
         signal = max(-1.0, min(1.0, usage + cold))
         return 1.0 + max_boost * signal
 
+    @staticmethod
+    def _reinforce_telemetry(
+        *,
+        order_before: list[str],
+        order_after: list[str],
+        factors: dict[str, float],
+        zero_adoption_ids: set[str],
+        top_k: int,
+    ) -> dict[str, object]:
+        """Issue #1069: a pure, side-effect-free summary of one reinforce re-rank.
+
+        Emitted as a ``reinforce_rerank_applied`` structured log so per-context
+        enabling and any regression are observable without a metrics backend (the
+        codebase's observability is structlog/JSON, not Prometheus). The load-bearing
+        regression signal is ``zero_adoption_in_topk`` — the cold-start /
+        popularity-bias guard: if reinforce starves brand-new (adoption=0) memories
+        out of the user-visible slice, this drops. ``reordered`` / ``top1_changed``
+        confirm the re-rank is actually active once an operator flips
+        ``reinforce_enabled`` on a context; the ``factor_*`` distribution shows how
+        hard it is pushing. ``top_k`` is the user-visible slice (``request.k``).
+        """
+        vals = list(factors.values())
+        eps = 1e-9
+        k = max(0, top_k)
+        return {
+            "candidates": len(order_after),
+            "reordered": order_before != order_after,
+            "top1_changed": order_before[:1] != order_after[:1],
+            "factor_min": round(min(vals), 4) if vals else 1.0,
+            "factor_max": round(max(vals), 4) if vals else 1.0,
+            "factor_mean": round(sum(vals) / len(vals), 4) if vals else 1.0,
+            "boosted": sum(1 for f in vals if f > 1.0 + eps),
+            "demoted": sum(1 for f in vals if f < 1.0 - eps),
+            "zero_adoption_in_topk": sum(1 for mid in order_after[:k] if mid in zero_adoption_ids),
+            "topk": min(k, len(order_after)),
+        }
+
     async def _maybe_reinforce_rerank(
         self,
         search_results: list[dict],
         memories: dict,
         context_id: UUID | None,
+        top_k: int | None = None,
     ) -> None:
         """Issue #1048: bounded, config-gated recall re-rank by adoption + feedback.
 
@@ -1509,6 +1547,12 @@ class MemoryService:
         (default OFF → recall ranking is byte-identical to pre-#1048). Single-context
         only — a per-context config/feedback set can't govern a cross-context pool.
         Re-sorts ``search_results`` IN PLACE by ``hybrid_score * _reinforce_factor``.
+
+        Issue #1069: when the re-rank fires it emits a ``reinforce_rerank_applied``
+        structured log carrying per-context uplift + popularity-bias telemetry, so a
+        staged rollout is monitorable. ``top_k`` is the user-visible slice the
+        telemetry measures the zero-adoption surfacing rate over (the caller passes
+        ``request.k``); ``None`` falls back to the whole candidate pool.
         """
         if context_id is None or len(search_results) < 2:
             return
@@ -1539,24 +1583,55 @@ class MemoryService:
             feedback = await FeedbackService(self.db).aggregate_for_memories(context_id, cand_ids)
             now = utcnow()
 
-            def _adjusted(r: dict) -> float:
-                base = r.get("hybrid_score")
-                if base is None:
-                    base = r.get("score") or 0.0
+            # Precompute the per-memory factor once (id-keyed) so the sort key and the
+            # telemetry summary share one computation and can never diverge.
+            factors: dict[str, float] = {}
+            zero_adoption_ids: set[str] = set()
+            for r in search_results:
                 mem = memories.get(r["id"])
                 if mem is None:
-                    return base
-                agg = feedback.get(str(mem.id))
-                factor = self._reinforce_factor(
+                    continue
+                sid = str(mem.id)
+                if sid in factors:
+                    continue
+                agg = feedback.get(sid)
+                factors[sid] = self._reinforce_factor(
                     reference_count=mem.reference_count or 0,
                     net_helpful=agg.net if agg else 0,
                     importance=mem.importance,
                     age_days=max(0, (now - mem.created_at).days),
                     max_boost=max_boost,
                 )
-                return base * factor
+                if (mem.reference_count or 0) == 0:
+                    zero_adoption_ids.add(sid)
 
+            def _sid(r: dict) -> str | None:
+                mem = memories.get(r["id"])
+                return str(mem.id) if mem is not None else None
+
+            def _adjusted(r: dict) -> float:
+                base = r.get("hybrid_score")
+                if base is None:
+                    base = r.get("score") or 0.0
+                sid = _sid(r)
+                return base * (factors.get(sid, 1.0) if sid is not None else 1.0)
+
+            order_before = [s for s in (_sid(r) for r in search_results) if s is not None]
             search_results.sort(key=_adjusted, reverse=True)
+            order_after = [s for s in (_sid(r) for r in search_results) if s is not None]
+
+            logger.info(
+                "reinforce_rerank_applied",
+                context_id=str(context_id),
+                max_boost=round(max_boost, 4),
+                **self._reinforce_telemetry(
+                    order_before=order_before,
+                    order_after=order_after,
+                    factors=factors,
+                    zero_adoption_ids=zero_adoption_ids,
+                    top_k=top_k if top_k is not None else len(order_after),
+                ),
+            )
         except Exception as exc:  # noqa: BLE001 — reinforce must never break recall
             logger.warning("reinforce_rerank_skipped", error=str(exc))
 
@@ -1864,7 +1939,10 @@ class MemoryService:
         # candidate pool BEFORE the top-k slice below; uses only reference_count +
         # feedback + importance + recency — never graph signals (respects #120).
         await self._maybe_reinforce_rerank(
-            search_results, memories, current_context_id if not context_ids else None
+            search_results,
+            memories,
+            current_context_id if not context_ids else None,
+            top_k=request.k,
         )
 
         responses = []

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1620,18 +1620,26 @@ class MemoryService:
             search_results.sort(key=_adjusted, reverse=True)
             order_after = [s for s in (_sid(r) for r in search_results) if s is not None]
 
-            logger.info(
-                "reinforce_rerank_applied",
-                context_id=str(context_id),
-                max_boost=round(max_boost, 4),
-                **self._reinforce_telemetry(
-                    order_before=order_before,
-                    order_after=order_after,
-                    factors=factors,
-                    zero_adoption_ids=zero_adoption_ids,
-                    top_k=top_k if top_k is not None else len(order_after),
-                ),
-            )
+            # Telemetry is isolated in its own guard: the re-rank has ALREADY been
+            # applied above, so a telemetry/log failure must NOT fall through to the
+            # outer except and emit the misleading "skipped" signal an operator is
+            # monitoring the rollout on. It also must not break recall — hence a
+            # distinct, swallowed ``reinforce_telemetry_failed`` event.
+            try:
+                logger.info(
+                    "reinforce_rerank_applied",
+                    context_id=str(context_id),
+                    max_boost=round(max_boost, 4),
+                    **self._reinforce_telemetry(
+                        order_before=order_before,
+                        order_after=order_after,
+                        factors=factors,
+                        zero_adoption_ids=zero_adoption_ids,
+                        top_k=top_k if top_k is not None else len(order_after),
+                    ),
+                )
+            except Exception as texc:  # noqa: BLE001 — telemetry must not break recall
+                logger.warning("reinforce_telemetry_failed", error=str(texc))
         except Exception as exc:  # noqa: BLE001 — reinforce must never break recall
             logger.warning("reinforce_rerank_skipped", error=str(exc))
 

--- a/backend/tests/eval/fixtures/reinforce_corpus.yaml
+++ b/backend/tests/eval/fixtures/reinforce_corpus.yaml
@@ -1,0 +1,177 @@
+# Reinforce ON-vs-OFF eval corpus (Issue #1069).
+#
+# Two-population, adoption-stratified — distinct from the static golden corpus
+# (#344), which is not stratified by adoption. The live runner
+# (tests.eval.reinforce_runner) seeds adoption + positive feedback on every doc
+# in meta.adopted_docs BEFORE the ON arm, then measures:
+#
+#   * current_fact queries — gold is an ADOPTED canonical answer competing with a
+#     near-duplicate, non-adopted phrasing. Reinforce should lift the canonical.
+#   * rare queries — gold is a ZERO-ADOPTION niche memory. The adopted/popular
+#     docs are distractors; reinforce must NOT bury the long tail (no regression),
+#     and the zero-adoption surfacing rate must hold (popularity-bias guard).
+#
+# All docs are `memory` source (the reinforce re-rank is a memory-ranking signal).
+meta:
+  version: 1
+  domain: "Kagura Memory Cloud (dogfooded knowledge-base content)"
+  notes: "10 queries x 2 populations (current_fact / rare); 15 memory docs. Authored starter set."
+  # Seeded with adoption (reference_count) + net-helpful feedback before the ON arm.
+  adopted_docs:
+    - doc_cf_hybrid_canon
+    - doc_cf_sleep_canon
+    - doc_cf_reinforce_canon
+    - doc_cf_trust_canon
+    - doc_cf_conf_canon
+
+documents:
+  # --- current_fact: canonical (adopted) vs near-duplicate competitor (not adopted) ---
+  - id: doc_cf_hybrid_canon
+    source: memory
+    text: >-
+      Hybrid recall blends dense semantic similarity with BM25 full-text scoring,
+      weighted 60 percent semantic and 40 percent keyword by default. This is the
+      confirmed, canonical configuration the team standardized on.
+  - id: doc_cf_hybrid_alt
+    source: memory
+    text: >-
+      Search can combine vector similarity and lexical matching. Different teams
+      have tried various splits between embedding scores and keyword scores when
+      fusing the two ranking signals together.
+
+  - id: doc_cf_sleep_canon
+    source: memory
+    text: >-
+      Sleep maintenance runs consolidation as a scheduled background pass: it
+      deduplicates near-identical memories and re-evaluates importance. The
+      canonical cadence the team adopted is a nightly edges-only consolidation.
+  - id: doc_cf_sleep_alt
+    source: memory
+    text: >-
+      A maintenance job can periodically tidy stored memories, merging things that
+      look alike and adjusting how important each item is considered over time on
+      some recurring schedule.
+
+  - id: doc_cf_reinforce_canon
+    source: memory
+    text: >-
+      The reinforce recall re-rank applies a bounded multiplier from adoption and
+      retrieval feedback, default max boost 0.15, and ships default-off per
+      context. This is the confirmed production guardrail.
+  - id: doc_cf_reinforce_alt
+    source: memory
+    text: >-
+      Usage signals such as how often something is reused can nudge ranking. The
+      amount of nudge is capped so popularity cannot dominate relevance in the
+      returned ordering of results.
+
+  - id: doc_cf_trust_canon
+    source: memory
+    text: >-
+      Context trust_tier is server-stamped: connector-provisioned contexts are
+      marked external, user-created contexts default to trusted. This is the
+      authoritative, confirmed provenance rule.
+  - id: doc_cf_trust_alt
+    source: memory
+    text: >-
+      Where a context comes from can be recorded so the system knows whether its
+      contents arrived from an outside integration or were entered directly by a
+      person using the product.
+
+  - id: doc_cf_conf_canon
+    source: memory
+    text: >-
+      Recall returns a confidence level — none, low, moderate, or high — derived
+      from the top score and its prominence over the candidate pool. This is the
+      canonical signal agents use to decide whether to trust a result.
+  - id: doc_cf_conf_alt
+    source: memory
+    text: >-
+      A retrieval response may carry some indication of how strong the match was,
+      letting a caller gauge whether the returned items are likely to be useful or
+      should be treated with caution.
+
+  # --- rare: niche, zero-adoption gold (never in adopted_docs) ---
+  - id: doc_rare_cp932
+    source: memory
+    text: >-
+      On Windows, pytest collection raised a cp932 UnicodeDecodeError reading
+      UTF-8 source; setting PYTHONUTF8=1 and adding encoding="utf-8" to file IO
+      fixed the portability bug.
+  - id: doc_rare_bfs
+    source: memory
+    text: >-
+      The neural-edge get_neighbors BFS had an off-by-one: guarding expansion
+      before recording made max_hops=1 return an empty set. Guard expansion after
+      recording so direct neighbors are returned.
+  - id: doc_rare_pagination
+    source: memory
+    text: >-
+      Paginated memory listing ordered by created_at alone was non-deterministic:
+      ties could duplicate or skip rows across pages. Adding a descending id
+      tiebreaker to the ORDER BY made offset/limit stable.
+  - id: doc_rare_qdrant
+    source: memory
+    text: >-
+      The Qdrant upsert can hit a transient client-side stall on local dev stacks,
+      timing out at a random doc without reaching the server. One reset-and-retry
+      of the pending embedding recovers it.
+  - id: doc_rare_vdb
+    source: memory
+    text: >-
+      Vector-store evaluation: the server stays on Qdrant because alternative
+      embedded stores are weak at multi-writer workloads; the embedded Lite build
+      chose LanceDB over zvec for Japanese full-text maturity.
+
+queries:
+  - id: q_cf_hybrid
+    bucket: retrieval-semantic
+    population: current_fact
+    text: "What is the standard weighting between semantic and keyword scores in hybrid recall?"
+    relevant: [doc_cf_hybrid_canon]
+  - id: q_cf_sleep
+    bucket: retrieval-semantic
+    population: current_fact
+    text: "What consolidation cadence did the team standardize on for sleep maintenance?"
+    relevant: [doc_cf_sleep_canon]
+  - id: q_cf_reinforce
+    bucket: retrieval-semantic
+    population: current_fact
+    text: "What is the default bounded boost and rollout posture of the reinforce re-rank?"
+    relevant: [doc_cf_reinforce_canon]
+  - id: q_cf_trust
+    bucket: retrieval-semantic
+    population: current_fact
+    text: "How is a context's trust tier decided between external and trusted?"
+    relevant: [doc_cf_trust_canon]
+  - id: q_cf_conf
+    bucket: retrieval-semantic
+    population: current_fact
+    text: "What confidence levels does recall return and what are they derived from?"
+    relevant: [doc_cf_conf_canon]
+
+  - id: q_rare_cp932
+    bucket: memory-only
+    population: rare
+    text: "Why did pytest collection fail with a cp932 decode error on Windows and what fixed it?"
+    relevant: [doc_rare_cp932]
+  - id: q_rare_bfs
+    bucket: memory-only
+    population: rare
+    text: "What caused get_neighbors to return an empty set at max_hops=1?"
+    relevant: [doc_rare_bfs]
+  - id: q_rare_pagination
+    bucket: memory-only
+    population: rare
+    text: "Why was paginated memory listing duplicating or skipping rows across pages?"
+    relevant: [doc_rare_pagination]
+  - id: q_rare_qdrant
+    bucket: memory-only
+    population: rare
+    text: "How is a transient Qdrant upsert stall during ingest recovered?"
+    relevant: [doc_rare_qdrant]
+  - id: q_rare_vdb
+    bucket: memory-only
+    population: rare
+    text: "Why does the server stay on Qdrant while the embedded Lite build uses LanceDB?"
+    relevant: [doc_rare_vdb]

--- a/backend/tests/eval/reinforce_gate.py
+++ b/backend/tests/eval/reinforce_gate.py
@@ -1,0 +1,176 @@
+"""Pure logic for the #1069 reinforce ON-vs-OFF eval gate.
+
+Tier-C companion to the #344 static harness (``runner.py``) and the #969
+compounding harness (``replay_runner.py``). The bounded reinforce re-rank (#1048)
+ships **default-OFF**; this module defines the gate that decides whether enabling
+it on a context is safe — the eval the rollout (#1069) is gated on:
+
+- **current-fact** queries (the canonical answer has been adopted + confirmed
+  helpful) must **improve** — that is the whole point of reinforce;
+- **rare-but-correct / historical** queries (gold is a zero-adoption memory) must
+  **not regress** — reinforce must not bury the long tail;
+- **popularity bias is measured, not assumed away** — the zero-adoption surfacing
+  rate (share of the top-k slots held by never-adopted memories) must be retained,
+  so the cold-start floor still lets brand-new memories through.
+
+Everything here is deterministic and infrastructure-free (unit-tested in
+``test_reinforce_gate.py``). The live ingest → seed-adoption → OFF/ON → score
+orchestration that actually drives ``recall()`` lives in
+``tests.eval.reinforce_runner``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from tests.eval.metrics import mean_ndcg_at_k, mean_precision_at_k, mrr_at_k
+
+#: Query strata (Query.population in the reinforce corpus).
+POPULATION_CURRENT_FACT = "current_fact"
+POPULATION_RARE = "rare"
+POPULATIONS = (POPULATION_CURRENT_FACT, POPULATION_RARE)
+
+#: The metric the gate decides on. MRR@10 is the most sensitive to a single
+#: canonical answer moving a few ranks — exactly the reinforce effect.
+PRIMARY_METRIC = "mrr@10"
+
+#: One query result: the ranked doc-ids and its gold set. Matches the shape the
+#: live runner builds (and the #344 metrics module consumes).
+Ranking = tuple[Sequence[str], set[str]]
+
+
+def population_metrics(rankings: Sequence[Ranking]) -> dict[str, float]:
+    """The metric block for one population (reuses the #344 binary-relevance
+    metrics). ``n`` is the query count; the rest are the gate-comparable scores.
+    """
+    return {
+        "n": len(rankings),
+        "p@5": round(mean_precision_at_k(rankings, 5), 4),
+        "mrr@10": round(mrr_at_k(rankings, 10), 4),
+        "ndcg@10": round(mean_ndcg_at_k(rankings, 10), 4),
+    }
+
+
+def zero_adoption_surfacing_rate(
+    rankings: Sequence[Ranking], adopted_ids: set[str], k: int
+) -> float:
+    """Share of the realized top-``k`` slots, across all queries, filled by a
+    NEVER-ADOPTED (zero-adoption) doc.
+
+    The popularity-bias guard from #1069: if enabling reinforce makes adopted
+    memories crowd the surface, this rate falls vs the OFF arm — brand-new
+    memories stop getting through. Counts realized slots (``min(k, len)``) so an
+    under-filled result set is measured honestly, not diluted by empty positions.
+    Returns 0.0 for an empty input.
+    """
+    surfaced = 0
+    zero = 0
+    for ranked, _relevant in rankings:
+        top = list(ranked[:k])
+        surfaced += len(top)
+        zero += sum(1 for d in top if d not in adopted_ids)
+    return round(zero / surfaced, 4) if surfaced else 0.0
+
+
+@dataclass(frozen=True)
+class GateThresholds:
+    """The rollout gate's decision thresholds (all on ``PRIMARY_METRIC``).
+
+    Conservative defaults: the gate PASSES when reinforce does not *regress* the
+    current-fact population, does not regress the rare population beyond a small
+    tolerance, and retains most of the zero-adoption surfacing rate. An
+    experiment wanting a stronger "improves" claim can raise
+    ``min_current_fact_uplift`` above 0 (the verdict always reports the strict
+    ``improved`` flag separately, so the distinction is never hidden).
+    """
+
+    #: ON − OFF on the current-fact population must be >= this (0.0 = no regression).
+    min_current_fact_uplift: float = 0.0
+    #: OFF − ON on the rare population must be <= this (the long-tail no-regress band).
+    max_rare_regression: float = 0.02
+    #: ON zero-adoption surfacing must be >= this fraction of OFF (cold-start retention).
+    min_zero_adoption_retention: float = 0.90
+
+
+@dataclass(frozen=True)
+class ArmBlock:
+    """One arm's scored result: per-population metric blocks + the corpus-level
+    zero-adoption surfacing rate. Both the OFF and ON arms are this shape."""
+
+    populations: dict[str, dict[str, float]]
+    zero_adoption_surfacing_rate: float
+
+
+def _primary(arm: ArmBlock, population: str) -> float:
+    block = arm.populations.get(population)
+    if block is None:
+        raise ValueError(f"arm is missing the {population!r} population block")
+    return float(block[PRIMARY_METRIC])
+
+
+def evaluate_reinforce_gate(
+    off: ArmBlock,
+    on: ArmBlock,
+    *,
+    thresholds: GateThresholds | None = None,
+) -> dict[str, Any]:
+    """Compare an OFF-arm and ON-arm block and decide the rollout gate.
+
+    Returns a verdict dict with the per-population deltas on ``PRIMARY_METRIC``,
+    the popularity-bias retention, a boolean ``passed``, and human-readable
+    ``reasons`` for every failed condition. Pure — no I/O, no global state.
+    """
+    th = thresholds or GateThresholds()
+
+    cf_off, cf_on = _primary(off, POPULATION_CURRENT_FACT), _primary(on, POPULATION_CURRENT_FACT)
+    rare_off, rare_on = _primary(off, POPULATION_RARE), _primary(on, POPULATION_RARE)
+    za_off = off.zero_adoption_surfacing_rate
+    za_on = on.zero_adoption_surfacing_rate
+
+    uplift = cf_on - cf_off
+    regression = rare_off - rare_on
+    # If OFF surfaced no zero-adoption docs at all there is nothing to "retain" —
+    # report None and do not fail the gate on a 0/0 ratio.
+    retention = round(za_on / za_off, 4) if za_off > 0 else None
+
+    reasons: list[str] = []
+    if uplift < th.min_current_fact_uplift - 1e-9:
+        reasons.append(
+            f"current-fact {PRIMARY_METRIC} uplift {uplift:+.4f} < required "
+            f"{th.min_current_fact_uplift:+.4f}"
+        )
+    if regression > th.max_rare_regression + 1e-9:
+        reasons.append(
+            f"rare {PRIMARY_METRIC} regressed {regression:+.4f} > allowed "
+            f"{th.max_rare_regression:+.4f}"
+        )
+    if retention is not None and retention < th.min_zero_adoption_retention - 1e-9:
+        reasons.append(
+            f"zero-adoption surfacing retention {retention:.4f} < required "
+            f"{th.min_zero_adoption_retention:.4f}"
+        )
+
+    return {
+        "primary_metric": PRIMARY_METRIC,
+        "current_fact": {
+            "off": round(cf_off, 4),
+            "on": round(cf_on, 4),
+            "uplift": round(uplift, 4),
+            "improved": uplift > 1e-9,
+        },
+        "rare": {
+            "off": round(rare_off, 4),
+            "on": round(rare_on, 4),
+            "regression": round(regression, 4),
+        },
+        "zero_adoption_surfacing": {
+            "off": round(za_off, 4),
+            "on": round(za_on, 4),
+            "retention": retention,
+        },
+        "thresholds": asdict(th),
+        "passed": not reasons,
+        "reasons": reasons,
+    }

--- a/backend/tests/eval/reinforce_gate.py
+++ b/backend/tests/eval/reinforce_gate.py
@@ -41,9 +41,10 @@ PRIMARY_METRIC = "mrr@10"
 Ranking = tuple[Sequence[str], set[str]]
 
 
-def population_metrics(rankings: Sequence[Ranking]) -> dict[str, float]:
+def population_metrics(rankings: Sequence[Ranking]) -> dict[str, float | int]:
     """The metric block for one population (reuses the #344 binary-relevance
-    metrics). ``n`` is the query count; the rest are the gate-comparable scores.
+    metrics). ``n`` is the query count (int); the rest are the gate-comparable
+    float scores.
     """
     return {
         "n": len(rankings),
@@ -99,7 +100,7 @@ class ArmBlock:
     """One arm's scored result: per-population metric blocks + the corpus-level
     zero-adoption surfacing rate. Both the OFF and ON arms are this shape."""
 
-    populations: dict[str, dict[str, float]]
+    populations: dict[str, dict[str, float | int]]
     zero_adoption_surfacing_rate: float
 
 

--- a/backend/tests/eval/reinforce_runner.py
+++ b/backend/tests/eval/reinforce_runner.py
@@ -154,6 +154,21 @@ async def _run_reinforce_arms(
     evaluate the rollout gate. Neural memory is forced OFF so the only thing that
     changes between arms is the reinforce re-rank itself.
     """
+    # Fail fast on a malformed corpus: a typo'd / missing population would be
+    # silently dropped from the per-population breakdown, shrinking the gate's
+    # sample with no error. Every query must carry a recognized population and
+    # both populations must be represented, or the A/B is not what it claims.
+    by_population: dict[str, int] = dict.fromkeys(POPULATIONS, 0)
+    for q in corpus.queries:
+        if q.population not in by_population:
+            raise RuntimeError(
+                f"query {q.id!r} has population {q.population!r}; expected one of {POPULATIONS}"
+            )
+        by_population[q.population] += 1
+    empty = [p for p, n in by_population.items() if n == 0]
+    if empty:
+        raise RuntimeError(f"reinforce corpus has no queries for population(s) {empty}")
+
     rev: dict[str, UUID] = {doc_id: UUID(mid) for mid, doc_id in id_map.items()}
     adopted_docs = {d for d in corpus.meta.get("adopted_docs", []) if d in rev}
     adopted_mem_ids = [rev[d] for d in sorted(adopted_docs)]

--- a/backend/tests/eval/reinforce_runner.py
+++ b/backend/tests/eval/reinforce_runner.py
@@ -1,0 +1,268 @@
+"""Live reinforce ON-vs-OFF eval orchestration (Issue #1069).
+
+Tier-C harness: the #344 ``runner.py`` measures *static* retrieval quality and
+the #969 ``replay_runner.py`` measures graph *compounding*; this one measures
+whether enabling the bounded reinforce re-rank (#1048) on a context is **safe** —
+the eval the staged production rollout is gated on.
+
+Protocol (one ingested corpus, one A/B flip — only the config changes):
+
+    ingest reinforce_corpus
+      → seed adoption (reference_count) + net-helpful feedback on the canonical
+        current-fact docs (meta.adopted_docs)
+      → OFF arm: reinforce disabled (default) → score current_fact / rare + the
+        zero-adoption surfacing rate
+      → flip ContextSearchConfig.reinforce_enabled = true
+      → ON arm: score the same queries again
+      → evaluate_reinforce_gate(off, on)  → results/reinforce-<date>.json
+
+The decision logic + metrics are pure (``reinforce_gate.py``, unit-tested); this
+module is the live driver. Heavy imports are function-local so importing the
+module stays cheap and CI-safe. Produces JSON from a REAL run only — never
+fabricated. Run via ``make eval-reinforce`` (needs the live stack).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+from uuid import UUID, uuid4
+
+from tests.eval.reinforce_gate import (
+    POPULATIONS,
+    ArmBlock,
+    GateThresholds,
+    evaluate_reinforce_gate,
+    population_metrics,
+    zero_adoption_surfacing_rate,
+)
+from tests.eval.runner import _ingest_corpus, _teardown
+from tests.eval.tools.corpus import Corpus, load_corpus
+
+_RESULTS_DIR = Path(__file__).resolve().parent / "results"
+_REINFORCE_CORPUS = Path(__file__).resolve().parent / "fixtures" / "reinforce_corpus.yaml"
+_RECALL_K = 10
+_MAX_BOOST = 0.15
+# Adoption seeding for the canonical current-fact docs before the ON arm: each
+# adopted doc gets _SEED_REFERENCES reference() bumps (adoption signal) and
+# _SEED_HELPFUL net-helpful feedback events. Enough to clear the log-scaled
+# adoption term meaningfully without saturating it (the factor is bounded anyway).
+_SEED_REFERENCES = 5
+_SEED_HELPFUL = 3
+
+
+def _load_reinforce_corpus() -> Corpus:
+    return load_corpus(_REINFORCE_CORPUS)
+
+
+async def _seed_adoption(
+    svc: Any,
+    ctx_id: UUID,
+    owner: str,
+    memory_ids: list[UUID],
+    *,
+    references: int = _SEED_REFERENCES,
+    helpful: int = _SEED_HELPFUL,
+) -> None:
+    """Seed adoption (reference_count) + net-helpful feedback on the canonical docs.
+
+    ``reference()`` is the adoption signal (#1046): each call bumps
+    ``reference_count`` by one. ``record_feedback(helpful=True)`` is the retrieval
+    feedback signal (#888). Together these are exactly the inputs the reinforce
+    factor reads, so the ON arm has real signal to act on while the rare
+    (zero-adoption) docs stay untouched.
+    """
+    from services.feedback_service import FeedbackService
+
+    fb = FeedbackService(svc.db)
+    for mid in memory_ids:
+        for _ in range(references):
+            await svc.reference(mid, owner)
+        for _ in range(helpful):
+            await fb.record_feedback(ctx_id, mid, helpful=True, user_id=owner)
+    await svc.db.commit()
+
+
+async def _set_reinforce(db: Any, ctx_id: UUID, *, enabled: bool, max_boost: float) -> None:
+    """Flip ``ContextSearchConfig.reinforce_enabled`` for the eval context.
+
+    Sets the attribute directly on the (created-if-missing) config row — the
+    ``ContextSearchConfigUpdate`` schema requires the full weight set, which we do
+    not want to disturb for an A/B that only toggles reinforce.
+    """
+    from decimal import Decimal
+
+    from repositories.config_repository import ContextSearchConfigRepository
+
+    config = await ContextSearchConfigRepository(db).create_or_get(ctx_id)
+    config.reinforce_enabled = enabled
+    config.reinforce_max_boost = Decimal(str(max_boost))
+    await db.commit()
+
+
+async def _score_reinforce_arm(
+    svc: Any,
+    corpus: Corpus,
+    id_map: dict[str, str],
+    owner: str,
+    ctx_id: UUID,
+    ws_id: UUID,
+    adopted_docs: set[str],
+) -> ArmBlock:
+    """Recall every query (hybrid), group rankings by population, and compute the
+    per-population metric blocks + the corpus-level zero-adoption surfacing rate.
+    """
+    from models.schemas import RecallRequest
+
+    by_pop: dict[str, list[tuple[list[str], set[str]]]] = {p: [] for p in POPULATIONS}
+    all_rankings: list[tuple[list[str], set[str]]] = []
+    for q in corpus.queries:
+        resp = await svc.recall(
+            request=RecallRequest(query=q.text, k=_RECALL_K, search_mode="hybrid"),
+            user_id=owner,
+            current_context_id=ctx_id,
+            current_workspace_id=ws_id,
+        )
+        ranked_docs = [id_map.get(str(r.memory_id), "?") for r in resp.results]
+        relevant = set(q.relevant)
+        if q.population in by_pop:
+            by_pop[q.population].append((ranked_docs, relevant))
+        all_rankings.append((ranked_docs, relevant))
+
+    return ArmBlock(
+        populations={p: population_metrics(by_pop[p]) for p in POPULATIONS},
+        zero_adoption_surfacing_rate=zero_adoption_surfacing_rate(
+            all_rankings, adopted_docs, _RECALL_K
+        ),
+    )
+
+
+async def _run_reinforce_arms(
+    svc: Any,
+    corpus: Corpus,
+    id_map: dict[str, str],
+    owner: str,
+    ctx_id: UUID,
+    ws_id: UUID,
+    run_date: str,
+    write: bool,
+) -> dict[str, Any]:
+    """Seed adoption, score the OFF arm, flip reinforce on, score the ON arm, and
+    evaluate the rollout gate. Neural memory is forced OFF so the only thing that
+    changes between arms is the reinforce re-rank itself.
+    """
+    rev: dict[str, UUID] = {doc_id: UUID(mid) for mid, doc_id in id_map.items()}
+    adopted_docs = {d for d in corpus.meta.get("adopted_docs", []) if d in rev}
+    adopted_mem_ids = [rev[d] for d in sorted(adopted_docs)]
+
+    prev_neural = os.environ.get("ENABLE_NEURAL_MEMORY")
+    os.environ["ENABLE_NEURAL_MEMORY"] = "false"
+    try:
+        await _seed_adoption(svc, ctx_id, owner, adopted_mem_ids)
+
+        # OFF arm: reinforce disabled by default (no config row → byte-identical
+        # to pre-#1048). Score before any config row exists.
+        off = await _score_reinforce_arm(svc, corpus, id_map, owner, ctx_id, ws_id, adopted_docs)
+
+        # Flip reinforce ON for the same context + same seeded signal.
+        await _set_reinforce(svc.db, ctx_id, enabled=True, max_boost=_MAX_BOOST)
+        on = await _score_reinforce_arm(svc, corpus, id_map, owner, ctx_id, ws_id, adopted_docs)
+    finally:
+        if prev_neural is None:
+            os.environ.pop("ENABLE_NEURAL_MEMORY", None)
+        else:
+            os.environ["ENABLE_NEURAL_MEMORY"] = prev_neural
+
+    gate = evaluate_reinforce_gate(off, on, thresholds=GateThresholds())
+    results: dict[str, Any] = {
+        "run_date": run_date,
+        "experiment": "reinforce_on_vs_off",
+        "corpus_version": corpus.meta.get("version"),
+        "query_count": len(corpus.queries),
+        "doc_count": len(corpus.documents),
+        "recall_k": _RECALL_K,
+        "max_boost": _MAX_BOOST,
+        "seed": {
+            "references": _SEED_REFERENCES,
+            "helpful_feedback": _SEED_HELPFUL,
+            "adopted_docs": sorted(adopted_docs),
+        },
+        "off": asdict(off),
+        "on": asdict(on),
+        "gate": gate,
+    }
+
+    if write:
+        _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        out = _RESULTS_DIR / f"reinforce-{run_date}.json"
+        out.write_text(json.dumps(results, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+        print(f"eval-reinforce: wrote {out}")
+    return results
+
+
+async def run_reinforce_eval(write: bool = True, run_date: str | None = None) -> dict[str, Any]:
+    """Ingest the reinforce corpus, run the OFF/ON A/B, evaluate the gate."""
+    from auth.workspace_roles import WorkspaceRole
+    from db.base import get_db
+    from models.auth import Context, Workspace, WorkspaceMember
+    from services.memory_service import MemoryService
+    from utils.datetime import utcnow
+
+    corpus = _load_reinforce_corpus()
+    run_date = run_date or utcnow().strftime("%Y-%m-%d")
+
+    async for db in get_db():
+        owner = f"eval_{uuid4().hex[:8]}"
+        ws = Workspace(
+            id=uuid4(),
+            name=f"eval-ws-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=owner,
+            daily_api_limit=10_000_000,
+            weekly_api_limit=50_000_000,
+        )
+        ctx = Context(
+            id=uuid4(),
+            workspace_id=ws.id,
+            name=f"eval-ctx-{uuid4().hex[:8]}",
+            created_by=owner,
+            is_private=False,
+        )
+        db.add(ws)
+        await db.flush()
+        db.add(ctx)
+        db.add(WorkspaceMember(workspace_id=ws.id, user_id=owner, role=WorkspaceRole.OWNER))
+        await db.flush()
+        await db.commit()
+
+        svc = MemoryService(db)
+        id_map: dict[str, str] = {}
+        try:
+            await _ingest_corpus(svc, corpus, owner, ctx.id, ws.id, id_map)
+            return await _run_reinforce_arms(
+                svc, corpus, id_map, owner, ctx.id, ws.id, run_date, write
+            )
+        finally:
+            await _teardown(svc, db, owner, ctx.id, ws.id, list(id_map.keys()))
+
+    raise RuntimeError("database session unavailable — is the stack up?")
+
+
+def _main() -> int:
+    import asyncio
+
+    results = asyncio.run(run_reinforce_eval())
+    print(json.dumps(results, indent=2, ensure_ascii=False))
+    gate = results["gate"]
+    print(f"\nreinforce gate: {'PASS' if gate['passed'] else 'FAIL'}")
+    for reason in gate["reasons"]:
+        print(f"  - {reason}")
+    # Non-zero exit on a failed gate so CI / an operator notices.
+    return 0 if gate["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/backend/tests/eval/test_reinforce_gate.py
+++ b/backend/tests/eval/test_reinforce_gate.py
@@ -1,0 +1,120 @@
+"""Unit tests for the #1069 reinforce ON-vs-OFF eval gate (pure logic).
+
+DB-free: pins the two-population metric blocks, the zero-adoption surfacing
+(popularity-bias) rate, and the decision gate that the staged rollout is gated
+on. The live ingest/seed/score orchestration is tested separately with fakes in
+``test_reinforce_runner.py``.
+"""
+
+from __future__ import annotations
+
+from tests.eval.reinforce_gate import (
+    POPULATION_CURRENT_FACT,
+    POPULATION_RARE,
+    ArmBlock,
+    GateThresholds,
+    evaluate_reinforce_gate,
+    population_metrics,
+    zero_adoption_surfacing_rate,
+)
+
+
+class TestPopulationMetrics:
+    def test_perfect_ranking_scores_one(self):
+        rankings = [(["a", "b"], {"a"}), (["c"], {"c"})]
+        m = population_metrics(rankings)
+        assert m["n"] == 2
+        assert m["mrr@10"] == 1.0
+        assert m["ndcg@10"] == 1.0
+
+    def test_empty_is_zero_not_error(self):
+        m = population_metrics([])
+        assert m["n"] == 0
+        assert m["mrr@10"] == 0.0
+
+
+class TestZeroAdoptionSurfacingRate:
+    def test_all_adopted_surfaced_is_zero(self):
+        # Every surfaced doc is adopted → zero-adoption surfacing rate 0.
+        rankings = [(["a", "b"], {"a"}), (["a"], {"a"})]
+        assert zero_adoption_surfacing_rate(rankings, adopted_ids={"a", "b"}, k=10) == 0.0
+
+    def test_counts_only_non_adopted_within_topk(self):
+        # top-2 of [z, a, w]: z (new) + a (adopted) → 1 of 2 slots is zero-adoption.
+        rankings = [(["z", "a", "w"], {"z"})]
+        assert zero_adoption_surfacing_rate(rankings, adopted_ids={"a"}, k=2) == 0.5
+
+    def test_empty_is_safe(self):
+        assert zero_adoption_surfacing_rate([], adopted_ids=set(), k=10) == 0.0
+
+    def test_realized_slots_not_diluted_by_empty_positions(self):
+        # Only one doc returned but k=10 — rate is over the 1 realized slot, not 10.
+        rankings = [(["z"], {"z"})]
+        assert zero_adoption_surfacing_rate(rankings, adopted_ids=set(), k=10) == 1.0
+
+
+def _arm(cf: float, rare: float, za: float) -> ArmBlock:
+    return ArmBlock(
+        populations={
+            POPULATION_CURRENT_FACT: {"n": 5, "p@5": cf, "mrr@10": cf, "ndcg@10": cf},
+            POPULATION_RARE: {"n": 5, "p@5": rare, "mrr@10": rare, "ndcg@10": rare},
+        },
+        zero_adoption_surfacing_rate=za,
+    )
+
+
+class TestEvaluateReinforceGate:
+    def test_passes_when_current_fact_improves_and_rare_holds(self):
+        off = _arm(cf=0.70, rare=0.80, za=0.50)
+        on = _arm(cf=0.85, rare=0.80, za=0.49)  # cf up, rare flat, za retained
+        v = evaluate_reinforce_gate(off, on)
+        assert v["passed"] is True
+        assert v["reasons"] == []
+        assert v["current_fact"]["uplift"] == 0.15
+        assert v["current_fact"]["improved"] is True
+
+    def test_fails_when_current_fact_regresses(self):
+        off = _arm(cf=0.80, rare=0.80, za=0.50)
+        on = _arm(cf=0.70, rare=0.80, za=0.50)  # cf DOWN
+        v = evaluate_reinforce_gate(off, on)
+        assert v["passed"] is False
+        assert any("current-fact" in r for r in v["reasons"])
+        assert v["current_fact"]["improved"] is False
+
+    def test_fails_when_rare_regresses_beyond_tolerance(self):
+        off = _arm(cf=0.70, rare=0.80, za=0.50)
+        on = _arm(cf=0.85, rare=0.70, za=0.50)  # rare drops 0.10 > 0.02 band
+        v = evaluate_reinforce_gate(off, on)
+        assert v["passed"] is False
+        assert any("rare" in r for r in v["reasons"])
+
+    def test_small_rare_dip_within_tolerance_passes(self):
+        off = _arm(cf=0.70, rare=0.80, za=0.50)
+        on = _arm(cf=0.85, rare=0.79, za=0.50)  # rare drops only 0.01 <= 0.02
+        v = evaluate_reinforce_gate(off, on)
+        assert v["passed"] is True
+
+    def test_fails_when_zero_adoption_surfacing_collapses(self):
+        off = _arm(cf=0.70, rare=0.80, za=0.50)
+        on = _arm(cf=0.85, rare=0.80, za=0.30)  # retention 0.6 < 0.9
+        v = evaluate_reinforce_gate(off, on)
+        assert v["passed"] is False
+        assert any("retention" in r for r in v["reasons"])
+        assert v["zero_adoption_surfacing"]["retention"] == 0.6
+
+    def test_retention_none_when_off_surfaced_no_zero_adoption(self):
+        # OFF already surfaced no zero-adoption docs → nothing to retain, no fail.
+        off = _arm(cf=0.70, rare=0.80, za=0.0)
+        on = _arm(cf=0.85, rare=0.80, za=0.0)
+        v = evaluate_reinforce_gate(off, on)
+        assert v["zero_adoption_surfacing"]["retention"] is None
+        assert v["passed"] is True
+
+    def test_thresholds_are_configurable_for_stronger_claim(self):
+        # Require a real +0.05 uplift; a flat current-fact now fails.
+        off = _arm(cf=0.80, rare=0.80, za=0.50)
+        on = _arm(cf=0.80, rare=0.80, za=0.50)
+        strict = GateThresholds(min_current_fact_uplift=0.05)
+        v = evaluate_reinforce_gate(off, on, thresholds=strict)
+        assert v["passed"] is False
+        assert any("uplift" in r for r in v["reasons"])

--- a/backend/tests/eval/test_reinforce_runner.py
+++ b/backend/tests/eval/test_reinforce_runner.py
@@ -11,8 +11,11 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
+import pytest
+
 from tests.eval import reinforce_runner
 from tests.eval.reinforce_gate import POPULATION_CURRENT_FACT, POPULATION_RARE, ArmBlock
+from tests.eval.tools.corpus import Corpus, Document, Query
 
 
 class _Hit:
@@ -126,3 +129,25 @@ class TestRunReinforceArms:
         assert results["off"]["zero_adoption_surfacing_rate"] == 0.50
         assert results["on"]["populations"][POPULATION_CURRENT_FACT]["mrr@10"] == 0.88
         assert results["experiment"] == "reinforce_on_vs_off"
+
+    async def test_typod_population_fails_fast(self):
+        # A query with an unrecognized population would otherwise be silently
+        # dropped from the gate's sample — the runner must reject it loudly.
+        corpus = Corpus(
+            meta={"adopted_docs": ["d1"]},
+            documents=(Document(id="d1", source="memory", text="x" * 20),),
+            queries=(
+                Query(
+                    id="q1",
+                    bucket="memory-only",
+                    text="q",
+                    relevant=("d1",),
+                    population="current-fact",
+                ),  # hyphen typo, not current_fact
+            ),
+        )
+        svc = MagicMock()
+        with pytest.raises(RuntimeError, match="population"):
+            await reinforce_runner._run_reinforce_arms(
+                svc, corpus, {str(uuid4()): "d1"}, "owner", uuid4(), uuid4(), "2026-06-26", False
+            )

--- a/backend/tests/eval/test_reinforce_runner.py
+++ b/backend/tests/eval/test_reinforce_runner.py
@@ -1,0 +1,128 @@
+"""DB-free orchestration tests for the #1069 reinforce ON/OFF live runner.
+
+Pins the control flow (seed adoption → score OFF → flip reinforce ON → score ON →
+gate) and the per-arm scoring (population split + zero-adoption surfacing) with
+fakes, so it runs in the plain unit suite — no live stack, no embeddings. The
+gate decision math itself is pinned separately in ``test_reinforce_gate.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+from tests.eval import reinforce_runner
+from tests.eval.reinforce_gate import POPULATION_CURRENT_FACT, POPULATION_RARE, ArmBlock
+
+
+class _Hit:
+    def __init__(self, memory_id: str) -> None:
+        self.memory_id = memory_id
+
+
+class _Resp:
+    def __init__(self, ids: list[str]) -> None:
+        self.results = [_Hit(i) for i in ids]
+
+
+def _corpus_and_idmap():
+    """The real reinforce corpus + a synthetic doc→memory id_map."""
+    corpus = reinforce_runner._load_reinforce_corpus()
+    # id_map is memory_id(str) -> doc_id; give every doc a stable synthetic uuid.
+    doc_to_mem = {d.id: str(uuid4()) for d in corpus.documents}
+    id_map = {mem: doc for doc, mem in doc_to_mem.items()}
+    return corpus, id_map, doc_to_mem
+
+
+class TestScoreReinforceArm:
+    async def test_perfect_ranking_splits_populations_and_counts_zero_adoption(self):
+        corpus, id_map, doc_to_mem = _corpus_and_idmap()
+        adopted_docs = set(corpus.meta["adopted_docs"])
+        gold_by_text = {q.text: q.relevant for q in corpus.queries}
+
+        async def _recall(*, request, user_id, current_context_id, current_workspace_id):
+            # Perfect retrieval: return each query's gold docs (as memory ids) first.
+            ids = [doc_to_mem[d] for d in gold_by_text[request.query]]
+            return _Resp(ids)
+
+        svc = MagicMock()
+        svc.recall = AsyncMock(side_effect=_recall)
+
+        arm = await reinforce_runner._score_reinforce_arm(
+            svc, corpus, id_map, "owner", uuid4(), uuid4(), adopted_docs
+        )
+        assert isinstance(arm, ArmBlock)
+        # Both populations are perfectly retrieved.
+        assert arm.populations[POPULATION_CURRENT_FACT]["mrr@10"] == 1.0
+        assert arm.populations[POPULATION_RARE]["mrr@10"] == 1.0
+        assert arm.populations[POPULATION_CURRENT_FACT]["n"] == 5
+        assert arm.populations[POPULATION_RARE]["n"] == 5
+        # 5 current-fact golds are adopted, 5 rare golds are zero-adoption → half
+        # the 10 surfaced slots are zero-adoption.
+        assert arm.zero_adoption_surfacing_rate == 0.5
+
+
+class TestSeedAdoption:
+    async def test_drives_reference_and_feedback_per_doc(self):
+        svc = MagicMock()
+        svc.reference = AsyncMock()
+        svc.db = MagicMock()
+        svc.db.commit = AsyncMock()
+        mem_ids = [uuid4(), uuid4()]
+        with patch("services.feedback_service.FeedbackService") as FB:
+            FB.return_value.record_feedback = AsyncMock()
+            await reinforce_runner._seed_adoption(
+                svc, uuid4(), "owner", mem_ids, references=5, helpful=3
+            )
+        assert svc.reference.await_count == 2 * 5  # references per adopted doc
+        assert FB.return_value.record_feedback.await_count == 2 * 3  # helpful per doc
+
+
+class TestRunReinforceArms:
+    async def test_off_scored_before_reinforce_flipped_on(self, monkeypatch):
+        corpus, id_map, _ = _corpus_and_idmap()
+        order: list[str] = []
+
+        off_arm = ArmBlock(
+            populations={
+                POPULATION_CURRENT_FACT: {"n": 5, "p@5": 0.6, "mrr@10": 0.70, "ndcg@10": 0.6},
+                POPULATION_RARE: {"n": 5, "p@5": 0.8, "mrr@10": 0.80, "ndcg@10": 0.8},
+            },
+            zero_adoption_surfacing_rate=0.50,
+        )
+        on_arm = ArmBlock(
+            populations={
+                POPULATION_CURRENT_FACT: {"n": 5, "p@5": 0.8, "mrr@10": 0.88, "ndcg@10": 0.8},
+                POPULATION_RARE: {"n": 5, "p@5": 0.8, "mrr@10": 0.80, "ndcg@10": 0.8},
+            },
+            zero_adoption_surfacing_rate=0.49,
+        )
+        arms = iter((off_arm, on_arm))
+
+        async def _seed(*a, **k):
+            order.append("seed")
+
+        async def _set(db, ctx_id, *, enabled, max_boost):
+            order.append(f"set_reinforce={enabled}")
+
+        async def _score(*a, **k):
+            order.append("score")
+            return next(arms)
+
+        monkeypatch.setattr(reinforce_runner, "_seed_adoption", _seed)
+        monkeypatch.setattr(reinforce_runner, "_set_reinforce", _set)
+        monkeypatch.setattr(reinforce_runner, "_score_reinforce_arm", _score)
+
+        svc = MagicMock()
+        svc.db = MagicMock()
+        results = await reinforce_runner._run_reinforce_arms(
+            svc, corpus, id_map, "owner", uuid4(), uuid4(), "2026-06-26", write=False
+        )
+
+        # Seed first, OFF arm scored while reinforce is still off, THEN flip on,
+        # THEN score the ON arm — the A/B is honest only in this order.
+        assert order == ["seed", "score", "set_reinforce=True", "score"]
+        assert results["gate"]["passed"] is True
+        assert results["off"]["zero_adoption_surfacing_rate"] == 0.50
+        assert results["on"]["populations"][POPULATION_CURRENT_FACT]["mrr@10"] == 0.88
+        assert results["experiment"] == "reinforce_on_vs_off"

--- a/backend/tests/eval/tools/corpus.py
+++ b/backend/tests/eval/tools/corpus.py
@@ -52,6 +52,11 @@ class Query:
     bucket: str
     text: str
     relevant: tuple[str, ...]
+    # Optional reinforce-eval stratum (Issue #1069): "current_fact" (the canonical
+    # answer has been adopted/confirmed — reinforce should help) vs "rare" (gold is
+    # a zero-adoption memory — reinforce must not bury it). None for the static
+    # golden corpus, which is not stratified by adoption.
+    population: str | None = None
 
 
 @dataclass(frozen=True)
@@ -93,6 +98,7 @@ def load_corpus(path: Path | None = None) -> Corpus:
             bucket=q["bucket"],
             text=q["text"],
             relevant=tuple(q.get("relevant", [])),
+            population=q.get("population"),
         )
         for q in raw.get("queries", [])
     )

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1475,6 +1475,34 @@ class TestReinforceRerank:
         events = [c.args[0] for c in log.info.call_args_list]
         assert "reinforce_rerank_applied" not in events
 
+    @pytest.mark.asyncio
+    async def test_telemetry_failure_does_not_mask_applied_rerank(self):
+        # A telemetry/log failure must NOT emit the misleading "skipped" signal the
+        # rollout is monitored on (the re-rank already fired), and must not break
+        # recall. It surfaces as a distinct reinforce_telemetry_failed instead.
+        from decimal import Decimal
+
+        svc = MemoryService(MagicMock())
+        cfg = MagicMock(reinforce_enabled=True, reinforce_max_boost=Decimal("0.15"))
+        old = datetime(2020, 1, 1)
+        mem_a = MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old)
+        mem_b = MagicMock(id=uuid4(), reference_count=10, importance=0.9, created_at=old)
+        memories = {"a": mem_a, "b": mem_b}
+        sr = [{"id": "a", "hybrid_score": 0.85}, {"id": "b", "hybrid_score": 0.80}]
+        with (
+            patch("repositories.config_repository.ContextSearchConfigRepository") as Repo,
+            patch("services.feedback_service.FeedbackService") as FB,
+            patch.object(MemoryService, "_reinforce_telemetry", side_effect=RuntimeError("boom")),
+            patch("services.memory_service.logger") as log,
+        ):
+            Repo.return_value.get_by_context = AsyncMock(return_value=cfg)
+            FB.return_value.aggregate_for_memories = AsyncMock(return_value={})
+            await svc._maybe_reinforce_rerank(sr, memories, uuid4(), top_k=10)
+        warn_events = [c.args[0] for c in log.warning.call_args_list]
+        assert "reinforce_telemetry_failed" in warn_events
+        assert "reinforce_rerank_skipped" not in warn_events  # the re-rank DID fire
+        assert {r["id"] for r in sr} == {"a", "b"}  # recall results intact
+
 
 class TestReinforceTelemetry:
     """Issue #1069: the pure per-recall reinforce summary that makes enabling and any

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1431,6 +1431,119 @@ class TestReinforceRerank:
             await svc._maybe_reinforce_rerank(sr, memories, uuid4())
         assert [r["id"] for r in sr][0] == "a"  # relevance still dominates
 
+    @pytest.mark.asyncio
+    async def test_emits_telemetry_when_enabled(self):
+        # Issue #1069: a fired re-rank emits one reinforce_rerank_applied event so a
+        # staged rollout is observable; a disabled context emits nothing.
+        from decimal import Decimal
+
+        svc = MemoryService(MagicMock())
+        cfg = MagicMock(reinforce_enabled=True, reinforce_max_boost=Decimal("0.15"))
+        old = datetime(2020, 1, 1)
+        mem_a = MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old)
+        mem_b = MagicMock(id=uuid4(), reference_count=10, importance=0.9, created_at=old)
+        memories = {"a": mem_a, "b": mem_b}
+        sr = [{"id": "a", "hybrid_score": 0.85}, {"id": "b", "hybrid_score": 0.80}]
+        with (
+            patch("repositories.config_repository.ContextSearchConfigRepository") as Repo,
+            patch("services.feedback_service.FeedbackService") as FB,
+            patch("services.memory_service.logger") as log,
+        ):
+            Repo.return_value.get_by_context = AsyncMock(return_value=cfg)
+            FB.return_value.aggregate_for_memories = AsyncMock(return_value={})
+            await svc._maybe_reinforce_rerank(sr, memories, uuid4(), top_k=10)
+        events = [c.args[0] for c in log.info.call_args_list]
+        assert events.count("reinforce_rerank_applied") == 1
+        # The emitted summary carries the popularity-bias guard metric.
+        kwargs = next(
+            c.kwargs for c in log.info.call_args_list if c.args[0] == "reinforce_rerank_applied"
+        )
+        assert kwargs["candidates"] == 2
+        assert "zero_adoption_in_topk" in kwargs
+
+    @pytest.mark.asyncio
+    async def test_no_telemetry_when_disabled(self):
+        svc = MemoryService(MagicMock())
+        cfg = MagicMock(reinforce_enabled=False)
+        sr = [{"id": "a", "hybrid_score": 0.9}, {"id": "b", "hybrid_score": 0.8}]
+        with (
+            patch("repositories.config_repository.ContextSearchConfigRepository") as Repo,
+            patch("services.memory_service.logger") as log,
+        ):
+            Repo.return_value.get_by_context = AsyncMock(return_value=cfg)
+            await svc._maybe_reinforce_rerank(sr, {}, uuid4())
+        events = [c.args[0] for c in log.info.call_args_list]
+        assert "reinforce_rerank_applied" not in events
+
+
+class TestReinforceTelemetry:
+    """Issue #1069: the pure per-recall reinforce summary that makes enabling and any
+    popularity-bias regression observable per context (structlog, no metrics backend)."""
+
+    def _t(self, **kw):
+        kw.setdefault("order_before", [])
+        kw.setdefault("order_after", [])
+        kw.setdefault("factors", {})
+        kw.setdefault("zero_adoption_ids", set())
+        kw.setdefault("top_k", 10)
+        return MemoryService._reinforce_telemetry(**kw)
+
+    def test_no_reorder_when_order_identical(self):
+        t = self._t(order_before=["a", "b"], order_after=["a", "b"], factors={"a": 1.0, "b": 1.0})
+        assert t["reordered"] is False
+        assert t["top1_changed"] is False
+        assert t["candidates"] == 2
+
+    def test_detects_reorder_and_top1_change(self):
+        t = self._t(order_before=["a", "b"], order_after=["b", "a"], factors={"a": 0.9, "b": 1.1})
+        assert t["reordered"] is True
+        assert t["top1_changed"] is True
+
+    def test_reorder_without_top1_change(self):
+        # Lower ranks shuffle but the head is stable → reordered, not top1_changed.
+        t = self._t(
+            order_before=["a", "b", "c"],
+            order_after=["a", "c", "b"],
+            factors={"a": 1.0, "b": 0.95, "c": 1.05},
+        )
+        assert t["reordered"] is True
+        assert t["top1_changed"] is False
+
+    def test_factor_distribution(self):
+        t = self._t(
+            order_before=["a", "b", "c"],
+            order_after=["a", "b", "c"],
+            factors={"a": 1.1, "b": 1.0, "c": 0.9},
+        )
+        assert abs(t["factor_min"] - 0.9) < 1e-9
+        assert abs(t["factor_max"] - 1.1) < 1e-9
+        assert abs(t["factor_mean"] - 1.0) < 1e-9
+        assert t["boosted"] == 1
+        assert t["demoted"] == 1
+
+    def test_zero_adoption_surfacing_counted_within_topk_only(self):
+        # z and w are both zero-adoption, but only z is inside the user-visible top-2.
+        t = self._t(
+            order_before=["z", "a", "w"],
+            order_after=["z", "a", "w"],
+            factors={"z": 1.03, "a": 1.0, "w": 1.03},
+            zero_adoption_ids={"z", "w"},
+            top_k=2,
+        )
+        assert t["zero_adoption_in_topk"] == 1
+        assert t["topk"] == 2
+
+    def test_empty_pool_is_safe(self):
+        t = self._t()
+        assert t["candidates"] == 0
+        assert t["reordered"] is False
+        assert t["top1_changed"] is False
+        assert t["factor_min"] == 1.0
+        assert t["factor_max"] == 1.0
+        assert t["factor_mean"] == 1.0
+        assert t["zero_adoption_in_topk"] == 0
+        assert t["topk"] == 0
+
 
 class TestExploreAccessStats:
     """Issue #644: explore() bumps access_count / last_used_at on returned memories

--- a/docs/eval/reinforce-rollout-gate.md
+++ b/docs/eval/reinforce-rollout-gate.md
@@ -1,0 +1,97 @@
+# Reinforce Rollout Gate (Issue #1069)
+
+The bounded **reinforce** recall re-rank (#1048) — adoption (`reference_count`,
+#1046) + retrieval feedback (#888) gently nudge a memory's recall standing —
+ships **default-off** per context (`ContextSearchConfig.reinforce_enabled`). This
+document defines the **eval gate** that decides whether enabling it on a context
+is safe, and the **staged rollout + monitoring** procedure that gate feeds.
+
+The principle (from the milestone): *trust before integration*. Reinforce only
+goes live where an eval shows it helps the canonical answers **without** burying
+the long tail or starving brand-new memories.
+
+## The gate (what "safe to enable" means)
+
+A repeatable ON-vs-OFF A/B on one ingested corpus, flipping only
+`reinforce_enabled`. Two query populations + one popularity-bias metric:
+
+| Signal | Population / metric | Gate condition (default) |
+|---|---|---|
+| **Helps the canonical** | `current_fact` — gold is an adopted+confirmed answer competing with a near-duplicate phrasing | ON − OFF on MRR@10 ≥ `min_current_fact_uplift` (0.0 = no regression) |
+| **Doesn't bury the tail** | `rare` — gold is a zero-adoption niche memory | OFF − ON on MRR@10 ≤ `max_rare_regression` (0.02) |
+| **Doesn't starve new memories** | zero-adoption surfacing rate (share of top-k slots held by never-adopted docs) | ON ≥ `min_zero_adoption_retention` × OFF (0.90) |
+
+Thresholds live in `GateThresholds` (`backend/tests/eval/reinforce_gate.py`) and
+are configurable. The defaults are conservative (the gate passes on
+*non-regression* of the current-fact population); an experiment wanting a
+stronger "improves" claim raises `min_current_fact_uplift` above 0. The verdict
+always reports the strict `improved` flag separately, so the distinction is never
+hidden.
+
+### Why these three
+
+The compounding "+lift" claim's standard kill-shot is *"the boost just measures
+that popular things were marked popular."* The gate pre-empts it: the `rare`
+no-regression band and the zero-adoption retention floor are the controls that
+separate "reinforce encodes useful adoption" from "reinforce introduces
+popularity bias." A run that lifts `current_fact` **but** fails either control is
+a FAIL, not a win.
+
+## How to run
+
+```bash
+make up                 # live stack: postgres + qdrant + embeddings
+make eval-reinforce     # KAGURA_EVAL_LIVE=1 python -m tests.eval.reinforce_runner
+```
+
+Writes `backend/tests/eval/results/reinforce-<date>.json` from a **real run
+only** (never fabricated) and **exits non-zero if the gate FAILS**. The harness:
+
+1. ingests `fixtures/reinforce_corpus.yaml` (15 memory docs, 10 queries × 2 populations);
+2. seeds adoption (`reference()` ×5) + net-helpful feedback (×3) on the canonical
+   `meta.adopted_docs` — the rare docs stay untouched (zero-adoption);
+3. scores the **OFF** arm (default, no config row);
+4. flips `reinforce_enabled = true`, `reinforce_max_boost = 0.15`;
+5. scores the **ON** arm and evaluates the gate.
+
+The decision math + metrics are pure and unit-tested (`test_reinforce_gate.py`);
+the seed→OFF→ON→gate orchestration is pinned DB-free with fakes
+(`test_reinforce_runner.py`). Only the live numbers need the stack.
+
+## Staged rollout (gate-gated, no blanket flip)
+
+1. **Pick a high-traffic, trusted context** with real adoption + feedback signal
+   (a re-rank with no signal is a no-op — leave cold/low-signal contexts off).
+2. **Run the gate** above against a corpus representative of that context. Enable
+   only on a **green** gate.
+3. **Enable** via REST `PUT /api/v1/contexts/{id}/search-config`
+   (`reinforce_enabled: true`) or the `update_search_config` MCP tool.
+4. **Monitor** the telemetry below; **disable** on regression.
+5. **Graduate** context-by-context. There is **no** blanket default-on
+   (out of scope, and would cross the #120 recall/explore boundary debate).
+
+## Monitoring (telemetry, #1069)
+
+When the re-rank fires, recall emits a `reinforce_rerank_applied` structured log
+(structlog/JSON — the codebase's observability backbone; there is no Prometheus).
+Per recall, per context:
+
+| Field | Watch for |
+|---|---|
+| `reordered`, `top1_changed` | the re-rank is actually active after you flip it on |
+| `factor_min` / `factor_max` / `factor_mean` | how hard it is pushing (bounded by `max_boost`) |
+| `boosted` / `demoted` | how many candidates moved which way |
+| `zero_adoption_in_topk` | **the regression alarm** — if this trends toward 0, reinforce is starving brand-new memories out of the user-visible slice; disable and re-tune |
+
+`zero_adoption_in_topk` is the live counterpart of the gate's
+`zero_adoption_surfacing_rate`: the gate proves the cold-start floor holds on the
+eval corpus, the log proves it still holds on live traffic.
+
+## Out of scope
+
+- Blanket default-on across all contexts.
+- Tuning the bounded design or the #120 boundary (separate follow-up if the
+  bounded nudge proves insufficient once felt in production).
+- The forge-resistance of the signal for untrusted autonomous agents — that is
+  #1065 (a host-arbitrated, forge-resistant reinforce signal), the milestone's
+  second half.


### PR DESCRIPTION
## Summary

Closes #1069 — the eval-gated production rollout of the bounded **reinforce**
recall re-rank (#1048, merged default-off). #1048 shipped the mechanism; this
delivers the two things its ACs require to turn it on *safely*: **per-context
uplift telemetry** (so a staged rollout is monitorable) and **a documented,
repeatable ON-vs-OFF eval gate** (so we only enable it where it helps without
introducing popularity bias).

No behaviour change by default — reinforce stays default-off; recall is
byte-identical until an operator enables it on a context.

## What's in here

**1. Telemetry (`backend/src/services/memory_service.py`)**
When the re-rank fires it emits a `reinforce_rerank_applied` structured log
(structlog/JSON — the codebase's observability backbone; no Prometheus). Per
recall, per context: `reordered`/`top1_changed` (is it active?), the `factor_*`
distribution (how hard it pushes), and the load-bearing `zero_adoption_in_topk`
**popularity-bias guard** (does the cold-start floor still surface brand-new
memories?). Computed by a pure `_reinforce_telemetry` helper that shares one
factor computation with the sort key so they can't diverge; isolated in its own
guard so a telemetry failure neither breaks recall nor masks an applied re-rank.

**2. Eval gate (`backend/tests/eval/`)**
A two-population A/B on one ingested corpus, flipping only `reinforce_enabled`:
- `current_fact` (gold = adopted canonical vs a near-duplicate phrasing) must **improve**;
- `rare` (gold = zero-adoption niche memory) must **not regress**;
- the zero-adoption surfacing rate (popularity-bias guard) must be **retained**.

`reinforce_gate.py` is pure decision logic + metrics; `reinforce_runner.py` is
the live Tier-C driver (seed adoption/feedback → score OFF → flip on → score ON →
gate). Adds `fixtures/reinforce_corpus.yaml`, `make eval-reinforce` (exits
non-zero on a failed gate), and `docs/eval/reinforce-rollout-gate.md` (gate +
staged-rollout + telemetry runbook).

## Acceptance criteria

- [x] Documented, repeatable eval comparing current-fact uplift vs rare no-regress, with popularity bias **measured** (zero-adoption surfacing rate) — `reinforce-rollout-gate.md` + `make eval-reinforce`.
- [x] Cold-start: the exploration/recency floor is asserted in the factor (#1048) and **monitored live** via `zero_adoption_in_topk`.
- [x] Per-context uplift metrics observable → `reinforce_rerank_applied`.
- [x] Rollout is opt-in / threshold-gated per context — no blanket default-on (documented runbook).
- [x] Respects the #120 recall↔explore boundary — reinforce inputs unchanged (adoption + feedback + importance + recency only).

## Scope / honesty

- The **harness + telemetry** are delivered and unit-tested. The **live numbers**
  (and the actual production enable on a high-traffic context) come from a real
  run on the stack — `make eval-reinforce` writes `results/reinforce-<date>.json`
  from a real run only, never fabricated. The gate exits non-zero on FAIL.
- Forge-resistance of the signal for untrusted autonomous agents is the
  milestone's second half (#1065), intentionally not in this PR.

## Test plan

- `backend/tests/eval/test_reinforce_gate.py` — 13 tests pin the gate math + metrics.
- `backend/tests/eval/test_reinforce_runner.py` — orchestration (seed→OFF→flip→ON→gate), per-arm scoring, fail-fast on a typo'd population — DB-free with fakes.
- `backend/tests/services/test_memory_service.py` — telemetry emission, the pure summary helper, and that a telemetry failure surfaces as `reinforce_telemetry_failed` (not `skipped`) without breaking recall.
- Loader change (optional `Query.population`) is backward-compatible; full eval suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
