### PR TITLE
docs(lite): document embedded LanceDB "Kagura Lite" backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ This separation is intentional: mixing graph signals into recall degrades precis
 
 **Tech stack:** FastAPI (async) · PostgreSQL · Qdrant · Redis · Next.js 16 · OAuth2 · MCP over Streamable HTTP
 
+**Vector backend:** Qdrant by default. A single-process self-hosted / CLI / edge deployment can instead run the embedded **LanceDB backend — "Kagura Lite" (preview)** with no separate Qdrant server (`KAGURA_VECTOR_BACKEND=lance`, `pip install '.[lite]'`). Not for multi-worker / SaaS (LanceDB is single-writer). See [Deployment → Embedded Vector Backend](docs/deployment.md#embedded-vector-backend-kagura-lite-preview).
+
 ## Quick Start
 
 ### System Requirements

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,5 +19,5 @@
 - [Resource Tokens Guide](resource-tokens-guide.md) — External data ingestion via resource tokens (the **Ingest** layer)
 - [Neural Memory Evaluation](neural-memory-evaluation.md) — Benchmark results, architecture decisions, known limitations (the **Enhance** layer evidence)
 - [Sleep Maintenance](sleep-maintenance.md) — Background 6-phase cleanup cycle, sleep_mode, observability, and rollback (the **Compile / Enhance** consolidation layer)
-- [Deployment](deployment.md) — Production deployment with Caddy reverse proxy
+- [Deployment](deployment.md) — Production deployment with Caddy reverse proxy (incl. the embedded LanceDB **"Kagura Lite"** backend, preview)
 - [Troubleshooting](troubleshooting.md) — Environment-specific setup fixes (e.g. WSL2 + Claude Code MCP OAuth callback)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -302,3 +302,53 @@ construction in `storage/factory.py`. Today the factory builds one process-wide
 instance from the global `STORAGE_*` settings; per-workspace BYO would move
 construction behind a workspace-scoped credential lookup. Recorded here as a
 seam only — no implementation in #994.
+
+## Embedded Vector Backend: Kagura Lite (preview)
+
+By default the backend stores vectors in **Qdrant** (the `QDRANT_URL` service).
+For a **single-process, self-hosted / CLI / desktop / edge** deployment that
+does not want to run a separate Qdrant server, you can switch to an embedded,
+in-process **LanceDB** backend — "Kagura Lite". This is a **preview**.
+
+### When to use which
+
+| | Qdrant (default) | LanceDB / Kagura Lite |
+|---|---|---|
+| Topology | Server, multi-worker, SaaS | **Single process** (CLI / desktop / edge) |
+| Extra services | Separate Qdrant container | None (a local file) |
+| Concurrent writers | Yes | **No — single-writer** |
+| Nightly Sleep writer | Yes | Single process only |
+| Status | Stable | **Preview** |
+
+> Keep Qdrant for any server / multi-worker / SaaS deployment. LanceDB writes
+> are single-process; a multi-worker API plus the nightly Sleep maintenance
+> writer would conflict.
+
+### Enabling
+
+```bash
+# 1. Install the optional backend extra (adds lancedb + pyarrow)
+pip install '.[lite]'
+
+# 2. Configure the backend (env)
+KAGURA_VECTOR_BACKEND=lance
+KAGURA_LANCE_DB_PATH=./data/kagura.lance   # store location (default)
+```
+
+Japanese full-text quality is unchanged: the existing Sudachi tokenization
+pipeline still owns segmentation (lemmas + readings + synonym/hiragana
+augmentation); LanceDB only stores and searches the resulting vectors and
+pre-tokenized FTS text. Semantic + BM25 hybrid fusion is unchanged.
+
+### Preview limitations
+
+- **Single-writer only.** Not for multi-process / SaaS topologies.
+- These operations raise `NotImplementedError` on the lance backend: context
+  copy (`copy_context_points`), cross-collection GDPR erasure
+  (`delete_user_points`), and the admin BM25-drift reverse-lookup scroll.
+- End-to-end LanceDB behavior is pending live validation; the backend selector
+  and the SQL isolation/escaping filter are unit-tested independently of
+  LanceDB.
+
+Configuration: `KAGURA_VECTOR_BACKEND` (`qdrant` | `lance`, default `qdrant`)
+and `KAGURA_LANCE_DB_PATH`. Implementation: `backend/src/db/lance_store.py`.


### PR DESCRIPTION
## Summary

User-facing docs for the `KAGURA_VECTOR_BACKEND=lance` embedded backend shipped in [#1088](https://github.com/kagura-ai/memory-cloud/pull/1088) (the code merged without docs). No code changes.

- **`docs/deployment.md`** — new "Embedded Vector Backend: Kagura Lite (preview)" section: when-to-use table (Qdrant vs LanceDB), enabling steps (`pip install '.[lite]'` + env), and preview limitations.
- **`README.md`** — a vector-backend note under the tech stack, linking to the deployment section.
- **`docs/README.md`** — index entry updated.

## Note on `.env.example`

The two env vars (`KAGURA_VECTOR_BACKEND`, `KAGURA_LANCE_DB_PATH`) are **not** added to `.env.example` because a repo pre-edit hook protects all `.env*` files. They are documented in `docs/deployment.md` instead. If you want them in `.env.example` too, that edit needs to bypass/relax the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)