### PR TITLE
feat(workspace): owner-initiated ownership transfer + epoch (#1094)

### DIFF
--- a/backend/alembic/versions/e45_1094_workspace_ownership_epoch.py
+++ b/backend/alembic/versions/e45_1094_workspace_ownership_epoch.py
@@ -1,0 +1,32 @@
+"""Add workspaces.ownership_epoch (#1094).
+
+Issue #1094: owner-initiated ownership transfer needs a monotonic per-workspace
+version that bumps on each transfer, so external sessions / tokens bound to a
+previous owner can be invalidated by a downstream consumer. NOT NULL with a
+``0`` server_default so every existing row backfills to epoch 0 without a data
+migration.
+
+Revision ID: e45_1094_ownership_epoch
+Revises: e44_1065_host_arbitration
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e45_1094_ownership_epoch"
+down_revision = "e44_1065_host_arbitration"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column("ownership_epoch", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspaces", "ownership_epoch")

--- a/backend/alembic/versions/e45_1094_workspace_ownership_epoch.py
+++ b/backend/alembic/versions/e45_1094_workspace_ownership_epoch.py
@@ -8,6 +8,10 @@ migration.
 
 Revision ID: e45_1094_ownership_epoch
 Revises: e44_1065_host_arbitration
+
+Note: the revision id is kept <=32 chars (shorter than the filename stem) for
+the ``alembic_version.version_num`` VARCHAR(32) column — same convention as the
+sibling capped migrations.
 """
 
 import sqlalchemy as sa

--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -14,14 +14,16 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.analysis_allowlist import check_workspace_in_allowlist
-from auth.dependencies import get_current_user
+from auth.dependencies import SessionUser, get_current_user
 from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from models.auth import Context, ExternalAPIKey, User
 from models.schemas import OpenAIKeyStatusResponse
 from services.permission_service import PermissionService
+from services.workspace_ownership_service import WorkspaceOwnershipService
 from services.workspace_service import WorkspaceService
+from utils.auth_helpers import get_user_id
 from utils.datetime import to_utc_iso
 from utils.logger import get_logger
 
@@ -1152,4 +1154,67 @@ async def check_openai_key_status(
         has_key=openai_key is not None,
         can_configure=can_configure,
         external_keys_url="/integrations/external-keys",
+    )
+
+
+# ============================================================================
+# Ownership transfer (Issue #1094)
+# ============================================================================
+
+
+class TransferOwnershipRequest(BaseModel):
+    """Request to transfer workspace ownership to an existing member."""
+
+    target_user_id: str = Field(
+        ...,
+        min_length=1,
+        max_length=255,
+        description="User ID of an existing workspace member to promote to owner.",
+    )
+
+
+class TransferOwnershipResponse(BaseModel):
+    """Result of an ownership transfer (or idempotent no-op)."""
+
+    workspace_id: str
+    previous_owner_id: str
+    new_owner_id: str
+    ownership_epoch: int
+    changed: bool = Field(
+        ..., description="False when the target already owned the workspace (no-op)."
+    )
+
+
+@router.post("/{workspace_id}/transfer-ownership", response_model=TransferOwnershipResponse)
+async def transfer_workspace_ownership(
+    workspace_id: UUID,
+    body: TransferOwnershipRequest,
+    user: SessionUser,
+    db: AsyncSession = Depends(get_db),
+) -> TransferOwnershipResponse:
+    """Transfer ownership of a workspace to an existing member.
+
+    Current-owner-only and session-only (a Bearer API key / OAuth token is
+    rejected 403 — a sensitive governance action must require a real browser
+    session). The owner check binds to the **path** ``workspace_id``, never the
+    caller's current workspace. Atomic single-owner invariant under a row lock,
+    idempotent, and writes an audit row + bumps the ownership epoch on success.
+    """
+    user_id = get_user_id(user)
+    # Owner-only against the explicit path workspace_id (#389 cross-tenant guard).
+    await PermissionService(db).check_workspace_owner(user_id, workspace_id)
+
+    result = await WorkspaceOwnershipService(db).transfer_ownership(
+        workspace_id=workspace_id,
+        current_owner_id=user_id,
+        target_user_id=body.target_user_id,
+        performed_by_email=str(user.get("email") or user_id),
+    )
+
+    return TransferOwnershipResponse(
+        workspace_id=str(result.workspace_id),
+        previous_owner_id=result.previous_owner_id,
+        new_owner_id=result.new_owner_id,
+        ownership_epoch=result.ownership_epoch,
+        changed=result.changed,
     )

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1447,6 +1447,11 @@ class Workspace(Base):
     name: Mapped[str] = mapped_column(String(255), nullable=False)
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
     owner_user_id: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
+    # Issue #1094: monotonic version bumped on every ownership transfer, so
+    # external sessions / tokens bound to a *previous* owner can be invalidated
+    # by a downstream consumer. The consumer (e.g. handoff-token epoch check) is
+    # a separate follow-up — this column is the producer side of that contract.
+    ownership_epoch: Mapped[int] = mapped_column(Integer, nullable=False, server_default="0")
 
     # Billing & Plan
     plan_name: Mapped[str] = mapped_column(String(50), nullable=False, server_default="free")

--- a/backend/src/services/workspace_ownership_service.py
+++ b/backend/src/services/workspace_ownership_service.py
@@ -7,15 +7,24 @@ every owner-gated billing/admin action.
 
 Single-owner invariant
 -----------------------
-A live workspace has exactly **one** OWNER. OWNER promotion on an *existing*
-workspace happens **only** through :meth:`WorkspaceOwnershipService.transfer_ownership`,
-which takes a ``SELECT ... FOR UPDATE`` lock on the workspace row as the
-synchronization point. The other OWNER assignments in the codebase are confined
-to workspace *creation* (``workspace_service`` / ``context_service`` personal
-workspace) and the erasure auto-transfer — none of which can create a second
-owner on a live, concurrently-transferred workspace. Do not introduce another
-code path that assigns ``WorkspaceRole.OWNER`` on an existing workspace without
-routing through this service (or taking the same row lock).
+A live workspace has exactly **one** OWNER. This is the voluntary transfer path;
+it takes a ``SELECT ... FOR UPDATE`` lock on the workspace row as the
+synchronization point and re-checks the caller is still owner *under* the lock.
+The other OWNER-assigning paths and how the invariant holds against them:
+
+* workspace *creation* (``workspace_service`` / ``context_service`` personal
+  workspace) — a brand-new workspace, never a live concurrent-transfer target.
+* ``WorkspaceService.update_member_role`` — has its own single-owner guard: it
+  refuses to promote a member to OWNER while any OWNER row exists. Combined with
+  this service's *atomic* demote+promote (no committed zero-owner window), it
+  cannot produce two owners on a workspace that already has one.
+* the account-erasure auto-transfer (``account_erasure_service``) — does **not**
+  take this lock. Unifying every owner-mutating path under one workspace row lock
+  is a tracked follow-up; this service's under-lock owner re-check (→ 409)
+  defends the common direction.
+
+Do not add a new OWNER-assigning path on an existing workspace without either
+this row lock or an equivalent single-owner guard.
 
 Ownership epoch
 ---------------
@@ -130,15 +139,27 @@ class WorkspaceOwnershipService:
                 changed=False,
             )
 
-        # 4. Target must be an existing member of THIS workspace.
-        target_member = (
-            await self.db.execute(
-                select(WorkspaceMember).where(
-                    WorkspaceMember.workspace_id == workspace_id,
-                    WorkspaceMember.user_id == target_user_id,
+        previous_owner_id = workspace.owner_user_id
+
+        # 4 + 5. Fetch BOTH the target and previous-owner member rows in a single
+        # round-trip — keeps the critical section under the workspace lock short.
+        # target_user_id != previous_owner_id here (the idempotent no-op above
+        # already returned when they are equal), so this is two distinct rows.
+        member_rows = (
+            (
+                await self.db.execute(
+                    select(WorkspaceMember).where(
+                        WorkspaceMember.workspace_id == workspace_id,
+                        WorkspaceMember.user_id.in_([target_user_id, previous_owner_id]),
+                    )
                 )
             )
-        ).scalar_one_or_none()
+            .scalars()
+            .all()
+        )
+        members_by_user = {m.user_id: m for m in member_rows}
+
+        target_member = members_by_user.get(target_user_id)
         if target_member is None:
             # Well-formed request, but the named user is not a member of THIS
             # workspace — a state precondition failure (400), not a shape error.
@@ -147,19 +168,10 @@ class WorkspaceOwnershipService:
                 error_code="WS-OWNER-001",
             )
 
-        previous_owner_id = workspace.owner_user_id
-
-        # 5. Demote the previous owner's member row to ADMIN — if it exists. Some
+        # Demote the previous owner's member row to ADMIN — if it exists. Some
         # legacy workspaces carry owner_user_id without a matching member row;
         # there is nothing to demote in that case, so flip ownership regardless.
-        previous_member = (
-            await self.db.execute(
-                select(WorkspaceMember).where(
-                    WorkspaceMember.workspace_id == workspace_id,
-                    WorkspaceMember.user_id == previous_owner_id,
-                )
-            )
-        ).scalar_one_or_none()
+        previous_member = members_by_user.get(previous_owner_id)
         if previous_member is not None:
             previous_member.role = WorkspaceRole.ADMIN
 
@@ -171,18 +183,20 @@ class WorkspaceOwnershipService:
         workspace.ownership_epoch = new_epoch
 
         # 6. Audit row in the SAME transaction → the transfer and its audit trail
-        # commit (or roll back) atomically. user_id columns are stable OAuth subs
-        # and are stored legibly (the audit consumer needs "who became owner");
-        # the #481 HMAC rule targets *mutable* identifiers, not these.
+        # commit (or roll back) atomically. The previous/new owner user_ids go in
+        # user_metadata (JSON, unbounded), NOT old_value_hash/new_value_hash —
+        # those columns are String(64) (sized for SHA256/HMAC hex) and a
+        # federated OAuth sub can exceed 64 chars (User.user_id is String(255)),
+        # which would truncate-error on INSERT.
         self.db.add(
             AuditLog(
                 user_email=performed_by_email,
                 user_id=current_owner_id,
                 action=OWNERSHIP_TRANSFER_ACTION,
                 resource=f"workspace:{workspace_id}",
-                old_value_hash=previous_owner_id,
-                new_value_hash=target_user_id,
                 user_metadata={
+                    "previous_owner_id": previous_owner_id,
+                    "new_owner_id": target_user_id,
                     "ownership_epoch": new_epoch,
                     "performed_by": current_owner_id,
                 },

--- a/backend/src/services/workspace_ownership_service.py
+++ b/backend/src/services/workspace_ownership_service.py
@@ -1,0 +1,206 @@
+"""Owner-initiated workspace ownership transfer (#1094).
+
+Adds the first *voluntary* ownership transfer path. Until now the only way a
+workspace changed owner was the account-erasure auto-transfer
+(``account_erasure_service``); a sole owner was a single point of failure for
+every owner-gated billing/admin action.
+
+Single-owner invariant
+-----------------------
+A live workspace has exactly **one** OWNER. OWNER promotion on an *existing*
+workspace happens **only** through :meth:`WorkspaceOwnershipService.transfer_ownership`,
+which takes a ``SELECT ... FOR UPDATE`` lock on the workspace row as the
+synchronization point. The other OWNER assignments in the codebase are confined
+to workspace *creation* (``workspace_service`` / ``context_service`` personal
+workspace) and the erasure auto-transfer — none of which can create a second
+owner on a live, concurrently-transferred workspace. Do not introduce another
+code path that assigns ``WorkspaceRole.OWNER`` on an existing workspace without
+routing through this service (or taking the same row lock).
+
+Ownership epoch
+---------------
+Each successful transfer bumps ``workspaces.ownership_epoch``. That is the
+*producer* side of a contract; the *consumer* (invalidating external sessions /
+billing-handoff tokens bound to the previous owner) is a separate follow-up and
+is intentionally NOT faked here.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.workspace_roles import WorkspaceRole
+from models.auth import AuditLog, Workspace, WorkspaceMember
+from utils.exceptions import BadRequestError, ConflictError, NotFoundException
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+OWNERSHIP_TRANSFER_ACTION = "workspace_ownership_transfer"
+
+
+class OwnershipTransferResult(NamedTuple):
+    """Outcome of a transfer attempt.
+
+    ``changed`` is ``False`` for the idempotent no-op (the target already owns
+    the workspace) — in that case ``ownership_epoch`` is unchanged and no audit
+    row is written.
+    """
+
+    workspace_id: UUID
+    previous_owner_id: str
+    new_owner_id: str
+    ownership_epoch: int
+    changed: bool
+
+
+class WorkspaceOwnershipService:
+    """Transactional workspace ownership transfer."""
+
+    def __init__(self, db: AsyncSession):
+        self.db = db
+
+    async def transfer_ownership(
+        self,
+        *,
+        workspace_id: UUID,
+        current_owner_id: str,
+        target_user_id: str,
+        performed_by_email: str,
+    ) -> OwnershipTransferResult:
+        """Transfer ownership of ``workspace_id`` to ``target_user_id``.
+
+        The caller MUST have already verified that ``current_owner_id`` is the
+        owner (the route does this via ``PermissionService.check_workspace_owner``).
+        That check runs *before* the row lock, so this method re-verifies the
+        owner **under the lock** to close the check→lock TOCTOU window.
+
+        Steps (all under the workspace row lock):
+          1. Lock the workspace row (``FOR UPDATE``) — serializes concurrent
+             transfers; 404 if missing/soft-deleted.
+          2. Re-verify ``current_owner_id`` still owns it → else 409.
+          3. Idempotent no-op if the target already owns it (no epoch bump,
+             no audit).
+          4. Require the target to be an existing member → else 400.
+          5. Promote target → OWNER, demote previous owner → ADMIN (if a member
+             row exists), flip ``owner_user_id``, bump ``ownership_epoch``.
+          6. Write the audit row and commit atomically.
+
+        Args:
+            workspace_id: The workspace whose ownership is moving.
+            current_owner_id: The authenticated caller (must currently own it).
+            target_user_id: The member to promote to owner.
+            performed_by_email: Email of the actor, for the audit row.
+
+        Returns:
+            The transfer outcome (``changed=False`` for the idempotent no-op).
+
+        Raises:
+            NotFoundException: workspace missing or soft-deleted (404).
+            ConflictError: ownership changed concurrently (409).
+            BadRequestError: target is not a member of this workspace (400).
+        """
+        # 1. Lock the workspace row first — the single-owner synchronization point.
+        workspace = (
+            await self.db.execute(
+                select(Workspace)
+                .where(Workspace.id == workspace_id, Workspace.deleted_at.is_(None))
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        if workspace is None:
+            raise NotFoundException("Workspace")
+
+        # 2. TOCTOU close: the route's owner check ran before this lock. If the
+        # owner changed in between, refuse rather than transfer on a stale premise.
+        if workspace.owner_user_id != current_owner_id:
+            raise ConflictError("Workspace ownership changed concurrently; reload and retry")
+
+        # 3. Idempotent no-op: already owned by the target.
+        if workspace.owner_user_id == target_user_id:
+            return OwnershipTransferResult(
+                workspace_id=workspace_id,
+                previous_owner_id=workspace.owner_user_id,
+                new_owner_id=target_user_id,
+                ownership_epoch=workspace.ownership_epoch,
+                changed=False,
+            )
+
+        # 4. Target must be an existing member of THIS workspace.
+        target_member = (
+            await self.db.execute(
+                select(WorkspaceMember).where(
+                    WorkspaceMember.workspace_id == workspace_id,
+                    WorkspaceMember.user_id == target_user_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if target_member is None:
+            # Well-formed request, but the named user is not a member of THIS
+            # workspace — a state precondition failure (400), not a shape error.
+            raise BadRequestError(
+                "Target user must be an existing workspace member",
+                error_code="WS-OWNER-001",
+            )
+
+        previous_owner_id = workspace.owner_user_id
+
+        # 5. Demote the previous owner's member row to ADMIN — if it exists. Some
+        # legacy workspaces carry owner_user_id without a matching member row;
+        # there is nothing to demote in that case, so flip ownership regardless.
+        previous_member = (
+            await self.db.execute(
+                select(WorkspaceMember).where(
+                    WorkspaceMember.workspace_id == workspace_id,
+                    WorkspaceMember.user_id == previous_owner_id,
+                )
+            )
+        ).scalar_one_or_none()
+        if previous_member is not None:
+            previous_member.role = WorkspaceRole.ADMIN
+
+        target_member.role = WorkspaceRole.OWNER
+        workspace.owner_user_id = target_user_id
+        # Capture the new epoch in a local — attributes may be expired after
+        # commit, and the result/log must not trigger a post-commit lazy load.
+        new_epoch = (workspace.ownership_epoch or 0) + 1
+        workspace.ownership_epoch = new_epoch
+
+        # 6. Audit row in the SAME transaction → the transfer and its audit trail
+        # commit (or roll back) atomically. user_id columns are stable OAuth subs
+        # and are stored legibly (the audit consumer needs "who became owner");
+        # the #481 HMAC rule targets *mutable* identifiers, not these.
+        self.db.add(
+            AuditLog(
+                user_email=performed_by_email,
+                user_id=current_owner_id,
+                action=OWNERSHIP_TRANSFER_ACTION,
+                resource=f"workspace:{workspace_id}",
+                old_value_hash=previous_owner_id,
+                new_value_hash=target_user_id,
+                user_metadata={
+                    "ownership_epoch": new_epoch,
+                    "performed_by": current_owner_id,
+                },
+            )
+        )
+        await self.db.commit()
+
+        logger.info(
+            "workspace_ownership_transferred",
+            workspace_id=str(workspace_id),
+            previous_owner=previous_owner_id,
+            new_owner=target_user_id,
+            ownership_epoch=new_epoch,
+        )
+        return OwnershipTransferResult(
+            workspace_id=workspace_id,
+            previous_owner_id=previous_owner_id,
+            new_owner_id=target_user_id,
+            ownership_epoch=new_epoch,
+            changed=True,
+        )

--- a/backend/src/services/workspace_ownership_service.py
+++ b/backend/src/services/workspace_ownership_service.py
@@ -179,7 +179,9 @@ class WorkspaceOwnershipService:
         workspace.owner_user_id = target_user_id
         # Capture the new epoch in a local — attributes may be expired after
         # commit, and the result/log must not trigger a post-commit lazy load.
-        new_epoch = (workspace.ownership_epoch or 0) + 1
+        # ownership_epoch is NOT NULL (server_default "0") and this row was just
+        # loaded under the FOR UPDATE lock, so it is never None here.
+        new_epoch = workspace.ownership_epoch + 1
         workspace.ownership_epoch = new_epoch
 
         # 6. Audit row in the SAME transaction → the transfer and its audit trail
@@ -198,7 +200,6 @@ class WorkspaceOwnershipService:
                     "previous_owner_id": previous_owner_id,
                     "new_owner_id": target_user_id,
                     "ownership_epoch": new_epoch,
-                    "performed_by": current_owner_id,
                 },
             )
         )

--- a/backend/tests/api/test_workspace_transfer_ownership_route.py
+++ b/backend/tests/api/test_workspace_transfer_ownership_route.py
@@ -112,6 +112,8 @@ class TestTransferOwnerHappyPath:
         assert call["workspace_id"] == WS
         assert call["current_owner_id"] == OWNER
         assert call["target_user_id"] == TARGET
+        # The audit actor is the authenticated session, not the body.
+        assert call["performed_by_email"] == "owner@test.com"
 
     def test_idempotent_noop_reports_changed_false(self, owner_client):
         perm = _owner_ok()

--- a/backend/tests/api/test_workspace_transfer_ownership_route.py
+++ b/backend/tests/api/test_workspace_transfer_ownership_route.py
@@ -1,0 +1,213 @@
+"""Route-level tests for POST /api/v1/workspaces/{id}/transfer-ownership (#1094).
+
+The transactional transfer logic (row lock, single-owner invariant, epoch bump,
+audit) lives in WorkspaceOwnershipService and is covered by the integration
+suite against a real DB. These tests pin the route contract: session-only auth,
+owner-only gate bound to the PATH workspace_id, the service-error → HTTP-status
+mapping, and the response shape — all DB-free via dependency overrides + a
+patched service.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from api.routes import workspaces as route_mod
+from auth.dependencies import require_session_auth
+from db.base import get_db
+from services.workspace_ownership_service import OwnershipTransferResult
+from utils.exceptions import (
+    AuthorizationError,
+    BadRequestError,
+    ConflictError,
+    MemoryCloudException,
+    NotFoundException,
+)
+
+WS = uuid4()
+OWNER = "owner-1"
+TARGET = "member-2"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(route_mod.router, prefix="/api/v1/workspaces")
+
+    async def _mc_handler(_request, exc: MemoryCloudException) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error_code": exc.error_code, "message": exc.message},
+        )
+
+    app.add_exception_handler(MemoryCloudException, _mc_handler)
+    return app
+
+
+@pytest.fixture
+def owner_client():
+    """Client where require_session_auth yields the owner and the owner gate passes."""
+    app = _build_app()
+
+    async def _mock_session():
+        return {"user_id": OWNER, "email": "owner@test.com", "current_workspace_id": uuid4()}
+
+    async def _mock_db():
+        yield MagicMock()
+
+    app.dependency_overrides[require_session_auth] = _mock_session
+    app.dependency_overrides[get_db] = _mock_db
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+def _result(changed: bool, epoch: int) -> OwnershipTransferResult:
+    return OwnershipTransferResult(
+        workspace_id=WS,
+        previous_owner_id=OWNER,
+        new_owner_id=TARGET,
+        ownership_epoch=epoch,
+        changed=changed,
+    )
+
+
+def _owner_ok():
+    perm = MagicMock()
+    perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
+    return perm
+
+
+class TestTransferOwnerHappyPath:
+    def test_owner_transfers_returns_200_and_shape(self, owner_client):
+        perm = _owner_ok()
+        svc = MagicMock()
+        svc.transfer_ownership = AsyncMock(return_value=_result(changed=True, epoch=1))
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "WorkspaceOwnershipService", return_value=svc),
+        ):
+            resp = owner_client.post(
+                f"/api/v1/workspaces/{WS}/transfer-ownership",
+                json={"target_user_id": TARGET},
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body == {
+            "workspace_id": str(WS),
+            "previous_owner_id": OWNER,
+            "new_owner_id": TARGET,
+            "ownership_epoch": 1,
+            "changed": True,
+        }
+        # Owner gate is bound to the PATH workspace id; service gets the same id,
+        # the authenticated caller as current_owner, and the body target.
+        assert perm.check_workspace_owner.await_args.args[1] == WS
+        call = svc.transfer_ownership.await_args.kwargs
+        assert call["workspace_id"] == WS
+        assert call["current_owner_id"] == OWNER
+        assert call["target_user_id"] == TARGET
+
+    def test_idempotent_noop_reports_changed_false(self, owner_client):
+        perm = _owner_ok()
+        svc = MagicMock()
+        svc.transfer_ownership = AsyncMock(return_value=_result(changed=False, epoch=3))
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "WorkspaceOwnershipService", return_value=svc),
+        ):
+            resp = owner_client.post(
+                f"/api/v1/workspaces/{WS}/transfer-ownership",
+                json={"target_user_id": TARGET},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["changed"] is False
+        assert body["ownership_epoch"] == 3
+
+
+class TestTransferOwnerOnly:
+    def test_non_owner_gets_403(self, owner_client):
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(
+            side_effect=AuthorizationError(reason="role_too_low")
+        )
+        with patch.object(route_mod, "PermissionService", return_value=perm):
+            resp = owner_client.post(
+                f"/api/v1/workspaces/{WS}/transfer-ownership",
+                json={"target_user_id": TARGET},
+            )
+        assert resp.status_code == 403, resp.text
+
+    @pytest.mark.parametrize(
+        "bearer", ["kagura_live_testkey", "opaque-oauth-token-xyz"], ids=["api_key", "oauth"]
+    )
+    def test_any_bearer_credential_is_rejected_403(self, bearer):
+        # Real require_session_auth: a sensitive governance action must reject any
+        # Bearer credential before the owner check or any mutation.
+        app = _build_app()
+
+        async def _mock_db():
+            yield MagicMock()
+
+        app.dependency_overrides[get_db] = _mock_db
+        with TestClient(app, raise_server_exceptions=False) as client:
+            resp = client.post(
+                f"/api/v1/workspaces/{WS}/transfer-ownership",
+                json={"target_user_id": TARGET},
+                headers={"Authorization": f"Bearer {bearer}"},
+            )
+        assert resp.status_code == 403, resp.text
+
+
+class TestTransferServiceErrorMapping:
+    @pytest.mark.parametrize(
+        ("exc", "status"),
+        [
+            (BadRequestError("not a member", error_code="WS-OWNER-001"), 400),
+            (ConflictError("ownership changed concurrently"), 409),
+            (NotFoundException("Workspace"), 404),
+        ],
+        ids=["target_not_member_400", "concurrent_conflict_409", "missing_workspace_404"],
+    )
+    def test_service_errors_map_to_status(self, owner_client, exc, status):
+        perm = _owner_ok()
+        svc = MagicMock()
+        svc.transfer_ownership = AsyncMock(side_effect=exc)
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "WorkspaceOwnershipService", return_value=svc),
+        ):
+            resp = owner_client.post(
+                f"/api/v1/workspaces/{WS}/transfer-ownership",
+                json={"target_user_id": TARGET},
+            )
+        assert resp.status_code == status, resp.text
+
+
+class TestTransferValidation:
+    def test_missing_target_is_422(self, owner_client):
+        with patch.object(route_mod, "PermissionService", return_value=_owner_ok()):
+            resp = owner_client.post(f"/api/v1/workspaces/{WS}/transfer-ownership", json={})
+        assert resp.status_code == 422
+
+    def test_empty_target_is_422(self, owner_client):
+        with patch.object(route_mod, "PermissionService", return_value=_owner_ok()):
+            resp = owner_client.post(
+                f"/api/v1/workspaces/{WS}/transfer-ownership",
+                json={"target_user_id": ""},
+            )
+        assert resp.status_code == 422
+
+    def test_non_uuid_workspace_is_422(self, owner_client):
+        with patch.object(route_mod, "PermissionService", return_value=_owner_ok()):
+            resp = owner_client.post(
+                "/api/v1/workspaces/not-a-uuid/transfer-ownership",
+                json={"target_user_id": TARGET},
+            )
+        assert resp.status_code == 422

--- a/backend/tests/integration/test_workspace_ownership_transfer.py
+++ b/backend/tests/integration/test_workspace_ownership_transfer.py
@@ -1,0 +1,280 @@
+"""Integration tests for WorkspaceOwnershipService.transfer_ownership (#1094).
+
+These exercise the transactional core against a real Postgres session (the row
+lock, single-owner invariant, epoch bump, role flip, audit row, idempotency, and
+the TOCTOU re-check). They require the DB container (run via
+``make test-integration``); they are not part of the DB-free unit suite.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.workspace_roles import WorkspaceRole
+from models.auth import AuditLog, User, Workspace, WorkspaceMember
+from services.workspace_ownership_service import (
+    OWNERSHIP_TRANSFER_ACTION,
+    WorkspaceOwnershipService,
+)
+from utils.exceptions import BadRequestError, ConflictError
+
+
+async def _add_user(db: AsyncSession, uid: str) -> None:
+    db.add(
+        User(
+            email=f"{uid}@transfer.invalid",
+            user_id=uid,
+            name="Transfer Test",
+            role="user",
+            is_initial_admin=False,
+            auth_method="oauth",
+            auth_provider="google",
+        )
+    )
+
+
+async def _add_member(db: AsyncSession, workspace_id, uid: str, role: WorkspaceRole) -> None:
+    db.add(WorkspaceMember(workspace_id=workspace_id, user_id=uid, role=role))
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def ws_fixture(db_session: AsyncSession) -> AsyncIterator[SimpleNamespace]:
+    """Owner + member + outsider, a workspace owned by owner, with member rows.
+
+    Roles: owner=OWNER, member=MEMBER. ``outsider`` is a real user but NOT a
+    member of the workspace.
+    """
+    owner = f"own_{uuid4().hex[:8]}"
+    member = f"mem_{uuid4().hex[:8]}"
+    outsider = f"out_{uuid4().hex[:8]}"
+    workspace_id = uuid4()
+
+    for uid in (owner, member, outsider):
+        await _add_user(db_session, uid)
+    await db_session.flush()
+
+    db_session.add(
+        Workspace(
+            id=workspace_id,
+            name=f"xfer-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=owner,
+            daily_api_limit=500,
+            weekly_api_limit=2500,
+            deleted_at=None,
+        )
+    )
+    await db_session.flush()
+    await _add_member(db_session, workspace_id, owner, WorkspaceRole.OWNER)
+    await _add_member(db_session, workspace_id, member, WorkspaceRole.MEMBER)
+    await db_session.commit()
+
+    yield SimpleNamespace(owner=owner, member=member, outsider=outsider, workspace_id=workspace_id)
+
+    await db_session.execute(
+        AuditLog.__table__.delete().where(AuditLog.resource == f"workspace:{workspace_id}")
+    )
+    await db_session.execute(
+        WorkspaceMember.__table__.delete().where(WorkspaceMember.workspace_id == workspace_id)
+    )
+    await db_session.execute(Workspace.__table__.delete().where(Workspace.id == workspace_id))
+    await db_session.execute(
+        User.__table__.delete().where(User.user_id.in_([owner, member, outsider]))
+    )
+    await db_session.commit()
+
+
+async def _role_of(db: AsyncSession, workspace_id, uid: str) -> WorkspaceRole | None:
+    row = (
+        await db.execute(
+            select(WorkspaceMember).where(
+                WorkspaceMember.workspace_id == workspace_id,
+                WorkspaceMember.user_id == uid,
+            )
+        )
+    ).scalar_one_or_none()
+    return None if row is None else row.role
+
+
+async def _workspace(db: AsyncSession, workspace_id) -> Workspace:
+    return (await db.execute(select(Workspace).where(Workspace.id == workspace_id))).scalar_one()
+
+
+class TestOwnershipTransfer:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_transfer_promotes_demotes_bumps_epoch_and_audits(self, ws_fixture, db_session):
+        s = ws_fixture
+        result = await WorkspaceOwnershipService(db_session).transfer_ownership(
+            workspace_id=s.workspace_id,
+            current_owner_id=s.owner,
+            target_user_id=s.member,
+            performed_by_email="owner@transfer.invalid",
+        )
+
+        assert result.changed is True
+        assert result.previous_owner_id == s.owner
+        assert result.new_owner_id == s.member
+        assert result.ownership_epoch == 1
+
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.member
+        assert ws.ownership_epoch == 1
+        assert await _role_of(db_session, s.workspace_id, s.member) == WorkspaceRole.OWNER
+        assert await _role_of(db_session, s.workspace_id, s.owner) == WorkspaceRole.ADMIN
+
+        audit = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(
+                        AuditLog.resource == f"workspace:{s.workspace_id}",
+                        AuditLog.action == OWNERSHIP_TRANSFER_ACTION,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audit) == 1
+        assert audit[0].old_value_hash == s.owner
+        assert audit[0].new_value_hash == s.member
+        assert audit[0].user_metadata["ownership_epoch"] == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_idempotent_when_target_already_owner(self, ws_fixture, db_session):
+        s = ws_fixture
+        # Owner transfers to themselves → no-op, no epoch bump, no audit.
+        result = await WorkspaceOwnershipService(db_session).transfer_ownership(
+            workspace_id=s.workspace_id,
+            current_owner_id=s.owner,
+            target_user_id=s.owner,
+            performed_by_email="owner@transfer.invalid",
+        )
+        assert result.changed is False
+        assert result.ownership_epoch == 0
+
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.owner
+        assert ws.ownership_epoch == 0
+        assert await _role_of(db_session, s.workspace_id, s.owner) == WorkspaceRole.OWNER
+        audit = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(AuditLog.resource == f"workspace:{s.workspace_id}")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert audit == []
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_repeat_transfer_to_same_owner_is_noop(self, ws_fixture, db_session):
+        s = ws_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        first = await svc.transfer_ownership(
+            workspace_id=s.workspace_id,
+            current_owner_id=s.owner,
+            target_user_id=s.member,
+            performed_by_email="owner@transfer.invalid",
+        )
+        assert first.changed is True and first.ownership_epoch == 1
+
+        # Now member is owner; transferring to member again is the no-op path.
+        second = await svc.transfer_ownership(
+            workspace_id=s.workspace_id,
+            current_owner_id=s.member,
+            target_user_id=s.member,
+            performed_by_email="member@transfer.invalid",
+        )
+        assert second.changed is False
+        assert second.ownership_epoch == 1  # not bumped again
+        assert (await _workspace(db_session, s.workspace_id)).ownership_epoch == 1
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_target_not_member_raises_bad_request_and_no_change(self, ws_fixture, db_session):
+        s = ws_fixture
+        with pytest.raises(BadRequestError):
+            await WorkspaceOwnershipService(db_session).transfer_ownership(
+                workspace_id=s.workspace_id,
+                current_owner_id=s.owner,
+                target_user_id=s.outsider,  # real user, NOT a member
+                performed_by_email="owner@transfer.invalid",
+            )
+        await db_session.rollback()
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.owner
+        assert ws.ownership_epoch == 0
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_stale_current_owner_raises_conflict(self, ws_fixture, db_session):
+        s = ws_fixture
+        # The route's owner check passed for a caller who is no longer the owner
+        # (raced). The under-lock re-check must reject with 409.
+        with pytest.raises(ConflictError):
+            await WorkspaceOwnershipService(db_session).transfer_ownership(
+                workspace_id=s.workspace_id,
+                current_owner_id=s.member,  # NOT the current owner
+                target_user_id=s.member,
+                performed_by_email="member@transfer.invalid",
+            )
+        await db_session.rollback()
+        assert (await _workspace(db_session, s.workspace_id)).owner_user_id == s.owner
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_missing_previous_owner_member_row_still_transfers(self, db_session):
+        # Legacy shape: owner_user_id set, but the owner has NO WorkspaceMember row.
+        owner = f"legown_{uuid4().hex[:8]}"
+        member = f"legmem_{uuid4().hex[:8]}"
+        workspace_id = uuid4()
+        for uid in (owner, member):
+            await _add_user(db_session, uid)
+        await db_session.flush()
+        db_session.add(
+            Workspace(
+                id=workspace_id,
+                name=f"legacy-{uuid4().hex[:8]}",
+                plan_name="free",
+                owner_user_id=owner,
+                daily_api_limit=100,
+                weekly_api_limit=500,
+                deleted_at=None,
+            )
+        )
+        await db_session.flush()
+        await _add_member(db_session, workspace_id, member, WorkspaceRole.MEMBER)  # only the member
+        await db_session.commit()
+        try:
+            result = await WorkspaceOwnershipService(db_session).transfer_ownership(
+                workspace_id=workspace_id,
+                current_owner_id=owner,
+                target_user_id=member,
+                performed_by_email="legacy@transfer.invalid",
+            )
+            assert result.changed is True
+            ws = await _workspace(db_session, workspace_id)
+            assert ws.owner_user_id == member
+            assert ws.ownership_epoch == 1
+            assert await _role_of(db_session, workspace_id, member) == WorkspaceRole.OWNER
+        finally:
+            await db_session.execute(
+                AuditLog.__table__.delete().where(AuditLog.resource == f"workspace:{workspace_id}")
+            )
+            await db_session.execute(
+                WorkspaceMember.__table__.delete().where(
+                    WorkspaceMember.workspace_id == workspace_id
+                )
+            )
+            await db_session.execute(
+                Workspace.__table__.delete().where(Workspace.id == workspace_id)
+            )
+            await db_session.execute(
+                User.__table__.delete().where(User.user_id.in_([owner, member]))
+            )
+            await db_session.commit()

--- a/backend/tests/integration/test_workspace_ownership_transfer.py
+++ b/backend/tests/integration/test_workspace_ownership_transfer.py
@@ -147,6 +147,9 @@ class TestOwnershipTransfer:
         assert audit[0].user_metadata["previous_owner_id"] == s.owner
         assert audit[0].user_metadata["new_owner_id"] == s.member
         assert audit[0].user_metadata["ownership_epoch"] == 1
+        # The actor lives in the first-class AuditLog.user_id column (asserted
+        # above); it must NOT be duplicated into user_metadata as "performed_by".
+        assert "performed_by" not in audit[0].user_metadata
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_idempotent_when_target_already_owner(self, ws_fixture, db_session):

--- a/backend/tests/integration/test_workspace_ownership_transfer.py
+++ b/backend/tests/integration/test_workspace_ownership_transfer.py
@@ -8,6 +8,7 @@ the TOCTOU re-check). They require the DB container (run via
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from uuid import uuid4
@@ -15,7 +16,7 @@ from uuid import uuid4
 import pytest
 import pytest_asyncio
 from sqlalchemy import select
-from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from auth.workspace_roles import WorkspaceRole
 from models.auth import AuditLog, User, Workspace, WorkspaceMember
@@ -142,8 +143,9 @@ class TestOwnershipTransfer:
             .all()
         )
         assert len(audit) == 1
-        assert audit[0].old_value_hash == s.owner
-        assert audit[0].new_value_hash == s.member
+        assert audit[0].user_id == s.owner  # actor = the performing owner
+        assert audit[0].user_metadata["previous_owner_id"] == s.owner
+        assert audit[0].user_metadata["new_owner_id"] == s.member
         assert audit[0].user_metadata["ownership_epoch"] == 1
 
     @pytest.mark.asyncio(loop_scope="session")
@@ -211,6 +213,17 @@ class TestOwnershipTransfer:
         ws = await _workspace(db_session, s.workspace_id)
         assert ws.owner_user_id == s.owner
         assert ws.ownership_epoch == 0
+        # A rejected attempt writes NO audit row.
+        leftover = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(AuditLog.resource == f"workspace:{s.workspace_id}")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert leftover == []
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_stale_current_owner_raises_conflict(self, ws_fixture, db_session):
@@ -226,6 +239,16 @@ class TestOwnershipTransfer:
             )
         await db_session.rollback()
         assert (await _workspace(db_session, s.workspace_id)).owner_user_id == s.owner
+        leftover = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(AuditLog.resource == f"workspace:{s.workspace_id}")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert leftover == []
 
     @pytest.mark.asyncio(loop_scope="session")
     async def test_missing_previous_owner_member_row_still_transfers(self, db_session):
@@ -262,6 +285,18 @@ class TestOwnershipTransfer:
             assert ws.owner_user_id == member
             assert ws.ownership_epoch == 1
             assert await _role_of(db_session, workspace_id, member) == WorkspaceRole.OWNER
+            # Audit trail is intact even on the legacy (no previous-member) path.
+            audit = (
+                (
+                    await db_session.execute(
+                        select(AuditLog).where(AuditLog.resource == f"workspace:{workspace_id}")
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(audit) == 1
+            assert audit[0].user_metadata["new_owner_id"] == member
         finally:
             await db_session.execute(
                 AuditLog.__table__.delete().where(AuditLog.resource == f"workspace:{workspace_id}")
@@ -276,5 +311,95 @@ class TestOwnershipTransfer:
             )
             await db_session.execute(
                 User.__table__.delete().where(User.user_id.in_([owner, member]))
+            )
+            await db_session.commit()
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_concurrent_transfers_preserve_single_owner(self, async_engine, db_session):
+        # THE acceptance criterion: single-owner invariant preserved under
+        # concurrency (row lock). Two simultaneous transfers from the same owner
+        # to two DIFFERENT members race on independent sessions. The workspace
+        # FOR UPDATE lock must serialize them: exactly one commits, the loser's
+        # under-lock owner re-check fails with 409 — never two OWNER rows, never a
+        # double epoch bump. (If the lock were dropped, both could read owner==A,
+        # both pass the re-check, and both promote → this test would fail.)
+        owner = f"cown_{uuid4().hex[:8]}"
+        m1 = f"cm1_{uuid4().hex[:8]}"
+        m2 = f"cm2_{uuid4().hex[:8]}"
+        workspace_id = uuid4()
+        for uid in (owner, m1, m2):
+            await _add_user(db_session, uid)
+        await db_session.flush()
+        db_session.add(
+            Workspace(
+                id=workspace_id,
+                name=f"conc-{uuid4().hex[:8]}",
+                plan_name="pro",
+                owner_user_id=owner,
+                daily_api_limit=500,
+                weekly_api_limit=2500,
+                deleted_at=None,
+            )
+        )
+        await db_session.flush()
+        await _add_member(db_session, workspace_id, owner, WorkspaceRole.OWNER)
+        await _add_member(db_session, workspace_id, m1, WorkspaceRole.MEMBER)
+        await _add_member(db_session, workspace_id, m2, WorkspaceRole.MEMBER)
+        await db_session.commit()
+
+        session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+        async def _xfer(target: str) -> str:
+            async with session_maker() as s:
+                try:
+                    await WorkspaceOwnershipService(s).transfer_ownership(
+                        workspace_id=workspace_id,
+                        current_owner_id=owner,
+                        target_user_id=target,
+                        performed_by_email="conc@transfer.invalid",
+                    )
+                    return "ok"
+                except ConflictError:
+                    return "conflict"
+
+        try:
+            statuses = sorted(await asyncio.gather(_xfer(m1), _xfer(m2)))
+            assert statuses == ["conflict", "ok"], f"expected one ok + one conflict, got {statuses}"
+
+            # Exactly one OWNER member row; owner_user_id agrees; epoch bumped once.
+            async with session_maker() as s:
+                ws = (
+                    await s.execute(select(Workspace).where(Workspace.id == workspace_id))
+                ).scalar_one()
+                owners = (
+                    (
+                        await s.execute(
+                            select(WorkspaceMember).where(
+                                WorkspaceMember.workspace_id == workspace_id,
+                                WorkspaceMember.role == WorkspaceRole.OWNER,
+                            )
+                        )
+                    )
+                    .scalars()
+                    .all()
+                )
+                assert len(owners) == 1
+                assert owners[0].user_id == ws.owner_user_id
+                assert ws.owner_user_id in (m1, m2)
+                assert ws.ownership_epoch == 1
+        finally:
+            await db_session.execute(
+                AuditLog.__table__.delete().where(AuditLog.resource == f"workspace:{workspace_id}")
+            )
+            await db_session.execute(
+                WorkspaceMember.__table__.delete().where(
+                    WorkspaceMember.workspace_id == workspace_id
+                )
+            )
+            await db_session.execute(
+                Workspace.__table__.delete().where(Workspace.id == workspace_id)
+            )
+            await db_session.execute(
+                User.__table__.delete().where(User.user_id.in_([owner, m1, m2]))
             )
             await db_session.commit()


### PR DESCRIPTION
Closes #1094

## Summary
- Add `POST /api/v1/workspaces/{id}/transfer-ownership`: **current-owner-only + session-only** (a Bearer API key / OAuth token is rejected 403), transferring ownership to an existing member.
- `WorkspaceOwnershipService.transfer_ownership` locks the workspace row (`SELECT ... FOR UPDATE`) as the single-owner synchronization point, **re-verifies the caller is still owner under the lock** (closes the route-check→lock TOCTOU → 409), is **idempotent** (no-op when the target already owns it — no epoch bump, no audit), promotes target → OWNER, demotes previous owner → ADMIN (skipping a missing legacy member row), bumps `ownership_epoch`, and writes an audit row in the **same transaction**.
- New `workspaces.ownership_epoch` column (Integer, NOT NULL, server_default 0) + migration `e45` (down_revision `e44_1065_host_arbitration`, linear head). The epoch is the **producer** side; the invalidation consumer is a documented follow-up.
- Owner gate binds to the explicit **path** `workspace_id` (#389 cross-tenant guard); target-not-member → 400.

## Implementation notes
- New `backend/src/services/workspace_ownership_service.py` (dedicated transactional service); route added to the existing `workspaces` router.
- Reuses `WorkspaceRole` / `check_workspace_owner` / `AuditLog`; owner user_ids are stored in the audit `user_metadata` (JSON), not the `String(64)` hash columns.
- **18 tests**: 11 route RBAC/mapping (DB-free) + 7 service integration (real DB) including a **two-session concurrent-transfer test** proving the row lock keeps a single OWNER + one epoch bump (the headline acceptance criterion).

## Pre-PR review summary
- gate2 mode: advisor-only · audit: skipped · binary_gate: (none)
- cso: green · qa-lead: green · cto: green
- gate1: yellow via /claude-c-suite:ask (3 constraints pinned + implemented: under-lock TOCTOU re-check, missing-prev-member, accurate invariant docstring)
- review provider: none (post-PR review opt-in)
- An independent `/code-review max` pass ran during implementation and caught + fixed a real audit-column truncation bug (owner user_ids in `String(64)` → moved to `user_metadata`) and the missing concurrency test.

## Scoped as follow-ups (beyond the stated acceptance)
- Break-glass admin force-transfer + dual-control + zero-member case.
- New-owner notification.
- The ownership-epoch invalidation consumer (e.g. invalidating handoff tokens from #1093 bound to a previous owner).
- Unifying all owner-mutating paths (incl. the account-erasure auto-transfer) under one workspace row lock.

🤖 Generated via /gh-issue-driven:ship
