### PR TITLE
chore(release): v0.37.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Kagura Memory Cloud plugin — session management, memory recall/save, and setup tools",
   "author": {
     "name": "Kagura AI, Inc.",

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "kagura-memory-cloud"
-version = "0.36.0"
+version = "0.37.0"
 description = "Universal AI Memory Platform - Remote MCP Server + Web Management UI"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/backend/src/__init__.py
+++ b/backend/src/__init__.py
@@ -1,3 +1,3 @@
 """Kagura Memory Cloud - Universal AI Memory Platform (Remote MCP Server)."""
 
-__version__ = "0.36.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION
+__version__ = "0.37.0"  # Kept for compatibility; canonical source is config.constants.APP_VERSION

--- a/backend/src/config/constants.py
+++ b/backend/src/config/constants.py
@@ -8,7 +8,7 @@ All constants are grouped by category with clear documentation.
 # Application Version (single source of truth for runtime)
 # ============================================================================
 
-APP_VERSION = "0.36.0"
+APP_VERSION = "0.37.0"
 
 # ============================================================================
 # Memory Content Limits

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kagura-web",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kagura-web",
-      "version": "0.36.0",
+      "version": "0.37.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-web",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "private": true,
   "description": "Kagura Memory Cloud - Web Management UI",
   "license": "Apache-2.0",

--- a/plugins/kagura-memory/.codex-plugin/plugin.json
+++ b/plugins/kagura-memory/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "kagura-memory",
-  "version": "0.36.0",
+  "version": "0.37.0",
   "description": "Kagura Memory Cloud workflows for Codex session restore, recall, remember, and setup",
   "author": {
     "name": "Kagura AI, Inc.",


### PR DESCRIPTION
## Release v0.37.0

Version bump only (0.36.0 → 0.37.0) across all canonical locations:
`backend/pyproject.toml`, `backend/src/config/constants.py` (`APP_VERSION`),
`backend/src/__init__.py`, `frontend/package.json` (+ `package-lock.json`),
`.claude-plugin/plugin.json`, `plugins/kagura-memory/.codex-plugin/plugin.json`.

### Headline
**Embedded LanceDB vector backend — "Kagura Lite" (preview)** (#1088) + max code-review hardening (#1089) + docs (#1090, #1091).

Tag `v0.37.0` + GitHub Release will be created on the merge commit.

> Note: the prior release (`v0.36.0`) was a direct-to-main commit, but direct pushes to `main` are blocked here, so the bump goes via this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)