### PR TITLE
feat(api): forge-resistant host-arbitrated reinforce signal (#1065)

### DIFF
--- a/backend/alembic/versions/e44_1065_host_arbitration.py
+++ b/backend/alembic/versions/e44_1065_host_arbitration.py
@@ -1,0 +1,67 @@
+"""Forge-resistant reinforce signal: feedback provenance + host-arbitration gate (#1065).
+
+Issue #1065 (the "harden the signal" half of v0.36.0): an autonomous agent can
+forge its own ranking boost by calling ``feedback(helpful=True)`` on whatever it
+grounded on. This adds the substrate to distinguish that forgeable self-report
+from a host-arbitrated, independent verdict, and to let recall ranking weight
+only the unforgeable signal for untrusted callers.
+
+- ``retrieval_feedback.provenance VARCHAR(16) NOT NULL DEFAULT 'agent'`` + CHECK
+  IN ('agent','host'). Server-stamped; the public feedback path can only ever
+  write 'agent'. The default backfills every existing row as 'agent' (correct —
+  all historical feedback was agent/caller-emitted).
+- ``context_search_configs.reinforce_require_host_arbitration BOOLEAN NOT NULL
+  DEFAULT false`` — when true the #1048 re-rank counts only provenance='host'
+  feedback. Default OFF → recall ranking is byte-identical to pre-#1065.
+
+The provenance column lives on ``retrieval_feedback``, whose context/memory FKs
+already cascade on delete, so the new aggregate is erasable for free (GDPR/APPI).
+
+Revision ID: e44_1065_host_arbitration
+Revises: e43_1027_share_keys
+
+(Revision id kept <=32 chars for alembic_version.version_num.)
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e44_1065_host_arbitration"
+down_revision = "e43_1027_share_keys"
+branch_labels = None
+depends_on = None
+
+# Byte-identical to the model CHECK literal (retrieval_feedback._ALL_FEEDBACK_PROVENANCES).
+_PROVENANCE_CHECK = "provenance IN ('agent', 'host')"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "retrieval_feedback",
+        sa.Column(
+            "provenance",
+            sa.String(16),
+            nullable=False,
+            server_default="agent",
+        ),
+    )
+    op.create_check_constraint(
+        "valid_retrieval_feedback_provenance", "retrieval_feedback", _PROVENANCE_CHECK
+    )
+    op.add_column(
+        "context_search_configs",
+        sa.Column(
+            "reinforce_require_host_arbitration",
+            sa.Boolean(),
+            nullable=False,
+            server_default="false",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("context_search_configs", "reinforce_require_host_arbitration")
+    op.drop_constraint("valid_retrieval_feedback_provenance", "retrieval_feedback", type_="check")
+    op.drop_column("retrieval_feedback", "provenance")

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1184,15 +1184,15 @@ Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fe
                     },
                     "reinforce_enabled": {
                         "type": "boolean",
-                        "description": "Issue #1048: enable the bounded adoption+feedback recall re-rank — memories that are deliberately referenced (adopted) and marked helpful gain a small, bounded standing boost; never-adopted recent memories keep a cold-start prior so they still surface. Off by default; does not override semantic relevance.",
+                        "description": "Enable the bounded adoption+feedback recall re-rank — memories that are deliberately referenced (adopted) and marked helpful gain a small, bounded standing boost; never-adopted recent memories keep a cold-start prior so they still surface. Off by default; does not override semantic relevance.",
                     },
                     "reinforce_max_boost": {
                         "type": "number",
-                        "description": "Issue #1048: bound on the reinforce adjustment (0.0-0.5; default 0.15). Each result's score is multiplied by a factor in [1-boost, 1+boost], so semantic relevance always dominates.",
+                        "description": "Bound on the reinforce adjustment (0.0-0.5; default 0.15). Each result's score is multiplied by a factor in [1-boost, 1+boost], so semantic relevance always dominates.",
                     },
                     "reinforce_require_host_arbitration": {
                         "type": "boolean",
-                        "description": "Issue #1065: forge-resistant mode. When true, the reinforce re-rank counts ONLY host-arbitrated feedback (an independent verdict), so an untrusted agent's self-emitted feedback(helpful=True) cannot manufacture its own ranking boost. Off by default. Enable on contexts exposed to untrusted autonomous agents.",
+                        "description": "Forge-resistant mode. When true, the reinforce re-rank counts ONLY host-arbitrated feedback (an independent verdict), so an untrusted agent's self-emitted feedback(helpful=True) cannot manufacture its own ranking boost. Off by default. Enable on contexts exposed to untrusted autonomous agents.",
                     },
                 },
             },

--- a/backend/src/mcp_server/tools/_definitions.py
+++ b/backend/src/mcp_server/tools/_definitions.py
@@ -1147,7 +1147,7 @@ Examples:
 
 Weights must sum to 1.0.
 
-Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fetch_factor, use_rerank, reranker_provider, reranker_model, reinforce_enabled, reinforce_max_boost}}. semantic_weight + bm25_weight must sum to 1.0.""",
+Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fetch_factor, use_rerank, reranker_provider, reranker_model, reinforce_enabled, reinforce_max_boost, reinforce_require_host_arbitration}}. semantic_weight + bm25_weight must sum to 1.0.""",
             "inputSchema": {
                 "type": "object",
                 "required": ["context_id"],
@@ -1189,6 +1189,10 @@ Returns: {status, message, context_id, config: {semantic_weight, bm25_weight, fe
                     "reinforce_max_boost": {
                         "type": "number",
                         "description": "Issue #1048: bound on the reinforce adjustment (0.0-0.5; default 0.15). Each result's score is multiplied by a factor in [1-boost, 1+boost], so semantic relevance always dominates.",
+                    },
+                    "reinforce_require_host_arbitration": {
+                        "type": "boolean",
+                        "description": "Issue #1065: forge-resistant mode. When true, the reinforce re-rank counts ONLY host-arbitrated feedback (an independent verdict), so an untrusted agent's self-emitted feedback(helpful=True) cannot manufacture its own ranking boost. Off by default. Enable on contexts exposed to untrusted autonomous agents.",
                     },
                 },
             },

--- a/backend/src/mcp_server/tools/search_config.py
+++ b/backend/src/mcp_server/tools/search_config.py
@@ -78,6 +78,11 @@ async def handle_update_search_config(
                 "reinforce_max_boost": args.get(
                     "reinforce_max_boost", float(config.reinforce_max_boost)
                 ),
+                # Issue #1065: forge-resistant mode (round-trip current value).
+                "reinforce_require_host_arbitration": args.get(
+                    "reinforce_require_host_arbitration",
+                    config.reinforce_require_host_arbitration,
+                ),
             }
 
             # Validate via Pydantic (same as REST API)
@@ -116,6 +121,9 @@ async def handle_update_search_config(
                                 "reranker_model": config.reranker_model,
                                 "reinforce_enabled": config.reinforce_enabled,
                                 "reinforce_max_boost": float(config.reinforce_max_boost),
+                                "reinforce_require_host_arbitration": (
+                                    config.reinforce_require_host_arbitration
+                                ),
                             },
                         }
                     ),

--- a/backend/src/models/config.py
+++ b/backend/src/models/config.py
@@ -109,6 +109,14 @@ class ContextSearchConfig(Base):
     reinforce_max_boost: Mapped[Decimal] = mapped_column(
         DECIMAL(3, 2), nullable=False, server_default="0.15", default=Decimal("0.15")
     )
+    # Issue #1065: forge-resistant mode. When true, the reinforce re-rank counts
+    # ONLY host-arbitrated feedback (provenance='host') — an untrusted agent's
+    # self-emitted feedback(helpful=True) can no longer move ranking. Default OFF
+    # preserves #1048 behaviour (all feedback counts). Enable on contexts exposed
+    # to untrusted autonomous agents (e.g. trust_tier='external').
+    reinforce_require_host_arbitration: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default="false", default=False
+    )
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(

--- a/backend/src/models/config.py
+++ b/backend/src/models/config.py
@@ -114,6 +114,9 @@ class ContextSearchConfig(Base):
     # self-emitted feedback(helpful=True) can no longer move ranking. Default OFF
     # preserves #1048 behaviour (all feedback counts). Enable on contexts exposed
     # to untrusted autonomous agents (e.g. trust_tier='external').
+    # Threat-model note: this flag is itself editable via update_search_config,
+    # so it is only meaningful when set out-of-band by an operator/cockpit and the
+    # untrusted agent lacks EDITOR/OWNER on the context (else it could flip it off).
     reinforce_require_host_arbitration: Mapped[bool] = mapped_column(
         Boolean, nullable=False, server_default="false", default=False
     )

--- a/backend/src/models/retrieval_feedback.py
+++ b/backend/src/models/retrieval_feedback.py
@@ -119,8 +119,10 @@ class RetrievalFeedback(Base):
         Index("idx_retrieval_feedback_context_memory", "context_id", "memory_id"),
         # Provenance is a closed enum — reject anything but the known kinds so a
         # bad value can never silently slip past the forge-resistant aggregation.
+        # CHECK derived from _ALL_FEEDBACK_PROVENANCES (single source of truth,
+        # mirrors memory.py:source_type). Byte-identical to the migration literal.
         CheckConstraint(
-            "provenance IN ('agent', 'host')",
+            f"provenance IN ({', '.join(repr(p) for p in _ALL_FEEDBACK_PROVENANCES)})",
             name="valid_retrieval_feedback_provenance",
         ),
     )

--- a/backend/src/models/retrieval_feedback.py
+++ b/backend/src/models/retrieval_feedback.py
@@ -27,7 +27,17 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, Index, String, Text, func, text
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+    text,
+)
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -40,6 +50,23 @@ QUERY_MAX_LEN = 1024
 # single source of truth enforced at every boundary (API schema, MCP handler,
 # service truncation) to avoid silent truncation / unbounded request bodies.
 NOTE_MAX_LEN = 2000
+
+# Issue #1065: server-stamped provenance of a feedback signal. ``agent`` is the
+# default — the signal an autonomous caller emits via feedback(), which a
+# hijacked / prompt-injected agent can forge to manufacture its own ranking
+# boost. ``host`` is the forge-resistant variant: stamped server-side as
+# originating from the trusted host/cockpit and backed by an INDEPENDENT verdict
+# (a check/test result or an operator HITL approval), never the agent's
+# self-report. The agent-callable feedback() path can only ever produce ``agent``
+# (the public schema does not expose this field); only the host-arbitration seam
+# stamps ``host``. Recall ranking (#1048) can be configured to weight only the
+# unforgeable signal for untrusted callers.
+FEEDBACK_PROVENANCE_AGENT = "agent"
+FEEDBACK_PROVENANCE_HOST = "host"
+_ALL_FEEDBACK_PROVENANCES: tuple[str, ...] = (
+    FEEDBACK_PROVENANCE_AGENT,
+    FEEDBACK_PROVENANCE_HOST,
+)
 
 
 class RetrievalFeedback(Base):
@@ -71,6 +98,16 @@ class RetrievalFeedback(Base):
     # Optional free-text note (e.g. why it was wrong). Truncation enforced in the
     # service layer; Text column keeps the model permissive.
     note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Issue #1065: server-stamped provenance — 'agent' (forgeable self-report,
+    # the default) vs 'host' (host/cockpit-arbitrated, backed by an independent
+    # verdict). Server-authoritative: clients cannot set it (not on the public
+    # schema), so an agent's signal is always 'agent'.
+    provenance: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        server_default=FEEDBACK_PROVENANCE_AGENT,
+        default=FEEDBACK_PROVENANCE_AGENT,
+    )
     # Naive UTC by convention (engine pins the session to UTC).
     created_at: Mapped[datetime] = mapped_column(
         DateTime, nullable=False, server_default=func.now()
@@ -80,4 +117,10 @@ class RetrievalFeedback(Base):
         # Aggregation reads (net-helpful per memory within a context) scan by
         # this pair — the append-only log has no unique key.
         Index("idx_retrieval_feedback_context_memory", "context_id", "memory_id"),
+        # Provenance is a closed enum — reject anything but the known kinds so a
+        # bad value can never silently slip past the forge-resistant aggregation.
+        CheckConstraint(
+            "provenance IN ('agent', 'host')",
+            name="valid_retrieval_feedback_provenance",
+        ),
     )

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -895,17 +895,17 @@ class ContextSearchConfigUpdate(BaseModel):
     # them are unaffected; the MCP handler always round-trips current values.
     reinforce_enabled: bool = Field(
         default=False,
-        description="Issue #1048: enable the bounded adoption+feedback recall re-rank",
+        description="Enable the bounded adoption+feedback recall re-rank",
     )
     reinforce_max_boost: float = Field(
         default=0.15,
         ge=0.0,
         le=0.5,
-        description="Issue #1048: bound on the reinforce adjustment (factor stays in [1-b, 1+b])",
+        description="Bound on the reinforce adjustment (factor stays in [1-b, 1+b])",
     )
     reinforce_require_host_arbitration: bool = Field(
         default=False,
-        description="Issue #1065: forge-resistant mode — only host-arbitrated feedback "
+        description="Forge-resistant mode — only host-arbitrated feedback "
         "(provenance='host') moves ranking; an untrusted agent's self-feedback is ignored",
     )
 

--- a/backend/src/models/schemas.py
+++ b/backend/src/models/schemas.py
@@ -866,6 +866,10 @@ class ContextSearchConfigResponse(TZAwareBaseModel):
     reinforce_max_boost: float = Field(
         default=0.15, description="Bound on the reinforce adjustment (factor in [1-b, 1+b])"
     )
+    # Issue #1065: forge-resistant mode — only host-arbitrated feedback moves ranking.
+    reinforce_require_host_arbitration: bool = Field(
+        default=False, description="Count only host-arbitrated (provenance='host') feedback"
+    )
     created_at: datetime
     updated_at: datetime
 
@@ -898,6 +902,11 @@ class ContextSearchConfigUpdate(BaseModel):
         ge=0.0,
         le=0.5,
         description="Issue #1048: bound on the reinforce adjustment (factor stays in [1-b, 1+b])",
+    )
+    reinforce_require_host_arbitration: bool = Field(
+        default=False,
+        description="Issue #1065: forge-resistant mode — only host-arbitrated feedback "
+        "(provenance='host') moves ranking; an untrusted agent's self-feedback is ignored",
     )
 
     @model_validator(mode="after")

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -126,7 +126,12 @@ class FeedbackService:
         server-authoritative provenance. The verdict reference is preserved in the
         note for audit.
         """
-        host_note = f"host-verdict: {verdict}"
+        # Flatten whitespace (no newlines fracturing the audit note) and cap so
+        # the "host-verdict: " prefix is never lost to record_feedback's silent
+        # NOTE_MAX_LEN truncation — the prefix is what marks the entry as a verdict.
+        prefix = "host-verdict: "
+        flat_verdict = " ".join(str(verdict).split())
+        host_note = f"{prefix}{flat_verdict[: NOTE_MAX_LEN - len(prefix)]}"
         return await self.record_feedback(
             context_id=context_id,
             memory_id=memory_id,

--- a/backend/src/services/feedback_service.py
+++ b/backend/src/services/feedback_service.py
@@ -16,7 +16,14 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from models.memory import Memory
-from models.retrieval_feedback import NOTE_MAX_LEN, QUERY_MAX_LEN, RetrievalFeedback
+from models.retrieval_feedback import (
+    _ALL_FEEDBACK_PROVENANCES,
+    FEEDBACK_PROVENANCE_AGENT,
+    FEEDBACK_PROVENANCE_HOST,
+    NOTE_MAX_LEN,
+    QUERY_MAX_LEN,
+    RetrievalFeedback,
+)
 from utils.exceptions import NotFoundException
 
 
@@ -47,6 +54,7 @@ class FeedbackService:
         user_id: str,
         query: str | None = None,
         note: str | None = None,
+        provenance: str = FEEDBACK_PROVENANCE_AGENT,
     ) -> RetrievalFeedback:
         """Append one feedback event. Query/note are truncated, never embedded.
 
@@ -59,7 +67,16 @@ class FeedbackService:
         a context they cannot read (cross-context signal injection). A uniform
         ``NotFoundException`` is raised on miss (same IDOR-safe shape as the
         context gate; does not reveal whether the memory exists elsewhere).
+
+        Issue #1065: ``provenance`` is server-stamped. The public feedback path
+        (REST/MCP) never passes it, so an agent's signal is always ``agent`` (it
+        cannot forge ``host``); only :meth:`record_host_feedback` stamps ``host``.
         """
+        if provenance not in _ALL_FEEDBACK_PROVENANCES:
+            raise ValueError(
+                f"invalid feedback provenance {provenance!r}; "
+                f"expected one of {_ALL_FEEDBACK_PROVENANCES}"
+            )
         exists = (
             await self.db.execute(
                 select(Memory.id).where(
@@ -79,23 +96,67 @@ class FeedbackService:
             user_id=user_id,
             query=query[:QUERY_MAX_LEN] if query is not None else None,
             note=note[:NOTE_MAX_LEN] if note is not None else None,
+            provenance=provenance,
         )
         self.db.add(row)
         await self.db.commit()
         await self.db.refresh(row)
         return row
 
-    async def aggregate_for_memory(self, context_id: UUID, memory_id: UUID) -> FeedbackAggregate:
-        """Net-helpful tally for one memory in a context (read-time only)."""
+    async def record_host_feedback(
+        self,
+        context_id: UUID,
+        memory_id: UUID,
+        helpful: bool,
+        user_id: str,
+        verdict: str,
+        query: str | None = None,
+    ) -> RetrievalFeedback:
+        """Record a HOST-ARBITRATED, forge-resistant feedback signal (Issue #1065).
+
+        The substrate seam for a trusted host/cockpit to stamp a reinforce signal
+        backed by an **independent verdict** (a check/test exit code or an operator
+        HITL approval) — never the agent's self-report. Stamps
+        ``provenance='host'`` so the re-rank can weight it distinctly from an
+        agent's self-emitted ``feedback`` for untrusted callers.
+
+        This is deliberately NOT exposed on the agent-callable feedback() path —
+        the *computation* of the verdict is the host's job (e.g.
+        ``kagura-ai/kagura-agent#165``); this records its outcome with
+        server-authoritative provenance. The verdict reference is preserved in the
+        note for audit.
+        """
+        host_note = f"host-verdict: {verdict}"
+        return await self.record_feedback(
+            context_id=context_id,
+            memory_id=memory_id,
+            helpful=helpful,
+            user_id=user_id,
+            query=query,
+            note=host_note,
+            provenance=FEEDBACK_PROVENANCE_HOST,
+        )
+
+    async def aggregate_for_memory(
+        self, context_id: UUID, memory_id: UUID, *, host_only: bool = False
+    ) -> FeedbackAggregate:
+        """Net-helpful tally for one memory in a context (read-time only).
+
+        Issue #1065: ``host_only`` counts only host-arbitrated (forge-resistant)
+        feedback — the unforgeable signal — for untrusted callers.
+        """
+        conditions = [
+            RetrievalFeedback.context_id == context_id,
+            RetrievalFeedback.memory_id == memory_id,
+        ]
+        if host_only:
+            conditions.append(RetrievalFeedback.provenance == FEEDBACK_PROVENANCE_HOST)
         result = await self.db.execute(
             select(
                 RetrievalFeedback.helpful,
                 func.count().label("n"),
             )
-            .where(
-                RetrievalFeedback.context_id == context_id,
-                RetrievalFeedback.memory_id == memory_id,
-            )
+            .where(*conditions)
             .group_by(RetrievalFeedback.helpful)
         )
         helpful_count = 0
@@ -112,26 +173,34 @@ class FeedbackService:
         )
 
     async def aggregate_for_memories(
-        self, context_id: UUID, memory_ids: list[UUID]
+        self, context_id: UUID, memory_ids: list[UUID], *, host_only: bool = False
     ) -> dict[str, FeedbackAggregate]:
         """Batch net-helpful tallies for many memories in a context (one query).
 
         Issue #1048: the recall reinforce re-rank needs feedback for every
         candidate without N round-trips. Returns a dict keyed by ``str(memory_id)``;
         memories with no feedback are absent (callers treat missing as net=0).
+
+        Issue #1065: ``host_only`` restricts the tally to host-arbitrated
+        (provenance='host') feedback — the forge-resistant signal an untrusted
+        agent cannot emit. With it set, agent self-emitted feedback contributes
+        nothing to ranking.
         """
         if not memory_ids:
             return {}
+        conditions = [
+            RetrievalFeedback.context_id == context_id,
+            RetrievalFeedback.memory_id.in_(memory_ids),
+        ]
+        if host_only:
+            conditions.append(RetrievalFeedback.provenance == FEEDBACK_PROVENANCE_HOST)
         result = await self.db.execute(
             select(
                 RetrievalFeedback.memory_id,
                 RetrievalFeedback.helpful,
                 func.count().label("n"),
             )
-            .where(
-                RetrievalFeedback.context_id == context_id,
-                RetrievalFeedback.memory_id.in_(memory_ids),
-            )
+            .where(*conditions)
             .group_by(RetrievalFeedback.memory_id, RetrievalFeedback.helpful)
         )
         counts: dict[str, list[int]] = {}  # str(memory_id) -> [helpful, not_helpful]

--- a/backend/src/services/memory_service.py
+++ b/backend/src/services/memory_service.py
@@ -1570,6 +1570,11 @@ class MemoryService:
             if cfg is None or not getattr(cfg, "reinforce_enabled", False):
                 return
             max_boost = float(cfg.reinforce_max_boost)
+            # Issue #1065: forge-resistant mode. When set, only host-arbitrated
+            # feedback (an unforgeable, independently-verdicted signal) moves
+            # ranking — an untrusted agent's self-emitted feedback(helpful=True)
+            # is ignored. Default OFF → all feedback counts (pre-#1065 behaviour).
+            require_host = bool(getattr(cfg, "reinforce_require_host_arbitration", False))
 
             from services.feedback_service import FeedbackService
 
@@ -1580,7 +1585,9 @@ class MemoryService:
                 if mem is not None and mem.id not in seen:
                     seen.add(mem.id)
                     cand_ids.append(mem.id)
-            feedback = await FeedbackService(self.db).aggregate_for_memories(context_id, cand_ids)
+            feedback = await FeedbackService(self.db).aggregate_for_memories(
+                context_id, cand_ids, host_only=require_host
+            )
             now = utcnow()
 
             # Precompute the per-memory factor once (id-keyed) so the sort key and the
@@ -1630,6 +1637,7 @@ class MemoryService:
                     "reinforce_rerank_applied",
                     context_id=str(context_id),
                     max_boost=round(max_boost, 4),
+                    require_host_arbitration=require_host,
                     **self._reinforce_telemetry(
                         order_before=order_before,
                         order_after=order_after,

--- a/backend/tests/integration/test_e44_1065_host_arbitration_migration.py
+++ b/backend/tests/integration/test_e44_1065_host_arbitration_migration.py
@@ -1,0 +1,82 @@
+"""Integration pins for #1065 — DB-level feedback provenance behaviour.
+
+Covers what the service-layer unit tests cannot: the PostgreSQL DEFAULT backfill
+('agent'), the NOT NULL constraint, and the CHECK rejecting out-of-set values at
+the engine level for ``retrieval_feedback.provenance`` — the forge-resistance
+backstop (a bad provenance can never slip past the host-only aggregation).
+"""
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+# Static SQL (no f-strings — project rule forbids interpolated SQL).
+_INSERT_FEEDBACK_DEFAULT = (
+    "INSERT INTO retrieval_feedback (context_id, memory_id, helpful, user_id) "
+    "VALUES (:ctx, :mem, true, 'u-1065')"
+)
+_INSERT_FEEDBACK_WITH_PROVENANCE = (
+    "INSERT INTO retrieval_feedback (context_id, memory_id, helpful, user_id, provenance) "
+    "VALUES (:ctx, :mem, true, 'u-1065', :prov)"
+)
+_SELECT_PROVENANCE = "SELECT provenance FROM retrieval_feedback WHERE memory_id = :m"
+
+
+async def _ctx_with_memory(db_session):
+    """Create a workspace + context + memory and return (ctx_id, mem_id)."""
+    ws, ctx, mem, owner = uuid.uuid4(), uuid.uuid4(), uuid.uuid4(), "u-1065"
+    await db_session.execute(
+        text("INSERT INTO workspaces (id, name, owner_user_id) VALUES (:id, :n, :o)"),
+        {"id": ws, "n": "ws-1065", "o": owner},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO contexts (id, workspace_id, name, created_by) VALUES (:id, :ws, :n, :by)"
+        ),
+        {"id": ctx, "ws": ws, "n": "ctx-1065", "by": owner},
+    )
+    await db_session.execute(
+        text(
+            "INSERT INTO memories "
+            "(id, user_id, context_id, summary, content, type, importance, confidence, scope, "
+            " embedding_status, client, source, long_term, access_count) "
+            "VALUES (:id, :u, :ctx, 's', 'c', 'note', 0.5, 1.0, 'working', "
+            " 'success', 'test', 'mcp_remember', false, 0)"
+        ),
+        {"id": mem, "u": owner, "ctx": ctx},
+    )
+    return ctx, mem
+
+
+@pytest.mark.asyncio
+async def test_provenance_defaults_to_agent(db_session):
+    """A feedback row inserted WITHOUT provenance backfills to 'agent' — the
+    public path never sets it, so every agent signal is server-stamped 'agent'."""
+    ctx, mem = await _ctx_with_memory(db_session)
+    await db_session.execute(text(_INSERT_FEEDBACK_DEFAULT), {"ctx": ctx, "mem": mem})
+    row = (await db_session.execute(text(_SELECT_PROVENANCE), {"m": mem})).one()
+    assert row.provenance == "agent"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("prov", ["agent", "host"])
+async def test_provenance_accepts_valid_values(db_session, prov):
+    ctx, mem = await _ctx_with_memory(db_session)
+    await db_session.execute(
+        text(_INSERT_FEEDBACK_WITH_PROVENANCE), {"ctx": ctx, "mem": mem, "prov": prov}
+    )
+    row = (await db_session.execute(text(_SELECT_PROVENANCE), {"m": mem})).one()
+    assert row.provenance == prov
+
+
+@pytest.mark.asyncio
+async def test_provenance_check_rejects_unknown_value(db_session):
+    """The DB CHECK is the forge-resistance backstop — a bogus provenance can
+    never be persisted (and so can never masquerade as 'host')."""
+    ctx, mem = await _ctx_with_memory(db_session)
+    with pytest.raises(IntegrityError):
+        await db_session.execute(
+            text(_INSERT_FEEDBACK_WITH_PROVENANCE), {"ctx": ctx, "mem": mem, "prov": "forged"}
+        )

--- a/backend/tests/integration/test_retrieval_feedback.py
+++ b/backend/tests/integration/test_retrieval_feedback.py
@@ -278,3 +278,40 @@ async def test_aggregate_for_memories_batch(db_session: AsyncSession, feedback_s
     assert agg[str(mem_a.id)].net == 2
     assert str(mem_b.id) not in agg  # no feedback → absent
     assert await svc.aggregate_for_memories(s["ctx"].id, []) == {}
+
+
+@pytest.mark.asyncio
+async def test_host_only_aggregation_excludes_agent_feedback(
+    db_session: AsyncSession, feedback_scenario
+):
+    """Issue #1065: host_only counts ONLY host-arbitrated feedback — an agent's
+    self-emitted feedback contributes nothing to the forge-resistant tally."""
+    s = feedback_scenario
+    svc = FeedbackService(db_session)
+    mem = s["mem"]
+
+    # Agent forges 3 helpful; the host independently verdicts 1 helpful.
+    for _ in range(3):
+        await svc.record_feedback(s["ctx"].id, mem.id, True, s["owner"])  # provenance='agent'
+    await svc.record_host_feedback(s["ctx"].id, mem.id, True, s["owner"], verdict="check_exit=0")
+
+    # Default (all provenances): the agent self-report inflates the tally.
+    all_agg = await svc.aggregate_for_memories(s["ctx"].id, [mem.id])
+    assert all_agg[str(mem.id)].helpful_count == 4
+
+    # Forge-resistant: only the 1 host-arbitrated signal counts.
+    host_agg = await svc.aggregate_for_memories(s["ctx"].id, [mem.id], host_only=True)
+    assert host_agg[str(mem.id)].helpful_count == 1
+    assert host_agg[str(mem.id)].net == 1
+
+    # The default-stamped agent rows really are 'agent' (server-authoritative).
+    provenances = (
+        (
+            await db_session.execute(
+                select(RetrievalFeedback.provenance).where(RetrievalFeedback.memory_id == mem.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert sorted(provenances) == ["agent", "agent", "agent", "host"]

--- a/backend/tests/services/test_feedback_provenance.py
+++ b/backend/tests/services/test_feedback_provenance.py
@@ -14,7 +14,11 @@ from uuid import uuid4
 
 import pytest
 
-from models.retrieval_feedback import FEEDBACK_PROVENANCE_AGENT, FEEDBACK_PROVENANCE_HOST
+from models.retrieval_feedback import (
+    FEEDBACK_PROVENANCE_AGENT,
+    FEEDBACK_PROVENANCE_HOST,
+    NOTE_MAX_LEN,
+)
 from services.feedback_service import FeedbackService
 
 
@@ -47,6 +51,20 @@ class TestFeedbackProvenance:
         row = db.add.call_args.args[0]
         assert row.provenance == FEEDBACK_PROVENANCE_HOST
         assert row.note is not None and "check_exit=0" in row.note
+
+    async def test_host_verdict_is_flattened_and_capped(self):
+        # The verdict is the audit trail of the host seam: newlines are flattened
+        # (no fractured audit log) and the "host-verdict: " prefix always survives
+        # record_feedback's NOTE_MAX_LEN truncation.
+        svc, db = _svc_with_existing_memory()
+        long_verdict = "line1\nline2\t" + "x" * 5000
+        await svc.record_host_feedback(
+            uuid4(), uuid4(), helpful=True, user_id="cockpit", verdict=long_verdict
+        )
+        row = db.add.call_args.args[0]
+        assert row.note.startswith("host-verdict: ")
+        assert "\n" not in row.note and "\t" not in row.note
+        assert len(row.note) <= NOTE_MAX_LEN
 
     async def test_record_feedback_rejects_forged_provenance(self):
         # Defence in depth: even a service-layer caller cannot inject a bad value

--- a/backend/tests/services/test_feedback_provenance.py
+++ b/backend/tests/services/test_feedback_provenance.py
@@ -1,0 +1,59 @@
+"""Unit tests for the #1065 forge-resistant feedback provenance stamping.
+
+DB-free: the memory-exists check and the insert are mocked, so these pin the
+server-side stamping logic — the agent-callable path can only produce 'agent',
+only the host seam stamps 'host', and a forged provenance is rejected. The DB
+filtering (host_only aggregation) is pinned end-to-end in
+tests/integration/test_retrieval_feedback.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from models.retrieval_feedback import FEEDBACK_PROVENANCE_AGENT, FEEDBACK_PROVENANCE_HOST
+from services.feedback_service import FeedbackService
+
+
+def _svc_with_existing_memory():
+    """A FeedbackService whose memory-exists guard passes and whose insert is a
+    no-op, so we can inspect the row handed to ``db.add``."""
+    db = MagicMock()
+    exec_result = MagicMock()
+    exec_result.scalar_one_or_none = MagicMock(return_value=uuid4())
+    db.execute = AsyncMock(return_value=exec_result)
+    db.add = MagicMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    return FeedbackService(db), db
+
+
+class TestFeedbackProvenance:
+    async def test_record_feedback_defaults_to_agent(self):
+        # The public REST/MCP path calls record_feedback without provenance.
+        svc, db = _svc_with_existing_memory()
+        await svc.record_feedback(uuid4(), uuid4(), helpful=True, user_id="u")
+        row = db.add.call_args.args[0]
+        assert row.provenance == FEEDBACK_PROVENANCE_AGENT
+
+    async def test_record_host_feedback_stamps_host_and_keeps_verdict(self):
+        svc, db = _svc_with_existing_memory()
+        await svc.record_host_feedback(
+            uuid4(), uuid4(), helpful=True, user_id="cockpit", verdict="check_exit=0"
+        )
+        row = db.add.call_args.args[0]
+        assert row.provenance == FEEDBACK_PROVENANCE_HOST
+        assert row.note is not None and "check_exit=0" in row.note
+
+    async def test_record_feedback_rejects_forged_provenance(self):
+        # Defence in depth: even a service-layer caller cannot inject a bad value
+        # (the DB CHECK is the backstop; this fails fast before the insert).
+        svc, db = _svc_with_existing_memory()
+        with pytest.raises(ValueError, match="provenance"):
+            await svc.record_feedback(
+                uuid4(), uuid4(), helpful=True, user_id="u", provenance="forged"
+            )
+        db.add.assert_not_called()

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1432,6 +1432,61 @@ class TestReinforceRerank:
         assert [r["id"] for r in sr][0] == "a"  # relevance still dominates
 
     @pytest.mark.asyncio
+    async def test_require_host_arbitration_forwards_host_only(self):
+        # Issue #1065: when forge-resistant mode is on, the actuator aggregates
+        # ONLY host-arbitrated feedback (agent self-feedback cannot move ranking).
+        from decimal import Decimal
+
+        svc = MemoryService(MagicMock())
+        cfg = MagicMock(
+            reinforce_enabled=True,
+            reinforce_max_boost=Decimal("0.15"),
+            reinforce_require_host_arbitration=True,
+        )
+        old = datetime(2020, 1, 1)
+        memories = {
+            "a": MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old),
+            "b": MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old),
+        }
+        sr = [{"id": "a", "hybrid_score": 0.9}, {"id": "b", "hybrid_score": 0.8}]
+        agg = AsyncMock(return_value={})
+        with (
+            patch("repositories.config_repository.ContextSearchConfigRepository") as Repo,
+            patch("services.feedback_service.FeedbackService") as FB,
+        ):
+            Repo.return_value.get_by_context = AsyncMock(return_value=cfg)
+            FB.return_value.aggregate_for_memories = agg
+            await svc._maybe_reinforce_rerank(sr, memories, uuid4(), top_k=10)
+        assert agg.await_args.kwargs.get("host_only") is True
+
+    @pytest.mark.asyncio
+    async def test_default_counts_all_feedback(self):
+        # Default (flag off) keeps pre-#1065 behaviour: all feedback counts.
+        from decimal import Decimal
+
+        svc = MemoryService(MagicMock())
+        cfg = MagicMock(
+            reinforce_enabled=True,
+            reinforce_max_boost=Decimal("0.15"),
+            reinforce_require_host_arbitration=False,
+        )
+        old = datetime(2020, 1, 1)
+        memories = {
+            "a": MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old),
+            "b": MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old),
+        }
+        sr = [{"id": "a", "hybrid_score": 0.9}, {"id": "b", "hybrid_score": 0.8}]
+        agg = AsyncMock(return_value={})
+        with (
+            patch("repositories.config_repository.ContextSearchConfigRepository") as Repo,
+            patch("services.feedback_service.FeedbackService") as FB,
+        ):
+            Repo.return_value.get_by_context = AsyncMock(return_value=cfg)
+            FB.return_value.aggregate_for_memories = agg
+            await svc._maybe_reinforce_rerank(sr, memories, uuid4(), top_k=10)
+        assert agg.await_args.kwargs.get("host_only") is False
+
+    @pytest.mark.asyncio
     async def test_emits_telemetry_when_enabled(self):
         # Issue #1069: a fired re-rank emits one reinforce_rerank_applied event so a
         # staged rollout is observable; a disabled context emits nothing.

--- a/backend/tests/services/test_memory_service.py
+++ b/backend/tests/services/test_memory_service.py
@@ -1387,7 +1387,11 @@ class TestReinforceRerank:
         from services.feedback_service import FeedbackAggregate
 
         svc = MemoryService(MagicMock())
-        cfg = MagicMock(reinforce_enabled=True, reinforce_max_boost=Decimal("0.15"))
+        cfg = MagicMock(
+            reinforce_enabled=True,
+            reinforce_max_boost=Decimal("0.15"),
+            reinforce_require_host_arbitration=False,
+        )
         old = datetime(2020, 1, 1)
         mem_a = MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old)
         mem_b = MagicMock(id=uuid4(), reference_count=10, importance=0.9, created_at=old)
@@ -1415,7 +1419,11 @@ class TestReinforceRerank:
         from decimal import Decimal
 
         svc = MemoryService(MagicMock())
-        cfg = MagicMock(reinforce_enabled=True, reinforce_max_boost=Decimal("0.15"))
+        cfg = MagicMock(
+            reinforce_enabled=True,
+            reinforce_max_boost=Decimal("0.15"),
+            reinforce_require_host_arbitration=False,
+        )
         old = datetime(2020, 1, 1)
         mem_a = MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old)
         mem_b = MagicMock(id=uuid4(), reference_count=50, importance=1.0, created_at=old)
@@ -1493,7 +1501,11 @@ class TestReinforceRerank:
         from decimal import Decimal
 
         svc = MemoryService(MagicMock())
-        cfg = MagicMock(reinforce_enabled=True, reinforce_max_boost=Decimal("0.15"))
+        cfg = MagicMock(
+            reinforce_enabled=True,
+            reinforce_max_boost=Decimal("0.15"),
+            reinforce_require_host_arbitration=False,
+        )
         old = datetime(2020, 1, 1)
         mem_a = MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old)
         mem_b = MagicMock(id=uuid4(), reference_count=10, importance=0.9, created_at=old)
@@ -1538,7 +1550,11 @@ class TestReinforceRerank:
         from decimal import Decimal
 
         svc = MemoryService(MagicMock())
-        cfg = MagicMock(reinforce_enabled=True, reinforce_max_boost=Decimal("0.15"))
+        cfg = MagicMock(
+            reinforce_enabled=True,
+            reinforce_max_boost=Decimal("0.15"),
+            reinforce_require_host_arbitration=False,
+        )
         old = datetime(2020, 1, 1)
         mem_a = MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old)
         mem_b = MagicMock(id=uuid4(), reference_count=10, importance=0.9, created_at=old)


### PR DESCRIPTION
## Summary

Closes #1065 — the **forge-resistant** half of v0.36.0 (the milestone's second issue; #1069 is already merged via #1082).

> Supersedes #1083, which was stacked on the (now-merged, deleted) #1069 branch and so GitHub **auto-closed it without merging**. This branch is the same work **rebased onto current `main`** (only the two #1065 commits replay; the #1069 changes are already in `main`). No content change from the reviewed #1083.

## Why

#1048 reinforces recall ranking from `feedback()`/`reference()`, both signals the **agent emits**. A hijacked / prompt-injected untrusted agent can call `feedback(helpful=True)` on its own grounding and manufacture a ranking boost. This adds the substrate to distinguish that forgeable self-report from a **host-arbitrated, independent verdict**, and lets ranking weight only the unforgeable signal.

## What's in here

- **`retrieval_feedback.provenance`** (`'agent'` default | `'host'`) — server-stamped, NOT NULL + DB CHECK. The public `feedback()` path (REST + MCP) never sets it → an agent's signal is **always** `'agent'`; only `FeedbackService.record_host_feedback()` stamps `'host'` (verdict preserved, flattened + capped, in the note).
- **`reinforce_require_host_arbitration`** per-context config (default `false`) — when on, the #1048 re-rank counts **only** host-arbitrated feedback (`host_only` aggregation). Config-exposed via the search-config schema, REST, and `update_search_config` MCP. Surfaced in the `reinforce_rerank_applied` telemetry.
- **Default-OFF → recall byte-identical to pre-#1065.** Erasable for free (provenance lives on the cascading `retrieval_feedback`).

## Scope / threat model

The verdict **computation** (host-side `VerifiedOutcome`) is `kagura-ai/kagura-agent#165` (proves value single-machine first); this is the substrate that records its outcome with server-authoritative provenance. Adversarial self-review traced every path to `record_feedback` — none lets a client set `provenance` or call `record_host_feedback`, so an agent cannot forge `'host'`; the DB CHECK is the backstop. Caveat (documented on the flag): `reinforce_require_host_arbitration` is itself editable via `update_search_config`, so it is only meaningful when set out-of-band by an operator and the untrusted agent lacks `EDITOR`/`OWNER`.

## Test plan

- Migration **e44** verified by upgrade/downgrade roundtrip on a scratch DB (revision id kept ≤32 chars for `alembic_version.version_num`).
- Unit: `test_feedback_provenance.py` (default→agent, host stamping, forged-value reject, verdict flatten/cap); reinforce actuator forwards `host_only` only when the flag is set.
- Integration (real Postgres): `test_e44_1065_host_arbitration_migration.py` + `test_retrieval_feedback.py` — DEFAULT backfill, CHECK rejection, and `host_only` excludes agent feedback (3 forged agent + 1 host verdict → host_only counts 1). Re-verified green on the rebased tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
