### PR TITLE
fix(eval): harden reinforce rollout gate — graduate on improved + validate adopted_docs (#1084)

### DIFF
--- a/backend/tests/eval/reinforce_runner.py
+++ b/backend/tests/eval/reinforce_runner.py
@@ -169,8 +169,18 @@ async def _run_reinforce_arms(
     if empty:
         raise RuntimeError(f"reinforce corpus has no queries for population(s) {empty}")
 
+    # Fail fast on an unresolvable adopted doc (#1084): silently dropping a typo'd
+    # canonical id un-seeds its adoption and understates uplift with no error —
+    # the asymmetry the population check above already guards against.
     rev: dict[str, UUID] = {doc_id: UUID(mid) for mid, doc_id in id_map.items()}
-    adopted_docs = {d for d in corpus.meta.get("adopted_docs", []) if d in rev}
+    declared_adopted = list(corpus.meta.get("adopted_docs", []))
+    unresolved = [d for d in declared_adopted if d not in rev]
+    if unresolved:
+        raise RuntimeError(
+            f"adopted_docs has unresolved doc id(s) {unresolved} — a typo here is "
+            "silently un-seeded and understates the measured uplift; fix the corpus meta"
+        )
+    adopted_docs = set(declared_adopted)
     adopted_mem_ids = [rev[d] for d in sorted(adopted_docs)]
 
     prev_neural = os.environ.get("ENABLE_NEURAL_MEMORY")
@@ -192,6 +202,13 @@ async def _run_reinforce_arms(
             os.environ["ENABLE_NEURAL_MEMORY"] = prev_neural
 
     gate = evaluate_reinforce_gate(off, on, thresholds=GateThresholds())
+    # Vacuous-pass guard (#1084): a neutered reinforce_enabled toggle (config not
+    # read, or no adoption seeded) yields an ON arm identical to OFF, which still
+    # PASSES the default gate (uplift 0 → improved False). Surfaced as a diagnostic
+    # rather than raised — a legitimately no-headroom corpus (OFF already optimal)
+    # can also tie. The rollout runbook graduates on gate.current_fact.improved,
+    # NOT bare passed, so an identical/no-uplift run never graduates a context.
+    off_on_arms_identical = asdict(off) == asdict(on)
     results: dict[str, Any] = {
         "run_date": run_date,
         "experiment": "reinforce_on_vs_off",
@@ -207,6 +224,7 @@ async def _run_reinforce_arms(
         },
         "off": asdict(off),
         "on": asdict(on),
+        "off_on_arms_identical": off_on_arms_identical,
         "gate": gate,
     }
 
@@ -272,9 +290,20 @@ def _main() -> int:
     results = asyncio.run(run_reinforce_eval())
     print(json.dumps(results, indent=2, ensure_ascii=False))
     gate = results["gate"]
-    print(f"\nreinforce gate: {'PASS' if gate['passed'] else 'FAIL'}")
+    improved = gate["current_fact"]["improved"]
+    # PASS alone is NOT a graduation signal (#1084): the default gate passes on
+    # non-regression, so a no-op reinforce passes with improved=False. Graduate a
+    # context only when reinforce actually HELPS (improved) — surface both.
+    print(f"\nreinforce gate: {'PASS' if gate['passed'] else 'FAIL'}  (improved={improved})")
     for reason in gate["reasons"]:
         print(f"  - {reason}")
+    if results.get("off_on_arms_identical"):
+        print(
+            "  ! OFF and ON arms are identical — reinforce had NO observable effect "
+            "(neutered toggle / no seeded signal / no headroom). Do NOT graduate."
+        )
+    if gate["passed"] and not improved:
+        print("  ! gate PASSED but reinforce did not improve current-fact — do NOT graduate.")
     # Non-zero exit on a failed gate so CI / an operator notices.
     return 0 if gate["passed"] else 1
 

--- a/backend/tests/eval/test_reinforce_runner.py
+++ b/backend/tests/eval/test_reinforce_runner.py
@@ -129,6 +129,57 @@ class TestRunReinforceArms:
         assert results["off"]["zero_adoption_surfacing_rate"] == 0.50
         assert results["on"]["populations"][POPULATION_CURRENT_FACT]["mrr@10"] == 0.88
         assert results["experiment"] == "reinforce_on_vs_off"
+        # #1084: the OFF/ON arms genuinely differ (off_arm != on_arm), so the
+        # vacuous-pass diagnostic is present and false.
+        assert results["off_on_arms_identical"] is False
+
+    async def test_identical_arms_flagged_for_vacuous_pass(self, monkeypatch):
+        # #1084: a neutered toggle yields ON == OFF. The run still completes (a
+        # no-headroom corpus can also tie) but flags off_on_arms_identical so the
+        # operator does not graduate on a vacuous pass.
+        corpus, id_map, _ = _corpus_and_idmap()
+        same = ArmBlock(
+            populations={
+                POPULATION_CURRENT_FACT: {"n": 5, "p@5": 0.7, "mrr@10": 0.70, "ndcg@10": 0.7},
+                POPULATION_RARE: {"n": 5, "p@5": 0.8, "mrr@10": 0.80, "ndcg@10": 0.8},
+            },
+            zero_adoption_surfacing_rate=0.50,
+        )
+        monkeypatch.setattr(reinforce_runner, "_seed_adoption", AsyncMock())
+        monkeypatch.setattr(reinforce_runner, "_set_reinforce", AsyncMock())
+        monkeypatch.setattr(reinforce_runner, "_score_reinforce_arm", AsyncMock(return_value=same))
+        svc = MagicMock()
+        svc.db = MagicMock()
+        results = await reinforce_runner._run_reinforce_arms(
+            svc, corpus, id_map, "owner", uuid4(), uuid4(), "2026-06-26", write=False
+        )
+        assert results["off_on_arms_identical"] is True
+        assert results["gate"]["current_fact"]["improved"] is False
+
+    async def test_unresolved_adopted_doc_fails_fast(self):
+        # #1084: a typo'd adopted doc id was silently dropped (un-seeded), quietly
+        # understating uplift. It must now fail fast like the population check.
+        corpus = Corpus(
+            meta={"adopted_docs": ["d1", "doc_typo"]},  # doc_typo is not in id_map
+            documents=(Document(id="d1", source="memory", text="x" * 20),),
+            queries=(
+                Query(
+                    id="q_cf",
+                    bucket="memory-only",
+                    text="q",
+                    relevant=("d1",),
+                    population="current_fact",
+                ),
+                Query(
+                    id="q_rare", bucket="memory-only", text="q", relevant=("d1",), population="rare"
+                ),
+            ),
+        )
+        svc = MagicMock()
+        with pytest.raises(RuntimeError, match="adopted_docs"):
+            await reinforce_runner._run_reinforce_arms(
+                svc, corpus, {str(uuid4()): "d1"}, "owner", uuid4(), uuid4(), "2026-06-26", False
+            )
 
     async def test_typod_population_fails_fast(self):
         # A query with an unrecognized population would otherwise be silently
@@ -151,3 +202,55 @@ class TestRunReinforceArms:
             await reinforce_runner._run_reinforce_arms(
                 svc, corpus, {str(uuid4()): "d1"}, "owner", uuid4(), uuid4(), "2026-06-26", False
             )
+
+
+class TestToggleChangesRanking:
+    """#1084: the eval's OFF/ON arms are only meaningful if the real
+    reinforce_enabled toggle actually reorders recall. The orchestration tests
+    above mock _score_reinforce_arm, so this drives the REAL
+    MemoryService._maybe_reinforce_rerank on a seeded-corpus-shaped candidate set
+    and asserts OFF != ON — a regression that neuters the toggle fails here
+    instead of letting the gate pass vacuously."""
+
+    async def test_off_and_on_orderings_differ_under_real_toggle(self):
+        from datetime import datetime
+        from decimal import Decimal
+
+        from services.feedback_service import FeedbackAggregate
+        from services.memory_service import MemoryService
+
+        old = datetime(2020, 1, 1)
+        # Mirrors a current_fact probe: an adopted+helpful canonical with a LOWER
+        # raw score than a non-adopted near-duplicate. Reinforce must lift it.
+        canon = MagicMock(id=uuid4(), reference_count=8, importance=0.9, created_at=old)
+        altdup = MagicMock(id=uuid4(), reference_count=0, importance=0.5, created_at=old)
+        memories = {"canon": canon, "alt": altdup}
+
+        async def _order(enabled: bool) -> list[str]:
+            svc = MemoryService(MagicMock())
+            cfg = MagicMock(
+                reinforce_enabled=enabled,
+                reinforce_max_boost=Decimal("0.15"),
+                reinforce_require_host_arbitration=False,
+            )
+            sr = [{"id": "alt", "hybrid_score": 0.85}, {"id": "canon", "hybrid_score": 0.80}]
+            with (
+                patch("repositories.config_repository.ContextSearchConfigRepository") as Repo,
+                patch("services.feedback_service.FeedbackService") as FB,
+            ):
+                Repo.return_value.get_by_context = AsyncMock(return_value=cfg)
+                FB.return_value.aggregate_for_memories = AsyncMock(
+                    return_value={
+                        str(canon.id): FeedbackAggregate(
+                            memory_id=str(canon.id), helpful_count=5, not_helpful_count=0
+                        )
+                    }
+                )
+                await svc._maybe_reinforce_rerank(sr, memories, uuid4(), top_k=10)
+            return [r["id"] for r in sr]
+
+        off_order = await _order(enabled=False)
+        on_order = await _order(enabled=True)
+        assert off_order == ["alt", "canon"]  # OFF: raw hybrid order preserved
+        assert on_order == ["canon", "alt"]  # ON: adopted+helpful canonical rises
+        assert off_order != on_order  # the toggle MUST change ranking

--- a/docs/eval/reinforce-rollout-gate.md
+++ b/docs/eval/reinforce-rollout-gate.md
@@ -28,6 +28,14 @@ stronger "improves" claim raises `min_current_fact_uplift` above 0. The verdict
 always reports the strict `improved` flag separately, so the distinction is never
 hidden.
 
+> **PASS ≠ "reinforce helps" (#1084).** With the default `min_current_fact_uplift = 0.0`,
+> a *no-op* reinforce — or a silently-broken `reinforce_enabled` toggle — produces
+> `passed: true, improved: false` (uplift 0 is non-regression). **Graduate a context
+> on `gate.current_fact.improved == true`, not on bare `passed`** (or set
+> `min_current_fact_uplift > 0` so `passed` *implies* improved). The runner also
+> emits `off_on_arms_identical`; a `true` there means reinforce changed nothing
+> (neutered toggle / no seeded signal / no headroom) — never graduate on it.
+
 ### Why these three
 
 The compounding "+lift" claim's standard kill-shot is *"the boost just measures
@@ -63,7 +71,8 @@ the seed→OFF→ON→gate orchestration is pinned DB-free with fakes
 1. **Pick a high-traffic, trusted context** with real adoption + feedback signal
    (a re-rank with no signal is a no-op — leave cold/low-signal contexts off).
 2. **Run the gate** above against a corpus representative of that context. Enable
-   only on a **green** gate.
+   only when `gate.current_fact.improved` is **true** (and `off_on_arms_identical`
+   is false) — a bare `passed` can be a vacuous non-regression, not a win.
 3. **Enable** via REST `PUT /api/v1/contexts/{id}/search-config`
    (`reinforce_enabled: true`) or the `update_search_config` MCP tool.
 4. **Monitor** the telemetry below; **disable** on regression.


### PR DESCRIPTION
## Summary

Closes #1084 — follow-up to #1082 (eval-gated reinforce rollout). Addresses the two non-blocking robustness findings from the max-rigor review of the gate. Pure test/eval-harness + docs; no production code change. **This is the last open issue in milestone v0.36.0.**

## 1. Gate PASS ≠ "reinforce helps" — graduate on `improved`, guard against a neutered toggle

With the default `min_current_fact_uplift = 0.0`, a no-op reinforce (or a silently-broken `reinforce_enabled` toggle) yields `passed: true, improved: false` — and nothing automated asserted the ON arm actually ranks differently from OFF under the real toggle (the orchestration test mocks `_score_reinforce_arm`).

- ✅ Runbook (`docs/eval/reinforce-rollout-gate.md`) now graduates a context on **`gate.current_fact.improved == true`**, not bare `passed` (with a callout box + step-2 change).
- ✅ The runner records an **`off_on_arms_identical`** diagnostic; the CLI prints `improved=…` and a `do NOT graduate` warning when `passed` but not improved / arms identical (surfaced, not raised — a no-headroom corpus can also legitimately tie).
- ✅ New fixtured test `test_off_and_on_orderings_differ_under_real_toggle` drives the **real** `_maybe_reinforce_rerank` OFF vs ON on a seeded-corpus-shaped candidate set and asserts the order changes — a regression that neuters the toggle now **fails CI** instead of passing the gate vacuously.

## 2. `adopted_docs` typos silently dropped

`reinforce_runner.py` discarded unresolved `adopted_docs` ids with no error, so a typo'd canonical doc was never seeded and uplift was silently understated — asymmetric with the population check, which fails fast.

- ✅ Now raises on any unresolved `adopted_docs` id, mirroring the population fail-fast.

## Out of scope (per the issue)

The trivial cleanups (`population_metrics`/`_bucket_metrics` overlap, `factor_mean` → `statistics.fmean`, `_sid` recomputed 3×, eval workspace-bootstrap duplication) — left for a general eval-harness tidy.

## Test plan

`backend/tests/eval/` — 90 passed / 2 live-skipped. New: identical-arms diagnostic, unresolved-`adopted_docs` fail-fast, and the real-toggle OFF≠ON ordering guard. lint + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
