### PR TITLE
docs(billing): clarify handoff aud/iss are frozen cross-repo JWT contracts

### DIFF
--- a/backend/src/api/routes/billing_handoff.py
+++ b/backend/src/api/routes/billing_handoff.py
@@ -131,6 +131,13 @@ async def mint_billing_handoff(
 
     Owner-only + session-only. Returns 403 for admin/member/API-key callers and
     503 when the signing key is unconfigured (fail-closed).
+
+    The token's ``iss`` / ``aud`` claims (``billing_handoff_issuer`` /
+    ``billing_handoff_audience``) are FROZEN cross-repo JWT contract values
+    verified by the external billing service — they are NOT repo or service
+    names. ``billing`` is the function; the external service provides it.
+    Changing either claim is a coordinated breaking change (the verifier must
+    change in lockstep), never a local rename.
     """
     user_id = get_user_id(user)
 

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -124,11 +124,22 @@ class Settings(BaseSettings):
     )
     billing_handoff_issuer: str = Field(
         default="kagura-memory-cloud",
-        description="iss claim asserted on billing handoff tokens.",
+        description=(
+            "iss claim stamped on billing handoff tokens. A FROZEN cross-repo "
+            "JWT contract value verified by the external billing service — NOT a "
+            "repo or service name. Changing it is a coordinated breaking change "
+            "(the verifier must change in lockstep), never a local rename."
+        ),
     )
     billing_handoff_audience: str = Field(
         default="kagura-billing",
-        description="aud claim — the billing service that verifies handoff tokens.",
+        description=(
+            "aud claim — the billing audience served by the external billing "
+            "service that verifies handoff tokens ('billing' is the function; the "
+            "external service provides it). A FROZEN cross-repo JWT contract value, "
+            "NOT a repo name; changing it is a coordinated breaking change (the "
+            "verifier must change in lockstep), never a local rename."
+        ),
     )
     billing_handoff_ttl_seconds: int = Field(
         default=120,


### PR DESCRIPTION
## Summary
Documents that the handoff token's `iss` / `aud` claims (`billing_handoff_issuer`=`kagura-memory-cloud`, `billing_handoff_audience`=`kagura-billing`) are **frozen cross-repo JWT contract values** verified by the external billing service — **not** repo or service names. `billing` is the function; the external service provides it.

Adds clarifying text to the two settings (`backend/src/config/settings.py`) and the `mint_billing_handoff` docstring so a reader doesn't mistake the values for a rename target. Changing either claim is a coordinated breaking change (the verifier must change in lockstep), never a local rename.

## Scope
- **Prose only** — no logic, no behavior change, no default-value/field/type/path change.
- Lint clean (ruff check + format).
- Code-review (max) returned no findings; it independently confirmed memory-cloud only *mints* these claims (the verifier is external), so the docstrings are factually accurate.

Closes #1117

🤖 Generated with [Claude Code](https://claude.com/claude-code)