### PR TITLE
fix(frontend): add Plan link to the settings sidebar

### DIFF
--- a/frontend/src/components/dashboard/Sidebar.test.tsx
+++ b/frontend/src/components/dashboard/Sidebar.test.tsx
@@ -92,6 +92,13 @@ describe("Sidebar", () => {
     expect(link).toHaveAttribute("aria-label", "kaguraLogoAria");
   });
 
+  it("shows the owner Plan link wired to the settings/plan route (#1121/#1126)", () => {
+    render(<Sidebar />);
+    // next-intl is mocked to echo the key, so the nav label is "plan".
+    const planLink = screen.getByRole("link", { name: "plan" });
+    expect(planLink).toHaveAttribute("href", "/workspace/settings/plan");
+  });
+
   it("user menu trigger button shows user name", () => {
     render(<Sidebar />);
     expect(screen.getByText("Test User")).toBeInTheDocument();

--- a/frontend/src/components/dashboard/Sidebar.tsx
+++ b/frontend/src/components/dashboard/Sidebar.tsx
@@ -57,6 +57,7 @@ import {
   X,
   Users,
   BarChart,
+  CreditCard,
   Gauge,
   ChevronDown,
   AlertTriangle,
@@ -178,6 +179,16 @@ const navigationGroups: NavGroup[] = [
     titleKey: "settings",
     collapsible: false,
     items: [
+      {
+        // Issue #1121: owner plan view + billing handoff. The page's data API
+        // (getWorkspacePlan) is owner-only (#246), so gate the nav entry to
+        // owner too — mirrors the other settings items and avoids a link that
+        // would 403 on click for member/viewer.
+        nameKey: "plan",
+        href: "/workspace/settings/plan",
+        icon: CreditCard,
+        requiredWorkspaceRole: WorkspaceRole.Owner,
+      },
       {
         nameKey: "workspaceSettings",
         href: "/workspace/settings/general",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -139,6 +139,7 @@
     "noExternalKeys": "No API keys configured — add OpenAI key to enable memory features",
     "noContexts": "No contexts found",
     "settings": "Settings",
+    "plan": "Plan",
     "workspaceSettings": "Workspace",
     "admin": "Admin",
     "users": "Users",

--- a/frontend/src/messages/ja.json
+++ b/frontend/src/messages/ja.json
@@ -139,6 +139,7 @@
     "noExternalKeys": "APIキー未設定 — OpenAIキーを追加してメモリ機能を有効化",
     "noContexts": "コンテキストがありません",
     "settings": "設定",
+    "plan": "プラン",
     "workspaceSettings": "ワークスペース",
     "admin": "管理",
     "users": "ユーザー",


### PR DESCRIPTION
Closes #1126 (follow-up to #1121).

## Problem
The owner Settings → Plan page (#1121, `/workspace/settings/plan`) shipped and the scattered quota/upgrade CTAs were repointed to it — but the **sidebar never got a "Plan" nav entry**. The 設定 / Settings section only listed Workspace + External Keys, so an owner could only reach the plan page by typing the URL (reported on prod).

## Fix
- Add a **Plan** item (`CreditCard` icon) as the first entry in the `settings` nav group in `Sidebar.tsx`, **owner-gated** — `getWorkspacePlan` is owner-only (#246), so mirroring that gate avoids a nav link that would 403 on click for member/viewer (same pattern as the other settings items).
- Add `sidebar.plan` i18n key (en `"Plan"` / ja `"プラン"`).
- Add a Sidebar test asserting the owner sees the link wired to `/workspace/settings/plan`.

## Verify
- `tsc --noEmit`: 0 errors. Sidebar test 5/5 (incl. the new owner-link assertion).
- Confirmed live on the local stack: the 設定 section now renders プラン → `/workspace/settings/plan`.