### PR TITLE
feat(workspace): break-glass admin force-transfer of ownership (#1101)

### DIFF
--- a/backend/alembic/versions/e47_1101_workspace_member_unique.py
+++ b/backend/alembic/versions/e47_1101_workspace_member_unique.py
@@ -1,0 +1,61 @@
+"""Add UNIQUE(workspace_id, user_id) on workspace_members (#1101).
+
+The model has always documented "(workspace_id, user_id) must be unique" and
+every membership path does a check-then-insert, but the constraint was never
+enforced at the DB level — only non-unique indexes existed. The break-glass
+force-transfer ADD path (#1101) inserts a fresh OWNER member for a non-member
+target while holding only the workspace row lock, which does NOT serialize
+against the lock-free ``add_member`` / invitation-accept inserts. Without a DB
+constraint that race could produce two membership rows for the same
+(workspace_id, user_id). This makes the long-assumed invariant structural.
+
+The upgrade first defensively de-duplicates any pre-existing rows (the app has
+always assumed uniqueness, so this is expected to be a no-op), keeping the
+highest-privilege then oldest row per (workspace_id, user_id), before creating
+the unique constraint.
+
+Revision ID: e47_1101_member_unique
+Revises: e46_1095_entitlement_src
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e47_1101_member_unique"
+down_revision = "e46_1095_entitlement_src"
+branch_labels = None
+depends_on = None
+
+_DEDUP_SQL = """
+DELETE FROM workspace_members wm
+USING (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY workspace_id, user_id
+               ORDER BY
+                   CASE role
+                       WHEN 'owner' THEN 0
+                       WHEN 'admin' THEN 1
+                       WHEN 'member' THEN 2
+                       ELSE 3
+                   END,
+                   joined_at NULLS LAST,
+                   id
+           ) AS rn
+    FROM workspace_members
+) ranked
+WHERE wm.id = ranked.id AND ranked.rn > 1
+"""
+
+
+def upgrade() -> None:
+    op.execute(_DEDUP_SQL)
+    op.create_unique_constraint(
+        "uq_workspace_members_workspace_user",
+        "workspace_members",
+        ["workspace_id", "user_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_workspace_members_workspace_user", "workspace_members", type_="unique")

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -7,9 +7,10 @@ Issue #106: Refactored to use consolidated utilities
 
 from datetime import datetime
 from typing import Any, cast
+from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy import and_, delete, func, or_, select, text, update
 from sqlalchemy.engine import CursorResult
 from sqlalchemy.exc import DBAPIError
@@ -34,6 +35,8 @@ from models.schemas import (
     UpdateWorkspaceSlotBonusRequest,
     UpdateWorkspaceSlotBonusResponse,
 )
+from services.email_service import get_email_service
+from services.workspace_ownership_service import WorkspaceOwnershipService
 from utils import db_transaction, get_user_id
 from utils.datetime import to_utc_iso
 from utils.exceptions import (
@@ -42,6 +45,7 @@ from utils.exceptions import (
     BonusBelowZeroError,
     InsufficientReasonError,
     NotFoundException,
+    ValidationError,
 )
 from utils.logger import get_logger
 from utils.plan_resolver import BASE_CAP, get_user_workspace_cap_summary
@@ -1141,6 +1145,109 @@ async def admin_force_erase_user(
         "status": record.status,
         "deleted_data_summary": record.deleted_data_summary,
     }
+
+
+# ============================================================================
+# Break-glass ownership force-transfer (Issue #1101)
+# ============================================================================
+
+
+class ForceTransferOwnershipRequest(BaseModel):
+    """Break-glass force-transfer request (#1101).
+
+    ``reason`` is REQUIRED (non-empty) — a privileged ownership override with no
+    justification is a red flag; it is recorded verbatim in the mandatory audit.
+    """
+
+    target_user_id: str = Field(..., min_length=1, max_length=255)
+    reason: str = Field(
+        ...,
+        min_length=3,
+        max_length=1000,
+        description="Why ownership is being force-transferred (required, audited).",
+    )
+
+
+@router.post("/workspaces/{workspace_id}/force-transfer-ownership")
+async def force_transfer_workspace_ownership(
+    workspace_id: str,
+    body: ForceTransferOwnershipRequest,
+    admin: dict = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Break-glass: a system admin force-transfers workspace ownership (#1101).
+
+    For when the current owner is unavailable. System-admin-gated
+    (``require_admin``), bound to the PATH ``workspace_id``, serialized on the
+    shared workspace row lock, bumps ``ownership_epoch`` (invalidates the displaced
+    owner's billing-handoff tokens / sessions — #1100), and writes a MANDATORY
+    audit row (``break_glass`` + ``reason`` + acting admin) atomically with the
+    transfer. The target need not be a member — a non-member is added as OWNER,
+    which handles the zero-member workspace. The displaced previous owner is
+    notified best-effort.
+    """
+    admin_id = get_user_id(admin)
+    try:
+        ws_uuid = UUID(workspace_id)
+    except ValueError as exc:
+        raise ValidationError("Invalid workspace_id", field="workspace_id") from exc
+
+    result = await WorkspaceOwnershipService(db).force_transfer_ownership(
+        workspace_id=ws_uuid,
+        target_user_id=body.target_user_id,
+        performed_by_user_id=admin_id,
+        performed_by_email=str(admin.get("email") or admin_id),
+        reason=body.reason,
+    )
+
+    # Notify the displaced previous owner (#1101) — only on an actual change, and
+    # best-effort: the transfer already committed, so a notification failure must
+    # never surface to the admin caller.
+    if result.changed:
+        await _notify_force_transfer_best_effort(db, ws_uuid, result.previous_owner_id)
+
+    return {
+        "workspace_id": str(result.workspace_id),
+        "previous_owner_id": result.previous_owner_id,
+        "new_owner_id": result.new_owner_id,
+        "ownership_epoch": result.ownership_epoch,
+        "changed": result.changed,
+    }
+
+
+async def _notify_force_transfer_best_effort(
+    db: AsyncSession, workspace_id: UUID, previous_owner_id: str
+) -> None:
+    """Best-effort notify the displaced previous owner (#1101).
+
+    The transfer is already committed, so the WHOLE block is guarded — neither the
+    resolution queries nor the (no-raise) EmailService call may surface to the
+    admin caller. A previous owner without an email is simply skipped.
+    """
+    try:
+        email = (
+            await db.execute(select(User.email).where(User.user_id == previous_owner_id))
+        ).scalar_one_or_none()
+        if not email:
+            return
+        name = (
+            await db.execute(select(Workspace.name).where(Workspace.id == workspace_id))
+        ).scalar_one_or_none()
+        await get_email_service().send_workspace_ownership_force_transferred(
+            to_email=email,
+            workspace_name=name or "your workspace",
+        )
+    except Exception as exc:
+        # Best-effort — swallow everything (resolution query or provider error). Log
+        # the exception TYPE only (a SQLAlchemy error string echoes bound params).
+        # Include previous_owner_id so ops can reconcile / hand-deliver the dropped
+        # security-transparency notice (it is a user id, not PII like the email).
+        logger.warning(
+            "force_transfer_notify_failed",
+            workspace_id=str(workspace_id),
+            previous_owner_id=previous_owner_id,
+            error_type=type(exc).__name__,
+        )
 
 
 # ============================================================================

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -1839,6 +1839,11 @@ class WorkspaceMember(Base):
         Index("idx_workspace_members_user", "user_id"),
         Index("idx_workspace_members_role", "workspace_id", "role"),
         CheckConstraint(WORKSPACE_ROLE_CHECK_SQL, name="valid_workspace_member_role"),
+        # #1101: a user is a member of a workspace at most once. This was always
+        # assumed (check-then-insert everywhere + the docstring) but never enforced
+        # at the DB level; the break-glass force-transfer ADD path made the gap
+        # reachable under concurrency, so the invariant is now structural.
+        UniqueConstraint("workspace_id", "user_id", name="uq_workspace_members_workspace_user"),
     )
 
     def __repr__(self) -> str:

--- a/backend/src/services/email_providers/resend.py
+++ b/backend/src/services/email_providers/resend.py
@@ -311,6 +311,34 @@ class ResendEmailService:
             },
         )
 
+    async def send_workspace_ownership_force_transferred(
+        self,
+        *,
+        to_email: str,
+        workspace_name: str,
+    ) -> bool:
+        text = (
+            f'Ownership of the "{workspace_name}" workspace on Kagura Memory Cloud '
+            "was transferred away from your account by a Kagura administrator.\n"
+            "\n"
+            "Administrators can reassign workspace ownership (for example, when the "
+            "owner is unavailable). You no longer have owner privileges on this "
+            "workspace.\n"
+            "\n"
+            "If you believe this was a mistake, contact your Kagura administrator.\n"
+        )
+        return await self._send(
+            to_email=to_email,
+            subject=f"Ownership of the {workspace_name} workspace was reassigned",
+            text=text,
+            log_event="workspace_ownership_force_transferred_email",
+            log_context={
+                "to_email": to_email,
+                "workspace_name": workspace_name,
+                "template": "workspace_ownership_force_transferred",
+            },
+        )
+
     async def send_erasure_confirmation(
         self,
         *,

--- a/backend/src/services/email_service.py
+++ b/backend/src/services/email_service.py
@@ -204,6 +204,30 @@ class EmailService(Protocol):
         """
         ...
 
+    async def send_workspace_ownership_force_transferred(
+        self,
+        *,
+        to_email: str,
+        workspace_name: str,
+    ) -> bool:
+        """Notify the **displaced previous owner** that an administrator force-
+        transferred their workspace ownership (#1101 break-glass).
+
+        A security-transparency notice (the transfer was involuntary, so the
+        displaced owner learns of it when they return) — but it follows the same
+        best-effort, no-raise contract as every method here: the ownership row +
+        audit row are the source of truth, so a delivery failure MUST NOT roll
+        anything back.
+
+        Args:
+            to_email: The displaced previous owner's account email.
+            workspace_name: Workspace display name.
+
+        Returns:
+            True on delivery (or logging fallback), False on hard failure.
+        """
+        ...
+
 
 class LoggingEmailService:
     """Default stub implementation: structured logs only, no SMTP.
@@ -332,6 +356,21 @@ class LoggingEmailService:
             workspace_name=workspace_name,
             email_dispatch_required=True,
             template="workspace_ownership_transferred",
+        )
+        return True
+
+    async def send_workspace_ownership_force_transferred(
+        self,
+        *,
+        to_email: str,
+        workspace_name: str,
+    ) -> bool:
+        logger.info(
+            "workspace_ownership_force_transferred_email",
+            to_email=to_email,
+            workspace_name=workspace_name,
+            email_dispatch_required=True,
+            template="workspace_ownership_force_transferred",
         )
         return True
 

--- a/backend/src/services/workspace_ownership_service.py
+++ b/backend/src/services/workspace_ownership_service.py
@@ -50,14 +50,16 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.workspace_roles import WorkspaceRole
-from models.auth import AuditLog, WorkspaceMember
+from models.auth import AuditLog, User, WorkspaceMember
 from services.workspace_locks import lock_workspace_for_update
+from utils.datetime import utcnow
 from utils.exceptions import BadRequestError, ConflictError
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
 
 OWNERSHIP_TRANSFER_ACTION = "workspace_ownership_transfer"
+FORCE_OWNERSHIP_TRANSFER_ACTION = "workspace_ownership_force_transfer"
 
 
 class OwnershipTransferResult(NamedTuple):
@@ -213,6 +215,179 @@ class WorkspaceOwnershipService:
             previous_owner=previous_owner_id,
             new_owner=target_user_id,
             ownership_epoch=new_epoch,
+        )
+        return OwnershipTransferResult(
+            workspace_id=workspace_id,
+            previous_owner_id=previous_owner_id,
+            new_owner_id=target_user_id,
+            ownership_epoch=new_epoch,
+            changed=True,
+        )
+
+    async def force_transfer_ownership(
+        self,
+        *,
+        workspace_id: UUID,
+        target_user_id: str,
+        performed_by_user_id: str,
+        performed_by_email: str,
+        reason: str,
+    ) -> OwnershipTransferResult:
+        """Break-glass system-admin force-transfer of ownership (#1101).
+
+        For when the current owner is unavailable. Unlike ``transfer_ownership``
+        there is **no current-owner check** — the route enforces the system-admin
+        gate (``require_admin``) instead. Like the voluntary path it serializes on
+        the shared workspace row lock and bumps ``ownership_epoch`` (so the #1100
+        consumer invalidates the displaced owner's billing-handoff tokens /
+        sessions).
+
+        Differs from the voluntary path in two ways:
+          * The target need NOT already be a member — a non-member is **added** as
+            OWNER, which handles the zero-member workspace (no eligible member to
+            promote). The target MUST still be a real ``User`` (never hand
+            ownership to a phantom/typo'd id, which would orphan the workspace).
+          * A **mandatory** audit row records ``break_glass=true`` + the operator's
+            ``reason`` + ``target_was_member`` so a privileged override is always
+            forensically attributable. It commits in the SAME transaction as the
+            transfer (fail-closed: no audit ⇒ no transfer).
+
+        Args:
+            workspace_id: The workspace whose ownership is being seized.
+            target_user_id: The user to install as owner.
+            performed_by_user_id: The acting system admin (the audit actor).
+            performed_by_email: The acting admin's email, for the audit row.
+            reason: Non-empty justification (route enforces non-empty).
+
+        Returns:
+            The transfer outcome (``changed=False`` for the idempotent no-op).
+
+        Raises:
+            NotFoundException: workspace missing or soft-deleted (404).
+            BadRequestError: the target user does not exist (400, WS-OWNER-002).
+        """
+        # 1. Lock the workspace row — the shared single-owner synchronization point
+        # (#1102): break-glass serializes with the voluntary transfer, role change,
+        # and erasure auto-transfer on the SAME FOR UPDATE row.
+        workspace = await lock_workspace_for_update(self.db, workspace_id)
+
+        # 2. Idempotent no-op: already owned by the target (no epoch bump / audit).
+        # Still record the privileged invocation: a break-glass control's whole
+        # justification is attributability, so an admin hitting this endpoint must
+        # leave a trace even when nothing changes (this log line is the alertable
+        # signal; the no-op writes no AuditLog row, mirroring the voluntary path).
+        if workspace.owner_user_id == target_user_id:
+            logger.info(
+                "workspace_ownership_force_transfer_noop",
+                workspace_id=str(workspace_id),
+                target=target_user_id,
+                performed_by=performed_by_user_id,
+            )
+            return OwnershipTransferResult(
+                workspace_id=workspace_id,
+                previous_owner_id=workspace.owner_user_id,
+                new_owner_id=target_user_id,
+                ownership_epoch=workspace.ownership_epoch,
+                changed=False,
+            )
+
+        # 3. The target must be a real account — handing ownership to a phantom
+        # user_id would permanently orphan the workspace (worse than the original
+        # unavailable-owner problem). This is a best-effort existence check, not a
+        # FK (``owner_user_id`` has no FK to ``users.user_id``); a target concurrently
+        # hard-erased between this check and commit is a narrow accepted race — the
+        # erase path itself auto-transfers/blocks on owned workspaces.
+        target_user = (
+            await self.db.execute(select(User).where(User.user_id == target_user_id))
+        ).scalar_one_or_none()
+        if target_user is None:
+            raise BadRequestError(
+                "Target user does not exist",
+                error_code="WS-OWNER-002",
+            )
+
+        previous_owner_id = workspace.owner_user_id
+
+        # 4. Load BOTH the target and previous-owner member rows in one round-trip.
+        member_rows = (
+            (
+                await self.db.execute(
+                    select(WorkspaceMember).where(
+                        WorkspaceMember.workspace_id == workspace_id,
+                        WorkspaceMember.user_id.in_([target_user_id, previous_owner_id]),
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        members_by_user = {m.user_id: m for m in member_rows}
+
+        target_member = members_by_user.get(target_user_id)
+        target_was_member = target_member is not None
+        if target_member is None:
+            # Break-glass elevated path: the target is not a member (e.g. a
+            # zero-member workspace). Add them as OWNER. Flagged in the audit via
+            # target_was_member=False so forensics can isolate the elevated case.
+            # joined_at is set like every other membership-creation path so the new
+            # owner does not carry a NULL join timestamp. The (workspace_id, user_id)
+            # UNIQUE constraint (#1101) makes a concurrent duplicate insert fail
+            # cleanly (IntegrityError → rollback → admin retries) rather than
+            # silently creating two membership rows.
+            self.db.add(
+                WorkspaceMember(
+                    workspace_id=workspace_id,
+                    user_id=target_user_id,
+                    role=WorkspaceRole.OWNER,
+                    joined_at=utcnow(),
+                )
+            )
+        else:
+            target_member.role = WorkspaceRole.OWNER
+
+        # Demote the previous owner's member row to ADMIN if it exists (some legacy
+        # workspaces carry owner_user_id without a matching member row).
+        previous_member = members_by_user.get(previous_owner_id)
+        if previous_member is not None:
+            previous_member.role = WorkspaceRole.ADMIN
+
+        workspace.owner_user_id = target_user_id
+        new_epoch = workspace.ownership_epoch + 1
+        workspace.ownership_epoch = new_epoch
+
+        # 5. Mandatory audit in the SAME transaction (fail-closed). The actor is the
+        # acting ADMIN's user_id (NOT the displaced workspace owner). reason +
+        # break_glass + target_was_member make the override fully attributable.
+        self.db.add(
+            AuditLog(
+                user_email=performed_by_email,
+                user_id=performed_by_user_id,
+                action=FORCE_OWNERSHIP_TRANSFER_ACTION,
+                resource=f"workspace:{workspace_id}",
+                user_metadata={
+                    "break_glass": True,
+                    "reason": reason,
+                    "previous_owner_id": previous_owner_id,
+                    "new_owner_id": target_user_id,
+                    "ownership_epoch": new_epoch,
+                    "target_was_member": target_was_member,
+                    # Self-dealing (the acting admin installs themselves) is allowed
+                    # by break-glass but flagged explicitly so forensics needn't
+                    # compare the actor column against new_owner_id by hand.
+                    "self_transfer": performed_by_user_id == target_user_id,
+                },
+            )
+        )
+        await self.db.commit()
+
+        logger.info(
+            "workspace_ownership_force_transferred",
+            workspace_id=str(workspace_id),
+            previous_owner=previous_owner_id,
+            new_owner=target_user_id,
+            ownership_epoch=new_epoch,
+            performed_by=performed_by_user_id,
+            target_was_member=target_was_member,
         )
         return OwnershipTransferResult(
             workspace_id=workspace_id,

--- a/backend/tests/api/test_admin_force_transfer_route.py
+++ b/backend/tests/api/test_admin_force_transfer_route.py
@@ -1,0 +1,193 @@
+"""Route tests for the break-glass admin force-transfer endpoint (#1101).
+
+DB-free: dependency overrides + a patched service. Verifies the system-admin gate,
+the required non-empty reason, the path-bound workspace id, the response shape, and
+that the displaced PREVIOUS owner is the notification target.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from api.routes import admin as admin_mod
+from auth.dependencies import get_current_user
+from db.base import get_db
+from services.workspace_ownership_service import OwnershipTransferResult
+from utils.exceptions import MemoryCloudException
+
+ADMIN = "admin_user_1"
+TARGET = "target_user_1"
+PREV = "prev_owner_1"
+WS = uuid4()
+_PATH = f"/admin/workspaces/{WS}/force-transfer-ownership"
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_mod.router)
+
+    async def _mc_handler(_request, exc: MemoryCloudException) -> JSONResponse:
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"error": {"code": getattr(exc, "error_code", None), "message": str(exc)}},
+        )
+
+    app.add_exception_handler(MemoryCloudException, _mc_handler)
+    return app
+
+
+def _client(role: str = "admin") -> TestClient:
+    app = _build_app()
+
+    async def _user():
+        return {"user_id": ADMIN, "email": "admin@test.com", "role": role}
+
+    async def _db():
+        yield MagicMock()
+
+    app.dependency_overrides[get_current_user] = _user
+    app.dependency_overrides[get_db] = _db
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _result(changed: bool = True, epoch: int = 1) -> OwnershipTransferResult:
+    return OwnershipTransferResult(
+        workspace_id=WS,
+        previous_owner_id=PREV,
+        new_owner_id=TARGET,
+        ownership_epoch=epoch,
+        changed=changed,
+    )
+
+
+class TestForceTransferRoute:
+    def test_admin_force_transfers_returns_200_and_calls_service(self):
+        svc = MagicMock()
+        svc.force_transfer_ownership = AsyncMock(return_value=_result())
+        notify = AsyncMock()
+        with (
+            patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc),
+            patch.object(admin_mod, "_notify_force_transfer_best_effort", notify),
+        ):
+            resp = _client().post(
+                _PATH, json={"target_user_id": TARGET, "reason": "owner unreachable"}
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["new_owner_id"] == TARGET
+        assert body["previous_owner_id"] == PREV
+        assert body["changed"] is True
+        # Bound to the PATH workspace id; actor is the authenticated admin.
+        call = svc.force_transfer_ownership.await_args.kwargs
+        assert call["workspace_id"] == WS
+        assert call["target_user_id"] == TARGET
+        assert call["performed_by_user_id"] == ADMIN
+        assert call["performed_by_email"] == "admin@test.com"
+        assert call["reason"] == "owner unreachable"
+        # The DISPLACED previous owner is the notification target.
+        notify.assert_awaited_once()
+        assert notify.await_args.args[1] == WS
+        assert notify.await_args.args[2] == PREV
+
+    def test_non_admin_is_403(self):
+        # require_admin rejects role != "admin" before the body runs.
+        resp = _client(role="user").post(
+            _PATH, json={"target_user_id": TARGET, "reason": "valid reason"}
+        )
+        assert resp.status_code == 403
+
+    def test_short_reason_is_422(self):
+        resp = _client().post(_PATH, json={"target_user_id": TARGET, "reason": "ab"})
+        assert resp.status_code == 422
+
+    def test_missing_reason_is_422(self):
+        resp = _client().post(_PATH, json={"target_user_id": TARGET})
+        assert resp.status_code == 422
+
+    def test_no_notification_on_idempotent_noop(self):
+        svc = MagicMock()
+        svc.force_transfer_ownership = AsyncMock(return_value=_result(changed=False, epoch=0))
+        notify = AsyncMock()
+        with (
+            patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc),
+            patch.object(admin_mod, "_notify_force_transfer_best_effort", notify),
+        ):
+            resp = _client().post(_PATH, json={"target_user_id": TARGET, "reason": "noop reason"})
+        assert resp.status_code == 200
+        notify.assert_not_awaited()
+
+
+class TestNotifyForceTransferBestEffort:
+    @pytest.mark.asyncio
+    async def test_resolves_previous_owner_email_and_sends(self):
+        db = MagicMock()
+        email_res = MagicMock()
+        email_res.scalar_one_or_none.return_value = "prev@owner.com"
+        name_res = MagicMock()
+        name_res.scalar_one_or_none.return_value = "My WS"
+        db.execute = AsyncMock(side_effect=[email_res, name_res])
+        svc = MagicMock()
+        svc.send_workspace_ownership_force_transferred = AsyncMock(return_value=True)
+        with patch.object(admin_mod, "get_email_service", return_value=svc):
+            await admin_mod._notify_force_transfer_best_effort(db, WS, PREV)
+        svc.send_workspace_ownership_force_transferred.assert_awaited_once_with(
+            to_email="prev@owner.com", workspace_name="My WS"
+        )
+
+    @pytest.mark.asyncio
+    async def test_skips_when_previous_owner_has_no_email(self):
+        db = MagicMock()
+        email_res = MagicMock()
+        email_res.scalar_one_or_none.return_value = None
+        db.execute = AsyncMock(return_value=email_res)
+        svc = MagicMock()
+        svc.send_workspace_ownership_force_transferred = AsyncMock()
+        with patch.object(admin_mod, "get_email_service", return_value=svc):
+            await admin_mod._notify_force_transfer_best_effort(db, WS, PREV)
+        svc.send_workspace_ownership_force_transferred.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_swallows_resolution_error(self):
+        db = MagicMock()
+        db.execute = AsyncMock(side_effect=RuntimeError("db down"))
+        with patch.object(admin_mod, "get_email_service") as ges:
+            await admin_mod._notify_force_transfer_best_effort(db, WS, PREV)  # no raise
+        ges.assert_not_called()
+
+
+class TestForceTransferRouteServiceErrors:
+    """The route maps the service's canonical exceptions to HTTP status at the
+    edge (via the app-wide MemoryCloudException handler)."""
+
+    def test_nonexistent_target_returns_400(self):
+        from utils.exceptions import BadRequestError
+
+        svc = MagicMock()
+        svc.force_transfer_ownership = AsyncMock(
+            side_effect=BadRequestError("Target user does not exist", error_code="WS-OWNER-002")
+        )
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().post(_PATH, json={"target_user_id": TARGET, "reason": "valid reason"})
+        assert resp.status_code == 400
+
+    def test_missing_workspace_returns_404(self):
+        from utils.exceptions import NotFoundException
+
+        svc = MagicMock()
+        svc.force_transfer_ownership = AsyncMock(side_effect=NotFoundException("Workspace"))
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().post(_PATH, json={"target_user_id": TARGET, "reason": "valid reason"})
+        assert resp.status_code == 404
+
+    def test_malformed_workspace_id_returns_422(self):
+        resp = _client().post(
+            "/admin/workspaces/not-a-uuid/force-transfer-ownership",
+            json={"target_user_id": TARGET, "reason": "valid reason"},
+        )
+        assert resp.status_code == 422

--- a/backend/tests/integration/test_workspace_ownership_transfer.py
+++ b/backend/tests/integration/test_workspace_ownership_transfer.py
@@ -21,6 +21,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from auth.workspace_roles import WorkspaceRole
 from models.auth import AuditLog, User, Workspace, WorkspaceMember
 from services.workspace_ownership_service import (
+    FORCE_OWNERSHIP_TRANSFER_ACTION,
     OWNERSHIP_TRANSFER_ACTION,
     WorkspaceOwnershipService,
 )
@@ -406,3 +407,324 @@ class TestOwnershipTransfer:
                 User.__table__.delete().where(User.user_id.in_([owner, m1, m2]))
             )
             await db_session.commit()
+
+
+class TestForceTransfer:
+    """Break-glass admin force-transfer (#1101) — no current-owner check, may add
+    a non-member target as OWNER, mandatory break_glass audit."""
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_force_transfer_existing_member_promotes_demotes_audits(
+        self, ws_fixture, db_session
+    ):
+        s = ws_fixture
+        # The admin actor is NOT the owner — break-glass has no current-owner check.
+        result = await WorkspaceOwnershipService(db_session).force_transfer_ownership(
+            workspace_id=s.workspace_id,
+            target_user_id=s.member,
+            performed_by_user_id="admin_runner",
+            performed_by_email="admin@kagura.invalid",
+            reason="owner unreachable for 30 days",
+        )
+        assert result.changed is True
+        assert result.previous_owner_id == s.owner
+        assert result.new_owner_id == s.member
+        assert result.ownership_epoch == 1
+
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.member
+        assert ws.ownership_epoch == 1
+        assert await _role_of(db_session, s.workspace_id, s.member) == WorkspaceRole.OWNER
+        assert await _role_of(db_session, s.workspace_id, s.owner) == WorkspaceRole.ADMIN
+
+        audit = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(
+                        AuditLog.resource == f"workspace:{s.workspace_id}",
+                        AuditLog.action == FORCE_OWNERSHIP_TRANSFER_ACTION,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audit) == 1
+        meta = audit[0].user_metadata
+        assert audit[0].user_id == "admin_runner"  # actor = the acting ADMIN
+        assert meta["break_glass"] is True
+        assert meta["reason"] == "owner unreachable for 30 days"
+        assert meta["previous_owner_id"] == s.owner
+        assert meta["new_owner_id"] == s.member
+        assert meta["ownership_epoch"] == 1
+        assert meta["target_was_member"] is True
+        assert meta["self_transfer"] is False  # admin_runner != the target member
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_force_transfer_adds_non_member_target_as_owner(self, ws_fixture, db_session):
+        # The outsider is a real User but NOT a member — break-glass ADDS them as
+        # OWNER (the voluntary path would reject this with 400).
+        s = ws_fixture
+        result = await WorkspaceOwnershipService(db_session).force_transfer_ownership(
+            workspace_id=s.workspace_id,
+            target_user_id=s.outsider,
+            performed_by_user_id="admin_runner",
+            performed_by_email="admin@kagura.invalid",
+            reason="break glass to outsider",
+        )
+        assert result.changed is True
+        assert result.new_owner_id == s.outsider
+
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.outsider
+        assert await _role_of(db_session, s.workspace_id, s.outsider) == WorkspaceRole.OWNER
+        # The freshly-added OWNER member carries a join timestamp like every other
+        # membership-creation path (not a NULL joined_at).
+        new_member = (
+            await db_session.execute(
+                select(WorkspaceMember).where(
+                    WorkspaceMember.workspace_id == s.workspace_id,
+                    WorkspaceMember.user_id == s.outsider,
+                )
+            )
+        ).scalar_one()
+        assert new_member.joined_at is not None
+        audit = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(
+                        AuditLog.resource == f"workspace:{s.workspace_id}",
+                        AuditLog.action == FORCE_OWNERSHIP_TRANSFER_ACTION,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert audit[0].user_metadata["target_was_member"] is False
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_force_transfer_idempotent_when_target_already_owner(
+        self, ws_fixture, db_session
+    ):
+        s = ws_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        # First a REAL force-transfer so the baseline epoch is non-zero (1) and one
+        # audit row exists — otherwise asserting epoch==0 cannot distinguish a
+        # correct no-op from the server_default the fixture row already carries.
+        await svc.force_transfer_ownership(
+            workspace_id=s.workspace_id,
+            target_user_id=s.member,
+            performed_by_user_id="admin_runner",
+            performed_by_email="admin@kagura.invalid",
+            reason="initial break-glass",
+        )
+        # Now a no-op: force-transfer to the CURRENT owner (member). No epoch bump,
+        # no NEW audit row.
+        result = await svc.force_transfer_ownership(
+            workspace_id=s.workspace_id,
+            target_user_id=s.member,
+            performed_by_user_id="admin_runner",
+            performed_by_email="admin@kagura.invalid",
+            reason="noop",
+        )
+        assert result.changed is False
+        assert result.ownership_epoch == 1  # unchanged from the first transfer, not bumped
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.ownership_epoch == 1
+        audit = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(AuditLog.resource == f"workspace:{s.workspace_id}")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audit) == 1  # the no-op added NO new audit row
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_force_transfer_nonexistent_target_raises(self, ws_fixture, db_session):
+        s = ws_fixture
+        with pytest.raises(BadRequestError):
+            await WorkspaceOwnershipService(db_session).force_transfer_ownership(
+                workspace_id=s.workspace_id,
+                target_user_id="ghost_user_does_not_exist",
+                performed_by_user_id="admin_runner",
+                performed_by_email="admin@kagura.invalid",
+                reason="typo target",
+            )
+        await db_session.rollback()
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.owner
+        assert ws.ownership_epoch == 0
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_force_transfer_zero_member_workspace(self, db_session):
+        # A workspace with owner_user_id set but ZERO member rows — break-glass to a
+        # real user installs them as the OWNER member (the "no eligible target" case).
+        owner = f"zoown_{uuid4().hex[:8]}"
+        target = f"zotgt_{uuid4().hex[:8]}"
+        workspace_id = uuid4()
+        for uid in (owner, target):
+            await _add_user(db_session, uid)
+        await db_session.flush()
+        db_session.add(
+            Workspace(
+                id=workspace_id,
+                name=f"zeromember-{uuid4().hex[:8]}",
+                plan_name="free",
+                owner_user_id=owner,
+                daily_api_limit=100,
+                weekly_api_limit=500,
+                deleted_at=None,
+            )
+        )
+        await db_session.commit()  # NOTE: no WorkspaceMember rows at all
+        try:
+            result = await WorkspaceOwnershipService(db_session).force_transfer_ownership(
+                workspace_id=workspace_id,
+                target_user_id=target,
+                performed_by_user_id="admin_runner",
+                performed_by_email="admin@kagura.invalid",
+                reason="zero-member rescue",
+            )
+            assert result.changed is True
+            ws = await _workspace(db_session, workspace_id)
+            assert ws.owner_user_id == target
+            assert ws.ownership_epoch == 1
+            assert await _role_of(db_session, workspace_id, target) == WorkspaceRole.OWNER
+        finally:
+            await db_session.execute(
+                AuditLog.__table__.delete().where(AuditLog.resource == f"workspace:{workspace_id}")
+            )
+            await db_session.execute(
+                WorkspaceMember.__table__.delete().where(
+                    WorkspaceMember.workspace_id == workspace_id
+                )
+            )
+            await db_session.execute(
+                Workspace.__table__.delete().where(Workspace.id == workspace_id)
+            )
+            await db_session.execute(
+                User.__table__.delete().where(User.user_id.in_([owner, target]))
+            )
+            await db_session.commit()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_force_transfer_concurrent_preserves_single_owner(async_engine, db_session):
+    # Two concurrent break-glass force-transfers (to different targets) from
+    # independent sessions. force_transfer has NO current-owner check, so BOTH
+    # succeed -- but the shared workspace row lock must SERIALIZE them: each epoch
+    # bump applies (final epoch == 2, no lost increment) and there is exactly ONE
+    # OWNER member at the end (no torn double-owner). Without the lock both could
+    # read epoch==0, write epoch==1 (lost update), and both promote.
+    owner = f"fcown_{uuid4().hex[:8]}"
+    m1 = f"fcm1_{uuid4().hex[:8]}"
+    m2 = f"fcm2_{uuid4().hex[:8]}"
+    workspace_id = uuid4()
+    for uid in (owner, m1, m2):
+        await _add_user(db_session, uid)
+    await db_session.flush()
+    db_session.add(
+        Workspace(
+            id=workspace_id,
+            name=f"fconc-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=owner,
+            daily_api_limit=500,
+            weekly_api_limit=2500,
+            deleted_at=None,
+        )
+    )
+    await db_session.flush()
+    await _add_member(db_session, workspace_id, owner, WorkspaceRole.OWNER)
+    await _add_member(db_session, workspace_id, m1, WorkspaceRole.MEMBER)
+    await _add_member(db_session, workspace_id, m2, WorkspaceRole.MEMBER)
+    await db_session.commit()
+
+    session_maker = async_sessionmaker(async_engine, expire_on_commit=False)
+
+    async def _fxfer(target: str) -> str:
+        async with session_maker() as s:
+            await WorkspaceOwnershipService(s).force_transfer_ownership(
+                workspace_id=workspace_id,
+                target_user_id=target,
+                performed_by_user_id="admin_runner",
+                performed_by_email="admin@kagura.invalid",
+                reason="concurrent break-glass",
+            )
+            return "ok"
+
+    try:
+        statuses = sorted(await asyncio.gather(_fxfer(m1), _fxfer(m2)))
+        assert statuses == ["ok", "ok"]  # force has no current-owner conflict
+        async with session_maker() as s:
+            ws = (
+                await s.execute(select(Workspace).where(Workspace.id == workspace_id))
+            ).scalar_one()
+            owners = (
+                (
+                    await s.execute(
+                        select(WorkspaceMember).where(
+                            WorkspaceMember.workspace_id == workspace_id,
+                            WorkspaceMember.role == WorkspaceRole.OWNER,
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            assert len(owners) == 1  # lock prevented a torn double-owner
+            assert owners[0].user_id == ws.owner_user_id
+            assert ws.owner_user_id in (m1, m2)
+            assert ws.ownership_epoch == 2  # BOTH increments applied -- none lost
+    finally:
+        await db_session.execute(
+            AuditLog.__table__.delete().where(AuditLog.resource == f"workspace:{workspace_id}")
+        )
+        await db_session.execute(
+            WorkspaceMember.__table__.delete().where(WorkspaceMember.workspace_id == workspace_id)
+        )
+        await db_session.execute(Workspace.__table__.delete().where(Workspace.id == workspace_id))
+        await db_session.execute(User.__table__.delete().where(User.user_id.in_([owner, m1, m2])))
+        await db_session.commit()
+
+
+@pytest.mark.asyncio(loop_scope="session")
+async def test_workspace_member_unique_constraint_rejects_duplicate(db_session):
+    # #1101: (workspace_id, user_id) is UNIQUE at the DB level now, so the duplicate
+    # membership row the break-glass ADD path could otherwise race into is rejected.
+    from sqlalchemy.exc import IntegrityError
+
+    owner = f"uqo_{uuid4().hex[:8]}"
+    workspace_id = uuid4()
+    await _add_user(db_session, owner)
+    await db_session.flush()
+    db_session.add(
+        Workspace(
+            id=workspace_id,
+            name=f"uq-{uuid4().hex[:8]}",
+            plan_name="free",
+            owner_user_id=owner,
+            daily_api_limit=100,
+            weekly_api_limit=500,
+            deleted_at=None,
+        )
+    )
+    await db_session.flush()
+    await _add_member(db_session, workspace_id, owner, WorkspaceRole.OWNER)
+    await db_session.commit()
+    try:
+        await _add_member(db_session, workspace_id, owner, WorkspaceRole.MEMBER)  # dup (ws, user)
+        with pytest.raises(IntegrityError):
+            await db_session.commit()
+        await db_session.rollback()
+    finally:
+        await db_session.execute(
+            WorkspaceMember.__table__.delete().where(WorkspaceMember.workspace_id == workspace_id)
+        )
+        await db_session.execute(Workspace.__table__.delete().where(Workspace.id == workspace_id))
+        await db_session.execute(User.__table__.delete().where(User.user_id == owner))
+        await db_session.commit()

--- a/backend/tests/services/email_providers/test_resend.py
+++ b/backend/tests/services/email_providers/test_resend.py
@@ -531,3 +531,36 @@ async def test_send_workspace_ownership_transferred_returns_false_when_sdk_raise
             to_email="new@owner.com", workspace_name="Acme"
         )
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_ownership_force_transferred_calls_sdk_with_expected_payload():
+    # #1101: the prod (Resend) path notifies the displaced previous owner.
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+
+    with patch.object(
+        resend_module.resend.Emails, "send", return_value={"id": "re_force_001"}
+    ) as mock_send:
+        result = await svc.send_workspace_ownership_force_transferred(
+            to_email="prev@owner.com",
+            workspace_name="Acme Research",
+        )
+
+    assert result is True
+    mock_send.assert_called_once()
+    params = mock_send.call_args.args[0]
+    assert params["from"] == "noreply@example.com"
+    assert params["to"] == ["prev@owner.com"]
+    assert "Acme Research" in params["subject"]
+    assert "Acme Research" in params["text"]
+    assert "administrator" in params["text"]
+
+
+@pytest.mark.asyncio
+async def test_send_workspace_ownership_force_transferred_returns_false_when_sdk_raises():
+    svc = ResendEmailService(api_key="re_test", from_email="noreply@example.com")
+    with patch.object(resend_module.resend.Emails, "send", side_effect=RuntimeError("resend down")):
+        result = await svc.send_workspace_ownership_force_transferred(
+            to_email="prev@owner.com", workspace_name="Acme"
+        )
+    assert result is False

--- a/backend/tests/services/test_email_service.py
+++ b/backend/tests/services/test_email_service.py
@@ -374,3 +374,27 @@ def test_reset_email_service_for_testing_drops_singleton(monkeypatch: pytest.Mon
     reset_email_service_for_testing()
     second = get_email_service()
     assert first is not second
+
+
+@pytest.mark.asyncio
+async def test_logging_send_workspace_ownership_force_transferred():
+    """#1101: the logging stub records the displaced owner's address + workspace
+    for ops triage and returns True (no-raise courtesy-notification contract)."""
+    svc = LoggingEmailService()
+
+    with patch.object(email_service_module, "logger") as mock_logger:
+        result = await svc.send_workspace_ownership_force_transferred(
+            to_email="prev@owner.com",
+            workspace_name="Acme Research",
+        )
+
+    assert result is True
+    mock_logger.info.assert_called_once()
+    args, kwargs = mock_logger.info.call_args
+    assert args[0] == "workspace_ownership_force_transferred_email"
+    assert kwargs == {
+        "to_email": "prev@owner.com",
+        "workspace_name": "Acme Research",
+        "email_dispatch_required": True,
+        "template": "workspace_ownership_force_transferred",
+    }


### PR DESCRIPTION
Closes #1101

## Summary
A system-admin **break-glass** force-transfer of workspace ownership for when the owner is unavailable. `POST /admin/workspaces/{id}/force-transfer-ownership` (`require_admin`, path-bound) → `WorkspaceOwnershipService.force_transfer_ownership`:
- serializes on the **shared workspace row lock** (#1102) — same single-owner synchronization point as the voluntary transfer / role change / erasure;
- bumps `ownership_epoch` (#1100 invalidates the displaced owner's billing-handoff tokens / sessions);
- writes a **mandatory** audit row (`break_glass` + `reason` + acting admin + `target_was_member` + `self_transfer`) **atomically** with the transfer (fail-closed).

Unlike the voluntary path (#1094): **no current-owner check**; the target need not be a member — a non-member is **added** as OWNER (with `joined_at`), handling the **zero-member workspace**. The target must be a real `User` (else 400 `WS-OWNER-002` — never orphan the workspace). `reason` is **required** non-empty (422). The displaced **previous owner** is notified best-effort; an idempotent no-op still logs the privileged invocation.

## Hardening from code-review max (27-agent find→verify→sweep)
- **[HIGH] DB UNIQUE(workspace_id, user_id)** on `workspace_members` (migration **e47**, defensive dedup). The invariant was always assumed (docstring + check-then-insert) but never enforced; the break-glass non-member ADD made the gap reachable under concurrency. A duplicate insert now fails cleanly (IntegrityError → rollback → retry) instead of silently corrupting membership. Verified safe across the integration suite (erasure auto-transfer, etc.).
- `joined_at` on the added owner; `self_transfer` audit marker; no-op transparency log; notify-failure log carries `previous_owner_id`.
- Tests added: **force-transfer concurrency** (single owner + no lost epoch increment under the lock), unique-constraint rejection, route exception mapping (400/404/422), strengthened (non-default-epoch) idempotent assertion.

## Review
- gate1: **yellow** via /claude-c-suite:ask (CSO). Conditions all met: notify previous owner, require non-empty reason, validate target User, log `target_was_member`, atomic/alertable audit. Dual-control (optional per the issue) deferred → follow-up issue filed.
- code-review max: see above. CI is the final gate.

🤖 Generated via /gh-issue-driven:ship
