### PR TITLE
refactor(workspace): unify owner-mutating paths under one row lock (#1102)

### DIFF
--- a/backend/src/services/account_erasure_service.py
+++ b/backend/src/services/account_erasure_service.py
@@ -73,6 +73,7 @@ from models.erasure import (
 from services.email_service import EmailService, get_email_service
 from services.stripe_service import cancel_subscription_and_delete_customer_for_erasure
 from services.system_admin_service import SystemAdminService
+from services.workspace_locks import lock_workspace_for_update
 from utils.datetime import to_utc_iso, utcnow
 from utils.exceptions import (
     EmailDispatchError,
@@ -927,8 +928,30 @@ class AccountErasureService:
                 )
 
             new_owner = other_admins[0]
-            ws.owner_user_id = new_owner.user_id
+            # #1102: take the SHARED workspace-row lock so this owner-mutation
+            # serializes with transfer_ownership / update_member_role on the same
+            # FOR UPDATE row — the workspaces were loaded by an UNLOCKED SELECT
+            # (_list_owned_workspaces), so without this the epoch read-modify-write
+            # below could race a concurrent transfer and lose an increment.
+            try:
+                locked_ws = await lock_workspace_for_update(self.db, ws.id)
+            except NotFoundException:
+                # The workspace was soft-deleted concurrently (it will be cascade-
+                # cleaned anyway) — nothing to auto-transfer. A benign race must NOT
+                # fail the whole GDPR erasure request.
+                continue
+            # Re-read under the lock — the helper uses populate_existing, so this
+            # reflects committed concurrent changes even though the row was already
+            # in the session. If a concurrent transfer already moved ownership away
+            # from the erased user, this is no longer ours to auto-transfer.
+            if locked_ws.owner_user_id != user_id:
+                continue
+            locked_ws.owner_user_id = new_owner.user_id
             new_owner.role = "owner"
+            # Bump the ownership epoch on every owner change (#1102) so the #1100
+            # consumer invalidates external credentials (billing-handoff tokens /
+            # sessions) bound to the erased previous owner.
+            locked_ws.ownership_epoch = locked_ws.ownership_epoch + 1
             transfers.append({"workspace_id": str(ws.id), "new_owner_user_id": new_owner.user_id})
 
         # Commit so the cascade on workspace delete (step 4) sees the new

--- a/backend/src/services/workspace_locks.py
+++ b/backend/src/services/workspace_locks.py
@@ -1,0 +1,63 @@
+"""Shared workspace-row lock — the single synchronization point for every
+owner-mutating path (#1102).
+
+Workspace ownership is reassigned from three places: ``WorkspaceOwnershipService.
+transfer_ownership`` (voluntary), ``WorkspaceService.update_member_role`` (role
+promotion/demotion that touches OWNER), and ``account_erasure_service`` (owner
+erasure auto-transfer). All three acquire THIS ``SELECT ... FOR UPDATE`` on the
+workspace row before mutating ownership, so concurrent owner-mutations on the
+same workspace **serialize** (row-level mutual exclusion) instead of racing —
+e.g. two paths can no longer read the same ``ownership_epoch`` and both write
+``epoch + 1``, losing an increment. (The lock serializes the *paths*; it does not
+itself reconcile the ``owner_user_id`` pointer with ``WorkspaceMember.role`` —
+see ``workspace_ownership_service`` for that representation contract.)
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from models.auth import Workspace
+from utils.exceptions import NotFoundException
+
+
+async def lock_workspace_for_update(db: AsyncSession, workspace_id: UUID) -> Workspace:
+    """``SELECT ... FOR UPDATE`` the live (non-soft-deleted) workspace row.
+
+    The lock is the single-owner synchronization point: every path that reassigns
+    OWNER must hold it, so two owner-mutations on the same workspace serialize
+    instead of racing. The row lock is held until the surrounding transaction
+    commits or rolls back (it cannot be released early — callers must keep the
+    mutation in the same transaction).
+
+    Args:
+        db: The request-scoped async session.
+        workspace_id: The workspace to lock.
+
+    Returns:
+        The locked :class:`Workspace` row.
+
+    Raises:
+        NotFoundException: the workspace is missing or soft-deleted (404).
+    """
+    workspace = (
+        await db.execute(
+            select(Workspace)
+            .where(Workspace.id == workspace_id, Workspace.deleted_at.is_(None))
+            .with_for_update()
+            # populate_existing is load-bearing: if the row is ALREADY in this
+            # session's identity map (e.g. account_erasure loaded it with an
+            # unlocked SELECT), a plain re-SELECT returns the cached instance with
+            # its STALE attributes — the FOR UPDATE takes the DB lock but discards
+            # the freshly-read values. populate_existing forces the under-lock row
+            # to overwrite the cached attributes, so callers see committed concurrent
+            # changes (owner_user_id / ownership_epoch) and read-modify-write is safe.
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one_or_none()
+    if workspace is None:
+        raise NotFoundException("Workspace")
+    return workspace

--- a/backend/src/services/workspace_ownership_service.py
+++ b/backend/src/services/workspace_ownership_service.py
@@ -7,24 +7,31 @@ every owner-gated billing/admin action.
 
 Single-owner invariant
 -----------------------
-A live workspace has exactly **one** OWNER. This is the voluntary transfer path;
-it takes a ``SELECT ... FOR UPDATE`` lock on the workspace row as the
-synchronization point and re-checks the caller is still owner *under* the lock.
-The other OWNER-assigning paths and how the invariant holds against them:
+A live workspace has exactly **one** OWNER. Since #1102 every owner-mutating path
+serializes on the **same** ``SELECT ... FOR UPDATE`` workspace-row lock — the
+shared ``services.workspace_locks.lock_workspace_for_update`` — so the invariant
+is *structural* (row-level serialization) rather than *emergent* (each path's
+local guards happening to line up). This voluntary transfer path takes the lock,
+then re-checks the caller is still owner *under* the lock. The other paths:
 
 * workspace *creation* (``workspace_service`` / ``context_service`` personal
   workspace) — a brand-new workspace, never a live concurrent-transfer target.
-* ``WorkspaceService.update_member_role`` — has its own single-owner guard: it
-  refuses to promote a member to OWNER while any OWNER row exists. Combined with
-  this service's *atomic* demote+promote (no committed zero-owner window), it
-  cannot produce two owners on a workspace that already has one.
-* the account-erasure auto-transfer (``account_erasure_service``) — does **not**
-  take this lock. Unifying every owner-mutating path under one workspace row lock
-  is a tracked follow-up; this service's under-lock owner re-check (→ 409)
-  defends the common direction.
+* ``WorkspaceService.update_member_role`` — takes the shared lock whenever the
+  role change adds OR removes an OWNER (#1102), in addition to its own
+  single-owner guard. NOTE: it adjusts ``WorkspaceMember.role`` only, never
+  ``owner_user_id`` (that canonical pointer is moved solely by this service and
+  by erasure). Demoting the ``owner_user_id`` holder via this path therefore
+  leaves the two representations out of sync — a pre-existing gap the lock does
+  NOT close; tracked separately, not in #1102's scope.
+* the account-erasure auto-transfer (``account_erasure_service``) — takes the
+  shared ``lock_workspace_for_update`` per workspace before its auto-transfer
+  (#1102; it loads workspaces with an unlocked SELECT, so the lock is acquired at
+  mutation time, then re-checks the erased user still owns the row) and bumps
+  ``ownership_epoch`` so the epoch contract below holds for every ``owner_user_id``
+  change.
 
-Do not add a new OWNER-assigning path on an existing workspace without either
-this row lock or an equivalent single-owner guard.
+Do not move ``owner_user_id`` on an existing workspace without taking
+``lock_workspace_for_update`` and bumping ``ownership_epoch``.
 
 Ownership epoch
 ---------------
@@ -43,8 +50,9 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.workspace_roles import WorkspaceRole
-from models.auth import AuditLog, Workspace, WorkspaceMember
-from utils.exceptions import BadRequestError, ConflictError, NotFoundException
+from models.auth import AuditLog, WorkspaceMember
+from services.workspace_locks import lock_workspace_for_update
+from utils.exceptions import BadRequestError, ConflictError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -113,16 +121,10 @@ class WorkspaceOwnershipService:
             ConflictError: ownership changed concurrently (409).
             BadRequestError: target is not a member of this workspace (400).
         """
-        # 1. Lock the workspace row first — the single-owner synchronization point.
-        workspace = (
-            await self.db.execute(
-                select(Workspace)
-                .where(Workspace.id == workspace_id, Workspace.deleted_at.is_(None))
-                .with_for_update()
-            )
-        ).scalar_one_or_none()
-        if workspace is None:
-            raise NotFoundException("Workspace")
+        # 1. Lock the workspace row first — the single-owner synchronization point,
+        # shared with update_member_role + account_erasure via lock_workspace_for_update
+        # (#1102) so every owner-mutating path serializes on the same row.
+        workspace = await lock_workspace_for_update(self.db, workspace_id)
 
         # 2. TOCTOU close: the route's owner check ran before this lock. If the
         # owner changed in between, refuse rather than transfer on a stale premise.

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, ExternalAPIKey, UsageStats, Workspace, WorkspaceMember
 from models.memory import Memory
+from services.workspace_locks import lock_workspace_for_update
 from utils.datetime import utcnow
 from utils.exceptions import NotFoundException, ValidationError
 from utils.logger import get_logger
@@ -659,6 +660,14 @@ class WorkspaceService:
             # get_member raises by default; narrow for pyright + any future
             # call site that passes raise_if_not_found=False.
             raise NotFoundException(f"Member not found: {user_id} in workspace {workspace_id}")
+
+        # #1102: a role change that ADDS or REMOVES an OWNER must serialize on the
+        # workspace row with the other owner-mutating paths (transfer_ownership,
+        # account_erasure) so the single-owner invariant is structural rather than
+        # emergent. Plain member<->viewer changes never touch ownership and skip
+        # the lock to keep the common path contention-free.
+        if WorkspaceRole.OWNER in (new_role, member.role):
+            await lock_workspace_for_update(self.db, workspace_id)
 
         # Validate single owner constraint (Issue #165)
         if new_role == WorkspaceRole.OWNER and member.role != WorkspaceRole.OWNER:

--- a/backend/tests/integration/test_account_erasure_integration.py
+++ b/backend/tests/integration/test_account_erasure_integration.py
@@ -227,6 +227,10 @@ class TestAdminForceEraseHappyPath:
         ws = result.scalar_one_or_none()
         assert ws is not None
         assert ws.owner_user_id == erasure_scenario["other_user_id"]
+        # #1102: the auto-transfer bumped ownership_epoch and it persisted through
+        # the full DB orchestration — this is the #1100 signal that invalidates the
+        # erased owner's billing-handoff tokens/sessions.
+        assert ws.ownership_epoch >= 1
 
         # Pre-existing audit_logs row survives but PII is pseudonymized.
         result = await db_session.execute(select(AuditLog).where(AuditLog.id == prior_audit_id))

--- a/backend/tests/services/test_account_erasure_service.py
+++ b/backend/tests/services/test_account_erasure_service.py
@@ -777,7 +777,7 @@ class TestHandleOwnedWorkspaces:
     async def test_other_admin_triggers_auto_transfer(self):
         svc = _service()
         ws_id = uuid4()
-        ws = SimpleNamespace(id=ws_id, owner_user_id="u-1")
+        ws = SimpleNamespace(id=ws_id, owner_user_id="u-1", ownership_epoch=5)
         new_admin = SimpleNamespace(workspace_id=ws_id, user_id="u-2", role=WorkspaceRole.ADMIN)
         rows = [
             SimpleNamespace(workspace_id=ws_id, user_id="u-1", role=WorkspaceRole.OWNER),
@@ -786,10 +786,72 @@ class TestHandleOwnedWorkspaces:
         svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
         svc.db.commit = AsyncMock()
 
-        out = await svc._handle_owned_workspaces("u-1", [ws])
+        # #1102: the auto-transfer takes the SHARED workspace-row lock (returning
+        # the same locked row) so it serializes with transfer_ownership.
+        with patch(
+            "services.account_erasure_service.lock_workspace_for_update",
+            AsyncMock(return_value=ws),
+        ) as lock:
+            out = await svc._handle_owned_workspaces("u-1", [ws])
+        lock.assert_awaited_once()
         assert ws.owner_user_id == "u-2"
         assert new_admin.role == "owner"
         assert len(out["transferred"]) == 1
+        # #1102: the erasure auto-transfer bumps ownership_epoch so the #1100
+        # consumer invalidates credentials bound to the erased previous owner.
+        assert ws.ownership_epoch == 6
+
+    @pytest.mark.asyncio
+    async def test_auto_transfer_skips_when_ownership_moved_under_lock(self):
+        # #1102: if a concurrent transfer moved ownership away from the erased user
+        # before we acquired the lock, the locked row no longer names them as owner
+        # → skip the auto-transfer rather than clobber the new owner.
+        svc = _service()
+        ws_id = uuid4()
+        ws = SimpleNamespace(id=ws_id, owner_user_id="u-1", ownership_epoch=5)
+        # The row as re-read UNDER the lock: ownership already moved to someone else.
+        locked = SimpleNamespace(id=ws_id, owner_user_id="someone-else", ownership_epoch=9)
+        rows = [
+            SimpleNamespace(workspace_id=ws_id, user_id="u-1", role=WorkspaceRole.OWNER),
+            SimpleNamespace(workspace_id=ws_id, user_id="u-2", role=WorkspaceRole.ADMIN),
+        ]
+        svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
+        svc.db.commit = AsyncMock()
+
+        with patch(
+            "services.account_erasure_service.lock_workspace_for_update",
+            AsyncMock(return_value=locked),
+        ):
+            out = await svc._handle_owned_workspaces("u-1", [ws])
+
+        assert out["transferred"] == []
+        assert locked.owner_user_id == "someone-else"  # untouched
+        assert locked.ownership_epoch == 9  # not bumped
+
+    @pytest.mark.asyncio
+    async def test_soft_deleted_workspace_skipped_not_failed(self):
+        # #1102: if a workspace was soft-deleted concurrently, the shared lock
+        # raises NotFoundException — that benign race must be skipped, NOT allowed
+        # to fail the whole GDPR erasure request.
+        from utils.exceptions import NotFoundException
+
+        svc = _service()
+        ws_id = uuid4()
+        ws = SimpleNamespace(id=ws_id, owner_user_id="u-1", ownership_epoch=5)
+        rows = [
+            SimpleNamespace(workspace_id=ws_id, user_id="u-1", role=WorkspaceRole.OWNER),
+            SimpleNamespace(workspace_id=ws_id, user_id="u-2", role=WorkspaceRole.ADMIN),
+        ]
+        svc.db.execute = AsyncMock(return_value=self._bulk_members_result(rows))
+        svc.db.commit = AsyncMock()
+
+        with patch(
+            "services.account_erasure_service.lock_workspace_for_update",
+            AsyncMock(side_effect=NotFoundException("Workspace")),
+        ):
+            out = await svc._handle_owned_workspaces("u-1", [ws])
+
+        assert out["transferred"] == []  # skipped, no exception bubbled
 
     @pytest.mark.asyncio
     async def test_members_without_admin_blocks_with_typed_error(self):

--- a/backend/tests/services/test_workspace_service.py
+++ b/backend/tests/services/test_workspace_service.py
@@ -14,7 +14,9 @@ import pytest
 from auth.workspace_roles import WorkspaceRole
 from models.auth import Context, User, Workspace, WorkspaceMember
 from models.memory import Memory
+from services.workspace_locks import lock_workspace_for_update
 from services.workspace_service import WorkspaceService
+from utils.datetime import utcnow
 from utils.exceptions import NotFoundException, ValidationError
 
 # ---------------------------------------------------------------------------
@@ -292,6 +294,97 @@ class TestUpdateMemberRole:
 
         updated = await service.update_member_role(ws.id, "u18", "admin")
         assert updated.role == "admin"
+
+    @pytest.mark.asyncio
+    async def test_owner_change_takes_workspace_lock(self, db_session) -> None:
+        # #1102: demoting an OWNER must serialize on the workspace row lock.
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="WLk1", owner_user_id="o1", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="o1", role=WorkspaceRole.OWNER))
+        await db_session.flush()
+
+        with patch("services.workspace_service.lock_workspace_for_update", AsyncMock()) as lock:
+            await service.update_member_role(ws.id, "o1", "admin")
+        lock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_owner_change_skips_workspace_lock(self, db_session) -> None:
+        # A plain member<->viewer/admin change never touches ownership → no lock,
+        # keeping the common path contention-free.
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="WLk2", owner_user_id="o2", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="o2", role=WorkspaceRole.OWNER))
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="m2", role=WorkspaceRole.MEMBER))
+        await db_session.flush()
+
+        with patch("services.workspace_service.lock_workspace_for_update", AsyncMock()) as lock:
+            await service.update_member_role(ws.id, "m2", "admin")
+        lock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# lock_workspace_for_update (#1102 shared owner-mutation lock)
+# ---------------------------------------------------------------------------
+
+
+class TestLockWorkspaceForUpdate:
+    @pytest.mark.asyncio
+    async def test_returns_live_workspace(self, db_session) -> None:
+        ws = Workspace(id=uuid4(), name="WLock", owner_user_id="o", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        locked = await lock_workspace_for_update(db_session, ws.id)
+        assert locked.id == ws.id
+
+    @pytest.mark.asyncio
+    async def test_missing_workspace_raises_notfound(self, db_session) -> None:
+        with pytest.raises(NotFoundException):
+            await lock_workspace_for_update(db_session, uuid4())
+
+    @pytest.mark.asyncio
+    async def test_soft_deleted_workspace_raises_notfound(self, db_session) -> None:
+        ws = Workspace(
+            id=uuid4(), name="WLockX", owner_user_id="o", plan_name="free", deleted_at=utcnow()
+        )
+        db_session.add(ws)
+        await db_session.flush()
+
+        with pytest.raises(NotFoundException):
+            await lock_workspace_for_update(db_session, ws.id)
+
+    @pytest.mark.asyncio
+    async def test_populate_existing_refreshes_already_loaded_row(self, db_session) -> None:
+        # Keystone of the #1102 erasure fix: when the row is ALREADY in the session
+        # (e.g. loaded by account_erasure's unlocked SELECT), the locked re-SELECT
+        # MUST refresh its attributes (populate_existing), not return stale cached
+        # values — otherwise the under-lock owner re-check and the epoch
+        # read-modify-write operate on a stale base.
+        from sqlalchemy import update as sa_update
+
+        ws = Workspace(id=uuid4(), name="WLockR", owner_user_id="orig", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+
+        # Mutate the DB row out-of-band (stands in for a committed concurrent
+        # transfer) WITHOUT touching the cached ORM instance — synchronize_session
+        # =False keeps the in-session instance stale, exactly the identity-map
+        # situation account_erasure hits.
+        await db_session.execute(
+            sa_update(Workspace)
+            .where(Workspace.id == ws.id)
+            .values(owner_user_id="moved")
+            .execution_options(synchronize_session=False)
+        )
+        assert ws.owner_user_id == "orig"  # cached instance still stale
+
+        locked = await lock_workspace_for_update(db_session, ws.id)
+        assert locked is ws  # same identity-mapped instance
+        assert locked.owner_user_id == "moved"  # ...but refreshed from the locked row
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1102

## Summary
- The paths that move workspace ownership now all acquire the **same** `SELECT ... FOR UPDATE` workspace-row lock — `services.workspace_locks.lock_workspace_for_update` — so concurrent owner-mutations serialize on the row instead of racing, and the `ownership_epoch` read-modify-write can no longer lose an increment.
- **Closes the #1100 gap on the erasure path**: the account-erasure auto-transfer now bumps `ownership_epoch`, so an erasure-driven owner change invalidates the erased owner's billing-handoff tokens/sessions.

## Implementation notes
- New `lock_workspace_for_update(db, workspace_id)` with **`populate_existing=True`** — load-bearing: if the row is already in the session (account-erasure loads it with an unlocked SELECT), a plain re-SELECT returns the cached *stale* instance (the `FOR UPDATE` takes the DB lock but discards fresh values); `populate_existing` forces the under-lock attributes to refresh so the owner re-check + epoch bump read a fresh base.
- `transfer_ownership` → uses the helper (pure refactor, no behavior change).
- `update_member_role` → takes the lock when a role change **adds or removes an OWNER** (member↔viewer/admin changes skip it; common path stays contention-free). It serializes the *workspace-row* aspect of owner add/remove.
- `account_erasure` auto-transfer → locks per workspace at mutation time, re-checks the erased user still owns the row (genuine refresh via `populate_existing`), **skips a concurrently soft-deleted workspace** (`NotFoundException`) rather than failing the GDPR erasure, and bumps `ownership_epoch`.

## Scope / follow-up
This unifies the **workspace-row** lock + the epoch contract. The deeper **member-row consistency** of the dual owner representation (`workspace.owner_user_id` vs `WorkspaceMember.role==OWNER`) — e.g. `update_member_role` demoting the owner without updating `owner_user_id`, or an `admin→member` change racing a transfer — is a larger change tracked in **#1108** (surfaced by this PR's code-review).

## Review
- gate1: yellow via /claude-c-suite:ask (CTO — the key insight: it's lock-unification **plus** epoch-unification to close the #1100 gap).
- **code-review max ×2** (find→verify→sweep, ~30 agents each). Round 1 caught the erasure path not actually holding the workspace lock (the `skip_locked` is on `ErasureRequest`, not `Workspace`). Round 2 caught that my first fix's under-lock re-read returned the stale identity-mapped instance (no `populate_existing`) and a soft-delete `NotFoundException` regression. Both fixed + tested; the member-row-consistency findings are deferred to #1108.
- gate2: consolidated (CTO/CSO/QA lenses covered by the two code-review-max rounds above). CI is the final gate.

🤖 Generated via /gh-issue-driven:ship
