### PR TITLE
feat(billing): owner-only Ed25519 handoff token endpoint (#1093)

### DIFF
--- a/backend/src/api/main.py
+++ b/backend/src/api/main.py
@@ -509,6 +509,7 @@ from api.routes import (  # noqa: E402
     api_keys,
     attachments,  # Issue #330 → deprecated by #555 (returns HTTP 410 Gone)
     auth,
+    billing_handoff,  # Issue #1093: owner-only billing handoff token (/api/v1/billing/handoff)
     bm25_drift,  # Issue #343: BM25 IDF drift admin (preview, cron disabled by default)
     config,
     connectors_slack,  # Spec 2026-06-02: Slack connector OAuth install/callback
@@ -674,6 +675,10 @@ app.include_router(workers.router, prefix="/api/v1")
 # deploy by deploy.sh `verify_internal_blocked`); reachable only over the
 # internal Docker network, with BILLING_SERVICE_TOKEN as the in-app control.
 app.include_router(internal_billing.router)
+# Issue #1093: owner-only billing handoff token. Public surface (/api/v1/billing),
+# session-auth + owner-only, Stripe-agnostic — always mounted (unlike the
+# BILLING_ENABLED-gated Stripe plugin); fail-closed (503) when the signing key is unset.
+app.include_router(billing_handoff.router, prefix="/api/v1")
 app.include_router(connectors_slack.router, prefix="/api/v1")
 
 # Public Search routes (Issue #238 - Public REST API)

--- a/backend/src/api/routes/billing_handoff.py
+++ b/backend/src/api/routes/billing_handoff.py
@@ -1,0 +1,104 @@
+"""Owner-only billing handoff endpoint (#1093).
+
+``POST /api/v1/billing/handoff`` lets an authenticated workspace **owner** start
+a billing session on the external billing host without that host re-implementing
+user auth. It mints a short-lived Ed25519-signed token (see
+``auth.billing_handoff.BillingHandoffSigner``) bound to
+``(user_id, workspace_id, role=owner)``.
+
+Two-layer gate, deliberately strict:
+
+1. **session-auth only** (``SessionUser`` → ``require_session_auth``): a Bearer
+   credential (API key / OAuth) is rejected 403. A leaked long-lived API key must
+   never be able to open a billing session (mirrors the #398 billing RBAC stance).
+2. **owner-only against the explicit target workspace**: the owner check runs on
+   the request-body ``workspace_id``, never the caller's mutable
+   ``current_workspace_id`` — closing the #389 multi-workspace cross-tenant trap.
+
+Stripe-agnostic and always mounted (unlike the ``BILLING_ENABLED``-gated Stripe
+plugin): the token is the auth primitive the billing host consumes, independent
+of which payment processor it wraps.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.billing_handoff import BillingHandoffSigner
+from auth.dependencies import SessionUser
+from db.base import get_db
+from models.api_base import TZAwareBaseModel
+from services.permission_service import PermissionService
+from utils.auth_helpers import get_user_id
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/billing", tags=["billing-handoff"])
+
+
+class BillingHandoffRequest(BaseModel):
+    """Request to mint a handoff token for one owned workspace."""
+
+    workspace_id: UUID = Field(
+        ...,
+        description=(
+            "The workspace to start a billing session for. The caller MUST be "
+            "its owner — the owner check binds to this value, not the session's "
+            "current workspace."
+        ),
+    )
+
+
+class BillingHandoffResponse(TZAwareBaseModel):
+    """The minted handoff token and the metadata the billing host needs."""
+
+    token: str = Field(..., description="Ed25519-signed JWT (alg=EdDSA).")
+    token_type: str = Field(default="billing_handoff", description="Token kind discriminator.")
+    kid: str = Field(..., description="Signing key id — selects the verifier's public key.")
+    jti: str = Field(..., description="Unique token id (verifier enforces single-use).")
+    expires_at: datetime = Field(..., description="Token expiry (UTC, short-lived).")
+
+
+@router.post("/handoff", response_model=BillingHandoffResponse)
+async def mint_billing_handoff(
+    body: BillingHandoffRequest,
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> BillingHandoffResponse:
+    """Mint an owner-scoped, short-lived billing handoff token.
+
+    Owner-only + session-only. Returns 403 for admin/member/API-key callers and
+    503 when the signing key is unconfigured (fail-closed).
+    """
+    user_id = get_user_id(user)
+
+    # Owner gate against the EXPLICIT target workspace — check_workspace_owner
+    # raises AuthorizationError (403) for non-owners and never trusts
+    # current_workspace_id, so a multi-workspace member cannot mint for a
+    # workspace they merely belong to (#389 guard).
+    await PermissionService(db).check_workspace_owner(user_id, body.workspace_id)
+
+    # Mint AFTER authz so an unconfigured deployment returns 403 to non-owners
+    # (no info leak) and 503 only to an authorized owner.
+    minted = BillingHandoffSigner().mint(user_id=user_id, workspace_id=body.workspace_id)
+
+    logger.info(
+        "billing_handoff_issued",
+        user_id=user_id,
+        workspace_id=str(body.workspace_id),
+        jti=minted.jti,
+        kid=minted.kid,
+    )
+
+    return BillingHandoffResponse(
+        token=minted.token,
+        kid=minted.kid,
+        jti=minted.jti,
+        expires_at=minted.expires_at,
+    )

--- a/backend/src/api/routes/billing_handoff.py
+++ b/backend/src/api/routes/billing_handoff.py
@@ -35,9 +35,6 @@ from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from services.permission_service import PermissionService
 from utils.auth_helpers import get_user_id
-from utils.logger import get_logger
-
-logger = get_logger(__name__)
 
 router = APIRouter(prefix="/billing", tags=["billing-handoff"])
 
@@ -88,14 +85,8 @@ async def mint_billing_handoff(
     # (no info leak) and 503 only to an authorized owner.
     minted = BillingHandoffSigner().mint(user_id=user_id, workspace_id=body.workspace_id)
 
-    logger.info(
-        "billing_handoff_issued",
-        user_id=user_id,
-        workspace_id=str(body.workspace_id),
-        jti=minted.jti,
-        kid=minted.kid,
-    )
-
+    # Issuance is audit-logged exactly once, inside BillingHandoffSigner.mint()
+    # as "billing_handoff_minted" (same fields + expires_at) — no duplicate here.
     return BillingHandoffResponse(
         token=minted.token,
         kid=minted.kid,

--- a/backend/src/auth/billing_handoff.py
+++ b/backend/src/auth/billing_handoff.py
@@ -1,0 +1,178 @@
+"""Ed25519 signer for owner-scoped billing handoff tokens (#1093).
+
+The external billing service (kagura-billing) needs to trust an authenticated
+workspace **owner** without re-implementing user auth on the billing host.
+memory-cloud mints a short-lived, **Ed25519-signed** JWT bound to
+``(user_id, workspace_id, role=owner)`` with ``iss/aud/exp/iat/jti``; the billing
+service verifies it with the matching **public** key (``kid``-based rotation).
+
+Design boundaries (kept deliberately narrow — the rest is the verifier's job):
+
+- **Mint only.** This signer produces a unique ``jti`` per token. **Single-use /
+  replay rejection is the verifier's responsibility** — memory-cloud mints and
+  immediately hands off; it does not keep a consumed-``jti`` store. The token is
+  short-lived (``billing_handoff_ttl_seconds``, default 120s) so the replay
+  window is small even before the verifier's own ``jti`` check.
+- **Fail-closed.** An unset signing key OR an unset ``kid`` raises
+  :class:`BillingHandoffNotConfigured` (503, ``BILLING-002``) — a misconfigured
+  deployment never mints an unsigned or unrotatable token. Mirrors
+  ``internal_billing.verify_billing_service_token``'s unset-token 503.
+- **EdDSA via authlib.jose** — the same JWT toolkit the OAuth2 server uses; no
+  new crypto dependency (``cryptography`` already ships Ed25519 for the keypair).
+"""
+
+from __future__ import annotations
+
+import secrets
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from authlib.jose import JsonWebKey, JsonWebToken
+
+from config.settings import get_settings
+from utils.datetime import utcnow
+from utils.exceptions import MemoryCloudException
+from utils.logger import get_logger
+
+if TYPE_CHECKING:
+    from config.settings import Settings
+
+logger = get_logger(__name__)
+
+# EdDSA is opt-in per authlib's JsonWebToken allow-list — pin it explicitly so
+# the signer can never be downgraded to a weaker alg by a permissive default.
+_JWT = JsonWebToken(["EdDSA"])
+_ALG = "EdDSA"
+_TOKEN_TYP = "JWT"
+# The handoff token always asserts the owner role — the route only mints after a
+# successful owner gate, so the claim is a constant, not caller-supplied.
+_ROLE_OWNER = "owner"
+
+
+class BillingHandoffNotConfigured(MemoryCloudException):
+    """The billing handoff signing key (or its ``kid``) is unset — fail closed.
+
+    Surfaces 503 (not 500): the endpoint is *disabled by configuration*, the
+    same shape ``internal_billing`` uses for an unset ``BILLING_SERVICE_TOKEN``.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Billing handoff signing is not configured",
+            status_code=503,
+            error_code="BILLING-002",
+        )
+
+
+@dataclass(frozen=True)
+class MintedHandoffToken:
+    """A freshly minted handoff token plus the metadata the route echoes back."""
+
+    token: str
+    jti: str
+    kid: str
+    issued_at: datetime
+    expires_at: datetime
+    workspace_id: str
+    user_id: str
+
+
+class BillingHandoffSigner:
+    """Mints Ed25519-signed owner handoff tokens from configured key material."""
+
+    def __init__(self, settings: Settings | None = None) -> None:
+        # Accept an injected settings object (tests pass a lightweight stand-in);
+        # default to the process settings. Only a handful of fields are read.
+        self._settings = settings if settings is not None else get_settings()
+
+    @property
+    def is_configured(self) -> bool:
+        """True only when BOTH a non-blank signing key AND a ``kid`` are set."""
+        key = (self._settings.billing_handoff_signing_key or "").strip()
+        kid = (self._settings.billing_handoff_key_id or "").strip()
+        return bool(key) and bool(kid)
+
+    def mint(self, *, user_id: str, workspace_id: UUID | str) -> MintedHandoffToken:
+        """Mint a signed handoff token for ``user_id`` scoped to ``workspace_id``.
+
+        The caller MUST have already verified that ``user_id`` owns
+        ``workspace_id`` (the route does this via
+        ``PermissionService.check_workspace_owner``). This signer enforces only
+        the token invariants: owner-role claim, short expiry, unique ``jti``,
+        and ``kid``-tagged EdDSA signature.
+
+        Args:
+            user_id: The authenticated owner (becomes the ``sub`` claim).
+            workspace_id: The target workspace (becomes the ``workspace_id``
+                claim) — the route binds this to the request body, never the
+                caller's mutable ``current_workspace_id``.
+
+        Returns:
+            The minted token and its metadata.
+
+        Raises:
+            BillingHandoffNotConfigured: 503 if the signing key or ``kid`` is unset.
+        """
+        if not self.is_configured:
+            logger.error(
+                "billing_handoff_signing_unconfigured",
+                has_key=bool((self._settings.billing_handoff_signing_key or "").strip()),
+                has_kid=bool((self._settings.billing_handoff_key_id or "").strip()),
+            )
+            raise BillingHandoffNotConfigured()
+
+        settings = self._settings
+        kid = settings.billing_handoff_key_id.strip()
+        try:
+            key = JsonWebKey.import_key(settings.billing_handoff_signing_key)
+        except Exception as exc:
+            # Malformed key material is a configuration failure, not a runtime
+            # bug — fail closed (503) like the unset case rather than 500-leaking
+            # a stack trace. The exception detail is logged, never returned.
+            logger.error("billing_handoff_signing_key_invalid", error=str(exc))
+            raise BillingHandoffNotConfigured() from exc
+
+        # utcnow() is naive UTC by convention; stamp tzinfo before .timestamp()
+        # so the unix claims are real UTC seconds, not host-local (#backend rules).
+        issued_at = utcnow()
+        ttl_seconds = max(1, int(settings.billing_handoff_ttl_seconds))
+        expires_at = issued_at + timedelta(seconds=ttl_seconds)
+        jti = secrets.token_urlsafe(24)
+        workspace_str = str(workspace_id)
+
+        header = {"alg": _ALG, "typ": _TOKEN_TYP, "kid": kid}
+        payload = {
+            "iss": settings.billing_handoff_issuer,
+            "aud": settings.billing_handoff_audience,
+            "sub": user_id,
+            "workspace_id": workspace_str,
+            "role": _ROLE_OWNER,
+            "iat": int(issued_at.replace(tzinfo=UTC).timestamp()),
+            "exp": int(expires_at.replace(tzinfo=UTC).timestamp()),
+            "jti": jti,
+        }
+
+        token = _JWT.encode(header, payload, key)
+        if isinstance(token, bytes):
+            token = token.decode("ascii")
+
+        logger.info(
+            "billing_handoff_minted",
+            user_id=user_id,
+            workspace_id=workspace_str,
+            jti=jti,
+            kid=kid,
+            expires_at=expires_at.isoformat(),
+        )
+
+        return MintedHandoffToken(
+            token=token,
+            jti=jti,
+            kid=kid,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            workspace_id=workspace_str,
+            user_id=user_id,
+        )

--- a/backend/src/auth/billing_handoff.py
+++ b/backend/src/auth/billing_handoff.py
@@ -87,11 +87,22 @@ class BillingHandoffSigner:
         # default to the process settings. Only a handful of fields are read.
         self._settings = settings if settings is not None else get_settings()
 
+    def _stripped_material(self) -> tuple[str, str]:
+        """Return ``(signing_key, kid)`` with surrounding whitespace stripped.
+
+        Single source of truth for "what key material do we have?" so the
+        ``is_configured`` gate, the unconfigured-log breadcrumb, and ``mint``
+        can never disagree about whether a value is blank.
+        """
+        return (
+            (self._settings.billing_handoff_signing_key or "").strip(),
+            (self._settings.billing_handoff_key_id or "").strip(),
+        )
+
     @property
     def is_configured(self) -> bool:
         """True only when BOTH a non-blank signing key AND a ``kid`` are set."""
-        key = (self._settings.billing_handoff_signing_key or "").strip()
-        kid = (self._settings.billing_handoff_key_id or "").strip()
+        key, kid = self._stripped_material()
         return bool(key) and bool(kid)
 
     def mint(self, *, user_id: str, workspace_id: UUID | str) -> MintedHandoffToken:
@@ -115,18 +126,18 @@ class BillingHandoffSigner:
         Raises:
             BillingHandoffNotConfigured: 503 if the signing key or ``kid`` is unset.
         """
-        if not self.is_configured:
+        key_pem, kid = self._stripped_material()
+        if not key_pem or not kid:
             logger.error(
                 "billing_handoff_signing_unconfigured",
-                has_key=bool((self._settings.billing_handoff_signing_key or "").strip()),
-                has_kid=bool((self._settings.billing_handoff_key_id or "").strip()),
+                has_key=bool(key_pem),
+                has_kid=bool(kid),
             )
             raise BillingHandoffNotConfigured()
 
         settings = self._settings
-        kid = settings.billing_handoff_key_id.strip()
         try:
-            key = JsonWebKey.import_key(settings.billing_handoff_signing_key)
+            key = JsonWebKey.import_key(key_pem)
         except Exception as exc:
             # Malformed key material is a configuration failure, not a runtime
             # bug — fail closed (503) like the unset case rather than 500-leaking
@@ -154,7 +165,14 @@ class BillingHandoffSigner:
             "jti": jti,
         }
 
-        token = _JWT.encode(header, payload, key)
+        try:
+            token = _JWT.encode(header, payload, key)
+        except Exception as exc:
+            # A well-formed key of the WRONG type (e.g. a PUBLIC key, or a
+            # non-Ed25519 OKP key) imports cleanly but cannot sign — also a
+            # configuration failure, so fail closed (503) rather than 500-leaking.
+            logger.error("billing_handoff_signing_failed", error=str(exc))
+            raise BillingHandoffNotConfigured() from exc
         if isinstance(token, bytes):
             token = token.decode("ascii")
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -103,6 +103,39 @@ class Settings(BaseSettings):
         default="",
         description="Shared bearer token authenticating the billing service to /internal/* (RFC 6750)",
     )
+    # Issue #1093: Ed25519 signing material for owner billing handoff tokens
+    # (POST /api/v1/billing/handoff). memory-cloud holds the PRIVATE key; the
+    # billing service verifies with the matching public key (kid-based rotation).
+    # Empty key OR empty kid disables the endpoint (fail-closed, 503 BILLING-002).
+    # Generate: openssl genpkey -algorithm ed25519 -out handoff.pem
+    billing_handoff_signing_key: str = Field(
+        default="",
+        description=(
+            "Ed25519 private key (PEM / PKCS8) signing billing handoff tokens. "
+            "Empty disables POST /api/v1/billing/handoff (fail-closed, 503)."
+        ),
+    )
+    billing_handoff_key_id: str = Field(
+        default="",
+        description=(
+            "kid for the active billing handoff signing key (verifier-side key "
+            "rotation). Empty disables the endpoint (fail-closed, 503)."
+        ),
+    )
+    billing_handoff_issuer: str = Field(
+        default="kagura-memory-cloud",
+        description="iss claim asserted on billing handoff tokens.",
+    )
+    billing_handoff_audience: str = Field(
+        default="kagura-billing",
+        description="aud claim — the billing service that verifies handoff tokens.",
+    )
+    billing_handoff_ttl_seconds: int = Field(
+        default=120,
+        ge=1,
+        le=900,
+        description="Billing handoff token lifetime in seconds (short-lived; <=15min).",
+    )
     # Public MCP base URL handed back to the worker in its config so it can write
     # memories. Defaults to local dev; override in prod (e.g. https://memory.kagura-ai.com/mcp).
     kmc_mcp_url: str = Field(

--- a/backend/tests/api/test_billing_handoff_route.py
+++ b/backend/tests/api/test_billing_handoff_route.py
@@ -34,7 +34,7 @@ from auth.billing_handoff import BillingHandoffNotConfigured, MintedHandoffToken
 from auth.dependencies import require_session_auth
 from db.base import get_db
 from utils.datetime import utcnow
-from utils.exceptions import AuthorizationError, MemoryCloudException
+from utils.exceptions import AdminProtectionError, AuthorizationError, MemoryCloudException
 
 WS_A = uuid4()  # the caller's "current" workspace
 WS_B = uuid4()  # a different workspace the caller does NOT own
@@ -45,10 +45,14 @@ def _build_app() -> FastAPI:
     app.include_router(route_mod.router, prefix="/api/v1")
 
     async def _mc_handler(_request, exc: MemoryCloudException) -> JSONResponse:
-        # Faithful to production memory_cloud_exception_handler for status codes.
+        # Mirror production memory_cloud_exception_handler (api/main.py): the wire
+        # body is {"error", "message", "details"} — NOT "error_code" — with
+        # details stripped to {} for deny-class exceptions (CWE-639). Asserting
+        # against this shape verifies the body clients actually receive.
+        details = {} if isinstance(exc, (AuthorizationError, AdminProtectionError)) else exc.details
         return JSONResponse(
             status_code=exc.status_code,
-            content={"error_code": exc.error_code, "message": exc.message},
+            content={"error": exc.error_code, "message": exc.message, "details": details},
         )
 
     app.add_exception_handler(MemoryCloudException, _mc_handler)
@@ -223,7 +227,11 @@ class TestHandoffFailClosed:
             signer_cls.return_value.mint.side_effect = BillingHandoffNotConfigured()
             resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
         assert resp.status_code == 503, resp.text
-        assert resp.json()["error_code"] == "BILLING-002"
+        # Production envelope keys on "error" (not "error_code") and carries
+        # "message"/"details" — assert the shape clients actually receive.
+        body = resp.json()
+        assert body["error"] == "BILLING-002"
+        assert set(body) >= {"error", "message", "details"}
 
 
 # ============================================================================

--- a/backend/tests/api/test_billing_handoff_route.py
+++ b/backend/tests/api/test_billing_handoff_route.py
@@ -116,6 +116,10 @@ class TestHandoffOwnerHappyPath:
         assert body["jti"] == "jti-test-1"
         assert body["token_type"] == "billing_handoff"
         assert body["expires_at"].endswith("Z")  # TZAwareBaseModel serialization
+        # The signer must be invoked with the body workspace and the session user.
+        mint_call = signer_cls.return_value.mint.call_args
+        assert mint_call.kwargs["workspace_id"] == WS_A
+        assert mint_call.kwargs["user_id"] == "owner-1"
 
     def test_owner_check_uses_body_workspace_not_session_current(self, session_client):
         """The #389 trap guard: owner is verified against the body workspace_id."""
@@ -133,6 +137,12 @@ class TestHandoffOwnerHappyPath:
         called_args = perm.check_workspace_owner.await_args
         assert WS_B in called_args.args or WS_B in called_args.kwargs.values()
         assert WS_A not in called_args.args
+        # AND the token itself must be minted for WS_B, not the session's WS_A —
+        # a correct owner-check that then minted for current_workspace would still
+        # re-open the cross-tenant trap, so assert the mint binding too.
+        mint_call = signer_cls.return_value.mint.call_args
+        assert mint_call.kwargs["workspace_id"] == WS_B
+        assert mint_call.kwargs["user_id"] == "owner-1"
 
 
 # ============================================================================
@@ -172,9 +182,16 @@ class TestHandoffOwnerOnly:
 
 
 class TestHandoffSessionOnly:
-    def test_api_key_bearer_is_rejected_403(self):
-        # Use the REAL require_session_auth: a Bearer credential must 403 before
-        # any owner check or minting runs.
+    # require_session_auth rejects EVERY Bearer credential — both a kagura_* API
+    # key and an opaque/OAuth device-flow token (distinguished only for the
+    # token_kind log field). Both must 403 before any owner check or minting.
+    @pytest.mark.parametrize(
+        "bearer",
+        ["kagura_live_testkey", "opaque-oauth-access-token-abc123"],
+        ids=["api_key", "oauth_bearer"],
+    )
+    def test_any_bearer_credential_is_rejected_403(self, bearer):
+        # Use the REAL require_session_auth (not overridden).
         app = _build_app()
 
         async def _mock_db():
@@ -185,7 +202,7 @@ class TestHandoffSessionOnly:
             resp = client.post(
                 "/api/v1/billing/handoff",
                 json={"workspace_id": str(WS_A)},
-                headers={"Authorization": "Bearer kagura_live_testkey"},
+                headers={"Authorization": f"Bearer {bearer}"},
             )
         assert resp.status_code == 403, resp.text
 

--- a/backend/tests/api/test_billing_handoff_route.py
+++ b/backend/tests/api/test_billing_handoff_route.py
@@ -1,0 +1,224 @@
+"""RBAC + wiring tests for POST /api/v1/billing/handoff (#1093).
+
+The handoff endpoint mints a short-lived Ed25519 token that lets the external
+billing service trust an authenticated workspace **owner** without re-implementing
+user auth. The security contract under test:
+
+- **session-auth only** — a Bearer credential (API key / OAuth) is rejected 403
+  by ``require_session_auth`` (exercised with the real dependency).
+- **owner-only** — admin/member get 403 via ``PermissionService.check_workspace_owner``.
+- **explicit-target-workspace binding** — the owner check runs against the
+  *request body* ``workspace_id``, never the caller's ``current_workspace_id``
+  (the #389 multi-workspace cross-tenant trap).
+- **fail-closed** — an unconfigured signing key surfaces 503 (BILLING-002), even
+  for an owner.
+
+The router is mounted on a fresh app with overridden deps so the suite needs no
+DB/redis. A local ``MemoryCloudException`` handler mirrors the production
+status-code mapping without importing the umap-heavy ``api.main``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from api.routes import billing_handoff as route_mod
+from auth.billing_handoff import BillingHandoffNotConfigured, MintedHandoffToken
+from auth.dependencies import require_session_auth
+from db.base import get_db
+from utils.datetime import utcnow
+from utils.exceptions import AuthorizationError, MemoryCloudException
+
+WS_A = uuid4()  # the caller's "current" workspace
+WS_B = uuid4()  # a different workspace the caller does NOT own
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(route_mod.router, prefix="/api/v1")
+
+    async def _mc_handler(_request, exc: MemoryCloudException) -> JSONResponse:
+        # Faithful to production memory_cloud_exception_handler for status codes.
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error_code": exc.error_code, "message": exc.message},
+        )
+
+    app.add_exception_handler(MemoryCloudException, _mc_handler)
+    return app
+
+
+def _session_user(user_id: str = "owner-1") -> dict:
+    return {
+        "user_id": user_id,
+        "email": f"{user_id}@test.com",
+        "current_workspace_id": WS_A,
+    }
+
+
+def _fake_minted(workspace_id) -> MintedHandoffToken:
+    issued = utcnow()
+    return MintedHandoffToken(
+        token="eyJhbGciOiJFZERTQSJ9.fake.sig",
+        jti="jti-test-1",
+        kid="kid-1",
+        issued_at=issued,
+        expires_at=issued + timedelta(seconds=120),
+        workspace_id=str(workspace_id),
+        user_id="owner-1",
+    )
+
+
+@pytest.fixture
+def session_client():
+    """Client where require_session_auth yields an owner session user."""
+    app = _build_app()
+
+    async def _mock_session():
+        return _session_user()
+
+    async def _mock_db():
+        yield MagicMock()
+
+    app.dependency_overrides[require_session_auth] = _mock_session
+    app.dependency_overrides[get_db] = _mock_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+# ============================================================================
+# Owner happy path
+# ============================================================================
+
+
+class TestHandoffOwnerHappyPath:
+    def test_owner_gets_token(self, session_client):
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "BillingHandoffSigner") as signer_cls,
+        ):
+            signer_cls.return_value.mint.return_value = _fake_minted(WS_A)
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["token"] == "eyJhbGciOiJFZERTQSJ9.fake.sig"
+        assert body["kid"] == "kid-1"
+        assert body["jti"] == "jti-test-1"
+        assert body["token_type"] == "billing_handoff"
+        assert body["expires_at"].endswith("Z")  # TZAwareBaseModel serialization
+
+    def test_owner_check_uses_body_workspace_not_session_current(self, session_client):
+        """The #389 trap guard: owner is verified against the body workspace_id."""
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "BillingHandoffSigner") as signer_cls,
+        ):
+            signer_cls.return_value.mint.return_value = _fake_minted(WS_B)
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_B)})
+
+        assert resp.status_code == 200, resp.text
+        # The owner gate must have been called with WS_B (the body), not WS_A (session).
+        called_args = perm.check_workspace_owner.await_args
+        assert WS_B in called_args.args or WS_B in called_args.kwargs.values()
+        assert WS_A not in called_args.args
+
+
+# ============================================================================
+# Owner-only denial
+# ============================================================================
+
+
+class TestHandoffOwnerOnly:
+    @pytest.mark.parametrize("denied_role", ["admin", "member", "viewer"])
+    def test_non_owner_gets_403(self, session_client, denied_role):
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(
+            side_effect=AuthorizationError(reason="role_too_low")
+        )
+        with patch.object(route_mod, "PermissionService", return_value=perm):
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+        assert resp.status_code == 403, f"{denied_role}: {resp.text}"
+
+    def test_owner_of_other_workspace_cannot_mint_for_unowned_target(self, session_client):
+        # Caller owns WS_A but requests a handoff for WS_B → owner check raises → 403.
+        perm = MagicMock()
+
+        async def _owner_only_of_a(_user_id, workspace_id):
+            if workspace_id != WS_A:
+                raise AuthorizationError(reason="not_a_member")
+            return MagicMock()
+
+        perm.check_workspace_owner = AsyncMock(side_effect=_owner_only_of_a)
+        with patch.object(route_mod, "PermissionService", return_value=perm):
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_B)})
+        assert resp.status_code == 403, resp.text
+
+
+# ============================================================================
+# Session-only enforcement (real dependency)
+# ============================================================================
+
+
+class TestHandoffSessionOnly:
+    def test_api_key_bearer_is_rejected_403(self):
+        # Use the REAL require_session_auth: a Bearer credential must 403 before
+        # any owner check or minting runs.
+        app = _build_app()
+
+        async def _mock_db():
+            yield MagicMock()
+
+        app.dependency_overrides[get_db] = _mock_db
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                "/api/v1/billing/handoff",
+                json={"workspace_id": str(WS_A)},
+                headers={"Authorization": "Bearer kagura_live_testkey"},
+            )
+        assert resp.status_code == 403, resp.text
+
+
+# ============================================================================
+# Fail-closed when unconfigured
+# ============================================================================
+
+
+class TestHandoffFailClosed:
+    def test_unconfigured_signing_key_returns_503_even_for_owner(self, session_client):
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "BillingHandoffSigner") as signer_cls,
+        ):
+            signer_cls.return_value.mint.side_effect = BillingHandoffNotConfigured()
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+        assert resp.status_code == 503, resp.text
+        assert resp.json()["error_code"] == "BILLING-002"
+
+
+# ============================================================================
+# Input validation
+# ============================================================================
+
+
+class TestHandoffValidation:
+    def test_missing_workspace_id_is_422(self, session_client):
+        resp = session_client.post("/api/v1/billing/handoff", json={})
+        assert resp.status_code == 422
+
+    def test_non_uuid_workspace_id_is_422(self, session_client):
+        resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": "not-a-uuid"})
+        assert resp.status_code == 422

--- a/backend/tests/auth/test_billing_handoff_signer.py
+++ b/backend/tests/auth/test_billing_handoff_signer.py
@@ -1,0 +1,200 @@
+"""Unit tests for the Ed25519 billing-handoff token signer (#1093).
+
+These tests exercise the crypto core in isolation — no DB, no FastAPI. A throw-away
+Ed25519 keypair is generated per test; the minted token is verified with the
+*public* key exactly as the external billing service would, asserting the
+``(user_id, workspace_id, role)`` binding plus ``iss/aud/exp/iat/jti`` claims and
+the ``kid``/``alg`` header. The fail-closed-when-unset contract (503, BILLING-002)
+is the security-critical invariant.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import time
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from authlib.jose import JsonWebKey, JsonWebToken
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from auth.billing_handoff import BillingHandoffNotConfigured, BillingHandoffSigner
+
+_JWT = JsonWebToken(["EdDSA"])
+
+
+def _keypair() -> tuple[str, str]:
+    """Return ``(private_pem, public_pem)`` for a fresh Ed25519 key."""
+    priv = Ed25519PrivateKey.generate()
+    private_pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        priv.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    return private_pem, public_pem
+
+
+def _settings(
+    signing_key: str,
+    *,
+    kid: str = "kid-1",
+    iss: str = "kagura-memory-cloud",
+    aud: str = "kagura-billing",
+    ttl: int = 120,
+) -> SimpleNamespace:
+    """A minimal settings stand-in carrying only the fields the signer reads."""
+    return SimpleNamespace(
+        billing_handoff_signing_key=signing_key,
+        billing_handoff_key_id=kid,
+        billing_handoff_issuer=iss,
+        billing_handoff_audience=aud,
+        billing_handoff_ttl_seconds=ttl,
+    )
+
+
+def _b64url_json(segment: str) -> dict:
+    return json.loads(base64.urlsafe_b64decode(segment + "=" * (-len(segment) % 4)))
+
+
+def _header(token: str) -> dict:
+    return _b64url_json(token.split(".")[0])
+
+
+def _payload(token: str) -> dict:
+    return _b64url_json(token.split(".")[1])
+
+
+class TestBillingHandoffSigner:
+    def test_mint_produces_eddsa_jwt_verifiable_with_public_key(self) -> None:
+        private_pem, public_pem = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+        workspace_id = uuid4()
+
+        minted = signer.mint(user_id="user-123", workspace_id=workspace_id)
+
+        # Verify exactly as the billing service would: with the public key only.
+        claims = _JWT.decode(minted.token, JsonWebKey.import_key(public_pem))
+        claims.validate()  # exp/iat are sane
+
+        assert claims["sub"] == "user-123"
+        assert claims["workspace_id"] == str(workspace_id)
+        assert claims["role"] == "owner"
+        assert claims["iss"] == "kagura-memory-cloud"
+        assert claims["aud"] == "kagura-billing"
+        assert claims["jti"] == minted.jti
+        assert claims["exp"] > claims["iat"]
+
+    def test_wrong_public_key_rejects_signature(self) -> None:
+        private_pem, _ = _keypair()
+        _, other_public = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+
+        minted = signer.mint(user_id="u", workspace_id=uuid4())
+
+        with pytest.raises(Exception):  # noqa: B017 - authlib BadSignatureError
+            _JWT.decode(minted.token, JsonWebKey.import_key(other_public)).validate()
+
+    def test_header_carries_alg_and_kid(self) -> None:
+        private_pem, _ = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem, kid="rotate-2026"))
+
+        minted = signer.mint(user_id="u", workspace_id=uuid4())
+
+        header = _header(minted.token)
+        assert header["alg"] == "EdDSA"
+        assert header["typ"] == "JWT"
+        assert header["kid"] == "rotate-2026"
+        assert minted.kid == "rotate-2026"
+
+    def test_exp_is_short_lived(self) -> None:
+        private_pem, _ = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem, ttl=120))
+
+        minted = signer.mint(user_id="u", workspace_id=uuid4())
+
+        delta = (minted.expires_at - minted.issued_at).total_seconds()
+        assert 1 <= delta <= 120
+
+    def test_iat_and_exp_are_utc_unix_seconds(self) -> None:
+        # Regression guard: utcnow() is naive UTC; calling .timestamp() on a naive
+        # datetime would interpret it as *local* time and shift iat by the host's
+        # UTC offset (e.g. -9h in JST). Assert iat tracks real UTC wall-clock.
+        private_pem, _ = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem, ttl=120))
+
+        before = int(time.time())
+        minted = signer.mint(user_id="u", workspace_id=uuid4())
+        after = int(time.time())
+
+        payload = _payload(minted.token)
+        assert before - 2 <= payload["iat"] <= after + 2
+        assert payload["exp"] - payload["iat"] == 120
+
+    def test_jti_is_unique_per_mint(self) -> None:
+        private_pem, _ = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+
+        jtis = {signer.mint(user_id="u", workspace_id=uuid4()).jti for _ in range(25)}
+        assert len(jtis) == 25
+
+    def test_workspace_id_accepts_uuid_and_str_equivalently(self) -> None:
+        private_pem, public_pem = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+        workspace_id = uuid4()
+
+        from_uuid = signer.mint(user_id="u", workspace_id=workspace_id)
+        from_str = signer.mint(user_id="u", workspace_id=str(workspace_id))
+
+        for minted in (from_uuid, from_str):
+            claims = _JWT.decode(minted.token, JsonWebKey.import_key(public_pem))
+            assert claims["workspace_id"] == str(workspace_id)
+
+    def test_fail_closed_when_signing_key_unset(self) -> None:
+        signer = BillingHandoffSigner(settings=_settings(""))
+
+        with pytest.raises(BillingHandoffNotConfigured) as exc_info:
+            signer.mint(user_id="u", workspace_id=uuid4())
+
+        assert exc_info.value.status_code == 503
+        assert exc_info.value.error_code == "BILLING-002"
+
+    def test_fail_closed_when_kid_unset(self) -> None:
+        # A signing key without a kid breaks verifier-side rotation — fail closed
+        # rather than mint an unrotatable token.
+        private_pem, _ = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem, kid=""))
+
+        with pytest.raises(BillingHandoffNotConfigured):
+            signer.mint(user_id="u", workspace_id=uuid4())
+
+    def test_malformed_key_fails_closed_not_500(self) -> None:
+        # A non-PEM / garbage key passes the non-blank is_configured check but
+        # must fail closed (503) on import rather than raising a raw 500.
+        signer = BillingHandoffSigner(
+            settings=_settings("-----BEGIN PRIVATE KEY-----\nnot-base64\n-----END PRIVATE KEY-----")
+        )
+        with pytest.raises(BillingHandoffNotConfigured):
+            signer.mint(user_id="u", workspace_id=uuid4())
+
+    def test_is_configured_reflects_key_and_kid(self) -> None:
+        private_pem, _ = _keypair()
+        assert BillingHandoffSigner(settings=_settings(private_pem)).is_configured is True
+        assert BillingHandoffSigner(settings=_settings("")).is_configured is False
+        assert BillingHandoffSigner(settings=_settings(private_pem, kid="")).is_configured is False
+
+    def test_whitespace_only_key_is_treated_as_unset(self) -> None:
+        signer = BillingHandoffSigner(settings=_settings("   \n  "))
+        assert signer.is_configured is False
+        with pytest.raises(BillingHandoffNotConfigured):
+            signer.mint(user_id="u", workspace_id=uuid4())

--- a/backend/tests/auth/test_billing_handoff_signer.py
+++ b/backend/tests/auth/test_billing_handoff_signer.py
@@ -11,9 +11,11 @@ is the security-critical invariant.
 from __future__ import annotations
 
 import base64
+import calendar
 import json
-import time
+from datetime import datetime
 from types import SimpleNamespace
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
@@ -126,20 +128,24 @@ class TestBillingHandoffSigner:
         delta = (minted.expires_at - minted.issued_at).total_seconds()
         assert 1 <= delta <= 120
 
-    def test_iat_and_exp_are_utc_unix_seconds(self) -> None:
-        # Regression guard: utcnow() is naive UTC; calling .timestamp() on a naive
-        # datetime would interpret it as *local* time and shift iat by the host's
-        # UTC offset (e.g. -9h in JST). Assert iat tracks real UTC wall-clock.
+    def test_iat_and_exp_are_utc_unix_seconds(self, monkeypatch) -> None:
+        # Deterministic, host-TZ-independent regression guard for the naive
+        # .timestamp() trap. Pin utcnow() to a fixed naive instant and assert iat
+        # equals its *UTC* unix second (calendar.timegm always interprets as UTC).
+        # A buggy `int(naive.timestamp())` (host-local) would differ from timegm on
+        # any non-UTC host — and this exact-value assertion catches it there, where
+        # the old time.time() +/-2s window on a UTC CI runner could not.
+        fixed = datetime(2026, 6, 27, 12, 0, 0)  # naive UTC
+        monkeypatch.setattr("auth.billing_handoff.utcnow", lambda: fixed)
         private_pem, _ = _keypair()
         signer = BillingHandoffSigner(settings=_settings(private_pem, ttl=120))
 
-        before = int(time.time())
         minted = signer.mint(user_id="u", workspace_id=uuid4())
-        after = int(time.time())
 
         payload = _payload(minted.token)
-        assert before - 2 <= payload["iat"] <= after + 2
-        assert payload["exp"] - payload["iat"] == 120
+        expected_iat = calendar.timegm(fixed.timetuple())
+        assert payload["iat"] == expected_iat
+        assert payload["exp"] == expected_iat + 120
 
     def test_jti_is_unique_per_mint(self) -> None:
         private_pem, _ = _keypair()
@@ -186,6 +192,46 @@ class TestBillingHandoffSigner:
         )
         with pytest.raises(BillingHandoffNotConfigured):
             signer.mint(user_id="u", workspace_id=uuid4())
+
+    def test_public_key_as_signing_key_fails_closed_not_500(self) -> None:
+        # A PUBLIC-key PEM imports cleanly (kty=OKP) but cannot sign — the failure
+        # surfaces at encode() time, NOT import. Must still fail closed (503),
+        # never a raw 500. (Regression guard for the encode-outside-try bug.)
+        _, public_pem = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(public_pem))
+        with pytest.raises(BillingHandoffNotConfigured):
+            signer.mint(user_id="u", workspace_id=uuid4())
+
+    def test_different_workspaces_produce_distinct_claims(self) -> None:
+        # Guard against a memoized/closed-over workspace_id binding every token to
+        # the first workspace.
+        private_pem, public_pem = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+        ws1, ws2 = uuid4(), uuid4()
+
+        c1 = _JWT.decode(
+            signer.mint(user_id="u", workspace_id=ws1).token, JsonWebKey.import_key(public_pem)
+        )
+        c2 = _JWT.decode(
+            signer.mint(user_id="u", workspace_id=ws2).token, JsonWebKey.import_key(public_pem)
+        )
+
+        assert c1["workspace_id"] == str(ws1)
+        assert c2["workspace_id"] == str(ws2)
+        assert c1["workspace_id"] != c2["workspace_id"]
+
+    def test_token_string_is_never_logged(self) -> None:
+        # The token is a bearer credential — it must never reach a log sink. jti/kid
+        # are non-secret identifiers and may be logged; the raw token must not be.
+        private_pem, _ = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+
+        with patch("auth.billing_handoff.logger") as mock_logger:
+            minted = signer.mint(user_id="u", workspace_id=uuid4())
+
+        logged = repr(mock_logger.mock_calls)
+        assert minted.token not in logged
+        assert minted.jti in logged  # sanity: the audit breadcrumb did fire
 
     def test_is_configured_reflects_key_and_kid(self) -> None:
         private_pem, _ = _keypair()


### PR DESCRIPTION
Closes #1093

## Summary
- Add `POST /api/v1/billing/handoff`: **session-auth + owner-only**, minting a short-lived **Ed25519-signed** JWT bound to `(user_id, workspace_id, role=owner)` with `iss/aud/exp/iat/jti` for the external billing service to verify with the public key (`kid`-based rotation).
- **Fail-closed (503 BILLING-002)** when the signing key/`kid` is unset, the PEM is malformed, or the key is the wrong type (a public key imports cleanly but cannot sign). No new crypto dependency — `authlib.jose` EdDSA; `cryptography` already provides Ed25519.
- Owner gate binds to the **explicit request-body `workspace_id`** via `PermissionService.check_workspace_owner`, never the caller's `current_workspace_id` — closing the #389 multi-workspace cross-tenant trap. `require_session_auth` rejects API-key/OAuth bearer (403); admin/member get 403.
- 26 unit tests (signer crypto/claims/fail-closed + route RBAC matrix); ruff clean.

## Implementation notes
- New: `backend/src/auth/billing_handoff.py` (`BillingHandoffSigner`), `backend/src/api/routes/billing_handoff.py` (route, registered always — distinct from the `BILLING_ENABLED`-gated Stripe plugin).
- Settings: `BILLING_HANDOFF_{SIGNING_KEY,KEY_ID,ISSUER,AUDIENCE,TTL_SECONDS}`.
- Single-use `jti` replay rejection is the **verifier's (billing service) responsibility** (documented); memory-cloud mints a unique `jti` per token with a short TTL (default 120s).

## Pre-PR review summary
- gate2 mode: advisor-only · audit: skipped · binary_gate: (none)
- cso: green · qa-lead: green · cto: green
- gate1: yellow via /claude-c-suite:ask (CSO design review; 4 constraints pinned + implemented)
- review provider: none (post-PR review opt-in)
- An independent `/code-review max` pass ran during implementation and caught + fixed a real fail-closed bug (`encode()` outside the try/except → 500 instead of 503 on a wrong-key-type config).

🤖 Generated via /gh-issue-driven:ship
