### PR TITLE
feat(workspace): dual-control for break-glass force-transfer (#1113)

### DIFF
--- a/backend/alembic/versions/e48_1113_force_transfer_dual_control.py
+++ b/backend/alembic/versions/e48_1113_force_transfer_dual_control.py
@@ -1,0 +1,94 @@
+"""Add workspace_ownership_force_transfer_requests for dual-control (#1113).
+
+Optional four-eyes approval for the break-glass ownership force-transfer
+(#1101). When ``require_dual_control_force_transfer`` is enabled, an initiating
+system admin files a ``pending`` request in this table and a second, distinct
+system admin must approve it before the transfer commits. Default config keeps
+the immediate single-control behavior, so this table is unused there.
+
+``ownership_epoch_at_initiation`` snapshots the workspace epoch so approval can
+reject a stale request whose workspace ownership moved since it was filed. The
+partial-unique index enforces at most one ``pending`` request per workspace (a
+fresh initiate supersedes any prior pending one).
+
+Revision ID: e48_1113_dual_control
+Revises: e47_1101_member_unique
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e48_1113_dual_control"
+down_revision = "e47_1101_member_unique"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_ownership_force_transfer_requests",
+        sa.Column(
+            "id",
+            UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("workspace_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("target_user_id", sa.String(length=255), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=False),
+        sa.Column("ownership_epoch_at_initiation", sa.Integer(), nullable=False),
+        sa.Column("initiated_by_user_id", sa.String(length=255), nullable=False),
+        sa.Column("initiated_by_email", sa.String(length=255), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=20),
+            nullable=False,
+            server_default="pending",
+        ),
+        sa.Column("decided_by_user_id", sa.String(length=255), nullable=True),
+        sa.Column("decided_by_email", sa.String(length=255), nullable=True),
+        sa.Column("decided_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index(
+        "ix_force_transfer_request_workspace_id",
+        "workspace_ownership_force_transfer_requests",
+        ["workspace_id"],
+    )
+    op.create_index(
+        "ix_force_transfer_request_created_at",
+        "workspace_ownership_force_transfer_requests",
+        ["created_at"],
+    )
+    # At most one PENDING request per workspace (the supersede / unblock invariant).
+    op.create_index(
+        "uq_force_transfer_request_one_pending_per_workspace",
+        "workspace_ownership_force_transfer_requests",
+        ["workspace_id"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "uq_force_transfer_request_one_pending_per_workspace",
+        table_name="workspace_ownership_force_transfer_requests",
+    )
+    op.drop_index(
+        "ix_force_transfer_request_created_at",
+        table_name="workspace_ownership_force_transfer_requests",
+    )
+    op.drop_index(
+        "ix_force_transfer_request_workspace_id",
+        table_name="workspace_ownership_force_transfer_requests",
+    )
+    op.drop_table("workspace_ownership_force_transfer_requests")

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -1318,6 +1318,42 @@ async def cancel_force_transfer_request(
     }
 
 
+@router.get("/force-transfer-requests/{request_id}")
+async def get_force_transfer_request(
+    request_id: str,
+    admin: dict = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Dual-control (#1113): inspect a force-transfer request before approving.
+
+    System-admin-gated read so the SECOND admin can verify the target, reason,
+    and initiator before calling ``/approve`` — making four-eyes an informed
+    review rather than a blind second button-press. 404 if no such request.
+    """
+    # ``admin`` is the system-admin auth gate (require_admin); the read itself
+    # needs no actor identity.
+    _ = get_user_id(admin)
+    try:
+        req_uuid = UUID(request_id)
+    except ValueError as exc:
+        raise ValidationError("Invalid request_id", field="request_id") from exc
+
+    req = await WorkspaceOwnershipService(db).get_force_transfer_request(request_id=req_uuid)
+    return {
+        "request_id": str(req.id),
+        "workspace_id": str(req.workspace_id),
+        "target_user_id": req.target_user_id,
+        "reason": req.reason,
+        "status": req.status,
+        "initiated_by_user_id": req.initiated_by_user_id,
+        "initiated_by_email": req.initiated_by_email,
+        "ownership_epoch_at_initiation": req.ownership_epoch_at_initiation,
+        "created_at": to_utc_iso(req.created_at),
+        "decided_by_user_id": req.decided_by_user_id,
+        "decided_at": to_utc_iso(req.decided_at) if req.decided_at else None,
+    }
+
+
 async def _notify_force_transfer_best_effort(
     db: AsyncSession, workspace_id: UUID, previous_owner_id: str
 ) -> None:

--- a/backend/src/api/routes/admin.py
+++ b/backend/src/api/routes/admin.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from typing import Any, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel, Field
 from sqlalchemy import and_, delete, func, or_, select, text, update
 from sqlalchemy.engine import CursorResult
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.dependencies import require_admin
 from auth.workspace_roles import ContextRole, WorkspaceRole
+from config.settings import get_settings
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from models.auth import (
@@ -1172,6 +1173,7 @@ class ForceTransferOwnershipRequest(BaseModel):
 async def force_transfer_workspace_ownership(
     workspace_id: str,
     body: ForceTransferOwnershipRequest,
+    response: Response,
     admin: dict = Depends(require_admin),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
@@ -1185,6 +1187,12 @@ async def force_transfer_workspace_ownership(
     transfer. The target need not be a member — a non-member is added as OWNER,
     which handles the zero-member workspace. The displaced previous owner is
     notified best-effort.
+
+    Dual-control (#1113): when ``require_dual_control_force_transfer`` is enabled,
+    this does NOT seize ownership immediately — it files a PENDING request and
+    returns ``202`` with a ``request_id`` that a SECOND, distinct system admin
+    must approve via ``/admin/force-transfer-requests/{request_id}/approve``.
+    Default config keeps the immediate single-control behavior.
     """
     admin_id = get_user_id(admin)
     try:
@@ -1192,11 +1200,33 @@ async def force_transfer_workspace_ownership(
     except ValueError as exc:
         raise ValidationError("Invalid workspace_id", field="workspace_id") from exc
 
-    result = await WorkspaceOwnershipService(db).force_transfer_ownership(
+    svc = WorkspaceOwnershipService(db)
+    admin_email = str(admin.get("email") or admin_id)
+
+    # Dual-control: file a pending request for second-admin approval (202).
+    if get_settings().require_dual_control_force_transfer:
+        req = await svc.initiate_force_transfer(
+            workspace_id=ws_uuid,
+            target_user_id=body.target_user_id,
+            performed_by_user_id=admin_id,
+            performed_by_email=admin_email,
+            reason=body.reason,
+        )
+        response.status_code = status.HTTP_202_ACCEPTED
+        return {
+            "workspace_id": str(req.workspace_id),
+            "request_id": str(req.id),
+            "status": "pending_approval",
+            "target_user_id": req.target_user_id,
+            "initiated_by": req.initiated_by_user_id,
+            "dual_control": True,
+        }
+
+    result = await svc.force_transfer_ownership(
         workspace_id=ws_uuid,
         target_user_id=body.target_user_id,
         performed_by_user_id=admin_id,
-        performed_by_email=str(admin.get("email") or admin_id),
+        performed_by_email=admin_email,
         reason=body.reason,
     )
 
@@ -1212,6 +1242,79 @@ async def force_transfer_workspace_ownership(
         "new_owner_id": result.new_owner_id,
         "ownership_epoch": result.ownership_epoch,
         "changed": result.changed,
+        "dual_control": False,
+    }
+
+
+@router.post("/force-transfer-requests/{request_id}/approve")
+async def approve_force_transfer_request(
+    request_id: str,
+    admin: dict = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Dual-control (#1113): a SECOND system admin approves a pending force-transfer.
+
+    System-admin-gated. The approver MUST be a different admin than the initiator
+    (enforced in the service → 400). On approval the seizure applies atomically
+    with a mandatory audit recording BOTH identities, bumps ``ownership_epoch``,
+    and the displaced previous owner is notified best-effort. Refused with 409 if
+    the request is not pending, or if the workspace's ownership moved since the
+    request was filed (stale — re-initiate).
+    """
+    admin_id = get_user_id(admin)
+    try:
+        req_uuid = UUID(request_id)
+    except ValueError as exc:
+        raise ValidationError("Invalid request_id", field="request_id") from exc
+
+    result = await WorkspaceOwnershipService(db).approve_force_transfer(
+        request_id=req_uuid,
+        approver_user_id=admin_id,
+        approver_email=str(admin.get("email") or admin_id),
+    )
+
+    if result.changed:
+        await _notify_force_transfer_best_effort(db, result.workspace_id, result.previous_owner_id)
+
+    return {
+        "workspace_id": str(result.workspace_id),
+        "request_id": request_id,
+        "status": "approved",
+        "previous_owner_id": result.previous_owner_id,
+        "new_owner_id": result.new_owner_id,
+        "ownership_epoch": result.ownership_epoch,
+        "changed": result.changed,
+    }
+
+
+@router.post("/force-transfer-requests/{request_id}/cancel")
+async def cancel_force_transfer_request(
+    request_id: str,
+    admin: dict = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Dual-control (#1113): retract a pending force-transfer request.
+
+    System-admin-gated. Lets an admin cancel a pending request (e.g. filed in
+    error) without having to initiate a fresh one to supersede it. Refused with
+    409 if the request is not pending.
+    """
+    admin_id = get_user_id(admin)
+    try:
+        req_uuid = UUID(request_id)
+    except ValueError as exc:
+        raise ValidationError("Invalid request_id", field="request_id") from exc
+
+    req = await WorkspaceOwnershipService(db).cancel_force_transfer(
+        request_id=req_uuid,
+        cancelled_by_user_id=admin_id,
+        cancelled_by_email=str(admin.get("email") or admin_id),
+    )
+    return {
+        "workspace_id": str(req.workspace_id),
+        "request_id": str(req.id),
+        "status": req.status,
+        "cancelled_by": admin_id,
     }
 
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -310,6 +310,15 @@ class Settings(BaseSettings):
         "When False, only invited users and the first admin can register.",
     )
 
+    # Workspace Governance (Issue #1113)
+    require_dual_control_force_transfer: bool = Field(
+        default=False,
+        description="Require a second, distinct system admin to approve a break-glass "
+        "ownership force-transfer before it commits (four-eyes). When False (default), "
+        "force-transfer commits immediately as today. Enabling this needs >=2 system "
+        "admins — with only one, no force-transfer can be approved.",
+    )
+
     # Billing Plugin (OSS: disabled by default, SaaS: enabled with Stripe)
     billing_enabled: bool = Field(
         default=False,

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -2135,3 +2135,91 @@ class MCPToolDescription(Base):
     def __repr__(self) -> str:
         """String representation."""
         return f"<MCPToolDescription(tool='{self.tool_name}', locale='{self.locale}')>"
+
+
+# Force-transfer dual-control lifecycle statuses (#1113).
+FORCE_TRANSFER_STATUS_PENDING = "pending"
+FORCE_TRANSFER_STATUS_APPROVED = "approved"
+FORCE_TRANSFER_STATUS_CANCELLED = "cancelled"
+FORCE_TRANSFER_STATUS_SUPERSEDED = "superseded"
+
+
+class WorkspaceOwnershipForceTransferRequest(Base):
+    """Pending dual-control approval for a break-glass ownership force-transfer (#1113).
+
+    When ``require_dual_control_force_transfer`` is enabled, a break-glass
+    force-transfer (#1101) does NOT commit immediately: the initiating system
+    admin creates a ``pending`` request here, and a *second, distinct* system
+    admin must approve it before the transfer applies. The mandatory #1101
+    ``AuditLog`` row written at approval records BOTH identities. With the default
+    config the immediate single-control behavior is unchanged and this table is
+    unused.
+
+    ``ownership_epoch_at_initiation`` snapshots the workspace's epoch when the
+    request was filed. Approval re-reads the epoch under the workspace row lock
+    and refuses if it changed (a concurrent voluntary transfer / erasure /
+    another force-transfer moved ownership), so the second approver always
+    approves the *current* reality rather than a stale snapshot — closing a
+    confused-deputy gap.
+
+    A partial-unique index forbids more than one ``pending`` request per
+    workspace; a fresh ``initiate`` supersedes any existing pending one (marks it
+    ``superseded``), which doubles as the unblock path for an abandoned request.
+
+    Attributes:
+        id: Primary key (UUID).
+        workspace_id: Workspace whose ownership the request would seize.
+        target_user_id: User to be installed as owner on approval.
+        reason: Required justification (audited at approval).
+        ownership_epoch_at_initiation: Workspace epoch snapshot for staleness check.
+        initiated_by_user_id / initiated_by_email: The first admin (initiator).
+        status: pending | approved | cancelled | superseded.
+        decided_by_user_id / decided_by_email / decided_at: The deciding admin
+            (approver or canceller); NULL while pending.
+        created_at: Filing timestamp.
+    """
+
+    __tablename__ = "workspace_ownership_force_transfer_requests"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
+    )
+    workspace_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    target_user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False)
+    ownership_epoch_at_initiation: Mapped[int] = mapped_column(Integer, nullable=False)
+
+    # Initiator (first admin)
+    initiated_by_user_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    initiated_by_email: Mapped[str] = mapped_column(String(255), nullable=False)
+
+    # Lifecycle: pending -> approved | cancelled | superseded
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default=FORCE_TRANSFER_STATUS_PENDING
+    )
+
+    # Decider (approver or canceller) — NULL while pending
+    decided_by_user_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    decided_by_email: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    decided_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, server_default=func.now(), index=True
+    )
+
+    __table_args__ = (
+        # At most one PENDING request per workspace (the supersede/unblock invariant).
+        Index(
+            "uq_force_transfer_request_one_pending_per_workspace",
+            "workspace_id",
+            unique=True,
+            postgresql_where=text("status = 'pending'"),
+        ),
+    )
+
+    def __repr__(self) -> str:
+        """String representation."""
+        return (
+            "<WorkspaceOwnershipForceTransferRequest("
+            f"id={self.id}, workspace_id={self.workspace_id}, status='{self.status}')>"
+        )

--- a/backend/src/models/auth.py
+++ b/backend/src/models/auth.py
@@ -2184,7 +2184,7 @@ class WorkspaceOwnershipForceTransferRequest(Base):
     id: Mapped[uuid.UUID] = mapped_column(
         UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid()
     )
-    workspace_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
+    workspace_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False)
     target_user_id: Mapped[str] = mapped_column(String(255), nullable=False)
     reason: Mapped[str] = mapped_column(Text, nullable=False)
     ownership_epoch_at_initiation: Mapped[int] = mapped_column(Integer, nullable=False)
@@ -2204,10 +2204,16 @@ class WorkspaceOwnershipForceTransferRequest(Base):
     decided_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(
-        DateTime, nullable=False, server_default=func.now(), index=True
+        DateTime, nullable=False, server_default=func.now()
     )
 
+    # Indexes are declared explicitly (not via column-level ``index=True``) so the
+    # names match the alembic migration e48 verbatim — column-level index=True
+    # would auto-generate the long NAMING_CONVENTION names (db/base.py), drifting
+    # from the migration's hand-coded names and causing autogenerate churn (#613).
     __table_args__ = (
+        Index("ix_force_transfer_request_workspace_id", "workspace_id"),
+        Index("ix_force_transfer_request_created_at", "created_at"),
         # At most one PENDING request per workspace (the supersede/unblock invariant).
         Index(
             "uq_force_transfer_request_one_pending_per_workspace",

--- a/backend/src/models/data_boundary.py
+++ b/backend/src/models/data_boundary.py
@@ -73,6 +73,9 @@ OPERATIONAL_TABLES: frozenset[str] = frozenset(
         "workspace_addons",
         "workspace_connectors",
         "workspace_storage_usage",
+        # break-glass dual-control approval workflow (#1113) — governance plumbing,
+        # like erasure_requests/audit_logs; no user content, no learned structure
+        "workspace_ownership_force_transfer_requests",
         "context_members",
         "context_search_configs",
         "plan_changes",

--- a/backend/src/services/workspace_ownership_service.py
+++ b/backend/src/services/workspace_ownership_service.py
@@ -43,17 +43,27 @@ is intentionally NOT faked here.
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import Any, NamedTuple
 from uuid import UUID
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from auth.workspace_roles import WorkspaceRole
-from models.auth import AuditLog, User, WorkspaceMember
+from models.auth import (
+    FORCE_TRANSFER_STATUS_APPROVED,
+    FORCE_TRANSFER_STATUS_CANCELLED,
+    FORCE_TRANSFER_STATUS_PENDING,
+    FORCE_TRANSFER_STATUS_SUPERSEDED,
+    AuditLog,
+    User,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceOwnershipForceTransferRequest,
+)
 from services.workspace_locks import lock_workspace_for_update
 from utils.datetime import utcnow
-from utils.exceptions import BadRequestError, ConflictError
+from utils.exceptions import BadRequestError, ConflictError, NotFoundException
 from utils.logger import get_logger
 
 logger = get_logger(__name__)
@@ -271,11 +281,63 @@ class WorkspaceOwnershipService:
         # and erasure auto-transfer on the SAME FOR UPDATE row.
         workspace = await lock_workspace_for_update(self.db, workspace_id)
 
-        # 2. Idempotent no-op: already owned by the target (no epoch bump / audit).
-        # Still record the privileged invocation: a break-glass control's whole
-        # justification is attributability, so an admin hitting this endpoint must
-        # leave a trace even when nothing changes (this log line is the alertable
-        # signal; the no-op writes no AuditLog row, mirroring the voluntary path).
+        # 2. Single-control path (#1101): apply the seizure on the locked row and
+        # commit. The shared core (_apply_force_transfer) stages the swap + epoch
+        # bump + mandatory audit; this path preserves #1101 behavior exactly — the
+        # idempotent no-op neither commits nor audits (its log line is the signal).
+        result = await self._apply_force_transfer(
+            workspace=workspace,
+            target_user_id=target_user_id,
+            performed_by_user_id=performed_by_user_id,
+            performed_by_email=performed_by_email,
+            reason=reason,
+        )
+        if result.changed:
+            await self.db.commit()
+            logger.info(
+                "workspace_ownership_force_transferred",
+                workspace_id=str(workspace_id),
+                previous_owner=result.previous_owner_id,
+                new_owner=result.new_owner_id,
+                ownership_epoch=result.ownership_epoch,
+                performed_by=performed_by_user_id,
+            )
+        return result
+
+    async def _apply_force_transfer(
+        self,
+        *,
+        workspace: Workspace,
+        target_user_id: str,
+        performed_by_user_id: str,
+        performed_by_email: str,
+        reason: str,
+        audit_extra: dict[str, Any] | None = None,
+    ) -> OwnershipTransferResult:
+        """Apply a break-glass ownership seizure on an ALREADY-LOCKED workspace.
+
+        Shared core of ``force_transfer_ownership`` (#1101, single-control) and
+        ``approve_force_transfer`` (#1113, dual-control). The caller MUST already
+        hold the workspace row lock (``lock_workspace_for_update``) and owns the
+        final ``commit`` — this method stages the membership swap, ``ownership_epoch``
+        bump, and the mandatory audit row but does NOT commit, so the caller can
+        atomically include its own mutations (e.g. marking the dual-control request
+        approved) in the same transaction.
+
+        Idempotent no-op (target already owns it): logs the alertable no-op line
+        and returns ``changed=False`` WITHOUT staging an audit row, mirroring the
+        #1101 voluntary-path behavior.
+
+        ``audit_extra`` is merged into the AuditLog ``user_metadata`` so the
+        dual-control path can record both the initiator and the approver.
+
+        Raises:
+            BadRequestError: the target user does not exist (400, WS-OWNER-002).
+        """
+        workspace_id = workspace.id
+
+        # Idempotent no-op: already owned by the target (no epoch bump / audit).
+        # The log line is the alertable signal even when nothing changes.
         if workspace.owner_user_id == target_user_id:
             logger.info(
                 "workspace_ownership_force_transfer_noop",
@@ -291,12 +353,9 @@ class WorkspaceOwnershipService:
                 changed=False,
             )
 
-        # 3. The target must be a real account — handing ownership to a phantom
-        # user_id would permanently orphan the workspace (worse than the original
-        # unavailable-owner problem). This is a best-effort existence check, not a
-        # FK (``owner_user_id`` has no FK to ``users.user_id``); a target concurrently
-        # hard-erased between this check and commit is a narrow accepted race — the
-        # erase path itself auto-transfers/blocks on owned workspaces.
+        # The target must be a real account — handing ownership to a phantom
+        # user_id would permanently orphan the workspace. Best-effort existence
+        # check (``owner_user_id`` has no FK to ``users.user_id``).
         target_user = (
             await self.db.execute(select(User).where(User.user_id == target_user_id))
         ).scalar_one_or_none()
@@ -308,7 +367,7 @@ class WorkspaceOwnershipService:
 
         previous_owner_id = workspace.owner_user_id
 
-        # 4. Load BOTH the target and previous-owner member rows in one round-trip.
+        # Load BOTH the target and previous-owner member rows in one round-trip.
         member_rows = (
             (
                 await self.db.execute(
@@ -327,13 +386,9 @@ class WorkspaceOwnershipService:
         target_was_member = target_member is not None
         if target_member is None:
             # Break-glass elevated path: the target is not a member (e.g. a
-            # zero-member workspace). Add them as OWNER. Flagged in the audit via
-            # target_was_member=False so forensics can isolate the elevated case.
-            # joined_at is set like every other membership-creation path so the new
-            # owner does not carry a NULL join timestamp. The (workspace_id, user_id)
+            # zero-member workspace). Add them as OWNER. The (workspace_id, user_id)
             # UNIQUE constraint (#1101) makes a concurrent duplicate insert fail
-            # cleanly (IntegrityError → rollback → admin retries) rather than
-            # silently creating two membership rows.
+            # cleanly rather than silently creating two membership rows.
             self.db.add(
                 WorkspaceMember(
                     workspace_id=workspace_id,
@@ -355,39 +410,31 @@ class WorkspaceOwnershipService:
         new_epoch = workspace.ownership_epoch + 1
         workspace.ownership_epoch = new_epoch
 
-        # 5. Mandatory audit in the SAME transaction (fail-closed). The actor is the
-        # acting ADMIN's user_id (NOT the displaced workspace owner). reason +
-        # break_glass + target_was_member make the override fully attributable.
+        # Mandatory audit staged in the caller's transaction (fail-closed). The
+        # actor is the acting ADMIN (NOT the displaced owner). ``audit_extra`` adds
+        # the dual-control identities (initiator + approver) when present.
+        metadata: dict[str, Any] = {
+            "break_glass": True,
+            "reason": reason,
+            "previous_owner_id": previous_owner_id,
+            "new_owner_id": target_user_id,
+            "ownership_epoch": new_epoch,
+            "target_was_member": target_was_member,
+            # Self-dealing (the acting admin installs themselves) is allowed by
+            # break-glass but flagged explicitly so forensics needn't compare the
+            # actor column against new_owner_id by hand.
+            "self_transfer": performed_by_user_id == target_user_id,
+        }
+        if audit_extra:
+            metadata.update(audit_extra)
         self.db.add(
             AuditLog(
                 user_email=performed_by_email,
                 user_id=performed_by_user_id,
                 action=FORCE_OWNERSHIP_TRANSFER_ACTION,
                 resource=f"workspace:{workspace_id}",
-                user_metadata={
-                    "break_glass": True,
-                    "reason": reason,
-                    "previous_owner_id": previous_owner_id,
-                    "new_owner_id": target_user_id,
-                    "ownership_epoch": new_epoch,
-                    "target_was_member": target_was_member,
-                    # Self-dealing (the acting admin installs themselves) is allowed
-                    # by break-glass but flagged explicitly so forensics needn't
-                    # compare the actor column against new_owner_id by hand.
-                    "self_transfer": performed_by_user_id == target_user_id,
-                },
+                user_metadata=metadata,
             )
-        )
-        await self.db.commit()
-
-        logger.info(
-            "workspace_ownership_force_transferred",
-            workspace_id=str(workspace_id),
-            previous_owner=previous_owner_id,
-            new_owner=target_user_id,
-            ownership_epoch=new_epoch,
-            performed_by=performed_by_user_id,
-            target_was_member=target_was_member,
         )
         return OwnershipTransferResult(
             workspace_id=workspace_id,
@@ -396,3 +443,221 @@ class WorkspaceOwnershipService:
             ownership_epoch=new_epoch,
             changed=True,
         )
+
+    # ------------------------------------------------------------------
+    # Dual-control force-transfer (#1113)
+    # ------------------------------------------------------------------
+
+    async def initiate_force_transfer(
+        self,
+        *,
+        workspace_id: UUID,
+        target_user_id: str,
+        performed_by_user_id: str,
+        performed_by_email: str,
+        reason: str,
+    ) -> WorkspaceOwnershipForceTransferRequest:
+        """File a PENDING dual-control force-transfer request (#1113).
+
+        Used when ``require_dual_control_force_transfer`` is enabled: instead of
+        seizing ownership immediately, the initiating admin records intent here
+        and a second, distinct admin must ``approve_force_transfer`` before it
+        commits. Snapshots ``ownership_epoch`` so approval can reject a stale
+        request whose ownership moved since filing.
+
+        Supersedes any existing pending request for the workspace (marks it
+        ``superseded``) — this is the unblock path for an abandoned request, and
+        keeps the one-pending-per-workspace partial-unique invariant.
+
+        Raises:
+            NotFoundException: workspace missing or soft-deleted (404).
+            BadRequestError: the target user does not exist (400, WS-OWNER-002).
+        """
+        # Lock the workspace row (validates exists / not soft-deleted) and pin the
+        # epoch snapshot under the same serialization as every owner-mutating path.
+        workspace = await lock_workspace_for_update(self.db, workspace_id)
+
+        # Don't file a request for a phantom target — same guard as the apply path.
+        target_user = (
+            await self.db.execute(select(User).where(User.user_id == target_user_id))
+        ).scalar_one_or_none()
+        if target_user is None:
+            raise BadRequestError(
+                "Target user does not exist",
+                error_code="WS-OWNER-002",
+            )
+
+        # Supersede any existing pending request for this workspace, then flush so
+        # the partial-unique (one pending per workspace) is satisfied before the
+        # new insert.
+        existing = (
+            (
+                await self.db.execute(
+                    select(WorkspaceOwnershipForceTransferRequest).where(
+                        WorkspaceOwnershipForceTransferRequest.workspace_id == workspace_id,
+                        WorkspaceOwnershipForceTransferRequest.status
+                        == FORCE_TRANSFER_STATUS_PENDING,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for prior in existing:
+            prior.status = FORCE_TRANSFER_STATUS_SUPERSEDED
+            prior.decided_by_user_id = performed_by_user_id
+            prior.decided_by_email = performed_by_email
+            prior.decided_at = utcnow()
+        if existing:
+            await self.db.flush()
+
+        request = WorkspaceOwnershipForceTransferRequest(
+            workspace_id=workspace_id,
+            target_user_id=target_user_id,
+            reason=reason,
+            ownership_epoch_at_initiation=workspace.ownership_epoch,
+            initiated_by_user_id=performed_by_user_id,
+            initiated_by_email=performed_by_email,
+            status=FORCE_TRANSFER_STATUS_PENDING,
+        )
+        self.db.add(request)
+        await self.db.commit()
+        await self.db.refresh(request)
+
+        logger.info(
+            "workspace_ownership_force_transfer_initiated",
+            workspace_id=str(workspace_id),
+            request_id=str(request.id),
+            target=target_user_id,
+            initiated_by=performed_by_user_id,
+            superseded=len(existing),
+        )
+        return request
+
+    async def approve_force_transfer(
+        self,
+        *,
+        request_id: UUID,
+        approver_user_id: str,
+        approver_email: str,
+    ) -> OwnershipTransferResult:
+        """Approve a pending dual-control request and apply the transfer (#1113).
+
+        Four-eyes control: the approver MUST be a *different* system admin than
+        the initiator. Under the workspace row lock, re-checks that ownership has
+        not moved since the request was filed (staleness) before applying the
+        seizure; the apply, the request status update, and the mandatory audit
+        (recording BOTH identities) commit atomically.
+
+        Raises:
+            NotFoundException: no such request (404).
+            ConflictError: request not pending (409) or ownership moved since
+                filing (409, stale — re-initiate).
+            BadRequestError: approver is the initiator (400, WS-OWNER-DUAL-001)
+                or the target user no longer exists (400, WS-OWNER-002).
+        """
+        request = (
+            await self.db.execute(
+                select(WorkspaceOwnershipForceTransferRequest).where(
+                    WorkspaceOwnershipForceTransferRequest.id == request_id
+                )
+            )
+        ).scalar_one_or_none()
+        if request is None:
+            raise NotFoundException("Force-transfer request", str(request_id))
+        if request.status != FORCE_TRANSFER_STATUS_PENDING:
+            raise ConflictError(f"Force-transfer request is not pending (status={request.status})")
+
+        # No self-approval — the whole point of dual-control is a second pair of
+        # eyes. Checked before the lock (cheap, request-only) so we fail fast.
+        if approver_user_id == request.initiated_by_user_id:
+            raise BadRequestError(
+                "A force-transfer must be approved by a different system admin "
+                "than the one who initiated it",
+                error_code="WS-OWNER-DUAL-001",
+            )
+
+        # Lock the workspace and re-validate the snapshot: if ownership moved since
+        # the request was filed, the approver would be acting on a stale premise
+        # (confused deputy). Refuse and require a fresh initiate.
+        workspace = await lock_workspace_for_update(self.db, request.workspace_id)
+        if workspace.ownership_epoch != request.ownership_epoch_at_initiation:
+            raise ConflictError(
+                "Workspace ownership changed since this force-transfer was "
+                "initiated; re-initiate the request and have it re-approved"
+            )
+
+        result = await self._apply_force_transfer(
+            workspace=workspace,
+            target_user_id=request.target_user_id,
+            performed_by_user_id=approver_user_id,
+            performed_by_email=approver_email,
+            reason=request.reason,
+            audit_extra={
+                "dual_control": True,
+                "force_transfer_request_id": str(request.id),
+                "initiated_by_user_id": request.initiated_by_user_id,
+                "initiated_by_email": request.initiated_by_email,
+                "approved_by_user_id": approver_user_id,
+            },
+        )
+
+        # Mark the request approved atomically with the transfer.
+        request.status = FORCE_TRANSFER_STATUS_APPROVED
+        request.decided_by_user_id = approver_user_id
+        request.decided_by_email = approver_email
+        request.decided_at = utcnow()
+        await self.db.commit()
+
+        logger.info(
+            "workspace_ownership_force_transfer_approved",
+            workspace_id=str(request.workspace_id),
+            request_id=str(request.id),
+            initiated_by=request.initiated_by_user_id,
+            approved_by=approver_user_id,
+            changed=result.changed,
+        )
+        return result
+
+    async def cancel_force_transfer(
+        self,
+        *,
+        request_id: UUID,
+        cancelled_by_user_id: str,
+        cancelled_by_email: str,
+    ) -> WorkspaceOwnershipForceTransferRequest:
+        """Cancel a pending dual-control request (#1113).
+
+        Lets an admin retract a pending force-transfer (e.g. filed in error)
+        without having to initiate a fresh one to supersede it. Only a pending
+        request can be cancelled.
+
+        Raises:
+            NotFoundException: no such request (404).
+            ConflictError: request is not pending (409).
+        """
+        request = (
+            await self.db.execute(
+                select(WorkspaceOwnershipForceTransferRequest).where(
+                    WorkspaceOwnershipForceTransferRequest.id == request_id
+                )
+            )
+        ).scalar_one_or_none()
+        if request is None:
+            raise NotFoundException("Force-transfer request", str(request_id))
+        if request.status != FORCE_TRANSFER_STATUS_PENDING:
+            raise ConflictError(f"Force-transfer request is not pending (status={request.status})")
+
+        request.status = FORCE_TRANSFER_STATUS_CANCELLED
+        request.decided_by_user_id = cancelled_by_user_id
+        request.decided_by_email = cancelled_by_email
+        request.decided_at = utcnow()
+        await self.db.commit()
+
+        logger.info(
+            "workspace_ownership_force_transfer_cancelled",
+            workspace_id=str(request.workspace_id),
+            request_id=str(request.id),
+            cancelled_by=cancelled_by_user_id,
+        )
+        return request

--- a/backend/src/services/workspace_ownership_service.py
+++ b/backend/src/services/workspace_ownership_service.py
@@ -549,6 +549,18 @@ class WorkspaceOwnershipService:
         seizure; the apply, the request status update, and the mandatory audit
         (recording BOTH identities) commit atomically.
 
+        Security notes:
+          * Four-eyes is enforced by ``user_id`` inequality. It assumes the
+            operational invariant "one human ⇒ at most one system-admin account";
+            a single operator holding two admin accounts can still satisfy it.
+            That invariant is an identity-provisioning concern, not enforced here.
+          * The *policy* gate (whether dual-control applies at all) lives at the
+            route via ``require_dual_control_force_transfer``; this service method
+            is the *mechanism*. ``force_transfer_ownership`` performs the immediate
+            single-control seizure and is NOT itself flag-gated, so any future
+            direct caller of it bypasses four-eyes — route it through ``initiate``
+            when the flag is on.
+
         Raises:
             NotFoundException: no such request (404).
             ConflictError: request not pending (409) or ownership moved since
@@ -569,19 +581,51 @@ class WorkspaceOwnershipService:
             raise ConflictError(f"Force-transfer request is not pending (status={request.status})")
 
         # No self-approval — the whole point of dual-control is a second pair of
-        # eyes. Checked before the lock (cheap, request-only) so we fail fast.
+        # eyes. Checked before the lock (cheap, request-only) so we fail fast. This
+        # is the exact attack the control exists to stop, so log the denial as an
+        # alertable security signal.
         if approver_user_id == request.initiated_by_user_id:
+            logger.warning(
+                "workspace_ownership_force_transfer_self_approval_denied",
+                workspace_id=str(request.workspace_id),
+                request_id=str(request.id),
+                actor=approver_user_id,
+            )
             raise BadRequestError(
                 "A force-transfer must be approved by a different system admin "
                 "than the one who initiated it",
                 error_code="WS-OWNER-DUAL-001",
             )
 
-        # Lock the workspace and re-validate the snapshot: if ownership moved since
-        # the request was filed, the approver would be acting on a stale premise
-        # (confused deputy). Refuse and require a fresh initiate.
+        # Lock the workspace — the shared serialization point that every owner- and
+        # request-mutating path takes (approve, cancel, initiate-supersede).
         workspace = await lock_workspace_for_update(self.db, request.workspace_id)
+
+        # Re-validate the request status UNDER the lock to close the TOCTOU between
+        # the pre-lock read above and here: a concurrent cancel or initiate-
+        # supersede (both hold this same lock) may have decided the request, and the
+        # epoch check alone cannot catch that — cancel/supersede do not move the
+        # epoch. refresh() re-SELECTs the row; under READ COMMITTED a concurrent
+        # committed transition is now visible, and because the mutators serialize on
+        # this lock the re-check is authoritative.
+        await self.db.refresh(request)
+        if request.status != FORCE_TRANSFER_STATUS_PENDING:
+            raise ConflictError(
+                f"Force-transfer request is no longer pending (status={request.status})"
+            )
+
+        # Staleness: if ownership moved since the request was filed, the approver
+        # would be acting on a stale premise (confused deputy). Refuse and require a
+        # fresh initiate; log as an alertable signal.
         if workspace.ownership_epoch != request.ownership_epoch_at_initiation:
+            logger.warning(
+                "workspace_ownership_force_transfer_stale_denied",
+                workspace_id=str(request.workspace_id),
+                request_id=str(request.id),
+                epoch_at_initiation=request.ownership_epoch_at_initiation,
+                current_epoch=workspace.ownership_epoch,
+                actor=approver_user_id,
+            )
             raise ConflictError(
                 "Workspace ownership changed since this force-transfer was "
                 "initiated; re-initiate the request and have it re-approved"
@@ -648,6 +692,17 @@ class WorkspaceOwnershipService:
         if request.status != FORCE_TRANSFER_STATUS_PENDING:
             raise ConflictError(f"Force-transfer request is not pending (status={request.status})")
 
+        # Serialize with approve / initiate-supersede on the workspace row so a
+        # cancel cannot race an in-flight approval (TOCTOU): whoever takes the lock
+        # second re-reads the status under it and sees the other's decision. (A
+        # request whose workspace is gone is moot — lock_workspace_for_update 404s.)
+        await lock_workspace_for_update(self.db, request.workspace_id)
+        await self.db.refresh(request)
+        if request.status != FORCE_TRANSFER_STATUS_PENDING:
+            raise ConflictError(
+                f"Force-transfer request is no longer pending (status={request.status})"
+            )
+
         request.status = FORCE_TRANSFER_STATUS_CANCELLED
         request.decided_by_user_id = cancelled_by_user_id
         request.decided_by_email = cancelled_by_email
@@ -660,4 +715,27 @@ class WorkspaceOwnershipService:
             request_id=str(request.id),
             cancelled_by=cancelled_by_user_id,
         )
+        return request
+
+    async def get_force_transfer_request(
+        self, *, request_id: UUID
+    ) -> WorkspaceOwnershipForceTransferRequest:
+        """Fetch a force-transfer request by id (#1113).
+
+        Lets the SECOND admin inspect what they are approving (target, reason,
+        initiator) before calling ``approve_force_transfer`` — without this, the
+        four-eyes control degrades to a blind second button-press. Read-only.
+
+        Raises:
+            NotFoundException: no such request (404).
+        """
+        request = (
+            await self.db.execute(
+                select(WorkspaceOwnershipForceTransferRequest).where(
+                    WorkspaceOwnershipForceTransferRequest.id == request_id
+                )
+            )
+        ).scalar_one_or_none()
+        if request is None:
+            raise NotFoundException("Force-transfer request", str(request_id))
         return request

--- a/backend/tests/api/test_admin_force_transfer_route.py
+++ b/backend/tests/api/test_admin_force_transfer_route.py
@@ -7,6 +7,7 @@ that the displaced PREVIOUS owner is the notification target.
 
 from __future__ import annotations
 
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -352,4 +353,51 @@ class TestDualControlCancel:
 
     def test_non_admin_is_403(self):
         resp = _client(role="user").post(self._cancel(uuid4()))
+        assert resp.status_code == 403
+
+
+class TestDualControlGet:
+    @staticmethod
+    def _get(rid) -> str:
+        return f"/admin/force-transfer-requests/{rid}"
+
+    def test_get_returns_request_details_200(self):
+        rid = uuid4()
+        req = _pending_req(rid)
+        req.reason = "owner unreachable"
+        req.initiated_by_email = "ada@test.com"
+        req.ownership_epoch_at_initiation = 3
+        req.created_at = datetime(2026, 6, 28, 12, 0, 0)
+        req.decided_by_user_id = None
+        req.decided_at = None
+        svc = MagicMock()
+        svc.get_force_transfer_request = AsyncMock(return_value=req)
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().get(self._get(rid))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["request_id"] == str(rid)
+        assert body["target_user_id"] == TARGET
+        assert body["reason"] == "owner unreachable"
+        assert body["status"] == "pending"
+        assert body["decided_at"] is None
+        assert svc.get_force_transfer_request.await_args.kwargs["request_id"] == rid
+
+    def test_get_unknown_request_404(self):
+        from utils.exceptions import NotFoundException
+
+        svc = MagicMock()
+        svc.get_force_transfer_request = AsyncMock(
+            side_effect=NotFoundException("Force-transfer request")
+        )
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().get(self._get(uuid4()))
+        assert resp.status_code == 404
+
+    def test_get_malformed_request_id_is_422(self):
+        resp = _client().get("/admin/force-transfer-requests/not-a-uuid")
+        assert resp.status_code == 422
+
+    def test_get_non_admin_is_403(self):
+        resp = _client(role="user").get(self._get(uuid4()))
         assert resp.status_code == 403

--- a/backend/tests/api/test_admin_force_transfer_route.py
+++ b/backend/tests/api/test_admin_force_transfer_route.py
@@ -191,3 +191,165 @@ class TestForceTransferRouteServiceErrors:
             json={"target_user_id": TARGET, "reason": "valid reason"},
         )
         assert resp.status_code == 422
+
+
+def _settings(dual: bool) -> MagicMock:
+    s = MagicMock()
+    s.require_dual_control_force_transfer = dual
+    return s
+
+
+def _pending_req(rid):
+    req = MagicMock()
+    req.id = rid
+    req.workspace_id = WS
+    req.target_user_id = TARGET
+    req.initiated_by_user_id = ADMIN
+    req.status = "pending"
+    return req
+
+
+class TestDualControlInitiate:
+    """#1113: with dual-control enabled, the POST files a pending request (202)
+    instead of transferring immediately."""
+
+    def test_enabled_files_pending_request_202(self):
+        rid = uuid4()
+        svc = MagicMock()
+        svc.initiate_force_transfer = AsyncMock(return_value=_pending_req(rid))
+        svc.force_transfer_ownership = AsyncMock()
+        notify = AsyncMock()
+        with (
+            patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc),
+            patch.object(admin_mod, "get_settings", return_value=_settings(True)),
+            patch.object(admin_mod, "_notify_force_transfer_best_effort", notify),
+        ):
+            resp = _client().post(
+                _PATH, json={"target_user_id": TARGET, "reason": "owner unreachable"}
+            )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body["status"] == "pending_approval"
+        assert body["request_id"] == str(rid)
+        assert body["dual_control"] is True
+        # The immediate transfer must NOT run; no notification on a mere filing.
+        svc.force_transfer_ownership.assert_not_awaited()
+        svc.initiate_force_transfer.assert_awaited_once()
+        notify.assert_not_awaited()
+
+    def test_disabled_transfers_immediately_200(self):
+        svc = MagicMock()
+        svc.force_transfer_ownership = AsyncMock(return_value=_result())
+        svc.initiate_force_transfer = AsyncMock()
+        with (
+            patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc),
+            patch.object(admin_mod, "get_settings", return_value=_settings(False)),
+            patch.object(admin_mod, "_notify_force_transfer_best_effort", AsyncMock()),
+        ):
+            resp = _client().post(_PATH, json={"target_user_id": TARGET, "reason": "unreachable"})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["dual_control"] is False
+        svc.initiate_force_transfer.assert_not_awaited()
+        svc.force_transfer_ownership.assert_awaited_once()
+
+
+class TestDualControlApprove:
+    _APPROVE = staticmethod(lambda rid: f"/admin/force-transfer-requests/{rid}/approve")
+
+    def test_approve_transfers_and_notifies_200(self):
+        rid = uuid4()
+        svc = MagicMock()
+        svc.approve_force_transfer = AsyncMock(return_value=_result())
+        notify = AsyncMock()
+        with (
+            patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc),
+            patch.object(admin_mod, "_notify_force_transfer_best_effort", notify),
+        ):
+            resp = _client().post(self._APPROVE(rid))
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "approved"
+        assert body["new_owner_id"] == TARGET
+        call = svc.approve_force_transfer.await_args.kwargs
+        assert call["request_id"] == rid
+        assert call["approver_user_id"] == ADMIN
+        notify.assert_awaited_once()
+        assert notify.await_args.args[2] == PREV
+
+    def test_self_approval_maps_to_400(self):
+        from utils.exceptions import BadRequestError
+
+        svc = MagicMock()
+        svc.approve_force_transfer = AsyncMock(
+            side_effect=BadRequestError(
+                "A force-transfer must be approved by a different system admin than the "
+                "one who initiated it",
+                error_code="WS-OWNER-DUAL-001",
+            )
+        )
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().post(self._APPROVE(uuid4()))
+        assert resp.status_code == 400
+
+    def test_stale_request_maps_to_409(self):
+        from utils.exceptions import ConflictError
+
+        svc = MagicMock()
+        svc.approve_force_transfer = AsyncMock(
+            side_effect=ConflictError("Workspace ownership changed since this force-transfer")
+        )
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().post(self._APPROVE(uuid4()))
+        assert resp.status_code == 409
+
+    def test_unknown_request_maps_to_404(self):
+        from utils.exceptions import NotFoundException
+
+        svc = MagicMock()
+        svc.approve_force_transfer = AsyncMock(
+            side_effect=NotFoundException("Force-transfer request")
+        )
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().post(self._APPROVE(uuid4()))
+        assert resp.status_code == 404
+
+    def test_malformed_request_id_is_422(self):
+        resp = _client().post("/admin/force-transfer-requests/not-a-uuid/approve")
+        assert resp.status_code == 422
+
+    def test_non_admin_is_403(self):
+        resp = _client(role="user").post(self._APPROVE(uuid4()))
+        assert resp.status_code == 403
+
+
+class TestDualControlCancel:
+    @staticmethod
+    def _cancel(rid) -> str:
+        return f"/admin/force-transfer-requests/{rid}/cancel"
+
+    def test_cancel_pending_200(self):
+        rid = uuid4()
+        cancelled = _pending_req(rid)
+        cancelled.status = "cancelled"
+        svc = MagicMock()
+        svc.cancel_force_transfer = AsyncMock(return_value=cancelled)
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().post(self._cancel(rid))
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["status"] == "cancelled"
+        assert svc.cancel_force_transfer.await_args.kwargs["request_id"] == rid
+
+    def test_cancel_non_pending_maps_to_409(self):
+        from utils.exceptions import ConflictError
+
+        svc = MagicMock()
+        svc.cancel_force_transfer = AsyncMock(
+            side_effect=ConflictError("Force-transfer request is not pending (status=approved)")
+        )
+        with patch.object(admin_mod, "WorkspaceOwnershipService", return_value=svc):
+            resp = _client().post(self._cancel(uuid4()))
+        assert resp.status_code == 409
+
+    def test_non_admin_is_403(self):
+        resp = _client(role="user").post(self._cancel(uuid4()))
+        assert resp.status_code == 403

--- a/backend/tests/integration/test_force_transfer_dual_control.py
+++ b/backend/tests/integration/test_force_transfer_dual_control.py
@@ -1,0 +1,430 @@
+"""Integration tests for dual-control break-glass force-transfer (#1113).
+
+Exercises ``WorkspaceOwnershipService.initiate_force_transfer`` /
+``approve_force_transfer`` / ``cancel_force_transfer`` against a real Postgres
+session: the pending-request lifecycle, the four-eyes (no self-approval) rule,
+the epoch-staleness re-check at approval, supersede-on-initiate, and that the
+refactored single-control ``force_transfer_ownership`` (#1101) still behaves
+exactly as before. Requires the DB container (``make test-integration``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from auth.workspace_roles import WorkspaceRole
+from models.auth import (
+    FORCE_TRANSFER_STATUS_APPROVED,
+    FORCE_TRANSFER_STATUS_CANCELLED,
+    FORCE_TRANSFER_STATUS_PENDING,
+    FORCE_TRANSFER_STATUS_SUPERSEDED,
+    AuditLog,
+    User,
+    Workspace,
+    WorkspaceMember,
+    WorkspaceOwnershipForceTransferRequest,
+)
+from services.workspace_ownership_service import (
+    FORCE_OWNERSHIP_TRANSFER_ACTION,
+    WorkspaceOwnershipService,
+)
+from utils.exceptions import BadRequestError, ConflictError, NotFoundException
+
+
+async def _add_user(db: AsyncSession, uid: str) -> None:
+    db.add(
+        User(
+            email=f"{uid}@dc.invalid",
+            user_id=uid,
+            name="Dual Control Test",
+            role="user",
+            is_initial_admin=False,
+            auth_method="oauth",
+            auth_provider="google",
+        )
+    )
+
+
+@pytest_asyncio.fixture(loop_scope="session")
+async def dc_fixture(db_session: AsyncSession) -> AsyncIterator[SimpleNamespace]:
+    """Workspace owned by ``owner`` plus a ``target`` and two admins (a/b).
+
+    ``admin_a`` initiates; ``admin_b`` is the distinct approver. ``target`` is a
+    real user who is NOT a member (exercises the elevated add-as-OWNER path).
+    """
+    owner = f"own_{uuid4().hex[:8]}"
+    target = f"tgt_{uuid4().hex[:8]}"
+    admin_a = f"ada_{uuid4().hex[:8]}"
+    admin_b = f"adb_{uuid4().hex[:8]}"
+    workspace_id = uuid4()
+
+    for uid in (owner, target, admin_a, admin_b):
+        await _add_user(db_session, uid)
+    await db_session.flush()
+
+    db_session.add(
+        Workspace(
+            id=workspace_id,
+            name=f"dc-{uuid4().hex[:8]}",
+            plan_name="pro",
+            owner_user_id=owner,
+            daily_api_limit=500,
+            weekly_api_limit=2500,
+            deleted_at=None,
+        )
+    )
+    await db_session.flush()
+    db_session.add(
+        WorkspaceMember(workspace_id=workspace_id, user_id=owner, role=WorkspaceRole.OWNER)
+    )
+    await db_session.commit()
+
+    yield SimpleNamespace(
+        owner=owner, target=target, admin_a=admin_a, admin_b=admin_b, workspace_id=workspace_id
+    )
+
+    await db_session.execute(
+        WorkspaceOwnershipForceTransferRequest.__table__.delete().where(
+            WorkspaceOwnershipForceTransferRequest.workspace_id == workspace_id
+        )
+    )
+    await db_session.execute(
+        AuditLog.__table__.delete().where(AuditLog.resource == f"workspace:{workspace_id}")
+    )
+    await db_session.execute(
+        WorkspaceMember.__table__.delete().where(WorkspaceMember.workspace_id == workspace_id)
+    )
+    await db_session.execute(Workspace.__table__.delete().where(Workspace.id == workspace_id))
+    await db_session.execute(
+        User.__table__.delete().where(User.user_id.in_([owner, target, admin_a, admin_b]))
+    )
+    await db_session.commit()
+
+
+async def _workspace(db: AsyncSession, workspace_id) -> Workspace:
+    return (await db.execute(select(Workspace).where(Workspace.id == workspace_id))).scalar_one()
+
+
+async def _role_of(db: AsyncSession, workspace_id, uid: str) -> WorkspaceRole | None:
+    row = (
+        await db.execute(
+            select(WorkspaceMember).where(
+                WorkspaceMember.workspace_id == workspace_id,
+                WorkspaceMember.user_id == uid,
+            )
+        )
+    ).scalar_one_or_none()
+    return None if row is None else row.role
+
+
+async def _pending(db: AsyncSession, workspace_id) -> list[WorkspaceOwnershipForceTransferRequest]:
+    return list(
+        (
+            await db.execute(
+                select(WorkspaceOwnershipForceTransferRequest).where(
+                    WorkspaceOwnershipForceTransferRequest.workspace_id == workspace_id,
+                    WorkspaceOwnershipForceTransferRequest.status == FORCE_TRANSFER_STATUS_PENDING,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+
+class TestInitiate:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_initiate_creates_pending_without_transferring(self, dc_fixture, db_session):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        req = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="owner unreachable",
+        )
+        assert req.status == FORCE_TRANSFER_STATUS_PENDING
+        assert req.target_user_id == s.target
+        assert req.initiated_by_user_id == s.admin_a
+        assert req.ownership_epoch_at_initiation == 0
+
+        # No transfer happened — ownership and epoch are untouched.
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.owner
+        assert ws.ownership_epoch == 0
+        # No audit row yet (the transfer has not been applied).
+        audit = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(AuditLog.resource == f"workspace:{s.workspace_id}")
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert audit == []
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_initiate_phantom_target_rejected(self, dc_fixture, db_session):
+        s = dc_fixture
+        with pytest.raises(BadRequestError):
+            await WorkspaceOwnershipService(db_session).initiate_force_transfer(
+                workspace_id=s.workspace_id,
+                target_user_id="ghost_does_not_exist",
+                performed_by_user_id=s.admin_a,
+                performed_by_email="ada@dc.invalid",
+                reason="owner unreachable",
+            )
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_initiate_supersedes_prior_pending(self, dc_fixture, db_session):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        first = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="first",
+        )
+        second = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_b,
+            performed_by_email="adb@dc.invalid",
+            reason="second",
+        )
+        # Exactly one pending request — the second — and the first is superseded.
+        pending = await _pending(db_session, s.workspace_id)
+        assert [p.id for p in pending] == [second.id]
+        await db_session.refresh(first)
+        assert first.status == FORCE_TRANSFER_STATUS_SUPERSEDED
+        assert first.decided_by_user_id == s.admin_b
+
+
+class TestApprove:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_approve_by_distinct_admin_transfers_and_audits_both(
+        self, dc_fixture, db_session
+    ):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        req = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="owner unreachable",
+        )
+        result = await svc.approve_force_transfer(
+            request_id=req.id,
+            approver_user_id=s.admin_b,
+            approver_email="adb@dc.invalid",
+        )
+        assert result.changed is True
+        assert result.new_owner_id == s.target
+        assert result.ownership_epoch == 1
+
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.target
+        assert ws.ownership_epoch == 1
+        assert await _role_of(db_session, s.workspace_id, s.target) == WorkspaceRole.OWNER
+        assert await _role_of(db_session, s.workspace_id, s.owner) == WorkspaceRole.ADMIN
+
+        await db_session.refresh(req)
+        assert req.status == FORCE_TRANSFER_STATUS_APPROVED
+        assert req.decided_by_user_id == s.admin_b
+
+        audit = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(
+                        AuditLog.resource == f"workspace:{s.workspace_id}",
+                        AuditLog.action == FORCE_OWNERSHIP_TRANSFER_ACTION,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audit) == 1
+        meta = audit[0].user_metadata
+        assert audit[0].user_id == s.admin_b  # actor = approver
+        assert meta["break_glass"] is True
+        assert meta["dual_control"] is True
+        assert meta["initiated_by_user_id"] == s.admin_a
+        assert meta["approved_by_user_id"] == s.admin_b
+        assert meta["new_owner_id"] == s.target
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_self_approval_rejected(self, dc_fixture, db_session):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        req = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="owner unreachable",
+        )
+        with pytest.raises(BadRequestError, match="different system admin"):
+            await svc.approve_force_transfer(
+                request_id=req.id,
+                approver_user_id=s.admin_a,  # same as initiator
+                approver_email="ada@dc.invalid",
+            )
+        # No transfer; request still pending.
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.owner
+        assert ws.ownership_epoch == 0
+        await db_session.refresh(req)
+        assert req.status == FORCE_TRANSFER_STATUS_PENDING
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_stale_epoch_rejected(self, dc_fixture, db_session):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        req = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="owner unreachable",
+        )
+        # Simulate a concurrent ownership change between initiation and approval:
+        # the epoch moves, so the snapshot is stale.
+        ws = await _workspace(db_session, s.workspace_id)
+        ws.ownership_epoch = ws.ownership_epoch + 1
+        await db_session.commit()
+
+        with pytest.raises(ConflictError, match="changed since"):
+            await svc.approve_force_transfer(
+                request_id=req.id,
+                approver_user_id=s.admin_b,
+                approver_email="adb@dc.invalid",
+            )
+        # Request remains pending (a fresh initiate is required to re-snapshot).
+        await db_session.refresh(req)
+        assert req.status == FORCE_TRANSFER_STATUS_PENDING
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_approve_non_pending_rejected(self, dc_fixture, db_session):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        req = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="owner unreachable",
+        )
+        await svc.approve_force_transfer(
+            request_id=req.id, approver_user_id=s.admin_b, approver_email="adb@dc.invalid"
+        )
+        # A second approval of the now-approved request is refused.
+        with pytest.raises(ConflictError, match="not pending"):
+            await svc.approve_force_transfer(
+                request_id=req.id, approver_user_id=s.admin_b, approver_email="adb@dc.invalid"
+            )
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_approve_unknown_request_404(self, dc_fixture, db_session):
+        with pytest.raises(NotFoundException):
+            await WorkspaceOwnershipService(db_session).approve_force_transfer(
+                request_id=uuid4(),
+                approver_user_id=dc_fixture.admin_b,
+                approver_email="adb@dc.invalid",
+            )
+
+
+class TestCancel:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_cancel_pending_then_approve_refused(self, dc_fixture, db_session):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        req = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="filed in error",
+        )
+        cancelled = await svc.cancel_force_transfer(
+            request_id=req.id,
+            cancelled_by_user_id=s.admin_a,
+            cancelled_by_email="ada@dc.invalid",
+        )
+        assert cancelled.status == FORCE_TRANSFER_STATUS_CANCELLED
+        assert cancelled.decided_by_user_id == s.admin_a
+
+        with pytest.raises(ConflictError, match="not pending"):
+            await svc.approve_force_transfer(
+                request_id=req.id, approver_user_id=s.admin_b, approver_email="adb@dc.invalid"
+            )
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_cancel_non_pending_rejected(self, dc_fixture, db_session):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        req = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="owner unreachable",
+        )
+        await svc.approve_force_transfer(
+            request_id=req.id, approver_user_id=s.admin_b, approver_email="adb@dc.invalid"
+        )
+        with pytest.raises(ConflictError):
+            await svc.cancel_force_transfer(
+                request_id=req.id,
+                cancelled_by_user_id=s.admin_a,
+                cancelled_by_email="ada@dc.invalid",
+            )
+
+
+class TestSingleControlRegression:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_force_transfer_ownership_unchanged_by_refactor(self, dc_fixture, db_session):
+        # The refactored #1101 single-control path must still transfer + audit,
+        # WITHOUT any dual_control metadata.
+        s = dc_fixture
+        result = await WorkspaceOwnershipService(db_session).force_transfer_ownership(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="break glass",
+        )
+        assert result.changed is True
+        assert result.new_owner_id == s.target
+        assert result.ownership_epoch == 1
+
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.target
+        assert await _role_of(db_session, s.workspace_id, s.target) == WorkspaceRole.OWNER
+
+        audit = (
+            (
+                await db_session.execute(
+                    select(AuditLog).where(
+                        AuditLog.resource == f"workspace:{s.workspace_id}",
+                        AuditLog.action == FORCE_OWNERSHIP_TRANSFER_ACTION,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        assert len(audit) == 1
+        assert audit[0].user_metadata["break_glass"] is True
+        assert "dual_control" not in audit[0].user_metadata

--- a/backend/tests/integration/test_force_transfer_dual_control.py
+++ b/backend/tests/integration/test_force_transfer_dual_control.py
@@ -428,3 +428,58 @@ class TestSingleControlRegression:
         assert len(audit) == 1
         assert audit[0].user_metadata["break_glass"] is True
         assert "dual_control" not in audit[0].user_metadata
+
+
+class TestRequestLifecycleEdges:
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_approve_superseded_request_rejected(self, dc_fixture, db_session):
+        # Initiating again supersedes the first request; the superseded one can no
+        # longer be approved (status != pending) — and no transfer happens.
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        first = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="first",
+        )
+        await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_b,
+            performed_by_email="adb@dc.invalid",
+            reason="second",
+        )
+        with pytest.raises(ConflictError, match="not pending"):
+            await svc.approve_force_transfer(
+                request_id=first.id, approver_user_id=s.admin_b, approver_email="adb@dc.invalid"
+            )
+        ws = await _workspace(db_session, s.workspace_id)
+        assert ws.owner_user_id == s.owner
+        assert ws.ownership_epoch == 0
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_get_request_returns_details(self, dc_fixture, db_session):
+        s = dc_fixture
+        svc = WorkspaceOwnershipService(db_session)
+        req = await svc.initiate_force_transfer(
+            workspace_id=s.workspace_id,
+            target_user_id=s.target,
+            performed_by_user_id=s.admin_a,
+            performed_by_email="ada@dc.invalid",
+            reason="inspect me",
+        )
+        fetched = await svc.get_force_transfer_request(request_id=req.id)
+        assert fetched.id == req.id
+        assert fetched.target_user_id == s.target
+        assert fetched.reason == "inspect me"
+        assert fetched.initiated_by_user_id == s.admin_a
+        assert fetched.status == FORCE_TRANSFER_STATUS_PENDING
+
+    @pytest.mark.asyncio(loop_scope="session")
+    async def test_get_unknown_request_404(self, dc_fixture, db_session):
+        with pytest.raises(NotFoundException):
+            await WorkspaceOwnershipService(db_session).get_force_transfer_request(
+                request_id=uuid4()
+            )


### PR DESCRIPTION
Closes #1113

## Summary
- Adds an **opt-in four-eyes approval** in front of the #1101 break-glass admin force-transfer. With `require_dual_control_force_transfer=True`, `POST /admin/workspaces/{id}/force-transfer-ownership` files a **pending request (202)** instead of seizing ownership; a **second, distinct system admin** must approve before it commits.
- Default config is **off** → today's immediate single-control behavior is unchanged (byte-identical).
- New endpoints (all `require_admin`): `POST /admin/force-transfer-requests/{id}/approve`, `/cancel`, and `GET /admin/force-transfer-requests/{id}` (so the approver can inspect target/reason/initiator before approving — informed four-eyes, not a blind button-press).

## Design
- **Service**: extracts the post-lock seizure core `_apply_force_transfer` (no commit — caller owns the transaction) shared by `force_transfer_ownership` (#1101, single-control) and the new `approve_force_transfer`, so approval applies the transfer + marks the request approved + writes the mandatory audit **atomically**. Plus `initiate` / `cancel` / `get`.
- **Serialization**: initiate-supersede / approve / cancel all take the shared #1102 `lock_workspace_for_update` row lock; approve & cancel re-read `request.status` under it. No new lock primitive.
- **Staleness guard**: approve snapshots `ownership_epoch` at initiation and re-checks under the lock — rejects (409) if ownership moved since filing (confused-deputy guard).
- **No-self-approval**: `approver != initiator` (400); both identities are server-derived and recorded in the audit (`dual_control` + `initiated_by` + `approved_by`).
- **Model + migration e48**: `workspace_ownership_force_transfer_requests` with a partial-unique index (one pending per workspace); supersede-on-initiate + cancel are the unblock paths.

## Quality
- gate1 (CSO) **yellow** → folded in its two must-haves: epoch-staleness re-check + supersede/cancel unblock path.
- **code-review max**: found 2 CONFIRMED (a TOCTOU where a cancelled/superseded request could still seize ownership; a model↔migration index-name drift) + several lower findings — all fixed in `f8bce110`, and the concurrency fix independently re-verified.
- gate2: **cso green / qa-lead green / cto green**.
- Migration verified `upgrade head` + `downgrade -1` on a scratch DB; model↔migration index-name parity asserted. 14 service integration tests + dual-control route tests; #1101 single-control path regression-guarded (no `dual_control` metadata leak).

## Operational notes
- Enabling dual-control requires **≥2 system admins** (with one, no force-transfer can be approved).
- Four-eyes is enforced by `user_id` distinctness (assumes one human ⇒ one admin account). Denial paths (self-approval, stale) emit warning logs; wiring logs→SOC is deployment-side.

🤖 Generated via /gh-issue-driven:ship
