### PR TITLE
feat(frontend): owner Settings > Plan page consolidating quota gates

### DIFF
--- a/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/contexts/page.tsx
@@ -516,7 +516,7 @@ export default function ContextsPage() {
         <div className="mb-6 text-sm text-yellow-600 dark:text-yellow-400 bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-800 rounded-lg p-3">
           ⚠️ {t("quotaWarning")}{" "}
           <a
-            href="/workspace/plan"
+            href="/workspace/settings/plan"
             className="underline hover:text-yellow-700 dark:hover:text-yellow-300 font-medium"
           >
             {t("upgradePrompt")}

--- a/frontend/src/app/(authenticated)/workspace/members/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/members/page.tsx
@@ -96,7 +96,6 @@ export default function WorkspaceMembersPage() {
   const [invitations, setInvitations] = useState<WorkspaceInvitation[]>([]);
   const [loading, setLoading] = useState(true);
   const [showInviteDialog, setShowInviteDialog] = useState(false);
-  const [showUpgradePrompt, setShowUpgradePrompt] = useState(false); // Issue #165: Pro plan gate
 
   // Invite dialog state
   const [inviteEmail, setInviteEmail] = useState("");
@@ -526,9 +525,11 @@ export default function WorkspaceMembersPage() {
   };
 
   const handleInviteClick = () => {
-    // Issue #165: Check Pro plan before showing invite dialog
+    // Issue #165 / #1121: team invitations are a Pro feature. Send free
+    // workspaces to the consolidated plan page instead of an inline upgrade
+    // modal (the plan/benefits/upgrade UX now lives in settings > plan).
     if (!isProPlan) {
-      setShowUpgradePrompt(true);
+      router.push("/workspace/settings/plan");
       return;
     }
     // Migration 042: Initialize with all shared contexts selected
@@ -1088,7 +1089,7 @@ export default function WorkspaceMembersPage() {
                         </p>
                       </div>
                       {memberQuota.percentage >= 100 && (
-                        <Link href="/workspace/plan">
+                        <Link href="/workspace/settings/plan">
                           <button className="px-3 py-1 text-xs bg-red-600 text-white rounded hover:bg-red-700">
                             {t("upgradeToAddMembers")}
                           </button>
@@ -1112,7 +1113,7 @@ export default function WorkspaceMembersPage() {
                         limit: memberQuota.limit,
                       })}
                     </p>
-                    <Link href="/workspace/plan">
+                    <Link href="/workspace/settings/plan">
                       <button className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700">
                         {t("upgradeToAddMembers")}
                       </button>
@@ -1380,50 +1381,6 @@ export default function WorkspaceMembersPage() {
                 </div>
               </div>
             )}
-          </div>
-        </div>
-      )}
-
-      {/* Upgrade to Pro Prompt (Issue #165) */}
-      {showUpgradePrompt && (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full mx-4">
-            <h3 className="text-lg font-semibold mb-4 text-gray-900 dark:text-gray-100">
-              {t("proPlanRequiredTitle")}
-            </h3>
-
-            <p className="text-gray-600 dark:text-gray-400 mb-6">
-              {t("proPlanRequiredDesc")}
-            </p>
-
-            <div className="bg-purple-50 dark:bg-purple-900/20 border border-purple-200 dark:border-purple-800 rounded-lg p-4 mb-6">
-              <p className="text-sm text-purple-900 dark:text-purple-100 font-medium mb-2">
-                {t("proPlanBenefits")}
-              </p>
-              <ul className="text-sm text-purple-800 dark:text-purple-200 space-y-1">
-                <li>✓ {t("benefitTeamInvitations")}</li>
-                <li>✓ {t("benefitSharedContexts")}</li>
-                <li>✓ {t("benefitCollaboration")}</li>
-              </ul>
-            </div>
-
-            <div className="flex gap-2">
-              <button
-                onClick={() => setShowUpgradePrompt(false)}
-                className="flex-1 px-4 py-2 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-md"
-              >
-                {tCommon("cancel")}
-              </button>
-              <button
-                onClick={() => {
-                  setShowUpgradePrompt(false);
-                  window.location.href = "/workspace/plan";
-                }}
-                className="flex-1 px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700"
-              >
-                {t("upgradeToPro")}
-              </button>
-            </div>
           </div>
         </div>
       )}

--- a/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/[id]/page.tsx
@@ -202,7 +202,7 @@ export default function ResourceDetailPage() {
           title={t("planGate.title")}
           description={t("planGate.description")}
           actionLabel={t("planGate.action")}
-          onAction={() => router.push("/workspace/settings/billing")}
+          onAction={() => router.push("/workspace/settings/plan")}
         />
       </PageContainer>
     );

--- a/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.test.tsx
@@ -143,7 +143,7 @@ describe("ResourcesListPage", () => {
     expect(mockListResources).not.toHaveBeenCalled();
   });
 
-  it("upgrade CTA button navigates to billing", async () => {
+  it("upgrade CTA button navigates to the plan page", async () => {
     mockCurrentWorkspace = { plan_name: "free", current_user_role: "owner" };
 
     render(<ResourcesListPage />);
@@ -152,7 +152,7 @@ describe("ResourcesListPage", () => {
       expect(screen.getByText("planGate.title")).toBeInTheDocument();
     });
     fireEvent.click(screen.getByRole("button", { name: "planGate.action" }));
-    expect(mockPush).toHaveBeenCalledWith("/workspace/settings/billing");
+    expect(mockPush).toHaveBeenCalledWith("/workspace/settings/plan");
   });
 
   it("holds the fetch until WorkspaceContext hydrates", async () => {

--- a/frontend/src/app/(authenticated)/workspace/resources/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/resources/page.tsx
@@ -111,7 +111,7 @@ export default function ResourcesListPage() {
           title={t("planGate.title")}
           description={t("planGate.description")}
           actionLabel={t("planGate.action")}
-          onAction={() => router.push("/workspace/settings/billing")}
+          onAction={() => router.push("/workspace/settings/plan")}
         />
       </PageContainer>
     );

--- a/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
@@ -125,19 +125,16 @@ export default function WorkspacePlanPage() {
               </p>
             )}
           </div>
-          {plan?.can_upgrade &&
-            (isOwner ? (
-              <Button onClick={handleManageBilling} disabled={upgrading}>
-                <Sparkles className="mr-2 h-4 w-4" />
-                {upgrading
-                  ? t("planPage.opening")
-                  : t("planPage.manageBilling")}
-              </Button>
-            ) : (
-              <p className="text-sm text-gray-500 dark:text-gray-400">
-                {t("planPage.ownerOnly")}
-              </p>
-            ))}
+          {isOwner ? (
+            <Button onClick={handleManageBilling} disabled={upgrading}>
+              <Sparkles className="mr-2 h-4 w-4" />
+              {upgrading ? t("planPage.opening") : t("planPage.manageBilling")}
+            </Button>
+          ) : (
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {t("planPage.ownerOnly")}
+            </p>
+          )}
         </div>
       </Section>
 

--- a/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
@@ -1,5 +1,155 @@
-import { redirect } from 'next/navigation';
+"use client";
 
-export default function PlanRedirect() {
-  redirect('/workspace/dashboard');
+/**
+ * Workspace Settings > Plan (#1121)
+ *
+ * Owner-facing plan view + billing handoff. Consolidates the previously
+ * scattered upgrade prompts (the members "Pro plan required" modal, the
+ * contexts/resources quota CTAs) into one page; those gates now route here.
+ *
+ * - Read-only plan/entitlement for every workspace member.
+ * - "Manage billing" routes the OWNER through the signed billing handoff
+ *   (#1118) to the external billing service. memory-cloud stays Stripe-agnostic
+ *   (#1096) — there is NO self-serve plan mutation here. When billing is
+ *   unconfigured the handoff returns 503 and we surface "not available".
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+import { Sparkles } from "lucide-react";
+import { PageContainer } from "@/components/common/PageContainer";
+import { PageHeader } from "@/components/common/PageHeader";
+import { Section } from "@/components/common/Section";
+import { SpinnerLoading } from "@/components/common/LoadingState";
+import { ErrorBanner } from "@/components/common/ErrorBanner";
+import { Button } from "@/components/ui/button";
+import { useWorkspace } from "@/contexts/WorkspaceContext";
+import { useToast } from "@/hooks/use-toast";
+import { getWorkspacePlan, type WorkspacePlanInfo } from "@/lib/api/workspaces";
+import { mintBillingHandoff } from "@/lib/api/billing";
+import { ApiError } from "@/lib/api/base";
+
+export default function WorkspacePlanPage() {
+  const t = useTranslations("workspace");
+  const tCommon = useTranslations("common");
+  const { currentWorkspaceId, currentWorkspace } = useWorkspace();
+  const { toast } = useToast();
+
+  const [plan, setPlan] = useState<WorkspacePlanInfo | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+  const [upgrading, setUpgrading] = useState(false);
+
+  const isOwner = currentWorkspace?.current_user_role === "owner";
+
+  const loadPlan = useCallback(async () => {
+    if (!currentWorkspaceId) return;
+    try {
+      setLoading(true);
+      setError(null);
+      setPlan(await getWorkspacePlan(currentWorkspaceId));
+    } catch (e) {
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      setLoading(false);
+    }
+  }, [currentWorkspaceId]);
+
+  useEffect(() => {
+    loadPlan();
+  }, [loadPlan]);
+
+  const handleManageBilling = async () => {
+    if (!currentWorkspaceId) return;
+    try {
+      setUpgrading(true);
+      const res = await mintBillingHandoff(currentWorkspaceId);
+      if (res.url) {
+        window.location.href = res.url;
+        return;
+      }
+      // Token minted but no ready-to-use URL (PAYMENT_PUBLIC_BASE_URL unset):
+      // there is nowhere to send the owner from this deployment.
+      toast({
+        variant: "destructive",
+        title: tCommon("error"),
+        description: t("planPage.unavailable"),
+      });
+    } catch (e) {
+      // 503 (BILLING-002) = handoff signing key unconfigured → billing disabled.
+      const description =
+        e instanceof ApiError && e.status === 503
+          ? t("planPage.unavailable")
+          : e instanceof Error
+            ? e.message
+            : t("planPage.upgradeError");
+      toast({ variant: "destructive", title: tCommon("error"), description });
+    } finally {
+      setUpgrading(false);
+    }
+  };
+
+  if (loading) {
+    return <SpinnerLoading size="lg" message={tCommon("loading")} />;
+  }
+
+  if (error) {
+    return (
+      <PageContainer>
+        <PageHeader
+          title={t("planPage.title")}
+          description={t("planPage.description")}
+        />
+        <ErrorBanner error={error.message} />
+      </PageContainer>
+    );
+  }
+
+  const planName =
+    plan?.plan_display_name ?? currentWorkspace?.plan_name ?? "—";
+
+  return (
+    <PageContainer>
+      <PageHeader
+        title={t("planPage.title")}
+        description={t("planPage.description")}
+      />
+
+      <Section title={t("planPage.currentPlan")}>
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <p className="text-2xl font-semibold capitalize">{planName}</p>
+            {plan && plan.price_monthly > 0 && (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t("planPage.pricePerMonth", { price: plan.price_monthly })}
+              </p>
+            )}
+          </div>
+          {plan?.can_upgrade &&
+            (isOwner ? (
+              <Button onClick={handleManageBilling} disabled={upgrading}>
+                <Sparkles className="mr-2 h-4 w-4" />
+                {upgrading
+                  ? t("planPage.opening")
+                  : t("planPage.manageBilling")}
+              </Button>
+            ) : (
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {t("planPage.ownerOnly")}
+              </p>
+            ))}
+        </div>
+      </Section>
+
+      {plan?.can_upgrade && (
+        <Section title={t("proPlanBenefits")}>
+          <ul className="space-y-1 text-sm text-gray-700 dark:text-gray-300">
+            <li>✓ {t("benefitTeamInvitations")}</li>
+            <li>✓ {t("benefitSharedContexts")}</li>
+            <li>✓ {t("benefitCollaboration")}</li>
+          </ul>
+        </Section>
+      )}
+    </PageContainer>
+  );
 }

--- a/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
+++ b/frontend/src/app/(authenticated)/workspace/settings/plan/page.tsx
@@ -141,6 +141,55 @@ export default function WorkspacePlanPage() {
         </div>
       </Section>
 
+      {plan && (
+        <Section title={t("planPage.usageTitle")}>
+          <dl className="grid grid-cols-1 gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+            <div className="flex justify-between border-b border-gray-100 pb-1 dark:border-gray-800">
+              <dt className="text-gray-500 dark:text-gray-400">
+                {t("planPage.memories")}
+              </dt>
+              <dd className="font-medium">
+                {plan.usage.memories.toLocaleString()} /{" "}
+                {plan.quotas.memory_limit.toLocaleString()}
+              </dd>
+            </div>
+            <div className="flex justify-between border-b border-gray-100 pb-1 dark:border-gray-800">
+              <dt className="text-gray-500 dark:text-gray-400">
+                {t("planPage.contexts")}
+              </dt>
+              <dd className="font-medium">
+                {plan.usage.contexts.toLocaleString()} /{" "}
+                {plan.quotas.max_contexts.toLocaleString()}
+              </dd>
+            </div>
+            <div className="flex justify-between border-b border-gray-100 pb-1 dark:border-gray-800">
+              <dt className="text-gray-500 dark:text-gray-400">
+                {t("planPage.mcpPerDay")}
+              </dt>
+              <dd className="font-medium">
+                {plan.quotas.mcp_calls_per_day.toLocaleString()}
+              </dd>
+            </div>
+            <div className="flex justify-between border-b border-gray-100 pb-1 dark:border-gray-800">
+              <dt className="text-gray-500 dark:text-gray-400">
+                {t("planPage.restPerDay")}
+              </dt>
+              <dd className="font-medium">
+                {plan.quotas.rest_calls_per_day.toLocaleString()}
+              </dd>
+            </div>
+            <div className="flex justify-between border-b border-gray-100 pb-1 dark:border-gray-800">
+              <dt className="text-gray-500 dark:text-gray-400">
+                {t("planPage.publicPerDay")}
+              </dt>
+              <dd className="font-medium">
+                {plan.quotas.public_calls_per_day.toLocaleString()}
+              </dd>
+            </div>
+          </dl>
+        </Section>
+      )}
+
       {plan?.can_upgrade && (
         <Section title={t("proPlanBenefits")}>
           <ul className="space-y-1 text-sm text-gray-700 dark:text-gray-300">

--- a/frontend/src/components/contexts/SearchSettingsSection.tsx
+++ b/frontend/src/components/contexts/SearchSettingsSection.tsx
@@ -232,8 +232,8 @@ export function SearchSettingsSection({
   ): ContextSearchConfig[K] => {
     return (
       (editedConfig[key as keyof ContextSearchConfigUpdate] as
-        | ContextSearchConfig[K]
-        | undefined) ?? (config?.[key] as ContextSearchConfig[K])
+        ContextSearchConfig[K] | undefined) ??
+      (config?.[key] as ContextSearchConfig[K])
     );
   };
 
@@ -445,7 +445,7 @@ export function SearchSettingsSection({
                   <p className="text-sm">
                     {t("upgradeToBasic").split("Basic plan")[0]}
                     <Link
-                      href="/workspace/plan"
+                      href="/workspace/settings/plan"
                       className="underline font-medium"
                     >
                       Basic plan

--- a/frontend/src/lib/api/billing.ts
+++ b/frontend/src/lib/api/billing.ts
@@ -1,0 +1,34 @@
+/**
+ * Billing handoff API (#1093 / #1118).
+ *
+ * Mints an owner-scoped, short-lived Ed25519 token to start a billing session
+ * on the external billing service without that service re-implementing auth.
+ *
+ * - When the deployment sets PAYMENT_PUBLIC_BASE_URL, the response includes a
+ *   ready-to-use `url` ({base}/enter?t={token}); otherwise `url` is null and the
+ *   caller holds only the raw token.
+ * - When the handoff signing key is unconfigured the backend returns 503
+ *   (BILLING-002) — surface that as "billing not available on this deployment"
+ *   rather than a hard error. memory-cloud stays Stripe-agnostic (#1096); plan
+ *   changes flow through this signed handoff, never a self-serve plan mutation.
+ */
+import { apiClient } from "@/lib/api/base";
+
+export interface BillingHandoffResponse {
+  token: string;
+  token_type: string;
+  kid: string;
+  jti: string;
+  expires_at: string;
+  /** Ready-to-use redirect URL, or null when the billing host base is unset. */
+  url: string | null;
+}
+
+/** Mint an owner handoff token for the given workspace (owner + session only). */
+export async function mintBillingHandoff(
+  workspaceId: string,
+): Promise<BillingHandoffResponse> {
+  return apiClient.post<BillingHandoffResponse>("/api/v1/billing/handoff", {
+    workspace_id: workspaceId,
+  });
+}

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1153,7 +1153,13 @@
       "opening": "Opening billing…",
       "ownerOnly": "Only the workspace owner can change the plan.",
       "unavailable": "Plan changes are not available on this deployment.",
-      "upgradeError": "Could not start the billing session. Please try again."
+      "upgradeError": "Could not start the billing session. Please try again.",
+      "usageTitle": "Usage & limits",
+      "memories": "Memories",
+      "contexts": "Contexts",
+      "mcpPerDay": "MCP calls / day",
+      "restPerDay": "REST calls / day",
+      "publicPerDay": "Public calls / day"
     },
     "removeMemberTitle": "Remove Member?",
     "removeMemberDesc": "Are you sure you want to remove {name} from the workspace?",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1149,7 +1149,7 @@
       "description": "View your workspace plan and manage billing.",
       "currentPlan": "Current plan",
       "pricePerMonth": "${price}/month",
-      "manageBilling": "Manage billing",
+      "manageBilling": "Change plan",
       "opening": "Opening billing…",
       "ownerOnly": "Only the workspace owner can change the plan.",
       "unavailable": "Plan changes are not available on this deployment.",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -1144,6 +1144,17 @@
     "benefitSharedContexts": "Shared contexts",
     "benefitCollaboration": "Collaboration features",
     "upgradeToPro": "Upgrade to Pro",
+    "planPage": {
+      "title": "Plan",
+      "description": "View your workspace plan and manage billing.",
+      "currentPlan": "Current plan",
+      "pricePerMonth": "${price}/month",
+      "manageBilling": "Manage billing",
+      "opening": "Opening billing…",
+      "ownerOnly": "Only the workspace owner can change the plan.",
+      "unavailable": "Plan changes are not available on this deployment.",
+      "upgradeError": "Could not start the billing session. Please try again."
+    },
     "removeMemberTitle": "Remove Member?",
     "removeMemberDesc": "Are you sure you want to remove {name} from the workspace?",
     "removeMemberWarning": "This will revoke their access to all contexts in this workspace. They can be re-invited later if needed.",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1152,7 +1152,13 @@
       "opening": "請求ページを開いています…",
       "ownerOnly": "プランの変更はワークスペースのオーナーのみ可能です。",
       "unavailable": "この環境ではプラン変更を利用できません。",
-      "upgradeError": "請求セッションを開始できませんでした。もう一度お試しください。"
+      "upgradeError": "請求セッションを開始できませんでした。もう一度お試しください。",
+      "usageTitle": "利用状況・上限",
+      "memories": "メモリ",
+      "contexts": "コンテキスト",
+      "mcpPerDay": "MCP呼び出し / 日",
+      "restPerDay": "REST呼び出し / 日",
+      "publicPerDay": "公開呼び出し / 日"
     },
     "removeMemberTitle": "メンバーを削除しますか？",
     "removeMemberDesc": "{name}をワークスペースから削除してもよろしいですか？",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1148,7 +1148,7 @@
       "description": "ワークスペースのプランを確認し、請求を管理します。",
       "currentPlan": "現在のプラン",
       "pricePerMonth": "月額 ${price}",
-      "manageBilling": "請求を管理",
+      "manageBilling": "プランを変更",
       "opening": "請求ページを開いています…",
       "ownerOnly": "プランの変更はワークスペースのオーナーのみ可能です。",
       "unavailable": "この環境ではプラン変更を利用できません。",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -1143,6 +1143,17 @@
     "benefitSharedContexts": "共有コンテキスト",
     "benefitCollaboration": "コラボレーション機能",
     "upgradeToPro": "Proにアップグレード",
+    "planPage": {
+      "title": "プラン",
+      "description": "ワークスペースのプランを確認し、請求を管理します。",
+      "currentPlan": "現在のプラン",
+      "pricePerMonth": "月額 ${price}",
+      "manageBilling": "請求を管理",
+      "opening": "請求ページを開いています…",
+      "ownerOnly": "プランの変更はワークスペースのオーナーのみ可能です。",
+      "unavailable": "この環境ではプラン変更を利用できません。",
+      "upgradeError": "請求セッションを開始できませんでした。もう一度お試しください。"
+    },
     "removeMemberTitle": "メンバーを削除しますか？",
     "removeMemberDesc": "{name}をワークスペースから削除してもよろしいですか？",
     "removeMemberWarning": "このワークスペースのすべてのコンテキストへのアクセスが取り消されます。必要に応じて後で再招待できます。",


### PR DESCRIPTION
Closes #1121

## What

Turns `workspace/settings/plan` from a `redirect()` stub into the real
owner-facing **Plan** page, and consolidates the previously scattered
upgrade prompts into it.

- **Plan page** (`settings/plan/page.tsx`): read-only current plan + price,
  a **Usage & limits** panel (memories / contexts / MCP·REST·public per-day
  quotas), and a **Change plan** action for the owner.
- **Change plan** routes the owner through the signed billing handoff
  (#1118) → `mintBillingHandoff()` → redirect to the external billing
  service. memory-cloud stays Stripe-agnostic (#1096): **no self-serve plan
  mutation here**. When billing is unconfigured the handoff returns 503 and
  we surface "not available on this deployment".
- **Consolidation (not deletion)**: the members "Pro plan required" modal and
  the contexts/resources quota CTAs are removed/repointed — every upgrade gate
  now routes to `settings/plan` instead of dead/scattered links. `proxy.ts`
  already redirects legacy `/workspace/plan` → `/workspace/settings/plan`, so
  old bookmarks still land correctly.

## Files

- `settings/plan/page.tsx` — real page (was a redirect stub)
- `lib/api/billing.ts` (new) — `mintBillingHandoff(workspaceId)`
- `members/page.tsx` — drop inline upgrade modal + state; free-gate → `router.push(settings/plan)`
- `contexts/page.tsx`, `resources/page.tsx`, `resources/[id]/page.tsx`, `SearchSettingsSection.tsx` — quota CTAs repointed
- `messages/en.json` / `ja.json` — `workspace.planPage.*`

## Quality

- `tsc --noEmit`: 0 errors
- Targeted vitest: members (5) + resources list/detail (27) pass
- i18n keys verified complete + parity across en/ja
- code-review (xhigh): 1 finding — a resources test still asserted the old
  `settings/billing` route; fixed in `a3e90f81`. No correctness/security/
  public-repo-hygiene blockers.

> Note: the full vitest suite hits an unrelated V8/happy-dom native crash in
> `profile/page.test.tsx` on this WSL2 box; verified via per-file runs of the
> changed-area tests.