### PR TITLE
feat(workspace): notify the new owner on ownership transfer (#1103)

### DIFF
--- a/backend/src/api/routes/workspaces.py
+++ b/backend/src/api/routes/workspaces.py
@@ -18,8 +18,9 @@ from auth.dependencies import SessionUser, get_current_user
 from auth.workspace_roles import WorkspaceRole
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
-from models.auth import Context, ExternalAPIKey, User
+from models.auth import Context, ExternalAPIKey, User, Workspace
 from models.schemas import OpenAIKeyStatusResponse
+from services.email_service import get_email_service
 from services.permission_service import PermissionService
 from services.workspace_ownership_service import WorkspaceOwnershipService
 from services.workspace_service import WorkspaceService
@@ -1211,6 +1212,12 @@ async def transfer_workspace_ownership(
         performed_by_email=str(user.get("email") or user_id),
     )
 
+    # Courtesy-notify the new owner (#1103) — only on an actual change (skip the
+    # idempotent no-op), best-effort: the transfer already committed, so a
+    # notification failure must never surface to the caller.
+    if result.changed:
+        await _notify_new_owner_best_effort(db, workspace_id, result.new_owner_id)
+
     return TransferOwnershipResponse(
         workspace_id=str(result.workspace_id),
         previous_owner_id=result.previous_owner_id,
@@ -1218,3 +1225,38 @@ async def transfer_workspace_ownership(
         ownership_epoch=result.ownership_epoch,
         changed=result.changed,
     )
+
+
+async def _notify_new_owner_best_effort(
+    db: AsyncSession, workspace_id: UUID, new_owner_id: str
+) -> None:
+    """Email the new owner that the workspace was transferred to them (#1103).
+
+    Best-effort: the transfer is already committed, so the WHOLE block is guarded
+    — neither the email resolution queries nor the (no-raise) EmailService call
+    may surface to the caller. A new owner without an email is simply skipped.
+    """
+    try:
+        email = (
+            await db.execute(select(User.email).where(User.user_id == new_owner_id))
+        ).scalar_one_or_none()
+        if not email:
+            return
+        name = (
+            await db.execute(select(Workspace.name).where(Workspace.id == workspace_id))
+        ).scalar_one_or_none()
+        await get_email_service().send_workspace_ownership_transferred(
+            to_email=email,
+            workspace_name=name or "your workspace",
+        )
+    except Exception as exc:
+        # Notification is best-effort — swallow everything (resolution query or
+        # provider error) so it never affects the committed transfer. Log the
+        # exception TYPE only, not str(exc): a SQLAlchemy error string echoes the
+        # bound parameters (here the client-supplied new_owner_id), so we keep the
+        # same no-request-field-echo discipline as the Resend provider layer.
+        logger.warning(
+            "ownership_transfer_notify_failed",
+            workspace_id=str(workspace_id),
+            error_type=type(exc).__name__,
+        )

--- a/backend/src/services/email_providers/resend.py
+++ b/backend/src/services/email_providers/resend.py
@@ -282,6 +282,35 @@ class ResendEmailService:
             },
         )
 
+    async def send_workspace_ownership_transferred(
+        self,
+        *,
+        to_email: str,
+        workspace_name: str,
+    ) -> bool:
+        text = (
+            f'You are now the owner of the "{workspace_name}" workspace on '
+            "Kagura Memory Cloud.\n"
+            "\n"
+            "Ownership was transferred to you by the previous owner. You now have "
+            "full control of the workspace, including billing and member "
+            "management.\n"
+            "\n"
+            "If you were not expecting this, contact the previous owner or your "
+            "Kagura administrator.\n"
+        )
+        return await self._send(
+            to_email=to_email,
+            subject=f"You're now the owner of the {workspace_name} workspace on Kagura",
+            text=text,
+            log_event="workspace_ownership_transferred_email",
+            log_context={
+                "to_email": to_email,
+                "workspace_name": workspace_name,
+                "template": "workspace_ownership_transferred",
+            },
+        )
+
     async def send_erasure_confirmation(
         self,
         *,

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -182,6 +182,28 @@ class EmailService(Protocol):
         """
         ...
 
+    async def send_workspace_ownership_transferred(
+        self,
+        *,
+        to_email: str,
+        workspace_name: str,
+    ) -> bool:
+        """Notify the new owner that a workspace was transferred to them (#1103).
+
+        A **courtesy** notification sent AFTER the transfer has committed (the
+        ownership row + audit row are the source of truth), so a delivery failure
+        MUST NOT roll anything back. Like every method here, implementations MUST
+        NOT raise — log and return False on failure.
+
+        Args:
+            to_email: The new owner's account email.
+            workspace_name: Workspace display name (for the body / subject).
+
+        Returns:
+            True on delivery (or logging fallback), False on hard failure.
+        """
+        ...
+
 
 class LoggingEmailService:
     """Default stub implementation: structured logs only, no SMTP.
@@ -295,6 +317,21 @@ class LoggingEmailService:
             threshold_pct=threshold_pct,
             email_dispatch_required=True,
             template="embedding_spend_alert",
+        )
+        return True
+
+    async def send_workspace_ownership_transferred(
+        self,
+        *,
+        to_email: str,
+        workspace_name: str,
+    ) -> bool:
+        logger.info(
+            "workspace_ownership_transferred_email",
+            to_email=to_email,
+            workspace_name=workspace_name,
+            email_dispatch_required=True,
+            template="workspace_ownership_transferred",
         )
         return True
 

--- a/backend/tests/api/test_workspace_transfer_ownership_route.py
+++ b/backend/tests/api/test_workspace_transfer_ownership_route.py
@@ -213,3 +213,119 @@ class TestTransferValidation:
                 json={"target_user_id": TARGET},
             )
         assert resp.status_code == 422
+
+
+# ============================================================================
+# New-owner notification (#1103)
+# ============================================================================
+
+
+class TestTransferNotification:
+    def test_notifies_new_owner_on_change(self, owner_client):
+        perm = _owner_ok()
+        svc = MagicMock()
+        svc.transfer_ownership = AsyncMock(return_value=_result(changed=True, epoch=1))
+        notify = AsyncMock()
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "WorkspaceOwnershipService", return_value=svc),
+            patch.object(route_mod, "_notify_new_owner_best_effort", notify),
+        ):
+            resp = owner_client.post(
+                f"/api/v1/workspaces/{WS}/transfer-ownership",
+                json={"target_user_id": TARGET},
+            )
+        assert resp.status_code == 200, resp.text
+        notify.assert_awaited_once()
+        # called as (db, workspace_id, new_owner_id)
+        assert notify.await_args.args[1] == WS
+        assert notify.await_args.args[2] == TARGET
+
+    def test_no_notification_on_idempotent_noop(self, owner_client):
+        perm = _owner_ok()
+        svc = MagicMock()
+        svc.transfer_ownership = AsyncMock(return_value=_result(changed=False, epoch=3))
+        notify = AsyncMock()
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "WorkspaceOwnershipService", return_value=svc),
+            patch.object(route_mod, "_notify_new_owner_best_effort", notify),
+        ):
+            resp = owner_client.post(
+                f"/api/v1/workspaces/{WS}/transfer-ownership",
+                json={"target_user_id": TARGET},
+            )
+        assert resp.status_code == 200, resp.text
+        notify.assert_not_awaited()
+
+
+class TestNotifyNewOwnerBestEffort:
+    @pytest.mark.asyncio
+    async def test_resolves_email_and_sends(self):
+        db = MagicMock()
+        email_res = MagicMock()
+        email_res.scalar_one_or_none.return_value = "new@owner.com"
+        name_res = MagicMock()
+        name_res.scalar_one_or_none.return_value = "My WS"
+        db.execute = AsyncMock(side_effect=[email_res, name_res])
+        svc = MagicMock()
+        svc.send_workspace_ownership_transferred = AsyncMock(return_value=True)
+        with patch.object(route_mod, "get_email_service", return_value=svc):
+            await route_mod._notify_new_owner_best_effort(db, WS, TARGET)
+        svc.send_workspace_ownership_transferred.assert_awaited_once_with(
+            to_email="new@owner.com", workspace_name="My WS"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_when_new_owner_has_no_email(self):
+        db = MagicMock()
+        email_res = MagicMock()
+        email_res.scalar_one_or_none.return_value = None
+        db.execute = AsyncMock(return_value=email_res)
+        svc = MagicMock()
+        svc.send_workspace_ownership_transferred = AsyncMock()
+        with patch.object(route_mod, "get_email_service", return_value=svc):
+            await route_mod._notify_new_owner_best_effort(db, WS, TARGET)
+        svc.send_workspace_ownership_transferred.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swallows_resolution_error(self):
+        # A failing resolution query must NOT propagate (transfer already committed).
+        db = MagicMock()
+        db.execute = AsyncMock(side_effect=RuntimeError("db down"))
+        with patch.object(route_mod, "get_email_service") as ges:
+            await route_mod._notify_new_owner_best_effort(db, WS, TARGET)  # no raise
+        ges.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_swallows_provider_error(self):
+        # If the provider violates its no-raise contract, the helper must still
+        # swallow it — the transfer already committed.
+        db = MagicMock()
+        email_res = MagicMock()
+        email_res.scalar_one_or_none.return_value = "new@owner.com"
+        name_res = MagicMock()
+        name_res.scalar_one_or_none.return_value = "My WS"
+        db.execute = AsyncMock(side_effect=[email_res, name_res])
+        svc = MagicMock()
+        svc.send_workspace_ownership_transferred = AsyncMock(
+            side_effect=RuntimeError("provider down")
+        )
+        with patch.object(route_mod, "get_email_service", return_value=svc):
+            await route_mod._notify_new_owner_best_effort(db, WS, TARGET)  # no raise
+
+    @pytest.mark.asyncio
+    async def test_uses_fallback_when_workspace_name_missing(self):
+        db = MagicMock()
+        email_res = MagicMock()
+        email_res.scalar_one_or_none.return_value = "new@owner.com"
+        name_res = MagicMock()
+        name_res.scalar_one_or_none.return_value = None
+        db.execute = AsyncMock(side_effect=[email_res, name_res])
+        svc = MagicMock()
+        svc.send_workspace_ownership_transferred = AsyncMock(return_value=True)
+        with patch.object(route_mod, "get_email_service", return_value=svc):
+            await route_mod._notify_new_owner_best_effort(db, WS, TARGET)
+        svc.send_workspace_ownership_transferred.assert_awaited_once_with(
+            to_email="new@owner.com", workspace_name="your workspace"
+        )

--- a/backend/tests/services/email_providers/test_resend.py
+++ b/backend/tests/services/email_providers/test_resend.py
@@ -498,3 +498,38 @@ async def test_send_workspace_invitation_failure_does_not_leak_token_in_logs():
     haystack = " ".join(haystack_parts)
     assert token not in haystack, "invitation token leaked into failure log"
     assert accept_url not in haystack, "accept_url leaked into failure log"
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_ownership_transferred_calls_sdk_with_expected_payload():
+    # #1103: the prod (Resend) path builds a real subject/body and sends to the
+    # new owner. Mirrors the sibling coverage (payload shape + return True).
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+
+    with patch.object(
+        resend_module.resend.Emails, "send", return_value={"id": "re_own_001"}
+    ) as mock_send:
+        result = await svc.send_workspace_ownership_transferred(
+            to_email="new@owner.com",
+            workspace_name="Acme Research",
+        )
+
+    assert result is True
+    mock_send.assert_called_once()
+    params = mock_send.call_args.args[0]
+    assert params["from"] == "noreply@example.com"
+    assert params["to"] == ["new@owner.com"]
+    assert "Acme Research" in params["subject"]
+    assert "Acme Research" in params["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_ownership_transferred_returns_false_when_sdk_raises():
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+    with patch.object(
+        resend_module.resend.Emails, "send", side_effect=RuntimeError("resend down")
+    ):
+        result = await svc.send_workspace_ownership_transferred(
+            to_email="new@owner.com", workspace_name="Acme"
+        )
+    assert result is False

--- a/backend/tests/services/email_providers/test_resend.py
+++ b/backend/tests/services/email_providers/test_resend.py
@@ -526,9 +526,7 @@ async def test_send_workspace_ownership_transferred_calls_sdk_with_expected_payl
 @pytest.mark.asyncio
 async def test_send_workspace_ownership_transferred_returns_false_when_sdk_raises():
     svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
-    with patch.object(
-        resend_module.resend.Emails, "send", side_effect=RuntimeError("resend down")
-    ):
+    with patch.object(resend_module.resend.Emails, "send", side_effect=RuntimeError("resend down")):
         result = await svc.send_workspace_ownership_transferred(
             to_email="new@owner.com", workspace_name="Acme"
         )

--- a/backend/tests/services/test_email_service.py
+++ b/backend/tests/services/test_email_service.py
@@ -184,6 +184,30 @@ async def test_logging_send_workspace_invitation_logs_safe_fields_only():
     assert "Alice Admin" not in haystack, "inviter name leaked into log payload"
 
 
+@pytest.mark.asyncio
+async def test_logging_send_workspace_ownership_transferred():
+    """#1103: the logging stub records the new owner's address + workspace for
+    ops triage and returns True (the no-raise courtesy-notification contract)."""
+    svc = LoggingEmailService()
+
+    with patch.object(email_service_module, "logger") as mock_logger:
+        result = await svc.send_workspace_ownership_transferred(
+            to_email="new@owner.com",
+            workspace_name="Acme Research",
+        )
+
+    assert result is True
+    mock_logger.info.assert_called_once()
+    args, kwargs = mock_logger.info.call_args
+    assert args[0] == "workspace_ownership_transferred_email"
+    assert kwargs == {
+        "to_email": "new@owner.com",
+        "workspace_name": "Acme Research",
+        "email_dispatch_required": True,
+        "template": "workspace_ownership_transferred",
+    }
+
+
 # ---------------------------------------------------------------------------
 # Singleton + provider switch
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #1103

## Summary
- After a voluntary ownership transfer commits, courtesy-email the **new owner** (best-effort, only on `result.changed` — the idempotent no-op sends nothing).
- Adds `EmailService.send_workspace_ownership_transferred(*, to_email, workspace_name)` to the Protocol + the `LoggingEmailService` stub + the Resend provider (all **no-raise**).
- A guarded `_notify_new_owner_best_effort` in the transfer route resolves the new owner's email + workspace name and dispatches, wrapped so **neither the resolution queries nor the provider can affect the already-committed transfer**. A new owner without an email is skipped.

## Notes
- The transactional core (`WorkspaceOwnershipService`) stays pure — the dispatch lives in the route (orchestration layer). Best-effort matches the existing invitation-email pattern; a durable outbox is the separate #1080 design, not needed here.
- The fallback log records the exception **type** only — a SQLAlchemy error string echoes the bound `new_owner_id`, so this keeps the Resend layer's no-request-field-echo discipline.
- Previous-owner notification is out of scope (voluntary transfer = the previous owner initiated it); relevant for the involuntary paths (break-glass #1101 / erasure) as a follow-up.

## Review
- gate1: green via /claude-c-suite:ask (CTO — route dispatch, only-on-changed, best-effort/no-raise, notify-new-owner-only).
- code-review max: 13-agent find→verify→sweep. Caught: no Resend-provider test (HIGH), missing provider-raise swallow test + name-fallback test, and `str(exc)` echoing the bound `new_owner_id`. All fixed.
- gate2: consolidated (covered by code-review max). CI is the final gate.

🤖 Generated via /gh-issue-driven:ship
