### PR TITLE
feat(billing): usage-fit downgrade-eligibility read on /internal

### DIFF
--- a/backend/src/api/routes/internal_billing.py
+++ b/backend/src/api/routes/internal_billing.py
@@ -52,6 +52,10 @@ from config.settings import get_settings
 from db.base import get_db
 from models.api_base import TZAwareBaseModel
 from models.auth import ENTITLEMENT_SOURCE_EXTERNAL_BILLING, Workspace
+from services.downgrade_eligibility_service import (
+    DowngradeEligibilityService,
+    TierDowngradeEligibility,
+)
 from utils.exceptions import (
     AuthenticationError,
     MemoryCloudException,
@@ -261,4 +265,52 @@ async def get_workspace_entitlement(
         plan_name=workspace.plan_name,
         addons=current_addons,
         entitlement_source=workspace.entitlement_source,
+    )
+
+
+class DowngradeEligibilityView(BaseModel):
+    """Usage-fit downgrade eligibility for every tier below the current one (#1123)."""
+
+    workspace_id: str
+    current_plan: str
+    targets: list[TierDowngradeEligibility]
+
+
+@router.get(
+    "/workspaces/{workspace_id}/downgrade-eligibility",
+    response_model=DowngradeEligibilityView,
+)
+async def get_downgrade_eligibility(
+    workspace_id: str,
+    _: None = Depends(verify_billing_service_token),
+    db: AsyncSession = Depends(get_db),
+) -> DowngradeEligibilityView:
+    """Report whether a workspace's usage fits each lower tier (#1123).
+
+    Service-authenticated, internal-only. memory-cloud is the usage SoT; the
+    external billing service gates its portal downgrade UI on this so it never
+    offers a downgrade that current usage cannot satisfy (purchased addons are
+    kept — the fit is against the target tier base + retained addon bonuses).
+    The absolute ``PUT .../plan`` push stays reconcile-safe and does NOT itself
+    enforce this guard; enforcement is the portal's responsibility, informed by
+    this read. Soft-deleted workspaces 404 (consistent with the entitlement read).
+    """
+    try:
+        ws_uuid = UUID(workspace_id)
+    except ValueError as exc:
+        raise ValidationError("Invalid workspace_id", field="workspace_id") from exc
+
+    workspace = (
+        await db.execute(
+            select(Workspace).where(Workspace.id == ws_uuid, Workspace.deleted_at.is_(None))
+        )
+    ).scalar_one_or_none()
+    if workspace is None:
+        raise NotFoundException("Workspace")
+
+    targets = await DowngradeEligibilityService(db).evaluate(workspace)
+    return DowngradeEligibilityView(
+        workspace_id=workspace_id,
+        current_plan=workspace.plan_name,
+        targets=targets,
     )

--- a/backend/src/services/downgrade_eligibility_service.py
+++ b/backend/src/services/downgrade_eligibility_service.py
@@ -6,7 +6,8 @@ usage fits the TARGET tier's *effective* limit (target tier base + the
 workspace's retained addon bonuses). Dimensions that exceed the target are
 "blockers" — each names the destructive cleanup needed before the downgrade can
 apply (remove members / delete contexts / delete memories / revoke resource
-tokens / unshare contexts).
+tokens / unshare contexts / remove connectors / disable sleep contexts / delete
+files).
 
 This service is READ-ONLY. It reports eligibility + per-dimension blockers for
 every tier strictly below the workspace's current tier. The external billing
@@ -14,10 +15,14 @@ service gates its portal downgrade UI on this read; the absolute ``/internal``
 plan push stays reconcile-safe and does not itself enforce the guard (#1096 made
 memory-cloud Stripe-agnostic — enforcement is the portal's responsibility,
 informed by this read).
+
+Each count is workspace-scoped and matches its write-time enforcement basis so
+the eligibility verdict agrees with the live quota gates.
 """
 
 from __future__ import annotations
 
+from enum import StrEnum
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -26,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from config.plan_tiers import PLAN_TIERS, PlanTier
 from models.auth import Context, Workspace, WorkspaceMember, _zero_floor
+from models.file_objects import FileObject
 from models.memory import Memory
 from models.resource import ResourceToken, WorkspaceConnector
 
@@ -34,20 +40,46 @@ from models.resource import ResourceToken, WorkspaceConnector
 _PLAN_ORDER: list[str] = ["free", "basic", "pro"]
 
 
+class DowngradeDimension(StrEnum):
+    """Usage dimensions that can block a downgrade (stable wire contract)."""
+
+    MEMBERS = "members"
+    CONTEXTS = "contexts"
+    MEMORIES = "memories"
+    RESOURCE_TOKENS = "resource_tokens"
+    SHARED_CONTEXTS = "shared_contexts"
+    CONNECTORS = "connectors"
+    SLEEP_ENABLED_CONTEXTS = "sleep_enabled_contexts"
+    STORAGE_BYTES = "storage_bytes"
+
+
+class DowngradeCleanup(StrEnum):
+    """The destructive cleanup a blocker requires (stable wire contract)."""
+
+    REMOVE_MEMBERS = "remove_members"
+    DELETE_CONTEXTS = "delete_contexts"
+    DELETE_MEMORIES = "delete_memories"
+    REVOKE_RESOURCE_TOKENS = "revoke_resource_tokens"
+    UNSHARE_CONTEXTS = "unshare_contexts"
+    REMOVE_CONNECTORS = "remove_connectors"
+    DISABLE_SLEEP_CONTEXTS = "disable_sleep_contexts"
+    DELETE_FILES = "delete_files"
+
+
 class DowngradeBlocker(BaseModel):
     """One usage dimension that blocks (or requires cleanup before) a downgrade.
 
     ``overage`` is how much must be shed to fit the target. For ``shared_contexts``
     (a tier feature, not a numeric cap) the limit is 0 and ``overage`` equals the
-    full shared-context count — all of them must be unshared.
+    full shared-context count — all of them must be unshared. ``storage_bytes`` is
+    in bytes.
     """
 
-    dimension: str  # members | contexts | memories | resource_tokens | shared_contexts
+    dimension: DowngradeDimension
     usage: int
     limit: int
     overage: int
-    cleanup: str  # remove_members | delete_contexts | delete_memories |
-    #             # revoke_resource_tokens | unshare_contexts
+    cleanup: DowngradeCleanup
 
 
 class TierDowngradeEligibility(BaseModel):
@@ -66,6 +98,9 @@ class WorkspaceUsage(BaseModel):
     shared_contexts: int
     memories: int
     resource_tokens: int
+    connectors: int
+    sleep_enabled_contexts: int
+    storage_bytes: int
 
 
 class DowngradeEligibilityService:
@@ -93,13 +128,19 @@ class DowngradeEligibilityService:
         ]
 
     async def current_usage(self, workspace_id: UUID) -> WorkspaceUsage:
-        """Count current workspace-scoped usage across every guarded dimension."""
-        members = await self._count(
+        """Count current workspace-scoped usage across every guarded dimension.
+
+        Each count mirrors its write-time enforcement basis so the verdict agrees
+        with the live quota gates. Pending invitations are intentionally excluded
+        from ``members`` — they consume no seat until accepted and are re-gated at
+        accept-time, so they do not block a downgrade of the current membership.
+        """
+        members = await self._scalar(
             select(func.count(WorkspaceMember.id)).where(
                 WorkspaceMember.workspace_id == workspace_id
             )
         )
-        contexts = await self._count(
+        contexts = await self._scalar(
             select(func.count(Context.id)).where(
                 Context.workspace_id == workspace_id,
                 Context.deleted_at.is_(None),
@@ -108,24 +149,22 @@ class DowngradeEligibilityService:
         # Shared == non-private (is_private is False). Shared contexts are a Pro
         # feature; on a downgrade to a tier that disallows them they must all be
         # made private again.
-        shared_contexts = await self._count(
+        shared_contexts = await self._scalar(
             select(func.count(Context.id)).where(
                 Context.workspace_id == workspace_id,
                 Context.is_private.is_(False),
                 Context.deleted_at.is_(None),
             )
         )
-        # Match the ENFORCEMENT count (quota_service.check_memory_quota): memories
-        # created by this workspace's members, with a non-null workspace_id, not
-        # soft-deleted. Using the same basis keeps the eligibility verdict in
-        # agreement with the live memory-quota gate (and the #1121 plan display).
-        memories = await self._count(
-            select(func.count(Memory.id))
-            .select_from(Memory)
-            .join(WorkspaceMember, Memory.user_id == WorkspaceMember.user_id)
-            .where(
-                WorkspaceMember.workspace_id == workspace_id,
-                Memory.workspace_id.isnot(None),
+        # Memories belonging to THIS workspace (the per-workspace memory_limit is
+        # what a downgrade must fit, and the cleanup must be actionable here). NB:
+        # the live memory-quota gate (quota_service) joins on member user_id and
+        # can over-count a multi-workspace member's memories across workspaces —
+        # an orthogonal #273 quirk; the eligibility read uses the precise
+        # per-workspace count.
+        memories = await self._scalar(
+            select(func.count(Memory.id)).where(
+                Memory.workspace_id == workspace_id,
                 Memory.deleted_at.is_(None),
             )
         )
@@ -135,7 +174,7 @@ class DowngradeEligibilityService:
         # ``workspace_id`` column is a Phase-1 shadow (#323) still nullable, so a
         # legacy token with NULL workspace_id is not counted here — acceptable
         # for an advisory eligibility read while the backfill (#324/#325) lands.
-        resource_tokens = await self._count(
+        resource_tokens = await self._scalar(
             select(func.count(ResourceToken.id))
             .outerjoin(
                 WorkspaceConnector,
@@ -147,15 +186,44 @@ class DowngradeEligibilityService:
                 WorkspaceConnector.id.is_(None),
             )
         )
+        # Active ai-worker connectors (#850). WorkspaceConnector has no status
+        # column — every row is an active seat.
+        connectors = await self._scalar(
+            select(func.count(WorkspaceConnector.id)).where(
+                WorkspaceConnector.workspace_id == workspace_id
+            )
+        )
+        # Sleep-enabled contexts (#560): sleep_mode anything but "skip".
+        sleep_enabled_contexts = await self._scalar(
+            select(func.count(Context.id)).where(
+                Context.workspace_id == workspace_id,
+                Context.deleted_at.is_(None),
+                Context.sleep_mode != "skip",
+            )
+        )
+        # Committed file storage in bytes (#485): only "uploaded" (not reserved/
+        # failed) and not soft-deleted, matching storage_quota_service's DB
+        # aggregate. A direct aggregate (not the Redis-cached value) keeps the
+        # eligibility verdict authoritative.
+        storage_bytes = await self._scalar(
+            select(func.coalesce(func.sum(FileObject.size_bytes), 0)).where(
+                FileObject.workspace_id == workspace_id,
+                FileObject.status == "uploaded",
+                FileObject.deleted_at.is_(None),
+            )
+        )
         return WorkspaceUsage(
             members=members,
             contexts=contexts,
             shared_contexts=shared_contexts,
             memories=memories,
             resource_tokens=resource_tokens,
+            connectors=connectors,
+            sleep_enabled_contexts=sleep_enabled_contexts,
+            storage_bytes=storage_bytes,
         )
 
-    async def _count(self, stmt) -> int:
+    async def _scalar(self, stmt) -> int:
         return (await self.db.execute(stmt)).scalar() or 0
 
     def _evaluate_tier(
@@ -164,68 +232,78 @@ class DowngradeEligibilityService:
         """Compare usage against one target tier's effective limits (addons kept)."""
         blockers: list[DowngradeBlocker] = []
 
+        def check(dimension, used, limit, cleanup):
+            if used > limit:
+                blockers.append(
+                    DowngradeBlocker(
+                        dimension=dimension,
+                        usage=used,
+                        limit=limit,
+                        overage=used - limit,
+                        cleanup=cleanup,
+                    )
+                )
+
         # Numeric caps: target effective limit = _zero_floor(target base, kept
         # addon bonus). Reusing _zero_floor keeps the #569 zero-base rule (a
         # zero-base tier never stacks addons) consistent with the live quotas.
-        members_limit = _zero_floor(tier.max_members_per_workspace, workspace.addon_member_bonus)
-        if usage.members > members_limit:
-            blockers.append(
-                DowngradeBlocker(
-                    dimension="members",
-                    usage=usage.members,
-                    limit=members_limit,
-                    overage=usage.members - members_limit,
-                    cleanup="remove_members",
-                )
-            )
-
-        contexts_limit = _zero_floor(tier.max_contexts_per_workspace, workspace.addon_context_bonus)
-        if usage.contexts > contexts_limit:
-            blockers.append(
-                DowngradeBlocker(
-                    dimension="contexts",
-                    usage=usage.contexts,
-                    limit=contexts_limit,
-                    overage=usage.contexts - contexts_limit,
-                    cleanup="delete_contexts",
-                )
-            )
-
-        memories_limit = _zero_floor(tier.memory_limit, workspace.addon_memory_bonus)
-        if usage.memories > memories_limit:
-            blockers.append(
-                DowngradeBlocker(
-                    dimension="memories",
-                    usage=usage.memories,
-                    limit=memories_limit,
-                    overage=usage.memories - memories_limit,
-                    cleanup="delete_memories",
-                )
-            )
-
+        check(
+            DowngradeDimension.MEMBERS,
+            usage.members,
+            _zero_floor(tier.max_members_per_workspace, workspace.addon_member_bonus),
+            DowngradeCleanup.REMOVE_MEMBERS,
+        )
+        check(
+            DowngradeDimension.CONTEXTS,
+            usage.contexts,
+            _zero_floor(tier.max_contexts_per_workspace, workspace.addon_context_bonus),
+            DowngradeCleanup.DELETE_CONTEXTS,
+        )
+        check(
+            DowngradeDimension.MEMORIES,
+            usage.memories,
+            _zero_floor(tier.memory_limit, workspace.addon_memory_bonus),
+            DowngradeCleanup.DELETE_MEMORIES,
+        )
         # Resource tokens are tier-fixed (no addon → effective == base).
-        tokens_limit = tier.max_resource_tokens
-        if usage.resource_tokens > tokens_limit:
-            blockers.append(
-                DowngradeBlocker(
-                    dimension="resource_tokens",
-                    usage=usage.resource_tokens,
-                    limit=tokens_limit,
-                    overage=usage.resource_tokens - tokens_limit,
-                    cleanup="revoke_resource_tokens",
-                )
-            )
+        check(
+            DowngradeDimension.RESOURCE_TOKENS,
+            usage.resource_tokens,
+            tier.max_resource_tokens,
+            DowngradeCleanup.REVOKE_RESOURCE_TOKENS,
+        )
+        check(
+            DowngradeDimension.CONNECTORS,
+            usage.connectors,
+            _zero_floor(tier.max_connectors, workspace.addon_connector_bonus),
+            DowngradeCleanup.REMOVE_CONNECTORS,
+        )
+        check(
+            DowngradeDimension.SLEEP_ENABLED_CONTEXTS,
+            usage.sleep_enabled_contexts,
+            _zero_floor(tier.sleep_enabled_contexts_limit, workspace.addon_sleep_contexts_bonus),
+            DowngradeCleanup.DISABLE_SLEEP_CONTEXTS,
+        )
+        # Storage addon is stored in MB; scale to bytes before the zero-floor so
+        # the check happens on the final unit (matches effective_storage_limit_bytes).
+        storage_addon_bytes = (workspace.addon_storage_bonus_mb or 0) * 1024 * 1024
+        check(
+            DowngradeDimension.STORAGE_BYTES,
+            usage.storage_bytes,
+            _zero_floor(tier.storage_limit_bytes, storage_addon_bytes),
+            DowngradeCleanup.DELETE_FILES,
+        )
 
         # Shared contexts are a tier FEATURE, not a numeric cap: a target tier
         # that disallows shared contexts requires unsharing all of them.
         if not tier.allows_shared_contexts and usage.shared_contexts > 0:
             blockers.append(
                 DowngradeBlocker(
-                    dimension="shared_contexts",
+                    dimension=DowngradeDimension.SHARED_CONTEXTS,
                     usage=usage.shared_contexts,
                     limit=0,
                     overage=usage.shared_contexts,
-                    cleanup="unshare_contexts",
+                    cleanup=DowngradeCleanup.UNSHARE_CONTEXTS,
                 )
             )
 

--- a/backend/src/services/downgrade_eligibility_service.py
+++ b/backend/src/services/downgrade_eligibility_service.py
@@ -1,0 +1,236 @@
+"""Usage-fit plan-downgrade eligibility (#1123).
+
+memory-cloud is the usage source of truth, so a plan DOWNGRADE must be guarded:
+purchased addons are KEPT, but a tier downgrade is only allowed when current
+usage fits the TARGET tier's *effective* limit (target tier base + the
+workspace's retained addon bonuses). Dimensions that exceed the target are
+"blockers" — each names the destructive cleanup needed before the downgrade can
+apply (remove members / delete contexts / delete memories / revoke resource
+tokens / unshare contexts).
+
+This service is READ-ONLY. It reports eligibility + per-dimension blockers for
+every tier strictly below the workspace's current tier. The external billing
+service gates its portal downgrade UI on this read; the absolute ``/internal``
+plan push stays reconcile-safe and does not itself enforce the guard (#1096 made
+memory-cloud Stripe-agnostic — enforcement is the portal's responsibility,
+informed by this read).
+"""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from pydantic import BaseModel
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.plan_tiers import PLAN_TIERS, PlanTier
+from models.auth import Context, Workspace, WorkspaceMember, _zero_floor
+from models.memory import Memory
+from models.resource import ResourceToken, WorkspaceConnector
+
+# Lowest → highest tier. A downgrade target is any tier strictly left of the
+# workspace's current tier; mirrors ``plan_order`` in workspace_plan.py.
+_PLAN_ORDER: list[str] = ["free", "basic", "pro"]
+
+
+class DowngradeBlocker(BaseModel):
+    """One usage dimension that blocks (or requires cleanup before) a downgrade.
+
+    ``overage`` is how much must be shed to fit the target. For ``shared_contexts``
+    (a tier feature, not a numeric cap) the limit is 0 and ``overage`` equals the
+    full shared-context count — all of them must be unshared.
+    """
+
+    dimension: str  # members | contexts | memories | resource_tokens | shared_contexts
+    usage: int
+    limit: int
+    overage: int
+    cleanup: str  # remove_members | delete_contexts | delete_memories |
+    #             # revoke_resource_tokens | unshare_contexts
+
+
+class TierDowngradeEligibility(BaseModel):
+    """Whether the workspace's usage fits one specific lower tier."""
+
+    target_plan: str
+    eligible: bool
+    blockers: list[DowngradeBlocker]
+
+
+class WorkspaceUsage(BaseModel):
+    """Current workspace-scoped usage counts used for the fit check."""
+
+    members: int
+    contexts: int
+    shared_contexts: int
+    memories: int
+    resource_tokens: int
+
+
+class DowngradeEligibilityService:
+    """Evaluate whether a workspace can downgrade to each lower tier."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def evaluate(self, workspace: Workspace) -> list[TierDowngradeEligibility]:
+        """Eligibility for every tier strictly below the workspace's current tier.
+
+        Returns an empty list when the workspace is already on the lowest tier
+        (or on an unknown tier — fail-closed to "no downgrade targets").
+        """
+        current_index = (
+            _PLAN_ORDER.index(workspace.plan_name) if workspace.plan_name in _PLAN_ORDER else 0
+        )
+        if current_index == 0:
+            return []
+
+        usage = await self.current_usage(workspace.id)
+        return [
+            self._evaluate_tier(workspace, usage, PLAN_TIERS[target])
+            for target in _PLAN_ORDER[:current_index]
+        ]
+
+    async def current_usage(self, workspace_id: UUID) -> WorkspaceUsage:
+        """Count current workspace-scoped usage across every guarded dimension."""
+        members = await self._count(
+            select(func.count(WorkspaceMember.id)).where(
+                WorkspaceMember.workspace_id == workspace_id
+            )
+        )
+        contexts = await self._count(
+            select(func.count(Context.id)).where(
+                Context.workspace_id == workspace_id,
+                Context.deleted_at.is_(None),
+            )
+        )
+        # Shared == non-private (is_private is False). Shared contexts are a Pro
+        # feature; on a downgrade to a tier that disallows them they must all be
+        # made private again.
+        shared_contexts = await self._count(
+            select(func.count(Context.id)).where(
+                Context.workspace_id == workspace_id,
+                Context.is_private.is_(False),
+                Context.deleted_at.is_(None),
+            )
+        )
+        # Match the ENFORCEMENT count (quota_service.check_memory_quota): memories
+        # created by this workspace's members, with a non-null workspace_id, not
+        # soft-deleted. Using the same basis keeps the eligibility verdict in
+        # agreement with the live memory-quota gate (and the #1121 plan display).
+        memories = await self._count(
+            select(func.count(Memory.id))
+            .select_from(Memory)
+            .join(WorkspaceMember, Memory.user_id == WorkspaceMember.user_id)
+            .where(
+                WorkspaceMember.workspace_id == workspace_id,
+                Memory.workspace_id.isnot(None),
+                Memory.deleted_at.is_(None),
+            )
+        )
+        # Workspace-scoped active resource tokens, excluding connector-owned
+        # tokens (mirrors the create-time count in resource_tokens.py: connector
+        # tokens are gated by max_connectors, not max_resource_tokens). The
+        # ``workspace_id`` column is a Phase-1 shadow (#323) still nullable, so a
+        # legacy token with NULL workspace_id is not counted here — acceptable
+        # for an advisory eligibility read while the backfill (#324/#325) lands.
+        resource_tokens = await self._count(
+            select(func.count(ResourceToken.id))
+            .outerjoin(
+                WorkspaceConnector,
+                WorkspaceConnector.resource_pk == ResourceToken.resource_pk,
+            )
+            .where(
+                ResourceToken.workspace_id == workspace_id,
+                ResourceToken.is_active.is_(True),
+                WorkspaceConnector.id.is_(None),
+            )
+        )
+        return WorkspaceUsage(
+            members=members,
+            contexts=contexts,
+            shared_contexts=shared_contexts,
+            memories=memories,
+            resource_tokens=resource_tokens,
+        )
+
+    async def _count(self, stmt) -> int:
+        return (await self.db.execute(stmt)).scalar() or 0
+
+    def _evaluate_tier(
+        self, workspace: Workspace, usage: WorkspaceUsage, tier: PlanTier
+    ) -> TierDowngradeEligibility:
+        """Compare usage against one target tier's effective limits (addons kept)."""
+        blockers: list[DowngradeBlocker] = []
+
+        # Numeric caps: target effective limit = _zero_floor(target base, kept
+        # addon bonus). Reusing _zero_floor keeps the #569 zero-base rule (a
+        # zero-base tier never stacks addons) consistent with the live quotas.
+        members_limit = _zero_floor(tier.max_members_per_workspace, workspace.addon_member_bonus)
+        if usage.members > members_limit:
+            blockers.append(
+                DowngradeBlocker(
+                    dimension="members",
+                    usage=usage.members,
+                    limit=members_limit,
+                    overage=usage.members - members_limit,
+                    cleanup="remove_members",
+                )
+            )
+
+        contexts_limit = _zero_floor(tier.max_contexts_per_workspace, workspace.addon_context_bonus)
+        if usage.contexts > contexts_limit:
+            blockers.append(
+                DowngradeBlocker(
+                    dimension="contexts",
+                    usage=usage.contexts,
+                    limit=contexts_limit,
+                    overage=usage.contexts - contexts_limit,
+                    cleanup="delete_contexts",
+                )
+            )
+
+        memories_limit = _zero_floor(tier.memory_limit, workspace.addon_memory_bonus)
+        if usage.memories > memories_limit:
+            blockers.append(
+                DowngradeBlocker(
+                    dimension="memories",
+                    usage=usage.memories,
+                    limit=memories_limit,
+                    overage=usage.memories - memories_limit,
+                    cleanup="delete_memories",
+                )
+            )
+
+        # Resource tokens are tier-fixed (no addon → effective == base).
+        tokens_limit = tier.max_resource_tokens
+        if usage.resource_tokens > tokens_limit:
+            blockers.append(
+                DowngradeBlocker(
+                    dimension="resource_tokens",
+                    usage=usage.resource_tokens,
+                    limit=tokens_limit,
+                    overage=usage.resource_tokens - tokens_limit,
+                    cleanup="revoke_resource_tokens",
+                )
+            )
+
+        # Shared contexts are a tier FEATURE, not a numeric cap: a target tier
+        # that disallows shared contexts requires unsharing all of them.
+        if not tier.allows_shared_contexts and usage.shared_contexts > 0:
+            blockers.append(
+                DowngradeBlocker(
+                    dimension="shared_contexts",
+                    usage=usage.shared_contexts,
+                    limit=0,
+                    overage=usage.shared_contexts,
+                    cleanup="unshare_contexts",
+                )
+            )
+
+        return TierDowngradeEligibility(
+            target_plan=tier.name,
+            eligible=not blockers,
+            blockers=blockers,
+        )

--- a/backend/tests/api/test_internal_downgrade_eligibility.py
+++ b/backend/tests/api/test_internal_downgrade_eligibility.py
@@ -29,6 +29,9 @@ def _make_ws(plan_name: str = "pro"):
     ws.addon_member_bonus = 0
     ws.addon_context_bonus = 0
     ws.addon_memory_bonus = 0
+    ws.addon_connector_bonus = 0
+    ws.addon_sleep_contexts_bonus = 0
+    ws.addon_storage_bonus_mb = 0
     return ws
 
 
@@ -106,8 +109,18 @@ def test_missing_workspace_returns_404(billing):
 
 def test_pro_with_low_usage_is_eligible_for_all_lower_tiers(billing):
     ws = _make_ws("pro")
-    # ws load, then members/contexts/shared/memories/tokens.
-    results = [_ws_result(ws), _count(1), _count(1), _count(0), _count(10), _count(0)]
+    # ws load, then members/contexts/shared/memories/tokens/connectors/sleep/storage.
+    results = [
+        _ws_result(ws),
+        _count(1),  # members
+        _count(1),  # contexts
+        _count(0),  # shared
+        _count(10),  # memories
+        _count(0),  # resource_tokens
+        _count(0),  # connectors
+        _count(0),  # sleep_enabled_contexts
+        _count(0),  # storage_bytes
+    ]
     resp = billing.client(execute_results=results).get(
         _PATH, headers={"Authorization": "Bearer secret"}
     )
@@ -121,8 +134,18 @@ def test_pro_with_low_usage_is_eligible_for_all_lower_tiers(billing):
 
 def test_pro_with_high_usage_is_blocked(billing):
     ws = _make_ws("pro")
-    # 5 members, 25 contexts, 2 shared, 10 memories, 0 tokens.
-    results = [_ws_result(ws), _count(5), _count(25), _count(2), _count(10), _count(0)]
+    # 5 members, 25 contexts, 2 shared, 10 memories; 0 tokens/connectors/sleep/storage.
+    results = [
+        _ws_result(ws),
+        _count(5),  # members
+        _count(25),  # contexts
+        _count(2),  # shared
+        _count(10),  # memories
+        _count(0),  # resource_tokens
+        _count(0),  # connectors
+        _count(0),  # sleep_enabled_contexts
+        _count(0),  # storage_bytes
+    ]
     resp = billing.client(execute_results=results).get(
         _PATH, headers={"Authorization": "Bearer secret"}
     )

--- a/backend/tests/api/test_internal_downgrade_eligibility.py
+++ b/backend/tests/api/test_internal_downgrade_eligibility.py
@@ -1,0 +1,146 @@
+"""Unit tests for GET /internal/workspaces/{id}/downgrade-eligibility (#1123).
+
+TestClient + mocked DB (mirrors test_internal_billing_plan.py). The eligibility
+math is unit-tested in tests/services/test_downgrade_eligibility_service.py; here
+we pin the route: service-token auth, soft-delete 404, bad-id 422, and that the
+handler wires the service + serializes the per-tier blockers.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.main import app
+from db.base import get_db
+
+WS_ID = str(uuid4())
+_PATH = f"/internal/workspaces/{WS_ID}/downgrade-eligibility"
+
+
+def _make_ws(plan_name: str = "pro"):
+    ws = MagicMock()
+    ws.id = uuid4()
+    ws.plan_name = plan_name
+    ws.deleted_at = None
+    ws.addon_member_bonus = 0
+    ws.addon_context_bonus = 0
+    ws.addon_memory_bonus = 0
+    return ws
+
+
+def _ws_result(ws):
+    r = MagicMock()
+    r.scalar_one_or_none.return_value = ws
+    return r
+
+
+def _count(n: int):
+    r = MagicMock()
+    r.scalar.return_value = n
+    return r
+
+
+@pytest.fixture
+def billing(monkeypatch):
+    """Harness mirroring test_internal_billing_plan.py."""
+    mock_settings = MagicMock()
+    mock_settings.billing_service_token = "secret"
+    monkeypatch.setattr("api.routes.internal_billing.get_settings", lambda: mock_settings)
+
+    class _Harness:
+        @property
+        def token(self) -> str:
+            return mock_settings.billing_service_token
+
+        @token.setter
+        def token(self, value: str) -> None:
+            mock_settings.billing_service_token = value
+
+        def client(self, execute_results=None) -> TestClient:
+            async def mock_db():
+                db = MagicMock()
+                db.execute = AsyncMock(side_effect=execute_results)
+                yield db
+
+            app.dependency_overrides[get_db] = mock_db
+            return TestClient(app, raise_server_exceptions=False)
+
+    yield _Harness()
+    app.dependency_overrides.clear()
+
+
+def test_requires_bearer_token(billing):
+    resp = billing.client().get(_PATH)
+    assert resp.status_code == 401
+
+
+def test_invalid_token_returns_401(billing):
+    resp = billing.client().get(_PATH, headers={"Authorization": "Bearer wrong"})
+    assert resp.status_code == 401
+
+
+def test_unset_token_returns_503(billing):
+    billing.token = ""
+    resp = billing.client().get(_PATH, headers={"Authorization": "Bearer x"})
+    assert resp.status_code == 503
+
+
+def test_invalid_workspace_id_returns_422(billing):
+    resp = billing.client().get(
+        "/internal/workspaces/not-a-uuid/downgrade-eligibility",
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert resp.status_code == 422
+
+
+def test_missing_workspace_returns_404(billing):
+    resp = billing.client(execute_results=[_ws_result(None)]).get(
+        _PATH, headers={"Authorization": "Bearer secret"}
+    )
+    assert resp.status_code == 404
+
+
+def test_pro_with_low_usage_is_eligible_for_all_lower_tiers(billing):
+    ws = _make_ws("pro")
+    # ws load, then members/contexts/shared/memories/tokens.
+    results = [_ws_result(ws), _count(1), _count(1), _count(0), _count(10), _count(0)]
+    resp = billing.client(execute_results=results).get(
+        _PATH, headers={"Authorization": "Bearer secret"}
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["current_plan"] == "pro"
+    assert [t["target_plan"] for t in body["targets"]] == ["free", "basic"]
+    assert all(t["eligible"] for t in body["targets"])
+    assert all(t["blockers"] == [] for t in body["targets"])
+
+
+def test_pro_with_high_usage_is_blocked(billing):
+    ws = _make_ws("pro")
+    # 5 members, 25 contexts, 2 shared, 10 memories, 0 tokens.
+    results = [_ws_result(ws), _count(5), _count(25), _count(2), _count(10), _count(0)]
+    resp = billing.client(execute_results=results).get(
+        _PATH, headers={"Authorization": "Bearer secret"}
+    )
+    assert resp.status_code == 200
+    by_plan = {t["target_plan"]: t for t in resp.json()["targets"]}
+    free_dims = {b["dimension"] for b in by_plan["free"]["blockers"]}
+    assert free_dims == {"members", "contexts", "shared_contexts"}
+    assert by_plan["free"]["eligible"] is False
+    members_blocker = next(b for b in by_plan["free"]["blockers"] if b["dimension"] == "members")
+    assert members_blocker["cleanup"] == "remove_members"
+    assert members_blocker["overage"] == 4  # 5 - free limit(1)
+
+
+def test_free_workspace_has_no_downgrade_targets(billing):
+    ws = _make_ws("free")
+    # Only the workspace load runs — evaluate() short-circuits before counting.
+    resp = billing.client(execute_results=[_ws_result(ws)]).get(
+        _PATH, headers={"Authorization": "Bearer secret"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["targets"] == []

--- a/backend/tests/integration/test_downgrade_eligibility_db.py
+++ b/backend/tests/integration/test_downgrade_eligibility_db.py
@@ -1,0 +1,99 @@
+"""DB-level pins for downgrade eligibility (#1123).
+
+Exercises the workspace-scoped COUNT queries and the ``/internal`` route handler
+against a real session (the pure eligibility math is unit-tested in
+tests/services/test_downgrade_eligibility_service.py). Members / contexts /
+shared-contexts are constructed here; the memory and resource-token counts reuse
+the same ``func.count`` + workspace-filter shape and are covered by the unit
+matrix.
+"""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.routes.internal_billing import get_downgrade_eligibility
+from models.auth import WorkspaceMember, WorkspaceRole
+from services.downgrade_eligibility_service import DowngradeEligibilityService
+from utils.exceptions import NotFoundException
+
+from ._admin_helpers import make_context, make_user, make_workspace
+
+
+@pytest_asyncio.fixture
+async def pro_workspace(db_session: AsyncSession) -> dict:
+    """A PRO workspace: 3 members, 2 contexts (1 shared, 1 private)."""
+    owner = make_user()
+    m2 = make_user()
+    m3 = make_user()
+    db_session.add_all([owner, m2, m3])
+    await db_session.flush()
+
+    ws = make_workspace(owner_user_id=owner.user_id, plan_name="pro")
+    db_session.add(ws)
+    await db_session.flush()
+
+    for member in (owner, m2, m3):
+        db_session.add(
+            WorkspaceMember(
+                workspace_id=ws.id,
+                user_id=member.user_id,
+                role=(WorkspaceRole.OWNER if member is owner else WorkspaceRole.MEMBER),
+            )
+        )
+    db_session.add(make_context(workspace_id=ws.id, created_by=owner.user_id, is_private=False))
+    db_session.add(make_context(workspace_id=ws.id, created_by=owner.user_id, is_private=True))
+    await db_session.commit()
+    return {"workspace_id": str(ws.id), "owner_id": owner.user_id}
+
+
+@pytest.mark.asyncio
+async def test_current_usage_counts_members_and_contexts(
+    db_session: AsyncSession, pro_workspace: dict
+):
+    svc = DowngradeEligibilityService(db_session)
+    from uuid import UUID
+
+    usage = await svc.current_usage(UUID(pro_workspace["workspace_id"]))
+    assert usage.members == 3
+    assert usage.contexts == 2
+    assert usage.shared_contexts == 1
+    assert usage.memories == 0
+    assert usage.resource_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_route_reports_blockers_for_each_lower_tier(
+    db_session: AsyncSession, pro_workspace: dict
+):
+    view = await get_downgrade_eligibility(
+        workspace_id=pro_workspace["workspace_id"], _=None, db=db_session
+    )
+    assert view.current_plan == "pro"
+    by_plan = {t.target_plan: t for t in view.targets}
+    assert set(by_plan) == {"free", "basic"}
+
+    # free: 3 members > 1, 2 contexts > 1, 1 shared context disallowed.
+    free_dims = {b.dimension for b in by_plan["free"].blockers}
+    assert free_dims == {"members", "contexts", "shared_contexts"}
+    assert by_plan["free"].eligible is False
+
+    # basic: 3 members > 1 and shared disallowed, but 2 contexts <= 3 (fits).
+    basic_dims = {b.dimension for b in by_plan["basic"].blockers}
+    assert basic_dims == {"members", "shared_contexts"}
+    assert by_plan["basic"].eligible is False
+
+
+@pytest.mark.asyncio
+async def test_route_404_for_soft_deleted_workspace(db_session: AsyncSession):
+    owner = make_user()
+    db_session.add(owner)
+    await db_session.flush()
+    ws = make_workspace(owner_user_id=owner.user_id, plan_name="pro", soft_deleted=True)
+    db_session.add(ws)
+    await db_session.commit()
+
+    with pytest.raises(NotFoundException):
+        await get_downgrade_eligibility(workspace_id=str(ws.id), _=None, db=db_session)

--- a/backend/tests/integration/test_downgrade_eligibility_db.py
+++ b/backend/tests/integration/test_downgrade_eligibility_db.py
@@ -62,6 +62,9 @@ async def test_current_usage_counts_members_and_contexts(
     assert usage.shared_contexts == 1
     assert usage.memories == 0
     assert usage.resource_tokens == 0
+    assert usage.connectors == 0
+    assert usage.sleep_enabled_contexts == 0
+    assert usage.storage_bytes == 0
 
 
 @pytest.mark.asyncio

--- a/backend/tests/services/test_downgrade_eligibility_service.py
+++ b/backend/tests/services/test_downgrade_eligibility_service.py
@@ -1,0 +1,166 @@
+"""Unit tests for DowngradeEligibilityService (#1123).
+
+The eligibility MATH (usage vs target-tier effective limits, addons kept) is the
+load-bearing logic and is tested here with no DB: ``_evaluate_tier`` is a pure
+function of (workspace addon bonuses, usage counts, target PlanTier). The
+workspace-scoped COUNT queries are pinned separately in
+tests/integration/test_downgrade_eligibility_db.py.
+"""
+
+from __future__ import annotations
+
+import types
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from config.plan_tiers import PLAN_TIERS
+from services.downgrade_eligibility_service import (
+    DowngradeEligibilityService,
+    WorkspaceUsage,
+)
+
+FREE = PLAN_TIERS["free"]
+BASIC = PLAN_TIERS["basic"]
+PRO = PLAN_TIERS["pro"]
+
+
+def _ws(plan_name="pro", *, member=0, context=0, memory=0):
+    """A minimal workspace stand-in carrying the 3 addon bonuses the math reads."""
+    return types.SimpleNamespace(
+        id=uuid4(),
+        plan_name=plan_name,
+        addon_member_bonus=member,
+        addon_context_bonus=context,
+        addon_memory_bonus=memory,
+    )
+
+
+def _usage(*, members=0, contexts=0, shared=0, memories=0, tokens=0):
+    return WorkspaceUsage(
+        members=members,
+        contexts=contexts,
+        shared_contexts=shared,
+        memories=memories,
+        resource_tokens=tokens,
+    )
+
+
+def _svc():
+    return DowngradeEligibilityService(db=MagicMock())
+
+
+def _by_dim(result):
+    return {b.dimension: b for b in result.blockers}
+
+
+# --------------------------------------------------------------------------- #
+# _evaluate_tier — the eligibility matrix
+# --------------------------------------------------------------------------- #
+
+
+def test_all_within_target_is_eligible():
+    # PRO workspace, tiny usage → fits BASIC with no blockers.
+    result = _svc()._evaluate_tier(
+        _ws(), _usage(members=1, contexts=1, memories=10, tokens=0, shared=0), BASIC
+    )
+    assert result.target_plan == "basic"
+    assert result.eligible is True
+    assert result.blockers == []
+
+
+def test_members_over_target_blocks():
+    result = _svc()._evaluate_tier(_ws(), _usage(members=5), FREE)  # free limit = 1
+    assert result.eligible is False
+    b = _by_dim(result)["members"]
+    assert (b.usage, b.limit, b.overage, b.cleanup) == (5, 1, 4, "remove_members")
+
+
+def test_contexts_over_target_blocks():
+    result = _svc()._evaluate_tier(_ws(), _usage(contexts=25), BASIC)  # basic limit = 3
+    b = _by_dim(result)["contexts"]
+    assert (b.usage, b.limit, b.overage, b.cleanup) == (25, 3, 22, "delete_contexts")
+
+
+def test_memories_over_target_blocks():
+    result = _svc()._evaluate_tier(_ws(), _usage(memories=2000), FREE)  # free memory_limit = 1000
+    b = _by_dim(result)["memories"]
+    assert (b.usage, b.limit, b.overage, b.cleanup) == (2000, 1000, 1000, "delete_memories")
+
+
+def test_resource_tokens_over_target_blocks():
+    # tier-fixed cap (no addon): basic = 3.
+    result = _svc()._evaluate_tier(_ws(), _usage(tokens=5), BASIC)
+    b = _by_dim(result)["resource_tokens"]
+    assert (b.usage, b.limit, b.overage, b.cleanup) == (5, 3, 2, "revoke_resource_tokens")
+
+
+def test_shared_contexts_block_when_target_disallows():
+    result = _svc()._evaluate_tier(_ws(), _usage(shared=2), FREE)  # free disallows shared
+    b = _by_dim(result)["shared_contexts"]
+    assert (b.usage, b.limit, b.overage, b.cleanup) == (2, 0, 2, "unshare_contexts")
+
+
+def test_shared_contexts_no_block_when_zero():
+    result = _svc()._evaluate_tier(_ws(), _usage(shared=0), FREE)
+    assert "shared_contexts" not in _by_dim(result)
+
+
+def test_addons_are_kept_and_raise_the_target_effective_limit():
+    # +5 context addon on BASIC (base 3) → effective 8. 8 fits, 9 does not.
+    ws = _ws(context=5)
+    assert _svc()._evaluate_tier(ws, _usage(contexts=8), BASIC).eligible is True
+    over = _svc()._evaluate_tier(ws, _usage(contexts=9), BASIC)
+    b = _by_dim(over)["contexts"]
+    assert (b.limit, b.overage) == (8, 1)  # base(3) + addon(5) = 8
+
+
+def test_multiple_blockers_collected():
+    result = _svc()._evaluate_tier(_ws(), _usage(members=5, contexts=25, shared=2), FREE)
+    assert result.eligible is False
+    assert set(_by_dim(result)) == {"members", "contexts", "shared_contexts"}
+
+
+def test_at_limit_is_not_over():
+    # usage == effective limit is allowed (strict ">" blocks).
+    result = _svc()._evaluate_tier(_ws(), _usage(contexts=3), BASIC)  # basic limit = 3
+    assert result.eligible is True
+
+
+# --------------------------------------------------------------------------- #
+# evaluate — which tiers are downgrade targets
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_evaluate_free_workspace_has_no_targets():
+    # Lowest tier → no downgrade targets, and current_usage is never queried.
+    svc = _svc()
+    svc.current_usage = AsyncMock()
+    assert await svc.evaluate(_ws(plan_name="free")) == []
+    svc.current_usage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_evaluate_basic_targets_free_only():
+    svc = _svc()
+    svc.current_usage = AsyncMock(return_value=_usage())
+    targets = await svc.evaluate(_ws(plan_name="basic"))
+    assert [t.target_plan for t in targets] == ["free"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_pro_targets_free_then_basic_in_order():
+    svc = _svc()
+    svc.current_usage = AsyncMock(return_value=_usage())
+    targets = await svc.evaluate(_ws(plan_name="pro"))
+    assert [t.target_plan for t in targets] == ["free", "basic"]
+
+
+@pytest.mark.asyncio
+async def test_evaluate_unknown_plan_fails_closed_to_no_targets():
+    svc = _svc()
+    svc.current_usage = AsyncMock()
+    assert await svc.evaluate(_ws(plan_name="enterprise")) == []
+    svc.current_usage.assert_not_awaited()

--- a/backend/tests/services/test_downgrade_eligibility_service.py
+++ b/backend/tests/services/test_downgrade_eligibility_service.py
@@ -26,24 +26,40 @@ BASIC = PLAN_TIERS["basic"]
 PRO = PLAN_TIERS["pro"]
 
 
-def _ws(plan_name="pro", *, member=0, context=0, memory=0):
-    """A minimal workspace stand-in carrying the 3 addon bonuses the math reads."""
+def _ws(plan_name="pro", *, member=0, context=0, memory=0, connector=0, sleep=0, storage_mb=0):
+    """A minimal workspace stand-in carrying the addon bonuses the math reads."""
     return types.SimpleNamespace(
         id=uuid4(),
         plan_name=plan_name,
         addon_member_bonus=member,
         addon_context_bonus=context,
         addon_memory_bonus=memory,
+        addon_connector_bonus=connector,
+        addon_sleep_contexts_bonus=sleep,
+        addon_storage_bonus_mb=storage_mb,
     )
 
 
-def _usage(*, members=0, contexts=0, shared=0, memories=0, tokens=0):
+def _usage(
+    *,
+    members=0,
+    contexts=0,
+    shared=0,
+    memories=0,
+    tokens=0,
+    connectors=0,
+    sleep=0,
+    storage=0,
+):
     return WorkspaceUsage(
         members=members,
         contexts=contexts,
         shared_contexts=shared,
         memories=memories,
         resource_tokens=tokens,
+        connectors=connectors,
+        sleep_enabled_contexts=sleep,
+        storage_bytes=storage,
     )
 
 
@@ -126,6 +142,39 @@ def test_at_limit_is_not_over():
     # usage == effective limit is allowed (strict ">" blocks).
     result = _svc()._evaluate_tier(_ws(), _usage(contexts=3), BASIC)  # basic limit = 3
     assert result.eligible is True
+
+
+def test_connectors_over_target_blocks():
+    # free max_connectors = 0 → any connector blocks.
+    result = _svc()._evaluate_tier(_ws(), _usage(connectors=2), FREE)
+    b = _by_dim(result)["connectors"]
+    assert (b.usage, b.limit, b.overage, b.cleanup) == (2, 0, 2, "remove_connectors")
+
+
+def test_sleep_enabled_contexts_over_target_blocks():
+    # basic sleep_enabled_contexts_limit = 0 → any sleep context blocks (PRO→BASIC).
+    result = _svc()._evaluate_tier(_ws(), _usage(sleep=1), BASIC)
+    b = _by_dim(result)["sleep_enabled_contexts"]
+    assert (b.usage, b.limit, b.overage, b.cleanup) == (1, 0, 1, "disable_sleep_contexts")
+
+
+def test_storage_bytes_over_target_blocks():
+    # free storage_limit_bytes = 100 MiB → 200 MiB blocks.
+    two_hundred_mb = 200 * 1024 * 1024
+    result = _svc()._evaluate_tier(_ws(), _usage(storage=two_hundred_mb), FREE)
+    b = _by_dim(result)["storage_bytes"]
+    assert b.limit == 100 * 1024 * 1024
+    assert b.overage == two_hundred_mb - 100 * 1024 * 1024
+    assert b.cleanup == "delete_files"
+
+
+def test_storage_addon_is_kept_and_raises_the_limit():
+    # +200 MB storage addon on FREE (base 100 MiB) → 100 MiB + 200 MB effective.
+    ws = _ws(storage_mb=200)
+    limit = (100 * 1024 * 1024) + (200 * 1024 * 1024)
+    assert _svc()._evaluate_tier(ws, _usage(storage=limit), FREE).eligible is True
+    over = _svc()._evaluate_tier(ws, _usage(storage=limit + 1), FREE)
+    assert _by_dim(over)["storage_bytes"].limit == limit
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Partially addresses #1123 (item 1 of 3: the usage-fit eligibility read).

## What

memory-cloud is the usage source of truth, so a plan **downgrade** must be guarded: purchased addons are kept, but a tier downgrade only fits when current usage is within the target tier's *effective* limit (target base + retained addons). This adds a read-only, service-authenticated endpoint reporting that.

`GET /internal/workspaces/{id}/downgrade-eligibility` → for every tier **below** the current one, whether usage fits and which dimensions block, each with the cleanup it needs:

- `members` → remove_members
- `contexts` → delete_contexts
- `memories` → delete_memories
- `resource_tokens` → revoke_resource_tokens
- `shared_contexts` → unshare_contexts (target tier disallows the feature)
- `connectors` → remove_connectors
- `sleep_enabled_contexts` → disable_sleep_contexts
- `storage_bytes` → delete_files

The external billing service gates its portal downgrade UI on this read; the absolute `PUT .../plan` push stays **reconcile-safe** and does not itself enforce the guard. memory-cloud stays Stripe-agnostic (#1096).

## Design

- `DowngradeEligibilityService` (new) holds the logic — pure `_evaluate_tier` math + workspace-scoped count queries. **Each count matches its write-time enforcement basis** so the verdict agrees with the live quota gates.
- Effective target limit = `_zero_floor(target_base, kept_addon)` — the #569 zero-base rule, so addons compose correctly (and a zero-base tier never stacks them).
- `DowngradeDimension` / `DowngradeCleanup` are `StrEnum`s (stable wire contract).
- Service-token auth (`verify_billing_service_token`); internal-only (edge-blocked under `/internal*`); soft-deleted workspaces 404.

## Tests

- `tests/services/...` (18) — the eligibility matrix: every dimension's blocker, addon-keep raising the target limit (incl. storage MB→bytes), at-limit-is-not-over, tier-selection (free→[], basic→[free], pro→[free,basic]), fail-closed on unknown plan.
- `tests/api/...` (8) — route: service-token 401/503, bad-id 422, soft-delete 404, end-to-end serialization of the per-tier blockers.
- `tests/integration/...` (3, real DB) — workspace-scoped counts + route + soft-delete.
- ruff + ruff format clean; pyright 0 errors. Existing `internal_billing` tests still green (no regression).

## Adversarial review applied
Memory count moved to workspace-scoped (actionable cleanup); 3 omitted tier dimensions added (connectors/sleep/storage) to prevent false-positive eligibility; `cleanup`/`dimension` promoted to enums.

> Item 2 (publish the contract to the external billing side) and item 3 (`/internal` addon full-replace) follow under #1123.