### PR TITLE
feat(billing): rate-limit the owner handoff mint endpoint (#1104)

### DIFF
--- a/backend/src/api/routes/billing_handoff.py
+++ b/backend/src/api/routes/billing_handoff.py
@@ -32,13 +32,70 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.billing_handoff import BillingHandoffSigner
 from auth.dependencies import SessionUser
+from config.settings import get_settings
 from db.base import get_db
+from db.redis import incrby_counter
 from models.api_base import TZAwareBaseModel
 from models.auth import Workspace
 from services.permission_service import PermissionService
 from utils.auth_helpers import get_user_id
+from utils.exceptions import RateLimitError
+from utils.logger import get_logger
+
+logger = get_logger(__name__)
 
 router = APIRouter(prefix="/billing", tags=["billing-handoff"])
+
+# Per-(owner, workspace) mint rate-limit window. Mirrors the Redis counter idiom
+# in ``public_search.check_bound_key_rate_limit`` (#626): ``incrby_counter`` sets
+# a TTL even under concurrent first-increments so the bucket cannot grow forever.
+_RATE_WINDOW_SECONDS = 60
+
+
+async def _check_handoff_rate_limit(
+    user_id: str, workspace_id: UUID | str, limit_per_minute: int
+) -> None:
+    """Bound a single owner's mint rate for one workspace (#1104).
+
+    Defense-in-depth on top of the owner gate + short-TTL token: caps abusive
+    minting per ``(user_id, workspace_id)`` per minute. ``limit<=0`` disables
+    minting (fail-safe). **Fail-open** on a Redis outage — the primary controls
+    (owner-only + session-only + short TTL + audit log) still hold, and a billing
+    handoff must not become unavailable because the rate-limit store is down
+    (consistent with the ``public_search`` buckets).
+
+    Raises:
+        RateLimitError: 429 when the per-minute bucket is exhausted (or disabled).
+    """
+    if limit_per_minute <= 0:
+        raise RateLimitError(
+            message="Billing handoff minting is not available on this deployment",
+            retry_after=_RATE_WINDOW_SECONDS,
+        )
+
+    redis_key = f"billing_handoff:{user_id}:{workspace_id}:minute"
+    try:
+        current = await incrby_counter(redis_key, amount=1, ttl=_RATE_WINDOW_SECONDS)
+        if current > limit_per_minute:
+            logger.warning(
+                "billing_handoff_rate_limit_exceeded",
+                user_id=user_id,
+                workspace_id=str(workspace_id),
+                current=current,
+                limit=limit_per_minute,
+            )
+            raise RateLimitError(
+                message=(
+                    f"Billing handoff rate limit exceeded: {current}/{limit_per_minute} per minute"
+                ),
+                retry_after=_RATE_WINDOW_SECONDS,
+            )
+    except RateLimitError:
+        raise
+    except Exception as exc:
+        # Fail-open on any Redis error — availability of the handoff must not
+        # depend on the rate-limit store (mirrors public_search's buckets).
+        logger.error("billing_handoff_rate_limit_check_failed", error=str(exc))
 
 
 class BillingHandoffRequest(BaseModel):
@@ -82,6 +139,14 @@ async def mint_billing_handoff(
     # current_workspace_id, so a multi-workspace member cannot mint for a
     # workspace they merely belong to (#389 guard).
     await PermissionService(db).check_workspace_owner(user_id, body.workspace_id)
+
+    # Rate-limit the owner's mint rate per workspace (#1104), AFTER the owner gate
+    # (non-owners 403 without consuming quota) and BEFORE mint. 429 on exceed.
+    await _check_handoff_rate_limit(
+        user_id,
+        body.workspace_id,
+        get_settings().billing_handoff_rate_limit_per_minute,
+    )
 
     # Stamp the workspace's live ownership epoch into the token (#1100) so the
     # external verifier can reject it once ownership is transferred (the epoch

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -136,6 +136,14 @@ class Settings(BaseSettings):
         le=900,
         description="Billing handoff token lifetime in seconds (short-lived; <=15min).",
     )
+    billing_handoff_rate_limit_per_minute: int = Field(
+        default=10,
+        description=(
+            "Per-(owner, workspace) mint rate limit for POST /api/v1/billing/handoff "
+            "(#1104). Abuse bound, not a per-plan quota. <=0 disables minting "
+            "(fail-safe). Fail-open on a Redis outage."
+        ),
+    )
     # Public MCP base URL handed back to the worker in its config so it can write
     # memories. Defaults to local dev; override in prod (e.g. https://memory.kagura-ai.com/mcp).
     kmc_mcp_url: str = Field(

--- a/backend/tests/api/test_billing_handoff_route.py
+++ b/backend/tests/api/test_billing_handoff_route.py
@@ -34,7 +34,13 @@ from auth.billing_handoff import BillingHandoffNotConfigured, MintedHandoffToken
 from auth.dependencies import require_session_auth
 from db.base import get_db
 from utils.datetime import utcnow
-from utils.exceptions import AdminProtectionError, AuthorizationError, MemoryCloudException
+from utils.exceptions import (
+    AdminProtectionError,
+    AuthorizationError,
+    MemoryCloudException,
+    RateLimitError,
+    RedisError,
+)
 
 WS_A = uuid4()  # the caller's "current" workspace
 WS_B = uuid4()  # a different workspace the caller does NOT own
@@ -280,3 +286,112 @@ class TestHandoffValidation:
     def test_non_uuid_workspace_id_is_422(self, session_client):
         resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": "not-a-uuid"})
         assert resp.status_code == 422
+
+
+# ============================================================================
+# Rate limiting (#1104)
+# ============================================================================
+
+
+class TestHandoffRateLimitHelper:
+    """Unit tests for the per-(owner, workspace) mint rate-limit helper."""
+
+    @pytest.mark.asyncio
+    async def test_under_limit_passes_and_pins_bucket_shape(self):
+        # Pin the Redis call shape: the bucket MUST be keyed per (user, workspace)
+        # with a self-expiring 60s window. A regression to a global/static key
+        # (shared-bucket DoS) or a dropped TTL (never-expiring lockout) must fail here.
+        ic = AsyncMock(return_value=3)
+        with patch.object(route_mod, "incrby_counter", ic):
+            await route_mod._check_handoff_rate_limit("u", WS_A, 10)  # no raise
+        ic.assert_awaited_once_with(f"billing_handoff:u:{WS_A}:minute", amount=1, ttl=60)
+
+    @pytest.mark.asyncio
+    async def test_bucket_keys_are_isolated_per_user_and_workspace(self):
+        # Distinct (user, workspace) tuples MUST map to distinct buckets, so one
+        # owner (or one workspace) cannot exhaust another's quota.
+        keys: list[str] = []
+        ic = AsyncMock(return_value=1)
+        ic.side_effect = lambda key, **_: keys.append(key) or 1
+        with patch.object(route_mod, "incrby_counter", ic):
+            await route_mod._check_handoff_rate_limit("alice", WS_A, 10)
+            await route_mod._check_handoff_rate_limit("bob", WS_A, 10)
+            await route_mod._check_handoff_rate_limit("alice", WS_B, 10)
+        assert len(set(keys)) == 3, keys
+
+    @pytest.mark.asyncio
+    async def test_at_limit_passes(self):
+        with patch.object(route_mod, "incrby_counter", AsyncMock(return_value=10)):
+            await route_mod._check_handoff_rate_limit("u", WS_A, 10)  # no raise
+
+    @pytest.mark.asyncio
+    async def test_over_limit_raises_429(self):
+        with patch.object(route_mod, "incrby_counter", AsyncMock(return_value=11)):
+            with pytest.raises(RateLimitError) as exc:
+                await route_mod._check_handoff_rate_limit("u", WS_A, 10)
+        assert exc.value.status_code == 429
+
+    @pytest.mark.asyncio
+    async def test_zero_limit_rejects(self):
+        # limit<=0 disables minting (fail-safe), mirroring the sibling buckets.
+        with pytest.raises(RateLimitError):
+            await route_mod._check_handoff_rate_limit("u", WS_A, 0)
+
+    @pytest.mark.asyncio
+    async def test_fail_open_on_redis_error(self):
+        # Redis down → log and allow (consistent with the public_search buckets);
+        # the owner gate + short-TTL token remain the primary controls. Use the
+        # production error type (incrby_counter wraps failures in RedisError) so a
+        # future narrowing of the catch that excludes RedisError is caught here.
+        with patch.object(
+            route_mod, "incrby_counter", AsyncMock(side_effect=RedisError("redis down"))
+        ):
+            await route_mod._check_handoff_rate_limit("u", WS_A, 10)  # no raise
+
+
+class TestHandoffRateLimitRoute:
+    def test_over_limit_returns_429(self, session_client):
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "BillingHandoffSigner") as signer_cls,
+            patch.object(route_mod, "incrby_counter", AsyncMock(return_value=9999)),
+        ):
+            signer_cls.return_value.mint.return_value = _fake_minted(WS_A)
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+        assert resp.status_code == 429, resp.text
+        # Mint must NOT have run once the rate limit tripped.
+        signer_cls.return_value.mint.assert_not_called()
+
+    def test_rate_limit_runs_after_owner_gate(self, session_client):
+        # A non-owner is 403'd by the owner gate BEFORE the rate-limit bucket is
+        # touched, so a non-owner cannot exhaust the owner's quota.
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(
+            side_effect=AuthorizationError(reason="role_too_low")
+        )
+        ic = AsyncMock(return_value=1)
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "incrby_counter", ic),
+        ):
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+        assert resp.status_code == 403
+        ic.assert_not_called()
+
+    def test_fail_open_lets_mint_proceed(self, session_client):
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "BillingHandoffSigner") as signer_cls,
+            patch.object(
+                route_mod, "incrby_counter", AsyncMock(side_effect=RedisError("redis down"))
+            ),
+        ):
+            signer_cls.return_value.mint.return_value = _fake_minted(WS_A)
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+        assert resp.status_code == 200, resp.text
+        # Fail-open means the request reaches mint — assert it actually ran.
+        signer_cls.return_value.mint.assert_called_once()


### PR DESCRIPTION
Closes #1104

## Summary
- Adds a per-(owner, workspace) Redis mint rate limit to `POST /api/v1/billing/handoff`, bounding abuse on the owner-only credential endpoint (complements the `billing_handoff_minted` audit log).
- Applied **after** the owner gate (a non-owner is 403'd without consuming the owner's bucket) and **before** mint; **429** on exceed.
- **Fail-open** on a Redis outage — the owner gate + session-only + short-TTL token + audit remain the primary controls, so a handoff must not become unavailable because the rate-limit store is down (consistent with the `public_search` buckets). `limit<=0` disables minting (fail-safe).

## Implementation notes
- `_check_handoff_rate_limit(user_id, workspace_id, limit_per_minute)` reuses the `incrby_counter(key, amount=1, ttl=60)` idiom from `public_search.check_bound_key_rate_limit` (race-safe TTL). Key: `billing_handoff:{user_id}:{workspace_id}:minute`.
- Limit from `settings.billing_handoff_rate_limit_per_minute` (default 10).

## Pre-PR review
- gate1: green via /claude-c-suite:ask (CSO lens — per-(user,workspace) key, after-gate placement, fail-open acceptable for defense-in-depth, flat config constant).
- code-review max: 15-agent find→verify→sweep on the diff; 10 candidates → 6 findings (0 production correctness bugs). Fixed: pin the `incrby_counter` call-shape + key-isolation test (HIGH — would have let a shared-bucket DoS / never-expiring-bucket regression ship green), drop a dead `# noqa: BLE001`, use the production `RedisError` type in the fail-open tests + assert mint runs on fail-open.
- gate2: consolidated (security/quality/architecture lenses covered by the dedicated code-review-max finders above; all findings fixed). CI is the final gate.

🤖 Generated via /gh-issue-driven:ship
