### PR TITLE
feat(billing): ownership-epoch invalidation consumer (#1100)

### DIFF
--- a/backend/src/api/routes/billing_handoff.py
+++ b/backend/src/api/routes/billing_handoff.py
@@ -27,12 +27,14 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel, Field
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.billing_handoff import BillingHandoffSigner
 from auth.dependencies import SessionUser
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
+from models.auth import Workspace
 from services.permission_service import PermissionService
 from utils.auth_helpers import get_user_id
 
@@ -81,9 +83,26 @@ async def mint_billing_handoff(
     # workspace they merely belong to (#389 guard).
     await PermissionService(db).check_workspace_owner(user_id, body.workspace_id)
 
+    # Stamp the workspace's live ownership epoch into the token (#1100) so the
+    # external verifier can reject it once ownership is transferred (the epoch
+    # advances). Read AFTER the owner gate confirmed the workspace exists; a newer
+    # epoch read here would only make the token immediately stale (fail-safe).
+    ownership_epoch = (
+        await db.execute(
+            select(Workspace.ownership_epoch).where(
+                Workspace.id == body.workspace_id,
+                Workspace.deleted_at.is_(None),
+            )
+        )
+    ).scalar_one()
+
     # Mint AFTER authz so an unconfigured deployment returns 403 to non-owners
     # (no info leak) and 503 only to an authorized owner.
-    minted = BillingHandoffSigner().mint(user_id=user_id, workspace_id=body.workspace_id)
+    minted = BillingHandoffSigner().mint(
+        user_id=user_id,
+        workspace_id=body.workspace_id,
+        ownership_epoch=ownership_epoch,
+    )
 
     # Issuance is audit-logged exactly once, inside BillingHandoffSigner.mint()
     # as "billing_handoff_minted" (same fields + expires_at) — no duplicate here.

--- a/backend/src/auth/billing_handoff.py
+++ b/backend/src/auth/billing_handoff.py
@@ -66,6 +66,38 @@ class BillingHandoffNotConfigured(MemoryCloudException):
         )
 
 
+class BillingHandoffStale(MemoryCloudException):
+    """The token's ownership epoch is older than the workspace's live epoch (#1100).
+
+    Ownership was transferred since the token was minted, so the credential is
+    invalidated. 401 (not 403): the token is a once-valid credential that has
+    been superseded, mirroring an expired-token rejection.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Billing handoff token is stale (workspace ownership changed)",
+            status_code=401,
+            error_code="BILLING-003",
+        )
+
+
+class BillingHandoffInvalid(MemoryCloudException):
+    """The handoff token failed signature or standard-claim (iss/aud/exp) checks.
+
+    Raised by the reference verifier; the staleness check (:class:`BillingHandoffStale`)
+    is a *separate*, later gate so a caller can distinguish "forged/expired" from
+    "superseded by ownership transfer".
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            "Billing handoff token is invalid",
+            status_code=401,
+            error_code="BILLING-004",
+        )
+
+
 @dataclass(frozen=True)
 class MintedHandoffToken:
     """A freshly minted handoff token plus the metadata the route echoes back."""
@@ -77,6 +109,7 @@ class MintedHandoffToken:
     expires_at: datetime
     workspace_id: str
     user_id: str
+    ownership_epoch: int
 
 
 class BillingHandoffSigner:
@@ -105,7 +138,13 @@ class BillingHandoffSigner:
         key, kid = self._stripped_material()
         return bool(key) and bool(kid)
 
-    def mint(self, *, user_id: str, workspace_id: UUID | str) -> MintedHandoffToken:
+    def mint(
+        self,
+        *,
+        user_id: str,
+        workspace_id: UUID | str,
+        ownership_epoch: int = 0,
+    ) -> MintedHandoffToken:
         """Mint a signed handoff token for ``user_id`` scoped to ``workspace_id``.
 
         The caller MUST have already verified that ``user_id`` owns
@@ -119,6 +158,11 @@ class BillingHandoffSigner:
             workspace_id: The target workspace (becomes the ``workspace_id``
                 claim) — the route binds this to the request body, never the
                 caller's mutable ``current_workspace_id``.
+            ownership_epoch: The workspace's live ``ownership_epoch`` at mint time
+                (#1100). Embedded as the ``epoch`` claim so the verifier can reject
+                the token once ownership is transferred (the epoch advances). The
+                route MUST pass the live value; the ``0`` default is the fail-safe
+                floor (only valid while the workspace has never been transferred).
 
         Returns:
             The minted token and its metadata.
@@ -160,6 +204,7 @@ class BillingHandoffSigner:
             "sub": user_id,
             "workspace_id": workspace_str,
             "role": _ROLE_OWNER,
+            "epoch": int(ownership_epoch),
             "iat": int(issued_at.replace(tzinfo=UTC).timestamp()),
             "exp": int(expires_at.replace(tzinfo=UTC).timestamp()),
             "jti": jti,
@@ -193,4 +238,71 @@ class BillingHandoffSigner:
             expires_at=expires_at,
             workspace_id=workspace_str,
             user_id=user_id,
+            ownership_epoch=int(ownership_epoch),
         )
+
+
+def verify_handoff_token(
+    token: str,
+    verifying_key: str,
+    *,
+    current_epoch: int,
+    issuer: str,
+    audience: str,
+) -> dict:
+    """Reference verifier — the canonical ownership-epoch staleness check (#1100).
+
+    memory-cloud mints handoff tokens but does **not** gate their redemption (the
+    mint-only boundary documented above): the external billing service is the
+    verifier. This helper is the *spec* that verifier implements, and the in-repo
+    test hook that makes the "minted at epoch N → rejected after a transfer to
+    N+1" acceptance criterion provable without the external repo.
+
+    It verifies the EdDSA signature with ``verifying_key`` (the distributed public
+    key), enforces ``iss``/``aud``/``exp``, then rejects the token when its
+    embedded ``epoch`` claim is **strictly older** than ``current_epoch`` — i.e.
+    ownership was transferred since the token was minted. A missing ``epoch`` claim
+    (a token minted before #1100) is treated as ``0``.
+
+    Unlike a token claim consumed blindly, ``epoch`` is **not** trusted as an
+    authorization fact — it is a freshness assertion that is always compared
+    against the live ``current_epoch``. This is deliberately the opposite stance to
+    #649 (where the token's ``workspace_id`` was declared "not security-bearing,
+    point-in-time"): there the claim was trusted and so kept non-bearing; here the
+    claim is re-validated against live state on every verify, so it can be bearing.
+
+    Args:
+        token: The compact EdDSA handoff JWS.
+        verifying_key: PEM/JWK public key matching the token's ``kid``.
+        current_epoch: The workspace's live ``ownership_epoch`` at verify time.
+        issuer: Expected ``iss`` claim.
+        audience: Expected ``aud`` claim.
+
+    Returns:
+        The validated claims as a plain ``dict``.
+
+    Raises:
+        BillingHandoffInvalid: 401 (BILLING-004) — bad signature / iss / aud / exp.
+        BillingHandoffStale: 401 (BILLING-003) — the ownership epoch advanced.
+    """
+    try:
+        claims = _JWT.decode(
+            token,
+            JsonWebKey.import_key(verifying_key),
+            claims_options={
+                "iss": {"essential": True, "value": issuer},
+                "aud": {"essential": True, "value": audience},
+            },
+        )
+        claims.validate()  # exp/iat/iss/aud — raises on any mismatch
+    except Exception as exc:
+        raise BillingHandoffInvalid() from exc
+
+    # Staleness is a SEPARATE gate, after signature/claims pass, so the caller can
+    # tell "forged/expired" (BILLING-004) apart from "superseded by transfer"
+    # (BILLING-003). Missing claim → 0 (pre-#1100 token). Strict ``<``: an equal
+    # epoch is the same ownership generation and stays valid.
+    token_epoch = int(claims.get("epoch", 0) or 0)
+    if token_epoch < int(current_epoch):
+        raise BillingHandoffStale()
+    return dict(claims)

--- a/backend/src/auth/billing_handoff.py
+++ b/backend/src/auth/billing_handoff.py
@@ -196,6 +196,7 @@ class BillingHandoffSigner:
         expires_at = issued_at + timedelta(seconds=ttl_seconds)
         jti = secrets.token_urlsafe(24)
         workspace_str = str(workspace_id)
+        epoch = int(ownership_epoch)
 
         header = {"alg": _ALG, "typ": _TOKEN_TYP, "kid": kid}
         payload = {
@@ -204,7 +205,7 @@ class BillingHandoffSigner:
             "sub": user_id,
             "workspace_id": workspace_str,
             "role": _ROLE_OWNER,
-            "epoch": int(ownership_epoch),
+            "epoch": epoch,
             "iat": int(issued_at.replace(tzinfo=UTC).timestamp()),
             "exp": int(expires_at.replace(tzinfo=UTC).timestamp()),
             "jti": jti,
@@ -227,6 +228,7 @@ class BillingHandoffSigner:
             workspace_id=workspace_str,
             jti=jti,
             kid=kid,
+            epoch=epoch,
             expires_at=expires_at.isoformat(),
         )
 
@@ -238,7 +240,7 @@ class BillingHandoffSigner:
             expires_at=expires_at,
             workspace_id=workspace_str,
             user_id=user_id,
-            ownership_epoch=int(ownership_epoch),
+            ownership_epoch=epoch,
         )
 
 
@@ -273,7 +275,9 @@ def verify_handoff_token(
 
     Args:
         token: The compact EdDSA handoff JWS.
-        verifying_key: PEM/JWK public key matching the token's ``kid``.
+        verifying_key: PEM/JWK public key. This single-key verifier does NOT
+            resolve the token's ``kid`` header — the caller is responsible for
+            selecting the public key that matches the token's ``kid`` (rotation).
         current_epoch: The workspace's live ``ownership_epoch`` at verify time.
         issuer: Expected ``iss`` claim.
         audience: Expected ``aud`` claim.
@@ -282,7 +286,8 @@ def verify_handoff_token(
         The validated claims as a plain ``dict``.
 
     Raises:
-        BillingHandoffInvalid: 401 (BILLING-004) — bad signature / iss / aud / exp.
+        BillingHandoffInvalid: 401 (BILLING-004) — bad signature / iss / aud / exp
+            (incl. a missing ``exp``) / a malformed (non-numeric) ``epoch`` claim.
         BillingHandoffStale: 401 (BILLING-003) — the ownership epoch advanced.
     """
     try:
@@ -292,17 +297,24 @@ def verify_handoff_token(
             claims_options={
                 "iss": {"essential": True, "value": issuer},
                 "aud": {"essential": True, "value": audience},
+                # exp essential: authlib's exp validator is a no-op when the claim
+                # is ABSENT, so without this a token minted with no exp would never
+                # expire — defeating the short-TTL replay window. Reject it instead.
+                "exp": {"essential": True},
             },
         )
         claims.validate()  # exp/iat/iss/aud — raises on any mismatch
+        # Coerce the epoch INSIDE the guarded region: a validly-signed token from a
+        # cross-impl minter could carry a non-numeric / null ``epoch``, and that
+        # must surface as BILLING-004, not an unhandled 500. Missing / null → 0.
+        token_epoch = int(claims.get("epoch", 0) or 0)
     except Exception as exc:
         raise BillingHandoffInvalid() from exc
 
     # Staleness is a SEPARATE gate, after signature/claims pass, so the caller can
-    # tell "forged/expired" (BILLING-004) apart from "superseded by transfer"
-    # (BILLING-003). Missing claim → 0 (pre-#1100 token). Strict ``<``: an equal
-    # epoch is the same ownership generation and stays valid.
-    token_epoch = int(claims.get("epoch", 0) or 0)
+    # tell "forged/expired/malformed" (BILLING-004) apart from "superseded by
+    # transfer" (BILLING-003). Strict ``<``: an equal epoch is the same ownership
+    # generation and stays valid.
     if token_epoch < int(current_epoch):
         raise BillingHandoffStale()
     return dict(claims)

--- a/backend/tests/api/test_billing_handoff_route.py
+++ b/backend/tests/api/test_billing_handoff_route.py
@@ -67,7 +67,7 @@ def _session_user(user_id: str = "owner-1") -> dict:
     }
 
 
-def _fake_minted(workspace_id) -> MintedHandoffToken:
+def _fake_minted(workspace_id, ownership_epoch: int = 0) -> MintedHandoffToken:
     issued = utcnow()
     return MintedHandoffToken(
         token="eyJhbGciOiJFZERTQSJ9.fake.sig",
@@ -77,7 +77,18 @@ def _fake_minted(workspace_id) -> MintedHandoffToken:
         expires_at=issued + timedelta(seconds=120),
         workspace_id=str(workspace_id),
         user_id="owner-1",
+        ownership_epoch=ownership_epoch,
     )
+
+
+def _db_with_epoch(epoch: int = 0) -> MagicMock:
+    """A db stand-in whose single ``execute(...).scalar_one()`` yields ``epoch`` —
+    the route reads the workspace's live ownership_epoch this way (#1100)."""
+    db = MagicMock()
+    result = MagicMock()
+    result.scalar_one.return_value = epoch
+    db.execute = AsyncMock(return_value=result)
+    return db
 
 
 @pytest.fixture
@@ -89,7 +100,7 @@ def session_client():
         return _session_user()
 
     async def _mock_db():
-        yield MagicMock()
+        yield _db_with_epoch(0)
 
     app.dependency_overrides[require_session_auth] = _mock_session
     app.dependency_overrides[get_db] = _mock_db
@@ -147,6 +158,28 @@ class TestHandoffOwnerHappyPath:
         mint_call = signer_cls.return_value.mint.call_args
         assert mint_call.kwargs["workspace_id"] == WS_B
         assert mint_call.kwargs["user_id"] == "owner-1"
+
+    def test_route_stamps_workspace_ownership_epoch_into_token(self, session_client):
+        """#1100: the route reads the workspace's live ownership_epoch and passes it
+        to mint, so the token carries the generation it was minted under."""
+
+        async def _db_epoch_5():
+            yield _db_with_epoch(5)
+
+        session_client.app.dependency_overrides[get_db] = _db_epoch_5
+
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "BillingHandoffSigner") as signer_cls,
+        ):
+            signer_cls.return_value.mint.return_value = _fake_minted(WS_A, ownership_epoch=5)
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+
+        assert resp.status_code == 200, resp.text
+        mint_call = signer_cls.return_value.mint.call_args
+        assert mint_call.kwargs["ownership_epoch"] == 5
 
 
 # ============================================================================

--- a/backend/tests/auth/test_billing_handoff_signer.py
+++ b/backend/tests/auth/test_billing_handoff_signer.py
@@ -372,3 +372,109 @@ class TestOwnershipEpochClaim:
                 issuer=s.billing_handoff_issuer,
                 audience="someone-else",
             )
+
+    def test_mint_logs_ownership_epoch(self) -> None:
+        # The epoch is the field the staleness gate keys on — it must be in the
+        # issuance audit breadcrumb so a transfer dispute is reconstructable.
+        private_pem, _ = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+
+        with patch("auth.billing_handoff.logger") as mock_logger:
+            signer.mint(user_id="u", workspace_id=uuid4(), ownership_epoch=9)
+
+        assert mock_logger.info.call_args.kwargs.get("epoch") == 9
+
+
+def _sign(private_pem: str, payload: dict, *, kid: str = "kid-1") -> str:
+    """Sign an arbitrary payload with the EdDSA private key (cross-impl minter sim)."""
+    header = {"alg": "EdDSA", "typ": "JWT", "kid": kid}
+    tok = _JWT.encode(header, payload, JsonWebKey.import_key(private_pem))
+    return tok.decode() if isinstance(tok, bytes) else tok
+
+
+def _base_payload(s, **overrides) -> dict:
+    iat = calendar.timegm(datetime(2026, 6, 27, 12, 0, 0).timetuple())
+    payload = {
+        "iss": s.billing_handoff_issuer,
+        "aud": s.billing_handoff_audience,
+        "sub": "u",
+        "workspace_id": str(uuid4()),
+        "role": "owner",
+        "epoch": 1,
+        "iat": iat,
+        "exp": calendar.timegm(datetime(2099, 1, 1).timetuple()),
+        "jti": "t",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestVerifierHardening:
+    """#1100 code-review max follow-ups: the reference verifier must fail closed on
+    a missing/expired exp, a non-numeric epoch, and a tampered signature."""
+
+    def test_verify_rejects_token_missing_exp_claim(self) -> None:
+        # exp is essential — a token with no exp would otherwise never expire,
+        # and the epoch gate does not compensate within the same generation.
+        private_pem, public_pem = _keypair()
+        s = _settings(private_pem)
+        payload = _base_payload(s)
+        payload.pop("exp")
+
+        with pytest.raises(BillingHandoffInvalid):
+            verify_handoff_token(
+                _sign(private_pem, payload),
+                public_pem,
+                current_epoch=1,
+                issuer=s.billing_handoff_issuer,
+                audience=s.billing_handoff_audience,
+            )
+
+    def test_verify_rejects_expired_token(self) -> None:
+        private_pem, public_pem = _keypair()
+        s = _settings(private_pem)
+        past = calendar.timegm(datetime(2020, 1, 1).timetuple())
+
+        with pytest.raises(BillingHandoffInvalid):
+            verify_handoff_token(
+                _sign(private_pem, _base_payload(s, iat=past, exp=past + 120)),
+                public_pem,
+                current_epoch=1,
+                issuer=s.billing_handoff_issuer,
+                audience=s.billing_handoff_audience,
+            )
+
+    def test_verify_rejects_non_numeric_epoch_as_invalid_not_500(self) -> None:
+        # A validly-signed but cross-impl token with a non-numeric epoch must
+        # surface as BILLING-004, never an unhandled coercion error (500).
+        private_pem, public_pem = _keypair()
+        s = _settings(private_pem)
+
+        with pytest.raises(BillingHandoffInvalid):
+            verify_handoff_token(
+                _sign(private_pem, _base_payload(s, epoch="not-a-number")),
+                public_pem,
+                current_epoch=1,
+                issuer=s.billing_handoff_issuer,
+                audience=s.billing_handoff_audience,
+            )
+
+    def test_verify_rejects_tampered_signature(self) -> None:
+        # The verifier's core promise: a tampered token raises BillingHandoffInvalid
+        # (not a raw authlib error) — regression guard for the decode try/except.
+        private_pem, public_pem = _keypair()
+        s = _settings(private_pem)
+        minted = BillingHandoffSigner(settings=s).mint(
+            user_id="u", workspace_id=uuid4(), ownership_epoch=1
+        )
+        head, body, sig = minted.token.split(".")
+        tampered = f"{head}.{body}.{'BB' if sig[-2:] != 'BB' else 'CC'}{sig[2:]}"
+
+        with pytest.raises(BillingHandoffInvalid):
+            verify_handoff_token(
+                tampered,
+                public_pem,
+                current_epoch=1,
+                issuer=s.billing_handoff_issuer,
+                audience=s.billing_handoff_audience,
+            )

--- a/backend/tests/auth/test_billing_handoff_signer.py
+++ b/backend/tests/auth/test_billing_handoff_signer.py
@@ -23,7 +23,13 @@ from authlib.jose import JsonWebKey, JsonWebToken
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
-from auth.billing_handoff import BillingHandoffNotConfigured, BillingHandoffSigner
+from auth.billing_handoff import (
+    BillingHandoffInvalid,
+    BillingHandoffNotConfigured,
+    BillingHandoffSigner,
+    BillingHandoffStale,
+    verify_handoff_token,
+)
 
 _JWT = JsonWebToken(["EdDSA"])
 
@@ -244,3 +250,125 @@ class TestBillingHandoffSigner:
         assert signer.is_configured is False
         with pytest.raises(BillingHandoffNotConfigured):
             signer.mint(user_id="u", workspace_id=uuid4())
+
+
+class TestOwnershipEpochClaim:
+    """#1100 — the handoff token carries the workspace ownership epoch so the
+    verifier can reject a token minted under a *previous* owner after an
+    ownership transfer bumps the epoch."""
+
+    def test_mint_embeds_ownership_epoch_claim(self) -> None:
+        private_pem, public_pem = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+
+        minted = signer.mint(user_id="u", workspace_id=uuid4(), ownership_epoch=7)
+
+        claims = _JWT.decode(minted.token, JsonWebKey.import_key(public_pem))
+        assert claims["epoch"] == 7
+        assert minted.ownership_epoch == 7
+
+    def test_mint_defaults_epoch_to_zero(self) -> None:
+        # Omitting ownership_epoch is the fail-safe floor (0): valid only while the
+        # workspace is still at epoch 0 (never transferred).
+        private_pem, public_pem = _keypair()
+        signer = BillingHandoffSigner(settings=_settings(private_pem))
+
+        minted = signer.mint(user_id="u", workspace_id=uuid4())
+
+        assert _JWT.decode(minted.token, JsonWebKey.import_key(public_pem))["epoch"] == 0
+        assert minted.ownership_epoch == 0
+
+    def test_verify_accepts_equal_epoch(self) -> None:
+        private_pem, public_pem = _keypair()
+        s = _settings(private_pem)
+        signer = BillingHandoffSigner(settings=s)
+        minted = signer.mint(user_id="u", workspace_id=uuid4(), ownership_epoch=3)
+
+        claims = verify_handoff_token(
+            minted.token,
+            public_pem,
+            current_epoch=3,
+            issuer=s.billing_handoff_issuer,
+            audience=s.billing_handoff_audience,
+        )
+        assert claims["epoch"] == 3
+        assert claims["sub"] == "u"
+
+    def test_verify_rejects_stale_epoch_after_transfer(self) -> None:
+        # The acceptance criterion: a token minted at epoch N is rejected once the
+        # workspace epoch advances to N+1 (ownership transferred away).
+        private_pem, public_pem = _keypair()
+        s = _settings(private_pem)
+        minted = BillingHandoffSigner(settings=s).mint(
+            user_id="u", workspace_id=uuid4(), ownership_epoch=3
+        )
+
+        with pytest.raises(BillingHandoffStale) as exc_info:
+            verify_handoff_token(
+                minted.token,
+                public_pem,
+                current_epoch=4,
+                issuer=s.billing_handoff_issuer,
+                audience=s.billing_handoff_audience,
+            )
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.error_code == "BILLING-003"
+
+    def test_verify_missing_epoch_claim_treated_as_zero(self) -> None:
+        # Backward-compat: a token minted before #1100 (no epoch claim) is treated
+        # as epoch 0 — valid pre-transfer, rejected once any transfer bumps to >=1.
+        private_pem, public_pem = _keypair()
+        s = _settings(private_pem)
+        key = JsonWebKey.import_key(private_pem)
+        header = {"alg": "EdDSA", "typ": "JWT", "kid": s.billing_handoff_key_id}
+        payload = {
+            "iss": s.billing_handoff_issuer,
+            "aud": s.billing_handoff_audience,
+            "sub": "u",
+            "workspace_id": str(uuid4()),
+            "role": "owner",
+            "iat": calendar.timegm(datetime(2026, 6, 27, 12, 0, 0).timetuple()),
+            "exp": calendar.timegm(datetime(2099, 1, 1).timetuple()),
+            "jti": "legacy",
+        }
+        legacy_token = _JWT.encode(header, payload, key)
+        if isinstance(legacy_token, bytes):
+            legacy_token = legacy_token.decode()
+
+        # epoch 0 vs current 0 → accepted
+        assert (
+            verify_handoff_token(
+                legacy_token,
+                public_pem,
+                current_epoch=0,
+                issuer=s.billing_handoff_issuer,
+                audience=s.billing_handoff_audience,
+            )["sub"]
+            == "u"
+        )
+        # epoch 0 vs current 1 → rejected
+        with pytest.raises(BillingHandoffStale):
+            verify_handoff_token(
+                legacy_token,
+                public_pem,
+                current_epoch=1,
+                issuer=s.billing_handoff_issuer,
+                audience=s.billing_handoff_audience,
+            )
+
+    def test_verify_rejects_wrong_audience(self) -> None:
+        # The reference verifier still enforces the standard binding, not just epoch.
+        private_pem, public_pem = _keypair()
+        s = _settings(private_pem)
+        minted = BillingHandoffSigner(settings=s).mint(
+            user_id="u", workspace_id=uuid4(), ownership_epoch=1
+        )
+
+        with pytest.raises(BillingHandoffInvalid):
+            verify_handoff_token(
+                minted.token,
+                public_pem,
+                current_epoch=1,
+                issuer=s.billing_handoff_issuer,
+                audience="someone-else",
+            )


### PR DESCRIPTION
Closes #1100

## Summary
- Consumer side of #1094's `ownership_epoch` (producer-only until now): the #1093 Ed25519 billing handoff token now embeds the workspace's ownership epoch as a signed `epoch` claim at mint.
- New reference verifier `verify_handoff_token(token, public_key, *, current_epoch, issuer, audience)` that verifies the EdDSA signature + `iss`/`aud`/`exp` then **rejects a token whose embedded epoch is older than the live workspace epoch** — i.e. ownership was transferred since mint.
- memory-cloud stays **mint-only**: enforcement is the external billing verifier's job. This helper is the canonical spec it mirrors, plus the in-repo test hook that proves the acceptance criterion without the external repo.

## Implementation notes
- `auth/billing_handoff.py`: `mint(..., ownership_epoch)` adds the `epoch` claim + `MintedHandoffToken.ownership_epoch`; the `billing_handoff_minted` audit breadcrumb now logs `epoch`. Two new exceptions follow the `BILLING-00X` convention: `BillingHandoffStale` (401, BILLING-003 — epoch advanced) and `BillingHandoffInvalid` (401, BILLING-004 — bad signature / iss / aud / exp / malformed epoch). `exp` is marked **essential** (a token with no exp would otherwise never expire); epoch coercion is inside the guarded block (a non-numeric epoch from a cross-impl minter → BILLING-004, not a 500). Missing epoch claim → treated as `0` (pre-#1100 token); strict `<` (equal epoch = same ownership generation, still valid).
- `api/routes/billing_handoff.py`: reads `workspace.ownership_epoch` after the owner gate (keyed on the explicit body `workspace_id`, inheriting #1098's #389 guard) and passes it to mint. A newer epoch read here only makes the token immediately stale downstream (fail-safe).
- Session-invalidation is deliberately **out of scope** (gate1/CTO) — tracked as a separate follow-up; this PR scopes the handoff-token credential.

## Acceptance
`test_verify_rejects_stale_epoch_after_transfer`: mint at epoch N → `verify(current_epoch=N+1)` raises `BillingHandoffStale` (401 / BILLING-003). 38 tests green across the signer + route suites; ruff clean.

## Pre-PR review summary
- gate2 mode: advisor-only
- audit: skipped
- binary_gate: (none)
- cso: green
- qa-lead: green
- cto: green
- gate1: yellow via /claude-c-suite:ask (CTO lens — scope decisions locked: reference-verifier-not-endpoint, session split deferred, missing-epoch→0)
- review provider: none (opt-in)
- code-review: independent code-review max (20-agent find→verify→sweep) ran on the diff; 14 candidates → 11 findings (0 CONFIRMED correctness bugs); the real ones (exp-essential, epoch-coercion-in-try, audit-log epoch, single cast, kid docstring) were fixed TDD-style in 0e9e291.

Full reviews are saved in the plugin cache (gate1.md / gate2.md).

🤖 Generated via /gh-issue-driven:ship
