### PR TITLE
fix(billing): full-replace addons on the /internal plan push

### DIFF
--- a/backend/src/api/routes/internal_billing.py
+++ b/backend/src/api/routes/internal_billing.py
@@ -21,13 +21,14 @@ Design decisions (documented for the cross-repo contract; see #954):
   silently destroying members/memories on a billing glitch. Billing-driven
   membership/context cleanup is handled by the interactive flow or a
   reconciliation job, not here.
-- **Idempotent.** PUT sets absolute values; re-delivery (reconciliation) yields
-  the same state and 200, never a "already on this plan" 400. Addons are an
-  *absolute, partial* update: omitted dimensions are left unchanged. The billing
-  service therefore owns re-baselining addons on a tier change — on a downgrade
-  it must push the new ``plan_name`` AND the addon values for the new tier
-  (e.g. ``addons:{...:0}``); this endpoint will not zero a prior tier's addon
-  bonus on its own (it has no notion of which addons "belong" to a tier).
+- **Idempotent, full-replace addons.** PUT sets absolute values; re-delivery
+  (reconciliation) yields the same state and 200, never a "already on this plan"
+  400. When ``addons`` is provided it is the **complete desired addon state**:
+  every dimension absent from the map is reset to 0, so a tier change cannot
+  strand a prior tier's addon bonus (over-grant). The billing service therefore
+  pushes the full addon state for the new tier on every change (an empty ``{}``
+  zeros all). Omit ``addons`` entirely (null) for a tier-only change that leaves
+  the existing addon bonuses untouched.
 - **Internal-only.** Mounted under ``/internal`` (NOT ``/api/v1``) so it stays
   off the public surface (#622 freeze). It is also blocked at the edge:
   ``terraform/single-server/Caddyfile.tpl`` has a ``handle /internal* {respond
@@ -80,6 +81,11 @@ _ADDON_COLUMNS: dict[str, str] = {
     "connector": "addon_connector_bonus",
 }
 
+# Upper bound on any addon bonus, matching the admin quota endpoint's
+# ``le=2_000_000_000``. Keeps an oversized push a clean 422 instead of letting it
+# overflow the INTEGER column and surface as a 500 at commit.
+_ADDON_MAX_BONUS = 2_000_000_000
+
 
 async def verify_billing_service_token(authorization: str | None = Header(None)) -> None:
     """Authenticate the billing service by its shared service token (RFC 6750 Bearer).
@@ -126,8 +132,10 @@ class BillingPlanPush(BaseModel):
         description=(
             "Absolute addon bonus values keyed by addon dimension "
             "(memory, mcp_quota, rest_quota, public_quota, member, context, "
-            "analysis, storage_mb, sleep_contexts, connector). Partial update: "
-            "omitted dimensions are left unchanged."
+            "analysis, storage_mb, sleep_contexts, connector). FULL REPLACE: when "
+            "provided this is the complete addon state — dimensions omitted from "
+            "the map are reset to 0 (an empty object zeros all). Omit the field "
+            "entirely (null) to leave existing addons unchanged (tier-only change)."
         ),
     )
 
@@ -153,9 +161,11 @@ async def set_workspace_plan_from_billing(
 ) -> BillingPlanPushResult:
     """Set a workspace's entitlement (plan tier + addon quota) from billing.
 
-    Idempotent, service-authenticated, internal-only. Sets ``plan_name`` and any
-    provided ``addons`` (absolute). Does not perform destructive downgrade
-    cascades (see module docstring). Returns the full applied addon state.
+    Idempotent, service-authenticated, internal-only. Sets ``plan_name``; when
+    ``addons`` is provided it is applied as a FULL REPLACE (dimensions omitted
+    from the map reset to 0) so a tier change cannot strand a prior tier's addon
+    bonus; omit ``addons`` to leave them unchanged. Does not perform destructive
+    downgrade cascades (see module docstring). Returns the full applied addon state.
     """
     # Validate the wire contract BEFORE any mutation. Canonical VAL-001 (422).
     if body.plan_name not in PLAN_TIERS:
@@ -174,6 +184,11 @@ async def set_workspace_plan_from_billing(
                 raise ValidationError(
                     f"Addon '{key}' bonus must be >= 0, got {value}", field="addons"
                 )
+            if value > _ADDON_MAX_BONUS:
+                raise ValidationError(
+                    f"Addon '{key}' bonus exceeds the maximum {_ADDON_MAX_BONUS}, got {value}",
+                    field="addons",
+                )
 
     try:
         ws_uuid = UUID(workspace_id)
@@ -191,7 +206,13 @@ async def set_workspace_plan_from_billing(
     # a prior admin/comp grant is overwritten here by an explicit billing push.
     workspace.plan_name = body.plan_name
     workspace.entitlement_source = ENTITLEMENT_SOURCE_EXTERNAL_BILLING
-    if body.addons:
+    # Full-replace: a provided ``addons`` map is the COMPLETE desired state — zero
+    # every dimension first, then apply the provided values, so a partial or empty
+    # push cannot leave a higher tier's addon bonus stranded (over-grant).
+    # ``addons is None`` (field omitted) is a tier-only change: leave addons as-is.
+    if body.addons is not None:
+        for col in _ADDON_COLUMNS.values():
+            setattr(workspace, col, 0)
         for key, value in body.addons.items():
             setattr(workspace, _ADDON_COLUMNS[key], value)
     await db.commit()

--- a/backend/tests/api/test_internal_billing_plan.py
+++ b/backend/tests/api/test_internal_billing_plan.py
@@ -134,6 +134,16 @@ def test_negative_addon_returns_422(billing):
     assert resp.status_code == 422
 
 
+def test_oversized_addon_returns_422(billing):
+    # Above the INTEGER-column ceiling → clean 422, not a 500 at commit.
+    resp = billing.client(_make_ws()).put(
+        _PATH,
+        json={"plan_name": "pro", "addons": {"memory": 9_999_999_999}},
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert resp.status_code == 422
+
+
 def test_workspace_not_found_returns_404(billing):
     resp = billing.client(workspace=None).put(
         _PATH, json={"plan_name": "pro"}, headers={"Authorization": "Bearer secret"}
@@ -166,6 +176,54 @@ def test_sets_plan_and_addons(billing):
     assert ws.addon_sleep_contexts_bonus == 2
     assert ws.addon_storage_bonus_mb == 1024
     assert ws.entitlement_source == "external_billing"
+
+
+def test_addons_full_replace_zeroes_omitted(billing):
+    # Over-grant guard: a workspace carrying a prior tier's sleep addon, then a
+    # push that lists only `member`, must end with sleep zeroed (not stranded).
+    ws = _make_ws()
+    ws.addon_sleep_contexts_bonus = 5  # left over from a higher tier
+    resp = billing.client(ws).put(
+        _PATH,
+        json={"plan_name": "basic", "addons": {"member": 2}},
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["addons"]["member"] == 2
+    assert body["addons"]["sleep_contexts"] == 0  # omitted → reset, not stranded
+    assert ws.addon_member_bonus == 2
+    assert ws.addon_sleep_contexts_bonus == 0
+
+
+def test_empty_addons_object_zeroes_all(billing):
+    # An explicit empty object means "no addons" — every dimension resets to 0.
+    ws = _make_ws()
+    ws.addon_member_bonus = 3
+    ws.addon_storage_bonus_mb = 512
+    resp = billing.client(ws).put(
+        _PATH,
+        json={"plan_name": "free", "addons": {}},
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert resp.status_code == 200
+    assert all(v == 0 for v in resp.json()["addons"].values())
+    assert ws.addon_member_bonus == 0
+    assert ws.addon_storage_bonus_mb == 0
+
+
+def test_omitted_addons_leaves_existing_unchanged(billing):
+    # A tier-only push (no `addons` field) must NOT touch existing addon bonuses.
+    ws = _make_ws()
+    ws.addon_member_bonus = 3
+    resp = billing.client(ws).put(
+        _PATH,
+        json={"plan_name": "pro"},
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["addons"]["member"] == 3
+    assert ws.addon_member_bonus == 3
 
 
 def test_get_entitlement_returns_source(billing):

--- a/backend/tests/integration/test_internal_billing_plan_db.py
+++ b/backend/tests/integration/test_internal_billing_plan_db.py
@@ -64,7 +64,9 @@ async def test_idempotent_repeated_push(db_session):
 
 
 @pytest.mark.asyncio
-async def test_partial_addon_update_leaves_others_unchanged(db_session):
+async def test_addons_full_replace_zeroes_omitted_dimensions(db_session):
+    # Full replace: a provided addons map is the COMPLETE state. A leftover bonus
+    # on a dimension omitted from the push is reset to 0 (over-grant guard).
     ws = await _make_workspace(db_session, plan_name="pro")
     ws.addon_memory_bonus = 100
     await db_session.commit()
@@ -78,7 +80,26 @@ async def test_partial_addon_update_leaves_others_unchanged(db_session):
 
     await db_session.refresh(ws)
     assert ws.addon_sleep_contexts_bonus == 1
-    assert ws.addon_memory_bonus == 100  # untouched dimension preserved
+    assert ws.addon_memory_bonus == 0  # omitted dimension reset, not stranded
+
+
+@pytest.mark.asyncio
+async def test_tier_only_push_leaves_addons_unchanged(db_session):
+    # Omitting the addons field entirely is a tier-only change: addons untouched.
+    ws = await _make_workspace(db_session, plan_name="pro")
+    ws.addon_memory_bonus = 100
+    await db_session.commit()
+
+    await set_workspace_plan_from_billing(
+        workspace_id=str(ws.id),
+        body=BillingPlanPush(plan_name="basic"),
+        _=None,
+        db=db_session,
+    )
+
+    await db_session.refresh(ws)
+    assert ws.plan_name == "basic"
+    assert ws.addon_memory_bonus == 100  # tier-only push leaves addons as-is
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Partially addresses #1123 (item 3 of 3; item 1 is #1124, item 2 is the cross-repo handoff).

## Why

The `/internal` plan push applied `addons` as a **partial** update — only the dimensions present in the map were written, the rest left as-is. On a tier change that lets a higher tier's addon bonus **strand** on the workspace (over-grant): downgrade to a tier whose push omits an addon, and that bonus silently survives.

## What

`addons` is now a **full replace**: when provided it is the complete desired addon state — every dimension absent from the map is reset to 0.

- `addons: {"member": 2}` on a workspace carrying a leftover `sleep_contexts` bonus → `member=2`, **`sleep_contexts=0`** (no longer stranded).
- `addons: {}` (explicit empty) → all addon dimensions zeroed.
- `addons` **omitted** (null) → tier-only change, existing addons untouched.

Idempotency and the absolute-set / `entitlement_source` semantics are unchanged (zero-all-then-apply is still deterministic on re-delivery). The billing service pushes the full addon state for the new tier on every change.

Also: addon values are now bounded at `2_000_000_000` (matching the admin quota cap) so an oversized push returns a clean **422** instead of overflowing the INTEGER column into a 500 at commit.

## Tests
- Unit (`test_internal_billing_plan.py`): full-replace zeroes an omitted dimension (over-grant guard); empty `{}` zeros all; omitted field leaves addons unchanged; oversized value → 422. 15 pass.
- Integration (`test_internal_billing_plan_db.py`): the old "partial leaves others unchanged" test is **replaced** by full-replace-zeroes + tier-only-unchanged against a real DB. 11 pass.
- ruff + pyright clean; no other caller relied on the old partial semantics (grep-verified). Docstrings (module + field + handler) updated to the new contract.

> The external billing side is informed via the cross-repo handoff (item 2): downgrade pushes must send the full addon state for the target tier.