### PR TITLE
feat(billing): owner-only handoff endpoint minting Ed25519 token (#1093)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -509,6 +509,7 @@ from api.routes import (  # noqa: E402
     api_keys,
     attachments,  # Issue #330 → deprecated by #555 (returns HTTP 410 Gone)
     auth,
+    billing_handoff,  # Issue #1093: owner-only Ed25519 handoff to payment service
     bm25_drift,  # Issue #343: BM25 IDF drift admin (preview, cron disabled by default)
     config,
     connectors_slack,  # Spec 2026-06-02: Slack connector OAuth install/callback
@@ -592,6 +593,9 @@ app.include_router(invitations.router, prefix="/api/v1")
 
 # Workspace Plan routes (Issue #164 - User Management拡張)
 app.include_router(workspace_plan.router, prefix="/api/v1")
+
+# Billing handoff route (Issue #1093 - owner-only Ed25519 handoff to payment service)
+app.include_router(billing_handoff.router, prefix="/api/v1")
 
 # Member Credentials routes (Migration 034 - Zero-knowledge credential management)
 app.include_router(member_credentials.router)

--- a/backend/src/api/routes/billing_handoff.py
+++ b/backend/src/api/routes/billing_handoff.py
@@ -1,0 +1,67 @@
+"""Owner-only billing handoff endpoint (Issue #1093 — RFC kagura-payment §1).
+
+``POST /api/v1/billing/handoff`` mints a short-lived Ed25519-signed JWT that the
+external payment service (payment.kagura-ai.com) redeems to establish the
+user-auth handoff (Layer-1). memory-cloud stays the source of truth for *who*
+the user is and *which* workspace they own; the payment service trusts the
+signed assertion instead of re-authenticating.
+
+Security posture:
+
+- **Owner-only, session-only.** Guarded by ``WorkspaceOwnerSession`` so only a
+  workspace owner on a real browser session can mint a handoff. A leaked API
+  key / OAuth bearer is rejected at the door (403) — the dependency chains
+  through ``require_session_auth``.
+- **No request-controlled claims.** The token is minted from
+  ``(user["user_id"], user["current_workspace_id"])`` only; the request has no
+  body. This forecloses a member from minting an owner token for another
+  workspace.
+- **Fail-closed.** With no signing key configured the mint raises HANDOFF-001
+  (503) — the endpoint never returns an unsigned/forgeable token.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+from auth.dependencies import WorkspaceOwnerSession
+from config.settings import get_settings
+from services.billing_handoff_service import HANDOFF_TTL_SECONDS, mint_handoff_token
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/billing", tags=["billing-handoff"])
+
+
+class HandoffResult(BaseModel):
+    """Redirect target for the payment-service handoff."""
+
+    url: str
+    expires_in: int
+
+
+@router.post("/handoff", response_model=HandoffResult)
+async def create_billing_handoff(user: WorkspaceOwnerSession) -> HandoffResult:
+    """Mint a short-lived handoff token for the calling owner's workspace.
+
+    Returns the payment-service ``/enter`` URL carrying the signed token and the
+    token TTL. Owner-only, session-only; fails closed (503 HANDOFF-001) when the
+    signing key is unset.
+    """
+    settings = get_settings()
+    user_id = user["user_id"]
+    workspace_id = user["current_workspace_id"]
+
+    # mint_handoff_token raises HANDOFF-001 (503) when fail-closed.
+    token = mint_handoff_token(user_id, workspace_id)
+
+    logger.info(
+        "billing_handoff_minted",
+        user_id=user_id,
+        workspace_id=str(workspace_id),
+        expires_in=HANDOFF_TTL_SECONDS,
+    )
+    base = settings.payment_public_base_url.rstrip("/")
+    return HandoffResult(url=f"{base}/enter?t={token}", expires_in=HANDOFF_TTL_SECONDS)

--- a/backend/src/auth/dependencies.py
+++ b/backend/src/auth/dependencies.py
@@ -677,6 +677,60 @@ async def require_workspace_admin_session(
     return user
 
 
+async def require_workspace_owner_session(
+    user: dict = Depends(require_session_auth),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Verify user is workspace owner — session auth only.
+
+    Issue #1093: the billing handoff endpoint uses this variant so a leaked API
+    key cannot mint a payment-service handoff token on behalf of an owner.
+    Mirrors ``require_workspace_admin_session`` but requires the strict *owner*
+    role (``check_workspace_owner``) rather than admin-or-owner, and rejects
+    API-key auth at the door (require_session_auth raises 403 for any Bearer
+    token).
+
+    Args:
+        user: Current authenticated user (session only)
+        db: Database session
+
+    Returns:
+        User info dict (full dict, like require_workspace_member)
+
+    Raises:
+        HTTPException: 400 if no workspace selected
+        HTTPException: 403 if API key was provided OR if not the owner
+    """
+    user_id = user.get("user_id")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+
+    workspace_id = user.get("current_workspace_id")
+    if not workspace_id:
+        raise HTTPException(
+            status_code=400, detail="No workspace selected. Please select a workspace first."
+        )
+
+    from services.permission_service import PermissionService
+
+    perm_service = PermissionService(db)
+    try:
+        await perm_service.check_workspace_owner(user_id, workspace_id)
+    except AuthorizationError as exc:
+        logger.warning(
+            "workspace_owner_session_denied",
+            user_id=user_id,
+            workspace_id=str(workspace_id),
+            status_code=exc.status_code,
+            reason=exc.reason,
+        )
+        raise
+
+    logger.info("workspace_owner_session_verified", user_id=user_id, workspace_id=str(workspace_id))
+
+    return user
+
+
 async def require_workspace_admin(
     user: dict = Depends(get_user_from_api_key_or_session),
     db: AsyncSession = Depends(get_db),
@@ -860,4 +914,5 @@ WorkspaceOwner = Annotated[tuple[str, UUID], Depends(require_workspace_owner)]  
 ShareKeyUser = Annotated[dict, Depends(get_share_key_principal)]  # Issue #1027
 WorkspaceAdmin = Annotated[dict, Depends(require_workspace_admin)]  # Issue #398
 WorkspaceAdminSession = Annotated[dict, Depends(require_workspace_admin_session)]  # Issue #398
+WorkspaceOwnerSession = Annotated[dict, Depends(require_workspace_owner_session)]  # Issue #1093
 WorkspaceMember = Annotated[dict, Depends(require_workspace_member)]  # Issue #59

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -103,6 +103,33 @@ class Settings(BaseSettings):
         default="",
         description="Shared bearer token authenticating the billing service to /internal/* (RFC 6750)",
     )
+    # Issue #1093: owner-only handoff to the external payment service. memory-cloud
+    # mints a short-lived Ed25519 (EdDSA) JWT that payment.kagura-ai.com redeems
+    # for the user-auth handoff (RFC kagura-payment §1, Layer-1). Empty signing key
+    # disables the endpoint (fail-closed, 503 HANDOFF-001) so a misconfigured
+    # deployment never mints unsigned/forgeable handoff tokens.
+    # Generate: openssl genpkey -algorithm ed25519 -out handoff.pem (PEM, PKCS8).
+    billing_handoff_signing_key: str = Field(
+        default="",
+        description=(
+            "Ed25519 PRIVATE key (PEM, PKCS8) used to sign billing-handoff JWTs. "
+            "Empty disables POST /api/v1/billing/handoff (fail-closed, 503)."
+        ),
+    )
+    billing_handoff_kid: str = Field(
+        default="",
+        description=(
+            "Key id placed in the handoff JWT header so the payment service can "
+            "select the right public key during signing-key rotation."
+        ),
+    )
+    payment_public_base_url: str = Field(
+        default="https://payment.kagura-ai.com",
+        description=(
+            "Public base URL of the external payment service. The handoff endpoint "
+            "returns {base}/enter?t=<jwt> for the browser redirect."
+        ),
+    )
     # Public MCP base URL handed back to the worker in its config so it can write
     # memories. Defaults to local dev; override in prod (e.g. https://memory.kagura-ai.com/mcp).
     kmc_mcp_url: str = Field(

--- a/backend/src/services/billing_handoff_service.py
+++ b/backend/src/services/billing_handoff_service.py
@@ -1,0 +1,127 @@
+"""Billing handoff token minting (Issue #1093 — RFC kagura-payment §1, Layer-1).
+
+memory-cloud is the authority for *who* a user is and *which* workspace they
+own. The external payment service (payment.kagura-ai.com) must not re-run our
+login; instead memory-cloud mints a short-lived, Ed25519-signed JWT that the
+payment service redeems on a single browser-redirect hop. This module owns that
+mint (and a reference verify used by the security tests / documenting the
+contract the payment service implements).
+
+Security properties (asserted in tests/services/test_billing_handoff_service.py):
+
+- **EdDSA only.** The algorithm list on the ``JsonWebToken`` instance is pinned
+  to ``["EdDSA"]``. authlib refuses to encode or verify any token whose header
+  ``alg`` is not in that list, which closes the classic alg-confusion holes
+  (``alg:none`` and HS256-with-public-key-as-secret). We never fall back to a
+  symmetric algorithm.
+- **Fail-closed.** An unset signing key raises HANDOFF-001 (503) — a
+  misconfigured deployment returns "not configured", never an unsigned or
+  forgeable token. Mirrors ``internal_billing.verify_billing_service_token``.
+- **No request-controlled claims.** The token is minted purely from
+  ``(user_id, workspace_id)`` that the caller already proved ownership of via
+  the owner-only session dependency. Nothing from the request body reaches the
+  claims.
+- **Short TTL.** 120 seconds: the token is redeemed immediately on the redirect
+  and is never stored.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC
+from typing import Any
+from uuid import UUID
+
+from authlib.jose import JsonWebToken
+
+from config.settings import get_settings
+from utils.datetime import utcnow
+from utils.exceptions import MemoryCloudException
+
+# Token lifetime in seconds. Short by design: redeemed on the redirect hop,
+# never persisted. The route echoes this as ``expires_in``.
+HANDOFF_TTL_SECONDS = 120
+
+# EdDSA only. Pinning the algorithm allow-list on the JsonWebToken instance is
+# the primary defense against alg-confusion: authlib will not encode or decode a
+# token whose header ``alg`` is outside this list, so an ``alg:none`` or
+# HS256(public-key) token is rejected before any signature check.
+_ALLOWED_ALGS = ["EdDSA"]
+
+_jwt = JsonWebToken(_ALLOWED_ALGS)
+
+
+def mint_handoff_token(user_id: str, workspace_id: str | UUID) -> str:
+    """Mint a short-lived Ed25519 handoff JWT for ``(user_id, workspace_id)``.
+
+    Args:
+        user_id: The owner's user id (already authorized by the caller — the
+            owner-only session dependency).
+        workspace_id: The workspace the user owns, taken from the SESSION (never
+            from request input). Stringified into the ``workspace_id`` claim.
+
+    Returns:
+        The compact-serialized JWT as a ``str``.
+
+    Raises:
+        MemoryCloudException: HANDOFF-001 (503) when the signing key is unset —
+            the endpoint is fail-closed.
+    """
+    settings = get_settings()
+    signing_key = settings.billing_handoff_signing_key
+    if not signing_key:
+        # Mirror internal_billing's fail-closed contract: raise the base
+        # MemoryCloudException so the global handler emits the canonical
+        # envelope, and we avoid a raw HTTPException (#992 ratchet).
+        raise MemoryCloudException(
+            "Billing handoff endpoint is not configured",
+            status_code=503,
+            error_code="HANDOFF-001",
+        )
+
+    # Epoch seconds. ``utcnow()`` is naive UTC by project convention; attach UTC
+    # before ``.timestamp()`` so the epoch is correct regardless of host tz.
+    iat = int(utcnow().replace(tzinfo=UTC).timestamp())
+    exp = iat + HANDOFF_TTL_SECONDS
+
+    header: dict[str, Any] = {"alg": "EdDSA", "kid": settings.billing_handoff_kid}
+    claims: dict[str, Any] = {
+        "iss": "memory-cloud",
+        "aud": "payment.kagura-ai.com",
+        "sub": str(user_id),
+        "workspace_id": str(workspace_id),
+        "role": "owner",
+        "iat": iat,
+        "exp": exp,
+        "jti": uuid.uuid4().hex,
+        "ver": 1,
+    }
+
+    token = _jwt.encode(header, claims, signing_key)
+    # authlib returns bytes for the compact serialization; the route embeds the
+    # token in a URL/JSON string.
+    return token.decode("utf-8") if isinstance(token, bytes) else token
+
+
+def verify_handoff_token(token: str, public_key_pem: str) -> dict[str, Any]:
+    """Verify and decode a handoff token, pinning EdDSA.
+
+    Reference implementation of the contract the payment service performs. It is
+    exercised by the security tests and documents that verification MUST pin the
+    algorithm: ``_jwt`` only accepts ``alg=EdDSA``, so ``alg:none`` and
+    HS256-with-public-key tokens are rejected here just as they must be on the
+    payment side.
+
+    Args:
+        token: The compact JWT string.
+        public_key_pem: Ed25519 public key (PEM, SubjectPublicKeyInfo).
+
+    Returns:
+        The decoded claims as a plain dict.
+
+    Raises:
+        authlib.jose.errors.JoseError: on a bad signature, an unsupported
+            algorithm (alg-confusion), or malformed input.
+    """
+    claims = _jwt.decode(token, public_key_pem)
+    return dict(claims)

--- a/backend/tests/api/test_billing_handoff.py
+++ b/backend/tests/api/test_billing_handoff.py
@@ -1,0 +1,160 @@
+"""RBAC + behavior tests for the billing handoff endpoint (Issue #1093).
+
+``POST /api/v1/billing/handoff`` is owner-only and session-only: it mints a
+short-lived Ed25519 handoff token for the payment service. Mirrors
+``tests/api/test_billing_rbac.py`` — the route is mounted on a fresh FastAPI app
+and the auth gate is exercised in isolation via ``dependency_overrides`` so the
+suite runs without Postgres or the full app harness.
+
+Coverage:
+- owner (session) → 200 with a payment ``url`` and ``expires_in == 120``;
+- non-owner member → 403 (role gate);
+- API-key / Bearer credential → 403 (session-only gate, real dependency chain);
+- signing key unset → 503 HANDOFF-001 (fail-closed).
+"""
+
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from api.routes.billing_handoff import router as handoff_router
+from auth.dependencies import require_workspace_owner_session
+from config.settings import get_settings
+from db.base import get_db
+from utils.exceptions import MemoryCloudException
+
+WORKSPACE_ID = uuid4()
+
+
+def _mock_owner() -> dict:
+    return {
+        "user_id": "test_owner",
+        "email": "owner@test.com",
+        "role": "user",
+        "current_workspace_id": WORKSPACE_ID,
+        "workspace_role": "owner",
+    }
+
+
+async def _mock_db():
+    yield MagicMock()
+
+
+async def _mc_handler(request, exc: MemoryCloudException) -> JSONResponse:
+    """Minimal stand-in for the production ``memory_cloud_exception_handler``.
+
+    The fresh test app does not register the global handlers; this mirrors the
+    status_code + error_code mapping so a route-raised MemoryCloudException
+    surfaces as its real HTTP status (e.g. HANDOFF-001 → 503).
+    """
+    return JSONResponse(
+        status_code=exc.status_code,
+        content={"error": exc.error_code, "message": exc.message},
+    )
+
+
+def _build_app() -> FastAPI:
+    """Mount the handoff router on a fresh app with the MemoryCloud handler."""
+    app = FastAPI()
+    app.include_router(handoff_router, prefix="/api/v1")
+    app.add_exception_handler(MemoryCloudException, _mc_handler)
+    return app
+
+
+def _install_signing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Point the settings singleton at an ephemeral Ed25519 private key."""
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode("utf-8")
+    settings = get_settings()
+    monkeypatch.setattr(settings, "billing_handoff_signing_key", priv_pem)
+    monkeypatch.setattr(settings, "billing_handoff_kid", "test-kid")
+    monkeypatch.setattr(settings, "payment_public_base_url", "https://payment.example.com")
+
+
+@pytest.fixture
+def owner_client():
+    """Client where the owner-only session gate accepts (owner)."""
+    app = _build_app()
+    app.dependency_overrides[require_workspace_owner_session] = _mock_owner
+    app.dependency_overrides[get_db] = _mock_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def non_owner_client():
+    """Client where the owner-only gate rejects with 403 (admin/member/viewer)."""
+    app = _build_app()
+
+    async def mock_reject():
+        raise HTTPException(status_code=403, detail="Requires 'owner' role")
+
+    app.dependency_overrides[require_workspace_owner_session] = mock_reject
+    app.dependency_overrides[get_db] = _mock_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def bearer_client():
+    """Client exercising the REAL owner-only dependency chain (no override).
+
+    Only ``get_db`` is mocked. The real ``require_workspace_owner_session`` ->
+    ``require_session_auth`` rejects any Bearer credential at the door (403)
+    before any DB access, proving a leaked API key cannot mint a handoff.
+    """
+    app = _build_app()
+    app.dependency_overrides[get_db] = _mock_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+class TestBillingHandoffOwnerHappyPath:
+    def test_owner_gets_200_with_url(self, owner_client, monkeypatch):
+        _install_signing_key(monkeypatch)
+        response = owner_client.post("/api/v1/billing/handoff")
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["expires_in"] == 120
+        assert body["url"].startswith("https://payment.example.com/enter?t=")
+        # A real token (three dot-separated segments) is embedded.
+        token = body["url"].split("?t=", 1)[1]
+        assert token.count(".") == 2
+
+
+class TestBillingHandoffDenied:
+    def test_non_owner_gets_403(self, non_owner_client, monkeypatch):
+        _install_signing_key(monkeypatch)  # set key so 403 is the role gate, not 503
+        response = non_owner_client.post("/api/v1/billing/handoff")
+        assert response.status_code == 403, response.text
+
+    def test_bearer_api_key_gets_403(self, bearer_client, monkeypatch):
+        _install_signing_key(monkeypatch)
+        response = bearer_client.post(
+            "/api/v1/billing/handoff",
+            headers={"Authorization": "Bearer kagura_fake_api_key_value"},
+        )
+        assert response.status_code == 403, response.text
+
+
+class TestBillingHandoffFailClosed:
+    def test_unset_signing_key_gives_503(self, owner_client, monkeypatch):
+        settings = get_settings()
+        monkeypatch.setattr(settings, "billing_handoff_signing_key", "")
+        monkeypatch.setattr(settings, "billing_handoff_kid", "")
+        response = owner_client.post("/api/v1/billing/handoff")
+        assert response.status_code == 503, response.text
+        assert response.json()["error"] == "HANDOFF-001"

--- a/backend/tests/services/test_billing_handoff_service.py
+++ b/backend/tests/services/test_billing_handoff_service.py
@@ -1,0 +1,178 @@
+"""Security-critical unit tests for the billing handoff token mint (Issue #1093).
+
+These tests stand alone — no DB, no app harness. They generate an ephemeral
+Ed25519 keypair, point the signing key at the private half, mint a handoff
+token, and assert every security property of the JWT that the external payment
+service will rely on (RFC kagura-payment §1, Layer-1 user-auth handoff):
+
+- algorithm is pinned to EdDSA and the header carries the rotation ``kid``;
+- the exact claim set is present and minted from (user_id, workspace_id);
+- the token is verifiable with the matching public key and *only* that key;
+- alg-confusion tokens (``alg:none`` / HS256-with-pubkey) are rejected by the
+  verify path;
+- a missing signing key fails closed with HANDOFF-001 (503), never minting.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from authlib.jose import JsonWebToken
+from authlib.jose.errors import JoseError
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from config.settings import get_settings
+from services.billing_handoff_service import (
+    HANDOFF_TTL_SECONDS,
+    mint_handoff_token,
+    verify_handoff_token,
+)
+from utils.exceptions import MemoryCloudException
+
+USER_ID = "user-abc-123"
+WORKSPACE_ID = "11111111-1111-1111-1111-111111111111"
+KID = "handoff-key-2026-06"
+
+
+def _ed25519_pem_pair() -> tuple[str, str]:
+    """Return (private_pem_pkcs8, public_pem_spki) as PEM strings."""
+    priv = Ed25519PrivateKey.generate()
+    priv_pem = priv.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode("utf-8")
+    pub_pem = (
+        priv.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
+    return priv_pem, pub_pem
+
+
+def _decode_segment(segment: str) -> dict:
+    """Base64url-decode one compact-JWT segment into its JSON dict."""
+    padded = segment + "=" * (-len(segment) % 4)
+    return json.loads(base64.urlsafe_b64decode(padded))
+
+
+@pytest.fixture
+def signing_key(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    """Install an ephemeral private signing key + kid; yield (priv, pub) PEMs."""
+    priv_pem, pub_pem = _ed25519_pem_pair()
+    settings = get_settings()
+    monkeypatch.setattr(settings, "billing_handoff_signing_key", priv_pem)
+    monkeypatch.setattr(settings, "billing_handoff_kid", KID)
+    return priv_pem, pub_pem
+
+
+def test_header_pins_eddsa_and_kid(signing_key: tuple[str, str]) -> None:
+    token = mint_handoff_token(USER_ID, WORKSPACE_ID)
+    header = _decode_segment(token.split(".")[0])
+    assert header["alg"] == "EdDSA"
+    assert header["kid"] == KID
+    # No HS*/none must ever appear in a minted header.
+    assert not header["alg"].lower().startswith("hs")
+    assert header["alg"].lower() != "none"
+
+
+def test_claims_are_exact_and_from_arguments(signing_key: tuple[str, str]) -> None:
+    _, pub_pem = signing_key
+    token = mint_handoff_token(USER_ID, WORKSPACE_ID)
+    claims = verify_handoff_token(token, pub_pem)
+
+    assert claims["iss"] == "memory-cloud"
+    assert claims["aud"] == "payment.kagura-ai.com"
+    assert claims["sub"] == USER_ID
+    assert claims["workspace_id"] == WORKSPACE_ID
+    assert claims["role"] == "owner"
+    assert claims["ver"] == 1
+    # jti is a unique, opaque, non-empty identifier.
+    assert isinstance(claims["jti"], str) and claims["jti"]
+
+
+def test_jti_is_unique_per_mint(signing_key: tuple[str, str]) -> None:
+    _, pub_pem = signing_key
+    a = verify_handoff_token(mint_handoff_token(USER_ID, WORKSPACE_ID), pub_pem)
+    b = verify_handoff_token(mint_handoff_token(USER_ID, WORKSPACE_ID), pub_pem)
+    assert a["jti"] != b["jti"]
+
+
+def test_ttl_is_exactly_120s(signing_key: tuple[str, str]) -> None:
+    _, pub_pem = signing_key
+    claims = verify_handoff_token(mint_handoff_token(USER_ID, WORKSPACE_ID), pub_pem)
+    assert HANDOFF_TTL_SECONDS == 120
+    assert claims["exp"] - claims["iat"] == 120
+
+
+def test_workspace_id_uuid_is_stringified(signing_key: tuple[str, str]) -> None:
+    from uuid import UUID
+
+    _, pub_pem = signing_key
+    ws = UUID(WORKSPACE_ID)
+    claims = verify_handoff_token(mint_handoff_token(USER_ID, ws), pub_pem)
+    assert claims["workspace_id"] == WORKSPACE_ID
+    assert isinstance(claims["workspace_id"], str)
+
+
+def test_token_verifies_only_with_matching_public_key(signing_key: tuple[str, str]) -> None:
+    _, pub_pem = signing_key
+    token = mint_handoff_token(USER_ID, WORKSPACE_ID)
+
+    # Correct key verifies.
+    assert verify_handoff_token(token, pub_pem)["sub"] == USER_ID
+
+    # A different keypair's public key must NOT verify the signature.
+    _, wrong_pub = _ed25519_pem_pair()
+    with pytest.raises(JoseError):  # BadSignatureError
+        verify_handoff_token(token, wrong_pub)
+
+
+def test_alg_none_token_is_rejected(signing_key: tuple[str, str]) -> None:
+    """An unsigned ``alg:none`` token must never verify (alg-confusion)."""
+    _, pub_pem = signing_key
+
+    def b64(d: bytes) -> bytes:
+        return base64.urlsafe_b64encode(d).rstrip(b"=")
+
+    forged = (
+        b64(json.dumps({"alg": "none", "typ": "JWT"}).encode())
+        + b"."
+        + b64(json.dumps({"sub": "attacker", "role": "owner"}).encode())
+        + b"."
+    ).decode()
+    with pytest.raises(JoseError):  # UnsupportedAlgorithmError
+        verify_handoff_token(forged, pub_pem)
+
+
+def test_hs256_pubkey_confusion_is_rejected(signing_key: tuple[str, str]) -> None:
+    """A token signed HS256 (the classic pubkey-as-HMAC-secret attack) must be
+    rejected because the verify path pins EdDSA."""
+    _, pub_pem = signing_key
+    hs = JsonWebToken(["HS256"])
+    forged = hs.encode(
+        {"alg": "HS256"},
+        {"sub": "attacker", "role": "owner"},
+        b"attacker-controlled-hmac-secret-0123456789",
+    ).decode()
+    with pytest.raises(JoseError):  # UnsupportedAlgorithmError
+        verify_handoff_token(forged, pub_pem)
+
+
+def test_unset_signing_key_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No signing key configured → HANDOFF-001 (503), never an unsigned token."""
+    settings = get_settings()
+    monkeypatch.setattr(settings, "billing_handoff_signing_key", "")
+    monkeypatch.setattr(settings, "billing_handoff_kid", "")
+
+    with pytest.raises(MemoryCloudException) as exc_info:
+        mint_handoff_token(USER_ID, WORKSPACE_ID)
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.error_code == "HANDOFF-001"


### PR DESCRIPTION
Implements kagura-ai/memory-cloud#1093 — owner-only `POST /api/v1/billing/handoff` that mints a short-lived **Ed25519-signed JWT** for the external billing service to redeem (Layer-1 user-auth handoff). memory-cloud is the authority for identity + workspace ownership; the billing service verifies with the public key and never re-runs login.

## Endpoint
`POST /api/v1/billing/handoff` — **owner-only, session-only** (Bearer/API-key rejected). Returns `{ "url": "<payment_public_base_url>/enter?t=<jwt>", "expires_in": 120 }`.

## Security properties (tested)
- **EdDSA only** — `JsonWebToken(["EdDSA"])` pins the algorithm; `alg:none` and HS256(public-key) are rejected (alg-confusion closed). No symmetric fallback.
- **Fail-closed** — unset `BILLING_HANDOFF_SIGNING_KEY` → 503 `HANDOFF-001` (mirrors `internal_billing.verify_billing_service_token`).
- **No request-controlled claims** — minted only from the session's `(user_id, current_workspace_id)`. Claims: `iss/aud/sub/workspace_id/role=owner/iat/exp(=iat+120)/jti/ver`.
- **Owner-only + session-only** — new `require_workspace_owner_session` (clone of `require_workspace_admin_session` using `check_workspace_owner`); a leaked API key cannot mint a handoff.

## Settings
`billing_handoff_signing_key` (Ed25519 PEM/PKCS8; empty disables the endpoint), `billing_handoff_kid` (rotation), `payment_public_base_url`.

## Tests
13 new tests, **no Postgres required** (mirrors `test_billing_rbac.py` dependency-override pattern): owner→200, non-owner→403, Bearer→403, unset-key→503. The mint service + a reference verify are unit-tested for alg-confusion + signature rejection. ruff clean; pyright clean on changed files.

Closes kagura-ai/memory-cloud#1093.

🤖 Generated with [Claude Code](https://claude.com/claude-code)