### PR TITLE
feat(plans): entitlement_source provenance to protect admin/comp grants (#1095)

### DIFF
--- a/backend/alembic/versions/e46_1095_entitlement_source.py
+++ b/backend/alembic/versions/e46_1095_entitlement_source.py
@@ -1,0 +1,54 @@
+"""Add workspaces.entitlement_source (#1095).
+
+Issue #1095: a periodic reconciliation against the external billing source must
+not revert legitimate admin/comp grants. ``entitlement_source`` records WHO last
+set the entitlement so the external reconciler (kagura-billing#5) reverts only
+what it owns:
+
+- ``external_billing`` — billing-owned (set via the internal endpoint); reconcilable.
+- ``admin_grant`` — locally-owned (admin/comp grant or owner self-service); the
+  reconciler MUST NOT revert it.
+
+NOT NULL with an ``admin_grant`` server_default so every existing row backfills
+**protectively** (no data migration, no comp grant ever reverted on the first
+reconcile). An external-billing workspace self-heals to ``external_billing`` on
+its next push from the billing service.
+
+Revision ID: e46_1095_entitlement_src
+Revises: e45_1094_ownership_epoch
+
+Note: the revision id is kept <=32 chars for the ``alembic_version.version_num``
+VARCHAR(32) column — same convention as the sibling capped migrations.
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e46_1095_entitlement_src"
+down_revision = "e45_1094_ownership_epoch"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspaces",
+        sa.Column(
+            "entitlement_source",
+            sa.String(length=32),
+            nullable=False,
+            server_default="admin_grant",
+        ),
+    )
+    op.create_check_constraint(
+        "valid_entitlement_source",
+        "workspaces",
+        "entitlement_source IN ('external_billing', 'admin_grant')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("valid_entitlement_source", "workspaces", type_="check")
+    op.drop_column("workspaces", "entitlement_source")

--- a/backend/src/api/routes/admin_plans.py
+++ b/backend/src/api/routes/admin_plans.py
@@ -24,7 +24,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import require_admin as auth_require_admin
 from config.plan_tiers import PLAN_TIERS, PlanName, get_plan_tier
 from db.base import get_db
-from models.auth import Context, PlanChange, User, Workspace, WorkspaceInvitation, WorkspaceMember
+from models.auth import (
+    ENTITLEMENT_SOURCE_ADMIN_GRANT,
+    Context,
+    PlanChange,
+    User,
+    Workspace,
+    WorkspaceInvitation,
+    WorkspaceMember,
+)
 from models.memory import Memory
 from models.resource import WorkspaceAddon  # Issue #665: row-based admin grants
 from services.addon_calculator_service import ADDON_UNIT_VALUES, AddonCalculatorService
@@ -453,6 +461,9 @@ async def update_workspace_plan(
         workspace.plan_name = request.plan_name
         workspace.daily_api_limit = new_plan_tier.daily_api_limit
         workspace.weekly_api_limit = new_plan_tier.weekly_api_limit
+        # #1095: a manual system-admin set is a locally-owned grant — mark it so the
+        # external billing reconciler never reverts an admin/comp grant.
+        workspace.entitlement_source = ENTITLEMENT_SOURCE_ADMIN_GRANT
 
         # Create audit log entry
         audit_entry = PlanChange(

--- a/backend/src/api/routes/internal_billing.py
+++ b/backend/src/api/routes/internal_billing.py
@@ -51,7 +51,7 @@ from config.plan_tiers import PLAN_TIERS
 from config.settings import get_settings
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
-from models.auth import Workspace
+from models.auth import ENTITLEMENT_SOURCE_EXTERNAL_BILLING, Workspace
 from utils.exceptions import (
     AuthenticationError,
     MemoryCloudException,
@@ -138,6 +138,7 @@ class BillingPlanPushResult(TZAwareBaseModel):
     workspace_id: str
     plan_name: str
     addons: dict[str, int]
+    entitlement_source: str
     status: str | None = None
     current_period_end: datetime | None = None
     applied: bool = True
@@ -185,8 +186,11 @@ async def set_workspace_plan_from_billing(
     if workspace is None:
         raise NotFoundException("Workspace")
 
-    # Apply entitlement (absolute set → idempotent).
+    # Apply entitlement (absolute set → idempotent). Mark provenance as
+    # billing-owned (#1095) so the external reconciler may reconcile this row;
+    # a prior admin/comp grant is overwritten here by an explicit billing push.
     workspace.plan_name = body.plan_name
+    workspace.entitlement_source = ENTITLEMENT_SOURCE_EXTERNAL_BILLING
     if body.addons:
         for key, value in body.addons.items():
             setattr(workspace, _ADDON_COLUMNS[key], value)
@@ -199,11 +203,62 @@ async def set_workspace_plan_from_billing(
         plan_name=body.plan_name,
         billing_status=body.status,
         addons=body.addons,
+        entitlement_source=workspace.entitlement_source,
     )
     return BillingPlanPushResult(
         workspace_id=workspace_id,
         plan_name=workspace.plan_name,
         addons=current_addons,
+        entitlement_source=workspace.entitlement_source,
         status=body.status,
         current_period_end=body.current_period_end,
+    )
+
+
+class WorkspaceEntitlementView(BaseModel):
+    """Read model for the reconciler (#1095): the current entitlement + provenance."""
+
+    workspace_id: str
+    plan_name: str
+    addons: dict[str, int]
+    entitlement_source: str
+
+
+@router.get("/workspaces/{workspace_id}/plan", response_model=WorkspaceEntitlementView)
+async def get_workspace_entitlement(
+    workspace_id: str,
+    _: None = Depends(verify_billing_service_token),
+    db: AsyncSession = Depends(get_db),
+) -> WorkspaceEntitlementView:
+    """Read a workspace's current entitlement + ``entitlement_source`` (#1095).
+
+    Service-authenticated, internal-only. The external reconciler reads this to
+    decide whether to reconcile a workspace (``external_billing``) or leave it
+    untouched (``admin_grant``) — so a periodic billing reconcile never reverts a
+    locally-owned admin/comp grant.
+    """
+    try:
+        ws_uuid = UUID(workspace_id)
+    except ValueError as exc:
+        raise ValidationError("Invalid workspace_id", field="workspace_id") from exc
+
+    # Soft-delete safe (#687/#681 pattern): a soft-deleted workspace is "gone" →
+    # 404, so the reconciler treats it as cancellable rather than resurrecting a
+    # stale entitlement. (The idempotent PUT deliberately does NOT filter — a #954
+    # reconciliation set may target a just-deleted row; a READ for a skip decision
+    # is the opposite concern.)
+    workspace = (
+        await db.execute(
+            select(Workspace).where(Workspace.id == ws_uuid, Workspace.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+    if workspace is None:
+        raise NotFoundException("Workspace")
+
+    current_addons = {key: getattr(workspace, col) for key, col in _ADDON_COLUMNS.items()}
+    return WorkspaceEntitlementView(
+        workspace_id=workspace_id,
+        plan_name=workspace.plan_name,
+        addons=current_addons,
+        entitlement_source=workspace.entitlement_source,
     )

--- a/backend/src/api/routes/workspace_plan.py
+++ b/backend/src/api/routes/workspace_plan.py
@@ -25,7 +25,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from auth.dependencies import SessionUser
 from config.plan_tiers import PLAN_TIERS, PlanName, get_plan_tier
 from db.base import get_db
-from models.auth import Context, PlanChange, Workspace, WorkspaceMember
+from models.auth import (
+    ENTITLEMENT_SOURCE_ADMIN_GRANT,
+    Context,
+    PlanChange,
+    Workspace,
+    WorkspaceMember,
+)
 from models.config import ContextSearchConfig
 from models.memory import Memory
 from services.member_credentials_service import MemberCredentialsService
@@ -322,6 +328,11 @@ async def update_workspace_plan(
     workspace.plan_name = request.plan_name
     workspace.daily_api_limit = new_tier.daily_api_limit
     workspace.weekly_api_limit = new_tier.weekly_api_limit
+    # #1095: owner self-service (legacy in-process path, retired by #1096) is a
+    # locally-owned change the external billing reconciler doesn't manage — mark it
+    # admin_grant so a reconcile pass never reverts it (self-heals to
+    # external_billing on the next billing push).
+    workspace.entitlement_source = ENTITLEMENT_SOURCE_ADMIN_GRANT
 
     await db.commit()
 

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1409,6 +1409,25 @@ def _zero_floor(base: int, addon: int | None) -> int:
     return base + (addon or 0)
 
 
+# Entitlement provenance (#1095). The values name WHO last set the entitlement, so
+# the external billing reconciler (kagura-billing#5) can revert ONLY what it owns:
+#   - external_billing → billing-owned: the external service set it via the internal
+#     endpoint; the reconciler MAY reconcile/revert it against the billing source.
+#   - admin_grant      → locally-owned: a human set it locally (admin/comp grant OR
+#     owner self-service); the reconciler MUST NOT revert it. This is also the
+#     protective default, so pre-column rows and never-touched workspaces are never
+#     auto-reverted (an external-billing workspace self-heals to external_billing on
+#     the next push). "No active billing linkage" is a separate signal the reconciler
+#     derives from its own subscription data, not from this column.
+ENTITLEMENT_SOURCE_EXTERNAL_BILLING = "external_billing"
+ENTITLEMENT_SOURCE_ADMIN_GRANT = "admin_grant"
+# Ordered (tuple) so the derived CHECK literal is deterministic and byte-identical
+# to the alembic migration — the single-source-of-truth pattern used for
+# ``_ALL_CONTEXT_TRUST_TIERS`` (#887). Append-only: a new value must be added to
+# the END so the literal stays stable, and the migration literal updated to match.
+ENTITLEMENT_SOURCES = (ENTITLEMENT_SOURCE_EXTERNAL_BILLING, ENTITLEMENT_SOURCE_ADMIN_GRANT)
+
+
 class Workspace(Base):
     """Workspace model for multi-user team management.
 
@@ -1486,6 +1505,14 @@ class Workspace(Base):
     addon_connector_bonus: Mapped[int] = mapped_column(
         Integer, nullable=False, server_default="0"
     )  # Spec 2026-06-02: extra ai-worker connector seats addon
+
+    # Issue #1095: provenance of the current entitlement. ``admin_grant`` (default)
+    # = locally-owned, protected from the external billing reconciler;
+    # ``external_billing`` = billing-owned, reconcilable. See the module-level
+    # ENTITLEMENT_SOURCE_* constants for the full contract.
+    entitlement_source: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default=ENTITLEMENT_SOURCE_ADMIN_GRANT
+    )
 
     # Issue #709: Per-workspace embedding spend caps (USD, BYOK-only). NULL =
     # "inherit tier default from ``PlanTier.embedding_*_cap_usd``"; non-NULL =
@@ -1714,6 +1741,12 @@ class Workspace(Base):
     # Constraints
     __table_args__ = (
         CheckConstraint("plan_name IN ('free', 'basic', 'pro')", name="valid_plan_name"),
+        # #1095: CHECK derived from ``ENTITLEMENT_SOURCES`` (single quotes),
+        # byte-identical to the alembic migration literal.
+        CheckConstraint(
+            f"entitlement_source IN ({', '.join(repr(s) for s in ENTITLEMENT_SOURCES)})",
+            name="valid_entitlement_source",
+        ),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/services/stripe_service.py
+++ b/backend/src/services/stripe_service.py
@@ -19,7 +19,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config.plan_tiers import get_plan_tier
 from config.settings import get_settings
-from models.auth import PlanChange, Workspace
+from models.auth import ENTITLEMENT_SOURCE_ADMIN_GRANT, PlanChange, Workspace
 from utils.datetime import utcnow
 from utils.exceptions import StripeError
 from utils.logger import get_logger
@@ -272,6 +272,11 @@ async def _apply_plan_change(
 
     # Update workspace
     workspace.plan_name = new_plan_name
+    # #1095: the legacy in-app Stripe path is NOT managed by the external billing
+    # reconciler (kagura-billing#5) — it has its own subscription lifecycle
+    # (_handle_subscription_cancelled). Mark it locally-owned so a reconcile pass
+    # never reverts an in-app Stripe plan it has no record of.
+    workspace.entitlement_source = ENTITLEMENT_SOURCE_ADMIN_GRANT
     workspace.daily_api_limit = new_tier.daily_api_limit
     workspace.weekly_api_limit = new_tier.weekly_api_limit
     if customer_id:
@@ -316,6 +321,8 @@ async def _handle_subscription_cancelled(
     old_plan = workspace.plan_name
 
     workspace.plan_name = "free"
+    # #1095: in-app Stripe cancel is locally-owned (not external-reconciler-managed).
+    workspace.entitlement_source = ENTITLEMENT_SOURCE_ADMIN_GRANT
     workspace.daily_api_limit = free_tier.daily_api_limit
     workspace.weekly_api_limit = free_tier.weekly_api_limit
     workspace.stripe_subscription_id = None

--- a/backend/tests/api/test_internal_billing_plan.py
+++ b/backend/tests/api/test_internal_billing_plan.py
@@ -39,6 +39,9 @@ def _make_ws():
         "addon_connector_bonus",
     ):
         setattr(ws, col, 0)
+    # #1095: the protective default; a push flips it to external_billing. Set it
+    # to a real str (not a MagicMock) so the result/GET echo is JSON-serializable.
+    ws.entitlement_source = "admin_grant"
     return ws
 
 
@@ -156,7 +159,34 @@ def test_sets_plan_and_addons(billing):
     assert body["addons"]["storage_mb"] == 1024
     assert body["status"] == "active"
     assert body["applied"] is True
+    # #1095: a billing push marks provenance billing-owned (and echoes it).
+    assert body["entitlement_source"] == "external_billing"
     # The workspace object was mutated (entitlement is the SoT).
     assert ws.plan_name == "pro"
     assert ws.addon_sleep_contexts_bonus == 2
     assert ws.addon_storage_bonus_mb == 1024
+    assert ws.entitlement_source == "external_billing"
+
+
+def test_get_entitlement_returns_source(billing):
+    # #1095 reconciler read surface: GET echoes plan + addons + provenance.
+    # Use a non-default value (external_billing) so this proves the handler READS
+    # workspace.entitlement_source rather than echoing a hardcoded literal.
+    ws = _make_ws()
+    ws.entitlement_source = "external_billing"
+    resp = billing.client(ws).get(_PATH, headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["plan_name"] == "free"
+    assert body["entitlement_source"] == "external_billing"
+    assert "addons" in body
+
+
+def test_get_entitlement_requires_token(billing):
+    resp = billing.client(_make_ws()).get(_PATH)
+    assert resp.status_code == 401
+
+
+def test_get_entitlement_not_found_returns_404(billing):
+    resp = billing.client(workspace=None).get(_PATH, headers={"Authorization": "Bearer secret"})
+    assert resp.status_code == 404

--- a/backend/tests/integration/test_entitlement_source_db.py
+++ b/backend/tests/integration/test_entitlement_source_db.py
@@ -1,0 +1,144 @@
+"""DB-level pins for entitlement_source provenance on the local set paths (#1095).
+
+The internal billing push (→ ``external_billing``) is covered in
+``test_internal_billing_plan_db.py``. This file pins the two **locally-owned**
+paths that must mark ``admin_grant`` so the external billing reconciler never
+reverts them:
+
+- the system-admin manual set (``admin_plans.update_workspace_plan``), and
+- the owner self-service legacy path (``workspace_plan.update_workspace_plan``).
+
+Each test PRE-SETS ``entitlement_source = "external_billing"`` before calling the
+handler, so the assertion proves the handler actively flips it back — the
+``admin_grant`` server_default cannot mask a missing write.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.workspace_roles import WorkspaceRole
+from models.auth import Workspace, WorkspaceMember
+
+from ._admin_helpers import make_user, make_workspace, mock_admin
+
+
+async def _reload_workspace(db: AsyncSession, workspace_id: str) -> Workspace:
+    """Re-read the workspace under lock-free fresh state after a handler commit."""
+    ws = (
+        await db.execute(
+            select(Workspace)
+            .where(Workspace.id == UUID(workspace_id))
+            .execution_options(populate_existing=True)
+        )
+    ).scalar_one()
+    return ws
+
+
+@pytest_asyncio.fixture
+async def billed_workspace(db_session: AsyncSession) -> dict:
+    """A FREE workspace already marked external_billing, owned by a real user."""
+    user = make_user()
+    db_session.add(user)
+    await db_session.flush()
+
+    ws = make_workspace(owner_user_id=user.user_id, plan_name="free")
+    ws.entitlement_source = "external_billing"  # pre-state the reconciler "owns"
+    db_session.add(ws)
+    db_session.add(
+        WorkspaceMember(workspace_id=ws.id, user_id=user.user_id, role=WorkspaceRole.OWNER)
+    )
+    await db_session.commit()
+    return {"workspace_id": str(ws.id), "user_id": user.user_id}
+
+
+@pytest.mark.asyncio
+async def test_admin_set_marks_admin_grant(db_session: AsyncSession, billed_workspace: dict):
+    """A system-admin plan set flips external_billing → admin_grant (#1095)."""
+    from api.routes.admin_plans import AdminUpdatePlanRequest, update_workspace_plan
+
+    await update_workspace_plan(
+        workspace_id=billed_workspace["workspace_id"],
+        request=AdminUpdatePlanRequest(plan_name="pro"),  # upgrade — no member cascade
+        admin_user=mock_admin(),
+        db=db_session,
+    )
+
+    ws = await _reload_workspace(db_session, billed_workspace["workspace_id"])
+    assert ws.plan_name == "pro"
+    assert ws.entitlement_source == "admin_grant"
+
+
+@pytest.mark.asyncio
+async def test_owner_self_service_marks_admin_grant(
+    db_session: AsyncSession, billed_workspace: dict
+):
+    """Owner self-service (legacy in-process path) flips external_billing →
+    admin_grant so the reconciler doesn't revert a change it doesn't manage."""
+    from api.routes.workspace_plan import UpdatePlanRequest, update_workspace_plan
+
+    # Exercise the REAL owner gate — the fixture seeds a genuine OWNER member +
+    # owner_user_id, so check_workspace_owner must pass without mocking it. Only the
+    # billing-plugin flag is patched (the gate that makes self-service reachable).
+    with patch("plugins.billing.is_billing_enabled", return_value=True):
+        await update_workspace_plan(
+            workspace_id=billed_workspace["workspace_id"],
+            request=UpdatePlanRequest(plan_name="pro"),  # upgrade — no member removal
+            user={"user_id": billed_workspace["user_id"], "email": "o@test.invalid"},
+            db=db_session,
+        )
+
+    ws = await _reload_workspace(db_session, billed_workspace["workspace_id"])
+    assert ws.plan_name == "pro"
+    assert ws.entitlement_source == "admin_grant"
+
+
+@pytest.mark.asyncio
+async def test_stripe_checkout_marks_admin_grant(db_session: AsyncSession, billed_workspace: dict):
+    """The legacy in-app Stripe checkout webhook marks admin_grant (locally-owned):
+    the external reconciler doesn't manage in-app Stripe subs, so it must not
+    revert them (#1095 sweep follow-up)."""
+    from services.stripe_service import _apply_plan_change
+
+    await _apply_plan_change(
+        db=db_session,
+        workspace_id=UUID(billed_workspace["workspace_id"]),
+        new_plan_name="pro",
+        customer_id="cus_test_123",
+        subscription_id="sub_test_123",
+    )
+
+    ws = await _reload_workspace(db_session, billed_workspace["workspace_id"])
+    assert ws.plan_name == "pro"
+    assert ws.entitlement_source == "admin_grant"
+
+
+@pytest.mark.asyncio
+async def test_stripe_cancel_marks_admin_grant(db_session: AsyncSession, billed_workspace: dict):
+    """A Stripe subscription cancellation downgrades to free AND marks admin_grant."""
+    from services.stripe_service import _apply_plan_change, _handle_subscription_cancelled
+
+    # First put it on pro via checkout (sets the stripe_customer_id the cancel reads).
+    await _apply_plan_change(
+        db=db_session,
+        workspace_id=UUID(billed_workspace["workspace_id"]),
+        new_plan_name="pro",
+        customer_id="cus_cancel_1",
+        subscription_id="sub_cancel_1",
+    )
+    # Re-dirty the provenance to prove the cancel path actively re-marks it.
+    ws = await _reload_workspace(db_session, billed_workspace["workspace_id"])
+    ws.entitlement_source = "external_billing"
+    await db_session.commit()
+
+    await _handle_subscription_cancelled(db=db_session, customer_id="cus_cancel_1")
+
+    ws = await _reload_workspace(db_session, billed_workspace["workspace_id"])
+    assert ws.plan_name == "free"
+    assert ws.entitlement_source == "admin_grant"

--- a/backend/tests/integration/test_internal_billing_plan_db.py
+++ b/backend/tests/integration/test_internal_billing_plan_db.py
@@ -93,3 +93,98 @@ async def test_missing_workspace_raises_not_found(db_session):
             db=db_session,
         )
     assert exc.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# entitlement_source provenance (#1095)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_new_workspace_defaults_admin_grant(db_session):
+    """The server_default is the protective 'admin_grant' — a never-billed
+    workspace is locally-owned, so a reconcile pass leaves it untouched."""
+    ws = await _make_workspace(db_session, plan_name="free")
+    await db_session.refresh(ws)
+    assert ws.entitlement_source == "admin_grant"
+
+
+@pytest.mark.asyncio
+async def test_push_marks_external_billing_and_echoes(db_session):
+    """A billing push flips provenance to 'external_billing' (default is
+    'admin_grant', so this genuinely proves the handler set it) and echoes it."""
+    ws = await _make_workspace(db_session, plan_name="free")
+    assert ws.entitlement_source == "admin_grant"  # precondition
+
+    result = await set_workspace_plan_from_billing(
+        workspace_id=str(ws.id),
+        body=BillingPlanPush(plan_name="pro"),
+        _=None,
+        db=db_session,
+    )
+
+    await db_session.refresh(ws)
+    assert ws.entitlement_source == "external_billing"
+    assert result.entitlement_source == "external_billing"
+
+
+@pytest.mark.asyncio
+async def test_get_entitlement_returns_source(db_session):
+    """The reconciler read surface returns plan + entitlement_source; it reflects
+    admin_grant before any push and external_billing after."""
+    from api.routes.internal_billing import get_workspace_entitlement
+
+    ws = await _make_workspace(db_session, plan_name="basic")
+
+    before = await get_workspace_entitlement(workspace_id=str(ws.id), _=None, db=db_session)
+    assert before.plan_name == "basic"
+    assert before.entitlement_source == "admin_grant"
+
+    await set_workspace_plan_from_billing(
+        workspace_id=str(ws.id),
+        body=BillingPlanPush(plan_name="pro"),
+        _=None,
+        db=db_session,
+    )
+    after = await get_workspace_entitlement(workspace_id=str(ws.id), _=None, db=db_session)
+    assert after.plan_name == "pro"
+    assert after.entitlement_source == "external_billing"
+
+
+@pytest.mark.asyncio
+async def test_get_entitlement_missing_workspace_raises_not_found(db_session):
+    from api.routes.internal_billing import get_workspace_entitlement
+    from utils.exceptions import NotFoundException
+
+    with pytest.raises(NotFoundException) as exc:
+        await get_workspace_entitlement(workspace_id=str(uuid4()), _=None, db=db_session)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_check_constraint_rejects_invalid_source(db_session):
+    """The valid_entitlement_source CHECK rejects an out-of-enum value."""
+    from sqlalchemy.exc import IntegrityError
+
+    ws = await _make_workspace(db_session, plan_name="free")
+    ws.entitlement_source = "bogus_source"
+    with pytest.raises(IntegrityError):
+        await db_session.commit()
+    await db_session.rollback()
+
+
+@pytest.mark.asyncio
+async def test_get_entitlement_skips_soft_deleted(db_session):
+    """A soft-deleted workspace is 'gone' to the reconciler → 404 (not stale
+    entitlement it might resurrect). The GET filters deleted_at (#1095)."""
+    from api.routes.internal_billing import get_workspace_entitlement
+    from utils.datetime import utcnow
+    from utils.exceptions import NotFoundException
+
+    ws = await _make_workspace(db_session, plan_name="pro")
+    ws.deleted_at = utcnow()
+    await db_session.commit()
+
+    with pytest.raises(NotFoundException) as exc:
+        await get_workspace_entitlement(workspace_id=str(ws.id), _=None, db=db_session)
+    assert exc.value.status_code == 404

--- a/backend/tests/test_entitlement_source_constants.py
+++ b/backend/tests/test_entitlement_source_constants.py
@@ -1,0 +1,46 @@
+"""Regression tests for #1095: Workspace.entitlement_source constant + CHECK.
+
+``entitlement_source`` records WHO last set the entitlement so the external
+billing reconciler reverts only what it owns: ``external_billing`` (billing-owned)
+vs ``admin_grant`` (locally-owned, default). The CHECK is derived from
+``ENTITLEMENT_SOURCES`` so ``create_all()`` stays byte-identical to the alembic
+head (same single-source-of-truth pattern as ``_ALL_CONTEXT_TRUST_TIERS`` #887).
+"""
+
+from models.auth import (
+    ENTITLEMENT_SOURCE_ADMIN_GRANT,
+    ENTITLEMENT_SOURCE_EXTERNAL_BILLING,
+    ENTITLEMENT_SOURCES,
+    Workspace,
+)
+
+
+def test_entitlement_sources_tuple_matches_constants() -> None:
+    assert ENTITLEMENT_SOURCES == (
+        ENTITLEMENT_SOURCE_EXTERNAL_BILLING,
+        ENTITLEMENT_SOURCE_ADMIN_GRANT,
+    )
+
+
+def test_entitlement_source_values() -> None:
+    assert ENTITLEMENT_SOURCE_EXTERNAL_BILLING == "external_billing"
+    assert ENTITLEMENT_SOURCE_ADMIN_GRANT == "admin_grant"
+
+
+def test_valid_entitlement_source_check_constraint_matches_migration_literal() -> None:
+    # Byte-identical to e46_1095_entitlement_source.py's CHECK predicate.
+    expected = "entitlement_source IN ('external_billing', 'admin_grant')"
+    check = next(
+        c
+        for c in Workspace.__table_args__
+        if getattr(c, "name", None) == "valid_entitlement_source"
+    )
+    assert check.sqltext.text == expected
+
+
+def test_entitlement_source_column_defaults_to_admin_grant() -> None:
+    """The protective default: a never-billed workspace is locally-owned, so a
+    reconcile pass leaves it untouched."""
+    col = Workspace.__table__.c.entitlement_source
+    assert col.nullable is False
+    assert col.server_default.arg == ENTITLEMENT_SOURCE_ADMIN_GRANT


### PR DESCRIPTION
Closes #1095

## Summary
Add `workspaces.entitlement_source` (`external_billing | admin_grant`) so a periodic billing reconcile never reverts a legitimate admin/comp grant. The values name **who last set** the entitlement, so the external reconciler reverts only what it owns:
- `external_billing` — billing-owned (the external billing service set it via the internal endpoint); **reconcilable**.
- `admin_grant` — **locally-owned** (admin set, owner self-service, legacy in-app Stripe, or the protective default); the reconciler **must not revert** it.

## What changed
- **Every** plan_name-mutating path now stamps provenance: internal billing push → `external_billing`; system-admin set, owner self-service, and the legacy in-app Stripe webhook (checkout + subscription-cancelled) → `admin_grant`.
- New `GET /internal/workspaces/{id}/plan` (service-token, internal-only) returns plan + addons + `entitlement_source` so the external reconciler can skip `admin_grant` workspaces. Soft-delete safe (404 on a deleted workspace).
- `entitlement_source` echoed in the push result.
- NOT NULL, `server_default admin_grant`: existing/never-billed rows backfill **protectively** (no comp grant reverted on first reconcile); an external-billing workspace self-heals to `external_billing` on its next push.
- Migration e46 (CHECK constraint, down reverts). CHECK derived from `ENTITLEMENT_SOURCES` (single source of truth, byte-identical to the migration, pinned by a constants test — the `trust_tier` #887 convention).

## Design notes
- Default `admin_grant` is the protective choice: defaulting `external_billing` would let the first reconcile revert pre-column comp grants (grant data loss); `admin_grant` is safe and self-heals. (CIO gate1.)
- "No active billing linkage" is the reconciler's own signal (its subscription data), not this column — so two values suffice.

## Review
- gate1: green via /claude-c-suite:ask (CIO — provenance/data-contract; validated the default + the two-value choice + the GET read surface).
- code-review max: 16-agent find→verify→sweep. Caught a **HIGH**: the legacy in-app Stripe webhook (`stripe_service.py`) wrote plan_name without provenance (mislabeled a Stripe-paid workspace) — now stamped + tested. Also fixed: GET `deleted_at` filter, CHECK derived from the constant (was an orphaned frozenset), owner-path test now exercises the real owner gate, unit GET echo strengthened. Two by-design/naming nits left as documented.
- gate2: consolidated (covered by code-review max). CI is the final gate.

🤖 Generated via /gh-issue-driven:ship
