### PR TITLE
feat(billing): optionally return a ready-to-use handoff URL (opt-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,12 @@ AUDIT_HMAC_KEY=change-me-audit-hmac-key
 # so the two services rotate independently. Use: openssl rand -hex 32.
 # BILLING_SERVICE_TOKEN=
 
+# Issue #1118: optional public base URL (origin, no path) of the external billing
+# service's handoff entry. When set, POST /api/v1/billing/handoff ALSO returns a
+# ready-to-use {base}/enter?t={token} redirect URL; empty (default) returns only
+# the raw token. Opt-in convenience, inert when unset.
+# PAYMENT_PUBLIC_BASE_URL=https://billing.example.com
+
 # Public MCP base URL handed back to the worker so it can write memories.
 # KMC_MCP_URL=http://localhost:8080/mcp
 

--- a/backend/src/api/routes/billing_handoff.py
+++ b/backend/src/api/routes/billing_handoff.py
@@ -103,15 +103,18 @@ def _build_handoff_url(base_url: str, token: str) -> str | None:
 
     ``{base}/enter?t={token}`` — ``/enter?t=`` is the FROZEN cross-repo handoff
     entry contract; this only materializes ``{base}`` (operator config) + that path.
-    Returns None when ``base_url`` is empty/blank so the response keeps the
-    decoupled raw-token shape (#1098). No query-encoding is needed: the token is a
-    URL-safe JWT (base64url segments + '.'), and there is no user input in the URL
-    (``base_url`` is trusted operator config), so this cannot be injection-shaped.
+    Returns None when ``base_url`` is empty/blank (including a slash-only value) so
+    the response keeps the decoupled raw-token shape (#1098). No query-encoding is
+    needed: the token is a URL-safe JWT (base64url segments + '.'), and there is no
+    user input in the URL (``base_url`` is trusted, startup-validated operator
+    config), so this cannot be injection-shaped.
     """
-    base = base_url.strip()
+    # rstrip BEFORE the empty-guard so a slash-only base ("/", "//") collapses to
+    # "" → None, not a relative "/enter?t=..." that resolves against the API host.
+    base = base_url.strip().rstrip("/")
     if not base:
         return None
-    return f"{base.rstrip('/')}/enter?t={token}"
+    return f"{base}/enter?t={token}"
 
 
 class BillingHandoffRequest(BaseModel):

--- a/backend/src/api/routes/billing_handoff.py
+++ b/backend/src/api/routes/billing_handoff.py
@@ -98,6 +98,22 @@ async def _check_handoff_rate_limit(
         logger.error("billing_handoff_rate_limit_check_failed", error=str(exc))
 
 
+def _build_handoff_url(base_url: str, token: str) -> str | None:
+    """Build the ready-to-use handoff redirect URL, or None when unconfigured (#1118).
+
+    ``{base}/enter?t={token}`` — ``/enter?t=`` is the FROZEN cross-repo handoff
+    entry contract; this only materializes ``{base}`` (operator config) + that path.
+    Returns None when ``base_url`` is empty/blank so the response keeps the
+    decoupled raw-token shape (#1098). No query-encoding is needed: the token is a
+    URL-safe JWT (base64url segments + '.'), and there is no user input in the URL
+    (``base_url`` is trusted operator config), so this cannot be injection-shaped.
+    """
+    base = base_url.strip()
+    if not base:
+        return None
+    return f"{base.rstrip('/')}/enter?t={token}"
+
+
 class BillingHandoffRequest(BaseModel):
     """Request to mint a handoff token for one owned workspace."""
 
@@ -119,6 +135,14 @@ class BillingHandoffResponse(TZAwareBaseModel):
     kid: str = Field(..., description="Signing key id — selects the verifier's public key.")
     jti: str = Field(..., description="Unique token id (verifier enforces single-use).")
     expires_at: datetime = Field(..., description="Token expiry (UTC, short-lived).")
+    url: str | None = Field(
+        default=None,
+        description=(
+            "Ready-to-use redirect URL ({base}/enter?t={token}) when "
+            "payment_public_base_url is configured; null otherwise (the decoupled "
+            "raw-token contract, #1098). The caller redirects the owner's browser here."
+        ),
+    )
 
 
 @router.post("/handoff", response_model=BillingHandoffResponse)
@@ -133,6 +157,7 @@ async def mint_billing_handoff(
     503 when the signing key is unconfigured (fail-closed).
     """
     user_id = get_user_id(user)
+    settings = get_settings()
 
     # Owner gate against the EXPLICIT target workspace — check_workspace_owner
     # raises AuthorizationError (403) for non-owners and never trusts
@@ -145,7 +170,7 @@ async def mint_billing_handoff(
     await _check_handoff_rate_limit(
         user_id,
         body.workspace_id,
-        get_settings().billing_handoff_rate_limit_per_minute,
+        settings.billing_handoff_rate_limit_per_minute,
     )
 
     # Stamp the workspace's live ownership epoch into the token (#1100) so the
@@ -176,4 +201,7 @@ async def mint_billing_handoff(
         kid=minted.kid,
         jti=minted.jti,
         expires_at=minted.expires_at,
+        # Opt-in convenience (#1118): a ready-to-use redirect URL when the billing
+        # host base is configured; None otherwise (raw-token contract preserved).
+        url=_build_handoff_url(settings.payment_public_base_url, minted.token),
     )

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -144,6 +144,22 @@ class Settings(BaseSettings):
             "(fail-safe). Fail-open on a Redis outage."
         ),
     )
+    # #1118: optional public base URL (origin) of the external billing service's
+    # handoff entry. When set, POST /api/v1/billing/handoff ALSO returns a
+    # ready-to-use redirect url = ``{base}/enter?t={token}`` so a caller need not
+    # re-implement the frozen /enter?t= contract. EMPTY (default) => the response
+    # carries only the raw token (the decoupled #1098 contract); self-hosted
+    # deployments without an external billing service are unaffected (inert).
+    # Set to the billing host origin, no path (e.g. https://billing.example.com).
+    payment_public_base_url: str = Field(
+        default="",
+        description=(
+            "Public base URL (origin, no path) of the external billing service's "
+            "handoff entry. When set, /billing/handoff also returns a ready-to-use "
+            "{base}/enter?t={token} redirect URL; empty (default) returns only the "
+            "raw token. Opt-in convenience, inert when unset."
+        ),
+    )
     # Public MCP base URL handed back to the worker in its config so it can write
     # memories. Defaults to local dev; override in prod (e.g. https://memory.kagura-ai.com/mcp).
     kmc_mcp_url: str = Field(

--- a/backend/src/config/settings.py
+++ b/backend/src/config/settings.py
@@ -8,11 +8,37 @@ Database URLs are managed directly via os.getenv() in config/database.py.
 import os
 from datetime import datetime
 from typing import Any, Literal
+from urllib.parse import urlparse
 
 from pydantic import AliasChoices, Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from utils.media_types import MEDIA_TYPE_RE, normalize_media_type
+
+
+def _validate_handoff_base_url(value: str) -> str:
+    """Validate/normalize the optional billing handoff base URL (#1118).
+
+    Empty (default) → ``""`` (the convenience is inert). When set, the value must
+    be an ``https`` origin (``http`` allowed only for localhost) with NO path
+    component: the redirect is materialized as ``{base}/enter?t={token}``, so a
+    non-https scheme would leak the short-lived token over plaintext (server /
+    proxy logs, Referer) and a path component would break the frozen ``/enter``
+    cross-repo contract. Raises ``ValueError`` (loud boot-time failure) on a
+    malformed base rather than silently emitting a broken redirect URL.
+    """
+    v = (value or "").strip()
+    if not v:
+        return ""
+    parsed = urlparse(v)
+    host_is_local = parsed.hostname in {"localhost", "127.0.0.1"}
+    if not (parsed.scheme == "https" or (parsed.scheme == "http" and host_is_local)):
+        raise ValueError(
+            "payment_public_base_url must use https:// (http:// allowed only for localhost)"
+        )
+    if parsed.path not in ("", "/"):
+        raise ValueError("payment_public_base_url must be an origin with no path component")
+    return v
 
 
 class Settings(BaseSettings):
@@ -157,9 +183,16 @@ class Settings(BaseSettings):
             "Public base URL (origin, no path) of the external billing service's "
             "handoff entry. When set, /billing/handoff also returns a ready-to-use "
             "{base}/enter?t={token} redirect URL; empty (default) returns only the "
-            "raw token. Opt-in convenience, inert when unset."
+            "raw token. Opt-in convenience, inert when unset. Must be https (http "
+            "only for localhost) with no path — validated at startup."
         ),
     )
+
+    @field_validator("payment_public_base_url")
+    @classmethod
+    def _check_payment_public_base_url(cls, v: str) -> str:
+        return _validate_handoff_base_url(v)
+
     # Public MCP base URL handed back to the worker in its config so it can write
     # memories. Defaults to local dev; override in prod (e.g. https://memory.kagura-ai.com/mcp).
     kmc_mcp_url: str = Field(

--- a/backend/tests/api/test_billing_handoff_route.py
+++ b/backend/tests/api/test_billing_handoff_route.py
@@ -137,6 +137,7 @@ class TestHandoffOwnerHappyPath:
         assert body["jti"] == "jti-test-1"
         assert body["token_type"] == "billing_handoff"
         assert body["expires_at"].endswith("Z")  # TZAwareBaseModel serialization
+        assert body.get("url") is None  # inert by default (PAYMENT_PUBLIC_BASE_URL unset)
         # The signer must be invoked with the body workspace and the session user.
         mint_call = signer_cls.return_value.mint.call_args
         assert mint_call.kwargs["workspace_id"] == WS_A
@@ -401,7 +402,8 @@ class TestHandoffRateLimitRoute:
 # Ready-to-use handoff URL (#1118) — opt-in, additive
 # ============================================================================
 
-_FAKE_TOKEN = "eyJhbGciOiJFZERTQSJ9.fake.sig"
+# Single source of truth for the fake JWT (mirrors _fake_minted's token).
+_FAKE_TOKEN = _fake_minted(uuid4()).token
 
 
 class TestHandoffReadyToUseUrl:
@@ -410,6 +412,14 @@ class TestHandoffReadyToUseUrl:
     the decoupled raw-token contract (#1098) with ``url=None``."""
 
     def _post_with_base(self, session_client, base_url: str):
+        """POST as an owner with ``payment_public_base_url=base_url``.
+
+        Returns ``(response, build_spy)``. ``build_spy`` WRAPS the real
+        ``_build_handoff_url`` so a test can prove the route actually invoked it
+        (so ``url is None`` reflects a real builder call on the empty base, not
+        merely the response field default). ``incrby_counter`` is stubbed so the
+        rate-limit takes its normal under-limit path, not the Redis fail-open one.
+        """
         perm = MagicMock()
         perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
         # Patch get_settings so both the rate-limit read and the new base-url read
@@ -417,24 +427,32 @@ class TestHandoffReadyToUseUrl:
         settings = MagicMock()
         settings.payment_public_base_url = base_url
         settings.billing_handoff_rate_limit_per_minute = 10
+        build_spy = MagicMock(wraps=route_mod._build_handoff_url)
         with (
             patch.object(route_mod, "PermissionService", return_value=perm),
             patch.object(route_mod, "BillingHandoffSigner") as signer_cls,
             patch.object(route_mod, "get_settings", return_value=settings),
+            patch.object(route_mod, "incrby_counter", AsyncMock(return_value=1)),
+            patch.object(route_mod, "_build_handoff_url", build_spy),
         ):
             signer_cls.return_value.mint.return_value = _fake_minted(WS_A)
-            return session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+            resp = session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+        return resp, build_spy
 
     def test_url_is_null_when_base_unset(self, session_client):
-        resp = self._post_with_base(session_client, "")
+        resp, build_spy = self._post_with_base(session_client, "")
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["url"] is None
+        # Non-vacuous: the route actually called the builder with the empty base,
+        # so url is None because the builder returned None — not because the arg
+        # was dropped or the field merely defaults to None.
+        build_spy.assert_called_once_with("", _FAKE_TOKEN)
         # The raw-token contract is intact regardless of the opt-in field.
         assert body["token"] == _FAKE_TOKEN
 
     def test_url_built_when_base_set(self, session_client):
-        resp = self._post_with_base(session_client, "https://billing.example.com")
+        resp, _ = self._post_with_base(session_client, "https://billing.example.com")
         assert resp.status_code == 200, resp.text
         body = resp.json()
         assert body["url"] == f"https://billing.example.com/enter?t={_FAKE_TOKEN}"
@@ -443,7 +461,7 @@ class TestHandoffReadyToUseUrl:
         assert body["kid"] == "kid-1"
 
     def test_url_normalizes_trailing_slash_on_base(self, session_client):
-        resp = self._post_with_base(session_client, "https://billing.example.com/")
+        resp, _ = self._post_with_base(session_client, "https://billing.example.com/")
         assert resp.status_code == 200, resp.text
         # No double slash before /enter.
         assert resp.json()["url"] == f"https://billing.example.com/enter?t={_FAKE_TOKEN}"
@@ -456,6 +474,13 @@ class TestBuildHandoffUrlHelper:
         assert route_mod._build_handoff_url("", "tok") is None
         assert route_mod._build_handoff_url("   ", "tok") is None
 
+    def test_returns_none_for_slash_only_base(self):
+        # A slash-only base must collapse to None, not a relative "/enter?t=..."
+        # that a browser resolves against the API host (rstrip runs BEFORE guard).
+        assert route_mod._build_handoff_url("/", "tok") is None
+        assert route_mod._build_handoff_url("//", "tok") is None
+        assert route_mod._build_handoff_url("  /  ", "tok") is None
+
     def test_builds_enter_url(self):
         assert (
             route_mod._build_handoff_url("https://billing.example.com", "tok")
@@ -467,3 +492,41 @@ class TestBuildHandoffUrlHelper:
             route_mod._build_handoff_url("https://billing.example.com/", "tok")
             == "https://billing.example.com/enter?t=tok"
         )
+
+
+class TestValidateHandoffBaseUrl:
+    """Unit tests for the startup validator on ``payment_public_base_url`` (#1118)."""
+
+    def test_empty_is_allowed_and_normalized(self):
+        from config.settings import _validate_handoff_base_url
+
+        assert _validate_handoff_base_url("") == ""
+        assert _validate_handoff_base_url("   ") == ""
+
+    def test_https_origin_passes(self):
+        from config.settings import _validate_handoff_base_url
+
+        assert (
+            _validate_handoff_base_url("https://billing.example.com")
+            == "https://billing.example.com"
+        )
+
+    def test_http_localhost_allowed_for_dev(self):
+        from config.settings import _validate_handoff_base_url
+
+        assert _validate_handoff_base_url("http://localhost:9000") == "http://localhost:9000"
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "http://billing.example.com",  # plaintext non-local → token-over-HTTP leak
+            "billing.example.com",  # no scheme → relative URL
+            "javascript:alert(1)",  # non-http(s) scheme
+            "https://billing.example.com/v2",  # path component → breaks /enter contract
+        ],
+    )
+    def test_rejects_malformed_base(self, bad):
+        from config.settings import _validate_handoff_base_url
+
+        with pytest.raises(ValueError):
+            _validate_handoff_base_url(bad)

--- a/backend/tests/api/test_billing_handoff_route.py
+++ b/backend/tests/api/test_billing_handoff_route.py
@@ -395,3 +395,75 @@ class TestHandoffRateLimitRoute:
         assert resp.status_code == 200, resp.text
         # Fail-open means the request reaches mint — assert it actually ran.
         signer_cls.return_value.mint.assert_called_once()
+
+
+# ============================================================================
+# Ready-to-use handoff URL (#1118) — opt-in, additive
+# ============================================================================
+
+_FAKE_TOKEN = "eyJhbGciOiJFZERTQSJ9.fake.sig"
+
+
+class TestHandoffReadyToUseUrl:
+    """The opt-in ``url`` convenience: when ``payment_public_base_url`` is set the
+    response ADDS a ready-to-use ``{base}/enter?t={token}`` redirect; unset keeps
+    the decoupled raw-token contract (#1098) with ``url=None``."""
+
+    def _post_with_base(self, session_client, base_url: str):
+        perm = MagicMock()
+        perm.check_workspace_owner = AsyncMock(return_value=MagicMock())
+        # Patch get_settings so both the rate-limit read and the new base-url read
+        # come from one stand-in (the route reads settings once).
+        settings = MagicMock()
+        settings.payment_public_base_url = base_url
+        settings.billing_handoff_rate_limit_per_minute = 10
+        with (
+            patch.object(route_mod, "PermissionService", return_value=perm),
+            patch.object(route_mod, "BillingHandoffSigner") as signer_cls,
+            patch.object(route_mod, "get_settings", return_value=settings),
+        ):
+            signer_cls.return_value.mint.return_value = _fake_minted(WS_A)
+            return session_client.post("/api/v1/billing/handoff", json={"workspace_id": str(WS_A)})
+
+    def test_url_is_null_when_base_unset(self, session_client):
+        resp = self._post_with_base(session_client, "")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["url"] is None
+        # The raw-token contract is intact regardless of the opt-in field.
+        assert body["token"] == _FAKE_TOKEN
+
+    def test_url_built_when_base_set(self, session_client):
+        resp = self._post_with_base(session_client, "https://billing.example.com")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["url"] == f"https://billing.example.com/enter?t={_FAKE_TOKEN}"
+        # Additive: the raw token is still present and unchanged (shape not replaced).
+        assert body["token"] == _FAKE_TOKEN
+        assert body["kid"] == "kid-1"
+
+    def test_url_normalizes_trailing_slash_on_base(self, session_client):
+        resp = self._post_with_base(session_client, "https://billing.example.com/")
+        assert resp.status_code == 200, resp.text
+        # No double slash before /enter.
+        assert resp.json()["url"] == f"https://billing.example.com/enter?t={_FAKE_TOKEN}"
+
+
+class TestBuildHandoffUrlHelper:
+    """Unit tests for the ``{base}/enter?t={token}`` URL builder."""
+
+    def test_returns_none_for_empty_or_blank_base(self):
+        assert route_mod._build_handoff_url("", "tok") is None
+        assert route_mod._build_handoff_url("   ", "tok") is None
+
+    def test_builds_enter_url(self):
+        assert (
+            route_mod._build_handoff_url("https://billing.example.com", "tok")
+            == "https://billing.example.com/enter?t=tok"
+        )
+
+    def test_normalizes_trailing_slash(self):
+        assert (
+            route_mod._build_handoff_url("https://billing.example.com/", "tok")
+            == "https://billing.example.com/enter?t=tok"
+        )


### PR DESCRIPTION
## Summary
Adds an **opt-in** convenience on top of the merged #1098 raw-token handoff contract. When the new `payment_public_base_url` setting is configured, `POST /api/v1/billing/handoff` also returns a ready-to-use redirect `url = {base}/enter?t={token}`. Unset (default) → the response is **unchanged** (raw token only), so OSS / self-hosted deployments without an external billing service are unaffected — **inert-by-default**, mirroring the handoff signing-key's fail-closed-when-unset posture.

## Changes
- `payment_public_base_url` setting (default "") + a **startup validator**: when set it must be an `https` origin (`http` only for localhost) with **no path** — fails loud at boot rather than silently leaking the token over plaintext or breaking the frozen `/enter` contract.
- `_build_handoff_url` helper (`/enter?t=` is the frozen cross-repo entry contract; `rstrip('/')` before the empty-guard so a slash-only base → None, not a relative URL).
- Additive `url: str | None` field on `BillingHandoffResponse` — existing fields unchanged.
- Keeps the explicit `workspace_id` body binding (#389 guard); no user input reaches the URL (no open redirect / SSRF / injection).
- `.env.example` documents `PAYMENT_PUBLIC_BASE_URL` with a placeholder host (no hosted URL committed).

## Quality
- **code-review max** (4 finder angles → verify → fix): surfaced + fixed a slash-only edge bug and added the https/no-path startup validator; remaining notes were non-blocking. All findings addressed.
- **gate2**: cso / qa-lead / cto all green.
- Tests: handoff suite 35 passed (route + helper + validator units, slash-only regression, non-vacuous builder spy); broader `tests/api` 872 passed / 15 xfailed (pre-existing) / 3 skipped; ruff clean; pyright 0 errors.

## Note (not a blocker)
End-to-end upgrade completes only once the external checkout UI ships (tracked cross-repo); this readies the memory-cloud half (as #1098 did for the raw token).

Closes #1118

🤖 Generated with [Claude Code](https://claude.com/claude-code)