### PR TITLE
fix(workspace): refuse owner demotion in update_member_role (#1108)

### DIFF
--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -666,21 +666,30 @@ class WorkspaceService:
         # account_erasure) so the single-owner invariant is structural rather than
         # emergent. Plain member<->viewer changes never touch ownership and skip
         # the lock to keep the common path contention-free.
+        locked_workspace = None
         if WorkspaceRole.OWNER in (new_role, member.role):
-            await lock_workspace_for_update(self.db, workspace_id)
+            locked_workspace = await lock_workspace_for_update(self.db, workspace_id)
 
-        # #1108: refuse to DEMOTE the owner via this path. The owner is the
-        # single OWNER-role member, which in a consistent workspace IS the
-        # ``owner_user_id`` holder — the source of truth that transfer_ownership
-        # and downstream consumers read. Lowering that member's role here would
-        # drop the OWNER-row count to zero while ``owner_user_id`` still names
-        # them, desyncing the two owner representations (the gap #1102's lock
-        # serialized but did not itself close). Owner changes must go through
-        # transfer_ownership, which moves both representations atomically under
-        # this same lock — mirroring the promote-to-owner guard below and its
-        # 'transfer first' guidance. The lock above is already held on this
-        # branch (member.role == OWNER), so the check runs serialized.
-        if new_role != WorkspaceRole.OWNER and member.role == WorkspaceRole.OWNER:
+        # #1108: refuse to demote the workspace owner via this path. The source of
+        # truth for ownership is ``workspace.owner_user_id`` (what transfer_ownership
+        # and downstream consumers read); in a consistent workspace its holder is the
+        # single OWNER-role member. Lowering that holder's role here would drop the
+        # OWNER-row count to zero while ``owner_user_id`` still names them, desyncing
+        # the two representations (the gap #1102's lock serialized but did not itself
+        # close). Key the guard on the SoT holder — NOT merely on
+        # ``member.role == OWNER`` — so it (a) fires precisely for the real owner and
+        # (b) still permits demoting a *stray* OWNER-role row that is not the
+        # ``owner_user_id`` holder, which is the repair path out of a multi-owner
+        # corruption. Owner changes must go through transfer_ownership, which moves
+        # both representations atomically under this same lock (mirrors the
+        # promote-to-owner guard below). ``locked_workspace`` is always present when
+        # ``member.role == OWNER`` (the lock fires on that branch), so the consistent
+        # owner-demotion case is always covered and the check runs serialized.
+        if (
+            new_role != WorkspaceRole.OWNER
+            and locked_workspace is not None
+            and locked_workspace.owner_user_id == user_id
+        ):
             raise ValidationError(
                 "Cannot demote the workspace owner via a role change. "
                 "Only one owner is allowed per workspace. "

--- a/backend/src/services/workspace_service.py
+++ b/backend/src/services/workspace_service.py
@@ -669,6 +669,24 @@ class WorkspaceService:
         if WorkspaceRole.OWNER in (new_role, member.role):
             await lock_workspace_for_update(self.db, workspace_id)
 
+        # #1108: refuse to DEMOTE the owner via this path. The owner is the
+        # single OWNER-role member, which in a consistent workspace IS the
+        # ``owner_user_id`` holder — the source of truth that transfer_ownership
+        # and downstream consumers read. Lowering that member's role here would
+        # drop the OWNER-row count to zero while ``owner_user_id`` still names
+        # them, desyncing the two owner representations (the gap #1102's lock
+        # serialized but did not itself close). Owner changes must go through
+        # transfer_ownership, which moves both representations atomically under
+        # this same lock — mirroring the promote-to-owner guard below and its
+        # 'transfer first' guidance. The lock above is already held on this
+        # branch (member.role == OWNER), so the check runs serialized.
+        if new_role != WorkspaceRole.OWNER and member.role == WorkspaceRole.OWNER:
+            raise ValidationError(
+                "Cannot demote the workspace owner via a role change. "
+                "Only one owner is allowed per workspace. "
+                "Please transfer ownership first if you want to change the owner."
+            )
+
         # Validate single owner constraint (Issue #165)
         if new_role == WorkspaceRole.OWNER and member.role != WorkspaceRole.OWNER:
             # Promoting to owner - check if owner already exists

--- a/backend/tests/services/test_workspace_service.py
+++ b/backend/tests/services/test_workspace_service.py
@@ -343,7 +343,9 @@ class TestUpdateMemberRole:
         # #1102: an owner-mutating change must serialize on the workspace row
         # lock. #1108: that change is now refused (demotion → transfer first),
         # but the lock is still acquired BEFORE the refusal, so the owner
-        # invariant check runs under serialization.
+        # invariant check runs under serialization. The mock returns the
+        # workspace so the guard can read locked_workspace.owner_user_id (the SoT
+        # it now keys on).
         service = WorkspaceService(db_session)
         ws = Workspace(id=uuid4(), name="WLk1", owner_user_id="o1", plan_name="free")
         db_session.add(ws)
@@ -351,10 +353,58 @@ class TestUpdateMemberRole:
         db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="o1", role=WorkspaceRole.OWNER))
         await db_session.flush()
 
-        with patch("services.workspace_service.lock_workspace_for_update", AsyncMock()) as lock:
+        with patch(
+            "services.workspace_service.lock_workspace_for_update",
+            AsyncMock(return_value=ws),
+        ) as lock:
             with pytest.raises(ValidationError, match="transfer ownership"):
                 await service.update_member_role(ws.id, "o1", "admin")
         lock.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_demote_stray_owner_row_allowed_for_repair(self, db_session) -> None:
+        # #1108 (PR #1114 review): the guard keys on the owner_user_id SoT, not
+        # on member.role == OWNER. So a *stray* second OWNER-role row that is NOT
+        # the owner_user_id holder (a multi-owner corruption) CAN be demoted —
+        # this is the repair path. Demoting it neither touches owner_user_id nor
+        # drops the real owner's OWNER row, so no desync results.
+        from sqlalchemy import select
+
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W10c", owner_user_id="real_owner", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+        db_session.add(
+            WorkspaceMember(workspace_id=ws.id, user_id="real_owner", role=WorkspaceRole.OWNER)
+        )
+        db_session.add(
+            WorkspaceMember(workspace_id=ws.id, user_id="stray", role=WorkspaceRole.OWNER)
+        )
+        await db_session.flush()
+
+        # Demoting the stray (non-SoT) OWNER row is allowed — it repairs the
+        # corruption rather than causing a desync.
+        updated = await service.update_member_role(ws.id, "stray", "admin")
+        assert updated.role == "admin"
+
+        # The SoT owner is untouched and remains the sole OWNER.
+        refreshed = await db_session.get(Workspace, ws.id)
+        assert refreshed is not None
+        assert refreshed.owner_user_id == "real_owner"
+        owners = (
+            (
+                await db_session.execute(
+                    select(WorkspaceMember).where(
+                        WorkspaceMember.workspace_id == ws.id,
+                        WorkspaceMember.role == WorkspaceRole.OWNER,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(owners) == 1
+        assert owners[0].user_id == "real_owner"
 
     @pytest.mark.asyncio
     async def test_non_owner_change_skips_workspace_lock(self, db_session) -> None:

--- a/backend/tests/services/test_workspace_service.py
+++ b/backend/tests/services/test_workspace_service.py
@@ -283,7 +283,13 @@ class TestUpdateMemberRole:
             await service.update_member_role(ws.id, "u17", "owner")
 
     @pytest.mark.asyncio
-    async def test_demote_owner(self, db_session) -> None:
+    async def test_demote_owner_blocked(self, db_session) -> None:
+        # #1108: demoting the owner via update_member_role would desync
+        # owner_user_id (the SoT) from member.role — it would leave zero
+        # OWNER-role rows while owner_user_id still names the demoted user.
+        # Refuse here; owner changes must go through transfer_ownership
+        # (symmetric to the promote-to-owner guard, same 'transfer first'
+        # guidance).
         service = WorkspaceService(db_session)
         ws = Workspace(id=uuid4(), name="W10", owner_user_id="u18", plan_name="free")
         db_session.add(ws)
@@ -292,12 +298,52 @@ class TestUpdateMemberRole:
         db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u18", role=WorkspaceRole.OWNER))
         await db_session.flush()
 
-        updated = await service.update_member_role(ws.id, "u18", "admin")
-        assert updated.role == "admin"
+        with pytest.raises(ValidationError, match="transfer ownership"):
+            await service.update_member_role(ws.id, "u18", "admin")
+
+    @pytest.mark.asyncio
+    async def test_demote_owner_preserves_owner_invariant(self, db_session) -> None:
+        # The refused demotion must leave BOTH owner representations intact:
+        # owner_user_id unchanged AND exactly one OWNER-role member remaining
+        # (and it is still the owner_user_id holder). This is the desync the
+        # #1102 lock did not by itself prevent.
+        from sqlalchemy import select
+
+        service = WorkspaceService(db_session)
+        ws = Workspace(id=uuid4(), name="W10b", owner_user_id="u19", plan_name="free")
+        db_session.add(ws)
+        await db_session.flush()
+        db_session.add(WorkspaceMember(workspace_id=ws.id, user_id="u19", role=WorkspaceRole.OWNER))
+        await db_session.flush()
+
+        with pytest.raises(ValidationError):
+            await service.update_member_role(ws.id, "u19", "viewer")
+
+        refreshed = await db_session.get(Workspace, ws.id)
+        assert refreshed is not None
+        assert refreshed.owner_user_id == "u19"
+
+        owners = (
+            (
+                await db_session.execute(
+                    select(WorkspaceMember).where(
+                        WorkspaceMember.workspace_id == ws.id,
+                        WorkspaceMember.role == WorkspaceRole.OWNER,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(owners) == 1
+        assert owners[0].user_id == "u19"
 
     @pytest.mark.asyncio
     async def test_owner_change_takes_workspace_lock(self, db_session) -> None:
-        # #1102: demoting an OWNER must serialize on the workspace row lock.
+        # #1102: an owner-mutating change must serialize on the workspace row
+        # lock. #1108: that change is now refused (demotion → transfer first),
+        # but the lock is still acquired BEFORE the refusal, so the owner
+        # invariant check runs under serialization.
         service = WorkspaceService(db_session)
         ws = Workspace(id=uuid4(), name="WLk1", owner_user_id="o1", plan_name="free")
         db_session.add(ws)
@@ -306,7 +352,8 @@ class TestUpdateMemberRole:
         await db_session.flush()
 
         with patch("services.workspace_service.lock_workspace_for_update", AsyncMock()) as lock:
-            await service.update_member_role(ws.id, "o1", "admin")
+            with pytest.raises(ValidationError, match="transfer ownership"):
+                await service.update_member_role(ws.id, "o1", "admin")
         lock.assert_awaited_once()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1108

## Summary
- `update_member_role` mutated `WorkspaceMember.role` only; demoting the owner left **zero** OWNER-role rows while `workspace.owner_user_id` still named the demoted user — desyncing the two owner representations (a later `transfer_ownership` then reads a stale owner).
- Adds a service-layer guard (after the #1102 workspace-row lock) refusing to demote the OWNER-role member, directing owner changes through `transfer_ownership`. Symmetric to the existing promote-to-owner guard 15 lines below.
- Defense-in-depth: owner-demotion is already unreachable via the HTTP route (#254 self-role-change + owner-only guards); this makes the single-owner / `owner_user_id` invariant **structural** for any caller.

## Implementation notes
- The guard runs under `lock_workspace_for_update`, so the invariant check is serialized with the other owner-mutating paths.
- `transfer_ownership` / `account_erasure` mutate `member.role` directly (not via this method), so they bypass the guard and are unaffected.
- Tests: `test_demote_owner` → `test_demote_owner_blocked`; new `test_demote_owner_preserves_owner_invariant` (asserts `owner_user_id` unchanged + exactly one OWNER member after the refusal); `test_owner_change_takes_workspace_lock` now asserts the lock is still acquired before the refusal.

## Pre-PR review summary
- gate2 mode: advisor-only
- cso: green / qa-lead: green / cto: green
- gate1: green via /ask (routed to CTO)
- code-review (max): 0 findings

🤖 Generated via /gh-issue-driven:ship
